### PR TITLE
cli: swallow --sql-preconnect / --redis-preconnect connection failures

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -902,7 +902,7 @@ const SQL: typeof Bun.SQL = function SQL(
     pool.connect(onTransactionConnected.bind(null, callback, options, resolve, reject, false, false), useReserved);
     return promise;
   };
-  sql.connect = () => {
+  sql.connect = preconnect => {
     if (pool.closed) {
       return Promise.$reject(pool.connectionClosedError());
     }
@@ -921,7 +921,7 @@ const SQL: typeof Bun.SQL = function SQL(
       resolve(sql);
     };
 
-    pool.connect(onConnected);
+    pool.connect(onConnected, false, preconnect === true);
 
     return promise;
   };

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -931,9 +931,13 @@ const SQL: typeof Bun.SQL = function SQL(
     if (pool.closed || pool.isConnected()) {
       return;
     }
-    pool.connect((err, connection) => {
-      if (!err) pool.release(connection);
-    }, false, true);
+    pool.connect(
+      (err, connection) => {
+        if (!err) pool.release(connection);
+      },
+      false,
+      true,
+    );
   };
 
   sql.close = async (options?: { timeout?: number }) => {

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -12,6 +12,7 @@ const { SQLHelper, parseOptions } = require("internal/sql/shared");
 const { SQLError, PostgresError, SQLiteError, MySQLError } = require("internal/sql/errors");
 
 const defineProperties = Object.defineProperties;
+const preconnectSymbol = Symbol.for("bun.sql.preconnect");
 
 type TransactionCallback = (sql: (strings: string, ...values: any[]) => Query<any, any>) => Promise<any>;
 
@@ -902,7 +903,7 @@ const SQL: typeof Bun.SQL = function SQL(
     pool.connect(onTransactionConnected.bind(null, callback, options, resolve, reject, false, false), useReserved);
     return promise;
   };
-  sql.connect = preconnect => {
+  sql.connect = () => {
     if (pool.closed) {
       return Promise.$reject(pool.connectionClosedError());
     }
@@ -921,9 +922,18 @@ const SQL: typeof Bun.SQL = function SQL(
       resolve(sql);
     };
 
-    pool.connect(onConnected, false, preconnect === true);
+    pool.connect(onConnected);
 
     return promise;
+  };
+
+  sql[preconnectSymbol] = () => {
+    if (pool.closed || pool.isConnected()) {
+      return;
+    }
+    pool.connect((err, connection) => {
+      if (!err) pool.release(connection);
+    }, false, true);
   };
 
   sql.close = async (options?: { timeout?: number }) => {
@@ -992,6 +1002,11 @@ defaultSQLObject.distributed = defaultSQLObject.beginDistributed = (...args) => 
 defaultSQLObject.connect = (...args) => {
   ensureDefaultSQL();
   return lazyDefaultSQL.connect(...args);
+};
+
+defaultSQLObject[preconnectSymbol] = () => {
+  ensureDefaultSQL();
+  return lazyDefaultSQL[preconnectSymbol]();
 };
 
 defaultSQLObject.unsafe = (...args) => {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -724,7 +724,8 @@ abstract class BasePooledConnection<ConnectionHandle extends { close(): void; fl
       return false;
     }
     // only retry while queries are actually waiting for a connection
-    if (this.adapter.waitingQueue.length === 0 && this.adapter.reservedQueue.length === 0) {
+    const adapter = this.adapter;
+    if (adapter.waitingQueue.length <= adapter.preconnectWaiters && adapter.reservedQueue.length === 0) {
       return false;
     }
     // an explicit connectionTimeout of 0 disables the connect timer, and with
@@ -913,6 +914,7 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
 
   public waitingQueue: Array<(err: Error | null, result: any) => void> = [];
   public reservedQueue: Array<(err: Error | null, result: any) => void> = [];
+  public preconnectWaiters: number = 0;
 
   public poolStarted: boolean = false;
   public closed: boolean = false;
@@ -1279,9 +1281,19 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
    * @param {function} onConnected - The callback function to be called when the connection is established.
    * @param {boolean} reserved - Whether the connection is reserved, if is reserved the connection will not be released until release is called, if not release will only decrement the queryCount counter
    */
-  connect(onConnected: (err: Error | null, result: any) => void, reserved: boolean = false) {
+  connect(onConnected: (err: Error | null, result: any) => void, reserved: boolean = false, preconnect: boolean = false) {
     if (this.closed) {
       return onConnected(this.connectionClosedError(), null);
+    }
+
+    if (preconnect) {
+      this.preconnectWaiters++;
+      const inner = onConnected;
+      const adapter = this;
+      onConnected = function (err, result) {
+        adapter.preconnectWaiters--;
+        inner(err, result);
+      };
     }
 
     if (this.readyConnections.size === 0) {
@@ -2113,7 +2125,7 @@ export interface TransactionCommands {
 export interface DatabaseAdapter<Connection, ConnectionHandle, QueryHandle> {
   normalizeQuery(strings: string | TemplateStringsArray, values: unknown[]): [sql: string, values: unknown[]];
   createQueryHandle(sql: string, values: unknown[], flags: number): QueryHandle;
-  connect(onConnected: OnConnected<Connection>, reserved?: boolean): void;
+  connect(onConnected: OnConnected<Connection>, reserved?: boolean, preconnect?: boolean): void;
   release(connection: Connection, connectingEvent?: boolean): void;
   close(options?: { timeout?: number }): Promise<void>;
   flush(): void;

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1281,7 +1281,11 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
    * @param {function} onConnected - The callback function to be called when the connection is established.
    * @param {boolean} reserved - Whether the connection is reserved, if is reserved the connection will not be released until release is called, if not release will only decrement the queryCount counter
    */
-  connect(onConnected: (err: Error | null, result: any) => void, reserved: boolean = false, preconnect: boolean = false) {
+  connect(
+    onConnected: (err: Error | null, result: any) => void,
+    reserved: boolean = false,
+    preconnect: boolean = false,
+  ) {
     if (this.closed) {
       return onConnected(this.connectionClosedError(), null);
     }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1456,9 +1456,6 @@ impl Run {
             };
             match connect_fn.call(global, sql_object, &[]) {
                 Ok(promise) => {
-                    // Preconnect is best-effort: a failed attempt must not
-                    // surface as an unhandled rejection and kill a script that
-                    // never touches SQL.
                     if let Some(p) = promise.as_promise() {
                         bun_jsc::JSPromise::opaque_mut(p).set_handled();
                     }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1419,7 +1419,7 @@ impl Run {
             };
             // SAFETY: `as_` returns a live `m_ctx` pointer owned by the JS
             // wrapper; accessed here under the API lock.
-            if let Err(e) = unsafe { &*client }.do_connect(global, redis) {
+            if let Err(e) = unsafe { &*client }.do_preconnect(global, redis) {
                 global.report_active_exception_as_unhandled(e);
             }
         }
@@ -1454,8 +1454,16 @@ impl Run {
                     break 'do_postgres_preconnect;
                 }
             };
-            if let Err(e) = connect_fn.call(global, sql_object, &[]) {
-                global.report_active_exception_as_unhandled(e);
+            match connect_fn.call(global, sql_object, &[]) {
+                Ok(promise) => {
+                    // Preconnect is best-effort: a failed attempt must not
+                    // surface as an unhandled rejection and kill a script that
+                    // never touches SQL.
+                    if let Some(p) = promise.as_promise() {
+                        bun_jsc::JSPromise::opaque_mut(p).set_handled();
+                    }
+                }
+                Err(e) => global.report_active_exception_as_unhandled(e),
             }
         }
 

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1454,7 +1454,7 @@ impl Run {
                     break 'do_postgres_preconnect;
                 }
             };
-            match connect_fn.call(global, sql_object, &[]) {
+            match connect_fn.call(global, sql_object, &[JSValue::js_boolean(true)]) {
                 Ok(promise) => {
                     if let Some(p) = promise.as_promise() {
                         bun_jsc::JSPromise::opaque_mut(p).set_handled();

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1448,8 +1448,15 @@ impl Run {
             };
             let mut key = bun_jsc::zig_string::ZigString::init(b"bun.sql.preconnect");
             let sym = JSValue::symbol_for(global, &mut key);
-            let Some(preconnect_fn) = sql_object.get_own_by_value(global, sym) else {
-                break 'do_postgres_preconnect;
+            let preconnect_fn = match bun_jsc::from_js_host_call_generic(global, || {
+                sql_object.get_own_by_value(global, sym)
+            }) {
+                Ok(Some(v)) => v,
+                Ok(None) => break 'do_postgres_preconnect,
+                Err(e) => {
+                    global.report_active_exception_as_unhandled(e);
+                    break 'do_postgres_preconnect;
+                }
             };
             if let Err(e) = preconnect_fn.call(global, sql_object, &[]) {
                 global.report_active_exception_as_unhandled(e);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1446,21 +1446,13 @@ impl Run {
                     break 'do_postgres_preconnect;
                 }
             };
-            let connect_fn = match sql_object.get(global, "connect") {
-                Ok(Some(v)) => v,
-                Ok(None) => break 'do_postgres_preconnect,
-                Err(e) => {
-                    global.report_active_exception_as_unhandled(e);
-                    break 'do_postgres_preconnect;
-                }
+            let mut key = bun_jsc::zig_string::ZigString::init(b"bun.sql.preconnect");
+            let sym = JSValue::symbol_for(global, &mut key);
+            let Some(preconnect_fn) = sql_object.get_own_by_value(global, sym) else {
+                break 'do_postgres_preconnect;
             };
-            match connect_fn.call(global, sql_object, &[JSValue::js_boolean(true)]) {
-                Ok(promise) => {
-                    if let Some(p) = promise.as_promise() {
-                        bun_jsc::JSPromise::opaque_mut(p).set_handled();
-                    }
-                }
-                Err(e) => global.report_active_exception_as_unhandled(e),
+            if let Err(e) = preconnect_fn.call(global, sql_object, &[]) {
+                global.report_active_exception_as_unhandled(e);
             }
         }
 

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1627,6 +1627,8 @@ impl JSValkeyClient {
         // the host-fn shim passes a bare `&self` with no ref of its own.
         let _guard = self.ref_scope();
 
+        self.client_mut().flags.is_preconnecting = false;
+
         if self.client.get().flags.needs_to_open_socket {
             bun_core::hint::cold();
 

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1081,8 +1081,7 @@ impl JSValkeyClient {
         Ok(promise)
     }
 
-    /// Best-effort connect for `--redis-preconnect`. Does not ref the event
-    /// loop; marks the returned promise handled so a failure is silent.
+    /// `--redis-preconnect`: best-effort, no event-loop ref, failure is silent.
     pub fn do_preconnect(
         &self,
         global_object: &JSGlobalObject,
@@ -1103,8 +1102,6 @@ impl JSValkeyClient {
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         if self.client.get().flags.is_preconnecting {
-            // `do_connect` early-returns the cached promise without touching
-            // `poll_ref`, so re-ref explicitly now the user is waiting on it.
             self.client_mut().flags.is_preconnecting = false;
             self.update_poll_ref();
         }

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1081,12 +1081,38 @@ impl JSValkeyClient {
         Ok(promise)
     }
 
+    /// Best-effort connect for `--redis-preconnect`: starts the connection
+    /// without letting it (or its retry loop) keep the event loop alive, and
+    /// marks the connection promise handled so a failure never becomes an
+    /// unhandled rejection. A later explicit `.connect()` or any queued
+    /// command re-asserts the keep-alive.
+    pub fn do_preconnect(
+        &self,
+        global_object: &JSGlobalObject,
+        this_value: JSValue,
+    ) -> JsResult<()> {
+        self.client_mut().flags.is_preconnecting = true;
+        let promise = self.do_connect(global_object, this_value)?;
+        if let Some(p) = promise.as_promise() {
+            JSPromise::opaque_mut(p).set_handled();
+        }
+        Ok(())
+    }
+
     #[bun_jsc::host_fn(method)]
     pub fn js_connect(
         &self,
         global_object: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
+        // An explicit .connect() supersedes any background preconnect: the
+        // caller is now waiting on the returned promise, so the loop must
+        // stay alive for it. `do_connect` may early-return the cached promise
+        // without touching `poll_ref`, hence the explicit update here.
+        if self.client.get().flags.is_preconnecting {
+            self.client_mut().flags.is_preconnecting = false;
+            self.update_poll_ref();
+        }
         self.do_connect(global_object, callframe.this())
     }
 
@@ -1193,10 +1219,13 @@ impl JSValkeyClient {
         let _guard = self.ref_scope();
 
         // Ref the poll to keep event loop alive during connection
+        let is_preconnecting = self.client.get().flags.is_preconnecting;
         self.poll_ref.with_mut(|r| {
             r.disable();
             *r = KeepAlive::default();
-            r.ref_(vm_event_loop_ctx());
+            if !is_preconnecting {
+                r.ref_(vm_event_loop_ctx());
+            }
         });
 
         if let Err(err) = self.connect() {
@@ -1708,11 +1737,16 @@ impl JSValkeyClient {
                 .has_subscriptions(&self.global_object)
                 .unwrap_or(false);
 
-        let has_activity =
-            has_pending_commands || !subs_deletable || self.client.get().flags.is_reconnecting;
+        // A `--redis-preconnect`-initiated attempt must not keep the loop alive
+        // on its own; real work (commands/subscriptions) still refs below.
+        let keep_alive_for_connect = !self.client.get().flags.is_preconnecting
+            && (self.client.get().flags.is_reconnecting
+                || self.client.get().status == valkey::Status::Connecting);
+
+        let has_activity = has_pending_commands || !subs_deletable || keep_alive_for_connect;
 
         // There's a couple cases to handle here:
-        if has_activity || self.client.get().status == valkey::Status::Connecting {
+        if has_activity {
             // If we currently have pending activity or we are connecting, we need to keep the
             // event loop alive.
             self.poll_ref.with_mut(|r| r.ref_(vm_event_loop_ctx()));

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1081,11 +1081,8 @@ impl JSValkeyClient {
         Ok(promise)
     }
 
-    /// Best-effort connect for `--redis-preconnect`: starts the connection
-    /// without letting it (or its retry loop) keep the event loop alive, and
-    /// marks the connection promise handled so a failure never becomes an
-    /// unhandled rejection. A later explicit `.connect()` or any queued
-    /// command re-asserts the keep-alive.
+    /// Best-effort connect for `--redis-preconnect`. Does not ref the event
+    /// loop; marks the returned promise handled so a failure is silent.
     pub fn do_preconnect(
         &self,
         global_object: &JSGlobalObject,
@@ -1105,11 +1102,9 @@ impl JSValkeyClient {
         global_object: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        // An explicit .connect() supersedes any background preconnect: the
-        // caller is now waiting on the returned promise, so the loop must
-        // stay alive for it. `do_connect` may early-return the cached promise
-        // without touching `poll_ref`, hence the explicit update here.
         if self.client.get().flags.is_preconnecting {
+            // `do_connect` early-returns the cached promise without touching
+            // `poll_ref`, so re-ref explicitly now the user is waiting on it.
             self.client_mut().flags.is_preconnecting = false;
             self.update_poll_ref();
         }
@@ -1737,8 +1732,6 @@ impl JSValkeyClient {
                 .has_subscriptions(&self.global_object)
                 .unwrap_or(false);
 
-        // A `--redis-preconnect`-initiated attempt must not keep the loop alive
-        // on its own; real work (commands/subscriptions) still refs below.
         let keep_alive_for_connect = !self.client.get().flags.is_preconnecting
             && (self.client.get().flags.is_reconnecting
                 || self.client.get().status == valkey::Status::Connecting);

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -41,8 +41,7 @@ pub struct ConnectionFlags {
     pub failed: bool,
     pub enable_auto_pipelining: bool,
     pub finalized: bool,
-    /// Connection was initiated by `--redis-preconnect`; while set,
-    /// connect/reconnect does not ref the event loop on its own.
+    /// `--redis-preconnect` started this connect; suppresses the event-loop ref.
     pub is_preconnecting: bool,
     // This flag is a slight hack to allow returning the client instance in the
     // promise which resolves when the connection is established. There are two

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -985,6 +985,7 @@ impl ValkeyClient {
                     self.status = Status::Connected;
                     self.flags.is_authenticated = true;
                     self.flags.is_reconnecting = false;
+                    self.flags.is_preconnecting = false;
                     self.retry_attempts = 0;
                     self.on_valkey_connect(value)?;
                     return Ok(());
@@ -1025,6 +1026,7 @@ impl ValkeyClient {
                 self.status = Status::Connected;
                 self.flags.is_authenticated = true;
                 self.flags.is_reconnecting = false;
+                self.flags.is_preconnecting = false;
                 self.retry_attempts = 0;
                 self.on_valkey_connect(value)?;
                 Ok(())

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -41,12 +41,8 @@ pub struct ConnectionFlags {
     pub failed: bool,
     pub enable_auto_pipelining: bool,
     pub finalized: bool,
-    /// Set when the in-flight connection was initiated by `--redis-preconnect`
-    /// rather than user code. While true the connect/reconnect machinery does
-    /// not ref the event loop on its own (pending commands and subscriptions
-    /// still do), so a script that never touches Redis can exit instead of
-    /// waiting out the retry backoff. Cleared on the first explicit
-    /// `.connect()` call.
+    /// Connection was initiated by `--redis-preconnect`; while set,
+    /// connect/reconnect does not ref the event loop on its own.
     pub is_preconnecting: bool,
     // This flag is a slight hack to allow returning the client instance in the
     // promise which resolves when the connection is established. There are two

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -41,6 +41,13 @@ pub struct ConnectionFlags {
     pub failed: bool,
     pub enable_auto_pipelining: bool,
     pub finalized: bool,
+    /// Set when the in-flight connection was initiated by `--redis-preconnect`
+    /// rather than user code. While true the connect/reconnect machinery does
+    /// not ref the event loop on its own (pending commands and subscriptions
+    /// still do), so a script that never touches Redis can exit instead of
+    /// waiting out the retry backoff. Cleared on the first explicit
+    /// `.connect()` call.
+    pub is_preconnecting: bool,
     // This flag is a slight hack to allow returning the client instance in the
     // promise which resolves when the connection is established. There are two
     // modes through which a client may connect:
@@ -66,6 +73,7 @@ impl Default for ConnectionFlags {
             failed: false,
             enable_auto_pipelining: true,
             finalized: false,
+            is_preconnecting: false,
             connection_promise_returns_client: false,
         }
     }

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -985,7 +985,6 @@ impl ValkeyClient {
                     self.status = Status::Connected;
                     self.flags.is_authenticated = true;
                     self.flags.is_reconnecting = false;
-                    self.flags.is_preconnecting = false;
                     self.retry_attempts = 0;
                     self.on_valkey_connect(value)?;
                     return Ok(());
@@ -1026,7 +1025,6 @@ impl ValkeyClient {
                 self.status = Status::Connected;
                 self.flags.is_authenticated = true;
                 self.flags.is_reconnecting = false;
-                self.flags.is_preconnecting = false;
                 self.retry_attempts = 0;
                 self.on_valkey_connect(value)?;
                 Ok(())

--- a/test/cli/run/redis-preconnect.test.ts
+++ b/test/cli/run/redis-preconnect.test.ts
@@ -26,7 +26,7 @@ describe("--redis-preconnect", () => {
       "index.js": `console.log("Script executed");`,
     });
 
-    const proc = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "--redis-preconnect", "index.js"],
       env: {
         ...bunEnv,
@@ -73,13 +73,11 @@ describe("--redis-preconnect", () => {
     // Preconnect starts a background attempt that does not ref the loop. When
     // the script then calls .connect() itself, the returned promise must still
     // settle (resolve here) before the process exits.
-    const { promise, resolve } = Promise.withResolvers<void>();
     await using server = Bun.listen({
       port: 0,
       hostname: "127.0.0.1",
       socket: {
         open(socket) {
-          resolve();
           // RESP3 HELLO → reply with a minimal map so the handshake succeeds.
           socket.write("%1\r\n$6\r\nserver\r\n$5\r\nredis\r\n");
         },
@@ -98,7 +96,6 @@ describe("--redis-preconnect", () => {
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    await promise;
 
     expect(stderr).toBe("");
     expect(stdout).toBe("connected\n");

--- a/test/cli/run/redis-preconnect.test.ts
+++ b/test/cli/run/redis-preconnect.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-describe("--sql-preconnect", () => {
-  test("should attempt to preconnect to PostgreSQL on startup", async () => {
+describe("--redis-preconnect", () => {
+  test("should attempt to preconnect to Redis on startup", async () => {
     let connectionAttempts = 0;
     const { promise, resolve } = Promise.withResolvers<void>();
 
@@ -22,15 +22,15 @@ describe("--sql-preconnect", () => {
       },
     });
 
-    await using testDir = tempDir("sql-preconnect-test", {
+    await using testDir = tempDir("redis-preconnect-test", {
       "index.js": `console.log("Script executed");`,
     });
 
     const proc = Bun.spawn({
-      cmd: [bunExe(), "--sql-preconnect", "index.js"],
+      cmd: [bunExe(), "--redis-preconnect", "index.js"],
       env: {
         ...bunEnv,
-        DATABASE_URL: `postgres://127.0.0.1:${server.port}/MY_DATABASE`,
+        REDIS_URL: `redis://127.0.0.1:${server.port}`,
       },
       cwd: testDir,
     });
@@ -42,7 +42,7 @@ describe("--sql-preconnect", () => {
     expect(connectionAttempts).toBeGreaterThan(0);
   });
 
-  test("does not fail the script when the server is unreachable", async () => {
+  test("does not fail or hang when the server is unreachable", async () => {
     // Grab a port that has nothing listening on it.
     const server = Bun.listen({
       port: 0,
@@ -53,10 +53,10 @@ describe("--sql-preconnect", () => {
     server.stop(true);
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "--sql-preconnect", "-e", `console.log("script done")`],
+      cmd: [bunExe(), "--redis-preconnect", "-e", `console.log("script done")`],
       env: {
         ...bunEnv,
-        DATABASE_URL: `postgres://127.0.0.1:${port}/nope`,
+        REDIS_URL: `redis://127.0.0.1:${port}`,
       },
       stderr: "pipe",
     });
@@ -68,48 +68,53 @@ describe("--sql-preconnect", () => {
     ]);
 
     expect(stdout).toBe("script done\n");
-    expect(stderr).not.toContain("PostgresError");
-    expect(stderr).not.toContain("ERR_POSTGRES");
+    expect(stderr).not.toContain("RedisError");
+    expect(stderr).not.toContain("ERR_REDIS");
     expect(exitCode).toBe(0);
   });
 
-  test("should not connect when flag is not used", async () => {
-    let connectionAttempts = 0;
-
+  test("a later explicit .connect() still keeps the loop alive", async () => {
+    // Preconnect starts a background attempt that does not ref the loop. When
+    // the script then calls .connect() itself, the returned promise must still
+    // settle (resolve here) before the process exits.
+    const { promise, resolve } = Promise.withResolvers<void>();
     await using server = Bun.listen({
       port: 0,
       hostname: "127.0.0.1",
       socket: {
         open(socket) {
-          connectionAttempts++;
-          socket.end();
+          resolve();
+          // RESP3 HELLO → reply with a minimal map so the handshake succeeds.
+          socket.write("%1\r\n$6\r\nserver\r\n$5\r\nredis\r\n");
         },
         data() {},
         close() {},
       },
     });
 
-    await using testDir = tempDir("sql-no-preconnect", {
-      "index.js": `console.log("Normal script executed");`,
-    });
-
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "index.js"],
+      cmd: [
+        bunExe(),
+        "--redis-preconnect",
+        "-e",
+        `await Bun.redis.connect(); console.log("connected");`,
+      ],
       env: {
         ...bunEnv,
-        DATABASE_URL: `postgres://127.0.0.1:${server.port}/MY_DATABASE`,
+        REDIS_URL: `redis://127.0.0.1:${server.port}`,
       },
-      cwd: testDir,
+      stderr: "pipe",
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
+      proc.stdout.text(),
+      proc.stderr.text(),
       proc.exited,
     ]);
+    await promise;
 
+    expect(stderr).toBe("");
+    expect(stdout).toBe("connected\n");
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("Normal script executed");
-    expect(connectionAttempts).toBe(0); // No connection should be attempted without the flag
   });
 });

--- a/test/cli/run/redis-preconnect.test.ts
+++ b/test/cli/run/redis-preconnect.test.ts
@@ -61,11 +61,7 @@ describe("--redis-preconnect", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("script done\n");
     expect(stderr).not.toContain("RedisError");
@@ -93,12 +89,7 @@ describe("--redis-preconnect", () => {
     });
 
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "--redis-preconnect",
-        "-e",
-        `await Bun.redis.connect(); console.log("connected");`,
-      ],
+      cmd: [bunExe(), "--redis-preconnect", "-e", `await Bun.redis.connect(); console.log("connected");`],
       env: {
         ...bunEnv,
         REDIS_URL: `redis://127.0.0.1:${server.port}`,
@@ -106,11 +97,7 @@ describe("--redis-preconnect", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     await promise;
 
     expect(stderr).toBe("");

--- a/test/cli/run/redis-preconnect.test.ts
+++ b/test/cli/run/redis-preconnect.test.ts
@@ -4,7 +4,7 @@ import { bunEnv, bunExe, tempDir } from "harness";
 describe("--redis-preconnect", () => {
   test("should attempt to preconnect to Redis on startup", async () => {
     let connectionAttempts = 0;
-    const { promise, resolve } = Promise.withResolvers<void>();
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
 
     await using server = Bun.listen({
       port: 0,
@@ -35,6 +35,7 @@ describe("--redis-preconnect", () => {
       cwd: testDir,
     });
 
+    proc.exited.then(code => reject(new Error(`child exited (${code}) before preconnecting`)));
     await promise;
     proc.kill();
     await proc.exited;

--- a/test/cli/run/sql-preconnect.test.ts
+++ b/test/cli/run/sql-preconnect.test.ts
@@ -69,6 +69,36 @@ describe("--sql-preconnect", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("does not hang when the server accepts then closes", async () => {
+    await using server = Bun.listen({
+      port: 0,
+      hostname: "127.0.0.1",
+      socket: {
+        open(socket) {
+          socket.end();
+        },
+        data() {},
+        close() {},
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--sql-preconnect", "-e", `console.log("script done")`],
+      env: {
+        ...bunEnv,
+        DATABASE_URL: `postgres://127.0.0.1:${server.port}/nope`,
+      },
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("script done\n");
+    expect(stderr).not.toContain("PostgresError");
+    expect(stderr).not.toContain("ERR_POSTGRES");
+    expect(exitCode).toBe(0);
+  });
+
   test("should not connect when flag is not used", async () => {
     let connectionAttempts = 0;
 

--- a/test/cli/run/sql-preconnect.test.ts
+++ b/test/cli/run/sql-preconnect.test.ts
@@ -61,11 +61,7 @@ describe("--sql-preconnect", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("script done\n");
     expect(stderr).not.toContain("PostgresError");

--- a/test/cli/run/sql-preconnect.test.ts
+++ b/test/cli/run/sql-preconnect.test.ts
@@ -4,7 +4,7 @@ import { bunEnv, bunExe, tempDir } from "harness";
 describe("--sql-preconnect", () => {
   test("should attempt to preconnect to PostgreSQL on startup", async () => {
     let connectionAttempts = 0;
-    const { promise, resolve } = Promise.withResolvers<void>();
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
 
     await using server = Bun.listen({
       port: 0,
@@ -26,7 +26,7 @@ describe("--sql-preconnect", () => {
       "index.js": `console.log("Script executed");`,
     });
 
-    const proc = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "--sql-preconnect", "index.js"],
       env: {
         ...bunEnv,
@@ -35,6 +35,7 @@ describe("--sql-preconnect", () => {
       cwd: testDir,
     });
 
+    proc.exited.then(code => reject(new Error(`child exited (${code}) before preconnecting`)));
     await promise;
     proc.kill();
     await proc.exited;


### PR DESCRIPTION
## Problem

`--sql-preconnect` and `--redis-preconnect` are startup latency optimizations that warm the default `Bun.sql` / `Bun.redis` connection before the entry module loads. When the target server is unreachable (or accepts then immediately closes) they turned into hard failures of a script that never touched SQL/Redis:

```console
$ DATABASE_URL=postgres://localhost:54399/x bun --sql-preconnect -e 'console.log("script done")'
script done
PostgresError: Failed to connect
 code: "ERR_POSTGRES_CONNECTION_REFUSED"
# exit 1

$ REDIS_URL=redis://localhost:63799 bun --redis-preconnect -e 'console.log("script done")'
script done
# ... hangs ~31s ...
RedisError: Connection closed
 code: "ERR_REDIS_CONNECTION_CLOSED"
# exit 1
```

## Cause

`Run::start` in `src/runtime/cli/run_command.rs` invoked `Bun.sql.connect()` / `JSValkeyClient::do_connect()` and dropped the returned `Promise`. When the connection later failed the rejection had no handler and became an unhandled rejection, so the process exited 1.

For Redis, the valkey client's `update_poll_ref()` keeps the event loop ref'd while `status == Connecting` or `flags.is_reconnecting`, and `reconnect()` re-refs every retry (20 retries with exponential backoff to 2s cap, ~31s total), so the process sat idle past the script's own completion.

For SQL against a server that accepts then closes during the handshake, the pool's connect-retry loop (`BasePooledConnection.#canKeepRetrying()`) kept going for the 30s `connectionTimeout` window because the preconnect callback sat in `waitingQueue`.

## Fix

- Redis: `JSValkeyClient::do_preconnect()` sets a new `ConnectionFlags::is_preconnecting` bit and marks the connection promise handled. While the bit is set, `update_poll_ref()` and `reconnect()` do not ref the event loop for the connection attempt alone; pending commands and subscriptions still do. The bit is cleared on the first user command (`send()`) or an explicit `.connect()`, so once the client is actually in use its reconnect behavior is unchanged.
- SQL: the startup path calls a `Symbol.for("bun.sql.preconnect")`-keyed internal hook on `Bun.sql` (public `sql.connect()` stays zero-arg). The hook enqueues a preconnect-tagged waiter whose callback swallows the error; `BaseSQLAdapter` counts `preconnectWaiters` and `#canKeepRetrying()` no longer retries when the only queued waiter is the preconnect probe.

## Verification

```
test/cli/run/sql-preconnect.test.ts:
(pass) --sql-preconnect > should attempt to preconnect to PostgreSQL on startup
(pass) --sql-preconnect > does not fail the script when the server is unreachable
(pass) --sql-preconnect > does not hang when the server accepts then closes
(pass) --sql-preconnect > should not connect when flag is not used

test/cli/run/redis-preconnect.test.ts:
(pass) --redis-preconnect > should attempt to preconnect to Redis on startup
(pass) --redis-preconnect > does not fail or hang when the server is unreachable
(pass) --redis-preconnect > a later explicit .connect() still keeps the loop alive
```

The three failure-mode tests fail on main (SQL unreachable: stderr contains `PostgresError`; SQL accept-then-close: times out at 30s; Redis unreachable: times out at 31s).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/redis-preconnect.test.ts test/cli/run/sql-preconnect.test.ts
bun test v1.4.0 (fef989e70)

test/cli/run/sql-preconnect.test.ts:
(pass) --sql-preconnect > should attempt to preconnect to PostgreSQL on startup [1045.72ms]
63 |     });
64 | 
65 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
66 | 
67 |     expect(stdout).toBe("script done\n");
68 |     expect(stderr).not.toContain("PostgresError");
                            ^
error: expect(received).not.toContain(expected)

Expected to not contain: "PostgresError"
Received: "204 |   return `{${values.map(arrayValueSerializer.bind(this, type, isPostgresNumericType(type), isPostgresJsonType(type))).join(delimiter)}}`;\n205 | }\n206 | function wrapPostgresError(error) {\n207 |   if (Error.isError(error)) {\n208 |     return error;\n209 |   return new PostgresError(error.message, error);\n               ^\nPostgresError: Failed to connect\n code: \"ERR_POSTGRES_CONNECTION_REFUSED\"\n\n      at wrapPostgresError (
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (32f7de851)

test/cli/run/sql-preconnect.test.ts:
(pass) --sql-preconnect > should attempt to preconnect to PostgreSQL on startup [21.17ms]
(pass) --sql-preconnect > does not fail the script when the server is unreachable [23.52ms]
(pass) --sql-preconnect > does not hang when the server accepts then closes [22.89ms]
(pass) --sql-preconnect > should not connect when flag is not used [72.87ms]

test/cli/run/redis-preconnect.test.ts:
(pass) --redis-preconnect > should attempt to preconnect to Redis on startup [7.52ms]
(pass) --redis-preconnect > does not fail or hang when the server is unreachable [6.80ms]
(pass) --redis-preconnect > a later explicit .connect() still keeps the loop alive [7.00ms]

 7 pass
 0 fail
 20 expect() calls
Ran 7 tests across 2 files. [380.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/redis-preconnect.test.ts test/cli/run/sql-preconnect.test.ts
bun test v1.4.0 (fef989e70)

test/cli/run/sql-preconnect.test.ts:
(pass) --sql-preconnect > should attempt to preconnect to PostgreSQL on startup [1043.07ms]
(pass) --sql-preconnect > does not fail the script when the server is unreachable [1237.37ms]
(pass) --sql-preconnect > does not hang when the server accepts then closes [1123.66ms]
(pass) --sql-preconnect > should not connect when flag is not used [286.45ms]

test/cli/run/redis-preconnect.test.ts:
(pass) --redis-preconnect > should attempt to preconnect to Redis on startup [230.32ms]
(pass) --redis-preconnect > does not fail or hang when the server is unreachable [288.47ms]
(pass) --redis-preconnect > a later explicit .connect() still keeps the loop alive [296.70ms]

 7 pass
 0 fail
 20 expect() calls
Ran 7 tests across 2 files. [6.59s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 750ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (9733ms)
Bundle modules (34ms)
Postprocesss modules (233ms)
Bundle Functions (758ms)
Generate Code (37ms)

[10.81s] Bundled "src/js" for production
  2571 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/bun/sql.ts                     |  19 ++++++
 src/js/internal/sql/shared.ts         |  22 ++++++-
 src/runtime/cli/run_command.rs        |  10 +++-
 src/runtime/valkey_jsc/js_valkey.rs   |  34 +++++++++--
 src/runtime/valkey_jsc/valkey.rs      |   3 +
 test/cli/run/redis-preconnect.test.ts | 105 ++++++++++++++++++++++++++++++++++
 test/cli/run/sql-preconnect.test.ts   |  62 +++++++++++++++++++-
 7 files changed, 243 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/bun/sql.ts                          4      4      0
src/js/internal/sql/shared.ts              4      4      0
src/runtime/cli/run_command.rs             6      9      0
src/runtime/valkey_jsc/js_valkey.rs       11      8      0
src/runtime/valkey_jsc/valkey.rs           6      7      0
test/cli/run/redis-preconnect.test.ts      3      4      0
test/cli/run/sql-preconnect.test.ts        3      3      0
```

</details>

<!-- robobun:evidence:end -->