### PR TITLE
event_loop: reserve TaskTag(0) as a sentinel for zeroed ConcurrentTask

### DIFF
--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -44,12 +44,23 @@ pub struct TaskTag(pub u8);
 #[allow(non_upper_case_globals)]
 pub mod task_tag {
     use super::TaskTag;
+
+    /// Reserved: never produced by any `Taskable` impl. A `Task` with this tag
+    /// is an all-zeros bit pattern (the state of `ConcurrentTask::default()`),
+    /// so observing it in dispatch means the consumer read a `ConcurrentTask`
+    /// whose owner was freed (or whose `.task` field was never written) before
+    /// the drain. `bun_runtime::dispatch::run_task` panics on it so the bug
+    /// class surfaces as a labelled crash rather than dispatching as whichever
+    /// real tag happens to be value 0.
+    pub const INVALID: TaskTag = TaskTag(0);
+
     macro_rules! tags {
         ($($name:ident),* $(,)?) => {
-            tags!(@ 0u8, $($name,)*);
-            /// Number of task tags. `bun_runtime::dispatch::run_task` asserts
+            tags!(@ 1u8, $($name,)*);
+            /// Number of task tag values, including the reserved [`INVALID`]
+            /// sentinel at 0. `bun_runtime::dispatch::run_task` asserts
             /// exhaustiveness against this.
-            pub const COUNT: u8 = tags!(@count 0u8, $($name,)*);
+            pub const COUNT: u8 = tags!(@count 1u8, $($name,)*);
         };
         (@ $n:expr, $head:ident, $($rest:ident,)*) => {
             pub const $head: TaskTag = TaskTag($n);
@@ -232,8 +243,10 @@ pub struct ConcurrentTask {
 impl Default for ConcurrentTask {
     fn default() -> Self {
         Self {
+            // All-zero `Task` is `{tag: task_tag::INVALID, ptr: null}`; caller
+            // must overwrite it before enqueueing. Dispatch panics on `INVALID`.
             // SAFETY: all-zero is a valid bit pattern for `Task` (plain tag
-            // byte + raw pointer); caller must set a real task before use.
+            // byte + raw pointer).
             task: unsafe { bun_core::ffi::zeroed_unchecked() },
             next: Link::new(),
             auto_delete: false,

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -45,21 +45,16 @@ pub struct TaskTag(pub u8);
 pub mod task_tag {
     use super::TaskTag;
 
-    /// Reserved: never produced by any `Taskable` impl. A `Task` with this tag
-    /// is an all-zeros bit pattern (the state of `ConcurrentTask::default()`),
-    /// so observing it in dispatch means the consumer read a `ConcurrentTask`
-    /// whose owner was freed (or whose `.task` field was never written) before
-    /// the drain. `bun_runtime::dispatch::run_task` panics on it so the bug
-    /// class surfaces as a labelled crash rather than dispatching as whichever
-    /// real tag happens to be value 0.
+    /// Reserved: never produced by any `Taskable` impl. An all-zeros `Task`
+    /// (`ConcurrentTask::default()`) carries this tag; dispatch panics on it
+    /// rather than matching whichever real type is value 0.
     pub const INVALID: TaskTag = TaskTag(0);
 
     macro_rules! tags {
         ($($name:ident),* $(,)?) => {
             tags!(@ 1u8, $($name,)*);
-            /// Number of task tag values, including the reserved [`INVALID`]
-            /// sentinel at 0. `bun_runtime::dispatch::run_task` asserts
-            /// exhaustiveness against this.
+            /// Number of task tag values (includes [`INVALID`] at 0).
+            /// `bun_runtime::dispatch::run_task` asserts exhaustiveness against this.
             pub const COUNT: u8 = tags!(@count 1u8, $($name,)*);
         };
         (@ $n:expr, $head:ident, $($rest:ident,)*) => {
@@ -243,10 +238,9 @@ pub struct ConcurrentTask {
 impl Default for ConcurrentTask {
     fn default() -> Self {
         Self {
-            // All-zero `Task` is `{tag: task_tag::INVALID, ptr: null}`; caller
-            // must overwrite it before enqueueing. Dispatch panics on `INVALID`.
             // SAFETY: all-zero is a valid bit pattern for `Task` (plain tag
-            // byte + raw pointer).
+            // byte + raw pointer). Tag 0 is `task_tag::INVALID`; caller must
+            // overwrite `.task` before enqueueing.
             task: unsafe { bun_core::ffi::zeroed_unchecked() },
             next: Link::new(),
             auto_delete: false,

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -424,6 +424,12 @@ export const isMemoryPressureWatcherInstalled: () => boolean = $newCppFunction(
 export const getEventLoopStats: () => { activeTasks: number; concurrentRef: number; numPolls: number } =
   $newRustFunction("event_loop.rs", "getActiveTasks", 0);
 
+export const enqueueZeroedConcurrentTaskForTesting: () => void = $newRustFunction(
+  "event_loop.rs",
+  "enqueueZeroedConcurrentTaskForTesting",
+  0,
+);
+
 export const hostedGitInfo = {
   parseUrl: $newRustFunction("hosted_git_info.rs", "TestingAPIs.jsParseUrl", 1),
   fromUrl: $newRustFunction("hosted_git_info.rs", "TestingAPIs.jsFromUrl", 1),

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1217,12 +1217,8 @@ pub fn get_active_tasks(global_object: &JSGlobalObject, _frame: &CallFrame) -> J
     Ok(result)
 }
 
-/// Testing API: enqueues a `ConcurrentTask` whose `.task` field is left at its
-/// `Default` (all-zeros) value, so the next drain observes
-/// `task_tag::INVALID` and the dispatch panic fires. This is the shape a
-/// use-after-free of an inline `concurrent_task` field produces in the wild;
-/// exercising it directly proves the sentinel reports it rather than
-/// dispatching as whichever real type is tag 0.
+/// Testing API: enqueues a `ConcurrentTask` with `.task` left zeroed so the
+/// next drain hits `task_tag::INVALID` and the dispatch panic fires.
 #[bun_jsc::host_fn]
 pub fn enqueue_zeroed_concurrent_task_for_testing(
     global_object: &JSGlobalObject,

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1224,6 +1224,9 @@ pub fn enqueue_zeroed_concurrent_task_for_testing(
     global_object: &JSGlobalObject,
     _frame: &CallFrame,
 ) -> JsResult<JSValue> {
+    // The next drain panics deliberately; keep the core file and crash-report
+    // upload out of CI's result set.
+    bun_crash_handler::suppress_reporting();
     let event_loop = global_object.bun_vm().event_loop_shared();
     let raw = ConcurrentTaskItem::new(ConcurrentTaskItem {
         auto_delete: true,

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -519,6 +519,10 @@ impl EventLoop {
                 to_destroy = Some(task);
             }
 
+            debug_assert!(
+                task_ref.task.tag != bun_event_loop::task_tag::INVALID,
+                "zeroed ConcurrentTask at {task:p} drained from concurrent queue",
+            );
             // LinearFifo's fields are private — `write_item` is the
             // public path (single-slot copy, same complexity).
             let _ = self.tasks.write_item(task_ref.task);
@@ -1211,6 +1215,27 @@ pub fn get_active_tasks(global_object: &JSGlobalObject, _frame: &CallFrame) -> J
         JSValue::js_number(num_polls as f64),
     );
     Ok(result)
+}
+
+/// Testing API: enqueues a `ConcurrentTask` whose `.task` field is left at its
+/// `Default` (all-zeros) value, so the next drain observes
+/// `task_tag::INVALID` and the dispatch panic fires. This is the shape a
+/// use-after-free of an inline `concurrent_task` field produces in the wild;
+/// exercising it directly proves the sentinel reports it rather than
+/// dispatching as whichever real type is tag 0.
+#[bun_jsc::host_fn]
+pub fn enqueue_zeroed_concurrent_task_for_testing(
+    global_object: &JSGlobalObject,
+    _frame: &CallFrame,
+) -> JsResult<JSValue> {
+    let event_loop = global_object.bun_vm().event_loop_shared();
+    let raw = ConcurrentTaskItem::new(ConcurrentTaskItem {
+        auto_delete: true,
+        ..Default::default()
+    });
+    // SAFETY: `ConcurrentTaskItem::new` heap-allocates via `heap::into_raw`.
+    event_loop.enqueue_task_concurrent(unsafe { core::ptr::NonNull::new_unchecked(raw) });
+    Ok(JSValue::UNDEFINED)
 }
 
 #[cfg(windows)]

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -467,12 +467,8 @@ pub fn run_task(
             panic!("Unexpected Task tag: {}", task.tag.0);
         }
 
-        // ── reserved sentinel ────────────────────────────────────────────
+        // ── reserved sentinel (all-zeros `Task`) ─────────────────────────
         task_tag::INVALID => {
-            // All-zeros `Task` — the consumer read a `ConcurrentTask` whose
-            // `.task` field was never written (or whose owner was freed and
-            // its storage reused) between enqueue and drain. See
-            // `bun_event_loop::task_tag::INVALID`.
             panic!(
                 "zeroed ConcurrentTask (tag=INVALID, ptr={:p}): use-after-free of an inline \
                  concurrent_task field, or enqueue of a default-initialised ConcurrentTask",

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -467,6 +467,19 @@ pub fn run_task(
             panic!("Unexpected Task tag: {}", task.tag.0);
         }
 
+        // ── reserved sentinel ────────────────────────────────────────────
+        task_tag::INVALID => {
+            // All-zeros `Task` — the consumer read a `ConcurrentTask` whose
+            // `.task` field was never written (or whose owner was freed and
+            // its storage reused) between enqueue and drain. See
+            // `bun_event_loop::task_tag::INVALID`.
+            panic!(
+                "zeroed ConcurrentTask (tag=INVALID, ptr={:p}): use-after-free of an inline \
+                 concurrent_task field, or enqueue of a default-initialised ConcurrentTask",
+                task.ptr,
+            );
+        }
+
         _ => {
             // A value outside `task_tag::COUNT` is a producer bug, but it's
             // treated as a recoverable crash, not UB.
@@ -585,7 +598,7 @@ fn run_task_cold(task: Task) {
 /// Compile-time guard that the arm count above tracks
 /// `bun_event_loop::task_tag::COUNT`. Bump when adding a variant.
 const _: () = assert!(
-    task_tag::COUNT == 96,
+    task_tag::COUNT == 97,
     "dispatch::run_task arm count out of sync with bun_event_loop::task_tag",
 );
 

--- a/src/runtime/dispatch_js2native.rs
+++ b/src/runtime/dispatch_js2native.rs
@@ -38,6 +38,7 @@ pub use bun_install_jsc::ini_jsc::ini_testing_parse as ini_ini_ini_testing_ap_is
 
 pub use bun_jsc::bindgen_test::get_bindgen_test_functions as jsc_bindgen_test_get_bindgen_test_functions;
 pub use bun_jsc::counters::create_counters_object as jsc_counters_create_counters_object;
+pub use bun_jsc::event_loop::enqueue_zeroed_concurrent_task_for_testing as jsc_event_loop_enqueue_zeroed_concurrent_task_for_testing;
 pub use bun_jsc::event_loop::get_active_tasks as jsc_event_loop_get_active_tasks;
 pub use bun_jsc::virtual_machine_exports::Bun__setSyntheticAllocationLimitForTesting as jsc_virtual_machine_exports_bun__set_synthetic_allocation_limit_for_testing;
 // `emit_handle_ipc_message` is implemented in this crate (`ipc_host.rs`)

--- a/test/internal/concurrent-task-sentinel.test.ts
+++ b/test/internal/concurrent-task-sentinel.test.ts
@@ -15,9 +15,9 @@ import { access } from "node:fs/promises";
 test("tag 0 is no longer a real task type (fs.promises.access still dispatches)", async () => {
   // `access` was the tag-0 type before the sentinel reserved it; this round-trip
   // through the work-pool → concurrent queue → dispatch path proves the shift
-  // left it intact.
-  await expect(access(import.meta.path)).resolves.toBeNull();
-  await expect(access(import.meta.path + ".does-not-exist")).rejects.toThrow();
+  // left it intact. A plain await proves dispatch (any rejection fails the test).
+  await access(import.meta.path);
+  await expect(access(import.meta.path + ".does-not-exist")).rejects.toMatchObject({ code: "ENOENT" });
 });
 
 // The child intentionally panics; the debug build's crash handler symbolicates

--- a/test/internal/concurrent-task-sentinel.test.ts
+++ b/test/internal/concurrent-task-sentinel.test.ts
@@ -22,34 +22,30 @@ test("tag 0 is no longer a real task type (fs.promises.access still dispatches)"
 
 // The child intentionally panics; the debug build's crash handler symbolicates
 // the full backtrace, which is slow under ASAN.
-test(
-  "a zeroed ConcurrentTask is reported, not dispatched",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
+test("a zeroed ConcurrentTask is reported, not dispatched", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
         const { enqueueZeroedConcurrentTaskForTesting } = require("bun:internal-for-testing");
         enqueueZeroedConcurrentTaskForTesting();
         // Return to the loop so the concurrent queue drains and run_task sees it.
         await new Promise(r => setImmediate(r));
         console.log("unreachable");
       `,
-      ],
-      env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    ],
+    env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout).not.toContain("unreachable");
-    // The sentinel panic message. Without the sentinel, tag 0 dispatched as
-    // `fs.access` with a null self and the process segfaulted (no such text).
-    expect(stderr).toContain("zeroed ConcurrentTask");
-    expect(stderr).not.toMatch(/Segmentation fault|EXC_BAD_ACCESS|EXCEPTION_ACCESS_VIOLATION/);
-    expect(exitCode).not.toBe(0);
-  },
-  30_000,
-);
+  expect(stdout).not.toContain("unreachable");
+  // The sentinel panic message. Without the sentinel, tag 0 dispatched as
+  // `fs.access` with a null self and the process segfaulted (no such text).
+  expect(stderr).toContain("zeroed ConcurrentTask");
+  expect(stderr).not.toMatch(/Segmentation fault|EXC_BAD_ACCESS|EXCEPTION_ACCESS_VIOLATION/);
+  expect(exitCode).not.toBe(0);
+}, 30_000);

--- a/test/internal/concurrent-task-sentinel.test.ts
+++ b/test/internal/concurrent-task-sentinel.test.ts
@@ -1,0 +1,55 @@
+// Verifies that a zeroed ConcurrentTask (the bit pattern produced by
+// `ConcurrentTask::default()`, and the one the event loop observes when an
+// inline `concurrent_task` field's owner is freed while still queued) is
+// caught by the `task_tag::INVALID` sentinel in `run_task` instead of being
+// dispatched as whichever real task type happens to be tag value 0.
+//
+// Before the sentinel existed, tag 0 was `Access` and the dispatch called
+// `AsyncFSTask<_, Access, _>::run_from_js_thread` with `self = null`, which
+// segfaults at the `self.result` field offset with no hint as to why.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { access } from "node:fs/promises";
+
+test("tag 0 is no longer a real task type (fs.promises.access still dispatches)", async () => {
+  // `access` was the tag-0 type before the sentinel reserved it; this round-trip
+  // through the work-pool → concurrent queue → dispatch path proves the shift
+  // left it intact.
+  await expect(access(import.meta.path)).resolves.toBeNull();
+  await expect(access(import.meta.path + ".does-not-exist")).rejects.toThrow();
+});
+
+// The child intentionally panics; the debug build's crash handler symbolicates
+// the full backtrace, which is slow under ASAN.
+test(
+  "a zeroed ConcurrentTask is reported, not dispatched",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { enqueueZeroedConcurrentTaskForTesting } = require("bun:internal-for-testing");
+        enqueueZeroedConcurrentTaskForTesting();
+        // Return to the loop so the concurrent queue drains and run_task sees it.
+        await new Promise(r => setImmediate(r));
+        console.log("unreachable");
+      `,
+      ],
+      env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).not.toContain("unreachable");
+    // The sentinel panic message. Without the sentinel, tag 0 dispatched as
+    // `fs.access` with a null self and the process segfaulted (no such text).
+    expect(stderr).toContain("zeroed ConcurrentTask");
+    expect(stderr).not.toMatch(/Segmentation fault|EXC_BAD_ACCESS|EXCEPTION_ACCESS_VIOLATION/);
+    expect(exitCode).not.toBe(0);
+  },
+  30_000,
+);


### PR DESCRIPTION
## What

`ConcurrentTask::default()` produces an all-zeros `.task` field, and that is also what the consumer reads when an inline `concurrent_task` field's owner is freed while the node is still linked in the concurrent queue. Until now tag value `0` was `task_tag::Access`, so such a node dispatched as `AsyncFSTask<_, Access, _>::run_from_js_thread` with `self = null` and segfaulted at the `self.result` field offset.

This reserves `TaskTag(0)` as `task_tag::INVALID` (real tags now start at 1) and:
- `run_task` panics on it with a message that says what happened
- a `debug_assert!` at the concurrent-queue drain site catches it one step earlier with the node address

Nothing references hard-coded tag values; every `Taskable` impl and `NodeFSFunctionEnum::task_tag()` use the named `task_tag::*` constants, so the shift is transparent.

## Why

Seen on Windows 11 aarch64 in build 83933 (`test/js/bun/http/bun-serve-html.test.ts`):

```
panic(main thread): Segmentation fault at address 0x48
```

Symbolicating the trace against the profile PDB:

```
0xcbb3c4  core::mem::replace
          AsyncFSTask::run_from_js_thread<Null, Access, ...>  node_fs.rs:1327
0xcc0840  run_task                                            dispatch.rs:394
0xcc0634  tick_queue_with_count                               dispatch.rs:610
0x6c24f8  EventLoop::tick                                     event_loop.rs:637
```

The faulting instruction is `ldur q0, [x0, #0x48]` with `x0 = 0`. The `run_task` jump table confirms only `task_tag::Access` (tag `0`) reaches that call site, so the dispatched `Task` was literally `{tag: 0, ptr: null}`, which is the all-zeros bit pattern of `ConcurrentTask::default()`.

Every enqueue site writes `.task` immediately before pushing, and the MPSC queue's release/acquire chain checks out, so the zeroed value came from a use-after-free of an inline `concurrent_task` field (suspects: `DevServer.watcher_atomics.events[*].concurrent_task`, `FetchTasklet.concurrent_task`, or the HTML-bundle abort path). Did not reproduce locally in 80+ runs.

This does not fix that UAF; it turns the whole class into a labelled crash so the next occurrence is diagnosable on any platform instead of looking like a spurious null deref in `fs.access`.

## Test

`test/internal/concurrent-task-sentinel.test.ts` enqueues a zeroed `ConcurrentTask` via a test-only hook and asserts the child panics with `zeroed ConcurrentTask` rather than segfaulting, and that `fs.promises.access` (the former tag-0 type) still dispatches.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/concurrent-task-sentinel.test.ts
bun test v1.4.0 (f08142e16)

test/internal/concurrent-task-sentinel.test.ts:
(pass) tag 0 is no longer a real task type (fs.promises.access still dispatches) [21.77ms]
43 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
44 | 
45 |   expect(stdout).not.toContain("unreachable");
46 |   // The sentinel panic message. Without the sentinel, tag 0 dispatched as
47 |   // `fs.access` with a null self and the process segfaulted (no such text).
48 |   expect(stderr).toContain("zeroed ConcurrentTask");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "zeroed ConcurrentTask"
Received: "1 | \n2 |         const { enqueueZeroedConcurrentTaskForTesting } = require(\"bun:internal-for-testing\");\n3 |         enqueueZeroedConcurrentTaskForTesting();\n            ^\nTypeError: enqueueZeroedConcurrentTaskForTesting is not a function. (In 'enqueueZeroedConcurrentTaskForTesting()', 'enqueueZeroedConcurrentT
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (239966108)

test/internal/concurrent-task-sentinel.test.ts:
(pass) tag 0 is no longer a real task type (fs.promises.access still dispatches) [0.57ms]
(pass) a zeroed ConcurrentTask is reported, not dispatched [129.22ms]

 2 pass
 0 fail
 5 expect() calls
Ran 2 tests across 1 file. [434.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/concurrent-task-sentinel.test.ts
bun test v1.4.0 (f08142e16)

test/internal/concurrent-task-sentinel.test.ts:
(pass) tag 0 is no longer a real task type (fs.promises.access still dispatches) [23.75ms]
(pass) a zeroed ConcurrentTask is reported, not dispatched [6190.74ms]

 2 pass
 0 fail
 5 expect() calls
Ran 2 tests across 1 file. [8.54s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 654ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (8682ms)
Bundle modules (32ms)
Postprocesss modules (25ms)
Bundle Functions (611ms)
Generate Code (15ms)

[9.38s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_event_loop v0.0.0 (/workspace/bun/src/event_loop)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_spawn v0.0.0 (/workspace/bun/src/spawn)
[1m[92m   Compiling[0m bun_patch v0.0.0 (/workspace/bun/src/patch)
[1m[92m   Compiling[0m bun_standalone_g
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/event_loop/ConcurrentTask.rs               | 17 ++++++---
 src/js/internal-for-testing.ts                 |  6 +++
 src/jsc/event_loop.rs                          | 24 ++++++++++++
 src/runtime/dispatch.rs                        | 11 +++++-
 src/runtime/dispatch_js2native.rs              |  1 +
 test/internal/concurrent-task-sentinel.test.ts | 51 ++++++++++++++++++++++++++
 6 files changed, 104 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/event_loop/ConcurrentTask.rs                    6      5      0
src/js/internal-for-testing.ts                      1      1      0
src/jsc/event_loop.rs                               5      4      0
src/runtime/dispatch.rs                             5      3      0
src/runtime/dispatch_js2native.rs                   1      1      0
test/internal/concurrent-task-sentinel.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->