### PR TITLE
bun test: record load errors and unhandled errors in the JUnit report

### DIFF
--- a/src/runtime/cli/test/parallel/aggregate.rs
+++ b/src/runtime/cli/test/parallel/aggregate.rs
@@ -43,6 +43,7 @@ pub(crate) fn merge_junit_fragments(coord: &mut Coordinator, outfile: &[u8], sum
     struct Totals {
         tests: u32,
         failures: u32,
+        errors: u32,
         skipped: u32,
     }
     let mut totals = Totals::default();
@@ -64,6 +65,7 @@ pub(crate) fn merge_junit_fragments(coord: &mut Coordinator, outfile: &[u8], sum
         let head = &file[open_start..head_end];
         totals.tests += attr_value(head, b"tests");
         totals.failures += attr_value(head, b"failures");
+        totals.errors += attr_value(head, b"errors");
         totals.skipped += attr_value(head, b"skipped");
         let body_start = head_end + 1;
         let Some(body_end) = strings::last_index_of(&file, b"</testsuites>") else {
@@ -84,7 +86,7 @@ pub(crate) fn merge_junit_fragments(coord: &mut Coordinator, outfile: &[u8], sum
         let rel = coord.rel_path(idx);
         body.extend_from_slice(b"  <testsuite name=\"");
         let _ = test_command::escape_xml(rel, &mut body); // fmt::Result into Vec<u8> is infallible
-        body.extend_from_slice(b"\" tests=\"1\" assertions=\"0\" failures=\"1\" skipped=\"0\" time=\"0\">\n    <testcase name=\"(worker crashed)\" classname=\"");
+        body.extend_from_slice(b"\" tests=\"1\" assertions=\"0\" failures=\"1\" errors=\"0\" skipped=\"0\" time=\"0\">\n    <testcase name=\"(worker crashed)\" classname=\"");
         let _ = test_command::escape_xml(rel, &mut body); // fmt::Result into Vec<u8> is infallible
         body.extend_from_slice(
             b"\">\n\
@@ -102,8 +104,8 @@ pub(crate) fn merge_junit_fragments(coord: &mut Coordinator, outfile: &[u8], sum
     let _ = write!(
         &mut contents,
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-         <testsuites name=\"bun test\" tests=\"{}\" assertions=\"{}\" failures=\"{}\" skipped=\"{}\" time=\"{}\">\n",
-        totals.tests, summary.expectations, totals.failures, totals.skipped, elapsed_time,
+         <testsuites name=\"bun test\" tests=\"{}\" assertions=\"{}\" failures=\"{}\" errors=\"{}\" skipped=\"{}\" time=\"{}\">\n",
+        totals.tests, summary.expectations, totals.failures, totals.errors, totals.skipped, elapsed_time,
     );
     contents.extend_from_slice(&body);
     contents.extend_from_slice(b"</testsuites>\n");

--- a/src/runtime/cli/test/parallel/aggregate.rs
+++ b/src/runtime/cli/test/parallel/aggregate.rs
@@ -105,7 +105,12 @@ pub(crate) fn merge_junit_fragments(coord: &mut Coordinator, outfile: &[u8], sum
         &mut contents,
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
          <testsuites name=\"bun test\" tests=\"{}\" assertions=\"{}\" failures=\"{}\" errors=\"{}\" skipped=\"{}\" time=\"{}\">\n",
-        totals.tests, summary.expectations, totals.failures, totals.errors, totals.skipped, elapsed_time,
+        totals.tests,
+        summary.expectations,
+        totals.failures,
+        totals.errors,
+        totals.skipped,
+        elapsed_time,
     );
     contents.extend_from_slice(&body);
     contents.extend_from_slice(b"</testsuites>\n");

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -849,8 +849,7 @@ impl JunitReporter {
         Ok(())
     }
 
-    /// Emit a synthetic `<testcase><error>` for an exception not attributable
-    /// to any test entry. Consumes `last_failure` for the error details.
+    /// Emit a `<testcase><error>` for `last_failure`, attributed to `file`.
     pub fn write_unhandled_error(&mut self, file: &[u8]) -> crate::Result<()> {
         let top = FileSystem::instance().top_level_dir;
         let filename: &[u8] = if strings::has_prefix(file, top) {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -864,12 +864,12 @@ impl JunitReporter {
             file
         };
 
-        while !self.suite_stack.is_empty()
-            && !self.suite_stack[self.suite_stack.len() - 1].is_file_suite
-        {
-            self.end_test_suite()?;
-        }
         if !strings::eql(&self.current_file, filename) {
+            while !self.suite_stack.is_empty()
+                && !self.suite_stack[self.suite_stack.len() - 1].is_file_suite
+            {
+                self.end_test_suite()?;
+            }
             if !self.current_file.is_empty() {
                 self.end_test_suite()?;
             }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -410,8 +410,6 @@ impl JunitReporter {
         }
     }
 
-    /// Fallback when `record_failure` is never called (e.g. `BuildMessage` /
-    /// `ResolveMessage`, which bypass the `ZigException` formatter).
     pub fn record_failure_text(&mut self, name: &[u8], message: &[u8]) {
         let failure = self.last_failure.get_or_insert_default();
         if failure.name.is_empty() {
@@ -851,11 +849,8 @@ impl JunitReporter {
         Ok(())
     }
 
-    /// Emit a synthetic `<testcase>` carrying an `<error>` for an exception that
-    /// was not attributable to any test entry (file failed to load, top-level
-    /// throw, throwing `describe` body, rejection between tests). Consumes
-    /// `last_failure` for the error details. `file` may be absolute; it is
-    /// relativized here the same way `maybe_print_junit_line` does.
+    /// Emit a synthetic `<testcase><error>` for an exception not attributable
+    /// to any test entry. Consumes `last_failure` for the error details.
     pub fn write_unhandled_error(&mut self, file: &[u8]) -> crate::Result<()> {
         let top = FileSystem::instance().top_level_dir;
         let filename: &[u8] = if strings::has_prefix(file, top) {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -275,6 +275,7 @@ pub struct Metrics {
     pub test_cases: u32,
     pub assertions: u32,
     pub failures: u32,
+    pub errors: u32,
     pub skipped: u32,
     pub elapsed_time: u64,
 }
@@ -284,6 +285,7 @@ impl Metrics {
         self.test_cases += other.test_cases;
         self.assertions += other.assertions;
         self.failures += other.failures;
+        self.errors += other.errors;
         self.skipped += other.skipped;
     }
 }
@@ -405,6 +407,22 @@ impl JunitReporter {
                 body.push(b')');
             }
             body.push(b'\n');
+        }
+    }
+
+    /// Fallback when `record_failure` is never called (e.g. `BuildMessage` /
+    /// `ResolveMessage`, which bypass the `ZigException` formatter).
+    pub fn record_failure_text(&mut self, name: &[u8], message: &[u8]) {
+        let failure = self.last_failure.get_or_insert_default();
+        if failure.name.is_empty() {
+            failure.name.extend_from_slice(name);
+        }
+        if failure.message.is_empty() {
+            push_stripping_ansi(&mut failure.message, message);
+        }
+        if failure.body.is_empty() {
+            push_stripping_ansi(&mut failure.body, message);
+            failure.body.push(b'\n');
         }
     }
 
@@ -610,10 +628,11 @@ impl JunitReporter {
             // Std::io::Write removed; bun_io::Write (top-level) provides write_fmt.
             let _ = write!(
                 &mut summary,
-                "tests=\"{}\" assertions=\"{}\" failures=\"{}\" skipped=\"{}\" time=\"{}\" hostname=\"{}\"",
+                "tests=\"{}\" assertions=\"{}\" failures=\"{}\" errors=\"{}\" skipped=\"{}\" time=\"{}\" hostname=\"{}\"",
                 suite_info.metrics.test_cases,
                 suite_info.metrics.assertions,
                 suite_info.metrics.failures,
+                suite_info.metrics.errors,
                 suite_info.metrics.skipped,
                 elapsed_time_seconds,
                 bstr::BStr::new(&hostname),
@@ -832,9 +851,84 @@ impl JunitReporter {
         Ok(())
     }
 
+    /// Emit a synthetic `<testcase>` carrying an `<error>` for an exception that
+    /// was not attributable to any test entry (file failed to load, top-level
+    /// throw, throwing `describe` body, rejection between tests). Consumes
+    /// `last_failure` for the error details. `file` may be absolute; it is
+    /// relativized here the same way `maybe_print_junit_line` does.
+    pub fn write_unhandled_error(&mut self, file: &[u8]) -> crate::Result<()> {
+        let top = FileSystem::instance().top_level_dir;
+        let filename: &[u8] = if strings::has_prefix(file, top) {
+            without_leading_path_separator(&file[top.len()..])
+        } else {
+            file
+        };
+
+        while !self.suite_stack.is_empty()
+            && !self.suite_stack[self.suite_stack.len() - 1].is_file_suite
+        {
+            self.end_test_suite()?;
+        }
+        if !strings::eql(&self.current_file, filename) {
+            if !self.current_file.is_empty() {
+                self.end_test_suite()?;
+            }
+            self.begin_test_suite(filename)?;
+        }
+
+        if !self.suite_stack.is_empty() {
+            let last = self.suite_stack.len() - 1;
+            self.suite_stack[last].metrics.test_cases += 1;
+            self.suite_stack[last].metrics.errors += 1;
+        }
+
+        let indent = Self::get_indent(self.current_depth);
+        self.contents.extend_from_slice(indent);
+        self.contents
+            .extend_from_slice(b"<testcase name=\"(load error)\" classname=\"");
+        escape_xml(filename, &mut self.contents)?;
+        self.contents.extend_from_slice(b"\" time=\"0\" file=\"");
+        escape_xml(filename, &mut self.contents)?;
+        self.contents.extend_from_slice(b"\" assertions=\"0\">\n");
+
+        let failure = self.last_failure.take();
+        let type_name: &[u8] = failure
+            .as_ref()
+            .map(|f| f.name.as_slice())
+            .filter(|n| !n.is_empty())
+            .unwrap_or(b"Error");
+        self.contents.extend_from_slice(indent);
+        self.contents.extend_from_slice(b"  <error type=\"");
+        escape_xml(type_name, &mut self.contents)?;
+        self.contents.extend_from_slice(b"\"");
+        if let Some(f) = failure.as_ref().filter(|f| !f.message.is_empty()) {
+            self.contents.extend_from_slice(b" message=\"");
+            escape_xml(&f.message, &mut self.contents)?;
+            self.contents.extend_from_slice(b"\"");
+        }
+        match failure.as_ref().filter(|f| !f.body.is_empty()) {
+            Some(f) => {
+                self.contents.extend_from_slice(b">");
+                escape_xml(&f.body, &mut self.contents)?;
+                self.contents.extend_from_slice(b"</error>\n");
+            }
+            None => {
+                self.contents.extend_from_slice(b" />\n");
+            }
+        }
+        self.contents.extend_from_slice(indent);
+        self.contents.extend_from_slice(b"</testcase>\n");
+        Ok(())
+    }
+
     pub fn write_to_file(&mut self, path: &[u8]) -> crate::Result<()> {
         if self.contents.is_empty() {
-            return Ok(());
+            self.contents
+                .extend_from_slice(b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+            self.contents
+                .extend_from_slice(b"<testsuites name=\"bun test\" ");
+            self.offset_of_testsuites_value = self.contents.len();
+            self.contents.extend_from_slice(b">\n");
         }
 
         while !self.suite_stack.is_empty() {
@@ -850,10 +944,11 @@ impl JunitReporter {
                 // Std::io::Write removed; bun_io::Write (top-level) provides write_fmt.
                 let _ = write!(
                     &mut summary,
-                    "tests=\"{}\" assertions=\"{}\" failures=\"{}\" skipped=\"{}\" time=\"{}\"",
+                    "tests=\"{}\" assertions=\"{}\" failures=\"{}\" errors=\"{}\" skipped=\"{}\" time=\"{}\"",
                     metrics.test_cases,
                     metrics.assertions,
                     metrics.failures,
+                    metrics.errors,
                     metrics.skipped,
                     elapsed_time,
                 );

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1313,9 +1313,6 @@ impl BunTest {
         };
 
         let junit_ctx: *mut core::ffi::c_void = 'ctx: {
-            if handle_status != HandleUncaughtExceptionResult::ShowHandledError {
-                break 'ctx core::ptr::null_mut();
-            }
             let Some(reporter) = self.reporter else {
                 break 'ctx core::ptr::null_mut();
             };
@@ -1327,12 +1324,27 @@ impl BunTest {
             }
         };
 
-        self.bun_test_root.on_before_print();
-        if matches!(
+        let is_unhandled = matches!(
             handle_status,
             HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests
                 | HandleUncaughtExceptionResult::ShowUnhandledErrorInDescribe
-        ) {
+        );
+        // For unhandled errors we consume `last_failure` ourselves below; stash
+        // any pending handled-error state so it still reaches its test's
+        // `write_test_case`.
+        let saved_failure = if is_unhandled && !junit_ctx.is_null() {
+            // SAFETY: `junit_ctx` is `&mut JunitReporter`; see the derivation above.
+            unsafe {
+                (*junit_ctx.cast::<crate::cli::test_command::JunitReporter>())
+                    .last_failure
+                    .take()
+            }
+        } else {
+            None
+        };
+
+        self.bun_test_root.on_before_print();
+        if is_unhandled {
             // SAFETY: reporter is Some (asserted by call sites that reach here);
             // `NonNull<CommandLineReporter>` carries write provenance from
             // `enter_file`'s `&mut`; single-threaded, no other borrow live.
@@ -1357,12 +1369,35 @@ impl BunTest {
             vm.on_print_error_zig_exception_ctx = core::ptr::null_mut();
         }
 
-        if matches!(
-            handle_status,
-            HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests
-                | HandleUncaughtExceptionResult::ShowUnhandledErrorInDescribe
-        ) {
+        if is_unhandled {
             bun_core::pretty_error!("<r><d>-------------------------------<r>\n\n");
+            if !junit_ctx.is_null() {
+                // SAFETY: `self.reporter` is `Some` whenever `junit_ctx` is set
+                // (both derive from the same `Some(reporter)` arm above).
+                let file: &[u8] = unsafe {
+                    (*self.reporter.unwrap().as_ptr()).jest.files.items_source()
+                        [self.file_id as usize]
+                        .path
+                        .text
+                };
+                // SAFETY: `junit_ctx` is `&mut JunitReporter`; `run_error_handler`
+                // has returned so no other borrow of the reporter is live.
+                let junit = unsafe {
+                    &mut *junit_ctx.cast::<crate::cli::test_command::JunitReporter>()
+                };
+                // `run_error_handler` short-circuits before populating a
+                // `ZigException` for `BuildMessage`/`ResolveMessage`, so pull
+                // their text directly when the callback never fired.
+                if junit.last_failure.is_none() {
+                    if let Some(m) = exception.as_class_ref::<crate::api::BuildMessage>() {
+                        junit.record_failure_text(b"BuildMessage", m.msg.data.text.as_ref());
+                    } else if let Some(m) = exception.as_class_ref::<crate::api::ResolveMessage>() {
+                        junit.record_failure_text(b"ResolveMessage", m.msg.data.text.as_ref());
+                    }
+                }
+                junit.write_unhandled_error(file).expect("oom");
+                junit.last_failure = saved_failure;
+            }
         }
 
         Output::flush();

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1382,8 +1382,6 @@ impl BunTest {
                 let junit = unsafe {
                     &mut *junit_ctx.cast::<crate::cli::test_command::JunitReporter>()
                 };
-                // BuildMessage/ResolveMessage/AggregateError never reach the
-                // ZigException callback; pull their text directly.
                 if junit.last_failure.is_none() {
                     if let Some(m) = exception.as_class_ref::<crate::api::BuildMessage>() {
                         junit.record_failure_text(b"BuildMessage", m.msg.data.text.as_ref());

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1386,13 +1386,25 @@ impl BunTest {
                     &mut *junit_ctx.cast::<crate::cli::test_command::JunitReporter>()
                 };
                 // `run_error_handler` short-circuits before populating a
-                // `ZigException` for `BuildMessage`/`ResolveMessage`, so pull
-                // their text directly when the callback never fired.
+                // `ZigException` for `BuildMessage`/`ResolveMessage` (and for an
+                // `AggregateError` wrapping them), so pull their text directly
+                // when the callback never fired.
                 if junit.last_failure.is_none() {
                     if let Some(m) = exception.as_class_ref::<crate::api::BuildMessage>() {
                         junit.record_failure_text(b"BuildMessage", m.msg.data.text.as_ref());
                     } else if let Some(m) = exception.as_class_ref::<crate::api::ResolveMessage>() {
                         junit.record_failure_text(b"ResolveMessage", m.msg.data.text.as_ref());
+                    } else if exception.is_aggregate_error(global_this) {
+                        let msg = exception
+                            .fast_get(global_this, bun_jsc::BuiltinName::Message)
+                            .ok()
+                            .flatten()
+                            .and_then(|v| v.to_bun_string(global_this).ok());
+                        global_this.clear_exception();
+                        if let Some(msg) = msg {
+                            let bytes = msg.to_utf8();
+                            junit.record_failure_text(b"AggregateError", bytes.slice());
+                        }
                     }
                 }
                 junit.write_unhandled_error(file).expect("oom");

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1329,9 +1329,6 @@ impl BunTest {
             HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests
                 | HandleUncaughtExceptionResult::ShowUnhandledErrorInDescribe
         );
-        // For unhandled errors we consume `last_failure` ourselves below; stash
-        // any pending handled-error state so it still reaches its test's
-        // `write_test_case`.
         let saved_failure = if is_unhandled && !junit_ctx.is_null() {
             // SAFETY: `junit_ctx` is `&mut JunitReporter`; see the derivation above.
             unsafe {
@@ -1385,10 +1382,8 @@ impl BunTest {
                 let junit = unsafe {
                     &mut *junit_ctx.cast::<crate::cli::test_command::JunitReporter>()
                 };
-                // `run_error_handler` short-circuits before populating a
-                // `ZigException` for `BuildMessage`/`ResolveMessage` (and for an
-                // `AggregateError` wrapping them), so pull their text directly
-                // when the callback never fired.
+                // BuildMessage/ResolveMessage/AggregateError never reach the
+                // ZigException callback; pull their text directly.
                 if junit.last_failure.is_none() {
                     if let Some(m) = exception.as_class_ref::<crate::api::BuildMessage>() {
                         junit.record_failure_text(b"BuildMessage", m.msg.data.text.as_ref());

--- a/test/js/junit-reporter/__snapshots__/junit.test.js.snap
+++ b/test/js/junit-reporter/__snapshots__/junit.test.js.snap
@@ -2,19 +2,19 @@
 
 exports[`junit reporter more scenarios 1`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="bun test" tests="22" assertions="16" failures="1" skipped="6">
-  <testsuite name="comprehensive.test.js" file="comprehensive.test.js" tests="22" assertions="16" failures="1" skipped="6">
-    <testsuite name="comprehensive test suite" file="comprehensive.test.js" line="4" tests="22" assertions="16" failures="1" skipped="6">
-      <testsuite name="division suite 10 / 5" file="comprehensive.test.js" line="8" tests="1" assertions="1" failures="0" skipped="0">
+<testsuites name="bun test" tests="22" assertions="16" failures="1" errors="0" skipped="6">
+  <testsuite name="comprehensive.test.js" file="comprehensive.test.js" tests="22" assertions="16" failures="1" errors="0" skipped="6">
+    <testsuite name="comprehensive test suite" file="comprehensive.test.js" line="4" tests="22" assertions="16" failures="1" errors="0" skipped="6">
+      <testsuite name="division suite 10 / 5" file="comprehensive.test.js" line="8" tests="1" assertions="1" failures="0" errors="0" skipped="0">
         <testcase name="should divide correctly" classname="division suite 10 / 5 &gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="1" />
       </testsuite>
-      <testsuite name="division suite 20 / 10" file="comprehensive.test.js" line="8" tests="1" assertions="1" failures="0" skipped="0">
+      <testsuite name="division suite 20 / 10" file="comprehensive.test.js" line="8" tests="1" assertions="1" failures="0" errors="0" skipped="0">
         <testcase name="should divide correctly" classname="division suite 20 / 10 &gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="1" />
       </testsuite>
-      <testsuite name="conditional describe that runs" file="comprehensive.test.js" line="14" tests="1" assertions="1" failures="0" skipped="0">
+      <testsuite name="conditional describe that runs" file="comprehensive.test.js" line="14" tests="1" assertions="1" failures="0" errors="0" skipped="0">
         <testcase name="nested test in conditional describe" classname="conditional describe that runs &gt; comprehensive test suite" file="comprehensive.test.js" line="15" assertions="1" />
       </testsuite>
-      <testsuite name="conditional describe that skips" file="comprehensive.test.js" line="20" tests="1" assertions="0" failures="0" skipped="1">
+      <testsuite name="conditional describe that skips" file="comprehensive.test.js" line="20" tests="1" assertions="0" failures="0" errors="0" skipped="1">
         <testcase name="nested test that gets skipped" classname="conditional describe that skips &gt; comprehensive test suite" file="comprehensive.test.js" line="21" assertions="0">
           <skipped />
         </testcase>
@@ -57,25 +57,25 @@ exports[`junit reporter more scenarios 1`] = `
 
 exports[`junit reporter more scenarios 2`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="bun test" tests="22" assertions="1" failures="0" skipped="21">
-  <testsuite name="comprehensive.test.js" file="comprehensive.test.js" tests="22" assertions="1" failures="0" skipped="21">
-    <testsuite name="comprehensive test suite" file="comprehensive.test.js" line="4" tests="22" assertions="1" failures="0" skipped="21">
-      <testsuite name="division suite 10 / 5" file="comprehensive.test.js" line="8" tests="1" assertions="0" failures="0" skipped="1">
+<testsuites name="bun test" tests="22" assertions="1" failures="0" errors="0" skipped="21">
+  <testsuite name="comprehensive.test.js" file="comprehensive.test.js" tests="22" assertions="1" failures="0" errors="0" skipped="21">
+    <testsuite name="comprehensive test suite" file="comprehensive.test.js" line="4" tests="22" assertions="1" failures="0" errors="0" skipped="21">
+      <testsuite name="division suite 10 / 5" file="comprehensive.test.js" line="8" tests="1" assertions="0" failures="0" errors="0" skipped="1">
         <testcase name="should divide correctly" classname="division suite 10 / 5 &gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="0">
           <skipped />
         </testcase>
       </testsuite>
-      <testsuite name="division suite 20 / 10" file="comprehensive.test.js" line="8" tests="1" assertions="0" failures="0" skipped="1">
+      <testsuite name="division suite 20 / 10" file="comprehensive.test.js" line="8" tests="1" assertions="0" failures="0" errors="0" skipped="1">
         <testcase name="should divide correctly" classname="division suite 20 / 10 &gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="0">
           <skipped />
         </testcase>
       </testsuite>
-      <testsuite name="conditional describe that runs" file="comprehensive.test.js" line="14" tests="1" assertions="0" failures="0" skipped="1">
+      <testsuite name="conditional describe that runs" file="comprehensive.test.js" line="14" tests="1" assertions="0" failures="0" errors="0" skipped="1">
         <testcase name="nested test in conditional describe" classname="conditional describe that runs &gt; comprehensive test suite" file="comprehensive.test.js" line="15" assertions="0">
           <skipped />
         </testcase>
       </testsuite>
-      <testsuite name="conditional describe that skips" file="comprehensive.test.js" line="20" tests="1" assertions="0" failures="0" skipped="1">
+      <testsuite name="conditional describe that skips" file="comprehensive.test.js" line="20" tests="1" assertions="0" failures="0" errors="0" skipped="1">
         <testcase name="nested test that gets skipped" classname="conditional describe that skips &gt; comprehensive test suite" file="comprehensive.test.js" line="21" assertions="0">
           <skipped />
         </testcase>

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -503,6 +503,108 @@ describe("junit reporter", () => {
     expect(exitCode).toBe(1);
   });
 
+  it("records files that fail to load as <error> testcases", async () => {
+    await using tmpDir = tempDir("junit-load-errors", {
+      "package.json": "{}",
+      "a_good.test.js": `
+        import { test, expect } from "bun:test";
+        test("good", () => { expect(1).toBe(1); });
+      `,
+      "b_syntax_error.test.js": `const x = ;`,
+      "c_top_level_throw.test.js": `throw new Error("top-level-import-throw");`,
+      "d_missing_import.test.js": `
+        import { nope } from "./does-not-exist";
+        nope();
+      `,
+      "e_describe_throw.test.js": `
+        import { describe } from "bun:test";
+        describe("boom-describe", () => { throw new Error("describe-body-throw"); });
+      `,
+    });
+
+    const junitPath = join(tmpDir, "junit.xml");
+    await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
+      cwd: tmpDir,
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const xmlContent = await file(junitPath).text();
+    const result = await new Promise((resolve, reject) => {
+      xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
+    });
+
+    // Every file, including the ones that failed to load, must have a suite.
+    const suites = Object.fromEntries(result.testsuites.testsuite.map(s => [s.$.name, s]));
+    expect(Object.keys(suites).sort()).toEqual([
+      "a_good.test.js",
+      "b_syntax_error.test.js",
+      "c_top_level_throw.test.js",
+      "d_missing_import.test.js",
+      "e_describe_throw.test.js",
+    ]);
+
+    // The broken files each carry a single <error> testcase with the real
+    // message (not a placeholder).
+    for (const [name, expectedMsg] of [
+      ["b_syntax_error.test.js", "Unexpected"],
+      ["c_top_level_throw.test.js", "top-level-import-throw"],
+      ["d_missing_import.test.js", "does-not-exist"],
+      ["e_describe_throw.test.js", "describe-body-throw"],
+    ]) {
+      const suite = suites[name];
+      expect(suite.$.errors).toBe("1");
+      expect(suite.$.tests).toBe("1");
+      const tc = suite.testcase[0];
+      expect(tc.$.file).toBe(name);
+      expect(tc.error).toBeDefined();
+      const err = tc.error[0];
+      const haystack = [err.$?.message, err.$?.type, err._].filter(Boolean).join(" ");
+      expect(haystack).toContain(expectedMsg);
+    }
+
+    // Top-level aggregates must reconcile with the console: tests counts every
+    // emitted testcase, and failures+errors covers every non-pass file.
+    expect(result.testsuites.$).toMatchObject({
+      tests: "5",
+      failures: "0",
+      errors: "4",
+    });
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("writes the junit outfile even when every file fails to load", async () => {
+    await using tmpDir = tempDir("junit-all-errors", {
+      "package.json": "{}",
+      "a.test.js": `throw new Error("a-load-error");`,
+      "b.test.js": `const x = ;`,
+    });
+
+    const junitPath = join(tmpDir, "junit.xml");
+    await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
+      cwd: tmpDir,
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const xmlContent = await file(junitPath).text();
+    const result = await new Promise((resolve, reject) => {
+      xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
+    });
+
+    expect(result.testsuites.$).toMatchObject({ tests: "2", failures: "0", errors: "2" });
+    expect(result.testsuites.testsuite).toHaveLength(2);
+    for (const suite of result.testsuites.testsuite) {
+      expect(suite.testcase[0].error).toBeDefined();
+    }
+    expect(exitCode).toBe(1);
+  });
+
   it("includes the error type, message and stack in <failure>", async () => {
     await using tmpDir = tempDir("junit-failure", {
       "package.json": "{}",

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -576,6 +576,46 @@ describe("junit reporter", () => {
     expect(exitCode).toBe(1);
   });
 
+  it("records load errors under --parallel and aggregates errors= in the merged root", async () => {
+    await using tmpDir = tempDir("junit-load-errors-parallel", {
+      "package.json": "{}",
+      "a_good.test.js": `
+        import { test, expect } from "bun:test";
+        test("good", () => { expect(1).toBe(1); });
+      `,
+      "b_throw.test.js": `throw new Error("boom");`,
+      "c_syntax.test.js": `const x = ;`,
+    });
+
+    const junitPath = join(tmpDir, "junit.xml");
+    await using proc = spawn(
+      [bunExe(), "test", "--parallel=2", "--reporter=junit", "--reporter-outfile", junitPath],
+      {
+        cwd: tmpDir,
+        env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const xmlContent = await file(junitPath).text();
+    const result = await new Promise((resolve, reject) => {
+      xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
+    });
+
+    // The merged <testsuites> must carry the same errors= as the sum of inner
+    // suites; before this change the aggregator dropped it entirely.
+    const outerErrors = Number(result.testsuites.$.errors);
+    const innerErrors = result.testsuites.testsuite.reduce((a, s) => a + Number(s.$.errors), 0);
+    expect({ outerErrors, innerErrors }).toEqual({ outerErrors: 2, innerErrors: 2 });
+    expect(result.testsuites.$.tests).toBe("3");
+
+    const names = result.testsuites.testsuite.map(s => s.$.name).sort();
+    expect(names).toEqual(["a_good.test.js", "b_throw.test.js", "c_syntax.test.js"]);
+    expect(exitCode).toBe(1);
+  });
+
   it("writes the junit outfile even when every file fails to load", async () => {
     await using tmpDir = tempDir("junit-all-errors", {
       "package.json": "{}",

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -588,15 +588,12 @@ describe("junit reporter", () => {
     });
 
     const junitPath = join(tmpDir, "junit.xml");
-    await using proc = spawn(
-      [bunExe(), "test", "--parallel=2", "--reporter=junit", "--reporter-outfile", junitPath],
-      {
-        cwd: tmpDir,
-        env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
-        stdout: "pipe",
-        stderr: "pipe",
-      },
-    );
+    await using proc = spawn([bunExe(), "test", "--parallel=2", "--reporter=junit", "--reporter-outfile", junitPath], {
+      cwd: tmpDir,
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
     const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     const xmlContent = await file(junitPath).text();


### PR DESCRIPTION
## Problem

A test file that fails to load (syntax error, top-level `throw`, unresolved import), or a `describe()` body that throws, is counted on the console and in the exit code but is **absent from the JUnit XML**. The only `<testcase>` producer is `maybe_print_junit_line`, reached solely from the executed-test-entry result path; load errors go through the `Status::Rejected` branch of `run_test_file` and describe/between-tests errors through `on_uncaught_exception` with `ShowUnhandledError*`, neither of which ever touched the junit reporter. Because `write_to_file` early-returned when `contents` was empty, a run where *every* file fails to load produced no outfile at all.

Net effect: the artifact CI dashboards parse reports `tests="1" failures="0"` (or nothing) for a run whose console is red and whose exit code is 1.

```sh
mkdir repro && cd repro
printf 'import {test,expect} from "bun:test"; test("ok",()=>expect(1).toBe(1));' > a.test.ts
printf 'const x = ;'                           > b.test.ts
printf 'throw new Error("boom");'              > c.test.ts
printf 'import {n} from "./nope"; n();'        > d.test.ts
bun test . --reporter=junit --reporter-outfile=junit.xml
# console: 1 pass / 3 fail / 3 errors, rc=1
# junit.xml: <testsuites tests="1" failures="0"> (only a.test.ts present)
```

## Fix

* `JunitReporter::write_unhandled_error(file)` emits a synthetic `<testcase name="(load error)" file="..."><error type=".." message="..">..</error></testcase>` inside the file's `<testsuite>`, counted in a new `errors` field on `Metrics`.
* `on_uncaught_exception` now installs the `ZigException` capture callback for `ShowUnhandledErrorBetweenTests` / `ShowUnhandledErrorInDescribe` as well, then calls `write_unhandled_error`. Any pending handled-error `last_failure` is stashed/restored so it still reaches its own `write_test_case`.
* `BuildMessage` / `ResolveMessage` (syntax errors, unresolved imports) bypass the `ZigException` formatter entirely, so their message text is extracted directly via `record_failure_text` when the callback never fired.
* `end_test_suite` / `write_to_file` now emit `errors="N"` on every `<testsuite>` / `<testsuites>`; `write_to_file` always writes the outfile (the `contents.is_empty()` gate is replaced with header emission).

After:

```xml
<testsuites name="bun test" tests="4" assertions="1" failures="0" errors="3" skipped="0" ...>
  <testsuite name="a.test.ts" ... tests="1" errors="0" ...>
    <testcase name="ok" .../>
  </testsuite>
  <testsuite name="b.test.ts" ... tests="1" errors="1" ...>
    <testcase name="(load error)" file="b.test.ts" ...>
      <error type="BuildMessage" message="Unexpected ;">...</error>
    </testcase>
  </testsuite>
  <testsuite name="c.test.ts" ... tests="1" errors="1" ...>
    <testcase name="(load error)" file="c.test.ts" ...>
      <error type="Error" message="boom">Error: boom
      at c.test.ts:1:11</error>
    </testcase>
  </testsuite>
  ...
</testsuites>
```

## Tests

Two new cases in `test/js/junit-reporter/junit.test.js`:

* `records files that fail to load as <error> testcases`: mixed run (one good file, syntax error, top-level throw, missing import, throwing describe body). Asserts every file has a `<testsuite>`, each error file carries an `<error>` with the actual message, and the `<testsuites>` aggregate reconciles (`tests=5 failures=0 errors=4`).
* `writes the junit outfile even when every file fails to load`: all-error run produces `tests=2 errors=2` instead of no file.

Both fail on current `bun` and pass with this change. The existing snapshot is updated to include `errors="0"` on suites.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/junit-reporter/junit.test.js
bun test v1.4.0 (56cf5e6a1)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [645.31ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [439.42ms]
[String: "/tmp/junit-comprehensive_Gm4iTG"]
253 |       stderr: "pipe",
254 |     });
255 |     await proc1.exited;
256 | 
257 |     const xmlContent1 = await file(junitPath1).text();
258 |     expect(filterJunitXmlOutput(xmlContent1)).toMatchSnapshot();
                                                    ^
error: expect(received).toMatchSnapshot(expected)

@@ -1,20 +1,20 @@
  
  "<?xml version="1.0" encoding="UTF-8"?>
- <testsuites name="bun test" tests="22" assertions="16" failures="1" errors="0" skipped="6">
-   <testsuite name="comprehensive.test.js" file="comprehensive.test.js" tests="22" assertions="16" failures="1" errors="0" skipped="6">
-     <testsuite name="comprehensive test suite" file="comprehensive.test.js" line="4" tests="22" assertions="16" fai
... (truncated)

release without fix: 8 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [21.78ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [16.52ms]
[String: "/tmp/junit-comprehensive_LQcClu"]
253 |       stderr: "pipe",
254 |     });
255 |     await proc1.exited;
256 | 
257 |     const xmlContent1 = await file(junitPath1).text();
258 |     expect(filterJunitXmlOutput(xmlContent1)).toMatchSnapshot();
                                                    ^
error: expect(received).toMatchSnapshot(expected)

@@ -1,27 +1,27 @@
  
  "
- 
-   
-     
-       
-         
+ 
+   
+     
+       
+         
        
-       
-         
+       
+         
        
-       
-         
+       
+         
        
-       
-         
+       
+         
            
          
        
        
        
-         AssertionError: expect(received).toBe(expected)&#10;&#10;Expected: 3&#10;Received: 2&#10;&#10;      at comprehensive.test.js:31:27&#10;
+         
        
        
          
        
        

- Expected  - 12
+ Received  + 12

      at <anonymous> (/workspace/bun/test
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/junit-reporter/junit.test.js
bun test v1.4.0 (56cf5e6a1)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [658.21ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [453.96ms]
[String: "/tmp/junit-comprehensive_GiVLIa"]
(pass) junit reporter > more scenarios [1023.12ms]
(pass) junit reporter > should report only the final result for a retried test [373.13ms]
(pass) junit reporter > produces well-formed XML when test names contain control characters [433.97ms]
(pass) junit reporter > escapes the classname attribute exactly once [347.82ms]
(pass) junit reporter > keeps the test body's error in <failure> when afterEach also throws [294.93ms]
(pass) junit reporter > records files that fail to load as <error> testcases [381.65ms]
(pass) junit reporter > writes the junit outfile even when every file fails to load [298.93ms]
(pass) junit reporter > includes the error type, message and stack in <failure> [322.03ms]

 10 pass
 0 fail
 2 snaps
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     56cf5e6a15
  features     baseline

22 deps, 108 codegen, 1171 objects in 805ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [29.00ms]
[2/1234] gen ErrorCode+*.h
[3/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[4/1234] fetch zlib
[zlib] up to date
[5/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1234] gen bindgenv2
[7/1234] fetch picohttpparser
[picohttpparser] up to date
[8/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[9/1234] fetch tinycc
[tinycc] up to date
[10/1234] gen .bind.ts → GeneratedBindings.cpp
[11/1234] subst deps/zlib/zconf.h
[12/1234] subst deps/zlib/zlib.h
[13/1234] subst deps/libjpeg-turbo/jconfig.h
[14/1234] subst 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/test_command.rs                    | 101 +++++++++++++++++++-
 src/runtime/test_runner/bun_test.rs                |  57 +++++++++---
 .../__snapshots__/junit.test.js.snap               |  28 +++---
 test/js/junit-reporter/junit.test.js               | 102 +++++++++++++++++++++
 4 files changed, 260 insertions(+), 28 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/runtime/cli/test_command.rs                              5      6      0
src/runtime/test_runner/bun_test.rs                          4      5      0
test/js/junit-reporter/__snapshots__/junit.test.js.snap      1      0      0
test/js/junit-reporter/junit.test.js                         1      1      0
```

</details>

<!-- robobun:evidence:end -->