### PR TITLE
install: propagate `[install.cache] disable = true` to the manifest cache

### DIFF
--- a/docs/pm/global-cache.mdx
+++ b/docs/pm/global-cache.mdx
@@ -12,8 +12,8 @@ Bun stores every package downloaded from the registry in a global cache at `~/.b
 # the directory to use for the cache
 dir = "~/.bun/install/cache"
 
-# when true, don't load from the global cache.
-# Bun may still write to node_modules/.cache
+# when true, disable both the global cache and the npm manifest cache
+# (same as `install.cache = false`)
 disable = false
 
 # when true, always resolve the latest versions from the registry

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -619,8 +619,8 @@ To configure the cache behavior:
 # the directory to use for the cache
 dir = "~/.bun/install/cache"
 
-# when true, don't load from the global cache.
-# Bun may still write to node_modules/.cache
+# when true, disable both the global cache and the npm manifest cache
+# (same as `install.cache = false`)
 disable = false
 
 # when true, always resolve the latest versions from the registry

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2029,6 +2029,19 @@ pub fn init(
     {
         // SAFETY: as above; scoped reborrow for the options/manifest-cache block.
         let manager = unsafe { &mut *manager_ptr };
+        if let Some(manifest_cache) = env.get(b"BUN_MANIFEST_CACHE") {
+            if manifest_cache == b"1" {
+                manager.options.enable.set_manifest_cache(true);
+                manager.options.enable.set_manifest_cache_control(false);
+            } else if manifest_cache == b"2" {
+                manager.options.enable.set_manifest_cache(true);
+                manager.options.enable.set_manifest_cache_control(true);
+            } else {
+                manager.options.enable.set_manifest_cache(false);
+                manager.options.enable.set_manifest_cache_control(false);
+            }
+        }
+
         manager.options.load(
             // SAFETY: ctx.log is the process-lifetime CLI log set by
             // create_context_data(); single-threaded init region.
@@ -2042,19 +2055,6 @@ pub fn init(
         if !manager.options.enable.cache() {
             manager.options.enable.set_manifest_cache(false);
             manager.options.enable.set_manifest_cache_control(false);
-        }
-
-        if let Some(manifest_cache) = env.get(b"BUN_MANIFEST_CACHE") {
-            if manifest_cache == b"1" {
-                manager.options.enable.set_manifest_cache(true);
-                manager.options.enable.set_manifest_cache_control(false);
-            } else if manifest_cache == b"2" {
-                manager.options.enable.set_manifest_cache(true);
-                manager.options.enable.set_manifest_cache_control(true);
-            } else {
-                manager.options.enable.set_manifest_cache(false);
-                manager.options.enable.set_manifest_cache_control(false);
-            }
         }
 
         if let Some(config) = ctx.install.as_deref_mut() {
@@ -2414,6 +2414,19 @@ pub(crate) fn init_with_runtime_once(
         manager.options.log_level = package_manager_options::LogLevel::DefaultNoProgress;
     }
 
+    if let Some(manifest_cache) = env.get(b"BUN_MANIFEST_CACHE") {
+        if manifest_cache == b"1" {
+            manager.options.enable.set_manifest_cache(true);
+            manager.options.enable.set_manifest_cache_control(false);
+        } else if manifest_cache == b"2" {
+            manager.options.enable.set_manifest_cache(true);
+            manager.options.enable.set_manifest_cache_control(true);
+        } else {
+            manager.options.enable.set_manifest_cache(false);
+            manager.options.enable.set_manifest_cache_control(false);
+        }
+    }
+
     match manager
         .options
         .load(log, env, Some(cli), bun_install, Subcommand::Install)
@@ -2429,19 +2442,6 @@ pub(crate) fn init_with_runtime_once(
     if !manager.options.enable.cache() {
         manager.options.enable.set_manifest_cache(false);
         manager.options.enable.set_manifest_cache_control(false);
-    }
-
-    if let Some(manifest_cache) = env.get(b"BUN_MANIFEST_CACHE") {
-        if manifest_cache == b"1" {
-            manager.options.enable.set_manifest_cache(true);
-            manager.options.enable.set_manifest_cache_control(false);
-        } else if manifest_cache == b"2" {
-            manager.options.enable.set_manifest_cache(true);
-            manager.options.enable.set_manifest_cache_control(true);
-        } else {
-            manager.options.enable.set_manifest_cache(false);
-            manager.options.enable.set_manifest_cache_control(false);
-        }
     }
 
     manager.timestamp_for_manifest_cache_control =

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2029,6 +2029,16 @@ pub fn init(
     {
         // SAFETY: as above; scoped reborrow for the options/manifest-cache block.
         let manager = unsafe { &mut *manager_ptr };
+        manager.options.load(
+            // SAFETY: ctx.log is the process-lifetime CLI log set by
+            // create_context_data(); single-threaded init region.
+            unsafe { &mut *ctx.log },
+            env,
+            Some(cli),
+            ctx.install.as_deref(),
+            subcommand,
+        )?;
+
         if !manager.options.enable.cache() {
             manager.options.enable.set_manifest_cache(false);
             manager.options.enable.set_manifest_cache_control(false);
@@ -2046,16 +2056,6 @@ pub fn init(
                 manager.options.enable.set_manifest_cache_control(false);
             }
         }
-
-        manager.options.load(
-            // SAFETY: ctx.log is the process-lifetime CLI log set by
-            // create_context_data(); single-threaded init region.
-            unsafe { &mut *ctx.log },
-            env,
-            Some(cli),
-            ctx.install.as_deref(),
-            subcommand,
-        )?;
 
         if let Some(config) = ctx.install.as_deref_mut() {
             if let Some(p) = config.public_hoist_pattern.take() {
@@ -2414,6 +2414,18 @@ pub(crate) fn init_with_runtime_once(
         manager.options.log_level = package_manager_options::LogLevel::DefaultNoProgress;
     }
 
+    match manager
+        .options
+        .load(log, env, Some(cli), bun_install, Subcommand::Install)
+    {
+        Ok(()) => {}
+        Err(e) => {
+            // only error.OutOfMemory possible
+            let _ = e;
+            bun_core::out_of_memory();
+        }
+    }
+
     if !manager.options.enable.cache() {
         manager.options.enable.set_manifest_cache(false);
         manager.options.enable.set_manifest_cache_control(false);
@@ -2429,18 +2441,6 @@ pub(crate) fn init_with_runtime_once(
         } else {
             manager.options.enable.set_manifest_cache(false);
             manager.options.enable.set_manifest_cache_control(false);
-        }
-    }
-
-    match manager
-        .options
-        .load(log, env, Some(cli), bun_install, Subcommand::Install)
-    {
-        Ok(()) => {}
-        Err(e) => {
-            // only error.OutOfMemory possible
-            let _ = e;
-            bun_core::out_of_memory();
         }
     }
 

--- a/test/cli/install/__snapshots__/bun-security-scanner-matrix-with-node-modules.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-security-scanner-matrix-with-node-modules.test.ts.snap
@@ -20,23 +20,43 @@ exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists:
 
 exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0005 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0006 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0006 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0006 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0007 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0007 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0007 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0008 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0008 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0008 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0009 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0009 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0009 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0010 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0010 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0010 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
@@ -60,23 +80,48 @@ exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: t
 
 exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0015 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0016 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0016 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0016 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0017 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0017 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0017 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0018 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0018 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0018 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0019 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0019 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0019 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0020 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0020 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0020 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
@@ -100,23 +145,43 @@ exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.loc
 
 exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0025 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0026 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0026 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0026 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0027 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0027 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0027 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0028 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0028 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0028 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0029 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0029 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0029 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0030 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0030 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0030 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
@@ -140,23 +205,43 @@ exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists
 
 exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0035 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0036 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0036 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0036 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0037 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0037 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0037 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0038 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0038 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0038 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0039 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0039 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0039 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0040 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0040 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0040 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
@@ -180,23 +265,48 @@ exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: 
 
 exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0045 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0046 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0046 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0046 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0047 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0047 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0047 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0048 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0048 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0048 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0049 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0049 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0049 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0050 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0050 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0050 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
@@ -220,23 +330,43 @@ exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lo
 
 exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0055 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0056 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0056 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0056 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0057 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0057 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0057 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0058 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0058 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0058 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0059 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0059 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0059 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
-exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0060 (with modules): requested-packages: install without args 1`] = `[]`;
+exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0060 (with modules): requested-packages: install without args 1`] = `
+[
+  "left-pad",
+]
+`;
 
 exports[`bun install no args --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0060 (with modules): requested-tarballs: install without args 1`] = `[]`;
 
@@ -299,6 +429,7 @@ exports[`bun install is-even --linker=hoisted (scanner: local) (bun.lock exists:
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -313,6 +444,7 @@ exports[`bun install is-even --linker=hoisted (scanner: local) (bun.lock exists:
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -322,6 +454,7 @@ exports[`bun install is-even --linker=hoisted (scanner: local) (bun.lock exists:
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -336,6 +469,7 @@ exports[`bun install is-even --linker=hoisted (scanner: local) (bun.lock exists:
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -345,6 +479,7 @@ exports[`bun install is-even --linker=hoisted (scanner: local) (bun.lock exists:
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -409,6 +544,8 @@ exports[`bun install is-even --linker=hoisted (scanner: npm) (bun.lock exists: f
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -423,6 +560,8 @@ exports[`bun install is-even --linker=hoisted (scanner: npm) (bun.lock exists: f
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -432,6 +571,8 @@ exports[`bun install is-even --linker=hoisted (scanner: npm) (bun.lock exists: f
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -446,6 +587,8 @@ exports[`bun install is-even --linker=hoisted (scanner: npm) (bun.lock exists: f
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -455,6 +598,8 @@ exports[`bun install is-even --linker=hoisted (scanner: npm) (bun.lock exists: f
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -509,6 +654,7 @@ exports[`bun install is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -518,6 +664,7 @@ exports[`bun install is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -527,6 +674,7 @@ exports[`bun install is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -536,6 +684,7 @@ exports[`bun install is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -545,6 +694,7 @@ exports[`bun install is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -609,6 +759,7 @@ exports[`bun install is-even --linker=isolated (scanner: local) (bun.lock exists
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -623,6 +774,7 @@ exports[`bun install is-even --linker=isolated (scanner: local) (bun.lock exists
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -632,6 +784,7 @@ exports[`bun install is-even --linker=isolated (scanner: local) (bun.lock exists
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -646,6 +799,7 @@ exports[`bun install is-even --linker=isolated (scanner: local) (bun.lock exists
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -655,6 +809,7 @@ exports[`bun install is-even --linker=isolated (scanner: local) (bun.lock exists
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -719,6 +874,8 @@ exports[`bun install is-even --linker=isolated (scanner: npm) (bun.lock exists: 
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -733,6 +890,8 @@ exports[`bun install is-even --linker=isolated (scanner: npm) (bun.lock exists: 
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -742,6 +901,8 @@ exports[`bun install is-even --linker=isolated (scanner: npm) (bun.lock exists: 
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -756,6 +917,8 @@ exports[`bun install is-even --linker=isolated (scanner: npm) (bun.lock exists: 
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -765,6 +928,8 @@ exports[`bun install is-even --linker=isolated (scanner: npm) (bun.lock exists: 
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -819,6 +984,7 @@ exports[`bun install is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -828,6 +994,7 @@ exports[`bun install is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -837,6 +1004,7 @@ exports[`bun install is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -846,6 +1014,7 @@ exports[`bun install is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -855,6 +1024,7 @@ exports[`bun install is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -864,6 +1034,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: local) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -878,6 +1049,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: local) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -887,6 +1059,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: local) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -901,6 +1074,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: local) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -910,6 +1084,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: local) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -919,6 +1094,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: local) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -933,6 +1109,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: local) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -942,6 +1119,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: local) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -956,6 +1134,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: local) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -965,6 +1144,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: local) (bun.loc
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -974,6 +1154,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock 
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -988,6 +1169,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock 
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -997,6 +1179,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock 
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1011,6 +1194,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock 
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1020,6 +1204,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock 
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1029,6 +1214,8 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock 
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -1043,6 +1230,8 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock 
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -1052,6 +1241,8 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock 
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -1066,6 +1257,8 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock 
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -1075,6 +1268,8 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock 
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -1084,6 +1279,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly)
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1093,6 +1289,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly)
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1102,6 +1299,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly)
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1111,6 +1309,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly)
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1120,6 +1319,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly)
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1129,6 +1329,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly)
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1138,6 +1339,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly)
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1147,6 +1349,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly)
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1156,6 +1359,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly)
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1165,6 +1369,7 @@ exports[`bun install left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly)
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1174,6 +1379,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: local) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1188,6 +1394,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: local) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1197,6 +1404,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: local) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1211,6 +1419,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: local) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1220,6 +1429,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: local) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1229,6 +1439,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: local) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1243,6 +1454,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: local) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1252,6 +1464,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: local) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1266,6 +1479,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: local) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1275,6 +1489,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: local) (bun.lo
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1284,6 +1499,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm) (bun.lock
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1298,6 +1514,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm) (bun.lock
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1307,6 +1524,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm) (bun.lock
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1321,6 +1539,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm) (bun.lock
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1330,6 +1549,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm) (bun.lock
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1339,6 +1559,8 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm) (bun.lock
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -1353,6 +1575,8 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm) (bun.lock
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -1362,6 +1586,8 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm) (bun.lock
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -1376,6 +1602,8 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm) (bun.lock
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -1385,6 +1613,8 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm) (bun.lock
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -1394,6 +1624,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm.bunfigonly
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1403,6 +1634,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm.bunfigonly
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1412,6 +1644,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm.bunfigonly
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1421,6 +1654,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm.bunfigonly
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1430,6 +1664,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm.bunfigonly
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1439,6 +1674,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm.bunfigonly
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1448,6 +1684,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm.bunfigonly
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1457,6 +1694,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm.bunfigonly
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1466,6 +1704,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm.bunfigonly
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -1475,6 +1714,7 @@ exports[`bun install left-pad,is-even --linker=isolated (scanner: npm.bunfigonly
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3389,6 +3629,7 @@ exports[`bun add is-even --linker=hoisted (scanner: local) (bun.lock exists: fal
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3403,6 +3644,7 @@ exports[`bun add is-even --linker=hoisted (scanner: local) (bun.lock exists: fal
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3412,6 +3654,7 @@ exports[`bun add is-even --linker=hoisted (scanner: local) (bun.lock exists: fal
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3426,6 +3669,7 @@ exports[`bun add is-even --linker=hoisted (scanner: local) (bun.lock exists: fal
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3435,6 +3679,7 @@ exports[`bun add is-even --linker=hoisted (scanner: local) (bun.lock exists: fal
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3499,6 +3744,8 @@ exports[`bun add is-even --linker=hoisted (scanner: npm) (bun.lock exists: false
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -3513,6 +3760,8 @@ exports[`bun add is-even --linker=hoisted (scanner: npm) (bun.lock exists: false
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -3522,6 +3771,8 @@ exports[`bun add is-even --linker=hoisted (scanner: npm) (bun.lock exists: false
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -3536,6 +3787,8 @@ exports[`bun add is-even --linker=hoisted (scanner: npm) (bun.lock exists: false
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -3545,6 +3798,8 @@ exports[`bun add is-even --linker=hoisted (scanner: npm) (bun.lock exists: false
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -3599,6 +3854,7 @@ exports[`bun add is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3608,6 +3864,7 @@ exports[`bun add is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3617,6 +3874,7 @@ exports[`bun add is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3626,6 +3884,7 @@ exports[`bun add is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3635,6 +3894,7 @@ exports[`bun add is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3699,6 +3959,7 @@ exports[`bun add is-even --linker=isolated (scanner: local) (bun.lock exists: fa
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3713,6 +3974,7 @@ exports[`bun add is-even --linker=isolated (scanner: local) (bun.lock exists: fa
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3722,6 +3984,7 @@ exports[`bun add is-even --linker=isolated (scanner: local) (bun.lock exists: fa
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3736,6 +3999,7 @@ exports[`bun add is-even --linker=isolated (scanner: local) (bun.lock exists: fa
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3745,6 +4009,7 @@ exports[`bun add is-even --linker=isolated (scanner: local) (bun.lock exists: fa
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3809,6 +4074,8 @@ exports[`bun add is-even --linker=isolated (scanner: npm) (bun.lock exists: fals
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -3823,6 +4090,8 @@ exports[`bun add is-even --linker=isolated (scanner: npm) (bun.lock exists: fals
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -3832,6 +4101,8 @@ exports[`bun add is-even --linker=isolated (scanner: npm) (bun.lock exists: fals
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -3846,6 +4117,8 @@ exports[`bun add is-even --linker=isolated (scanner: npm) (bun.lock exists: fals
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -3855,6 +4128,8 @@ exports[`bun add is-even --linker=isolated (scanner: npm) (bun.lock exists: fals
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -3909,6 +4184,7 @@ exports[`bun add is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3918,6 +4194,7 @@ exports[`bun add is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3927,6 +4204,7 @@ exports[`bun add is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3936,6 +4214,7 @@ exports[`bun add is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3945,6 +4224,7 @@ exports[`bun add is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3954,6 +4234,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: local) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3968,6 +4249,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: local) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3977,6 +4259,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: local) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -3991,6 +4274,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: local) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4000,6 +4284,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: local) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4009,6 +4294,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: local) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4023,6 +4309,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: local) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4032,6 +4319,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: local) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4046,6 +4334,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: local) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4055,6 +4344,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: local) (bun.lock ex
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4064,6 +4354,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exis
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4078,6 +4369,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exis
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4087,6 +4379,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exis
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4101,6 +4394,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exis
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4110,6 +4404,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exis
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4119,6 +4414,8 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exis
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -4133,6 +4430,8 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exis
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -4142,6 +4441,8 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exis
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -4156,6 +4457,8 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exis
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -4165,6 +4468,8 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exis
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -4174,6 +4479,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bu
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4183,6 +4489,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bu
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4192,6 +4499,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bu
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4201,6 +4509,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bu
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4210,6 +4519,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bu
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4219,6 +4529,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bu
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4228,6 +4539,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bu
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4237,6 +4549,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bu
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4246,6 +4559,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bu
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4255,6 +4569,7 @@ exports[`bun add left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bu
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4264,6 +4579,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: local) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4278,6 +4594,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: local) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4287,6 +4604,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: local) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4301,6 +4619,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: local) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4310,6 +4629,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: local) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4319,6 +4639,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: local) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4333,6 +4654,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: local) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4342,6 +4664,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: local) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4356,6 +4679,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: local) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4365,6 +4689,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: local) (bun.lock e
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4374,6 +4699,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exi
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4388,6 +4714,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exi
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4397,6 +4724,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exi
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4411,6 +4739,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exi
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4420,6 +4749,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exi
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4429,6 +4759,8 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exi
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -4443,6 +4775,8 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exi
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -4452,6 +4786,8 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exi
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -4466,6 +4802,8 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exi
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -4475,6 +4813,8 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exi
 [
   "is-even",
   "is-odd",
+  "left-pad",
+  "test-security-scanner",
 ]
 `;
 
@@ -4484,6 +4824,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (b
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4493,6 +4834,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (b
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4502,6 +4844,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (b
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4511,6 +4854,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (b
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4520,6 +4864,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (b
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4529,6 +4874,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (b
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4538,6 +4884,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (b
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4547,6 +4894,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (b
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4556,6 +4904,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (b
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4565,6 +4914,7 @@ exports[`bun add left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (b
 [
   "is-even",
   "is-odd",
+  "left-pad",
 ]
 `;
 
@@ -4590,23 +4940,53 @@ exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: 
 
 exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0485 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0486 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0486 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0486 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0487 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0487 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0487 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0488 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0488 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0488 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0489 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0489 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0489 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0490 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0490 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0490 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
@@ -4630,23 +5010,58 @@ exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: tr
 
 exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0495 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0496 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0496 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0496 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0497 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0497 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0497 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0498 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0498 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0498 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0499 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0499 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0499 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0500 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0500 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0500 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
@@ -4670,23 +5085,53 @@ exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock
 
 exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0505 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0506 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0506 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0506 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0507 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0507 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0507 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0508 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0508 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0508 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0509 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0509 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0509 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0510 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0510 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0510 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
@@ -4710,23 +5155,53 @@ exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists:
 
 exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0515 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0516 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0516 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0516 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0517 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0517 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0517 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0518 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0518 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0518 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0519 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0519 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0519 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0520 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0520 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0520 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
@@ -4750,23 +5225,58 @@ exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: t
 
 exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0525 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0526 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0526 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0526 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0527 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0527 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0527 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0528 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0528 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0528 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0529 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0529 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0529 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0530 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0530 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0530 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
@@ -4790,23 +5300,53 @@ exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.loc
 
 exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0535 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0536 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0536 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0536 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0537 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0537 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0537 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0538 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0538 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0538 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0539 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0539 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0539 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0540 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0540 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun remove is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0540 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
@@ -4830,23 +5370,48 @@ exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0545 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0546 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0546 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0546 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0547 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0547 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0547 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0548 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0548 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0548 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0549 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0549 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0549 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0550 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0550 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0550 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
@@ -4870,23 +5435,53 @@ exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock e
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0555 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0556 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0556 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0556 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0557 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0557 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0557 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0558 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0558 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0558 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0559 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0559 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0559 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0560 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0560 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0560 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
@@ -4910,23 +5505,48 @@ exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) 
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0565 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0566 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0566 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0566 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0567 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0567 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0567 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0568 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0568 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0568 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0569 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0569 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0569 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0570 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0570 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0570 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
@@ -4950,23 +5570,48 @@ exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.loc
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0575 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0576 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0576 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0576 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0577 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0577 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0577 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0578 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0578 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0578 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0579 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0579 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0579 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0580 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0580 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0580 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
@@ -4990,23 +5635,53 @@ exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock 
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0585 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0586 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0586 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0586 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0587 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0587 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0587 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0588 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0588 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0588 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0589 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0589 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0589 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0590 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0590 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0590 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
@@ -5030,23 +5705,48 @@ exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly)
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0595 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0596 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0596 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0596 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0597 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0597 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0597 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0598 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0598 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0598 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0599 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0599 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0599 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
-exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0600 (with modules): requested-packages: remove with args 1`] = `[]`;
+exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0600 (with modules): requested-packages: remove with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun remove left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0600 (with modules): requested-tarballs: remove with args 1`] = `[]`;
 
@@ -5070,23 +5770,53 @@ exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exist
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0605 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0606 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0606 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0606 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0607 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0607 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0607 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0608 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0608 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0608 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0609 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0609 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0609 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0610 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0610 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0610 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
@@ -5110,23 +5840,58 @@ exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists:
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0615 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0616 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0616 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0616 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0617 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0617 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0617 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0618 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0618 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0618 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0619 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0619 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0619 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0620 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0620 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0620 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
@@ -5150,23 +5915,53 @@ exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.l
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0625 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0626 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0626 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0626 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0627 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0627 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0627 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0628 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0628 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0628 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0629 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0629 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0629 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0630 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0630 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0630 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
@@ -5190,23 +5985,53 @@ exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exis
 
 exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0635 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0636 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0636 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0636 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0637 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0637 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0637 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0638 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0638 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0638 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0639 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0639 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0639 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0640 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0640 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0640 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
@@ -5230,23 +6055,58 @@ exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists
 
 exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0645 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0646 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0646 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0646 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0647 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0647 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0647 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0648 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0648 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0648 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0649 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0649 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0649 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0650 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0650 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0650 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
@@ -5270,23 +6130,53 @@ exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.
 
 exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0655 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0656 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0656 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0656 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0657 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0657 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0657 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0658 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0658 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0658 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0659 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0659 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0659 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0660 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0660 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "left-pad",
+]
+`;
 
 exports[`bun uninstall is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0660 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
@@ -5310,23 +6200,48 @@ exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.l
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0665 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0666 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0666 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0666 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0667 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0667 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0667 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0668 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0668 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0668 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0669 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0669 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0669 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0670 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0670 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0670 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
@@ -5350,23 +6265,53 @@ exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.loc
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0675 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0676 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0676 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0676 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0677 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0677 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0677 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0678 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0678 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0678 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0679 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0679 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0679 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0680 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0680 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0680 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
@@ -5390,23 +6335,48 @@ exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonl
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0685 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0686 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0686 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0686 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0687 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0687 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0687 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0688 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0688 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0688 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0689 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0689 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0689 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0690 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0690 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=hoisted (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0690 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
@@ -5430,23 +6400,48 @@ exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0695 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0696 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0696 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: none) (no-TTY) 0696 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0697 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0697 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (no-TTY) 0697 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0698 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0698 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:y) 0698 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0699 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0699 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: warn) (TTY:n) 0699 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0700 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0700 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: local) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0700 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
@@ -5470,23 +6465,53 @@ exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lo
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0705 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0706 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0706 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: none) (no-TTY) 0706 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0707 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0707 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (no-TTY) 0707 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0708 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0708 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:y) 0708 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0709 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0709 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: warn) (TTY:n) 0709 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0710 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0710 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+  "test-security-scanner",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0710 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
@@ -5510,22 +6535,47 @@ exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigon
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: true) (advisories: fatal) (no-TTY) 0715 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0716 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0716 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: none) (no-TTY) 0716 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0717 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0717 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (no-TTY) 0717 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0718 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0718 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:y) 0718 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0719 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0719 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: warn) (TTY:n) 0719 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;
 
-exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0720 (with modules): requested-packages: uninstall with args 1`] = `[]`;
+exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0720 (with modules): requested-packages: uninstall with args 1`] = `
+[
+  "is-even",
+  "is-odd",
+]
+`;
 
 exports[`bun uninstall left-pad,is-even --linker=isolated (scanner: npm.bunfigonly) (bun.lock exists: false) (advisories: fatal) (no-TTY) 0720 (with modules): requested-tarballs: uninstall with args 1`] = `[]`;

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10018,3 +10018,64 @@ it.each([
     expect(exitCode).not.toBe(0);
   });
 });
+
+it("bunfig '[install.cache] disable = true' also disables the npm manifest cache", async () => {
+  await withContext(undefined, async ctx => {
+    const urls: string[] = [];
+    setContextHandler(ctx, dummyRegistryForContext(ctx, urls));
+
+    // createTestContext writes `cache = false` (boolean form, disables both the
+    // global cache and the manifest cache). This test needs the table form with
+    // `disable = true`, which previously left the manifest cache enabled.
+    await writeFile(
+      join(ctx.package_dir, "bunfig.toml"),
+      `[install]
+registry = "${ctx.registry_url}"
+saveTextLockfile = false
+[install.cache]
+disable = true
+`,
+    );
+    await writeFile(
+      join(ctx.package_dir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        version: "0.0.1",
+        dependencies: { bar: "0.0.2" },
+      }),
+    );
+
+    async function install() {
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+    }
+
+    await install();
+    expect(urls.sort()).toEqual([`${ctx.registry_url}bar`, `${ctx.registry_url}bar-0.0.2.tgz`]);
+
+    // `disable = true` points the cache at node_modules/.cache. With the manifest
+    // cache left on (the bug), a *.npm manifest file lands here and a second
+    // install reads it instead of asking the registry.
+    const cacheDir = join(ctx.package_dir, "node_modules", ".cache");
+    expect(await readdirSorted(cacheDir).then(files => files.filter(f => f.endsWith(".npm")))).toEqual([]);
+
+    // Re-resolve from scratch but keep node_modules/.cache so any manifest cache
+    // entry written above would be picked up. The extracted tarball is cached
+    // under node_modules/.cache as well, so only the manifest request repeats.
+    await rm(join(ctx.package_dir, "bun.lockb"), { force: true });
+    await rm(join(ctx.package_dir, "node_modules", "bar"), { recursive: true, force: true });
+    urls.length = 0;
+
+    await install();
+    expect(urls).toContain(`${ctx.registry_url}bar`);
+  });
+});


### PR DESCRIPTION
## What

`[install.cache] disable = true` in bunfig left the npm manifest cache enabled, so `*.npm` manifest files were still written to `node_modules/.cache` and a subsequent install could read them instead of asking the registry. The shorthand `install.cache = false` already disabled both. Surfaced as nondeterministic registry-request counts in the security-scanner matrix tests (#36215), where the async manifest-save raced process exit.

This is a behavior change: `disable` and `disableManifest` were previously independent knobs (docs described `disable` as "don't load from the global cache. Bun may still write to node_modules/.cache"). After this PR, `disable = true` matches `install.cache = false` and subsumes `disableManifest`; `disableManifest = true` alone remains useful for "keep using the global cache directory, always fetch fresh manifests". Docs updated.

## Repro

```
[install]
registry = "http://localhost:PORT/"
[install.cache]
disable = true
```

Install once, then again after removing the lockfile + installed package but keeping `node_modules/.cache`:

|  | `.npm` in `node_modules/.cache` | 2nd-install manifest requests |
|---|---|---|
| `[install.cache] disable = true` (before) | yes | 0 |
| `install.cache = false` | no | 1 |
| `[install.cache] disable = true` (after) | no | 1 |

## Cause

Both `PackageManager` init paths (`init` for the CLI, `init_with_runtime_once` for auto-install) had `if !manager.options.enable.cache() { disable manifest cache }` before `options.load()`. `Enable::default()` has `CACHE` set, so the guard was always false. The block dates to a765b13f52 where it ran after an eager cache-dir open that cleared `Enable::CACHE` on failure (and which already cleared the manifest flags inline, so the block was redundant even then); 3915e01cfb made the open lazy and the block went fully dead.

## Fix

Move the `if !enable.cache()` propagation to after `options.load()` in both init paths so it sees the bunfig-loaded value. The `BUN_MANIFEST_CACHE` block stays before `load()` so `Subcommand::Update`, `--no-cache`, and `--force` (which clear the manifest-cache flags inside `load()`) still win as before.

## Verification

New test in `test/cli/install/bun-install.test.ts`: install with `[install.cache] disable = true`, assert no `*.npm` files land in `node_modules/.cache`, and assert a second install (lockfile removed, `.cache` kept) still fetches the manifest from the registry.

```
stash src/:  (fail) ... + [ "a0e1958550aff71e-....npm" ]
with fix:    (pass)
```

`bun-security-scanner-matrix-with-node-modules.test.ts` used `cache.disable = true` and its `requested-packages` snapshots had captured manifest-cache-served results. Regenerated: the `bun.lock exists: false` cases go from `[]` to the full resolution set, and 60 `bun.lock exists: true` cases for `install|add left-pad,is-even` gain `"left-pad"` (explicitly-named, already-locked args now hit the registry instead of the pre-install's cached manifest). The `without-node-modules` variant is unaffected since it removes `node_modules/.cache` between the pre-install and the measured run.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->