### PR TITLE
perf_hooks: queue buffered PerformanceObserver delivery instead of firing synchronously

### DIFF
--- a/src/jsc/bindings/webcore/Performance.h
+++ b/src/jsc/bindings/webcore/Performance.h
@@ -116,6 +116,7 @@ public:
     void removeAllObservers();
     void registerPerformanceObserver(PerformanceObserver&);
     void unregisterPerformanceObserver(PerformanceObserver&);
+    void scheduleTaskIfNeeded();
 
     static void allowHighPrecisionTime();
     static Seconds timeResolution();
@@ -151,7 +152,6 @@ private:
     // void resourceTimingBufferFullTimerFired();
 
     void queueEntry(PerformanceEntry&);
-    void scheduleTaskIfNeeded();
 
     // mutable RefPtr<PerformanceNavigation> m_navigation;
     mutable RefPtr<PerformanceTiming> m_timing;

--- a/src/jsc/bindings/webcore/PerformanceObserver.cpp
+++ b/src/jsc/bindings/webcore/PerformanceObserver.cpp
@@ -102,9 +102,6 @@ ExceptionOr<void> PerformanceObserver::observe(Init&& init)
         m_performance->registerPerformanceObserver(*this);
         m_registered = true;
     }
-    // Performance Timeline L2 §observe: buffered entries are appended to the
-    // observer buffer synchronously, and delivery is queued as a task so a
-    // following takeRecords() sees them and disconnect() cancels the callback.
     if (isBuffered && !m_entriesToDeliver.isEmpty())
         m_performance->scheduleTaskIfNeeded();
 

--- a/src/jsc/bindings/webcore/PerformanceObserver.cpp
+++ b/src/jsc/bindings/webcore/PerformanceObserver.cpp
@@ -133,6 +133,8 @@ void PerformanceObserver::queueEntry(PerformanceEntry& entry)
 
 void PerformanceObserver::deliver()
 {
+    if (!m_registered)
+        return;
     if (m_entriesToDeliver.isEmpty())
         return;
 

--- a/src/jsc/bindings/webcore/PerformanceObserver.cpp
+++ b/src/jsc/bindings/webcore/PerformanceObserver.cpp
@@ -102,8 +102,11 @@ ExceptionOr<void> PerformanceObserver::observe(Init&& init)
         m_performance->registerPerformanceObserver(*this);
         m_registered = true;
     }
-    if (isBuffered)
-        deliver();
+    // Performance Timeline L2 §observe: buffered entries are appended to the
+    // observer buffer synchronously, and delivery is queued as a task so a
+    // following takeRecords() sees them and disconnect() cancels the callback.
+    if (isBuffered && !m_entriesToDeliver.isEmpty())
+        m_performance->scheduleTaskIfNeeded();
 
     return {};
 }

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -169,6 +169,70 @@ test("timerify and AsyncResource.bind survive Object.prototype.get pollution", a
   expect(exitCode).toBe(0);
 });
 
+// Performance Timeline L2 §observe: with {buffered:true} the existing entries
+// are appended to the observer buffer synchronously and delivery is queued as
+// a task, not invoked inside observe(). Verified against Node v26.3.0.
+test("observe({type, buffered: true}) buffers synchronously and delivers as one deferred batch", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { performance, PerformanceObserver } = require("node:perf_hooks");
+       const tick = () => new Promise(r => setImmediate(r));
+       (async () => {
+         const out = {};
+
+         // takeRecords() right after a buffered observe() sees the buffered
+         // entries plus any entry added before the first delivery task runs.
+         performance.mark("pre1"); performance.mark("pre2");
+         let syncFired = false;
+         const oA = new PerformanceObserver(() => { syncFired = true; });
+         oA.observe({ type: "mark", buffered: true });
+         out.syncFired = syncFired;
+         performance.mark("post1");
+         out.takeRecords = oA.takeRecords().map(e => e.name);
+         oA.disconnect(); performance.clearMarks();
+         await tick();
+
+         // Buffered entries and entries queued before the task runs arrive in
+         // a single callback batch.
+         performance.mark("b1");
+         const batches = [];
+         const oB = new PerformanceObserver(l => batches.push(l.getEntries().map(e => e.name)));
+         oB.observe({ type: "mark", buffered: true });
+         performance.mark("b2");
+         await tick();
+         out.batches = batches;
+         oB.disconnect(); performance.clearMarks();
+         await tick();
+
+         // disconnect() before the task runs drops the buffered delivery.
+         performance.mark("c1");
+         const late = [];
+         const oC = new PerformanceObserver(l => late.push(l.getEntries().map(e => e.name)));
+         oC.observe({ type: "mark", buffered: true });
+         oC.disconnect();
+         await tick();
+         out.afterDisconnect = late;
+
+         console.log(JSON.stringify(out));
+       })();`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    syncFired: false,
+    takeRecords: ["pre1", "pre2", "post1"],
+    batches: [["b1", "b2"]],
+    afterDisconnect: [],
+  });
+  expect(exitCode).toBe(0);
+});
+
 test("net entries are instanceof PerformanceEntry", async () => {
   const { promise, resolve } = Promise.withResolvers();
   const observer = new PerformanceObserver(list => resolve(list.getEntries()[0]));


### PR DESCRIPTION
## Problem

`PerformanceObserver.observe({ type, buffered: true })` called `deliver()` synchronously inside `observe()`, so the callback ran before `observe()` returned and the observer buffer was drained immediately. This diverged from both Performance Timeline L2 and Node.js in three observable ways:

```js
import { performance, PerformanceObserver } from "node:perf_hooks";

performance.mark("pre1"); performance.mark("pre2");
const o = new PerformanceObserver(() => {});
o.observe({ type: "mark", buffered: true });
performance.mark("post1");
o.takeRecords().map(e => e.name);
// node: ["pre1","pre2","post1"]   bun: ["post1"]
```

- `takeRecords()` right after a buffered `observe()` missed the buffered entries (they had already been delivered and cleared).
- Buffered entries and entries added before the next tick arrived as two callback batches instead of one.
- `disconnect()` right after a buffered `observe()` did not prevent the callback, because it had already fired inside `observe()`.

## Fix

`PerformanceObserver::observe` already appends the buffered entries to `m_entriesToDeliver` synchronously. Replace the trailing synchronous `deliver()` with `Performance::scheduleTaskIfNeeded()` so delivery happens via the same queued task that handles fresh entries. `disconnect()` unregisters the observer and clears its buffer, so a disconnect before that task runs now drops the delivery, matching Node.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/perf_hooks/perf_hooks.test.ts -t "buffered: true"
(fail) observe({type, buffered: true}) buffers synchronously and delivers as one deferred batch
  syncFired: true -> false, takeRecords: ["post1"] -> ["pre1","pre2","post1"],
  batches: [["b1"],["b2"]] -> [["b1","b2"]], afterDisconnect: [["c1"]] -> []

$ bun bd test test/js/node/perf_hooks/perf_hooks.test.ts
 11 pass  0 fail
```

Verified against Node v26.3.0 output.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
bun test v1.4.0 (b2ee8c8f7)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [17.62ms]
(pass) doesn't throw [14.44ms]
(pass) Symbol name argument throws V8 wording [7.58ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [5.04ms]
(pass) timerify entry shape [54.59ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [1.67ms]
(pass) export surface matches Node v26.3.0 [7.10ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [432.39ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [499.89ms]
222 |     stdout: "pipe",
223 |     stderr: "pipe",
224 |   });
225 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
226 |   expect(stderr).toBe("");
227 |   expect(JSON.parse(stdout)).toEqual({
                                   ^
error: expect(received).toEqual(expected)

  {
-   "afterDisconnect": []
... (truncated)

release without fix: 9 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [0.07ms]
(pass) doesn't throw [0.14ms]
26 | 
27 | // Node coerces the name via `${name}` for mark/clearMarks/clearMeasures, so a
28 | // Symbol hits V8's ToString message. Verified against Node v26.3.0.
29 | test("Symbol name argument throws V8 wording", () => {
30 |   const msg = "Cannot convert a Symbol value to a string";
31 |   expect(() => performance.mark(Symbol())).toThrow(new TypeError(msg));
                                                ^
error: expect(received).toThrow(expected)

Expected message: "Cannot convert a Symbol value to a string"
Received message: "Cannot convert a symbol to a string"

      at <anonymous> (/workspace/bun/test/js/node/perf_hooks/perf_hooks.test.ts:31:44)
(fail) Symbol name argument throws V8 wording [0.21ms]
36 | // Node only looks at start/end to decide whether the options dict supplies
37 | // timing; a {detail}/{duration}-only dict falls through and the trailing
38 | // endMark is honoured. Verified against Node v26.3.0.
39 | test("measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark", () => {
40 |   perfo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
bun test v1.4.0 (b2ee8c8f7)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [16.33ms]
(pass) doesn't throw [15.42ms]
(pass) Symbol name argument throws V8 wording [7.02ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [4.97ms]
(pass) timerify entry shape [55.85ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [1.70ms]
(pass) export surface matches Node v26.3.0 [7.14ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [436.36ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [507.63ms]
(pass) observe({type, buffered: true}) buffers synchronously and delivers as one deferred batch [514.34ms]
(pass) net entries are instanceof PerformanceEntry [438.22ms]

 11 pass
 0 fail
 59 expect() calls
Ran 11 tests across 1 file. [4.22s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 741ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/132] gen cpp.rs (cppbind)
[1/132] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m std v0.0.0 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std)
[1m[92m   Compiling[0m proc_macro v0.0.0 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/proc_macro)
[1m[92m   Compiling[0m bitflags v2.11.1
[1m[92m   Compiling[0m memchr v2.8.0
[1m[92m   Compiling[0m libc v0.2.186
[1m[92m   Compiling[0m konst_macro_rules v0.2.19
[1m[92m   Compiling[0m enumset v1.1.10
[1m[92m   Compiling[0m konst v0.2.20
[1m[92m   Compiling[0m const_format v0.2.36
[1m[92m   Compiling[0m bstr v1.12.1
[1m[92m   Compiling[0m scopeguard v1.2.0
[1m[92m   Compiling[0m enum-map v2.7.3
[1m[92m   Compiling[0m strum v0.26.3
[1m[92m   Compiling[0m allocator-api2 v0.2.2
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/Performance.h           |  2 +-
 src/jsc/bindings/webcore/PerformanceObserver.cpp |  6 ++-
 test/js/node/perf_hooks/perf_hooks.test.ts       | 64 ++++++++++++++++++++++++
 3 files changed, 69 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/jsc/bindings/webcore/Performance.h                1      2      0
src/jsc/bindings/webcore/PerformanceObserver.cpp      3      7      0
test/js/node/perf_hooks/perf_hooks.test.ts            1      2      0
```

</details>

<!-- robobun:evidence:end -->