### PR TITLE
node:crypto: register aes-192-cfb in BoringSSL's cipher lookup table

### DIFF
--- a/patches/boringssl/register-aes-192-cfb.patch
+++ b/patches/boringssl/register-aes-192-cfb.patch
@@ -1,0 +1,20 @@
+--- a/crypto/cipher/get_cipher.cc
++++ b/crypto/cipher/get_cipher.cc
+@@ -37,6 +37,7 @@
+     {NID_aes_128_gcm, "aes-128-gcm", EVP_aes_128_gcm},
+     {NID_aes_128_ofb128, "aes-128-ofb", EVP_aes_128_ofb},
+     {NID_aes_192_cbc, "aes-192-cbc", EVP_aes_192_cbc},
++    {NID_aes_192_cfb128, "aes-192-cfb", EVP_aes_192_cfb128},
+     {NID_aes_192_ctr, "aes-192-ctr", EVP_aes_192_ctr},
+     {NID_aes_192_ecb, "aes-192-ecb", EVP_aes_192_ecb},
+     {NID_aes_192_gcm, "aes-192-gcm", EVP_aes_192_gcm},
+--- a/decrepit/evp/evp_do_all.cc
++++ b/decrepit/evp/evp_do_all.cc
+@@ -31,6 +31,7 @@
+   callback(EVP_aes_128_gcm(), "aes-128-gcm", nullptr, arg);
+   callback(EVP_aes_128_ofb(), "aes-128-ofb", nullptr, arg);
+   callback(EVP_aes_192_cbc(), "aes-192-cbc", nullptr, arg);
++  callback(EVP_aes_192_cfb128(), "aes-192-cfb", nullptr, arg);
+   callback(EVP_aes_192_ctr(), "aes-192-ctr", nullptr, arg);
+   callback(EVP_aes_192_ecb(), "aes-192-ecb", nullptr, arg);
+   callback(EVP_aes_192_gcm(), "aes-192-gcm", nullptr, arg);

--- a/scripts/build/deps/boringssl.ts
+++ b/scripts/build/deps/boringssl.ts
@@ -36,10 +36,16 @@ export const boringssl: Dependency = {
     commit: BORINGSSL_COMMIT,
   }),
 
-  // Upstream mem.cc gates OPENSSL_memory_* weak-symbol overrides on __ELF__;
-  // on Mach-O/COFF the hooks compile to static nullptr and OPENSSL_malloc goes
-  // straight to libc. Declare them as plain externs so lib.rs binds everywhere.
-  patches: ["patches/boringssl/require-memory-hooks.patch"],
+  patches: [
+    // Upstream mem.cc gates OPENSSL_memory_* weak-symbol overrides on __ELF__;
+    // on Mach-O/COFF the hooks compile to static nullptr and OPENSSL_malloc goes
+    // straight to libc. Declare them as plain externs so lib.rs binds everywhere.
+    "patches/boringssl/require-memory-hooks.patch",
+    // BoringSSL ships EVP_aes_192_cfb128 in decrepit/cfb/cfb.cc but omits it
+    // from the kCiphers lookup table and EVP_CIPHER_do_all_sorted, so
+    // EVP_get_cipherbyname("aes-192-cfb") returns null while 128/256 work.
+    "patches/boringssl/register-aes-192-cfb.patch",
+  ],
 
   build: cfg => {
     // win-x64 uses NASM-syntax .asm; everything else (including win-aarch64)

--- a/test/js/bun/crypto/cipheriv-decipheriv.test.ts
+++ b/test/js/bun/crypto/cipheriv-decipheriv.test.ts
@@ -1,5 +1,14 @@
 import { expect, it } from "bun:test";
-import { BinaryLike, CipherGCM, createCipheriv, createDecipheriv, DecipherGCM, getCipherInfo, getCiphers, randomBytes } from "crypto";
+import {
+  BinaryLike,
+  CipherGCM,
+  createCipheriv,
+  createDecipheriv,
+  DecipherGCM,
+  getCipherInfo,
+  getCiphers,
+  randomBytes,
+} from "crypto";
 
 /**
  * Perform a sample encryption and decryption

--- a/test/js/bun/crypto/cipheriv-decipheriv.test.ts
+++ b/test/js/bun/crypto/cipheriv-decipheriv.test.ts
@@ -270,9 +270,6 @@ it("should ignore authTagLength for non-authenticated cipher modes", () => {
   expect(gcm.getAuthTag().length).toBe(12);
 });
 
-// https://github.com/oven-sh/bun/issues/6890
-// BoringSSL's cipher lookup table omitted aes-192-cfb while its 128/256
-// siblings (and every other aes-192-* mode) were present.
 it.each([
   ["aes-128-cfb", 16],
   ["aes-192-cfb", 24],

--- a/test/js/bun/crypto/cipheriv-decipheriv.test.ts
+++ b/test/js/bun/crypto/cipheriv-decipheriv.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "bun:test";
-import { BinaryLike, CipherGCM, createCipheriv, createDecipheriv, DecipherGCM, randomBytes } from "crypto";
+import { BinaryLike, CipherGCM, createCipheriv, createDecipheriv, DecipherGCM, getCipherInfo, getCiphers, randomBytes } from "crypto";
 
 /**
  * Perform a sample encryption and decryption
@@ -149,6 +149,18 @@ const references = {
     ciphertext: "8497dba3f7f3252e7f5f3cf2c49c5e16cd83da98a942532537a77283afb875ec5a865020ced4242615edb7ec2eaf7e6c",
     authTag: null,
   },
+  "aes-192-cfb": {
+    iv: "c367b0a830ab0fc8aacaa5674c1f3b4d",
+    key: "d5bb1ece4b60a10b34a7e5e1ff0cb49f846fde6105346c5b",
+    ciphertext: "52e454fbba99f8891db30a34d989524e2bd701e8df157b4983080061bb6b11d9ee3d3d7665bd6b58b5f0f2175cd44a67",
+    authTag: null,
+  },
+  "aes-256-cfb": {
+    iv: "e3985bfbe4b780790ea8df1eafba3f60",
+    key: "4a020405fcd8d24a3c73346b0556a5bcc341c48e87234d7ac7e5abb5222cd4f3",
+    ciphertext: "9a2df90bf614aae748e7c32a978e73db1c1cd405871afbd30521eacc672fc421ab7cb58c6cd7e0a00e9bc01259954cc4",
+    authTag: null,
+  },
 
   // BoringSSL does not support these modes
   // "aes-128-cfb8": {
@@ -247,4 +259,27 @@ it("should ignore authTagLength for non-authenticated cipher modes", () => {
   gcm.update("hi");
   gcm.final();
   expect(gcm.getAuthTag().length).toBe(12);
+});
+
+// https://github.com/oven-sh/bun/issues/6890
+// BoringSSL's cipher lookup table omitted aes-192-cfb while its 128/256
+// siblings (and every other aes-192-* mode) were present.
+it.each([
+  ["aes-128-cfb", 16],
+  ["aes-192-cfb", 24],
+  ["aes-256-cfb", 32],
+] as const)("%s is registered and round-trips", (name, keyLength) => {
+  expect(getCiphers()).toContain(name);
+  expect(getCipherInfo(name)).toEqual({
+    mode: "cfb",
+    name,
+    nid: expect.any(Number),
+    keyLength,
+    blockSize: 1,
+    ivLength: 16,
+  });
+
+  const key = randomBytes(keyLength);
+  const iv = randomBytes(16);
+  expect(sampleEncryptDecrypt(name, key, iv)).toBe(true);
 });


### PR DESCRIPTION
## Problem

`createCipheriv("aes-192-cfb", ...)` throws `ERR_CRYPTO_UNKNOWN_CIPHER` while `aes-128-cfb`, `aes-256-cfb`, and every other `aes-192-*` mode work. `getCipherInfo("aes-192-cfb")` returns `undefined` and `getCiphers()` does not list it. Node lists and round-trips it.

```js
import crypto from "node:crypto";
crypto.createCipheriv("aes-192-cfb", Buffer.alloc(24, 1), Buffer.alloc(16, 2));
// error: Unknown cipher
//  code: "ERR_CRYPTO_UNKNOWN_CIPHER"
```

## Cause

BoringSSL implements `EVP_aes_192_cfb128` in `decrepit/cfb/cfb.cc` alongside its 128/256-bit siblings, but the 192-bit entry is omitted from both the `kCiphers[]` name lookup table in `crypto/cipher/get_cipher.cc` and the `EVP_CIPHER_do_all_sorted` enumeration in `decrepit/evp/evp_do_all.cc`. So `EVP_get_cipherbyname("aes-192-cfb")` returns null even though the cipher itself is compiled in.

## Fix

Add a build-time BoringSSL patch that inserts the missing `{NID_aes_192_cfb128, "aes-192-cfb", EVP_aes_192_cfb128}` row in `kCiphers[]` and the matching `callback(EVP_aes_192_cfb128(), "aes-192-cfb", ...)` in `EVP_CIPHER_do_all_sorted`. No new cipher code; this only wires the existing implementation into the name tables.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/crypto/cipheriv-decipheriv.test.ts
 14 pass  2 fail   # "aes-192-cfb is registered and round-trips" + well-known-values
$ bun bd test test/js/bun/crypto/cipheriv-decipheriv.test.ts
 16 pass  0 fail
```

With the fix, Bun's output for the issue's repro is byte-identical to Node v26.3.0. `getCipherInfo("aes-192-cfb")` now returns `{mode:"cfb", name:"aes-192-cfb", nid:425, keyLength:24, blockSize:1, ivLength:16}` matching Node.

Related: #28526 adds the separate CFB8 mode.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/crypto/cipheriv-decipheriv.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/crypto/cipheriv-decipheriv.test.ts
bun test v1.4.0 (b4502d471)

test/js/bun/crypto/cipheriv-decipheriv.test.ts:
(pass) should encrypt & decrypt using update & final interface [23.88ms]
(pass) should encrypt & decrypt using streaming interface [171.93ms]
(pass) should fail when cipher is not defined [4.78ms]
(pass) should fail when key is not defined [2.65ms]
(pass) should fail when iv is not defined [2.61ms]
(pass) should fail when key length is invalid [7.51ms]
(pass) should fail when iv length is invalid [6.39ms]
(pass) only zero-sized iv or null should be accepted in ECB mode [9.32ms]
(pass) should allow only valid iv lengths in GCM mode [9.44ms]
(pass) should encrypt & decrypt well-known values [25.94ms]
(pass) should work with authTagLength missing from options [2.39ms]
(pass) should not accept negative authTagLength, or other coercable values [6.84ms]
(pass) should ignore authTagLength for non-authenticated cipher modes [5.79ms]
(pass) aes-128-cfb is registered and round-trips [5.59ms]
(pass) aes-192-cfb is registered and round-trips [3.22ms]
(pass) aes-256-cfb is registered and round-trips [3.92ms]

 16 pass
 0 fail
 51 expect() calls
Ran 16 tests across 1 file. [2.78s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
patches/boringssl/register-aes-192-cfb.patch   | 20 ++++++++++++
 scripts/build/deps/boringssl.ts                | 14 ++++++---
 test/js/bun/crypto/cipheriv-decipheriv.test.ts | 43 +++++++++++++++++++++++++-
 3 files changed, 72 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
patches/boringssl/register-aes-192-cfb.patch        0      1      0
scripts/build/deps/boringssl.ts                     1      1      0
test/js/bun/crypto/cipheriv-decipheriv.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->