### PR TITLE
css: implement `@keyframes` minification

### DIFF
--- a/src/css/context.rs
+++ b/src/css/context.rs
@@ -81,9 +81,12 @@ impl<'a> PropertyHandlerContext<'a> {
     }
 
     pub fn should_compile_logical(&self, feature: css::compat::Feature) -> bool {
-        // Don't convert logical properties in style attributes because
-        // our fallbacks rely on extra rules to define --ltr and --rtl.
-        if self.context == DeclarationContext::StyleAttribute {
+        // Don't convert logical properties in style attributes or keyframes
+        // because our fallbacks rely on extra rules to define --ltr and --rtl.
+        if matches!(
+            self.context,
+            DeclarationContext::StyleAttribute | DeclarationContext::Keyframes
+        ) {
             return false;
         }
 

--- a/src/css/context.rs
+++ b/src/css/context.rs
@@ -81,8 +81,7 @@ impl<'a> PropertyHandlerContext<'a> {
     }
 
     pub fn should_compile_logical(&self, feature: css::compat::Feature) -> bool {
-        // Don't convert logical properties in style attributes or keyframes
-        // because our fallbacks rely on extra rules to define --ltr and --rtl.
+        // Fallbacks rely on extra `:dir()` rules; these contexts can't host them.
         if matches!(
             self.context,
             DeclarationContext::StyleAttribute | DeclarationContext::Keyframes

--- a/src/css/rules/keyframes.rs
+++ b/src/css/rules/keyframes.rs
@@ -26,8 +26,6 @@ pub enum KeyframesName {
 }
 
 impl KeyframesName {
-    /// The name bytes, regardless of whether it was written as an ident or a
-    /// string. Used for the unused-symbol lookup.
     pub(crate) fn as_bytes(&self) -> &[u8] {
         match self {
             KeyframesName::Ident(ident) => ident.v(),
@@ -340,8 +338,6 @@ impl KeyframesRule {
         }
     }
 
-    /// Run the property handlers over every keyframe's declarations so they
-    /// fold shorthands / emit prefix fallbacks exactly like style-rule bodies.
     pub(crate) fn minify(&mut self, context: &mut MinifyContext<'_, '_>) {
         context.handler_context.context = DeclarationContext::Keyframes;
 
@@ -353,9 +349,7 @@ impl KeyframesRule {
             );
         }
 
-        // Property handlers for logical properties stage `ltr`/`rtl` entries
-        // regardless of the declaration context; keyframe blocks have no
-        // `:dir()` wrapper to emit them into, so drop whatever was staged.
+        // Drop any ltr/rtl staging; keyframes have no `:dir()` to emit it into.
         context.handler_context.reset();
         context.handler_context.context = DeclarationContext::None;
     }
@@ -369,11 +363,7 @@ impl KeyframesRule {
                 .all(|(a, b)| a.eql(b))
     }
 
-    /// Compute color-gamut fallback `@supports` rules for wide-gamut colors in
-    /// custom / unparsed property values, and rewrite those values in `self`
-    /// to the lowest common fallback. Only custom and unparsed values are
-    /// inspected because typed color properties have already been lowered by
-    /// the property handlers in [`minify`](Self::minify).
+    /// Typed color properties were already lowered in [`minify`](Self::minify).
     pub(crate) fn get_fallbacks<R>(
         &mut self,
         arena: &bun_alloc::Arena,

--- a/src/css/rules/keyframes.rs
+++ b/src/css/rules/keyframes.rs
@@ -1,7 +1,8 @@
 use core::hash::{Hash, Hasher};
 
 use crate as css;
-use crate::css_rules::Location;
+use crate::context::DeclarationContext;
+use crate::css_rules::{Location, MinifyContext};
 use crate::css_values::ident::{CustomIdent, is_reserved_custom_ident};
 use crate::css_values::percentage::Percentage;
 use crate::{DeclarationBlock, PrintErr, Printer, VendorPrefix};
@@ -16,11 +17,23 @@ use super::ArrayList;
 // Stores `&'static [u8]` per the rules/mod.rs `CssRule<R>` lifetime-erasure
 // note (mod.rs:37-41).
 // TODO(refactor): re-thread `'bump` here.
+#[derive(Clone, Copy)]
 pub enum KeyframesName {
     /// `<custom-ident>` of a `@keyframes` name.
     Ident(CustomIdent),
     /// `<string>` of a `@keyframes` name.
     Custom(&'static [u8]),
+}
+
+impl KeyframesName {
+    /// The name bytes, regardless of whether it was written as an ident or a
+    /// string. Used for the unused-symbol lookup.
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        match self {
+            KeyframesName::Ident(ident) => ident.v(),
+            KeyframesName::Custom(s) => s,
+        }
+    }
 }
 
 // A generic type alias keyed by `KeyframesName` with the custom hash/eq below.
@@ -170,6 +183,14 @@ impl KeyframeSelector {
             Self::To => Self::To,
         }
     }
+
+    pub(crate) fn eql(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Percentage(a), Self::Percentage(b)) => a.eql(*b),
+            (Self::From, Self::From) | (Self::To, Self::To) => true,
+            _ => false,
+        }
+    }
 }
 
 // ─── KeyframeSelector parse ───────────────────────────────────────────────
@@ -221,6 +242,16 @@ impl Keyframe {
             selectors: self.selectors.iter().map(|s| s.deep_clone(bump)).collect(),
             declarations: super::dc::decl_block_static(&self.declarations, bump),
         }
+    }
+
+    pub(crate) fn eql(&self, other: &Self) -> bool {
+        self.selectors.len() == other.selectors.len()
+            && self
+                .selectors
+                .iter()
+                .zip(other.selectors.iter())
+                .all(|(a, b)| a.eql(b))
+            && self.declarations.eql(&other.declarations)
     }
 }
 
@@ -307,6 +338,144 @@ impl KeyframesRule {
             vendor_prefix: self.vendor_prefix,
             loc: self.loc,
         }
+    }
+
+    /// Run the property handlers over every keyframe's declarations so they
+    /// fold shorthands / emit prefix fallbacks exactly like style-rule bodies.
+    pub(crate) fn minify(&mut self, context: &mut MinifyContext<'_, '_>) {
+        context.handler_context.context = DeclarationContext::Keyframes;
+
+        for keyframe in self.keyframes.iter_mut() {
+            keyframe.declarations.minify(
+                super::dc::decl_handler_static(&mut *context.handler),
+                super::dc::decl_handler_static(&mut *context.important_handler),
+                &mut context.handler_context,
+            );
+        }
+
+        // Property handlers for logical properties stage `ltr`/`rtl` entries
+        // regardless of the declaration context; keyframe blocks have no
+        // `:dir()` wrapper to emit them into, so drop whatever was staged.
+        context.handler_context.reset();
+        context.handler_context.context = DeclarationContext::None;
+    }
+
+    pub(crate) fn keyframes_eql(&self, other: &Self) -> bool {
+        self.keyframes.len() == other.keyframes.len()
+            && self
+                .keyframes
+                .iter()
+                .zip(other.keyframes.iter())
+                .all(|(a, b)| a.eql(b))
+    }
+
+    /// Compute color-gamut fallback `@supports` rules for wide-gamut colors in
+    /// custom / unparsed property values, and rewrite those values in `self`
+    /// to the lowest common fallback. Only custom and unparsed values are
+    /// inspected because typed color properties have already been lowered by
+    /// the property handlers in [`minify`](Self::minify).
+    pub(crate) fn get_fallbacks<R>(
+        &mut self,
+        arena: &bun_alloc::Arena,
+        targets: &css::targets::Targets,
+    ) -> Vec<super::CssRule<R>> {
+        use css::css_properties::Property;
+        use css::css_properties::custom::{CustomProperty, UnparsedProperty};
+        use css::css_values::color::ColorFallbackKind;
+
+        let mut fallbacks = ColorFallbackKind::empty();
+        for keyframe in &self.keyframes {
+            for property in keyframe.declarations.declarations.iter() {
+                match property {
+                    Property::Custom(CustomProperty { value, .. })
+                    | Property::Unparsed(UnparsedProperty { value, .. }) => {
+                        fallbacks |= value.get_necessary_fallbacks(targets);
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        let mut res = Vec::new();
+        let lowest_fallback = fallbacks.lowest();
+        fallbacks.remove(lowest_fallback);
+
+        if fallbacks.contains(ColorFallbackKind::P3) {
+            res.push(self.get_fallback(arena, ColorFallbackKind::P3));
+        }
+
+        if fallbacks.contains(ColorFallbackKind::LAB)
+            || (!lowest_fallback.is_empty() && lowest_fallback != ColorFallbackKind::LAB)
+        {
+            res.push(self.get_fallback(arena, ColorFallbackKind::LAB));
+        }
+
+        if !lowest_fallback.is_empty() {
+            for keyframe in &mut self.keyframes {
+                for property in keyframe.declarations.declarations.iter_mut() {
+                    match property {
+                        Property::Custom(CustomProperty { value, .. })
+                        | Property::Unparsed(UnparsedProperty { value, .. }) => {
+                            *value = value.get_fallback(arena, lowest_fallback);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        res
+    }
+
+    fn get_fallback<R>(
+        &self,
+        arena: &bun_alloc::Arena,
+        kind: css::css_values::color::ColorFallbackKind,
+    ) -> super::CssRule<R> {
+        use css::css_properties::Property;
+        use css::css_properties::custom::{CustomProperty, UnparsedProperty};
+
+        let keyframes = self
+            .keyframes
+            .iter()
+            .map(|keyframe| {
+                let mut declarations = super::dc::decl_block_empty_static(arena);
+                for property in keyframe.declarations.declarations.iter() {
+                    declarations.declarations.push(match property {
+                        Property::Custom(custom) => Property::Custom(CustomProperty {
+                            name: custom.name,
+                            value: custom.value.get_fallback(arena, kind),
+                        }),
+                        Property::Unparsed(unparsed) => Property::Unparsed(UnparsedProperty {
+                            property_id: unparsed.property_id.deep_clone(arena),
+                            value: unparsed.value.get_fallback(arena, kind),
+                        }),
+                        _ => property.deep_clone(arena),
+                    });
+                }
+                Keyframe {
+                    selectors: keyframe
+                        .selectors
+                        .iter()
+                        .map(|s| s.deep_clone(arena))
+                        .collect(),
+                    declarations,
+                }
+            })
+            .collect();
+
+        super::CssRule::Supports(super::supports::SupportsRule {
+            condition: kind.supports_condition(),
+            rules: super::CssRuleList {
+                v: vec![super::CssRule::Keyframes(KeyframesRule {
+                    name: self.name,
+                    keyframes,
+                    vendor_prefix: self.vendor_prefix,
+                    loc: self.loc,
+                })],
+            },
+            loc: self.loc,
+        })
     }
 }
 

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -1312,10 +1312,8 @@ pub(crate) struct SliceAdapter;
 impl bun_collections::array_hash_map::ArrayHashAdapter<[u8], Box<[u8]>> for SliceAdapter {
     #[inline]
     fn hash(&self, key: &[u8]) -> u32 {
-        use core::hash::{Hash, Hasher};
-        let mut h = bun_wyhash::Wyhash11::init(0);
-        key.hash(&mut h);
-        h.finish() as u32
+        use bun_collections::array_hash_map::{ArrayHashContext, AutoContext};
+        AutoContext.hash(key)
     }
     #[inline]
     fn eql(&self, a: &[u8], b: &Box<[u8]>, _: usize) -> bool {

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -498,6 +498,7 @@ impl<R> CssRuleList<R> {
     where
         R: for<'b> css::generics::DeepClone<'b>,
     {
+        let mut keyframe_rules = bun_collections::HashMap::<keyframes::KeyframesName, usize>::new();
         let mut style_rules = StyleRuleKeyMap::default();
         let mut merge_state = StyleRuleMergeState::default();
         let mut rules: Vec<CssRule<R>> = Vec::new();
@@ -509,10 +510,66 @@ impl<R> CssRuleList<R> {
 
             'arm: {
                 match rule {
-                    CssRule::Keyframes(_keyframez) => {
-                        // KeyframesRule minify (unused-symbol drop + same-name
-                        // merge + vendor-prefix downlevel + fallbacks) is
-                        // not implemented; fall through.
+                    CssRule::Keyframes(keyframez) => {
+                        if context.unused_symbols.count() > 0
+                            && context
+                                .unused_symbols
+                                .contains_adapted(keyframez.name.as_bytes(), &SliceAdapter)
+                        {
+                            break 'arm;
+                        }
+
+                        keyframez.minify(context);
+
+                        // Merge @keyframes rules with the same name.
+                        if let Some(existing_idx) = keyframe_rules.get(&keyframez.name).copied()
+                            && let Some(CssRule::Keyframes(existing)) = rules.get_mut(existing_idx)
+                        {
+                            // If the existing rule has the same vendor
+                            // prefixes, replace it with this rule.
+                            if existing.vendor_prefix == keyframez.vendor_prefix {
+                                *existing = core::mem::replace(
+                                    keyframez,
+                                    keyframes::KeyframesRule {
+                                        name: keyframez.name,
+                                        keyframes: ArrayList::new(),
+                                        vendor_prefix: keyframez.vendor_prefix,
+                                        loc: keyframez.loc,
+                                    },
+                                );
+                                break 'arm;
+                            }
+                            // Otherwise, if the keyframes are identical, merge
+                            // the prefixes.
+                            if existing.keyframes_eql(keyframez) {
+                                existing.vendor_prefix |= keyframez.vendor_prefix;
+                                existing.vendor_prefix = context.targets.prefixes(
+                                    existing.vendor_prefix,
+                                    css::prefixes::Feature::AtKeyframes,
+                                );
+                                break 'arm;
+                            }
+                        }
+
+                        keyframez.vendor_prefix = context
+                            .targets
+                            .prefixes(keyframez.vendor_prefix, css::prefixes::Feature::AtKeyframes);
+
+                        let name = keyframez.name;
+                        let fallbacks = keyframez.get_fallbacks::<R>(context.arena, context.targets);
+
+                        // Appending a non-style rule ends the current
+                        // style-rule merge run; mirror the fall-through path
+                        // at the bottom of the loop. The flush can shrink
+                        // `rules`, so record the keyframes index after it.
+                        flush_pending_style_merge(&mut rules, &mut merge_state, context);
+                        merge_state.last_compat = None;
+                        keyframe_rules.insert(name, rules.len());
+                        rules.push(core::mem::replace(rule, CssRule::Ignored));
+                        moved_rule = true;
+                        rules.extend(fallbacks);
+                        style_rules.clear();
+                        break 'arm;
                     }
                     CssRule::CustomMedia(_) => {
                         if context.custom_media.is_some() {
@@ -1256,4 +1313,21 @@ pub struct MinifyContext<'a, 'bump> {
     /// Running total of selectors that compiling nested rules for the targets
     /// will expand to, checked against [`MAX_SELECTOR_EXPANSION`].
     pub selector_expansion_total: u32,
+}
+
+/// Borrowed-`[u8]` lookup against `MinifyContext::unused_symbols`'s owned
+/// `Box<[u8]>` keys.
+pub(crate) struct SliceAdapter;
+impl bun_collections::array_hash_map::ArrayHashAdapter<[u8], Box<[u8]>> for SliceAdapter {
+    #[inline]
+    fn hash(&self, key: &[u8]) -> u32 {
+        use core::hash::{Hash, Hasher};
+        let mut h = bun_wyhash::Wyhash11::init(0);
+        key.hash(&mut h);
+        h.finish() as u32
+    }
+    #[inline]
+    fn eql(&self, a: &[u8], b: &Box<[u8]>, _: usize) -> bool {
+        a == &**b
+    }
 }

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -521,12 +521,9 @@ impl<R> CssRuleList<R> {
 
                         keyframez.minify(context);
 
-                        // Merge @keyframes rules with the same name.
                         if let Some(existing_idx) = keyframe_rules.get(&keyframez.name).copied()
                             && let Some(CssRule::Keyframes(existing)) = rules.get_mut(existing_idx)
                         {
-                            // If the existing rule has the same vendor
-                            // prefixes, replace it with this rule.
                             if existing.vendor_prefix == keyframez.vendor_prefix {
                                 *existing = core::mem::replace(
                                     keyframez,
@@ -539,8 +536,6 @@ impl<R> CssRuleList<R> {
                                 );
                                 break 'arm;
                             }
-                            // Otherwise, if the keyframes are identical, merge
-                            // the prefixes.
                             if existing.keyframes_eql(keyframez) {
                                 existing.vendor_prefix |= keyframez.vendor_prefix;
                                 existing.vendor_prefix = context.targets.prefixes(
@@ -559,10 +554,7 @@ impl<R> CssRuleList<R> {
                         let fallbacks =
                             keyframez.get_fallbacks::<R>(context.arena, context.targets);
 
-                        // Appending a non-style rule ends the current
-                        // style-rule merge run; mirror the fall-through path
-                        // at the bottom of the loop. The flush can shrink
-                        // `rules`, so record the keyframes index after it.
+                        // Flush may shrink `rules`; record the index after.
                         flush_pending_style_merge(&mut rules, &mut merge_state, context);
                         merge_state.last_compat = None;
                         keyframe_rules.insert(name, rules.len());
@@ -1316,8 +1308,6 @@ pub struct MinifyContext<'a, 'bump> {
     pub selector_expansion_total: u32,
 }
 
-/// Borrowed-`[u8]` lookup against `MinifyContext::unused_symbols`'s owned
-/// `Box<[u8]>` keys.
 pub(crate) struct SliceAdapter;
 impl bun_collections::array_hash_map::ArrayHashAdapter<[u8], Box<[u8]>> for SliceAdapter {
     #[inline]

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -556,7 +556,8 @@ impl<R> CssRuleList<R> {
                             .prefixes(keyframez.vendor_prefix, css::prefixes::Feature::AtKeyframes);
 
                         let name = keyframez.name;
-                        let fallbacks = keyframez.get_fallbacks::<R>(context.arena, context.targets);
+                        let fallbacks =
+                            keyframez.get_fallbacks::<R>(context.arena, context.targets);
 
                         // Appending a non-style rule ends the current
                         // style-rule merge run; mirror the fall-through path

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -539,23 +539,7 @@ fn is_selector_unused(
         match component {
             Component::Class(ident) | Component::Id(ident) => {
                 let actual_ident: &[u8] = ident.as_original_string(symbols);
-                // Look up the borrowed `&[u8]` against the map's owned
-                // `Box<[u8]>` keys without allocating.
-                struct SliceAdapter;
-                impl bun_collections::array_hash_map::ArrayHashAdapter<[u8], Box<[u8]>> for SliceAdapter {
-                    #[inline]
-                    fn hash(&self, key: &[u8]) -> u32 {
-                        use core::hash::{Hash, Hasher};
-                        let mut h = bun_wyhash::Wyhash11::init(0);
-                        key.hash(&mut h);
-                        h.finish() as u32
-                    }
-                    #[inline]
-                    fn eql(&self, a: &[u8], b: &Box<[u8]>, _: usize) -> bool {
-                        a == &**b
-                    }
-                }
-                if unused_symbols.contains_adapted(actual_ident, &SliceAdapter) {
+                if unused_symbols.contains_adapted(actual_ident, &css::css_rules::SliceAdapter) {
                     return true;
                 }
             }

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7859,6 +7859,101 @@ describe("css tests", () => {
       `,
     );
 
+    describe("@keyframes minify", () => {
+      // Per-keyframe declaration minify: the property handlers fold adjacent
+      // longhands into a shorthand inside a keyframe block just like they do
+      // in a style rule.
+      minify_test(
+        "@keyframes foo{0%{padding-top:1px;padding-right:1px;padding-bottom:1px;padding-left:1px}}",
+        "@keyframes foo{0%{padding:1px}}",
+      );
+
+      // Same-name merge: a later `@keyframes` with the same name and the same
+      // vendor prefix replaces the earlier one.
+      minify_test(
+        "@keyframes foo{0%{color:red}}@keyframes foo{0%{color:#00f}}",
+        "@keyframes foo{0%{color:#00f}}",
+      );
+
+      // Same-name merge across vendor prefixes: identical keyframe bodies
+      // under different prefixes collapse into a single rule that emits both
+      // prefixed forms.
+      minify_test(
+        "@-webkit-keyframes foo{0%{color:red}}@keyframes foo{0%{color:red}}",
+        "@-webkit-keyframes foo{0%{color:red}}@keyframes foo{0%{color:red}}",
+      );
+      // Same name but different prefixes and different bodies stay separate.
+      minify_test(
+        "@-webkit-keyframes foo{0%{color:red}}@keyframes foo{0%{color:#00f}}",
+        "@-webkit-keyframes foo{0%{color:red}}@keyframes foo{0%{color:#00f}}",
+      );
+
+      // Different names are untouched.
+      minify_test(
+        "@keyframes foo{0%{color:red}}@keyframes bar{0%{color:#00f}}",
+        "@keyframes foo{0%{color:red}}@keyframes bar{0%{color:#00f}}",
+      );
+
+      // Vendor-prefix downlevel: targeting a browser that only supports
+      // `@-webkit-keyframes` emits the prefixed rule alongside the unprefixed
+      // one.
+      prefix_test(
+        "@keyframes foo{from{opacity:0}to{opacity:1}}",
+        indoc`
+          @-webkit-keyframes foo {
+            from {
+              opacity: 0;
+            }
+
+            to {
+              opacity: 1;
+            }
+          }
+
+          @keyframes foo {
+            from {
+              opacity: 0;
+            }
+
+            to {
+              opacity: 1;
+            }
+          }
+        `,
+        { safari: 4 << 16 },
+      );
+
+      // Authored `@-webkit-keyframes` alone stays prefixed; no unprefixed
+      // variant is synthesized.
+      minify_test(
+        "@-webkit-keyframes foo{0%{opacity:0}}",
+        "@-webkit-keyframes foo{0%{opacity:0}}",
+      );
+
+      // Color fallback: a wide-gamut color in a `var()` fallback inside a
+      // keyframe emits an `@supports`-guarded copy and rewrites the original
+      // to the RGB fallback.
+      prefix_test(
+        "@keyframes foo{0%{--a:lab(40% 56.6 39)}}",
+        indoc`
+          @keyframes foo {
+            0% {
+              --a: #b32323;
+            }
+          }
+
+          @supports (color: lab(0% 0 0)) {
+            @keyframes foo {
+              0% {
+                --a: lab(40% 56.6 39);
+              }
+            }
+          }
+        `,
+        { chrome: 90 << 16 },
+      );
+    });
+
     // Unicode and escape sequence edge cases
     describe("unicode edge cases", async () => {
       const input = await Bun.file(join(__dirname, "unicode.css")).text();

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7924,6 +7924,27 @@ describe("css tests", () => {
       // variant is synthesized.
       minify_test("@-webkit-keyframes foo{0%{opacity:0}}", "@-webkit-keyframes foo{0%{opacity:0}}");
 
+      // Logical properties inside keyframe blocks are preserved verbatim when
+      // the targets would otherwise lower them, because keyframes have no
+      // `:dir()` wrapper to emit the ltr/rtl fallbacks into.
+      prefix_test(
+        "@keyframes foo{0%{padding-inline-start:10px}}",
+        indoc`
+          @-webkit-keyframes foo {
+            0% {
+              padding-inline-start: 10px;
+            }
+          }
+
+          @keyframes foo {
+            0% {
+              padding-inline-start: 10px;
+            }
+          }
+        `,
+        { safari: 4 << 16 },
+      );
+
       // Color fallback: a wide-gamut color in a `var()` fallback inside a
       // keyframe emits an `@supports`-guarded copy and rewrites the original
       // to the RGB fallback.

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7870,10 +7870,7 @@ describe("css tests", () => {
 
       // Same-name merge: a later `@keyframes` with the same name and the same
       // vendor prefix replaces the earlier one.
-      minify_test(
-        "@keyframes foo{0%{color:red}}@keyframes foo{0%{color:#00f}}",
-        "@keyframes foo{0%{color:#00f}}",
-      );
+      minify_test("@keyframes foo{0%{color:red}}@keyframes foo{0%{color:#00f}}", "@keyframes foo{0%{color:#00f}}");
 
       // Same-name merge across vendor prefixes: identical keyframe bodies
       // under different prefixes collapse into a single rule that emits both
@@ -7925,10 +7922,7 @@ describe("css tests", () => {
 
       // Authored `@-webkit-keyframes` alone stays prefixed; no unprefixed
       // variant is synthesized.
-      minify_test(
-        "@-webkit-keyframes foo{0%{opacity:0}}",
-        "@-webkit-keyframes foo{0%{opacity:0}}",
-      );
+      minify_test("@-webkit-keyframes foo{0%{opacity:0}}", "@-webkit-keyframes foo{0%{opacity:0}}");
 
       // Color fallback: a wide-gamut color in a `var()` fallback inside a
       // keyframe emits an `@supports`-guarded copy and rewrites the original


### PR DESCRIPTION
## What

Part of #14167 (ticks the `keyframes` box under the Minification pass checklist).

Implements the `@keyframes` minification pass in the CSS parser. The `CssRule::Keyframes` arm in `CssRuleList::minify` was a documented stub, so `DeclarationContext::Keyframes` was unreachable and keyframe bodies never ran through the property handlers. Surfaced by the dead-code sweep in #36184.

## Before

```css
/* input */
@keyframes foo { 0% { padding-top: 1px; padding-right: 1px; padding-bottom: 1px; padding-left: 1px } }
@keyframes foo { 0% { color: red } }
@keyframes foo { 0% { color: blue } }

/* minified output (main) */
@keyframes foo{0%{padding-top:1px;padding-right:1px;padding-bottom:1px;padding-left:1px}}
@keyframes foo{0%{color:red}}
@keyframes foo{0%{color:#00f}}
```

Longhands are not folded, duplicate `@keyframes` with the same name are not merged, and old browser targets do not emit `@-webkit-keyframes`.

## After

Ports the lightningcss behavior:

- **Per-keyframe declaration minify** (`KeyframesRule::minify`): each keyframe's declarations now run through the property handlers under `DeclarationContext::Keyframes`, so longhands fold into shorthands and per-declaration prefixing applies inside keyframe blocks.
- **Same-name merge**: a later `@keyframes` with the same name and vendor prefix replaces the earlier one; with a different prefix but identical keyframe bodies, the prefixes are merged into one rule.
- **Vendor-prefix downlevel**: `Targets::prefixes(Feature::AtKeyframes)` now adds `@-webkit-keyframes` / `@-moz-keyframes` / `@-o-keyframes` alongside the unprefixed rule when the configured targets require it.
- **`unused_symbols` drop**: an `@keyframes` rule whose name is listed as unused is removed (the bundler does not currently populate `unused_symbols`, so this is a no-op today but completes the port).
- **Color fallbacks** (`KeyframesRule::get_fallbacks`): wide-gamut colors in custom / unparsed values emit an `@supports`-guarded copy of the rule and rewrite the original to the lowest common fallback.

## How did you verify your code works?

New cases in `test/js/bun/css/css.test.ts` under `@keyframes minify`:

| case | `USE_SYSTEM_BUN=1` | `bun bd` |
|---|---|---|
| padding longhands fold to shorthand | fail | pass |
| same-name merge (later wins) | fail | pass |
| vendor-prefix downlevel for safari 4 | fail | pass |
| wide-gamut color `@supports` fallback | fail | pass |
| negative cases (different prefix+body, different name, authored prefix only) | pass | pass |

Full `test/js/bun/css/css.test.ts` (1148 tests), `test/bundler/esbuild/css.test.ts` (56 tests), and `test/bundler/css/css-modules.test.ts` (6 tests) pass with the debug build.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/css.test.ts
bun test v1.4.0 (e39543fce)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.57ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.16ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.02ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: w
... (truncated)

release without fix: 67 skipped
bun test v1.4.0-canary.1 (4e054e040)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.13ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.05ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.78ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/css.test.ts
bun test v1.4.0 (e39543fce)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.50ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.16ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.04ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: w
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 760ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/1] reconfigure
[1/13] install /workspace/bun
bun install v1.4.0-canary.1 (4e054e040)

Checked 124 installs across 170 packages (no changes) [8.00ms]
[2/13] esbuild runtime.out.js

  build/release/codegen/runtime.out.js  5.3kb

⚡ Done in 11ms
[3/13] esbuild fallback-decoder.js

  build/release/codegen/fallback-decoder.js  8.8kb

⚡ Done in 19ms
[4/13] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       42.9kb
  ../../build/release/codegen/bun-error/bun-error.css  12.8kb

⚡ Done in 27ms
[5/13] gen cpp.rs (cppbind)
[6/13] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[6/13] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/context.rs            |   8 ++-
 src/css/rules/keyframes.rs    | 161 +++++++++++++++++++++++++++++++++++++++++-
 src/css/rules/mod.rs          |  71 +++++++++++++++++--
 src/css/selectors/selector.rs |  18 +----
 test/js/bun/css/css.test.ts   | 110 +++++++++++++++++++++++++++++
 5 files changed, 343 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/css/context.rs                 3      2      0
src/css/rules/keyframes.rs         3     11      0
src/css/rules/mod.rs               7      9      0
src/css/selectors/selector.rs      3      1      0
test/js/bun/css/css.test.ts        4      2      0
```

</details>

<!-- robobun:evidence:end -->