### PR TITLE
console: publish to diagnostics_channel console.* built-in channels

### DIFF
--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -145,6 +145,13 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
   const { inspect, formatWithOptions } = require("node:util");
   const { isBuffer } = require("node:buffer");
   const { isMapIterator, isSetIterator } = require("node:util/types");
+  const { channel } = require("node:diagnostics_channel");
+
+  const onLog = channel("console.log");
+  const onWarn = channel("console.warn");
+  const onError = channel("console.error");
+  const onInfo = channel("console.info");
+  const onDebug = channel("console.debug");
 
   const { validateObject, validateInteger, validateArray, validateOneOf } = require("internal/validators");
   const kMaxGroupIndentation = 1000;
@@ -537,10 +544,37 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
 
   const consoleMethods: any = {
     log(...args) {
+      if (onLog.hasSubscribers) {
+        onLog.publish(args);
+      }
+      this[kWriteToConsole](kUseStdout, this[kFormatForStdout](args));
+    },
+
+    info(...args) {
+      if (onInfo.hasSubscribers) {
+        onInfo.publish(args);
+      }
+      this[kWriteToConsole](kUseStdout, this[kFormatForStdout](args));
+    },
+
+    debug(...args) {
+      if (onDebug.hasSubscribers) {
+        onDebug.publish(args);
+      }
       this[kWriteToConsole](kUseStdout, this[kFormatForStdout](args));
     },
 
     warn(...args) {
+      if (onWarn.hasSubscribers) {
+        onWarn.publish(args);
+      }
+      this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args));
+    },
+
+    error(...args) {
+      if (onError.hasSubscribers) {
+        onError.publish(args);
+      }
       this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args));
     },
 
@@ -812,10 +846,7 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
 
   for (const method of Reflect.ownKeys(consoleMethods)) Console.prototype[method] = consoleMethods[method];
 
-  Console.prototype.debug = Console.prototype.log;
-  Console.prototype.info = Console.prototype.log;
   Console.prototype.dirxml = Console.prototype.log;
-  Console.prototype.error = Console.prototype.warn;
   Console.prototype.groupCollapsed = Console.prototype.group;
 
   return Console;

--- a/src/js/node/diagnostics_channel.ts
+++ b/src/js/node/diagnostics_channel.ts
@@ -62,6 +62,9 @@ function markActive(channel) {
   ObjectSetPrototypeOf.$call(null, channel, ActiveChannel.prototype);
   channel._subscribers = [];
   channel._stores = new SafeMap();
+
+  const consoleMethod = typeof channel.name === "string" ? consoleChannelMethods[channel.name] : undefined;
+  if (consoleMethod !== undefined) wrapConsoleMethodForChannel(channel, consoleMethod);
 }
 
 function maybeMarkInactive(channel) {
@@ -215,7 +218,8 @@ class Channel {
 const channels = new WeakRefMap();
 
 // Bun's global console methods are native; wrap one to publish the first time its
-// channel is materialized. The closure pins the Channel so it is never re-wrapped.
+// channel becomes active. The closure pins the Channel, so later channel(name)
+// lookups return the same instance and we never re-wrap.
 const consoleChannelMethods = {
   __proto__: null,
   "console.log": "log",
@@ -224,17 +228,21 @@ const consoleChannelMethods = {
   "console.warn": "warn",
   "console.error": "error",
 };
+const wrappedConsoleMethods = { __proto__: null };
 
 function wrapConsoleMethodForChannel(ch, method) {
+  if (wrappedConsoleMethods[method]) return;
   const console = globalThis.console;
   const orig = console[method];
   if (typeof orig !== "function") return;
-  const wrapped = function (...args) {
-    if (ch.hasSubscribers) ch.publish(args);
-    return orig.$apply(this, args);
-  };
-  Object.defineProperty(wrapped, "name", { value: method, configurable: true });
-  console[method] = wrapped;
+  wrappedConsoleMethods[method] = true;
+  // Shorthand method: non-constructible and .name === method, like the native fn.
+  console[method] = {
+    [method](...args) {
+      if (ch.hasSubscribers) ch.publish(args);
+      return orig.$apply(this, args);
+    },
+  }[method];
 }
 
 function channel(name) {
@@ -245,12 +253,7 @@ function channel(name) {
     throw $ERR_INVALID_ARG_TYPE("channel", "string or symbol", name);
   }
 
-  const ch = new Channel(name);
-  const consoleMethod = typeof name === "string" ? consoleChannelMethods[name] : undefined;
-  if (consoleMethod !== undefined) {
-    wrapConsoleMethodForChannel(ch, consoleMethod);
-  }
-  return ch;
+  return new Channel(name);
 }
 
 function subscribe(name, subscription) {

--- a/src/js/node/diagnostics_channel.ts
+++ b/src/js/node/diagnostics_channel.ts
@@ -233,19 +233,20 @@ const nativeConsole = globalThis.console;
 
 function wrapConsoleMethodForChannel(ch, method) {
   if (wrappedConsoleMethods[method]) return;
-  // A replaced global console either already publishes (new console.Console, via
-  // Console.prototype.<method>) or is user-owned; wrapping it would double-publish.
-  if (globalThis.console !== nativeConsole) return;
   const orig = nativeConsole[method];
   if (typeof orig !== "function") return;
-  wrappedConsoleMethods[method] = true;
-  // Shorthand method: non-constructible and .name === method, like the native fn.
-  nativeConsole[method] = {
-    [method](...args) {
-      if (ch.hasSubscribers) ch.publish(args);
-      return orig.$apply(this, args);
-    },
-  }[method];
+  try {
+    // Shorthand method: non-constructible and .name === method, like the native fn.
+    nativeConsole[method] = {
+      [method](...args) {
+        if (ch.hasSubscribers) ch.publish(args);
+        return orig.$apply(this, args);
+      },
+    }[method];
+    wrappedConsoleMethods[method] = true;
+  } catch {
+    // Frozen / non-writable console: leave subscribe() infallible.
+  }
 }
 
 function channel(name) {

--- a/src/js/node/diagnostics_channel.ts
+++ b/src/js/node/diagnostics_channel.ts
@@ -229,15 +229,18 @@ const consoleChannelMethods = {
   "console.error": "error",
 };
 const wrappedConsoleMethods = { __proto__: null };
+const nativeConsole = globalThis.console;
 
 function wrapConsoleMethodForChannel(ch, method) {
   if (wrappedConsoleMethods[method]) return;
-  const console = globalThis.console;
-  const orig = console[method];
+  // A replaced global console either already publishes (new console.Console, via
+  // Console.prototype.<method>) or is user-owned; wrapping it would double-publish.
+  if (globalThis.console !== nativeConsole) return;
+  const orig = nativeConsole[method];
   if (typeof orig !== "function") return;
   wrappedConsoleMethods[method] = true;
   // Shorthand method: non-constructible and .name === method, like the native fn.
-  console[method] = {
+  nativeConsole[method] = {
     [method](...args) {
       if (ch.hasSubscribers) ch.publish(args);
       return orig.$apply(this, args);

--- a/src/js/node/diagnostics_channel.ts
+++ b/src/js/node/diagnostics_channel.ts
@@ -214,6 +214,29 @@ class Channel {
 
 const channels = new WeakRefMap();
 
+// Bun's global console methods are native; wrap one to publish the first time its
+// channel is materialized. The closure pins the Channel so it is never re-wrapped.
+const consoleChannelMethods = {
+  __proto__: null,
+  "console.log": "log",
+  "console.info": "info",
+  "console.debug": "debug",
+  "console.warn": "warn",
+  "console.error": "error",
+};
+
+function wrapConsoleMethodForChannel(ch, method) {
+  const console = globalThis.console;
+  const orig = console[method];
+  if (typeof orig !== "function") return;
+  const wrapped = function (...args) {
+    if (ch.hasSubscribers) ch.publish(args);
+    return orig.$apply(this, args);
+  };
+  Object.defineProperty(wrapped, "name", { value: method, configurable: true });
+  console[method] = wrapped;
+}
+
 function channel(name) {
   const channel = channels.get(name);
   if (channel) return channel;
@@ -222,7 +245,12 @@ function channel(name) {
     throw $ERR_INVALID_ARG_TYPE("channel", "string or symbol", name);
   }
 
-  return new Channel(name);
+  const ch = new Channel(name);
+  const consoleMethod = typeof name === "string" ? consoleChannelMethods[name] : undefined;
+  if (consoleMethod !== undefined) {
+    wrapConsoleMethodForChannel(ch, consoleMethod);
+  }
+  return ch;
 }
 
 function subscribe(name, subscription) {

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -397,14 +397,20 @@ describe.concurrent("built-in console.* channels", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("no publish when diagnostics_channel was never required", async () => {
-    // Publishing is gated on node:diagnostics_channel having been loaded; when
-    // it is required only after the console calls, those earlier calls must not
-    // have published (and must not have thrown).
+  test("global console stays native until a console channel has a subscriber", async () => {
+    // Wrapping happens at subscribe time, so neither requiring the module nor
+    // materializing the channel (nor reading console.Console, which does both
+    // internally) may replace the native global console methods.
     const script = `
+      const origLog = console.log;
       console.log("before-1");
       console.error("before-2");
       const dc = require("node:diagnostics_channel");
+      if (console.log !== origLog) throw new Error("mutated by require");
+      dc.channel("console.log");
+      if (console.log !== origLog) throw new Error("mutated by channel()");
+      void console.Console;
+      if (console.log !== origLog) throw new Error("mutated by console.Console");
       let count = 0;
       dc.subscribe("console.log", () => count++);
       console.log("after");

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -1,5 +1,6 @@
 import { gc } from "bun";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { channel, Channel, hasSubscribers, subscribe, unsubscribe } from "node:diagnostics_channel";
 
@@ -343,6 +344,146 @@ describe("TracingChannel", () => {
   // Port tests from:
   // https://github.com/search?q=repo%3Anodejs%2Fnode+test-diagnostics-channel+AND+%2Ftracing%2F&type=code
   test.todo("TODO");
+});
+
+// Node.js documents built-in console.{log,info,debug,warn,error} channels that
+// receive the argument array on every corresponding console.* call. These run
+// in a subprocess so the test runner's own console output is not polluted.
+describe.concurrent("built-in console.* channels", () => {
+  test("global console methods publish their arguments", async () => {
+    const script = `
+      const dc = require("node:diagnostics_channel");
+      const NAMES = ["console.log", "console.info", "console.debug", "console.warn", "console.error"];
+      const received = {};
+      const held = [];
+      for (const n of NAMES) {
+        received[n] = [];
+        const ch = dc.channel(n);
+        const f = (args, name) => received[name].push(args);
+        ch.subscribe(f);
+        held.push([ch, f]);
+      }
+      const obj = { x: 2 };
+      console.log("a", 1);
+      console.info("i");
+      console.debug("d", obj);
+      console.warn("w");
+      console.error("e", 3, 4);
+      console.log();
+      void held.length;
+      if (received["console.debug"][0][1] !== obj) throw new Error("object identity not preserved");
+      process.stdout.write("RESULT " + JSON.stringify(received) + "\\n");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const line = stdout.split("\n").find(l => l.startsWith("RESULT "));
+    expect(line).toBeDefined();
+    const received = JSON.parse(line!.slice("RESULT ".length));
+
+    expect(received).toEqual({
+      "console.log": [["a", 1], []],
+      "console.info": [["i"]],
+      "console.debug": [["d", { x: 2 }]],
+      "console.warn": [["w"]],
+      "console.error": [["e", 3, 4]],
+    });
+    expect(stderr).toContain("w\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("no publish when diagnostics_channel was never required", async () => {
+    // Publishing is gated on node:diagnostics_channel having been loaded; when
+    // it is required only after the console calls, those earlier calls must not
+    // have published (and must not have thrown).
+    const script = `
+      console.log("before-1");
+      console.error("before-2");
+      const dc = require("node:diagnostics_channel");
+      let count = 0;
+      dc.subscribe("console.log", () => count++);
+      console.log("after");
+      process.stdout.write("RESULT " + count + "\\n");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("before-1\n");
+    expect(stdout).toContain("RESULT 1\n");
+    expect(stderr).toContain("before-2\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("Console constructor instances publish to the same channels", async () => {
+    const script = `
+      const dc = require("node:diagnostics_channel");
+      const { Writable } = require("node:stream");
+      const received = {};
+      for (const n of ["console.log", "console.info", "console.debug", "console.warn", "console.error"]) {
+        received[n] = 0;
+        dc.subscribe(n, () => received[n]++);
+      }
+      const sink = new Writable({ write(chunk, enc, cb) { cb(); } });
+      const c = new console.Console(sink, sink);
+      c.log("a");
+      c.info("b");
+      c.debug("c");
+      c.warn("d");
+      c.error("e");
+      process.stdout.write("RESULT " + JSON.stringify(received) + "\\n");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const line = stdout.split("\n").find(l => l.startsWith("RESULT "));
+    expect(line).toBeDefined();
+    expect(JSON.parse(line!.slice("RESULT ".length))).toEqual({
+      "console.log": 1,
+      "console.info": 1,
+      "console.debug": 1,
+      "console.warn": 1,
+      "console.error": 1,
+    });
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("materializing the console.log channel does not affect other console methods", async () => {
+    const script = `
+      const dc = require("node:diagnostics_channel");
+      let logCount = 0;
+      dc.subscribe("console.log", () => logCount++);
+      console.dir({ a: 1 });
+      console.trace("t");
+      console.assert(false, "ok");
+      process.stdout.write("RESULT " + logCount + "\\n");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("RESULT 0\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 const mocks = new Map();

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -469,6 +469,28 @@ describe.concurrent("built-in console.* channels", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("replacing globalThis.console with a Console instance before subscribing publishes once", async () => {
+    const script = `
+      globalThis.console = new console.Console(process.stdout, process.stderr);
+      const dc = require("node:diagnostics_channel");
+      let n = 0;
+      dc.subscribe("console.log", () => n++);
+      console.log("x");
+      process.stdout.write("RESULT " + n + "\\n");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("RESULT 1\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   test("materializing the console.log channel does not affect other console methods", async () => {
     const script = `
       const dc = require("node:diagnostics_channel");

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -491,6 +491,30 @@ describe.concurrent("built-in console.* channels", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("subscribe on a console channel does not throw when console is frozen", async () => {
+    const script = `
+      Object.freeze(console);
+      const dc = require("node:diagnostics_channel");
+      let n = 0;
+      dc.subscribe("console.log", () => n++);
+      dc.subscribe("console.log", () => {});
+      console.log("x");
+      if (!dc.hasSubscribers("console.log")) throw new Error("not subscribed");
+      process.stdout.write("RESULT " + n + "\\n");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain("RESULT 0\n");
+    expect(exitCode).toBe(0);
+  });
+
   test("materializing the console.log channel does not affect other console methods", async () => {
     const script = `
       const dc = require("node:diagnostics_channel");


### PR DESCRIPTION
## What this fixes

Node.js publishes the argument array to the `console.log`, `console.info`, `console.debug`, `console.warn`, and `console.error` diagnostics_channel channels on every corresponding `console.*` call (documented under *diagnostics_channel > Built-in Channels > Console*). This is the monkeypatch-free way to intercept console output for log capture / log shipping.

Bun's global `console.log`/`info`/`debug`/`warn`/`error` are native JSC host functions, so subscribers to these channels received nothing.

## Repro

```js
const dc = require("node:diagnostics_channel");
const NAMES = ["console.log","console.info","console.debug","console.warn","console.error"];
const counts = {}, held = [];
for (const n of NAMES) { counts[n] = 0; const ch = dc.channel(n); const f = () => counts[n]++; ch.subscribe(f); held.push([ch, f]); }
console.log("a", 1); console.info("i"); console.debug("d"); console.warn("w"); console.error("e");
process.stdout.write(JSON.stringify(counts) + "\n");
// node v26.3.0: {"console.log":1,"console.info":1,"console.debug":1,"console.warn":1,"console.error":1}
// bun before:  {"console.log":0,"console.info":0,"console.debug":0,"console.warn":0,"console.error":0}
```

## Fix

- `node:diagnostics_channel`: when a `console.*` channel first becomes active (`markActive`, i.e. first `subscribe`/`bindStore`), wrap `globalThis.console[m]` once with a computed shorthand method that publishes `args` when `ch.hasSubscribers` and delegates to the original. The closure holds the `Channel` strongly, so the `WeakRefMap` keeps returning the same instance and the method is never re-wrapped; a `wrappedConsoleMethods` guard keeps inactive→active transitions idempotent. Console stays fully native until someone actually subscribes; once wrapped, the per-call overhead is one `hasSubscribers` read. The shorthand-method wrapper keeps `.name === method` and is not constructible, matching the native host function.
- `console.Console` constructor instances go through the JS path in `src/js/builtins/ConsoleObject.ts`; `log`/`info`/`debug`/`warn`/`error` are now separate methods that each publish to their own channel before writing, mirroring Node's `lib/internal/console/constructor.js`. These call `channel()` (not `subscribe`), so reading `console.Console` does not mutate the global console.

Known caveat: a `console.log` reference captured before the first subscribe bypasses the wrapper (the lazy approach trades this for keeping console native in the common case). The global `console.trace`/`assert`/`count`/`dirxml`/`group`/`timeLog` are native and do not delegate through the wrapped `console.error`/`warn`/`log`, so unlike Node they do not publish; the five documented direct channels are the scope here.

## Tests

Four new cases in `test/js/node/diagnostics_channel/diagnostics_channel.test.ts` (subprocess-based so the runner's own console output isn't affected): global methods publish their raw args array with object identity preserved; `Console` constructor instances publish; the global console stays native across `require`/`channel()`/reading `console.Console` and only changes after `subscribe`; materializing `console.log` does not affect other console methods. They fail on main and pass on this build. `test-console-methods.js`, `inspector-profiler.test.ts`, all 113 existing `console` tests and all 35 vendored `test-diagnostics-channel-*` node-parallel tests pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/diagnostics_channel/diagnostics_channel.test.ts
bun test v1.4.0 (c28bf9b6b)

test/js/node/diagnostics_channel/diagnostics_channel.test.ts:
(pass) Channel > can have subscribers [23.33ms]
(pass) Channel > can have symbol as name [15.94ms]
(pass) Channel > does not throw when unsubscribed [10.45ms]
(pass) Channel > can publish and subscribe [15.97ms]
(pass) Channel > can publish and subscribe using object [11.37ms]
(todo) Channel > can handle subscriber errors
(todo) Channel > can use bind store
(pass) Channel > references are not leaked [304.50ms]
(todo) TracingChannel > TODO
381 |       stderr: "pipe",
382 |     });
383 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
384 | 
385 |     const line = stdout.split("\n").find(l => l.startsWith("RESULT "));
386 |     expect(line).toBeDefined();
                       ^
error: expect(received).toBeDefined()

Received: undefined

      at <anonymous> (/workspace/bun/test/js/node/diagnostics_channel/diagnostics_chann
... (truncated)

release without fix: 4 failed, 3 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/diagnostics_channel/diagnostics_channel.test.ts:
(pass) Channel > can have subscribers [0.33ms]
(pass) Channel > can have symbol as name [0.31ms]
(pass) Channel > does not throw when unsubscribed [0.18ms]
(pass) Channel > can publish and subscribe [0.23ms]
(pass) Channel > can publish and subscribe using object [0.15ms]
(todo) Channel > can handle subscriber errors
(todo) Channel > can use bind store
(pass) Channel > references are not leaked [4.50ms]
(todo) TracingChannel > TODO
381 |       stderr: "pipe",
382 |     });
383 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
384 | 
385 |     const line = stdout.split("\n").find(l => l.startsWith("RESULT "));
386 |     expect(line).toBeDefined();
                       ^
error: expect(received).toBeDefined()

Received: undefined

      at <anonymous> (/workspace/bun/test/js/node/diagnostics_channel/diagnostics_channel.test.ts:386:18)
(fail) built-in console.* channels > global console methods publish their arguments [19.59ms]
(pass) built-in console.* channels > materializing the console.log channel does
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/diagnostics_channel/diagnostics_channel.test.ts
bun test v1.4.0 (c28bf9b6b)

test/js/node/diagnostics_channel/diagnostics_channel.test.ts:
(pass) Channel > can have subscribers [25.10ms]
(pass) Channel > can have symbol as name [16.87ms]
(pass) Channel > does not throw when unsubscribed [10.79ms]
(pass) Channel > can publish and subscribe [15.47ms]
(pass) Channel > can publish and subscribe using object [11.84ms]
(todo) Channel > can handle subscriber errors
(todo) Channel > can use bind store
(pass) Channel > references are not leaked [341.09ms]
(todo) TracingChannel > TODO
(pass) built-in console.* channels > global console methods publish their arguments [1269.19ms]
(pass) built-in console.* channels > global console stays native until a console channel has a subscriber [1621.64ms]
(pass) built-in console.* channels > subscribe on a console channel does not throw when console is frozen [1579.55ms]
(pass) built-in console.* channels > Console constructor instances publish to the same channels [1711.89ms]
(pass) built-in 
... (truncated)

release with fix: 3 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 953ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/132] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/132] gen JS modules (bundle-modules)
Preprocess modules (10085ms)
Bundle modules (51ms)
Postprocesss modules (169ms)
Bundle Functions (753ms)
Generate Code (33ms)

[11.11s] Bundled "src/js" for production
  2572 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/132] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m gimli v0.34.0
[1m[92m   Compiling[0m object v0.39.1
[1m[92m   Compiling[0m addr2line v0.27.0
[1m[92m   Compiling[0m std v0.0.0 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std)
[1m[92m   Compiling[0m proc_macro v0.0.0 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/r
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins/ConsoleObject.ts                   |  37 +++-
 src/js/node/diagnostics_channel.ts                 |  35 ++++
 .../diagnostics_channel.test.ts                    | 193 +++++++++++++++++++++
 3 files changed, 262 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 6 passed · 1 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/builtins/ConsoleObject.ts                              1      3      0
src/js/node/diagnostics_channel.ts                            5      9      0
…js/node/diagnostics_channel/diagnostics_channel.test.ts      1      8      0
```

</details>

<!-- robobun:evidence:end -->