### PR TITLE
js_parser: validate function statement names for await/yield

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4620,21 +4620,48 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .original_name
                 .slice();
 
-            if func.flags.contains(Flags::Function::IsAsync) && original_name == b"await" {
-                self.log().add_range_error(
-                    Some(self.source),
-                    js_lexer::range_of_identifier(self.source, name.loc),
-                    b"An async function cannot be named \"await\"",
-                );
-            } else if kind == FunctionKind::Expr
-                && func.flags.contains(Flags::Function::IsGenerator)
-                && original_name == b"yield"
-            {
-                self.log().add_range_error(
-                    Some(self.source),
-                    js_lexer::range_of_identifier(self.source, name.loc),
-                    b"An generator function expression cannot be named \"yield\"",
-                );
+            if original_name == b"await" {
+                // The name of a function expression binds inside the function itself, so
+                // an async function expression named "await" is always an early error.
+                // The name of a function statement binds in the enclosing scope, so it
+                // is only an error when "await" is reserved there (inside an async
+                // function or at the top level of a module). Node/V8 accept
+                // `async function await() {}` at statement position in scripts.
+                let reject = match kind {
+                    FunctionKind::Expr => func.flags.contains(Flags::Function::IsAsync),
+                    FunctionKind::Stmt => {
+                        self.fn_or_arrow_data_parse.allow_await != crate::AwaitOrYield::AllowIdent
+                    }
+                };
+                if reject {
+                    self.log().add_range_error(
+                        Some(self.source),
+                        js_lexer::range_of_identifier(self.source, name.loc),
+                        if kind == FunctionKind::Expr {
+                            b"An async function cannot be named \"await\""
+                        } else {
+                            b"Cannot use \"await\" as an identifier here"
+                        },
+                    );
+                }
+            } else if original_name == b"yield" {
+                let reject = match kind {
+                    FunctionKind::Expr => func.flags.contains(Flags::Function::IsGenerator),
+                    FunctionKind::Stmt => {
+                        self.fn_or_arrow_data_parse.allow_yield != crate::AwaitOrYield::AllowIdent
+                    }
+                };
+                if reject {
+                    self.log().add_range_error(
+                        Some(self.source),
+                        js_lexer::range_of_identifier(self.source, name.loc),
+                        if kind == FunctionKind::Expr {
+                            b"A generator function expression cannot be named \"yield\""
+                        } else {
+                            b"Cannot use \"yield\" as an identifier here"
+                        },
+                    );
+                }
             }
         }
     }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4620,9 +4620,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .original_name
                 .slice();
 
+            // Expr names bind inside the function; Stmt names bind in the enclosing scope.
             if original_name == b"await" {
-                // Expr: name binds inside the function (reserved when the function is async).
-                // Stmt: name binds in the enclosing scope (reserved when that scope is [+Await]).
                 let reject = match kind {
                     FunctionKind::Expr => func.flags.contains(Flags::Function::IsAsync),
                     FunctionKind::Stmt => {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4621,12 +4621,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .slice();
 
             if original_name == b"await" {
-                // The name of a function expression binds inside the function itself, so
-                // an async function expression named "await" is always an early error.
-                // The name of a function statement binds in the enclosing scope, so it
-                // is only an error when "await" is reserved there (inside an async
-                // function or at the top level of a module). Node/V8 accept
-                // `async function await() {}` at statement position in scripts.
+                // Expr: name binds inside the function (reserved when the function is async).
+                // Stmt: name binds in the enclosing scope (reserved when that scope is [+Await]).
                 let reject = match kind {
                     FunctionKind::Expr => func.flags.contains(Flags::Function::IsAsync),
                     FunctionKind::Stmt => {

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -102,6 +102,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )?;
         p.fn_or_arrow_data_parse.has_argument_decorators = false;
 
+        p.validate_function_name(&func, FunctionKind::Stmt);
+
         if Self::IS_TYPESCRIPT_ENABLED {
             // Don't output anything if it's just a forward declaration of a function
             if opts.is_typescript_declare
@@ -144,8 +146,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             n.ref_ = p.declare_symbol(kind, n.loc, name_text)?;
         }
         func.name = name;
-
-        p.validate_function_name(&func, FunctionKind::Stmt);
 
         // flags is freshly built so unset → only insert when true
         if has_if_scope {

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -145,6 +145,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
         func.name = name;
 
+        p.validate_function_name(&func, FunctionKind::Stmt);
+
         // flags is freshly built so unset → only insert when true
         if has_if_scope {
             func.flags.insert(Flags::Function::HasIfScope);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2663,6 +2663,8 @@ console.log(<div {...obj} key="after" />);`),
         'Cannot use "await" as an identifier here',
       );
       expectParseError("async function outer() { function await() {} }", 'Cannot use "await" as an identifier here');
+      // At the top level of a module (top-level await is enabled here), "await" is reserved.
+      expectParseError("function await() {}", 'Cannot use "await" as an identifier here');
       // Inside a generator, "yield" cannot name a nested function declaration.
       expectParseError("function* outer() { function* yield() {} }", 'Cannot use "yield" as an identifier here');
       expectParseError("function* outer() { function yield() {} }", 'Cannot use "yield" as an identifier here');

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2642,6 +2642,47 @@ console.log(<div {...obj} key="after" />);`),
       // );
     });
 
+    it("function declaration names: await/yield", () => {
+      // A function statement's name binds in the enclosing scope, so "await" is
+      // only reserved when the enclosing scope is async (or the module top level).
+      // Node/V8 accept `async function await(){}` at statement position in scripts.
+      expectPrinted_(
+        "function outer() { async function await() {} }",
+        "function outer() {\n  async function await() {}\n}",
+      );
+      expectPrinted_("function outer() { function await() {} }", "function outer() {\n  function await() {}\n}");
+      expectPrinted_(
+        "async function outer() { (function() { function await() {} })() }",
+        "async function outer() {\n  (function() {\n    function await() {}\n  })();\n}",
+      );
+      expectPrinted_(
+        "function outer() { function* yield() {} }",
+        "function outer() {\n  function* yield() {}\n}",
+      );
+
+      // Inside an async function, "await" cannot name a nested function declaration.
+      expectParseError(
+        "async function outer() { async function await() {} }",
+        'Cannot use "await" as an identifier here',
+      );
+      expectParseError(
+        "async function outer() { function await() {} }",
+        'Cannot use "await" as an identifier here',
+      );
+      // Inside a generator, "yield" cannot name a nested function declaration.
+      expectParseError(
+        "function* outer() { function* yield() {} }",
+        'Cannot use "yield" as an identifier here',
+      );
+      expectParseError("function* outer() { function yield() {} }", 'Cannot use "yield" as an identifier here');
+
+      // Function expression names bind inside the function itself.
+      expectParseError("(async function await() {})", 'An async function cannot be named "await"');
+      expectParseError("(function* yield() {})", 'A generator function expression cannot be named "yield"');
+      expectPrinted_("x = function await() {}", "x = function await() {}");
+      expectPrinted_("x = async function yield() {}", "x = async function yield() {}");
+    });
+
     it("import assert", () => {
       expectPrinted_(`import json from "./foo.json" assert { type: "json" };`, `import json from "./foo.json"`);
       expectPrinted_(`import json from "./foo.json";`, `import json from "./foo.json"`);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2674,6 +2674,12 @@ console.log(<div {...obj} key="after" />);`),
       expectParseError("(function* yield() {})", 'A generator function expression cannot be named "yield"');
       expectPrinted_("x = function await() {}", "x = function await() {}");
       expectPrinted_("x = async function yield() {}", "x = async function yield() {}");
+
+      // TypeScript overload signatures take the forward-declaration early return but are still checked.
+      ts.expectParseError(
+        "async function outer() { function await(): void; function await(): void {} }",
+        'Cannot use "await" as an identifier here',
+      );
     });
 
     it("import assert", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2655,25 +2655,16 @@ console.log(<div {...obj} key="after" />);`),
         "async function outer() { (function() { function await() {} })() }",
         "async function outer() {\n  (function() {\n    function await() {}\n  })();\n}",
       );
-      expectPrinted_(
-        "function outer() { function* yield() {} }",
-        "function outer() {\n  function* yield() {}\n}",
-      );
+      expectPrinted_("function outer() { function* yield() {} }", "function outer() {\n  function* yield() {}\n}");
 
       // Inside an async function, "await" cannot name a nested function declaration.
       expectParseError(
         "async function outer() { async function await() {} }",
         'Cannot use "await" as an identifier here',
       );
-      expectParseError(
-        "async function outer() { function await() {} }",
-        'Cannot use "await" as an identifier here',
-      );
+      expectParseError("async function outer() { function await() {} }", 'Cannot use "await" as an identifier here');
       // Inside a generator, "yield" cannot name a nested function declaration.
-      expectParseError(
-        "function* outer() { function* yield() {} }",
-        'Cannot use "yield" as an identifier here',
-      );
+      expectParseError("function* outer() { function* yield() {} }", 'Cannot use "yield" as an identifier here');
       expectParseError("function* outer() { function yield() {} }", 'Cannot use "yield" as an identifier here');
 
       // Function expression names bind inside the function itself.


### PR DESCRIPTION
## Summary

`parse_fn_stmt` never called `validate_function_name`; only the function *expression* path did. The `FunctionKind::Stmt` variant existed but was never passed (flagged by the dead-code sweep in #36184). This meant that a function declaration named `await` inside an async function, or named `yield` inside a generator, parsed without an error.

## Repro

```js
async function outer() {
  function await() {}   // previously accepted, now: Cannot use "await" as an identifier here
}
function* outer2() {
  function yield() {}   // previously accepted, now: Cannot use "yield" as an identifier here
}
```

Node/V8 reject both as `SyntaxError: Unexpected reserved word`.

## Fix

`parse_fn_stmt` now calls `validate_function_name(&func, FunctionKind::Stmt)` after the name symbol is declared. `validate_function_name` distinguishes the two kinds:

- **Expression**: the name binds inside the function itself, so an async function expression named `await` (or a generator expression named `yield`) is always an early error. Unchanged.
- **Statement**: the name binds in the *enclosing* scope, so it is only an error when `await`/`yield` is reserved there (`fn_or_arrow_data_parse.allow_await != AllowIdent` / `allow_yield != AllowIdent`). This matches Node/V8, which accept `async function await(){}` at statement position in scripts but reject it inside an async function or at module top level. esbuild rejects it unconditionally; we deliberately follow Node instead.

Also fixes the existing "An generator function expression" typo.

## Verification

```
bun bd test test/bundler/transpiler/transpiler.test.js -t "function declaration names"
```

Full `transpiler.test.js` (184 tests) and `bundler/esbuild/default.test.ts` (151 tests) pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (0a1bfd1ee)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [9.34ms]
(pass) Bun.Transpiler > normalizes \r\n [10.29ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [6.60ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [11.26ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [4.01ms]
(pass) Bun.Transpiler > property access inlining > works [3.45ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.88ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [28.53ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [5.47ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [3.88ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [12.81ms]
(pass) Bun.Transpiler > TypeScript > context
... (truncated)

release without fix: 16 failed, 22 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.15ms]
(pass) Bun.Transpiler > normalizes \r\n [0.22ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.14ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.17ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.05ms]
(pass) Bun.Transpiler > property access inlining > works [0.05ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.05ms]
141 |     });
142 |     it("bails out on optional-chain index into enum", () => {
143 |       const pre = "enum Foo { A }\nenum Bar { 'a-b' = 1 }\n";
144 |       const lastLine = out => out.trimEnd().split("\n").at(-1);
145 |       expect(lastLine(ts.parsed(pre + 'export let y = Foo["A"];', false))).toBe("export let y = 0 /* A */;");
146 |       expect(lastLine(ts.parsed(pre + 'export let y = Foo?.["A"];', false))).toBe('export let y = Foo?.["A"];');
                                                                                   ^
error: expect(received).toBe(expected)

Expected: "export let y = F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (0a1bfd1ee)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.25ms]
(pass) Bun.Transpiler > normalizes \r\n [5.49ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [3.65ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.51ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.32ms]
(pass) Bun.Transpiler > property access inlining > works [2.02ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.39ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [16.48ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.71ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.22ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [8.49ms]
(pass) Bun.Transpiler > TypeScript > contextual
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0a1bfd1eec
  features     baseline

22 deps, 108 codegen, 1171 objects in 887ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [5.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [6.00ms]
[3/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [5.00ms]
[4/1234] gen bindgenv2
[5/1234] fetch picohttpparser
[picohttpparser] up to date
[6/1234] gen ErrorCode+*.h
[7/1234] fetch tinycc
[tinycc] up to date
[8/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1234] fetch zlib
[zlib] up to date
[10/1234] gen .bind.ts → GeneratedBindings.cpp
[11/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                         | 52 +++++++++++++++++++++---------
 src/js_parser/parse/parse_fn.rs            |  2 ++
 test/bundler/transpiler/transpiler.test.js | 40 +++++++++++++++++++++++
 3 files changed, 79 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/p.rs                              5      4      0
src/js_parser/parse/parse_fn.rs                 3      5      0
test/bundler/transpiler/transpiler.test.js      5      4      0
```

</details>

<!-- robobun:evidence:end -->