### PR TITLE
node:http2: rate-limit stream resets per connection (CVE-2023-44487 rapid reset, CVE-2025-8671 MadeYouReset)

### DIFF
--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -150,6 +150,51 @@ pub struct Feed {
 /// behind a non-reading peer before the session is treated as flooded (NGHTTP2_ERR_FLOODED).
 const MAX_OUTBOUND_ACK_QUEUE: u32 = 1000;
 
+/// nghttp2's NGHTTP2_DEFAULT_STREAM_RESET_BURST / _RATE (node's streamResetBurst / streamResetRate).
+pub const DEFAULT_STREAM_RESET_BURST: u32 = 1000;
+pub const DEFAULT_STREAM_RESET_RATE: u32 = 33;
+
+enum ResetBy {
+    Peer,
+    Us,
+}
+
+/// nghttp2_ratelim: `rate` tokens per whole elapsed second, capped at `burst`.
+struct RateLimit {
+    burst: u32,
+    rate: u32,
+    tokens: u32,
+    last_refill: std::time::Instant,
+}
+
+impl RateLimit {
+    fn new(burst: u32, rate: u32) -> Self {
+        RateLimit {
+            burst,
+            rate,
+            tokens: burst,
+            last_refill: std::time::Instant::now(),
+        }
+    }
+
+    /// Returns false once the bucket is empty.
+    fn drain(&mut self) -> bool {
+        let elapsed = self.last_refill.elapsed().as_secs();
+        if elapsed > 0 {
+            let gain = u32::try_from(elapsed)
+                .unwrap_or(u32::MAX)
+                .saturating_mul(self.rate);
+            self.tokens = self.tokens.saturating_add(gain).min(self.burst);
+            self.last_refill += std::time::Duration::from_secs(elapsed);
+        }
+        if self.tokens == 0 {
+            return false;
+        }
+        self.tokens -= 1;
+        true
+    }
+}
+
 /// What the connection engine calls back into the embedder (the JSC binding) for. Methods take
 /// `&self`: the JSC binding (H2FrameParser) is fully interior-mutable (Cell/JsCell) and its host
 /// functions receive `&Self`, so it can own the `Connection` and pass itself as the sink without an
@@ -184,6 +229,10 @@ pub trait Sink {
     /// is allocated; the header block is still decoded for HPACK-table sync (§4.3).
     fn can_open_stream(&self) -> bool {
         true
+    }
+    /// Queried per reset: a GOAWAY sent mid-dispatch counts for the rest of that read.
+    fn goaway_sent(&self) -> bool {
+        false
     }
     /// A SETTINGS entry with an id outside the standard registry (node's remoteCustomSettings).
     fn on_remote_custom_setting(&self, _id: u16, _value: u32) {}
@@ -301,6 +350,12 @@ pub struct Connection {
     /// obq_flood_counter_). Reset only via note_outbound_drained() when the
     /// embedder confirms its outbound buffer emptied — never per receive().
     obq_ack_pending: u32,
+    /// Inbound RST_STREAM (nghttp2's stream_reset_ratelim; node's streamResetBurst/Rate).
+    stream_reset_limit: RateLimit,
+    /// RST_STREAM this engine sends in reaction to inbound frames (nghttp2 >= 1.67 has one too).
+    sent_reset_limit: RateLimit,
+    /// A bucket ran dry mid-frame; receive() tears the session down between frames.
+    reset_flood: bool,
 
     /// Scratch buffer for the outbound HPACK-encoded header block.
     enc_buf: Vec<u8>,
@@ -339,6 +394,12 @@ impl Connection {
             data_in_flight: None,
             terminated: false,
             obq_ack_pending: 0,
+            stream_reset_limit: RateLimit::new(
+                DEFAULT_STREAM_RESET_BURST,
+                DEFAULT_STREAM_RESET_RATE,
+            ),
+            sent_reset_limit: RateLimit::new(DEFAULT_STREAM_RESET_BURST, DEFAULT_STREAM_RESET_RATE),
+            reset_flood: false,
             enc_buf: Vec::new(),
             replenish_buf: Vec::new(),
             evict_buf: Vec::new(),
@@ -428,6 +489,7 @@ impl Connection {
             stream_id,
             &code.as_u32().to_be_bytes(),
         );
+        self.note_reset(sink, ResetBy::Us);
     }
 
     // ---- Inbound --------------------------------------------------------
@@ -554,6 +616,18 @@ impl Connection {
                 };
             }
             offset += total;
+            if self.check_reset_flood(sink) {
+                return Feed {
+                    consumed: offset,
+                    fatal: true,
+                };
+            }
+        }
+        if self.check_reset_flood(sink) {
+            return Feed {
+                consumed: offset,
+                fatal: true,
+            };
         }
         // Re-open consumed receive windows once per batch (RFC 9113 §6.9; mirrors how the
         // application-consumption-driven update works in node) — doing it per frame would both spam
@@ -774,6 +848,44 @@ impl Connection {
     /// from receive() itself so a peer that never reads cannot reset it.
     pub fn note_outbound_drained(&mut self) {
         self.obq_ack_pending = 0;
+    }
+
+    /// No-op when unchanged: the embedder re-syncs this on every read and must not refill the bucket.
+    pub fn set_stream_reset_limit(&mut self, burst: u32, rate: u32) {
+        let lim = &self.stream_reset_limit;
+        if lim.burst != burst || lim.rate != rate {
+            self.stream_reset_limit = RateLimit::new(burst, rate);
+        }
+    }
+
+    /// Servers only. Our GOAWAY exempts the peer's resets (as in nghttp2) but not ours: the peer
+    /// can keep provoking those.
+    fn note_reset(&mut self, sink: &impl Sink, by: ResetBy) {
+        if !self.is_server || self.reset_flood {
+            return;
+        }
+        let limit = match by {
+            ResetBy::Peer if sink.goaway_sent() => return,
+            ResetBy::Peer => &mut self.stream_reset_limit,
+            ResetBy::Us => &mut self.sent_reset_limit,
+        };
+        if !limit.drain() {
+            self.reset_flood = true;
+        }
+    }
+
+    /// nghttp2 sends INTERNAL_ERROR here; ENHANCE_YOUR_CALM matches note_outbound_ack.
+    fn check_reset_flood(&mut self, sink: &impl Sink) -> bool {
+        if !self.reset_flood || self.terminated {
+            return false;
+        }
+        self.local_connection_error(
+            sink,
+            ErrorCode::EnhanceYourCalm,
+            wire::lib_error::FLOODED,
+            b"too many stream resets",
+        );
+        true
     }
 
     /// Bound queued PING/SETTINGS ACKs behind a non-reading peer — nghttp2's
@@ -1649,6 +1761,8 @@ impl Connection {
             && (hdr.stream_id <= self.last_stream_id
                 || hdr.stream_id <= sink.highest_started_stream_id())
         {
+            // nghttp2 charges the ratelim regardless of stream lookup.
+            self.note_reset(sink, ResetBy::Peer);
             return false;
         }
         if on_idle {
@@ -1656,6 +1770,7 @@ impl Connection {
             return true;
         }
         sink.on_stream_reset(hdr.stream_id, code_raw);
+        self.note_reset(sink, ResetBy::Peer);
         false
     }
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1319,6 +1319,9 @@ pub struct H2FrameParser {
     dispatch_depth: Cell<u32>,
     max_rejected_streams: Cell<u32>,
     max_session_invalid_frames: Cell<u32>,
+    stream_reset_burst: Cell<u32>,
+    stream_reset_rate: Cell<u32>,
+    goaway_sent: Cell<bool>,
     max_outstanding_settings: Cell<u32>,
     outstanding_settings: Cell<u32>,
     rejected_streams: Cell<u32>,
@@ -2557,6 +2560,7 @@ impl H2FrameParser {
             BStr::new(debug_data),
             emit_error
         );
+        self.goaway_sent.set(true);
         let mut buffer = [0u8; FrameHeader::BYTE_SIZE + 8];
         let mut stream = FixedBufferStream::new(&mut buffer);
 
@@ -5776,6 +5780,10 @@ impl H2FrameParser {
             engine.max_header_list_pairs = self.max_header_list_pairs.get();
             engine.max_settings = self.max_settings.get();
             engine.max_invalid_frames = self.max_session_invalid_frames.get();
+            engine.set_stream_reset_limit(
+                self.stream_reset_burst.get(),
+                self.stream_reset_rate.get(),
+            );
             // Outbound-ACK-flood counter: only reset when the transport actually
             // drained (nghttp2 decrements per-send). Resetting per receive() lets
             // a peer that never reads keep it under the limit forever.
@@ -6149,6 +6157,10 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
         // The legacy outbound created an entry in the legacy streams map for every locally
         // initiated stream (request/respond), so membership there means "we sent HEADERS on it".
         self.streams.get().contains_key(&stream_id)
+    }
+
+    fn goaway_sent(&self) -> bool {
+        self.goaway_sent.get()
     }
 
     fn highest_started_stream_id(&self) -> u32 {
@@ -9864,6 +9876,9 @@ impl H2FrameParser {
             pending_settings_window_submissions: JsCell::new(Vec::new()),
             max_rejected_streams: Cell::new(100),
             max_session_invalid_frames: Cell::new(1000),
+            stream_reset_burst: Cell::new(crate::api::h2::connection::DEFAULT_STREAM_RESET_BURST),
+            stream_reset_rate: Cell::new(crate::api::h2::connection::DEFAULT_STREAM_RESET_RATE),
+            goaway_sent: Cell::new(false),
             max_outstanding_settings: Cell::new(10),
             outstanding_settings: Cell::new(0),
             rejected_streams: Cell::new(0),
@@ -10008,6 +10023,15 @@ impl H2FrameParser {
                             .max_session_invalid_frames
                             .set(max_session_invalid_frames.to_uint64_no_truncate() as u32);
                     }
+                }
+                // node: MathMax(1, x) per key (util.js), applied when both are given (node_http2.cc).
+                if let Some(reset_burst) = settings_js.get(global_object, "streamResetBurst")?
+                    && let Some(reset_rate) = settings_js.get(global_object, "streamResetRate")?
+                    && reset_burst.is_number()
+                    && reset_rate.is_number()
+                {
+                    this_ref.stream_reset_burst.set(reset_burst.to_u32().max(1));
+                    this_ref.stream_reset_rate.set(reset_rate.to_u32().max(1));
                 }
                 if let Some(max_outstanding_settings) =
                     settings_js.get(global_object, "maxOutstandingSettings")?

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1879,3 +1879,199 @@ describe("stream release after a queued END_STREAM", () => {
     }
   });
 });
+
+// Stream resets are rate-limited per connection like nghttp2's stream_reset_ratelim (burst 1000,
+// refill 33/s): past the bucket the session dies with GOAWAY, surfaced as ERR_HTTP2_ERROR.
+describe("stream-reset floods (CVE-2023-44487 rapid reset, CVE-2025-8671 MadeYouReset)", () => {
+  const CANCEL = Buffer.alloc(4);
+  CANCEL.writeUInt32BE(ErrorCode.CANCEL, 0);
+  const rstStream = (sid: number) => encodeFrame(FrameType.RST_STREAM, 0, sid, CANCEL);
+  const request = (sid: number) => encodeFrame(FrameType.HEADERS, 0x5, sid, requestHeaderBlock("GET"));
+  const requestAndKill = (sid: number, kill: (sid: number) => Buffer) => Buffer.concat([request(sid), kill(sid)]);
+
+  function respondingServer(options: Record<string, unknown> = {}) {
+    const state = { handlers: 0, sessionErrorCode: undefined as string | undefined };
+    const server = http2.createServer(options);
+    server.on("sessionError", (e: any) => (state.sessionErrorCode = e.code));
+    server.on("session", s => s.on("error", () => {}));
+    server.on("stream", (stream: any) => {
+      state.handlers++;
+      stream.on("error", () => {});
+      stream.respond({ ":status": 200 });
+      stream.end("x");
+    });
+    return { server, state };
+  }
+
+  async function flood(opts: { options?: Record<string, unknown>; count: number; kill?: (sid: number) => Buffer }) {
+    const { server, state } = respondingServer(opts.options);
+    server.listen(0);
+    await once(server, "listening");
+    const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      const frames: Buffer[] = [];
+      for (let i = 0; i < opts.count; i++) frames.push(requestAndKill(1 + 2 * i, opts.kill ?? rstStream));
+      c.send(Buffer.concat(frames));
+      const goaway = await c.waitForGoaway(10_000);
+      return { c, goaway, ...state };
+    } finally {
+      c.destroy();
+      server.close();
+    }
+  }
+
+  test("a RST_STREAM flood is answered with GOAWAY(ENHANCE_YOUR_CALM) and a session error", async () => {
+    const { goaway, handlers, sessionErrorCode } = await flood({ count: 1200 });
+    expect(goawayErrorCode(goaway)).toBe(ErrorCode.ENHANCE_YOUR_CALM);
+    expect(goaway.payload.subarray(8).toString()).toBe("too many stream resets");
+    // Like node, every request up to the bucket's edge still reaches the handler.
+    expect(handlers).toBeGreaterThan(900);
+    expect(sessionErrorCode).toBe("ERR_HTTP2_ERROR");
+  });
+
+  test("streamResetBurst sets where the flood is detected", async () => {
+    const { goaway } = await flood({ options: { streamResetBurst: 50, streamResetRate: 1 }, count: 200 });
+    expect(goawayErrorCode(goaway)).toBe(ErrorCode.ENHANCE_YOUR_CALM);
+    // Burst 50 empties on the 51st reset (stream 101); the default burst would need stream 2001.
+    expect(goaway.payload.readUInt32BE(0)).toBeGreaterThanOrEqual(101);
+    expect(goaway.payload.readUInt32BE(0)).toBeLessThan(200);
+  });
+
+  test("a flood under the burst keeps the session serving requests", async () => {
+    const { server, state } = respondingServer();
+    server.listen(0);
+    await once(server, "listening");
+    const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      const frames: Buffer[] = [];
+      for (let i = 0; i < 500; i++) frames.push(requestAndKill(1 + 2 * i, rstStream));
+      frames.push(request(1001));
+      c.send(Buffer.concat(frames));
+      await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1001, 10_000);
+      expect(c.frames.find(f => f.type === FrameType.GOAWAY)).toBeUndefined();
+      expect(state.handlers).toBe(501);
+    } finally {
+      c.destroy();
+      server.close();
+    }
+  });
+
+  test("the bucket refills at streamResetRate per second", async () => {
+    // Burst 0 is floored to 1 like node, so the bucket holds exactly one token.
+    const { server } = respondingServer({ streamResetBurst: 0, streamResetRate: 1 });
+    server.listen(0);
+    await once(server, "listening");
+    const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.send(requestAndKill(1, rstStream)); // drains the only token
+      await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      await Bun.sleep(1500); // the refill under test is per whole second of wall clock
+      // The refilled token covers stream 3, stream 5 is served, and the later resets find the
+      // bucket empty again because the refill clock advanced.
+      c.send(
+        Buffer.concat([
+          requestAndKill(3, rstStream),
+          request(5),
+          ...[7, 9, 11].map(sid => requestAndKill(sid, rstStream)),
+        ]),
+      );
+      const goaway = await c.waitForGoaway(10_000);
+      expect(goawayErrorCode(goaway)).toBe(ErrorCode.ENHANCE_YOUR_CALM);
+      expect(c.frames.some(f => f.type === FrameType.HEADERS && f.streamId === 5)).toBe(true);
+    } finally {
+      c.destroy();
+      server.close();
+    }
+  });
+
+  test("resets are not charged once the server has sent its own GOAWAY", async () => {
+    // nghttp2 stops charging as soon as a local GOAWAY is submitted. The requests and their
+    // cancellations arrive in one read and close() is called from the last request's handler, so
+    // the cancellations behind it in the same read must already go uncharged: one GOAWAY
+    // (NO_ERROR) and 'close', not a second GOAWAY and a session error.
+    const open = 20;
+    let sessionError: Error | undefined;
+    const closed = Promise.withResolvers<void>();
+    const server = http2.createServer({ streamResetBurst: 2, streamResetRate: 1 });
+    server.on("sessionError", e => (sessionError = e));
+    server.on("stream", stream => {
+      stream.on("error", () => {});
+      if (stream.id !== 2 * open - 1) return;
+      stream.session!.once("close", () => closed.resolve());
+      stream.session!.close();
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      const ids = Array.from({ length: open }, (_, i) => 1 + 2 * i);
+      c.send(Buffer.concat([...ids.map(request), ...ids.map(rstStream)]));
+      await closed.promise;
+      await c.waitClosed(10_000); // everything the server wrote before closing has been parsed
+      expect(c.frames.filter(f => f.type === FrameType.GOAWAY).map(goawayErrorCode)).toEqual([ErrorCode.NO_ERROR]);
+      expect(sessionError).toBeUndefined();
+    } finally {
+      c.destroy();
+      server.close();
+    }
+  });
+
+  // MadeYouReset: the client never sends RST_STREAM; each stream is killed by a frame this engine
+  // answers with its own RST_STREAM (nghttp2 escalates both shapes to connection errors instead).
+  // Those resets drain a separate fixed bucket, so streamResetBurst does not apply to them.
+  const madeYouReset = {
+    "WINDOW_UPDATE with a 0 increment": (sid: number) => encodeFrame(FrameType.WINDOW_UPDATE, 0, sid, Buffer.alloc(4)),
+    "DATA after END_STREAM": (sid: number) => encodeFrame(FrameType.DATA, 0, sid, Buffer.from("x")),
+  };
+
+  test("server-sent resets stay charged after the server has sent its GOAWAY", async () => {
+    // The GOAWAY exemption is only for the peer's own resets. Here the client holds stream 1 open
+    // (so the session survives its GOAWAY-triggered close()) and then provokes server resets.
+    const { server, state } = respondingServer();
+    server.listen(0);
+    await once(server, "listening");
+    const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendFrame(FrameType.HEADERS, 0x4 /* END_HEADERS only: stream 1 stays open */, 1, requestHeaderBlock("POST"));
+      c.sendFrame(FrameType.GOAWAY, 0, 0, Buffer.alloc(8));
+      const ours = await c.waitForGoaway();
+      expect(goawayErrorCode(ours)).toBe(ErrorCode.NO_ERROR);
+      const kill = madeYouReset["WINDOW_UPDATE with a 0 increment"];
+      c.send(Buffer.concat(Array.from({ length: 1200 }, () => kill(3))));
+      const calm = await c.waitFor(
+        f => f.type === FrameType.GOAWAY && goawayErrorCode(f) === ErrorCode.ENHANCE_YOUR_CALM,
+        10_000,
+      );
+      expect(calm.payload.subarray(8).toString()).toBe("too many stream resets");
+      expect(c.frames.filter(f => f.type === FrameType.RST_STREAM).length).toBeGreaterThanOrEqual(1000);
+      expect(state.sessionErrorCode).toBe("ERR_HTTP2_ERROR");
+    } finally {
+      c.destroy();
+      server.close();
+    }
+  });
+
+  for (const [name, kill] of Object.entries(madeYouReset)) {
+    test(`a flood of server-sent resets via ${name} is answered with GOAWAY(ENHANCE_YOUR_CALM)`, async () => {
+      const { c, goaway, handlers, sessionErrorCode } = await flood({
+        options: { streamResetBurst: 5, streamResetRate: 1 },
+        count: 1200,
+        kill,
+      });
+      expect(goawayErrorCode(goaway)).toBe(ErrorCode.ENHANCE_YOUR_CALM);
+      expect(c.frames.filter(f => f.type === FrameType.RST_STREAM).length).toBeGreaterThanOrEqual(1000);
+      expect(handlers).toBeGreaterThanOrEqual(1000);
+      expect(sessionErrorCode).toBe("ERR_HTTP2_ERROR");
+    });
+  }
+});


### PR DESCRIPTION
A client that opens streams and immediately kills them could make a `node:http2` server do unbounded work: one h2c connection sending `HEADERS`+`RST_STREAM(CANCEL)` pairs got the `'stream'` handler run and a response serialized for all 20,000 of them at ~60-80% CPU and a few hundred MB of RSS growth, and the server never sent `GOAWAY`. Node kills the same connection after ~1,400 resets.

### What Node does

Node's mitigation is nghttp2's, from the CVE-2023-44487 release. In `nghttp2_session.c`, `session_update_stream_reset_ratelim` is called from `nghttp2_session_on_rst_stream_received` only (not for resets nghttp2 generates itself), returns early unless the session is a server and this side has not yet submitted a GOAWAY, updates/drains `stream_reset_ratelim` (a token bucket: `NGHTTP2_DEFAULT_STREAM_RESET_BURST` 1000, `NGHTTP2_DEFAULT_STREAM_RESET_RATE` 33 per second, integer-second timestamps), and when the bucket is empty submits a `GOAWAY(INTERNAL_ERROR)` with no debug data (node v22.20.0 on the wire: error code 2, empty payload; JS sees a `sessionError` with code `ERR_HTTP2_ERROR`). nghttp2 1.67+ additionally keeps a separate, non-configurable bucket for the `RST_STREAM`s it sends itself.

The options are not validated. `lib/internal/http2/util.js` `updateOptionsBuffer` (verbatim from the node 26.3 binary; `optionsBuffer` is a `Uint32Array`):

```js
  if (typeof options.streamResetRate === 'number') {
    flags |= (1 << IDX_OPTIONS_STREAM_RESET_RATE);
    optionsBuffer[IDX_OPTIONS_STREAM_RESET_RATE] =
      MathMax(1, options.streamResetRate);
  }
  if (typeof options.streamResetBurst === 'number') {
    flags |= (1 << IDX_OPTIONS_STREAM_RESET_BURST);
    optionsBuffer[IDX_OPTIONS_STREAM_RESET_BURST] =
      MathMax(1, options.streamResetBurst);
  }
```

so `-1` becomes 1, `33.5` becomes 33 and a non-number is ignored; `node_http2.cc` then calls `nghttp2_option_set_stream_reset_rate_limit` only when both flags are set.

For a request whose `RST_STREAM` is in the same read as its `HEADERS`, node still runs the `'stream'` handler (its `test-http2-client-rststream-before-connect` depends on that), but it emits the event from `process.nextTick` (`onSessionHeaders` in `lib/internal/http2/core.js`), after nghttp2 has consumed the whole read. The stream is already reset by then, so nothing the handler does reaches the wire: 10,000 pairs against node v26.3.0 give ~1,700 handler runs and 0 response frames.

### What this PR does, per item

| | node | this PR |
|---|---|---|
| inbound `RST_STREAM` bucket | 1000 burst / 33 per s, server only, stops after a local GOAWAY, charged even when the stream is already gone | same (`Connection::stream_reset_limit`, `note_reset(ResetBy::Peer)`). The GOAWAY check asks the embedder per reset (`Sink::goaway_sent`, set by the parser's `send_go_away`, which is what `session.close()`/`goaway()` use), so a `close()` from inside a handler counts for the cancellations behind it in the same read, like nghttp2's synchronous flag. The exemption covers the peer's resets only: resets we send stay charged, because a client can hold one stream open past our GOAWAY and keep provoking them |
| `streamResetBurst` / `streamResetRate` | per-key number check, `MathMax(1)`, uint32, applied only when both given, no validation | same (`to_u32().max(1)`, both-or-neither, the earlier `validateUint32` calls are gone so `http2.ts` is untouched). Only difference: values above 2^32 saturate instead of wrapping |
| GOAWAY on exhaustion | `INTERNAL_ERROR`, no debug data | **differs**: `ENHANCE_YOUR_CALM` + `"too many stream resets"`, the same code and shape as this engine's existing flood guard (`note_outbound_ack`). JS-visible result is `ERR_HTTP2_ERROR` either way |
| resets the server sends itself | nghttp2 1.67+: separate fixed bucket; the two shapes in the tests never get there because nghttp2 answers a stream `WINDOW_UPDATE(0)` with `GOAWAY(PROTOCOL_ERROR)` and `DATA` after `END_STREAM` with `GOAWAY(STREAM_CLOSED)` (v22.20.0) | separate fixed bucket too (`sent_reset_limit`, charged inside `send_rst_stream`, sized 1000 / 33 per s; I have not checked nghttp2's numbers). Needed because this engine answers those shapes with the RFC 9113 stream error, so a client can farm resets out of it. **Known difference** from the extra bucket: a pure flood of malformed frames at default options now dies one frame earlier as `ERR_HTTP2_ERROR` instead of `ERR_HTTP2_TOO_MANY_INVALID_FRAMES` (the sent bucket is 1000, `maxSessionInvalidFrames` trips on the 1002nd); a configured `maxSessionInvalidFrames` still wins, and node's own test for it passes |
| request reset in the same read | handler runs on the next tick, on an already-reset stream; 0 responses written | **differs**: Bun emits `'stream'` synchronously from the HEADERS dispatch, before the `RST_STREAM` is parsed, so the handler's response is serialized. This PR does not change that ordering; the bucket bounds it. The same 10,000 pairs on this branch: 1,133 handler runs and 1,133 response HEADERS, then the GOAWAY (main: all 10,000 of both). The earlier lookahead that dropped those responses is removed because it changed the stream's events depending on where the read boundary fell |

Exhaustion sets a flag and `receive()` tears the session down between frames, so the frame that emptied the bucket finishes its own bookkeeping and dispatch first.

### Tests

`test/js/node/http2/h2-conformance.test.ts`, `stream-reset floods` block, 8 tests. Six fail on main (the RST_STREAM flood, `streamResetBurst`, refill, both server-sent-reset shapes, and server-sent resets after our GOAWAY). The other two pass on main by design and are pinned by mutation instead; I ran each of these and got exactly the listed failures:

* refill block removed: "the bucket refills" fails
* `last_refill +=` removed (bucket refills on every reset once the connection is a second old): "the bucket refills" fails
* GOAWAY check dropped: "resets are not charged once the server has sent its own GOAWAY" fails (that test now sends the requests and their cancellations in one read and calls `close()` from the last request's handler, so it also fails for a once-per-read snapshot of the flag)
* GOAWAY check applied to our own resets as well: "server-sent resets stay charged after the server has sent its GOAWAY" fails
* server-sent resets charged to the configurable bucket: both MadeYouReset tests fail (they use `streamResetBurst: 5` and expect ~1000 server resets before the GOAWAY)
* the refill test uses `streamResetBurst: 0`, so it also fails if the floor to 1 goes missing

The refill test waits 1.5 s of wall clock on purpose; the refill is per whole second. The peer-GOAWAY test from the previous round is gone (it passed on main).

Also passing: the rest of `h2-conformance.test.ts` (74), `node-http2.test.js` (357), and node's 256 `test-http2-*.js`.

Rebased onto current main as a single commit.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.0 (fa1465739)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [592.54ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [144.61ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [158.32ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [63.74ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [64.73ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [61.66ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [71.89ms]
(pass) PING (checklist §3.7) > a PING on a non-zero s
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (eabb96de7)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [14.21ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [3.70ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [3.20ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [1.66ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [1.20ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [1.17ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [1.40ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [1.03ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [1.19ms]
(pass) WINDOW_UPDAT
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.0 (fa1465739)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [504.41ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [117.84ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [119.22ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [50.95ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [46.34ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [39.53ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [46.43ms]
(pass) PING (checklist §3.7) > a PING on a non-zero s
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     fa14657399
  features     baseline

22 deps, 123 codegen, 1176 objects in 999ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] install /workspace/bun
bun install v1.4.0-canary.1 (eabb96de7)

Checked 107 installs across 153 packages (no changes) [57.00ms]
[4/1238] fetch tinycc
[tinycc] up to date
[5/1237] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (eabb96de7)

Checked 1 install across 2 packages (no changes) [6.00ms]
[6/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1237] gen .bind.ts → GeneratedBindings.cpp
[8/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1237] fetch zlib
[zlib] up to date
[10/1237] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bind
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2/connection.rs      | 115 ++++++++++++++++++
 src/runtime/api/bun/h2_frame_parser.rs    |  24 ++++
 test/js/node/http2/h2-conformance.test.ts | 196 ++++++++++++++++++++++++++++++
 3 files changed, 335 insertions(+)
```

</details>

**gate history** · 12 passed · 0 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/api/bun/h2/connection.rs          39     72      0
src/runtime/api/bun/h2_frame_parser.rs        44     41      0
test/js/node/http2/h2-conformance.test.ts     12     24      0
```

</details>

<!-- robobun:evidence:end -->

