### PR TITLE
ci(runner): cap parallel test width at 4 on macOS (x64 and arm64)

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -618,8 +618,13 @@ async function runTests() {
   // finished, so no parallel-safe process ever overlaps a serial test (an
   // overlap surfaced new flakes in tight-timeout / port-bind tests such as
   // dns-tcp-bidirectional-poll and test-https-timeout). `--parallel` already
-  // widens `limit` above and supersedes this split.
-  const parallelSafeWidth = parallelism > 1 ? parallelism : Math.max(availableParallelism() - 1, 1);
+  // widens `limit` above and supersedes this split. The Intel Mac minis are
+  // 6-core i7-8700B (12 HT threads): 11 coordinators each spawning worker
+  // processes pushes the 800-file batch past the 45-minute job timeout, so
+  // darwin x64 is capped at 4.
+  const parallelSafeCap = isMacOS && isX64 ? 4 : Infinity;
+  const parallelSafeWidth =
+    parallelism > 1 ? parallelism : Math.min(parallelSafeCap, Math.max(availableParallelism() - 1, 1));
   const parallelSafeLimit = parallelism > 1 ? limit : pLimit(parallelSafeWidth);
   const isParallelSafeTest = testPath => {
     const p = testPath.replaceAll("\\", "/");

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -618,11 +618,11 @@ async function runTests() {
   // finished, so no parallel-safe process ever overlaps a serial test (an
   // overlap surfaced new flakes in tight-timeout / port-bind tests such as
   // dns-tcp-bidirectional-poll and test-https-timeout). `--parallel` already
-  // widens `limit` above and supersedes this split. The Intel Mac minis are
-  // 6-core i7-8700B (12 HT threads): 11 coordinators each spawning worker
-  // processes pushes the 800-file batch past the 45-minute job timeout, so
-  // darwin x64 is capped at 4.
-  const parallelSafeCap = isMacOS && isX64 ? 4 : Infinity;
+  // widens `limit` above and supersedes this split. macOS is capped at 4: the
+  // Intel minis are 6-core i7-8700B (12 HT threads => width 11), and each
+  // M2 Ultra host runs two 18-vCPU tart VMs (width 17 apiece, 34 on 24
+  // cores when both are busy); both hit the 45-minute job timeout uncapped.
+  const parallelSafeCap = isMacOS ? 4 : Infinity;
   const parallelSafeWidth =
     parallelism > 1 ? parallelism : Math.min(parallelSafeCap, Math.max(availableParallelism() - 1, 1));
   const parallelSafeLimit = parallelism > 1 ? limit : pLimit(parallelSafeWidth);


### PR DESCRIPTION
### What

Cap `parallelSafeWidth` at 4 on macOS in `scripts/runner.node.mjs`. Linux and Windows are unchanged.

### Why

#36175 removed the per-platform cap (previously `isWindows ? 2 : 4`) and switched to `availableParallelism() - 1`. On macOS this oversubscribes:

- **x64**: all eight Intel minis are i7-8700B (6 physical cores, 12 HT threads), so width jumped **4 → 11**.
- **arm64 tart VMs**: each M2 Ultra host runs two 18-vCPU tart VMs (one per macOS release), so width jumped **4 → 17** per VM, i.e. 34 coordinators contending for 24 physical cores when both VMs are busy.

Each `bun test --parallel` coordinator also forks its own worker subprocesses, so the ~800-file batch phase no longer fits inside the 45-minute job timeout:

- build [84092](https://buildkite.com/bun/bun/builds/84092): `813 files in parallel (11×)` on `darwin-matzo-x64` hit the job timeout mid-batch
- build [84124](https://buildkite.com/bun/bun/builds/84124) (first main build with #36175): `darwin-bagel-x64` shard was at 35 minutes when the build was canceled
- build [84151](https://buildkite.com/bun/bun/builds/84151) (this PR with x64-only cap): x64 passed at width 4, but `darwin-sourdough-arm64-tart-15` ran `800 files in parallel (17×)` and hit the 45-minute timeout
- build [84142](https://buildkite.com/bun/bun/builds/84142): `darwin-ciabatta-arm64-tart-26` also hit the 45-minute timeout at width 17

Resulting width per lane:

| lane | cores | before | after |
|---|---|---|---|
| darwin x64 (i7-8700B) | 12 | 11 | **4** |
| darwin arm64 tart (M2 Ultra, 2 VMs/host) | 18 | 17 | **4** |
| darwin arm64 bare (M2) | 8 | 7 | **4** |
| linux/windows EC2 | 4 | 3 | 3 |

This matches the pre-#36175 behavior on macOS exactly.

### Verification

Build 84151 confirmed the x64 side: both darwin x64 shards passed in ~15 min at width 4 (log shows `parallel-safe width 4`, `814 files in parallel (4×)`). `node --check` passes.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->