### PR TITLE
ci: detect stalled test batches by silence; fix worker panic under --bail

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -74,6 +74,12 @@ let isQuiet = false;
 const cwd = import.meta.dirname ? dirname(import.meta.dirname) : process.cwd();
 const testsPath = join(cwd, "test");
 
+const runnerStartedAt = Date.now();
+const jobBudgetMs = () => {
+  const minutes = parseInt(process.env.BUILDKITE_TIMEOUT || "", 10);
+  if (!Number.isFinite(minutes) || minutes <= 0) return Infinity;
+  return minutes * 60_000 - (Date.now() - runnerStartedAt);
+};
 const spawnTimeout = 5_000;
 const spawnBunTimeout = 20_000; // when running with ASAN/LSAN bun can take a bit longer to exit, not a bug.
 const testTimeout = 3 * 60_000;
@@ -981,7 +987,11 @@ async function runTests() {
             ...bucketFiles.map(t => join(testsPath, t)),
           ],
           cwd,
-          timeout: Math.max(10 * 60_000, bucketFiles.length * 5_000),
+          timeout: Math.max(
+            60_000,
+            Math.min(Math.max(10 * 60_000, bucketFiles.length * 5_000), jobBudgetMs() - 5 * 60_000),
+          ),
+          idleTimeout: parseInt(process.env.BUN_RUNNER_BATCH_IDLE_MS || "", 10) || 4 * 60_000,
           gracefulTimeout: true,
           env,
           stdout: chunk => pipeTestStdout(process.stdout, chunk),
@@ -1440,9 +1450,12 @@ async function spawnSafe(options) {
   let spawnError;
   let timestamp;
   let timedOut = false;
+  let idledOut = false;
   let duration;
   let subprocess;
   let timer;
+  let idleTimer;
+  let armIdleTimer;
   let buffer = "";
   let doneCalls = 0;
   const beforeDone = resolve => {
@@ -1455,6 +1468,7 @@ async function spawnSafe(options) {
     if (timer) {
       clearTimeout(timer);
     }
+    clearTimeout(idleTimer);
     subprocess.stderr.unref();
     subprocess.stdout.unref();
     subprocess.unref();
@@ -1496,8 +1510,9 @@ async function spawnSafe(options) {
       });
       subprocess.on("spawn", () => {
         timestamp = Date.now();
-        timer = setTimeout(() => {
+        const expire = () => {
           timedOut = true;
+          clearTimeout(idleTimer);
           if (options.gracefulTimeout && !isWindows) {
             subprocess.kill("SIGTERM");
             timer = setTimeout(() => {
@@ -1507,7 +1522,18 @@ async function spawnSafe(options) {
             return;
           }
           done(resolve);
-        }, timeout);
+        };
+        timer = setTimeout(expire, timeout);
+        if (options.idleTimeout) {
+          armIdleTimer = () => {
+            clearTimeout(idleTimer);
+            idleTimer = setTimeout(() => {
+              idledOut = true;
+              expire();
+            }, options.idleTimeout);
+          };
+          armIdleTimer();
+        }
       });
       subprocess.on("error", error => {
         spawnError = error;
@@ -1527,11 +1553,13 @@ async function spawnSafe(options) {
         beforeDone(resolve);
       });
       subprocess.stdout.on("data", chunk => {
+        armIdleTimer?.();
         const text = chunk.toString("utf-8");
         stdout?.(text);
         buffer += text;
       });
       subprocess.stderr.on("data", chunk => {
+        armIdleTimer?.();
         const text = chunk.toString("utf-8");
         stderr?.(text);
         buffer += text;
@@ -1674,7 +1702,8 @@ async function spawnSafe(options) {
     }
     error = `code ${exitCode}`;
   }
-  if (timedOut && (!error || error === signalCode || /^code \d+$/.test(error))) error = "timeout";
+  if (timedOut && (!error || error === signalCode || /^code \d+$/.test(error)))
+    error = idledOut ? "stalled" : "timeout";
   return {
     ok: exitCode === 0 && !signalCode && !spawnError,
     error,
@@ -1724,7 +1753,7 @@ function getCombinedPath(execPath) {
  * @param {SpawnOptions} options
  * @returns {Promise<SpawnBunResult>}
  */
-async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, env, stdout, stderr }) {
+async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTimeout, env, stdout, stderr }) {
   const path = getCombinedPath(execPath);
   const tmpdirPath = mkdtempSync(join(tmpdir(), "buntmp-"));
   const { username, homedir } = userInfo();
@@ -1779,6 +1808,7 @@ async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, env, st
       cwd,
       timeout,
       gracefulTimeout,
+      idleTimeout,
       env: bunEnv,
       stdout,
       stderr,

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -532,14 +532,15 @@ impl<'a> Coordinator<'a> {
             // the exit status reflects the crash. SIGKILL is treated as a
             // regular failure (commonly the OOM killer or the user).
             let panicked = is_panic_status(status);
-            if self.bailed {
+            let was_bailed = self.bailed;
+            if was_bailed && !panicked {
                 self.account_unfinished(idx, b"aborted: sibling worker panicked");
             } else {
                 self.account_crash(idx, status);
             }
             Output::flush();
             w.inflight = None;
-            if panicked && !self.bailed {
+            if panicked {
                 self.abort_on_worker_panic(idx, status);
             }
         }

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tls } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, normalizeBunSnapshot, tempDir, tls } from "harness";
 
 test("--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID", async () => {
   // Sleep so worker 0 is busy when workers 1/2 come online and pick up the
@@ -199,6 +199,28 @@ test("--parallel --bail stops dispatching new files after threshold", async () =
   expect(Number(m![1])).toBeLessThanOrEqual(2);
   expect(exitCode).toBe(1);
 });
+
+test(
+  "--parallel --bail: a worker panic still prints the panic banner and stops sibling workers",
+  async () => {
+    using dir = tempDir("parallel-bail-panic", {
+      "a-hang.test.js": `import {test} from "bun:test"; test("hang", async () => { await new Promise(() => {}); }, 999999);`,
+      "b-panic.test.js": `import {test} from "bun:test"; test("panic", () => { process.kill(process.pid, "SIGSEGV"); });`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--parallel=2", "--bail=1"],
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("a test worker process crashed with");
+    expect(stderr).toContain("Aborting");
+    expect(exitCode).not.toBe(0);
+  },
+  isASAN || isDebug ? 60_000 : 20_000,
+);
 
 test("--parallel prints per-test lines under their file's header", async () => {
   using dir = tempDir("parallel-output", {

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -205,7 +205,9 @@ test(
   async () => {
     using dir = tempDir("parallel-bail-panic", {
       "a-hang.test.js": `import {test} from "bun:test"; test("hang", async () => { await new Promise(() => {}); }, 999999);`,
-      "b-panic.test.js": `import {test} from "bun:test"; test("panic", () => { process.kill(process.pid, "SIGSEGV"); });`,
+      // A real segfault the OS delivers on every platform (SIGSEGV isn't a
+      // signal you can `process.kill` on Windows).
+      "b-panic.test.js": `import {test} from "bun:test"; import { crash_handler } from "bun:internal-for-testing"; test("panic", () => { crash_handler.segfault(); });`,
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--parallel=2", "--bail=1"],

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, normalizeBunSnapshot, tempDir, tls } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows, normalizeBunSnapshot, tempDir, tls } from "harness";
 
 test("--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID", async () => {
   // Sleep so worker 0 is busy when workers 1/2 come online and pick up the
@@ -200,7 +200,10 @@ test("--parallel --bail stops dispatching new files after threshold", async () =
   expect(exitCode).toBe(1);
 });
 
-test(
+// Worker crashes are classified as panics by fatal signal, which Windows
+// never surfaces (a crash there is exit code 3, indistinguishable from
+// process.exit) — see is_panic_status. So this contract is POSIX-only.
+test.skipIf(isWindows)(
   "--parallel --bail: a worker panic still prints the panic banner and stops sibling workers",
   async () => {
     using dir = tempDir("parallel-bail-panic", {


### PR DESCRIPTION
Follow-up to #36175, from the first day of runs.

### What went wrong

**A darwin shard died at the Buildkite job timeout inside its batch** (build 84092, `darwin-14-x64`, `019fa900`): darwin buckets ~800 files into one `bun test --parallel` batch, and the runner's batch cap was `max(10 min, 5 s × files)` ≈ 68 min — longer than the 45-minute job. So when the batch wedged, the interrupt → name-the-hung-file → solo-retry net never fired; the job was simply killed with no report.

**Panic under `--bail=N`**: the coordinator decided whether the panic path or `--bail` had set `bailed` by reading it *after* `account_crash` — which can itself set it via `bail_out()`. When the Nth failure was a worker panic, the panic banner was skipped and in-flight siblings kept running.

### Fixes

| | |
|---|---|
| **Stall detection by silence** | `spawnSafe` gains an `idleTimeout`, re-armed on every stdout/stderr chunk. A wedged batch is silent, so the batch now aborts gracefully after **4 minutes of no output**, naming the hung file — a bound that doesn't grow with batch size. |
| **Cap bounded by the job's life** | the wall-clock backstop is `min(5 s × files, job remaining − 5 min)` via `BUILDKITE_TIMEOUT`, so it can never outlive the job either. |
| **Panic under `--bail`** | snapshot `bailed` before accounting; run `abort_on_worker_panic` on every panic (its own contract: "runs even if `--bail` already set `bailed`"). |

Distinct annotation title for the new case: a silence stop reads `stalled`, a wall-clock one `timeout`.

### Verified

Drove the runner over a bucket with one worker-only silent hang and a 10 s idle window: the guard fired at 13 s, the coordinator named the hung file, the seven finished files kept their results, and the hanger was retried alone — 22 s total instead of running to the cap. `parallel.test.ts` crash/bail/junit cases pass.