### PR TITLE
cli: wire --breakpoint-resolve/--breakpoint-print into bun_core::debug_flags

### DIFF
--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -388,19 +388,34 @@ macro_rules! mark_binding {
 pub static JSC_SCOPE: crate::output::ScopedLogger =
     crate::output::ScopedLogger::new("JSC", crate::output::Visibility::Hidden);
 
-// ─── debug_flags (MOVE_DOWN from bun_cli, for bun_resolver) ───────────────
+// ─── debug_flags (populated by bun_cli, read by bun_resolver/bundler) ─────
 // Debug-build-only breakpoint matchers.
 pub mod debug_flags {
     #[cfg(debug_assertions)]
-    pub(crate) static RESOLVE_BREAKPOINTS: crate::Once<&'static [&'static [u8]]> =
-        crate::Once::new();
+    static RESOLVE_BREAKPOINTS: crate::Once<Vec<&'static [u8]>> = crate::Once::new();
     #[cfg(debug_assertions)]
-    pub(crate) static PRINT_BREAKPOINTS: crate::Once<&'static [&'static [u8]]> = crate::Once::new();
+    static PRINT_BREAKPOINTS: crate::Once<Vec<&'static [u8]>> = crate::Once::new();
+
+    #[inline]
+    pub fn set_resolve_breakpoints(list: Vec<&'static [u8]>) {
+        #[cfg(debug_assertions)]
+        let _ = RESOLVE_BREAKPOINTS.set(list);
+        #[cfg(not(debug_assertions))]
+        let _ = list;
+    }
+
+    #[inline]
+    pub fn set_print_breakpoints(list: Vec<&'static [u8]>) {
+        #[cfg(debug_assertions)]
+        let _ = PRINT_BREAKPOINTS.set(list);
+        #[cfg(not(debug_assertions))]
+        let _ = list;
+    }
 
     #[inline]
     pub fn has_resolve_breakpoint(str_: &[u8]) -> bool {
         #[cfg(debug_assertions)]
-        for bp in RESOLVE_BREAKPOINTS.get().copied().unwrap_or(&[]) {
+        for bp in RESOLVE_BREAKPOINTS.get().map(Vec::as_slice).unwrap_or(&[]) {
             if crate::strings::includes(str_, bp) {
                 return true;
             }
@@ -412,7 +427,7 @@ pub mod debug_flags {
     #[inline]
     pub fn has_print_breakpoint(pretty: &[u8], text: &[u8]) -> bool {
         #[cfg(debug_assertions)]
-        for bp in PRINT_BREAKPOINTS.get().copied().unwrap_or(&[]) {
+        for bp in PRINT_BREAKPOINTS.get().map(Vec::as_slice).unwrap_or(&[]) {
             if crate::strings::includes(pretty, bp) || crate::strings::includes(text, bp) {
                 return true;
             }

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1544,10 +1544,10 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
 
     if bun_core::env::SHOW_CRASH_TRACE {
         // argv slices are process-lifetime.
-        let _ = cli::debug_flags::RESOLVE_BREAKPOINTS
-            .set(args.options(b"--breakpoint-resolve").to_vec());
-        let _ =
-            cli::debug_flags::PRINT_BREAKPOINTS.set(args.options(b"--breakpoint-print").to_vec());
+        bun_core::debug_flags::set_resolve_breakpoints(
+            args.options(b"--breakpoint-resolve").to_vec(),
+        );
+        bun_core::debug_flags::set_print_breakpoints(args.options(b"--breakpoint-print").to_vec());
     }
 
     Ok(opts)

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -574,17 +574,6 @@ pub mod cli {
 }
 pub use cli as Cli;
 
-// ─── debug_flags (resolve/print breakpoints) ─────────────────────────────────
-pub mod debug_flags {
-    // `Vec<&'static [u8]>` (not `&'static [&[u8]]`) so `parse()` can
-    // hand off ownership of the argv-borrowed list without leaking the backing
-    // storage. Each `&'static [u8]` element is a process-lifetime argv slice.
-    pub(crate) static RESOLVE_BREAKPOINTS: std::sync::OnceLock<Vec<&'static [u8]>> =
-        std::sync::OnceLock::new();
-    pub(crate) static PRINT_BREAKPOINTS: std::sync::OnceLock<Vec<&'static [u8]>> =
-        std::sync::OnceLock::new();
-}
-
 // ─── HelpCommand ─────────────────────────────────────────────────────────────
 pub mod help_command {
     use super::*;

--- a/test/cli/run/breakpoint-flags.test.ts
+++ b/test/cli/run/breakpoint-flags.test.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+
+// --breakpoint-resolve / --breakpoint-print are debug-build-only flags that
+// trap into an attached debugger when the resolver or printer encounters a
+// path containing the given substring. Without a debugger attached the trap
+// terminates the process via the crash handler.
+test.skipIf(!isDebug)("--breakpoint-resolve fires when a matching import is resolved", async () => {
+  using dir = tempDir("breakpoint-resolve", {
+    "entry.ts": `import "./needle-mod.ts";\n`,
+    "needle-mod.ts": `export {};\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--breakpoint-resolve=needle-mod", "run", "entry.ts"],
+    env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The resolver prints a debug line and then raises SIGTRAP; without a
+  // debugger attached the process crashes.
+  expect(stderr).toContain("Resolving");
+  expect(stderr).toContain("needle-mod");
+  expect(stdout).toBe("");
+  expect(exitCode).not.toBe(0);
+});
+
+test.skipIf(!isDebug)("--breakpoint-resolve does not fire when no import matches", async () => {
+  using dir = tempDir("breakpoint-resolve-nomatch", {
+    "entry.ts": `import "./other.ts"; console.log("ran");\n`,
+    "other.ts": `export {};\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--breakpoint-resolve=never-appears-anywhere", "run", "entry.ts"],
+    env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("Resolving");
+  expect(stdout).toBe("ran\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/run/breakpoint-flags.test.ts
+++ b/test/cli/run/breakpoint-flags.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 
 // --breakpoint-resolve / --breakpoint-print are debug-build-only flags that


### PR DESCRIPTION
## Problem

The debug-only `--breakpoint-resolve` and `--breakpoint-print` flags were parsed and stored into `cli::debug_flags::{RESOLVE,PRINT}_BREAKPOINTS` (src/runtime/cli/mod.rs), but the resolver and bundler read from a separate `bun_core::debug_flags` module (src/bun_core/Global.rs) whose statics were never written. The two modules were disconnected, so the flags were accepted and silently ignored: the resolver breakpoint never fired.

```
bun-debug --breakpoint-resolve=foo run entry.ts   # resolves ./foo.ts, no trap, exits 0
```

## Cause

`bun_core::debug_flags` was split out of the CLI crate so `bun_resolver` could read it without a dependency cycle, but the write side in `Arguments.rs` was left pointing at the original (now dead) `cli::debug_flags` statics.

## Fix

- Add `set_resolve_breakpoints` / `set_print_breakpoints` to `bun_core::debug_flags` (no-ops outside `debug_assertions` builds, matching the existing readers).
- Change the statics to `Once<Vec<&'static [u8]>>` so the parser can hand over the argv-borrowed list directly.
- Point `Arguments.rs` at the new setters.
- Delete the dead `cli::debug_flags` module.

## Why this is correct

`bun_core::debug_flags` already owns the readers (`has_resolve_breakpoint` / `has_print_breakpoint`) that the resolver and bundler call. Giving it the setters keeps the whole feature in one place at the bottom of the crate graph, and removes the duplicate module that let the two sides drift apart.

## Verification

`test/cli/run/breakpoint-flags.test.ts` (debug-only, `test.skipIf(!isDebug)`):
- With a matching import, the spawned debug bun prints the `Resolving` debug line and crashes on the `int3`/`brk` trap (non-zero exit).
- With no matching import, the process runs to completion and exits 0.

The first test fails on main (stderr empty, exit 0) and passes with this change.