### PR TITLE
spawn: surface stdin ReadableStream producer errors via onExit / unhandledRejection

### DIFF
--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -1064,7 +1064,15 @@ impl Subprocess<'_> {
             self.close_readable_pipes();
         }
 
+        let mut stdin_stream_error = JSValue::ZERO;
         if let Some(pipe_ptr) = stdin {
+            // Pull the stdin ReadableStream pump error (if any) before
+            // `on_attached_process_exit` tears the sink down.
+            stdin_stream_error = bun_ptr::BackRef::from(pipe_ptr)
+                .take_stream_error()
+                .unwrap_or(JSValue::ZERO);
+            stdin_stream_error.ensure_still_alive();
+
             self.weak_file_sink_stdin_ptr.set(None);
             self.update_flags(|f| f.insert(Flags::HAS_STDIN_DESTRUCTOR_CALLED));
 
@@ -1161,6 +1169,8 @@ impl Subprocess<'_> {
                 {
                     let waitpid_value: JSValue = if let Status::Err(err) = status {
                         err.to_js(global_this)
+                    } else if !stdin_stream_error.is_empty() {
+                        stdin_stream_error
                     } else {
                         JSValue::UNDEFINED
                     };
@@ -1186,6 +1196,10 @@ impl Subprocess<'_> {
 
                     // SAFETY: event_loop points into the live VM.
                     unsafe { (*event_loop).run_callback(callback, global_this, this_value, &args) };
+                } else if !stdin_stream_error.is_empty() {
+                    // No onExit handler to receive the stdin producer error;
+                    // report it so the truncation is not silent.
+                    let _ = bun_jsc::JSPromise::rejected_promise(global_this, stdin_stream_error);
                 }
             }
         }

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -1066,8 +1066,6 @@ impl Subprocess<'_> {
 
         let mut stdin_stream_error = JSValue::ZERO;
         if let Some(pipe_ptr) = stdin {
-            // Pull the stdin ReadableStream pump error (if any) before
-            // `on_attached_process_exit` tears the sink down.
             stdin_stream_error = bun_ptr::BackRef::from(pipe_ptr)
                 .take_stream_error()
                 .unwrap_or(JSValue::ZERO);
@@ -1197,8 +1195,6 @@ impl Subprocess<'_> {
                     // SAFETY: event_loop points into the live VM.
                     unsafe { (*event_loop).run_callback(callback, global_this, this_value, &args) };
                 } else if !stdin_stream_error.is_empty() {
-                    // No onExit handler to receive the stdin producer error;
-                    // report it so the truncation is not silent.
                     let _ = bun_jsc::JSPromise::rejected_promise(global_this, stdin_stream_error);
                 }
             }

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -60,6 +60,11 @@ pub struct FileSink {
     /// Currently, only used when `stdin` in `Bun.spawn` is a ReadableStream.
     pub readable_stream: JsCell<readable_stream::Strong>,
 
+    /// Producer error from the stdin ReadableStream pump (spawn-only, like
+    /// `readable_stream`). Set by `handle_reject_stream`; `Subprocess::
+    /// on_process_exit` forwards it as `onExit`'s fourth argument.
+    pub stream_error: JsCell<bun_jsc::strong::Optional>,
+
     /// Strong reference to the JS wrapper object to prevent GC from collecting it
     /// while an async operation is pending. This is set when endFromJS returns a
     /// pending Promise and cleared when the operation completes.
@@ -949,6 +954,7 @@ impl FileSink {
         // `Blob::get_writer`).
         self.readable_stream.set(readable_stream::Strong::default());
         self.pending.set(streams::WritablePending::default());
+        self.stream_error.with_mut(|r| r.deinit());
         self.js_sink_ref.with_mut(|r| r.deinit());
         // SAFETY: `&mut self` carries write provenance over the whole
         // allocation; this is the last use of `self` in `finalize`.
@@ -1403,6 +1409,7 @@ impl FileSink {
             auto_flusher: JsCell::new(AutoFlusher::default()),
             run_pending_later: FlushPendingTask::default(),
             readable_stream: JsCell::new(readable_stream::Strong::default()),
+            stream_error: JsCell::new(bun_jsc::strong::Optional::empty()),
             js_sink_ref: JsCell::new(bun_jsc::strong::Optional::empty()),
         }
     }
@@ -1452,15 +1459,27 @@ impl FileSink {
     }
 
     /// Does not ref or unref.
-    fn handle_reject_stream(&self, global_this: &JSGlobalObject, _err: JSValue) {
+    fn handle_reject_stream(&self, global_this: &JSGlobalObject, err: JSValue) {
         if let Some(stream) = self.readable_stream.get().get(global_this).as_mut() {
             stream.abort(global_this);
             self.readable_stream.set(readable_stream::Strong::default());
         }
 
-        if !self.done.get() {
+        if self.done.get() {
+            // The attached subprocess has already run `on_process_exit` (which
+            // is what sets `done` via `on_attached_process_exit`), so there is
+            // no later consumer for `stream_error`. Surface it now.
+            let _ = bun_jsc::JSPromise::rejected_promise(global_this, err);
+        } else {
+            self.stream_error.with_mut(|s| s.set(global_this, err));
             self.writer.with_mut(|w| w.close());
         }
+    }
+
+    /// Take the stdin ReadableStream pump error, if one was recorded. Called by
+    /// `Subprocess::on_process_exit` to populate `onExit`'s error argument.
+    pub fn take_stream_error(&self) -> Option<JSValue> {
+        self.stream_error.with_mut(|s| s.try_swap())
     }
 }
 
@@ -1559,6 +1578,12 @@ impl FileSink {
                         // These don't ref().
                         // SAFETY: `js_promise` is non-null (`as_any_promise`).
                         let result = unsafe { (*js_promise).result(global_this.vm()) };
+                        // `handle_reject_stream` captures `result` into
+                        // `stream_error` for `Subprocess::on_process_exit` to
+                        // deliver; mark the pump promise handled so it is not
+                        // also reported via the unhandled-rejection tracker.
+                        // SAFETY: `js_promise` is non-null (`as_any_promise`).
+                        unsafe { (*js_promise).set_handled() };
                         self.handle_reject_stream(global_this, result);
                     }
                 }

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1463,11 +1463,8 @@ impl FileSink {
             self.readable_stream.set(readable_stream::Strong::default());
         }
 
-        if self.done.get() {
-            // `done` ⇒ `on_process_exit` already ran; no later `take_stream_error`.
-            let _ = bun_jsc::JSPromise::rejected_promise(global_this, err);
-        } else {
-            self.stream_error.with_mut(|s| s.set(global_this, err));
+        self.stream_error.with_mut(|s| s.set(global_this, err));
+        if !self.done.get() {
             self.writer.with_mut(|w| w.close());
         }
     }

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -60,9 +60,7 @@ pub struct FileSink {
     /// Currently, only used when `stdin` in `Bun.spawn` is a ReadableStream.
     pub readable_stream: JsCell<readable_stream::Strong>,
 
-    /// Producer error from the stdin ReadableStream pump (spawn-only, like
-    /// `readable_stream`). Set by `handle_reject_stream`; `Subprocess::
-    /// on_process_exit` forwards it as `onExit`'s fourth argument.
+    /// Producer error from the stdin ReadableStream pump, for `Subprocess::on_process_exit`.
     pub stream_error: JsCell<bun_jsc::strong::Optional>,
 
     /// Strong reference to the JS wrapper object to prevent GC from collecting it
@@ -1466,9 +1464,7 @@ impl FileSink {
         }
 
         if self.done.get() {
-            // The attached subprocess has already run `on_process_exit` (which
-            // is what sets `done` via `on_attached_process_exit`), so there is
-            // no later consumer for `stream_error`. Surface it now.
+            // `done` ⇒ `on_process_exit` already ran; no later `take_stream_error`.
             let _ = bun_jsc::JSPromise::rejected_promise(global_this, err);
         } else {
             self.stream_error.with_mut(|s| s.set(global_this, err));
@@ -1476,8 +1472,6 @@ impl FileSink {
         }
     }
 
-    /// Take the stdin ReadableStream pump error, if one was recorded. Called by
-    /// `Subprocess::on_process_exit` to populate `onExit`'s error argument.
     pub fn take_stream_error(&self) -> Option<JSValue> {
         self.stream_error.with_mut(|s| s.try_swap())
     }
@@ -1578,10 +1572,7 @@ impl FileSink {
                         // These don't ref().
                         // SAFETY: `js_promise` is non-null (`as_any_promise`).
                         let result = unsafe { (*js_promise).result(global_this.vm()) };
-                        // `handle_reject_stream` captures `result` into
-                        // `stream_error` for `Subprocess::on_process_exit` to
-                        // deliver; mark the pump promise handled so it is not
-                        // also reported via the unhandled-rejection tracker.
+                        // `handle_reject_stream` owns delivering `result`; don't also report it.
                         // SAFETY: `js_promise` is non-null (`as_any_promise`).
                         unsafe { (*js_promise).set_handled() };
                         self.handle_reject_stream(global_this, result);

--- a/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
@@ -28,17 +28,23 @@ describe("spawn stdin ReadableStream edge cases", () => {
       },
     });
 
+    const { promise: onExit, resolve } = Promise.withResolvers<unknown>();
     const proc = spawn({
       cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
       stdin: stream,
       stdout: "pipe",
       env: bunEnv,
+      onExit(_proc, _code, _signal, err) {
+        resolve(err);
+      },
     });
 
     const text = await proc.stdout.text();
     // Should receive data before the exception
     expect(text).toContain("chunk 1\n");
     expect(text).toContain("chunk 2\n");
+    // The pull exception is delivered as onExit's error argument.
+    expect(((await onExit) as Error)?.message).toBe("Pull error");
   });
 
   test("ReadableStream writing after process closed", async () => {

--- a/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
@@ -453,33 +453,28 @@ describe("spawn stdin ReadableStream edge cases", () => {
     expect(await proc.exited).toBe(0);
   });
 
-  test("ReadableStream with spawn options variations", async () => {
-    // Test with different spawn configurations
-    const configs = [
-      { stdout: "pipe", stderr: "ignore" },
-      { stdout: "pipe", stderr: "pipe" },
-      { stdout: "pipe", stderr: "inherit" },
-    ];
+  test.concurrent.each([
+    { stdout: "pipe", stderr: "ignore" } as const,
+    { stdout: "pipe", stderr: "pipe" } as const,
+    { stdout: "pipe", stderr: "inherit" } as const,
+  ])("ReadableStream with spawn options variations: stderr=$stderr", async config => {
+    const stream = new ReadableStream({
+      async pull(controller) {
+        await Bun.sleep(0);
+        controller.enqueue("test input");
+        controller.close();
+      },
+    });
 
-    for (const config of configs) {
-      const stream = new ReadableStream({
-        async pull(controller) {
-          await Bun.sleep(0);
-          controller.enqueue("test input");
-          controller.close();
-        },
-      });
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
+      stdin: stream,
+      ...config,
+      env: bunEnv,
+    });
 
-      const proc = spawn({
-        cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
-        stdin: stream,
-        ...config,
-        env: bunEnv,
-      });
-
-      const stdout = await proc.stdout.text();
-      expect(stdout).toBe("test input");
-      expect(await proc.exited).toBe(0);
-    }
+    const stdout = await proc.stdout.text();
+    expect(stdout).toBe("test input");
+    expect(await proc.exited).toBe(0);
   });
 });

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -341,6 +341,56 @@ describe("spawn stdin ReadableStream", () => {
     await expectStdinStreamErrorSurfaces("pull", false);
   });
 
+  // When the producer errors while a chunk is still backpressured in the pipe,
+  // the pump's abrupt-completion path calls sink.close() -> FileSink::end()
+  // (which sets `done`) before the pump promise rejection lands. The error must
+  // still be stored for onExit rather than falling back to unhandledRejection.
+  test("ReadableStream error with a backpressured write surfaces via onExit", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const reasons = [];
+        process.on("unhandledRejection", r => { reasons.push(String(r?.message ?? r)); });
+        const chunk = Buffer.alloc(256 * 1024, "x");
+        let n = 0;
+        const stream = new ReadableStream({
+          async pull(c) {
+            n++;
+            if (n === 1) { c.enqueue(chunk); await Bun.sleep(10); return; }
+            c.error(new Error("stdin stream boom"));
+          },
+        });
+        let onExitArgs = null;
+        const child = Bun.spawn({
+          // Child never reads stdin, so the 256 KiB chunk cannot drain.
+          cmd: [process.execPath, "-e", "setTimeout(() => {}, 1e9)"],
+          stdin: stream,
+          stdout: "ignore",
+          onExit(proc, code, signal, err) { onExitArgs = String(err?.message ?? err); },
+        });
+        await Bun.sleep(100);
+        child.kill();
+        await child.exited;
+        await Bun.sleep(50);
+        console.log(JSON.stringify({ onExitArgs, reasons }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("stdin stream boom");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      onExitArgs: "stdin stream boom",
+      reasons: [],
+    });
+    expect(exitCode).toBe(0);
+  });
+
   // The ReadableStream -> stdin FileSink pump intentionally does not await the
   // Promise FileSink.write() returns for writes it cannot complete synchronously
   // (a full pipe on POSIX, every pipe write on Windows). When the child dies

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -255,59 +255,56 @@ describe("spawn stdin ReadableStream", () => {
     expect(text.trim().split("\n").length).toBe(2);
   });
 
-  test("ReadableStream error handling", async () => {
-    const stream = new ReadableStream({
-      async start(controller) {
-        controller.enqueue("before error\n");
-        // Give time for the data to be consumed
-        await Bun.sleep(10);
-        controller.error(new Error("Stream error"));
-      },
-    });
-
-    await using proc = spawn({
-      cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
-      stdin: stream,
-      stdout: "pipe",
-      env: bunEnv,
-    });
-
-    const text = await proc.stdout.text();
-    // Process should receive data before the error
-    expect(text).toBe("before error\n");
-
-    // Process should exit normally (the stream error happens after data is sent)
-    expect(await proc.exited).toBe(0);
-  });
-
-  test("erroring the stdin ReadableStream does not surface an unhandled rejection", async () => {
-    // Regression: once ReadableStream locked-state detection works, the FileSink
-    // teardown's stream.cancel() reaches readableStreamCancel, which returns a
-    // rejected promise for an already-errored stream. That promise must be marked
-    // handled, otherwise the stored error surfaces as an uncaught rejection in the
-    // parent process. Run it in a child so a stray rejection lands on its stderr.
+  // When the user's ReadableStream producer fails mid-stream (controller.error()),
+  // the child's stdin pipe is closed and the child sees EOF on the bytes delivered
+  // so far. The producer's error must still surface: it is delivered as the fourth
+  // `error` argument to onExit(proc, exitCode, signalCode, error). When no onExit
+  // handler is registered it is reported as an unhandled rejection instead, the
+  // same as an un-caught stream.pipeTo(sink). proc.exited stays truthful (resolves
+  // to the real exit code). Previously the pump's .then() rejection handler
+  // swallowed the error and the truncation was silent.
+  //
+  // The FileSink teardown's own stream.cancel() on the already-errored stream
+  // yields a rejected promise too; that one is internal and stays handled
+  // (markCancelResultHandled in ReadableStream.cpp), so exactly one report
+  // reaches the user and it carries the producer's reason verbatim.
+  async function expectStdinStreamErrorSurfaces(source: "start" | "pull", withOnExit: boolean) {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `
-        let uncaught = 0;
-        process.on("unhandledRejection", () => { uncaught++; });
-        const stream = new ReadableStream({
+        const reasons = [];
+        process.on("unhandledRejection", r => { reasons.push(String(r?.message ?? r)); });
+        const stream = new ReadableStream(${
+          source === "start"
+            ? `{
           async start(controller) {
-            controller.enqueue("hi\\n");
+            controller.enqueue("before error\\n");
             await Bun.sleep(10);
             controller.error(new Error("stdin stream boom"));
           },
+        }`
+            : `{
+          async pull(controller) {
+            this.n = (this.n ?? 0) + 1;
+            if (this.n <= 2) { controller.enqueue("chunk" + this.n + "\\n"); await Bun.sleep(10); return; }
+            controller.error(new Error("stdin stream boom"));
+          },
+        }`
         });
+        let onExitArgs = null;
+        let exitedRejection = null;
         const child = Bun.spawn({
           cmd: [process.execPath, "-e", "process.stdin.pipe(process.stdout)"],
           stdin: stream,
-          stdout: "ignore",
+          stdout: "pipe",
+          ${withOnExit ? `onExit(proc, code, signal, err) { onExitArgs = [code, signal, String(err?.message ?? err)]; },` : ``}
         });
-        await child.exited;
+        const out = await child.stdout.text();
+        const code = await child.exited.catch(e => { exitedRejection = String(e?.message ?? e); return -1; });
         await Bun.sleep(50);
-        console.log("uncaught=" + uncaught);
+        console.log(JSON.stringify({ out, code, onExitArgs, exitedRejection, reasons }));
         `,
       ],
       env: bunEnv,
@@ -316,9 +313,32 @@ describe("spawn stdin ReadableStream", () => {
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The handler intercepts the report; nothing leaks to stderr.
     expect(stderr).not.toContain("stdin stream boom");
-    expect(stdout.trim()).toBe("uncaught=0");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      out: source === "start" ? "before error\n" : "chunk1\nchunk2\n",
+      code: 0,
+      onExitArgs: withOnExit ? [0, null, "stdin stream boom"] : null,
+      exitedRejection: null,
+      reasons: withOnExit ? [] : ["stdin stream boom"],
+    });
     expect(exitCode).toBe(0);
+  }
+
+  test("ReadableStream error mid-stream surfaces via onExit error arg (start)", async () => {
+    await expectStdinStreamErrorSurfaces("start", true);
+  });
+
+  test("ReadableStream error mid-stream surfaces via onExit error arg (pull)", async () => {
+    await expectStdinStreamErrorSurfaces("pull", true);
+  });
+
+  test("ReadableStream error mid-stream with no onExit surfaces as unhandledRejection (start)", async () => {
+    await expectStdinStreamErrorSurfaces("start", false);
+  });
+
+  test("ReadableStream error mid-stream with no onExit surfaces as unhandledRejection (pull)", async () => {
+    await expectStdinStreamErrorSurfaces("pull", false);
   });
 
   // The ReadableStream -> stdin FileSink pump intentionally does not await the

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -303,7 +303,9 @@ describe("spawn stdin ReadableStream", () => {
         });
         const out = await child.stdout.text();
         const code = await child.exited.catch(e => { exitedRejection = String(e?.message ?? e); return -1; });
-        await Bun.sleep(50);
+        // The no-onExit fallback creates its rejected promise inside
+        // on_process_exit; the tracker reports it on a later event-loop turn.
+        for (let i = 0; i < 10; i++) await Bun.sleep(0);
         console.log(JSON.stringify({ out, code, onExitArgs, exitedRejection, reasons }));
         `,
       ],
@@ -354,12 +356,14 @@ describe("spawn stdin ReadableStream", () => {
         const reasons = [];
         process.on("unhandledRejection", r => { reasons.push(String(r?.message ?? r)); });
         const chunk = Buffer.alloc(256 * 1024, "x");
+        const { promise: errored, resolve: markErrored } = Promise.withResolvers();
         let n = 0;
         const stream = new ReadableStream({
           async pull(c) {
             n++;
-            if (n === 1) { c.enqueue(chunk); await Bun.sleep(10); return; }
+            if (n === 1) { c.enqueue(chunk); await Bun.sleep(0); return; }
             c.error(new Error("stdin stream boom"));
+            markErrored();
           },
         });
         let onExitArgs = null;
@@ -370,10 +374,15 @@ describe("spawn stdin ReadableStream", () => {
           stdout: "ignore",
           onExit(proc, code, signal, err) { onExitArgs = String(err?.message ?? err); },
         });
-        await Bun.sleep(100);
+        await errored;
+        // One task turn so the pump's rejection microtask chain from c.error()
+        // reaches handle_reject_stream before the child is killed.
+        await Bun.sleep(0);
         child.kill();
         await child.exited;
-        await Bun.sleep(50);
+        // Give the unhandled-rejection tracker enough turns to report any stray
+        // rejection so asserting reasons: [] below is meaningful.
+        for (let i = 0; i < 10; i++) await Bun.sleep(0);
         console.log(JSON.stringify({ onExitArgs, reasons }));
         `,
       ],


### PR DESCRIPTION
## What

When `Bun.spawn({ stdin: readableStream })` is given a producer that calls `controller.error()` after delivering some chunks, the child's stdin pipe is closed as a clean EOF, `proc.exited` resolves `0`, and the producer's error surfaces nowhere: no rejected promise, no `unhandledRejection`, no `onExit` error argument. Silent input truncation.

```js
let n = 0;
const stream = new ReadableStream({
  async pull(c) {
    n++;
    if (n <= 2) { c.enqueue(new TextEncoder().encode(`chunk${n}\n`)); await Bun.sleep(30); return; }
    c.error(new Error("PRODUCER-BOOM"));
  },
});
let unhandled = null;
process.on("unhandledRejection", r => { unhandled = String(r?.message ?? r); });
const proc = Bun.spawn(["cat"], { stdin: stream, stdout: "pipe" });
const out = await new Response(proc.stdout).text();
const code = await proc.exited;
await Bun.sleep(200);
console.log({ childReceived: out, exitCode: code, signalCode: proc.signalCode, unhandled });
// before: { childReceived: "chunk1\nchunk2\n", exitCode: 0, signalCode: null, unhandled: null }
// after:  { childReceived: "chunk1\nchunk2\n", exitCode: 0, signalCode: null, unhandled: "PRODUCER-BOOM" }
```

Every sibling consumer of the same stream already rejects with the producer's error (`new Response(s).text()`, `s.pipeTo(ws)`); spawn was the only sink that ate it.

## Cause

`readStreamIntoSink` (BunStreamSource.cpp) rejects its result promise with the producer's error via `rsisAbrupt`. `FileSink::assign_to_stream` attaches `.then(on_resolve_stream_shim, on_reject_stream_shim)` to that promise, which marks it handled. `on_reject_stream` forwarded the reason to `handle_reject_stream` whose parameter was `_err: JSValue` and never read; the body just aborted the (already errored) source stream and closed the writer. With `proc.stdin` cached as the source `ReadableStream` itself (`Subprocess::js::stdin_set_cached`), there was no user-visible handle for the pump to reject.

## Fix

`FileSink` gains a `stream_error` Strong (spawn-stdin only, alongside `readable_stream`). `handle_reject_stream` stores the reason there before closing the writer. `Subprocess::on_process_exit` reads it via the existing `Writable::Pipe` / `weak_file_sink_stdin_ptr` handle before `on_attached_process_exit` tears the sink down, and:

- when an `onExit` handler is registered, delivers it as the fourth `error` argument (the slot that previously only carried `Status::Err` from waitpid), alongside the truthful exit code and signal
- when no `onExit` handler is registered, emits it as a fresh rejected promise so it reaches `unhandledRejection`, matching an un-caught `stream.pipeTo(sink)`

`proc.exited` keeps resolving to the real exit code (the child really did exit 0). If the subprocess has already run `on_process_exit` by the time the rejection arrives (indicated by `done`), the error is reported immediately instead of being stored.

The synchronous already-Rejected branch in `assign_to_stream` now marks the pump promise handled before calling `handle_reject_stream`, so the error is delivered exactly once through the same channel instead of also surfacing via the VM rejection tracker.

## Tests

`test/js/bun/spawn/spawn-stdin-readable-stream.test.ts` replaces the two earlier error-handling tests with four variants covering `start()`/`pull()` x with/without `onExit`. Each asserts the child received only the prefix, `proc.exited` resolved `0`, and exactly one report carrying `"stdin stream boom"` arrived on the expected channel. All four fail on main (`reasons: []`, `onExitArgs[3] === undefined`) and pass with this change. The rest of the file (30 tests) continues to pass, including the child-death EPIPE guards and the tee()-after-exit crash guards.

The previous `uncaught=0` assertion guarded a different concern (the teardown `stream.cancel()` rejected promise on an already-errored stream); that promise is still marked handled by `markCancelResultHandled` in `ReadableStream.cpp`, and the new assertions confirm exactly one rejection reaches the user.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 failed, 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
bun test v1.4.0 (9a29d227f)

test/js/bun/spawn/spawn-stdin-readable-stream.test.ts:
(pass) spawn stdin ReadableStream > basic ReadableStream as stdin [1651.34ms]
(pass) spawn stdin ReadableStream > ReadableStream with multiple chunks [1605.27ms]
(pass) spawn stdin ReadableStream > ReadableStream with Uint8Array chunks [1634.78ms]
(pass) spawn stdin ReadableStream > ReadableStream with delays between chunks [1583.73ms]
(pass) spawn stdin ReadableStream > ReadableStream with pull method [1642.28ms]
(pass) spawn stdin ReadableStream > ReadableStream with async pull and delays [1503.82ms]
(pass) spawn stdin ReadableStream > ReadableStream with large data [1574.60ms]
1048576
(pass) spawn stdin ReadableStream > ReadableStream with very large chunked data [1596.87ms]
(todo) spawn stdin ReadableStream > ReadableStream cancellation when process exits early
315 |     });
316 | 
317 |     const [stdout, stderr, exitCode] = await 
... (truncated)

release without fix: 3 skipped
bun test v1.4.0-canary.1 (b541cdd6c)

test/js/bun/spawn/spawn-stdin-readable-stream.test.ts:
(pass) spawn stdin ReadableStream > basic ReadableStream as stdin [30.42ms]
(pass) spawn stdin ReadableStream > ReadableStream with multiple chunks [28.72ms]
(pass) spawn stdin ReadableStream > ReadableStream with Uint8Array chunks [27.74ms]
(pass) spawn stdin ReadableStream > ReadableStream with delays between chunks [107.00ms]
(pass) spawn stdin ReadableStream > ReadableStream with pull method [32.19ms]
(pass) spawn stdin ReadableStream > ReadableStream with async pull and delays [97.22ms]
(pass) spawn stdin ReadableStream > ReadableStream with large data [33.11ms]
1048576
(pass) spawn stdin ReadableStream > ReadableStream with very large chunked data [30.08ms]
(todo) spawn stdin ReadableStream > ReadableStream cancellation when process exits early
(pass) spawn stdin ReadableStream > ReadableStream error mid-stream surfaces via onExit error arg (start) [42.03ms]
(pass) spawn stdin ReadableStream > ReadableStream error mid-stream surfaces via onExit error arg (pull) [44.90ms]
(pass) spawn stdin ReadableStream > ReadableStream error mid-stream with no onExit surfaces as unha
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
bun test v1.4.0 (9a29d227f)

test/js/bun/spawn/spawn-stdin-readable-stream.test.ts:
(pass) spawn stdin ReadableStream > basic ReadableStream as stdin [2177.93ms]
(pass) spawn stdin ReadableStream > ReadableStream with multiple chunks [2063.13ms]
(pass) spawn stdin ReadableStream > ReadableStream with Uint8Array chunks [1907.48ms]
(pass) spawn stdin ReadableStream > ReadableStream with delays between chunks [2031.24ms]
(pass) spawn stdin ReadableStream > ReadableStream with pull method [1622.72ms]
(pass) spawn stdin ReadableStream > ReadableStream with async pull and delays [1567.23ms]
(pass) spawn stdin ReadableStream > ReadableStream with large data [1744.47ms]
1048576
(pass) spawn stdin ReadableStream > ReadableStream with very large chunked data [1778.36ms]
(todo) spawn stdin ReadableStream > ReadableStream cancellation when process exits early
(pass) spawn stdin ReadableStream > ReadableStream error mid-stream surf
... (truncated)

release with fix: 3 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1048ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/subprocess.rs                  |  10 ++
 src/runtime/webcore/FileSink.rs                    |  15 ++-
 .../spawn-stdin-readable-stream-edge-cases.test.ts |  53 ++++----
 .../bun/spawn/spawn-stdin-readable-stream.test.ts  | 147 ++++++++++++++++-----
 4 files changed, 164 insertions(+), 61 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/api/bun/subprocess.rs                             7      9      0
src/runtime/webcore/FileSink.rs                              11     13      0
…un/spawn/spawn-stdin-readable-stream-edge-cases.test.ts      2      2      0
test/js/bun/spawn/spawn-stdin-readable-stream.test.ts         3     12      0
```

</details>

<!-- robobun:evidence:end -->