### PR TITLE
node:vm: don't install a context's own global proxy as its sandbox in runInContext

### DIFF
--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -609,15 +609,10 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInContext, (JSGlobalObject * globalObject, Cal
     RETURN_IF_EXCEPTION(scope, {});
     ASSERT(nodeVmGlobalObject != nullptr);
 
-    // The resolved NodeVMGlobalObject already knows its sandbox (set at
-    // createContext time). Pass that through rather than the raw contextArg:
-    // contextArg may be the context's own global proxy (e.g.
-    // `vm.runInContext('typeof Array', vm.runInNewContext('globalThis'))`), and
-    // installing that as m_sandbox makes getOwnPropertySlot recurse into itself
-    // until the native stack is exhausted.
-    JSObject* sandbox = nodeVmGlobalObject->contextifiedObject();
-
-    RELEASE_AND_RETURN(scope, runInContext(nodeVmGlobalObject, script, sandbox, args.at(1)));
+    // Use the sandbox registered at createContext time: contextArg may be this
+    // global's own proxy, which as m_sandbox makes getOwnPropertySlot recurse
+    // into itself.
+    RELEASE_AND_RETURN(scope, runInContext(nodeVmGlobalObject, script, nodeVmGlobalObject->contextifiedObject(), args.at(1)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(scriptRunInNewContext, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -607,10 +607,17 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInContext, (JSGlobalObject * globalObject, Cal
     JSValue contextArg = args.at(0);
     NodeVMGlobalObject* nodeVmGlobalObject = getGlobalObjectFromContext(globalObject, contextArg, true);
     RETURN_IF_EXCEPTION(scope, {});
-    JSObject* context = asObject(contextArg);
     ASSERT(nodeVmGlobalObject != nullptr);
 
-    RELEASE_AND_RETURN(scope, runInContext(nodeVmGlobalObject, script, context, args.at(1)));
+    // The resolved NodeVMGlobalObject already knows its sandbox (set at
+    // createContext time). Pass that through rather than the raw contextArg:
+    // contextArg may be the context's own global proxy (e.g.
+    // `vm.runInContext('typeof Array', vm.runInNewContext('globalThis'))`), and
+    // installing that as m_sandbox makes getOwnPropertySlot recurse into itself
+    // until the native stack is exhausted.
+    JSObject* sandbox = nodeVmGlobalObject->contextifiedObject();
+
+    RELEASE_AND_RETURN(scope, runInContext(nodeVmGlobalObject, script, sandbox, args.at(1)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(scriptRunInNewContext, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1071,6 +1071,55 @@ describe("DONT_CONTEXTIFY", () => {
   });
 });
 
+test("runInContext on a vm context's own globalThis does not recurse unboundedly", async () => {
+  // Passing a vm context's own global proxy (the `globalThis` seen inside the
+  // context) as the contextified object used to overwrite that context's
+  // sandbox with a reference to itself. The next global identifier lookup then
+  // bounced NodeVMGlobalObject::getOwnPropertySlot -> sandbox->getPropertySlot
+  // -> NodeVMGlobalObject::getOwnPropertySlot until the native stack was
+  // exhausted, crashing with a raw SIGSEGV and no Bun crash report. Run out of
+  // process so the fail-before state is an observable non-zero exit rather
+  // than a crashed test runner.
+  const fixture = `
+    const vm = require("node:vm");
+
+    // via createContext + runInContext('globalThis')
+    const a = {};
+    vm.createContext(a);
+    const g = vm.runInContext("globalThis", a);
+    vm.createContext(g);
+    console.log("literal", vm.runInContext("40 + 2", g));
+    console.log("typeof-Array", vm.runInContext("typeof Array", g));
+    console.log("Array-identity", vm.runInContext("Array", g) === vm.runInContext("Array", a));
+    vm.runInContext("var fromG = 1", g);
+    console.log("var-visible", a.fromG, vm.runInContext("fromG", a));
+
+    // via runInNewContext('globalThis')
+    const g2 = vm.runInNewContext("globalThis");
+    vm.createContext(g2);
+    console.log("typeof-Object", vm.runInContext("typeof Object", g2));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+    "literal 42
+    typeof-Array function
+    Array-identity true
+    var-visible 1 1
+    typeof-Object function"
+  `);
+  expect(exitCode).toBe(0);
+});
+
 test("Loader is not defined in vm context", () => {
   // Test with empty context - internal Loader should not leak through
   const emptyContext = createContext({});


### PR DESCRIPTION
### Repro

```js
import vm from "node:vm";
const a = {}; vm.createContext(a);
const g = vm.runInContext("globalThis", a);  // context's own global proxy
vm.createContext(g);
vm.runInContext("typeof Array", g);          // node: "function"   bun: SIGSEGV
```

The `createContext(g)` call is not actually required; `vm.runInContext("typeof Array", vm.runInNewContext("globalThis"))` crashes on its own. A literal-only script (`"40 + 2"`) survives; any global identifier lookup enters the loop. The crash is a raw `Segmentation fault` from native stack exhaustion with no Bun crash report (stack use scales with `ulimit -s`).

### Cause

`Script.prototype.runInContext` resolves the `NodeVMGlobalObject` from the context argument and then passes the raw argument as `contextifiedObject` into the static `runInContext` helper, which calls `setContextifiedObject()` unconditionally. When the argument is the context's own `globalThis` proxy (a `JSGlobalProxy` whose target is the very `NodeVMGlobalObject` being resolved), `m_sandbox` becomes a self-reference:

```
NodeVMGlobalObject::getOwnPropertySlot("Array")
  contextifiedObject->getPropertySlot("Array")   // contextifiedObject is this global's own proxy
    NodeVMGlobalObject::getOwnPropertySlot("Array")
      ...
```

### Fix

`scriptRunInContext` now passes `nodeVmGlobalObject->contextifiedObject()` (the sandbox that `createContext` already registered) instead of the raw caller argument. For the normal case (argument is the sandbox) this is a no-op; for the global-proxy case it keeps the original sandbox and avoids the cycle. Observable behavior matches Node: `Array` identity is shared with the originating context and `var` assignments land on the originating sandbox.

### Verification

New test in `test/js/node/vm/vm.test.ts` spawns a subprocess that exercises both entry shapes (`createContext` + `runInContext("globalThis", a)` and `runInNewContext("globalThis")`) and asserts the Node-matching output. Without the fix the subprocess segfaults after printing `literal 42` and the snapshot fails; with the fix `vm.test.ts` is 213 pass / 0 fail and all 95 `test/js/node/test/parallel/test-vm-*.js` continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (28b9b2cfd)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [21.28ms]
(pass) vm > runInContext() > can return a value [15.71ms]
(pass) vm > runInContext() > can return a complex value [15.51ms]
(pass) vm > runInContext() > can return the last value [14.74ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [17.15ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.94ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.40ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [16.18ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.73ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [14.97ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [15.22ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [15.57ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release without fix: 62 skipped
bun test v1.4.0-canary.1 (dfe0082a9)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.41ms]
(pass) vm > runInContext() > can return a value [0.21ms]
(pass) vm > runInContext() > can return a complex value [0.20ms]
(pass) vm > runInContext() > can return the last value [0.17ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.21ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.28ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (28b9b2cfd)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [23.01ms]
(pass) vm > runInContext() > can return a value [15.42ms]
(pass) vm > runInContext() > can return a complex value [16.28ms]
(pass) vm > runInContext() > can return the last value [15.67ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [17.17ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [14.11ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [16.06ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [16.26ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.59ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [15.45ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [15.58ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [15.29ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 767ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] cxx obj/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp.o
[2/9] gen cpp.rs (cppbind)
[3/9] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Comp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVMScript.cpp |  6 +++--
 test/js/node/vm/vm.test.ts        | 49 +++++++++++++++++++++++++++++++++++++++
 2 files changed, 53 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/jsc/bindings/NodeVMScript.cpp      3      3      0
test/js/node/vm/vm.test.ts             4      2      0
```

</details>

<!-- robobun:evidence:end -->