### PR TITLE
Bun.CookieMap.delete: accept undefined/null options and coerce non-string names

### DIFF
--- a/src/jsc/bindings/webcore/JSCookieMap.cpp
+++ b/src/jsc/bindings/webcore/JSCookieMap.cpp
@@ -448,9 +448,12 @@ static inline JSC::EncodedJSValue jsCookieMapPrototypeFunction_deleteBody(JSC::J
     } else {
         nameArg = arg0;
         if (callFrame->argumentCount() >= 2) {
-            optionsArg = callFrame->uncheckedArgument(1);
-            if (!optionsArg.isObject()) {
-                return throwVMError(lexicalGlobalObject, throwScope, createTypeError(lexicalGlobalObject, "Options must be an object"_s));
+            JSValue arg1 = callFrame->uncheckedArgument(1);
+            if (!arg1.isUndefinedOrNull()) {
+                if (!arg1.isObject()) {
+                    return throwVMError(lexicalGlobalObject, throwScope, createTypeError(lexicalGlobalObject, "Options must be an object"_s));
+                }
+                optionsArg = arg1;
             }
         }
     }
@@ -487,17 +490,12 @@ static inline JSC::EncodedJSValue jsCookieMapPrototypeFunction_deleteBody(JSC::J
         }
     }
 
-    if (nameValue && nameValue.isString()) {
-        RETURN_IF_EXCEPTION(throwScope, {});
-
-        if (!nameValue.isUndefined() && !nameValue.isNull()) {
-            deleteOptions.name = convert<IDLUSVString>(*lexicalGlobalObject, nameValue);
-        }
-
-        RETURN_IF_EXCEPTION(throwScope, {});
-    } else {
+    if (!nameValue || nameValue.isUndefinedOrNull()) {
         return throwVMError(lexicalGlobalObject, throwScope, createTypeError(lexicalGlobalObject, "Cookie name is required"_s));
     }
+
+    deleteOptions.name = convert<IDLUSVString>(*lexicalGlobalObject, nameValue);
+    RETURN_IF_EXCEPTION(throwScope, {});
 
     WebCore::propagateException(*lexicalGlobalObject, throwScope, impl.remove(deleteOptions));
     RETURN_IF_EXCEPTION(throwScope, {});

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -466,3 +466,59 @@ describe("invalid delete usage", () => {
     }).toThrow("Cookie name is required");
   });
 });
+
+describe("CookieMap.delete argument handling", () => {
+  test.each([undefined, null] as const)("delete(name, %p) treats the options argument as omitted", nothing => {
+    const map = new Bun.CookieMap("a=1; b=2");
+    // @ts-expect-error
+    map.delete("a", nothing);
+    expect(map.has("a")).toBe(false);
+    expect(map.has("b")).toBe(true);
+    expect(map.toSetCookieHeaders()).toEqual(["a=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"]);
+  });
+
+  test("delete(name, options) honours the options when a non-nullish object is passed", () => {
+    const map = new Bun.CookieMap("a=1");
+    map.delete("a", { path: "/foo", domain: "example.com" });
+    expect(map.toSetCookieHeaders()).toEqual([
+      "a=; Domain=example.com; Path=/foo; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+    ]);
+  });
+
+  test("delete(name, primitive) still rejects a non-nullish non-object options argument", () => {
+    for (const bad of [42, "x", true]) {
+      const map = new Bun.CookieMap("a=1");
+      // @ts-expect-error
+      expect(() => map.delete("a", bad)).toThrow("Options must be an object");
+      expect(map.has("a")).toBe(true);
+    }
+  });
+
+  test("delete coerces a non-string name the same way get/has/set do", () => {
+    const map = new Bun.CookieMap("5=x; true=y");
+    expect(map.get(5 as any)).toBe("x");
+    expect(map.has(5 as any)).toBe(true);
+
+    // @ts-expect-error
+    map.delete(5);
+    expect(map.has("5")).toBe(false);
+
+    // @ts-expect-error
+    map.delete(true);
+    expect(map.has("true")).toBe(false);
+
+    expect(map.size).toBe(0);
+  });
+
+  test("delete({ name }) coerces a non-string name property", () => {
+    const map = new Bun.CookieMap("5=x");
+    map.delete({ name: 5 as any });
+    expect(map.has("5")).toBe(false);
+  });
+
+  test("delete with a missing or nullish name still throws", () => {
+    expect(() => new Bun.CookieMap("a=1").delete(undefined as any)).toThrow("Cookie name is required");
+    expect(() => new Bun.CookieMap("a=1").delete(null as any)).toThrow("Cookie name is required");
+    expect(() => new Bun.CookieMap("a=1").delete({} as any)).toThrow("Cookie name is required");
+  });
+});


### PR DESCRIPTION
## Repro

```js
new Bun.CookieMap("a=1").delete("a", undefined);
// TypeError: Options must be an object

const m = new Bun.CookieMap("5=x");
m.get(5);    // "x"  (coerced)
m.has(5);    // true (coerced)
m.delete(5); // TypeError: Cookie name is required
```

## Cause

`jsCookieMapPrototypeFunction_deleteBody` diverged from its siblings in two places:

- The optional second argument was read with an argument-count check followed by `!arg.isObject()`, so an explicit `undefined`/`null` threw. `CookieMap.set`, `new Bun.Cookie`, `Cookie.from`, and `Cookie.parse` all treat a nullish optional dictionary as omitted via `isUndefinedOrNull()` (WebIDL optional-dictionary semantics). The object-overload form `delete({ name }, undefined)` already worked because the second argument is ignored on that path, so the inconsistency only hit the `delete(name, options)` overload.
- The name was gated on `isString()` instead of being run through `convert<IDLUSVString>`, so a numeric or boolean name threw where `get`/`has`/`set` coerce.

## Fix

- A nullish second argument is treated as omitted; a non-nullish non-object still throws `"Options must be an object"`.
- The name is converted via `IDLUSVString` like `get`/`has`/`set`. A missing or nullish name still throws `"Cookie name is required"`, preserving the existing guard against `delete(undefined)` / `delete({})`.

## Verification

`bun bd test test/js/bun/cookie/cookie-map.test.ts`: 40 pass / 0 fail. New `CookieMap.delete argument handling` describe block fails on main (4 failures: `Options must be an object` / `Cookie name is required`) and passes with this change. The adjacent `cookie.test.ts` and `util/cookie.test.js` suites are unchanged (136 pass, 18 skip).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/cookie/cookie-map.test.ts
bun test v1.4.0 (c1b5a6a86)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [8.83ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [8.03ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [8.28ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [277.54ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [4.67ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [5.63ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [5.01ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [4.70ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [2.23ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse reads every attribute in any order [10.28ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.seriali
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (915c7a536)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [0.08ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [0.06ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [0.07ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [5.90ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [0.10ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [0.07ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [0.06ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [0.06ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [0.03ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse reads every attribute in any order [0.14ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.serialize creates cookie string [0.04ms]
(pass) Bun.Cookie and Bun.CookieMap > can create an empty CookieMap [0.05ms]
(pass) Bun.Cookie and Bun.CookieMap > can create Cooki
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/cookie/cookie-map.test.ts
bun test v1.4.0 (c1b5a6a86)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [5.25ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [4.64ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [4.86ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [154.41ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [4.69ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [5.77ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [4.89ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [5.09ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [2.38ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse reads every attribute in any order [10.08ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.seriali
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 654ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-1.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 3m 32s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.0-canary.1+c1b5a6a86
[build] done
bun test v1.4.0-canary.1 (c1b5a6a86)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [0.16ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [0.12ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [0.17ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [9.87ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [0.14ms]
(pass
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSCookieMap.cpp | 22 ++++++-------
 test/js/bun/cookie/cookie-map.test.ts    | 56 ++++++++++++++++++++++++++++++++
 2 files changed, 66 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/jsc/bindings/webcore/JSCookieMap.cpp      3      2      0
test/js/bun/cookie/cookie-map.test.ts         1      1      0
```

</details>

<!-- robobun:evidence:end -->