### PR TITLE
sql(postgres): hex-encode Uint8Array/DataView elements in sql.array; stop TypedArray.map coercion

### DIFF
--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -145,9 +145,7 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
     const buf = Buffer.isBuffer(value) ? value : Buffer.from(value.buffer, value.byteOffset, value.byteLength);
     const hexValue = buf.toString("hex");
     if (type === "BYTEA") {
-      // The array-literal parser consumes one level of backslash escaping, so
-      // the \x that reaches bytea_in must be written as \\x here.
-      return `"\\\\x${hexValue}"`;
+      return `"${arrayEscape("\\x" + hexValue)}"`;
     }
     if (is_json) {
       return `"${arrayEscape(JSON.stringify(hexValue))}"`;

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -150,11 +150,6 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
     return `{${value.map(arrayValueSerializer.bind(this, type, is_numeric, is_json)).join(delimiter)}}`;
   }
   if (ArrayBuffer.isView(value)) {
-    // Uint8Array / Uint8ClampedArray / DataView (and Buffer, a Uint8Array
-    // subclass) are a single binary element, so they follow the Buffer hex
-    // path. Every other typed array is a nested dimension of numbers; build
-    // the per-element strings into a plain Array because
-    // TypedArray.prototype.map would coerce them back to numbers.
     if (isByteView(value)) {
       const buf = Buffer.isBuffer(value) ? value : Buffer.from(value.buffer, value.byteOffset, value.byteLength);
       const hexValue = buf.toString("hex");
@@ -168,6 +163,7 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
     }
     if (!value.length) return "{}";
     const delimiter = type === "BOX" ? ";" : ",";
+    // Array.from, not value.map: TypedArray.prototype.map would coerce the strings back to numbers.
     return `{${Array.from(value, arrayValueSerializer.bind(this, type, is_numeric, is_json)).join(delimiter)}}`;
   }
 
@@ -247,8 +243,7 @@ function serializeArray(values: any[], type: ArrayType) {
   const delimiter = type === "BOX" ? ";" : ",";
 
   const serialize = arrayValueSerializer.bind(this, type, isPostgresNumericType(type), isPostgresJsonType(type));
-  // TypedArray.prototype.map returns the same typed array species, which would
-  // coerce the serialized strings back to numbers; build a plain Array instead.
+  // Array.from for TypedArrays: their .map would coerce the strings back to numbers.
   const parts = isArray ? values.map(serialize) : Array.from(values as ArrayLike<unknown>, serialize);
   return `{${parts.join(delimiter)}}`;
 }

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -158,7 +158,7 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
     throw $ERR_INVALID_ARG_VALUE(
       "values",
       value,
-      `binary (ArrayBuffer / TypedArray) elements are only supported in BYTEA or JSON arrays (got ${type})`,
+      `binary (ArrayBuffer / TypedArray) elements are only supported in BYTEA, JSON, or JSONB arrays (got ${type})`,
     );
   }
   if ($isArray(value)) {

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -145,7 +145,9 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
     const buf = Buffer.isBuffer(value) ? value : Buffer.from(value.buffer, value.byteOffset, value.byteLength);
     const hexValue = buf.toString("hex");
     if (type === "BYTEA") {
-      return `"\\x${arrayEscape(hexValue)}"`;
+      // The array-literal parser consumes one level of backslash escaping, so
+      // the \x that reaches bytea_in must be written as \\x here.
+      return `"\\\\x${hexValue}"`;
     }
     if (is_json) {
       return `"${arrayEscape(JSON.stringify(hexValue))}"`;

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -14,9 +14,6 @@ const {
   SQLQueryFlags,
   symbols: { _results, _handle },
 } = require("internal/sql/query");
-function isByteView(value: ArrayBufferView) {
-  return value instanceof Uint8Array || value instanceof Uint8ClampedArray || value instanceof DataView;
-}
 
 const { PostgresError } = require("internal/sql/errors");
 
@@ -144,27 +141,21 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
   // we do minimal to none type validation, we just try to format nicely and let the server handle if is valid SQL
   // postgres will try to convert string -> array type
   // postgres will emit a nice error saying what value dont have the expected format outputing the value in the error
+  if (ArrayBuffer.isView(value)) {
+    const buf = Buffer.isBuffer(value) ? value : Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+    const hexValue = buf.toString("hex");
+    if (type === "BYTEA") {
+      return `"\\x${arrayEscape(hexValue)}"`;
+    }
+    if (is_json) {
+      return `"${arrayEscape(JSON.stringify(hexValue))}"`;
+    }
+    throw $ERR_INVALID_ARG_VALUE("values", value, `ArrayBufferView elements are only supported in BYTEA or JSON arrays (got ${type})`);
+  }
   if ($isArray(value)) {
     if (!value.length) return "{}";
     const delimiter = type === "BOX" ? ";" : ",";
     return `{${value.map(arrayValueSerializer.bind(this, type, is_numeric, is_json)).join(delimiter)}}`;
-  }
-  if (ArrayBuffer.isView(value)) {
-    if (isByteView(value)) {
-      const buf = Buffer.isBuffer(value) ? value : Buffer.from(value.buffer, value.byteOffset, value.byteLength);
-      const hexValue = buf.toString("hex");
-      if (type === "BYTEA") {
-        return `"\\x${arrayEscape(hexValue)}"`;
-      }
-      if (is_json) {
-        return `"${arrayEscape(JSON.stringify(hexValue))}"`;
-      }
-      return `"${arrayEscape(hexValue)}"`;
-    }
-    if (!value.length) return "{}";
-    const delimiter = type === "BOX" ? ";" : ",";
-    // Array.from, not value.map: TypedArray.prototype.map would coerce the strings back to numbers.
-    return `{${Array.from(value, arrayValueSerializer.bind(this, type, is_numeric, is_json)).join(delimiter)}}`;
   }
 
   switch (typeof value) {

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -150,7 +150,11 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
     if (is_json) {
       return `"${arrayEscape(JSON.stringify(hexValue))}"`;
     }
-    throw $ERR_INVALID_ARG_VALUE("values", value, `ArrayBufferView elements are only supported in BYTEA or JSON arrays (got ${type})`);
+    throw $ERR_INVALID_ARG_VALUE(
+      "values",
+      value,
+      `ArrayBufferView elements are only supported in BYTEA or JSON arrays (got ${type})`,
+    );
   }
   if ($isArray(value)) {
     if (!value.length) return "{}";

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -14,10 +14,8 @@ const {
   SQLQueryFlags,
   symbols: { _results, _handle },
 } = require("internal/sql/query");
-function isTypedArray(value: any) {
-  // Buffer should be treated as a normal object
-  // Typed arrays should be treated like an array
-  return ArrayBuffer.isView(value) && !Buffer.isBuffer(value);
+function isByteView(value: ArrayBufferView) {
+  return value instanceof Uint8Array || value instanceof Uint8ClampedArray || value instanceof DataView;
 }
 
 const { PostgresError } = require("internal/sql/errors");
@@ -146,10 +144,31 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
   // we do minimal to none type validation, we just try to format nicely and let the server handle if is valid SQL
   // postgres will try to convert string -> array type
   // postgres will emit a nice error saying what value dont have the expected format outputing the value in the error
-  if ($isArray(value) || isTypedArray(value)) {
+  if ($isArray(value)) {
     if (!value.length) return "{}";
     const delimiter = type === "BOX" ? ";" : ",";
     return `{${value.map(arrayValueSerializer.bind(this, type, is_numeric, is_json)).join(delimiter)}}`;
+  }
+  if (ArrayBuffer.isView(value)) {
+    // Uint8Array / Uint8ClampedArray / DataView (and Buffer, a Uint8Array
+    // subclass) are a single binary element, so they follow the Buffer hex
+    // path. Every other typed array is a nested dimension of numbers; build
+    // the per-element strings into a plain Array because
+    // TypedArray.prototype.map would coerce them back to numbers.
+    if (isByteView(value)) {
+      const buf = Buffer.isBuffer(value) ? value : Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+      const hexValue = buf.toString("hex");
+      if (type === "BYTEA") {
+        return `"\\x${arrayEscape(hexValue)}"`;
+      }
+      if (is_json) {
+        return `"${arrayEscape(JSON.stringify(hexValue))}"`;
+      }
+      return `"${arrayEscape(hexValue)}"`;
+    }
+    if (!value.length) return "{}";
+    const delimiter = type === "BOX" ? ";" : ",";
+    return `{${Array.from(value, arrayValueSerializer.bind(this, type, is_numeric, is_json)).join(delimiter)}}`;
   }
 
   switch (typeof value) {
@@ -190,17 +209,6 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
         }
         return `"${arrayEscape(isoValue)}"`;
       }
-      if (Buffer.isBuffer(value)) {
-        const hexValue = value.toString("hex");
-        // bytea array
-        if (type === "BYTEA") {
-          return `"\\x${arrayEscape(hexValue)}"`;
-        }
-        if (is_json) {
-          return `"${arrayEscape(JSON.stringify(hexValue))}"`;
-        }
-        return `"${arrayEscape(hexValue)}"`;
-      }
       // fallback to JSON.stringify
       return `"${arrayEscape(JSON.stringify(value))}"`;
   }
@@ -230,14 +238,19 @@ function getArrayType(typeNameOrID: number | ArrayType | undefined = undefined):
   return "JSON";
 }
 function serializeArray(values: any[], type: ArrayType) {
-  if (!$isArray(values) && !isTypedArray(values)) return values;
+  const isArray = $isArray(values);
+  if (!isArray && !(ArrayBuffer.isView(values) && !Buffer.isBuffer(values))) return values;
 
   if (!values.length) return "{}";
 
   // Only _box (1020) has the ';' delimiter for arrays, all other types use the ',' delimiter
   const delimiter = type === "BOX" ? ";" : ",";
 
-  return `{${values.map(arrayValueSerializer.bind(this, type, isPostgresNumericType(type), isPostgresJsonType(type))).join(delimiter)}}`;
+  const serialize = arrayValueSerializer.bind(this, type, isPostgresNumericType(type), isPostgresJsonType(type));
+  // TypedArray.prototype.map returns the same typed array species, which would
+  // coerce the serialized strings back to numbers; build a plain Array instead.
+  const parts = isArray ? values.map(serialize) : Array.from(values as ArrayLike<unknown>, serialize);
+  return `{${parts.join(delimiter)}}`;
 }
 
 function wrapPostgresError(error: Error | PostgresErrorOptions) {

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -141,8 +141,13 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
   // we do minimal to none type validation, we just try to format nicely and let the server handle if is valid SQL
   // postgres will try to convert string -> array type
   // postgres will emit a nice error saying what value dont have the expected format outputing the value in the error
-  if (ArrayBuffer.isView(value)) {
-    const buf = Buffer.isBuffer(value) ? value : Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  const isView = ArrayBuffer.isView(value);
+  if (isView || value instanceof ArrayBuffer || value instanceof SharedArrayBuffer) {
+    const buf = Buffer.isBuffer(value)
+      ? value
+      : isView
+        ? Buffer.from(value.buffer, value.byteOffset, value.byteLength)
+        : Buffer.from(value);
     const hexValue = buf.toString("hex");
     if (type === "BYTEA") {
       return `"${arrayEscape("\\x" + hexValue)}"`;
@@ -153,7 +158,7 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
     throw $ERR_INVALID_ARG_VALUE(
       "values",
       value,
-      `ArrayBufferView elements are only supported in BYTEA or JSON arrays (got ${type})`,
+      `binary (ArrayBuffer / TypedArray) elements are only supported in BYTEA or JSON arrays (got ${type})`,
     );
   }
   if ($isArray(value)) {

--- a/test/js/sql/postgres-array-typedarray-serialize.test.ts
+++ b/test/js/sql/postgres-array-typedarray-serialize.test.ts
@@ -1,0 +1,138 @@
+// sql.array(values, type) must serialize TypedArray elements to the same
+// array literal as the equivalent Buffer or number[] input. Before the fix
+// every non-Buffer ArrayBufferView was treated as a nested dimension and its
+// per-element string serializations were written back INTO the typed array
+// via TypedArray.prototype.map, so a Uint8Array([1,2,44]) bytea element went
+// on the wire as {{0,0,0}} ('"1"' → NaN → 0) instead of {"\x01022c"}.
+//
+// The serialization happens entirely on the client before Bind, so a scripted
+// v3 backend that records the first Bind parameter is sufficient.
+
+import { SQL } from "bun";
+import { afterAll, expect, test } from "bun:test";
+import {
+  listeningServer,
+  pgAuthenticationOk,
+  pgBindComplete,
+  pgCommandComplete,
+  pgDataRow,
+  pgParameterDescription,
+  pgParseComplete,
+  pgReadFrontendMessages,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
+
+function readFirstBindParameter(body: Buffer): string {
+  // PostgreSQL FE/BE §55.7 Bind: String(portal) String(stmt) Int16(nFmt)
+  // Int16[nFmt] Int16(nParams) (Int32 len, Byte[len])[nParams] ...
+  let o = body.indexOf(0) + 1;
+  o = body.indexOf(0, o) + 1;
+  const nFmt = body.readInt16BE(o);
+  o += 2 + 2 * nFmt;
+  o += 2; // nParams
+  const len = body.readInt32BE(o);
+  o += 4;
+  return len < 0 ? "NULL" : body.toString("utf8", o, o + len);
+}
+
+let captured: string | undefined;
+const backend = await listeningServer(socket => {
+  let pending = Buffer.alloc(0);
+  let sawStartup = false;
+  socket.on("data", chunk => {
+    pending = Buffer.concat([pending, chunk]);
+    if (!sawStartup) {
+      if (pending.length < 4) return;
+      const len = pending.readInt32BE(0);
+      if (pending.length < len) return;
+      pending = pending.subarray(len);
+      sawStartup = true;
+      socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+    }
+    pending = pgReadFrontendMessages(pending, (type, body) => {
+      if (type === 0x50 /* Parse */) {
+        socket.write(
+          Buffer.concat([
+            pgParseComplete(),
+            pgParameterDescription([25]),
+            pgRowDescription([{ name: "v", typeOid: 25 }]),
+            pgReadyForQuery(),
+          ]),
+        );
+      } else if (type === 0x42 /* Bind */) {
+        captured = readFirstBindParameter(body);
+        socket.write(
+          Buffer.concat([
+            pgBindComplete(),
+            pgDataRow([Buffer.from("ok")]),
+            pgCommandComplete("SELECT 1"),
+            pgReadyForQuery(),
+          ]),
+        );
+      }
+    });
+  });
+  socket.on("error", () => {});
+});
+afterAll(() => new Promise<void>(r => backend.server.close(() => r())));
+
+async function bindLiteral(make: (sql: SQL) => unknown): Promise<string> {
+  captured = undefined;
+  const sql = new SQL({
+    adapter: "postgres",
+    hostname: "127.0.0.1",
+    port: backend.port,
+    username: "u",
+    database: "db",
+    tls: false,
+    max: 1,
+    prepare: true,
+    connectionTimeout: 2,
+  });
+  try {
+    await sql`select ${make(sql)} as v`;
+  } finally {
+    await sql.close({ timeout: 0 }).catch(() => {});
+  }
+  if (captured === undefined) throw new Error("no Bind observed");
+  return captured;
+}
+
+test("Uint8Array element in a BYTEA array is hex-encoded like Buffer", async () => {
+  const bytes = [1, 2, 44];
+  const fromBuffer = await bindLiteral(sql => sql.array([Buffer.from(bytes)], "BYTEA"));
+  const fromUint8 = await bindLiteral(sql => sql.array([new Uint8Array(bytes)], "BYTEA"));
+  const fromClamped = await bindLiteral(sql => sql.array([new Uint8ClampedArray(bytes)], "BYTEA"));
+  expect({ fromBuffer, fromUint8, fromClamped }).toEqual({
+    fromBuffer: '{"\\x01022c"}',
+    fromUint8: '{"\\x01022c"}',
+    fromClamped: '{"\\x01022c"}',
+  });
+});
+
+test("DataView element in a BYTEA array is hex-encoded like Buffer", async () => {
+  const fromDataView = await bindLiteral(sql => sql.array([new DataView(new Uint8Array([0xca, 0xfe]).buffer)], "BYTEA"));
+  expect(fromDataView).toBe('{"\\xcafe"}');
+});
+
+test("Uint8Array element in a non-BYTEA array follows the Buffer hex path", async () => {
+  const fromBuffer = await bindLiteral(sql => sql.array([Buffer.from([65, 66])], "TEXT"));
+  const fromUint8 = await bindLiteral(sql => sql.array([new Uint8Array([65, 66])], "TEXT"));
+  expect({ fromBuffer, fromUint8 }).toEqual({ fromBuffer: '{"4142"}', fromUint8: '{"4142"}' });
+});
+
+test("numeric TypedArray element becomes a nested dimension without coercion loss", async () => {
+  expect(await bindLiteral(sql => sql.array([new Float32Array([1.5, -2.25])], "DOUBLE PRECISION"))).toBe(
+    "{{1.5,-2.25}}",
+  );
+  expect(await bindLiteral(sql => sql.array([new BigInt64Array([1n, -2n])], "BIGINT"))).toBe("{{1,-2}}");
+  // Int16Array with a non-numeric element type: the quoted per-element strings
+  // previously coerced to NaN → 0 inside TypedArray.prototype.map.
+  expect(await bindLiteral(sql => sql.array([new Int16Array([7, 8])], "TEXT"))).toBe('{{"7","8"}}');
+});
+
+test("top-level Int16Array with a non-numeric element type is serialized without coercion", async () => {
+  const got = await bindLiteral(sql => sql.array(new Int16Array([7, 8, 9]), "TEXT"));
+  expect(got).toBe('{"7","8","9"}');
+});

--- a/test/js/sql/postgres-array-typedarray-serialize.test.ts
+++ b/test/js/sql/postgres-array-typedarray-serialize.test.ts
@@ -105,9 +105,9 @@ test("Uint8Array element in a BYTEA array is hex-encoded like Buffer", async () 
   const fromUint8 = await bindLiteral(sql => sql.array([new Uint8Array(bytes)], "BYTEA"));
   const fromClamped = await bindLiteral(sql => sql.array([new Uint8ClampedArray(bytes)], "BYTEA"));
   expect({ fromBuffer, fromUint8, fromClamped }).toEqual({
-    fromBuffer: '{"\\x01022c"}',
-    fromUint8: '{"\\x01022c"}',
-    fromClamped: '{"\\x01022c"}',
+    fromBuffer: '{"\\\\x01022c"}',
+    fromUint8: '{"\\\\x01022c"}',
+    fromClamped: '{"\\\\x01022c"}',
   });
 });
 
@@ -115,14 +115,14 @@ test("DataView element in a BYTEA array is hex-encoded like Buffer", async () =>
   const fromDataView = await bindLiteral(sql =>
     sql.array([new DataView(new Uint8Array([0xca, 0xfe]).buffer)], "BYTEA"),
   );
-  expect(fromDataView).toBe('{"\\xcafe"}');
+  expect(fromDataView).toBe('{"\\\\xcafe"}');
 });
 
 test("byte-view elements honour byteOffset / byteLength", async () => {
   const backing = new Uint8Array([0xaa, 0xca, 0xfe, 0xbb]);
   const fromDataView = await bindLiteral(sql => sql.array([new DataView(backing.buffer, 1, 2)], "BYTEA"));
   const fromSubarray = await bindLiteral(sql => sql.array([backing.subarray(1, 3)], "BYTEA"));
-  expect({ fromDataView, fromSubarray }).toEqual({ fromDataView: '{"\\xcafe"}', fromSubarray: '{"\\xcafe"}' });
+  expect({ fromDataView, fromSubarray }).toEqual({ fromDataView: '{"\\\\xcafe"}', fromSubarray: '{"\\\\xcafe"}' });
 });
 
 test("ArrayBufferView element in a JSON array is hex-encoded like Buffer", async () => {

--- a/test/js/sql/postgres-array-typedarray-serialize.test.ts
+++ b/test/js/sql/postgres-array-typedarray-serialize.test.ts
@@ -112,7 +112,9 @@ test("Uint8Array element in a BYTEA array is hex-encoded like Buffer", async () 
 });
 
 test("DataView element in a BYTEA array is hex-encoded like Buffer", async () => {
-  const fromDataView = await bindLiteral(sql => sql.array([new DataView(new Uint8Array([0xca, 0xfe]).buffer)], "BYTEA"));
+  const fromDataView = await bindLiteral(sql =>
+    sql.array([new DataView(new Uint8Array([0xca, 0xfe]).buffer)], "BYTEA"),
+  );
   expect(fromDataView).toBe('{"\\xcafe"}');
 });
 

--- a/test/js/sql/postgres-array-typedarray-serialize.test.ts
+++ b/test/js/sql/postgres-array-typedarray-serialize.test.ts
@@ -111,11 +111,14 @@ test("Uint8Array element in a BYTEA array is hex-encoded like Buffer", async () 
   });
 });
 
-test("DataView element in a BYTEA array is hex-encoded like Buffer", async () => {
-  const fromDataView = await bindLiteral(sql =>
-    sql.array([new DataView(new Uint8Array([0xca, 0xfe]).buffer)], "BYTEA"),
-  );
-  expect(fromDataView).toBe('{"\\\\xcafe"}');
+test("DataView and bare ArrayBuffer elements in a BYTEA array are hex-encoded like Buffer", async () => {
+  const backing = new Uint8Array([0xca, 0xfe]);
+  const fromDataView = await bindLiteral(sql => sql.array([new DataView(backing.buffer)], "BYTEA"));
+  const fromArrayBuffer = await bindLiteral(sql => sql.array([backing.buffer], "BYTEA"));
+  expect({ fromDataView, fromArrayBuffer }).toEqual({
+    fromDataView: '{"\\\\xcafe"}',
+    fromArrayBuffer: '{"\\\\xcafe"}',
+  });
 });
 
 test("byte-view elements honour byteOffset / byteLength", async () => {
@@ -131,10 +134,16 @@ test("ArrayBufferView element in a JSON array is hex-encoded like Buffer", async
   expect({ fromBuffer, fromUint8 }).toEqual({ fromBuffer: '{"\\"4142\\""}', fromUint8: '{"\\"4142\\""}' });
 });
 
-test("ArrayBufferView element in a non-BYTEA non-JSON array is rejected", () => {
+test("binary element in a non-BYTEA non-JSON array is rejected", () => {
   // sql.array() serializes eagerly, so the error surfaces before any I/O.
   const sql = new SQL({ adapter: "postgres", hostname: "127.0.0.1", port: 1, database: "d", max: 1 });
-  for (const element of [new Uint8Array([65, 66]), Buffer.from([65, 66]), new Float32Array([1.5, 2.5])]) {
+  const elements = [
+    new Uint8Array([65, 66]),
+    Buffer.from([65, 66]),
+    new Float32Array([1.5, 2.5]),
+    new Uint8Array([65, 66]).buffer,
+  ];
+  for (const element of elements) {
     for (const type of ["TEXT", "INT", "REAL"]) {
       const err = (() => {
         try {

--- a/test/js/sql/postgres-array-typedarray-serialize.test.ts
+++ b/test/js/sql/postgres-array-typedarray-serialize.test.ts
@@ -154,7 +154,7 @@ test("binary element in a non-BYTEA non-JSON array is rejected", () => {
         throw new Error(`expected sql.array([${element.constructor.name}], ${JSON.stringify(type)}) to throw`);
       })();
       expect(err.code).toBe("ERR_INVALID_ARG_VALUE");
-      expect(err.message).toContain("BYTEA or JSON");
+      expect(err.message).toContain("BYTEA, JSON, or JSONB");
     }
   }
 });

--- a/test/js/sql/postgres-array-typedarray-serialize.test.ts
+++ b/test/js/sql/postgres-array-typedarray-serialize.test.ts
@@ -1,9 +1,9 @@
-// sql.array(values, type) must serialize TypedArray elements to the same
-// array literal as the equivalent Buffer or number[] input. Before the fix
-// every non-Buffer ArrayBufferView was treated as a nested dimension and its
-// per-element string serializations were written back INTO the typed array
-// via TypedArray.prototype.map, so a Uint8Array([1,2,44]) bytea element went
-// on the wire as {{0,0,0}} ('"1"' → NaN → 0) instead of {"\x01022c"}.
+// sql.array(values, type) must hex-encode any ArrayBufferView element (Buffer,
+// Uint8Array, DataView, ...) in a BYTEA or JSON array and reject one anywhere
+// else. Before the fix every non-Buffer view was treated as a nested dimension
+// and its per-element string serializations were written back INTO the typed
+// array via TypedArray.prototype.map, so a Uint8Array([1,2,44]) bytea element
+// went on the wire as {{0,0,0}} ('"1"' → NaN → 0) instead of {"\x01022c"}.
 //
 // The serialization happens entirely on the client before Bind, so a scripted
 // v3 backend that records the first Bind parameter is sufficient.
@@ -125,23 +125,34 @@ test("byte-view elements honour byteOffset / byteLength", async () => {
   expect({ fromDataView, fromSubarray }).toEqual({ fromDataView: '{"\\xcafe"}', fromSubarray: '{"\\xcafe"}' });
 });
 
-test("Uint8Array element in a non-BYTEA array follows the Buffer hex path", async () => {
-  const fromBuffer = await bindLiteral(sql => sql.array([Buffer.from([65, 66])], "TEXT"));
-  const fromUint8 = await bindLiteral(sql => sql.array([new Uint8Array([65, 66])], "TEXT"));
-  expect({ fromBuffer, fromUint8 }).toEqual({ fromBuffer: '{"4142"}', fromUint8: '{"4142"}' });
+test("ArrayBufferView element in a JSON array is hex-encoded like Buffer", async () => {
+  const fromBuffer = await bindLiteral(sql => sql.array([Buffer.from([65, 66])], "JSON"));
+  const fromUint8 = await bindLiteral(sql => sql.array([new Uint8Array([65, 66])], "JSON"));
+  expect({ fromBuffer, fromUint8 }).toEqual({ fromBuffer: '{"\\"4142\\""}', fromUint8: '{"\\"4142\\""}' });
 });
 
-test("numeric TypedArray element becomes a nested dimension without coercion loss", async () => {
-  expect(await bindLiteral(sql => sql.array([new Float32Array([1.5, -2.25])], "DOUBLE PRECISION"))).toBe(
-    "{{1.5,-2.25}}",
-  );
-  expect(await bindLiteral(sql => sql.array([new BigInt64Array([1n, -2n])], "BIGINT"))).toBe("{{1,-2}}");
-  // Int16Array with a non-numeric element type: the quoted per-element strings
-  // previously coerced to NaN → 0 inside TypedArray.prototype.map.
-  expect(await bindLiteral(sql => sql.array([new Int16Array([7, 8])], "TEXT"))).toBe('{{"7","8"}}');
+test("ArrayBufferView element in a non-BYTEA non-JSON array is rejected", () => {
+  // sql.array() serializes eagerly, so the error surfaces before any I/O.
+  const sql = new SQL({ adapter: "postgres", hostname: "127.0.0.1", port: 1, database: "d", max: 1 });
+  for (const element of [new Uint8Array([65, 66]), Buffer.from([65, 66]), new Float32Array([1.5, 2.5])]) {
+    for (const type of ["TEXT", "INT", "REAL"]) {
+      const err = (() => {
+        try {
+          sql.array([element], type);
+        } catch (e) {
+          return e as Error;
+        }
+        throw new Error(`expected sql.array([${element.constructor.name}], ${JSON.stringify(type)}) to throw`);
+      })();
+      expect(err.code).toBe("ERR_INVALID_ARG_VALUE");
+      expect(err.message).toContain("BYTEA or JSON");
+    }
+  }
 });
 
-test("top-level Int16Array with a non-numeric element type is serialized without coercion", async () => {
-  const got = await bindLiteral(sql => sql.array(new Int16Array([7, 8, 9]), "TEXT"));
-  expect(got).toBe('{"7","8","9"}');
+test("top-level TypedArray with a non-numeric element type is serialized without coercion", async () => {
+  // serializeArray must not use TypedArray.prototype.map, which would coerce the
+  // per-element '"7"' strings back to NaN → 0.
+  expect(await bindLiteral(sql => sql.array(new Int16Array([7, 8, 9]), "TEXT"))).toBe('{"7","8","9"}');
+  expect(await bindLiteral(sql => sql.array(new Float32Array([1.5, -2.25]), "TEXT"))).toBe('{"1.5","-2.25"}');
 });

--- a/test/js/sql/postgres-array-typedarray-serialize.test.ts
+++ b/test/js/sql/postgres-array-typedarray-serialize.test.ts
@@ -111,13 +111,17 @@ test("Uint8Array element in a BYTEA array is hex-encoded like Buffer", async () 
   });
 });
 
-test("DataView and bare ArrayBuffer elements in a BYTEA array are hex-encoded like Buffer", async () => {
+test("DataView and bare ArrayBuffer/SharedArrayBuffer elements in a BYTEA array are hex-encoded like Buffer", async () => {
   const backing = new Uint8Array([0xca, 0xfe]);
+  const sab = new SharedArrayBuffer(2);
+  new Uint8Array(sab).set(backing);
   const fromDataView = await bindLiteral(sql => sql.array([new DataView(backing.buffer)], "BYTEA"));
   const fromArrayBuffer = await bindLiteral(sql => sql.array([backing.buffer], "BYTEA"));
-  expect({ fromDataView, fromArrayBuffer }).toEqual({
+  const fromSharedArrayBuffer = await bindLiteral(sql => sql.array([sab], "BYTEA"));
+  expect({ fromDataView, fromArrayBuffer, fromSharedArrayBuffer }).toEqual({
     fromDataView: '{"\\\\xcafe"}',
     fromArrayBuffer: '{"\\\\xcafe"}',
+    fromSharedArrayBuffer: '{"\\\\xcafe"}',
   });
 });
 

--- a/test/js/sql/postgres-array-typedarray-serialize.test.ts
+++ b/test/js/sql/postgres-array-typedarray-serialize.test.ts
@@ -118,6 +118,13 @@ test("DataView element in a BYTEA array is hex-encoded like Buffer", async () =>
   expect(fromDataView).toBe('{"\\xcafe"}');
 });
 
+test("byte-view elements honour byteOffset / byteLength", async () => {
+  const backing = new Uint8Array([0xaa, 0xca, 0xfe, 0xbb]);
+  const fromDataView = await bindLiteral(sql => sql.array([new DataView(backing.buffer, 1, 2)], "BYTEA"));
+  const fromSubarray = await bindLiteral(sql => sql.array([backing.subarray(1, 3)], "BYTEA"));
+  expect({ fromDataView, fromSubarray }).toEqual({ fromDataView: '{"\\xcafe"}', fromSubarray: '{"\\xcafe"}' });
+});
+
 test("Uint8Array element in a non-BYTEA array follows the Buffer hex path", async () => {
   const fromBuffer = await bindLiteral(sql => sql.array([Buffer.from([65, 66])], "TEXT"));
   const fromUint8 = await bindLiteral(sql => sql.array([new Uint8Array([65, 66])], "TEXT"));

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -270,6 +270,15 @@ if (isDockerEnabled()) {
         }
       });
 
+      test("sql.array should support BYTEA arrays with Uint8Array and Buffer elements", async () => {
+        await using sql = postgres(options);
+
+        const a = new Uint8Array([1, 2, 44]);
+        const b = Buffer.from([0xca, 0xfe]);
+        const [{ x }] = await sql`select ${sql.array([a, b], "BYTEA")} as x`;
+        expect(x).toEqual([Buffer.from(a), b]);
+      });
+
       test("sql.array should support BIGINT arrays", async () => {
         await using sql = postgres(options);
 


### PR DESCRIPTION
## What

`sql.array(values, type)` silently zeroed any non-Buffer `ArrayBufferView` element.

```js
await sql`select ${sql.array([new Uint8Array([1, 2, 44])], "bytea")}`;
// Bind parameter on the wire: {{0,0,0}}
// same bytes via Buffer.from: {"\x01022c"}
```

No error; the row is written with the wrong data. `Float32Array` elements became `{{NaN,NaN}}` and `BigInt64Array` threw `Failed to parse String to BigInt`.

## Why

`arrayValueSerializer` treated every non-Buffer `ArrayBuffer.isView` as a nested array dimension and recursed with `value.map(...)`. `TypedArray.prototype.map` returns the same typed-array species, so each per-element string serialization was coerced back into the element type: `'"1"'` -> `NaN` -> `0` for `Uint8Array`, `NaN` for `Float32Array`. A `DataView` element has no `.length`, so it became `{}`. `serializeArray` had the same `.map` coercion for a top-level typed array.

## Fix

`arrayValueSerializer` now checks `ArrayBuffer.isView` first. Any view element (Buffer, `Uint8Array`, `DataView`, `Float32Array`, ...) is hex-encoded in a `BYTEA` or JSON/JSONB array and rejected with `ERR_INVALID_ARG_VALUE` for every other element type, so the silent corruption becomes a clear error and `Uint8Array` matches `Buffer` byte for byte in `bytea[]`. The typed-array nested-dimension arm is gone from the element dispatch. `serializeArray` builds per-element strings into a plain `Array` via `Array.from` for a top-level typed array so nothing is coerced.

## Tests

`test/js/sql/postgres-array-typedarray-serialize.test.ts` scripts a v3 backend that records the Bind parameter and asserts the exact literal for the `BYTEA`/JSON cases and the rejection for everything else (fails on `main`, passes here). A `BYTEA` round-trip with `Uint8Array` and `Buffer` elements is added to the container-backed `sql.array` suite in `test/js/sql/sql.test.ts`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-array-typedarray-serialize.test.ts test/js/sql/sql.test.ts
bun test v1.4.0 (c11121bdd)

test/js/sql/sql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) text-format json[] with a malformed boolean literal returns an error instead of looping [2302.31ms]
(pass) rejects Postgres connection options containing null bytes [91.58ms]
(pass) shared createInstance validation (no server) > rejects username containing null bytes [144.00ms]
(pass) shared createInstance validation (no server) > rejects password containing null bytes [9.88ms]
(pass) shared createInstance validation (no server) > rejects database containing null bytes [6.63ms]
(pass) shared createInstance validation (no server) > SSL_CTX creation failure throws the structured BoringSSL error [18.05ms]
(pass) shared createInstance validation (no server) > postgres: rejects tls that is neither a boolean nor 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (d876c5669)

test/js/sql/sql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) text-format json[] with a malformed boolean literal returns an error instead of looping [70.20ms]
(pass) rejects Postgres connection options containing null bytes [3.59ms]
(pass) shared createInstance validation (no server) > rejects username containing null bytes [3.58ms]
(pass) shared createInstance validation (no server) > rejects password containing null bytes [0.24ms]
(pass) shared createInstance validation (no server) > rejects database containing null bytes [0.12ms]
(pass) shared createInstance validation (no server) > SSL_CTX creation failure throws the structured BoringSSL error [3.58ms]
(pass) shared createInstance validation (no server) > postgres: rejects tls that is neither a boolean nor an object [0.40ms]
(pass) shared createInstance validation (no server) > mysql: rejects tls that is neither a boolean nor an object [0.41ms]
(pass) shared createInstance validation (no server) > rejects simple 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-array-typedarray-serialize.test.ts test/js/sql/sql.test.ts
bun test v1.4.0 (c11121bdd)

test/js/sql/sql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) text-format json[] with a malformed boolean literal returns an error instead of looping [2419.81ms]
(pass) rejects Postgres connection options containing null bytes [101.06ms]
(pass) shared createInstance validation (no server) > rejects username containing null bytes [153.93ms]
(pass) shared createInstance validation (no server) > rejects password containing null bytes [10.93ms]
(pass) shared createInstance validation (no server) > rejects database containing null bytes [7.38ms]
(pass) shared createInstance validation (no server) > SSL_CTX creation failure throws the structured BoringSSL error [20.05ms]
(pass) shared createInstance validation (no server) > postgres: rejects tls that is neither a boolean no
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 827ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (11539ms)
Bundle modules (42ms)
Postprocesss modules (263ms)
Bundle Functions (932ms)
Generate Code (37ms)

[12.84s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/sql/postgres.ts                    |  46 +++---
 .../postgres-array-typedarray-serialize.test.ts    | 171 +++++++++++++++++++++
 test/js/sql/sql.test.ts                            |   9 ++
 3 files changed, 207 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/js/internal/sql/postgres.ts                             11     14      0
test/js/sql/postgres-array-typedarray-serialize.test.ts      6     10      0
test/js/sql/sql.test.ts                                      1      1      0
```

</details>

<!-- robobun:evidence:end -->