### PR TITLE
bundler: reject --env patterns where '*' is not a trailing wildcard

### DIFF
--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1645,19 +1645,19 @@ impl<'a> Parser<'a> {
                             }
                             self.ctx.args.serve_env_behavior = behavior;
                         }
-                        Err(()) => {
-                            self.add_error(
-                                    env.loc,
-                                    b"Invalid env behavior, must be 'inline', 'disable', or a string with a '*' character",
-                                )?;
+                        Err(msg) => {
+                            self.add_error_format(
+                                env.loc,
+                                format_args!("Invalid serve.static.env: {msg}"),
+                            )?;
                         }
                     }
                 }
                 _ => {
                     self.add_error(
-                            env.loc,
-                            b"Invalid env behavior, must be 'inline', 'disable', or a string with a '*' character",
-                        )?;
+                        env.loc,
+                        b"Invalid serve.static.env, must be 'inline', 'disable', or a prefix pattern ending in '*'",
+                    )?;
                 }
             }
         }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -71,9 +71,9 @@ impl DotEnvBehavior {
         }
         match s.iter().filter(|&&b| b == b'*').count() {
             0 => Err("must be \"inline\", \"disable\", or a prefix pattern like \"PUBLIC_*\""),
-            1 if s == b"*" => {
-                Err("pattern \"*\" has no prefix; use \"inline\" to inline every environment variable")
-            }
+            1 if s == b"*" => Err(
+                "pattern \"*\" has no prefix; use \"inline\" to inline every environment variable",
+            ),
             1 if *s.last().unwrap() == b'*' => Ok((Self::prefix, Some(&s[..s.len() - 1]))),
             1 => Err(
                 "pattern must end with '*' (e.g. \"PUBLIC_*\"); a leading '*' would inline every variable including secrets",

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -62,8 +62,6 @@ impl DotEnvBehavior {
     pub const LoadAll: Self = Self::load_all;
     pub const LoadAllWithoutInlining: Self = Self::load_all_without_inlining;
 
-    /// Shared string classifier for `Bun.build({env})` and bunfig `serve.static.env`.
-    /// `Err` carries a user-facing reason; callers own the surrounding null/bool dispatch.
     pub fn parse_str(s: &[u8]) -> Result<(Self, Option<&[u8]>), &'static str> {
         if s == b"inline" {
             Ok((Self::load_all, None))

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -77,14 +77,20 @@ impl DotEnvBehavior {
             Ok((Self::disable, None))
         } else if let Some(asterisk) = s.iter().position(|&b| b == b'*') {
             if asterisk + 1 != s.len() {
-                Err("'*' in an env pattern must be the final character; suffix and infix patterns are not supported")
+                Err(
+                    "'*' in an env pattern must be the final character; suffix and infix patterns are not supported",
+                )
             } else if asterisk == 0 {
-                Err("env pattern \"*\" has no prefix; use \"inline\" to inline every environment variable")
+                Err(
+                    "env pattern \"*\" has no prefix; use \"inline\" to inline every environment variable",
+                )
             } else {
                 Ok((Self::prefix, Some(&s[..asterisk])))
             }
         } else {
-            Err("expected \"inline\", \"disable\", or a prefix pattern ending in '*' (e.g. \"PUBLIC_*\")")
+            Err(
+                "expected \"inline\", \"disable\", or a prefix pattern ending in '*' (e.g. \"PUBLIC_*\")",
+            )
         }
     }
 }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -64,25 +64,21 @@ impl DotEnvBehavior {
 
     pub fn parse_str(s: &[u8]) -> Result<(Self, Option<&[u8]>), &'static str> {
         if s == b"inline" {
-            Ok((Self::load_all, None))
-        } else if s == b"disable" {
-            Ok((Self::disable, None))
-        } else if let Some(asterisk) = s.iter().position(|&b| b == b'*') {
-            if asterisk + 1 != s.len() {
-                Err(
-                    "'*' in an env pattern must be the final character; suffix and infix patterns are not supported",
-                )
-            } else if asterisk == 0 {
-                Err(
-                    "env pattern \"*\" has no prefix; use \"inline\" to inline every environment variable",
-                )
-            } else {
-                Ok((Self::prefix, Some(&s[..asterisk])))
+            return Ok((Self::load_all, None));
+        }
+        if s == b"disable" {
+            return Ok((Self::disable, None));
+        }
+        match s.iter().filter(|&&b| b == b'*').count() {
+            0 => Err("must be \"inline\", \"disable\", or a prefix pattern like \"PUBLIC_*\""),
+            1 if s == b"*" => {
+                Err("pattern \"*\" has no prefix; use \"inline\" to inline every environment variable")
             }
-        } else {
-            Err(
-                "expected \"inline\", \"disable\", or a prefix pattern ending in '*' (e.g. \"PUBLIC_*\")",
-            )
+            1 if *s.last().unwrap() == b'*' => Ok((Self::prefix, Some(&s[..s.len() - 1]))),
+            1 => Err(
+                "pattern must end with '*' (e.g. \"PUBLIC_*\"); a leading '*' would inline every variable including secrets",
+            ),
+            _ => Err("pattern may contain only one '*'"),
         }
     }
 }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -62,14 +62,8 @@ impl DotEnvBehavior {
     pub const LoadAll: Self = Self::load_all;
     pub const LoadAllWithoutInlining: Self = Self::load_all_without_inlining;
 
-    /// String-branch classifier shared by bunfig (serve.env) and
-    /// JSBundler (Bun.build env). Only the *string* arm is common to
-    /// both specs — the surrounding null/bool/number dispatch and the error
-    /// reporting intentionally diverge per call site, so they stay inline there.
-    ///
-    /// Returns `Ok((behavior, prefix))` where `prefix` is `Some(&s[..idx])` only for
-    /// `DotEnvBehavior::prefix`; `Err(msg)` carries a descriptive reason the caller
-    /// surfaces in its site-specific diagnostic.
+    /// Shared string classifier for `Bun.build({env})` and bunfig `serve.static.env`.
+    /// `Err` carries a user-facing reason; callers own the surrounding null/bool dispatch.
     pub fn parse_str(s: &[u8]) -> Result<(Self, Option<&[u8]>), &'static str> {
         if s == b"inline" {
             Ok((Self::load_all, None))

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -68,22 +68,23 @@ impl DotEnvBehavior {
     /// reporting intentionally diverge per call site, so they stay inline there.
     ///
     /// Returns `Ok((behavior, prefix))` where `prefix` is `Some(&s[..idx])` only for
-    /// `DotEnvBehavior::prefix`; `Err(())` means the string is none of
-    /// `"inline"` / `"disable"` / contains-`*`, and the caller emits its own
-    /// site-specific diagnostic.
-    pub fn parse_str(s: &[u8]) -> Result<(Self, Option<&[u8]>), ()> {
+    /// `DotEnvBehavior::prefix`; `Err(msg)` carries a descriptive reason the caller
+    /// surfaces in its site-specific diagnostic.
+    pub fn parse_str(s: &[u8]) -> Result<(Self, Option<&[u8]>), &'static str> {
         if s == b"inline" {
             Ok((Self::load_all, None))
         } else if s == b"disable" {
             Ok((Self::disable, None))
         } else if let Some(asterisk) = s.iter().position(|&b| b == b'*') {
-            if asterisk > 0 {
-                Ok((Self::prefix, Some(&s[..asterisk])))
+            if asterisk + 1 != s.len() {
+                Err("'*' in an env pattern must be the final character; suffix and infix patterns are not supported")
+            } else if asterisk == 0 {
+                Err("env pattern \"*\" has no prefix; use \"inline\" to inline every environment variable")
             } else {
-                Ok((Self::load_all, None))
+                Ok((Self::prefix, Some(&s[..asterisk])))
             }
         } else {
-            Err(())
+            Err("expected \"inline\", \"disable\", or a prefix pattern ending in '*' (e.g. \"PUBLIC_*\")")
         }
     }
 }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -75,9 +75,10 @@ impl DotEnvBehavior {
                 "pattern \"*\" has no prefix; use \"inline\" to inline every environment variable",
             ),
             1 if *s.last().unwrap() == b'*' => Ok((Self::prefix, Some(&s[..s.len() - 1]))),
-            1 => Err(
+            1 if s[0] == b'*' => Err(
                 "pattern must end with '*' (e.g. \"PUBLIC_*\"); a leading '*' would inline every variable including secrets",
             ),
+            1 => Err("pattern must end with '*' (e.g. \"PUBLIC_*\")"),
             _ => Err("pattern may contain only one '*'"),
         }
     }

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -679,8 +679,9 @@ pub mod js_bundler {
                                 }
                             }
                             Err(msg) => {
-                                return Err(global_this
-                                    .throw_invalid_arguments(format_args!("env: {msg}")));
+                                return Err(
+                                    global_this.throw_invalid_arguments(format_args!("env: {msg}"))
+                                );
                             }
                         }
                         drop(slice);

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -678,14 +678,15 @@ pub mod js_bundler {
                                     this.env_prefix.append_slice_exact(prefix)?;
                                 }
                             }
-                            Err(()) => {
-                                return Err(global_this.throw_invalid_arguments(format_args!("env must be 'inline', 'disable', or a string with a '*' character")));
+                            Err(msg) => {
+                                return Err(global_this
+                                    .throw_invalid_arguments(format_args!("env: {msg}")));
                             }
                         }
                         drop(slice);
                     } else {
                         return Err(global_this.throw_invalid_arguments(format_args!(
-                            "env must be 'inline', 'disable', or a string with a '*' character"
+                            "env must be 'inline', 'disable', or a prefix pattern ending in '*'"
                         )));
                     }
                 }

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -679,9 +679,10 @@ pub mod js_bundler {
                                 }
                             }
                             Err(msg) => {
-                                return Err(
-                                    global_this.throw_invalid_arguments(format_args!("env: {msg}"))
-                                );
+                                return Err(global_this.throw_invalid_arguments(format_args!(
+                                    "env \"{}\": {msg}",
+                                    bstr::BStr::new(slice.slice())
+                                )));
                             }
                         }
                         drop(slice);

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1947,31 +1947,26 @@ fn parse_build_command_options(
     }
 
     if let Some(env) = args.option(b"--env") {
-        if env == b"inline" || env == b"1" {
+        if env == b"inline" {
             ctx.bundler_options.env_behavior = options::EnvBehavior::LoadAll;
-        } else if env == b"disable" || env == b"0" {
+        } else if env == b"disable" {
             ctx.bundler_options.env_behavior = options::EnvBehavior::LoadAllWithoutInlining;
-        } else if let Some(asterisk) = strings::index_of_char(env, b'*') {
-            if asterisk as usize + 1 != env.len() {
-                bun_core::pretty_errorln!(
-                    "<r><red>error<r>: Invalid --env pattern \"{}\": '*' must be the final character; suffix and infix patterns are not supported",
-                    BStr::new(env)
-                );
-                Global::crash();
-            }
-            if asterisk == 0 {
-                bun_core::pretty_errorln!(
-                    "<r><red>error<r>: Invalid --env pattern \"*\": use --env=inline to inline every environment variable"
-                );
-                Global::crash();
-            }
-            ctx.bundler_options.env_behavior = options::EnvBehavior::Prefix;
-            ctx.bundler_options.env_prefix = Box::<[u8]>::from(&env[..asterisk as usize]);
         } else {
-            bun_core::pretty_errorln!(
-                "<r><red>error<r>: Expected --env to be 'inline', 'disable', or a prefix pattern ending in '*' (e.g. \"PUBLIC_*\")"
-            );
-            Global::crash();
+            match options::EnvBehavior::parse_str(env) {
+                Ok((options::EnvBehavior::Prefix, Some(prefix))) => {
+                    ctx.bundler_options.env_behavior = options::EnvBehavior::Prefix;
+                    ctx.bundler_options.env_prefix = Box::<[u8]>::from(prefix);
+                }
+                Ok(_) => unreachable!(),
+                Err(msg) => {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error<r>: Invalid --env \"{}\": {}",
+                        BStr::new(env),
+                        msg
+                    );
+                    Global::crash();
+                }
+            }
         }
     }
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1947,20 +1947,29 @@ fn parse_build_command_options(
     }
 
     if let Some(env) = args.option(b"--env") {
-        if let Some(asterisk) = strings::index_of_char(env, b'*') {
-            if asterisk == 0 {
-                ctx.bundler_options.env_behavior = options::EnvBehavior::LoadAll;
-            } else {
-                ctx.bundler_options.env_behavior = options::EnvBehavior::Prefix;
-                ctx.bundler_options.env_prefix = Box::<[u8]>::from(&env[..asterisk as usize]);
-            }
-        } else if env == b"inline" || env == b"1" {
+        if env == b"inline" || env == b"1" {
             ctx.bundler_options.env_behavior = options::EnvBehavior::LoadAll;
         } else if env == b"disable" || env == b"0" {
             ctx.bundler_options.env_behavior = options::EnvBehavior::LoadAllWithoutInlining;
+        } else if let Some(asterisk) = strings::index_of_char(env, b'*') {
+            if asterisk as usize + 1 != env.len() {
+                bun_core::pretty_errorln!(
+                    "<r><red>error<r>: Invalid --env pattern \"{}\": '*' must be the final character; suffix and infix patterns are not supported",
+                    BStr::new(env)
+                );
+                Global::crash();
+            }
+            if asterisk == 0 {
+                bun_core::pretty_errorln!(
+                    "<r><red>error<r>: Invalid --env pattern \"*\": use --env=inline to inline every environment variable"
+                );
+                Global::crash();
+            }
+            ctx.bundler_options.env_behavior = options::EnvBehavior::Prefix;
+            ctx.bundler_options.env_prefix = Box::<[u8]>::from(&env[..asterisk as usize]);
         } else {
             bun_core::pretty_errorln!(
-                "<r><red>error<r>: Expected 'env' to be 'inline', 'disable', or a prefix with a '*' character"
+                "<r><red>error<r>: Expected --env to be 'inline', 'disable', or a prefix pattern ending in '*' (e.g. \"PUBLIC_*\")"
             );
             Global::crash();
         }

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -134,6 +134,7 @@ describe("env/invalid-pattern", () => {
     { pattern: "*", expect: `use "inline"` },
     { pattern: "1", expect: `must be "inline", "disable"` },
     { pattern: "0", expect: `must be "inline", "disable"` },
+    { pattern: "", expect: `must be "inline", "disable"` },
   ] as const;
 
   describe.each(cases)("$pattern", ({ pattern, expect: fragment }) => {

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -144,11 +144,7 @@ describe("env/invalid-pattern", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toContain(fragment);
       expect(stdout).not.toContain("sec");
       expect(exitCode).not.toBe(0);
@@ -167,11 +163,7 @@ describe("env/invalid-pattern", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toContain(fragment);
       expect(stdout).not.toContain("built");
       expect(exitCode).not.toBe(0);
@@ -191,11 +183,7 @@ describe("env/invalid-pattern", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout).toContain(`"ab"`);
     expect(stdout).toContain("process.env.SECRET_ZZ");

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -170,6 +170,24 @@ describe("env/invalid-pattern", () => {
       expect(stdout).not.toContain("built");
       expect(exitCode).not.toBe(0);
     });
+
+    test.concurrent("bunfig serve.static.env", async () => {
+      using dir = tempDir("bundler-env-invalid", {
+        "a.js": source,
+        "bunfig.toml": `[serve.static]\nenv = ${JSON.stringify(pattern)}\n`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "a.js"],
+        env: childEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain(fragment);
+      expect(stdout).not.toContain("sec");
+      expect(exitCode).not.toBe(0);
+    });
   });
 
   // Positive control: a single trailing '*' with a non-empty prefix is still

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -1,4 +1,5 @@
-import { describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { itBundled } from "./expectBundled";
 
 for (let backend of ["api", "cli"] as const) {
@@ -118,3 +119,87 @@ for (let backend of ["api", "cli"] as const) {
       });
   });
 }
+
+// Patterns that used to be silently accepted but are now rejected.
+// A leading '*' ("*_PUBLIC", "*") previously meant "inline every env var",
+// and any text after the first '*' ("A*B") was dropped with no diagnostic.
+describe("env/invalid-pattern", () => {
+  const source = `console.log(process.env.SECRET_ZZ, process.env.A_B);`;
+  const childEnv = { ...bunEnv, SECRET_ZZ: "sec", A_B: "ab" };
+
+  const cases = [
+    { pattern: "*_PUBLIC", expect: "must be the final character" },
+    { pattern: "A*B", expect: "must be the final character" },
+    { pattern: "A*B*", expect: "must be the final character" },
+    { pattern: "*", expect: "inline every environment variable" },
+  ] as const;
+
+  describe.each(cases)("$pattern", ({ pattern, expect: fragment }) => {
+    test.concurrent("cli", async () => {
+      using dir = tempDir("bundler-env-invalid", { "a.js": source });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "a.js", `--env=${pattern}`],
+        env: childEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).toContain(fragment);
+      expect(stdout).not.toContain("sec");
+      expect(exitCode).not.toBe(0);
+    });
+
+    test.concurrent("Bun.build", async () => {
+      using dir = tempDir("bundler-env-invalid", { "a.js": source });
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `try { await Bun.build({ entrypoints: ["a.js"], env: ${JSON.stringify(pattern)} }); console.log("built"); } catch (e) { console.error(e.message); process.exitCode = 1; }`,
+        ],
+        env: childEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).toContain(fragment);
+      expect(stdout).not.toContain("built");
+      expect(exitCode).not.toBe(0);
+    });
+  });
+
+  // Positive control: a single trailing '*' with a non-empty prefix is still
+  // accepted and only inlines matching vars.
+  test.concurrent("trailing-star prefix still works", async () => {
+    using dir = tempDir("bundler-env-valid", {
+      "a.js": `console.log(process.env.A_B, process.env.SECRET_ZZ);`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "a.js", "--env=A_*"],
+      env: childEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain(`"ab"`);
+    expect(stdout).toContain("process.env.SECRET_ZZ");
+    expect(stdout).not.toContain(`"sec"`);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -128,10 +128,12 @@ describe("env/invalid-pattern", () => {
   const childEnv = { ...bunEnv, SECRET_ZZ: "sec", A_B: "ab" };
 
   const cases = [
-    { pattern: "*_PUBLIC", expect: "must be the final character" },
-    { pattern: "A*B", expect: "must be the final character" },
-    { pattern: "A*B*", expect: "must be the final character" },
-    { pattern: "*", expect: "inline every environment variable" },
+    { pattern: "*_PUBLIC", expect: "must end with '*'" },
+    { pattern: "A*B", expect: "must end with '*'" },
+    { pattern: "A*B*", expect: "only one '*'" },
+    { pattern: "*", expect: `use "inline"` },
+    { pattern: "1", expect: `must be "inline", "disable"` },
+    { pattern: "0", expect: `must be "inline", "disable"` },
   ] as const;
 
   describe.each(cases)("$pattern", ({ pattern, expect: fragment }) => {


### PR DESCRIPTION
## What does this PR do?

The `--env` / `Bun.build({env})` / bunfig `serve.static.env` string parser split at the **first** `*` in the pattern. This meant:

- A leading `*` (empty prefix) silently mapped to "inline every environment variable". `--env='*_PUBLIC'` looks like a suffix filter but would bake every secret in the process environment into the bundle.
- Anything after the first `*` was silently discarded. `--env='A*B*'` was treated as prefix `A`.
- `--env=1` / `--env=0` were undocumented aliases for `inline` / `disable`.

None of these produced a diagnostic.

### Repro

```sh
export A_B=ab SECRET_ZZ=sec
printf 'console.log(process.env.A_B, process.env.SECRET_ZZ);\n' > e.mjs
bun build e.mjs --env='*_PUBLIC'
# // e.mjs
# console.log("ab", "sec");      <- SECRET_ZZ baked in; user asked for *_PUBLIC
```

### Fix

`DotEnvBehavior::parse_str` now requires exactly one `*` that is trailing with a non-empty prefix. The CLI `--env` parser routes through the same function (dropping the `1`/`0` aliases), so the CLI, `Bun.build({env})`, and bunfig share one validator. Any other shape errors:

```
error: Invalid --env "*_PUBLIC": pattern must end with '*' (e.g. "PUBLIC_*"); a leading '*' would inline every variable including secrets
error: Invalid --env "A*B*": pattern may contain only one '*'
error: Invalid --env "*": pattern "*" has no prefix; use "inline" to inline every environment variable
error: Invalid --env "1": must be "inline", "disable", or a prefix pattern like "PUBLIC_*"
```

The documented forms (`"inline"`, `"disable"`, `"PUBLIC_*"`) are unchanged.

### How did you verify your code works?

New tests in `test/bundler/bundler_env.test.ts` cover `*_PUBLIC`, `A*B`, `A*B*`, bare `*`, `1`, and `0` across both the CLI and `Bun.build`, plus a positive control that `A_*` still works and does not inline non-matching vars.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 21 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_env.test.ts
bun test v1.4.0 (ba910056c)

test/bundler/bundler_env.test.ts:
(pass) bundler/api > env/inline system [749.10ms]
(pass) bundler/api > env/disable [356.06ms]
(pass) bundler/cli > env/inline [550.81ms]
(pass) bundler/cli > env/inline system [558.05ms]
(pass) bundler/cli > env/disable [549.56ms]
(pass) bundler/cli > env/pattern-matching [556.26ms]
(pass) bundler/cli > nested-refs [558.67ms]
146 |         cwd: String(dir),
147 |         stdout: "pipe",
148 |         stderr: "pipe",
149 |       });
150 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
151 |       expect(stderr).toContain(fragment);
                           ^
error: expect(received).toContain(expected)

Expected to contain: "must end with '*'"
Received: ""

      at <anonymous> (/workspace/bun/test/bundler/bundler_env.test.ts:151:22)
(fail) env/invalid-pattern > *_PUBLIC > cli [301.82ms]
183 |         cwd: String(dir),
184 |         stdout: "pipe",
185 |         stderr: "pip
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (0b9f7ca3d)

test/bundler/bundler_env.test.ts:
(pass) bundler/api > env/inline system [19.32ms]
(pass) bundler/api > env/disable [10.07ms]
(pass) bundler/cli > env/inline [10.74ms]
(pass) bundler/cli > env/inline system [12.37ms]
(pass) bundler/cli > env/disable [10.80ms]
(pass) bundler/cli > env/pattern-matching [11.06ms]
(pass) bundler/cli > nested-refs [11.01ms]
(pass) env/invalid-pattern > *_PUBLIC > cli [9.91ms]
(pass) env/invalid-pattern > *_PUBLIC > bunfig serve.static.env [9.03ms]
(pass) env/invalid-pattern > A*B > cli [9.10ms]
(pass) env/invalid-pattern > A*B > bunfig serve.static.env [8.46ms]
(pass) env/invalid-pattern > A*B* > cli [8.00ms]
(pass) env/invalid-pattern > A*B* > bunfig serve.static.env [7.34ms]
(pass) env/invalid-pattern > * > cli [7.02ms]
(pass) env/invalid-pattern > *_PUBLIC > Bun.build [10.49ms]
(pass) env/invalid-pattern > * > bunfig serve.static.env [6.15ms]
(pass) env/invalid-pattern > 1 > cli [5.86ms]
(pass) env/invalid-pattern > A*B > Bun.build [8.78ms]
(pass) env/invalid-pattern > 1 > bunfig serve.static.env [5.09ms]
(pass) env/invalid-pattern > 0 > cli [4.74ms]
(pass) env/invalid-pattern > A*B* > Bun.build [
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_env.test.ts
bun test v1.4.0 (ba910056c)

test/bundler/bundler_env.test.ts:
(pass) bundler/api > env/inline system [735.58ms]
(pass) bundler/api > env/disable [379.98ms]
(pass) bundler/cli > env/inline [553.13ms]
(pass) bundler/cli > env/inline system [552.40ms]
(pass) bundler/cli > env/disable [551.37ms]
(pass) bundler/cli > env/pattern-matching [559.65ms]
(pass) bundler/cli > nested-refs [549.21ms]
(pass) env/invalid-pattern > *_PUBLIC > cli [141.35ms]
(pass) env/invalid-pattern > *_PUBLIC > bunfig serve.static.env [122.21ms]
(pass) env/invalid-pattern > A*B > cli [114.96ms]
(pass) env/invalid-pattern > A*B > bunfig serve.static.env [108.94ms]
(pass) env/invalid-pattern > A*B* > cli [108.27ms]
(pass) env/invalid-pattern > *_PUBLIC > Bun.build [278.78ms]
(pass) env/invalid-pattern > A*B > Bun.build [265.81ms]
(pass) env/invalid-pattern > A*B* > bunfig serve.static.env [113.67ms]
(pass) env/invalid-pattern > * > cli [104.58ms]
(pass) env/invalid-pattern > * > bunfig serve.static.env [118.35ms]
(pass) env/invalid-pat
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 645ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bunfig/bunfig.rs             | 16 +++----
 src/dotenv/env_loader.rs         | 38 +++++++---------
 src/runtime/api/JSBundler.rs     |  9 ++--
 src/runtime/cli/Arguments.rs     | 30 +++++++------
 test/bundler/bundler_env.test.ts | 96 +++++++++++++++++++++++++++++++++++++++-
 5 files changed, 143 insertions(+), 46 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/bunfig/bunfig.rs                  4      2      0
src/dotenv/env_loader.rs              4      5      0
src/runtime/api/JSBundler.rs          3      3      0
src/runtime/cli/Arguments.rs          2      2      0
test/bundler/bundler_env.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->