### PR TITLE
watcher: watch the parent directory of imports outside cwd on POSIX

### DIFF
--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -900,6 +900,34 @@ where
                         };
                     }
 
+                    // Linux safety net: the per-file inotify watch follows the
+                    // inode. A rename-over unlinks the watched inode while bun
+                    // still holds it open, which delivers only IN_ATTRIB for
+                    // the link-count drop (IN_DELETE_SELF waits for the last
+                    // close). Evict on st_nlink == 0 so the stale fd is not
+                    // served by `snapshot_fd_and_package_json` on reload.
+                    // IN_MOVE_SELF (the watched inode was renamed away) is
+                    // treated the same: the module at the recorded path is
+                    // gone. The parent-directory watch is the primary recovery
+                    // path; this covers the case where that watch is absent.
+                    #[cfg(any(target_os = "linux", target_os = "android"))]
+                    if !event.op.contains(WatchOp::DELETE)
+                        && event.op.intersects(WatchOp::METADATA | WatchOp::RENAME)
+                    {
+                        let fd = file_descriptors[event.index as usize];
+                        let orphaned = event.op.contains(WatchOp::RENAME)
+                            || (fd.is_valid()
+                                && bun_sys::fstat(fd)
+                                    .map(|st| st.st_nlink == 0)
+                                    .unwrap_or(false));
+                        if orphaned {
+                            ctx.remove_at_index(bun_watcher::Kind::File, event.index, 0, &[]);
+                            record_changed_path(file_path);
+                            current_task.append(current_hash);
+                            continue;
+                        }
+                    }
+
                     if self.verbose {
                         Self::debug(format_args!(
                             "File changed: {}",

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -900,10 +900,7 @@ where
                         };
                     }
 
-                    // inotify follows the inode: a rename-over delivers only
-                    // IN_ATTRIB while bun holds the old inode open. Evict on
-                    // st_nlink == 0 (or MOVE_SELF) so the reload re-opens by
-                    // path instead of reading the stale fd.
+                    // Rename-over of a held-open inode delivers only IN_ATTRIB; evict on st_nlink==0.
                     #[cfg(any(target_os = "linux", target_os = "android"))]
                     if !event.op.contains(WatchOp::DELETE)
                         && event.op.intersects(WatchOp::METADATA | WatchOp::RENAME)

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -912,7 +912,15 @@ where
                                     .map(|st| st.st_nlink == 0)
                                     .unwrap_or(false));
                         if orphaned {
-                            ctx.remove_at_index(bun_watcher::Kind::File, event.index, 0, &[]);
+                            // SAFETY: same as the DELETE eviction above.
+                            unsafe {
+                                (*ctx).remove_at_index::<false>(
+                                    bun_watcher::Kind::File,
+                                    event.index,
+                                    0,
+                                    &[],
+                                )
+                            };
                             record_changed_path(file_path);
                             current_task.append(current_hash);
                             continue;

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -900,16 +900,10 @@ where
                         };
                     }
 
-                    // Linux safety net: the per-file inotify watch follows the
-                    // inode. A rename-over unlinks the watched inode while bun
-                    // still holds it open, which delivers only IN_ATTRIB for
-                    // the link-count drop (IN_DELETE_SELF waits for the last
-                    // close). Evict on st_nlink == 0 so the stale fd is not
-                    // served by `snapshot_fd_and_package_json` on reload.
-                    // IN_MOVE_SELF (the watched inode was renamed away) is
-                    // treated the same: the module at the recorded path is
-                    // gone. The parent-directory watch is the primary recovery
-                    // path; this covers the case where that watch is absent.
+                    // inotify follows the inode: a rename-over delivers only
+                    // IN_ATTRIB while bun holds the old inode open. Evict on
+                    // st_nlink == 0 (or MOVE_SELF) so the reload re-opens by
+                    // path instead of reading the stale fd.
                     #[cfg(any(target_os = "linux", target_os = "android"))]
                     if !event.op.contains(WatchOp::DELETE)
                         && event.op.intersects(WatchOp::METADATA | WatchOp::RENAME)

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5796,7 +5796,9 @@ impl DevServer {
                     if !evict && event.op.contains(bun_watcher::Op::METADATA) {
                         let fd = slice.items_fd()[event.index as usize];
                         evict = fd.is_valid()
-                            && bun_sys::fstat(fd).map(|st| st.st_nlink == 0).unwrap_or(false);
+                            && bun_sys::fstat(fd)
+                                .map(|st| st.st_nlink == 0)
+                                .unwrap_or(false);
                     }
                     if evict {
                         // TODO: audit this line heavily

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5795,10 +5795,19 @@ impl DevServer {
                     #[cfg(any(target_os = "linux", target_os = "android"))]
                     if !evict && event.op.contains(bun_watcher::Op::METADATA) {
                         let fd = slice.items_fd()[event.index as usize];
-                        evict = fd.is_valid()
+                        if fd.is_valid()
                             && bun_sys::fstat(fd)
                                 .map(|st| st.st_nlink == 0)
-                                .unwrap_or(false);
+                                .unwrap_or(false)
+                        {
+                            evict = true;
+                        } else if !event.op.intersects(
+                            bun_watcher::Op::WRITE
+                                | bun_watcher::Op::MOVE_TO
+                                | bun_watcher::Op::CREATE,
+                        ) {
+                            continue;
+                        }
                     }
                     if evict {
                         // TODO: audit this line heavily
@@ -5808,10 +5817,6 @@ impl DevServer {
                             0,
                             &[],
                         );
-                    } else if !event.op.intersects(
-                        bun_watcher::Op::WRITE | bun_watcher::Op::MOVE_TO | bun_watcher::Op::CREATE,
-                    ) {
-                        continue;
                     }
 
                     // SAFETY: `ev_ptr` is this thread's exclusively-acquired

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5789,9 +5789,16 @@ impl DevServer {
 
             match kind {
                 bun_watcher::Kind::File => {
-                    if event.op.contains(bun_watcher::Op::DELETE)
-                        || event.op.contains(bun_watcher::Op::RENAME)
-                    {
+                    #[allow(unused_mut)]
+                    let mut evict = event.op.contains(bun_watcher::Op::DELETE)
+                        || event.op.contains(bun_watcher::Op::RENAME);
+                    #[cfg(any(target_os = "linux", target_os = "android"))]
+                    if !evict && event.op.contains(bun_watcher::Op::METADATA) {
+                        let fd = slice.items_fd()[event.index as usize];
+                        evict = fd.is_valid()
+                            && bun_sys::fstat(fd).map(|st| st.st_nlink == 0).unwrap_or(false);
+                    }
+                    if evict {
                         // TODO: audit this line heavily
                         self.bun_watcher.remove_at_index::<false>(
                             bun_watcher::Kind::File,
@@ -5799,6 +5806,10 @@ impl DevServer {
                             0,
                             &[],
                         );
+                    } else if !event.op.intersects(
+                        bun_watcher::Op::WRITE | bun_watcher::Op::MOVE_TO | bun_watcher::Op::CREATE,
+                    ) {
+                        continue;
                     }
 
                     // SAFETY: `ev_ptr` is this thread's exclusively-acquired

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -130,8 +130,7 @@ impl INotifyWatcher {
         use bun_sys::linux::IN;
         debug_assert!(self.loaded);
         let old_count = self.watch_count.fetch_add(1, Ordering::Release);
-        // IN_ATTRIB: a rename-over of a held-open watched inode delivers only
-        // the link-count ATTRIB (DELETE_SELF waits for the last close).
+        // IN_ATTRIB catches the link-count drop when a held-open inode is renamed over.
         let watch_file_mask = IN::EXCL_UNLINK
             | IN::MOVE_SELF
             | IN::DELETE_SELF

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -130,10 +130,8 @@ impl INotifyWatcher {
         use bun_sys::linux::IN;
         debug_assert!(self.loaded);
         let old_count = self.watch_count.fetch_add(1, Ordering::Release);
-        // IN_ATTRIB is the only event delivered when a held-open watched inode
-        // is unlinked by a rename-over (IN_DELETE_SELF waits for the last
-        // close). The hot-reloader's File arm fstats the pinned fd on
-        // METADATA and evicts when st_nlink == 0.
+        // IN_ATTRIB: a rename-over of a held-open watched inode delivers only
+        // the link-count ATTRIB (DELETE_SELF waits for the last close).
         let watch_file_mask = IN::EXCL_UNLINK
             | IN::MOVE_SELF
             | IN::DELETE_SELF

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -130,8 +130,16 @@ impl INotifyWatcher {
         use bun_sys::linux::IN;
         debug_assert!(self.loaded);
         let old_count = self.watch_count.fetch_add(1, Ordering::Release);
-        let watch_file_mask =
-            IN::EXCL_UNLINK | IN::MOVE_SELF | IN::DELETE_SELF | IN::MOVED_TO | IN::MODIFY;
+        // IN_ATTRIB is the only event delivered when a held-open watched inode
+        // is unlinked by a rename-over (IN_DELETE_SELF waits for the last
+        // close). The hot-reloader's File arm fstats the pinned fd on
+        // METADATA and evicts when st_nlink == 0.
+        let watch_file_mask = IN::EXCL_UNLINK
+            | IN::MOVE_SELF
+            | IN::DELETE_SELF
+            | IN::MOVED_TO
+            | IN::MODIFY
+            | IN::ATTRIB;
         // SAFETY: fd is a valid inotify fd (loaded == true), pathname is NUL-terminated.
         let rc = unsafe {
             bun_sys::linux::inotify_add_watch(self.fd.native(), pathname.as_ptr(), watch_file_mask)
@@ -538,6 +546,9 @@ fn watch_event_from_inotify_event(event: &Event, index: WatchItemIndex) -> Watch
     }
     if (event.mask & IN::MODIFY) > 0 {
         op |= Op::WRITE;
+    }
+    if (event.mask & IN::ATTRIB) > 0 {
+        op |= Op::METADATA;
     }
     if (event.mask & IN::CREATE) > 0 {
         op |= Op::CREATE;

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -773,10 +773,8 @@ impl Watcher {
         if strings::contains(dir, b"node_modules") {
             return false;
         }
-        // Windows' ReadDirectoryChangesW is rooted at cwd; on POSIX the
-        // parent-dir watch is what recovers from a rename-over, so allow it
-        // for any imported file's parent regardless of cwd.
         if cfg!(windows) {
+            // ReadDirectoryChangesW is cwd-rooted; POSIX has no such restriction.
             return strings::contains(dir, self.top_level_dir());
         }
         true

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -773,13 +773,9 @@ impl Watcher {
         if strings::contains(dir, b"node_modules") {
             return false;
         }
-        // On Windows the platform watcher is a single recursive
-        // ReadDirectoryChangesW rooted at `top_level_dir`; directories outside
-        // it cannot be watched here. On Linux/macOS the inode-based watchers
-        // have no such restriction, and the parent-directory watch is what
-        // recovers from an atomic rename-save (write temp + rename over, which
-        // replaces the file's inode and orphans the per-file watch), so watch
-        // the parent of every imported file regardless of cwd.
+        // Windows' ReadDirectoryChangesW is rooted at cwd; on POSIX the
+        // parent-dir watch is what recovers from a rename-over, so allow it
+        // for any imported file's parent regardless of cwd.
         if cfg!(windows) {
             return strings::contains(dir, self.top_level_dir());
         }

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -770,7 +770,20 @@ impl Watcher {
 
     #[inline]
     fn is_eligible_directory(&self, dir: &[u8]) -> bool {
-        strings::contains(dir, self.top_level_dir()) && !strings::contains(dir, b"node_modules")
+        if strings::contains(dir, b"node_modules") {
+            return false;
+        }
+        // On Windows the platform watcher is a single recursive
+        // ReadDirectoryChangesW rooted at `top_level_dir`; directories outside
+        // it cannot be watched here. On Linux/macOS the inode-based watchers
+        // have no such restriction, and the parent-directory watch is what
+        // recovers from an atomic rename-save (write temp + rename over, which
+        // replaces the file's inode and orphans the per-file watch), so watch
+        // the parent of every imported file regardless of cwd.
+        if cfg!(windows) {
+            return strings::contains(dir, self.top_level_dir());
+        }
+        true
     }
 
     #[inline]
@@ -953,12 +966,7 @@ impl Watcher {
     }
 
     pub(crate) fn on_maybe_watch_directory(&mut self, file_path: &[u8], dir_fd: Fd) {
-        // We don't want to watch:
-        // - Directories outside the root directory
-        // - Directories inside node_modules
-        if !strings::contains(file_path, b"node_modules")
-            && strings::contains(file_path, self.top_level_dir())
-        {
+        if self.is_eligible_directory(file_path) {
             let _ = self.add_directory::<false>(dir_fd, file_path, Self::get_hash(file_path));
         }
     }

--- a/test/cli/hot/watch.test.ts
+++ b/test/cli/hot/watch.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, forEachLine, isBroken, isWindows, tempDir } from "harness";
-import { rename, writeFile } from "node:fs/promises";
+import { rename, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 describe.todoIf(isBroken && isWindows)("--watch works", async () => {
@@ -87,9 +87,8 @@ describe.skipIf(isWindows)("picks up atomic rename-save of a module outside cwd"
         cmd: [bunExe(), flag, "--no-clear-screen", "entry.ts"],
         cwd: appDir,
         env: bunEnv,
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: ["ignore", "pipe", "inherit"],
       });
-      const stderr = proc.stderr.text();
       const iter = forEachLine(proc.stdout);
 
       expect(await nextEval(iter)).toBe("EVAL g=1 shared=V0");
@@ -108,7 +107,40 @@ describe.skipIf(isWindows)("picks up atomic rename-save of a module outside cwd"
 
       proc.kill("SIGKILL");
       await proc.exited;
-      expect(await stderr).not.toContain("is not in the project directory");
     });
   }
+
+  // A module reached through an in-cwd directory symlink is resolved to its
+  // real path (outside cwd) before being watched, so it hit the same gate.
+  test.concurrent("--hot via an in-cwd directory symlink to an out-of-cwd dir", async () => {
+    await using dir = tempDir("watch-symlink-outside-cwd", {
+      "app/entry.ts":
+        `import { sh } from "./link/dep.ts";\n` +
+        `globalThis.g = (globalThis.g ?? 0) + 1;\n` +
+        `console.log("EVAL g=" + globalThis.g + " shared=" + sh);\n`,
+      "realdir/dep.ts": `export const sh = "V0";\n`,
+    });
+    const appDir = join(String(dir), "app");
+    const realDep = join(String(dir), "realdir", "dep.ts");
+    await symlink(join(String(dir), "realdir"), join(appDir, "link"), "dir");
+
+    await using proc = spawn({
+      cmd: [bunExe(), "--hot", "--no-clear-screen", "entry.ts"],
+      cwd: appDir,
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+    const iter = forEachLine(proc.stdout);
+
+    expect(await nextEval(iter)).toBe("EVAL g=1 shared=V0");
+
+    await renameSave(realDep, `export const sh = "V1";\n`);
+    expect(await nextEval(iter)).toBe("EVAL g=2 shared=V1");
+
+    await renameSave(realDep, `export const sh = "V2";\n`);
+    expect(await nextEval(iter)).toBe("EVAL g=3 shared=V2");
+
+    proc.kill("SIGKILL");
+    await proc.exited;
+  });
 });

--- a/test/cli/hot/watch.test.ts
+++ b/test/cli/hot/watch.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, forEachLine, isBroken, isWindows, tempDir } from "harness";
-import { writeFile } from "node:fs/promises";
+import { rename, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 describe.todoIf(isBroken && isWindows)("--watch works", async () => {
@@ -45,6 +45,70 @@ describe.todoIf(isBroken && isWindows)("--watch works", async () => {
 
       process.kill("SIGKILL");
       await process.exited;
+    });
+  }
+});
+
+// A module imported from outside the process cwd (monorepo sibling package,
+// or the entrypoint itself when bun is launched from a different directory)
+// used to get only a per-inode inotify/kqueue watch and no parent-directory
+// watch. The first atomic rename-save (write temp + rename over; the default
+// for vim, sed -i, prettier, JetBrains safe-write, git checkout) replaces the
+// inode and orphans that watch, so the save and every later save of that file
+// were missed, and under --hot the stale pre-save source was served forever
+// from the pinned fd.
+describe.skipIf(isWindows)("picks up atomic rename-save of a module outside cwd", () => {
+  async function renameSave(path: string, content: string) {
+    await writeFile(path + ".next", content);
+    await rename(path + ".next", path);
+  }
+
+  async function nextEval(iter: AsyncIterator<string>): Promise<string> {
+    while (true) {
+      const { value, done } = await iter.next();
+      if (done) throw new Error("stream ended before an EVAL line");
+      if (value.startsWith("EVAL ")) return value;
+    }
+  }
+
+  for (const flag of ["--watch", "--hot"] as const) {
+    test.concurrent(flag, async () => {
+      await using dir = tempDir("watch-outside-cwd", {
+        "app/entry.ts":
+          `import { sh } from "../shared/lib.ts";\n` +
+          `globalThis.g = (globalThis.g ?? 0) + 1;\n` +
+          `console.log("EVAL g=" + globalThis.g + " shared=" + sh);\n`,
+        "shared/lib.ts": `export const sh = "V0";\n`,
+      });
+      const appDir = join(String(dir), "app");
+      const sharedLib = join(String(dir), "shared", "lib.ts");
+
+      await using proc = spawn({
+        cmd: [bunExe(), flag, "--no-clear-screen", "entry.ts"],
+        cwd: appDir,
+        env: bunEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const stderr = proc.stderr.text();
+      const iter = forEachLine(proc.stdout);
+
+      expect(await nextEval(iter)).toBe("EVAL g=1 shared=V0");
+
+      // Atomic rename-save of the out-of-cwd dependency. Before the fix this
+      // produced no reload at all (the per-inode watch is orphaned and the
+      // parent dir was not watched).
+      await renameSave(sharedLib, `export const sh = "V1";\n`);
+      const g2 = flag === "--hot" ? "2" : "1";
+      expect(await nextEval(iter)).toBe(`EVAL g=${g2} shared=V1`);
+
+      // Second rename-save on the (now new) inode.
+      await renameSave(sharedLib, `export const sh = "V2";\n`);
+      const g3 = flag === "--hot" ? "3" : "1";
+      expect(await nextEval(iter)).toBe(`EVAL g=${g3} shared=V2`);
+
+      proc.kill("SIGKILL");
+      await proc.exited;
+      expect(await stderr).not.toContain("is not in the project directory");
     });
   }
 });

--- a/test/cli/hot/watch.test.ts
+++ b/test/cli/hot/watch.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, forEachLine, isBroken, isWindows, tempDir } from "harness";
-import { rename, symlink, writeFile } from "node:fs/promises";
+import { mkdir, rename, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 describe.todoIf(isBroken && isWindows)("--watch works", async () => {
@@ -143,4 +143,50 @@ describe.skipIf(isWindows)("picks up atomic rename-save of a module outside cwd"
     proc.kill("SIGKILL");
     await proc.exited;
   });
+
+  // Workspace package imported by bare name from the workspace root: everything
+  // is inside cwd and the real-path parent dir IS watched, but the resolver's
+  // dir-entry cache is keyed by the `node_modules/lib/` spelling while the
+  // watchlist entry carries the real path, so the directory IN_MOVED_TO used to
+  // find no matching file entry and the rename-save was dropped. The per-file
+  // IN_ATTRIB (st_nlink == 0) eviction recovers it.
+  for (const flag of ["--watch", "--hot"] as const) {
+    test.concurrent(`${flag} a workspace package imported by bare name through node_modules`, async () => {
+      await using dir = tempDir("watch-workspace-bare-import", {
+        "package.json": JSON.stringify({ name: "root", private: true, workspaces: ["packages/*"] }),
+        "packages/app/package.json": JSON.stringify({ name: "app", dependencies: { lib: "workspace:*" } }),
+        "packages/app/entry.ts":
+          `import { sh } from "lib/index.js";\n` +
+          `globalThis.g = (globalThis.g ?? 0) + 1;\n` +
+          `console.log("EVAL g=" + globalThis.g + " shared=" + sh);\n`,
+        "packages/lib/package.json": JSON.stringify({ name: "lib", version: "1.0.0", main: "index.js" }),
+        "packages/lib/index.js": `export const sh = "V0";\n`,
+      });
+      const root = String(dir);
+      const libIndex = join(root, "packages", "lib", "index.js");
+      await mkdir(join(root, "packages", "app", "node_modules"), { recursive: true });
+      await symlink(join("..", "..", "lib"), join(root, "packages", "app", "node_modules", "lib"), "dir");
+
+      await using proc = spawn({
+        cmd: [bunExe(), flag, "--no-clear-screen", "packages/app/entry.ts"],
+        cwd: root,
+        env: bunEnv,
+        stdio: ["ignore", "pipe", "inherit"],
+      });
+      const iter = forEachLine(proc.stdout);
+
+      expect(await nextEval(iter)).toBe("EVAL g=1 shared=V0");
+
+      await renameSave(libIndex, `export const sh = "V1";\n`);
+      const g2 = flag === "--hot" ? "2" : "1";
+      expect(await nextEval(iter)).toBe(`EVAL g=${g2} shared=V1`);
+
+      await renameSave(libIndex, `export const sh = "V2";\n`);
+      const g3 = flag === "--hot" ? "3" : "1";
+      expect(await nextEval(iter)).toBe(`EVAL g=${g3} shared=V2`);
+
+      proc.kill("SIGKILL");
+      await proc.exited;
+    });
+  }
 });


### PR DESCRIPTION
### Problem

- `bun --hot` / `bun --watch` miss the atomic rename-save (write temp + rename over: vim, `sed -i`, prettier, JetBrains safe-write, `git checkout`) of a module whose parent-directory watch cannot map the event back to the module. After that, `--watch` ignores every later save of the file and `--hot` re-transpiles the stale pre-save source from the pinned fd for the life of the process.
- Three shapes hit this: a module outside the cwd tree (`import "../shared/x"` run from the package dir, or the entrypoint when bun starts elsewhere), a module reached through a symlink (resolved to its out-of-cwd real path), and a workspace package imported by bare name from the workspace root (`packages/app/node_modules/lib -> ../../lib`).
- Causes: `Watcher::is_eligible_directory` (`src/watcher/Watcher.rs:772`) only added the parent-directory watch when the path contained the cwd as a substring, so the first two shapes got a per-inode watch only. For the third shape the real-path directory is watched, but `NewHotReloader::on_file_update` maps a directory `IN_MOVED_TO` through the resolver's dir-entry cache, which is keyed by the `node_modules/lib/` spelling, so the event matched nothing. In all three the per-file inotify watch follows the old inode, which never reports `IN_DELETE_SELF` while bun holds it open.

### Fix

- Drop the cwd-containment term from `is_eligible_directory` on Linux/macOS (the `node_modules` exclusion stays; Windows keeps the term because `ReadDirectoryChangesW` is cwd-rooted, see #35596). `on_maybe_watch_directory` now calls the same predicate. Cost is one directory watch per unique parent directory of an imported file; the existing dir-fd/hash dedupe keeps it at one.
- Linux safety net on the per-file watch: add `IN_ATTRIB` to the file mask, and in the `Kind::File` arm of `NewHotReloader::on_file_update` and `DevServer::on_file_update` evict the entry and enqueue the reload when `fstat(fd).st_nlink == 0` (or `IN_MOVE_SELF`). A rename-over of a held-open inode delivers only that link-count `IN_ATTRIB`. This is what recovers the bare-name workspace shape, and any other case where the directory event cannot be mapped. `DevServer` skips a pure-`METADATA` event with `st_nlink > 0` so `chmod`/`touch` do not rebuild; that skip is `#[cfg(linux)]` so Windows and macOS keep the pre-PR path.
- Verified: `test/cli/hot/watch.test.ts` (five new cases: `--watch`/`--hot` x out-of-cwd relative import, `--hot` x directory symlink, `--watch`/`--hot` x bare-name workspace import; stock 1.4.3 fails all five at the first rename-save, the build passes 7/7). Also `test/cli/hot/hot.test.ts`, `watch-many-dirs.test.ts`, `test/cli/watch/*`, `test/bake/dev/hot.test.ts` (40/40), and `bun run rust:check-all` on all 12 targets.

### Background

- The watcher keeps two kinds of inotify watches: one per imported file (on the inode, mask `MODIFY|MOVE_SELF|DELETE_SELF|MOVED_TO`) and one per parent directory (adds `CREATE|DELETE|MOVED_TO` with child names). An in-place write fires `IN_MODIFY` on the file watch. A rename-over replaces the inode, so only the directory watch sees it (`IN_MOVED_TO name`).
- `NewHotReloader::on_file_update` (`src/jsc/hot_reloader.rs`) runs on the watcher thread. For a directory event it looks the child name up in the resolver's cached `DirEntry` for that directory to find the module's absolute path, hashes it, and matches the hash against the watchlist to evict the stale fd and enqueue a reload.
- `--hot` reads module source through the watchlist's cached fd (`snapshot_fd_and_package_json`). If the entry is never evicted after a rename-over, that fd still points at the unlinked old inode, so every reload re-reads the old bytes.
- `bake::DevServer` is the second `WatcherContext` consumer and shares the per-file inotify mask, so the `IN_ATTRIB` addition had to be audited there too.

<details><summary>Notes</summary>

Repro for the out-of-cwd shape (deterministic on 1.4.0 through 1.4.3):

```sh
mkdir -p /tmp/r/app /tmp/r/shared && cd /tmp/r/app
echo 'export const sh="V0";' > ../shared/lib.ts
printf 'import { sh } from "../shared/lib.ts";\nglobalThis.g=(globalThis.g??0)+1;\nconsole.log("EVAL g="+globalThis.g+" shared="+sh);\n' > entry.ts
bun --hot entry.ts &  sleep 2
sed 's/V0/V1/' ../shared/lib.ts > ../shared/lib.ts.tmp && mv ../shared/lib.ts.tmp ../shared/lib.ts   # missed
sleep 1; sed -i 's/V1/V2/' ../shared/lib.ts; sleep 1   # also missed
printf '\n// touch\n' >> entry.ts; sleep 1              # full re-eval still prints shared=V0 (disk has V2)
```

`strace -f -e trace=inotify_add_watch` on one `--hot` boot (cwd=`app/`, importing `../shared/dep.ts`, `./link/dep2.ts` with `link -> ../realdir`, and `./incwd/mod.ts`) shows `app` DIR, `app/entry.ts` FILE, `shared/dep.ts` FILE only (no watch on `shared/`), `app/incwd` DIR + `app/incwd/mod.ts` FILE, `realdir/dep2.ts` FILE only (no watch on `realdir/`). For the bare-name workspace shape run from the root, the `packages/lib` DIR watch is present and the `IN_MOVED_TO` is delivered but dropped at the dir-entry lookup.

The two halves are independent: with `Watcher.rs` reverted to main, the `IN_ATTRIB`/`st_nlink` path alone passes all five new tests. With only the `is_eligible_directory` change, the out-of-cwd and symlink shapes pass and the bare-name workspace shape still fails.

`add_file_by_path_slow` cannot be used to re-arm from inside `on_file_update` because it takes the non-recursive watcher mutex that `dispatch_file_updates` already holds; evicting and enqueueing is enough because the reload's `maybe_watch_file` re-registers the new inode.

Self-reviewed: 5 concerns raised across review rounds, 5 addressed (vacuous stderr assertion removed; `DevServer` gated for `IN_ATTRIB`; that gate scoped to Linux so Windows `Added`/`RenamedNew` events are not dropped; comment length; resource footprint answered as bounded by unique parent dirs).

Related: #33071 (directory-event mapping for in-cwd files via the resolver cache), #35596 (Windows multi-root watcher; carries `Fixes #9547`).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/hot/watch.test.ts

<!-- robobun:evidence:end -->