### PR TITLE
udp: retry unconnected send once when a stale ICMP poisons sk_err

### DIFF
--- a/packages/bun-usockets/src/udp.c
+++ b/packages/bun-usockets/src/udp.c
@@ -19,6 +19,9 @@
 #include "internal/internal.h"
 
 #include <string.h>
+#ifndef _WIN32
+#include <errno.h>
+#endif
 
 // int us_udp_packet_buffer_ecn(struct us_udp_packet_buffer_t *buf, int index) {
 //     return bsd_udp_packet_buffer_ecn((struct udp_recvbuf *)buf, index);
@@ -51,12 +54,11 @@ int us_udp_socket_send(struct us_udp_socket_t *s, void** payloads, size_t* lengt
     struct udp_sendbuf *buf = (struct udp_sendbuf *)s->loop->data.send_buf;
 
     int total_sent = 0;
+#ifndef _WIN32
+    int stale_icmp_retried = 0;
+#endif
     while (num > 0) {
         int count = bsd_udp_setup_sendbuf(buf, LIBUS_SEND_BUFFER_LENGTH, payloads, lengths, addresses, num);
-        payloads += count;
-        lengths += count;
-        addresses += count;
-        num -= count;
         // TODO nohang flag?
         int sent = bsd_sendmmsg(fd, buf, MSG_DONTWAIT);
         if (sent < 0) {
@@ -67,15 +69,47 @@ int us_udp_socket_send(struct us_udp_socket_t *s, void** payloads, size_t* lengt
                 us_poll_change((struct us_poll_t *) s, s->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
                 return total_sent;
             }
+#ifndef _WIN32
+            /* On an unconnected socket with IP_RECVERR armed, an ICMP for a
+             * previous datagram (to a different peer) is mirrored into sk_err
+             * and consumed by THIS sendmsg as ECONNREFUSED/E*UNREACH, failing
+             * a datagram whose own destination was never tried. sock_error()
+             * already cleared sk_err, so one retry succeeds. Connected sockets
+             * keep the error: there the ICMP is about the only peer. */
+            if (!s->connected && !stale_icmp_retried &&
+                (errno == ECONNREFUSED || errno == EHOSTUNREACH || errno == ENETUNREACH)) {
+                stale_icmp_retried = 1;
+                continue;
+            }
+#endif
             return total_sent > 0 ? total_sent : sent;
         }
         total_sent += sent;
+        payloads += sent;
+        lengths += sent;
+        addresses += sent;
+        num -= sent;
         if (sent < count) {
-            /* Partial batch: kernel send buffer is full. Re-arm writable so
-             * on_drain fires and stop — retrying now would just spin on EAGAIN. */
+#ifndef _WIN32
+            /* Partial batch on an unconnected socket: Linux sendmmsg returns a
+             * short count without setting errno, so a stale sk_err consumed
+             * mid-batch is indistinguishable from a full send buffer here.
+             * Resume at the failed index; the next iteration tells them apart
+             * (EAGAIN re-arms above, cleared sk_err succeeds). sent > 0
+             * guarantees forward progress so this cannot spin. */
+            if (sent > 0 && !s->connected) {
+                stale_icmp_retried = 0;
+                continue;
+            }
+#endif
+            /* Kernel send buffer is full. Re-arm writable so on_drain fires
+             * and stop; retrying now would just spin on EAGAIN. */
             us_poll_change((struct us_poll_t *) s, s->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
             return total_sent;
         }
+#ifndef _WIN32
+        stale_icmp_retried = 0;
+#endif
     }
     return total_sent;
 }
@@ -148,11 +182,15 @@ int us_udp_socket_set_ttl_multicast(struct us_udp_socket_t *s, int ttl) {
 }
 
 int us_udp_socket_connect(struct us_udp_socket_t *s, const char* host, unsigned short port) {
-    return bsd_connect_udp_socket(us_poll_fd((struct us_poll_t *)s), host, port);
+    int rc = bsd_connect_udp_socket(us_poll_fd((struct us_poll_t *)s), host, port);
+    if (rc == 0) s->connected = 1;
+    return rc;
 }
 
 int us_udp_socket_disconnect(struct us_udp_socket_t *s) {
-    return bsd_disconnect_udp_socket(us_poll_fd((struct us_poll_t *)s));
+    int rc = bsd_disconnect_udp_socket(us_poll_fd((struct us_poll_t *)s));
+    if (rc == 0) s->connected = 0;
+    return rc;
 }
 
 int us_udp_socket_set_multicast_loopback(struct us_udp_socket_t *s, int enabled) {

--- a/packages/bun-usockets/src/udp.c
+++ b/packages/bun-usockets/src/udp.c
@@ -54,7 +54,7 @@ int us_udp_socket_send(struct us_udp_socket_t *s, void** payloads, size_t* lengt
     struct udp_sendbuf *buf = (struct udp_sendbuf *)s->loop->data.send_buf;
 
     int total_sent = 0;
-#ifndef _WIN32
+#ifdef __linux__
     int stale_icmp_retried = 0;
 #endif
     while (num > 0) {
@@ -69,7 +69,7 @@ int us_udp_socket_send(struct us_udp_socket_t *s, void** payloads, size_t* lengt
                 us_poll_change((struct us_poll_t *) s, s->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
                 return total_sent;
             }
-#ifndef _WIN32
+#ifdef __linux__
             /* On an unconnected socket with IP_RECVERR armed, an ICMP for a
              * previous datagram (to a different peer) is mirrored into sk_err
              * and consumed by THIS sendmsg as ECONNREFUSED/E*UNREACH, failing
@@ -82,7 +82,14 @@ int us_udp_socket_send(struct us_udp_socket_t *s, void** payloads, size_t* lengt
                 continue;
             }
 #endif
-            return total_sent > 0 ? total_sent : sent;
+            /* Earlier iterations sent something: keep the short-count contract
+             * (re-arm writable so on_drain drives the retry, where the caller
+             * sees this errno thrown). */
+            if (total_sent > 0) {
+                us_poll_change((struct us_poll_t *) s, s->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
+                return total_sent;
+            }
+            return sent;
         }
         total_sent += sent;
         payloads += sent;
@@ -90,12 +97,13 @@ int us_udp_socket_send(struct us_udp_socket_t *s, void** payloads, size_t* lengt
         addresses += sent;
         num -= sent;
         if (sent < count) {
-#ifndef _WIN32
+#ifdef __linux__
             /* Partial batch on an unconnected socket: Linux sendmmsg returns a
              * short count without setting errno, so a stale sk_err consumed
              * mid-batch is indistinguishable from a full send buffer here.
              * Resume at the failed index; the next iteration tells them apart
-             * (EAGAIN re-arms above, cleared sk_err succeeds). sent > 0
+             * (EAGAIN re-arms above, cleared sk_err succeeds, a hard per-msg
+             * error re-arms via the total_sent fallthrough). sent > 0
              * guarantees forward progress so this cannot spin. */
             if (sent > 0 && !s->connected) {
                 stale_icmp_retried = 0;
@@ -107,7 +115,7 @@ int us_udp_socket_send(struct us_udp_socket_t *s, void** payloads, size_t* lengt
             us_poll_change((struct us_poll_t *) s, s->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
             return total_sent;
         }
-#ifndef _WIN32
+#ifdef __linux__
         stale_icmp_retried = 0;
 #endif
     }

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, jest, test } from "bun:test";
 import { createSocket } from "dgram";
 import { Worker } from "node:worker_threads";
 
-import { bunEnv, bunExe, disableAggressiveGCScope, isWindows } from "harness";
+import { bunEnv, bunExe, disableAggressiveGCScope, isLinux, isWindows } from "harness";
 import path from "path";
 import { nodeDataCases } from "./testdata";
 
@@ -438,6 +438,47 @@ test("setBroadcast()/setMulticastLoopback() before bind() throw EBADF", () => {
   }
   socket.close();
 });
+
+// IP_RECVERR (Linux) mirrors an ICMP port-unreachable into sk_err, and the next
+// sendmsg consumes it. Node never enables IP_RECVERR, so a send to a healthy
+// peer right after a send to a dead one must succeed with (null, bytes).
+test.skipIf(!isLinux)(
+  "unconnected send() after a bounced datagram delivers to a healthy peer (no stale ECONNREFUSED)",
+  async () => {
+    const got: string[] = [];
+    const live = createSocket("udp4");
+    await new Promise<void>(r => live.bind(0, "127.0.0.1", r));
+    live.on("message", d => got.push(d.toString()));
+    const tmp = createSocket("udp4");
+    await new Promise<void>(r => tmp.bind(0, "127.0.0.1", r));
+    const dead = tmp.address().port;
+    tmp.close();
+
+    try {
+      let cbErr = 0;
+      let lost = 0;
+      for (let t = 0; t < 20 && cbErr === 0 && lost === 0; t++) {
+        const s = createSocket("udp4");
+        s.on("error", () => {});
+        await new Promise<void>(r => s.bind(0, "127.0.0.1", r));
+        s.send("to-dead", dead, "127.0.0.1");
+        const before = got.length;
+        await new Promise<void>(r =>
+          s.send(`victim-${t}`, live.address().port, "127.0.0.1", e => {
+            if (e) cbErr++;
+            r();
+          }),
+        );
+        for (let i = 0; i < 100 && got.length === before; i++) await Bun.sleep(1);
+        if (got.length === before) lost++;
+        s.close();
+      }
+      expect({ cbErr, lost }).toEqual({ cbErr: 0, lost: 0 });
+    } finally {
+      live.close();
+    }
+  },
+);
 
 // An oversized datagram fails send(2) with EMSGSIZE; on the connected path no
 // address/port is known, so the error must match Node's bare `send <code>`.

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -1,7 +1,7 @@
 import { udpSocket } from "bun";
 import { heapStats } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, disableAggressiveGCScope, isWindows, randomPort } from "harness";
+import { bunEnv, bunExe, disableAggressiveGCScope, isLinux, isWindows, randomPort } from "harness";
 import path from "node:path";
 import { dataCases, dataTypes } from "./testdata";
 
@@ -582,6 +582,122 @@ describe("udpSocket()", () => {
       },
       30_000,
     );
+  });
+});
+
+// IP_RECVERR (Linux-only, enabled by default on every Bun UDP socket) mirrors
+// an ICMP port-unreachable into sk_err; the next sendmsg on the same socket
+// consumes it via sock_error() and fails with ECONNREFUSED for a datagram whose
+// own destination was never tried. The send path must retry once on an
+// unconnected socket so a bounce off one dead peer cannot poison the next send
+// to a healthy one.
+describe.skipIf(!isLinux)("send() is not poisoned by a stale ICMP from a previous datagram", () => {
+  async function deadPort() {
+    const tmp = await udpSocket({ hostname: "127.0.0.1" });
+    const port = tmp.port;
+    tmp.close();
+    return port;
+  }
+
+  test("same-tick send after a bounce reaches a healthy peer", async () => {
+    const got: string[] = [];
+    const live = await udpSocket({
+      hostname: "127.0.0.1",
+      socket: { data: (_s, d) => void got.push(d.toString()) },
+    });
+    const dead = await deadPort();
+    try {
+      let threw = 0;
+      let lost = 0;
+      for (let t = 0; t < 30 && threw === 0 && lost === 0; t++) {
+        const s = await udpSocket({ hostname: "127.0.0.1", socket: { error() {} } });
+        s.send("to-dead", dead, "127.0.0.1");
+        const before = got.length;
+        try {
+          s.send(`victim-${t}`, live.port, "127.0.0.1");
+        } catch {
+          threw++;
+        }
+        for (let i = 0; i < 100 && got.length === before; i++) await Bun.sleep(1);
+        if (got.length === before) lost++;
+        s.close();
+      }
+      expect({ threw, lost }).toEqual({ threw: 0, lost: 0 });
+    } finally {
+      live.close();
+    }
+  });
+
+  test("sendMany() after a bounce delivers the whole healthy batch", async () => {
+    const got: string[] = [];
+    const live = await udpSocket({
+      hostname: "127.0.0.1",
+      socket: { data: (_s, d) => void got.push(d.toString()) },
+    });
+    const dead = await deadPort();
+    const s = await udpSocket({ hostname: "127.0.0.1", socket: { error() {} } });
+    try {
+      s.send("to-dead", dead, "127.0.0.1");
+      const batch = Array.from({ length: 10 }, (_, i) => [`b${i}`, live.port, "127.0.0.1"]).flat();
+      const ret = s.sendMany(batch);
+      for (let i = 0; i < 200 && got.length < 10; i++) await Bun.sleep(1);
+      expect({ ret, delivered: got.length }).toEqual({ ret: 10, delivered: 10 });
+    } finally {
+      s.close();
+      live.close();
+    }
+  });
+
+  test("sendMany() resumes past a dead destination inside the batch", async () => {
+    const got = new Set<string>();
+    const live = await udpSocket({
+      hostname: "127.0.0.1",
+      socket: { data: (_s, d) => void got.add(d.toString()) },
+    });
+    const dead = await deadPort();
+    // The ICMP for index 1 lands during sendmmsg on loopback and short-counts
+    // the batch at index 2; the send loop must resume there instead of
+    // re-arming writable.
+    const batch: (string | number)[] = [];
+    const liveTags: string[] = [];
+    for (let i = 0; i < 8; i++) {
+      const d = i === 1 || i === 4;
+      batch.push(`m${i}`, d ? dead : live.port, "127.0.0.1");
+      if (!d) liveTags.push(`m${i}`);
+    }
+    const s = await udpSocket({ hostname: "127.0.0.1", socket: { error() {} } });
+    try {
+      const ret = s.sendMany(batch);
+      for (let i = 0; i < 200 && got.size < liveTags.length; i++) await Bun.sleep(1);
+      expect(ret).toBe(8);
+      expect([...got].sort()).toEqual(liveTags.sort());
+    } finally {
+      s.close();
+      live.close();
+    }
+  });
+
+  test("connected socket still surfaces ECONNREFUSED on the next same-tick send", async () => {
+    const dead = await deadPort();
+    let threw = 0;
+    for (let t = 0; t < 30; t++) {
+      const s = await udpSocket({
+        hostname: "127.0.0.1",
+        connect: { hostname: "127.0.0.1", port: dead },
+        socket: { error() {} },
+      });
+      s.send("a");
+      try {
+        s.send("b");
+      } catch (e: any) {
+        if (e.code === "ECONNREFUSED") threw++;
+      }
+      s.close();
+    }
+    // The unconnected-retry must not apply here: the ICMP IS about this
+    // socket's only peer. Loopback delivers it between the two sends, so the
+    // second send sees it on every trial.
+    expect(threw).toBe(30);
   });
 });
 

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -695,9 +695,10 @@ describe.skipIf(!isLinux)("send() is not poisoned by a stale ICMP from a previou
       s.close();
     }
     // The unconnected-retry must not apply here: the ICMP IS about this
-    // socket's only peer. Loopback delivers it between the two sends, so the
-    // second send sees it on every trial.
-    expect(threw).toBe(30);
+    // socket's only peer. Were the retry wrongly applied, every trial would
+    // succeed and threw === 0. Loopback usually delivers the ICMP between the
+    // two sends (30/30 locally) but a deferred softirq can miss one under load.
+    expect(threw).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Repro

```ts
const live = await Bun.udpSocket({ hostname: "127.0.0.1", socket: { data(_s, d) { got.push(d.toString()); } } });
const dead = /* port nothing listens on */;
const s = await Bun.udpSocket({ hostname: "127.0.0.1", socket: { error() {} } });
s.send("to-dead", dead, "127.0.0.1");          // bounces (ICMP port-unreachable)
s.send("victim", live.port, "127.0.0.1");      // HEALTHY destination
// -> throws ECONNREFUSED synchronously; victim never delivered
```

On `main`, 50/50 trials: the second `send` throws `ECONNREFUSED` and the datagram is lost. A following `sendMany` of 10 healthy datagrams throws outright (0/10 delivered), and a batch with a dead port at index 1 short-counts at 2 and drops the healthy tail. `node:dgram` under Bun hits the same path (50/50 callbacks get `ECONNREFUSED`, 50/50 lost). Node itself: 0/50.

## Cause

Bun enables `IP_RECVERR` on every UDP socket (`us_create_udp_socket` sets `LIBUS_UDP_LINUX_RECVERR` whenever an `on_recv_error` callback exists, which is always). With it armed, Linux mirrors an ICMP port-unreachable into `sk_err`. The next `sendmsg`/`sendmmsg` on the same socket hits `sock_error()` inside `sock_alloc_send_pskb`, which consumes `sk_err` and fails that send with `ECONNREFUSED` for a datagram whose own destination was never tried. On loopback the ICMP lands between two back-to-back sends, so the bounce poisons exactly the next send. `sendmmsg` returns a short count (without setting errno) when this happens mid-batch, which `us_udp_socket_send` treated as send-buffer-full and stopped.

This is the same mechanism as #4500 seen from the send side; the open PRs for that (#35922 / #35923 / #29135) handle the receive/dispatch path but not the same-tick send-send case, which is poisoned before any epoll pass can drain the error queue.

## Fix

`packages/bun-usockets/src/udp.c`:

- `us_udp_socket_send`: when a send on an unconnected socket fails with `ECONNREFUSED` / `EHOSTUNREACH` / `ENETUNREACH`, retry once. `sock_error()` already cleared `sk_err`, so the retry reaches the real destination. After a short count on an unconnected socket, resume at the failed index instead of re-arming writable; the next iteration distinguishes a genuine `EAGAIN` (re-arms) from a cleared `sk_err` (proceeds). `sent > 0` guarantees forward progress so the resume cannot spin, and `stale_icmp_retried` bounds the `-1` retry to once between progress.
- `us_udp_socket_connect` / `us_udp_socket_disconnect`: maintain `s->connected` (the field existed but was never set). Connected sockets keep the error: there the ICMP is about the only peer.

## Verification

New Linux-only tests in `test/js/bun/udp/udp_socket.test.ts` and `test/js/bun/udp/dgram.test.ts` (the bug is `IP_RECVERR`-specific), each failing on `main` and passing here, 5/5 runs:

- same-tick send after a bounce reaches a healthy peer: 0/30 lost (was 30/30 threw and lost)
- `sendMany()` after a bounce delivers the whole healthy batch: returns 10, 10/10 delivered (was threw `ECONNREFUSED`, 0/10)
- `sendMany()` resumes past a dead destination inside the batch: returns 8, 6/6 live delivered (was returned 2)
- connected socket still surfaces `ECONNREFUSED` on the next same-tick send: 30/30 (unchanged)
- `node:dgram` unconnected send after a bounce: 0/20 callback errors, 0/20 lost (was 20/20 each)

264/264 in `test/js/bun/udp/`, 75/75 `test/js/node/test/parallel/test-dgram-*.js`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/udp/dgram.test.ts test/js/bun/udp/udp_socket.test.ts

<!-- robobun:evidence:end -->