### PR TITLE
resolver, watcher: stop leaking file descriptors on every --hot reload

### DIFF
--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -984,9 +984,7 @@ where
 
                         let affected_len: usize = 'brk: {
                             if IS_KQUEUE {
-                                // Index lookup only (`BSSMap::get` locks internally); the slot
-                                // contents are read under `entries_mutex` in the 'locked block
-                                // below, since a JS-thread resolve can now rewrite them in place.
+                                // Slot contents are read under `entries_mutex` below.
                                 if let Some(existing) = rfs.entries.get(file_path) {
                                     self.put_tombstone(file_path, existing);
                                     entries_option = Some(existing);
@@ -1138,11 +1136,8 @@ where
                             let Some(dir_ent) = entries_option else {
                                 break 'locked;
                             };
-                            // `bust_entries_cache` now marks the `DirEntry` stale in place
-                            // instead of orphaning the slot, so a concurrent resolve on the
-                            // JS thread can rewrite this exact `DirEntry`/`EntryMap` via the
-                            // in-place path. Serialize with those writers by holding the
-                            // same mutex they take.
+                            // A stale `DirEntry` slot can be rewritten in place by a
+                            // JS-thread resolve; serialize with those writers.
                             let _entries_g = rfs.entries_mutex.lock_guard();
                             // SAFETY: dir_ent points into rfs.entries (or a tombstoned copy);
                             // both outlive this loop iteration.
@@ -1275,8 +1270,7 @@ where
                             }
                         }
 
-                        // Bust after releasing `entries_mutex`: `bust_entries_cache`
-                        // takes it internally and the lock is non-recursive.
+                        // `bust_entries_cache` takes `entries_mutex` itself (non-recursive).
                         let _ = self.ctx_mut().bust_dir_cache(
                             strings::paths::without_trailing_slash_windows_path(file_path),
                         );

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -984,8 +984,9 @@ where
 
                         let affected_len: usize = 'brk: {
                             if IS_KQUEUE {
-                                // SAFETY: hot-reload runs single-threaded on the JS thread;
-                                // no other live `&mut EntriesOption` for this key here.
+                                // Index lookup only (`BSSMap::get` locks internally); the slot
+                                // contents are read under `entries_mutex` in the 'locked block
+                                // below, since a JS-thread resolve can now rewrite them in place.
                                 if let Some(existing) = rfs.entries.get(file_path) {
                                     self.put_tombstone(file_path, existing);
                                     entries_option = Some(existing);
@@ -1085,10 +1086,6 @@ where
                             }
                         }
 
-                        let _ = self.ctx_mut().bust_dir_cache(
-                            strings::paths::without_trailing_slash_windows_path(file_path),
-                        );
-
                         // The watched entrypoint has a per-file inotify watch on its inode.
                         // An atomic rename (`rename(tmp, entrypoint)`) or a rm+recreate over
                         // the entrypoint replaces that inode, so the kernel drops the
@@ -1137,10 +1134,22 @@ where
                             }
                         }
 
-                        if let Some(dir_ent) = entries_option {
+                        'locked: {
+                            let Some(dir_ent) = entries_option else {
+                                break 'locked;
+                            };
+                            // `bust_entries_cache` now marks the `DirEntry` stale in place
+                            // instead of orphaning the slot, so a concurrent resolve on the
+                            // JS thread can rewrite this exact `DirEntry`/`EntryMap` via the
+                            // in-place path. Serialize with those writers by holding the
+                            // same mutex they take.
+                            let _entries_g = rfs.entries_mutex.lock_guard();
                             // SAFETY: dir_ent points into rfs.entries (or a tombstoned copy);
                             // both outlive this loop iteration.
                             let dir_ent = unsafe { &mut *dir_ent };
+                            if !matches!(dir_ent, Fs::EntriesOption::Entries(_)) {
+                                break 'locked;
+                            }
                             let mut last_file_hash: bun_watcher::HashType =
                                 bun_watcher::HashType::MAX;
 
@@ -1265,6 +1274,12 @@ where
                                 }
                             }
                         }
+
+                        // Bust after releasing `entries_mutex`: `bust_entries_cache`
+                        // takes it internally and the lock is non-recursive.
+                        let _ = self.ctx_mut().bust_dir_cache(
+                            strings::paths::without_trailing_slash_windows_path(file_path),
+                        );
 
                         if self.verbose {
                             Self::debug(format_args!(

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -1084,6 +1084,10 @@ where
                             }
                         }
 
+                        let _ = self.ctx_mut().bust_dir_cache(
+                            strings::paths::without_trailing_slash_windows_path(file_path),
+                        );
+
                         // The watched entrypoint has a per-file inotify watch on its inode.
                         // An atomic rename (`rename(tmp, entrypoint)`) or a rm+recreate over
                         // the entrypoint replaces that inode, so the kernel drops the
@@ -1269,11 +1273,6 @@ where
                                 }
                             }
                         }
-
-                        // `bust_entries_cache` takes `entries_mutex` itself (non-recursive).
-                        let _ = self.ctx_mut().bust_dir_cache(
-                            strings::paths::without_trailing_slash_windows_path(file_path),
-                        );
 
                         if self.verbose {
                             Self::debug(format_args!(

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -478,12 +478,9 @@ pub struct DirEntry {
     pub dir: &'static [u8],
     pub fd: Fd,
     pub generation: Generation,
-    /// Set by `RealFS::bust_entries_cache`. Forces the next read through
-    /// `read_directory_with_iterator` / `dir_info_cached_miss` /
-    /// `dir_info_for_resolution` to take the in-place re-scan path even when
-    /// `generation` matches, so the existing `DirEntry` (and its cached
-    /// directory `fd`) is reused instead of being orphaned with the fd left
-    /// open.
+    /// Set by `RealFS::bust_entries_cache`; forces the next locked directory
+    /// read to re-scan this slot in place (reusing the allocation and `fd`)
+    /// instead of orphaning it.
     pub stale: bool,
     pub data: dir_entry::EntryMap,
 }

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -478,6 +478,13 @@ pub struct DirEntry {
     pub dir: &'static [u8],
     pub fd: Fd,
     pub generation: Generation,
+    /// Set by `RealFS::bust_entries_cache`. Forces the next read through
+    /// `read_directory_with_iterator` / `dir_info_cached_miss` /
+    /// `dir_info_for_resolution` to take the in-place re-scan path even when
+    /// `generation` matches, so the existing `DirEntry` (and its cached
+    /// directory `fd`) is reused instead of being orphaned with the fd left
+    /// open.
+    pub stale: bool,
     pub data: dir_entry::EntryMap,
 }
 
@@ -490,6 +497,7 @@ impl DirEntry {
             dir,
             data: dir_entry::EntryMap::default(),
             generation,
+            stale: false,
             fd: Fd::INVALID,
         }
     }

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1277,13 +1277,8 @@ pub mod fs {
                     entries.fd = handle;
                 }
 
-                // When refreshing a slot that already holds an open directory
-                // handle, keep that handle: its raw value may also be cached
-                // in `ParseTask.contents_or_fd`, the watcher's watchlist, or
-                // the dev server's `DirectoryWatchStore`, so replacing it
-                // would strand an open fd with no owner. The freshly-opened
-                // `handle` was only needed for the readdir above; release it
-                // here (the guard above does not, under `store_fd`).
+                // See `DirEntry::stale`: carry an existing handle forward and
+                // release the fresh one the guard above would keep open.
                 if let Some(original) = in_place {
                     // SAFETY: BSSMap-owned; entries_mutex held.
                     let prev_fd = unsafe { (*original).fd };
@@ -1320,34 +1315,22 @@ pub mod fs {
 
         /// Invalidates `file_path` in the directory-entry cache; returns
         /// whether an entry was invalidated.
+        ///
+        /// `BSSMap::remove()` only drops the hash→index mapping, so removing a
+        /// live `DirEntry` would orphan its open `.fd` (also cached in
+        /// `ParseTask.contents_or_fd`, the watcher's watchlist, and the dev
+        /// server's `DirectoryWatchStore`, so closing it here would race those
+        /// readers). Mark it [stale](DirEntry::stale) instead so the next
+        /// locked directory read re-scans the slot in place and carries the
+        /// fd forward.
         pub fn bust_entries_cache(&mut self, file_path: &[u8]) -> bool {
-            // `entries` is the process-global BSSMap singleton; callers
-            // (transpiler / hot-reloader / VM) reach this without
-            // `RESOLVER_MUTEX`. `read_directory_with_iterator` and
-            // `dir_info_cached_miss` hold `entries_mutex` while they read and
-            // overwrite slot contents, so take it here too for the tag check
-            // and `stale` write. No caller already holds it (no re-entry from
-            // `read_directory`/`dir_info_cached_maybe_log`).
+            // No caller already holds `entries_mutex` (non-recursive).
             let _g = self.entries_mutex.lock_guard();
-
-            // `BSSMap::remove()` only drops the hash→index mapping; the backing
-            // slot (and the leaked `Box<DirEntry>` it points at, with its open
-            // `.fd` when `store_fd` is true) is orphaned, and the next lookup
-            // allocates a fresh slot and re-opens the directory. Under
-            // `--hot`/`--watch` this leaked one directory fd per reload.
-            //
-            // The fd cannot simply be closed here: its raw value is also copied
-            // into `ParseTask.contents_or_fd`, the dev server's
-            // `DirectoryWatchStore`, and the watcher's own watchlist, and a
-            // close would race those readers on another thread. Instead keep
-            // the slot reachable and mark it stale; the next locked directory
-            // read takes the in-place re-scan path and carries the fd forward.
             if let Some(EntriesOption::Entries(entries)) = self.entries.get(file_path) {
                 entries.stale = true;
                 return true;
             }
-            // `Err` slots and `NotFound` sentinels hold no `DirEntry`; drop the
-            // key so the next read re-checks disk.
+            // `Err`/`NotFound` sentinels hold no `DirEntry`.
             self.entries.remove(file_path)
         }
 
@@ -1632,11 +1615,7 @@ pub mod fs {
                         Ok(mut new_entry) => {
                             // SAFETY: see above.
                             unsafe { (*e_ptr).data.clear() };
-                            // `readdir(store_fd=false, …)` leaves `new_entry.fd` invalid;
-                            // carry over any previously stored descriptor so callers that
-                            // cached it via `DirInfo::get_file_descriptor` keep a live
-                            // handle and it is not leaked by the overwrite below.
-                            // SAFETY: see above.
+                            // SAFETY: see above. Preserve any stored descriptor.
                             new_entry.fd = unsafe { (*e_ptr).fd };
                             // SAFETY: see above — slot is exclusively owned here.
                             unsafe { *e_ptr = new_entry };

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1194,7 +1194,7 @@ pub mod fs {
                         // scrutinee directly so no second `&mut *cached_ptr` is materialized
                         // while the first is on the borrow stack (Stacked Borrows hygiene).
                         match unsafe { &mut *cached_ptr } {
-                            EntriesOption::Entries(e) if e.generation < generation => {
+                            EntriesOption::Entries(e) if e.stale || e.generation < generation => {
                                 in_place = Some(std::ptr::from_mut::<DirEntry>(*e));
                             }
                             cached => return Ok(cached),
@@ -1277,6 +1277,24 @@ pub mod fs {
                     entries.fd = handle;
                 }
 
+                // When refreshing a slot that already holds an open directory
+                // handle, keep that handle: its raw value may also be cached
+                // in `ParseTask.contents_or_fd`, the watcher's watchlist, or
+                // the dev server's `DirectoryWatchStore`, so replacing it
+                // would strand an open fd with no owner. The freshly-opened
+                // `handle` was only needed for the readdir above; release it
+                // here (the guard above does not, under `store_fd`).
+                if let Some(original) = in_place {
+                    // SAFETY: BSSMap-owned; entries_mutex held.
+                    let prev_fd = unsafe { (*original).fd };
+                    if prev_fd.is_valid() {
+                        if !should_close_handle && !had_handle && entries.fd != prev_fd {
+                            let _ = bun_sys::close(entries.fd);
+                        }
+                        entries.fd = prev_fd;
+                    }
+                }
+
                 // SAFETY: `entries_ptr` is either a live BSSMap slot (`in_place`) or a fresh
                 // leaked Box; exclusively owned here under `entries_mutex`.
                 unsafe { *entries_ptr = entries };
@@ -1300,16 +1318,36 @@ pub mod fs {
             })))
         }
 
-        /// Evicts `file_path` from the directory-entry cache; returns whether
-        /// an entry was removed.
+        /// Invalidates `file_path` in the directory-entry cache; returns
+        /// whether an entry was invalidated.
         pub fn bust_entries_cache(&mut self, file_path: &[u8]) -> bool {
-            // `entries` is the process-global
-            // BSSMap singleton and `remove` mutates it; callers (transpiler /
-            // hot-reloader / VM) reach this without `RESOLVER_MUTEX`, so take
-            // `entries_mutex` to satisfy `EntriesMap::inner`'s aliasing
-            // invariant. No caller already holds it (no re-entry from
+            // `entries` is the process-global BSSMap singleton; callers
+            // (transpiler / hot-reloader / VM) reach this without
+            // `RESOLVER_MUTEX`. `read_directory_with_iterator` and
+            // `dir_info_cached_miss` hold `entries_mutex` while they read and
+            // overwrite slot contents, so take it here too for the tag check
+            // and `stale` write. No caller already holds it (no re-entry from
             // `read_directory`/`dir_info_cached_maybe_log`).
             let _g = self.entries_mutex.lock_guard();
+
+            // `BSSMap::remove()` only drops the hash→index mapping; the backing
+            // slot (and the leaked `Box<DirEntry>` it points at, with its open
+            // `.fd` when `store_fd` is true) is orphaned, and the next lookup
+            // allocates a fresh slot and re-opens the directory. Under
+            // `--hot`/`--watch` this leaked one directory fd per reload.
+            //
+            // The fd cannot simply be closed here: its raw value is also copied
+            // into `ParseTask.contents_or_fd`, the dev server's
+            // `DirectoryWatchStore`, and the watcher's own watchlist, and a
+            // close would race those readers on another thread. Instead keep
+            // the slot reachable and mark it stale; the next locked directory
+            // read takes the in-place re-scan path and carries the fd forward.
+            if let Some(EntriesOption::Entries(entries)) = self.entries.get(file_path) {
+                entries.stale = true;
+                return true;
+            }
+            // `Err` slots and `NotFound` sentinels hold no `DirEntry`; drop the
+            // key so the next read re-checks disk.
             self.entries.remove(file_path)
         }
 
@@ -1591,9 +1629,15 @@ pub mod fs {
                     // SAFETY: see above — exclusive `&mut` on the prev map for the duration of `readdir`.
                     let prev = Some(unsafe { &mut (*e_ptr).data });
                     match self.readdir(false, prev, dir, generation, handle, ()) {
-                        Ok(new_entry) => {
+                        Ok(mut new_entry) => {
                             // SAFETY: see above.
                             unsafe { (*e_ptr).data.clear() };
+                            // `readdir(store_fd=false, …)` leaves `new_entry.fd` invalid;
+                            // carry over any previously stored descriptor so callers that
+                            // cached it via `DirInfo::get_file_descriptor` keep a live
+                            // handle and it is not leaked by the overwrite below.
+                            // SAFETY: see above.
+                            new_entry.fd = unsafe { (*e_ptr).fd };
                             // SAFETY: see above — slot is exclusively owned here.
                             unsafe { *e_ptr = new_entry };
                         }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3436,8 +3436,6 @@ impl<'a> Resolver<'a> {
                 .map(|p| unsafe { (*p).fd })
                 .filter(|f| f.is_valid());
             if let Some(prev) = prev_fd {
-                // Keep the descriptor that was already stored for this slot;
-                // see `bust_entries_cache` for why it cannot be released here.
                 new_entry.fd = prev;
             } else if self.store_fd {
                 new_entry.fd = open_dir;
@@ -4427,12 +4425,9 @@ impl<'a> Resolver<'a> {
                 bufs!(open_dirs)[open_dir_count.get()] = open_dir;
                 open_dir_count.set(open_dir_count.get() + 1);
             }
-            // Set when `open_dir` is stored as `DirEntry.fd`; otherwise, a
-            // freshly-opened `open_dir` is released after `dir_info_uncached`
-            // (which still uses it for `openat`). Previously the `store_fd`
-            // guard above assumed every opened handle was adopted and never
-            // closed the ones that were not (entry already fresh, or an
-            // existing handle carried over in place), leaking one per call.
+            // When `open_dir` is not stored as `DirEntry.fd` (entry already
+            // fresh, or an existing handle carried over), it is released after
+            // `dir_info_uncached` below; the `store_fd` guard does not.
             let mut open_dir_adopted = false;
 
             let dir_path: &'static [u8] = if !queue_top_safe_path.is_empty() {
@@ -4553,16 +4548,13 @@ impl<'a> Resolver<'a> {
                     // NOTE: bun_collections::StringHashMap exposes `clear`, which drops all entries.
                     unsafe { &mut *existing }.data.clear();
                 }
+                // See `bust_entries_cache`: carry an existing handle forward
+                // instead of stranding it.
                 // SAFETY: see block-wide note above.
                 let prev_fd = in_place
                     .map(|p| unsafe { (*p).fd })
                     .filter(|f| f.is_valid());
                 new_entry.fd = if let Some(prev) = prev_fd {
-                    // This slot already holds an open directory handle. Keep it:
-                    // its raw value may also be cached in `ParseTask`/bake/the
-                    // watcher (see `bust_entries_cache`), so replacing it would
-                    // strand an open fd with no owner. `open_dir` was only used
-                    // for the readdir above and for `dir_info_uncached` below.
                     prev
                 } else if self.store_fd {
                     open_dir_adopted = open_dir.is_valid();

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3369,10 +3369,16 @@ impl<'a> Resolver<'a> {
                 return Err(err.into());
             }
         };
+        let open_dir_adopted = core::cell::Cell::new(false);
+        let _close_open_dir = scopeguard::guard((), |()| {
+            if !open_dir_adopted.get() {
+                let _ = ::bun_sys::close(open_dir);
+            }
+        });
 
         if let Some(cached_entry) = rfs!().entries.at_index(cached_dir_entry_result.index) {
             if let Fs::file_system::real_fs::EntriesOption::Entries(entries) = cached_entry {
-                if entries.generation >= self.generation {
+                if !entries.stale && entries.generation >= self.generation {
                     dir_entries_option = cached_entry;
                     needs_iter = false;
                 } else {
@@ -3425,8 +3431,17 @@ impl<'a> Resolver<'a> {
                 unsafe { &mut *existing }.data.clear();
             }
 
-            if self.store_fd {
+            // SAFETY: see block-wide note above.
+            let prev_fd = in_place
+                .map(|p| unsafe { (*p).fd })
+                .filter(|f| f.is_valid());
+            if let Some(prev) = prev_fd {
+                // Keep the descriptor that was already stored for this slot;
+                // see `bust_entries_cache` for why it cannot be released here.
+                new_entry.fd = prev;
+            } else if self.store_fd {
                 new_entry.fd = open_dir;
+                open_dir_adopted.set(true);
             }
             // NOTE: see `dir_info_cached_maybe_log` — `DirEntry.data` holds a `NonNull`,
             // so a zeroed slot is UB; box `new_entry` directly for the fresh case.
@@ -4405,12 +4420,20 @@ impl<'a> Resolver<'a> {
 
             // `open_dir` is INVALID for a permission-denied ancestor treated as
             // an opaque directory; there is nothing to track or close then.
-            if !queue_top.fd.is_valid() && open_dir.is_valid() {
+            let open_dir_freshly_opened = !queue_top.fd.is_valid() && open_dir.is_valid();
+            if open_dir_freshly_opened {
                 Fs::FileSystem::set_max_fd(open_dir.native());
                 // these objects mostly just wrap the file descriptor, so it's fine to keep it.
                 bufs!(open_dirs)[open_dir_count.get()] = open_dir;
                 open_dir_count.set(open_dir_count.get() + 1);
             }
+            // Set when `open_dir` is stored as `DirEntry.fd`; otherwise, a
+            // freshly-opened `open_dir` is released after `dir_info_uncached`
+            // (which still uses it for `openat`). Previously the `store_fd`
+            // guard above assumed every opened handle was adopted and never
+            // closed the ones that were not (entry already fresh, or an
+            // existing handle carried over in place), leaking one per call.
+            let mut open_dir_adopted = false;
 
             let dir_path: &'static [u8] = if !queue_top_safe_path.is_empty() {
                 // SAFETY: non-empty `safe_path` is always a dirname_store-backed
@@ -4468,7 +4491,7 @@ impl<'a> Resolver<'a> {
 
             if let Some(cached_entry) = rfs!().entries.at_index(cached_dir_entry_result.index) {
                 if let Fs::file_system::real_fs::EntriesOption::Entries(entries) = cached_entry {
-                    if entries.generation >= self.generation {
+                    if !entries.stale && entries.generation >= self.generation {
                         dir_entries_option = cached_entry;
                         needs_iter = false;
                     } else {
@@ -4530,7 +4553,23 @@ impl<'a> Resolver<'a> {
                     // NOTE: bun_collections::StringHashMap exposes `clear`, which drops all entries.
                     unsafe { &mut *existing }.data.clear();
                 }
-                new_entry.fd = if self.store_fd { open_dir } else { FD::INVALID };
+                // SAFETY: see block-wide note above.
+                let prev_fd = in_place
+                    .map(|p| unsafe { (*p).fd })
+                    .filter(|f| f.is_valid());
+                new_entry.fd = if let Some(prev) = prev_fd {
+                    // This slot already holds an open directory handle. Keep it:
+                    // its raw value may also be cached in `ParseTask`/bake/the
+                    // watcher (see `bust_entries_cache`), so replacing it would
+                    // strand an open fd with no owner. `open_dir` was only used
+                    // for the readdir above and for `dir_info_uncached` below.
+                    prev
+                } else if self.store_fd {
+                    open_dir_adopted = open_dir.is_valid();
+                    open_dir
+                } else {
+                    FD::INVALID
+                };
                 // NOTE: `DirEntry.data` is a `HashMap`
                 // (`NonNull` inside), so a zeroed slot is UB and `*ptr = new_entry` would drop it.
                 // Box `new_entry` directly for the fresh case; assign-into only for `in_place`.
@@ -4593,6 +4632,13 @@ impl<'a> Resolver<'a> {
                 open_dir,
                 None,
             )?;
+
+            if open_dir_freshly_opened && !open_dir_adopted {
+                let n = open_dir_count.get();
+                debug_assert!(n > 0 && bufs!(open_dirs)[n - 1] == open_dir);
+                open_dir_count.set(n - 1);
+                let _ = ::bun_sys::close(open_dir);
+            }
 
             top_parent = queue_top.result;
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4201,7 +4201,11 @@ impl<'a> Resolver<'a> {
                         // SAFETY: slot was written immediately above.
                         let slot = unsafe { queue[i].assume_init_mut() };
                         slot.safe_path = bun_ptr::RawSlice::new(entries.dir);
-                        slot.fd = entries.fd;
+                        // A stale entry's stored fd is at EOF from its previous
+                        // iteration; leave it INVALID so the re-scan opens fresh.
+                        if !entries.stale {
+                            slot.fd = entries.fd;
+                        }
                     }
                     Fs::file_system::real_fs::EntriesOption::Err(err) => {
                         debuglog!(
@@ -4235,7 +4239,9 @@ impl<'a> Resolver<'a> {
                             // SAFETY: slot was written immediately above.
                             let slot = unsafe { queue[i].assume_init_mut() };
                             slot.safe_path = bun_ptr::RawSlice::new(entries.dir);
-                            slot.fd = entries.fd;
+                            if !entries.stale {
+                                slot.fd = entries.fd;
+                            }
                         }
                         Fs::file_system::real_fs::EntriesOption::Err(err) => {
                             debuglog!(

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4432,9 +4432,17 @@ impl<'a> Resolver<'a> {
                 open_dir_count.set(open_dir_count.get() + 1);
             }
             // When `open_dir` is not stored as `DirEntry.fd` (entry already
-            // fresh, or an existing handle carried over), it is released after
-            // `dir_info_uncached` below; the `store_fd` guard does not.
-            let mut open_dir_adopted = false;
+            // fresh, or an existing handle carried over), it is released at
+            // the end of this iteration; the `store_fd` guard does not.
+            let open_dir_adopted = core::cell::Cell::new(false);
+            let _close_unadopted = scopeguard::guard((), |()| {
+                if open_dir_freshly_opened && !open_dir_adopted.get() {
+                    let n = open_dir_count.get();
+                    debug_assert!(n > 0 && bufs!(open_dirs)[n - 1] == open_dir);
+                    open_dir_count.set(n - 1);
+                    let _ = ::bun_sys::close(open_dir);
+                }
+            });
 
             let dir_path: &'static [u8] = if !queue_top_safe_path.is_empty() {
                 // SAFETY: non-empty `safe_path` is always a dirname_store-backed
@@ -4563,7 +4571,7 @@ impl<'a> Resolver<'a> {
                 new_entry.fd = if let Some(prev) = prev_fd {
                     prev
                 } else if self.store_fd {
-                    open_dir_adopted = open_dir.is_valid();
+                    open_dir_adopted.set(open_dir.is_valid());
                     open_dir
                 } else {
                     FD::INVALID
@@ -4630,13 +4638,6 @@ impl<'a> Resolver<'a> {
                 open_dir,
                 None,
             )?;
-
-            if open_dir_freshly_opened && !open_dir_adopted {
-                let n = open_dir_count.get();
-                debug_assert!(n > 0 && bufs!(open_dirs)[n - 1] == open_dir);
-                open_dir_count.set(n - 1);
-                let _ = ::bun_sys::close(open_dir);
-            }
 
             top_parent = queue_top.result;
 

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -869,11 +869,9 @@ impl Watcher {
                     let fds = self.watchlist.items_fd_mut();
                     let previous = fds[index as usize];
                     fds[index as usize] = fd;
-                    // Close the replaced descriptor so it is not orphaned, but only
-                    // while its inode is still linked: releasing the last reference
-                    // to an unlinked inode makes the kernel deliver the deferred
-                    // IN_DELETE_SELF on this item's still-registered watch, which
-                    // the dev server would turn into a spurious reload.
+                    // st_nlink > 0: releasing the last reference to an unlinked
+                    // inode delivers a deferred IN_DELETE_SELF on this item's
+                    // still-registered watch (spurious reload in DEV:hot-9).
                     if previous.is_valid()
                         && previous != fd
                         && matches!(bun_sys::fstat(previous), Ok(st) if st.st_nlink > 0)

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -867,7 +867,19 @@ impl Watcher {
                 // On Linux, the file descriptor might be out of date.
                 if fd.is_valid() {
                     let fds = self.watchlist.items_fd_mut();
+                    let previous = fds[index as usize];
                     fds[index as usize] = fd;
+                    // Close the replaced descriptor so it is not orphaned, but only
+                    // while its inode is still linked: releasing the last reference
+                    // to an unlinked inode makes the kernel deliver the deferred
+                    // IN_DELETE_SELF on this item's still-registered watch, which
+                    // the dev server would turn into a spurious reload.
+                    if previous.is_valid()
+                        && previous != fd
+                        && matches!(bun_sys::fstat(previous), Ok(st) if st.st_nlink > 0)
+                    {
+                        let _ = bun_sys::close(previous);
+                    }
                 }
             }
             self.mutex.unlock();

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,6 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
 import {
-  appendFileSync,
   copyFileSync,
   cpSync,
   readdirSync,

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,19 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
-import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import {
+  appendFileSync,
+  copyFileSync,
+  cpSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { bunEnv, bunExe, isDebug, isLinux, isWindows, tempDir, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -775,4 +787,104 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
     // TODO: bun has a memory leak when --hot is used on very large files
   },
   longTimeout,
+);
+
+// /proc/<pid>/fd is Linux-only.
+it.skipIf(!isLinux)(
+  "does not leak file descriptors on each reload",
+  async () => {
+    using dir = tempDir("hot-fd-leak", {
+      "entry.ts": 'import { value } from "./sub/dep.ts";\nconsole.log("RELOAD", value, process.pid);\n',
+      "sub/dep.ts": "export const value = 0;\n",
+    });
+    const dirReal = realpathSync(String(dir));
+    const depPath = join(String(dir), "sub", "dep.ts");
+
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const stderrDrain = runner.stderr.text();
+
+    // Resolve once stdout prints `RELOAD <n>`; the module logs that line on
+    // every re-evaluation.
+    const seen = new Set<number>();
+    let pending: { n: number; resolve: () => void } | null = null;
+    let childPid = 0;
+    const pump = (async () => {
+      const decoder = new TextDecoder();
+      let buffered = "";
+      for await (const chunk of runner.stdout) {
+        buffered += decoder.decode(chunk, { stream: true });
+        let nl: number;
+        while ((nl = buffered.indexOf("\n")) !== -1) {
+          const line = buffered.slice(0, nl);
+          buffered = buffered.slice(nl + 1);
+          const match = /^RELOAD (\d+) (\d+)$/.exec(line);
+          if (!match) continue;
+          const n = Number(match[1]);
+          childPid ||= Number(match[2]);
+          seen.add(n);
+          if (pending?.n === n) {
+            pending.resolve();
+            pending = null;
+          }
+        }
+      }
+    })();
+    const waitForReload = (n: number) =>
+      new Promise<void>((resolve, reject) => {
+        if (seen.has(n)) return resolve();
+        pending = { n, resolve };
+        runner.exited.then(code => reject(new Error(`--hot exited early with code ${code}`)));
+      });
+
+    const countProjectFds = () => {
+      const counts: Record<string, number> = {};
+      for (const fd of readdirSync(`/proc/${childPid}/fd`)) {
+        let target: string;
+        try {
+          target = readlinkSync(`/proc/${childPid}/fd/${fd}`);
+        } catch {
+          continue;
+        }
+        if (target === dirReal || target.startsWith(dirReal + "/")) {
+          counts[target] = (counts[target] ?? 0) + 1;
+        }
+      }
+      return counts;
+    };
+
+    await waitForReload(0);
+    // Warm up: the resolver's `store_fd` flag is set after VM init, so the
+    // first reload is what caches a directory handle. Measure after it so the
+    // steady-state handle is already present in `before`.
+    {
+      const reloaded = waitForReload(1);
+      writeFileSync(depPath, "export const value = 1;\n");
+      await reloaded;
+    }
+    const before = countProjectFds();
+
+    const reloads = 20;
+    for (let i = 2; i <= reloads + 1; i++) {
+      const reloaded = waitForReload(i);
+      writeFileSync(depPath, `export const value = ${i};\n`);
+      await reloaded;
+    }
+    const after = countProjectFds();
+
+    runner.kill();
+    await Promise.allSettled([pump, stderrDrain, runner.exited]);
+
+    // Previously: every reload orphaned one open descriptor on the entrypoint
+    // and two O_DIRECTORY handles on the edited module's directory; long
+    // sessions eventually hit EMFILE.
+    expect({ reloads, before, after }).toEqual({ reloads, before, after: before });
+  },
+  timeout,
 );

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -868,6 +868,9 @@ it.skipIf(!isLinux)(
       await reloaded;
     }
     const before = countProjectFds();
+    // Guard against a vacuous pass (empty `before` would trivially equal `after`).
+    expect(before[join(dirReal, "sub")]).toBeGreaterThan(0);
+    expect(before[join(dirReal, "entry.ts")]).toBeGreaterThan(0);
 
     const reloads = 20;
     for (let i = 2; i <= reloads + 1; i++) {


### PR DESCRIPTION
## What

`bun --hot` leaked file descriptors on every reload: one open descriptor on the re-transpiled entrypoint and two `O_DIRECTORY` handles on the edited module's directory. Long sessions eventually exhaust the fd limit and every later `open`/`socket`/`accept` fails with `EMFILE`; every leaked dirfd also pins its directory.

## Repro

```sh
mkdir -p /tmp/fd/sub
printf 'import {value} from "./sub/dep.ts"; console.log("RELOAD", value, process.pid);\n' > /tmp/fd/entry.ts
printf 'export const value = 0;\n' > /tmp/fd/sub/dep.ts
cd /tmp/fd && bun --hot entry.ts &
for i in $(seq 20); do echo "export const value = $i;" > sub/dep.ts; sleep 0.2; done
ls -l /proc/$(pgrep -f 'bun --hot')/fd | awk '{print $NF}' | sort | uniq -c
```

On 1.4.0 this shows 21 fds on `entry.ts` and 43 on `sub/` after 20 reloads (strictly increasing, +3/reload).

## Cause

**Directory handles.** `RealFS::bust_entries_cache` called `BSSMap::remove`, which only drops the hash-to-index mapping; the `DirEntry` (with its open `.fd` under `store_fd`) stays orphaned in its backing slot. The next lookup allocates a fresh slot and re-opens the directory, so the old handle has no owner. Closing it at bust time is not safe: the raw fd is also copied into `ParseTask.contents_or_fd`, the dev server's `DirectoryWatchStore`, and the watcher's own watchlist, and a close would race those readers on another thread.

Separately, `dir_info_cached_miss` and `dir_info_for_resolution` open a fresh dirfd unconditionally and, under `store_fd`, assumed every such handle was adopted into a `DirEntry`; the ones that were not (entry already fresh, or an existing handle carried over) were never closed.

**Entrypoint handle.** `Watcher::add_file`'s already-watched branch overwrote the stored descriptor with the freshly-opened one and never closed the one it replaced.

## Fix

- `bust_entries_cache` keeps the `DirEntry` slot reachable and marks it `.stale` instead of orphaning it.
- The four in-place refresh sites (`read_directory_with_iterator`, `entries_at_locked`, `dir_info_cached_miss`, `dir_info_for_resolution`) carry a previously stored `DirEntry.fd` forward into the refreshed entry and release the freshly-opened handle they used for readdir. `dir_info_cached_miss` and `dir_info_for_resolution` additionally release the handle when the entry was already fresh.
- Because the slot is now rewritten in place instead of orphaned, the hot reloader takes `entries_mutex` while it reads the captured `DirEntry` (the previous code relied on the orphaned slot never being written again).
- `Watcher::add_file` closes the descriptor it just replaced, gated on `fstat().st_nlink > 0` so releasing the last reference to an unlinked inode cannot deliver a deferred `IN_DELETE_SELF` on the item's still-registered watch (which `DEV:hot-9` would otherwise turn into a spurious reload).

## Verification

New test in `test/cli/hot/hot.test.ts` runs `bun --hot` on an entry that imports `./sub/dep.ts`, triggers 20 reloads of `dep.ts`, and asserts that the set of `/proc/<pid>/fd` entries pointing into the project is identical before and after.

| | entry.ts fds | sub/ fds | total delta / 20 reloads |
|---|---|---|---|
| before | 2 -> 22 | 5 -> 45 | +60 |
| after | unchanged | unchanged | 0 |

`test/cli/hot` (16), `test/bake/dev/hot.test.ts` (11, including `DEV:hot-9`), `test/js/bun/util/filesystem_router.test.ts` (29), and `test/bundler/bun-build-api.test.ts` (51) all pass on a debug ASAN build.

## Related

#29919 also changes `bust_entries_cache` to mark `DirEntry` stale instead of removing it (for the `DirEntry`/`EntryMap` memory leak). This PR makes the same `bust_entries_cache` change but adds the fd carry-over that #29919 does not, without which the directory handle is still leaked when the slot is overwritten. #33197 is the `Watcher::add_file` half alone; this PR includes the same gated close.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/hot/hot.test.ts

<!-- robobun:evidence:end -->