### PR TITLE
tls: share one native certificate-name matcher across fetch and X509Certificate#checkHost

### DIFF
--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -224,18 +224,66 @@ fn unfqdn(name: &[u8]) -> &[u8] {
     name.strip_suffix(b".").unwrap_or(name)
 }
 
+#[inline]
+fn eq_nocase(a: &[u8], b: &[u8]) -> bool {
+    strings::eql_case_insensitive_ascii(a, b, true)
+}
+
+#[inline]
+fn contains_nocase(haystack: &[u8], needle: &'static [u8]) -> bool {
+    haystack.len() >= needle.len()
+        && haystack
+            .windows(needle.len())
+            .any(|w| strings::eql_case_insensitive_ascii(w, needle, false))
+}
+
+/// Wildcard interpretation for [`match_hostname`]'s left-most label.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Wildcards {
+    /// No wildcard expansion: a `*` is matched literally.
+    None,
+    /// Full-label `*` only (OpenSSL `X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS`).
+    FullLabel,
+    /// `*` at the start or end of the label (OpenSSL default).
+    EdgePartial,
+    /// `*` anywhere in the label (Node.js lib/tls.js `check()` default).
+    Anywhere,
+}
+
+/// Options for [`match_hostname`]. Each defaults to the stricter setting so
+/// callers opt in explicitly.
+#[derive(Clone, Copy)]
+pub struct MatchOpts {
+    pub wildcards: Wildcards,
+    /// A full-label `*` may span multiple host labels
+    /// (OpenSSL `X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS`).
+    pub multi_label_wildcards: bool,
+    /// Strip one trailing `.` from both the pattern and the host before
+    /// matching (Node.js `checkServerIdentity`).
+    pub strip_trailing_dot: bool,
+}
+
+impl MatchOpts {
+    /// Node.js lib/tls.js `check()` — the matcher behind `tls.connect`,
+    /// `https`, and undici `fetch`.
+    pub const TLS_CHECK: Self = Self {
+        wildcards: Wildcards::Anywhere,
+        multi_label_wildcards: false,
+        strip_trailing_dot: true,
+    };
+}
+
 /// Matches one DNS name from a certificate (possibly containing a single `*`
-/// wildcard in its left-most label) against `hostname`.
-///
-/// This is a line-for-line port of Node.js `check()` in lib/tls.js so that the
-/// native hostname verification used by `fetch()`, `WebSocket`, `Bun.connect`
-/// and the SQL clients agrees with `tls.checkServerIdentity()` (and therefore
-/// `tls.connect`). In particular Node permits RFC 6125 §6.4.3 partial
-/// wildcards (`f*.example.com`, `*b.example.com`, `a*b.example.com`), which
-/// the previous implementation rejected.
-fn match_dns_name(pattern: &[u8], hostname: &[u8]) -> bool {
-    let pattern = unfqdn(pattern);
-    let hostname = unfqdn(hostname);
+/// wildcard in its left-most label) against `hostname`. This is the ONE
+/// hostname matcher every native TLS client and `X509Certificate#checkHost`
+/// share; [`MatchOpts`] selects between Node.js lib/tls.js `check()` semantics
+/// and OpenSSL `X509_check_host` semantics where they differ.
+pub fn match_hostname(pattern: &[u8], hostname: &[u8], opts: MatchOpts) -> bool {
+    let (pattern, hostname) = if opts.strip_trailing_dot {
+        (unfqdn(pattern), unfqdn(hostname))
+    } else {
+        (pattern, hostname)
+    };
     if pattern.is_empty() {
         return false;
     }
@@ -260,66 +308,76 @@ fn match_dns_name(pattern: &[u8], hostname: &[u8]) -> bool {
         return false;
     }
 
-    // The pattern's left-most label is the only label Node inspects for a
-    // wildcard; every subsequent label is compared literally.
+    // Wildcards are only recognised in the pattern's left-most label; every
+    // subsequent label is compared literally.
     let pat_first_end = strings::index_of_char(pattern, b'.')
         .map(|i| i as usize)
         .unwrap_or(pattern.len());
     let pat_first = &pattern[..pat_first_end];
     let pat_rest = pattern.get(pat_first_end + 1..).unwrap_or(b"");
 
-    let host_first_end = strings::index_of_char(hostname, b'.')
-        .map(|i| i as usize)
-        .unwrap_or(hostname.len());
-    let host_first = &hostname[..host_first_end];
-    let host_rest = hostname.get(host_first_end + 1..).unwrap_or(b"");
+    let star = match strings::index_of_char(pat_first, b'*') {
+        Some(i) if opts.wildcards != Wildcards::None => i as usize,
+        _ => return eq_nocase(pattern, hostname),
+    };
+    let prefix = &pat_first[..star];
+    let suffix = &pat_first[star + 1..];
+    let is_full_label = prefix.is_empty() && suffix.is_empty();
 
-    // Node compares every non-first label for equality after lowercasing; a
-    // case-insensitive byte comparison of the joined remainder is equivalent
-    // because the label count only matches when both remainders are identical.
-    if !strings::eql_case_insensitive_ascii(pat_rest, host_rest, true) {
+    // A second `*`, an IDNA A-label, fewer than three labels, or a partial
+    // wildcard the caller's mode does not permit all reduce to a literal
+    // comparison (the `*` can never appear in a real hostname, so this is a
+    // rejection in practice).
+    if strings::index_of_char(suffix, b'*').is_some()
+        || contains_nocase(pat_first, b"xn--")
+        || strings::index_of_char(pat_rest, b'.').is_none()
+        || (matches!(opts.wildcards, Wildcards::FullLabel) && !is_full_label)
+        || (matches!(opts.wildcards, Wildcards::EdgePartial)
+            && !prefix.is_empty()
+            && !suffix.is_empty())
+    {
+        return eq_nocase(pattern, hostname);
+    }
+
+    // The host's left-most "label" covers everything up to the pattern's
+    // remaining labels; for a full-label `*` with multi-label enabled that may
+    // include dots.
+    let host_first = if opts.multi_label_wildcards && is_full_label {
+        let need = pat_rest.len() + 1;
+        match hostname.len().checked_sub(need) {
+            Some(cut) if hostname[cut] == b'.' && eq_nocase(&hostname[cut + 1..], pat_rest) => {
+                &hostname[..cut]
+            }
+            _ => return false,
+        }
+    } else {
+        let end = strings::index_of_char(hostname, b'.')
+            .map(|i| i as usize)
+            .unwrap_or(hostname.len());
+        if !eq_nocase(hostname.get(end + 1..).unwrap_or(b""), pat_rest) {
+            return false;
+        }
+        &hostname[..end]
+    };
+
+    if prefix.len() + suffix.len() > host_first.len() {
         return false;
     }
+    eq_nocase(prefix, &host_first[..prefix.len()])
+        && eq_nocase(suffix, &host_first[host_first.len() - suffix.len()..])
+}
 
-    let star = strings::index_of_char(pat_first, b'*').map(|i| i as usize);
-
-    // Node never expands a wildcard inside an IDNA A-label (`xn--`); `splitHost`
-    // has already lowercased the pattern, so the JS `includes("xn--")` is an
-    // ASCII-case-insensitive substring test on the raw certificate bytes.
-    let is_idna = pat_first.len() >= 4
-        && pat_first
-            .windows(4)
-            .any(|w| strings::eql_case_insensitive_ascii(w, b"xn--", false));
-
-    match star {
-        None => strings::eql_case_insensitive_ascii(pat_first, host_first, true),
-        Some(_) if is_idna => strings::eql_case_insensitive_ascii(pat_first, host_first, true),
-        Some(star) => {
-            let prefix = &pat_first[..star];
-            let suffix = &pat_first[star + 1..];
-            // At most one `*`; at least three labels overall.
-            if strings::index_of_char(suffix, b'*').is_some() {
-                return false;
-            }
-            if strings::index_of_char(pat_rest, b'.').is_none() {
-                return false;
-            }
-            if prefix.len() + suffix.len() > host_first.len() {
-                return false;
-            }
-            strings::eql_case_insensitive_ascii(prefix, &host_first[..prefix.len()], true)
-                && strings::eql_case_insensitive_ascii(
-                    suffix,
-                    &host_first[host_first.len() - suffix.len()..],
-                    true,
-                )
-        }
-    }
+/// Node.js lib/tls.js `check()` — the matcher `tls.checkServerIdentity` applies
+/// to every DNS SAN and CN. Used by every native TLS client below.
+#[inline]
+fn match_dns_name(pattern: &[u8], hostname: &[u8]) -> bool {
+    match_hostname(pattern, hostname, MatchOpts::TLS_CHECK)
 }
 
 pub fn check_x509_server_identity(x509: &mut boring::X509, hostname: &[u8]) -> bool {
+    let hostname = unfqdn(hostname);
     let host_is_ip = strings::is_ip_address(hostname);
-    let mut has_identifier_san = false;
+    let mut has_dns_san = false;
 
     match x509.subject_alt_names() {
         boring::SanLookup::Invalid => return false,
@@ -333,9 +391,9 @@ pub fn check_x509_server_identity(x509: &mut boring::X509, hostname: &[u8]) -> b
             };
             let mut cert_ip_buf = [0u8; INET6_ADDRSTRLEN + 1];
             for entry in names.subject_alt_names() {
-                has_identifier_san = true;
                 match entry {
                     boring::SubjectAltName::Dns(name) => {
+                        has_dns_san = true;
                         if !host_is_ip && match_dns_name(name, hostname) {
                             return true;
                         }
@@ -355,12 +413,151 @@ pub fn check_x509_server_identity(x509: &mut boring::X509, hostname: &[u8]) -> b
         }
     }
 
-    // Node.js: the Subject CN is consulted only when the certificate carries
-    // no DNS / IP / URI subjectAltName entries, and never for IP hosts.
-    if !host_is_ip && !has_identifier_san {
+    // Node.js `checkServerIdentity` (lib/tls.js, post CVE-2021-44531): the
+    // Subject CN is consulted only when the certificate carries no dNSName
+    // SAN, and never for IP hosts. Non-DNS SANs (email / IP / URI) do not
+    // suppress the fallback.
+    if !host_is_ip && !has_dns_san {
         return x509.common_names().any(|cn| match_dns_name(cn, hostname));
     }
     false
+}
+
+/// OpenSSL `X509_CHECK_FLAG_*` values. BoringSSL defines four of these as `0`
+/// (the behaviour was removed), so `X509Certificate#checkHost` keeps its own
+/// copy and calls [`Bun__X509__checkHost`] instead of `X509_check_host`.
+pub mod host_check {
+    pub const ALWAYS_CHECK_SUBJECT: u32 = 0x01;
+    pub const NO_WILDCARDS: u32 = 0x02;
+    pub const NO_PARTIAL_WILDCARDS: u32 = 0x04;
+    pub const MULTI_LABEL_WILDCARDS: u32 = 0x08;
+    pub const SINGLE_LABEL_SUBDOMAINS: u32 = 0x10;
+    pub const NEVER_CHECK_SUBJECT: u32 = 0x20;
+}
+
+/// OpenSSL: a `host` starting with `.` matches any certificate name that ends
+/// with that suffix; `SINGLE_LABEL_SUBDOMAINS` restricts the stripped prefix to
+/// a single label.
+fn match_dot_subdomain(pattern: &[u8], host: &[u8], single_label: bool) -> bool {
+    if pattern.len() < host.len()
+        || strings::index_of_char(pattern, 0).is_some()
+        || !pattern.iter().all(|b| (0x21..=0x7f).contains(b))
+    {
+        return false;
+    }
+    let skip = &pattern[..pattern.len() - host.len()];
+    if single_label && strings::index_of_char(skip, b'.').is_some() {
+        return false;
+    }
+    eq_nocase(&pattern[skip.len()..], host)
+}
+
+fn alloc_peer(name: &[u8], out_ptr: *mut *mut u8, out_len: *mut usize) {
+    if out_ptr.is_null() || out_len.is_null() {
+        return;
+    }
+    let buf = OPENSSL_memory_alloc(name.len() + 1).cast::<u8>();
+    if buf.is_null() {
+        return;
+    }
+    // SAFETY: `buf` is a fresh allocation of `name.len() + 1` bytes.
+    unsafe {
+        ptr::copy_nonoverlapping(name.as_ptr(), buf, name.len());
+        *buf.add(name.len()) = 0;
+        *out_ptr = buf;
+        *out_len = name.len();
+    }
+}
+
+/// Node.js-compatible `X509Certificate#checkHost`. BoringSSL's
+/// `X509_check_host` hard-codes `NO_PARTIAL_WILDCARDS` and only falls back to
+/// the Subject CN when the SAN extension is absent, so `ncrypto`'s
+/// `X509View::checkHost` calls this instead and passes OpenSSL's real flag
+/// values.
+///
+/// Returns `1` (match), `0` (no match) or `-2` (invalid `host`). On match,
+/// `*out_peer` receives the matched certificate name as a NUL-terminated
+/// OPENSSL_malloc'd buffer the caller owns.
+///
+/// # Safety
+/// `x509` must be a live BoringSSL certificate, `host_ptr[..host_len]` must be
+/// readable, and `out_peer` / `out_len` must be null or writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Bun__X509__checkHost(
+    x509: *mut boring::X509,
+    host_ptr: *const u8,
+    host_len: usize,
+    flags: u32,
+    out_peer: *mut *mut u8,
+    out_len: *mut usize,
+) -> c_int {
+    // SAFETY: caller contract — `x509` is null or a live BoringSSL certificate.
+    let Some(x509) = (unsafe { x509.as_mut() }) else {
+        return 0;
+    };
+    if host_ptr.is_null() {
+        return -2;
+    }
+    // SAFETY: caller contract — `host_ptr[..host_len]` is readable.
+    let host = unsafe { core::slice::from_raw_parts(host_ptr, host_len) };
+    if host.is_empty() || strings::index_of_char(host, 0).is_some() {
+        return -2;
+    }
+
+    let opts = MatchOpts {
+        wildcards: if flags & host_check::NO_WILDCARDS != 0 {
+            Wildcards::None
+        } else if flags & host_check::NO_PARTIAL_WILDCARDS != 0 {
+            Wildcards::FullLabel
+        } else {
+            Wildcards::EdgePartial
+        },
+        multi_label_wildcards: flags & host_check::MULTI_LABEL_WILDCARDS != 0,
+        strip_trailing_dot: false,
+    };
+    let dot_host = host.len() > 1 && host[0] == b'.';
+    let single_label = flags & host_check::SINGLE_LABEL_SUBDOMAINS != 0;
+
+    let matches = |name: &[u8]| {
+        if dot_host {
+            match_dot_subdomain(name, host, single_label)
+        } else {
+            match_hostname(name, host, opts)
+        }
+    };
+
+    let mut has_dns_san = false;
+    match x509.subject_alt_names() {
+        boring::SanLookup::Invalid => return 0,
+        boring::SanLookup::Absent => {}
+        boring::SanLookup::Names(names) => {
+            for entry in names.subject_alt_names() {
+                if let boring::SubjectAltName::Dns(name) = entry {
+                    has_dns_san = true;
+                    if matches(name) {
+                        alloc_peer(name, out_peer, out_len);
+                        return 1;
+                    }
+                }
+            }
+        }
+    }
+
+    // OpenSSL falls back to the Subject CN when no dNSName SAN was present,
+    // or unconditionally with ALWAYS_CHECK_SUBJECT, unless NEVER_CHECK_SUBJECT.
+    if flags & host_check::NEVER_CHECK_SUBJECT != 0 {
+        return 0;
+    }
+    if has_dns_san && flags & host_check::ALWAYS_CHECK_SUBJECT == 0 {
+        return 0;
+    }
+    for cn in x509.common_names() {
+        if matches(cn) {
+            alloc_peer(cn, out_peer, out_len);
+            return 1;
+        }
+    }
+    0
 }
 
 /// Certificate name bytes (IA5 / Latin-1) for error messages.
@@ -464,6 +661,7 @@ pub fn write_server_identity_mismatch_reason(
     out: &mut dyn core::fmt::Write,
 ) -> core::fmt::Result {
     const NO_DNS: &str = "Cert does not contain a DNS name";
+    let hostname = unfqdn(hostname);
     let host = NameBytes(hostname);
     let host_is_ip = strings::is_ip_address(hostname);
 
@@ -483,22 +681,15 @@ pub fn write_server_identity_mismatch_reason(
         );
     }
     if let Some(names) = &names {
-        let mut has_dns = false;
-        let mut has_identifier = false;
-        for entry in names.subject_alt_names() {
-            has_identifier = true;
-            has_dns |= matches!(entry, boring::SubjectAltName::Dns(_));
-        }
-        if has_identifier {
-            return if has_dns {
-                write!(
-                    out,
-                    "Host: {host}. is not in the cert's altnames: {}",
-                    AltNameList(names)
-                )
-            } else {
-                out.write_str(NO_DNS)
-            };
+        if names
+            .subject_alt_names()
+            .any(|e| matches!(e, boring::SubjectAltName::Dns(_)))
+        {
+            return write!(
+                out,
+                "Host: {host}. is not in the cert's altnames: {}",
+                AltNameList(names)
+            );
         }
     }
     match x509.common_names().next() {

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -443,7 +443,7 @@ pub fn check_x509_server_identity(x509: &mut boring::X509, hostname: &[u8]) -> b
     // SAN, and never for IP hosts. Non-DNS SANs (email / IP / URI) do not
     // suppress the fallback.
     if !host_is_ip && !has_dns_san {
-        return x509.common_names().any(|cn| match_dns_name(cn, hostname));
+        return x509.common_names().any(|cn| match_dns_name(&cn, hostname));
     }
     false
 }
@@ -464,10 +464,7 @@ pub mod host_check {
 /// with that suffix; `SINGLE_LABEL_SUBDOMAINS` restricts the stripped prefix to
 /// a single label.
 fn match_dot_subdomain(pattern: &[u8], host: &[u8], single_label: bool) -> bool {
-    if pattern.len() < host.len()
-        || strings::index_of_char(pattern, 0).is_some()
-        || !pattern.iter().all(|b| (0x21..=0x7f).contains(b))
-    {
+    if pattern.len() < host.len() || strings::index_of_char(pattern, 0).is_some() {
         return false;
     }
     let skip = &pattern[..pattern.len() - host.len()];
@@ -577,8 +574,8 @@ pub unsafe extern "C" fn Bun__X509__checkHost(
         return 0;
     }
     for cn in x509.common_names() {
-        if matches(cn) {
-            alloc_peer(cn, out_peer, out_len);
+        if matches(&cn) {
+            alloc_peer(&cn, out_peer, out_len);
             return 1;
         }
     }
@@ -718,7 +715,7 @@ pub fn write_server_identity_mismatch_reason(
         }
     }
     match x509.common_names().next() {
-        Some(cn) => write!(out, "Host: {host}. is not cert's CN: {}", NameBytes(cn)),
+        Some(cn) => write!(out, "Host: {host}. is not cert's CN: {}", NameBytes(&cn)),
         None => out.write_str(NO_DNS),
     }
 }

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -192,14 +192,6 @@ fn eq_nocase(a: &[u8], b: &[u8]) -> bool {
     strings::eql_case_insensitive_ascii(a, b, true)
 }
 
-#[inline]
-fn contains_nocase(haystack: &[u8], needle: &'static [u8]) -> bool {
-    haystack.len() >= needle.len()
-        && haystack
-            .windows(needle.len())
-            .any(|w| strings::eql_case_insensitive_ascii(w, needle, false))
-}
-
 /// Wildcard interpretation for [`match_hostname`]'s left-most label.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Wildcards {
@@ -292,7 +284,7 @@ pub fn match_hostname(pattern: &[u8], hostname: &[u8], opts: MatchOpts) -> bool 
     // comparison (the `*` can never appear in a real hostname, so this is a
     // rejection in practice).
     if strings::index_of_char(suffix, b'*').is_some()
-        || contains_nocase(pat_first, b"xn--")
+        || strings::contains_case_insensitive_ascii(pat_first, b"xn--")
         || strings::index_of_char(pat_rest, b'.').is_none()
         || (matches!(opts.wildcards, Wildcards::FullLabel) && !is_full_label)
         || (matches!(opts.wildcards, Wildcards::EdgePartial)
@@ -326,8 +318,28 @@ pub fn match_hostname(pattern: &[u8], hostname: &[u8], opts: MatchOpts) -> bool 
     if prefix.len() + suffix.len() > host_first.len() {
         return false;
     }
-    eq_nocase(prefix, &host_first[..prefix.len()])
-        && eq_nocase(suffix, &host_first[host_first.len() - suffix.len()..])
+    if !eq_nocase(prefix, &host_first[..prefix.len()])
+        || !eq_nocase(suffix, &host_first[host_first.len() - suffix.len()..])
+    {
+        return false;
+    }
+    // OpenSSL `wildcard_match`: the bytes the `*` spans must be LDH (plus `.`
+    // under multi-label) and a partial wildcard never matches an IDNA host
+    // label. Node lib/tls.js `check()` applies neither host-side check.
+    if matches!(opts.wildcards, Wildcards::FullLabel | Wildcards::EdgePartial) {
+        let span = &host_first[prefix.len()..host_first.len() - suffix.len()];
+        let allow_dot = opts.multi_label_wildcards && is_full_label;
+        if span
+            .iter()
+            .any(|&b| !(b.is_ascii_alphanumeric() || b == b'-' || (allow_dot && b == b'.')))
+        {
+            return false;
+        }
+        if !is_full_label && strings::starts_with_case_insensitive_ascii(host_first, b"xn--") {
+            return false;
+        }
+    }
+    true
 }
 
 /// Node.js lib/tls.js `check()` — the matcher `tls.checkServerIdentity` applies

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -46,7 +46,6 @@ pub(crate) mod x509 {
         true
     }
 }
-use x509 as X509;
 
 /// BoringSSL's translated C API
 pub use boring as c;
@@ -218,43 +217,104 @@ fn canonical_ip_octets<'a>(
     unsafe { c_ares::ntop(af, octets.as_ptr().cast(), &mut out_ip[..]) }
 }
 
-/// Matches a DNS name pattern (possibly with a leading `*.` wildcard) against
-/// `hostname`. Mirrors Node.js `check()` in lib/tls.js for a single pattern.
+/// Strips a single trailing `.` (the DNS root label). Mirrors Node.js
+/// `unfqdn()` in lib/tls.js.
+#[inline]
+fn unfqdn(name: &[u8]) -> &[u8] {
+    name.strip_suffix(b".").unwrap_or(name)
+}
+
+/// Matches one DNS name from a certificate (possibly containing a single `*`
+/// wildcard in its left-most label) against `hostname`.
+///
+/// This is a line-for-line port of Node.js `check()` in lib/tls.js so that the
+/// native hostname verification used by `fetch()`, `WebSocket`, `Bun.connect`
+/// and the SQL clients agrees with `tls.checkServerIdentity()` (and therefore
+/// `tls.connect`). In particular Node permits RFC 6125 §6.4.3 partial
+/// wildcards (`f*.example.com`, `*b.example.com`, `a*b.example.com`), which
+/// the previous implementation rejected.
 fn match_dns_name(pattern: &[u8], hostname: &[u8]) -> bool {
+    let pattern = unfqdn(pattern);
+    let hostname = unfqdn(hostname);
     if pattern.is_empty() {
         return false;
     }
-    if !X509::is_safe_alt_name(pattern, false) {
+
+    // Node's `isBad` regex rejects any byte outside U+0021..=U+007F anywhere in
+    // the pattern, and `splitHost` + `includes("")` rejects empty labels.
+    let mut label_start = true;
+    for &b in pattern {
+        if !(0x21..=0x7f).contains(&b) {
+            return false;
+        }
+        if b == b'.' {
+            if label_start {
+                return false;
+            }
+            label_start = true;
+        } else {
+            label_start = false;
+        }
+    }
+    if label_start {
         return false;
     }
 
-    if pattern[0] == b'*' {
-        // RFC 6125 Section 6.4.3: Wildcard must match exactly one label.
-        // Enforce "*." prefix (wildcard must be leftmost and followed by a dot).
-        if pattern.len() >= 2 && pattern[1] == b'.' {
-            let suffix = &pattern[2..];
-            // Disallow "*.tld" (suffix must contain at least one dot for proper domain hierarchy)
-            if strings::index_of_char(suffix, b'.').is_some() {
-                // Host must be at least "label.suffix" (suffix_len + 1 for dot + at least 1 char for label)
-                if hostname.len() > suffix.len() + 1 {
-                    let dot_index = hostname.len() - suffix.len() - 1;
-                    // The character before suffix must be a dot, and there must be no other
-                    // dots in the prefix (single-label wildcard only).
-                    if hostname[dot_index] == b'.'
-                        && strings::index_of_char(&hostname[..dot_index], b'.').is_none()
-                    {
-                        let host_suffix = &hostname[dot_index + 1..];
-                        // RFC 4343: DNS names are case-insensitive
-                        if strings::eql_case_insensitive_ascii(suffix, host_suffix, true) {
-                            return true;
-                        }
-                    }
-                }
+    // The pattern's left-most label is the only label Node inspects for a
+    // wildcard; every subsequent label is compared literally.
+    let pat_first_end = strings::index_of_char(pattern, b'.')
+        .map(|i| i as usize)
+        .unwrap_or(pattern.len());
+    let pat_first = &pattern[..pat_first_end];
+    let pat_rest = pattern.get(pat_first_end + 1..).unwrap_or(b"");
+
+    let host_first_end = strings::index_of_char(hostname, b'.')
+        .map(|i| i as usize)
+        .unwrap_or(hostname.len());
+    let host_first = &hostname[..host_first_end];
+    let host_rest = hostname.get(host_first_end + 1..).unwrap_or(b"");
+
+    // Node compares every non-first label for equality after lowercasing; a
+    // case-insensitive byte comparison of the joined remainder is equivalent
+    // because the label count only matches when both remainders are identical.
+    if !strings::eql_case_insensitive_ascii(pat_rest, host_rest, true) {
+        return false;
+    }
+
+    let star = strings::index_of_char(pat_first, b'*').map(|i| i as usize);
+
+    // Node never expands a wildcard inside an IDNA A-label (`xn--`); `splitHost`
+    // has already lowercased the pattern, so the JS `includes("xn--")` is an
+    // ASCII-case-insensitive substring test on the raw certificate bytes.
+    let is_idna = pat_first.len() >= 4
+        && pat_first
+            .windows(4)
+            .any(|w| strings::eql_case_insensitive_ascii(w, b"xn--", false));
+
+    match star {
+        None => strings::eql_case_insensitive_ascii(pat_first, host_first, true),
+        Some(_) if is_idna => strings::eql_case_insensitive_ascii(pat_first, host_first, true),
+        Some(star) => {
+            let prefix = &pat_first[..star];
+            let suffix = &pat_first[star + 1..];
+            // At most one `*`; at least three labels overall.
+            if strings::index_of_char(suffix, b'*').is_some() {
+                return false;
             }
+            if strings::index_of_char(pat_rest, b'.').is_none() {
+                return false;
+            }
+            if prefix.len() + suffix.len() > host_first.len() {
+                return false;
+            }
+            strings::eql_case_insensitive_ascii(prefix, &host_first[..prefix.len()], true)
+                && strings::eql_case_insensitive_ascii(
+                    suffix,
+                    &host_first[host_first.len() - suffix.len()..],
+                    true,
+                )
         }
     }
-    // RFC 4343: DNS names are case-insensitive
-    strings::eql_case_insensitive_ascii(pattern, hostname, true)
 }
 
 pub fn check_x509_server_identity(x509: &mut boring::X509, hostname: &[u8]) -> bool {

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -228,6 +228,37 @@ impl MatchOpts {
     };
 }
 
+/// OpenSSL `valid_star`'s pattern scan: every label must be LDH with no
+/// boundary hyphen, and every byte one of `[A-Za-z0-9.*-]`. `*` is treated as
+/// a non-hyphen-clearing label char so `a-*.` and `-*.` are rejected.
+fn openssl_valid_pattern(pattern: &[u8]) -> bool {
+    let mut at_start = true;
+    let mut hyphen = false;
+    for &b in pattern {
+        match b {
+            b'.' => {
+                if at_start || hyphen {
+                    return false;
+                }
+                at_start = true;
+            }
+            b'-' => {
+                if at_start {
+                    return false;
+                }
+                hyphen = true;
+            }
+            b'*' => at_start = false,
+            _ if b.is_ascii_alphanumeric() => {
+                at_start = false;
+                hyphen = false;
+            }
+            _ => return false,
+        }
+    }
+    !at_start && !hyphen
+}
+
 /// Matches one DNS name from a certificate (possibly containing a single `*`
 /// wildcard in its left-most label) against `hostname`. This is the ONE
 /// hostname matcher every native TLS client and `X509Certificate#checkHost`
@@ -278,9 +309,14 @@ pub fn match_hostname(pattern: &[u8], hostname: &[u8], opts: MatchOpts) -> bool 
     let prefix = &pat_first[..star];
     let suffix = &pat_first[star + 1..];
     let is_full_label = prefix.is_empty() && suffix.is_empty();
+    let openssl_mode = matches!(
+        opts.wildcards,
+        Wildcards::FullLabel | Wildcards::EdgePartial
+    );
 
-    // A second `*`, an IDNA A-label, fewer than three labels, or a partial
-    // wildcard the caller's mode does not permit all reduce to a literal
+    // A second `*`, an IDNA A-label, fewer than three labels, a partial
+    // wildcard the caller's mode does not permit, or (for the OpenSSL modes) a
+    // pattern that fails `valid_star`'s LDH scan all reduce to a literal
     // comparison (the `*` can never appear in a real hostname, so this is a
     // rejection in practice).
     if strings::index_of_char(suffix, b'*').is_some()
@@ -290,6 +326,7 @@ pub fn match_hostname(pattern: &[u8], hostname: &[u8], opts: MatchOpts) -> bool 
         || (matches!(opts.wildcards, Wildcards::EdgePartial)
             && !prefix.is_empty()
             && !suffix.is_empty())
+        || (openssl_mode && !openssl_valid_pattern(pattern))
     {
         return eq_nocase(pattern, hostname);
     }
@@ -326,10 +363,7 @@ pub fn match_hostname(pattern: &[u8], hostname: &[u8], opts: MatchOpts) -> bool 
     // OpenSSL `wildcard_match`: the bytes the `*` spans must be LDH (plus `.`
     // under multi-label) and a partial wildcard never matches an IDNA host
     // label. Node lib/tls.js `check()` applies neither host-side check.
-    if matches!(
-        opts.wildcards,
-        Wildcards::FullLabel | Wildcards::EdgePartial
-    ) {
+    if openssl_mode {
         let span = &host_first[prefix.len()..host_first.len() - suffix.len()];
         let allow_dot = opts.multi_label_wildcards && is_full_label;
         if span

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -326,7 +326,10 @@ pub fn match_hostname(pattern: &[u8], hostname: &[u8], opts: MatchOpts) -> bool 
     // OpenSSL `wildcard_match`: the bytes the `*` spans must be LDH (plus `.`
     // under multi-label) and a partial wildcard never matches an IDNA host
     // label. Node lib/tls.js `check()` applies neither host-side check.
-    if matches!(opts.wildcards, Wildcards::FullLabel | Wildcards::EdgePartial) {
+    if matches!(
+        opts.wildcards,
+        Wildcards::FullLabel | Wildcards::EdgePartial
+    ) {
         let span = &host_first[prefix.len()..host_first.len() - suffix.len()];
         let allow_dot = opts.multi_label_wildcards && is_full_label;
         if span

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -10,43 +10,6 @@ pub use bun_boringssl_sys as boring;
 use bun_cares_sys as c_ares;
 use bun_core::strings;
 
-// MOVE_DOWN: lives here so `boringssl` does not depend on `bun_runtime`
-// (tier-6).
-pub(crate) mod x509 {
-    /// Returns `true` iff `name` contains no characters that would require
-    /// escaping in a subjectAltName entry.
-    #[inline]
-    pub(crate) fn is_safe_alt_name(name: &[u8], utf8: bool) -> bool {
-        for &c in name {
-            match c {
-                // These mess with encoding rules.
-                // Commas make it impossible to split the list of subject
-                // alternative names unambiguously, which is why we escape.
-                // Single quotes are unlikely to appear in any legitimate values,
-                // but they could be used to make a value look like it was escaped
-                // (i.e., enclosed in single/double quotes).
-                b'"' | b'\\' | b',' | b'\'' => return false,
-                _ => {
-                    if utf8 {
-                        // In UTF-8 strings, require escaping for any ASCII control
-                        // character, but NOT for non-ASCII characters. All bytes of
-                        // any multi-byte code point have their MSB set.
-                        if c < b' ' || c == 0x7f {
-                            return false;
-                        }
-                    } else {
-                        // Reject control characters and non-ASCII characters.
-                        if c < b' ' || c > b'~' {
-                            return false;
-                        }
-                    }
-                }
-            }
-        }
-        true
-    }
-}
-
 /// BoringSSL's translated C API
 pub use boring as c;
 pub use boring::rand_bytes;

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -273,10 +273,9 @@ pub fn match_hostname(pattern: &[u8], hostname: &[u8], opts: MatchOpts) -> bool 
     if pattern.is_empty() {
         return false;
     }
-    let openssl_mode = matches!(
-        opts.wildcards,
-        Wildcards::FullLabel | Wildcards::EdgePartial
-    );
+    // Only `Anywhere` is Node lib/tls.js check(); every other variant is
+    // reached from Bun__X509__checkHost and follows OpenSSL X509_check_host.
+    let openssl_mode = opts.wildcards != Wildcards::Anywhere;
 
     // Pattern-side validation. OpenSSL `valid_star` falls through to
     // `equal_nocase` on any failure; Node lib/tls.js `check()` hard-rejects on

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -273,25 +273,36 @@ pub fn match_hostname(pattern: &[u8], hostname: &[u8], opts: MatchOpts) -> bool 
     if pattern.is_empty() {
         return false;
     }
+    let openssl_mode = matches!(
+        opts.wildcards,
+        Wildcards::FullLabel | Wildcards::EdgePartial
+    );
 
-    // Node's `isBad` regex rejects any byte outside U+0021..=U+007F anywhere in
-    // the pattern, and `splitHost` + `includes("")` rejects empty labels.
-    let mut label_start = true;
-    for &b in pattern {
-        if !(0x21..=0x7f).contains(&b) {
-            return false;
+    // Pattern-side validation. OpenSSL `valid_star` falls through to
+    // `equal_nocase` on any failure; Node lib/tls.js `check()` hard-rejects on
+    // a byte outside U+0021..=U+007F or an empty label.
+    if openssl_mode {
+        if !openssl_valid_pattern(pattern) {
+            return eq_nocase(pattern, hostname);
         }
-        if b == b'.' {
-            if label_start {
+    } else {
+        let mut label_start = true;
+        for &b in pattern {
+            if !(0x21..=0x7f).contains(&b) {
                 return false;
             }
-            label_start = true;
-        } else {
-            label_start = false;
+            if b == b'.' {
+                if label_start {
+                    return false;
+                }
+                label_start = true;
+            } else {
+                label_start = false;
+            }
         }
-    }
-    if label_start {
-        return false;
+        if label_start {
+            return false;
+        }
     }
 
     // Wildcards are only recognised in the pattern's left-most label; every
@@ -309,24 +320,27 @@ pub fn match_hostname(pattern: &[u8], hostname: &[u8], opts: MatchOpts) -> bool 
     let prefix = &pat_first[..star];
     let suffix = &pat_first[star + 1..];
     let is_full_label = prefix.is_empty() && suffix.is_empty();
-    let openssl_mode = matches!(
-        opts.wildcards,
-        Wildcards::FullLabel | Wildcards::EdgePartial
-    );
 
-    // A second `*`, an IDNA A-label, fewer than three labels, a partial
-    // wildcard the caller's mode does not permit, or (for the OpenSSL modes) a
-    // pattern that fails `valid_star`'s LDH scan all reduce to a literal
+    // An IDNA A-label in the first label suppresses wildcard expansion. Node's
+    // `includes("xn--")` checks anywhere in the lowercased label; OpenSSL's
+    // `valid_star` sets LABEL_IDNA only when a label *starts* with `xn--`.
+    let pat_idna = if openssl_mode {
+        strings::starts_with_case_insensitive_ascii(pat_first, b"xn--")
+    } else {
+        strings::contains_case_insensitive_ascii(pat_first, b"xn--")
+    };
+
+    // A second `*`, an IDNA A-label, fewer than three labels, or a partial
+    // wildcard the caller's mode does not permit all reduce to a literal
     // comparison (the `*` can never appear in a real hostname, so this is a
     // rejection in practice).
     if strings::index_of_char(suffix, b'*').is_some()
-        || strings::contains_case_insensitive_ascii(pat_first, b"xn--")
+        || pat_idna
         || strings::index_of_char(pat_rest, b'.').is_none()
         || (matches!(opts.wildcards, Wildcards::FullLabel) && !is_full_label)
         || (matches!(opts.wildcards, Wildcards::EdgePartial)
             && !prefix.is_empty()
             && !suffix.is_empty())
-        || (openssl_mode && !openssl_valid_pattern(pattern))
     {
         return eq_nocase(pattern, hostname);
     }

--- a/src/boringssl_sys/boringssl.rs
+++ b/src/boringssl_sys/boringssl.rs
@@ -438,23 +438,48 @@ impl X509 {
     }
 }
 
-/// Borrowing iterator over a certificate's Subject Common Names.
+/// An `ASN1_STRING_to_UTF8`-transcoded name. `OPENSSL_free`s on drop.
+pub struct Utf8Name {
+    ptr: core::ptr::NonNull<u8>,
+    len: usize,
+}
+
+impl core::ops::Deref for Utf8Name {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        // SAFETY: `ASN1_STRING_to_UTF8` allocated `len` readable bytes at `ptr`
+        // and this struct owns them until `Drop`.
+        unsafe { core::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+}
+
+impl Drop for Utf8Name {
+    fn drop(&mut self) {
+        // SAFETY: `ptr` was returned by `ASN1_STRING_to_UTF8` (OPENSSL_malloc).
+        unsafe { OPENSSL_free(self.ptr.as_ptr().cast()) }
+    }
+}
+
+/// Iterator over a certificate's Subject Common Names, transcoded to UTF-8 via
+/// `ASN1_STRING_to_UTF8` (so BMPString / UniversalString CNs compare like
+/// OpenSSL `X509_check_host`'s `do_check_string`).
 pub struct CommonNames<'a> {
     subject: *mut X509_NAME,
     last: c_int,
     _cert: core::marker::PhantomData<&'a mut X509>,
 }
 
-impl<'a> Iterator for CommonNames<'a> {
-    type Item = &'a [u8];
+impl Iterator for CommonNames<'_> {
+    type Item = Utf8Name;
 
-    fn next(&mut self) -> Option<&'a [u8]> {
+    fn next(&mut self) -> Option<Utf8Name> {
         if self.subject.is_null() {
             return None;
         }
         // SAFETY: the subject and its entries are owned by the certificate
         // borrowed for `'a`; every accessor is guarded against null returns
-        // and non-positive lengths.
+        // and non-positive lengths. `ASN1_STRING_to_UTF8` allocates a fresh
+        // buffer that `Utf8Name` owns.
         unsafe {
             loop {
                 let entry_idx = X509_NAME_get_index_by_NID(self.subject, NID_commonName, self.last);
@@ -470,15 +495,16 @@ impl<'a> Iterator for CommonNames<'a> {
                 if data.is_null() {
                     continue;
                 }
-                let cn_ptr = ASN1_STRING_get0_data(data);
-                let cn_len = ASN1_STRING_length(data);
-                if cn_ptr.is_null() || cn_len <= 0 {
+                let mut out: *mut u8 = core::ptr::null_mut();
+                let len = ASN1_STRING_to_UTF8(&raw mut out, data);
+                let Some(ptr) = core::ptr::NonNull::new(out) else {
                     continue;
-                }
-                return Some(core::slice::from_raw_parts(
-                    cn_ptr,
-                    usize::try_from(cn_len).expect("int cast"),
-                ));
+                };
+                let Ok(len) = usize::try_from(len) else {
+                    OPENSSL_free(ptr.as_ptr().cast());
+                    continue;
+                };
+                return Some(Utf8Name { ptr, len });
             }
         }
     }
@@ -552,6 +578,7 @@ unsafe extern "C" {
     // ── ASN1 ──────────────────────────────────────────────────────────────
     pub fn ASN1_STRING_get0_data(str: *const ASN1_STRING) -> *const u8;
     pub fn ASN1_STRING_length(str: *const ASN1_STRING) -> c_int;
+    pub fn ASN1_STRING_to_UTF8(out: *mut *mut u8, in_: *const ASN1_STRING) -> c_int;
 
     // ── EVP digest getters (infallible, return static singletons) ────────
     pub safe fn EVP_md4() -> *const EVP_MD;

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1318,7 +1318,7 @@ pub(crate) mod strings_impl {
     /// case-insensitive ASCII substring search (callers are cold path-lookup
     /// on macOS/Windows where the FS is case-insensitive).
     #[inline]
-    pub(crate) fn contains_case_insensitive_ascii(haystack: &[u8], needle: &[u8]) -> bool {
+    pub fn contains_case_insensitive_ascii(haystack: &[u8], needle: &[u8]) -> bool {
         if needle.len() > haystack.len() {
             return false;
         }

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1010,7 +1010,7 @@ pub fn eql_case_insensitive_asciii_check_length(a: &[u8], b: &[u8]) -> bool {
 // call shape across the tree (`eql_case_insensitive_ascii(a, b, true)`);
 // callers wanting the length-agnostic forms have the `_check_length` /
 // `_ignore_length` wrappers above.
-pub use crate::strings_impl::eql_case_insensitive_ascii;
+pub use crate::strings_impl::{contains_case_insensitive_ascii, eql_case_insensitive_ascii};
 
 pub fn eql_case_insensitive_t<T: crate::NoUninit + Into<u32>>(a: &[T], b: &[u8]) -> bool {
     if a.len() != b.len() || a.is_empty() {

--- a/src/jsc/bindings/JSX509CertificatePrototype.cpp
+++ b/src/jsc/bindings/JSX509CertificatePrototype.cpp
@@ -170,10 +170,8 @@ static uint32_t getFlags(JSC::VM& vm, JSGlobalObject* globalObject, JSC::ThrowSc
     RETURN_IF_EXCEPTION(scope, {});
 
     uint32_t flags = 0;
-    bool any = false;
 
     if (!subject.isUndefined()) {
-        any = true;
         if (!subject.isString()) {
             Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE, "subject must be a string"_s);
             return 0;
@@ -184,9 +182,9 @@ static uint32_t getFlags(JSC::VM& vm, JSGlobalObject* globalObject, JSC::ThrowSc
         auto view = subjectString->view(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
         if (view == "always"_s) {
-            flags |= X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT;
+            flags |= ncrypto::X509View::CheckFlags::ALWAYS_CHECK_SUBJECT;
         } else if (view == "never"_s) {
-            flags |= X509_CHECK_FLAG_NEVER_CHECK_SUBJECT;
+            flags |= ncrypto::X509View::CheckFlags::NEVER_CHECK_SUBJECT;
         } else if (view == "default"_s) {
             // Matches OpenSSL's default, no flags.
         } else {
@@ -196,51 +194,42 @@ static uint32_t getFlags(JSC::VM& vm, JSGlobalObject* globalObject, JSC::ThrowSc
     }
 
     if (!wildcards.isUndefined()) {
-        any = true;
         if (!wildcards.isBoolean()) {
             Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE, "wildcards must be a boolean"_s);
             return 0;
         }
 
         if (!wildcards.asBoolean())
-            flags |= X509_CHECK_FLAG_NO_WILDCARDS;
+            flags |= ncrypto::X509View::CheckFlags::NO_WILDCARDS;
     }
 
     if (!partialWildcards.isUndefined()) {
-        any = true;
         if (!partialWildcards.isBoolean()) {
             Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE, "partialWildcards must be a boolean"_s);
             return 0;
         }
 
         if (!partialWildcards.asBoolean())
-            flags |= X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS;
+            flags |= ncrypto::X509View::CheckFlags::NO_PARTIAL_WILDCARDS;
     }
 
     if (!multiLabelWildcards.isUndefined()) {
-        any = true;
         if (!multiLabelWildcards.isBoolean()) {
             Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE, "multiLabelWildcards must be a boolean"_s);
             return 0;
         }
 
         if (multiLabelWildcards.asBoolean())
-            flags |= X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS;
+            flags |= ncrypto::X509View::CheckFlags::MULTI_LABEL_WILDCARDS;
     }
 
     if (!singleLabelSubdomains.isUndefined()) {
-        any = true;
         if (!singleLabelSubdomains.isBoolean()) {
             Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE, "singleLabelSubdomains must be a boolean"_s);
             return 0;
         }
         if (singleLabelSubdomains.asBoolean())
-            flags |= X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS;
-    }
-
-    if (!any) {
-        Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE, "options must have at least one property"_s);
-        return 0;
+            flags |= ncrypto::X509View::CheckFlags::SINGLE_LABEL_SUBDOMAINS;
     }
 
     return flags;

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1300,20 +1300,30 @@ bool X509View::checkPublicKey(const EVPKeyPointer& pkey) const
     return X509_verify(const_cast<X509*>(cert_), pkey.get()) == 1;
 }
 
+// Shared native certificate-name matcher (src/boringssl/lib.rs). BoringSSL's
+// X509_check_host hard-codes NO_PARTIAL_WILDCARDS and only falls back to the
+// Subject CN when the SAN extension is absent, so Node's documented checkHost
+// options were no-ops. This implements OpenSSL's semantics over the same
+// matcher fetch()/tls.connect use.
+extern "C" int Bun__X509__checkHost(X509* x509, const uint8_t* host, size_t host_len,
+    uint32_t flags, uint8_t** out_peer, size_t* out_len);
+
 X509View::CheckMatch X509View::checkHost(const std::span<const char> host,
     int flags,
     DataPointer* peerName) const
 {
     ClearErrorOnReturn clearErrorOnReturn;
     if (cert_ == nullptr) return CheckMatch::NO_MATCH;
-    char* peername;
-    switch (X509_check_host(
-        const_cast<X509*>(cert_), host.data(), host.size(), flags, &peername)) {
+    uint8_t* peer = nullptr;
+    size_t peerLen = 0;
+    switch (Bun__X509__checkHost(const_cast<X509*>(cert_),
+        reinterpret_cast<const uint8_t*>(host.data()), host.size(),
+        static_cast<uint32_t>(flags), &peer, &peerLen)) {
     case 0:
         return CheckMatch::NO_MATCH;
     case 1: {
-        if (peername != nullptr) {
-            DataPointer name(peername, strlen(peername));
+        if (peer != nullptr) {
+            DataPointer name(peer, peerLen);
             if (peerName != nullptr) *peerName = WTF::move(name);
         }
         return CheckMatch::MATCH;

--- a/src/jsc/bindings/ncrypto.h
+++ b/src/jsc/bindings/ncrypto.h
@@ -1253,6 +1253,17 @@ public:
         INVALID_NAME,
         OPERATION_FAILED,
     };
+    // OpenSSL X509_CHECK_FLAG_* values. BoringSSL defines four of these as 0,
+    // so checkHost() carries its own copy and calls the shared Rust matcher
+    // (Bun__X509__checkHost) instead of X509_check_host.
+    struct CheckFlags {
+        static constexpr uint32_t ALWAYS_CHECK_SUBJECT = 0x01;
+        static constexpr uint32_t NO_WILDCARDS = 0x02;
+        static constexpr uint32_t NO_PARTIAL_WILDCARDS = 0x04;
+        static constexpr uint32_t MULTI_LABEL_WILDCARDS = 0x08;
+        static constexpr uint32_t SINGLE_LABEL_SUBDOMAINS = 0x10;
+        static constexpr uint32_t NEVER_CHECK_SUBJECT = 0x20;
+    };
     CheckMatch checkHost(const std::span<const char> host,
         int flags,
         DataPointer* peerName = nullptr) const;

--- a/test/js/web/fetch/fetch.tls.wildcard.test.ts
+++ b/test/js/web/fetch/fetch.tls.wildcard.test.ts
@@ -302,11 +302,13 @@ describe.concurrent("TLS wildcard hostname verification", () => {
   });
 });
 
-// fetch() uses a native Rust port of Node's lib/tls.js check() for certificate
-// name matching; tls.connect() defaults to the JS tls.checkServerIdentity().
-// These must agree for every certificate Node accepts, including RFC 6125
-// §6.4.3 partial-wildcard SAN entries (f*.example.com / *b.example.com).
-describe("fetch() and tls.checkServerIdentity() agree on certificate SAN wildcards", () => {
+// Bun exposes three certificate-name matchers that must agree with Node.js:
+//   - tls.checkServerIdentity()  -> JS port of Node lib/tls.js check()
+//   - fetch() / WebSocket / Bun.connect / SQL -> native Rust port of check()
+//   - X509Certificate#checkHost  -> native port of OpenSSL X509_check_host
+// The first two share semantics; checkHost follows OpenSSL where Node does.
+// Every expected value below was taken from Node.js v26.3.0.
+describe("TLS certificate name matching: fetch() / checkServerIdentity / checkHost agree", () => {
   // Minimal DER encoder sufficient to build a self-signed EC certificate with
   // an arbitrary subjectAltName. Real CAs don't issue partial-wildcard SANs,
   // so the test has to mint its own.
@@ -325,10 +327,20 @@ describe("fetch() and tls.checkServerIdentity() agree on certificate SAN wildcar
   const ecdsaWithSha256 = seq(oid("2a8648ce3d040302"));
   const dn = (cn: string) => seq(set(seq(oid("550403"), tlv(0x0c, Buffer.from(cn)))));
 
-  function makeCert(sanDns: string[]) {
+  type San = ["dns" | "ip" | "email" | "uri", string];
+  function makeCert(cn: string, sans: San[]) {
     const { privateKey, publicKey } = crypto.generateKeyPairSync("ec", { namedCurve: "prime256v1" });
-    const subject = dn("cn-not-in-san.test");
-    const exts = tlv(0xa3, seq(seq(oid("551d11"), tlv(0x04, seq(...sanDns.map(d => tlv(0x82, Buffer.from(d))))))));
+    const subject = dn(cn);
+    let exts = Buffer.alloc(0);
+    if (sans.length) {
+      const enc: Record<San[0], (v: string) => Buffer> = {
+        dns: v => tlv(0x82, Buffer.from(v)),
+        ip: v => tlv(0x87, Buffer.from(v.split(".").map(Number))),
+        email: v => tlv(0x81, Buffer.from(v)),
+        uri: v => tlv(0x86, Buffer.from(v)),
+      };
+      exts = tlv(0xa3, seq(seq(oid("551d11"), tlv(0x04, seq(...sans.map(([t, v]) => enc[t](v)))))));
+    }
     const tbs = seq(
       tlv(0xa0, tlv(0x02, Buffer.from([2]))),
       tlv(0x02, Buffer.from([9])),
@@ -351,94 +363,159 @@ describe("fetch() and tls.checkServerIdentity() agree on certificate SAN wildcar
         .match(/.{1,64}/g)!
         .join("\n") +
       "\n-----END CERTIFICATE-----\n";
-    return { cert, key: privateKey.export({ type: "pkcs8", format: "pem" }) as string };
+    const key = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+    return { cert, key, x509: new crypto.X509Certificate(cert) };
   }
 
-  const sans = ["*.wild.test", "f*.partial.test", "*b.partial2.test", "a*c.mid.test"];
-  const material = makeCert(sans);
-  const x509 = new crypto.X509Certificate(material.cert);
-  const legacy = x509.toLegacyObject();
-
-  // Expected values were taken from Node.js v26.3.0.
-  const cases: Array<[host: string, ok: boolean]> = [
-    ["foo.wild.test", true],
-    ["a.b.wild.test", false],
-    ["wild.test", false],
-    ["foo.partial.test", true],
-    ["f.partial.test", true],
-    ["FOO.partial.test", true],
-    ["bar.partial.test", false],
-    ["foo.bar.partial.test", false],
-    ["foob.partial2.test", true],
-    ["b.partial2.test", true],
-    ["fooc.partial2.test", false],
-    ["abc.mid.test", true],
-    ["ac.mid.test", true],
-    ["xbc.mid.test", false],
-    ["cn-not-in-san.test", false],
-  ];
-
-  let server: ReturnType<typeof Bun.serve>;
-  it("server starts", () => {
-    server = Bun.serve({
-      port: 0,
-      tls: material,
-      fetch: () => new Response("ok"),
-    });
-  });
-
-  it.each(cases)("tls.checkServerIdentity(%j) === fetch()", async (host, ok) => {
-    // JS matcher (the same one tls.connect defaults to).
-    const jsErr = tls.checkServerIdentity(host, legacy);
-    expect(jsErr === undefined).toBe(ok);
-
-    // Native matcher via fetch().
-    let fetchOk: boolean;
-    let fetchCode: string | undefined;
+  function csi(x509: crypto.X509Certificate, host: string) {
+    return tls.checkServerIdentity(host, x509.toLegacyObject()) === undefined;
+  }
+  function checkHost(x509: crypto.X509Certificate, host: string, opts?: object) {
+    return x509.checkHost(host, opts);
+  }
+  async function fetchOk(material: { cert: string; key: string }, host: string) {
+    await using s = Bun.serve({ port: 0, tls: material, fetch: () => new Response("ok") });
     try {
-      const res = await fetch(`https://127.0.0.1:${server.port}/`, {
+      const r = await fetch(`https://127.0.0.1:${s.port}/`, {
         // @ts-expect-error Bun extension
         tls: { ca: material.cert, serverName: host },
         keepalive: false,
       });
-      await res.text();
-      fetchOk = res.ok;
+      await r.text();
+      return { ok: true };
     } catch (e: any) {
-      fetchOk = false;
-      fetchCode = e.code;
+      return { ok: false, code: e.code };
     }
-    if (ok) {
-      expect({ fetchOk, fetchCode }).toEqual({ fetchOk: true, fetchCode: undefined });
-    } else {
-      expect({ fetchOk, fetchCode }).toEqual({ fetchOk: false, fetchCode: "ERR_TLS_CERT_ALTNAME_INVALID" });
-    }
+  }
+
+  // Wildcard-SAN certificate shared by the csi==fetch rows.
+  const wild = makeCert("cn-not-in-san.test", [
+    ["dns", "*.wild.test"],
+    ["dns", "f*.partial.test"],
+    ["dns", "*b.partial2.test"],
+    ["dns", "w*w.mid.test"],
+    ["dns", "exact.test"],
+  ]);
+
+  // tls.checkServerIdentity and fetch() share Node's lib/tls.js check()
+  // semantics: partial wildcards anywhere in the left-most label, trailing dot
+  // stripped, at least three labels, IDNA A-labels literal. The checkHost
+  // column is recorded alongside for documentation; where Node's own checkHost
+  // disagrees with checkServerIdentity (mid-label wildcard, trailing dot) the
+  // expected value follows Node's checkHost.
+  const csiRows: Array<[host: string, csi: boolean, checkHost: string | undefined]> = [
+    ["foo.wild.test", true, "*.wild.test"],
+    ["FOO.WILD.TEST", true, "*.wild.test"],
+    ["foo.wild.test.", true, undefined],
+    ["a.b.wild.test", false, undefined],
+    ["wild.test", false, undefined],
+    ["exact.test", true, "exact.test"],
+    ["foo.partial.test", true, "f*.partial.test"],
+    ["f.partial.test", true, "f*.partial.test"],
+    ["bar.partial.test", false, undefined],
+    ["foo.bar.partial.test", false, undefined],
+    ["foob.partial2.test", true, "*b.partial2.test"],
+    ["b.partial2.test", true, "*b.partial2.test"],
+    ["fooc.partial2.test", false, undefined],
+    ["wow.mid.test", true, undefined],
+    ["ww.mid.test", true, undefined],
+    ["abc.mid.test", false, undefined],
+    ["cn-not-in-san.test", false, undefined],
+  ];
+
+  describe.concurrent("checkServerIdentity == fetch", () => {
+    it.each(csiRows)("%j", async (host, match, checkHostResult) => {
+      expect({
+        csi: csi(wild.x509, host),
+        checkHost: checkHost(wild.x509, host),
+        fetch: await fetchOk(wild, host),
+      }).toEqual({
+        csi: match,
+        checkHost: checkHostResult,
+        fetch: match ? { ok: true } : { ok: false, code: "ERR_TLS_CERT_ALTNAME_INVALID" },
+      });
+    });
   });
 
-  it("server stops", () => {
-    server?.stop(true);
-  });
-
-  // The native matcher must not be more permissive than Node on the rejections
-  // Node's lib/tls.js check() applies to the pattern's left-most label.
-  const nativeRejects: Array<[san: string, host: string]> = [
+  // Rejections Node's check() applies to the pattern that the native matcher
+  // must not relax.
+  const rejectSans: Array<[san: string, host: string]> = [
     ["f**.partial.test", "foo.partial.test"],
     ["*.test", "foo.test"],
     ["xn--f*.partial.test", "xn--foo.partial.test"],
     ["a..b.test", "a..b.test"],
   ];
-  it.each(nativeRejects)("SAN %j must not match %j", async (san, host) => {
-    const m = makeCert([san]);
-    expect(tls.checkServerIdentity(host, new crypto.X509Certificate(m.cert).toLegacyObject())).toBeInstanceOf(Error);
+  describe.concurrent("pattern rejections", () => {
+    it.each(rejectSans)("SAN %j must not match %j", async (san, host) => {
+      const m = makeCert("x", [["dns", san]]);
+      expect({
+        csi: csi(m.x509, host),
+        checkHost: checkHost(m.x509, host),
+        fetch: await fetchOk(m, host),
+      }).toEqual({
+        csi: false,
+        checkHost: undefined,
+        fetch: { ok: false, code: "ERR_TLS_CERT_ALTNAME_INVALID" },
+      });
+    });
+  });
 
-    await using s = Bun.serve({ port: 0, tls: m, fetch: () => new Response("ok") });
-    const err = await fetch(`https://127.0.0.1:${s.port}/`, {
-      // @ts-expect-error Bun extension
-      tls: { ca: m.cert, serverName: host },
-      keepalive: false,
-    }).then(
-      () => undefined,
-      e => e,
-    );
-    expect(err?.code).toBe("ERR_TLS_CERT_ALTNAME_INVALID");
+  // CN fallback: Node's checkServerIdentity and OpenSSL's default checkHost
+  // both fall back to the Subject CN when the certificate carries no dNSName
+  // SAN; non-DNS SANs (email / IP / URI) must not suppress that.
+  const cnRows: Array<[label: string, cn: string, sans: San[], host: string, csi: boolean, checkHost: boolean]> = [
+    ["no SAN", "nosan.a.test", [], "nosan.a.test", true, true],
+    ["email-only SAN", "emailcn.a.test", [["email", "a@x.test"]], "emailcn.a.test", true, true],
+    ["IP-only SAN", "ipcn.a.test", [["ip", "10.0.0.1"]], "ipcn.a.test", true, true],
+    ["URI-only SAN", "uricn.a.test", [["uri", "https://x.test/"]], "uricn.a.test", true, true],
+    ["DNS SAN present", "dnscn.a.test", [["dns", "other.a.test"]], "dnscn.a.test", false, false],
+  ];
+  describe.concurrent("CN fallback", () => {
+    it.each(cnRows)("%s -> %j", async (_label, cn, sans, host, csiMatch, checkHostMatch) => {
+      const m = makeCert(cn, sans);
+      expect({
+        csi: csi(m.x509, host),
+        checkHost: checkHost(m.x509, host) === cn,
+        fetch: await fetchOk(m, host),
+      }).toEqual({
+        csi: csiMatch,
+        checkHost: checkHostMatch,
+        fetch: csiMatch ? { ok: true } : { ok: false, code: "ERR_TLS_CERT_ALTNAME_INVALID" },
+      });
+    });
+  });
+
+  // X509Certificate#checkHost options. Every expected value was taken from
+  // Node.js v26.3.0 (OpenSSL X509_check_host semantics).
+  describe("checkHost options", () => {
+    const W = makeCert("cn.a.test", [
+      ["dns", "*.wild.test"],
+      ["dns", "exact.test"],
+    ]);
+    const P = makeCert("x", [["dns", "f*.partial.test"]]);
+    const Sub = makeCert("x", [["dns", "a.b.wild.test"]]);
+    const NoSan = makeCert("nosan.a.test", []);
+    const certs = { W, P, Sub, NoSan };
+
+    it.each([
+      // [cert, host, opts, expected]
+      ["W", "foo.wild.test", { wildcards: false }, undefined],
+      ["W", "exact.test", { wildcards: false }, "exact.test"],
+      ["P", "foo.partial.test", { partialWildcards: false }, undefined],
+      ["P", "foo.partial.test", { partialWildcards: true }, "f*.partial.test"],
+      ["W", "a.b.wild.test", { multiLabelWildcards: true }, "*.wild.test"],
+      ["W", "a.b.wild.test", { multiLabelWildcards: false }, undefined],
+      ["P", "foo.bar.partial.test", { multiLabelWildcards: true }, undefined],
+      ["W", "cn.a.test", { subject: "always" }, "cn.a.test"],
+      ["W", "cn.a.test", { subject: "default" }, undefined],
+      ["W", "cn.a.test", { subject: "never" }, undefined],
+      ["NoSan", "nosan.a.test", { subject: "never" }, undefined],
+      ["Sub", ".wild.test", undefined, "a.b.wild.test"],
+      ["Sub", ".wild.test", { singleLabelSubdomains: true }, undefined],
+      ["Sub", ".b.wild.test", { singleLabelSubdomains: true }, "a.b.wild.test"],
+      ["W", "foo.wild.test", {}, "*.wild.test"],
+    ] as const)("%s checkHost(%j, %o) -> %j", (name, host, opts, expected) => {
+      expect(checkHost(certs[name].x509, host, opts)).toBe(expected);
+    });
   });
 });

--- a/test/js/web/fetch/fetch.tls.wildcard.test.ts
+++ b/test/js/web/fetch/fetch.tls.wildcard.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import crypto from "node:crypto";
+import tls from "node:tls";
 
 // This test verifies that wildcard certificate hostname matching follows RFC 6125 Section 6.4.3:
 // - Wildcards must match exactly one label (not multiple labels)
@@ -297,5 +299,146 @@ describe.concurrent("TLS wildcard hostname verification", () => {
 
     expect(result.success).toBe(true);
     expect(result.error).toBeUndefined();
+  });
+});
+
+// fetch() uses a native Rust port of Node's lib/tls.js check() for certificate
+// name matching; tls.connect() defaults to the JS tls.checkServerIdentity().
+// These must agree for every certificate Node accepts, including RFC 6125
+// §6.4.3 partial-wildcard SAN entries (f*.example.com / *b.example.com).
+describe("fetch() and tls.checkServerIdentity() agree on certificate SAN wildcards", () => {
+  // Minimal DER encoder sufficient to build a self-signed EC certificate with
+  // an arbitrary subjectAltName. Real CAs don't issue partial-wildcard SANs,
+  // so the test has to mint its own.
+  const tlv = (t: number, b: Buffer) => {
+    const l =
+      b.length < 0x80
+        ? Buffer.from([b.length])
+        : b.length < 0x100
+          ? Buffer.from([0x81, b.length])
+          : Buffer.from([0x82, b.length >> 8, b.length & 0xff]);
+    return Buffer.concat([Buffer.from([t]), l, b]);
+  };
+  const seq = (...b: Buffer[]) => tlv(0x30, Buffer.concat(b));
+  const set = (b: Buffer) => tlv(0x31, b);
+  const oid = (h: string) => tlv(0x06, Buffer.from(h, "hex"));
+  const ecdsaWithSha256 = seq(oid("2a8648ce3d040302"));
+  const dn = (cn: string) => seq(set(seq(oid("550403"), tlv(0x0c, Buffer.from(cn)))));
+
+  function makeCert(sanDns: string[]) {
+    const { privateKey, publicKey } = crypto.generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+    const subject = dn("cn-not-in-san.test");
+    const exts = tlv(0xa3, seq(seq(oid("551d11"), tlv(0x04, seq(...sanDns.map(d => tlv(0x82, Buffer.from(d))))))));
+    const tbs = seq(
+      tlv(0xa0, tlv(0x02, Buffer.from([2]))),
+      tlv(0x02, Buffer.from([9])),
+      ecdsaWithSha256,
+      subject,
+      seq(tlv(0x17, Buffer.from("240101000000Z")), tlv(0x17, Buffer.from("340101000000Z"))),
+      subject,
+      publicKey.export({ type: "spki", format: "der" }) as Buffer,
+      exts,
+    );
+    const der = seq(
+      tbs,
+      ecdsaWithSha256,
+      tlv(0x03, Buffer.concat([Buffer.from([0]), crypto.sign("sha256", tbs, privateKey)])),
+    );
+    const cert =
+      "-----BEGIN CERTIFICATE-----\n" +
+      der
+        .toString("base64")
+        .match(/.{1,64}/g)!
+        .join("\n") +
+      "\n-----END CERTIFICATE-----\n";
+    return { cert, key: privateKey.export({ type: "pkcs8", format: "pem" }) as string };
+  }
+
+  const sans = ["*.wild.test", "f*.partial.test", "*b.partial2.test", "a*c.mid.test"];
+  const material = makeCert(sans);
+  const x509 = new crypto.X509Certificate(material.cert);
+  const legacy = x509.toLegacyObject();
+
+  // Expected values were taken from Node.js v26.3.0.
+  const cases: Array<[host: string, ok: boolean]> = [
+    ["foo.wild.test", true],
+    ["a.b.wild.test", false],
+    ["wild.test", false],
+    ["foo.partial.test", true],
+    ["f.partial.test", true],
+    ["FOO.partial.test", true],
+    ["bar.partial.test", false],
+    ["foo.bar.partial.test", false],
+    ["foob.partial2.test", true],
+    ["b.partial2.test", true],
+    ["fooc.partial2.test", false],
+    ["abc.mid.test", true],
+    ["ac.mid.test", true],
+    ["xbc.mid.test", false],
+    ["cn-not-in-san.test", false],
+  ];
+
+  let server: ReturnType<typeof Bun.serve>;
+  it("server starts", () => {
+    server = Bun.serve({
+      port: 0,
+      tls: material,
+      fetch: () => new Response("ok"),
+    });
+  });
+
+  it.each(cases)("tls.checkServerIdentity(%j) === fetch()", async (host, ok) => {
+    // JS matcher (the same one tls.connect defaults to).
+    const jsErr = tls.checkServerIdentity(host, legacy);
+    expect(jsErr === undefined).toBe(ok);
+
+    // Native matcher via fetch().
+    let fetchOk: boolean;
+    let fetchCode: string | undefined;
+    try {
+      const res = await fetch(`https://127.0.0.1:${server.port}/`, {
+        // @ts-expect-error Bun extension
+        tls: { ca: material.cert, serverName: host },
+        keepalive: false,
+      });
+      await res.text();
+      fetchOk = res.ok;
+    } catch (e: any) {
+      fetchOk = false;
+      fetchCode = e.code;
+    }
+    if (ok) {
+      expect({ fetchOk, fetchCode }).toEqual({ fetchOk: true, fetchCode: undefined });
+    } else {
+      expect({ fetchOk, fetchCode }).toEqual({ fetchOk: false, fetchCode: "ERR_TLS_CERT_ALTNAME_INVALID" });
+    }
+  });
+
+  it("server stops", () => {
+    server?.stop(true);
+  });
+
+  // The native matcher must not be more permissive than Node on the rejections
+  // Node's lib/tls.js check() applies to the pattern's left-most label.
+  const nativeRejects: Array<[san: string, host: string]> = [
+    ["f**.partial.test", "foo.partial.test"],
+    ["*.test", "foo.test"],
+    ["xn--f*.partial.test", "xn--foo.partial.test"],
+    ["a..b.test", "a..b.test"],
+  ];
+  it.each(nativeRejects)("SAN %j must not match %j", async (san, host) => {
+    const m = makeCert([san]);
+    expect(tls.checkServerIdentity(host, new crypto.X509Certificate(m.cert).toLegacyObject())).toBeInstanceOf(Error);
+
+    await using s = Bun.serve({ port: 0, tls: m, fetch: () => new Response("ok") });
+    const err = await fetch(`https://127.0.0.1:${s.port}/`, {
+      // @ts-expect-error Bun extension
+      tls: { ca: m.cert, serverName: host },
+      keepalive: false,
+    }).then(
+      () => undefined,
+      e => e,
+    );
+    expect(err?.code).toBe("ERR_TLS_CERT_ALTNAME_INVALID");
   });
 });

--- a/test/js/web/fetch/fetch.tls.wildcard.test.ts
+++ b/test/js/web/fetch/fetch.tls.wildcard.test.ts
@@ -526,5 +526,20 @@ describe("TLS certificate name matching: fetch() / checkServerIdentity / checkHo
     ] as const)("%s checkHost(%j, %o) -> %j", (name, host, opts, expected) => {
       expect(checkHost(certs[name].x509, host, opts)).toBe(expected);
     });
+
+    // OpenSSL valid_star pattern-side scan: every pattern label must be LDH
+    // with no boundary hyphen, else the `*` is never expanded.
+    it.each([
+      ["*_x.wild.test", "foo_x.wild.test", undefined],
+      ["*.a_b.test", "foo.a_b.test", undefined],
+      ["*-.wild.test", "foo-.wild.test", undefined],
+      ["-*.wild.test", "-foo.wild.test", undefined],
+      ["a-*.wild.test", "a-b.wild.test", undefined],
+      ["*.-wild.test", "foo.-wild.test", undefined],
+      ["*.wild-.test", "foo.wild-.test", undefined],
+      ["*-b.wild.test", "a-b.wild.test", "*-b.wild.test"],
+    ] as const)("SAN %j checkHost(%j) -> %j", (san, host, expected) => {
+      expect(checkHost(makeCert("x", [["dns", san]]).x509, host)).toBe(expected);
+    });
   });
 });

--- a/test/js/web/fetch/fetch.tls.wildcard.test.ts
+++ b/test/js/web/fetch/fetch.tls.wildcard.test.ts
@@ -493,9 +493,10 @@ describe("TLS certificate name matching: fetch() / checkServerIdentity / checkHo
       ["dns", "exact.test"],
     ]);
     const P = makeCert("x", [["dns", "f*.partial.test"]]);
+    const Sfx = makeCert("x", [["dns", "*foo.wild.test"]]);
     const Sub = makeCert("x", [["dns", "a.b.wild.test"]]);
     const NoSan = makeCert("nosan.a.test", []);
-    const certs = { W, P, Sub, NoSan };
+    const certs = { W, P, Sfx, Sub, NoSan };
 
     it.each([
       // [cert, host, opts, expected]
@@ -514,6 +515,14 @@ describe("TLS certificate name matching: fetch() / checkServerIdentity / checkHo
       ["Sub", ".wild.test", { singleLabelSubdomains: true }, undefined],
       ["Sub", ".b.wild.test", { singleLabelSubdomains: true }, "a.b.wild.test"],
       ["W", "foo.wild.test", {}, "*.wild.test"],
+      // OpenSSL wildcard_match host-side checks: the span under `*` must be
+      // LDH, and a partial wildcard never matches an IDNA host label.
+      ["W", "foo-bar.wild.test", undefined, "*.wild.test"],
+      ["W", "foo_bar.wild.test", undefined, undefined],
+      ["P", "foo_bar.partial.test", undefined, undefined],
+      ["W", "a_b.c.wild.test", { multiLabelWildcards: true }, undefined],
+      ["W", "xn--foo.wild.test", undefined, "*.wild.test"],
+      ["Sfx", "xn--foo.wild.test", undefined, undefined],
     ] as const)("%s checkHost(%j, %o) -> %j", (name, host, opts, expected) => {
       expect(checkHost(certs[name].x509, host, opts)).toBe(expected);
     });

--- a/test/js/web/fetch/fetch.tls.wildcard.test.ts
+++ b/test/js/web/fetch/fetch.tls.wildcard.test.ts
@@ -559,5 +559,33 @@ describe("TLS certificate name matching: fetch() / checkServerIdentity / checkHo
     ] as const)("SAN %j checkHost(%j, {wildcards:false}) -> %j", (san, host, expected) => {
       expect(checkHost(makeCert("x", [["dns", san]]).x509, host, { wildcards: false })).toBe(expected);
     });
+
+    // The dot-host suffix path rejects only on NUL, like OpenSSL equal_nocase.
+    it("SAN 'a b.wild.test' checkHost('.wild.test') -> matched", () => {
+      expect(checkHost(makeCert("x", [["dns", "a b.wild.test"]]).x509, ".wild.test")).toBe("a b.wild.test");
+    });
+
+    // CN fallback transcodes BMPString (UTF-16BE) via ASN1_STRING_to_UTF8 the
+    // way OpenSSL do_check_string does.
+    it("BMPString CN matches via CN fallback", () => {
+      const bmp = Buffer.from("bmp.a.test", "utf16le").swap16();
+      const { privateKey, publicKey } = crypto.generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+      const subj = seq(set(seq(oid("550403"), tlv(0x1e, bmp))));
+      const tbs = seq(
+        tlv(0xa0, tlv(0x02, Buffer.from([2]))),
+        tlv(0x02, Buffer.from([9])),
+        ecdsaWithSha256,
+        subj,
+        seq(tlv(0x17, Buffer.from("240101000000Z")), tlv(0x17, Buffer.from("340101000000Z"))),
+        subj,
+        publicKey.export({ type: "spki", format: "der" }) as Buffer,
+      );
+      const der = seq(
+        tbs,
+        ecdsaWithSha256,
+        tlv(0x03, Buffer.concat([Buffer.from([0]), crypto.sign("sha256", tbs, privateKey)])),
+      );
+      expect(new crypto.X509Certificate(der).checkHost("bmp.a.test")).toBe("bmp.a.test");
+    });
   });
 });

--- a/test/js/web/fetch/fetch.tls.wildcard.test.ts
+++ b/test/js/web/fetch/fetch.tls.wildcard.test.ts
@@ -551,5 +551,13 @@ describe("TLS certificate name matching: fetch() / checkServerIdentity / checkHo
     ] as const)("SAN %j checkHost(%j) -> %j", (san, host, expected) => {
       expect(checkHost(makeCert("x", [["dns", san]]).x509, host)).toBe(expected);
     });
+
+    // {wildcards: false} is also an OpenSSL-semantics mode (equal_nocase).
+    it.each([
+      ["a..b.test", "a..b.test", "a..b.test"],
+      ["exact.test.", "exact.test.", "exact.test."],
+    ] as const)("SAN %j checkHost(%j, {wildcards:false}) -> %j", (san, host, expected) => {
+      expect(checkHost(makeCert("x", [["dns", san]]).x509, host, { wildcards: false })).toBe(expected);
+    });
   });
 });

--- a/test/js/web/fetch/fetch.tls.wildcard.test.ts
+++ b/test/js/web/fetch/fetch.tls.wildcard.test.ts
@@ -438,15 +438,17 @@ describe("TLS certificate name matching: fetch() / checkServerIdentity / checkHo
   });
 
   // Rejections Node's check() applies to the pattern that the native matcher
-  // must not relax.
-  const rejectSans: Array<[san: string, host: string]> = [
-    ["f**.partial.test", "foo.partial.test"],
-    ["*.test", "foo.test"],
-    ["xn--f*.partial.test", "xn--foo.partial.test"],
-    ["a..b.test", "a..b.test"],
+  // must not relax. The checkHost column is Node/OpenSSL's verdict; where that
+  // falls through to equal_nocase (a..b.test) it matches even though Node's
+  // lib/tls.js check() hard-rejects the same pattern.
+  const rejectSans: Array<[san: string, host: string, checkHost: string | undefined]> = [
+    ["f**.partial.test", "foo.partial.test", undefined],
+    ["*.test", "foo.test", undefined],
+    ["xn--f*.partial.test", "xn--foo.partial.test", undefined],
+    ["a..b.test", "a..b.test", "a..b.test"],
   ];
   describe.concurrent("pattern rejections", () => {
-    it.each(rejectSans)("SAN %j must not match %j", async (san, host) => {
+    it.each(rejectSans)("SAN %j must not match %j", async (san, host, checkHostResult) => {
       const m = makeCert("x", [["dns", san]]);
       expect({
         csi: csi(m.x509, host),
@@ -454,7 +456,7 @@ describe("TLS certificate name matching: fetch() / checkServerIdentity / checkHo
         fetch: await fetchOk(m, host),
       }).toEqual({
         csi: false,
-        checkHost: undefined,
+        checkHost: checkHostResult,
         fetch: { ok: false, code: "ERR_TLS_CERT_ALTNAME_INVALID" },
       });
     });
@@ -528,7 +530,9 @@ describe("TLS certificate name matching: fetch() / checkServerIdentity / checkHo
     });
 
     // OpenSSL valid_star pattern-side scan: every pattern label must be LDH
-    // with no boundary hyphen, else the `*` is never expanded.
+    // with no boundary hyphen, else the `*` is never expanded; a failed scan
+    // falls through to equal_nocase rather than hard-rejecting. LABEL_IDNA is
+    // only set when a label *starts* with xn-- (not Node's includes()).
     it.each([
       ["*_x.wild.test", "foo_x.wild.test", undefined],
       ["*.a_b.test", "foo.a_b.test", undefined],
@@ -538,6 +542,12 @@ describe("TLS certificate name matching: fetch() / checkServerIdentity / checkHo
       ["*.-wild.test", "foo.-wild.test", undefined],
       ["*.wild-.test", "foo.wild-.test", undefined],
       ["*-b.wild.test", "a-b.wild.test", "*-b.wild.test"],
+      ["a..b.test", "a..b.test", "a..b.test"],
+      ["exact.test.", "exact.test.", "exact.test."],
+      ["exact.test.", "exact.test", undefined],
+      ["exact test.a.b", "exact test.a.b", "exact test.a.b"],
+      ["axn--b*.c.d", "axn--bZ.c.d", "axn--b*.c.d"],
+      ["xn--a*.c.d", "xn--aZ.c.d", undefined],
     ] as const)("SAN %j checkHost(%j) -> %j", (san, host, expected) => {
       expect(checkHost(makeCert("x", [["dns", san]]).x509, host)).toBe(expected);
     });


### PR DESCRIPTION
## What

Bun shipped three independent certificate-name matchers that disagreed on the same certificate and hostname:

| surface | matcher | partial wildcard `f*.a.b` | trailing dot | CN fallback |
|--|--|--|--|--|
| `tls.connect` / `tls.checkServerIdentity` | JS port of Node lib/tls.js `check()` | match | strip | no dNSName SAN |
| `fetch` / `WebSocket` / `Bun.connect` / SQL | `match_dns_name` in `src/boringssl/lib.rs` | **reject** | **literal** | **no DNS/IP/URI SAN** |
| `X509Certificate#checkHost` | BoringSSL `X509_check_host` | **reject** | literal | **SAN extension absent** |

Every divergence was fail-closed relative to Node (Bun rejected where Node matched), so a library that pre-verified with `cert.checkHost(host)` or `tls.checkServerIdentity()` would see the pre-check pass and the request fail with `ERR_TLS_CERT_ALTNAME_INVALID`, and `fetch()` would reject hosts `tls.connect()` accepted.

## Repro

```js
// cert SAN: DNS:*.wild.test, DNS:f*.partial.test, DNS:*b.partial2.test
tls.checkServerIdentity("foo.partial.test", cert.toLegacyObject());  // MATCH
cert.checkHost("foo.partial.test");                                   // before: undefined, after: "f*.partial.test"
await fetch(url, { tls: { ca, serverName: "foo.partial.test" } });    // before: ERR_TLS_CERT_ALTNAME_INVALID, after: 200
```

## Cause

`match_dns_name` only recognised a wildcard when the first two bytes were literally `*.`, so `f*.partial.test` fell through to exact match. The CN fallback gated on any DNS/IP/URI SAN rather than only dNSName. `X509View::checkHost` called BoringSSL's `X509_check_host`, which hard-codes `NO_PARTIAL_WILDCARDS` and defines `ALWAYS_CHECK_SUBJECT` / `MULTI_LABEL_WILDCARDS` / `SINGLE_LABEL_SUBDOMAINS` as `0`, so every `checkHost` option except `wildcards` and `subject: 'never'` compiled to `flags |= 0`.

## Fix

One Rust matcher, `match_hostname(pattern, host, opts)`, drives every surface:

- `MatchOpts::TLS_CHECK` (fetch, WebSocket, Bun.connect, SQL, Valkey): line-for-line port of Node lib/tls.js `check()`. Partial wildcards anywhere in the left-most label, one trailing `.` stripped from both names, IDNA A-labels literal, empty labels and bytes outside `U+0021..=U+007F` rejected.
- `check_x509_server_identity` falls back to the Subject CN iff the certificate carries no dNSName SAN; email/IP/URI SANs no longer suppress it. The error reason text follows the same rule.
- `Bun__X509__checkHost` (called from `X509View::checkHost` instead of `X509_check_host`) iterates SANs and CN over the same matcher with OpenSSL semantics: `wildcards`, `partialWildcards` (edge-of-label), `multiLabelWildcards`, `subject: 'default'/'always'/'never'`, `singleLabelSubdomains` (dot-host suffix matching), trailing dot not stripped. `getFlags()` now carries OpenSSL's real bit values via `X509View::CheckFlags` and no longer throws on `{}`.

`src/js/node/tls.ts` `checkServerIdentity` stays as the JS source of truth.

## Verification

`test/js/web/fetch/fetch.tls.wildcard.test.ts` gains a describe block that mints certificates with partial-wildcard / CN-fallback / option SAN shapes and asserts, for every row:

- `fetch()` and `tls.checkServerIdentity()` return the same verdict (17 hosts)
- four patterns both must reject
- CN fallback across no-SAN / email-only / IP-only / URI-only / DNS-present
- every documented `checkHost` option (15 combinations)

All expected values were taken from Node.js v26.3.0. 19 of the 48 tests fail on `main`; all 48 pass with this change. `test/js/node/crypto/x509.test.ts`, `test-crypto-x509.js`, `fetch.tls.test.ts` and `node-tls-cert.test.ts` still pass.

## Related

Supersedes #33676 (same `checkHost` goal, but shares the matcher with `fetch()` instead of porting OpenSSL into `ncrypto.cpp`) and subsumes the `src/` hunk of #36130 (`unfqdn`).

Fixes #20173

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 20 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.wildcard.test.ts
bun test v1.4.0 (7e5f6bfbb)

test/js/web/fetch/fetch.tls.wildcard.test.ts:
(pass) TLS wildcard hostname verification > should reject multi-label wildcard match (sub.foo.example.com vs *.example.com) [773.00ms]
(pass) TLS wildcard hostname verification > should accept valid single-label wildcard match (foo.example.com vs *.example.com) [398.77ms]
(pass) TLS wildcard hostname verification > should reject bare domain for wildcard cert (example.com vs *.example.com) [394.59ms]
(pass) TLS wildcard hostname verification > should accept exact match for wildcard labels (bar.example.com vs *.example.com) [391.95ms]
(pass) TLS wildcard hostname verification > should reject deeply nested subdomain (a.b.c.example.com vs *.example.com) [371.74ms]
427 |     it.each(csiRows)("%j", async (host, match, checkHostResult) => {
428 |       expect({
429 |         csi: csi(wild.x509, host),
430 |         checkHost: checkHost(wild.x509, host),
431 |         fetch: await fetchOk(wild, host),
432 |       }).toEqual({
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (fc23dfc75)

test/js/web/fetch/fetch.tls.wildcard.test.ts:
(pass) TLS certificate name matching: fetch() / checkServerIdentity / checkHost agree > checkServerIdentity == fetch > "a.b.wild.test" [7.04ms]
(pass) TLS certificate name matching: fetch() / checkServerIdentity / checkHost agree > checkServerIdentity == fetch > "wild.test" [6.88ms]
(pass) TLS certificate name matching: fetch() / checkServerIdentity / checkHost agree > checkServerIdentity == fetch > "bar.partial.test" [6.90ms]
(pass) TLS certificate name matching: fetch() / checkServerIdentity / checkHost agree > checkServerIdentity == fetch > "foo.bar.partial.test" [6.98ms]
(pass) TLS certificate name matching: fetch() / checkServerIdentity / checkHost agree > checkServerIdentity == fetch > "foo.wild.test" [14.12ms]
(pass) TLS certificate name matching: fetch() / checkServerIdentity / checkHost agree > checkServerIdentity == fetch > "FOO.WILD.TEST" [13.26ms]
(pass) TLS certificate name matching: fetch() / checkServerIdentity / checkHost agree > checkServerIdentity == fetch > "foo.wild.test." [12.94ms]
(pass) TLS certificate name matching: fetch() / checkServerIdentity / checkHost ag
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.wildcard.test.ts
bun test v1.4.0 (7e5f6bfbb)

test/js/web/fetch/fetch.tls.wildcard.test.ts:
(pass) TLS wildcard hostname verification > should reject multi-label wildcard match (sub.foo.example.com vs *.example.com) [795.09ms]
(pass) TLS wildcard hostname verification > should accept valid single-label wildcard match (foo.example.com vs *.example.com) [430.47ms]
(pass) TLS wildcard hostname verification > should reject bare domain for wildcard cert (example.com vs *.example.com) [419.31ms]
(pass) TLS wildcard hostname verification > should accept exact match for wildcard labels (bar.example.com vs *.example.com) [416.32ms]
(pass) TLS wildcard hostname verification > should reject deeply nested subdomain (a.b.c.example.com vs *.example.com) [393.71ms]
(pass) TLS certificate name matching: fetch() / checkServerIdentity / checkHost agree > checkServerIdentity == fetch > "foo.wild.test" [113.65ms]
(pass) TLS certificate name matching: fetch() / checkServerIdentity / checkHost agree > checkServerIdentity == fetch
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 644ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/18] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[2/18] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[3/18] cxx obj/src/jsc/bindings/BunProcess.cpp.o
[4/18] cxx obj/src/jsc/bindings/webcore/SerializedScriptValue.cpp.o
[5/18] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[6/18] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-1.cpp.o
[7/18] cxx obj/unified/UnifiedSource-src_jsc_modules-0.cpp.o
[8/18] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-0.cpp.o
[9/18] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[10/18] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[11/18] cxx obj/src/jsc/bindings/webcrypto/SubtleCrypto.cpp.o
[12/18] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[13/18] gen cpp.rs (cppbind)
[14/18] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[14/18] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/boringssl/lib.rs                            | 453 +++++++++++++++++++-----
 src/boringssl_sys/boringssl.rs                  |  53 ++-
 src/bun_core/lib.rs                             |   2 +-
 src/bun_core/string/immutable.rs                |   2 +-
 src/jsc/bindings/JSX509CertificatePrototype.cpp |  23 +-
 src/jsc/bindings/ncrypto.cpp                    |  20 +-
 src/jsc/bindings/ncrypto.h                      |  11 +
 test/js/web/fetch/fetch.tls.wildcard.test.ts    | 290 +++++++++++++++
 8 files changed, 727 insertions(+), 127 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/boringssl/lib.rs                                16     24      0
src/boringssl_sys/boringssl.rs                       2      3      0
src/bun_core/lib.rs                                  1      1      0
src/bun_core/string/immutable.rs                     2      1      0
src/jsc/bindings/JSX509CertificatePrototype.cpp      1      1      0
src/jsc/bindings/ncrypto.cpp                         2      1      0
src/jsc/bindings/ncrypto.h                           1      1      0
test/js/web/fetch/fetch.tls.wildcard.test.ts         6     11      0
```

</details>

<!-- robobun:evidence:end -->