### PR TITLE
napi: validate receiver on napi_define_class prototype methods

### DIFF
--- a/src/jsc/bindings/NapiClass.cpp
+++ b/src/jsc/bindings/NapiClass.cpp
@@ -10,9 +10,21 @@ void NapiClass::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     NapiClass* thisObject = uncheckedDowncast<NapiClass>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
+    visitor.append(thisObject->m_signaturePrototype);
 }
 
 DEFINE_VISIT_CHILDREN(NapiClass);
+
+template<typename Visitor>
+void NapiPrototype::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    NapiPrototype* thisObject = uncheckedDowncast<NapiPrototype>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+    visitor.append(thisObject->m_constructedBy);
+}
+
+DEFINE_VISIT_CHILDREN(NapiPrototype);
 
 template<bool ConstructCall>
 JSC_HOST_CALL_ATTRIBUTES JSC::EncodedJSValue NapiClass_ConstructorFunction(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
@@ -45,21 +57,38 @@ JSC_HOST_CALL_ATTRIBUTES JSC::EncodedJSValue NapiClass_ConstructorFunction(JSC::
         }
 
         newTarget = callFrame->newTarget();
-        JSObject* thisValue;
+        NapiPrototype* thisValue;
         // Match the behavior from
         // https://github.com/oven-sh/WebKit/blob/397dafc9721b8f8046f9448abb6dbc14efe096d3/Source/JavaScriptCore/runtime/ObjectConstructor.cpp#L118-L145
         if (newTarget && newTarget != napi) {
             JSGlobalObject* functionGlobalObject = getFunctionRealm(globalObject, asObject(newTarget));
             RETURN_IF_EXCEPTION(scope, {});
-            Structure* baseStructure = functionGlobalObject->objectStructureForObjectConstructor();
+            auto* zigFunctionGlobal = dynamicDowncast<Zig::GlobalObject>(functionGlobalObject);
+            Structure* baseStructure = zigFunctionGlobal
+                ? zigFunctionGlobal->NapiPrototypeStructure()
+                : uncheckedDowncast<Zig::GlobalObject>(globalObject)->NapiPrototypeStructure();
             Structure* objectStructure = InternalFunction::createSubclassStructure(globalObject, asObject(newTarget), baseStructure);
             RETURN_IF_EXCEPTION(scope, {});
-            thisValue = constructEmptyObject(vm, objectStructure);
+            thisValue = NapiPrototype::create(vm, objectStructure);
         } else {
             thisValue = prototype->subclass(globalObject, asObject(newTarget));
         }
         RETURN_IF_EXCEPTION(scope, {});
+        if (thisValue) {
+            thisValue->setConstructedBy(vm, prototype);
+        }
         callFrame->setThisValue(thisValue);
+    } else if (NapiPrototype* signaturePrototype = napi->signaturePrototype()) {
+        // Node.js builds napi_define_class prototype methods with a
+        // v8::Signature, so V8 throws before the native callback when |this| is
+        // not an instance of the defining class. Enforce the same contract so
+        // addons cannot be handed a foreign napi_wrap pointer.
+        JSValue thisValue = callFrame->thisValue();
+        NapiPrototype* instance = thisValue.isCell() ? dynamicDowncast<NapiPrototype>(thisValue.asCell()) : nullptr;
+        if (!instance || instance->constructedBy() != signaturePrototype) [[unlikely]] {
+            JSC::throwVMError(globalObject, scope, JSC::createTypeError(globalObject, "Illegal invocation"_s));
+            return JSValue::encode(JSC::jsUndefined());
+        }
     }
 
     NAPICallFrame frame(globalObject, callFrame, napi->dataPtr(), newTarget);
@@ -124,8 +153,9 @@ napi_status NapiClass::finishCreation(VM& vm, const String& name, napi_callback 
     for (size_t i = 0; i < property_count; i++) {
         const napi_property_descriptor& property = properties[i];
 
-        JSC::JSObject* target = (property.attributes & napi_static) ? static_cast<JSC::JSObject*>(this) : prototype;
-        napi_status status = Napi::defineProperty(env, target, property, throwScope);
+        bool isStatic = property.attributes & napi_static;
+        JSC::JSObject* target = isStatic ? static_cast<JSC::JSObject*>(this) : prototype;
+        napi_status status = Napi::defineProperty(env, target, property, throwScope, isStatic ? nullptr : prototype);
 
         if (throwScope.exception()) {
             result = napi_pending_exception;

--- a/src/jsc/bindings/NapiClass.cpp
+++ b/src/jsc/bindings/NapiClass.cpp
@@ -79,10 +79,8 @@ JSC_HOST_CALL_ATTRIBUTES JSC::EncodedJSValue NapiClass_ConstructorFunction(JSC::
         }
         callFrame->setThisValue(thisValue);
     } else if (NapiPrototype* signaturePrototype = napi->signaturePrototype()) {
-        // Node.js builds napi_define_class prototype methods with a
-        // v8::Signature, so V8 throws before the native callback when |this| is
-        // not an instance of the defining class. Enforce the same contract so
-        // addons cannot be handed a foreign napi_wrap pointer.
+        // Node.js puts napi_define_class instance methods behind a v8::Signature
+        // so a foreign receiver never reaches the native callback. Match that.
         JSValue thisValue = callFrame->thisValue();
         NapiPrototype* instance = thisValue.isCell() ? dynamicDowncast<NapiPrototype>(thisValue.asCell()) : nullptr;
         if (!instance || instance->constructedBy() != signaturePrototype) [[unlikely]] {

--- a/src/jsc/bindings/NapiClass.cpp
+++ b/src/jsc/bindings/NapiClass.cpp
@@ -79,8 +79,7 @@ JSC_HOST_CALL_ATTRIBUTES JSC::EncodedJSValue NapiClass_ConstructorFunction(JSC::
         }
         callFrame->setThisValue(thisValue);
     } else if (NapiPrototype* signaturePrototype = napi->signaturePrototype()) {
-        // Node.js puts napi_define_class instance methods behind a v8::Signature
-        // so a foreign receiver never reaches the native callback. Match that.
+        // v8::Signature parity: reject a foreign |this| before the native callback runs.
         JSValue thisValue = callFrame->thisValue();
         NapiPrototype* instance = thisValue.isCell() ? dynamicDowncast<NapiPrototype>(thisValue.asCell()) : nullptr;
         if (!instance || instance->constructedBy() != signaturePrototype) [[unlikely]] {

--- a/src/jsc/bindings/NapiClass.cpp
+++ b/src/jsc/bindings/NapiClass.cpp
@@ -11,6 +11,7 @@ void NapiClass::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_signaturePrototype);
+    visitor.append(thisObject->m_classPrototype);
 }
 
 DEFINE_VISIT_CHILDREN(NapiClass);
@@ -46,15 +47,8 @@ JSC_HOST_CALL_ATTRIBUTES JSC::EncodedJSValue NapiClass_ConstructorFunction(JSC::
     JSValue newTarget;
 
     if constexpr (ConstructCall) {
-        // Use ::get instead of ::getIfPropertyExists here so that DontEnum is ignored.
-        auto prototypeValue = napi->get(globalObject, vm.propertyNames->prototype);
-        RETURN_IF_EXCEPTION(scope, {});
-        NapiPrototype* prototype = dynamicDowncast<NapiPrototype>(prototypeValue);
-
-        if (!prototype) {
-            JSC::throwVMError(globalObject, scope, JSC::createTypeError(globalObject, "NapiClass constructor is missing the prototype"_s));
-            return JSValue::encode(JSC::jsUndefined());
-        }
+        NapiPrototype* prototype = napi->classPrototype();
+        ASSERT(prototype);
 
         newTarget = callFrame->newTarget();
         NapiPrototype* thisValue;
@@ -142,6 +136,7 @@ napi_status NapiClass::finishCreation(VM& vm, const String& name, napi_callback 
     this->putDirect(vm, vm.propertyNames->name, jsString(vm, name), JSC::PropertyAttribute::DontEnum | 0);
 
     NapiPrototype* prototype = NapiPrototype::create(vm, globalObject->NapiPrototypeStructure());
+    m_classPrototype.set(vm, this, prototype);
 
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto env = m_env;

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -326,7 +326,7 @@ void NAPICallFrame::extract(size_t* argc, napi_value* argv, napi_value* this_arg
     }
 }
 
-napi_status Napi::defineProperty(napi_env env, JSC::JSObject* to, const napi_property_descriptor& property, JSC::ThrowScope& scope)
+napi_status Napi::defineProperty(napi_env env, JSC::JSObject* to, const napi_property_descriptor& property, JSC::ThrowScope& scope, Zig::NapiPrototype* signaturePrototype)
 {
     Zig::GlobalObject* globalObject = env->globalObject();
     JSC::VM& vm = JSC::getVM(globalObject);
@@ -370,7 +370,11 @@ napi_status Napi::defineProperty(napi_env env, JSC::JSObject* to, const napi_pro
         if (!propertyName.isSymbol()) {
             name = propertyName.string();
         }
-        descriptor.setValue(NapiClass::create(vm, env, name, property.method, dataPtr, 0, nullptr));
+        auto* function = NapiClass::create(vm, env, name, property.method, dataPtr, 0, nullptr);
+        if (signaturePrototype) {
+            function->setSignaturePrototype(vm, signaturePrototype);
+        }
+        descriptor.setValue(function);
         descriptor.setWritable(writable);
         failureStatus = napi_generic_failure;
     } else {

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -32,6 +32,10 @@ extern "C" void Bun__crashHandler(const char* message, size_t message_len);
 
 static bool equal(napi_async_cleanup_hook_handle, napi_async_cleanup_hook_handle);
 
+namespace Zig {
+class NapiPrototype;
+}
+
 namespace Napi {
 
 static constexpr int DEFAULT_NAPI_VERSION = 10;
@@ -126,7 +130,7 @@ private:
 
 using HookSet = std::unordered_set<EitherCleanupHook, EitherCleanupHook::Hash>;
 
-napi_status defineProperty(napi_env env, JSC::JSObject* to, const napi_property_descriptor& property, JSC::ThrowScope& scope);
+napi_status defineProperty(napi_env env, JSC::JSObject* to, const napi_property_descriptor& property, JSC::ThrowScope& scope, Zig::NapiPrototype* signaturePrototype = nullptr);
 }
 
 struct napi_async_cleanup_hook_handle__ {
@@ -886,6 +890,8 @@ static inline napi_ref toNapi(NapiRef* val)
     return reinterpret_cast<napi_ref>(val);
 }
 
+class NapiPrototype;
+
 class NapiClass final : public JSC::JSFunction {
 public:
     using Base = JSFunction;
@@ -929,6 +935,14 @@ public:
     inline void* const& dataPtr() const { return m_dataPtr; }
     inline napi_env env() const { return m_env; }
 
+    // When this function is a prototype method defined via napi_define_class,
+    // this points at the class's prototype object. A normal (non-construct)
+    // call then validates that |this| was constructed by that class and throws
+    // "Illegal invocation" otherwise, matching V8's FunctionTemplate signature
+    // check that Node.js applies to instance methods.
+    inline NapiPrototype* signaturePrototype() const { return m_signaturePrototype.get(); }
+    inline void setSignaturePrototype(VM& vm, NapiPrototype* prototype);
+
 private:
     NapiClass(VM& vm, NativeExecutable* executable, napi_env env, Structure* structure, void* data)
         : Base(vm, executable, env->globalObject(), structure)
@@ -945,6 +959,7 @@ private:
     void* m_dataPtr = nullptr;
     napi_callback m_constructor = nullptr;
     napi_env m_env = nullptr;
+    JSC::WriteBarrier<NapiPrototype> m_signaturePrototype;
 
     DECLARE_VISIT_CHILDREN;
 };
@@ -987,14 +1002,32 @@ public:
         return NapiPrototype::create(vm, structure);
     }
 
+    // Set on instances created via a NapiClass [[Construct]] to record which
+    // napi_define_class prototype produced them. Prototype methods compare this
+    // against their own signature prototype before invoking the native callback.
+    inline NapiPrototype* constructedBy() const { return m_constructedBy.get(); }
+    inline void setConstructedBy(VM& vm, NapiPrototype* prototype)
+    {
+        m_constructedBy.set(vm, this, prototype);
+    }
+
     NapiRef* napiRef = nullptr;
+
+    DECLARE_VISIT_CHILDREN;
 
 private:
     NapiPrototype(VM& vm, Structure* structure)
         : Base(vm, structure)
     {
     }
+
+    JSC::WriteBarrier<NapiPrototype> m_constructedBy;
 };
+
+inline void NapiClass::setSignaturePrototype(VM& vm, NapiPrototype* prototype)
+{
+    m_signaturePrototype.set(vm, this, prototype);
+}
 
 static inline NapiRef* toJS(napi_ref val)
 {

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -935,11 +935,8 @@ public:
     inline void* const& dataPtr() const { return m_dataPtr; }
     inline napi_env env() const { return m_env; }
 
-    // When this function is a prototype method defined via napi_define_class,
-    // this points at the class's prototype object. A normal (non-construct)
-    // call then validates that |this| was constructed by that class and throws
-    // "Illegal invocation" otherwise, matching V8's FunctionTemplate signature
-    // check that Node.js applies to instance methods.
+    // Set for napi_define_class instance methods; the call thunk rejects any
+    // |this| not constructed by this prototype (Node.js v8::Signature parity).
     inline NapiPrototype* signaturePrototype() const { return m_signaturePrototype.get(); }
     inline void setSignaturePrototype(VM& vm, NapiPrototype* prototype);
 
@@ -1002,9 +999,8 @@ public:
         return NapiPrototype::create(vm, structure);
     }
 
-    // Set on instances created via a NapiClass [[Construct]] to record which
-    // napi_define_class prototype produced them. Prototype methods compare this
-    // against their own signature prototype before invoking the native callback.
+    // The napi_define_class prototype that constructed this instance, compared
+    // against a method's signaturePrototype() before the native callback runs.
     inline NapiPrototype* constructedBy() const { return m_constructedBy.get(); }
     inline void setConstructedBy(VM& vm, NapiPrototype* prototype)
     {

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -935,8 +935,7 @@ public:
     inline void* const& dataPtr() const { return m_dataPtr; }
     inline napi_env env() const { return m_env; }
 
-    // Set for napi_define_class instance methods; the call thunk rejects any
-    // |this| not constructed by this prototype (Node.js v8::Signature parity).
+    // v8::Signature-style receiver check for napi_define_class instance methods.
     inline NapiPrototype* signaturePrototype() const { return m_signaturePrototype.get(); }
     inline void setSignaturePrototype(VM& vm, NapiPrototype* prototype);
 
@@ -999,8 +998,7 @@ public:
         return NapiPrototype::create(vm, structure);
     }
 
-    // The napi_define_class prototype that constructed this instance, compared
-    // against a method's signaturePrototype() before the native callback runs.
+    // napi_define_class prototype that constructed this instance; see NapiClass::signaturePrototype().
     inline NapiPrototype* constructedBy() const { return m_constructedBy.get(); }
     inline void setConstructedBy(VM& vm, NapiPrototype* prototype)
     {

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -939,6 +939,9 @@ public:
     inline NapiPrototype* signaturePrototype() const { return m_signaturePrototype.get(); }
     inline void setSignaturePrototype(VM& vm, NapiPrototype* prototype);
 
+    // The prototype created by napi_define_class, independent of the JS-visible .prototype property.
+    inline NapiPrototype* classPrototype() const { return m_classPrototype.get(); }
+
 private:
     NapiClass(VM& vm, NativeExecutable* executable, napi_env env, Structure* structure, void* data)
         : Base(vm, executable, env->globalObject(), structure)
@@ -956,6 +959,7 @@ private:
     napi_callback m_constructor = nullptr;
     napi_env m_env = nullptr;
     JSC::WriteBarrier<NapiPrototype> m_signaturePrototype;
+    JSC::WriteBarrier<NapiPrototype> m_classPrototype;
 
     DECLARE_VISIT_CHILDREN;
 };

--- a/test/napi/napi-app/class_test.cpp
+++ b/test/napi/napi-app/class_test.cpp
@@ -165,18 +165,15 @@ static napi_value get_class_with_constructor(const Napi::CallbackInfo &info) {
 }
 
 static int receiver_check_method_calls = 0;
-
-static void receiver_check_finalize(napi_env env, void *data, void *hint) {
-  free(data);
-}
+static int receiver_check_wrap_a;
+static int receiver_check_wrap_b;
 
 static napi_value receiver_check_ctor_a(napi_env env, napi_callback_info info) {
   napi_value self;
   size_t argc = 0;
   NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, nullptr, &self, nullptr));
-  void *p = calloc(1, 8);
-  NODE_API_CALL(env,
-                napi_wrap(env, self, p, receiver_check_finalize, nullptr, nullptr));
+  NODE_API_CALL(env, napi_wrap(env, self, &receiver_check_wrap_a, nullptr,
+                               nullptr, nullptr));
   return nullptr;
 }
 
@@ -184,9 +181,8 @@ static napi_value receiver_check_ctor_b(napi_env env, napi_callback_info info) {
   napi_value self;
   size_t argc = 0;
   NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, nullptr, &self, nullptr));
-  void *p = calloc(1, 40);
-  NODE_API_CALL(env,
-                napi_wrap(env, self, p, receiver_check_finalize, nullptr, nullptr));
+  NODE_API_CALL(env, napi_wrap(env, self, &receiver_check_wrap_b, nullptr,
+                               nullptr, nullptr));
   return nullptr;
 }
 

--- a/test/napi/napi-app/class_test.cpp
+++ b/test/napi/napi-app/class_test.cpp
@@ -164,6 +164,102 @@ static napi_value get_class_with_constructor(const Napi::CallbackInfo &info) {
   return napi_class;
 }
 
+static int receiver_check_method_calls = 0;
+
+static void receiver_check_finalize(napi_env env, void *data, void *hint) {
+  free(data);
+}
+
+static napi_value receiver_check_ctor_a(napi_env env, napi_callback_info info) {
+  napi_value self;
+  size_t argc = 0;
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, nullptr, &self, nullptr));
+  void *p = calloc(1, 8);
+  NODE_API_CALL(env,
+                napi_wrap(env, self, p, receiver_check_finalize, nullptr, nullptr));
+  return nullptr;
+}
+
+static napi_value receiver_check_ctor_b(napi_env env, napi_callback_info info) {
+  napi_value self;
+  size_t argc = 0;
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, nullptr, &self, nullptr));
+  void *p = calloc(1, 40);
+  NODE_API_CALL(env,
+                napi_wrap(env, self, p, receiver_check_finalize, nullptr, nullptr));
+  return nullptr;
+}
+
+static napi_value receiver_check_method(napi_env env, napi_callback_info info) {
+  // With a receiver signature check in place, this must never be reached for a
+  // receiver that was not constructed by B.
+  receiver_check_method_calls++;
+  napi_value self;
+  size_t argc = 0;
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, nullptr, &self, nullptr));
+  void *data = nullptr;
+  napi_status status = napi_unwrap(env, self, &data);
+  napi_value result;
+  NODE_API_CALL(env, napi_create_int32(env, static_cast<int32_t>(status), &result));
+  return result;
+}
+
+static napi_value receiver_check_getter(napi_env env, napi_callback_info info) {
+  receiver_check_method_calls++;
+  napi_value result;
+  NODE_API_CALL(env, napi_create_int32(env, 1, &result));
+  return result;
+}
+
+static napi_value receiver_check_setter(napi_env env, napi_callback_info info) {
+  receiver_check_method_calls++;
+  return nullptr;
+}
+
+static napi_value receiver_check_static(napi_env env, napi_callback_info info) {
+  napi_value result;
+  NODE_API_CALL(env, napi_create_string_utf8(env, "static", NAPI_AUTO_LENGTH, &result));
+  return result;
+}
+
+static napi_value get_receiver_check_classes(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  receiver_check_method_calls = 0;
+
+  napi_value class_a;
+  NODE_API_CALL(env, napi_define_class(env, "A", NAPI_AUTO_LENGTH,
+                                       receiver_check_ctor_a, nullptr, 0,
+                                       nullptr, &class_a));
+
+  const napi_property_descriptor b_props[] = {
+      {"check", nullptr, receiver_check_method, nullptr, nullptr, nullptr,
+       napi_default_method, nullptr},
+      {"accessor", nullptr, nullptr, receiver_check_getter,
+       receiver_check_setter, nullptr, napi_default, nullptr},
+      {"staticCheck", nullptr, receiver_check_static, nullptr, nullptr, nullptr,
+       static_cast<napi_property_attributes>(napi_default_method | napi_static),
+       nullptr},
+  };
+  napi_value class_b;
+  NODE_API_CALL(env, napi_define_class(env, "B", NAPI_AUTO_LENGTH,
+                                       receiver_check_ctor_b, nullptr,
+                                       sizeof(b_props) / sizeof(b_props[0]),
+                                       b_props, &class_b));
+
+  napi_value result;
+  NODE_API_CALL(env, napi_create_object(env, &result));
+  NODE_API_CALL(env, napi_set_named_property(env, result, "A", class_a));
+  NODE_API_CALL(env, napi_set_named_property(env, result, "B", class_b));
+  return result;
+}
+
+static napi_value get_receiver_check_call_count(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value result;
+  NODE_API_CALL(env, napi_create_int32(env, receiver_check_method_calls, &result));
+  return result;
+}
+
 static napi_value test_constructor_with_no_prototype(const Napi::CallbackInfo &info) {
   // This test verifies that Reflect.construct with a newTarget that has no prototype
   // property doesn't crash. This was a bug where jsDynamicCast was called on a JSValue
@@ -211,6 +307,8 @@ static napi_value test_constructor_with_no_prototype(const Napi::CallbackInfo &i
 void register_class_test(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, get_class_with_constructor);
   REGISTER_FUNCTION(env, exports, test_constructor_with_no_prototype);
+  REGISTER_FUNCTION(env, exports, get_receiver_check_classes);
+  REGISTER_FUNCTION(env, exports, get_receiver_check_call_count);
 }
 
 } // namespace napitests

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -767,6 +767,30 @@ nativeTests.test_napi_class_receiver_check = () => {
   console.log("native callback calls:", nativeTests.get_receiver_check_call_count());
 };
 
+nativeTests.test_napi_class_receiver_check_gc = gc => {
+  let classes = nativeTests.get_receiver_check_classes();
+  const check = classes.B.prototype.check;
+  const b = new classes.B();
+  const a = new classes.A();
+  // Sever every other path to the class prototypes so the WriteBarrier fields
+  // on the detached method and instances are the only remaining roots.
+  Object.setPrototypeOf(b, null);
+  Object.setPrototypeOf(a, null);
+  classes = null;
+  gc();
+  gc();
+  try {
+    console.log("b after GC:", check.call(b));
+  } catch (e) {
+    console.log("b after GC:", e.name + ":", e.message);
+  }
+  try {
+    console.log("a after GC:", check.call(a));
+  } catch (e) {
+    console.log("a after GC:", e.name + ":", e.message);
+  }
+};
+
 nativeTests.test_reflect_construct_napi_class = () => {
   const NapiClass = nativeTests.get_class_with_constructor();
   let instance = Reflect.construct(NapiClass, [], Object);

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -711,6 +711,62 @@ nativeTests.test_napi_class_non_constructor_call = () => {
   console.log("global foo set to ", typeof foo != "undefined" ? foo : undefined);
 };
 
+nativeTests.test_napi_class_receiver_check = () => {
+  const { A, B } = nativeTests.get_receiver_check_classes();
+  const report = (label, fn) => {
+    try {
+      console.log(label + ":", "returned", fn());
+    } catch (e) {
+      console.log(label + ":", e.name + ":", e.message);
+    }
+  };
+
+  const a = new A();
+  const b = new B();
+  const check = B.prototype.check;
+  const getAccessor = Object.getOwnPropertyDescriptor(B.prototype, "accessor").get;
+  const setAccessor = Object.getOwnPropertyDescriptor(B.prototype, "accessor").set;
+
+  // valid receivers
+  report("b.check()", () => b.check());
+  report("getter on b", () => getAccessor.call(b));
+  report("setter on b", () => (setAccessor.call(b, 1), "ok"));
+
+  // cross-class receiver: must throw before the native callback runs
+  report("check.call(a)", () => check.call(a));
+
+  // other non-instance receivers
+  report("check.call({})", () => check.call({}));
+  report("check.call(Object.create(B.prototype))", () => check.call(Object.create(B.prototype)));
+  report("check.call(42)", () => check.call(42));
+  report("check.call(null)", () => check.call(null));
+
+  // Node.js does not apply a signature check to prototype accessors; verify
+  // Bun matches that by letting the getter/setter run for a foreign receiver.
+  report("getter on a", () => getAccessor.call(a));
+  report("setter on a", () => (setAccessor.call(a, 1), "ok"));
+
+  // JS subclass instances remain valid receivers
+  class SubB extends B {}
+  const sub = new SubB();
+  report("sub.check()", () => sub.check());
+  report("getter on sub", () => getAccessor.call(sub));
+
+  // Reflect.construct still yields a valid receiver for prototype methods
+  const reflected = Reflect.construct(B, [], function () {});
+  report("check.call(reflected)", () => check.call(reflected));
+
+  // static methods must not have a receiver check
+  report("B.staticCheck.call({})", () => B.staticCheck.call({}));
+
+  // prototype mutation does not change the receiver's identity
+  const a2 = new A();
+  Object.setPrototypeOf(a2, B.prototype);
+  report("check.call(a with B.prototype)", () => a2.check());
+
+  console.log("native callback calls:", nativeTests.get_receiver_check_call_count());
+};
+
 nativeTests.test_reflect_construct_napi_class = () => {
   const NapiClass = nativeTests.get_class_with_constructor();
   let instance = Reflect.construct(NapiClass, [], Object);

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -764,6 +764,14 @@ nativeTests.test_napi_class_receiver_check = () => {
   Object.setPrototypeOf(a2, B.prototype);
   report("check.call(a with B.prototype)", () => a2.check());
 
+  // Reassigning the constructor's .prototype must not change which class the
+  // receiver check considers an instance to belong to.
+  const savedBProto = B.prototype;
+  B.prototype = A.prototype;
+  const b3 = new B();
+  report("check.call(b with swapped B.prototype)", () => check.call(b3));
+  B.prototype = savedBProto;
+
   console.log("native callback calls:", nativeTests.get_receiver_check_call_count());
 };
 

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -910,6 +910,26 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     it("does not crash with Reflect.construct when newTarget has no prototype", async () => {
       await checkSameOutput("test_reflect_construct_no_prototype_crash", []);
     });
+
+    it("throws Illegal invocation when a prototype method is called with a foreign receiver", async () => {
+      const output = await checkSameOutput("test_napi_class_receiver_check", []);
+      expect(output).toContain("b.check(): returned 0");
+      expect(output).toContain("check.call(a): TypeError: Illegal invocation");
+      expect(output).toContain("check.call({}): TypeError: Illegal invocation");
+      expect(output).toContain("check.call(Object.create(B.prototype)): TypeError: Illegal invocation");
+      expect(output).toContain("check.call(42): TypeError: Illegal invocation");
+      expect(output).toContain("check.call(null): TypeError: Illegal invocation");
+      // Node.js does not put accessors behind a signature check.
+      expect(output).toContain("getter on a: returned 1");
+      expect(output).toContain("setter on a: returned ok");
+      expect(output).toContain("sub.check(): returned 0");
+      expect(output).toContain("check.call(reflected): returned 0");
+      expect(output).toContain("B.staticCheck.call({}): returned static");
+      expect(output).toContain("check.call(a with B.prototype): TypeError: Illegal invocation");
+      // 3 on b + 2 accessor on a + 2 on sub + 1 on reflected = 8; the native
+      // method callback must not have been reached for any rejected receiver.
+      expect(output).toContain("native callback calls: 8");
+    });
   });
 
   describe("bigint conversion to int64/uint64", () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -930,6 +930,12 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       // method callback must not have been reached for any rejected receiver.
       expect(output).toContain("native callback calls: 8");
     });
+
+    it("keeps the receiver check working after GC drops the class", async () => {
+      const output = await checkSameOutput("test_napi_class_receiver_check_gc", []);
+      expect(output).toContain("b after GC: 0");
+      expect(output).toContain("a after GC: TypeError: Illegal invocation");
+    });
   });
 
   describe("bigint conversion to int64/uint64", () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -926,9 +926,10 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(output).toContain("check.call(reflected): returned 0");
       expect(output).toContain("B.staticCheck.call({}): returned static");
       expect(output).toContain("check.call(a with B.prototype): TypeError: Illegal invocation");
-      // 3 on b + 2 accessor on a + 2 on sub + 1 on reflected = 8; the native
-      // method callback must not have been reached for any rejected receiver.
-      expect(output).toContain("native callback calls: 8");
+      expect(output).toContain("check.call(b with swapped B.prototype): returned 0");
+      // 3 on b + 2 accessor on a + 2 on sub + 1 on reflected + 1 on b3 = 9;
+      // the callback must not have been reached for any rejected receiver.
+      expect(output).toContain("native callback calls: 9");
     });
 
     it("keeps the receiver check working after GC drops the class", async () => {


### PR DESCRIPTION
## What

`napi_define_class` prototype methods now throw `TypeError: Illegal invocation` when called with a receiver that was not constructed by the defining class, matching Node.js.

## Why

Node.js builds `napi_define_class` prototype methods on the class's `FunctionTemplate` with a `v8::Signature`, so V8 rejects any call whose receiver is not an instance of that template before the native callback runs. Bun attached prototype methods as plain functions with no such check, so this reached the addon:

```c
// addon
typedef struct { int64_t val; } a_t;                 // 8 bytes
typedef struct { double d[4]; uint64_t tag; } b_t;   // 40 bytes
// A wraps an a_t*, B wraps a b_t*; B.prototype.read unwraps and reads as b_t*
```
```js
const { A, B } = require('./addon.node');
B.prototype.read.call(new A());
// node: TypeError: Illegal invocation
// bun:  callback runs, napi_unwrap returns A's 8-byte allocation,
//       addon reads 40 bytes -> heap over-read
```

Any JS in the process could hand one native class's method another class's instance (or `{}`, `Object.create(B.prototype)`, a primitive, etc.) and reach the addon's `napi_unwrap` with a foreign pointer. Addons written against Node's guarantee (including `node-addon-api` `ObjectWrap`) unwrap unchecked.

## How

* `NapiPrototype` gains a `m_constructedBy` write barrier that `NapiClass_ConstructorFunction<true>` sets to the class's prototype object on every instance it allocates. The subclass/`Reflect.construct` path now allocates a `NapiPrototype` (instead of a plain object) so the stamp has somewhere to live; `napi_wrap` already handles both shapes.
* `NapiClass` gains a `m_signaturePrototype` write barrier that `Napi::defineProperty` sets on non-static prototype **methods** only (Node.js does not apply the signature check to accessors). Static methods, `napi_create_function` and `napi_define_properties` are untouched.
* `NapiClass_ConstructorFunction<false>` compares the receiver's `constructedBy` against the callee's `signaturePrototype` when the latter is set, and throws `TypeError: Illegal invocation` on mismatch before the native callback runs.

## Test

`test_napi_class_receiver_check` in `test/napi/napi.test.ts` defines two wrapped classes and asserts Bun's output is identical to Node's for:

* `b.check()`, a JS subclass instance, and a `Reflect.construct(B, ...)` instance: callback runs, `napi_unwrap` returns `napi_ok`.
* `check.call(new A())`, `check.call({})`, `check.call(Object.create(B.prototype))`, `check.call(42)`, `check.call(null)`, and an `A` instance with `__proto__` set to `B.prototype`: `TypeError: Illegal invocation`, callback never reached.
* Accessors on a foreign receiver and `B.staticCheck.call({})`: callback runs (no signature check, same as Node).
* A native-side call counter proves the rejected cases never entered the callback.

The existing `6_object_wrap`, `7_factory_wrap`, `8_passing_wrapped`, `test_constructor`, `test_new_target` and `test_reference_double_free` node-api tests continue to pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->