### PR TITLE
fix(runtime): clamp UV_THREADPOOL_SIZE below floor instead of discarding it

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2865,12 +2865,17 @@ pub fn get_thread_count() -> u16 {
                 crate::zstr!("UV_THREADPOOL_SIZE"),
                 crate::zstr!("GOMAXPROCS"),
             ] {
+                // A set override is always honoured (clamped), never discarded:
+                // libuv does `atoi(val); if 0 → 1; cap 1024`, so `=1`/`=0`/junk
+                // all yield the floor. Previously `n < MIN` fell through to
+                // `numberOfProcessorCores()`, turning `UV_THREADPOOL_SIZE=1`
+                // into <cores> threads.
                 if let Some(v) = getenv_z(key) {
-                    if let Ok(n) = crate::fmt::parse_int::<u16>(v.trim_ascii(), 10) {
-                        if n >= MIN {
-                            return Some(n.min(MAX));
-                        }
-                    }
+                    return Some(
+                        crate::fmt::parse_int::<u16>(v.trim_ascii(), 10)
+                            .unwrap_or(0)
+                            .clamp(MIN, MAX),
+                    );
                 }
                 // Windows: `getenv_z` is currently a no-op (no narrow C
                 // environ to borrow from); honour the override via
@@ -2881,11 +2886,7 @@ pub fn get_thread_count() -> u16 {
                     // SAFETY: keys above are ASCII literals.
                     unsafe { core::str::from_utf8_unchecked(key.as_bytes()) },
                 ) {
-                    if let Ok(n) = s.trim().parse::<u16>() {
-                        if n >= MIN {
-                            return Some(n.min(MAX));
-                        }
-                    }
+                    return Some(s.trim().parse::<u16>().unwrap_or(0).clamp(MIN, MAX));
                 }
             }
             None

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2865,11 +2865,7 @@ pub fn get_thread_count() -> u16 {
                 crate::zstr!("UV_THREADPOOL_SIZE"),
                 crate::zstr!("GOMAXPROCS"),
             ] {
-                // A set override is always honoured (clamped), never discarded:
-                // libuv does `atoi(val); if 0 → 1; cap 1024`, so `=1`/`=0`/junk
-                // all yield the floor. Previously `n < MIN` fell through to
-                // `numberOfProcessorCores()`, turning `UV_THREADPOOL_SIZE=1`
-                // into <cores> threads.
+                // Set var is always honoured (libuv semantics): unparseable/0/1 → MIN, not core count.
                 if let Some(v) = getenv_z(key) {
                     return Some(
                         crate::fmt::parse_int::<u16>(v.trim_ascii(), 10)

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2865,13 +2865,14 @@ pub fn get_thread_count() -> u16 {
                 crate::zstr!("UV_THREADPOOL_SIZE"),
                 crate::zstr!("GOMAXPROCS"),
             ] {
-                // Set var is always honoured (libuv semantics): unparseable/0/1 → MIN, not core count.
+                // Set var is always honoured (libuv semantics): junk/0/1 → MIN, overflow → MAX.
                 if let Some(v) = getenv_z(key) {
-                    return Some(
-                        crate::fmt::parse_int::<u16>(v.trim_ascii(), 10)
-                            .unwrap_or(0)
-                            .clamp(MIN, MAX),
-                    );
+                    use crate::fmt::ParseIntError;
+                    return Some(match crate::fmt::parse_int::<u32>(v.trim_ascii(), 10) {
+                        Ok(n) => n.clamp(u32::from(MIN), u32::from(MAX)) as u16,
+                        Err(ParseIntError::Overflow) => MAX,
+                        Err(ParseIntError::InvalidCharacter) => MIN,
+                    });
                 }
                 // Windows: `getenv_z` is currently a no-op (no narrow C
                 // environ to borrow from); honour the override via
@@ -2882,7 +2883,12 @@ pub fn get_thread_count() -> u16 {
                     // SAFETY: keys above are ASCII literals.
                     unsafe { core::str::from_utf8_unchecked(key.as_bytes()) },
                 ) {
-                    return Some(s.trim().parse::<u16>().unwrap_or(0).clamp(MIN, MAX));
+                    use core::num::IntErrorKind;
+                    return Some(match s.trim().parse::<u32>() {
+                        Ok(n) => n.clamp(u32::from(MIN), u32::from(MAX)) as u16,
+                        Err(e) if *e.kind() == IntErrorKind::PosOverflow => MAX,
+                        Err(_) => MIN,
+                    });
                 }
             }
             None

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2881,9 +2881,7 @@ pub fn get_thread_count() -> u16 {
                 if let Some(v) = getenv_z(key) {
                     return Some(parse(v));
                 }
-                // Windows: `getenv_z` is currently a no-op (no narrow C environ
-                // to borrow from); read via `std::env::var` and route through
-                // the same parser so accepted grammar matches POSIX.
+                // Windows: `getenv_z` is a no-op there (no narrow C environ).
                 #[cfg(windows)]
                 if let Ok(s) = std::env::var(
                     // SAFETY: keys above are ASCII literals.

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2860,34 +2860,23 @@ pub fn get_thread_count() -> u16 {
     *CELL.get_or_init(|| {
         const MAX: u16 = 1024;
         const MIN: u16 = 2;
-        // Set var is always honoured (libuv semantics): junk/0/1/negative → MIN, overflow → MAX.
-        let parse = |v: &[u8]| -> u16 {
-            use crate::fmt::ParseIntError;
-            let v = v.trim_ascii();
-            if v.first() == Some(&b'-') {
-                return MIN;
-            }
-            match crate::fmt::parse_int::<u32>(v, 10) {
-                Ok(n) => n.clamp(u32::from(MIN), u32::from(MAX)) as u16,
-                Err(ParseIntError::Overflow) => MAX,
-                Err(ParseIntError::InvalidCharacter) => MIN,
-            }
-        };
         let from_env = || -> Option<u16> {
             for key in [
                 crate::zstr!("UV_THREADPOOL_SIZE"),
                 crate::zstr!("GOMAXPROCS"),
             ] {
+                // Set var is always honoured (libuv semantics): junk/0/1/negative → MIN, overflow → MAX.
                 if let Some(v) = getenv_z(key) {
-                    return Some(parse(v));
-                }
-                // Windows: `getenv_z` is a no-op there (no narrow C environ).
-                #[cfg(windows)]
-                if let Ok(s) = std::env::var(
-                    // SAFETY: keys above are ASCII literals.
-                    unsafe { core::str::from_utf8_unchecked(key.as_bytes()) },
-                ) {
-                    return Some(parse(s.as_bytes()));
+                    use crate::fmt::ParseIntError;
+                    let v = v.trim_ascii();
+                    if v.first() == Some(&b'-') {
+                        return Some(MIN);
+                    }
+                    return Some(match crate::fmt::parse_int::<u32>(v, 10) {
+                        Ok(n) => n.clamp(u32::from(MIN), u32::from(MAX)) as u16,
+                        Err(ParseIntError::Overflow) => MAX,
+                        Err(ParseIntError::InvalidCharacter) => MIN,
+                    });
                 }
             }
             None

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2860,37 +2860,36 @@ pub fn get_thread_count() -> u16 {
     *CELL.get_or_init(|| {
         const MAX: u16 = 1024;
         const MIN: u16 = 2;
+        // Set var is always honoured (libuv semantics): junk/0/1/negative → MIN, overflow → MAX.
+        let parse = |v: &[u8]| -> u16 {
+            use crate::fmt::ParseIntError;
+            let v = v.trim_ascii();
+            if v.first() == Some(&b'-') {
+                return MIN;
+            }
+            match crate::fmt::parse_int::<u32>(v, 10) {
+                Ok(n) => n.clamp(u32::from(MIN), u32::from(MAX)) as u16,
+                Err(ParseIntError::Overflow) => MAX,
+                Err(ParseIntError::InvalidCharacter) => MIN,
+            }
+        };
         let from_env = || -> Option<u16> {
             for key in [
                 crate::zstr!("UV_THREADPOOL_SIZE"),
                 crate::zstr!("GOMAXPROCS"),
             ] {
-                // Set var is always honoured (libuv semantics): junk/0/1 → MIN, overflow → MAX.
                 if let Some(v) = getenv_z(key) {
-                    use crate::fmt::ParseIntError;
-                    return Some(
-                        match crate::fmt::parse_unsigned::<u32>(v.trim_ascii(), 10) {
-                            Ok(n) => n.clamp(u32::from(MIN), u32::from(MAX)) as u16,
-                            Err(ParseIntError::Overflow) => MAX,
-                            Err(ParseIntError::InvalidCharacter) => MIN,
-                        },
-                    );
+                    return Some(parse(v));
                 }
-                // Windows: `getenv_z` is currently a no-op (no narrow C
-                // environ to borrow from); honour the override via
-                // `std::env::var` so behaviour matches
-                // on all platforms. POSIX keeps the borrow path above.
+                // Windows: `getenv_z` is currently a no-op (no narrow C environ
+                // to borrow from); read via `std::env::var` and route through
+                // the same parser so accepted grammar matches POSIX.
                 #[cfg(windows)]
                 if let Ok(s) = std::env::var(
                     // SAFETY: keys above are ASCII literals.
                     unsafe { core::str::from_utf8_unchecked(key.as_bytes()) },
                 ) {
-                    use core::num::IntErrorKind;
-                    return Some(match s.trim().parse::<u32>() {
-                        Ok(n) => n.clamp(u32::from(MIN), u32::from(MAX)) as u16,
-                        Err(e) if *e.kind() == IntErrorKind::PosOverflow => MAX,
-                        Err(_) => MIN,
-                    });
+                    return Some(parse(s.as_bytes()));
                 }
             }
             None

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2868,7 +2868,7 @@ pub fn get_thread_count() -> u16 {
                 // Set var is always honoured (libuv semantics): junk/0/1 → MIN, overflow → MAX.
                 if let Some(v) = getenv_z(key) {
                     use crate::fmt::ParseIntError;
-                    return Some(match crate::fmt::parse_int::<u32>(v.trim_ascii(), 10) {
+                    return Some(match crate::fmt::parse_unsigned::<u32>(v.trim_ascii(), 10) {
                         Ok(n) => n.clamp(u32::from(MIN), u32::from(MAX)) as u16,
                         Err(ParseIntError::Overflow) => MAX,
                         Err(ParseIntError::InvalidCharacter) => MIN,

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2868,11 +2868,13 @@ pub fn get_thread_count() -> u16 {
                 // Set var is always honoured (libuv semantics): junk/0/1 → MIN, overflow → MAX.
                 if let Some(v) = getenv_z(key) {
                     use crate::fmt::ParseIntError;
-                    return Some(match crate::fmt::parse_unsigned::<u32>(v.trim_ascii(), 10) {
-                        Ok(n) => n.clamp(u32::from(MIN), u32::from(MAX)) as u16,
-                        Err(ParseIntError::Overflow) => MAX,
-                        Err(ParseIntError::InvalidCharacter) => MIN,
-                    });
+                    return Some(
+                        match crate::fmt::parse_unsigned::<u32>(v.trim_ascii(), 10) {
+                            Ok(n) => n.clamp(u32::from(MIN), u32::from(MAX)) as u16,
+                            Err(ParseIntError::Overflow) => MAX,
+                            Err(ParseIntError::InvalidCharacter) => MIN,
+                        },
+                    );
                 }
                 // Windows: `getenv_z` is currently a no-op (no narrow C
                 // environ to borrow from); honour the override via

--- a/test/js/bun/util/uv-threadpool-size.test.ts
+++ b/test/js/bun/util/uv-threadpool-size.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux } from "harness";
 
 // UV_THREADPOOL_SIZE / GOMAXPROCS controls the worker pool size (clamped to
@@ -45,11 +45,7 @@ describe.skipIf(!isLinux)("UV_THREADPOOL_SIZE", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
     return Number(stdout.trim());

--- a/test/js/bun/util/uv-threadpool-size.test.ts
+++ b/test/js/bun/util/uv-threadpool-size.test.ts
@@ -67,6 +67,10 @@ describe.skipIf(!isLinux)("UV_THREADPOOL_SIZE", () => {
     expect(await poolThreads({ UV_THREADPOOL_SIZE: "4" })).toBe(4);
   });
 
+  test.concurrent("=999999 caps at ceiling, does not collapse to floor", async () => {
+    expect(await poolThreads({ UV_THREADPOOL_SIZE: "999999" })).toBeGreaterThan(4);
+  });
+
   test.concurrent("GOMAXPROCS=1 clamps to floor (2)", async () => {
     expect(await poolThreads({ GOMAXPROCS: "1" })).toBe(2);
   });

--- a/test/js/bun/util/uv-threadpool-size.test.ts
+++ b/test/js/bun/util/uv-threadpool-size.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect } from "bun:test";
+import { bunEnv, bunExe, isLinux } from "harness";
+
+// UV_THREADPOOL_SIZE / GOMAXPROCS controls the worker pool size (clamped to
+// [2, 1024]). Values below the floor, zero, or unparseable must clamp to the
+// floor (matching libuv's `atoi → if 0 then 1`), not fall through to
+// `numberOfProcessorCores()`.
+//
+// Counting live pool threads requires /proc/self/task, so this is Linux-only.
+describe.skipIf(!isLinux)("UV_THREADPOOL_SIZE", () => {
+  // Flood the pool with slow CPU jobs, then poll /proc/self/task until the
+  // "Bun Pool" thread count is stable across several reads. Exits without
+  // waiting for the jobs to finish.
+  const script = /* js */ `
+    const fs = require("node:fs");
+    const crypto = require("node:crypto");
+    for (let i = 0; i < 32; i++)
+      crypto.pbkdf2("p" + i, "s", 1 << 20, 32, "sha256", () => {});
+    const count = () => {
+      let n = 0;
+      for (const tid of fs.readdirSync("/proc/self/task"))
+        try {
+          if (fs.readFileSync("/proc/self/task/" + tid + "/comm", "utf8").startsWith("Bun Pool"))
+            n++;
+        } catch {}
+      return n;
+    };
+    let last = -1, stable = 0;
+    const iv = setInterval(() => {
+      const n = count();
+      if (n === last && n > 0) stable++;
+      else { stable = 0; last = n; }
+      if (stable >= 5) {
+        clearInterval(iv);
+        console.log(n);
+        process.exit(0);
+      }
+    }, 20);
+  `;
+
+  async function poolThreads(env: Record<string, string | undefined>) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, UV_THREADPOOL_SIZE: undefined, GOMAXPROCS: undefined, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return Number(stdout.trim());
+  }
+
+  test.concurrent("=1 clamps to floor (2), does not fall through to core count", async () => {
+    expect(await poolThreads({ UV_THREADPOOL_SIZE: "1" })).toBe(2);
+  });
+
+  test.concurrent("=0 clamps to floor (2)", async () => {
+    expect(await poolThreads({ UV_THREADPOOL_SIZE: "0" })).toBe(2);
+  });
+
+  test.concurrent("unparseable clamps to floor (2)", async () => {
+    expect(await poolThreads({ UV_THREADPOOL_SIZE: "abc" })).toBe(2);
+  });
+
+  test.concurrent("=4 is honoured exactly", async () => {
+    expect(await poolThreads({ UV_THREADPOOL_SIZE: "4" })).toBe(4);
+  });
+
+  test.concurrent("GOMAXPROCS=1 clamps to floor (2)", async () => {
+    expect(await poolThreads({ GOMAXPROCS: "1" })).toBe(2);
+  });
+});

--- a/test/js/bun/util/uv-threadpool-size.test.ts
+++ b/test/js/bun/util/uv-threadpool-size.test.ts
@@ -25,7 +25,7 @@ describe.skipIf(!isLinux)("UV_THREADPOOL_SIZE", () => {
         } catch {}
       return n;
     };
-    let last = -1, stable = 0;
+    let last = -1, stable = 0, ticks = 0;
     const iv = setInterval(() => {
       const n = count();
       if (n === last && n > 0) stable++;
@@ -34,6 +34,14 @@ describe.skipIf(!isLinux)("UV_THREADPOOL_SIZE", () => {
         clearInterval(iv);
         console.log(n);
         process.exit(0);
+      }
+      if (++ticks > 200) {
+        clearInterval(iv);
+        const names = fs.readdirSync("/proc/self/task").map(t => {
+          try { return fs.readFileSync("/proc/self/task/" + t + "/comm", "utf8").trim(); } catch { return "?"; }
+        });
+        console.error("pool never stabilized; threads:", JSON.stringify(names));
+        process.exit(1);
       }
     }, 20);
   `;

--- a/test/js/bun/util/uv-threadpool-size.test.ts
+++ b/test/js/bun/util/uv-threadpool-size.test.ts
@@ -63,6 +63,10 @@ describe.skipIf(!isLinux)("UV_THREADPOOL_SIZE", () => {
     expect(await poolThreads({ UV_THREADPOOL_SIZE: "abc" })).toBe(2);
   });
 
+  test.concurrent("negative clamps to floor (2)", async () => {
+    expect(await poolThreads({ UV_THREADPOOL_SIZE: "-3" })).toBe(2);
+  });
+
   test.concurrent("=4 is honoured exactly", async () => {
     expect(await poolThreads({ UV_THREADPOOL_SIZE: "4" })).toBe(4);
   });

--- a/test/js/bun/util/uv-threadpool-size.test.ts
+++ b/test/js/bun/util/uv-threadpool-size.test.ts
@@ -79,6 +79,10 @@ describe.skipIf(!isLinux)("UV_THREADPOOL_SIZE", () => {
     expect(await poolThreads({ UV_THREADPOOL_SIZE: "4" })).toBe(4);
   });
 
+  test.concurrent("leading + is accepted (=+5 → 5)", async () => {
+    expect(await poolThreads({ UV_THREADPOOL_SIZE: "+5" })).toBe(5);
+  });
+
   test.concurrent(">u32::MAX caps at ceiling (Overflow arm), does not collapse to floor", async () => {
     expect(await poolThreads({ UV_THREADPOOL_SIZE: "99999999999" })).toBeGreaterThan(4);
   });

--- a/test/js/bun/util/uv-threadpool-size.test.ts
+++ b/test/js/bun/util/uv-threadpool-size.test.ts
@@ -71,8 +71,8 @@ describe.skipIf(!isLinux)("UV_THREADPOOL_SIZE", () => {
     expect(await poolThreads({ UV_THREADPOOL_SIZE: "4" })).toBe(4);
   });
 
-  test.concurrent("=999999 caps at ceiling, does not collapse to floor", async () => {
-    expect(await poolThreads({ UV_THREADPOOL_SIZE: "999999" })).toBeGreaterThan(4);
+  test.concurrent(">u32::MAX caps at ceiling (Overflow arm), does not collapse to floor", async () => {
+    expect(await poolThreads({ UV_THREADPOOL_SIZE: "99999999999" })).toBeGreaterThan(4);
   });
 
   test.concurrent("GOMAXPROCS=1 clamps to floor (2)", async () => {


### PR DESCRIPTION
## Problem

`get_thread_count()` reads `UV_THREADPOOL_SIZE` / `GOMAXPROCS` but rejects any parsed value `< 2` (and any unparseable value) by returning `None`, which falls through to `WTF::numberOfProcessorCores()`. So on a 64-core host, `UV_THREADPOOL_SIZE=1` yields **64** pool threads instead of the minimum the user asked for. `=0`, `=abc`, and `=-3` behave the same way.

Node/libuv honours any set value: `atoi(val)`, clamp `0 -> 1`, cap at 1024. `UV_THREADPOOL_SIZE=1` gives exactly 1 thread there (a value people set on purpose to serialize disk work).

## Repro

```js
// UV_THREADPOOL_SIZE=1 bun repro.mjs  -> "Bun Pool #":<cores>   (expected: 2)
// UV_THREADPOOL_SIZE=8 bun repro.mjs  -> 8 (honoured)
import fs from "node:fs"; import crypto from "node:crypto";
for (let i = 0; i < 200; i++) crypto.pbkdf2("p"+i, "s", 400000, 32, "sha256", ()=>{});
await new Promise(r => setTimeout(r, 300));
const t = {}; for (const tid of fs.readdirSync("/proc/self/task")) {
  const c = fs.readFileSync(`/proc/self/task/${tid}/comm`, "utf8").trim().replace(/[0-9]+$/, "#");
  t[c] = (t[c]||0)+1;
}
console.log(JSON.stringify(t));
```

## Fix

When the override env var is set, always honour it clamped to `[2, 1024]`: parse, `unwrap_or(0)`, `.clamp(MIN, MAX)`. Unparseable input now yields the floor (2) rather than the core count, matching libuv's effective behaviour. Unset still falls through to `numberOfProcessorCores()`.

Applied to both the POSIX `getenv_z` path and the Windows `std::env::var` path.

## Verification

`test/js/bun/util/uv-threadpool-size.test.ts` (Linux-only, counts `Bun Pool` threads via `/proc/self/task`):

| env                       | before (16-core) | after |
|---------------------------|------------------|-------|
| `UV_THREADPOOL_SIZE=1`    | 12+              | 2     |
| `UV_THREADPOOL_SIZE=0`    | 12+              | 2     |
| `UV_THREADPOOL_SIZE=abc`  | 12+              | 2     |
| `UV_THREADPOOL_SIZE=4`    | 4                | 4     |
| `GOMAXPROCS=1`            | 12+              | 2     |

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/uv-threadpool-size.test.ts

<!-- robobun:evidence:end -->