### PR TITLE
work_pool: cap CPU-bound job concurrency at cores-1 so the event loop keeps a core

### DIFF
--- a/src/jsc/ConcurrentPromiseTask.rs
+++ b/src/jsc/ConcurrentPromiseTask.rs
@@ -16,6 +16,10 @@ pub trait ConcurrentPromiseTaskContext: Sized {
     /// JS event loop's concurrent queue (`task_tag::*`).
     const TASK_TAG: TaskTag;
 
+    /// Whether [`run`](Self::run) is CPU-bound and should hold a
+    /// [`WorkPool::cpu_permit`]. Override to `false` for I/O bodies.
+    const CPU_BOUND: bool = true;
+
     fn run(&mut self);
     fn then(&mut self, promise: &mut JSPromise) -> Result<(), JsTerminated>;
 }
@@ -83,9 +87,12 @@ impl<'a, Context: ConcurrentPromiseTaskContext> ConcurrentPromiseTask<'a, Contex
         // field, so `from_task_ptr` recovers the live heap `Self` parent,
         // exclusively owned by the work pool for this callback's duration.
         let this = unsafe { Self::from_task_ptr(task) };
-        // SAFETY: `this` is alive for the duration of the thread-pool callback;
-        // exclusively owned by the work pool at this point.
-        unsafe { (*this).ctx.run() };
+        {
+            let _permit = Context::CPU_BOUND.then(WorkPool::cpu_permit);
+            // SAFETY: `this` is alive for the duration of the thread-pool callback;
+            // exclusively owned by the work pool at this point.
+            unsafe { (*this).ctx.run() };
+        }
         Self::on_finish(this);
     }
 

--- a/src/jsc/CppTask.rs
+++ b/src/jsc/CppTask.rs
@@ -76,8 +76,7 @@ impl ConcurrentCppTask {
         let maybe_vm = EventLoopTaskNoContext::opaque_ref(cpp_task).get_vm();
         drop(self);
         {
-            // Only dispatched via `PhonyWorkQueue` (WebCrypto SubtleCrypto),
-            // whose bodies are compute (AES/RSA/EC/SHA/PBKDF2/HKDF).
+            // Only caller is WebCrypto's `PhonyWorkQueue`; those bodies are compute.
             let _permit = WorkPool::cpu_permit();
             // SAFETY: `cpp_task` is the valid C++ handle stored by `ConcurrentCppTask__createAndRun`;
             // `opaque_ref` above proved it non-null and it has not yet been freed — `run` consumes it here.

--- a/src/jsc/CppTask.rs
+++ b/src/jsc/CppTask.rs
@@ -75,9 +75,14 @@ impl ConcurrentCppTask {
         // is the centralised non-null deref proof. Valid until `run` consumes it.
         let maybe_vm = EventLoopTaskNoContext::opaque_ref(cpp_task).get_vm();
         drop(self);
-        // SAFETY: `cpp_task` is the valid C++ handle stored by `ConcurrentCppTask__createAndRun`;
-        // `opaque_ref` above proved it non-null and it has not yet been freed — `run` consumes it here.
-        unsafe { EventLoopTaskNoContext::run(cpp_task) };
+        {
+            // Only dispatched via `PhonyWorkQueue` (WebCrypto SubtleCrypto),
+            // whose bodies are compute (AES/RSA/EC/SHA/PBKDF2/HKDF).
+            let _permit = WorkPool::cpu_permit();
+            // SAFETY: `cpp_task` is the valid C++ handle stored by `ConcurrentCppTask__createAndRun`;
+            // `opaque_ref` above proved it non-null and it has not yet been freed — `run` consumes it here.
+            unsafe { EventLoopTaskNoContext::run(cpp_task) };
+        }
         if let Some(vm) = maybe_vm {
             vm.event_loop_shared().unref_concurrently();
         }

--- a/src/jsc/JSSecrets.rs
+++ b/src/jsc/JSSecrets.rs
@@ -24,6 +24,9 @@ pub(crate) struct SecretsCtx {
 }
 
 impl AnyTaskJobCtx for SecretsCtx {
+    // Keychain / secret-service IPC, not compute.
+    const CPU_BOUND: bool = false;
+
     fn run(&mut self, global: *mut JSGlobalObject) {
         // `ctx` is a valid C++ SecretsJobOptions* held alive until Drop;
         // `global` is the creating VM's global pointer. Both are `opaque_ffi!`

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -568,6 +568,7 @@ impl TranspilerJob {
         // `transpile`; the WorkPool calls back with exactly that field, so
         // `from_field_ptr!` recovers the live heap `TranspilerJob` parent.
         let this = unsafe { &mut *bun_core::from_field_ptr!(TranspilerJob, work_task, work_task) };
+        let _permit = WorkPool::cpu_permit();
         this.run();
     }
 

--- a/src/jsc/any_task_job.rs
+++ b/src/jsc/any_task_job.rs
@@ -25,6 +25,12 @@ use crate::{JSGlobalObject, JsResult, VirtualMachineRef as VirtualMachine};
 /// (from `run_from_js`'s `heap::take`) on every exit, including the
 /// `is_shutting_down` early-out and `init` failure.
 pub trait AnyTaskJobCtx: Sized {
+    /// Whether [`run`](Self::run) is CPU-bound and should count against the
+    /// [`WorkPool::cpu_permit`] concurrency cap. Defaults to `true` (every
+    /// in-tree implementor is crypto/compression) — override to `false` for
+    /// IPC/I/O bodies that merely block.
+    const CPU_BOUND: bool = true;
+
     /// Optional fallible JS-thread setup, run after heap allocation but before
     /// `schedule`. On error the job is freed (running `Drop`). Default: no-op.
     #[inline]
@@ -140,7 +146,10 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
         // `run_from_js` reclaims it.
         let job = unsafe { &mut *Self::from_task_ptr(task) };
         let vm = job.vm;
-        job.ctx.run(vm.global);
+        {
+            let _permit = C::CPU_BOUND.then(WorkPool::cpu_permit);
+            job.ctx.run(vm.global);
+        }
         // `ConcurrentTask::create` heap-allocates a fresh task; the queue takes
         // ownership of it.
         vm.event_loop_shared()

--- a/src/jsc/any_task_job.rs
+++ b/src/jsc/any_task_job.rs
@@ -25,10 +25,8 @@ use crate::{JSGlobalObject, JsResult, VirtualMachineRef as VirtualMachine};
 /// (from `run_from_js`'s `heap::take`) on every exit, including the
 /// `is_shutting_down` early-out and `init` failure.
 pub trait AnyTaskJobCtx: Sized {
-    /// Whether [`run`](Self::run) is CPU-bound and should count against the
-    /// [`WorkPool::cpu_permit`] concurrency cap. Defaults to `true` (every
-    /// in-tree implementor is crypto/compression) — override to `false` for
-    /// IPC/I/O bodies that merely block.
+    /// Whether [`run`](Self::run) is CPU-bound and should hold a
+    /// [`WorkPool::cpu_permit`]. Override to `false` for IPC/I/O bodies.
     const CPU_BOUND: bool = true;
 
     /// Optional fallible JS-thread setup, run after heap allocation but before

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -236,6 +236,7 @@ impl<'a> WalkTask<'a> {
 
 impl<'a> ConcurrentPromiseTaskContext for WalkTask<'a> {
     const TASK_TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::AsyncGlobWalkTask;
+    const CPU_BOUND: bool = false;
     fn run(&mut self) {
         let guard = scopeguard::guard(self.has_pending_activity, |hpa| {
             decr_pending_activity_flag(hpa);

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -572,7 +572,10 @@ impl<Op: PasswordOp> PasswordJob<Op> {
     // is a false positive on this macro contract.
     #[allow(clippy::boxed_local)]
     fn run_owned(mut self: Box<Self>) {
-        let value = self.op.compute(&self.password);
+        let value = {
+            let _permit = WorkPool::cpu_permit();
+            self.op.compute(&self.password)
+        };
         let result = bun_core::heap::into_raw(Box::new(PasswordResult::<Op> {
             value,
             task: AnyTask::default(), // overwritten below

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -481,7 +481,10 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
             NonNull::new(global_this.bun_vm_concurrently()).expect("bun_vm_concurrently"),
         );
 
-        this_ref.stream().with_mut(|s| s.do_work());
+        {
+            let _permit = WorkPool::cpu_permit();
+            this_ref.stream().with_mut(|s| s.do_work());
+        }
 
         // SAFETY: `event_loop()` is a self-pointer into a live VM; the
         // `enqueue_task_concurrent` body only touches the lock-free

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -69,6 +69,7 @@ impl MkdirpTarget for CopyFile<'_> {
 
 impl jsc::concurrent_promise_task::ConcurrentPromiseTaskContext for CopyFile<'_> {
     const TASK_TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::CopyFilePromiseTask;
+    const CPU_BOUND: bool = false;
     fn run(&mut self) {
         self.run_async();
     }

--- a/src/threading/Semaphore.rs
+++ b/src/threading/Semaphore.rs
@@ -32,10 +32,15 @@ impl Default for Semaphore {
 impl Semaphore {
     /// Const-init with zero permits.
     pub const fn new() -> Self {
+        Self::with_permits(0)
+    }
+
+    /// Const-init with `n` permits available.
+    pub const fn with_permits(n: usize) -> Self {
         Self {
             mutex: Mutex::new(),
             cond: Condition::new(),
-            permits: UnsafeCell::new(0),
+            permits: UnsafeCell::new(n),
         }
     }
 

--- a/src/threading/lib.rs
+++ b/src/threading/lib.rs
@@ -39,7 +39,7 @@ pub use thread_pool::ThreadPool;
 pub use unbounded_queue::{Link, Linked, UnboundedQueue};
 pub use wait_group::WaitGroup;
 pub use work_pool::Task as WorkPoolTask;
-pub use work_pool::{IntrusiveWorkTask, OwnedTask, WorkPool};
+pub use work_pool::{CpuPermit, IntrusiveWorkTask, OwnedTask, WorkPool};
 
 /// Returns a non-zero OS thread id.
 /// Used by `Mutex` debug deadlock detection and `Condition` (Windows).

--- a/src/threading/work_pool.rs
+++ b/src/threading/work_pool.rs
@@ -140,17 +140,11 @@ fn create() -> ThreadPool {
     })
 }
 
-/// Concurrency cap for CPU-bound pool jobs (crypto KDFs, compression, WebCrypto).
-///
-/// Sized to `get_thread_count() - 1` (min 1) so a full CPU flood leaves one
-/// core free for the JS thread; the pool itself stays at `get_thread_count()`
-/// so I/O-bound jobs (fs, dns) are unaffected. Acquired via
-/// [`WorkPool::cpu_permit`] from a worker thread immediately before the
-/// compute body; released on drop.
 static CPU_SEM: OnceLock<Semaphore> = OnceLock::new();
 
 #[cold]
 fn create_cpu_sem() -> Semaphore {
+    // One fewer than the pool so a CPU flood leaves a core for the JS thread.
     let n = usize::from(bun_core::get_thread_count().saturating_sub(1).max(1));
     Semaphore::with_permits(n)
 }
@@ -172,13 +166,9 @@ impl WorkPool {
         POOL.get_or_init(create)
     }
 
-    /// Acquire one CPU-bound concurrency slot, blocking the calling worker
-    /// thread until one is free. Held for the duration of the compute body
-    /// and released on drop.
-    ///
-    /// Call this from the worker thread (inside the task callback), not from
-    /// the JS thread: blocking the JS thread here would deadlock it against
-    /// the very pool jobs it is waiting on.
+    /// Acquire one CPU-bound concurrency slot (pool size minus one), blocking
+    /// the calling worker until free. Must only be called from a worker
+    /// thread; calling from the JS thread can deadlock.
     pub fn cpu_permit() -> CpuPermit {
         let sem = CPU_SEM.get_or_init(create_cpu_sem);
         sem.wait();

--- a/src/threading/work_pool.rs
+++ b/src/threading/work_pool.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::ThreadPool;
+use crate::{Semaphore, ThreadPool};
 
 pub use crate::thread_pool::Batch;
 pub use crate::thread_pool::Task;
@@ -140,10 +140,49 @@ fn create() -> ThreadPool {
     })
 }
 
+/// Concurrency cap for CPU-bound pool jobs (crypto KDFs, compression, WebCrypto).
+///
+/// Sized to `get_thread_count() - 1` (min 1) so a full CPU flood leaves one
+/// core free for the JS thread; the pool itself stays at `get_thread_count()`
+/// so I/O-bound jobs (fs, dns) are unaffected. Acquired via
+/// [`WorkPool::cpu_permit`] from a worker thread immediately before the
+/// compute body; released on drop.
+static CPU_SEM: OnceLock<Semaphore> = OnceLock::new();
+
+#[cold]
+fn create_cpu_sem() -> Semaphore {
+    let n = usize::from(bun_core::get_thread_count().saturating_sub(1).max(1));
+    Semaphore::with_permits(n)
+}
+
+/// RAII guard for one CPU-bound concurrency slot; see [`WorkPool::cpu_permit`].
+#[must_use = "dropping the permit releases the slot"]
+pub struct CpuPermit(&'static Semaphore);
+
+impl Drop for CpuPermit {
+    #[inline]
+    fn drop(&mut self) {
+        self.0.post();
+    }
+}
+
 impl WorkPool {
     #[inline]
     pub fn get() -> &'static ThreadPool {
         POOL.get_or_init(create)
+    }
+
+    /// Acquire one CPU-bound concurrency slot, blocking the calling worker
+    /// thread until one is free. Held for the duration of the compute body
+    /// and released on drop.
+    ///
+    /// Call this from the worker thread (inside the task callback), not from
+    /// the JS thread: blocking the JS thread here would deadlock it against
+    /// the very pool jobs it is waiting on.
+    pub fn cpu_permit() -> CpuPermit {
+        let sem = CPU_SEM.get_or_init(create_cpu_sem);
+        sem.wait();
+        CpuPermit(sem)
     }
 
     pub fn schedule(task: *mut Task) {

--- a/test/js/bun/crypto/workpool-cpu-headroom.test.ts
+++ b/test/js/bun/crypto/workpool-cpu-headroom.test.ts
@@ -6,17 +6,15 @@
 // check that one of them is forced into a second wave (completes at ~2x the
 // first). Without the cap, all `cores` run in parallel and finish together.
 
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 const cores = navigator.hardwareConcurrency;
 
 // On a 1-core host get_thread_count() clamps the pool to 2 and the cap to 1,
 // but hardwareConcurrency would report 1 and the wave probe can't distinguish.
-test.skipIf(cores < 2)(
-  "CPU-bound work-pool jobs are capped at cores-1 so the event loop keeps a core",
-  async () => {
-    const body = /* js */ `
+test.skipIf(cores < 2)("CPU-bound work-pool jobs are capped at cores-1 so the event loop keeps a core", async () => {
+  const body = /* js */ `
       import crypto from "node:crypto";
       const cores = navigator.hardwareConcurrency;
       const ITERS = 1_500_000;
@@ -42,50 +40,49 @@ test.skipIf(cores < 2)(
       done.sort((a, b) => a - b);
       process.stdout.write(JSON.stringify({ cores, done, maxLate }));
     `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", body],
-      env: {
-        ...bunEnv,
-        // Ensure the child's pool is sized to the default (= hardwareConcurrency),
-        // not an inherited override.
-        UV_THREADPOOL_SIZE: undefined,
-        GOMAXPROCS: undefined,
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
-    expect(stderr).toBe("");
-    const { cores: childCores, done, maxLate } = JSON.parse(stdout) as {
-      cores: number;
-      done: number[];
-      maxLate: number;
-    };
-    expect(childCores).toBe(cores);
-    expect(done.length).toBe(cores);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", body],
+    env: {
+      ...bunEnv,
+      // Ensure the child's pool is sized to the default (= hardwareConcurrency),
+      // not an inherited override.
+      UV_THREADPOOL_SIZE: undefined,
+      GOMAXPROCS: undefined,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const {
+    cores: childCores,
+    done,
+    maxLate,
+  } = JSON.parse(stdout) as {
+    cores: number;
+    done: number[];
+    maxLate: number;
+  };
+  expect(childCores).toBe(cores);
+  expect(done.length).toBe(cores);
 
-    // With the cap at cores-1, exactly one job waits for a permit and lands in
-    // a second wave roughly one job-length after the first. Without the cap,
-    // all `cores` jobs run together and the last-to-second-last gap is noise.
-    const first = done[0];
-    const gap = done[cores - 1] - done[cores - 2];
-    // The second-wave job starts only after a first-wave job releases its
-    // permit, so the gap is at least ~first. Assert half that to absorb
-    // scheduler jitter; uncapped runs stay well under this (the spread across
-    // `cores` parallel jobs is a fraction of one job-length, not a whole one).
-    expect(gap).toBeGreaterThan(first * 0.5);
+  // With the cap at cores-1, exactly one job waits for a permit and lands in
+  // a second wave roughly one job-length after the first. Without the cap,
+  // all `cores` jobs run together and the last-to-second-last gap is noise.
+  const first = done[0];
+  const gap = done[cores - 1] - done[cores - 2];
+  // The second-wave job starts only after a first-wave job releases its
+  // permit, so the gap is at least ~first. Assert half that to absorb
+  // scheduler jitter; uncapped runs stay well under this (the spread across
+  // `cores` parallel jobs is a fraction of one job-length, not a whole one).
+  expect(gap).toBeGreaterThan(first * 0.5);
 
-    // Informational: with a core free the 10ms interval should not be tens of
-    // ms late. Logged so CI output carries the event-loop-latency number even
-    // though the hard assertion above is the one the cap guarantees.
-    console.log(
-      `cores=${cores} first=${first.toFixed(0)}ms last=${done[cores - 1].toFixed(0)}ms gap=${gap.toFixed(0)}ms maxLate=${maxLate.toFixed(0)}ms`,
-    );
+  // Informational: with a core free the 10ms interval should not be tens of
+  // ms late. Logged so CI output carries the event-loop-latency number even
+  // though the hard assertion above is the one the cap guarantees.
+  console.log(
+    `cores=${cores} first=${first.toFixed(0)}ms last=${done[cores - 1].toFixed(0)}ms gap=${gap.toFixed(0)}ms maxLate=${maxLate.toFixed(0)}ms`,
+  );
 
-    expect(exitCode).toBe(0);
-  },
-);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/crypto/workpool-cpu-headroom.test.ts
+++ b/test/js/bun/crypto/workpool-cpu-headroom.test.ts
@@ -1,0 +1,91 @@
+// CPU-bound work-pool jobs (pbkdf2, scrypt, argon2, zlib, WebCrypto) are capped
+// at `cores - 1` concurrent executions so a flood leaves one core free for the
+// JS event loop. I/O-bound jobs (fs, dns) are not capped.
+//
+// The assertion is mechanistic: queue exactly `cores` long pbkdf2 jobs and
+// check that one of them is forced into a second wave (completes at ~2x the
+// first). Without the cap, all `cores` run in parallel and finish together.
+
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const cores = navigator.hardwareConcurrency;
+
+// On a 1-core host get_thread_count() clamps the pool to 2 and the cap to 1,
+// but hardwareConcurrency would report 1 and the wave probe can't distinguish.
+test.skipIf(cores < 2)(
+  "CPU-bound work-pool jobs are capped at cores-1 so the event loop keeps a core",
+  async () => {
+    const body = /* js */ `
+      import crypto from "node:crypto";
+      const cores = navigator.hardwareConcurrency;
+      const ITERS = 1_500_000;
+      const t0 = performance.now();
+      const done = [];
+      let maxLate = 0, last = performance.now();
+      const iv = setInterval(() => {
+        const n = performance.now();
+        maxLate = Math.max(maxLate, n - last - 10);
+        last = n;
+      }, 10);
+      await Promise.all(
+        Array.from({ length: cores }, () =>
+          new Promise(r =>
+            crypto.pbkdf2("p", "s", ITERS, 32, "sha256", () => {
+              done.push(performance.now() - t0);
+              r();
+            })
+          )
+        )
+      );
+      clearInterval(iv);
+      done.sort((a, b) => a - b);
+      process.stdout.write(JSON.stringify({ cores, done, maxLate }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", body],
+      env: {
+        ...bunEnv,
+        // Ensure the child's pool is sized to the default (= hardwareConcurrency),
+        // not an inherited override.
+        UV_THREADPOOL_SIZE: undefined,
+        GOMAXPROCS: undefined,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    const { cores: childCores, done, maxLate } = JSON.parse(stdout) as {
+      cores: number;
+      done: number[];
+      maxLate: number;
+    };
+    expect(childCores).toBe(cores);
+    expect(done.length).toBe(cores);
+
+    // With the cap at cores-1, exactly one job waits for a permit and lands in
+    // a second wave roughly one job-length after the first. Without the cap,
+    // all `cores` jobs run together and the last-to-second-last gap is noise.
+    const first = done[0];
+    const gap = done[cores - 1] - done[cores - 2];
+    // The second-wave job starts only after a first-wave job releases its
+    // permit, so the gap is at least ~first. Assert half that to absorb
+    // scheduler jitter; uncapped runs stay well under this (the spread across
+    // `cores` parallel jobs is a fraction of one job-length, not a whole one).
+    expect(gap).toBeGreaterThan(first * 0.5);
+
+    // Informational: with a core free the 10ms interval should not be tens of
+    // ms late. Logged so CI output carries the event-loop-latency number even
+    // though the hard assertion above is the one the cap guarantees.
+    console.log(
+      `cores=${cores} first=${first.toFixed(0)}ms last=${done[cores - 1].toFixed(0)}ms gap=${gap.toFixed(0)}ms maxLate=${maxLate.toFixed(0)}ms`,
+    );
+
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/bun/crypto/workpool-cpu-headroom.test.ts
+++ b/test/js/bun/crypto/workpool-cpu-headroom.test.ts
@@ -1,22 +1,21 @@
-// CPU-bound work-pool jobs (pbkdf2, scrypt, argon2, zlib, WebCrypto) are capped
-// at `cores - 1` concurrent executions so a flood leaves one core free for the
-// JS event loop. I/O-bound jobs (fs, dns) are not capped.
+// CPU-bound work-pool jobs (pbkdf2, scrypt, argon2, zlib, WebCrypto, transpile,
+// image) are capped at `pool size - 1` concurrent executions so a flood leaves
+// one core free for the JS event loop. I/O-bound jobs (fs, dns, glob) are not
+// capped.
 //
-// The assertion is mechanistic: queue exactly `cores` long pbkdf2 jobs and
-// check that one of them is forced into a second wave (completes at ~2x the
-// first). Without the cap, all `cores` run in parallel and finish together.
+// The assertion is mechanistic and independent of host core count: pin the
+// child's pool at 2 (UV_THREADPOOL_SIZE=2 -> cap 1), queue 2 long pbkdf2 jobs,
+// and check that one is forced into a second wave (completes at ~2x the
+// first). Without the cap, both run in parallel and finish together.
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-const cores = navigator.hardwareConcurrency;
-
-// On a 1-core host get_thread_count() clamps the pool to 2 and the cap to 1,
-// but hardwareConcurrency would report 1 and the wave probe can't distinguish.
-test.skipIf(cores < 2)("CPU-bound work-pool jobs are capped at cores-1 so the event loop keeps a core", async () => {
+test("CPU-bound work-pool jobs are capped at pool-1 so the event loop keeps a core", async () => {
+  const N = 2;
   const body = /* js */ `
       import crypto from "node:crypto";
-      const cores = navigator.hardwareConcurrency;
+      const N = ${N};
       const ITERS = 1_500_000;
       const t0 = performance.now();
       const done = [];
@@ -27,7 +26,7 @@ test.skipIf(cores < 2)("CPU-bound work-pool jobs are capped at cores-1 so the ev
         last = n;
       }, 10);
       await Promise.all(
-        Array.from({ length: cores }, () =>
+        Array.from({ length: N }, () =>
           new Promise(r =>
             crypto.pbkdf2("p", "s", ITERS, 32, "sha256", () => {
               done.push(performance.now() - t0);
@@ -38,15 +37,15 @@ test.skipIf(cores < 2)("CPU-bound work-pool jobs are capped at cores-1 so the ev
       );
       clearInterval(iv);
       done.sort((a, b) => a - b);
-      process.stdout.write(JSON.stringify({ cores, done, maxLate }));
+      process.stdout.write(JSON.stringify({ done, maxLate }));
     `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", body],
     env: {
       ...bunEnv,
-      // Ensure the child's pool is sized to the default (= hardwareConcurrency),
-      // not an inherited override.
-      UV_THREADPOOL_SIZE: undefined,
+      // Pin pool=2, cap=1. Keeps the wave structure independent of host
+      // topology (cgroup-limited runners, oversubscribed parallel batches).
+      UV_THREADPOOL_SIZE: String(N),
       GOMAXPROCS: undefined,
     },
     stdout: "pipe",
@@ -54,34 +53,19 @@ test.skipIf(cores < 2)("CPU-bound work-pool jobs are capped at cores-1 so the ev
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  const {
-    cores: childCores,
-    done,
-    maxLate,
-  } = JSON.parse(stdout) as {
-    cores: number;
-    done: number[];
-    maxLate: number;
-  };
-  expect(childCores).toBe(cores);
-  expect(done.length).toBe(cores);
+  const { done, maxLate } = JSON.parse(stdout) as { done: number[]; maxLate: number };
+  expect(done.length).toBe(N);
 
-  // With the cap at cores-1, exactly one job waits for a permit and lands in
-  // a second wave roughly one job-length after the first. Without the cap,
-  // all `cores` jobs run together and the last-to-second-last gap is noise.
+  // With the cap at N-1=1, the second job waits for the first to release its
+  // permit, so the gap between them is a full job-length. Without the cap,
+  // both run in parallel and the gap is scheduler noise.
   const first = done[0];
-  const gap = done[cores - 1] - done[cores - 2];
-  // The second-wave job starts only after a first-wave job releases its
-  // permit, so the gap is at least ~first. Assert half that to absorb
-  // scheduler jitter; uncapped runs stay well under this (the spread across
-  // `cores` parallel jobs is a fraction of one job-length, not a whole one).
+  const gap = done[N - 1] - done[N - 2];
   expect(gap).toBeGreaterThan(first * 0.5);
 
-  // Informational: with a core free the 10ms interval should not be tens of
-  // ms late. Logged so CI output carries the event-loop-latency number even
-  // though the hard assertion above is the one the cap guarantees.
+  // Informational: the 10 ms interval's worst lateness during the flood.
   console.log(
-    `cores=${cores} first=${first.toFixed(0)}ms last=${done[cores - 1].toFixed(0)}ms gap=${gap.toFixed(0)}ms maxLate=${maxLate.toFixed(0)}ms`,
+    `first=${first.toFixed(0)}ms last=${done[N - 1].toFixed(0)}ms gap=${gap.toFixed(0)}ms maxLate=${maxLate.toFixed(0)}ms`,
   );
 
   expect(exitCode).toBe(0);


### PR DESCRIPTION
## What

The global `WorkPool` is sized to every logical core (`get_thread_count()`). When it is flooded with CPU-bound work (pbkdf2/scrypt/argon2 under a login storm, a compression burst, WebCrypto, an image pipeline), every core is busy in the pool and the JS event-loop thread has to compete for scheduler time. The loop is not blocked, but a 10 ms `setInterval` drops most of its ticks and individual ticks can be tens of ms late. Memory-hard KDFs also scale their transient allocation with the pool width (`N x memoryCost` for N concurrent argon2id jobs). Node.js avoids the whole class by defaulting `UV_THREADPOOL_SIZE` to 4.

## Repro

```js
import crypto from "node:crypto"; import os from "node:os";
const P = Number(process.env.UV_THREADPOOL_SIZE || os.availableParallelism());
let on = true;
const chain = () => !on ? 1 : new Promise(r => crypto.pbkdf2("p","s",4_000_000,32,"sha256",r)).then(chain);
const cs = Array.from({length: P}, chain);
await new Promise(r => setTimeout(r, 400));
let ticks = 0, late = 0, last = performance.now(); const t0 = last;
const iv = setInterval(() => { const n = performance.now(); late = Math.max(late, n-last-10); last = n; ticks++; }, 10);
await new Promise(r => setTimeout(r, 8000)); clearInterval(iv); on = false;
const wall = performance.now() - t0;
console.log({P, cores: os.availableParallelism(),
  tickLossPct: (100*(1 - ticks/(wall/10))).toFixed(1), maxLate_ms: late.toFixed(0)});
await Promise.all(cs);
```

On an 8-core box:

|            | tick loss | max late |
| ---------- | --------- | -------- |
| before (default = 8 pool threads) | 13-16% | 31-51 ms |
| `UV_THREADPOOL_SIZE=7` / after    | 1.8-4% | 1-12 ms |

## Fix

Add a counting semaphore in `work_pool.rs` sized to `get_thread_count() - 1` (min 1). CPU-bound call sites acquire it (`WorkPool::cpu_permit()`) around their compute body on the worker thread:

- `AnyTaskJob::run_task` (pbkdf2, scrypt, the `extern_crypto_job!` node:crypto async jobs, `Bun.zstd*`), gated by `AnyTaskJobCtx::CPU_BOUND` (default `true`; `SecretsCtx` overrides to `false` since it is keychain IPC)
- `ConcurrentPromiseTask::run_from_thread_pool` (`Bun.Image` pipeline, `Bun.Transpiler.transform`), gated by `ConcurrentPromiseTaskContext::CPU_BOUND` (default `true`; glob `WalkTask` and Blob `CopyFile` override to `false`)
- `PasswordJob::run_owned` (`Bun.password` argon2/bcrypt)
- `ConcurrentCppTask::run_owned` (WebCrypto SubtleCrypto via `PhonyWorkQueue`)
- `CompressionStream::async_job_run` (node:zlib/brotli/zstd streaming `write`)
- `RuntimeTranspilerStore::run_from_worker_thread` (off-thread module transpilation)

The pool itself stays at `get_thread_count()` so fs/dns and other I/O-bound tasks are unaffected. `UV_THREADPOOL_SIZE` continues to size both the pool and (via `get_thread_count()`) the cap, so setting it to `N` yields `N-1` concurrent CPU-bound jobs. That is conservative for a cgroup-limited container where the env var communicates the real core budget; on bare metal with more than `N` cores it costs `1/N` throughput with no latency gain, and users wanting exactly `N` concurrent CPU jobs there should set `N+1`.

**Intentionally not gated:** `napi_async_work`. Native addon work may be either CPU- or I/O-bound and Bun cannot tell which; Node.js makes the same non-distinction on the uv pool. A sharp-style addon that floods the pool behaves as before and can be mitigated with `UV_THREADPOOL_SIZE`. Archive write/extract is also left ungated since it is mixed I/O + compression on a single job.

## Verification

`test/js/bun/crypto/workpool-cpu-headroom.test.ts` pins the child's pool at `UV_THREADPOOL_SIZE=2` (cap=1), queues 2 pbkdf2 jobs, and asserts the second completion lands a full job-length after the first. Without the cap both run in parallel and the gap is noise. Pinning the pool keeps the assertion independent of host topology (cgroup-limited runners, parallel test batches).

```
first=1474ms last=2943ms gap=1468ms maxLate=23ms   # bun bd (pass)
gap=0.4ms, threshold=110ms                          # system bun (fail)
```

Existing `pbkdf2.test.ts`, `password.test.ts`, `scrypt.test.ts`, `zlib.test.js`, `glob/scan.test.ts` all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 13 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/crypto/workpool-cpu-headroom.test.ts
bun test v1.4.0 (167d3633d)

test/js/bun/crypto/workpool-cpu-headroom.test.ts:
59 |   // With the cap at N-1=1, the second job waits for the first to release its
60 |   // permit, so the gap between them is a full job-length. Without the cap,
61 |   // both run in parallel and the gap is scheduler noise.
62 |   const first = done[0];
63 |   const gap = done[N - 1] - done[N - 2];
64 |   expect(gap).toBeGreaterThan(first * 0.5);
                   ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 740.3615310000001
Received: 8.124231999999665

      at <anonymous> (/workspace/bun/test/js/bun/crypto/workpool-cpu-headroom.test.ts:64:15)
(fail) CPU-bound work-pool jobs are capped at pool-1 so the event loop keeps a core [2702.16ms]

 0 pass
 1 fail
 3 expect() calls
Ran 1 test across 1 file. [4.75s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/crypto/workpool-cpu-headroom.test.ts:
59 |   // With the cap at N-1=1, the second job waits for the first to release its
60 |   // permit, so the gap between them is a full job-length. Without the cap,
61 |   // both run in parallel and the gap is scheduler noise.
62 |   const first = done[0];
63 |   const gap = done[N - 1] - done[N - 2];
64 |   expect(gap).toBeGreaterThan(first * 0.5);
                   ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 109.4299595
Received: 0.053956999999996924

      at <anonymous> (/workspace/bun/test/js/bun/crypto/workpool-cpu-headroom.test.ts:64:15)
(fail) CPU-bound work-pool jobs are capped at pool-1 so the event loop keeps a core [249.57ms]

 0 pass
 1 fail
 3 expect() calls
Ran 1 test across 1 file. [403.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/crypto/workpool-cpu-headroom.test.ts
bun test v1.4.0 (167d3633d)

test/js/bun/crypto/workpool-cpu-headroom.test.ts:
first=1473ms last=2936ms gap=1463ms maxLate=23ms
(pass) CPU-bound work-pool jobs are capped at pool-1 so the event loop keeps a core [4138.25ms]

 1 pass
 0 fail
 4 expect() calls
Ran 1 test across 1 file. [6.08s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     167d3633de
  features     baseline

22 deps, 108 codegen, 1171 objects in 798ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [11.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [3.00ms]
[4/1234] gen bindgenv2
[5/1234] gen ErrorCode+*.h
[6/1234] fetch picohttpparser
[picohttpparser] up to date
[7/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1234] fetch zlib
[zlib] up to date
[9/1234] fetch tinycc
[tinycc] up to date
[10/1234] gen .bind.ts → GeneratedBindings.cpp
[11/1234] subst deps/zlib/zconf.h
[12/1234] subst deps/zlib/zlib.h
[13/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[14/123
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConcurrentPromiseTask.rs                 | 13 ++++-
 src/jsc/CppTask.rs                               | 10 +++-
 src/jsc/JSSecrets.rs                             |  3 +
 src/jsc/RuntimeTranspilerStore.rs                |  1 +
 src/jsc/any_task_job.rs                          |  9 ++-
 src/runtime/api/glob.rs                          |  1 +
 src/runtime/crypto/PasswordObject.rs             |  5 +-
 src/runtime/node/node_zlib_binding.rs            |  5 +-
 src/runtime/webcore/blob/copy_file.rs            |  1 +
 src/threading/Semaphore.rs                       |  7 ++-
 src/threading/lib.rs                             |  2 +-
 src/threading/work_pool.rs                       | 31 +++++++++-
 test/js/bun/crypto/workpool-cpu-headroom.test.ts | 72 ++++++++++++++++++++++++
 13 files changed, 148 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/jsc/ConcurrentPromiseTask.rs                      1      1      0
src/jsc/CppTask.rs                                    2      3      0
src/jsc/JSSecrets.rs                                  1      1      0
src/jsc/RuntimeTranspilerStore.rs                     1      1      0
src/jsc/any_task_job.rs                               2      3      0
src/runtime/api/glob.rs                               1      1      0
src/runtime/crypto/PasswordObject.rs                  1      1      0
src/runtime/node/node_zlib_binding.rs                 1      1      0
src/runtime/webcore/blob/copy_file.rs                 1      1      0
src/threading/Semaphore.rs                            1      1      0
src/threading/lib.rs                                  1      1      0
src/threading/work_pool.rs                            2      3      0
test/js/bun/crypto/workpool-cpu-headroom.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->