### PR TITLE
ci(runner): try macOS parallel test width cap of 8

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -618,11 +618,11 @@ async function runTests() {
   // finished, so no parallel-safe process ever overlaps a serial test (an
   // overlap surfaced new flakes in tight-timeout / port-bind tests such as
   // dns-tcp-bidirectional-poll and test-https-timeout). `--parallel` already
-  // widens `limit` above and supersedes this split. macOS is capped at 4: the
+  // widens `limit` above and supersedes this split. macOS is capped at 8: the
   // Intel minis are 6-core i7-8700B (12 HT threads => width 11), and each
   // M2 Ultra host runs two 18-vCPU tart VMs (width 17 apiece, 34 on 24
   // cores when both are busy); both hit the 45-minute job timeout uncapped.
-  const parallelSafeCap = isMacOS ? 4 : Infinity;
+  const parallelSafeCap = isMacOS ? 8 : Infinity;
   const parallelSafeWidth =
     parallelism > 1 ? parallelism : Math.min(parallelSafeCap, Math.max(availableParallelism() - 1, 1));
   const parallelSafeLimit = parallelism > 1 ? limit : pLimit(parallelSafeWidth);


### PR DESCRIPTION
Follow-up to #36231, which capped macOS at 4 after #36175 removed the cap entirely and the darwin lanes started hitting the 45-minute job timeout at width 11 (x64) / 17 (arm64 tart). This bumps the cap to 8 to compare CI timings.

Resulting width per lane:

| lane | cores | uncapped (#36175) | cap=4 (#36231) | cap=8 (this PR) |
|---|---|---|---|---|
| darwin x64 (i7-8700B) | 12 | 11 | 4 | **8** |
| darwin arm64 tart (M2 Ultra, 2 VMs/host) | 18 | 17 | 4 | **8** |
| darwin arm64 bare (M2) | 8 | 7 | 4 | **7** (unchanged, 7 < 8) |
| linux/windows EC2 | 4 | 3 | 3 | 3 (unchanged) |

For reference, at cap=4 ([build 84151](https://buildkite.com/bun/bun/builds/84151)) the darwin x64 shards finished in ~15 min. Uncapped, x64 and arm64 tart intermittently hit the 45-minute timeout (builds 84092, 84142, 84151).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->