### PR TITLE
cli: make --jsx-side-effects work when passed alone

### DIFF
--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -43,8 +43,7 @@ bun_core::declare_scope!(cache, visible);
 /// path reinstates the bug for any previously-cached TLA module (#30887).
 /// Version 23: `jsx.runtime`/`jsx.development` participate in the features hash,
 /// and tsconfig `"jsx": "react-jsx"` now emits the production runtime (#4227).
-/// Version 24: `jsx.side_effects` participates in the features hash so toggling
-/// `--jsx-side-effects` does not serve a stale cache entry.
+/// Version 24: `jsx.side_effects` participates in the features hash.
 const EXPECTED_VERSION: u32 = 24;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -43,7 +43,9 @@ bun_core::declare_scope!(cache, visible);
 /// path reinstates the bug for any previously-cached TLA module (#30887).
 /// Version 23: `jsx.runtime`/`jsx.development` participate in the features hash,
 /// and tsconfig `"jsx": "react-jsx"` now emits the production runtime (#4227).
-const EXPECTED_VERSION: u32 = 23;
+/// Version 24: `jsx.side_effects` participates in the features hash so toggling
+/// `--jsx-side-effects` does not serve a stale cache entry.
+const EXPECTED_VERSION: u32 = 24;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/options_types/jsx.rs
+++ b/src/options_types/jsx.rs
@@ -220,8 +220,14 @@ impl Pragma {
         hasher.update(&self.classic_import_source);
         hasher.update(&self.package_name);
         // `runtime` selects classic vs automatic emission; `development`
-        // selects `jsx` vs `jsxDEV`. Both shape transpiled output.
-        hasher.update(&[self.runtime as u8, self.development as u8]);
+        // selects `jsx` vs `jsxDEV`; `side_effects` controls whether JSX
+        // calls are marked pure (and so whether bare JSX statements survive
+        // DCE). All three shape transpiled output.
+        hasher.update(&[
+            self.runtime as u8,
+            self.development as u8,
+            self.side_effects as u8,
+        ]);
     }
 
     pub fn import_source(&self) -> &[u8] {

--- a/src/options_types/jsx.rs
+++ b/src/options_types/jsx.rs
@@ -219,10 +219,7 @@ impl Pragma {
         hasher.update(&self.import_source.production);
         hasher.update(&self.classic_import_source);
         hasher.update(&self.package_name);
-        // `runtime` selects classic vs automatic emission; `development`
-        // selects `jsx` vs `jsxDEV`; `side_effects` controls whether JSX
-        // calls are marked pure (and so whether bare JSX statements survive
-        // DCE). All three shape transpiled output.
+        // Each of these shapes the transpiled output.
         hasher.update(&[
             self.runtime as u8,
             self.development as u8,

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1434,6 +1434,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
         || jsx_fragment.is_some()
         || jsx_import_source.is_some()
         || jsx_runtime.is_some()
+        || jsx_side_effects
     {
         let default_factory: &[u8] = b"";
         let default_fragment: &[u8] = b"";
@@ -1448,7 +1449,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
                 } else {
                     api::JsxRuntime::Automatic
                 },
-                development: false,
+                development: true,
                 side_effects: jsx_side_effects,
             });
         } else {
@@ -1464,8 +1465,8 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
                 } else {
                     prev.runtime
                 },
-                development: false,
-                side_effects: jsx_side_effects,
+                development: prev.development,
+                side_effects: jsx_side_effects || prev.side_effects,
             });
         }
     }

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -927,34 +927,45 @@ describe("bundler", () => {
     // on the command line. Previously the CLI only materialized the JSX options
     // when one of factory/fragment/import-source/runtime was set, so passing the
     // flag alone was a silent no-op and JSX calls kept their pure annotation.
-    test("cli: --jsx-side-effects alone drops the pure annotation", async () => {
-      using dir = tempDir("jsx-cli-side-effects", {
-        "a.jsx": "export const a = <div />;\n",
+    // The bunfig row covers the merge-with-bunfig arm in Arguments.rs (any bunfig
+    // populates opts.jsx before CLI flags are applied).
+    describe.each([
+      ["no bunfig", undefined, "react/jsx-dev-runtime"],
+      ["bunfig (no jsx keys)", 'logLevel = "error"\n', "react/jsx-dev-runtime"],
+      ['bunfig jsx = "react-jsx"', 'jsx = "react-jsx"\n', "react/jsx-runtime"],
+    ] as const)("cli: --jsx-side-effects alone [%s]", (_label, bunfig, expectedRuntime) => {
+      test("drops the pure annotation without changing the runtime", async () => {
+        const files: Record<string, string> = {
+          "a.jsx": "export const a = <div />;\n",
+          "tsconfig.json": "{}",
+        };
+        if (bunfig !== undefined) files["bunfig.toml"] = bunfig;
+        using dir = tempDir("jsx-cli-side-effects", files);
+        const build = async (args: readonly string[]) => {
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), "build", "--no-bundle", ...args, "a.jsx"],
+            env: bunEnv,
+            cwd: String(dir),
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(exitCode).toBe(0);
+          return stdout;
+        };
+
+        // Baseline: without the flag, JSX calls are annotated pure.
+        const baseline = await build([]);
+        expect(baseline).toContain("/* @__PURE__ */");
+        expect(baseline).toContain(expectedRuntime);
+
+        // With only --jsx-side-effects (no other --jsx-* flags), the annotation
+        // is dropped and the runtime selection is unchanged.
+        const withFlag = await build(["--jsx-side-effects"]);
+        expect(withFlag).not.toContain("@__PURE__");
+        expect(withFlag).toContain(expectedRuntime);
       });
-      const build = async (args: readonly string[]) => {
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "build", "--no-bundle", ...args, "a.jsx"],
-          env: bunEnv,
-          cwd: String(dir),
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect(stderr).toBe("");
-        expect(exitCode).toBe(0);
-        return stdout;
-      };
-
-      // Baseline: without the flag, JSX calls are annotated pure.
-      const baseline = await build([]);
-      expect(baseline).toContain("/* @__PURE__ */");
-      expect(baseline).toContain("react/jsx-dev-runtime");
-
-      // With only --jsx-side-effects (no other --jsx-* flags), the annotation is
-      // dropped, and the automatic runtime stays in development mode.
-      const withFlag = await build(["--jsx-side-effects"]);
-      expect(withFlag).not.toContain("@__PURE__");
-      expect(withFlag).toContain("react/jsx-dev-runtime");
     });
   });
 });

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect } from "bun:test";
-import { normalizeBunSnapshot } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { BundlerTestInput, itBundled } from "./expectBundled";
 
 const helpers = {
@@ -921,6 +921,40 @@ describe("bundler", () => {
           console.log(jsxDEV(Fragment, {}, undefined, false, undefined, this));"
         `);
       },
+    });
+
+    // `--jsx-side-effects` must take effect even when it is the only --jsx-* flag
+    // on the command line. Previously the CLI only materialized the JSX options
+    // when one of factory/fragment/import-source/runtime was set, so passing the
+    // flag alone was a silent no-op and JSX calls kept their pure annotation.
+    test("cli: --jsx-side-effects alone drops the pure annotation", async () => {
+      using dir = tempDir("jsx-cli-side-effects", {
+        "a.jsx": "export const a = <div />;\n",
+      });
+      const build = async (args: readonly string[]) => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "build", "--no-bundle", ...args, "a.jsx"],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(exitCode).toBe(0);
+        return stdout;
+      };
+
+      // Baseline: without the flag, JSX calls are annotated pure.
+      const baseline = await build([]);
+      expect(baseline).toContain("/* @__PURE__ */");
+      expect(baseline).toContain("react/jsx-dev-runtime");
+
+      // With only --jsx-side-effects (no other --jsx-* flags), the annotation is
+      // dropped, and the automatic runtime stays in development mode.
+      const withFlag = await build(["--jsx-side-effects"]);
+      expect(withFlag).not.toContain("@__PURE__");
+      expect(withFlag).toContain("react/jsx-dev-runtime");
     });
   });
 });

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -815,7 +815,7 @@ function expectBundled(
               jsx.factory && ["--jsx-factory", jsx.factory],
               jsx.fragment && ["--jsx-fragment", jsx.fragment],
               jsx.importSource && ["--jsx-import-source", jsx.importSource],
-              jsx.side_effects && ["--jsx-side-effects"],
+              jsx.sideEffects && ["--jsx-side-effects"],
               dotenv && ["--env", dotenv],
               // metafile && `--manifest=${metafile}`,
               sourceMap && `--sourcemap=${sourceMap}`,

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -261,6 +261,41 @@ describe("transpiler cache", () => {
     expect(run(["--feature=OTHER", "--feature=SUPER_SECRET"])).toBe("enabled");
     expect(newCacheCount()).toBe(0); // cache hit, order doesn't matter
   });
+  test("--jsx-side-effects invalidates cache", () => {
+    // jsx.side_effects controls whether bare JSX expression statements survive
+    // DCE (via can_be_unwrapped_if_unused on the lowered call). It must be part
+    // of the features hash or toggling the flag serves a stale entry.
+    mkdirSync(join(temp_dir, "node_modules", "react"), { recursive: true });
+    writeFileSync(
+      join(temp_dir, "node_modules", "react", "package.json"),
+      JSON.stringify({ name: "react", exports: { "./jsx-dev-runtime": "./r.js", "./jsx-runtime": "./r.js" } }),
+    );
+    writeFileSync(
+      join(temp_dir, "node_modules", "react", "r.js"),
+      'let n=0;exports.jsxDEV=exports.jsx=exports.jsxs=()=>{n++};exports.Fragment={};process.on("exit",()=>console.log("calls="+n));',
+    );
+    writeFileSync(join(temp_dir, "tsconfig.json"), "{}");
+    // >= MINIMUM_CACHE_SIZE so the entry is written.
+    const pad = "// " + Buffer.alloc(50 * 1024, "x").toString() + "\n";
+    writeFileSync(join(temp_dir, "a.jsx"), pad + "<div />;\n<div />;\n<div />;\n");
+
+    const run = (extra: string[]) => {
+      const result = Bun.spawnSync({ cmd: [bunExe(), ...extra, "a.jsx"], cwd: temp_dir, env });
+      if (!result.success) throw new Error(result.stderr.toString());
+      return result.stdout.toString().trim();
+    };
+
+    // No flag: JSX calls are pure, the three bare statements are DCE'd.
+    expect(run([])).toBe("calls=0");
+    expect(newCacheCount()).toBe(1);
+    expect(run([])).toBe("calls=0");
+    expect(newCacheCount()).toBe(0); // cache hit
+
+    // With the flag: features hash differs, entry is re-transpiled with
+    // side_effects=true so all three calls execute.
+    expect(run(["--jsx-side-effects"])).toBe("calls=3");
+    expect(run(["--jsx-side-effects"])).toBe("calls=3");
+  });
 });
 
 test("rejects cached module records containing out-of-range string indices", () => {


### PR DESCRIPTION
## What

`bun --jsx-side-effects a.jsx` and `bun build --jsx-side-effects --no-bundle a.jsx` silently ignored the flag when no other `--jsx-*` flag was present: JSX calls kept their `/* @__PURE__ */` annotation exactly as if the flag had not been passed.

## Repro

```sh
echo 'const a = <div />;' > a.jsx

bun build --no-bundle a.jsx
# const a = /* @__PURE__ */ jsxDEV_7x81h0kn("div", ...)

bun build --jsx-side-effects --no-bundle a.jsx
# const a = /* @__PURE__ */ jsxDEV_7x81h0kn("div", ...)   <-- flag ignored

bun build --jsx-side-effects --jsx-runtime=automatic --no-bundle a.jsx
# const a = jsxDEV_7x81h0kn("div", ...)                   <-- works once another --jsx-* is present
```

## Cause

`src/runtime/cli/Arguments.rs` reads `--jsx-side-effects` but only consumes it inside a block gated by

```rust
if jsx_factory.is_some()
    || jsx_fragment.is_some()
    || jsx_import_source.is_some()
    || jsx_runtime.is_some()
```

With all four `None`, the block is skipped, `opts.jsx` stays `None`, and the transpiler falls back to `Pragma::default()` which has `side_effects = false`.

## Fix

Add `|| jsx_side_effects` to the gate. In the bunfig-merge arm, fall back to `prev.side_effects` the same way the other fields do.

Including the flag in the gate means this block now constructs an `api::Jsx` for `--jsx-side-effects` alone. The block previously hardcoded `development: false`, so left as-is the fix would trade one bug for another: the flag would start working but also flip the automatic runtime from `jsx-dev-runtime` to `jsx-runtime`. To keep `--jsx-side-effects` from changing the dev/prod selection, `development` now defaults to `true` (matching `Pragma::default()`, bunfig and `JSBundler`) and the merge arm preserves `prev.development`. `NODE_ENV=production` still selects the production runtime via `set_production()` exactly as before.

The `development` change is the same two lines as #36209, which was opened for the other `--jsx-*` flags hitting the same hardcoded `false` and carries its own test coverage for the dev/prod matrix. The two PRs are independently mergeable; whichever lands second will have a trivial rebase on those two lines.

`jsx.side_effects` also shapes the runtime-transpiled output (bare JSX expression statements are DCE'd when it is `false` and kept when `true`) but was not part of `Pragma::hash_for_runtime_transpiler`, so once the flag started taking effect, toggling it would serve a stale on-disk cache entry for any source over the 4 KiB minimum. Added `side_effects` to the hash and bumped `EXPECTED_VERSION` to 24.

Also fixed `jsx.side_effects` -> `jsx.sideEffects` in the `itBundled` CLI backend's argv builder so `{ jsx: { sideEffects: true } }` actually emits `--jsx-side-effects` on that path.

## Verification

- `test/bundler/bundler_jsx.test.ts`: new `describe.each` over no-bunfig / bunfig-no-jsx / bunfig `jsx="react-jsx"` spawns `bun build --no-bundle a.jsx` with and without `--jsx-side-effects` alone and asserts the baseline contains `/* @__PURE__ */` with the expected runtime, and the flag drops the annotation without changing the runtime. All three rows fail on main, pass here.
- `test/cli/run/transpiler-cache.test.ts`: new test runs a >4 KiB `.jsx` with three bare `<div />;` statements and a counting `jsxDEV` shim, first without the flag (`calls=0`, cache populated) then with it (`calls=3`). Without the hash change the second run served the stale `calls=0` entry.
- Existing `jsxSideEffects` `itBundled` suite, `jsx-tsconfig-react-jsx`, `jsx-production`, and the rest of `transpiler-cache.test.ts` all continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts test/cli/run/transpiler-cache.test.ts
bun test v1.4.0 (fbb3b23c0)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1626.31ms]
(pass) bundler > jsx/AutomaticProd [966.30ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [887.69ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [926.13ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [778.55ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [1099.51ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [580.23ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [449.07ms]
(pass) bundler > jsx/ClassicDev [914.85ms]
(pass) bundler > jsx/ClassicProd [1024.35ms]
(pass) bundler > jsx/ClassicPragmaDev [935.64ms]
(pass) bundler > jsx/ClassicPragmaProd [951.57ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [968.87ms]
(pass) bundler > jsx/FactoryProd [967.75m
... (truncated)

release without fix: 1 failed, 4 skipped
bun test v1.4.0-canary.1 (6a3e7ee3f)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [252.43ms]
(pass) bundler > jsx/AutomaticProd [146.68ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [20.32ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [18.06ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [19.15ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [18.96ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [39.42ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [10.08ms]
(pass) bundler > jsx/ClassicDev [85.31ms]
(pass) bundler > jsx/ClassicProd [18.01ms]
(pass) bundler > jsx/ClassicPragmaDev [132.87ms]
(pass) bundler > jsx/ClassicPragmaProd [44.04ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [68.87ms]
(pass) bundler > jsx/FactoryProd [18.18ms]
(pass) bundler > jsx/FactoryImportDev [19.06ms]
(pass) bundler > jsx/FactoryImportProd [236.88ms]
(pass) bundler > jsx/FactoryImportExplicitReactDefaultDev [21.30ms]
(pass) bundler > jsx/FactoryImportExplic
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts test/cli/run/transpiler-cache.test.ts
bun test v1.4.0 (fbb3b23c0)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1913.45ms]
(pass) bundler > jsx/AutomaticProd [1229.67ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [1192.93ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [885.33ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [1142.28ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [1218.24ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [682.14ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [481.88ms]
(pass) bundler > jsx/ClassicDev [1065.20ms]
(pass) bundler > jsx/ClassicProd [1153.01ms]
(pass) bundler > jsx/ClassicPragmaDev [1191.03ms]
(pass) bundler > jsx/ClassicPragmaProd [954.15ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [1069.35ms]
(pass) bundler > jsx/FactoryProd [9
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2747ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/RuntimeTranspilerCache.rs     |  3 ++-
 src/options_types/jsx.rs              |  9 ++++---
 src/runtime/cli/Arguments.rs          |  7 ++---
 test/bundler/bundler_jsx.test.ts      | 49 +++++++++++++++++++++++++++++++++--
 test/bundler/expectBundled.ts         |  2 +-
 test/cli/run/transpiler-cache.test.ts | 35 +++++++++++++++++++++++++
 6 files changed, 95 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/RuntimeTranspilerCache.rs          2      2      0
src/options_types/jsx.rs                   3      4      0
src/runtime/cli/Arguments.rs               2      4      0
test/bundler/bundler_jsx.test.ts           6      9      0
test/bundler/expectBundled.ts              6      1      0
test/cli/run/transpiler-cache.test.ts      3      1      0
```

</details>

<!-- robobun:evidence:end -->