### PR TITLE
jsc: don't leak builtin @-identifiers in TypeError messages (debug/ASAN)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+export const WEBKIT_VERSION = "autobuild-preview-pr-369-bce3c3e1";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/builtin-error-message.test.ts
+++ b/test/js/bun/jsc/builtin-error-message.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 // TypeError messages thrown from JSC builtin JavaScript must not leak the
 // builtin's private @-prefixed identifiers (e.g. `@call`, `@getWrapForValidIteratorInternalField`)
@@ -23,9 +23,7 @@ test("%WrapForValidIteratorPrototype%.next on a wrapped iterator with no next me
 });
 
 test("%WrapForValidIteratorPrototype%.return with a non-callable return", () => {
-  const msg = messageOf(() =>
-    Iterator.from({ next: () => ({ done: false, value: 1 }), return: 5 } as any).return(),
-  );
+  const msg = messageOf(() => Iterator.from({ next: () => ({ done: false, value: 1 }), return: 5 } as any).return());
   expect(msg).not.toContain("@");
   expect(msg).not.toContain("returnMethod");
   expect(msg).toBe("5 is not a function");

--- a/test/js/bun/jsc/builtin-error-message.test.ts
+++ b/test/js/bun/jsc/builtin-error-message.test.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test";
+
+// TypeError messages thrown from JSC builtin JavaScript must not leak the
+// builtin's private @-prefixed identifiers (e.g. `@call`, `@getWrapForValidIteratorInternalField`)
+// into user-visible `error.message`. Release builds already suppress this by
+// omitting expression info for builtins; this test guards the ASSERT_ENABLED
+// path (debug / ASAN) where builtins do carry expression info.
+
+function messageOf(fn: () => unknown): string {
+  try {
+    fn();
+  } catch (e) {
+    return (e as Error).message;
+  }
+  throw new Error("expected fn to throw");
+}
+
+test("%WrapForValidIteratorPrototype%.next on a wrapped iterator with no next method", () => {
+  const msg = messageOf(() => Iterator.from({} as any).next());
+  expect(msg).not.toContain("@");
+  expect(msg).not.toContain("WrapForValidIterator");
+  expect(msg).toBe("undefined is not a function");
+});
+
+test("%WrapForValidIteratorPrototype%.return with a non-callable return", () => {
+  const msg = messageOf(() =>
+    Iterator.from({ next: () => ({ done: false, value: 1 }), return: 5 } as any).return(),
+  );
+  expect(msg).not.toContain("@");
+  expect(msg).not.toContain("returnMethod");
+  expect(msg).toBe("5 is not a function");
+});
+
+test("Iterator.from with a non-callable Symbol.iterator", () => {
+  const msg = messageOf(() => Iterator.from({ [Symbol.iterator]: 5 } as any));
+  expect(msg).not.toContain("@");
+  expect(msg).not.toContain("method");
+  expect(msg).toBe("5 is not a function");
+});


### PR DESCRIPTION
## What

Bumps WebKit to a preview build containing oven-sh/WebKit#369 (the current `WEBKIT_VERSION` 549170099 plus one commit) and adds a regression test.

## Why

In ASSERT_ENABLED builds (debug and ASAN), JSC builtins emit expression info. When a `.@call()` inside a builtin hits a non-callable value, the Call IC slow path (`throwNotAFunctionErrorFromCallIC` in `RepatchInlines.h`) passes the builtin code block and bytecode index straight into `appendSourceToErrorMessage`, which splices the private `@`-identifier source text into the user-visible `TypeError` message.

Release builds are unaffected because `BytecodeGenerator::emitExpressionInfo` skips builtins under `#if !ASSERT_ENABLED`, so `hasExpressionInfo()` returns false and the append step bails early.

## Repro

```js
const t = (l, f) => { try { f(); } catch (e) { console.log(l, String(e)); } };
t("A", () => Iterator.from({}).next());
t("C", () => Iterator.from({ next: () => ({ done: false, value: 1 }), return: 5 }).return());
```

debug/ASAN before:
```
A TypeError: @getWrapForValidIteratorInternalField(this, @wrapForValidIteratorFieldIteratedNextMethod).@call is not a function. (In '@getWrapForValidIteratorInternalField(this, @wrapForValidIteratorFieldIteratedNextMethod).@call(@getWrapForValidIteratorInternalField(this, @wrapForValidIteratorFieldIteratedIterator))', '@getWrapForValidIteratorInternalField(this, @wrapForValidIteratorFieldIteratedNextMethod).@call' is undefined)
C TypeError: returnMethod.@call is not a function. (In 'returnMethod.@call(iterator)', 'returnMethod.@call' is 5)
```

after (matches release output):
```
A TypeError: undefined is not a function
C TypeError: 5 is not a function
```

Also covers `Iterator.from({[Symbol.iterator]: 5})` (`getIteratorFlattenable`) and any other builtin that reaches the Call IC slow path with a non-callable.

## Verification

Built WebKit from source with the fix applied; `test/js/bun/jsc/builtin-error-message.test.ts` fails under a debug build without the WebKit change and passes with it. Release builds pass either way (they never had the leak).

## Notes

Draft until the WebKit preview build (`autobuild-preview-pr-369-bce3c3e1`) finishes publishing; CI will fail fetching WebKit until then. Once oven-sh/WebKit#369 merges, `WEBKIT_VERSION` should be set to the resulting main sha rather than the preview tag.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/builtin-error-message.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/builtin-error-message.test.ts
bun test v1.4.0 (6e52dfd22)

test/js/bun/jsc/builtin-error-message.test.ts:
(pass) %WrapForValidIteratorPrototype%.next on a wrapped iterator with no next method [17.14ms]
(pass) %WrapForValidIteratorPrototype%.return with a non-callable return [7.66ms]
(pass) Iterator.from with a non-callable Symbol.iterator [5.68ms]

 3 pass
 0 fail
 9 expect() calls
Ran 3 tests across 1 file. [2.58s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                  |  2 +-
 test/js/bun/jsc/builtin-error-message.test.ts | 37 +++++++++++++++++++++++++++
 2 files changed, 38 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
scripts/build/deps/webkit.ts                       9      6      0
test/js/bun/jsc/builtin-error-message.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->