### PR TITLE
fetch: implement the blob scheme per the Fetch spec

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -221,6 +221,105 @@ fn data_url_response(data_url_: DataURL, global_this: &JSGlobalObject) -> JSValu
     )
 }
 
+/// https://fetch.spec.whatwg.org/#scheme-fetch, `blob` scheme.
+fn blob_scheme_fetch(
+    global_this: &JSGlobalObject,
+    url: &ZigURL<'_>,
+    method: Method,
+    range_header: Option<&[u8]>,
+) -> JsResult<JSValue> {
+    let reject = |msg: core::fmt::Arguments<'_>| -> JsResult<JSValue> {
+        let err = global_this.to_type_error(jsc::ErrorCode::INVALID_ARG_VALUE, msg);
+        Ok(
+            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                global_this,
+                err,
+            ),
+        )
+    };
+
+    let path = &url.href_without_fragment()[b"blob:".len()..];
+
+    if method != Method::GET {
+        return reject(format_args!(
+            "Request method must be GET when fetching a blob: URL"
+        ));
+    }
+
+    let Some(mut blob) = ObjectURLRegistry::singleton().resolve_and_dupe(path) else {
+        return reject(format_args!("Failed to resolve blob:{}", bstr::BStr::new(path)));
+    };
+
+    let full_length = blob.size.get();
+    let mut status_code: u16 = 200;
+    let mut status_text: &[u8] = b"OK";
+    let mut content_range_buf = [0u8; crate::server::range_request::CONTENT_RANGE_BUF];
+    let mut content_range: &[u8] = b"";
+
+    if let Some(header) = range_header {
+        match crate::server::range_request::parse(header, full_length) {
+            crate::server::range_request::Result::Satisfiable { start, end } => {
+                let len = end - start + 1;
+                blob.offset.set(blob.offset.get().saturating_add(start));
+                blob.size.set(len);
+                status_code = 206;
+                status_text = b"Partial Content";
+                content_range = crate::server::range_request::format_content_range(
+                    &mut content_range_buf,
+                    crate::server::range_request::Result::Satisfiable { start, end },
+                    Some(full_length),
+                );
+            }
+            _ => {
+                blob.deinit();
+                return reject(format_args!(
+                    "Failed to fetch blob:{}: invalid Range",
+                    bstr::BStr::new(path)
+                ));
+            }
+        }
+    }
+
+    let mut response_headers = response::HeadersRef::create_empty();
+    let mut len_buf = [0u8; 20];
+    let len_str = bun_core::fmt::buf_print_infallible(&mut len_buf, format_args!("{}", blob.size.get()));
+    response_headers.put(
+        HTTPHeaderName::ContentLength,
+        &BunString::borrow_utf8(len_str),
+        global_this,
+    )?;
+    let content_type = blob.content_type.get();
+    response_headers.put(
+        HTTPHeaderName::ContentType,
+        &BunString::borrow_utf8(content_type.as_slice()),
+        global_this,
+    )?;
+    if !content_range.is_empty() {
+        response_headers.put(
+            HTTPHeaderName::ContentRange,
+            &BunString::borrow_utf8(content_range),
+            global_this,
+        )?;
+    }
+
+    let response = bun_core::heap::into_raw(Box::new(Response::init(
+        response::Init {
+            status_code,
+            status_text: BunString::create_atom(status_text).into(),
+            headers: Some(response_headers),
+            ..Default::default()
+        },
+        Body::new(BodyValue::Blob(blob)),
+        BunString::create_format(format_args!("blob:{}", bstr::BStr::new(path))),
+        false,
+    )));
+
+    Ok(JSPromise::resolved_promise_value(
+        global_this,
+        Response::make_maybe_pooled(global_this, response),
+    ))
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Bun__fetchPreconnect
 // ──────────────────────────────────────────────────────────────────────────
@@ -1375,7 +1474,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             if let Some(hostname_) = headers_ref.fast_get(HTTPHeaderName::Host) {
                 hostname = Some(hostname_.to_owned_slice().into_boxed_slice());
             }
-            if url.is_s3() {
+            if url.is_s3() || url_type == URLType::Blob {
                 if let Some(range_) = headers_ref.fast_get(HTTPHeaderName::Range) {
                     range = Some(range_.to_owned_slice_z());
                 }
@@ -1423,6 +1522,15 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         return Ok(JSValue::ZERO);
     }
 
+    if url_type == URLType::Blob {
+        return blob_scheme_fetch(
+            global_this,
+            &url,
+            method,
+            range.as_ref().map(|z| z.as_bytes()),
+        );
+    }
+
     // This is not 100% correct.
     // We don't pass along headers, we ignore method, we ignore status code...
     // But it's better than status quo.
@@ -1434,8 +1542,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             &mut path_buf2[..],
             match url_type {
                 URLType::File => url.path,
-                URLType::Blob => &url.href_without_fragment()[b"blob:".len()..],
-                URLType::Remote => unreachable!(),
+                URLType::Blob | URLType::Remote => unreachable!(),
             },
         ) {
             Ok(n) => n,
@@ -1447,42 +1554,13 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         };
         let url_path_decoded = &path_buf2[0..decoded_len as usize];
 
-        // Carries a +1 WTFStringImpl ref on both assignment arms (`create_format`
-        // for blob:, `file_url_from_string` → `Bun::toStringRef` for file:).
-        // `Response::init` wraps it in `OwnedString` and adopts that +1, so it
-        // is passed by value below without an extra `.clone()`.
+        // Carries a +1 WTFStringImpl ref (`file_url_from_string` →
+        // `Bun::toStringRef`). `Response::init` wraps it in `OwnedString` and
+        // adopts that +1, so it is passed by value below without an extra
+        // `.clone()`.
         let url_string: BunString;
 
-        // This can be a blob: url or a file: url.
         let blob_to_use: Blob = 'blob: {
-            // Support blob: urls
-            if url_type == URLType::Blob {
-                if let Some(blob) =
-                    ObjectURLRegistry::singleton().resolve_and_dupe(url_path_decoded)
-                {
-                    url_string = BunString::create_format(format_args!(
-                        "blob:{}",
-                        bstr::BStr::new(url_path_decoded)
-                    ));
-                    break 'blob blob;
-                } else {
-                    // Consistent with what Node.js does - it rejects, not a 404.
-                    let err = global_this.to_type_error(
-                        jsc::ErrorCode::INVALID_ARG_VALUE,
-                        format_args!(
-                            "Failed to resolve blob:{}",
-                            bstr::BStr::new(url_path_decoded)
-                        ),
-                    );
-                    return Ok(
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            global_this,
-                            err,
-                        ),
-                    );
-                }
-            }
-
             let temp_file_path: &[u8] = 'brk: {
                 if bun_paths::is_absolute(url_path_decoded) {
                     #[cfg(windows)]
@@ -1584,19 +1662,19 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         ));
     }
 
-    if !url.protocol.is_empty() {
-        if !(url.is_http() || url.is_https() || url.is_s3()) {
-            let err = global_this.to_type_error(
-                jsc::ErrorCode::INVALID_ARG_VALUE,
-                format_args!("protocol must be http:, https: or s3:"),
-            );
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    err,
-                ),
-            );
-        }
+    if (!url.protocol.is_empty() && !(url.is_http() || url.is_https() || url.is_s3()))
+        || url.is_blob()
+    {
+        let err = global_this.to_type_error(
+            jsc::ErrorCode::INVALID_ARG_VALUE,
+            format_args!("protocol must be http:, https: or s3:"),
+        );
+        return Ok(
+            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                global_this,
+                err,
+            ),
+        );
     }
 
     // WHATWG Fetch step 36 forbids a body for GET/HEAD; Bun additionally

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -290,10 +290,8 @@ fn blob_scheme_fetch(
     let mut response_headers = response::HeadersRef::create_empty();
     if size_known {
         let mut len_buf = [0u8; 20];
-        let len_str = bun_core::fmt::buf_print_infallible(
-            &mut len_buf,
-            format_args!("{}", blob.size.get()),
-        );
+        let len_str =
+            bun_core::fmt::buf_print_infallible(&mut len_buf, format_args!("{}", blob.size.get()));
         response_headers.put(
             HTTPHeaderName::ContentLength,
             &BunString::borrow_utf8(len_str),

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1434,8 +1434,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             &mut path_buf2[..],
             match url_type {
                 URLType::File => url.path,
-                // Blob URL store lookup excludes the fragment
-                // (https://w3c.github.io/FileAPI/#blob-url-resolve).
                 URLType::Blob => &url.href_without_fragment()[b"blob:".len()..],
                 URLType::Remote => unreachable!(),
             },

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1434,7 +1434,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             &mut path_buf2[..],
             match url_type {
                 URLType::File => url.path,
-                URLType::Blob => &url.href[b"blob:".len()..],
+                // Blob URL store lookup excludes the fragment
+                // (https://w3c.github.io/FileAPI/#blob-url-resolve).
+                URLType::Blob => &url.href_without_fragment()[b"blob:".len()..],
                 URLType::Remote => unreachable!(),
             },
         ) {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -253,13 +253,17 @@ fn blob_scheme_fetch(
         ));
     };
 
+    if blob.size.get() == blob::MAX_SIZE {
+        blob.resolve_size();
+    }
     let full_length = blob.size.get();
+    let size_known = full_length != blob::MAX_SIZE;
     let mut status_code: u16 = 200;
     let mut status_text: &[u8] = b"OK";
     let mut content_range_buf = [0u8; crate::server::range_request::CONTENT_RANGE_BUF];
     let mut content_range: &[u8] = b"";
 
-    if let Some(header) = range_header {
+    if let Some(header) = range_header.filter(|_| size_known) {
         match crate::server::range_request::parse(header, full_length) {
             crate::server::range_request::Result::Satisfiable { start, end } => {
                 let len = end - start + 1;
@@ -284,14 +288,18 @@ fn blob_scheme_fetch(
     }
 
     let mut response_headers = response::HeadersRef::create_empty();
-    let mut len_buf = [0u8; 20];
-    let len_str =
-        bun_core::fmt::buf_print_infallible(&mut len_buf, format_args!("{}", blob.size.get()));
-    response_headers.put(
-        HTTPHeaderName::ContentLength,
-        &BunString::borrow_utf8(len_str),
-        global_this,
-    )?;
+    if size_known {
+        let mut len_buf = [0u8; 20];
+        let len_str = bun_core::fmt::buf_print_infallible(
+            &mut len_buf,
+            format_args!("{}", blob.size.get()),
+        );
+        response_headers.put(
+            HTTPHeaderName::ContentLength,
+            &BunString::borrow_utf8(len_str),
+            global_this,
+        )?;
+    }
     let content_type = blob.content_type.get();
     response_headers.put(
         HTTPHeaderName::ContentType,

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -247,7 +247,10 @@ fn blob_scheme_fetch(
     }
 
     let Some(mut blob) = ObjectURLRegistry::singleton().resolve_and_dupe(path) else {
-        return reject(format_args!("Failed to resolve blob:{}", bstr::BStr::new(path)));
+        return reject(format_args!(
+            "Failed to resolve blob:{}",
+            bstr::BStr::new(path)
+        ));
     };
 
     let full_length = blob.size.get();
@@ -282,7 +285,8 @@ fn blob_scheme_fetch(
 
     let mut response_headers = response::HeadersRef::create_empty();
     let mut len_buf = [0u8; 20];
-    let len_str = bun_core::fmt::buf_print_infallible(&mut len_buf, format_args!("{}", blob.size.get()));
+    let len_str =
+        bun_core::fmt::buf_print_infallible(&mut len_buf, format_args!("{}", blob.size.get()));
     response_headers.put(
         HTTPHeaderName::ContentLength,
         &BunString::borrow_utf8(len_str),

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -253,11 +253,11 @@ fn blob_scheme_fetch(
         ));
     };
 
-    if blob.size.get() == blob::MAX_SIZE && !blob.is_s3() {
+    if blob.needs_to_read_file() {
         blob.resolve_size();
     }
     let full_length = blob.size.get();
-    let size_known = full_length != blob::MAX_SIZE;
+    let size_known = full_length != blob::MAX_SIZE && !blob.is_s3();
     let mut status_code: u16 = 200;
     let mut status_text: &[u8] = b"OK";
     let mut content_range_buf = [0u8; crate::server::range_request::CONTENT_RANGE_BUF];

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -253,7 +253,7 @@ fn blob_scheme_fetch(
         ));
     };
 
-    if blob.size.get() == blob::MAX_SIZE {
+    if blob.size.get() == blob::MAX_SIZE && !blob.is_s3() {
         blob.resolve_size();
     }
     let full_length = blob.size.get();

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -338,11 +338,22 @@ impl<'a> URL<'a> {
         b""
     }
 
-    /// `"blob:".len + UUID.stringLength` — see `runtime/webcore/ObjectURLRegistry.specifier_len`.
-    const BLOB_SPECIFIER_LEN: usize = b"blob:".len() + 36;
+    /// `href` up to (not including) the fragment. `#` only ever occurs in a
+    /// serialized URL as the fragment delimiter (WHATWG URL serializer).
+    pub fn href_without_fragment(&self) -> &'a [u8] {
+        match strings::index_of_char(self.href, b'#') {
+            Some(i) => &self.href[..i as usize],
+            None => self.href,
+        }
+    }
 
+    /// Any `blob:`-scheme URL. A `blob:` URL is never a network request, so
+    /// fetch must not fall through to the HTTP path regardless of what follows
+    /// the scheme (fragment, query, or a pathname that does not parse as a
+    /// UUID). WHATWG parsing lowercases the scheme, so a literal prefix match
+    /// on `href` is sufficient.
     pub fn is_blob(&self) -> bool {
-        self.href.len() == Self::BLOB_SPECIFIER_LEN && self.href.starts_with(b"blob:")
+        self.href.starts_with(b"blob:")
     }
 
     // Ownership: returns an `OwnedURL` that owns the buffer; callers borrow

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -338,8 +338,6 @@ impl<'a> URL<'a> {
         b""
     }
 
-    /// `href` up to (not including) the fragment. `#` only ever occurs in a
-    /// serialized URL as the fragment delimiter (WHATWG URL serializer).
     pub fn href_without_fragment(&self) -> &'a [u8] {
         match strings::index_of_char(self.href, b'#') {
             Some(i) => &self.href[..i as usize],
@@ -347,11 +345,6 @@ impl<'a> URL<'a> {
         }
     }
 
-    /// Any `blob:`-scheme URL. A `blob:` URL is never a network request, so
-    /// fetch must not fall through to the HTTP path regardless of what follows
-    /// the scheme (fragment, query, or a pathname that does not parse as a
-    /// UUID). WHATWG parsing lowercases the scheme, so a literal prefix match
-    /// on `href` is sufficient.
     pub fn is_blob(&self) -> bool {
         self.href.starts_with(b"blob:")
     }

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 import type { BlobOptions } from "node:buffer";
 import type { BinaryLike } from "node:crypto";
@@ -180,6 +180,70 @@ test("blob: fetch with a fragment resolves from the store; any other blob: URL r
   } finally {
     URL.revokeObjectURL(url);
   }
+});
+
+// https://fetch.spec.whatwg.org/#scheme-fetch, blob scheme
+describe("blob: scheme fetch", () => {
+  const body = "hello-7420";
+  let url: string;
+  beforeAll(() => {
+    url = URL.createObjectURL(new Blob([body], { type: "video/mp4" }));
+  });
+  afterAll(() => URL.revokeObjectURL(url));
+
+  test("sets Content-Length and Content-Type", async () => {
+    const r = await fetch(url);
+    expect({
+      status: r.status,
+      statusText: r.statusText,
+      contentLength: r.headers.get("Content-Length"),
+      contentType: r.headers.get("Content-Type"),
+    }).toEqual({
+      status: 200,
+      statusText: "OK",
+      contentLength: String(body.length),
+      contentType: "video/mp4",
+    });
+    expect(await r.text()).toBe(body);
+  });
+
+  test("rejects any method other than GET", async () => {
+    for (const method of ["POST", "PUT", "DELETE", "HEAD", "PATCH", "OPTIONS"]) {
+      expect(async () => await fetch(url, { method })).toThrow(TypeError);
+    }
+  });
+
+  test.each([
+    ["bytes=2-5", 206, "bytes 2-5/10", "llo-"],
+    ["bytes=2-", 206, "bytes 2-9/10", "llo-7420"],
+    ["bytes=-3", 206, "bytes 7-9/10", "420"],
+    ["bytes=0-0", 206, "bytes 0-0/10", "h"],
+    ["bytes=2-999", 206, "bytes 2-9/10", "llo-7420"],
+    ["bytes=0-9", 206, "bytes 0-9/10", body],
+  ])("Range: %s", async (header, status, contentRange, expectedBody) => {
+    const r = await fetch(url, { headers: { Range: header } });
+    expect({
+      status: r.status,
+      statusText: r.statusText,
+      contentRange: r.headers.get("Content-Range"),
+      contentLength: r.headers.get("Content-Length"),
+      contentType: r.headers.get("Content-Type"),
+    }).toEqual({
+      status,
+      statusText: "Partial Content",
+      contentRange,
+      contentLength: String(expectedBody.length),
+      contentType: "video/mp4",
+    });
+    expect(await r.text()).toBe(expectedBody);
+  });
+
+  test.each(["bytes=999-", "garbage", "bytes=5-2", "bytes=1-3, 5-7", "bytes=-0"])(
+    "rejects invalid/unsatisfiable Range: %s",
+    async header => {
+      expect(async () => await fetch(url, { headers: { Range: header } })).toThrow(TypeError);
+    },
+  );
 });
 
 test("blob: URL has Content-Type", async () => {

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -247,21 +247,33 @@ describe("blob: scheme fetch", () => {
 
   test("resolves a file-backed blob's size before Content-Length/Range", async () => {
     using dir = tempDir("blob-scheme-file", { "x.bin": "hello" });
-    const fileUrl = URL.createObjectURL(Bun.file(path.join(String(dir), "x.bin")));
-    try {
-      const full = await fetch(fileUrl);
-      expect(full.headers.get("Content-Length")).toBe("5");
-      expect(await full.text()).toBe("hello");
+    const file = Bun.file(path.join(String(dir), "x.bin"));
 
-      const part = await fetch(fileUrl, { headers: { Range: "bytes=-3" } });
-      expect({
-        status: part.status,
-        contentLength: part.headers.get("Content-Length"),
-        contentRange: part.headers.get("Content-Range"),
-      }).toEqual({ status: 206, contentLength: "3", contentRange: "bytes 2-4/5" });
-      expect(await part.text()).toBe("llo");
-    } finally {
-      URL.revokeObjectURL(fileUrl);
+    for (const [blob, body] of [
+      [file, "hello"],
+      [file.slice(3), "lo"],
+      [file.slice(1, 4), "ell"],
+    ] as const) {
+      const url = URL.createObjectURL(blob);
+      try {
+        const full = await fetch(url);
+        expect(full.headers.get("Content-Length")).toBe(String(body.length));
+        expect(await full.text()).toBe(body);
+
+        const part = await fetch(url, { headers: { Range: "bytes=-1" } });
+        expect({
+          status: part.status,
+          contentLength: part.headers.get("Content-Length"),
+          contentRange: part.headers.get("Content-Range"),
+        }).toEqual({
+          status: 206,
+          contentLength: "1",
+          contentRange: `bytes ${body.length - 1}-${body.length - 1}/${body.length}`,
+        });
+        expect(await part.text()).toBe(body.at(-1));
+      } finally {
+        URL.revokeObjectURL(url);
+      }
     }
   });
 });

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -130,35 +130,41 @@ test("blob: can be fetched", async () => {
 // below fell through to the remote path and attempted a DNS lookup for host
 // "blob" (getaddrinfo ENOTFOUND blob).
 test("blob: fetch with a fragment resolves from the store; any other blob: URL rejects without touching the network", async () => {
+  // Sentinel proxy: if fetch ever hands a blob: URL to the HTTP client, the
+  // request lands here. The test asserts this stays at zero.
+  let proxyHits = 0;
+  using sentinel = Bun.serve({
+    port: 0,
+    fetch() {
+      proxyHits++;
+      return new Response("leaked to network");
+    },
+  });
+  const proxy = sentinel.url.href;
+
   const blob = new Blob(["payload"], { type: "video/mp4" });
   const url = URL.createObjectURL(blob);
   try {
     // Fragment is excluded from the store lookup.
-    const withFragment = await fetch(url + "#t=10");
+    const withFragment = await fetch(url + "#t=10", { proxy });
     expect(withFragment.headers.get("Content-Type")).toBe("video/mp4");
     expect(withFragment.url).toBe(url);
     expect(await withFragment.text()).toBe("payload");
 
-    const emptyFragment = await fetch(url + "#");
+    const emptyFragment = await fetch(url + "#", { proxy });
     expect(emptyFragment.url).toBe(url);
     expect(await emptyFragment.text()).toBe("payload");
 
     // Blob URL store misses: reject with TypeError (as Node does), and never
-    // fall through to the HTTP client. With http_proxy set (as in CI) the
-    // remote path would succeed against the proxy, so assert on the error
-    // shape rather than just "rejects".
+    // fall through to the HTTP client.
     const assertStoreMiss = async (u: string) => {
       let err: unknown;
       try {
-        await fetch(u);
+        await fetch(u, { proxy });
       } catch (e) {
         err = e;
       }
       expect(err).toBeInstanceOf(TypeError);
-      // When the blob: URL leaks to the HTTP client, the error is a DNS
-      // failure for host "blob" (or, with a proxy, no error at all).
-      expect((err as any)?.code).not.toBe("ENOTFOUND");
-      expect(String((err as Error)?.message)).not.toContain("getaddrinfo");
     };
 
     // Query is part of the serialization (not excluded), so this is a miss.
@@ -169,6 +175,8 @@ test("blob: fetch with a fragment resolves from the store; any other blob: URL r
     // Not a UUID at all.
     await assertStoreMiss("blob:not-a-uuid");
     await assertStoreMiss("blob:http://example.com/whatever");
+
+    expect(proxyHits).toBe(0);
   } finally {
     URL.revokeObjectURL(url);
   }

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -123,6 +123,57 @@ test("blob: can be fetched", async () => {
   }).toThrow();
 });
 
+// https://w3c.github.io/FileAPI/#blob-url-resolve: lookup uses the URL serialized
+// with the exclude-fragment flag, and a blob: URL that misses the store is a
+// network error. Either way, a blob: URL must never reach the HTTP/DNS stack.
+// Before this was fixed, the "with fragment"/"with query"/"not a UUID" cases
+// below fell through to the remote path and attempted a DNS lookup for host
+// "blob" (getaddrinfo ENOTFOUND blob).
+test("blob: fetch with a fragment resolves from the store; any other blob: URL rejects without touching the network", async () => {
+  const blob = new Blob(["payload"], { type: "video/mp4" });
+  const url = URL.createObjectURL(blob);
+  try {
+    // Fragment is excluded from the store lookup.
+    const withFragment = await fetch(url + "#t=10");
+    expect(withFragment.headers.get("Content-Type")).toBe("video/mp4");
+    expect(withFragment.url).toBe(url);
+    expect(await withFragment.text()).toBe("payload");
+
+    const emptyFragment = await fetch(url + "#");
+    expect(emptyFragment.url).toBe(url);
+    expect(await emptyFragment.text()).toBe("payload");
+
+    // Blob URL store misses: reject with TypeError (as Node does), and never
+    // fall through to the HTTP client. With http_proxy set (as in CI) the
+    // remote path would succeed against the proxy, so assert on the error
+    // shape rather than just "rejects".
+    const assertStoreMiss = async (u: string) => {
+      let err: unknown;
+      try {
+        await fetch(u);
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(TypeError);
+      // When the blob: URL leaks to the HTTP client, the error is a DNS
+      // failure for host "blob" (or, with a proxy, no error at all).
+      expect((err as any)?.code).not.toBe("ENOTFOUND");
+      expect(String((err as Error)?.message)).not.toContain("getaddrinfo");
+    };
+
+    // Query is part of the serialization (not excluded), so this is a miss.
+    await assertStoreMiss(url + "?x=1");
+    await assertStoreMiss(url + "?x=1#frag");
+    // Not a registered UUID.
+    await assertStoreMiss("blob:00000000-0000-0000-0000-000000000000#frag");
+    // Not a UUID at all.
+    await assertStoreMiss("blob:not-a-uuid");
+    await assertStoreMiss("blob:http://example.com/whatever");
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+});
+
 test("blob: URL has Content-Type", async () => {
   const blob = new File(["Bun", "Foo"], "file.txt", { type: "text/javascript;charset=utf-8" });
   const url = URL.createObjectURL(blob);

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -244,6 +244,26 @@ describe("blob: scheme fetch", () => {
       expect(async () => await fetch(url, { headers: { Range: header } })).toThrow(TypeError);
     },
   );
+
+  test("resolves a file-backed blob's size before Content-Length/Range", async () => {
+    using dir = tempDir("blob-scheme-file", { "x.bin": "hello" });
+    const fileUrl = URL.createObjectURL(Bun.file(path.join(String(dir), "x.bin")));
+    try {
+      const full = await fetch(fileUrl);
+      expect(full.headers.get("Content-Length")).toBe("5");
+      expect(await full.text()).toBe("hello");
+
+      const part = await fetch(fileUrl, { headers: { Range: "bytes=-3" } });
+      expect({
+        status: part.status,
+        contentLength: part.headers.get("Content-Length"),
+        contentRange: part.headers.get("Content-Range"),
+      }).toEqual({ status: 206, contentLength: "3", contentRange: "bytes 2-4/5" });
+      expect(await part.text()).toBe("llo");
+    } finally {
+      URL.revokeObjectURL(fileUrl);
+    }
+  });
 });
 
 test("blob: URL has Content-Type", async () => {

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -455,8 +455,8 @@ describe.each(["string", "object"])("fetch({proxy}) %s form does not leak the pr
         async function hit(i) {
           const proxyUrl = "http://127.0.0.1:1/" + i + "/" + pad;
           const opts = ${form === "string" ? `{ proxy: proxyUrl }` : `{ proxy: { url: proxyUrl } }`};
-          // 41-byte blob: URL (5 + 36-char UUID) so ZigURL::is_blob() matches
-          // and fetch rejects from the blob registry with no FetchTasklet.
+          // Unregistered blob: URL: fetch parses the proxy option then rejects
+          // from the blob registry with no FetchTasklet.
           try { await fetch("blob:00000000-0000-0000-0000-000000000000", opts); } catch {}
         }
 


### PR DESCRIPTION
## Repro

```js
const u = URL.createObjectURL(new Blob(["hello-7420"], { type: "text/plain" }));
await fetch(u);                                   // 200, but no Content-Length header
await fetch(u + "#t=10");                         // getaddrinfo ENOTFOUND blob (DNS lookup!)
await fetch(u + "?x=1");                          // getaddrinfo ENOTFOUND blob
await fetch("blob:not-a-uuid");                   // getaddrinfo ENOTFOUND blob
await fetch(u, { method: "POST", body: "x" });    // 200 (spec: network error)
await fetch(u, { headers: { Range: "bytes=2-5" }}); // 200 full body (spec: 206 slice)
```

`strace -e connect` shows a UDP connect to the DNS resolver on port 53 for every `blob:` URL that is not exactly 41 bytes long. On a host where `blob` resolves (search domain, wildcard DNS), a plaintext HTTP request goes out for what should be a purely in-process object URL.

## Cause

* `URL::is_blob()` required `href.len() == "blob:".len() + 36`, so any `blob:` URL carrying a fragment, a query, or a pathname that is not exactly a 36-character UUID was classified as `URLType::Remote`. `ZigURL::parse_protocol` only recognizes `scheme://` so `protocol` stayed empty; `parse_host` then took everything before the first `:` as hostname `blob`, and the scheme guard at the top of the remote path was skipped because `protocol` was empty. The HTTP thread called `getaddrinfo("blob")`.
* The blob/file response builder (`fetch.rs:1567`) ignored the request method, set no headers, and ignored `Range`: the comment above it said so.

## Fix

`blob:` URLs now go through a dedicated `blob_scheme_fetch()` that follows https://fetch.spec.whatwg.org/#scheme-fetch for the blob scheme:

* `URL::is_blob()` matches any `blob:`-scheme href (no length gate), so every `blob:` URL is routed here and none can ever reach the HTTP client.
* The store lookup uses the href serialized with the exclude-fragment flag ([File API](https://w3c.github.io/FileAPI/#blob-url-resolve)), so `blob:<uuid>#t=10` resolves exactly like `blob:<uuid>`. A query string is kept in the lookup key, so `blob:<uuid>?x=1` is a store miss.
* Any method other than `GET` is a network error.
* The response carries `Content-Length` and `Content-Type`.
* A `Range` request header is honored: a satisfiable single range returns `206 Partial Content` with `Content-Range` and a sliced body (reusing `server::range_request`); an unparseable or unsatisfiable range is a network error.
* A `blob:` URL that misses the store (unregistered, revoked, query string, non-UUID path) rejects with `TypeError: Failed to resolve blob:...` and never touches the network, matching Node/undici.
* The remote-path scheme guard now also rejects any `blob:`-prefixed href that reaches it, so a future `is_blob()` regression surfaces as a `TypeError` instead of a DNS lookup.

The `file:` handler is unchanged.

## Verification

```
GET      200 hello-7420 CL:10 CT:text/plain
#frag    200 hello-7420 CL:10
?q       rejected: Failed to resolve blob:<uuid>?q
POST     rejected: Request method must be GET when fetching a blob: URL
HEAD     rejected: Request method must be GET when fetching a blob: URL
bytes=2-5    206 "llo-"     CL:4 CR:bytes 2-5/10
bytes=2-     206 "llo-7420" CL:8 CR:bytes 2-9/10
bytes=-3     206 "420"      CL:3 CR:bytes 7-9/10
bytes=999-   rejected: invalid Range
garbage      rejected: invalid Range
```

Overlaps with the fragment-stripping part of #33499 (a broader `Response.type`/`url` change), but that PR's `is_blob()` still length-gates after stripping the fragment, so `blob:<uuid>?x=1` and `blob:not-a-uuid` still fall through to the HTTP client there.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch-leak.test.ts

<!-- robobun:evidence:end -->