### PR TITLE
fetch: implement the blob: URL scheme fetch (method gate, Content-Length, Range)

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1423,9 +1423,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         return Ok(JSValue::ZERO);
     }
 
-    // Scheme fetch for blob: and file:. blob: follows the fetch spec (method
-    // gate, Content-Length, Range). file: remains Bun-specific: method and
-    // request headers are ignored.
     if url_type != URLType::Remote {
         // `defer unix_socket_path.deinit()` → Drop on scope exit.
         let mut path_buf = PathBuffer::uninit();
@@ -1447,13 +1444,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         };
         let url_path_decoded = &path_buf2[0..decoded_len as usize];
 
-        // Carries a +1 WTFStringImpl ref on both assignment arms (`create_format`
-        // for blob:, `file_url_from_string` → `Bun::toStringRef` for file:).
-        // `Response::init` wraps it in `OwnedString` and adopts that +1, so it
-        // is passed by value below without an extra `.clone()`.
+        // +1 WTFStringImpl ref; `Response::init` wraps it in `OwnedString` and adopts it.
         let url_string: BunString;
 
-        // This can be a blob: url or a file: url.
         let blob_to_use: Blob = 'blob: {
             // https://fetch.spec.whatwg.org/#concept-scheme-fetch "blob"
             if url_type == URLType::Blob {
@@ -1472,8 +1465,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     }};
                 }
 
-                // 2. If request's method is not `GET` or blobURLEntry is null,
-                //    then return a network error.
                 if method != Method::GET {
                     reject!("fetch failed: only GET is allowed for blob: URLs");
                 }
@@ -1490,7 +1481,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     bstr::BStr::new(url_path_decoded)
                 ));
 
-                // 5. Let fullLength be blob's size.
                 blob.resolve_size();
                 let full_length = blob.size.get();
                 let blob_type = blob.content_type_slice();
@@ -1502,15 +1492,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
                 if let Some(range_header) = &range {
                     use crate::server::RangeRequest;
-                    // 9.4. If rangeValue is failure, then return a network error.
                     let (start, end) = match RangeRequest::parse_raw(range_header.as_bytes()) {
                         RangeRequest::Raw::None => {
                             reject!("fetch failed: invalid Range header")
                         }
                         RangeRequest::Raw::Suffix(n) => {
-                            // 9.6. If rangeStart is null:
-                            //   1. Set rangeStart to fullLength − rangeEnd.
-                            //   2. Set rangeEnd to rangeStart + rangeEnd − 1.
                             if full_length == 0 {
                                 reject!("fetch failed: Range is unsatisfiable for an empty blob")
                             }
@@ -1520,18 +1506,13 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                             if matches!(end, Some(e) if e < start) {
                                 reject!("fetch failed: invalid Range header")
                             }
-                            // 9.7.1. If rangeStart is greater than or equal to
-                            //        fullLength, then return a network error.
                             if start >= full_length {
                                 reject!("fetch failed: Range start is greater than the blob's size")
                             }
-                            // 9.7.2. If rangeEnd is null or rangeEnd is greater than or
-                            //        equal to fullLength, set rangeEnd to fullLength − 1.
                             (start, end.unwrap_or(full_length - 1).min(full_length - 1))
                         }
                     };
-                    // 9.8. Let slicedBlob be the result of invoking slice blob
-                    //      given blob, rangeStart, rangeEnd + 1, and type.
+                    // slice is [start, end+1); offset is relative to the dupe's existing window
                     blob.offset.set(blob.offset.get().saturating_add(start));
                     length = end - start + 1;
                     blob.size.set(length);
@@ -1579,8 +1560,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     false,
                 )));
 
-                // Ownership of the boxed Response transfers to the JS GC; see
-                // `data_url_response` for the rationale.
                 return Ok(JSPromise::resolved_promise_value(
                     global_this,
                     Response::make_maybe_pooled(global_this, response),

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1465,6 +1465,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     }};
                 }
 
+                use crate::server::RangeRequest;
+
                 if method != Method::GET {
                     reject!("fetch failed: only GET is allowed for blob: URLs");
                 }
@@ -1476,29 +1478,22 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     );
                 };
 
-                let url_string = BunString::create_format(format_args!(
-                    "blob:{}",
-                    bstr::BStr::new(url_path_decoded)
-                ));
-
                 blob.resolve_size();
                 let full_length = blob.size.get();
-                let blob_type = blob.content_type_slice();
 
                 let mut status_code: u16 = 200;
                 let mut status_text: &[u8] = b"OK";
                 let mut length = full_length;
-                let mut content_range: Option<(u64, u64)> = None;
+                let mut content_range = RangeRequest::Result::None;
 
                 if let Some(range_header) = &range {
-                    use crate::server::RangeRequest;
                     let (start, end) = match RangeRequest::parse_raw(range_header.as_bytes()) {
                         RangeRequest::Raw::None => {
                             reject!("fetch failed: invalid Range header")
                         }
                         RangeRequest::Raw::Suffix(n) => {
-                            if full_length == 0 {
-                                reject!("fetch failed: Range is unsatisfiable for an empty blob")
+                            if n == 0 || full_length == 0 {
+                                reject!("fetch failed: Range is unsatisfiable")
                             }
                             (full_length.saturating_sub(n), full_length - 1)
                         }
@@ -1518,7 +1513,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     blob.size.set(length);
                     status_code = 206;
                     status_text = b"Partial Content";
-                    content_range = Some((start, end));
+                    content_range = RangeRequest::Result::Satisfiable { start, end };
                 }
 
                 let mut response_headers = response::HeadersRef::create_empty();
@@ -1533,16 +1528,17 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 )?;
                 response_headers.put(
                     HTTPHeaderName::ContentType,
-                    &BunString::ascii(blob_type),
+                    &BunString::ascii(blob.content_type_slice()),
                     global_this,
                 )?;
-                if let Some((start, end)) = content_range {
-                    let mut cr_buf = [0u8; crate::server::RangeRequest::CONTENT_RANGE_BUF];
+                if let RangeRequest::Result::Satisfiable { .. } = content_range {
+                    let mut cr_buf = [0u8; RangeRequest::CONTENT_RANGE_BUF];
                     response_headers.put(
                         HTTPHeaderName::ContentRange,
-                        &BunString::ascii(bun_core::fmt::buf_print_infallible(
+                        &BunString::ascii(RangeRequest::format_content_range(
                             &mut cr_buf,
-                            format_args!("bytes {}-{}/{}", start, end, full_length),
+                            content_range,
+                            Some(full_length),
                         )),
                         global_this,
                     )?;
@@ -1556,7 +1552,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         ..Default::default()
                     },
                     Body::new(BodyValue::Blob(blob)),
-                    url_string,
+                    BunString::create_format(format_args!(
+                        "blob:{}",
+                        bstr::BStr::new(url_path_decoded)
+                    )),
                     false,
                 )));
 

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1375,7 +1375,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             if let Some(hostname_) = headers_ref.fast_get(HTTPHeaderName::Host) {
                 hostname = Some(hostname_.to_owned_slice().into_boxed_slice());
             }
-            if url.is_s3() {
+            if url.is_s3() || url_type == URLType::Blob {
                 if let Some(range_) = headers_ref.fast_get(HTTPHeaderName::Range) {
                     range = Some(range_.to_owned_slice_z());
                 }
@@ -1423,9 +1423,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         return Ok(JSValue::ZERO);
     }
 
-    // This is not 100% correct.
-    // We don't pass along headers, we ignore method, we ignore status code...
-    // But it's better than status quo.
+    // Scheme fetch for blob: and file:. blob: follows the fetch spec (method
+    // gate, Content-Length, Range). file: remains Bun-specific: method and
+    // request headers are ignored.
     if url_type != URLType::Remote {
         // `defer unix_socket_path.deinit()` → Drop on scope exit.
         let mut path_buf = PathBuffer::uninit();
@@ -1455,32 +1455,136 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
         // This can be a blob: url or a file: url.
         let blob_to_use: Blob = 'blob: {
-            // Support blob: urls
+            // https://fetch.spec.whatwg.org/#concept-scheme-fetch "blob"
             if url_type == URLType::Blob {
-                if let Some(blob) =
-                    ObjectURLRegistry::singleton().resolve_and_dupe(url_path_decoded)
-                {
-                    url_string = BunString::create_format(format_args!(
-                        "blob:{}",
-                        bstr::BStr::new(url_path_decoded)
-                    ));
-                    break 'blob blob;
-                } else {
-                    // Consistent with what Node.js does - it rejects, not a 404.
-                    let err = global_this.to_type_error(
-                        jsc::ErrorCode::INVALID_ARG_VALUE,
-                        format_args!(
-                            "Failed to resolve blob:{}",
-                            bstr::BStr::new(url_path_decoded)
-                        ),
-                    );
-                    return Ok(
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            global_this,
-                            err,
-                        ),
-                    );
+                macro_rules! reject {
+                    ($($args:tt)*) => {{
+                        let err = global_this.to_type_error(
+                            jsc::ErrorCode::INVALID_ARG_VALUE,
+                            format_args!($($args)*),
+                        );
+                        return Ok(
+                            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                                global_this,
+                                err,
+                            ),
+                        );
+                    }};
                 }
+
+                // 2. If request's method is not `GET` or blobURLEntry is null,
+                //    then return a network error.
+                if method != Method::GET {
+                    reject!("fetch failed: only GET is allowed for blob: URLs");
+                }
+                let Some(blob) =
+                    ObjectURLRegistry::singleton().resolve_and_dupe(url_path_decoded)
+                else {
+                    reject!("Failed to resolve blob:{}", bstr::BStr::new(url_path_decoded));
+                };
+
+                let url_string = BunString::create_format(format_args!(
+                    "blob:{}",
+                    bstr::BStr::new(url_path_decoded)
+                ));
+
+                // 5. Let fullLength be blob's size.
+                blob.resolve_size();
+                let full_length = blob.size.get();
+                let blob_type = blob.content_type_slice();
+
+                let mut status_code: u16 = 200;
+                let mut status_text: &[u8] = b"OK";
+                let mut length = full_length;
+                let mut content_range: Option<(u64, u64)> = None;
+
+                if let Some(range_header) = &range {
+                    use crate::server::RangeRequest;
+                    // 9.4. If rangeValue is failure, then return a network error.
+                    let (start, end) = match RangeRequest::parse_raw(range_header.as_bytes()) {
+                        RangeRequest::Raw::None => {
+                            reject!("fetch failed: invalid Range header")
+                        }
+                        RangeRequest::Raw::Suffix(n) => {
+                            // 9.6. If rangeStart is null:
+                            //   1. Set rangeStart to fullLength − rangeEnd.
+                            //   2. Set rangeEnd to rangeStart + rangeEnd − 1.
+                            if full_length == 0 {
+                                reject!("fetch failed: Range is unsatisfiable for an empty blob")
+                            }
+                            (full_length.saturating_sub(n), full_length - 1)
+                        }
+                        RangeRequest::Raw::Bounded { start, end } => {
+                            if matches!(end, Some(e) if e < start) {
+                                reject!("fetch failed: invalid Range header")
+                            }
+                            // 9.7.1. If rangeStart is greater than or equal to
+                            //        fullLength, then return a network error.
+                            if start >= full_length {
+                                reject!(
+                                    "fetch failed: Range start is greater than the blob's size"
+                                )
+                            }
+                            // 9.7.2. If rangeEnd is null or rangeEnd is greater than or
+                            //        equal to fullLength, set rangeEnd to fullLength − 1.
+                            (start, end.unwrap_or(full_length - 1).min(full_length - 1))
+                        }
+                    };
+                    // 9.8. Let slicedBlob be the result of invoking slice blob
+                    //      given blob, rangeStart, rangeEnd + 1, and type.
+                    blob.offset.set(blob.offset.get().saturating_add(start));
+                    length = end - start + 1;
+                    blob.size.set(length);
+                    status_code = 206;
+                    status_text = b"Partial Content";
+                    content_range = Some((start, end));
+                }
+
+                let mut response_headers = response::HeadersRef::create_empty();
+                let mut len_buf = [0u8; 20];
+                response_headers.put(
+                    HTTPHeaderName::ContentLength,
+                    &BunString::ascii(bun_core::fmt::buf_print_infallible(
+                        &mut len_buf,
+                        format_args!("{}", length),
+                    )),
+                    global_this,
+                )?;
+                response_headers.put(
+                    HTTPHeaderName::ContentType,
+                    &BunString::ascii(blob_type),
+                    global_this,
+                )?;
+                if let Some((start, end)) = content_range {
+                    let mut cr_buf = [0u8; crate::server::RangeRequest::CONTENT_RANGE_BUF];
+                    response_headers.put(
+                        HTTPHeaderName::ContentRange,
+                        &BunString::ascii(bun_core::fmt::buf_print_infallible(
+                            &mut cr_buf,
+                            format_args!("bytes {}-{}/{}", start, end, full_length),
+                        )),
+                        global_this,
+                    )?;
+                }
+
+                let response = bun_core::heap::into_raw(Box::new(Response::init(
+                    response::Init {
+                        status_code,
+                        status_text: BunString::create_atom(status_text).into(),
+                        headers: Some(response_headers),
+                        ..Default::default()
+                    },
+                    Body::new(BodyValue::Blob(blob)),
+                    url_string,
+                    false,
+                )));
+
+                // Ownership of the boxed Response transfers to the JS GC; see
+                // `data_url_response` for the rationale.
+                return Ok(JSPromise::resolved_promise_value(
+                    global_this,
+                    Response::make_maybe_pooled(global_this, response),
+                ));
             }
 
             let temp_file_path: &[u8] = 'brk: {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1477,10 +1477,12 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 if method != Method::GET {
                     reject!("fetch failed: only GET is allowed for blob: URLs");
                 }
-                let Some(blob) =
-                    ObjectURLRegistry::singleton().resolve_and_dupe(url_path_decoded)
+                let Some(blob) = ObjectURLRegistry::singleton().resolve_and_dupe(url_path_decoded)
                 else {
-                    reject!("Failed to resolve blob:{}", bstr::BStr::new(url_path_decoded));
+                    reject!(
+                        "Failed to resolve blob:{}",
+                        bstr::BStr::new(url_path_decoded)
+                    );
                 };
 
                 let url_string = BunString::create_format(format_args!(
@@ -1521,9 +1523,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                             // 9.7.1. If rangeStart is greater than or equal to
                             //        fullLength, then return a network error.
                             if start >= full_length {
-                                reject!(
-                                    "fetch failed: Range start is greater than the blob's size"
-                                )
+                                reject!("fetch failed: Range start is greater than the blob's size")
                             }
                             // 9.7.2. If rangeEnd is null or rangeEnd is greater than or
                             //        equal to fullLength, set rangeEnd to fullLength − 1.

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -135,6 +135,113 @@ test("blob: URL has Content-Type", async () => {
   }).toThrow();
 });
 
+// https://fetch.spec.whatwg.org/#concept-scheme-fetch "blob"
+describe("blob: URL scheme fetch", () => {
+  function blobURL(parts: BlobPart[], options?: BlobPropertyBag) {
+    const url = URL.createObjectURL(new Blob(parts, options));
+    return {
+      url,
+      [Symbol.dispose]: () => URL.revokeObjectURL(url),
+    };
+  }
+
+  test.each(["POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"])(
+    "rejects method %s as a network error",
+    async method => {
+      using u = blobURL(["hi"]);
+      const body = method === "HEAD" ? undefined : "x";
+      expect(fetch(u.url, { method, body })).rejects.toThrow(TypeError);
+      // and via a Request object
+      expect(fetch(new Request(u.url, { method, body }))).rejects.toThrow(TypeError);
+    },
+  );
+
+  test("sets Content-Length from the blob size", async () => {
+    using u = blobURL(["12345"], { type: "text/plain" });
+    const res = await fetch(u.url);
+    expect({
+      status: res.status,
+      statusText: res.statusText,
+      contentLength: res.headers.get("Content-Length"),
+      body: await res.text(),
+    }).toEqual({
+      status: 200,
+      statusText: "OK",
+      contentLength: "5",
+      body: "12345",
+    });
+    expect(res.headers.get("Content-Type")).toStartWith("text/plain");
+  });
+
+  test("sets Content-Length: 0 for an empty blob", async () => {
+    using u = blobURL([]);
+    const res = await fetch(u.url);
+    expect(res.headers.get("Content-Length")).toBe("0");
+    expect(await res.arrayBuffer()).toHaveLength(0);
+  });
+
+  test("honours a Range request with 206 + Content-Range", async () => {
+    using u = blobURL(["0123456789"], { type: "text/plain" });
+    const res = await fetch(u.url, { headers: { Range: "bytes=2-4" } });
+    expect({
+      status: res.status,
+      statusText: res.statusText,
+      contentLength: res.headers.get("Content-Length"),
+      contentRange: res.headers.get("Content-Range"),
+      body: await res.text(),
+    }).toEqual({
+      status: 206,
+      statusText: "Partial Content",
+      contentLength: "3",
+      contentRange: "bytes 2-4/10",
+      body: "234",
+    });
+    expect(res.headers.get("Content-Type")).toStartWith("text/plain");
+  });
+
+  test.each([
+    ["bytes=-3", "789", "bytes 7-9/10"],
+    ["bytes=7-", "789", "bytes 7-9/10"],
+    ["bytes=0-0", "0", "bytes 0-0/10"],
+    ["bytes=2-100", "23456789", "bytes 2-9/10"],
+    ["bytes=-100", "0123456789", "bytes 0-9/10"],
+  ])("Range %s -> 206 %j", async (range, body, contentRange) => {
+    using u = blobURL(["0123456789"]);
+    const res = await fetch(u.url, { headers: { Range: range } });
+    expect({
+      status: res.status,
+      contentLength: res.headers.get("Content-Length"),
+      contentRange: res.headers.get("Content-Range"),
+      body: await res.text(),
+    }).toEqual({
+      status: 206,
+      contentLength: String(body.length),
+      contentRange,
+      body,
+    });
+  });
+
+  test.each([
+    "bytes=20-30", // start >= size
+    "bytes=5-2", // end < start
+    "bytes=", // both missing
+    "not-a-range", // wrong unit
+    "bytes=0-1,3-4", // multi-range
+  ])("Range %j is a network error", async range => {
+    using u = blobURL(["0123456789"]);
+    expect(fetch(u.url, { headers: { Range: range } })).rejects.toThrow(TypeError);
+  });
+
+  test("Range on a Request object", async () => {
+    using u = blobURL(["0123456789"]);
+    const req = new Request(u.url, { headers: { Range: "bytes=1-3" } });
+    const res = await fetch(req);
+    expect(res.status).toBe(206);
+    expect(await res.text()).toBe("123");
+    expect(res.headers.get("Content-Range")).toBe("bytes 1-3/10");
+  });
+});
+
 test("blob: can be imported", async () => {
   const blob = new Blob(
     [

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -150,9 +150,9 @@ describe("blob: URL scheme fetch", () => {
     async method => {
       using u = blobURL(["hi"]);
       const body = method === "HEAD" ? undefined : "x";
-      expect(fetch(u.url, { method, body })).rejects.toThrow(TypeError);
+      await expect(fetch(u.url, { method, body })).rejects.toThrow(TypeError);
       // and via a Request object
-      expect(fetch(new Request(u.url, { method, body }))).rejects.toThrow(TypeError);
+      await expect(fetch(new Request(u.url, { method, body }))).rejects.toThrow(TypeError);
     },
   );
 
@@ -224,12 +224,13 @@ describe("blob: URL scheme fetch", () => {
   test.each([
     "bytes=20-30", // start >= size
     "bytes=5-2", // end < start
+    "bytes=-0", // zero-length suffix
     "bytes=", // both missing
     "not-a-range", // wrong unit
     "bytes=0-1,3-4", // multi-range
   ])("Range %j is a network error", async range => {
     using u = blobURL(["0123456789"]);
-    expect(fetch(u.url, { headers: { Range: range } })).rejects.toThrow(TypeError);
+    await expect(fetch(u.url, { headers: { Range: range } })).rejects.toThrow(TypeError);
   });
 
   test("Range on a Request object", async () => {


### PR DESCRIPTION
## What

`fetch(URL.createObjectURL(blob))` previously built a bare 200 response straight from the blob, ignoring the request method and headers. That diverged from [the Fetch spec's blob scheme fetch](https://fetch.spec.whatwg.org/#concept-scheme-fetch) and from Node/undici and browsers on three faces:

| | before | spec / Node |
|---|---|---|
| `fetch(blobURL, { method: "POST" })` | 200 with the blob body | `TypeError` (network error) |
| `(await fetch(blobURL)).headers.get("Content-Length")` | `null` | `"5"` (blob size) |
| `fetch(blobURL, { headers: { Range: "bytes=2-4" } })` | 200 full body, no `Content-Range` | 206 `"234"`, `Content-Range: bytes 2-4/10` |

## Repro

```js
const u = URL.createObjectURL(new Blob(["0123456789"]));
const r = await fetch(u, { headers: { range: "bytes=2-4" } });
console.log(r.status, await r.text(), r.headers.get("content-range"));
// before: 200 "0123456789" null
// after:  206 "234" "bytes 2-4/10"
```

## Fix

Fill in the spec's blob scheme-fetch steps in `src/runtime/webcore/fetch.rs`:

- Reject any method other than `GET` as a `TypeError`.
- Resolve the blob's size and set `Content-Length` and `Content-Type` on the response.
- When a `Range` header is present, parse it (reusing the existing `server::RangeRequest` single-range parser), slice the blob, and return `206 Partial Content` with `Content-Range` and the sliced `Content-Length`. A malformed range or a start past the blob's size is a network error, per the spec.

Range resolution follows the spec rather than the server's 416 semantics: parse failure and `start >= size` both reject; suffix ranges (`bytes=-N`) saturate at 0; open-ended ranges (`bytes=N-`) clamp to `size - 1`.

`file:` URL handling is untouched.

## Tests

`test/js/web/fetch/blob.test.ts` gains a `blob: URL scheme fetch` describe with 20 cases covering every method, headers on 200, bounded/suffix/open-end/oversized ranges, and the network-error cases. All 20 fail on canary and pass with this change; the rest of the file is unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 21 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/blob.test.ts
bun test v1.4.0 (34d21c744)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [42.69ms]
(pass) Blob.slice [67.75ms]
(pass) Bun.file().slice [68.43ms]
(pass) new Blob [5.61ms]
(pass) new Blob stringifies non-Blob object parts in order [17.75ms]
(pass) blob: can be fetched [19.43ms]
(pass) blob: URL has Content-Type [19.03ms]
148 |   test.each(["POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"])(
149 |     "rejects method %s as a network error",
150 |     async method => {
151 |       using u = blobURL(["hi"]);
152 |       const body = method === "HEAD" ? undefined : "x";
153 |       await expect(fetch(u.url, { method, body })).rejects.toThrow(TypeError);
                                                                 ^
error: expect(received).rejects.toThrow(expected)

Expected promise that rejects
Received promise that resolved: Promise { <resolved> }

      at <anonymous> (/workspace/bun/test/js/web/fetch/blob.test.ts:153:60)
      at <anonymous> (/workspace/bun/test/
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (75c6b424c)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [9.96ms]
(pass) Blob.slice [0.63ms]
(pass) Bun.file().slice [1.20ms]
(pass) new Blob [0.10ms]
(pass) new Blob stringifies non-Blob object parts in order [0.22ms]
(pass) blob: can be fetched [1.82ms]
(pass) blob: URL has Content-Type [1.45ms]
(pass) blob: URL scheme fetch > rejects method POST as a network error [1.01ms]
(pass) blob: URL scheme fetch > rejects method PUT as a network error [0.04ms]
(pass) blob: URL scheme fetch > rejects method DELETE as a network error [0.03ms]
(pass) blob: URL scheme fetch > rejects method PATCH as a network error [0.02ms]
(pass) blob: URL scheme fetch > rejects method HEAD as a network error [0.01ms]
(pass) blob: URL scheme fetch > rejects method OPTIONS as a network error [0.01ms]
(pass) blob: URL scheme fetch > sets Content-Length from the blob size [0.23ms]
(pass) blob: URL scheme fetch > sets Content-Length: 0 for an empty blob [0.14ms]
(pass) blob: URL scheme fetch > honours a Range request with 206 + Content-Range [0.18ms]
(pass) blob: URL scheme fetch > Range bytes=-3 -> 206 "789" [0.14ms]
(pass) blob: UR
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/blob.test.ts
bun test v1.4.0 (34d21c744)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [28.62ms]
(pass) Blob.slice [53.24ms]
(pass) Bun.file().slice [61.10ms]
(pass) new Blob [12.86ms]
(pass) new Blob stringifies non-Blob object parts in order [13.96ms]
(pass) blob: can be fetched [16.10ms]
(pass) blob: URL has Content-Type [16.29ms]
(pass) blob: URL scheme fetch > rejects method POST as a network error [20.70ms]
(pass) blob: URL scheme fetch > rejects method PUT as a network error [3.45ms]
(pass) blob: URL scheme fetch > rejects method DELETE as a network error [3.44ms]
(pass) blob: URL scheme fetch > rejects method PATCH as a network error [2.79ms]
(pass) blob: URL scheme fetch > rejects method HEAD as a network error [2.48ms]
(pass) blob: URL scheme fetch > rejects method OPTIONS as a network error [2.64ms]
(pass) blob: URL scheme fetch > sets Content-Length from the blob size [12.59ms]
(pass) blob: URL scheme fetch > sets Content-Length: 0 for an empty blob [11.10ms]
(pass) bl
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1365ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/fetch.rs   | 144 ++++++++++++++++++++++++++++++++---------
 test/js/web/fetch/blob.test.ts | 108 +++++++++++++++++++++++++++++++
 2 files changed, 221 insertions(+), 31 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/runtime/webcore/fetch.rs        7      8      0
test/js/web/fetch/blob.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->