### PR TITLE
pack: always include "main" and "browser" entry points in the tarball

### DIFF
--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2743,6 +2743,20 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                 }
             };
 
+            // `main` / `browser` / `bin` may name a directory (or other
+            // non-regular file). `openat` succeeds on a directory on POSIX,
+            // so the ENOENT skip above is bypassed; archiving it as a regular
+            // file would crash on EISDIR from `read()`.
+            if item.optional && !bun_core::S::ISREG(stat.st_mode as bun_sys::Mode) {
+                ctx.stats.total_files -= 1;
+                if log_level.show_progress() {
+                    node.as_mut()
+                        .expect("infallible: progress active")
+                        .complete_one();
+                }
+                continue;
+            }
+
             pack_list.push(PackListEntry {
                 subpath: ZBox::from_bytes(item.path.as_bytes()),
                 size: usize::try_from(stat.st_size).expect("int cast"),
@@ -3955,6 +3969,11 @@ fn print_archived_files_and_packages<const IS_DRY_RUN: bool>(
                     Global::crash();
                 }
             };
+
+            if item.optional && !bun_core::S::ISREG(stat.st_mode as bun_sys::Mode) {
+                ctx.stats.total_files -= 1;
+                continue;
+            }
 
             ctx.stats.unpacked_size += usize::try_from(stat.st_size).expect("int cast");
 

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1489,7 +1489,7 @@ fn get_package_bins(json: &Expr) -> Result<Vec<BinInfo>, AllocError> {
                 bin_str,
                 &mut path_buf,
             );
-            if !bin_path_escapes_root(normalized) {
+            if normalized != b"package.json" && !bin_path_escapes_root(normalized) {
                 bins.push(BinInfo {
                     path: ZBox::from_bytes(normalized),
                     ty: BinType::File,
@@ -1510,7 +1510,7 @@ fn get_package_bins(json: &Expr) -> Result<Vec<BinInfo>, AllocError> {
                             bin_str,
                             &mut path_buf,
                         );
-                        if !bin_path_escapes_root(normalized) {
+                        if normalized != b"package.json" && !bin_path_escapes_root(normalized) {
                             bins.push(BinInfo {
                                 path: ZBox::from_bytes(normalized),
                                 ty: BinType::File,
@@ -1565,7 +1565,10 @@ fn get_package_entry_points(json: &Expr, bins: &[BinInfo]) -> Result<Vec<ZBox>, 
         };
         let normalized =
             resolve_path::normalize_buf::<resolve_path::platform::Posix>(value, &mut path_buf);
-        if normalized.is_empty() || bin_path_escapes_root(normalized) {
+        if normalized.is_empty()
+            || normalized == b"package.json"
+            || bin_path_escapes_root(normalized)
+        {
             return Ok(());
         }
         for bin in bins {

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -451,6 +451,7 @@ struct DirInfo(Dir, Box<[u8]>, usize);
 fn iterate_included_project_tree(
     pack_queue: &mut PackQueue,
     bins: &[BinInfo],
+    entry_points: &[ZBox],
     includes: &[Pattern],
     excludes: &[Pattern],
     root_dir: &Dir,
@@ -636,6 +637,9 @@ fn iterate_included_project_tree(
                             continue 'next_entry;
                         }
                     }
+                    if is_package_entry_point(entry_points, entry_subpath.as_bytes()) {
+                        continue 'next_entry;
+                    }
 
                     pack_queue.add(PackQueueItem {
                         path: entry_subpath,
@@ -653,6 +657,7 @@ fn iterate_included_project_tree(
     for included_dir_info in included_dirs {
         add_entire_tree(
             bins,
+            entry_points,
             excludes,
             included_dir_info,
             pack_queue,
@@ -667,6 +672,7 @@ fn iterate_included_project_tree(
 /// Adds all files in a directory tree to `pack_list` (default ignores still apply)
 fn add_entire_tree(
     bins: &[BinInfo],
+    entry_points: &[ZBox],
     excludes: &[Pattern],
     root_dir_info: DirInfo,
     pack_queue: &mut PackQueue,
@@ -770,6 +776,9 @@ fn add_entire_tree(
                         {
                             continue 'next_entry;
                         }
+                    }
+                    if is_package_entry_point(entry_points, entry_subpath.as_bytes()) {
+                        continue 'next_entry;
                     }
                     pack_queue.add(PackQueueItem {
                         path: entry_subpath,
@@ -1252,6 +1261,7 @@ fn add_bundled_dep(
 fn iterate_project_tree(
     pack_queue: &mut PackQueue,
     bins: &[BinInfo],
+    entry_points: &[ZBox],
     root_dir: DirInfo,
     log_level: LogLevel,
 ) -> Result<(), AllocError> {
@@ -1344,6 +1354,9 @@ fn iterate_project_tree(
                         {
                             continue 'next_entry;
                         }
+                    }
+                    if is_package_entry_point(entry_points, entry_subpath_.as_bytes()) {
+                        continue 'next_entry;
                     }
                     pack_queue.add(PackQueueItem {
                         path: entry_subpath_,
@@ -1535,6 +1548,55 @@ fn get_package_bins(json: &Expr) -> Result<Vec<BinInfo>, AllocError> {
 
 fn bin_path_escapes_root(p: &[u8]) -> bool {
     path::is_absolute_loose(p) || p == b".." || p.starts_with(b"../")
+}
+
+/// `main` and the string form of `browser` are always packed, even if ignored
+/// or not in `files`. npm-packlist emits strict `!/${main}` / `!/${browser}`
+/// rules for these alongside the `bin` rules.
+fn get_package_entry_points(json: &Expr, bins: &[BinInfo]) -> Result<Vec<ZBox>, AllocError> {
+    let mut entry_points: Vec<ZBox> = Vec::new();
+    let mut path_buf = PathBuffer::uninit();
+
+    let mut push_field = |field: &'static [u8]| -> Result<(), AllocError> {
+        let Some(prop) = json.as_property(field) else {
+            return Ok(());
+        };
+        // `browser` may be an object map; only the string form is a file path.
+        let Some(value) = prop.expr.as_string(pack_bump()) else {
+            return Ok(());
+        };
+        let normalized =
+            resolve_path::normalize_buf::<resolve_path::platform::Posix>(value, &mut path_buf);
+        if normalized.is_empty() || bin_path_escapes_root(normalized) {
+            return Ok(());
+        }
+        for bin in bins {
+            if bin.ty == BinType::File && strings::eql_long(bin.path.as_bytes(), normalized, true) {
+                return Ok(());
+            }
+        }
+        for existing in &entry_points {
+            if strings::eql_long(existing.as_bytes(), normalized, true) {
+                return Ok(());
+            }
+        }
+        entry_points.push(ZBox::from_bytes(normalized));
+        Ok(())
+    };
+
+    push_field(b"main")?;
+    push_field(b"browser")?;
+
+    Ok(entry_points)
+}
+
+fn is_package_entry_point(entry_points: &[ZBox], subpath: &[u8]) -> bool {
+    for entry_point in entry_points {
+        if strings::eql_long(entry_point.as_bytes(), subpath, true) {
+            return true;
+        }
+    }
+    false
 }
 
 fn is_package_bin(bins: &[BinInfo], maybe_bin_path: &[u8]) -> bool {
@@ -2275,6 +2337,14 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     let mut pack_queue: PackQueue = new_pack_queue();
 
     let bins = get_package_bins(&json.root)?;
+    let entry_points = get_package_entry_points(&json.root, &bins)?;
+
+    for entry_point in &entry_points {
+        pack_queue.add(PackQueueItem {
+            path: ZBox::from_bytes(entry_point.as_bytes()),
+            optional: true,
+        })?;
+    }
 
     for bin in &bins {
         match bin.ty {
@@ -2303,6 +2373,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                 iterate_project_tree(
                     &mut pack_queue,
                     &[],
+                    &entry_points,
                     DirInfo(bin_dir, bin.path.as_bytes().into(), 2),
                     log_level,
                 )?;
@@ -2348,6 +2419,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                     iterate_included_project_tree(
                         &mut pack_queue,
                         &bins,
+                        &entry_points,
                         &includes,
                         &excludes,
                         &root_dir,
@@ -2367,6 +2439,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
             iterate_project_tree(
                 &mut pack_queue,
                 &bins,
+                &entry_points,
                 DirInfo(Dir::from_fd(root_dir.fd), Box::from(&b""[..]), 1),
                 log_level,
             )?;

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2741,8 +2741,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                 }
             };
 
-            // `openat` succeeds on directories on POSIX; skip non-regular
-            // optional items so a `main`/`bin` naming a directory is not fatal.
+            // openat(O_RDONLY) succeeds on directories on POSIX
             if item.optional && !bun_core::S::ISREG(stat.st_mode as bun_sys::Mode) {
                 ctx.stats.total_files -= 1;
                 if log_level.show_progress() {

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1550,9 +1550,7 @@ fn bin_path_escapes_root(p: &[u8]) -> bool {
     path::is_absolute_loose(p) || p == b".." || p.starts_with(b"../")
 }
 
-/// `main` and the string form of `browser` are always packed, even if ignored
-/// or not in `files`. npm-packlist emits strict `!/${main}` / `!/${browser}`
-/// rules for these alongside the `bin` rules.
+/// npm-packlist force-includes `main` and string-form `browser` alongside `bin`.
 fn get_package_entry_points(json: &Expr, bins: &[BinInfo]) -> Result<Vec<ZBox>, AllocError> {
     let mut entry_points: Vec<ZBox> = Vec::new();
     let mut path_buf = PathBuffer::uninit();
@@ -2743,10 +2741,8 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                 }
             };
 
-            // `main` / `browser` / `bin` may name a directory (or other
-            // non-regular file). `openat` succeeds on a directory on POSIX,
-            // so the ENOENT skip above is bypassed; archiving it as a regular
-            // file would crash on EISDIR from `read()`.
+            // `openat` succeeds on directories on POSIX; skip non-regular
+            // optional items so a `main`/`bin` naming a directory is not fatal.
             if item.optional && !bun_core::S::ISREG(stat.st_mode as bun_sys::Mode) {
                 ctx.stats.total_files -= 1;
                 if log_level.show_progress() {

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -1599,6 +1599,142 @@ describe("bins", () => {
   });
 });
 
+describe("entry points", () => {
+  test('"main" and "browser" are included even if not in "files"', async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-entry-files",
+          version: "1.0.0",
+          main: "lib/index.js",
+          browser: "lib/browser.js",
+          files: ["dist"],
+        }),
+      ),
+      write(join(packageDir, "dist", "bundle.js"), "exports.b=1"),
+      write(join(packageDir, "lib", "index.js"), "module.exports='entry'"),
+      write(join(packageDir, "lib", "browser.js"), "module.exports='browser'"),
+      write(join(packageDir, "lib", "other.js"), "module.exports='other'"),
+    ]);
+
+    await pack(packageDir, bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pack-entry-files-1.0.0.tgz"));
+    expect(tarball.entries).toMatchObject([
+      { pathname: "package/package.json" },
+      { pathname: "package/dist/bundle.js" },
+      { pathname: "package/lib/browser.js" },
+      { pathname: "package/lib/index.js" },
+    ]);
+  });
+
+  test('"main" cannot be excluded by .npmignore', async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-entry-npmignore",
+          version: "1.0.0",
+          main: "index.js",
+          bin: "cli.js",
+        }),
+      ),
+      write(join(packageDir, "index.js"), "module.exports=2"),
+      write(join(packageDir, "cli.js"), "#!/usr/bin/env node\n"),
+      write(join(packageDir, ".npmignore"), "index.js\ncli.js\n"),
+    ]);
+
+    await pack(packageDir, bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pack-entry-npmignore-1.0.0.tgz"));
+    expect(tarball.entries).toMatchObject([
+      { pathname: "package/package.json" },
+      { pathname: "package/cli.js" },
+      { pathname: "package/index.js" },
+    ]);
+
+    // "main" does not pick up the executable bit that "bin" gets
+    const indexEntry = tarball.entries.find(e => e.pathname === "package/index.js");
+    expect(indexEntry.perm & 0o111).toBe(0);
+  });
+
+  test('"main" inside "files" directory is not duplicated', async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-entry-dedupe",
+          version: "1.0.0",
+          main: "dist/index.js",
+          files: ["dist"],
+        }),
+      ),
+      write(join(packageDir, "dist", "index.js"), "module.exports=1"),
+      write(join(packageDir, "dist", "other.js"), "module.exports=2"),
+    ]);
+
+    await pack(packageDir, bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pack-entry-dedupe-1.0.0.tgz"));
+    expect(tarball.entries).toMatchObject([
+      { pathname: "package/package.json" },
+      { pathname: "package/dist/index.js" },
+      { pathname: "package/dist/other.js" },
+    ]);
+  });
+
+  test('"main" that does not exist is not an error', async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-entry-missing",
+          version: "1.0.0",
+          main: "lib/index.js",
+          files: ["dist"],
+        }),
+      ),
+      write(join(packageDir, "dist", "bundle.js"), "exports.b=1"),
+    ]);
+
+    await pack(packageDir, bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pack-entry-missing-1.0.0.tgz"));
+    expect(tarball.entries).toMatchObject([
+      { pathname: "package/package.json" },
+      { pathname: "package/dist/bundle.js" },
+    ]);
+  });
+
+  test('"browser" object map is not force-included', async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-entry-browser-map",
+          version: "1.0.0",
+          main: "lib/index.js",
+          browser: { "./lib/index.js": "./lib/browser.js" },
+          files: ["dist"],
+        }),
+      ),
+      write(join(packageDir, "dist", "bundle.js"), "exports.b=1"),
+      write(join(packageDir, "lib", "index.js"), "module.exports='entry'"),
+      write(join(packageDir, "lib", "browser.js"), "module.exports='browser'"),
+    ]);
+
+    await pack(packageDir, bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pack-entry-browser-map-1.0.0.tgz"));
+    expect(tarball.entries).toMatchObject([
+      { pathname: "package/package.json" },
+      { pathname: "package/dist/bundle.js" },
+      { pathname: "package/lib/index.js" },
+    ]);
+  });
+});
+
 test("unicode", async () => {
   await Promise.all([
     write(

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -1707,6 +1707,25 @@ describe("entry points", () => {
     ]);
   });
 
+  test('"main" or "bin" pointing at package.json does not duplicate it', async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-entry-pkgjson",
+          version: "1.0.0",
+          main: "./package.json",
+          bin: "./package.json",
+        }),
+      ),
+    ]);
+
+    await pack(packageDir, bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pack-entry-pkgjson-1.0.0.tgz"));
+    expect(tarball.entries).toMatchObject([{ pathname: "package/package.json" }]);
+  });
+
   test('"main" that names a directory is skipped', async () => {
     await Promise.all([
       write(

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -1707,6 +1707,30 @@ describe("entry points", () => {
     ]);
   });
 
+  test('"main" that names a directory is skipped', async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-entry-dir",
+          version: "1.0.0",
+          main: "./lib",
+          files: ["dist"],
+        }),
+      ),
+      write(join(packageDir, "dist", "bundle.js"), "exports.b=1"),
+      write(join(packageDir, "lib", "index.js"), "module.exports=1"),
+    ]);
+
+    await pack(packageDir, bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pack-entry-dir-1.0.0.tgz"));
+    expect(tarball.entries).toMatchObject([
+      { pathname: "package/package.json" },
+      { pathname: "package/dist/bundle.js" },
+    ]);
+  });
+
   test('"browser" object map is not force-included', async () => {
     await Promise.all([
       write(


### PR DESCRIPTION
## What

`bun pm pack` now force-includes the files referenced by `package.json`'s `"main"` and string-form `"browser"` fields, matching `npm pack`. Previously only `"bin"` targets were protected, so a `"files"` allowlist that omitted the entry point (or an `.npmignore` that matched it) produced a tarball whose `"main"` pointed at a file that was not shipped.

## Repro

```sh
mkdir -p /tmp/mainless/dist /tmp/mainless/lib && cd /tmp/mainless
printf '{"name":"mainless","version":"1.0.0","main":"lib/index.js","browser":"lib/browser.js","files":["dist"]}' > package.json
echo 'exports.b=1' > dist/bundle.js
echo 'module.exports="entry"' > lib/index.js
echo 'module.exports="browser"' > lib/browser.js
bun pm pack && tar -tf mainless-1.0.0.tgz
```

Before: tarball contains only `package/package.json` and `package/dist/bundle.js`. `lib/index.js` and `lib/browser.js` are missing, so `require("mainless")` fails after install.

After: tarball also contains `package/lib/index.js` and `package/lib/browser.js`, same as `npm pack`.

The `.npmignore` variant behaves the same way: `"bin"` was kept but `"main"` was dropped.

## Cause

`is_unconditionally_included_file` in `src/runtime/cli/pack_command.rs` covers `package.json`, `LICENSE*`, `LICENCE*`, and `README*`; `bin` targets are protected separately via `get_package_bins` / `is_package_bin`. There was no rule for `"main"` or `"browser"`. npm-packlist's `processPackage` appends strict `!/${main}` / `!/${browser}` rules alongside the `bin` rules.

## Fix

Add `get_package_entry_points`, which extracts `"main"` and the string form of `"browser"` (the object-map form is a remap table, not a file path), normalizes each path, and filters out values that duplicate a `"bin"` target or each other. These are queued as `optional: true` (a missing file is not an error, matching bin handling) and deduped against the three tree walks so an entry point that is also matched by `"files"` or not ignored appears exactly once. Entry points do not pick up the executable bit that `bin` targets get.

## Verification

New `entry points` describe block in `test/cli/install/bun-pack.test.ts`:

- `"main"` + `"browser"` are included when `"files"` omits them
- `"main"` is included when `.npmignore` matches it, and does not gain `+x`
- `"main"` already inside the `"files"` tree is not duplicated
- a `"main"` that does not exist on disk is not an error
- object-form `"browser"` is not force-included (npm compat)

Full `bun-pack.test.ts` suite passes (81 tests).

Fixes #15602

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-pack.test.ts
bun test v1.4.0 (5f018c639)

test/cli/install/bun-pack.test.ts:
(pass) basic [180.72ms]
(pass) in subdirectory [333.43ms]
(pass) package.json names and versions > rejects name and version containing parent directory components [466.40ms]
(pass) package.json names and versions > missing name [147.78ms]
(pass) package.json names and versions > missing version [140.92ms]
(pass) package.json names and versions > missing name and version [138.11ms]
(pass) package.json names and versions > empty name [135.09ms]
(pass) package.json names and versions > empty version [140.50ms]
(pass) package.json names and versions > empty name and version [146.17ms]
(pass) package.json names and versions > missing [120.96ms]
(pass) package.json names and versions > scoped name: @scoped/pkg [169.55ms]
(pass) package.json names and versions > scoped name: @ [156.46ms]
(pass) package.json names and versions > scoped name: @/ [157.85ms]
(pass) package.json names and versions > scoped name: // [159.66ms]
(pass) package.json names
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (c2ee42d36)

test/cli/install/bun-pack.test.ts:
(pass) basic [6.25ms]
(pass) in subdirectory [10.87ms]
(pass) package.json names and versions > rejects name and version containing parent directory components [11.02ms]
(pass) package.json names and versions > missing name [3.66ms]
(pass) package.json names and versions > missing version [2.27ms]
(pass) package.json names and versions > missing name and version [2.71ms]
(pass) package.json names and versions > empty name [2.37ms]
(pass) package.json names and versions > empty version [2.66ms]
(pass) package.json names and versions > empty name and version [2.22ms]
(pass) package.json names and versions > missing [1.96ms]
(pass) package.json names and versions > scoped name: @scoped/pkg [5.10ms]
(pass) package.json names and versions > scoped name: @ [5.04ms]
(pass) package.json names and versions > scoped name: @/ [4.65ms]
(pass) package.json names and versions > scoped name: // [5.05ms]
(pass) package.json names and versions > scoped name: @// [4.29ms]
(pass) package.json names and versions > scoped name: @/s [5.11ms]
(pass) package.json names and versions > scoped name: @s [4.75ms]
(pass) fl
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-pack.test.ts
bun test v1.4.0 (5f018c639)

test/cli/install/bun-pack.test.ts:
(pass) basic [183.60ms]
(pass) in subdirectory [331.23ms]
(pass) package.json names and versions > rejects name and version containing parent directory components [453.60ms]
(pass) package.json names and versions > missing name [136.13ms]
(pass) package.json names and versions > missing version [147.13ms]
(pass) package.json names and versions > missing name and version [143.35ms]
(pass) package.json names and versions > empty name [141.38ms]
(pass) package.json names and versions > empty version [135.33ms]
(pass) package.json names and versions > empty name and version [145.32ms]
(pass) package.json names and versions > missing [117.11ms]
(pass) package.json names and versions > scoped name: @scoped/pkg [165.90ms]
(pass) package.json names and versions > scoped name: @ [153.06ms]
(pass) package.json names and versions > scoped name: @/ [152.26ms]
(pass) package.json names and versions > scoped name: // [155.48ms]
(pass) package.json names
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 706ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/pack_command.rs   |  94 +++++++++++++++++++-
 test/cli/install/bun-pack.test.ts | 179 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 271 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/cli/pack_command.rs        0      0      0
test/cli/install/bun-pack.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->