### PR TITLE
bundler: stop --jsx-* flags from overriding tsconfig jsx dev/prod

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2532,15 +2532,13 @@ pub mod bv2_impl {
             task.task.node.next = core::ptr::null_mut();
             task.tree_shaking = self.linker.options.tree_shaking;
             task.known_target = target;
+            if let Some(dev) = self
+                .transpiler_for_target(target)
+                .options
+                .force_node_env
+                .jsx_development_override()
             {
-                let t = self.transpiler_for_target(target);
-                match t.options.force_node_env {
-                    options::ForceNodeEnv::Development => task.jsx.development = true,
-                    options::ForceNodeEnv::Production => task.jsx.development = false,
-                    // `task.jsx` is the per-file tsconfig-merged value from
-                    // `ParseTask::init` (via the resolver); keep it.
-                    options::ForceNodeEnv::Unspecified => {}
-                }
+                task.jsx.development = dev;
             }
 
             // Handle onLoad plugins as entry points
@@ -2644,15 +2642,13 @@ pub mod bv2_impl {
             task.tree_shaking = self.linker.options.tree_shaking;
             task.is_entry_point = is_entry_point;
             task.known_target = target;
+            if let Some(dev) = self
+                .transpiler_for_target(target)
+                .options
+                .force_node_env
+                .jsx_development_override()
             {
-                let bundler = self.transpiler_for_target(target);
-                match bundler.options.force_node_env {
-                    options::ForceNodeEnv::Development => task.jsx.development = true,
-                    options::ForceNodeEnv::Production => task.jsx.development = false,
-                    // `task.jsx` is the per-file tsconfig-merged value from
-                    // `ParseTask::init` (via the resolver); keep it.
-                    options::ForceNodeEnv::Unspecified => {}
-                }
+                task.jsx.development = dev;
             }
 
             // Handle onLoad plugins as entry points
@@ -6048,14 +6044,10 @@ pub mod bv2_impl {
                         resolve_task.known_target = target;
                         // Use transpiler JSX options, applying force_node_env like the disk path does
                         resolve_task.jsx = transpiler.options.jsx.clone();
-                        match transpiler.options.force_node_env {
-                            options::ForceNodeEnv::Development => {
-                                resolve_task.jsx.development = true
-                            }
-                            options::ForceNodeEnv::Production => {
-                                resolve_task.jsx.development = false
-                            }
-                            options::ForceNodeEnv::Unspecified => {}
+                        if let Some(dev) =
+                            transpiler.options.force_node_env.jsx_development_override()
+                        {
+                            resolve_task.jsx.development = dev;
                         }
                         resolve_task.loader = Some(import_record_loader);
                         resolve_task.tree_shaking = transpiler.options.tree_shaking;
@@ -6419,11 +6411,8 @@ pub mod bv2_impl {
                 };
 
                 resolve_task.jsx = resolve_result.jsx.clone();
-                match transpiler.options.force_node_env {
-                    options::ForceNodeEnv::Development => resolve_task.jsx.development = true,
-                    options::ForceNodeEnv::Production => resolve_task.jsx.development = false,
-                    // `resolve_result.jsx` is already tsconfig-merged; keep it.
-                    options::ForceNodeEnv::Unspecified => {}
+                if let Some(dev) = transpiler.options.force_node_env.jsx_development_override() {
+                    resolve_task.jsx.development = dev;
                 }
 
                 resolve_task.loader = Some(import_record_loader);

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2130,7 +2130,9 @@ pub mod bv2_impl {
                     &import_record.source_file,
                     &import_record.specifier,
                 ) {
-                    let file_map_result = _file_map_result;
+                    let mut file_map_result = _file_map_result;
+                    // SAFETY: see `transpiler` note above.
+                    file_map_result.jsx = unsafe { &(*transpiler).options.jsx }.clone();
                     let mut path_primary = file_map_result.path_pair.primary;
                     // reshaped for borrowck — `get_or_put` borrows `*self` mutably via
                     // `self.graph`; capture the slot as `*mut u32` so subsequent `self.*` calls
@@ -4661,11 +4663,18 @@ pub mod bv2_impl {
                                     file: bun_sys::Fd::INVALID,
                                 },
                                 side_effects: bun_ast::SideEffects::HasSideEffects,
-                                jsx: this
-                                    .transpiler_for_target(resolve.import_record.original_target)
-                                    .options
-                                    .jsx
-                                    .clone(),
+                                jsx: {
+                                    let t = this.transpiler_for_target(
+                                        resolve.import_record.original_target,
+                                    );
+                                    let mut jsx = t.options.jsx.clone();
+                                    if let Some(dev) =
+                                        t.options.force_node_env.jsx_development_override()
+                                    {
+                                        jsx.development = dev;
+                                    }
+                                    jsx
+                                },
                                 source_index: bun_ast::Index::init(source_index.get()),
                                 module_type: options::ModuleType::Unknown,
                                 loader: Some(loader),

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4668,6 +4668,17 @@ pub mod bv2_impl {
                                         resolve.import_record.original_target,
                                     );
                                     let mut jsx = t.options.jsx.clone();
+                                    if path.namespace == b"file" {
+                                        let dir =
+                                            Fs::PathName::init(path.text).dir_with_trailing_slash();
+                                        if let Some(tsconfig) = t
+                                            .resolver
+                                            .read_dir_info_ignore_error(dir)
+                                            .and_then(|d| d.enclosing_tsconfig_json)
+                                        {
+                                            jsx = tsconfig.merge_jsx(jsx);
+                                        }
+                                    }
                                     if let Some(dev) =
                                         t.options.force_node_env.jsx_development_override()
                                     {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2534,11 +2534,13 @@ pub mod bv2_impl {
             task.known_target = target;
             {
                 let t = self.transpiler_for_target(target);
-                task.jsx.development = match t.options.force_node_env {
-                    options::ForceNodeEnv::Development => true,
-                    options::ForceNodeEnv::Production => false,
-                    options::ForceNodeEnv::Unspecified => t.options.jsx.development,
-                };
+                match t.options.force_node_env {
+                    options::ForceNodeEnv::Development => task.jsx.development = true,
+                    options::ForceNodeEnv::Production => task.jsx.development = false,
+                    // `task.jsx` is the per-file tsconfig-merged value from
+                    // `ParseTask::init` (via the resolver); keep it.
+                    options::ForceNodeEnv::Unspecified => {}
+                }
             }
 
             // Handle onLoad plugins as entry points
@@ -2644,11 +2646,13 @@ pub mod bv2_impl {
             task.known_target = target;
             {
                 let bundler = self.transpiler_for_target(target);
-                task.jsx.development = match bundler.options.force_node_env {
-                    options::ForceNodeEnv::Development => true,
-                    options::ForceNodeEnv::Production => false,
-                    options::ForceNodeEnv::Unspecified => bundler.options.jsx.development,
-                };
+                match bundler.options.force_node_env {
+                    options::ForceNodeEnv::Development => task.jsx.development = true,
+                    options::ForceNodeEnv::Production => task.jsx.development = false,
+                    // `task.jsx` is the per-file tsconfig-merged value from
+                    // `ParseTask::init` (via the resolver); keep it.
+                    options::ForceNodeEnv::Unspecified => {}
+                }
             }
 
             // Handle onLoad plugins as entry points
@@ -6044,13 +6048,15 @@ pub mod bv2_impl {
                         resolve_task.known_target = target;
                         // Use transpiler JSX options, applying force_node_env like the disk path does
                         resolve_task.jsx = transpiler.options.jsx.clone();
-                        resolve_task.jsx.development = match transpiler.options.force_node_env {
-                            options::ForceNodeEnv::Development => true,
-                            options::ForceNodeEnv::Production => false,
-                            options::ForceNodeEnv::Unspecified => {
-                                transpiler.options.jsx.development
+                        match transpiler.options.force_node_env {
+                            options::ForceNodeEnv::Development => {
+                                resolve_task.jsx.development = true
                             }
-                        };
+                            options::ForceNodeEnv::Production => {
+                                resolve_task.jsx.development = false
+                            }
+                            options::ForceNodeEnv::Unspecified => {}
+                        }
                         resolve_task.loader = Some(import_record_loader);
                         resolve_task.tree_shaking = transpiler.options.tree_shaking;
                         resolve_task.side_effects = bun_ast::SideEffects::HasSideEffects;
@@ -6413,11 +6419,12 @@ pub mod bv2_impl {
                 };
 
                 resolve_task.jsx = resolve_result.jsx.clone();
-                resolve_task.jsx.development = match transpiler.options.force_node_env {
-                    options::ForceNodeEnv::Development => true,
-                    options::ForceNodeEnv::Production => false,
-                    options::ForceNodeEnv::Unspecified => transpiler.options.jsx.development,
-                };
+                match transpiler.options.force_node_env {
+                    options::ForceNodeEnv::Development => resolve_task.jsx.development = true,
+                    options::ForceNodeEnv::Production => resolve_task.jsx.development = false,
+                    // `resolve_result.jsx` is already tsconfig-merged; keep it.
+                    options::ForceNodeEnv::Unspecified => {}
+                }
 
                 resolve_task.loader = Some(import_record_loader);
                 resolve_task.tree_shaking = transpiler.options.tree_shaking;

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3540,7 +3540,7 @@ pub mod bv2_impl {
             let contents: &'static [u8] = unsafe { interned_slice(stored.contents()) };
             // Compute borrow-heavy fields up front so the `&self` borrow taken by
             // `arena()` doesn't overlap `&mut self` uses inside the literal.
-            let jsx = if known_target == Target::ServerComponentsSsr
+            let jsx_transpiler = if known_target == Target::ServerComponentsSsr
                 && !self
                     .framework
                     .as_ref()
@@ -3550,10 +3550,18 @@ pub mod bv2_impl {
                     .unwrap()
                     .separate_ssr_graph
             {
-                self.transpiler.options.jsx.clone()
+                &*self.transpiler
             } else {
-                self.transpiler_for_target(known_target).options.jsx.clone()
+                &*self.transpiler_for_target(known_target)
             };
+            let mut jsx = jsx_transpiler.options.jsx.clone();
+            if let Some(dev) = jsx_transpiler
+                .options
+                .force_node_env
+                .jsx_development_override()
+            {
+                jsx.development = dev;
+            }
             let tree_shaking = self.linker.options.tree_shaking;
             // SAFETY: arena (`self.graph.heap`) outlives the bundle pass; coerce the
             // `&mut ParseTask` to `*mut` immediately so the `&self` borrow from

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3471,7 +3471,14 @@ pub mod bv2_impl {
             // SAFETY: arena outlives the bundle pass; reborrow `*mut` as `&mut`.
             let task: &mut ParseTask = self.arena_create(task_val);
             task.loader = Some(loader);
-            task.jsx = self.transpiler_for_target(known_target).options.jsx.clone();
+            if let Some(dev) = self
+                .transpiler_for_target(known_target)
+                .options
+                .force_node_env
+                .jsx_development_override()
+            {
+                task.jsx.development = dev;
+            }
             task.task.node.next = core::ptr::null_mut();
             task.io_task.node.next = core::ptr::null_mut();
             task.tree_shaking = self.linker.options.tree_shaking;

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -595,6 +595,8 @@ impl<'a> Transpiler<'a> {
         } else if is_production {
             self.options.set_production(true);
             self.resolver.opts.set_production(true);
+            self.options.force_node_env = options::ForceNodeEnv::Production;
+            self.resolver.opts.force_node_env = options::ForceNodeEnv::Production;
         }
         Ok(())
     }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -587,16 +587,18 @@ impl<'a> Transpiler<'a> {
             }
         }
 
-        if is_development {
-            self.options.set_production(false);
-            self.resolver.opts.set_production(false);
-            self.options.force_node_env = options::ForceNodeEnv::Development;
-            self.resolver.opts.force_node_env = options::ForceNodeEnv::Development;
-        } else if is_production {
-            self.options.set_production(true);
-            self.resolver.opts.set_production(true);
-            self.options.force_node_env = options::ForceNodeEnv::Production;
-            self.resolver.opts.force_node_env = options::ForceNodeEnv::Production;
+        if self.options.force_node_env == options::ForceNodeEnv::Unspecified {
+            if is_development {
+                self.options.set_production(false);
+                self.resolver.opts.set_production(false);
+                self.options.force_node_env = options::ForceNodeEnv::Development;
+                self.resolver.opts.force_node_env = options::ForceNodeEnv::Development;
+            } else if is_production {
+                self.options.set_production(true);
+                self.resolver.opts.set_production(true);
+                self.options.force_node_env = options::ForceNodeEnv::Production;
+                self.resolver.opts.force_node_env = options::ForceNodeEnv::Production;
+            }
         }
         Ok(())
     }

--- a/src/options_types/bundle_enums.rs
+++ b/src/options_types/bundle_enums.rs
@@ -100,6 +100,19 @@ pub enum ForceNodeEnv {
     Production,
 }
 
+impl ForceNodeEnv {
+    /// `Some(dev)` when this value should override the per-file tsconfig
+    /// `jsx.development`; `None` (Unspecified) leaves the resolver-merged
+    /// value in place.
+    pub fn jsx_development_override(self) -> Option<bool> {
+        match self {
+            ForceNodeEnv::Development => Some(true),
+            ForceNodeEnv::Production => Some(false),
+            ForceNodeEnv::Unspecified => None,
+        }
+    }
+}
+
 /// package.json `"type"` field.
 #[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]

--- a/src/options_types/bundle_enums.rs
+++ b/src/options_types/bundle_enums.rs
@@ -101,9 +101,7 @@ pub enum ForceNodeEnv {
 }
 
 impl ForceNodeEnv {
-    /// `Some(dev)` when this value should override the per-file tsconfig
-    /// `jsx.development`; `None` (Unspecified) leaves the resolver-merged
-    /// value in place.
+    /// `Some(dev)` to override per-file tsconfig `jsx.development`; `None` keeps it.
     pub fn jsx_development_override(self) -> Option<bool> {
         match self {
             ForceNodeEnv::Development => Some(true),

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -128,6 +128,7 @@ pub mod js_bundler {
         pub outdir: OwnedString,
         pub rootdir: OwnedString,
         pub jsx: api::Jsx,
+        pub jsx_development_explicit: Option<bool>,
         pub force_node_env: options::ForceNodeEnv,
         pub code_splitting: bool,
         pub minify: Minify,
@@ -191,6 +192,7 @@ pub mod js_bundler {
                     development: true, // Default to development mode like old Pragma
                     ..Default::default()
                 },
+                jsx_development_explicit: None,
                 force_node_env: options::ForceNodeEnv::Unspecified,
                 code_splitting: false,
                 minify: Minify::default(),
@@ -717,11 +719,7 @@ pub mod js_bundler {
                         this.jsx.runtime = jsx_runtime_to_api(runtime.runtime);
                         if let Some(dev) = runtime.development {
                             this.jsx.development = dev;
-                            this.force_node_env = if dev {
-                                options::ForceNodeEnv::Development
-                            } else {
-                                options::ForceNodeEnv::Production
-                            };
+                            this.jsx_development_explicit = Some(dev);
                         }
                     } else {
                         return Err(global_this.throw_invalid_arguments(format_args!(
@@ -749,11 +747,7 @@ pub mod js_bundler {
 
                 if let Some(dev) = jsx_value.get_boolean_loose(global_this, "development")? {
                     this.jsx.development = dev;
-                    this.force_node_env = if dev {
-                        options::ForceNodeEnv::Development
-                    } else {
-                        options::ForceNodeEnv::Production
-                    };
+                    this.jsx_development_explicit = Some(dev);
                 }
 
                 if let Some(val) = jsx_value.get_boolean_loose(global_this, "sideEffects")? {

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -717,6 +717,11 @@ pub mod js_bundler {
                         this.jsx.runtime = jsx_runtime_to_api(runtime.runtime);
                         if let Some(dev) = runtime.development {
                             this.jsx.development = dev;
+                            this.force_node_env = if dev {
+                                options::ForceNodeEnv::Development
+                            } else {
+                                options::ForceNodeEnv::Production
+                            };
                         }
                     } else {
                         return Err(global_this.throw_invalid_arguments(format_args!(
@@ -744,6 +749,11 @@ pub mod js_bundler {
 
                 if let Some(dev) = jsx_value.get_boolean_loose(global_this, "development")? {
                     this.jsx.development = dev;
+                    this.force_node_env = if dev {
+                        options::ForceNodeEnv::Development
+                    } else {
+                        options::ForceNodeEnv::Production
+                    };
                 }
 
                 if let Some(val) = jsx_value.get_boolean_loose(global_this, "sideEffects")? {

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -969,6 +969,13 @@ impl CompletionStruct for JSBundleCompletionTask {
                 .conditions
                 .append_slice(&[b"development"])?;
         }
+        if let Some(dev) = config.jsx_development_explicit {
+            transpiler.options.force_node_env = if dev {
+                options::ForceNodeEnv::Development
+            } else {
+                options::ForceNodeEnv::Production
+            };
+        }
         // `transpiler.env` is the dotenv loader installed by
         // `Transpiler::init`; non-null and valid for `'a`.
         transpiler.resolver.env_loader = NonNull::new(transpiler.env);

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -970,6 +970,7 @@ impl CompletionStruct for JSBundleCompletionTask {
                 .append_slice(&[b"development"])?;
         }
         if let Some(dev) = config.jsx_development_explicit {
+            transpiler.options.jsx.development = dev;
             transpiler.options.force_node_env = if dev {
                 options::ForceNodeEnv::Development
             } else {

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -1246,6 +1246,13 @@ impl Framework {
         out.configure_defines()?;
 
         out.options.jsx.development = mode == Mode::Development;
+        out.options.force_node_env = match mode {
+            Mode::Development => bun_bundler::options::ForceNodeEnv::Development,
+            Mode::ProductionDynamic | Mode::ProductionStatic => {
+                bun_bundler::options::ForceNodeEnv::Production
+            }
+        };
+        out.resolver.opts.force_node_env = out.options.force_node_env;
 
         add_import_meta_defines(
             &mut out.options.define,

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -299,6 +299,13 @@ impl Framework {
         out.configure_linker();
         out.configure_defines()?;
         out.options.jsx.development = mode == Mode::Development;
+        out.options.force_node_env = match mode {
+            Mode::Development => bun_bundler::options::ForceNodeEnv::Development,
+            Mode::ProductionDynamic | Mode::ProductionStatic => {
+                bun_bundler::options::ForceNodeEnv::Production
+            }
+        };
+        out.resolver.opts.force_node_env = out.options.force_node_env;
 
         bake_body::add_import_meta_defines(
             &mut out.options.define,

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -461,6 +461,8 @@ impl BuildCommand {
         if ctx.bundler_options.production {
             this_transpiler.options.jsx.development = false;
             this_transpiler.resolver.opts.jsx.development = false;
+            this_transpiler.options.force_node_env = options::ForceNodeEnv::Production;
+            this_transpiler.resolver.opts.force_node_env = options::ForceNodeEnv::Production;
         }
 
         match &ctx.debug.macros {

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -900,25 +900,25 @@ describe("bundler", () => {
         const file = api.readFile("out.js");
         // When sideEffects is true via tsconfig with automatic jsx: should NOT include /* @__PURE__ */ comments
         expect(file).not.toContain("/* @__PURE__ */");
+        // tsconfig "react-jsx" selects the production automatic runtime; passing a
+        // jsx option to Bun.build must not flip it to the dev runtime.
         expect(normalizeBunSnapshot(file)).toMatchInlineSnapshot(`
           "// @bun
-          // node_modules/react/jsx-dev-runtime.js
-          var $$typeof = Symbol.for("jsxdev");
-          function jsxDEV(type, props, key, source, self) {
+          // node_modules/react/jsx-runtime.js
+          var $$typeof = Symbol.for("jsx");
+          function jsx(type, props, key) {
             return {
               $$typeof,
               type,
               props,
-              key,
-              source,
-              self
+              key
             };
           }
-          var Fragment = Symbol.for("jsxdev.fragment");
+          var Fragment = Symbol.for("jsx.fragment");
 
           // index.jsx
-          console.log(jsxDEV("a", {}, undefined, false, undefined, this));
-          console.log(jsxDEV(Fragment, {}, undefined, false, undefined, this));"
+          console.log(jsx("a", {}));
+          console.log(jsx(Fragment, {}));"
         `);
       },
     });

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -172,4 +172,44 @@ describe("tsconfig compilerOptions.jsx", () => {
       });
     }
   });
+
+  // A plugin onResolve that returns a disk path bypasses the resolver, so the
+  // bundler has to look up the enclosing tsconfig itself. Both the disk-resolved
+  // entry and the plugin-resolved file should land on the same runtime.
+  test.each([
+    ["react-jsx", "shim/jsx-runtime"],
+    ["react-jsxdev", "shim/jsx-dev-runtime"],
+  ] as const)("Bun.build onResolve -> disk path honors tsconfig %s", async (tsjsx, want) => {
+    using dir = tempDir("jsx-onresolve", {
+      ...shimFiles,
+      "v.jsx": `export const v = <span />;\n`,
+      "m.jsx": `import "virt"; export const a = <div />;\n`,
+      "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: tsjsx, jsxImportSource: "shim" } }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const r = await Bun.build({
+           entrypoints: ["m.jsx"],
+           external: ["shim*"],
+           plugins: [{ name: "p", setup(b) {
+             b.onResolve({ filter: /^virt$/ }, () => ({ path: process.cwd() + "/v.jsx", namespace: "file" }));
+           }}],
+         });
+         if (!r.success) { console.error(r.logs.join("\\n")); process.exit(1); }
+         process.stdout.write(await r.outputs[0].text());`,
+      ],
+      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const unwanted = want === "shim/jsx-runtime" ? "shim/jsx-dev-runtime" : "shim/jsx-runtime";
+    expect(stdout).toContain(`"${want}"`);
+    expect(stdout).not.toContain(`"${unwanted}"`);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -68,4 +68,77 @@ describe("tsconfig compilerOptions.jsx", () => {
       expect(exitCode).toBe(0);
     }
   });
+
+  // Passing any --jsx-* CLI flag must not override tsconfig's dev/prod selection.
+  // Previously bundle_v2 overwrote the per-file resolver-merged `jsx.development`
+  // with the global CLI default whenever force_node_env was Unspecified, so
+  // adding e.g. --jsx-import-source=shim would discard the tsconfig "jsx" value.
+  describe.concurrent("bun build: --jsx-* flags preserve tsconfig dev/prod", () => {
+    const flags = [
+      ["--jsx-runtime=automatic"],
+      ["--jsx-import-source=shim"],
+      ["--jsx-fragment=Fragment"],
+      ["--jsx-factory=h"],
+    ] as const;
+    for (const extraArgs of flags) {
+      for (const [jsx, importSource] of [
+        ["react-jsx", "shim/jsx-runtime"],
+        ["react-jsxdev", "shim/jsx-dev-runtime"],
+      ] as const) {
+        test(`tsconfig "${jsx}" + ${extraArgs.join(" ")} -> ${importSource}`, async () => {
+          using dir = tempDir("jsx-tsconfig-cli", {
+            ...shimFiles,
+            "b.jsx": `export const b = <span />;\n`,
+            "m.jsx": `import "./b.jsx";\nexport const a = <div p="1">x</div>;\n`,
+            "tsconfig.json": JSON.stringify({ compilerOptions: { jsx, jsxImportSource: "shim" } }),
+          });
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), "build", "m.jsx", "--external", "shim*", ...extraArgs],
+            env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined },
+            cwd: String(dir),
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([
+            proc.stdout.text(),
+            proc.stderr.text(),
+            proc.exited,
+          ]);
+          expect(stderr).toBe("");
+          // Both the entry point and the imported file go through the bundler;
+          // neither should have its runtime flipped.
+          const unwanted =
+            importSource === "shim/jsx-runtime" ? "shim/jsx-dev-runtime" : "shim/jsx-runtime";
+          expect(stdout).toContain(`"${importSource}"`);
+          expect(stdout).not.toContain(`"${unwanted}"`);
+          expect(exitCode).toBe(0);
+        });
+      }
+    }
+
+    test("--production still forces the production runtime over tsconfig react-jsxdev", async () => {
+      using dir = tempDir("jsx-tsconfig-prod", {
+        ...shimFiles,
+        "tsconfig.json": JSON.stringify({
+          compilerOptions: { jsx: "react-jsxdev", jsxImportSource: "shim" },
+        }),
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "m.jsx", "--external", "shim*", "--production"],
+        env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined },
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("shim/jsx-runtime");
+      expect(stdout).not.toContain("jsx-dev-runtime");
+      expect(exitCode).toBe(0);
+    });
+  });
 });

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -70,9 +70,6 @@ describe("tsconfig compilerOptions.jsx", () => {
   });
 
   // Passing any --jsx-* CLI flag must not override tsconfig's dev/prod selection.
-  // Previously bundle_v2 overwrote the per-file resolver-merged `jsx.development`
-  // with the global CLI default whenever force_node_env was Unspecified, so
-  // adding e.g. --jsx-import-source=shim would discard the tsconfig "jsx" value.
   describe.concurrent("bun build: --jsx-* flags preserve tsconfig dev/prod", () => {
     const flags = [
       ["--jsx-runtime=automatic"],

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -131,9 +131,8 @@ describe("tsconfig compilerOptions.jsx", () => {
   });
 
   // An explicit jsx.development / jsx.runtime value passed to Bun.build must win
-  // over a conflicting tsconfig "jsx" setting, same as it did before the per-file
-  // merge became load-bearing.
-  describe("Bun.build: explicit jsx.development overrides tsconfig", () => {
+  // over a conflicting tsconfig "jsx" setting.
+  describe.concurrent("Bun.build: explicit jsx.development overrides tsconfig", () => {
     for (const [opt, tsjsx, want] of [
       [{ development: false }, "react-jsxdev", "shim/jsx-runtime"],
       [{ development: true }, "react-jsx", "shim/jsx-dev-runtime"],
@@ -173,7 +172,7 @@ describe("tsconfig compilerOptions.jsx", () => {
   // A plugin onResolve that returns a disk path bypasses the resolver, so the
   // bundler has to look up the enclosing tsconfig itself. Both the disk-resolved
   // entry and the plugin-resolved file should land on the same runtime.
-  test.each([
+  test.concurrent.each([
     ["react-jsx", "shim/jsx-runtime"],
     ["react-jsxdev", "shim/jsx-dev-runtime"],
   ] as const)("Bun.build onResolve -> disk path honors tsconfig %s", async (tsjsx, want) => {

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -132,4 +132,44 @@ describe("tsconfig compilerOptions.jsx", () => {
       expect(exitCode).toBe(0);
     });
   });
+
+  // An explicit jsx.development / jsx.runtime value passed to Bun.build must win
+  // over a conflicting tsconfig "jsx" setting, same as it did before the per-file
+  // merge became load-bearing.
+  describe("Bun.build: explicit jsx.development overrides tsconfig", () => {
+    for (const [opt, tsjsx, want] of [
+      [{ development: false }, "react-jsxdev", "shim/jsx-runtime"],
+      [{ development: true }, "react-jsx", "shim/jsx-dev-runtime"],
+      [{ runtime: "react-jsx" }, "react-jsxdev", "shim/jsx-runtime"],
+      [{ runtime: "react-jsxdev" }, "react-jsx", "shim/jsx-dev-runtime"],
+      [{ runtime: "automatic" }, "react-jsx", "shim/jsx-runtime"],
+      [{ runtime: "automatic" }, "react-jsxdev", "shim/jsx-dev-runtime"],
+    ] as const) {
+      test(`jsx: ${JSON.stringify(opt)} vs tsconfig "${tsjsx}" -> ${want}`, async () => {
+        using dir = tempDir("jsx-api-override", {
+          ...shimFiles,
+          "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: tsjsx, jsxImportSource: "shim" } }),
+        });
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `const r = await Bun.build({ entrypoints: ["m.jsx"], external: ["shim*"], jsx: ${JSON.stringify(opt)} });
+             if (!r.success) { console.error(r.logs.join("\\n")); process.exit(1); }
+             process.stdout.write(await r.outputs[0].text());`,
+          ],
+          env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined },
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        const unwanted = want === "shim/jsx-runtime" ? "shim/jsx-dev-runtime" : "shim/jsx-runtime";
+        expect(stdout).toContain(`"${want}"`);
+        expect(stdout).not.toContain(`"${unwanted}"`);
+        expect(exitCode).toBe(0);
+      });
+    }
+  });
 });

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -99,16 +99,11 @@ describe("tsconfig compilerOptions.jsx", () => {
             stdout: "pipe",
             stderr: "pipe",
           });
-          const [stdout, stderr, exitCode] = await Promise.all([
-            proc.stdout.text(),
-            proc.stderr.text(),
-            proc.exited,
-          ]);
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
           expect(stderr).toBe("");
           // Both the entry point and the imported file go through the bundler;
           // neither should have its runtime flipped.
-          const unwanted =
-            importSource === "shim/jsx-runtime" ? "shim/jsx-dev-runtime" : "shim/jsx-runtime";
+          const unwanted = importSource === "shim/jsx-runtime" ? "shim/jsx-dev-runtime" : "shim/jsx-runtime";
           expect(stdout).toContain(`"${importSource}"`);
           expect(stdout).not.toContain(`"${unwanted}"`);
           expect(exitCode).toBe(0);
@@ -130,11 +125,7 @@ describe("tsconfig compilerOptions.jsx", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
       expect(stdout).toContain("shim/jsx-runtime");
       expect(stdout).not.toContain("jsx-dev-runtime");


### PR DESCRIPTION
## What

`bun build` (bundled mode) with a tsconfig that sets `"jsx": "react-jsx"` or `"react-jsxdev"` loses that dev/prod selection as soon as any `--jsx-*` CLI flag is passed. The same applies to `Bun.build({ jsx: {...} })` where the `jsx` option does not set `development`. The `--no-bundle` path and `bun run` read `resolve_result.jsx` per file and were already correct.

## Repro

```sh
mkdir /tmp/t && cd /tmp/t
echo '{"compilerOptions":{"jsx":"react-jsxdev","jsxImportSource":"preact"}}' > tsconfig.json
echo 'export const a = <div />;' > a.jsx

bun build --external 'preact*' a.jsx
# import { jsxDEV } from "preact/jsx-dev-runtime";     ok

bun build --external 'preact*' --jsx-runtime=automatic a.jsx
# import { jsx } from "preact/jsx-runtime";            WRONG: tsconfig said dev

bun build --external 'preact*' --jsx-import-source=preact a.jsx
# import { jsx } from "preact/jsx-runtime";            WRONG: same
```

## Cause

`ParseTask::init` copies the per-file `resolve_result.jsx` (which the resolver already merged from the nearest tsconfig) into `task.jsx`. Immediately afterwards, `bundle_v2` overwrote `task.jsx.development` with the global `options.jsx.development` when `force_node_env == Unspecified`. `options.jsx` normally tracks the root tsconfig (via `configure_linker_with_auto_jsx`), so the overwrite was a no-op by default, but any `--jsx-*` flag makes `transform_options.jsx` `Some`, skips that tsconfig copy, and the per-file value was discarded.

## Fix

- `bundle_v2.rs`: on `Unspecified`, leave `task.jsx.development` alone; it is already the resolver's tsconfig-merged value. The four match blocks and the `enqueue_parse_task` plugin-fallback sibling (which wholesale-cloned `options.jsx` over the per-file value) now call a shared `ForceNodeEnv::jsx_development_override() -> Option<bool>` helper.
- `configure_defines`: an explicit `NODE_ENV=production` (env or `--define`) now sets `force_node_env = Production`, mirroring the existing `Development` arm. The whole block is guarded on `force_node_env == Unspecified` so a caller-set value (HTMLBundle dev, bake) is not clobbered by ambient `NODE_ENV`.
- `build_command`: `--production` sets `force_node_env = Production` alongside the existing `jsx.development = false`.
- bake (`mod.rs`, `bake_body.rs`): set `force_node_env` from `mode` so the dev server keeps emitting `jsx-dev-runtime` with a `"jsx": "react-jsx"` tsconfig and stays dev under ambient `NODE_ENV=production`.
- `JSBundler`: when `jsx.development` or a dev/prod-carrying `jsx.runtime` is explicitly passed, record it in a new `jsx_development_explicit` field and apply it to `force_node_env` after `configure_defines()` and the `development` export-condition check, so the explicit API value still overrides a conflicting tsconfig without disturbing `options.production` or condition resolution.

Precedence in bundled mode is now:

```
--production / explicit NODE_ENV / explicit jsx.development  >  tsconfig "jsx"  >  default (dev)
```

`--jsx-import-source`, `--jsx-fragment`, `--jsx-factory`, and `--jsx-runtime=automatic` no longer participate in dev/prod selection at all.

### Behavior change

`bun build` with env `NODE_ENV=production` and tsconfig `"jsx": "react-jsxdev"` now emits the production runtime (was development). This is symmetric with the existing `NODE_ENV=development` handling (which already overrode tsconfig via `force_node_env = Development`) and matches what `Bun.build({ define: { "process.env.NODE_ENV": '"production"' } })` already did per the #3768 test matrix.

## Verification

New tests in `test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts`:
- `bun build m.jsx --external shim*` with each of `--jsx-runtime=automatic`, `--jsx-import-source=shim`, `--jsx-fragment=Fragment`, `--jsx-factory=h` against both `"react-jsx"` and `"react-jsxdev"` tsconfigs (entry point + imported file), plus a `--production` guard.
- `Bun.build({ jsx: {...} })` with explicit `development: true/false` and `runtime: 'react-jsx'/'react-jsxdev'/'automatic'` against a conflicting tsconfig.

5 of 17 cases fail on main, all 17 pass with the fix.

`jsx/sideEffectsTrueTsconfigAutomatic` snapshot updated: it has tsconfig `"react-jsx"` and was encoding the dev runtime the old clobber produced; its assertion (no `/* @__PURE__ */`) still holds.

Existing suites green: `bundler_jsx`, `esbuild/tsconfig`, `jsx-production`, `bundler_env`, `bun-build-api`.

## Related

#36209 fixes the `bun run` (non-bundled) half of `--jsx-*` flipping dev/prod by defaulting `Arguments.rs` to `development: true`. That change and this one are independent; with only #36209 applied the repro above flips which tsconfig value is discarded instead of fixing it.

#31651 adds the same two `force_node_env = Production` lines in `configure_defines`, but its premise and second test case predate #34422 (on current main `"react-jsx"` already selects the production runtime without `NODE_ENV`). This PR supersedes that change.

#33855 also sets `force_node_env = Production` for `--production` (for a different bug, ambient `NODE_ENV` leaking into the define). The two-line overlap in `build_command.rs` is trivially resolvable whichever lands first.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
bun test v1.4.0 (e7f8d3fe2)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1037.15ms]
(pass) bundler > jsx/AutomaticProd [715.37ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [649.19ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [620.61ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [660.73ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [658.94ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [363.13ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [310.92ms]
(pass) bundler > jsx/ClassicDev [687.85ms]
(pass) bundler > jsx/ClassicProd [653.31ms]
(pass) bundler > jsx/ClassicPragmaDev [622.19ms]
(pass) bundler > jsx/ClassicPragmaProd [638.04ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [666.00ms]
(pass) bundler > jsx/Facto
... (truncated)

release without fix: 4 skipped
bun test v1.4.0-canary.1 (18686dac5)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [38.43ms]
(pass) bundler > jsx/AutomaticProd [17.46ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [16.17ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [15.64ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [16.49ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [14.59ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [8.47ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [6.54ms]
(pass) bundler > jsx/ClassicDev [16.12ms]
(pass) bundler > jsx/ClassicProd [15.06ms]
(pass) bundler > jsx/ClassicPragmaDev [14.38ms]
(pass) bundler > jsx/ClassicPragmaProd [13.97ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [15.97ms]
(pass) bundler > jsx/FactoryProd [15.92ms]
(pass) bundler > jsx/FactoryImportDev [14.08ms]
(pass) bundler > jsx/FactoryImportProd [14.02ms]
(pass) bundler > jsx/FactoryImportExplicitReactDefaultDev [7.02ms]
(pass) bundler > jsx/FactoryImportExplicitReact
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
bun test v1.4.0 (e7f8d3fe2)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1025.09ms]
(pass) bundler > jsx/AutomaticProd [760.82ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [673.05ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [795.46ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [838.06ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [819.21ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [365.14ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [348.71ms]
(pass) bundler > jsx/ClassicDev [658.46ms]
(pass) bundler > jsx/ClassicProd [690.29ms]
(pass) bundler > jsx/ClassicPragmaDev [666.08ms]
(pass) bundler > jsx/ClassicPragmaProd [655.27ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [711.82ms]
(pass) bundler > jsx/Facto
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 740ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/bundle_v2.rs                           |  99 ++++++++++-----
 src/bundler/transpiler.rs                          |  20 +--
 src/options_types/bundle_enums.rs                  |  11 ++
 src/runtime/api/JSBundler.rs                       |   4 +
 src/runtime/api/js_bundle_completion_task.rs       |   8 ++
 src/runtime/bake/bake_body.rs                      |   7 ++
 src/runtime/bake/mod.rs                            |   7 ++
 src/runtime/cli/build_command.rs                   |   2 +
 test/bundler/bundler_jsx.test.ts                   |  18 +--
 .../transpiler/jsx-tsconfig-react-jsx.test.ts      | 140 +++++++++++++++++++++
 10 files changed, 265 insertions(+), 51 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/bundler/bundle_v2.rs                                   15     21      0
src/bundler/transpiler.rs                                   6      2      0
src/options_types/bundle_enums.rs                           3      3      0
src/runtime/api/JSBundler.rs                                2      7      0
src/runtime/api/js_bundle_completion_task.rs                4      2      0
src/runtime/bake/bake_body.rs                               1      1      0
src/runtime/bake/mod.rs                                     1      1      0
src/runtime/cli/build_command.rs                            1      1      0
test/bundler/bundler_jsx.test.ts                            2      1      0
test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts      5      6      0
```

</details>

<!-- robobun:evidence:end -->