### PR TITLE
fetch: bound decompressed output to reader demand (backpressure through the decoder)

### DIFF
--- a/src/brotli/lib.rs
+++ b/src/brotli/lib.rs
@@ -143,17 +143,22 @@ impl StreamingDecoder {
         unsafe { self.brotli.as_mut() }
     }
 
-    /// Consume all of `input`, appending decompressed bytes to `out`
-    /// (growing in 4096-byte steps). Returns `ShortRead` when more input is
+    /// Consume `input`, appending decompressed bytes to `out` (growing in
+    /// 4096-byte steps). Stops early once `out.len()` reaches `max_output`
+    /// and returns the number of input bytes consumed so the caller can
+    /// retain the remainder for the next call. The separate
+    /// [`max_output_size`](Self::max_output_size) field is the hard bomb
+    /// guard. Returns `ShortRead` when all input was consumed but more is
     /// required and `is_done` is false.
     pub fn decompress(
         &mut self,
         input: &[u8],
         out: &mut Vec<u8>,
+        max_output: usize,
         is_done: bool,
-    ) -> crate::Result<()> {
+    ) -> crate::Result<usize> {
         if matches!(self.state, ReaderState::End | ReaderState::Error) {
-            return Ok(());
+            return Ok(input.len());
         }
         debug_assert!(out.as_ptr() != input.as_ptr());
 
@@ -162,6 +167,9 @@ impl StreamingDecoder {
             self.state,
             ReaderState::Uninitialized | ReaderState::Inflating
         ) {
+            if out.len() >= max_output {
+                return Ok(total_in);
+            }
             out.reserve(4096);
             let spare = out.spare_capacity_mut();
             let out_len = spare.len();
@@ -198,7 +206,7 @@ impl StreamingDecoder {
             match result {
                 c::BrotliDecoderResult::success => {
                     self.state = ReaderState::End;
-                    return Ok(());
+                    return Ok(total_in);
                 }
                 c::BrotliDecoderResult::err => {
                     self.state = ReaderState::Error;
@@ -221,7 +229,7 @@ impl StreamingDecoder {
                 }
             }
         }
-        Ok(())
+        Ok(total_in)
     }
 }
 

--- a/src/http/Decompressor.rs
+++ b/src/http/Decompressor.rs
@@ -50,26 +50,32 @@ impl Decompressor {
 
     /// Feed one body chunk `buffer` through the decoder, appending the
     /// decompressed output to `body_out_str`. Creates the decoder on first
-    /// call. Returns `ShortRead` when more input is needed and the stream is
-    /// not yet done.
+    /// call. Decoding stops once `body_out_str` reaches `max_output` bytes;
+    /// the returned `Ok(n)` is the number of input bytes consumed so the
+    /// caller can retain `buffer[n..]` for the next call. Returns
+    /// `ShortRead` when all input was consumed but more is needed and the
+    /// stream is not yet done.
     pub fn decompress_chunk(
         &mut self,
         encoding: Encoding,
         buffer: &[u8],
         body_out_str: &mut MutableString,
+        max_output: usize,
         is_done: bool,
-    ) -> crate::Result<()> {
+    ) -> crate::Result<usize> {
         if !encoding.is_compressed() {
-            return Ok(());
+            return Ok(buffer.len());
         }
         if matches!(self, Decompressor::None) {
             self.init(encoding, buffer)?;
         }
         let out = &mut body_out_str.list;
         match self {
-            Decompressor::Zlib(reader) => Ok(reader.decompress(buffer, out, is_done)?),
-            Decompressor::Brotli(reader) => Ok(reader.decompress(buffer, out, is_done)?),
-            Decompressor::Zstd(reader) => Ok(reader.decompress(buffer, out, is_done)?),
+            Decompressor::Zlib(reader) => Ok(reader.decompress(buffer, out, max_output, is_done)?),
+            Decompressor::Brotli(reader) => {
+                Ok(reader.decompress(buffer, out, max_output, is_done)?)
+            }
+            Decompressor::Zstd(reader) => Ok(reader.decompress(buffer, out, max_output, is_done)?),
             Decompressor::None => {
                 unreachable!("Invalid encoding. This code should not be reachable")
             }

--- a/src/http/Decompressor.rs
+++ b/src/http/Decompressor.rs
@@ -19,6 +19,19 @@ impl Decompressor {
     // explicit `Drop` is unnecessary. Callers that want a mid-lifecycle reset
     // assign `*self = Decompressor::None`.
 
+    /// The underlying decoder has consumed input but not yet reached
+    /// stream-end: a further `decompress_chunk` call may emit more output
+    /// from its internal buffer even with empty input.
+    pub fn is_mid_stream(&self) -> bool {
+        use bun_core::compress::State;
+        match self {
+            Decompressor::Zlib(r) => matches!(r.state, State::Inflating),
+            Decompressor::Brotli(r) => matches!(r.state, State::Inflating),
+            Decompressor::Zstd(r) => matches!(r.state, State::Inflating),
+            Decompressor::None => false,
+        }
+    }
+
     fn init(&mut self, encoding: Encoding, first_chunk: &[u8]) -> crate::Result<()> {
         match encoding {
             Encoding::Gzip | Encoding::Deflate => {

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -234,6 +234,14 @@ impl<'a> InternalState<'a> {
         self.flags.received_last_chunk
     }
 
+    /// Compressed bytes received from the wire but not yet fed through the
+    /// decoder. Non-empty when `process_body_buffer` stopped at
+    /// `max_output`; the next drain/`on_data` picks up where it left off.
+    #[inline]
+    pub fn has_pending_compressed(&self) -> bool {
+        self.encoding.is_compressed() && !self.compressed_body.list.is_empty()
+    }
+
     /// True when a socket close during `in_progress` completes the body rather
     /// than failing it: chunked decoder already in the trailers state, or a
     /// close-delimited response (no Content-Length, no Transfer-Encoding).
@@ -254,7 +262,8 @@ impl<'a> InternalState<'a> {
     pub fn finalize_body_on_eof(&mut self) -> Result<(), Error> {
         self.flags.received_last_chunk = true;
         let buffer_snap = core::mem::take(&mut self.get_body_buffer().list);
-        self.process_body_buffer(buffer_snap, true).map(drop)
+        self.process_body_buffer(buffer_snap, true, usize::MAX)
+            .map(drop)
     }
 
     pub fn decompress_bytes(
@@ -262,20 +271,22 @@ impl<'a> InternalState<'a> {
         buffer: &[u8],
         body_out_str: &mut MutableString,
         is_final_chunk: bool,
-    ) -> Result<(), Error> {
+        max_output: usize,
+    ) -> Result<usize, Error> {
         // A response that declared a Content-Encoding but sent zero body bytes
         // (e.g. an empty chunked gzip response) has nothing to decompress.
         // Running the decompressor anyway makes it report a truncated stream
         // (ZlibError); Node treats this as an empty body.
         if buffer.is_empty() && self.total_body_received == 0 {
             self.compressed_body.reset();
-            return Ok(());
+            return Ok(0);
         }
 
         // `self.compressed_body.reset()` must run on every exit. scopeguard would
         // hold &mut self.compressed_body across the body and conflict with &mut self.decompressor,
         // so each early-return below calls it explicitly.
         let mut still_needs_to_decompress = true;
+        let mut consumed = buffer.len();
 
         if bun_core::feature_flags::is_libdeflate_enabled() {
             // Fast-path: use libdeflate
@@ -379,24 +390,30 @@ impl<'a> InternalState<'a> {
             }
 
             let is_done = self.is_done();
-            if let Err(err) =
-                self.decompressor
-                    .decompress_chunk(self.encoding, buffer, body_out_str, is_done)
-            {
-                if is_done || err != crate::Error::ShortRead {
-                    bun_core::pretty_errorln!(
-                        "<r><red>Decompression error: {}<r>",
-                        bstr::BStr::new(err.name()),
-                    );
-                    Output::flush();
-                    self.compressed_body.reset();
-                    return Err(err);
+            match self.decompressor.decompress_chunk(
+                self.encoding,
+                buffer,
+                body_out_str,
+                max_output,
+                is_done,
+            ) {
+                Ok(n) => consumed = n,
+                Err(err) => {
+                    if is_done || err != crate::Error::ShortRead {
+                        bun_core::pretty_errorln!(
+                            "<r><red>Decompression error: {}<r>",
+                            bstr::BStr::new(err.name()),
+                        );
+                        Output::flush();
+                        self.compressed_body.reset();
+                        return Err(err);
+                    }
                 }
             }
         }
 
         self.compressed_body.reset();
-        Ok(())
+        Ok(consumed)
     }
 
     // `buffer` is always the current body buffer's bytes. To avoid aliased &mut/& under
@@ -407,6 +424,7 @@ impl<'a> InternalState<'a> {
         &mut self,
         mut buffer: Vec<u8>,
         is_final_chunk: bool,
+        max_output: usize,
     ) -> Result<bool, Error> {
         if self.flags.is_redirect_pending {
             // Caller moved the bytes out of the body buffer; put them back so the
@@ -431,10 +449,16 @@ impl<'a> InternalState<'a> {
 
         match self.encoding {
             Encoding::Brotli | Encoding::Gzip | Encoding::Deflate | Encoding::Zstd => {
-                self.decompress_bytes(&buffer, body_out_str, is_final_chunk)?;
-                // Retain capacity by
-                // returning the (cleared) allocation to compressed_body instead of dropping it.
-                buffer.clear();
+                let consumed =
+                    self.decompress_bytes(&buffer, body_out_str, is_final_chunk, max_output)?;
+                if consumed < buffer.len() {
+                    // Output budget reached: keep unconsumed compressed input
+                    // for the next drain/on_data cycle.
+                    buffer.drain(..consumed);
+                } else {
+                    // Retain capacity by returning the (cleared) allocation.
+                    buffer.clear();
+                }
                 self.compressed_body.list = buffer;
             }
             _ => {

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -85,6 +85,10 @@ pub struct InternalStateFlags {
     /// `reset()`/`init()` so each redirect/retry hop re-compresses from the
     /// original uncompressed `original_request_body`.
     pub body_compressed: bool,
+    /// `process_body_buffer` stopped at its `max_output` budget with either
+    /// unconsumed compressed input or a mid-stream decoder. The next
+    /// drain/`on_data` must pump again before the request can finalize.
+    pub decompress_output_pending: bool,
 }
 
 impl InternalStateFlags {
@@ -101,6 +105,7 @@ impl InternalStateFlags {
             is_waiting_for_cert_check: false,
             receive_paused: false,
             body_compressed: false,
+            decompress_output_pending: false,
         }
     }
 }
@@ -234,12 +239,12 @@ impl<'a> InternalState<'a> {
         self.flags.received_last_chunk
     }
 
-    /// Compressed bytes received from the wire but not yet fed through the
-    /// decoder. Non-empty when `process_body_buffer` stopped at
-    /// `max_output`; the next drain/`on_data` picks up where it left off.
+    /// `process_body_buffer` stopped at its output budget with more to
+    /// deliver (unconsumed compressed input or a mid-stream decoder with
+    /// output buffered internally).
     #[inline]
     pub fn has_pending_compressed(&self) -> bool {
-        self.encoding.is_compressed() && !self.compressed_body.list.is_empty()
+        self.flags.decompress_output_pending
     }
 
     /// True when a socket close during `in_progress` completes the body rather
@@ -294,6 +299,7 @@ impl<'a> InternalState<'a> {
             'libdeflate: {
                 use bun_libdeflate_sys::libdeflate as bun_libdeflate;
                 if !(is_final_chunk
+                    && max_output == usize::MAX
                     && !self.flags.is_libdeflate_fast_path_disabled
                     && self.encoding.can_use_lib_deflate()
                     && self.is_done())
@@ -459,6 +465,11 @@ impl<'a> InternalState<'a> {
                     // Retain capacity by returning the (cleared) allocation.
                     buffer.clear();
                 }
+                // Decoder may still hold output internally even with no
+                // unconsumed input (brotli/zlib can read a whole command into
+                // their window and emit it across several calls).
+                self.flags.decompress_output_pending = max_output != usize::MAX
+                    && (!buffer.is_empty() || self.decompressor.is_mid_stream());
                 self.compressed_body.list = buffer;
             }
             _ => {

--- a/src/http/Signals.rs
+++ b/src/http/Signals.rs
@@ -79,6 +79,20 @@ impl Signals {
             .map(bun_ptr::BackRef::from)
             .is_some_and(|a| a.load(Ordering::Acquire) == BodyReceiveMode::Paused as u8)
     }
+
+    /// Streaming consumer is pulling chunk-by-chunk (`AutoPause`/`Paused`),
+    /// as opposed to `BufferAll` / `Ignore` / unwired.
+    #[inline]
+    pub fn is_auto_pause(self) -> bool {
+        self.body_receive_mode
+            .map(bun_ptr::BackRef::from)
+            .is_some_and(|a| {
+                matches!(
+                    BodyReceiveMode::from_u8(a.load(Ordering::Acquire)),
+                    BodyReceiveMode::AutoPause | BodyReceiveMode::Paused
+                )
+            })
+    }
 }
 
 pub struct Store {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4012,6 +4012,22 @@ impl<'a> HTTPClient<'a> {
         socket.set_timeout(self.effective_idle_timeout_seconds());
     }
 
+    /// Decompressed-output budget per `process_body_buffer` call. Capped
+    /// only while a streaming reader is attached (`AutoPause`/`Paused`):
+    /// the reader's pull cadence drives the decode, so one socket read
+    /// cannot inflate a high-ratio compressed chunk into hundreds of MB
+    /// ahead of demand. `BufferAll`/`Ignore` and unwired callers decode
+    /// unbounded as before.
+    #[inline]
+    fn decompress_output_cap(&self) -> usize {
+        const STREAMING_DECOMPRESS_MAX_OUTPUT: usize = 1024 * 1024;
+        if self.signals.is_auto_pause() {
+            STREAMING_DECOMPRESS_MAX_OUTPUT
+        } else {
+            usize::MAX
+        }
+    }
+
     fn maybe_pause_receive<const IS_SSL: bool>(&mut self, socket: HttpSocket<IS_SSL>) {
         if self.state.flags.receive_paused
             || self.proxy_tunnel.is_some()
@@ -4062,6 +4078,22 @@ impl<'a> HTTPClient<'a> {
         // from that.
         if self.state.flags.is_redirect_pending {
             return;
+        }
+
+        // Compressed bytes left over from a previous `process_body_buffer`
+        // that stopped at the output cap: decode the next bounded chunk now
+        // so the JS reader's pull drives the inflate.
+        if self.state.has_pending_compressed() {
+            let max_output = self.decompress_output_cap();
+            let is_final = self.state.is_done();
+            let buffer_snap = core::mem::take(&mut self.state.compressed_body.list);
+            if let Err(err) = self
+                .state
+                .process_body_buffer(buffer_snap, is_final, max_output)
+            {
+                self.close_and_fail::<IS_SSL>(err, socket);
+                return;
+            }
         }
 
         let Some(body_out_str) = self.body_out_str() else {
@@ -4439,7 +4471,8 @@ impl<'a> HTTPClient<'a> {
                     fail: self.state.fail,
                     dns_error: self.state.dns_error,
                     dns_hostname: self.state.dns_hostname.take(),
-                    has_more: self.state.fail.is_none() && !self.state.is_done(),
+                    has_more: self.state.fail.is_none()
+                        && (!self.state.is_done() || self.state.has_pending_compressed()),
                     body_size,
                     certificate_info: None,
                     can_stream: (self.state.request_stage == RequestStage::Body
@@ -4458,7 +4491,8 @@ impl<'a> HTTPClient<'a> {
             dns_hostname: self.state.dns_hostname.take(),
             // check if we are reporting cert errors, do not have a fail state and we are not done
             has_more: certificate_info.is_some()
-                || (self.state.fail.is_none() && !self.state.is_done()),
+                || (self.state.fail.is_none()
+                    && (!self.state.is_done() || self.state.has_pending_compressed())),
             body_size,
             certificate_info,
             // we can stream the request_body at this stage
@@ -4485,6 +4519,10 @@ impl<'a> HTTPClient<'a> {
         if is_only_buffer
             && let Some(len) = content_length
             && incoming_data.len() >= len
+            // A compressed body that fits in one packet would otherwise be
+            // inflated in full here; route streaming readers through the
+            // multiple-packets path so the output cap applies.
+            && !(self.state.encoding.is_compressed() && self.signals.is_auto_pause())
         {
             self.handle_response_body_from_single_packet(&incoming_data[0..len])?;
             Ok(true)
@@ -4509,8 +4547,12 @@ impl<'a> HTTPClient<'a> {
         if !self.state.flags.is_redirect_pending {
             if self.state.encoding.is_compressed() {
                 if let Some(body_out) = self.state.body_out_str {
-                    self.state
-                        .decompress_bytes(incoming_data, body_out::as_mut(body_out), true)?;
+                    self.state.decompress_bytes(
+                        incoming_data,
+                        body_out::as_mut(body_out),
+                        true,
+                        usize::MAX,
+                    )?;
                 }
             } else {
                 self.state
@@ -4567,13 +4609,14 @@ impl<'a> HTTPClient<'a> {
             || self.signals.body_receive_mode.is_some();
         if is_done || is_streaming || content_length.is_none() {
             let is_final_chunk = is_done;
+            let max_output = self.decompress_output_cap();
             // Move the body buffer's bytes out — process_body_buffer takes `&mut self.state`
             // and may mutate `compressed_body` (via decompress_bytes' reset) or `body_out_str`,
             // so any `&` into `self.state` held across the call would be aliased UB.
             let buffer_snap = core::mem::take(&mut self.state.get_body_buffer().list);
             let processed = self
                 .state
-                .process_body_buffer(buffer_snap, is_final_chunk)?;
+                .process_body_buffer(buffer_snap, is_final_chunk, max_output)?;
 
             // We can only use the libdeflate fast path when we are not streaming
             // If we ever call processBodyBuffer again, it cannot go through the fast path.
@@ -4657,10 +4700,13 @@ impl<'a> HTTPClient<'a> {
                 {
                     // If we're streaming, we cannot use the libdeflate fast path
                     self.state.flags.is_libdeflate_fast_path_disabled = true;
+                    let max_output = self.decompress_output_cap();
                     // Move the
                     // bytes out so no `&` into self.state aliases the `&mut self.state` call.
                     let buffer_snap = core::mem::take(&mut self.state.get_body_buffer().list);
-                    return self.state.process_body_buffer(buffer_snap, false);
+                    return self
+                        .state
+                        .process_body_buffer(buffer_snap, false, max_output);
                 }
 
                 return Ok(false);
@@ -4668,10 +4714,13 @@ impl<'a> HTTPClient<'a> {
             // Done
             _ => {
                 self.state.flags.received_last_chunk = true;
+                let max_output = self.decompress_output_cap();
                 // Move the
                 // bytes out so no `&` into self.state aliases the `&mut self.state` call.
                 let buffer_snap = core::mem::take(&mut self.state.get_body_buffer().list);
-                let _ = self.state.process_body_buffer(buffer_snap, true)?;
+                let _ = self
+                    .state
+                    .process_body_buffer(buffer_snap, true, max_output)?;
 
                 self.report_progress(buffer_len);
 
@@ -4734,11 +4783,14 @@ impl<'a> HTTPClient<'a> {
                     // If we're streaming, we cannot use the libdeflate fast path
                     self.state.flags.is_libdeflate_fast_path_disabled = true;
 
+                    let max_output = self.decompress_output_cap();
                     // Move
                     // the bytes out so no `&` into self.state aliases the `&mut self.state`
                     // taken by process_body_buffer (which mutates compressed_body/body_out_str).
                     let buffer_snap = core::mem::take(&mut self.state.get_body_buffer().list);
-                    return self.state.process_body_buffer(buffer_snap, false);
+                    return self
+                        .state
+                        .process_body_buffer(buffer_snap, false, max_output);
                 }
 
                 Ok(false)

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4012,16 +4012,14 @@ impl<'a> HTTPClient<'a> {
         socket.set_timeout(self.effective_idle_timeout_seconds());
     }
 
-    /// Decompressed-output budget per `process_body_buffer` call. Capped
-    /// only while a streaming reader is attached (`AutoPause`/`Paused`):
-    /// the reader's pull cadence drives the decode, so one socket read
-    /// cannot inflate a high-ratio compressed chunk into hundreds of MB
-    /// ahead of demand. `BufferAll`/`Ignore` and unwired callers decode
-    /// unbounded as before.
+    /// Decompressed-output budget per `process_body_buffer` call: capped to
+    /// 1 MB while a streaming reader is attached so one socket read cannot
+    /// inflate a high-ratio body ahead of demand. h3 has no leftover-drain
+    /// hook yet, so it stays unbounded.
     #[inline]
     fn decompress_output_cap(&self) -> usize {
         const STREAMING_DECOMPRESS_MAX_OUTPUT: usize = 1024 * 1024;
-        if self.signals.is_auto_pause() {
+        if self.flags.protocol != Protocol::Http3 && self.signals.is_auto_pause() {
             STREAMING_DECOMPRESS_MAX_OUTPUT
         } else {
             usize::MAX

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4013,13 +4013,14 @@ impl<'a> HTTPClient<'a> {
     }
 
     /// Decompressed-output budget per `process_body_buffer` call: capped to
-    /// 1 MB while a streaming reader is attached so one socket read cannot
-    /// inflate a high-ratio body ahead of demand. h3 has no leftover-drain
-    /// hook yet, so it stays unbounded.
+    /// 1 MB while an h1 streaming reader is attached so one socket read
+    /// cannot inflate a high-ratio body ahead of demand. h2/h3 detach the
+    /// stream before any leftover can be drained, so they stay unbounded
+    /// until that path gains a post-detach drain hook.
     #[inline]
     fn decompress_output_cap(&self) -> usize {
         const STREAMING_DECOMPRESS_MAX_OUTPUT: usize = 1024 * 1024;
-        if self.flags.protocol != Protocol::Http3 && self.signals.is_auto_pause() {
+        if self.flags.protocol == Protocol::Http1_1 && self.signals.is_auto_pause() {
             STREAMING_DECOMPRESS_MAX_OUTPUT
         } else {
             usize::MAX
@@ -4081,7 +4082,9 @@ impl<'a> HTTPClient<'a> {
         // Compressed bytes left over from a previous `process_body_buffer`
         // that stopped at the output cap: decode the next bounded chunk now
         // so the JS reader's pull drives the inflate.
+        let mut decoded_pending = false;
         if self.state.has_pending_compressed() {
+            decoded_pending = true;
             let max_output = self.decompress_output_cap();
             let is_final = self.state.is_done();
             let buffer_snap = core::mem::take(&mut self.state.compressed_body.list);
@@ -4098,8 +4101,15 @@ impl<'a> HTTPClient<'a> {
             return;
         };
         if body_out_str.list.is_empty() {
-            // No update! Don't do anything.
-            return;
+            // A leftover that decoded to 0 bytes (stream terminator only) can
+            // flip has_more to false with nothing to deliver; that terminal
+            // callback still has to fire or the reader never completes.
+            if !(decoded_pending
+                && self.state.is_done()
+                && !self.state.has_pending_compressed())
+            {
+                return;
+            }
         }
 
         let ctx = self.get_ssl_ctx::<IS_SSL>();
@@ -4635,7 +4645,10 @@ impl<'a> HTTPClient<'a> {
         incoming_data: &[u8],
     ) -> crate::Result<bool> {
         let small_len = 16 * 1024usize;
-        if incoming_data.len() <= small_len && self.state.get_body_buffer().list.is_empty() {
+        if incoming_data.len() <= small_len
+            && self.state.get_body_buffer().list.is_empty()
+            && !(self.state.encoding.is_compressed() && self.signals.is_auto_pause())
+        {
             self.handle_response_body_chunked_encoding_from_single_packet(incoming_data)
         } else {
             self.handle_response_body_chunked_encoding_from_multiple_packets(incoming_data)

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4614,9 +4614,9 @@ impl<'a> HTTPClient<'a> {
             // and may mutate `compressed_body` (via decompress_bytes' reset) or `body_out_str`,
             // so any `&` into `self.state` held across the call would be aliased UB.
             let buffer_snap = core::mem::take(&mut self.state.get_body_buffer().list);
-            let processed = self
-                .state
-                .process_body_buffer(buffer_snap, is_final_chunk, max_output)?;
+            let processed =
+                self.state
+                    .process_body_buffer(buffer_snap, is_final_chunk, max_output)?;
 
             // We can only use the libdeflate fast path when we are not streaming
             // If we ever call processBodyBuffer again, it cannot go through the fast path.

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4104,10 +4104,7 @@ impl<'a> HTTPClient<'a> {
             // A leftover that decoded to 0 bytes (stream terminator only) can
             // flip has_more to false with nothing to deliver; that terminal
             // callback still has to fire or the reader never completes.
-            if !(decoded_pending
-                && self.state.is_done()
-                && !self.state.has_pending_compressed())
-            {
+            if !(decoded_pending && self.state.is_done() && !self.state.has_pending_compressed()) {
                 return;
             }
         }

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -1152,9 +1152,13 @@ impl InflateDecoder {
         step(&mut self.strm, input, out, reserve, flush, inflate)
     }
 
-    /// Consume all of `input`, appending decompressed output to `out`
-    /// (growing by 4096-byte steps, capped at `max_output_size`). Returns
-    /// `ShortRead` when more input is required and `is_done` is false.
+    /// Consume `input`, appending decompressed output to `out` (growing by
+    /// 4096-byte steps). Stops early once `out.len()` reaches `max_output`
+    /// and returns the number of input bytes consumed so the caller can
+    /// retain the remainder for the next call. The separate
+    /// [`max_output_size`](Self::max_output_size) field is the hard bomb
+    /// guard (exceeding it is an error). Returns `ShortRead` when all input
+    /// was consumed but more is required and `is_done` is false.
     ///
     /// The stream state persists across calls so this can be driven one
     /// body chunk at a time.
@@ -1162,10 +1166,12 @@ impl InflateDecoder {
         &mut self,
         mut input: &[u8],
         out: &mut Vec<u8>,
+        max_output: usize,
         is_done: bool,
-    ) -> Result<(), ZlibError> {
+    ) -> Result<usize, ZlibError> {
+        let input_len = input.len();
         if matches!(self.state, State::Error) {
-            return Ok(());
+            return Ok(input_len);
         }
         if matches!(self.state, State::End) {
             // A prior call completed a gzip member at the chunk boundary.
@@ -1178,10 +1184,13 @@ impl InflateDecoder {
                     return Err(ZlibError::ZlibError);
                 }
             } else {
-                return Ok(());
+                return Ok(input_len);
             }
         }
         loop {
+            if out.len() >= max_output {
+                return Ok(input_len - input.len());
+            }
             let remaining = self.max_output_size.saturating_sub(out.len());
             if remaining == 0 {
                 self.state = State::Error;
@@ -1209,7 +1218,9 @@ impl InflateDecoder {
                         }
                         continue;
                     }
-                    return Ok(());
+                    // Trailing non-member bytes are tolerated garbage; report
+                    // them consumed so the caller does not re-feed them.
+                    return Ok(input_len);
                 }
                 ReturnCode::MemError => {
                     self.state = State::Error;

--- a/src/zstd/lib.rs
+++ b/src/zstd/lib.rs
@@ -539,17 +539,22 @@ impl StreamingDecoder {
         })
     }
 
-    /// Consume all of `input`, appending decompressed bytes to `out`
-    /// (growing in 4096-byte steps). Returns `ShortRead` when more input is
+    /// Consume `input`, appending decompressed bytes to `out` (growing in
+    /// 4096-byte steps). Stops early once `out.len()` reaches `max_output`
+    /// and returns the number of input bytes consumed so the caller can
+    /// retain the remainder for the next call. The separate
+    /// [`max_output_size`](Self::max_output_size) field is the hard bomb
+    /// guard. Returns `ShortRead` when all input was consumed but more is
     /// required and `is_done` is false.
     pub fn decompress(
         &mut self,
         input: &[u8],
         out: &mut Vec<u8>,
+        max_output: usize,
         is_done: bool,
-    ) -> core::result::Result<(), ZstdError> {
+    ) -> core::result::Result<usize, ZstdError> {
         if matches!(self.state, State::End | State::Error) {
-            return Ok(());
+            return Ok(input.len());
         }
 
         let mut total_in = 0usize;
@@ -564,7 +569,11 @@ impl StreamingDecoder {
                     }
                     self.state = State::End;
                 }
-                return Ok(());
+                return Ok(total_in);
+            }
+
+            if out.len() >= max_output {
+                return Ok(total_in);
             }
 
             let remaining_output = self.max_output_size.saturating_sub(out.len());
@@ -610,7 +619,7 @@ impl StreamingDecoder {
                     if is_done {
                         self.state = State::End;
                     }
-                    return Ok(());
+                    return Ok(total_in);
                 }
                 // More input available — reinitialize for the next frame.
                 // SAFETY: stream is a valid DStream.
@@ -631,7 +640,7 @@ impl StreamingDecoder {
                 return Err(ZstdError::ShortRead);
             }
         }
-        Ok(())
+        Ok(total_in)
     }
 }
 

--- a/test/js/web/fetch/fetch-backpressure.test.ts
+++ b/test/js/web/fetch/fetch-backpressure.test.ts
@@ -8,7 +8,7 @@ import { createServer } from "node:http";
 import { createSecureServer } from "node:http2";
 import { createServer as createHttpsServer } from "node:https";
 import net from "node:net";
-import { brotliCompressSync, gzipSync, zstdCompressSync } from "node:zlib";
+import { brotliCompressSync, constants as zlibConstants, gzipSync, zstdCompressSync } from "node:zlib";
 
 const CHUNK = 64 * 1024;
 const COUNT = 256; // 16 MiB
@@ -259,6 +259,9 @@ for (const kind of ["h1", "h1-chunked", "h1-gzip", "h1-tls", "h2", "h3"] as Kind
 // so withholding WINDOW_UPDATE only takes effect past that. Asserting a tight
 // RSS bound for h2 needs that window lowered, which is a separate change.
 
+// Serial: six subprocesses each drain 128 MB in ~1 MB pulls under debug+ASAN;
+// running them alongside the concurrent suites above pushed the h3 tests past
+// their default timeout on memory-constrained CI hosts.
 describe("fetch() receive backpressure — compressed body inflates on demand", () => {
   // One socket read (<= 512 KB) of a high-ratio compressed body must not be
   // inflated in full ahead of the reader. Without the output cap, a single read
@@ -274,7 +277,7 @@ describe("fetch() receive backpressure — compressed body inflates on demand", 
   const bombs: { [k: string]: Buffer } = {};
   function bombFor(kind: BombKind) {
     zeros ??= Buffer.alloc(DECOMPRESSED);
-    const q = require("node:zlib").constants.BROTLI_PARAM_QUALITY;
+    const q = zlibConstants.BROTLI_PARAM_QUALITY;
     return (bombs[kind] ??=
       kind === "gzip"
         ? gzipSync(zeros, { level: 1 })

--- a/test/js/web/fetch/fetch-backpressure.test.ts
+++ b/test/js/web/fetch/fetch-backpressure.test.ts
@@ -1,13 +1,14 @@
 // Receive-side backpressure: a stalled `res.body.getReader()` must stop the
 // HTTP thread from buffering the entire response in memory.
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tls } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, tls } from "harness";
 import { randomBytes } from "node:crypto";
 import { once } from "node:events";
 import { createServer } from "node:http";
 import { createSecureServer } from "node:http2";
 import { createServer as createHttpsServer } from "node:https";
-import { gzipSync } from "node:zlib";
+import net from "node:net";
+import { brotliCompressSync, gzipSync, zstdCompressSync } from "node:zlib";
 
 const CHUNK = 64 * 1024;
 const COUNT = 256; // 16 MiB
@@ -257,6 +258,100 @@ for (const kind of ["h1", "h1-chunked", "h1-gzip", "h1-tls", "h2", "h3"] as Kind
 // h2 advertises a 16 MiB initial per-stream window (LOCAL_INITIAL_WINDOW_SIZE),
 // so withholding WINDOW_UPDATE only takes effect past that. Asserting a tight
 // RSS bound for h2 needs that window lowered, which is a separate change.
+
+describe("fetch() receive backpressure — compressed body inflates on demand", () => {
+  // One socket read (<= 512 KB) of a high-ratio compressed body must not be
+  // inflated in full ahead of the reader. Without the output cap, a single read
+  // here decompresses to ~128 MB while the consumer holds one chunk.
+  const DECOMPRESSED = 128 * 1024 * 1024;
+  // Unfixed grows RSS by ~DECOMPRESSED; fixed stays within a few MB. ASAN
+  // quarantine inflates allocations, so keep the bound generous but well
+  // below the unfixed behavior.
+  const PEAK_LIMIT = (isASAN ? 64 : 48) * 1024 * 1024;
+
+  let zeros: Buffer;
+  const bombs: { [k: string]: Buffer } = {};
+  function bombFor(encoding: "gzip" | "br" | "zstd") {
+    zeros ??= Buffer.alloc(DECOMPRESSED);
+    return (bombs[encoding] ??=
+      encoding === "gzip"
+        ? gzipSync(zeros, { level: 1 })
+        : encoding === "br"
+          ? brotliCompressSync(zeros, { params: { [require("node:zlib").constants.BROTLI_PARAM_QUALITY]: 0 } })
+          : zstdCompressSync(zeros, { level: 1 }));
+  }
+
+  async function serveBomb(encoding: "gzip" | "br" | "zstd", chunked: boolean) {
+    const bomb = bombFor(encoding);
+    const head = chunked
+      ? `HTTP/1.1 200 OK\r\nContent-Encoding: ${encoding}\r\nTransfer-Encoding: chunked\r\n\r\n` +
+        `${bomb.length.toString(16)}\r\n`
+      : `HTTP/1.1 200 OK\r\nContent-Encoding: ${encoding}\r\nContent-Length: ${bomb.length}\r\nConnection: keep-alive\r\n\r\n`;
+    const tail = chunked ? "\r\n0\r\n\r\n" : "";
+    const srv = net.createServer(s => {
+      s.on("error", () => {});
+      s.once("data", () => {
+        s.write(head);
+        s.write(bomb);
+        s.write(tail);
+      });
+    });
+    srv.listen(0, "127.0.0.1");
+    await once(srv, "listening");
+    const { port } = srv.address() as net.AddressInfo;
+    return {
+      url: `http://127.0.0.1:${port}/`,
+      wire: bomb.length,
+      [Symbol.asyncDispose]: () => new Promise<void>(r => srv.close(() => r())),
+    };
+  }
+
+  const STALL_AND_DRAIN = /* js */ `
+    const base = process.memoryUsage.rss();
+    const res = await fetch(url, opts);
+    const reader = res.body.getReader();
+    const first = await reader.read();
+    let peak = process.memoryUsage.rss() - base;
+    let last = 0, stable = 0;
+    while (stable < 3) {
+      await Bun.sleep(20);
+      const now = process.memoryUsage.rss() - base;
+      peak = Math.max(peak, now);
+      stable = Math.abs(now - last) < (1 << 20) ? stable + 1 : 0;
+      last = now;
+    }
+    let total = first.value.byteLength;
+    for (let r; !(r = await reader.read()).done; ) total += r.value.byteLength;
+    process.stdout.write(JSON.stringify({ peak, total, firstLen: first.value.byteLength }));
+  `;
+
+  for (const [encoding, chunked] of [
+    ["gzip", false],
+    ["gzip", true],
+    ["br", false],
+    ["zstd", false],
+  ] as const) {
+    test(
+      `${encoding}${chunked ? " chunked" : ""}: one read() does not inflate the whole body`,
+      async () => {
+        await using server = await serveBomb(encoding, chunked);
+        const { peak, total, firstLen, exitCode } = await spawnClient(server.url, "h1", STALL_AND_DRAIN);
+        expect({
+          total,
+          firstLenAtMost2MB: firstLen <= 2 * 1024 * 1024,
+          peakUnder: peak < PEAK_LIMIT || { peak, limit: PEAK_LIMIT, wire: server.wire },
+        }).toEqual({
+          total: DECOMPRESSED,
+          firstLenAtMost2MB: true,
+          peakUnder: true,
+        });
+        expect(exitCode).toBe(0);
+      },
+      60_000,
+    );
+  }
+});
+
 
 describe.concurrent("fetch() receive backpressure — buffered consumers are not throttled", () => {
   const cases = [

--- a/test/js/web/fetch/fetch-backpressure.test.ts
+++ b/test/js/web/fetch/fetch-backpressure.test.ts
@@ -331,27 +331,22 @@ describe("fetch() receive backpressure — compressed body inflates on demand", 
     ["br", false],
     ["zstd", false],
   ] as const) {
-    test(
-      `${encoding}${chunked ? " chunked" : ""}: one read() does not inflate the whole body`,
-      async () => {
-        await using server = await serveBomb(encoding, chunked);
-        const { peak, total, firstLen, exitCode } = await spawnClient(server.url, "h1", STALL_AND_DRAIN);
-        expect({
-          total,
-          firstLenAtMost2MB: firstLen <= 2 * 1024 * 1024,
-          peakUnder: peak < PEAK_LIMIT || { peak, limit: PEAK_LIMIT, wire: server.wire },
-        }).toEqual({
-          total: DECOMPRESSED,
-          firstLenAtMost2MB: true,
-          peakUnder: true,
-        });
-        expect(exitCode).toBe(0);
-      },
-      60_000,
-    );
+    test(`${encoding}${chunked ? " chunked" : ""}: one read() does not inflate the whole body`, async () => {
+      await using server = await serveBomb(encoding, chunked);
+      const { peak, total, firstLen, exitCode } = await spawnClient(server.url, "h1", STALL_AND_DRAIN);
+      expect({
+        total,
+        firstLenAtMost2MB: firstLen <= 2 * 1024 * 1024,
+        peakUnder: peak < PEAK_LIMIT || { peak, limit: PEAK_LIMIT, wire: server.wire },
+      }).toEqual({
+        total: DECOMPRESSED,
+        firstLenAtMost2MB: true,
+        peakUnder: true,
+      });
+      expect(exitCode).toBe(0);
+    }, 60_000);
   }
 });
-
 
 describe.concurrent("fetch() receive backpressure — buffered consumers are not throttled", () => {
   const cases = [

--- a/test/js/web/fetch/fetch-backpressure.test.ts
+++ b/test/js/web/fetch/fetch-backpressure.test.ts
@@ -8,7 +8,7 @@ import { createServer } from "node:http";
 import { createSecureServer } from "node:http2";
 import { createServer as createHttpsServer } from "node:https";
 import net from "node:net";
-import { brotliCompressSync, constants as zlibConstants, gzipSync, zstdCompressSync } from "node:zlib";
+import { brotliCompressSync, gzipSync, constants as zlibConstants, zstdCompressSync } from "node:zlib";
 
 const CHUNK = 64 * 1024;
 const COUNT = 256; // 16 MiB

--- a/test/js/web/fetch/fetch-backpressure.test.ts
+++ b/test/js/web/fetch/fetch-backpressure.test.ts
@@ -269,20 +269,28 @@ describe("fetch() receive backpressure — compressed body inflates on demand", 
   // below the unfixed behavior.
   const PEAK_LIMIT = (isASAN ? 64 : 48) * 1024 * 1024;
 
+  type BombKind = "gzip" | "br" | "br-hq" | "zstd";
   let zeros: Buffer;
   const bombs: { [k: string]: Buffer } = {};
-  function bombFor(encoding: "gzip" | "br" | "zstd") {
+  function bombFor(kind: BombKind) {
     zeros ??= Buffer.alloc(DECOMPRESSED);
-    return (bombs[encoding] ??=
-      encoding === "gzip"
+    const q = require("node:zlib").constants.BROTLI_PARAM_QUALITY;
+    return (bombs[kind] ??=
+      kind === "gzip"
         ? gzipSync(zeros, { level: 1 })
-        : encoding === "br"
-          ? brotliCompressSync(zeros, { params: { [require("node:zlib").constants.BROTLI_PARAM_QUALITY]: 0 } })
-          : zstdCompressSync(zeros, { level: 1 }));
+        : kind === "br"
+          ? brotliCompressSync(zeros, { params: { [q]: 0 } })
+          : kind === "br-hq"
+            ? // q4 packs 128 MB of zeros into ~200 bytes, so the decoder
+              // consumes all input long before 1 MB of output: exercises the
+              // is_mid_stream() half of has_pending_compressed().
+              brotliCompressSync(zeros, { params: { [q]: 4 } })
+            : zstdCompressSync(zeros, { level: 1 }));
   }
 
-  async function serveBomb(encoding: "gzip" | "br" | "zstd", chunked: boolean) {
-    const bomb = bombFor(encoding);
+  async function serveBomb(kind: BombKind, chunked: boolean) {
+    const bomb = bombFor(kind);
+    const encoding = kind === "br-hq" ? "br" : kind;
     const head = chunked
       ? `HTTP/1.1 200 OK\r\nContent-Encoding: ${encoding}\r\nTransfer-Encoding: chunked\r\n\r\n` +
         `${bomb.length.toString(16)}\r\n`
@@ -325,14 +333,16 @@ describe("fetch() receive backpressure — compressed body inflates on demand", 
     process.stdout.write(JSON.stringify({ peak, total, firstLen: first.value.byteLength }));
   `;
 
-  for (const [encoding, chunked] of [
+  for (const [kind, chunked] of [
     ["gzip", false],
     ["gzip", true],
     ["br", false],
+    ["br-hq", false],
+    ["br-hq", true],
     ["zstd", false],
   ] as const) {
-    test(`${encoding}${chunked ? " chunked" : ""}: one read() does not inflate the whole body`, async () => {
-      await using server = await serveBomb(encoding, chunked);
+    test(`${kind}${chunked ? " chunked" : ""}: one read() does not inflate the whole body`, async () => {
+      await using server = await serveBomb(kind, chunked);
       const { peak, total, firstLen, exitCode } = await spawnClient(server.url, "h1", STALL_AND_DRAIN);
       expect({
         total,


### PR DESCRIPTION
## What

`fetch()` response decompression now honours consumer backpressure for HTTP/1.1 streaming readers. A slow or stalled `res.body.getReader()` no longer causes the HTTP thread to inflate the entire compressed body into memory ahead of demand.

## Repro

Server sends 500 MB of zeros as gzip (~2.3 MB on the wire). Client does one `reader.read()` then idles:

```js
const res = await fetch(url);
const rd = res.body.getReader();
await rd.read();          // one chunk, then stop consuming
// watch RSS for ~4s while holding one chunk
```

Before: RSS grows by +120 to +580 MB while the consumer holds a single chunk. `cancel()` frees it, so this is not a leak; the defect is missing pull-side backpressure between the socket/decoder and the JS reader.
Node/undici: +13 MB flat, 16 KB chunks.

## Cause

`process_body_buffer` feeds each socket read (up to 512 KB compressed) through the streaming decoder with no output limit. The zlib/brotli/zstd `decompress` loops drain all given input, appending to `body_out_str` unbounded. The existing socket-level pause (`maybe_pause_receive`) fires only after the callback has already delivered the fully inflated chunk to `ByteStream.buffer`, so one 512 KB compressed read at a 200:1 ratio lands ~100 MB in the queue before the pause takes effect.

## Fix

* `InflateDecoder::decompress` / `brotli::StreamingDecoder::decompress` / `zstd::StreamingDecoder::decompress` now take a soft `max_output` cap and return the number of input bytes consumed. Reaching the cap returns `Ok(consumed)` so the caller can retain the remainder; the existing `max_output_size` field remains the hard bomb-guard error. Trailing garbage after a completed stream is reported as consumed (previously implicit via the `()` return).
* `InternalState::process_body_buffer` keeps unconsumed compressed input in `compressed_body` and records `flags.decompress_output_pending` whenever the cap stopped the decode short (unconsumed input or a mid-stream decoder with output still buffered internally).
* `HTTPClient::decompress_output_cap()` caps output to 1 MB per cycle while an HTTP/1.1 receive mode is `AutoPause`/`Paused`; `BufferAll`/`Ignore`, unwired callers, and h2/h3 decode unbounded as before. h2/h3 detach the stream before leftover can be drained, so they stay out of scope here until they gain a post-detach drain hook.
* `drain_response_body` decodes the next bounded chunk from `compressed_body` (or pumps the decoder with empty input when it buffered output internally) on each JS-side drain, so the reader's pull cadence drives the inflate. A leftover that decodes to zero bytes but flips the request terminal still delivers the final `has_more=false` callback.
* `to_result().has_more` stays true while `decompress_output_pending` is set so the request does not finalize early.
* The Content-Length and chunked single-packet fast paths in `handle_response_body` / `handle_response_body_chunked_encoding` are skipped for compressed streaming responses so they are subject to the same cap, and the libdeflate one-shot fast path is gated on `max_output == usize::MAX`.

## Verification

New tests in `test/js/web/fetch/fetch-backpressure.test.ts` serve a 128 MB-of-zeros body as gzip / gzip-chunked / br / br-hq / br-hq-chunked / zstd (br-hq is brotli q4, ~200 B on the wire, which exercises the "decoder consumed all input, output buffered internally" path). Each test reads one chunk then asserts:
* RSS growth while holding one chunk is bounded (< 48 MB, < 64 MB under ASAN; unfixed grows by 130 to 460 MB)
* the first chunk is at most 2 MB
* draining the reader yields exactly 128 MB

```
=== FAIL-BEFORE (main) ===
(fail) gzip / gzip chunked / br / br-hq / br-hq chunked / zstd
=== FAIL-AFTER (this branch) ===
(pass) gzip / gzip chunked / br / br-hq / br-hq chunked / zstd
```

`fetch-gzip.test.ts`, `fetch-compress.test.ts`, `body-stream*.test.ts`, and the compression variants in `fetch.stream.test.ts` all pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch-backpressure.test.ts

<!-- robobun:evidence:end -->