### PR TITLE
docker: install adduser in Debian image final stages

### DIFF
--- a/dockerhub/debian-slim/Dockerfile
+++ b/dockerhub/debian-slim/Dockerfile
@@ -57,10 +57,14 @@ RUN apt-get update -qq \
 
 FROM debian:trixie-slim
 
-# Install CA certificates so tools that verify TLS (e.g. apt over HTTPS on
-# Debian 13) have a trust store. The base image ships none.
+# Debian 13 ships neither ca-certificates (needed for apt over HTTPS and other
+# TLS-verifying tools) nor adduser (addgroup/adduser, widely used in downstream
+# Dockerfiles to create a non-root user). Install both so images behave like
+# the previous Debian 12 base.
 RUN apt-get update -qq \
-    && apt-get install -qq --no-install-recommends ca-certificates \
+    && apt-get install -qq --no-install-recommends \
+      adduser \
+      ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/dockerhub/debian/Dockerfile
+++ b/dockerhub/debian/Dockerfile
@@ -58,10 +58,14 @@ RUN apt-get update -qq \
 
 FROM debian:trixie
 
-# Install CA certificates so tools that verify TLS (e.g. apt over HTTPS on
-# Debian 13) have a trust store. The base image ships none.
+# Debian 13 ships neither ca-certificates (needed for apt over HTTPS and other
+# TLS-verifying tools) nor adduser (addgroup/adduser, widely used in downstream
+# Dockerfiles to create a non-root user). Install both so images behave like
+# the previous Debian 12 base.
 RUN apt-get update -qq \
-    && apt-get install -qq --no-install-recommends ca-certificates \
+    && apt-get install -qq --no-install-recommends \
+      adduser \
+      ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/test/js/bun/test/parallel/test-docker-build-debian-slim.ts
+++ b/test/js/bun/test/parallel/test-docker-build-debian-slim.ts
@@ -20,13 +20,22 @@ if (isDockerEnabled()) {
     expect(build.exitCode).toBe(0);
 
     // https://github.com/oven-sh/bun/issues/33135
+    // https://github.com/oven-sh/bun/issues/25441
     const check = Bun.spawn({
-      cmd: [docker, "run", "--rm", tag, "sh", "-c", "test -s /etc/ssl/certs/ca-certificates.crt && echo HAS_CA_CERTS"],
+      cmd: [
+        docker,
+        "run",
+        "--rm",
+        tag,
+        "sh",
+        "-c",
+        "test -s /etc/ssl/certs/ca-certificates.crt && echo HAS_CA_CERTS && command -v addgroup >/dev/null && command -v adduser >/dev/null && echo HAS_ADDUSER",
+      ],
       stdio: ["ignore", "pipe", "inherit"],
       env: bunEnv,
     });
     const [stdout, exitCode] = await Promise.all([check.stdout.text(), check.exited]);
-    expect(stdout.trim()).toBe("HAS_CA_CERTS");
+    expect(stdout.trim().split("\n")).toEqual(["HAS_CA_CERTS", "HAS_ADDUSER"]);
     expect(exitCode).toBe(0);
   } finally {
     Bun.spawnSync({ cmd: [docker, "rmi", "-f", tag], stdio: ["ignore", "ignore", "ignore"], env: bunEnv });

--- a/test/js/bun/test/parallel/test-docker-build-debian.ts
+++ b/test/js/bun/test/parallel/test-docker-build-debian.ts
@@ -20,13 +20,22 @@ if (isDockerEnabled()) {
     expect(build.exitCode).toBe(0);
 
     // https://github.com/oven-sh/bun/issues/33135
+    // https://github.com/oven-sh/bun/issues/25441
     const check = Bun.spawn({
-      cmd: [docker, "run", "--rm", tag, "sh", "-c", "test -s /etc/ssl/certs/ca-certificates.crt && echo HAS_CA_CERTS"],
+      cmd: [
+        docker,
+        "run",
+        "--rm",
+        tag,
+        "sh",
+        "-c",
+        "test -s /etc/ssl/certs/ca-certificates.crt && echo HAS_CA_CERTS && command -v addgroup >/dev/null && command -v adduser >/dev/null && echo HAS_ADDUSER",
+      ],
       stdio: ["ignore", "pipe", "inherit"],
       env: bunEnv,
     });
     const [stdout, exitCode] = await Promise.all([check.stdout.text(), check.exited]);
-    expect(stdout.trim()).toBe("HAS_CA_CERTS");
+    expect(stdout.trim().split("\n")).toEqual(["HAS_CA_CERTS", "HAS_ADDUSER"]);
     expect(exitCode).toBe(0);
   } finally {
     Bun.spawnSync({ cmd: [docker, "rmi", "-f", tag], stdio: ["ignore", "ignore", "ignore"], env: bunEnv });


### PR DESCRIPTION
## Summary

`oven/bun:1.3.4` (and later) no longer provides `addgroup`/`adduser`. Downstream Dockerfiles that create a non-root user, including the official Next.js `with-docker` Bun example, fail with:

```
/bin/sh: 1: addgroup: not found
```

`oven/bun:1.3.3` works.

Fixes #25441. Related: #25420, vercel/next.js#87722.

## Reproduction

```dockerfile
FROM oven/bun:1
RUN addgroup --system --gid 1001 nodejs \
    && adduser --system --uid 1001 nextjs
```

```
 > [2/2] RUN addgroup --system --gid 1001 nodejs     && adduser --system --uid 1001 nextjs:
/bin/sh: 1: addgroup: not found
```

## Root cause

#24055 rebased the Debian images from `debian:bookworm` to `debian:trixie`. The Debian 13 base image no longer includes the `adduser` package (which provides both `/usr/sbin/adduser` and `/usr/sbin/addgroup`). Our own Dockerfiles already switched to `groupadd`/`useradd` (from `passwd`, which is still present), so the image builds fine; the break is for anyone doing `FROM oven/bun` and then calling `addgroup`/`adduser`.

## Fix

Install `adduser` alongside `ca-certificates` in the final stage of both Debian Dockerfiles. Same treatment #33136 applied for `ca-certificates`, for the same class of trixie-rebase regression. The package is tiny (~250 KB installed) and restores Debian 12 behavior.

Alpine is unaffected (BusyBox provides `addgroup`/`adduser`); distroless has no shell.

## Tests

Extended `test/js/bun/test/parallel/test-docker-build-debian.ts` and `test-docker-build-debian-slim.ts` to also assert that `addgroup` and `adduser` resolve on PATH in the built image, next to the existing ca-certificates check. These run on the Docker CI lane.

## Verification note

This is a Dockerfile-only change (`dockerhub/`, not `src/` or `packages/`), so the fail-before/pass-after harness cannot exercise it: stashing `src/` leaves the Dockerfile change in place. Building the image also requires pulling `debian:trixie` from Docker Hub, which the sandbox blocks. The root cause is confirmed from the Debian 13 base image manifest (no `adduser`), the regressing commit #24055, and the reporter's output. The added assertions verify the fix on the Docker CI lane where image pulls are allowed.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->