### PR TITLE
resolver: reject ?query on a bare package root that resolves via node_modules

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4158,7 +4158,7 @@ impl VirtualMachine {
         // `paths` aliases are Bun extensions and keep their query semantics.
         if query_string != b"?raw"
             && !query_string.is_empty()
-            && bun_paths::is_package_path(specifier)
+            && bun_paths::is_package_path(normalized_specifier)
             && result.is_node_module()
         {
             return Err(crate::CrateError::ModuleNotFound);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4153,27 +4153,27 @@ impl VirtualMachine {
             }
         };
 
-        if !self.macro_mode {
-            self.has_any_macro_remappings =
-                self.has_any_macro_remappings || self.transpiler.options.macro_remap.count() > 0;
-        }
-        let result_path = result
-            .path_const()
-            .ok_or(crate::CrateError::ModuleNotFound)?;
-
         // Node rejects `pkg?v=1`; letting it through here would evaluate a
-        // fresh package instance per distinct query. The `is_node_module`
-        // gate keeps tsconfig `paths` aliases (e.g. `@/util?raw`) working.
-        if !query_string.is_empty()
+        // fresh package instance per distinct query. `?raw` and tsconfig
+        // `paths` aliases are Bun extensions and keep their query semantics.
+        if query_string != b"?raw"
+            && !query_string.is_empty()
             && bun_paths::is_package_path(specifier)
-            && result_path.is_node_module()
+            && result.is_node_module()
         {
             return Err(crate::CrateError::ModuleNotFound);
         }
 
+        if !self.macro_mode {
+            self.has_any_macro_remappings =
+                self.has_any_macro_remappings || self.transpiler.options.macro_remap.count() > 0;
+        }
         // SAFETY: PORT — `query_string` re-slices `specifier` (caller-owned;
         // see lifetime erasure note above).
         ret.query_string = unsafe { bun_ptr::detach_lifetime(query_string) };
+        let result_path = result
+            .path_const()
+            .ok_or(crate::CrateError::ModuleNotFound)?;
         // SAFETY: `result_path.text` borrows the resolver's arena, which
         // outlives `ResolveFunctionResult` (see the struct's lifetime-erasure
         // note).

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4159,7 +4159,7 @@ impl VirtualMachine {
         if query_string != b"?raw"
             && !query_string.is_empty()
             && bun_paths::is_package_path(normalized_specifier)
-            && result.is_node_module()
+            && result.flags.is_from_node_modules()
         {
             return Err(crate::CrateError::ModuleNotFound);
         }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4154,11 +4154,13 @@ impl VirtualMachine {
         };
 
         // Node rejects `pkg?v=1`; letting it through here would evaluate a
-        // fresh package instance per distinct query. `?raw` and tsconfig
-        // `paths` aliases are Bun extensions and keep their query semantics.
-        if query_string != b"?raw"
-            && !query_string.is_empty()
+        // fresh package instance per distinct query. tsconfig `paths` aliases
+        // resolve with the flag unset; subpaths (`pkg/sub?q`) are left to the
+        // exports/imports map, where Node's answer depends on wildcard shape.
+        if !query_string.is_empty()
             && bun_paths::is_package_path(normalized_specifier)
+            && bun_resolver::package_json::Package::parse_name(normalized_specifier)
+                .is_some_and(|n| n.len() == normalized_specifier.len())
             && result.flags.is_from_node_modules()
         {
             return Err(crate::CrateError::ModuleNotFound);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2937,6 +2937,14 @@ fn normalize_specifier_for_resolution<'a>(
     specifier_: &'a [u8],
     query_string: &mut &'a [u8],
 ) -> &'a [u8] {
+    // Node only gives `?` URL-separator meaning for relative/absolute ESM
+    // specifiers. For a bare package specifier (`pkg`, `@scope/pkg/sub`) the
+    // `?` is part of the name/subpath and must reach the resolver verbatim so
+    // `import("pkg?v=1")` fails instead of evaluating a second instance of the
+    // package.
+    if bun_paths::is_package_path(specifier_) {
+        return specifier_;
+    }
     if let Some(i) = bun_core::strings::index_of_char_usize(specifier_, b'?') {
         *query_string = &specifier_[i..];
         &specifier_[..i]

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4153,16 +4153,7 @@ impl VirtualMachine {
             }
         };
 
-        // Node rejects `pkg?v=1`; letting it through here would evaluate a
-        // fresh package instance per distinct query. tsconfig `paths` aliases
-        // resolve with the flag unset; subpaths (`pkg/sub?q`) are left to the
-        // exports/imports map, where Node's answer depends on wildcard shape.
-        if !query_string.is_empty()
-            && bun_paths::is_package_path(normalized_specifier)
-            && bun_resolver::package_json::Package::parse_name(normalized_specifier)
-                .is_some_and(|n| n.len() == normalized_specifier.len())
-            && result.flags.is_from_node_modules()
-        {
+        if result.rejects_bare_root_query(normalized_specifier, query_string) {
             return Err(crate::CrateError::ModuleNotFound);
         }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2937,14 +2937,6 @@ fn normalize_specifier_for_resolution<'a>(
     specifier_: &'a [u8],
     query_string: &mut &'a [u8],
 ) -> &'a [u8] {
-    // Node only gives `?` URL-separator meaning for relative/absolute ESM
-    // specifiers. For a bare package specifier (`pkg`, `@scope/pkg/sub`) the
-    // `?` is part of the name/subpath and must reach the resolver verbatim so
-    // `import("pkg?v=1")` fails instead of evaluating a second instance of the
-    // package.
-    if bun_paths::is_package_path(specifier_) {
-        return specifier_;
-    }
     if let Some(i) = bun_core::strings::index_of_char_usize(specifier_, b'?') {
         *query_string = &specifier_[i..];
         &specifier_[..i]
@@ -4165,12 +4157,26 @@ impl VirtualMachine {
             self.has_any_macro_remappings =
                 self.has_any_macro_remappings || self.transpiler.options.macro_remap.count() > 0;
         }
-        // SAFETY: PORT — `query_string` re-slices `specifier` (caller-owned;
-        // see lifetime erasure note above).
-        ret.query_string = unsafe { bun_ptr::detach_lifetime(query_string) };
         let result_path = result
             .path_const()
             .ok_or(crate::CrateError::ModuleNotFound)?;
+
+        // Node gives `?` URL-separator meaning only for relative/absolute ESM
+        // specifiers; a bare specifier that resolves into node_modules is not a
+        // URL and Node rejects `pkg?v=1`. Re-appending the split-off query here
+        // would evaluate a fresh instance of the whole package for each
+        // distinct query. A tsconfig `paths` alias resolves outside
+        // node_modules, so `@/util?raw` keeps working.
+        if !query_string.is_empty()
+            && bun_paths::is_package_path(specifier)
+            && result_path.is_node_module()
+        {
+            return Err(crate::CrateError::ModuleNotFound);
+        }
+
+        // SAFETY: PORT — `query_string` re-slices `specifier` (caller-owned;
+        // see lifetime erasure note above).
+        ret.query_string = unsafe { bun_ptr::detach_lifetime(query_string) };
         // SAFETY: `result_path.text` borrows the resolver's arena, which
         // outlives `ResolveFunctionResult` (see the struct's lifetime-erasure
         // note).

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4161,12 +4161,9 @@ impl VirtualMachine {
             .path_const()
             .ok_or(crate::CrateError::ModuleNotFound)?;
 
-        // Node gives `?` URL-separator meaning only for relative/absolute ESM
-        // specifiers; a bare specifier that resolves into node_modules is not a
-        // URL and Node rejects `pkg?v=1`. Re-appending the split-off query here
-        // would evaluate a fresh instance of the whole package for each
-        // distinct query. A tsconfig `paths` alias resolves outside
-        // node_modules, so `@/util?raw` keeps working.
+        // Node rejects `pkg?v=1`; letting it through here would evaluate a
+        // fresh package instance per distinct query. The `is_node_module`
+        // gate keeps tsconfig `paths` aliases (e.g. `@/util?raw`) working.
         if !query_string.is_empty()
             && bun_paths::is_package_path(specifier)
             && result_path.is_node_module()

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2811,6 +2811,7 @@ impl<'a> Resolver<'a> {
                         .load_as_file_or_directory(abs_path, kind, out)
                         .is_success()
                     {
+                        out.is_node_module = true;
                         self.extension_order = prev_extension_order;
                         if let Some(d) = self.debug_logs.as_mut() {
                             d.decrease_indent();
@@ -2852,6 +2853,7 @@ impl<'a> Resolver<'a> {
                     .load_as_file_or_directory(abs_path, kind, out)
                     .is_success()
                 {
+                    out.is_node_module = true;
                     if let Some(d) = self.debug_logs.as_mut() {
                         d.decrease_indent();
                     }

--- a/src/resolver/result.rs
+++ b/src/resolver/result.rs
@@ -248,22 +248,6 @@ impl Result {
 
         None
     }
-
-    /// Whether this result was reached through a `node_modules` directory.
-    /// [`ResultFlags::IS_FROM_NODE_MODULES`] alone misses the no-`exports`
-    /// `main`-field success path in `load_node_modules`, and [`Path::text`]
-    /// is the realpath (symlinked packages lose the `node_modules` component),
-    /// so fall back to the pre-realpath location stashed in [`Path::pretty`].
-    pub fn is_node_module(&self) -> bool {
-        if self.flags.is_from_node_modules() {
-            return true;
-        }
-        let Some(path) = self.path_const() else {
-            return false;
-        };
-        path.is_node_module()
-            || (path.is_symlink && bun_paths::fs::Path::init(path.pretty).is_node_module())
-    }
 }
 
 pub struct DirEntryResolveQueueItem {

--- a/src/resolver/result.rs
+++ b/src/resolver/result.rs
@@ -248,6 +248,22 @@ impl Result {
 
         None
     }
+
+    /// Whether this result was reached through a `node_modules` directory.
+    /// [`ResultFlags::IS_FROM_NODE_MODULES`] alone misses the no-`exports`
+    /// `main`-field success path in `load_node_modules`, and [`Path::text`]
+    /// is the realpath (symlinked packages lose the `node_modules` component),
+    /// so fall back to the pre-realpath location stashed in [`Path::pretty`].
+    pub fn is_node_module(&self) -> bool {
+        if self.flags.is_from_node_modules() {
+            return true;
+        }
+        let Some(path) = self.path_const() else {
+            return false;
+        };
+        path.is_node_module()
+            || (path.is_symlink && bun_paths::fs::Path::init(path.pretty).is_node_module())
+    }
 }
 
 pub struct DirEntryResolveQueueItem {

--- a/src/resolver/result.rs
+++ b/src/resolver/result.rs
@@ -248,6 +248,23 @@ impl Result {
 
         None
     }
+
+    /// Node rejects `pkg?v=1`; letting it through the runtime resolver would
+    /// evaluate a fresh package instance per distinct query. tsconfig `paths`
+    /// aliases resolve with [`ResultFlags::IS_FROM_NODE_MODULES`] unset;
+    /// subpaths (`pkg/sub?q`) are left to the exports/imports map, where
+    /// Node's answer depends on wildcard shape.
+    pub fn rejects_bare_root_query(
+        &self,
+        normalized_specifier: &[u8],
+        query_string: &[u8],
+    ) -> bool {
+        !query_string.is_empty()
+            && bun_paths::is_package_path(normalized_specifier)
+            && crate::package_json::Package::parse_name(normalized_specifier)
+                .is_some_and(|n| n.len() == normalized_specifier.len())
+            && self.flags.is_from_node_modules()
+    }
 }
 
 pub struct DirEntryResolveQueueItem {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5038,7 +5038,7 @@ unsafe fn resolve<'a>(
     if query_string != b"?raw"
         && !query_string.is_empty()
         && bun_paths::is_package_path(normalized_specifier)
-        && result.is_node_module()
+        && result.flags.is_from_node_modules()
     {
         return Err(crate::Error::ModuleNotFound);
     }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5033,11 +5033,13 @@ unsafe fn resolve<'a>(
     };
 
     // Node rejects `pkg?v=1`; letting it through here would evaluate a
-    // fresh package instance per distinct query. `?raw` and tsconfig
-    // `paths` aliases are Bun extensions and keep their query semantics.
-    if query_string != b"?raw"
-        && !query_string.is_empty()
+    // fresh package instance per distinct query. tsconfig `paths` aliases
+    // resolve with the flag unset; subpaths (`pkg/sub?q`) are left to the
+    // exports/imports map, where Node's answer depends on wildcard shape.
+    if !query_string.is_empty()
         && bun_paths::is_package_path(normalized_specifier)
+        && bun_resolver::package_json::Package::parse_name(normalized_specifier)
+            .is_some_and(|n| n.len() == normalized_specifier.len())
         && result.flags.is_from_node_modules()
     {
         return Err(crate::Error::ModuleNotFound);

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5032,6 +5032,17 @@ unsafe fn resolve<'a>(
         }
     };
 
+    // Node rejects `pkg?v=1`; letting it through here would evaluate a
+    // fresh package instance per distinct query. `?raw` and tsconfig
+    // `paths` aliases are Bun extensions and keep their query semantics.
+    if query_string != b"?raw"
+        && !query_string.is_empty()
+        && bun_paths::is_package_path(specifier)
+        && result.is_node_module()
+    {
+        return Err(crate::Error::ModuleNotFound);
+    }
+
     // SAFETY: plain bool/usize fields.
     unsafe {
         if !(*vm).macro_mode {
@@ -5040,21 +5051,10 @@ unsafe fn resolve<'a>(
         }
     }
 
+    *ret_query = query_string;
     let Some(result_path) = result.path_const() else {
         return Err(crate::Error::ModuleNotFound);
     };
-
-    // Node rejects `pkg?v=1`; letting it through here would evaluate a
-    // fresh package instance per distinct query. The `is_node_module`
-    // gate keeps tsconfig `paths` aliases (e.g. `@/util?raw`) working.
-    if !query_string.is_empty()
-        && bun_paths::is_package_path(specifier)
-        && result_path.is_node_module()
-    {
-        return Err(crate::Error::ModuleNotFound);
-    }
-
-    *ret_query = query_string;
     // Note: `result_path.text` is a `&'_ [u8]` borrowed from the
     // resolver's interned `'static` BSSStringList stores (see resolver/lib.rs
     // §allocators) — the same store `load_preloads` reads from. Transmute the

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4827,20 +4827,11 @@ const STDIN_SUFFIX: &[u8] = b"\\[stdin]";
 const STDIN_SUFFIX: &[u8] = b"/[stdin]";
 
 /// Split off the `?query` suffix.
-///
-/// Node only gives `?` URL-separator meaning for relative/absolute ESM
-/// specifiers. For a bare package specifier (`pkg`, `@scope/pkg/sub`) the `?`
-/// is part of the name/subpath and must reach the resolver verbatim so
-/// `import("pkg?v=1")` fails instead of evaluating a second instance of the
-/// package.
 #[inline]
 fn normalize_specifier_for_resolution<'a>(
     specifier: &'a [u8],
     query_string: &mut &'a [u8],
 ) -> &'a [u8] {
-    if bun_paths::is_package_path(specifier) {
-        return specifier;
-    }
     if let Some(i) = bun_core::strings::index_of_char_usize(specifier, b'?') {
         let i = i as usize;
         *query_string = &specifier[i..];
@@ -5049,10 +5040,24 @@ unsafe fn resolve<'a>(
         }
     }
 
-    *ret_query = query_string;
     let Some(result_path) = result.path_const() else {
         return Err(crate::Error::ModuleNotFound);
     };
+
+    // Node gives `?` URL-separator meaning only for relative/absolute ESM
+    // specifiers; a bare specifier that resolves into node_modules is not a
+    // URL and Node rejects `pkg?v=1`. Re-appending the split-off query here
+    // would evaluate a fresh instance of the whole package for each distinct
+    // query. A tsconfig `paths` alias resolves outside node_modules, so
+    // `@/util?raw` keeps working.
+    if !query_string.is_empty()
+        && bun_paths::is_package_path(specifier)
+        && result_path.is_node_module()
+    {
+        return Err(crate::Error::ModuleNotFound);
+    }
+
+    *ret_query = query_string;
     // Note: `result_path.text` is a `&'_ [u8]` borrowed from the
     // resolver's interned `'static` BSSStringList stores (see resolver/lib.rs
     // §allocators) — the same store `load_preloads` reads from. Transmute the

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5044,12 +5044,9 @@ unsafe fn resolve<'a>(
         return Err(crate::Error::ModuleNotFound);
     };
 
-    // Node gives `?` URL-separator meaning only for relative/absolute ESM
-    // specifiers; a bare specifier that resolves into node_modules is not a
-    // URL and Node rejects `pkg?v=1`. Re-appending the split-off query here
-    // would evaluate a fresh instance of the whole package for each distinct
-    // query. A tsconfig `paths` alias resolves outside node_modules, so
-    // `@/util?raw` keeps working.
+    // Node rejects `pkg?v=1`; letting it through here would evaluate a
+    // fresh package instance per distinct query. The `is_node_module`
+    // gate keeps tsconfig `paths` aliases (e.g. `@/util?raw`) working.
     if !query_string.is_empty()
         && bun_paths::is_package_path(specifier)
         && result_path.is_node_module()

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5032,16 +5032,7 @@ unsafe fn resolve<'a>(
         }
     };
 
-    // Node rejects `pkg?v=1`; letting it through here would evaluate a
-    // fresh package instance per distinct query. tsconfig `paths` aliases
-    // resolve with the flag unset; subpaths (`pkg/sub?q`) are left to the
-    // exports/imports map, where Node's answer depends on wildcard shape.
-    if !query_string.is_empty()
-        && bun_paths::is_package_path(normalized_specifier)
-        && bun_resolver::package_json::Package::parse_name(normalized_specifier)
-            .is_some_and(|n| n.len() == normalized_specifier.len())
-        && result.flags.is_from_node_modules()
-    {
+    if result.rejects_bare_root_query(normalized_specifier, query_string) {
         return Err(crate::Error::ModuleNotFound);
     }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5037,7 +5037,7 @@ unsafe fn resolve<'a>(
     // `paths` aliases are Bun extensions and keep their query semantics.
     if query_string != b"?raw"
         && !query_string.is_empty()
-        && bun_paths::is_package_path(specifier)
+        && bun_paths::is_package_path(normalized_specifier)
         && result.is_node_module()
     {
         return Err(crate::Error::ModuleNotFound);

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4827,11 +4827,20 @@ const STDIN_SUFFIX: &[u8] = b"\\[stdin]";
 const STDIN_SUFFIX: &[u8] = b"/[stdin]";
 
 /// Split off the `?query` suffix.
+///
+/// Node only gives `?` URL-separator meaning for relative/absolute ESM
+/// specifiers. For a bare package specifier (`pkg`, `@scope/pkg/sub`) the `?`
+/// is part of the name/subpath and must reach the resolver verbatim so
+/// `import("pkg?v=1")` fails instead of evaluating a second instance of the
+/// package.
 #[inline]
 fn normalize_specifier_for_resolution<'a>(
     specifier: &'a [u8],
     query_string: &mut &'a [u8],
 ) -> &'a [u8] {
+    if bun_paths::is_package_path(specifier) {
+        return specifier;
+    }
     if let Some(i) = bun_core::strings::index_of_char_usize(specifier, b'?') {
         let i = i as usize;
         *query_string = &specifier[i..];

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -245,13 +245,11 @@ test("Bun.resolveSync with non-ASCII specifier and query string", async () => {
 // suffix-less wildcard.
 describe("?query on a bare package root does not resolve", () => {
   const pkgFiles = {
-    "node_modules/qk/package.json": JSON.stringify({
-      name: "qk",
-      main: "./i.js",
-      exports: { ".": "./i.js", "./s": "./s.js" },
-    }),
+    "node_modules/qk/package.json": JSON.stringify({ name: "qk", main: "./i.js", exports: { ".": "./i.js" } }),
     "node_modules/qk/i.js": "globalThis.__qk = (globalThis.__qk || 0) + 1; module.exports = { inst: globalThis.__qk };",
-    "node_modules/qk/s.js": 'module.exports = "SUB";',
+    "node_modules/@sc/pk/package.json": JSON.stringify({ name: "@sc/pk", main: "./i.js", exports: { ".": "./i.js" } }),
+    "node_modules/@sc/pk/i.js":
+      "globalThis.__scpk = (globalThis.__scpk || 0) + 1; module.exports = { inst: globalThis.__scpk };",
   };
 
   const noExportsPkgFiles = {
@@ -264,16 +262,18 @@ describe("?query on a bare package root does not resolve", () => {
       ...pkgFiles,
       "entry.cjs": `
         const out = { insts: [], errors: [] };
-        out.insts.push(require("qk").inst);
-        for (const spec of ["qk?v=1", "qk?v=2"]) {
-          try {
-            out.insts.push(require(spec).inst);
-          } catch (e) {
-            out.errors.push(e.code || e.name);
+        for (const name of ["qk", "@sc/pk"]) {
+          out.insts.push(require(name).inst);
+          for (const spec of [name + "?v=1", name + "?v=2"]) {
+            try {
+              out.insts.push(require(spec).inst);
+            } catch (e) {
+              out.errors.push(e.code || e.name);
+            }
           }
+          // The un-suffixed specifier must still be the one-and-only instance.
+          out.insts.push(require(name).inst);
         }
-        // The un-suffixed specifier must still be the one-and-only instance.
-        out.insts.push(require("qk").inst);
         console.log(JSON.stringify(out));
       `,
     });
@@ -287,8 +287,8 @@ describe("?query on a bare package root does not resolve", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(JSON.parse(stdout.trim())).toEqual({
-      insts: [1, 1],
-      errors: ["MODULE_NOT_FOUND", "MODULE_NOT_FOUND"],
+      insts: [1, 1, 1, 1],
+      errors: ["MODULE_NOT_FOUND", "MODULE_NOT_FOUND", "MODULE_NOT_FOUND", "MODULE_NOT_FOUND"],
     });
     expect(exitCode).toBe(0);
   });
@@ -298,15 +298,17 @@ describe("?query on a bare package root does not resolve", () => {
       ...pkgFiles,
       "entry.mjs": `
         const out = { insts: [], errors: [] };
-        out.insts.push((await import("qk")).default.inst);
-        for (const spec of ["qk?v=1", "qk?v=2"]) {
-          try {
-            out.insts.push((await import(spec)).default.inst);
-          } catch (e) {
-            out.errors.push(e.code || e.name);
+        for (const name of ["qk", "@sc/pk"]) {
+          out.insts.push((await import(name)).default.inst);
+          for (const spec of [name + "?v=1", name + "?v=2"]) {
+            try {
+              out.insts.push((await import(spec)).default.inst);
+            } catch (e) {
+              out.errors.push(e.code || e.name);
+            }
           }
+          out.insts.push((await import(name)).default.inst);
         }
-        out.insts.push((await import("qk")).default.inst);
         console.log(JSON.stringify(out));
       `,
     });
@@ -320,8 +322,8 @@ describe("?query on a bare package root does not resolve", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(JSON.parse(stdout.trim())).toEqual({
-      insts: [1, 1],
-      errors: ["ERR_MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND"],
+      insts: [1, 1, 1, 1],
+      errors: ["ERR_MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND"],
     });
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -448,6 +448,40 @@ describe("?query on a bare package specifier does not resolve", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.concurrent("import('pkg?v=N') on a package resolved via NODE_PATH", async () => {
+    using dir = tempDir("import-query-bare-nodepath", {
+      "mylibs/npk/package.json": JSON.stringify({ name: "npk", main: "./i.js" }),
+      "mylibs/npk/i.js": "globalThis.__np = (globalThis.__np || 0) + 1; module.exports = { inst: globalThis.__np };",
+      "app/entry.mjs": `
+        const out = { insts: [], errors: [] };
+        out.insts.push((await import("npk")).default.inst);
+        for (const spec of ["npk?v=1", "npk?v=2"]) {
+          try {
+            out.insts.push((await import(spec)).default.inst);
+          } catch (e) {
+            out.errors.push(e.code || e.name);
+          }
+        }
+        out.insts.push((await import("npk")).default.inst);
+        console.log(JSON.stringify(out));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: { ...bunEnv, NODE_PATH: join(String(dir), "mylibs") },
+      cwd: join(String(dir), "app"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      insts: [1, 1],
+      errors: ["ERR_MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("?raw on a bare package subpath still loads as text (control)", async () => {
     using dir = tempDir("import-query-bare-raw", {
       "node_modules/tp/package.json": JSON.stringify({ name: "tp", main: "./i.js" }),

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -335,7 +335,8 @@ describe("?query on a bare package root does not resolve", () => {
       "package.json": JSON.stringify({ name: "app", type: "module", imports: { "#hot/*": "./src/*" } }),
       "src/config.js": "globalThis.__wc = (globalThis.__wc || 0) + 1; export const inst = globalThis.__wc;",
       "node_modules/wp/package.json": JSON.stringify({ name: "wp", type: "module", exports: { "./*": "./dist/*" } }),
-      "node_modules/wp/dist/foo.js": "globalThis.__wp = (globalThis.__wp || 0) + 1; export const inst = globalThis.__wp;",
+      "node_modules/wp/dist/foo.js":
+        "globalThis.__wp = (globalThis.__wp || 0) + 1; export const inst = globalThis.__wp;",
       "entry.mjs": `
         const out = [];
         for (const spec of ["#hot/config.js", "#hot/config.js?v=1", "#hot/config.js?v=2"]) {

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 globalThis.importQueryFixtureOrder = [];
 const resolvedPath = require.resolve("./import-query-fixture.ts");
@@ -233,4 +233,147 @@ test("Bun.resolveSync with non-ASCII specifier and query string", async () => {
   const resolved = JSON.parse(stdout.trim());
   expect(resolved).toEndWith("target.js?v=caf\u00e9-\u65e5\u672c\u8a9e");
   expect(exitCode).toBe(0);
+});
+
+// Node gives `?` URL-separator meaning only for relative/absolute ESM specifiers.
+// A bare package specifier (`pkg`, `@scope/pkg/sub`) is not a URL: `?` is part of
+// the package name / subpath and must reach the resolver verbatim. Stripping it
+// made `import("pkg?v=1")` evaluate a second instance of the whole package,
+// splitting singleton state.
+describe("?query on a bare package specifier does not resolve", () => {
+  const pkgFiles = {
+    "node_modules/qk/package.json": JSON.stringify({
+      name: "qk",
+      main: "./i.js",
+      exports: { ".": "./i.js", "./s": "./s.js" },
+    }),
+    "node_modules/qk/i.js": "globalThis.__qk = (globalThis.__qk || 0) + 1; module.exports = { inst: globalThis.__qk };",
+    "node_modules/qk/s.js": 'module.exports = "SUB";',
+  };
+
+  test.concurrent("require('pkg?v=N') does not evaluate a new instance of the package", async () => {
+    using dir = tempDir("import-query-bare-require", {
+      ...pkgFiles,
+      "entry.cjs": `
+        const out = { insts: [], errors: [] };
+        out.insts.push(require("qk").inst);
+        for (const spec of ["qk?v=1", "qk?v=2"]) {
+          try {
+            out.insts.push(require(spec).inst);
+          } catch (e) {
+            out.errors.push(e.code || e.name);
+          }
+        }
+        // The un-suffixed specifier must still be the one-and-only instance.
+        out.insts.push(require("qk").inst);
+        console.log(JSON.stringify(out));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      insts: [1, 1],
+      errors: ["MODULE_NOT_FOUND", "MODULE_NOT_FOUND"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("import('pkg?v=N') does not evaluate a new instance of the package", async () => {
+    using dir = tempDir("import-query-bare-import", {
+      ...pkgFiles,
+      "entry.mjs": `
+        const out = { insts: [], errors: [] };
+        out.insts.push((await import("qk")).default.inst);
+        for (const spec of ["qk?v=1", "qk?v=2"]) {
+          try {
+            out.insts.push((await import(spec)).default.inst);
+          } catch (e) {
+            out.errors.push(e.code || e.name);
+          }
+        }
+        out.insts.push((await import("qk")).default.inst);
+        console.log(JSON.stringify(out));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      insts: [1, 1],
+      errors: ["ERR_MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("pkg/subpath?query is not matched against the exports map", async () => {
+    using dir = tempDir("import-query-bare-subpath", {
+      ...pkgFiles,
+      "entry.mjs": `
+        import { createRequire } from "node:module";
+        const require = createRequire(import.meta.url);
+        const out = {};
+        const go = (k, f) => { try { out[k] = f() } catch (e) { out[k] = "ERR:" + (e.code || e.name) } };
+        go("plain", () => require("qk/s"));
+        go("require", () => require("qk/s?x=1"));
+        go("imr", () => import.meta.resolve("qk/s?x=1"));
+        go("resolveSync", () => Bun.resolveSync("qk/s?x=1", import.meta.dir));
+        console.log(JSON.stringify(out));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout.trim());
+    // `./s` is exported; `./s?x=1` is not. Previously `imr` returned a file URL
+    // whose path ended in `/s.js%3Fx=1` (the query percent-encoded into the path).
+    expect(out).toEqual({
+      plain: "SUB",
+      require: "ERR:MODULE_NOT_FOUND",
+      imr: "ERR:ERR_MODULE_NOT_FOUND",
+      resolveSync: "ERR:ERR_MODULE_NOT_FOUND",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("?query on a relative ESM specifier still cache-busts (control)", async () => {
+    using dir = tempDir("import-query-bare-control", {
+      "rel.mjs": "globalThis.__rel = (globalThis.__rel || 0) + 1; export const inst = globalThis.__rel;",
+      "entry.mjs": `
+        const a = await import("./rel.mjs");
+        const b = await import("./rel.mjs?v=1");
+        const c = await import("./rel.mjs?v=2");
+        console.log(JSON.stringify([a.inst, b.inst, c.inst]));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual([1, 2, 3]);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -237,12 +237,13 @@ test("Bun.resolveSync with non-ASCII specifier and query string", async () => {
   expect(exitCode).toBe(0);
 });
 
-// Node gives `?` URL-separator meaning only for relative/absolute ESM specifiers.
-// A bare package specifier (`pkg`, `@scope/pkg/sub`) is not a URL: `?` is part of
-// the package name / subpath and must reach the resolver verbatim. Stripping it
-// made `import("pkg?v=1")` evaluate a second instance of the whole package,
-// splitting singleton state.
-describe("?query on a bare package specifier does not resolve", () => {
+// Node rejects a `?query` on a bare package *root* (`pkg?v=1`, `@scope/pkg?v=1`,
+// `#name?v=1`, self-reference by name). Stripping it made `import("pkg?v=1")`
+// evaluate a second instance of the whole package, splitting singleton state.
+// Subpaths (`pkg/sub?q`) are left to the exports/imports map, since Node's
+// answer there depends on whether the subpath matched an exact key or a
+// suffix-less wildcard.
+describe("?query on a bare package root does not resolve", () => {
   const pkgFiles = {
     "node_modules/qk/package.json": JSON.stringify({
       name: "qk",
@@ -325,18 +326,24 @@ describe("?query on a bare package specifier does not resolve", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent("pkg/subpath?query is not matched against the exports map", async () => {
-    using dir = tempDir("import-query-bare-subpath", {
-      ...pkgFiles,
+  test.concurrent("?query on a wildcard exports/imports subpath still resolves (control)", async () => {
+    // Node ESM accepts a ?query on a suffix-less wildcard key: the `*` captures
+    // the `?` into patternMatch, the href-replace substitution lands it in the
+    // URL `.search`, and the pathname stats. The rejection is limited to the
+    // package root so this Node behaviour stays intact.
+    using dir = tempDir("import-query-bare-wildcard", {
+      "package.json": JSON.stringify({ name: "app", type: "module", imports: { "#hot/*": "./src/*" } }),
+      "src/config.js": "globalThis.__wc = (globalThis.__wc || 0) + 1; export const inst = globalThis.__wc;",
+      "node_modules/wp/package.json": JSON.stringify({ name: "wp", type: "module", exports: { "./*": "./dist/*" } }),
+      "node_modules/wp/dist/foo.js": "globalThis.__wp = (globalThis.__wp || 0) + 1; export const inst = globalThis.__wp;",
       "entry.mjs": `
-        import { createRequire } from "node:module";
-        const require = createRequire(import.meta.url);
-        const out = {};
-        const go = (k, f) => { try { out[k] = f() } catch (e) { out[k] = "ERR:" + (e.code || e.name) } };
-        go("plain", () => require("qk/s"));
-        go("require", () => require("qk/s?x=1"));
-        go("imr", () => import.meta.resolve("qk/s?x=1"));
-        go("resolveSync", () => Bun.resolveSync("qk/s?x=1", import.meta.dir));
+        const out = [];
+        for (const spec of ["#hot/config.js", "#hot/config.js?v=1", "#hot/config.js?v=2"]) {
+          out.push((await import(spec)).inst);
+        }
+        for (const spec of ["wp/foo.js", "wp/foo.js?v=1", "wp/foo.js?v=2"]) {
+          out.push((await import(spec)).inst);
+        }
         console.log(JSON.stringify(out));
       `,
     });
@@ -349,15 +356,7 @@ describe("?query on a bare package specifier does not resolve", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    const out = JSON.parse(stdout.trim());
-    // `./s` is exported; `./s?x=1` is not. Previously `imr` returned a file URL
-    // whose path ended in `/s.js%3Fx=1` (the query percent-encoded into the path).
-    expect(out).toEqual({
-      plain: "SUB",
-      require: "ERR:MODULE_NOT_FOUND",
-      imr: "ERR:ERR_MODULE_NOT_FOUND",
-      resolveSync: "ERR:ERR_MODULE_NOT_FOUND",
-    });
+    expect(JSON.parse(stdout.trim())).toEqual([1, 2, 3, 1, 2, 3]);
     expect(exitCode).toBe(0);
   });
 
@@ -406,8 +405,8 @@ describe("?query on a bare package specifier does not resolve", () => {
 
   test.concurrent("import('#name?v=N') via package.json imports / self-reference by name", async () => {
     // Both routes go through handle_esm_resolution which sets
-    // IS_FROM_NODE_MODULES, so Result::is_node_module() catches them via the
-    // flag even though the resolved file lives outside any node_modules dir.
+    // IS_FROM_NODE_MODULES, so the flag check catches them even though the
+    // resolved file lives outside any node_modules dir.
     using dir = tempDir("import-query-bare-hash-self", {
       "package.json": JSON.stringify({
         name: "myapp",

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { symlinkSync } from "node:fs";
+import { join } from "node:path";
 globalThis.importQueryFixtureOrder = [];
 const resolvedPath = require.resolve("./import-query-fixture.ts");
 const resolvedURL = Bun.pathToFileURL(resolvedPath).href;
@@ -356,6 +358,72 @@ describe("?query on a bare package specifier does not resolve", () => {
       imr: "ERR:ERR_MODULE_NOT_FOUND",
       resolveSync: "ERR:ERR_MODULE_NOT_FOUND",
     });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("import('pkg?v=N') on a symlinked (workspace/link) package", async () => {
+    // Bun realpaths symlinks by default, so the resolved `text` has no
+    // `/node_modules/` component; the rejection must cover this layout too.
+    using dir = tempDir("import-query-bare-symlink", {
+      "packages/sk/package.json": JSON.stringify({ name: "sk", main: "./i.js", exports: { ".": "./i.js" } }),
+      "packages/sk/i.js": "globalThis.__sk = (globalThis.__sk || 0) + 1; module.exports = { inst: globalThis.__sk };",
+      "packages/sn/package.json": JSON.stringify({ name: "sn", main: "./i.js" }),
+      "packages/sn/i.js": "globalThis.__sn = (globalThis.__sn || 0) + 1; module.exports = { inst: globalThis.__sn };",
+      "app/node_modules/.keep": "",
+      "app/entry.mjs": `
+        const out = { insts: [], errors: [] };
+        for (const name of ["sk", "sn"]) {
+          out.insts.push((await import(name)).default.inst);
+          for (const spec of [name + "?v=1", name + "?v=2"]) {
+            try {
+              out.insts.push((await import(spec)).default.inst);
+            } catch (e) {
+              out.errors.push(e.code || e.name);
+            }
+          }
+          out.insts.push((await import(name)).default.inst);
+        }
+        console.log(JSON.stringify(out));
+      `,
+    });
+    symlinkSync(join(String(dir), "packages/sk"), join(String(dir), "app/node_modules/sk"), "junction");
+    symlinkSync(join(String(dir), "packages/sn"), join(String(dir), "app/node_modules/sn"), "junction");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: join(String(dir), "app"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      insts: [1, 1, 1, 1],
+      errors: ["ERR_MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("?raw on a bare package subpath still loads as text (control)", async () => {
+    using dir = tempDir("import-query-bare-raw", {
+      "node_modules/tp/package.json": JSON.stringify({ name: "tp", main: "./i.js" }),
+      "node_modules/tp/i.js": "module.exports = 0;",
+      "node_modules/tp/data.txt": "RAW TEXT CONTENT",
+      "entry.mjs": `
+        const a = await import("tp/data.txt?raw");
+        console.log(JSON.stringify(a.default));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toBe("RAW TEXT CONTENT");
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -404,6 +404,50 @@ describe("?query on a bare package specifier does not resolve", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.concurrent("import('#name?v=N') via package.json imports / self-reference by name", async () => {
+    // Both routes go through handle_esm_resolution which sets
+    // IS_FROM_NODE_MODULES, so Result::is_node_module() catches them via the
+    // flag even though the resolved file lives outside any node_modules dir.
+    using dir = tempDir("import-query-bare-hash-self", {
+      "package.json": JSON.stringify({
+        name: "myapp",
+        imports: { "#internal": "./src/util.js" },
+        exports: { ".": "./index.js" },
+      }),
+      "index.js": "globalThis.__ix = (globalThis.__ix || 0) + 1; module.exports = { inst: globalThis.__ix };",
+      "src/util.js": "globalThis.__iu = (globalThis.__iu || 0) + 1; module.exports = { inst: globalThis.__iu };",
+      "entry.mjs": `
+        const out = { insts: [], errors: [] };
+        for (const name of ["#internal", "myapp"]) {
+          out.insts.push((await import(name)).default.inst);
+          for (const spec of [name + "?v=1", name + "?v=2"]) {
+            try {
+              out.insts.push((await import(spec)).default.inst);
+            } catch (e) {
+              out.errors.push(e.code || e.name);
+            }
+          }
+          out.insts.push((await import(name)).default.inst);
+        }
+        console.log(JSON.stringify(out));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      insts: [1, 1, 1, 1],
+      errors: ["ERR_MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("?raw on a bare package subpath still loads as text (control)", async () => {
     using dir = tempDir("import-query-bare-raw", {
       "node_modules/tp/package.json": JSON.stringify({ name: "tp", main: "./i.js" }),

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -251,6 +251,11 @@ describe("?query on a bare package specifier does not resolve", () => {
     "node_modules/qk/s.js": 'module.exports = "SUB";',
   };
 
+  const noExportsPkgFiles = {
+    "node_modules/nx/package.json": JSON.stringify({ name: "nx", main: "./i.js" }),
+    "node_modules/nx/i.js": "globalThis.__nx = (globalThis.__nx || 0) + 1; module.exports = { inst: globalThis.__nx };",
+  };
+
   test.concurrent("require('pkg?v=N') does not evaluate a new instance of the package", async () => {
     using dir = tempDir("import-query-bare-require", {
       ...pkgFiles,
@@ -351,6 +356,68 @@ describe("?query on a bare package specifier does not resolve", () => {
       imr: "ERR:ERR_MODULE_NOT_FOUND",
       resolveSync: "ERR:ERR_MODULE_NOT_FOUND",
     });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("import('pkg?v=N') on a package without an exports field", async () => {
+    using dir = tempDir("import-query-bare-noexports", {
+      ...noExportsPkgFiles,
+      "entry.mjs": `
+        const out = { insts: [], errors: [] };
+        out.insts.push((await import("nx")).default.inst);
+        for (const spec of ["nx?v=1", "nx?v=2"]) {
+          try {
+            out.insts.push((await import(spec)).default.inst);
+          } catch (e) {
+            out.errors.push(e.code || e.name);
+          }
+        }
+        out.insts.push((await import("nx")).default.inst);
+        console.log(JSON.stringify(out));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      insts: [1, 1],
+      errors: ["ERR_MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("?query on a tsconfig paths alias still resolves (control)", async () => {
+    // A tsconfig `paths` alias is Bun-specific runtime resolution and resolves
+    // outside node_modules, so the split-off query is kept and `?raw` works.
+    using dir = tempDir("import-query-bare-tspaths", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { baseUrl: ".", paths: { "@/*": ["./src/*"] } } }),
+      "src/util.ts": "globalThis.__u = (globalThis.__u || 0) + 1; export const inst = globalThis.__u;",
+      "src/shader.glsl": "VERTEX SHADER CODE",
+      "entry.ts": `
+        const out = {};
+        out.a = (await import("@/util")).inst;
+        out.b = (await import("@/util?v=1")).inst;
+        out.c = (await import("@/util?v=2")).inst;
+        out.raw = (await import("@/shader.glsl?raw")).default;
+        console.log(JSON.stringify(out));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ a: 1, b: 2, c: 3, raw: "VERTEX SHADER CODE" });
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
## Repro

```js
// node_modules/qk/{package.json,i.js} laid out under a tempdir
require("qk").inst;        // 1
require("qk?v=1").inst;    // node: MODULE_NOT_FOUND   bun: 2 (new instance)
require("qk?v=2").inst;    // node: MODULE_NOT_FOUND   bun: 3 (new instance)
await import("qk?v=9");    // node: ERR_MODULE_NOT_FOUND   bun: 4th instance
```

Each distinct `?query` evaluated a fresh copy of the whole package, so anything relying on a package-level singleton (one React, one event emitter, one config cache) silently split. The same happened for a scoped package (`@scope/pkg?v=1`), a `bun link` / workspace / `file:` dependency whose `node_modules` entry is a symlink, a package without an `exports` field, a package.json `#imports` target (`#name?v=1`), a self-reference by package name, and a `NODE_PATH`-resolved package.

## Cause

`normalize_specifier_for_resolution` splits every specifier at the first `?` before handing it to the filesystem resolver. That is the correct URL rule for a relative or absolute ESM specifier (`import "./m.mjs?v=1"` is Node parity), but a bare package root is not a URL: Node parses the package name up to the first `/`, so `pkg?v=1` is looked up as the literal name `pkg?v=1` and rejected. Stripping it turned `pkg?v=1` into `pkg` (found) with a `?v=1` cache-key suffix.

## Fix

After `_resolve` has a result, fail the resolution when the stripped specifier is a bare package root (no subpath after the package name), carries a `?query`, and `ResultFlags::IS_FROM_NODE_MODULES` is set. Applied in both copies of the body (`src/jsc/VirtualMachine.rs` and `src/runtime/jsc_hooks.rs`).

The flag records how resolution reached the result (before symlinks are realpath'd), so it is true for a symlinked package and for `#imports` / self-reference / the global install cache, and false for a tsconfig `paths` alias. Two success returns in `load_node_modules` (the no-`exports` main-field fallthrough and the `NODE_PATH` fallthrough) were not writing `out.is_node_module = true`; those now match their six siblings in the same function.

### Subpaths are unchanged

`pkg/sub?q` and `#name/sub?q` are left at their pre-PR behaviour. Node's answer there depends on whether the subpath matches an exact `exports`/`imports` key (rejected) or a suffix-less wildcard key (accepted: the `*` captures the `?` into `patternMatch`, the href-replace substitution lands it in the URL `.search`, and the pathname stats). Bun's resolver does not currently surface that distinction, and the pre-PR behaviour already matches Node for the wildcard case; the exact-key subpath case, a slash-less `#`-imports wildcard key (`"#*": "./src/*"` with `import("#util.js?v=1")`), and the `import.meta.resolve("pkg/sub?x=1")` percent-encoding are left for a follow-up that threads the wildcard-vs-exact result out of `handle_esm_resolution`.

Kept working (each with a control test):

- `import("@/util?v=1")` / `import("@/shader.glsl?raw")` via a tsconfig `paths` alias: resolves with the flag unset.
- `import("pkg/data.txt?raw")` and any other bare subpath with a query: not a package root. `import("pkg?raw")` on the root itself is rejected like any other root query; the useful `?raw` spellings are all subpaths.
- `import("#hot/config.js?v=1")` / `import("wp/foo.js?v=1")` via a wildcard `imports`/`exports` key: not a package root (Node parity).
- `require("./m.cjs?v=2")` and `import("./m.mjs?v=1")`: relative specifiers are unchanged.

## Verification

```console
$ USE_SYSTEM_BUN=1 bun test test/js/bun/resolve/import-query.test.ts -t "bare package root"
(fail) require('pkg?v=N') does not evaluate a new instance of the package      # qk + @sc/pk, insts:[1,2,3,1,...]
(fail) import('pkg?v=N') does not evaluate a new instance of the package       # qk + @sc/pk
(fail) import('pkg?v=N') on a package without an exports field
(fail) import('pkg?v=N') on a symlinked (workspace/link) package
(fail) import('#name?v=N') via package.json imports / self-reference by name
(fail) import('pkg?v=N') on a package resolved via NODE_PATH
(pass) ?query on a wildcard exports/imports subpath still resolves (control)
(pass) ?raw on a bare package subpath still loads as text (control)
(pass) ?query on a tsconfig paths alias still resolves (control)
(pass) ?query on a relative ESM specifier still cache-busts (control)
 4 pass  6 fail

$ bun bd test test/js/bun/resolve/import-query.test.ts \
              test/js/bun/resolve/import-meta.test.js \
              test/js/bun/import-attributes/import-attributes.test.ts
 25 + 32 + 12 pass  0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/import-query.test.ts
bun test v1.4.0 (79ba4e003)

test/js/bun/resolve/import-query.test.ts:
(pass) [query, no query] [32.87ms]
(pass) [no query, query] [21.43ms]
(pass) [/import-query-fixture.ts, /import-query-fixture.ts?query, /import-query-fixture.ts?query2] [42.84ms]
(pass) [/import-query-fixture.ts?query, /import-query-fixture.ts?query2, /import-query-fixture.ts] [26.85ms]
(pass) [/import-query-fixture.ts?query, /import-query-fixture.ts, /import-query-fixture.ts?query2] [23.14ms]
(pass) [/import-query-fixture.ts, /import-query-fixture.ts?query2, /import-query-fixture.ts?query] [25.91ms]
(pass) [/import-query-fixture.ts?query2, /import-query-fixture.ts, /import-query-fixture.ts?query] [22.97ms]
(pass) [/import-query-fixture.ts?query2, /import-query-fixture.ts?query, /import-query-fixture.ts] [19.42ms]
(pass) query string with non-ASCII specifier (dynamic import) [334.90ms]
(pass) query string with non-ASCII specifier (static import) [323.20ms]
(pass) dynamic import of a .node addon ignores a query string suffix [
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (b03293deb)

test/js/bun/resolve/import-query.test.ts:
(pass) [query, no query] [1.17ms]
(pass) [no query, query] [0.27ms]
(pass) [/import-query-fixture.ts, /import-query-fixture.ts?query, /import-query-fixture.ts?query2] [0.39ms]
(pass) [/import-query-fixture.ts?query, /import-query-fixture.ts?query2, /import-query-fixture.ts] [0.22ms]
(pass) [/import-query-fixture.ts?query, /import-query-fixture.ts, /import-query-fixture.ts?query2] [0.26ms]
(pass) [/import-query-fixture.ts, /import-query-fixture.ts?query2, /import-query-fixture.ts?query] [0.21ms]
(pass) [/import-query-fixture.ts?query2, /import-query-fixture.ts, /import-query-fixture.ts?query] [0.20ms]
(pass) [/import-query-fixture.ts?query2, /import-query-fixture.ts?query, /import-query-fixture.ts] [0.20ms]
(pass) query string with non-ASCII specifier (dynamic import) [34.78ms]
(pass) query string with non-ASCII specifier (static import) [20.44ms]
(pass) dynamic import of a .node addon ignores a query string suffix [10.75ms]
(pass) static import of a .node addon ignores a query string suffix [11.96ms]
(pass) require of a .node addon with a query string reaches process.dlopen [28.95ms]
(pa
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/import-query.test.ts
bun test v1.4.0 (79ba4e003)

test/js/bun/resolve/import-query.test.ts:
(pass) [query, no query] [26.78ms]
(pass) [no query, query] [19.80ms]
(pass) [/import-query-fixture.ts, /import-query-fixture.ts?query, /import-query-fixture.ts?query2] [27.18ms]
(pass) [/import-query-fixture.ts?query, /import-query-fixture.ts?query2, /import-query-fixture.ts] [28.05ms]
(pass) [/import-query-fixture.ts?query, /import-query-fixture.ts, /import-query-fixture.ts?query2] [20.02ms]
(pass) [/import-query-fixture.ts, /import-query-fixture.ts?query2, /import-query-fixture.ts?query] [27.70ms]
(pass) [/import-query-fixture.ts?query2, /import-query-fixture.ts, /import-query-fixture.ts?query] [25.82ms]
(pass) [/import-query-fixture.ts?query2, /import-query-fixture.ts?query, /import-query-fixture.ts] [19.82ms]
(pass) query string with non-ASCII specifier (dynamic import) [327.60ms]
(pass) query string with non-ASCII specifier (static import) [306.16ms]
(pass) dynamic import of a .node addon ignores a query string suffix [
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 746ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs                |   4 +
 src/resolver/resolver.rs                 |   2 +
 src/resolver/result.rs                   |  17 ++
 src/runtime/jsc_hooks.rs                 |   4 +
 test/js/bun/resolve/import-query.test.ts | 360 ++++++++++++++++++++++++++++++-
 5 files changed, 386 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/jsc/VirtualMachine.rs                    13     19      0
src/resolver/resolver.rs                      1      1      0
src/resolver/result.rs                        3      5      0
src/runtime/jsc_hooks.rs                     11     11      0
test/js/bun/resolve/import-query.test.ts      8     14      0
```

</details>

<!-- robobun:evidence:end -->