### PR TITLE
node:module: make wrap, wrapper and _stat non-enumerable like Node

### DIFF
--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -960,7 +960,7 @@ _pathCache              getPathCacheObject                PropertyCallback
 _preloadModules         jsFunctionPreloadModules          Function 0
 _resolveFilename        nodeModuleResolveFilename         CustomAccessor
 _resolveLookupPaths     jsFunctionResolveLookupPaths      Function 2
-_stat                   &Generated::NodeModuleModule::js_stat Function 1
+_stat                   &Generated::NodeModuleModule::js_stat DontEnum|Function 1
 builtinModules          getBuiltinModulesObject           PropertyCallback
 constants               getConstantsObject                PropertyCallback
 createRequire           jsFunctionNodeModuleCreateRequire Function 1
@@ -975,8 +975,8 @@ register                jsFunctionRegister                Function 1
 runMain                 moduleRunMain                        CustomAccessor
 SourceMap               getSourceMapFunction              PropertyCallback
 syncBuiltinESMExports   jsFunctionSyncBuiltinESMExports   Function 0
-wrap                    jsFunctionWrap                    Function 1
-wrapper                 nodeModuleWrapper                 CustomAccessor
+wrap                    jsFunctionWrap                    DontEnum|Function 1
+wrapper                 nodeModuleWrapper                 DontEnum|CustomAccessor
 Module                  getModuleObject                   PropertyCallback
 @end
 */

--- a/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
+++ b/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
@@ -488,6 +488,8 @@ test.concurrent("node:module: linking constructs the linked bindings, not the re
     const exportNames = Reflect.ownKeys(ns).filter(key => typeof key === "string");
     // The export list is the static table, which is also exactly what Object.keys of the constructor lists.
     const exportListMatches = exportNames.sort().join() === [...Object.keys(Module), "default"].sort().join();
+    // Non-enumerable in Node too, so Node's namespace has none of them either.
+    const nonEnumerableExports = ["_stat", "prototype", "wrap", "wrapper"].filter(name => name in ns);
     const afterListing = constructedOnModule();
     const builtinModules = ns.builtinModules;
     print({
@@ -495,6 +497,7 @@ test.concurrent("node:module: linking constructs the linked bindings, not the re
       afterLink,
       createRequire: typeof createRequire(import.meta.url)("node:path").join === "function",
       exportListMatches,
+      nonEnumerableExports,
       afterListing,
       builtinModules: Array.isArray(builtinModules) && builtinModules === Module.builtinModules,
       afterRead: constructedOnModule(),
@@ -507,6 +510,7 @@ test.concurrent("node:module: linking constructs the linked bindings, not the re
     afterLink: ["createRequire"],
     createRequire: true,
     exportListMatches: true,
+    nonEnumerableExports: [],
     afterListing: ["createRequire"],
     builtinModules: true,
     afterRead: ["builtinModules", "createRequire"],

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
 import { bunEnv, bunExe, isWindows, ospath, tempDir } from "harness";
-import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
+import * as moduleNamespace from "module";
+import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin } from "module";
 import path from "path";
 
 describe.concurrent("node-module-module", () => {
@@ -41,10 +42,24 @@ describe.concurrent("node-module-module", () => {
     expect(ns.default.prototype).toBe(Module.prototype);
   });
 
+  test("wrap, wrapper and _stat are not enumerable either (#16933)", () => {
+    const hidden = ["_stat", "wrap", "wrapper"];
+    expect(hidden.filter(name => Object.getOwnPropertyDescriptor(Module, name).enumerable)).toEqual([]);
+    expect(Object.keys(Module).filter(name => hidden.includes(name))).toEqual([]);
+    // The ES module exports Object.keys(Module), so, as in Node, these are not named exports.
+    expect(hidden.filter(name => name in moduleNamespace)).toEqual([]);
+    expect(moduleNamespace.createRequire).toBe(createRequire);
+    // Still reachable the way Node code reaches them.
+    expect(typeof Module.wrap).toBe("function");
+    expect(typeof Module.wrapper[0]).toBe("string");
+    expect(typeof Module._stat).toBe("function");
+  });
+
   // jest-runtime builds the `Module` it hands to tests this way. Assigning a class's `prototype` throws, so this
-  // needs `prototype` to be non-enumerable; and the copy goes through the inherited `wrapper` / `_resolveFilename`
-  // / `runMain` setters with their current values, which must not count as overriding them (an overridden wrapper
-  // re-wraps every CommonJS module from source and bypasses the --isolate SourceProvider cache).
+  // needs `prototype` to be non-enumerable; and the copy goes through the inherited `_resolveFilename` / `runMain`
+  // setters with their current values, which must not count as overriding them. `wrapper` is not enumerable
+  // either, so the test writes its current value back explicitly: that must not count as an override (an
+  // overridden wrapper re-wraps every CommonJS module from source and bypasses the --isolate SourceProvider cache).
   test("Module's enumerable statics can be copied onto a subclass without overriding the CJS wrapper", async () => {
     using dir = tempDir("module-statics-copy", {
       "dep.cjs": `module.exports = "dep";`,
@@ -59,6 +74,7 @@ describe.concurrent("node-module-module", () => {
           expect(Sub.prototype).toBeInstanceOf(Module);
           expect(Sub._extensions).toBe(Module._extensions);
           expect(Sub.wrapper[0]).toBe(Module.wrapper[0]);
+          Module.wrapper = Module.wrapper;
 
           expect(require("./dep.cjs")).toBe("dep");
           expect(isolatedModuleCacheSourceType(require.resolve("./dep.cjs"))).toBe("Program");
@@ -514,9 +530,9 @@ console.log("survived", require("./late.js"));`,
 
   test("Module.wrap", () => {
     var mod = { exports: {} };
-    expect(eval(wrap("exports.foo = 1; return 42"))(mod.exports, mod)).toBe(42);
+    expect(eval(Module.wrap("exports.foo = 1; return 42"))(mod.exports, mod)).toBe(42);
     expect(mod.exports.foo).toBe(1);
-    expect(wrap()).toBe("(function (exports, require, module, __filename, __dirname) { undefined\n});");
+    expect(Module.wrap()).toBe("(function (exports, require, module, __filename, __dirname) { undefined\n});");
   });
 
   test("Overwriting _resolveFilename", async () => {


### PR DESCRIPTION
### Problem
- Node defines `Module.wrap`, `Module.wrapper` and `Module._stat` as non-enumerable (checked v22 and v26). Bun's `nodeModuleObjectTable` in `src/jsc/modules/NodeModuleModule.cpp` had all three enumerable, so they appear in `Object.keys(Module)` and are named exports of the `node:module` ES namespace, which Node does not have.
- Code that copies `Object.entries(Module)` onto a subclass (jest-runtime, the case from #16933) therefore still assigns `wrapper`, which runs the setter inherited from `Module` instead of creating a property on the subclass.
- The `prototype` half of #16933 (the `TypeError: Attempted to assign to readonly property.`) is already fixed on main by #39535, which also makes the namespace generator skip `DontEnum` entries. This PR is the remaining Node parity from the review of the earlier revision.

### Fix
- Add `DontEnum` to the `_stat`, `wrap` and `wrapper` table entries. With the generator from #39535 this also removes them from the ES namespace, so the export list stays equal to `Object.keys(Module)` and now matches Node's export list exactly.
- A named ES import of one of the three names fails to link, as in Node. The only such import in the tree was in `node-module-module.test.js`, which now uses `Module.wrap`.
- The existing jest-style copy test no longer reaches the `wrapper` setter, so it writes `Module.wrapper` back to itself explicitly to keep the "writing the default back is not an override" rule from #39535 covered.
- Verified:
  - `test/js/node/module/node-module-module.test.js`, new case `wrap, wrapper and _stat are not enumerable either`: descriptors, `Object.keys`, and `import * as` namespace. Fails against main's `src/`, passes with this change.
  - `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts`, `node:module` case now also asserts none of `_stat`, `prototype`, `wrap`, `wrapper` are exports. Fails against main's `src/`, passes with this change.
  - All other tests in both files, and Node's `test-module-wrap.js`, `test-module-wrapper.js`, `test-module-stat.js`, `test-module-readonly.js`, `test-module-prototype-mutation.js`, pass (they reach these through `require`, which is unaffected).

### Background
- `nodeModuleObjectTable` is a JSC static property table: one line per property of the `Module` constructor, with the property attributes in the last column. An entry without `DontEnum` is enumerable and shows up in `Object.keys` / `Object.entries`.
- `node:module` is an ES module Bun generates from the `Module` constructor. Since #39535, `generateNativeModule_NodeModule` exports the table's enumerable entries, so the attribute alone decides both `Object.keys` and the namespace.
- `Module.wrapper` is an accessor in Bun. Assigning to it on a subclass invokes the inherited setter rather than creating an own property on the subclass.

<details>
<summary>Before / after, and history of this PR</summary>

```console
$ bun -p 'Object.keys(require("node:module")).filter(k => ["_stat","wrap","wrapper"].includes(k))'
[ "_stat", "wrap", "wrapper" ]      # main
[]                                  # this PR, same as node

$ bun --input-type=module -e 'import * as ns from "node:module"; console.log(["_stat","wrap","wrapper"].filter(k => k in ns))'
[ "_stat", "wrap", "wrapper" ]      # main
[]                                  # this PR, same as node
```

Earlier revisions of this PR made `prototype` non-enumerable (the fix for the jest `TypeError`), filtered `DontEnum` entries out of the namespace generator, and added a strict-mode fixture for the jest copy loop. #39535 landed the `prototype` attribute, the generator filter, and an equivalent copy test on main first, so after the rebase this PR was reduced to the parts that are not on main: the three remaining attributes and their tests.
</details>

Related to #16933 (closed, the `prototype` part landed in #39535)

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->
