### PR TITLE
vscode: support "console": "integratedTerminal" / "externalTerminal" in launch config

### DIFF
--- a/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
+++ b/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
@@ -128,6 +128,7 @@ type LaunchRequest = DAP.LaunchRequest & {
   args?: string[];
   cwd?: string;
   env?: Record<string, string>;
+  console?: "internalConsole" | "integratedTerminal" | "externalTerminal";
   strictEnv?: boolean;
   stopOnEntry?: boolean;
   noDebug?: boolean;
@@ -213,7 +214,7 @@ export type DebugAdapterEventMap = InspectorEventMap & {
   "Adapter.response": [DAP.Response];
   "Adapter.event": [DAP.Event];
   "Adapter.error": [Error];
-  "Adapter.reverseRequest": [DAP.Request];
+  "Adapter.reverseRequest": [DAP.Request, (response: DAP.Response) => void];
 } & {
   "Process.requested": [unknown];
   "Process.spawned": [ChildProcess];
@@ -406,13 +407,26 @@ export abstract class BaseDebugAdapter<T extends Inspector = Inspector>
     });
   }
 
-  #reverseRequest<T extends keyof DAP.RequestMap>(command: T, args?: DAP.RequestMap[T]): void {
-    this.emit("Adapter.reverseRequest", {
-      type: "request",
-      seq: 0,
-      command,
-      arguments: args,
+  protected reverseRequest<T extends keyof DAP.RequestMap>(
+    command: T,
+    args?: DAP.RequestMap[T],
+  ): Promise<DAP.Response> {
+    return new Promise(resolve => {
+      this.emit(
+        "Adapter.reverseRequest",
+        {
+          type: "request",
+          seq: 0,
+          command,
+          arguments: args,
+        },
+        resolve,
+      );
     });
+  }
+
+  protected get initializeRequest(): InitializeRequest | undefined {
+    return this.#initialized;
   }
 
   async ["Adapter.request"](request: DAP.Request): Promise<void> {
@@ -2164,6 +2178,7 @@ export class WebSocketDebugAdapter extends BaseDebugAdapter<WebSocketInspector> 
       args = [],
       cwd,
       env = {},
+      console: console_ = "internalConsole",
       strictEnv = false,
       watchMode = false,
       stopOnEntry = false,
@@ -2202,74 +2217,79 @@ export class WebSocketDebugAdapter extends BaseDebugAdapter<WebSocketInspector> 
           ...env,
         };
 
+    let url: string;
+    let signal: UnixSignal | TCPSocketSignal;
     if (process.platform !== "win32") {
-      // we're on unix
-      const url = `ws+unix://${randomUnixPath()}`;
-      const signal = new UnixSignal();
-
-      signal.on("Signal.received", () => {
-        this.#attach({ url });
-      });
-
-      this.once("Adapter.terminated", () => {
-        signal.close();
-      });
-
-      const query = stopOnEntry ? "break=1" : "wait=1";
-      processEnv["BUN_INSPECT"] = `${url}?${query}`;
-      processEnv["BUN_INSPECT_NOTIFY"] = signal.url;
-
-      // This is probably not correct, but it's the best we can do for now.
-      processEnv["FORCE_COLOR"] = "1";
-      processEnv["BUN_QUIET_DEBUG_LOGS"] = "1";
-      processEnv["BUN_DEBUG_QUIET_LOGS"] = "1";
-
-      const started = await this.#spawn({
-        command: runtime,
-        args: processArgs,
-        env: processEnv,
-        cwd,
-        isDebugee: true,
-      });
-
-      if (!started) {
-        throw new Error("Program could not be started.");
-      }
+      url = `ws+unix://${randomUnixPath()}`;
+      signal = new UnixSignal();
     } else {
-      // we're on windows
-      // Create TCPSocketSignal
-      const url = `ws://127.0.0.1:${await getAvailablePort()}/${getRandomId()}`; // 127.0.0.1 so it resolves correctly on windows
-      const signal = new TCPSocketSignal(await getAvailablePort());
+      // 127.0.0.1 so it resolves correctly on windows
+      url = `ws://127.0.0.1:${await getAvailablePort()}/${getRandomId()}`;
+      signal = new TCPSocketSignal(await getAvailablePort());
+    }
 
-      signal.on("Signal.received", async () => {
-        this.#attach({ url });
+    signal.on("Signal.received", () => {
+      this.#attach({ url });
+    });
+
+    this.once("Adapter.terminated", () => {
+      signal.close();
+    });
+
+    const query = stopOnEntry ? "break=1" : "wait=1";
+    const inspectEnv: Record<string, string> = {
+      BUN_INSPECT: `${url}?${query}`,
+      BUN_INSPECT_NOTIFY: signal.url,
+      BUN_QUIET_DEBUG_LOGS: "1",
+      BUN_DEBUG_QUIET_LOGS: "1",
+    };
+
+    const terminalKind =
+      console_ === "integratedTerminal" ? "integrated" : console_ === "externalTerminal" ? "external" : undefined;
+
+    let started: boolean;
+    if (terminalKind && this.initializeRequest?.supportsRunInTerminalRequest) {
+      started = await this.#runInTerminal({
+        kind: terminalKind,
+        title: "Bun Debugger",
+        cwd: cwd ?? process.cwd(),
+        args: [runtime, ...processArgs],
+        // runInTerminal env is additive to the terminal's own environment, so only send
+        // the inspector variables and the user's explicit overrides.
+        env: { ...env, ...inspectEnv },
       });
-
-      this.once("Adapter.terminated", () => {
-        signal.close();
-      });
-
-      const query = stopOnEntry ? "break=1" : "wait=1";
-      processEnv["BUN_INSPECT"] = `${url}?${query}`;
-      processEnv["BUN_INSPECT_NOTIFY"] = signal.url; // 127.0.0.1 so it resolves correctly on windows
-
+    } else {
+      Object.assign(processEnv, inspectEnv);
       // This is probably not correct, but it's the best we can do for now.
       processEnv["FORCE_COLOR"] = "1";
-      processEnv["BUN_QUIET_DEBUG_LOGS"] = "1";
-      processEnv["BUN_DEBUG_QUIET_LOGS"] = "1";
 
-      const started = await this.#spawn({
+      started = await this.#spawn({
         command: runtime,
         args: processArgs,
         env: processEnv,
         cwd,
         isDebugee: true,
       });
-
-      if (!started) {
-        throw new Error("Program could not be started.");
-      }
     }
+
+    if (!started) {
+      throw new Error("Program could not be started.");
+    }
+  }
+
+  async #runInTerminal(request: DAP.RunInTerminalRequest): Promise<boolean> {
+    const response = await this.reverseRequest("runInTerminal", request);
+    if (!response.success) {
+      throw new Error(response.message || "runInTerminal request failed");
+    }
+    const body = response.body as DAP.RunInTerminalResponse | undefined;
+    this.emitAdapterEvent("process", {
+      name: request.args.join(" "),
+      systemProcessId: body?.processId,
+      isLocalProcess: true,
+      startMethod: "launch",
+    });
+    return true;
   }
 
   async #spawn(options: {

--- a/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
+++ b/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
@@ -2116,6 +2116,8 @@ export class NodeSocketDebugAdapter extends BaseDebugAdapter<NodeSocketInspector
  */
 export class WebSocketDebugAdapter extends BaseDebugAdapter<WebSocketInspector> {
   #process?: ChildProcess;
+  #signal?: UnixSignal | TCPSocketSignal;
+  #terminalLaunch?: { watchMode: boolean };
 
   public constructor(url?: string | URL, untitledDocPath?: string, bunEvalPath?: string) {
     super(new WebSocketInspector(url), untitledDocPath, bunEvalPath);
@@ -2124,7 +2126,14 @@ export class WebSocketDebugAdapter extends BaseDebugAdapter<WebSocketInspector> 
   async ["Inspector.disconnected"](error?: Error): Promise<void> {
     await super["Inspector.disconnected"](error);
 
-    if (this.#process?.exitCode !== null) {
+    if (this.#terminalLaunch) {
+      // The terminal owns the debuggee; we can't observe its exit directly. In watch
+      // mode the inspector disconnects on every restart, so only treat a disconnect
+      // as session termination when not watching.
+      if (!this.#terminalLaunch.watchMode) {
+        this.emitAdapterEvent("terminated");
+      }
+    } else if (this.#process?.exitCode !== null) {
       this.emitAdapterEvent("terminated");
     }
   }
@@ -2148,6 +2157,9 @@ export class WebSocketDebugAdapter extends BaseDebugAdapter<WebSocketInspector> 
 
   close() {
     this.#process?.kill();
+    this.#signal?.close();
+    this.#signal = undefined;
+    this.#terminalLaunch = undefined;
     super.close();
   }
 
@@ -2227,6 +2239,7 @@ export class WebSocketDebugAdapter extends BaseDebugAdapter<WebSocketInspector> 
       url = `ws://127.0.0.1:${await getAvailablePort()}/${getRandomId()}`;
       signal = new TCPSocketSignal(await getAvailablePort());
     }
+    this.#signal = signal;
 
     signal.on("Signal.received", () => {
       this.#attach({ url });
@@ -2249,6 +2262,7 @@ export class WebSocketDebugAdapter extends BaseDebugAdapter<WebSocketInspector> 
 
     let started: boolean;
     if (terminalKind && this.initializeRequest?.supportsRunInTerminalRequest) {
+      this.#terminalLaunch = { watchMode: !!watchMode };
       started = await this.#runInTerminal({
         kind: terminalKind,
         title: "Bun Debugger",

--- a/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
+++ b/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
@@ -2216,6 +2216,7 @@ export class WebSocketDebugAdapter extends BaseDebugAdapter<WebSocketInspector> 
       processArgs.unshift("test");
     }
 
+    const isWatching = !!watchMode || runtimeArgs.includes("--watch") || runtimeArgs.includes("--hot");
     if (watchMode && !runtimeArgs.includes("--watch") && !runtimeArgs.includes("--hot")) {
       processArgs.unshift(watchMode === "hot" ? "--hot" : "--watch");
     }
@@ -2262,7 +2263,13 @@ export class WebSocketDebugAdapter extends BaseDebugAdapter<WebSocketInspector> 
 
     let started: boolean;
     if (terminalKind && this.initializeRequest?.supportsRunInTerminalRequest) {
-      this.#terminalLaunch = { watchMode: !!watchMode };
+      if (strictEnv) {
+        this.emitAdapterEvent("output", {
+          category: "console",
+          output: `Warning: "strictEnv" is ignored when "console" is "${console_}"; the terminal's environment is inherited.\n`,
+        });
+      }
+      this.#terminalLaunch = { watchMode: isWatching };
       started = await this.#runInTerminal({
         kind: terminalKind,
         title: "Bun Debugger",

--- a/packages/bun-vscode/package.json
+++ b/packages/bun-vscode/package.json
@@ -224,6 +224,21 @@
                 "description": "The environment variables to pass to Bun.",
                 "default": {}
               },
+              "console": {
+                "type": "string",
+                "description": "Where to launch the debug target.",
+                "enum": [
+                  "internalConsole",
+                  "integratedTerminal",
+                  "externalTerminal"
+                ],
+                "enumDescriptions": [
+                  "VS Code Debug Console (does not support reading input from a program)",
+                  "VS Code's integrated terminal",
+                  "External terminal that can be configured via user settings"
+                ],
+                "default": "internalConsole"
+              },
               "strictEnv": {
                 "type": "boolean",
                 "description": "If environment variables should not be inherited from the parent process.",

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -410,8 +410,8 @@ class FileDebugSession extends DebugSession {
       });
     }
 
-    this.adapter.on("Adapter.reverseRequest", ({ command, arguments: args }) =>
-      this.sendRequest(command, args, 5000, () => {}),
+    this.adapter.on("Adapter.reverseRequest", ({ command, arguments: args }, reply) =>
+      this.sendRequest(command, args, 10_000, response => reply(response as DAP.Response)),
     );
 
     adapters.set(url, this);
@@ -435,6 +435,10 @@ class FileDebugSession extends DebugSession {
       }
 
       this.adapter.emit("Adapter.request", message);
+    } else if (type === "response") {
+      // Responses to reverse requests (e.g. runInTerminal) are routed by the base
+      // ProtocolServer back to the callback registered via sendRequest above.
+      super.handleMessage(message);
     } else {
       throw new Error(`Not supported: ${type}`);
     }

--- a/test/cli/inspect/debug-adapter.test.ts
+++ b/test/cli/inspect/debug-adapter.test.ts
@@ -159,4 +159,42 @@ describe("launch console", () => {
       adapter.close();
     }
   });
+
+  test.each([
+    [false, 1],
+    [true, 0],
+  ])(
+    "terminal launch with watchMode=%p emits terminated on inspector disconnect %p time(s)",
+    async (watchMode, expectedTerminated) => {
+      const adapter = new WebSocketDebugAdapter();
+
+      adapter.on("Adapter.reverseRequest", (request, reply) => {
+        reply({ type: "response", seq: 0, request_seq: 0, command: request.command, success: true });
+      });
+
+      adapter.initialize({ adapterID: "bun", supportsRunInTerminalRequest: true });
+
+      try {
+        await adapter.launch({
+          runtime: bunExe(),
+          program: "script.ts",
+          cwd: process.cwd(),
+          console: "integratedTerminal",
+          watchMode,
+        } as DAP.LaunchRequest);
+
+        let terminated = 0;
+        adapter.on("Adapter.terminated", () => void terminated++);
+        // Simulate a watch-mode restart: the inspector socket drops while the
+        // terminal process stays alive. resetInternal() clears `options`, so a
+        // second disconnect must still be suppressed in watch mode.
+        await adapter["Inspector.disconnected"]();
+        if (watchMode) await adapter["Inspector.disconnected"]();
+
+        expect(terminated).toBe(expectedTerminated);
+      } finally {
+        adapter.close();
+      }
+    },
+  );
 });

--- a/test/cli/inspect/debug-adapter.test.ts
+++ b/test/cli/inspect/debug-adapter.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import { bunExe } from "harness";
+import { WebSocketDebugAdapter } from "../../../packages/bun-debug-adapter-protocol/src/debugger/adapter.ts";
+import type { DAP } from "../../../packages/bun-debug-adapter-protocol/src/protocol/index.d.ts";
+
+// https://github.com/oven-sh/bun/issues/15706
+describe("launch console", () => {
+  test("integratedTerminal sends runInTerminal reverse request", async () => {
+    const adapter = new WebSocketDebugAdapter();
+
+    const reverseRequests: DAP.Request[] = [];
+    const spawnRequests: unknown[] = [];
+    adapter.on("Adapter.reverseRequest", (request, reply) => {
+      reverseRequests.push(request);
+      reply({
+        type: "response",
+        seq: 0,
+        request_seq: request.seq,
+        command: request.command,
+        success: true,
+        body: { shellProcessId: 1 },
+      });
+    });
+    adapter.on("Process.requested", request => spawnRequests.push(request));
+
+    adapter.initialize({
+      adapterID: "bun",
+      supportsRunInTerminalRequest: true,
+    });
+
+    try {
+      await adapter.launch({
+        runtime: bunExe(),
+        program: "script.ts",
+        cwd: process.cwd(),
+        console: "integratedTerminal",
+        env: { MY_VAR: "1" },
+      } as DAP.LaunchRequest);
+
+      expect(reverseRequests.length).toBe(1);
+      const [request] = reverseRequests;
+      expect(request.command).toBe("runInTerminal");
+      const args = request.arguments as DAP.RunInTerminalRequest;
+      expect(args.kind).toBe("integrated");
+      expect(args.args).toEqual([bunExe(), "script.ts"]);
+      expect(args.cwd).toBe(process.cwd());
+      const env = args.env as Record<string, string>;
+      expect(env.MY_VAR).toBe("1");
+      expect(env.BUN_INSPECT).toStartWith("ws");
+      expect(env.BUN_INSPECT_NOTIFY).toBeString();
+      // A real terminal is a TTY; FORCE_COLOR is only injected for the internal console.
+      expect(env.FORCE_COLOR).toBeUndefined();
+      // runInTerminal env is additive; the adapter's own process.env must not leak into it.
+      expect(Object.keys(env).sort()).toEqual([
+        "BUN_DEBUG_QUIET_LOGS",
+        "BUN_INSPECT",
+        "BUN_INSPECT_NOTIFY",
+        "BUN_QUIET_DEBUG_LOGS",
+        "MY_VAR",
+      ]);
+
+      // No child_process.spawn when launching in a terminal.
+      expect(spawnRequests.length).toBe(0);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  test("externalTerminal sends runInTerminal with kind external", async () => {
+    const adapter = new WebSocketDebugAdapter();
+
+    let kind: string | undefined;
+    adapter.on("Adapter.reverseRequest", (request, reply) => {
+      kind = (request.arguments as DAP.RunInTerminalRequest).kind;
+      reply({
+        type: "response",
+        seq: 0,
+        request_seq: request.seq,
+        command: request.command,
+        success: true,
+      });
+    });
+
+    adapter.initialize({ adapterID: "bun", supportsRunInTerminalRequest: true });
+
+    try {
+      await adapter.launch({
+        runtime: bunExe(),
+        program: "script.ts",
+        cwd: process.cwd(),
+        console: "externalTerminal",
+      } as DAP.LaunchRequest);
+
+      expect(kind).toBe("external");
+    } finally {
+      adapter.close();
+    }
+  });
+
+  test("falls back to spawn when client lacks runInTerminal support", async () => {
+    const adapter = new WebSocketDebugAdapter();
+
+    const reverseRequests: DAP.Request[] = [];
+    const spawnRequests: unknown[] = [];
+    adapter.on("Adapter.reverseRequest", (request, reply) => {
+      reverseRequests.push(request);
+      reply({ type: "response", seq: 0, request_seq: 0, command: request.command, success: true });
+    });
+    adapter.on("Process.requested", request => spawnRequests.push(request));
+
+    adapter.initialize({
+      adapterID: "bun",
+      supportsRunInTerminalRequest: false,
+    });
+
+    try {
+      await adapter.launch({
+        runtime: bunExe(),
+        runtimeArgs: ["-e", "0"],
+        cwd: process.cwd(),
+        console: "integratedTerminal",
+        __skipValidation: true,
+      } as DAP.LaunchRequest);
+
+      expect(reverseRequests.length).toBe(0);
+      expect(spawnRequests.length).toBe(1);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  test("default internalConsole still spawns", async () => {
+    const adapter = new WebSocketDebugAdapter();
+
+    const reverseRequests: DAP.Request[] = [];
+    const spawnRequests: unknown[] = [];
+    adapter.on("Adapter.reverseRequest", (request, reply) => {
+      reverseRequests.push(request);
+      reply({ type: "response", seq: 0, request_seq: 0, command: request.command, success: true });
+    });
+    adapter.on("Process.requested", request => spawnRequests.push(request));
+
+    adapter.initialize({
+      adapterID: "bun",
+      supportsRunInTerminalRequest: true,
+    });
+
+    try {
+      await adapter.launch({
+        runtime: bunExe(),
+        runtimeArgs: ["-e", "0"],
+        cwd: process.cwd(),
+        __skipValidation: true,
+      } as DAP.LaunchRequest);
+
+      expect(reverseRequests.length).toBe(0);
+      expect(spawnRequests.length).toBe(1);
+    } finally {
+      adapter.close();
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds `"console": "integratedTerminal" | "externalTerminal"` to the Bun `launch.json` configuration. When set, the debug adapter issues a DAP `runInTerminal` reverse request so VS Code spawns the debuggee in a real terminal instead of the Debug Console. Programs that read from stdin (`readline`, `prompt`, `process.stdin`) now work under the debugger.

Default remains `"internalConsole"` (unchanged behaviour).

## Why

Today the debug adapter always spawns the debuggee with `stdio: ["ignore", "pipe", "pipe"]`, so stdin reads return immediately and the Debug Console cannot accept input. Node's debugger solves this with `"console": "integratedTerminal"`; Bun's adapter ignored that field.

## How

- `packages/bun-debug-adapter-protocol/src/debugger/adapter.ts`
  - `LaunchRequest` gains a `console` field.
  - `#reverseRequest` becomes `protected reverseRequest(...)` returning a `Promise<DAP.Response>`; the `Adapter.reverseRequest` event now carries a reply callback so the host can deliver the client's response.
  - `#launch` unifies the unix/windows signal setup, then either calls the existing `#spawn` (internal console) or sends a `runInTerminal` reverse request with the inspector env vars. Falls back to `#spawn` when the client did not advertise `supportsRunInTerminalRequest`.
  - After a successful `runInTerminal` response, emits the DAP `process` event so the client knows the debuggee started.
  - Only the inspector env vars and the user's explicit `env` are sent to the terminal (the terminal already has its own environment); `FORCE_COLOR` is not injected there since it is a real TTY.
- `packages/bun-vscode/src/features/debug.ts`
  - `Adapter.reverseRequest` listener forwards the reply from `sendRequest` back to the adapter.
  - `handleMessage` routes `type: "response"` to `super.handleMessage` so `@vscode/debugadapter` can dispatch the `sendRequest` callback.
- `packages/bun-vscode/package.json`
  - Adds the `console` enum to the launch configuration schema.

## Test

`test/cli/inspect/debug-adapter.test.ts` drives `WebSocketDebugAdapter` directly:

- `integratedTerminal` emits exactly one `runInTerminal` reverse request with `kind: "integrated"`, the right `args`/`cwd`, the inspector env vars, and no `Process.requested` spawn.
- `externalTerminal` maps to `kind: "external"`.
- When the client initializes with `supportsRunInTerminalRequest: false`, the adapter falls back to spawning.
- Default (no `console`) still spawns as before.

```
bun bd test test/cli/inspect/debug-adapter.test.ts
# 4 pass, 0 fail
```

With `packages/` stashed (current behaviour), the two terminal tests fail because no reverse request is emitted.

Fixes #15706
Closes #12746
Closes #10153

Builds on the approach from #29217 by @flyor2017.


Partially addresses #8767 (`console` only; `envFile` is a follow-up).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/debug-adapter.test.ts
bun test v1.4.0 (8f1db4047)

test/cli/inspect/debug-adapter.test.ts:
35 |         cwd: process.cwd(),
36 |         console: "integratedTerminal",
37 |         env: { MY_VAR: "1" },
38 |       } as DAP.LaunchRequest);
39 | 
40 |       expect(reverseRequests.length).toBe(1);
                                          ^
error: expect(received).toBe(expected)

Expected: 1
Received: 0

      at <anonymous> (/workspace/bun/test/cli/inspect/debug-adapter.test.ts:40:38)
(fail) launch console > integratedTerminal sends runInTerminal reverse request [452.61ms]
89 |         program: "script.ts",
90 |         cwd: process.cwd(),
91 |         console: "externalTerminal",
92 |       } as DAP.LaunchRequest);
93 | 
94 |       expect(kind).toBe("external");
                        ^
error: expect(received).toBe(expected)

Expected: "external"
Received: undefined

      at <anonymous> (/workspace/bun/test/cli/inspect/debug-adapter.test.ts:94:20)
(fail) launch console > externalTerminal sends runInTerminal with kind 
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (bf425d96e)

test/cli/inspect/debug-adapter.test.ts:
35 |         cwd: process.cwd(),
36 |         console: "integratedTerminal",
37 |         env: { MY_VAR: "1" },
38 |       } as DAP.LaunchRequest);
39 | 
40 |       expect(reverseRequests.length).toBe(1);
                                          ^
error: expect(received).toBe(expected)

Expected: 1
Received: 0

      at <anonymous> (/workspace/bun/test/cli/inspect/debug-adapter.test.ts:40:38)
(fail) launch console > integratedTerminal sends runInTerminal reverse request [9.48ms]
89 |         program: "script.ts",
90 |         cwd: process.cwd(),
91 |         console: "externalTerminal",
92 |       } as DAP.LaunchRequest);
93 | 
94 |       expect(kind).toBe("external");
                        ^
error: expect(received).toBe(expected)

Expected: "external"
Received: undefined

      at <anonymous> (/workspace/bun/test/cli/inspect/debug-adapter.test.ts:94:20)
(fail) launch console > externalTerminal sends runInTerminal with kind external [1.18ms]
(pass) launch console > falls back to spawn when client lacks runInTerminal support [0.91ms]
(pass) launch console > default internalConsole still 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/debug-adapter.test.ts
bun test v1.4.0 (8f1db4047)

test/cli/inspect/debug-adapter.test.ts:
(pass) launch console > integratedTerminal sends runInTerminal reverse request [251.29ms]
(pass) launch console > externalTerminal sends runInTerminal with kind external [26.89ms]
(pass) launch console > falls back to spawn when client lacks runInTerminal support [190.25ms]
(pass) launch console > default internalConsole still spawns [44.44ms]
(pass) launch console > terminal launch with watchMode=false emits terminated on inspector disconnect 1 time(s) [36.96ms]
(pass) launch console > terminal launch with watchMode=true emits terminated on inspector disconnect 0 time(s) [13.32ms]

 6 pass
 0 fail
 18 expect() calls
Ran 6 tests across 1 file. [4.02s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 776ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../src/debugger/adapter.ts                        | 155 ++++++++++------
 packages/bun-vscode/package.json                   |  15 ++
 packages/bun-vscode/src/features/debug.ts          |   8 +-
 test/cli/inspect/debug-adapter.test.ts             | 200 +++++++++++++++++++++
 4 files changed, 319 insertions(+), 59 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…ages/bun-debug-adapter-protocol/src/debugger/adapter.ts     10     16      0
packages/bun-vscode/package.json                              1      1      0
packages/bun-vscode/src/features/debug.ts                     2      1      0
test/cli/inspect/debug-adapter.test.ts                        1      3      0
```

</details>

<!-- robobun:evidence:end -->