### PR TITLE
types: add Bun's FreeBSD platform values to navigator.platform

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1432,7 +1432,7 @@ interface PromiseConstructor {
 
 interface Navigator {
   readonly userAgent: string;
-  readonly platform: "MacIntel" | "Win32" | "Linux x86_64";
+  readonly platform: "MacIntel" | "Win32" | "Linux x86_64" | "FreeBSD arm64" | "FreeBSD amd64";
   readonly hardwareConcurrency: number;
 }
 

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -556,6 +556,34 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  describe("navigator.platform", () => {
+    typeTest("includes Bun's FreeBSD platform values", {
+      files: {
+        "navigator-platform.ts": `
+          // navigator.platform values come from functionNavigatorGetPlatform in
+          // src/jsc/bindings/ZigGlobalObject.cpp — Bun ships MacIntel, Win32,
+          // Linux x86_64, and the two FreeBSD variants.
+          const macIntel: typeof navigator.platform = "MacIntel";
+          const win32: typeof navigator.platform = "Win32";
+          const linux: typeof navigator.platform = "Linux x86_64";
+          const freebsdArm: typeof navigator.platform = "FreeBSD arm64";
+          const freebsdAmd: typeof navigator.platform = "FreeBSD amd64";
+          void macIntel;
+          void win32;
+          void linux;
+          void freebsdArm;
+          void freebsdAmd;
+          export {};
+        `,
+      },
+      emptyInterfaces: expectedEmptyInterfacesWhenNoDOM,
+      diagnostics: diagnostics => {
+        const relevantDiagnostics = diagnostics.filter(d => d.line?.startsWith("navigator-platform.ts"));
+        expect(relevantDiagnostics).toEqual([]);
+      },
+    });
+  });
+
   describe("Bunland reaching for JSX", () => {
     typeTest("Bun.markdown.react() returns type compatible with React.ReactElement", {
       packages: ["@types/react", "@types/react-dom"],


### PR DESCRIPTION
### What does this PR do?

`Navigator["platform"]` in `packages/bun-types/globals.d.ts` is typed as a closed union of three values:

```ts
readonly platform: "MacIntel" | "Win32" | "Linux x86_64";
```

But the runtime returns two more. `functionNavigatorGetPlatform` in [`src/jsc/bindings/ZigGlobalObject.cpp`](https://github.com/oven-sh/bun/blob/main/src/jsc/bindings/ZigGlobalObject.cpp) also handles FreeBSD (a supported target — there's a `freebsd-smoke` CI workflow and `x86_64/aarch64-freebsd` build targets):

```cpp
#elif OS(FREEBSD)
#if CPU(ARM64)
    return ... String("FreeBSD arm64"_s);
#else
    return ... String("FreeBSD amd64"_s);
#endif
```

So on FreeBSD, `navigator.platform` is `"FreeBSD arm64"` or `"FreeBSD amd64"` — values the type doesn't include, so narrowing against them was a compile error. This adds both literals to the union so the type matches the runtime on every shipped platform. (The `#else` fallback returns an empty string only on unsupported OSes, so it's left out of the union of real platform values.)

### How did you verify your code works?

- Cross-checked every branch of `functionNavigatorGetPlatform` against the union.
- Added a case to `test/integration/bun-types/bun-types.test.ts` (`navigator.platform`) asserting all five platform literals are assignable to `typeof navigator.platform`.
  - It **passes** with this change and **fails** without it: reverting the `.d.ts` produces `Type '"FreeBSD arm64"' is not assignable to type '"MacIntel" | "Win32" | "Linux x86_64"'` (2322) and the same for `"FreeBSD amd64"`, while the three existing values still type-check.
- Ran the full `bun test test/integration/bun-types/bun-types.test.ts` suite; the existing `checks with lib.dom.d.ts` case still passes, confirming widening the union doesn't perturb the lib.dom merge.
