### PR TITLE
pack: resolve workspace:* to the dependency's package.json version, not bun.lock's

### DIFF
--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -3297,10 +3297,8 @@ fn add_archive_entry(
     Ok(entry.clear())
 }
 
-/// Read the `"version"` field from a workspace dependency's `package.json` on
-/// disk. The lockfile is only used to map `dependency_name` to its relative
-/// workspace path. Returns `None` on any I/O or parse failure so callers can
-/// fall back to `lockfile.workspace_versions`.
+/// Read `"version"` from a workspace dependency's on-disk `package.json`.
+/// `None` on I/O/parse failure.
 fn read_workspace_version_from_package_json(
     lockfile: &Lockfile,
     dependency_name: &[u8],
@@ -3398,10 +3396,7 @@ fn edit_root_package_json(
                                         b'*' => b"",
                                         _ => unreachable!(),
                                     };
-                                    // Prefer the dependency's on-disk `package.json` version so
-                                    // a version bump that has not yet been written back to
-                                    // `bun.lock` is still picked up (issue #20477). Fall back to
-                                    // `lockfile.workspace_versions` if the file cannot be read.
+                                    // on-disk package.json wins; bun.lock's cached version may be stale (#20477)
                                     let tmp = if let Some(version) =
                                         read_workspace_version_from_package_json(
                                             lockfile,

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -29,6 +29,7 @@ use crate::cli::run_command::RunCommand;
 use bun_core::ZBox;
 use bun_core::{ZStr, strings};
 use bun_paths::resolve_path;
+use bun_resolver::fs::FileSystem;
 use bun_semver as Semver;
 use bun_sha_hmac::sha;
 use bun_sys::{
@@ -3296,6 +3297,37 @@ fn add_archive_entry(
     Ok(entry.clear())
 }
 
+/// Read the `"version"` field from a workspace dependency's `package.json` on
+/// disk. The lockfile is only used to map `dependency_name` to its relative
+/// workspace path. Returns `None` on any I/O or parse failure so callers can
+/// fall back to `lockfile.workspace_versions`.
+fn read_workspace_version_from_package_json(
+    lockfile: &Lockfile,
+    dependency_name: &[u8],
+) -> Option<&'static [u8]> {
+    let name_hash = Semver::string::Builder::string_hash(dependency_name);
+    let workspace_path = lockfile.workspace_paths.get(&name_hash)?;
+    let workspace_path = lockfile.str(workspace_path);
+
+    let mut path_buf = PathBuffer::uninit();
+    let abs_package_json = resolve_path::join_abs_string_buf_z::<resolve_path::platform::Auto>(
+        FileSystem::instance().top_level_dir(),
+        &mut path_buf,
+        &[workspace_path, b"package.json"],
+    );
+
+    let bytes = File::read_from(Fd::cwd(), abs_package_json).ok()?;
+    let source = bun_ast::Source::init_path_string_owned(abs_package_json.as_bytes(), bytes);
+    let mut log = bun_ast::Log::init();
+    let json = JSON::parse_package_json_utf8(&source, &mut log, pack_bump()).ok()?;
+
+    let version = json.get(b"version")?.as_string(pack_bump())?;
+    if version.is_empty() {
+        return None;
+    }
+    Some(pack_bump().alloc_slice_copy(version))
+}
+
 /// Strips workspace and catalog protocols from dependency versions then
 /// returns the printed json
 fn edit_root_package_json(
@@ -3360,26 +3392,40 @@ fn edit_root_package_json(
                                     let Some(lockfile) = maybe_lockfile else {
                                         break 'failed_to_resolve false;
                                     };
-                                    let Some(workspace_version) = lockfile.workspace_versions.get(
-                                        &Semver::string::Builder::string_hash(dependency_name),
-                                    ) else {
-                                        break 'failed_to_resolve false;
-                                    };
                                     let prefix: &[u8] = match c {
                                         b'^' => b"^",
                                         b'~' => b"~",
                                         b'*' => b"",
                                         _ => unreachable!(),
                                     };
-                                    // Format on the heap then copy into the
-                                    // pack arena; `EString::init` erases the
-                                    // lifetime.
-                                    let tmp = format!(
-                                        "{}{}",
-                                        bstr::BStr::new(prefix),
-                                        workspace_version
-                                            .fmt(lockfile.buffers.string_bytes.as_slice()),
-                                    );
+                                    // Prefer the dependency's on-disk `package.json` version so
+                                    // a version bump that has not yet been written back to
+                                    // `bun.lock` is still picked up (issue #20477). Fall back to
+                                    // `lockfile.workspace_versions` if the file cannot be read.
+                                    let tmp = if let Some(version) =
+                                        read_workspace_version_from_package_json(
+                                            lockfile,
+                                            dependency_name,
+                                        ) {
+                                        format!(
+                                            "{}{}",
+                                            bstr::BStr::new(prefix),
+                                            bstr::BStr::new(version),
+                                        )
+                                    } else if let Some(workspace_version) =
+                                        lockfile.workspace_versions.get(
+                                            &Semver::string::Builder::string_hash(dependency_name),
+                                        )
+                                    {
+                                        format!(
+                                            "{}{}",
+                                            bstr::BStr::new(prefix),
+                                            workspace_version
+                                                .fmt(lockfile.buffers.string_bytes.as_slice()),
+                                        )
+                                    } else {
+                                        break 'failed_to_resolve false;
+                                    };
                                     let data = pack_bump().alloc_slice_copy(tmp.as_bytes());
                                     dependency.value = Some(Expr::init(
                                         E::EString::init(data),

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -3412,10 +3412,9 @@ fn edit_root_package_json(
                                             bstr::BStr::new(prefix),
                                             bstr::BStr::new(version),
                                         )
-                                    } else if let Some(workspace_version) =
-                                        lockfile.workspace_versions.get(
-                                            &Semver::string::Builder::string_hash(dependency_name),
-                                        )
+                                    } else if let Some(workspace_version) = lockfile
+                                        .workspace_versions
+                                        .get(&Semver::string::Builder::string_hash(dependency_name))
                                     {
                                         format!(
                                             "{}{}",

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -3396,7 +3396,7 @@ fn edit_root_package_json(
                                         b'*' => b"",
                                         _ => unreachable!(),
                                     };
-                                    // on-disk package.json wins; bun.lock's cached version may be stale (#20477)
+                                    // on-disk version is authoritative; the lockfile's cached version may be stale
                                     let tmp = if let Some(version) =
                                         read_workspace_version_from_package_json(
                                             lockfile,

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -743,6 +743,46 @@ describe("workspaces", () => {
     });
   }
 
+  test("falls back to lockfile version when workspace package.json has no version", async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "root",
+          private: true,
+          workspaces: ["pkgs/*"],
+        }),
+      ),
+      write(join(packageDir, "pkgs", "pkg-a", "package.json"), JSON.stringify({ name: "pkg-a", version: "1.0.0" })),
+      write(
+        join(packageDir, "pkgs", "pkg-b", "package.json"),
+        JSON.stringify({
+          name: "pkg-b",
+          version: "1.0.0",
+          dependencies: { "pkg-a": "workspace:*" },
+        }),
+      ),
+    ]);
+
+    await runBunInstall(bunEnv, packageDir);
+
+    // Drop the version field so the on-disk read yields nothing and pack has
+    // to fall back to the lockfile's cached workspace version.
+    await write(join(packageDir, "pkgs", "pkg-a", "package.json"), JSON.stringify({ name: "pkg-a" }));
+
+    await pack(join(packageDir, "pkgs", "pkg-b"), bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pkgs", "pkg-b", "pkg-b-1.0.0.tgz"));
+    expect(tarball.entries).toMatchObject([{ "pathname": "package/package.json" }]);
+    expect(JSON.parse(tarball.entries[0].contents)).toEqual({
+      name: "pkg-b",
+      version: "1.0.0",
+      dependencies: {
+        "pkg-a": "1.0.0",
+      },
+    });
+  });
+
   test("fails gracefully when workspace version fails to resolve", async () => {
     await Promise.all([
       write(

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -691,6 +691,58 @@ describe("workspaces", () => {
     });
   }
 
+  // https://github.com/oven-sh/bun/issues/20477
+  const staleLockfileWorkspaceProtocolTests = [
+    { input: "workspace:*", expected: "2.0.0" },
+    { input: "workspace:^", expected: "^2.0.0" },
+    { input: "workspace:~", expected: "~2.0.0" },
+  ];
+
+  for (const { input, expected } of staleLockfileWorkspaceProtocolTests) {
+    test(`replaces ${input} with package.json version when lockfile is stale (#20477)`, async () => {
+      await Promise.all([
+        write(
+          join(packageDir, "package.json"),
+          JSON.stringify({
+            name: "root",
+            private: true,
+            workspaces: ["pkgs/*"],
+          }),
+        ),
+        write(join(packageDir, "pkgs", "pkg-a", "package.json"), JSON.stringify({ name: "pkg-a", version: "1.0.0" })),
+        write(
+          join(packageDir, "pkgs", "pkg-b", "package.json"),
+          JSON.stringify({
+            name: "pkg-b",
+            version: "1.0.0",
+            dependencies: { "pkg-a": input },
+          }),
+        ),
+      ]);
+
+      await runBunInstall(bunEnv, packageDir);
+
+      // Bump pkg-a's version on disk without re-running `bun install`, so the
+      // lockfile's cached workspace version is stale.
+      await write(
+        join(packageDir, "pkgs", "pkg-a", "package.json"),
+        JSON.stringify({ name: "pkg-a", version: "2.0.0" }),
+      );
+
+      await pack(join(packageDir, "pkgs", "pkg-b"), bunEnv);
+
+      const tarball = readTarball(join(packageDir, "pkgs", "pkg-b", "pkg-b-1.0.0.tgz"));
+      expect(tarball.entries).toMatchObject([{ "pathname": "package/package.json" }]);
+      expect(JSON.parse(tarball.entries[0].contents)).toEqual({
+        name: "pkg-b",
+        version: "1.0.0",
+        dependencies: {
+          "pkg-a": expected,
+        },
+      });
+    });
+  }
+
   test("fails gracefully when workspace version fails to resolve", async () => {
     await Promise.all([
       write(


### PR DESCRIPTION
## What does this PR do?

When packing a workspace package that depends on another workspace package via `workspace:*`, `workspace:^` or `workspace:~`, `bun pm pack` resolved the substituted version from `lockfile.workspace_versions`. That map holds whatever was in the dependency's `package.json` at the last `bun install`, so bumping a workspace package's version and packing a dependent without regenerating the lockfile produced a tarball pinned to the stale version. This is the common flow for changesets/lerna/release-please style release tooling, and it contradicts the docs ("replaced by the package's `package.json` version").

### Repro

```sh
# workspace root with packages/pkg-a@1.0.0 and packages/pkg-b depending on pkg-a via workspace:*
bun install
# release tool bumps pkg-a
echo '{"name":"pkg-a","version":"2.0.0"}' > packages/pkg-a/package.json
cd packages/pkg-b && bun pm pack
tar -xzOf pkg-b-1.0.0.tgz package/package.json
# dependencies.pkg-a is "1.0.0", should be "2.0.0"
```

### Fix

`edit_root_package_json` now reads the dependency's `package.json` from disk (its path is already in `lockfile.workspace_paths`) and uses its `version` field. It falls back to `lockfile.workspace_versions` only if the file cannot be read or parsed, so behavior is unchanged when the package.json is missing.

This matches pnpm's behavior.

### How did you verify your code works?

Added parameterized tests to `test/cli/install/bun-pack.test.ts` covering `workspace:*`, `workspace:^`, `workspace:~` with a lockfile that is stale relative to the on-disk `package.json`, plus a fallback case where the dependency's `package.json` has no version field. The first three fail on main and pass with this change; the fallback case passes in both. Existing workspace-protocol tests still pass.

Fixes #20477
Fixes #20829
Fixes #28935

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-pack.test.ts
bun test v1.4.0 (0fd26804f)

test/cli/install/bun-pack.test.ts:
(pass) basic [194.99ms]
(pass) in subdirectory [381.18ms]
(pass) package.json names and versions > rejects name and version containing parent directory components [472.51ms]
(pass) package.json names and versions > missing name [151.49ms]
(pass) package.json names and versions > missing version [138.30ms]
(pass) package.json names and versions > missing name and version [151.12ms]
(pass) package.json names and versions > empty name [146.37ms]
(pass) package.json names and versions > empty version [146.87ms]
(pass) package.json names and versions > empty name and version [147.54ms]
(pass) package.json names and versions > missing [129.74ms]
(pass) package.json names and versions > scoped name: @scoped/pkg [169.20ms]
(pass) package.json names and versions > scoped name: @ [167.66ms]
(pass) package.json names and versions > scoped name: @/ [170.14ms]
(pass) package.json names and versions > scoped name: // [159.55ms]
(pass) package.json names
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (199974e57)

test/cli/install/bun-pack.test.ts:
(pass) basic [28.95ms]
(pass) in subdirectory [9.79ms]
(pass) package.json names and versions > rejects name and version containing parent directory components [10.83ms]
(pass) package.json names and versions > missing name [2.62ms]
(pass) package.json names and versions > missing version [2.18ms]
(pass) package.json names and versions > missing name and version [2.41ms]
(pass) package.json names and versions > empty name [2.30ms]
(pass) package.json names and versions > empty version [2.31ms]
(pass) package.json names and versions > empty name and version [2.80ms]
(pass) package.json names and versions > missing [8.71ms]
(pass) package.json names and versions > scoped name: @scoped/pkg [4.69ms]
(pass) package.json names and versions > scoped name: @ [4.72ms]
(pass) package.json names and versions > scoped name: @/ [4.05ms]
(pass) package.json names and versions > scoped name: // [3.96ms]
(pass) package.json names and versions > scoped name: @// [4.11ms]
(pass) package.json names and versions > scoped name: @/s [4.02ms]
(pass) package.json names and versions > scoped name: @s [5.22ms]
(pass) fl
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-pack.test.ts
bun test v1.4.0 (0fd26804f)

test/cli/install/bun-pack.test.ts:
(pass) basic [255.76ms]
(pass) in subdirectory [479.30ms]
(pass) package.json names and versions > rejects name and version containing parent directory components [663.72ms]
(pass) package.json names and versions > missing name [233.93ms]
(pass) package.json names and versions > missing version [188.16ms]
(pass) package.json names and versions > missing name and version [189.46ms]
(pass) package.json names and versions > empty name [173.50ms]
(pass) package.json names and versions > empty version [242.59ms]
(pass) package.json names and versions > empty name and version [169.37ms]
(pass) package.json names and versions > missing [148.32ms]
(pass) package.json names and versions > scoped name: @scoped/pkg [206.56ms]
(pass) package.json names and versions > scoped name: @ [185.03ms]
(pass) package.json names and versions > scoped name: @/ [257.80ms]
(pass) package.json names and versions > scoped name: // [180.74ms]
(pass) package.json names
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 842ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/pack_command.rs   | 68 +++++++++++++++++++++++------
 test/cli/install/bun-pack.test.ts | 92 +++++++++++++++++++++++++++++++++++++++
 2 files changed, 146 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/cli/pack_command.rs        9      8      0
test/cli/install/bun-pack.test.ts      4      3      0
```

</details>

<!-- robobun:evidence:end -->