### PR TITLE
serve: add ignoreTrailingSlash and ignoreDuplicateSlashes route options

### DIFF
--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -98,6 +98,24 @@ Bun.serve({
 
 ---
 
+## Trailing and duplicate slashes
+
+By default, route matching is exact: `/api/users` and `/api/users/` are different paths. Set `ignoreTrailingSlash` and/or `ignoreDuplicateSlashes` to make the router lenient:
+
+```ts
+Bun.serve({
+  ignoreTrailingSlash: true, // `/api/users/` matches `/api/users`
+  ignoreDuplicateSlashes: true, // `//api//users` matches `/api/users`
+  routes: {
+    "/api/users": () => new Response("Users"),
+  },
+});
+```
+
+Only the routing key is normalized. `request.url` still contains the path as sent by the client.
+
+---
+
 ## Type-safe route parameters
 
 TypeScript parses route parameters when passed as a string literal, so your editor shows autocomplete when accessing `request.params`.

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -844,6 +844,20 @@ declare module "bun" {
       ipv6Only?: boolean;
 
       /**
+       * Match routes while ignoring a trailing slash, so `/api/users/` matches a
+       * route registered as `/api/users`. A lone root `/` is preserved.
+       * @default false
+       */
+      ignoreTrailingSlash?: boolean;
+
+      /**
+       * Match routes while collapsing duplicate slashes, so `//api//users`
+       * matches a route registered as `/api/users`.
+       * @default false
+       */
+      ignoreDuplicateSlashes?: boolean;
+
+      /**
        * Also listen for HTTP/3 (QUIC) on the same port. Requires {@link tls}.
        * @default false
        * @experimental

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -764,6 +764,20 @@ declare module "bun" {
       maxRequestBodySize?: number;
 
       /**
+       * Match routes while ignoring a trailing slash, so `/api/users/` matches a
+       * route registered as `/api/users`. A lone root `/` is preserved.
+       * @default false
+       */
+      ignoreTrailingSlash?: boolean;
+
+      /**
+       * Match routes while collapsing duplicate slashes, so `//api//users`
+       * matches a route registered as `/api/users`.
+       * @default false
+       */
+      ignoreDuplicateSlashes?: boolean;
+
+      /**
        * Whether to render contextual errors with Bun's error page
        * @default process.env.NODE_ENV !== 'production'
        */
@@ -842,20 +856,6 @@ declare module "bun" {
        * @default false
        */
       ipv6Only?: boolean;
-
-      /**
-       * Match routes while ignoring a trailing slash, so `/api/users/` matches a
-       * route registered as `/api/users`. A lone root `/` is preserved.
-       * @default false
-       */
-      ignoreTrailingSlash?: boolean;
-
-      /**
-       * Match routes while collapsing duplicate slashes, so `//api//users`
-       * matches a route registered as `/api/users`.
-       * @default false
-       */
-      ignoreDuplicateSlashes?: boolean;
 
       /**
        * Also listen for HTTP/3 (QUIC) on the same port. Requires {@link tls}.

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -113,6 +113,8 @@ private:
         HttpRouter<typename HttpContextData<SSL>::RouterData> *router;
     };
     std::vector<PendingServerName> pendingServerNames;
+    bool ignoreTrailingSlashFlag = false;
+    bool ignoreDuplicateSlashesFlag = false;
     /* No raw us_listen_socket_t* cache here. src/runtime/server/mod.rs's non-abrupt stop calls
      * us_listen_socket_close(ls) directly; the listener is queued for free in
      * loop_post, so any vector we kept would dangle by the time the deferred
@@ -152,6 +154,7 @@ public:
                 us_ssl_ctx_set_sni_policy(domainCtx, options.request_cert, options.reject_unauthorized);
             }
             auto *domainRouter = new HttpRouter<typename HttpContextData<SSL>::RouterData>();
+            domainRouter->setSlashNormalization(ignoreTrailingSlashFlag, ignoreDuplicateSlashesFlag);
             int result = 0;
             forEachListenSocket([&](us_listen_socket_t *ls) {
                 result |= us_listen_socket_add_server_name(ls, hostname_pattern.c_str(), domainCtx, domainRouter);
@@ -773,6 +776,16 @@ public:
 
     TemplatedApp &&setMaxHTTPHeaderSize(uint64_t maxHeaderSize) {
         httpContext->getSocketContextData()->maxHeaderSize = maxHeaderSize;
+        return std::move(*this);
+    }
+
+    TemplatedApp &&setSlashNormalization(bool ignoreTrailingSlash, bool ignoreDuplicateSlashes) {
+        httpContext->getSocketContextData()->router.setSlashNormalization(ignoreTrailingSlash, ignoreDuplicateSlashes);
+        for (auto &p : pendingServerNames) {
+            p.router->setSlashNormalization(ignoreTrailingSlash, ignoreDuplicateSlashes);
+        }
+        ignoreTrailingSlashFlag = ignoreTrailingSlash;
+        ignoreDuplicateSlashesFlag = ignoreDuplicateSlashes;
         return std::move(*this);
     }
 

--- a/packages/bun-uws/src/Http3App.h
+++ b/packages/bun-uws/src/Http3App.h
@@ -53,6 +53,9 @@ struct H3App {
     void clearRoutes() {
         http3Context->getContextData()->router = decltype(http3Context->getContextData()->router){};
     }
+    void setSlashNormalization(bool ignoreTrailingSlash, bool ignoreDuplicateSlashes) {
+        http3Context->getContextData()->router.setSlashNormalization(ignoreTrailingSlash, ignoreDuplicateSlashes);
+    }
     /* GOAWAY + drain. The engine itself is torn down in the destructor. */
     void close() { http3Context->shutdown(); }
     bool addServerNameWithOptions(const char *hostname, SocketContextOptions options) {

--- a/packages/bun-uws/src/HttpRouter.h
+++ b/packages/bun-uws/src/HttpRouter.h
@@ -52,6 +52,12 @@ private:
     std::string_view urlSegmentVector[MAX_URL_SEGMENTS] = {};
     int urlSegmentTop = -1;
 
+    /* Lenient slash matching (default off). See setSlashNormalization(). */
+    bool ignoreTrailingSlash = false;
+    bool ignoreDuplicateSlashes = false;
+    /* Backing buffer that currentUrl may view after cleanSlashes(). */
+    std::string normalizedUrl;
+
     /* The matching tree */
     struct Node {
         std::string name = {};
@@ -118,10 +124,36 @@ private:
         }
     } routeParameters;
 
+    /* Collapse duplicate and/or trailing slashes per the flags. */
+    std::string_view cleanSlashes(std::string_view url) {
+        normalizedUrl.clear();
+        normalizedUrl.reserve(url.size());
+
+        bool lastWasSlash = false;
+        for (char c : url) {
+            if (c == '/' && lastWasSlash && ignoreDuplicateSlashes) {
+                continue;
+            }
+            normalizedUrl.push_back(c);
+            lastWasSlash = (c == '/');
+        }
+
+        /* Trim a trailing slash, keeping the root "/". */
+        if (ignoreTrailingSlash && normalizedUrl.size() > 1 && normalizedUrl.back() == '/') {
+            normalizedUrl.pop_back();
+        }
+
+        return normalizedUrl;
+    }
+
     /* Set URL for router. Will reset any URL cache */
     void setUrl(std::string_view url) {
 
         /* Todo: URL may also start with "http://domain/" or "*", not only "/" */
+
+        if (ignoreTrailingSlash || ignoreDuplicateSlashes) {
+            url = cleanSlashes(url);
+        }
 
         /* We expect to stand on a slash */
         currentUrl = url;
@@ -241,6 +273,12 @@ public:
     HttpRouter() {
         /* Always have ANY route */
         getNode(&root, std::string(ANY_METHOD_TOKEN), false);
+    }
+
+    /* Enable lenient slash matching (default off). */
+    void setSlashNormalization(bool ignoreTrailing, bool ignoreDuplicate) {
+        ignoreTrailingSlash = ignoreTrailing;
+        ignoreDuplicateSlashes = ignoreDuplicate;
     }
 
     std::pair<int, std::string_view *> getParameters() {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -64,6 +64,8 @@ pub struct ServerConfig {
     pub(crate) ipv6_only: bool,
     pub(crate) http3: bool,
     pub(crate) http1: bool,
+    pub(crate) ignore_trailing_slash: bool,
+    pub(crate) ignore_duplicate_slashes: bool,
 
     pub(crate) had_routes_object: bool,
 
@@ -98,6 +100,8 @@ impl Default for ServerConfig {
             ipv6_only: false,
             http3: false,
             http1: true,
+            ignore_trailing_slash: false,
+            ignore_duplicate_slashes: false,
             had_routes_object: false,
             static_routes: Vec::new(),
             negative_routes: Vec::new(),
@@ -296,6 +300,8 @@ impl ServerConfig {
             ipv6_only: self.ipv6_only,
             http3: self.http3,
             http1: self.http1,
+            ignore_trailing_slash: self.ignore_trailing_slash,
+            ignore_duplicate_slashes: self.ignore_duplicate_slashes,
             had_routes_object: self.had_routes_object,
             static_routes: core::mem::take(&mut self.static_routes),
             negative_routes: core::mem::take(&mut self.negative_routes),
@@ -1170,6 +1176,20 @@ impl ServerConfig {
 
         if let Some(dev) = arg.get(global, "ipv6Only")? {
             args.ipv6_only = dev.to_boolean();
+        }
+        if global.has_exception() {
+            return Err(JsError::Thrown);
+        }
+
+        if let Some(v) = arg.get(global, "ignoreTrailingSlash")? {
+            args.ignore_trailing_slash = v.to_boolean();
+        }
+        if global.has_exception() {
+            return Err(JsError::Thrown);
+        }
+
+        if let Some(v) = arg.get(global, "ignoreDuplicateSlashes")? {
+            args.ignore_duplicate_slashes = v.to_boolean();
         }
         if global.has_exception() {
             return Err(JsError::Thrown);

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2235,6 +2235,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
         // set_routes is only called after `self.app = Some(..)` in listen().
         let app = bun_opaque::opaque_deref_mut(self.app.unwrap());
+        // Apply before routes register so registered patterns are normalized too.
+        app.set_slash_normalization(
+            self.config.ignore_trailing_slash,
+            self.config.ignore_duplicate_slashes,
+        );
         let self_ptr: *mut Self = self;
         let any_server = AnyServer::from(self_ptr.cast_const());
         // reshaped for borrowck — `dev_server` is `Option<Box<..>>`;

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2240,6 +2240,15 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             self.config.ignore_trailing_slash,
             self.config.ignore_duplicate_slashes,
         );
+        if Self::HAS_H3 {
+            if let Some(h3_app) = self.h3_app {
+                // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
+                bun_opaque::opaque_deref_mut(h3_app).set_slash_normalization(
+                    self.config.ignore_trailing_slash,
+                    self.config.ignore_duplicate_slashes,
+                );
+            }
+        }
         let self_ptr: *mut Self = self;
         let any_server = AnyServer::from(self_ptr.cast_const());
         // reshaped for borrowck — `dev_server` is `Option<Box<..>>`;

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -150,6 +150,19 @@ impl<const SSL: bool> App<SSL> {
         c::uws_app_set_max_http_header_size(Self::SSL_FLAG, self.as_raw(), max_header_size)
     }
 
+    pub fn set_slash_normalization(
+        &mut self,
+        ignore_trailing_slash: bool,
+        ignore_duplicate_slashes: bool,
+    ) {
+        c::uws_app_set_slash_normalization(
+            Self::SSL_FLAG,
+            self.as_raw(),
+            ignore_trailing_slash,
+            ignore_duplicate_slashes,
+        )
+    }
+
     pub fn clear_routes(&mut self) {
         c::uws_app_clear_routes(Self::SSL_FLAG, self.as_raw())
     }
@@ -547,6 +560,12 @@ pub mod c {
             ssl: i32,
             app: &mut uws_app_t,
             max_header_size: u64,
+        );
+        pub(crate) safe fn uws_app_set_slash_normalization(
+            ssl: i32,
+            app: &mut uws_app_t,
+            ignore_trailing_slash: bool,
+            ignore_duplicate_slashes: bool,
         );
         pub(crate) fn uws_app_get(
             ssl: i32,

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -421,6 +421,13 @@ impl App {
     pub fn clear_routes(&mut self) {
         c::uws_h3_app_clear_routes(self)
     }
+    pub fn set_slash_normalization(
+        &mut self,
+        ignore_trailing_slash: bool,
+        ignore_duplicate_slashes: bool,
+    ) {
+        c::uws_h3_app_set_slash_normalization(self, ignore_trailing_slash, ignore_duplicate_slashes)
+    }
 
     fn route<UD, H>(which: RouteKind, this: &mut App, pattern: &[u8], ud: *mut UD, _handler: H)
     where
@@ -596,6 +603,11 @@ mod c {
         pub(super) fn uws_h3_app_destroy(app: *mut App);
         pub(super) safe fn uws_h3_app_close(app: &mut App);
         pub(super) safe fn uws_h3_app_clear_routes(app: &mut App);
+        pub(super) safe fn uws_h3_app_set_slash_normalization(
+            app: &mut App,
+            ignore_trailing_slash: bool,
+            ignore_duplicate_slashes: bool,
+        );
         pub(super) fn uws_h3_app_add_server_name(
             app: *mut App,
             hostname: *const c_char,

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -516,6 +516,15 @@ extern "C"
       uwsApp->setFlags(require_host_header, use_strict_method_validation, lenient_http_flags, http_allow_half_open);
     }
   }
+  void uws_app_set_slash_normalization(int ssl, uws_app_t *app, bool ignore_trailing_slash, bool ignore_duplicate_slashes) {
+    if (ssl) {
+      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+      uwsApp->setSlashNormalization(ignore_trailing_slash, ignore_duplicate_slashes);
+    } else {
+      uWS::App *uwsApp = (uWS::App *)app;
+      uwsApp->setSlashNormalization(ignore_trailing_slash, ignore_duplicate_slashes);
+    }
+  }
 
   void uws_app_destroy(int ssl, uws_app_t *app)
   {

--- a/src/uws_sys/libuwsockets_h3.cpp
+++ b/src/uws_sys/libuwsockets_h3.cpp
@@ -52,6 +52,10 @@ uws_h3_app_t* uws_h3_create_app(struct us_bun_socket_context_options_t options, 
 void uws_h3_app_destroy(uws_h3_app_t* app) { delete (H3App*)app; }
 void uws_h3_app_close(uws_h3_app_t* app) { ((H3App*)app)->close(); }
 void uws_h3_app_clear_routes(uws_h3_app_t* app) { ((H3App*)app)->clearRoutes(); }
+void uws_h3_app_set_slash_normalization(uws_h3_app_t* app, bool ignore_trailing_slash, bool ignore_duplicate_slashes)
+{
+    ((H3App*)app)->setSlashNormalization(ignore_trailing_slash, ignore_duplicate_slashes);
+}
 
 bool uws_h3_app_add_server_name(uws_h3_app_t* app, const char* hostname,
     struct us_bun_socket_context_options_t options)

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -1136,9 +1136,9 @@ describe("ignoreTrailingSlash", () => {
     expect(await res.text()).toBe("/api/users");
   });
 
-  it("matches a trailing slash", async () => {
+  it("matches a trailing slash and keeps the raw request.url", async () => {
     const res = await fetch(new URL("/api/users/", server.url).href);
-    expect(await res.text()).not.toBe("fallback");
+    expect(await res.text()).toBe("/api/users/");
   });
 
   it("matches a static Response route with a trailing slash", async () => {
@@ -1149,11 +1149,6 @@ describe("ignoreTrailingSlash", () => {
   it("matches a param route with a trailing slash", async () => {
     const res = await fetch(new URL("/posts/123/", server.url).href);
     expect(await res.text()).toBe("123");
-  });
-
-  it("keeps the raw request.url (trailing slash preserved for the handler)", async () => {
-    const res = await fetch(new URL("/api/users/", server.url).href);
-    expect(await res.text()).toBe("/api/users/");
   });
 
   it("keeps the root route working", async () => {
@@ -1186,14 +1181,9 @@ describe("ignoreDuplicateSlashes", () => {
     server.stop(true);
   });
 
-  it("collapses duplicate slashes", async () => {
+  it("collapses duplicate slashes and keeps the raw request.url", async () => {
     const res = await fetch(`${server.url.origin}//api//users`);
-    expect(await res.text()).not.toBe("fallback");
-  });
-
-  it("keeps the raw request.url (duplicate slashes preserved for the handler)", async () => {
-    const res = await fetch(`${server.url.origin}//api//users`);
-    expect(await res.text()).toContain("//users");
+    expect(await res.text()).toBe("/api//users");
   });
 
   it("does not trim a trailing slash (that flag is off)", async () => {
@@ -1256,16 +1246,9 @@ describe("ignoreTrailingSlash + ignoreDuplicateSlashes", () => {
     server.stop(true);
   });
 
-  it("matches messy duplicate and trailing slashes together", async () => {
+  it("matches messy duplicate and trailing slashes together and keeps the raw request.url", async () => {
     const res = await fetch(`${server.url.origin}//api//users//`);
-    expect(await res.text()).not.toBe("fallback");
-  });
-
-  it("keeps the raw request.url (messy slashes preserved for the handler)", async () => {
-    const res = await fetch(`${server.url.origin}//api//users//`);
-    const pathname = await res.text();
-    expect(pathname).toContain("//users");
-    expect(pathname.endsWith("//")).toBe(true);
+    expect(await res.text()).toBe("/api//users//");
   });
 
   it("persists across server.reload()", async () => {

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -1107,3 +1107,175 @@ describe.concurrent("false route with no fetch handler", () => {
     await proc.exited;
   });
 });
+
+// https://github.com/oven-sh/bun/issues/17363
+describe("ignoreTrailingSlash", () => {
+  let server: Server;
+
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      ignoreTrailingSlash: true,
+      fetch: () => new Response("fallback"),
+      routes: {
+        "/": () => new Response("root"),
+        "/api/users": req => new Response(new URL(req.url).pathname),
+        "/api/static": new Response("static"),
+        "/posts/:id": req => new Response(req.params.id),
+      },
+    });
+    server.unref();
+  });
+
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  it("matches the exact path", async () => {
+    const res = await fetch(new URL("/api/users", server.url).href);
+    expect(await res.text()).toBe("/api/users");
+  });
+
+  it("matches a trailing slash", async () => {
+    const res = await fetch(new URL("/api/users/", server.url).href);
+    expect(await res.text()).not.toBe("fallback");
+  });
+
+  it("matches a static Response route with a trailing slash", async () => {
+    const res = await fetch(new URL("/api/static/", server.url).href);
+    expect(await res.text()).toBe("static");
+  });
+
+  it("matches a param route with a trailing slash", async () => {
+    const res = await fetch(new URL("/posts/123/", server.url).href);
+    expect(await res.text()).toBe("123");
+  });
+
+  it("keeps the raw request.url (trailing slash preserved for the handler)", async () => {
+    const res = await fetch(new URL("/api/users/", server.url).href);
+    expect(await res.text()).toBe("/api/users/");
+  });
+
+  it("keeps the root route working", async () => {
+    const res = await fetch(new URL("/", server.url).href);
+    expect(await res.text()).toBe("root");
+  });
+
+  it("does not collapse duplicate slashes (that flag is off)", async () => {
+    const res = await fetch(`${server.url.origin}//api//users`);
+    expect(await res.text()).toBe("fallback");
+  });
+});
+
+describe("ignoreDuplicateSlashes", () => {
+  let server: Server;
+
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      ignoreDuplicateSlashes: true,
+      fetch: () => new Response("fallback"),
+      routes: {
+        "/api/users": req => new Response(new URL(req.url).pathname),
+      },
+    });
+    server.unref();
+  });
+
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  it("collapses duplicate slashes", async () => {
+    const res = await fetch(`${server.url.origin}//api//users`);
+    expect(await res.text()).not.toBe("fallback");
+  });
+
+  it("keeps the raw request.url (duplicate slashes preserved for the handler)", async () => {
+    const res = await fetch(`${server.url.origin}//api//users`);
+    expect(await res.text()).toContain("//users");
+  });
+
+  it("does not trim a trailing slash (that flag is off)", async () => {
+    const res = await fetch(new URL("/api/users/", server.url).href);
+    expect(await res.text()).toBe("fallback");
+  });
+});
+
+describe("lenient slash matching is off by default", () => {
+  let server: Server;
+
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("fallback"),
+      routes: {
+        "/api/users": () => new Response("matched"),
+      },
+    });
+    server.unref();
+  });
+
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  it("still matches the exact path", async () => {
+    const res = await fetch(new URL("/api/users", server.url).href);
+    expect(await res.text()).toBe("matched");
+  });
+
+  it("falls through to fetch on a trailing slash", async () => {
+    const res = await fetch(new URL("/api/users/", server.url).href);
+    expect(await res.text()).toBe("fallback");
+  });
+
+  it("falls through to fetch on duplicate slashes", async () => {
+    const res = await fetch(`${server.url.origin}//api//users`);
+    expect(await res.text()).toBe("fallback");
+  });
+});
+
+describe("ignoreTrailingSlash + ignoreDuplicateSlashes", () => {
+  let server: Server;
+
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      ignoreTrailingSlash: true,
+      ignoreDuplicateSlashes: true,
+      fetch: () => new Response("fallback"),
+      routes: {
+        "/api/users": req => new Response(new URL(req.url).pathname),
+      },
+    });
+    server.unref();
+  });
+
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  it("matches messy duplicate and trailing slashes together", async () => {
+    const res = await fetch(`${server.url.origin}//api//users//`);
+    expect(await res.text()).not.toBe("fallback");
+  });
+
+  it("keeps the raw request.url (messy slashes preserved for the handler)", async () => {
+    const res = await fetch(`${server.url.origin}//api//users//`);
+    const pathname = await res.text();
+    expect(pathname).toContain("//users");
+    expect(pathname.endsWith("//")).toBe(true);
+  });
+
+  it("persists across server.reload()", async () => {
+    server.reload({
+      fetch: () => new Response("fallback"),
+      routes: {
+        "/api/users": () => new Response("reloaded"),
+      },
+    });
+    const res = await fetch(`${server.url.origin}//api//users//`);
+    expect(await res.text()).toBe("reloaded");
+  });
+});

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -1122,6 +1122,7 @@ describe("ignoreTrailingSlash", () => {
         "/api/users": req => new Response(new URL(req.url).pathname),
         "/api/static": new Response("static"),
         "/posts/:id": req => new Response(req.params.id),
+        "/registered/": () => new Response("registered with trailing slash"),
       },
     });
     server.unref();
@@ -1134,6 +1135,11 @@ describe("ignoreTrailingSlash", () => {
   it("matches the exact path", async () => {
     const res = await fetch(new URL("/api/users", server.url).href);
     expect(await res.text()).toBe("/api/users");
+  });
+
+  it("normalizes a registered pattern that has a trailing slash", async () => {
+    const res = await fetch(new URL("/registered", server.url).href);
+    expect(await res.text()).toBe("registered with trailing slash");
   });
 
   it("matches a trailing slash and keeps the raw request.url", async () => {
@@ -1172,6 +1178,7 @@ describe("ignoreDuplicateSlashes", () => {
       fetch: () => new Response("fallback"),
       routes: {
         "/api/users": req => new Response(new URL(req.url).pathname),
+        "/registered//path": () => new Response("registered with duplicate slashes"),
       },
     });
     server.unref();
@@ -1184,6 +1191,11 @@ describe("ignoreDuplicateSlashes", () => {
   it("collapses duplicate slashes and keeps the raw request.url", async () => {
     const res = await fetch(`${server.url.origin}//api//users`);
     expect(await res.text()).toBe("/api//users");
+  });
+
+  it("normalizes a registered pattern that has duplicate slashes", async () => {
+    const res = await fetch(new URL("/registered/path", server.url).href);
+    expect(await res.text()).toBe("registered with duplicate slashes");
   });
 
   it("does not trim a trailing slash (that flag is off)", async () => {
@@ -1201,6 +1213,7 @@ describe("lenient slash matching is off by default", () => {
       fetch: () => new Response("fallback"),
       routes: {
         "/api/users": () => new Response("matched"),
+        "/registered/": () => new Response("registered with trailing slash"),
       },
     });
     server.unref();
@@ -1213,6 +1226,13 @@ describe("lenient slash matching is off by default", () => {
   it("still matches the exact path", async () => {
     const res = await fetch(new URL("/api/users", server.url).href);
     expect(await res.text()).toBe("matched");
+  });
+
+  it("keeps a registered trailing slash significant", async () => {
+    expect(await fetch(new URL("/registered/", server.url).href).then(r => r.text())).toBe(
+      "registered with trailing slash",
+    );
+    expect(await fetch(new URL("/registered", server.url).href).then(r => r.text())).toBe("fallback");
   });
 
   it("falls through to fetch on a trailing slash", async () => {
@@ -1237,6 +1257,7 @@ describe("ignoreTrailingSlash + ignoreDuplicateSlashes", () => {
       fetch: () => new Response("fallback"),
       routes: {
         "/api/users": req => new Response(new URL(req.url).pathname),
+        "/registered//path/": () => new Response("registered messy"),
       },
     });
     server.unref();
@@ -1249,6 +1270,11 @@ describe("ignoreTrailingSlash + ignoreDuplicateSlashes", () => {
   it("matches messy duplicate and trailing slashes together and keeps the raw request.url", async () => {
     const res = await fetch(`${server.url.origin}//api//users//`);
     expect(await res.text()).toBe("/api//users//");
+  });
+
+  it("normalizes a registered pattern that has both duplicate and trailing slashes", async () => {
+    const res = await fetch(new URL("/registered/path", server.url).href);
+    expect(await res.text()).toBe("registered messy");
   });
 
   it("persists across server.reload()", async () => {

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -151,6 +151,45 @@ describe("Bun.serve SSL validations", () => {
       });
     }
   }
+
+  test("applies ignoreTrailingSlash to SNI domain routers", async () => {
+    using server = Bun.serve({
+      port: 0,
+      ignoreTrailingSlash: true,
+      tls: [
+        {
+          key: privateKey,
+          cert: publicKey,
+          serverName: "localhost",
+        },
+        {
+          key: privateKey,
+          cert: publicKey,
+          serverName: "localhost2.com",
+        },
+      ],
+      routes: {
+        "/api/users": () => new Response("matched"),
+      },
+      fetch: () => new Response("fallback"),
+    });
+
+    const requestUrl = new URL("/api/users/", server.url).href;
+
+    for (const serverName of ["localhost", "localhost2.com"]) {
+      const res = await fetch(requestUrl, {
+        headers: {
+          Host: serverName,
+        },
+        tls: {
+          rejectUnauthorized: false,
+          serverName,
+        },
+        keepAlive: false,
+      });
+      expect(await res.text()).toBe("matched");
+    }
+  });
 });
 
 describe("Bun.serve per-serverName client certificate policy", () => {

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -413,13 +413,17 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  test("routes: ignoreTrailingSlash and ignoreDuplicateSlashes apply to the H3 router", async () => {
+  // Each flag is exercised on its own, with the other flag's input asserted to
+  // still fall through, so a swapped argument anywhere in the H3 plumbing fails.
+  test.each([
+    ["ignoreTrailingSlash", "/api/users/", "/api//users"],
+    ["ignoreDuplicateSlashes", "/api//users", "/api/users/"],
+  ])("routes: %s applies to the H3 router", async (option, normalized, untouched) => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       const server = Bun.serve({
         port: 0, tls, http3: true,
-        ignoreTrailingSlash: true,
-        ignoreDuplicateSlashes: true,
+        ${option}: true,
         routes: { "/api/users": () => new Response("matched") },
         fetch: () => new Response("fallback"),
       });
@@ -429,8 +433,8 @@ describe("Bun.serve HTTP/3", () => {
     `;
     await withCustomServer(script, async port => {
       expect(await fetchH3(port, "/api/users").then(r => r.text())).toBe("matched");
-      expect(await fetchH3(port, "/api/users/").then(r => r.text())).toBe("matched");
-      expect(await fetchH3(port, "/api//users//").then(r => r.text())).toBe("matched");
+      expect(await fetchH3(port, normalized).then(r => r.text())).toBe("matched");
+      expect(await fetchH3(port, untouched).then(r => r.text())).toBe("fallback");
     });
   });
 

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -413,6 +413,27 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
+  test("routes: ignoreTrailingSlash and ignoreDuplicateSlashes apply to the H3 router", async () => {
+    const script = `
+      const tls = ${JSON.stringify(tls)};
+      const server = Bun.serve({
+        port: 0, tls, http3: true,
+        ignoreTrailingSlash: true,
+        ignoreDuplicateSlashes: true,
+        routes: { "/api/users": () => new Response("matched") },
+        fetch: () => new Response("fallback"),
+      });
+      console.error("PORT=" + server.port);
+      process.stdin.on("data", () => {});
+      ${STOP_ON_STDIN_END}
+    `;
+    await withCustomServer(script, async port => {
+      expect(await fetchH3(port, "/api/users").then(r => r.text())).toBe("matched");
+      expect(await fetchH3(port, "/api/users/").then(r => r.text())).toBe("matched");
+      expect(await fetchH3(port, "/api//users//").then(r => r.text())).toBe("matched");
+    });
+  });
+
   test("ReadableStream response body", async () => {
     await withServer(async port => {
       expect(await fetchH3(port, "/stream").then(r => r.text())).toBe("one two three");


### PR DESCRIPTION
### Problem

- Route matching in `Bun.serve` is exact, so `/api/users/` and `//api//users//` miss a route registered as `/api/users` and fall through to `fetch` (#17363).
- The router (`packages/bun-uws/src/HttpRouter.h`, `setUrl()`) has no way to relax this, and neither does the `Bun.serve` config.

```ts
Bun.serve({
  routes: { "/api/users": Response.json([...]) },
  fetch: () => new Response("fallback"),
});
// GET /api/users   -> JSON
// GET /api/users/  -> "fallback"
```

### Fix

- Adds two opt-in `Bun.serve` options, both default `false` (names match Fastify's):

```ts
Bun.serve({
  ignoreTrailingSlash: true,    // "/api/users/" matches "/api/users"
  ignoreDuplicateSlashes: true, // "//api//users" matches "/api/users"
  routes: { "/api/users": () => new Response("ok") },
});
```

- `HttpRouter::setUrl()` normalizes the path when either flag is set. Route registration (`add`), route lookup for removal (`findHandler`) and request dispatch (`route`) all go through `setUrl`, so registered patterns and incoming paths canonicalize the same way and the existing exact match does the rest. Root `/` is kept. With both flags off `setUrl` is unchanged.
- Only the routing key is normalized; `request.url` still carries the path as sent by the client.
- The flags are applied at the top of `set_routes()` (`src/runtime/server/mod.rs`) to the HTTP/1 app, the SNI domain routers, and the HTTP/3 app. `set_routes()` also runs on `server.reload()` after `clear_routes()` rebuilt the routers, so the setting survives reloads. The flags are part of `ServerConfig` and are carried through `clone_for_reloading_static_routes`.
- Types (`packages/bun-types/serve.d.ts`) and docs (`docs/runtime/http/routing.mdx`) are included.
- Verified with:
  - `test/js/bun/http/bun-serve-routes.test.ts`: each flag alone, both off (regression guard), both on, root `/`, static `Response` route, `:param` route with a trailing slash, `request.url` preserved, `server.reload()`.
  - `test/js/bun/http/bun-serve-ssl.test.ts`: SNI domain routers pick up the flag.
  - `test/js/bun/http/serve-http3.test.ts`: the HTTP/3 router picks up the flags.
  - The new route tests, the SNI test and the HTTP/3 test fail on `main` and pass with this change; `tsc` in `packages/bun-types` passes.

| File | What |
|---|---|
| `packages/bun-uws/src/HttpRouter.h` | The two flags, `cleanSlashes()`, the `setUrl()` hook, `setSlashNormalization()` |
| `packages/bun-uws/src/App.h` | App-level setter; stores the flags and applies them to the primary router and every SNI domain router, including ones added later |
| `packages/bun-uws/src/Http3App.h` | Same setter for the HTTP/3 router |
| `src/uws_sys/libuwsockets.cpp`, `src/uws_sys/libuwsockets_h3.cpp` | C ABI shims |
| `src/uws_sys/App.rs`, `src/uws_sys/h3.rs` | Rust bindings for the shims |
| `src/runtime/server/ServerConfig.rs` | Parses the options, default `false`, copied on reload |
| `src/runtime/server/mod.rs` | Applies the flags at the top of `set_routes()` |
| `packages/bun-types/serve.d.ts`, `docs/runtime/http/routing.mdx` | Types and docs |

### Background

- uWebSockets' `HttpRouter` is a segment tree. `setUrl()` stores the path being worked on and splits it into segments on demand; `add()` calls it with the route pattern at registration time and `route()` calls it with the request path at dispatch time, which is why normalizing inside `setUrl()` covers both sides.
- Bun keeps one `HttpRouter` per listening app, plus one per SNI `serverName` entry (`addServerName` in `App.h`) and one in the HTTP/3 app when `http3: true`. All three have to receive the flags or HTTP/1, per-hostname TLS and HTTP/3 requests to the same path would route differently.
- `server.reload()` calls `clear_routes()`, which replaces the routers with fresh instances, and then `set_routes()` again. That is why the flags are applied inside `set_routes()` rather than once at listen time.

Closes #17363.

Supersedes #32349 by @yohaidajurno, whose implementation this carries forward (credited as co-author on the commit); this PR adds the HTTP/3 wiring, docs and the extra tests on top, and is kept current with `main`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 14 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-routes.test.ts test/js/bun/http/bun-serve-ssl.test.ts "test/js/bun/http/serve-http3.test.ts"
bun test v1.4.1 (4448a2e21)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [10.11ms]
(pass) Bun.serve SSL validations > invalid key #2 development [2.02ms]
(pass) Bun.serve SSL validations > invalid cert development [1.92ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [73.32ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [2.49ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [2.03ms]
(pass) Bun.serve SSL validations > invalid key production [1.92ms]
(pass) Bun.serve SSL validations > invalid key #2 production [2.12ms]
(pass) Bun.serve SSL validations > invalid cert production [2.71ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [5.40ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [1.64ms]
(pass) Bun.serve SSL v
... (truncated)

release without fix: 12 failed, 1 skipped
bun test v1.4.0-canary.1 (4448a2e21)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [0.29ms]
(pass) Bun.serve SSL validations > invalid key #2 development [0.05ms]
(pass) Bun.serve SSL validations > invalid cert development [0.02ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [8.07ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [0.04ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [0.02ms]
(pass) Bun.serve SSL validations > invalid key production [0.06ms]
(pass) Bun.serve SSL validations > invalid key #2 production [0.05ms]
(pass) Bun.serve SSL validations > invalid cert production [0.02ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [0.30ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [0.01ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName production [0.02ms]
(pass) Bun.serve SSL validations > valid development [6.25ms]
(pass) Bun.serve SSL validations > valid 2 development [4.38ms]
(pass) Bun.serve SSL validations > valid productio
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-routes.test.ts test/js/bun/http/bun-serve-ssl.test.ts "test/js/bun/http/serve-http3.test.ts"
bun test v1.4.1 (4448a2e21)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [9.20ms]
(pass) Bun.serve SSL validations > invalid key #2 development [2.02ms]
(pass) Bun.serve SSL validations > invalid cert development [1.95ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [71.40ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [2.49ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [2.00ms]
(pass) Bun.serve SSL validations > invalid key production [1.94ms]
(pass) Bun.serve SSL validations > invalid key #2 production [2.05ms]
(pass) Bun.serve SSL validations > invalid cert production [1.84ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [5.41ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [1.98ms]
(pass) Bun.serve SSL va
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 614ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/14] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[2/14] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[3/14] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[4/14] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[5/14] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[6/14] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[7/14] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[8/14] cxx obj/src/jsc/bindings/bindings.cpp.o
[9/14] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 244 extern-C blocks audited
[10/14] gen cpp.rs (cppbind)
[10/14] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_uws_sys v0.0.0 (/workspace/bun/src/uws_sys)
[1m[92m   Compiling[0m bun_io v0.0.0 (/workspace/bun/src/io)
[1m[92m   Compiling[0m bun_uws v0.0.0 (
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/http/routing.mdx             |  18 +++
 packages/bun-types/serve.d.ts             |  14 +++
 packages/bun-uws/src/App.h                |  13 +++
 packages/bun-uws/src/Http3App.h           |   3 +
 packages/bun-uws/src/HttpRouter.h         |  38 +++++++
 src/runtime/server/ServerConfig.rs        |  20 ++++
 src/runtime/server/mod.rs                 |  14 +++
 src/uws_sys/App.rs                        |  19 ++++
 src/uws_sys/h3.rs                         |  12 ++
 src/uws_sys/libuwsockets.cpp              |   9 ++
 src/uws_sys/libuwsockets_h3.cpp           |   4 +
 test/js/bun/http/bun-serve-routes.test.ts | 181 ++++++++++++++++++++++++++++++
 test/js/bun/http/bun-serve-ssl.test.ts    |  39 +++++++
 test/js/bun/http/serve-http3.test.ts      |  25 +++++
 14 files changed, 409 insertions(+)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
docs/runtime/http/routing.mdx                  1      1      0
packages/bun-types/serve.d.ts                  2      3      0
packages/bun-uws/src/App.h                     3      3      0
packages/bun-uws/src/Http3App.h                1      1      0
packages/bun-uws/src/HttpRouter.h              1      3      0
src/runtime/server/ServerConfig.rs             4      5      0
src/runtime/server/mod.rs                      5      3      0
src/uws_sys/App.rs                             1      2      0
src/uws_sys/h3.rs                              1      2      0
src/uws_sys/libuwsockets.cpp                   1      1      0
src/uws_sys/libuwsockets_h3.cpp                2      2      0
test/js/bun/http/bun-serve-routes.test.ts      2     11      0
test/js/bun/http/bun-serve-ssl.test.ts         1      1      0
test/js/bun/http/serve-http3.test.ts           2      2      0
```

</details>

<!-- robobun:evidence:end -->
