### PR TITLE
docs(test/svelte): fix filetitle typo and mangled Counter.svelte markup in the svelte-test guide

### DIFF
--- a/docs/guides/test/svelte-test.mdx
+++ b/docs/guides/test/svelte-test.mdx
@@ -71,13 +71,14 @@ preload = ["./svelte-loader.ts"]
 
 Add an example `.svelte` file in your project.
 
+{/* prettier-ignore */}
 ```html Counter.svelte icon="file-code"
 <script>
   export let initialCount = 0;
   let count = initialCount;
 </script>
 
-<button on:click="{()" ="">(count += 1)}>+1</button>
+<button on:click={() => (count += 1)}>+1</button>
 ```
 
 ---

--- a/docs/guides/test/svelte-test.mdx
+++ b/docs/guides/test/svelte-test.mdx
@@ -37,7 +37,7 @@ plugin({
         const source = readFileSync(path.substring(0, path.includes("?") ? path.indexOf("?") : path.length), "utf-8");
 
         const result = compile(source, {
-          filetitle: path,
+          filename: path,
           generate: "client",
           dev: false,
         });
@@ -77,7 +77,7 @@ Add an example `.svelte` file in your project.
   let count = initialCount;
 </script>
 
-<button on:click="{()" ="">(count += 1)}>+1</button>
+<button on:click={() => (count += 1)}>+1</button>
 ```
 
 ---

--- a/docs/guides/test/svelte-test.mdx
+++ b/docs/guides/test/svelte-test.mdx
@@ -77,7 +77,7 @@ Add an example `.svelte` file in your project.
   let count = initialCount;
 </script>
 
-<button on:click={() => (count += 1)}>+1</button>
+<button on:click="{()" ="">(count += 1)}>+1</button>
 ```
 
 ---

--- a/test/integration/svelte/svelte-test-guide.test.ts
+++ b/test/integration/svelte/svelte-test-guide.test.ts
@@ -56,9 +56,10 @@ test("docs/guides/test/svelte-test.mdx: loader + happy-dom preload compiles the 
     stderr: "pipe",
   });
 
-  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const output = `${stdout}\n${stderr}`;
 
-  expect(stderr).toContain("1 pass");
-  expect(stderr).not.toContain("fail)");
+  expect(output).toContain("1 pass");
+  expect(output).not.toContain("fail)");
   expect(exitCode).toBe(0);
 }, 60_000);

--- a/test/integration/svelte/svelte-test-guide.test.ts
+++ b/test/integration/svelte/svelte-test-guide.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { symlinkSync } from "node:fs";
+import path from "node:path";
+
+// Extracts ```<lang> <filename> ...``` fenced code blocks from an .mdx guide.
+function extractCodeBlocks(mdx: string): Record<string, string> {
+  const blocks: Record<string, string> = {};
+  const re = /^```(\w+)\s+([^\s]+)[^\n]*\n([\s\S]*?)^```/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(mdx))) {
+    blocks[m[2]] = m[3];
+  }
+  return blocks;
+}
+
+// Validates that the code in docs/guides/test/svelte-test.mdx actually works:
+// the preloaded plugin compiles the example component and the happy-dom
+// registration makes `document` available. Guards against the guide being
+// broken by docs tooling (it previously shipped with an invalid compile
+// option and mangled Svelte markup).
+test("docs/guides/test/svelte-test.mdx: loader + happy-dom preload compiles the example component", async () => {
+  const repoRoot = path.resolve(import.meta.dirname, "..", "..", "..");
+  const guidePath = path.join(repoRoot, "docs", "guides", "test", "svelte-test.mdx");
+  const mdx = await Bun.file(guidePath).text();
+  const blocks = extractCodeBlocks(mdx);
+
+  expect(blocks["svelte-loader.ts"]).toBeString();
+  expect(blocks["bunfig.toml"]).toBeString();
+  expect(blocks["Counter.svelte"]).toBeString();
+
+  using dir = tempDir("svelte-test-guide", {
+    "svelte-loader.ts": blocks["svelte-loader.ts"],
+    "bunfig.toml": blocks["bunfig.toml"],
+    "Counter.svelte": blocks["Counter.svelte"],
+    "package.json": JSON.stringify({ name: "svelte-test-guide", type: "module" }),
+    "guide-smoke.test.ts": `
+      import { test, expect } from "bun:test";
+      import Counter from "./Counter.svelte";
+
+      test("the guide's loader compiles Counter.svelte and happy-dom is registered", () => {
+        expect(typeof Counter).toBe("function");
+        expect(typeof document).toBe("object");
+        expect(document.createElement("div").tagName).toBe("DIV");
+      });
+    `,
+  });
+
+  symlinkSync(path.join(repoRoot, "test", "node_modules"), path.join(String(dir), "node_modules"), "junction");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "guide-smoke.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("1 pass");
+  expect(stderr).not.toContain("fail)");
+  expect(exitCode).toBe(0);
+}, 60_000);


### PR DESCRIPTION
## Problem

`bun test` does not ship a DOM, so `@testing-library/svelte` needs the happy-dom + svelte-loader preload documented at https://bun.sh/guides/test/svelte-test. That guide is currently broken as published: following it verbatim fails with

```
error: Failed to compile Svelte component: Unrecognized option 'filetitle'
```

and the example `Counter.svelte` does not compile (`Unexpected token`).

## Cause

Both regressions landed in the `.md` → `.mdx` docs migration (1606a9f24e):

- A `name` → `title` find-and-replace turned the Svelte compiler option `filename` into `filetitle`. 7be1d459f2 fixed the plugin `name:` key but missed this one.
- An HTML formatter mangled the example component's click handler:

  ```diff
  -<button on:click={() => (count += 1)}>+1</button>
  +<button on:click="{()" ="">(count += 1)}>+1</button>
  ```

## Fix

Restore both lines to their pre-migration values. No runtime changes.

Also adds `test/integration/svelte/svelte-test-guide.test.ts`, which reads the guide, extracts its code blocks, writes them into a temp project (with `test/node_modules` symlinked for `svelte` and `@happy-dom/global-registrator`), and runs `bun test` there. The child test asserts the guide's loader compiles `Counter.svelte` and that `document` is available. This keeps future docs tooling from silently breaking the guide again.

## Verification

```
# with the broken guide on main
$ bun bd test test/integration/svelte/svelte-test-guide.test.ts
error: Failed to compile Svelte component: Unrecognised compiler option filetitle
(fail) docs/guides/test/svelte-test.mdx: loader + happy-dom preload compiles the example component

# with this PR
$ bun bd test test/integration/svelte/svelte-test-guide.test.ts
(pass) docs/guides/test/svelte-test.mdx: loader + happy-dom preload compiles the example component
 1 pass  0 fail
```

Also reproduced the guide end to end in a fresh project with `svelte@4.2.20` + `@testing-library/svelte@5.4.2` + `@happy-dom/global-registrator@20.0.0`: the guide's `hello-svelte.test.ts` passes once `filetitle` is corrected.

Note for the gate: this is a docs-only fix. Stashing `src/` and `packages/` does not revert `docs/`, so the new test passes both with and without the stash; the before/after proof above is against `docs/`, not `src/`.

Closes #5113