### PR TITLE
inspector: bind --inspect to 127.0.0.1 by default and print the bound IP

### DIFF
--- a/docs/guides/runtime/web-debugger.mdx
+++ b/docs/guides/runtime/web-debugger.mdx
@@ -30,9 +30,9 @@ bun --inspect server.ts
 ```txt
 --------------------- Bun Inspector ---------------------
 Listening:
-  ws://localhost:6499/0tqxs9exrgrm
+  ws://127.0.0.1:6499/0tqxs9exrgrm
 Inspect in browser:
-  https://debug.bun.sh/#localhost:6499/0tqxs9exrgrm
+  https://debug.bun.sh/#127.0.0.1:6499/0tqxs9exrgrm
 --------------------- Bun Inspector ---------------------
 ```
 

--- a/docs/runtime/debugger.mdx
+++ b/docs/runtime/debugger.mdx
@@ -27,9 +27,9 @@ bun --inspect server.ts
 ```txt id="terminal"
 --------------------- Bun Inspector ---------------------
 Listening:
-  ws://localhost:6499/0tqxs9exrgrm
+  ws://127.0.0.1:6499/0tqxs9exrgrm
 Inspect in browser:
-  https://debug.bun.sh/#localhost:6499/0tqxs9exrgrm
+  https://debug.bun.sh/#127.0.0.1:6499/0tqxs9exrgrm
 --------------------- Bun Inspector ---------------------
 ```
 

--- a/packages/bun-vscode/README.md
+++ b/packages/bun-vscode/README.md
@@ -100,7 +100,7 @@ You can use the following configurations to debug JavaScript and TypeScript file
 
       // The URL of the WebSocket inspector to attach to.
       // This value can be retrieved by using `bun --inspect`.
-      "url": "ws://localhost:6499/",
+      "url": "ws://127.0.0.1:6499/",
       // Optional path mapping for remote debugging
       "localRoot": "${workspaceFolder}",
       "remoteRoot": "/app",

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -40,7 +40,7 @@ const ATTACH_CONFIGURATION: vscode.DebugConfiguration = {
   internalConsoleOptions: "neverOpen",
   request: "attach",
   name: "Attach Bun",
-  url: "ws://localhost:6499/",
+  url: "ws://127.0.0.1:6499/",
   stopOnEntry: false,
 };
 

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -286,6 +286,9 @@ function unescapeUnixSocketUrl(href: string) {
 
 class Debugger {
   #url?: URL;
+  // Hostname as the user wrote it in --inspect; the Host-header allowlist must keep accepting it
+  // after #url.hostname is rewritten to the numeric bound address.
+  #requestedHostname?: string;
   #createBackend: (refEventLoop: boolean, receive: (...messages: string[]) => void) => Backend;
   // node:inspector mode: connections speak the V8 Chrome DevTools Protocol and
   // /json discovery endpoints are served.
@@ -364,6 +367,7 @@ class Debugger {
 
   #listen(): void {
     const { protocol, hostname, port, pathname } = this.#url!;
+    this.#requestedHostname = hostname;
 
     if (protocol === "ws:" || protocol === "wss:" || protocol === "ws+tcp:") {
       const server = Bun.serve({
@@ -375,7 +379,15 @@ class Debugger {
       });
 
       this.#server = server;
-      this.#url!.hostname = server.hostname;
+      // Bun.serve walks every getaddrinfo result for `hostname`, so `localhost` may bind [::1] on
+      // one system and 127.0.0.1 on another. Print the address that actually bound so the banner
+      // URL is reachable regardless of how the client resolves the name.
+      const addr = (server as { address?: { address?: string; family?: string } }).address;
+      if (addr && typeof addr.address === "string" && addr.address) {
+        this.#url!.hostname = addr.family === "IPv6" ? `[${addr.address}]` : addr.address;
+      } else {
+        this.#url!.hostname = server.hostname;
+      }
       this.#url!.port = `${server.port}`;
       return;
     }
@@ -495,7 +507,7 @@ class Debugger {
     }
 
     const isUnix = this.#url!.protocol.includes("unix");
-    if (!isUnix && !isHostAllowed(headers.get("Host"), this.#url!.hostname)) {
+    if (!isUnix && !isHostAllowed(headers.get("Host"), this.#requestedHostname ?? this.#url!.hostname)) {
       return new Response(null, {
         status: 400, // Bad Request
       });
@@ -774,7 +786,10 @@ function bufferedWriter(writer: Writer): Writer {
   };
 }
 
-const defaultHostname = "localhost";
+// Match Node's --inspect default: an IPv4 literal avoids the IPv4/IPv6 lottery that `localhost`
+// creates between Bun.serve (binds whichever family getaddrinfo returns first) and clients such
+// as browsers, IDEs, and WSL's localhost forwarding (which only relays 127.0.0.1).
+const defaultHostname = "127.0.0.1";
 const defaultPort = 6499;
 
 function parseUrl(input: string): URL {

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -382,9 +382,10 @@ class Debugger {
       // Bun.serve walks every getaddrinfo result for `hostname`, so `localhost` may bind [::1] on
       // one system and 127.0.0.1 on another. Print the address that actually bound so the banner
       // URL is reachable regardless of how the client resolves the name.
-      const addr = (server as { address?: { address?: string; family?: string } }).address;
-      if (addr && typeof addr.address === "string" && addr.address) {
-        this.#url!.hostname = addr.family === "IPv6" ? `[${addr.address}]` : addr.address;
+      const { address: boundIp, family } =
+        (server as { address?: { address?: string; family?: string } }).address ?? {};
+      if (typeof boundIp === "string" && boundIp) {
+        this.#url!.hostname = family === "IPv6" ? `[${boundIp}]` : boundIp;
       } else {
         this.#url!.hostname = server.hostname;
       }

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -286,8 +286,7 @@ function unescapeUnixSocketUrl(href: string) {
 
 class Debugger {
   #url?: URL;
-  // Hostname as the user wrote it in --inspect; the Host-header allowlist must keep accepting it
-  // after #url.hostname is rewritten to the numeric bound address.
+  // Kept for the Host-header allowlist after #url.hostname is rewritten to the bound IP.
   #requestedHostname?: string;
   #createBackend: (refEventLoop: boolean, receive: (...messages: string[]) => void) => Backend;
   // node:inspector mode: connections speak the V8 Chrome DevTools Protocol and
@@ -379,9 +378,7 @@ class Debugger {
       });
 
       this.#server = server;
-      // Bun.serve walks every getaddrinfo result for `hostname`, so `localhost` may bind [::1] on
-      // one system and 127.0.0.1 on another. Print the address that actually bound so the banner
-      // URL is reachable regardless of how the client resolves the name.
+      // server.hostname echoes the requested name; server.address is getsockname.
       const { address: boundIp, family } =
         (server as { address?: { address?: string; family?: string } }).address ?? {};
       if (typeof boundIp === "string" && boundIp) {
@@ -787,9 +784,7 @@ function bufferedWriter(writer: Writer): Writer {
   };
 }
 
-// Match Node's --inspect default: an IPv4 literal avoids the IPv4/IPv6 lottery that `localhost`
-// creates between Bun.serve (binds whichever family getaddrinfo returns first) and clients such
-// as browsers, IDEs, and WSL's localhost forwarding (which only relays 127.0.0.1).
+// Node's --inspect default; `localhost` would bind a resolver-dependent loopback family.
 const defaultHostname = "127.0.0.1";
 const defaultPort = 6499;
 

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -333,7 +333,6 @@ describe("websocket", () => {
     socket.addEventListener("close", cause => reject(new Error("WebSocket closed", { cause })));
     await promise;
     socket.close();
-    proc.kill();
   });
 
   afterEach(() => {

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -10,6 +10,9 @@ import { SocketFramer } from "./socket-framer";
 let inspectee: Subprocess;
 const anyPort = expect.stringMatching(/^\d+$/);
 const anyPathname = expect.stringMatching(/^\/[a-z0-9-]+$/);
+// When the user writes `localhost` explicitly, the banner shows whichever loopback
+// family Bun.serve actually bound (IPv6-first on some systems, IPv4-first on others).
+const localhostBoundIp = expect.stringMatching(/^(\[::1\]|127\.0\.0\.1)$/);
 
 /**
  * Get a function that creates a random `.sock` file in the specified temporary directory.
@@ -23,7 +26,7 @@ describe("websocket", () => {
       args: ["--inspect"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: "127.0.0.1",
         port: "6499",
         pathname: anyPathname,
       },
@@ -32,7 +35,7 @@ describe("websocket", () => {
       args: ["--inspect=0"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: "127.0.0.1",
         port: anyPort,
         pathname: anyPathname,
       },
@@ -41,7 +44,7 @@ describe("websocket", () => {
       args: [`--inspect=${randomPort()}`],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: "127.0.0.1",
         port: anyPort,
         pathname: anyPathname,
       },
@@ -50,7 +53,7 @@ describe("websocket", () => {
       args: ["--inspect=localhost"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: "6499",
         pathname: anyPathname,
       },
@@ -59,7 +62,7 @@ describe("websocket", () => {
       args: ["--inspect=localhost/"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: "6499",
         pathname: "/",
       },
@@ -68,7 +71,7 @@ describe("websocket", () => {
       args: ["--inspect=localhost:0"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: anyPort,
         pathname: anyPathname,
       },
@@ -77,7 +80,7 @@ describe("websocket", () => {
       args: ["--inspect=localhost:0/"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: anyPort,
         pathname: "/",
       },
@@ -86,7 +89,7 @@ describe("websocket", () => {
       args: ["--inspect=localhost/foo/bar"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: "6499",
         pathname: "/foo/bar",
       },
@@ -149,7 +152,7 @@ describe("websocket", () => {
       args: ["--inspect=/"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: "127.0.0.1",
         port: "6499",
         pathname: "/",
       },
@@ -158,7 +161,7 @@ describe("websocket", () => {
       args: ["--inspect=/foo"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: "127.0.0.1",
         port: "6499",
         pathname: "/foo",
       },
@@ -167,7 +170,7 @@ describe("websocket", () => {
       args: ["--inspect=/foo/baz/"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: "127.0.0.1",
         port: "6499",
         pathname: "/foo/baz/",
       },
@@ -176,7 +179,7 @@ describe("websocket", () => {
       args: ["--inspect=:0"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: "127.0.0.1",
         port: anyPort,
         pathname: anyPathname,
       },
@@ -185,7 +188,7 @@ describe("websocket", () => {
       args: ["--inspect=:0/"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: "127.0.0.1",
         port: anyPort,
         pathname: "/",
       },
@@ -194,7 +197,7 @@ describe("websocket", () => {
       args: ["--inspect=ws://localhost/"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: anyPort,
         pathname: "/",
       },
@@ -203,7 +206,7 @@ describe("websocket", () => {
       args: ["--inspect=ws://localhost:0/"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: anyPort,
         pathname: "/",
       },
@@ -212,7 +215,7 @@ describe("websocket", () => {
       args: ["--inspect=ws://localhost:6499/foo/bar"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: "6499",
         pathname: "/foo/bar",
       },
@@ -294,6 +297,43 @@ describe("websocket", () => {
 
   // FIXME: Depends on https://github.com/oven-sh/bun/pull/4649
   test.todo("bun --inspect=ws+unix:///tmp/inspect.sock");
+
+  // https://github.com/oven-sh/bun/issues/4716
+  // Default --inspect must bind 127.0.0.1 (like Node), not `localhost`, so the
+  // printed URL is reachable even when server/client disagree on which address
+  // family `localhost` resolves to (IPv6-first resolvers, WSL forwarding, etc.).
+  test("default --inspect binds 127.0.0.1 and the printed URL is connectable", async () => {
+    await using proc = spawn({
+      cwd: import.meta.dir,
+      cmd: [bunExe(), "--inspect=0", "inspectee.js"],
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+
+    let url: URL | undefined;
+    let stderr = "";
+    const decoder = new TextDecoder();
+    for await (const chunk of proc.stderr as ReadableStream) {
+      stderr += decoder.decode(chunk);
+      const m = stripAnsi(stderr).match(/ws:\/\/\S+/);
+      if (m) {
+        url = new URL(m[0]);
+        break;
+      }
+    }
+    if (!url) throw new Error("Unable to find listening URL in:\n" + stderr);
+
+    expect(url.hostname).toBe("127.0.0.1");
+
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const socket = new WebSocket(url);
+    socket.addEventListener("open", () => resolve());
+    socket.addEventListener("error", ev => reject(new Error("WebSocket error", { cause: ev })));
+    await promise;
+    socket.close();
+    proc.kill();
+  });
 
   afterEach(() => {
     inspectee?.kill();

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -329,7 +329,8 @@ describe("websocket", () => {
     const { promise, resolve, reject } = Promise.withResolvers<void>();
     const socket = new WebSocket(url);
     socket.addEventListener("open", () => resolve());
-    socket.addEventListener("error", ev => reject(new Error("WebSocket error", { cause: ev })));
+    socket.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
+    socket.addEventListener("close", cause => reject(new Error("WebSocket closed", { cause })));
     await promise;
     socket.close();
     proc.kill();


### PR DESCRIPTION
Fixes #4716.

## Problem

`bun --inspect` starts its WebSocket server with `Bun.serve({ hostname: "localhost", ... })`. `Bun.serve` walks every `getaddrinfo` result for that name and binds whichever family comes first, so on IPv6-first systems (most modern Linux distros, macOS) the inspector binds `[::1]`:

```console
$ bun --inspect=0 -e 'setInterval(()=>{},1e9)' &
Listening:
  ws://localhost:35683/02ee9c2d-...
$ ss -tlnp | grep bun
LISTEN 0 512  [::1]:35683  [::]:*
```

The banner prints `ws://localhost:.../` regardless of what actually bound. Any client that resolves `localhost` to the other family cannot connect:

```console
$ bun -e "new WebSocket('ws://localhost:35683/02ee9c2d-...')"
ERROR: WebSocket connection to 'ws://localhost:35683/...' failed: Failed to connect
```

This is what users in #4716 hit on WSL (whose localhost forwarding is `127.0.0.1`-only), on macOS, and with various browsers/IDEs. Debug.bun.sh opens but shows no source files because the WebSocket never connects.

Node avoids this by binding `127.0.0.1` explicitly:

```console
$ node --inspect -e 'setTimeout(()=>{},100)'
Debugger listening on ws://127.0.0.1:9229/...
```

## Fix

Two changes in `src/js/internal/debugger.ts`:

1. Default hostname is now `127.0.0.1` instead of `localhost`, matching Node. Bare `--inspect`, `--inspect=0`, `--inspect=:PORT`, and `--inspect=/path` all bind deterministic IPv4 loopback.
2. After `Bun.serve()` succeeds, the banner URL is rewritten to `server.address.address` (the actual bound IP) instead of echoing the requested name. An explicit `--inspect=localhost` now prints `ws://[::1]:6499/...` or `ws://127.0.0.1:6499/...` depending on what actually bound, so the printed URL is always reachable.

The Host-header allowlist still accepts the originally requested hostname via a saved `#requestedHostname`, so a client reaching the server through a tunnel that sends `Host: myhost.local` is not rejected after the URL is rewritten.

Related: #34994 prints the bound address in the same spot; this PR supersedes its `debugger.ts` change and additionally changes the default bind address, which is what fixes the WSL case.

## Verification

New test `default --inspect binds 127.0.0.1 and the printed URL is connectable` spawns `bun --inspect=0`, parses the banner, asserts `hostname === "127.0.0.1"`, and opens a WebSocket to the printed URL. Fails on main with `Received: "localhost"`.

The existing parametrized `websocket > bun --inspect*` tests (which already connect a WebSocket to the printed URL) are updated to expect `127.0.0.1` for the default case and the bound loopback IP for explicit `localhost`. On IPv6-first hosts these tests were previously failing on main; they now pass deterministically.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 17 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/inspect.test.ts
bun test v1.4.0 (e82f2716b)

test/cli/inspect/inspect.test.ts:
261 |       expect({
262 |         protocol,
263 |         hostname,
264 |         port,
265 |         pathname,
266 |       }).toMatchObject(expected);
               ^
error: expect(received).toMatchObject(expected)

  {
-   "hostname": "127.0.0.1",
-   "pathname": StringMatching /^\/[a-z0-9-]+$/,
+   "hostname": "localhost",
+   "pathname": "/75fdddec-5bad-414c-bd5f-38bbfe9932ca",
    "port": "6499",
    "protocol": "ws:",
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/cli/inspect/inspect.test.ts:266:10)
(fail) websocket > bun --inspect [576.75ms]
261 |       expect({
262 |         protocol,
263 |         hostname,
264 |         port,
265 |         pathname,
266 |       }).toMatchObject(expected);
               ^
error: expect(received).toMatchObject(expected)

  {
-   "hostname": "127.0.0.1",
-   "pathname": StringMatching /^\/[a-z0-9-]+$/,
-   "port": StringMatching /^\d+$/,
+   "hostname": "localhost",
... (truncated)

release without fix: 19 failed, 2 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/inspect/inspect.test.ts:
261 |       expect({
262 |         protocol,
263 |         hostname,
264 |         port,
265 |         pathname,
266 |       }).toMatchObject(expected);
               ^
error: expect(received).toMatchObject(expected)

  {
-   "hostname": "127.0.0.1",
-   "pathname": StringMatching /^\/[a-z0-9-]+$/,
+   "hostname": "localhost",
+   "pathname": "/ff4b70b3-2a66-4c2d-9b43-19993d57213e",
    "port": "6499",
    "protocol": "ws:",
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/cli/inspect/inspect.test.ts:266:10)
(fail) websocket > bun --inspect [52.75ms]
261 |       expect({
262 |         protocol,
263 |         hostname,
264 |         port,
265 |         pathname,
266 |       }).toMatchObject(expected);
               ^
error: expect(received).toMatchObject(expected)

  {
-   "hostname": "127.0.0.1",
-   "pathname": StringMatching /^\/[a-z0-9-]+$/,
-   "port": StringMatching /^\d+$/,
+   "hostname": "localhost",
+   "pathname": "/eb26ed2a-80bb-4625-b373-151025ccdf7f",
+   "port": "40529",
    "protocol": "ws:",
  }

- Expected  - 3
+ Received  + 3

      at <anonymou
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/inspect.test.ts
bun test v1.4.0 (e82f2716b)

test/cli/inspect/inspect.test.ts:
(pass) websocket > bun --inspect [1055.16ms]
(pass) websocket > bun --inspect=0 [627.87ms]
(pass) websocket > bun --inspect=50022 [750.30ms]
(pass) websocket > bun --inspect=localhost [688.57ms]
(pass) websocket > bun --inspect=localhost/ [604.08ms]
(pass) websocket > bun --inspect=localhost:0 [769.80ms]
(pass) websocket > bun --inspect=localhost:0/ [868.03ms]
(pass) websocket > bun --inspect=localhost/foo/bar [732.90ms]
(pass) websocket > bun --inspect=127.0.0.1 [763.77ms]
(pass) websocket > bun --inspect=127.0.0.1/ [843.18ms]
(pass) websocket > bun --inspect=127.0.0.1:0/ [640.93ms]
(pass) websocket > bun --inspect=[::1] [730.03ms]
(pass) websocket > bun --inspect=[::1]:0 [772.31ms]
(pass) websocket > bun --inspect=[::1]:0/ [624.61ms]
(pass) websocket > bun --inspect=/ [707.18ms]
(pass) websocket > bun --inspect=/foo [612.96ms]
(pass) websocket > bun --inspect=/foo/baz/ [651.77ms]
(pass) websocket > bun --inspect=:0 [644.17ms]
(pass) websoc
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1329ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/23] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/23] gen JS modules (bundle-modules)
Preprocess modules (10269ms)
Bundle modules (88ms)
Postprocesss modules (187ms)
Bundle Functions (763ms)
Generate Code (35ms)

[11.40s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Comp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/guides/runtime/web-debugger.mdx      |  4 +-
 docs/runtime/debugger.mdx                 |  4 +-
 packages/bun-vscode/README.md             |  2 +-
 packages/bun-vscode/src/features/debug.ts |  2 +-
 src/js/internal/debugger.ts               | 17 ++++++--
 test/cli/inspect/inspect.test.ts          | 72 ++++++++++++++++++++++++-------
 6 files changed, 76 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
docs/guides/runtime/web-debugger.mdx           1      1      0
docs/runtime/debugger.mdx                      1      1      0
packages/bun-vscode/README.md                  1      1      0
packages/bun-vscode/src/features/debug.ts      1      1      0
src/js/internal/debugger.ts                    2      9      0
test/cli/inspect/inspect.test.ts               4      6      0
```

</details>

<!-- robobun:evidence:end -->