### PR TITLE
npm(bun-release): prefer musl package first on musl hosts

### DIFF
--- a/packages/bun-release/scripts/upload-npm.ts
+++ b/packages/bun-release/scripts/upload-npm.ts
@@ -142,7 +142,7 @@ without *requiring* a postinstall script.
 
 async function buildModule(
   release: Awaited<ReturnType<typeof getRelease>>,
-  { bin, exe, os, arch }: Platform,
+  { bin, exe, os, arch, abi }: Platform,
 ): Promise<void> {
   const module = `${owner}/${bin}`;
   log("Building:", `${module}@${version}`);
@@ -167,6 +167,7 @@ async function buildModule(
     preferUnplugged: true,
     os: [os],
     cpu: [arch],
+    ...(os === "linux" ? { libc: [abi === "musl" ? "musl" : "glibc"] } : {}),
   });
   if (exists(".npmrc")) {
     copy(".npmrc", join(cwd, ".npmrc"));

--- a/packages/bun-release/src/platform.ts
+++ b/packages/bun-release/src/platform.ts
@@ -130,12 +130,31 @@ export const platforms: Platform[] = [
   },
 ];
 
-export const supportedPlatforms: Platform[] = platforms.filter(
-  platform =>
-    platform.os === os && platform.arch === arch && !platform.alias && (!platform.abi || abi === platform.abi),
-);
+export function getSupportedPlatforms(os: string, arch: string, abi: string | undefined): Platform[] {
+  return platforms
+    .filter(
+      platform =>
+        platform.os === os && platform.arch === arch && !platform.alias && (!platform.abi || abi === platform.abi),
+    )
+    .sort((a, b) => Number(a.abi !== abi) - Number(b.abi !== abi));
+}
+
+export const supportedPlatforms: Platform[] = getSupportedPlatforms(os, arch, abi);
 
 function isLinuxMusl(): boolean {
+  try {
+    if (process.report) {
+      const excludeNetwork = process.report.excludeNetwork;
+      process.report.excludeNetwork = true;
+      const report = process.report.getReport() as { header?: { glibcVersionRuntime?: string } };
+      process.report.excludeNetwork = excludeNetwork;
+      if (report && report.header) {
+        return !report.header.glibcVersionRuntime;
+      }
+    }
+  } catch (error) {
+    debug("process.report.getReport failed", error);
+  }
   try {
     return exists("/etc/alpine-release");
   } catch (error) {

--- a/packages/bun-release/src/platform.ts
+++ b/packages/bun-release/src/platform.ts
@@ -146,10 +146,13 @@ function isLinuxMusl(): boolean {
     if (process.report) {
       const excludeNetwork = process.report.excludeNetwork;
       process.report.excludeNetwork = true;
-      const report = process.report.getReport() as { header?: { glibcVersionRuntime?: string } };
-      process.report.excludeNetwork = excludeNetwork;
-      if (report && report.header) {
-        return !report.header.glibcVersionRuntime;
+      try {
+        const report = process.report.getReport() as { header?: { glibcVersionRuntime?: string } };
+        if (report && report.header) {
+          return !report.header.glibcVersionRuntime;
+        }
+      } finally {
+        process.report.excludeNetwork = excludeNetwork;
       }
     }
   } catch (error) {

--- a/test/regression/issue/05545.test.ts
+++ b/test/regression/issue/05545.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { getSupportedPlatforms } from "../../../packages/bun-release/src/platform";
+
+// https://github.com/oven-sh/bun/issues/5545
+//
+// On Alpine (musl), `npm install -g bun` printed:
+//   Failed to find package "@oven/bun-linux-x64". You may have used the "--no-optional" flag ...
+// because the postinstall picker tried the glibc build before the musl build.
+// The glibc binary is present in node_modules (npm installs both optionalDependencies
+// since they share os/cpu) but cannot run on musl, so the first attempt always failed
+// loudly before falling through.
+
+describe("npm postinstall platform selection (issue #5545)", () => {
+  test("musl hosts try the musl package first", () => {
+    expect(getSupportedPlatforms("linux", "x64", "musl").map(p => p.bin)).toEqual([
+      "bun-linux-x64-musl",
+      "bun-linux-x64",
+    ]);
+    expect(getSupportedPlatforms("linux", "arm64", "musl").map(p => p.bin)).toEqual([
+      "bun-linux-aarch64-musl",
+      "bun-linux-aarch64",
+    ]);
+  });
+
+  test("glibc hosts only try the glibc package", () => {
+    expect(getSupportedPlatforms("linux", "x64", undefined).map(p => p.bin)).toEqual(["bun-linux-x64"]);
+    expect(getSupportedPlatforms("linux", "arm64", undefined).map(p => p.bin)).toEqual(["bun-linux-aarch64"]);
+  });
+
+  test("other platforms are unaffected", () => {
+    expect(getSupportedPlatforms("darwin", "arm64", undefined).map(p => p.bin)).toEqual(["bun-darwin-aarch64"]);
+    expect(getSupportedPlatforms("darwin", "x64", undefined).map(p => p.bin)).toEqual(["bun-darwin-x64"]);
+    expect(getSupportedPlatforms("win32", "x64", undefined).map(p => p.bin)).toEqual(["bun-windows-x64"]);
+    expect(getSupportedPlatforms("win32", "arm64", undefined).map(p => p.bin)).toEqual(["bun-windows-aarch64"]);
+    expect(getSupportedPlatforms("android", "arm64", "android").map(p => p.bin)).toEqual([
+      "bun-linux-aarch64-android",
+    ]);
+  });
+});

--- a/test/regression/issue/05545.test.ts
+++ b/test/regression/issue/05545.test.ts
@@ -32,8 +32,6 @@ describe("npm postinstall platform selection (issue #5545)", () => {
     expect(getSupportedPlatforms("darwin", "x64", undefined).map(p => p.bin)).toEqual(["bun-darwin-x64"]);
     expect(getSupportedPlatforms("win32", "x64", undefined).map(p => p.bin)).toEqual(["bun-windows-x64"]);
     expect(getSupportedPlatforms("win32", "arm64", undefined).map(p => p.bin)).toEqual(["bun-windows-aarch64"]);
-    expect(getSupportedPlatforms("android", "arm64", "android").map(p => p.bin)).toEqual([
-      "bun-linux-aarch64-android",
-    ]);
+    expect(getSupportedPlatforms("android", "arm64", "android").map(p => p.bin)).toEqual(["bun-linux-aarch64-android"]);
   });
 });


### PR DESCRIPTION
## Repro

```dockerfile
FROM node:lts-alpine
RUN npm install -g bun
```

```
npm ERR! Failed to find package "@oven/bun-linux-x64". You may have used the "--no-optional" flag when running "npm install".
```

## Cause

`supportedPlatforms` in `packages/bun-release/src/platform.ts` kept entries in table order. The filter `(!platform.abi || abi === platform.abi)` lets the glibc entry (no `abi`) through on musl hosts, and since it appears earlier in the `platforms` array, the postinstall script tries `@oven/bun-linux-x64` first. npm has already placed that package on disk (its `os`/`cpu` match Alpine), but spawning the glibc binary fails with ENOENT because `/lib64/ld-linux-x86-64.so.2` does not exist, producing the misleading "--no-optional" error before eventually reaching the musl package.

`isLinuxMusl()` also only checked `/etc/alpine-release`, so non-Alpine musl distros never saw the musl package at all and failed hard.

## Fix

- Sort candidates so exact-ABI matches come first (musl → `[musl, glibc]`, glibc unchanged → `[glibc]`). glibc stays as a fallback rather than being dropped.
- Detect musl via `process.report.getReport().header.glibcVersionRuntime` (the same check npm and `detect-libc` use), falling back to `/etc/alpine-release` if `process.report` is unavailable.
- Add `libc: ["musl"|"glibc"]` to the generated `@oven/bun-linux-*` package.json so npm 9.6.5+ skips downloading the wrong-ABI optional dep entirely.
- Extracted `getSupportedPlatforms(os, arch, abi)` so the ordering is unit-testable.

## Verification

```
linux x64 musl:   ["bun-linux-x64-musl", "bun-linux-x64"]
linux x64 glibc:  ["bun-linux-x64"]
linux arm64 musl: ["bun-linux-aarch64-musl", "bun-linux-aarch64"]
```

`bun bd test test/regression/issue/05545.test.ts` passes; with `packages/` reverted the test fails.

Fixes #5545

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/05545.test.ts"
bun test v1.4.0 (7897987fb)

test/regression/issue/05545.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'getSupportedPlatforms' not found in module '/workspace/bun/packages/bun-release/src/platform.ts'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [3.90s]
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/regression/issue/05545.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'getSupportedPlatforms' not found in module '/workspace/bun/packages/bun-release/src/platform.ts'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [236.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/05545.test.ts"
bun test v1.4.0 (7897987fb)

test/regression/issue/05545.test.ts:
(pass) npm postinstall platform selection (issue #5545) > musl hosts try the musl package first [8.20ms]
(pass) npm postinstall platform selection (issue #5545) > glibc hosts only try the glibc package [8.37ms]
(pass) npm postinstall platform selection (issue #5545) > other platforms are unaffected [11.29ms]

 3 pass
 0 fail
 9 expect() calls
Ran 3 tests across 1 file. [3.43s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1826ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/47] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/47] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_outpu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-release/scripts/upload-npm.ts |  3 ++-
 packages/bun-release/src/platform.ts       | 30 ++++++++++++++++++++----
 test/regression/issue/05545.test.ts        | 37 ++++++++++++++++++++++++++++++
 3 files changed, 65 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-release/scripts/upload-npm.ts      1      1      0
packages/bun-release/src/platform.ts            3      3      0
test/regression/issue/05545.test.ts             0      1      0
```

</details>

<!-- robobun:evidence:end -->