### PR TITLE
install: move existing dependency when `bun add` is given an explicit group flag

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -976,6 +976,10 @@ pub(crate) fn edit(
     let mut remaining = updates.len();
     let mut replacing: usize = 0;
     let only_add_missing = manager.options.enable.only_missing();
+    // `--dev`/`--optional`/`--peer` moves an existing entry into that group; a bare `bun add` keeps its placement.
+    let move_to_target = !only_add_missing && dependency_list != DependencyGroup::DEPENDENCIES.prop;
+    // `(index into updates, existing devDependencies value)` pairs that follow the new peer range.
+    let mut dev_entries_to_sync: Vec<(usize, *mut E::EString)> = Vec::new();
 
     // There are three possible scenarios here
     // 1. There is no "dependencies" (or equivalent list) or it is empty
@@ -987,7 +991,7 @@ pub(crate) fn edit(
             let mut i: usize = 0;
             'loop_: while i < updates.len() {
                 let request = &mut updates[i];
-                // order-insensitive scan: `FOUR` is fine here
+                // `move_to_target` visits every group; otherwise order-insensitive (bails on first match).
                 'dependency_group: for list in DependencyGroup::FOUR.map(|g| g.prop) {
                     if let Some(query) = current_package_json.as_property(list) {
                         if matches!(query.expr.data, bun_ast::ExprData::EObject(_)) {
@@ -1004,14 +1008,48 @@ pub(crate) fn edit(
                                                     == dependency::Tag::Catalog
                                             },
                                         );
+                                    let in_target_list =
+                                        strings::eql_long(list, dependency_list, true);
 
                                     // `bun update <name>` edits the slot in place; the rebuild below re-sorts the keys.
                                     if request.package_id != INVALID_PACKAGE_ID
                                         && manager.subcommand != Subcommand::Update
-                                        && strings::eql_long(list, dependency_list, true)
+                                        && in_target_list
                                         && !keep_catalog_reference
                                     {
                                         replacing += 1;
+                                    } else if move_to_target && !in_target_list {
+                                        match list {
+                                            // A peer entry coexists with every other group.
+                                            b"peerDependencies" => {}
+                                            // A dev entry coexists with a peer entry and tracks its range.
+                                            b"devDependencies"
+                                                if dependency_list
+                                                    == DependencyGroup::PEER.prop =>
+                                            {
+                                                dev_entries_to_sync.push((
+                                                    i,
+                                                    value
+                                                        .expr
+                                                        .data
+                                                        .e_string()
+                                                        .expect("infallible: variant checked")
+                                                        .as_ptr(),
+                                                ));
+                                            }
+                                            _ => {
+                                                changed = true;
+                                                let mut group = query.expr.data.as_e_object();
+                                                let _ = group.properties.remove(value.i as usize);
+                                                if group.properties.is_empty() {
+                                                    let _ = current_package_json
+                                                        .data
+                                                        .as_e_object_mut()
+                                                        .properties
+                                                        .remove(query.i as usize);
+                                                }
+                                            }
+                                        }
                                     } else {
                                         if manager.subcommand == Subcommand::Update
                                             && options.before_install
@@ -1072,6 +1110,9 @@ pub(crate) fn edit(
                                             continue 'loop_;
                                         }
                                     }
+                                }
+                                if move_to_target {
+                                    continue 'dependency_group;
                                 }
                                 break;
                             } else {
@@ -1457,6 +1498,18 @@ pub(crate) fn edit(
             if e_string.data.slice() != new_literal {
                 changed = true;
                 e_string.data = bun_ast::StoreStr::new(new_literal);
+            }
+        }
+    }
+    for (update_index, dev_entry) in dev_entries_to_sync {
+        if let Some(peer_entry) = updates[update_index].e_string {
+            // SAFETY: both pointers were captured at the provenance sites described on the loop
+            // above and stay valid for the same reasons; that loop has released its borrows.
+            unsafe {
+                if (*dev_entry).data.slice() != (*peer_entry).data.slice() {
+                    changed = true;
+                    (*dev_entry).data = (*peer_entry).data;
+                }
             }
         }
     }

--- a/test/cli/install/bun-add-catalog.test.ts
+++ b/test/cli/install/bun-add-catalog.test.ts
@@ -699,8 +699,17 @@ describe.concurrent("bun add --catalog", () => {
       const plainPkg1 = await plain.pkg1();
       const catalogPkg1 = await catalog.pkg1();
       expect(Object.keys(catalogPkg1)).toStrictEqual(Object.keys(plainPkg1));
-      expect(plainPkg1).toStrictEqual({ name: "pkg1", peerDependencies: { "no-deps": "^2.0.0" } });
-      expect(catalogPkg1).toStrictEqual({ name: "pkg1", peerDependencies: { "no-deps": "catalog:" } });
+      // The peer entry is left alone; --dev adds a devDependencies entry next to it.
+      expect(plainPkg1).toStrictEqual({
+        name: "pkg1",
+        peerDependencies: { "no-deps": ">=1" },
+        devDependencies: { "no-deps": "^2.0.0" },
+      });
+      expect(catalogPkg1).toStrictEqual({
+        name: "pkg1",
+        peerDependencies: { "no-deps": ">=1" },
+        devDependencies: { "no-deps": "catalog:" },
+      });
     });
 
     test("--peer", async () => {

--- a/test/cli/install/bun-add-filter.test.ts
+++ b/test/cli/install/bun-add-filter.test.ts
@@ -179,13 +179,13 @@ test.concurrent("-F alias with --dev and --exact", async () => {
     expect(await pkg(dir, "web")).toStrictEqual(WEB);
   }
 
-  // Same as unfiltered `bun add -d`: an entry that already exists in another list is updated in place.
+  // Same as unfiltered `bun add -d`: an entry that already exists in another list is moved to the requested one.
   {
     const { stderr, exitCode } = await run(["add", "a-dep", "-F", "web", "-d", "-E"], dir);
     expect(stderr).not.toContain("error:");
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "web")).toStrictEqual({ name: "web", dependencies: { "a-dep": "1.0.10" } });
+    expect(await pkg(dir, "web")).toStrictEqual({ name: "web", devDependencies: { "a-dep": "1.0.10" } });
     expect(await pkg(dir, "api")).toStrictEqual({ name: "api", devDependencies: { "a-dep": "1.0.10" } });
     expect(await pkg(dir, "root")).toStrictEqual(ROOT);
   }
@@ -2340,12 +2340,11 @@ test.concurrent("a name declared in two groups stays in sync with bun.lock after
   expect(stderr).not.toContain("error:");
   expect(exitCode).toBe(0);
 
-  // Same as an unfiltered add: the entry that already exists (in dependencies) is updated in place.
+  // Same as an unfiltered add: the dependencies entry is dropped and the existing peer entry takes the new range.
   const api = await pkg(dir, "api");
   expect(api).toStrictEqual({
     name: "api",
-    dependencies: { "no-deps": "^2.0.0" },
-    peerDependencies: { "no-deps": "*" },
+    peerDependencies: { "no-deps": "^2.0.0" },
   });
   const { workspaces } = await lockfileJson(dir);
   expect(workspaces["packages/api"]).toStrictEqual(api);

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -754,6 +754,99 @@ it("should add to peerDependencies with --peer", async () => {
   await access(join(package_dir, "bun.lockb"));
 });
 
+describe("should move existing dependency when an explicit group flag is given", () => {
+  const root = { name: "foo", version: "0.0.1" };
+  const pkgJson = (pkg: Record<string, unknown>) => JSON.stringify(pkg, null, 2);
+
+  async function add(
+    initial: Record<string, unknown>,
+    args: string[],
+    registry: Record<string, unknown> = { "0.0.2": {} },
+  ) {
+    setHandler(dummyRegistry([], registry));
+    await writeFile(join(package_dir, "package.json"), JSON.stringify(initial));
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", ...args],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, , exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(exitCode).toBe(0);
+    return await file(join(package_dir, "package.json")).text();
+  }
+
+  it.each([
+    ["dependencies", "devDependencies", "--dev"],
+    ["dependencies", "optionalDependencies", "--optional"],
+    ["dependencies", "peerDependencies", "--peer"],
+    ["devDependencies", "optionalDependencies", "--optional"],
+    ["optionalDependencies", "devDependencies", "--dev"],
+    ["optionalDependencies", "peerDependencies", "--peer"],
+  ])("%s -> %s with %s", async (from, to, flag) => {
+    expect(await add({ ...root, [from]: { BaR: "^0.0.2" } }, [flag, "BaR"])).toBe(
+      pkgJson({ ...root, [to]: { BaR: "^0.0.2" } }),
+    );
+  });
+
+  it("keeps the remaining entries of the source group in their original order", async () => {
+    const dependencies = { monkey: "^0.0.2", BaR: "^0.0.2", boba: "^0.0.2", "depends-on-monkey": "^0.0.2" };
+    expect(await add({ ...root, dependencies }, ["--dev", "BaR"])).toBe(
+      pkgJson({
+        ...root,
+        dependencies: { monkey: "^0.0.2", boba: "^0.0.2", "depends-on-monkey": "^0.0.2" },
+        devDependencies: { BaR: "^0.0.2" },
+      }),
+    );
+  });
+
+  it("keeps the other root keys in their original order when the source group becomes empty", async () => {
+    const rest = { type: "module", scripts: { test: "true" }, license: "MIT" };
+    expect(await add({ ...root, dependencies: { BaR: "^0.0.2" }, ...rest }, ["--dev", "BaR"])).toBe(
+      pkgJson({ ...root, ...rest, devDependencies: { BaR: "^0.0.2" } }),
+    );
+  });
+
+  it("moves several packages out of the same group", async () => {
+    expect(await add({ ...root, dependencies: { BaR: "^0.0.2", monkey: "^0.0.2" } }, ["--dev", "BaR", "monkey"])).toBe(
+      pkgJson({ ...root, devDependencies: { BaR: "^0.0.2", monkey: "^0.0.2" } }),
+    );
+  });
+
+  it("removes the other group when the package is already in the target group", async () => {
+    const initial = { ...root, devDependencies: { BaR: "^0.0.2" }, optionalDependencies: { BaR: "^0.0.2" } };
+    expect(await add(initial, ["--dev", "BaR"])).toBe(pkgJson({ ...root, devDependencies: { BaR: "^0.0.2" } }));
+  });
+
+  it("leaves a peerDependencies entry untouched when adding to devDependencies", async () => {
+    const initial = { ...root, peerDependencies: { baz: ">=0.0.3" } };
+    expect(await add(initial, ["--dev", "baz"], { "0.0.3": {}, "0.0.5": {} })).toBe(
+      pkgJson({ ...root, peerDependencies: { baz: ">=0.0.3" }, devDependencies: { baz: "^0.0.5" } }),
+    );
+  });
+
+  it("updates the devDependencies range when adding to peerDependencies", async () => {
+    const initial = { ...root, devDependencies: { baz: ">=0.0.3" } };
+    expect(await add(initial, ["--peer", "baz"], { "0.0.3": {}, "0.0.5": {} })).toBe(
+      pkgJson({ ...root, devDependencies: { baz: "^0.0.5" }, peerDependencies: { baz: "^0.0.5" } }),
+    );
+  });
+
+  it("does not move when no group flag is given", async () => {
+    const initial = { ...root, devDependencies: { BaR: "^0.0.2" } };
+    expect(await add(initial, ["BaR"])).toBe(pkgJson(initial));
+  });
+
+  it("does not move with --only-missing", async () => {
+    const initial = { ...root, dependencies: { BaR: "^0.0.2" } };
+    expect(await add(initial, ["--dev", "--only-missing", "BaR"])).toBe(pkgJson(initial));
+  });
+});
+
 it("should add exact version with install.exact", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls));
@@ -1680,7 +1773,7 @@ it("should let you add the same package twice", async () => {
       {
         name: "Foo",
         version: "0.0.1",
-        dependencies: {
+        devDependencies: {
           baz: "^0.0.3",
         },
       },


### PR DESCRIPTION
### Problem
- `bun add -d <pkg>` (also `--optional` / `--peer`, and `bun install -d <pkg>`) leaves a package that is already listed in another dependency group where it is, so the only way to move a package between groups is `bun remove` followed by `bun add`.
- `PackageJSONEditor::edit` scans the four groups for an existing entry and, when it finds one in a group other than the target, updates that entry's value in place instead of moving it.

Fixes #5714.
Fixes #4852.

### Fix
- When a group flag was given (`dependency_list` is not `dependencies`) and the package is found in another group, remove that entry and let the normal add path write it into the target group. The scan visits every group in that mode so a stale copy in a later group is cleaned up too, and a removal marks the file as changed.
- Removal is an ordered `remove` of the entry (and of the group itself once it is empty), so the remaining entries and the other root keys of `package.json` keep their order.
- Exceptions, matching npm (`@npmcli/arborist` `add-rm-pkg-deps.js`) and pnpm:
  - a `peerDependencies` entry is left alone when adding to another group;
  - when adding to `peerDependencies`, an existing `devDependencies` entry is kept and rewritten to the new peer range.
- A bare `bun add <pkg>` keeps the existing placement, and `--only-missing` still leaves existing entries untouched. `bun update` and `bun link` never set a group flag, so they are unaffected. `--filter` and `--catalog` adds go through the same editor and pick the new behavior up.
- Out of scope: non-aliased URL/path positionals (git, tarball, folder, link) are matched by value, not by name, and keep their current in-place behavior.
- Verified:
  - `test/cli/install/bun-add.test.ts`: 14 cases compare the printed `package.json` text and cover every group pair, removal from the middle of a group, unranked root keys around an emptied group, several packages in one command, both peer/dev cases with a range that changes, and the no-flag / `--only-missing` opt-outs; the 12 that exercise the move fail on the released `bun`. "should let you add the same package twice" asserted the old behavior and now expects the move.
  - `test/cli/install/bun-add-filter.test.ts` and `bun-add-catalog.test.ts`: the three cases that pinned update-in-place now expect the move; the filtered `--peer` one keeps its checks that bun.lock matches the edited file, `--frozen-lockfile` passes and a second install saves nothing.
  - `bun-add`, `bun-add-filter` and `bun-add-catalog` pass in full on the rebased branch; swapping the ordered removes back to `swap_remove` + re-sort fails the two ordering tests.

### Background
- `edit()` runs twice per `bun add`: once before the install with the literal the user typed, and once after the install on a re-parsed `package.json` with the resolved range. The removal happens on the first pass, so the install already sees the moved entry and bun.lock is built from it; the second pass only rewrites version literals, which `package_json_write_back::sync_lockfile` copies into the lockfile.
- Each `UpdateRequest` carries an `e_string` pointer to the `package.json` value that receives the final version string. For the peer/dev case the existing dev value is recorded during the scan and copied from the peer value after the version strings have been written.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 10 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-add-filter.test.ts test/cli/install/bun-add.test.ts

<!-- robobun:evidence:end -->