### PR TITLE
install: update bun.lock workspace versions when only the version changes

### DIFF
--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -915,6 +915,7 @@ pub struct DiffSummary {
     pub(crate) script_only_updates: u32,
     pub(crate) overrides_changed: bool,
     pub(crate) catalogs_changed: bool,
+    pub(crate) workspace_versions_changed: bool,
 
     pub(crate) added_trusted_dependencies:
         ArrayHashMap<TruncatedPackageNameHash, AddedTrustedDependency, ArrayIdentityContext>,
@@ -938,6 +939,7 @@ impl DiffSummary {
     #[inline]
     pub(crate) fn has_diffs(&self) -> bool {
         self.changes_resolutions()
+            || self.workspace_versions_changed
             || self.added_trusted_dependencies.count() > 0
             || self.removed_trusted_dependencies.count() > 0
             || self.patched_dependencies_changed
@@ -1346,6 +1348,38 @@ impl Diff {
             }
             false
         };
+
+        if is_root {
+            summary.workspace_versions_changed = 'workspace_versions_changed: {
+                if from_lockfile.workspace_versions.count()
+                    != to_lockfile.workspace_versions.count()
+                {
+                    break 'workspace_versions_changed true;
+                }
+                let from_buf = from_lockfile.buffers.string_bytes.as_slice();
+                let to_buf = to_lockfile.buffers.string_bytes.as_slice();
+                for (key, to_version) in to_lockfile.workspace_versions.iter() {
+                    let Some(from_version) = from_lockfile.workspace_versions.get(key) else {
+                        break 'workspace_versions_changed true;
+                    };
+                    if from_version.major != to_version.major
+                        || from_version.minor != to_version.minor
+                        || from_version.patch != to_version.patch
+                        || from_version.tag.pre.slice(from_buf) != to_version.tag.pre.slice(to_buf)
+                        || from_version.tag.build.slice(from_buf)
+                            != to_version.tag.build.slice(to_buf)
+                    {
+                        break 'workspace_versions_changed true;
+                    }
+                }
+                for key in from_lockfile.workspace_versions.keys() {
+                    if !to_lockfile.workspace_versions.contains(key) {
+                        break 'workspace_versions_changed true;
+                    }
+                }
+                false
+            };
+        }
 
         let mut missing_workspaces: Vec<PackageID> = Vec::new();
         let mut survivors: Vec<(String, DependencySlice)> = Vec::new();

--- a/test/regression/issue/18906.test.ts
+++ b/test/regression/issue/18906.test.ts
@@ -1,0 +1,418 @@
+// https://github.com/oven-sh/bun/issues/18906
+// Changing only a workspace's "version" in its package.json must be written to bun.lock by the
+// next `bun install`, and the install after that must see no changes.
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// Every case below runs three or four `bun install`s back to back, concurrently with its siblings.
+setDefaultTimeout(30_000);
+
+function project(prefix: string, pkgA: Record<string, unknown>) {
+  return tempDir(prefix, {
+    "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"] }),
+    "packages/pkg-a/package.json": JSON.stringify(pkgA),
+    "packages/pkg-b/package.json": JSON.stringify({
+      name: "pkg-b",
+      version: "1.0.0",
+      dependencies: { "pkg-a": "workspace:*" },
+    }),
+  });
+}
+
+async function install(cwd: string, ...args: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", ...args],
+    cwd,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
+  return { stdout, stderr };
+}
+
+async function installSavesLockfile(cwd: string, ...args: string[]) {
+  const { stderr } = await install(cwd, ...args);
+  expect(stderr).toContain("Saved lockfile");
+}
+
+async function installIsNoop(cwd: string, ...args: string[]) {
+  const { stdout, stderr } = await install(cwd, ...args);
+  expect(stderr).not.toContain("Saved lockfile");
+  expect(stdout).toContain("no changes");
+}
+
+function lockfile(cwd: string) {
+  return Bun.file(join(cwd, "bun.lock")).text();
+}
+
+function setPkgA(cwd: string, pkgA: Record<string, unknown>) {
+  return Bun.write(join(cwd, "packages", "pkg-a", "package.json"), JSON.stringify(pkgA));
+}
+
+describe.concurrent("bun.lock tracks workspace package.json versions", () => {
+  for (const linker of ["isolated", "hoisted"]) {
+    test(`version bump is written once (--linker=${linker})`, async () => {
+      using dir = project(`issue-18906-${linker}`, { name: "pkg-a", version: "1.0.0" });
+      const cwd = String(dir);
+
+      await installSavesLockfile(cwd, `--linker=${linker}`);
+      expect(await lockfile(cwd)).toMatchInlineSnapshot(`
+        "{
+          "lockfileVersion": 2,
+          "configVersion": 1,
+          "workspaces": {
+            "": {
+              "name": "root",
+            },
+            "packages/pkg-a": {
+              "name": "pkg-a",
+              "version": "1.0.0",
+            },
+            "packages/pkg-b": {
+              "name": "pkg-b",
+              "version": "1.0.0",
+              "dependencies": {
+                "pkg-a": "workspace:*",
+              },
+            },
+          },
+          "packages": {
+            "pkg-a": ["pkg-a@workspace:packages/pkg-a"],
+
+            "pkg-b": ["pkg-b@workspace:packages/pkg-b"],
+          }
+        }
+        "
+      `);
+
+      await setPkgA(cwd, { name: "pkg-a", version: "2.0.0" });
+      await installSavesLockfile(cwd, `--linker=${linker}`);
+      expect(await lockfile(cwd)).toMatchInlineSnapshot(`
+        "{
+          "lockfileVersion": 2,
+          "configVersion": 1,
+          "workspaces": {
+            "": {
+              "name": "root",
+            },
+            "packages/pkg-a": {
+              "name": "pkg-a",
+              "version": "2.0.0",
+            },
+            "packages/pkg-b": {
+              "name": "pkg-b",
+              "version": "1.0.0",
+              "dependencies": {
+                "pkg-a": "workspace:*",
+              },
+            },
+          },
+          "packages": {
+            "pkg-a": ["pkg-a@workspace:packages/pkg-a"],
+
+            "pkg-b": ["pkg-b@workspace:packages/pkg-b"],
+          }
+        }
+        "
+      `);
+
+      await installIsNoop(cwd, `--linker=${linker}`);
+    });
+  }
+
+  test("version bump with --lockfile-only", async () => {
+    using dir = project("issue-18906-lockfile-only", { name: "pkg-a", version: "1.0.0" });
+    const cwd = String(dir);
+
+    await installSavesLockfile(cwd);
+    await setPkgA(cwd, { name: "pkg-a", version: "2.0.0" });
+    await installSavesLockfile(cwd, "--lockfile-only");
+    expect(await lockfile(cwd)).toMatchInlineSnapshot(`
+      "{
+        "lockfileVersion": 2,
+        "configVersion": 1,
+        "workspaces": {
+          "": {
+            "name": "root",
+          },
+          "packages/pkg-a": {
+            "name": "pkg-a",
+            "version": "2.0.0",
+          },
+          "packages/pkg-b": {
+            "name": "pkg-b",
+            "version": "1.0.0",
+            "dependencies": {
+              "pkg-a": "workspace:*",
+            },
+          },
+        },
+        "packages": {
+          "pkg-a": ["pkg-a@workspace:packages/pkg-a"],
+
+          "pkg-b": ["pkg-b@workspace:packages/pkg-b"],
+        }
+      }
+      "
+    `);
+
+    await installIsNoop(cwd);
+  });
+
+  test("build metadata change is written once", async () => {
+    using dir = project("issue-18906-build", { name: "pkg-a", version: "1.0.0+build.1" });
+    const cwd = String(dir);
+
+    await installSavesLockfile(cwd);
+    await setPkgA(cwd, { name: "pkg-a", version: "1.0.0+build.2" });
+    await installSavesLockfile(cwd);
+    expect(await lockfile(cwd)).toMatchInlineSnapshot(`
+      "{
+        "lockfileVersion": 2,
+        "configVersion": 1,
+        "workspaces": {
+          "": {
+            "name": "root",
+          },
+          "packages/pkg-a": {
+            "name": "pkg-a",
+            "version": "1.0.0+build.2",
+          },
+          "packages/pkg-b": {
+            "name": "pkg-b",
+            "version": "1.0.0",
+            "dependencies": {
+              "pkg-a": "workspace:*",
+            },
+          },
+        },
+        "packages": {
+          "pkg-a": ["pkg-a@workspace:packages/pkg-a"],
+
+          "pkg-b": ["pkg-b@workspace:packages/pkg-b"],
+        }
+      }
+      "
+    `);
+
+    await installIsNoop(cwd);
+  });
+
+  test("prerelease change is written once", async () => {
+    using dir = project("issue-18906-pre", { name: "pkg-a", version: "1.0.0" });
+    const cwd = String(dir);
+
+    await installSavesLockfile(cwd);
+    await setPkgA(cwd, { name: "pkg-a", version: "1.0.0-beta.1+build.7" });
+    await installSavesLockfile(cwd);
+    expect(await lockfile(cwd)).toMatchInlineSnapshot(`
+      "{
+        "lockfileVersion": 2,
+        "configVersion": 1,
+        "workspaces": {
+          "": {
+            "name": "root",
+          },
+          "packages/pkg-a": {
+            "name": "pkg-a",
+            "version": "1.0.0-beta.1+build.7",
+          },
+          "packages/pkg-b": {
+            "name": "pkg-b",
+            "version": "1.0.0",
+            "dependencies": {
+              "pkg-a": "workspace:*",
+            },
+          },
+        },
+        "packages": {
+          "pkg-a": ["pkg-a@workspace:packages/pkg-a"],
+
+          "pkg-b": ["pkg-b@workspace:packages/pkg-b"],
+        }
+      }
+      "
+    `);
+
+    await setPkgA(cwd, { name: "pkg-a", version: "1.0.0-beta.2+build.7" });
+    await installSavesLockfile(cwd);
+    expect(await lockfile(cwd)).toMatchInlineSnapshot(`
+      "{
+        "lockfileVersion": 2,
+        "configVersion": 1,
+        "workspaces": {
+          "": {
+            "name": "root",
+          },
+          "packages/pkg-a": {
+            "name": "pkg-a",
+            "version": "1.0.0-beta.2+build.7",
+          },
+          "packages/pkg-b": {
+            "name": "pkg-b",
+            "version": "1.0.0",
+            "dependencies": {
+              "pkg-a": "workspace:*",
+            },
+          },
+        },
+        "packages": {
+          "pkg-a": ["pkg-a@workspace:packages/pkg-a"],
+
+          "pkg-b": ["pkg-b@workspace:packages/pkg-b"],
+        }
+      }
+      "
+    `);
+
+    await installIsNoop(cwd);
+  });
+
+  // "1.0.0-" parses with an empty prerelease identifier, which bun.lock writes back as "1.0.0".
+  // Reinstalling must not treat the two spellings as a change.
+  test("empty prerelease identifier does not cause a rewrite on every install", async () => {
+    using dir = project("issue-18906-empty-pre", { name: "pkg-a", version: "1.0.0-" });
+    const cwd = String(dir);
+
+    await installSavesLockfile(cwd);
+    expect(await lockfile(cwd)).toMatchInlineSnapshot(`
+      "{
+        "lockfileVersion": 2,
+        "configVersion": 1,
+        "workspaces": {
+          "": {
+            "name": "root",
+          },
+          "packages/pkg-a": {
+            "name": "pkg-a",
+            "version": "1.0.0",
+          },
+          "packages/pkg-b": {
+            "name": "pkg-b",
+            "version": "1.0.0",
+            "dependencies": {
+              "pkg-a": "workspace:*",
+            },
+          },
+        },
+        "packages": {
+          "pkg-a": ["pkg-a@workspace:packages/pkg-a"],
+
+          "pkg-b": ["pkg-b@workspace:packages/pkg-b"],
+        }
+      }
+      "
+    `);
+
+    await installIsNoop(cwd);
+  });
+
+  test("adding a version is written once", async () => {
+    using dir = project("issue-18906-add", { name: "pkg-a" });
+    const cwd = String(dir);
+
+    await installSavesLockfile(cwd);
+    expect(await lockfile(cwd)).toMatchInlineSnapshot(`
+      "{
+        "lockfileVersion": 2,
+        "configVersion": 1,
+        "workspaces": {
+          "": {
+            "name": "root",
+          },
+          "packages/pkg-a": {
+            "name": "pkg-a",
+          },
+          "packages/pkg-b": {
+            "name": "pkg-b",
+            "version": "1.0.0",
+            "dependencies": {
+              "pkg-a": "workspace:*",
+            },
+          },
+        },
+        "packages": {
+          "pkg-a": ["pkg-a@workspace:packages/pkg-a"],
+
+          "pkg-b": ["pkg-b@workspace:packages/pkg-b"],
+        }
+      }
+      "
+    `);
+
+    await setPkgA(cwd, { name: "pkg-a", version: "1.0.0" });
+    await installSavesLockfile(cwd);
+    expect(await lockfile(cwd)).toMatchInlineSnapshot(`
+      "{
+        "lockfileVersion": 2,
+        "configVersion": 1,
+        "workspaces": {
+          "": {
+            "name": "root",
+          },
+          "packages/pkg-a": {
+            "name": "pkg-a",
+            "version": "1.0.0",
+          },
+          "packages/pkg-b": {
+            "name": "pkg-b",
+            "version": "1.0.0",
+            "dependencies": {
+              "pkg-a": "workspace:*",
+            },
+          },
+        },
+        "packages": {
+          "pkg-a": ["pkg-a@workspace:packages/pkg-a"],
+
+          "pkg-b": ["pkg-b@workspace:packages/pkg-b"],
+        }
+      }
+      "
+    `);
+
+    await installIsNoop(cwd);
+  });
+
+  test("removing a version is written once", async () => {
+    using dir = project("issue-18906-remove", { name: "pkg-a", version: "1.0.0" });
+    const cwd = String(dir);
+
+    await installSavesLockfile(cwd);
+    await setPkgA(cwd, { name: "pkg-a" });
+    await installSavesLockfile(cwd);
+    expect(await lockfile(cwd)).toMatchInlineSnapshot(`
+      "{
+        "lockfileVersion": 2,
+        "configVersion": 1,
+        "workspaces": {
+          "": {
+            "name": "root",
+          },
+          "packages/pkg-a": {
+            "name": "pkg-a",
+          },
+          "packages/pkg-b": {
+            "name": "pkg-b",
+            "version": "1.0.0",
+            "dependencies": {
+              "pkg-a": "workspace:*",
+            },
+          },
+        },
+        "packages": {
+          "pkg-a": ["pkg-a@workspace:packages/pkg-a"],
+
+          "pkg-b": ["pkg-b@workspace:packages/pkg-b"],
+        }
+      }
+      "
+    `);
+
+    await installIsNoop(cwd);
+  });
+});


### PR DESCRIPTION
Fixes #18906

### Problem
- Bump a workspace's `"version"` in its `package.json` and run `bun install` or `bun install --lockfile-only`: `bun.lock` keeps the old version. With the hoisted linker every later install also reports `1 package installed` for the bumped workspace, because the installer checks it against the stale version map.
- `install_with_manager` parses the root `package.json` into a fresh lockfile and calls `Diff::generate` against the loaded one. `DiffSummary::has_diffs()` (`src/install/lockfile/Package.rs`) only covers dependency add/remove/update, overrides, catalogs, trusted and patched dependencies. Workspace versions are never compared, so a version-only change yields no diff, the `workspace_versions` copy in `install_with_manager.rs` is skipped, and the save gate stays closed.

### Fix
- `Diff::generate` compares `workspace_versions` between the loaded and fresh lockfiles on the root pass (count, then per entry major/minor/patch plus the pre and build identifier bytes read from each lockfile's own string buffer, then the reverse key walk), mirroring the `patched_dependencies_changed` block above it. The result is a new `DiffSummary::workspace_versions_changed` included in `has_diffs()`, which opens the existing copy-and-save path. It is deliberately not part of `changes_resolutions()`: a version bump does not change what any dependency resolves to, so it should not affect the optional-peer and direct-dependency snapshots that method gates.
- Bytes rather than tag hashes: `bun.lock` omits empty identifiers, so `"1.0.0-"` is written back as `"1.0.0"`; comparing the bytes makes such a project settle after one write instead of depending on how empty identifiers hash.
- Removing a version (or making it unparseable) is caught by the count check; the reverse walk is kept for symmetry with the neighbouring block.
- Test: `test/regression/issue/18906.test.ts` (8 cases). Each case that changes a version checks the next install prints `Saved lockfile`, inline-snapshots the whole `bun.lock`, and then checks one more install prints `no changes` without saving. Cases: bump under `--linker=isolated` and `--linker=hoisted`, bump with `--lockfile-only`, build metadata only, prerelease (`1.0.0` to `1.0.0-beta.1+build.7` to `1.0.0-beta.2+build.7`), adding a version, removing a version, and the `1.0.0-` settle guard.
- Verified on this branch (rebased onto 39fb3c103e): with main's `src/install/lockfile/Package.rs` checked out and rebuilt, `bun bd test test/regression/issue/18906.test.ts` gives 7 fail / 1 pass (the `1.0.0-` guard passes either way; it guards the comparison, not the bug); with the change restored it gives 8 pass on repeated runs. The file sets a 30s default timeout because each case runs three or four installs concurrently with its siblings, which tipped over the 5s default once on a cold debug build.
- Also ran `test/cli/install/lockfile-only.test.ts` (pass). `--frozen-lockfile` after a bump behaves as on main (no error, file untouched).

### Background
- `bun.lock` has a `workspaces` section listing each workspace's name, version and dependencies. In memory that version lives in `Lockfile.workspace_versions`, a map from package name hash to `Semver::Version`.
- On `bun install`, bun loads the existing lockfile, parses the current `package.json` files into a second, throwaway `Lockfile`, and runs `Diff::generate` between them. `DiffSummary` is the result; `has_diffs()` decides whether the loaded lockfile gets the fresh data copied in and is rewritten, or is reused as is.
- `Semver::Version` stores the numeric parts inline and the prerelease/build identifiers as offsets into the owning lockfile's string buffer, so comparing two versions from different lockfiles needs both buffers. `Version::eql` is SemVer precedence equality (ignores build metadata), which is why it is not used here.

<details>
<summary>Earlier revision</summary>

The first revision compared with `Version::eql` plus `tag.build.hash`, had its tests in `bun-workspaces.test.ts`, only ran under the isolated linker and never reinstalled after a bump. Reworked after review: byte comparison, reverse key walk, standalone test file covering both linkers, settle-after-change, prerelease, add and remove.
</details>

