### PR TITLE
test(amqplib): add regression coverage for #5627 (large-message frame corruption)

### DIFF
--- a/test/bun.lock
+++ b/test/bun.lock
@@ -29,6 +29,7 @@
         "@verdaccio/config": "6.0.0-6-next.76",
         "@vitest/coverage-v8": "4.1.9",
         "acorn": "8.15.0",
+        "amqplib": "0.10.5",
         "ansi-regex": "6.1.0",
         "astro": "5.5.5",
         "aws-cdk-lib": "2.148.0",
@@ -129,6 +130,8 @@
     "react": "../node_modules/react",
   },
   "packages": {
+    "@acuminous/bitsyntax": ["@acuminous/bitsyntax@0.1.2", "", { "dependencies": { "buffer-more-ints": "~1.0.0", "debug": "^4.3.4", "safe-buffer": "~5.1.2" } }, "sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ=="],
+
     "@adobe/css-tools": ["@adobe/css-tools@4.4.1", "", {}, "sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
@@ -879,6 +882,8 @@
 
     "ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
 
+    "amqplib": ["amqplib@0.10.5", "", { "dependencies": { "@acuminous/bitsyntax": "^0.1.2", "buffer-more-ints": "~1.0.0", "url-parse": "~1.5.10" } }, "sha512-Dx5zmy0Ur+Q7LPPdhz+jx5IzmJBoHd15tOeAfQ8SuvEtyPJ20hBemhOBA4b1WeORCRa0ENM/kHCzmem1w/zHvQ=="],
+
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 
     "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
@@ -1010,6 +1015,8 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "buffer-more-ints": ["buffer-more-ints@1.0.0", "", {}, "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="],
 
     "buffer-writer": ["buffer-writer@2.0.0", "", {}, "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="],
 
@@ -2692,6 +2699,10 @@
     "zod-to-ts": ["zod-to-ts@1.2.0", "", { "peerDependencies": { "typescript": "^4.9.4 || ^5.0.2", "zod": "^3" } }, "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@acuminous/bitsyntax/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
+
+    "@acuminous/bitsyntax/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "@ampproject/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 

--- a/test/js/third_party/amqplib/amqplib-large-message-fixture.js
+++ b/test/js/third_party/amqplib/amqplib-large-message-fixture.js
@@ -1,0 +1,164 @@
+// Minimal in-process AMQP 0.9.1 server that speaks enough of the protocol for
+// amqplib to connect, open a channel, declare/purge a queue, publish a message,
+// and retrieve it with Basic.Get. Uses amqplib's own frame codec so the wire
+// format is identical to what a real RabbitMQ client sees.
+//
+// Exercises both directions over a real TCP socket at the default 4 KiB frame
+// size, so payloads larger than that are split across many body frames and go
+// through amqplib's Mux (objectMode PassThrough -> net.Socket) on the send side
+// and the 'readable' / socket.read() loop on the receive side.
+
+const net = require("net");
+const crypto = require("crypto");
+const defs = require("amqplib/lib/defs");
+const frame = require("amqplib/lib/frame");
+const amqplib = require("amqplib");
+
+const FRAME_MAX = 4096;
+
+function fakeServer(queue) {
+  const server = net.createServer(sock => {
+    let rest = Buffer.alloc(0);
+    let sawHeader = false;
+    let expectBody = 0;
+    let body = [];
+
+    function sendMethod(id, channel, fields) {
+      sock.write(defs.encodeMethod(id, channel, fields));
+    }
+    function sendContent(channel, id, fields, content) {
+      sock.write(defs.encodeMethod(id, channel, fields));
+      sock.write(defs.encodeProperties(defs.BasicProperties, channel, content.length, {}));
+      const maxBody = FRAME_MAX - defs.FRAME_OVERHEAD;
+      for (let off = 0; off < content.length; off += maxBody) {
+        sock.write(frame.makeBodyFrame(channel, content.subarray(off, off + maxBody)));
+      }
+    }
+
+    function accept(f) {
+      const ch = f.channel;
+      switch (f.id) {
+        case defs.ConnectionStartOk:
+          return sendMethod(defs.ConnectionTune, 0, { channelMax: 0, frameMax: FRAME_MAX, heartbeat: 0 });
+        case defs.ConnectionTuneOk:
+          return;
+        case defs.ConnectionOpen:
+          return sendMethod(defs.ConnectionOpenOk, 0, { knownHosts: "" });
+        case defs.ConnectionClose:
+          sendMethod(defs.ConnectionCloseOk, 0, {});
+          return sock.end();
+        case defs.ChannelOpen:
+          return sendMethod(defs.ChannelOpenOk, ch, { channelId: Buffer.from("") });
+        case defs.ChannelClose:
+          return sendMethod(defs.ChannelCloseOk, ch, {});
+        case defs.QueueDeclare:
+          return sendMethod(defs.QueueDeclareOk, ch, { queue: f.fields.queue, messageCount: 0, consumerCount: 0 });
+        case defs.QueuePurge:
+          queue.content = null;
+          return sendMethod(defs.QueuePurgeOk, ch, { messageCount: 0 });
+        case defs.BasicPublish:
+          expectBody = -1;
+          body = [];
+          return;
+        case defs.BasicGet:
+          if (queue.content) {
+            return sendContent(
+              ch,
+              defs.BasicGetOk,
+              {
+                deliveryTag: 1,
+                redelivered: false,
+                exchange: "",
+                routingKey: f.fields.queue,
+                messageCount: 0,
+              },
+              queue.content,
+            );
+          }
+          return sendMethod(defs.BasicGetEmpty, ch, { clusterId: "" });
+        case defs.BasicProperties:
+          expectBody = f.size;
+          if (expectBody === 0) queue.content = Buffer.alloc(0);
+          return;
+        case undefined:
+          if (f.content) {
+            body.push(f.content);
+            const got = body.reduce((a, b) => a + b.length, 0);
+            if (got >= expectBody) {
+              queue.content = Buffer.concat(body);
+              expectBody = 0;
+              body = [];
+            }
+          }
+          return;
+        default:
+          throw new Error(`unhandled method ${defs.info(f.id).name}`);
+      }
+    }
+
+    function go() {
+      let inc;
+      while ((inc = sock.read()) !== null) rest = Buffer.concat([rest, inc]);
+      if (!sawHeader) {
+        if (rest.length < 8) return;
+        sawHeader = true;
+        rest = rest.subarray(8);
+        sendMethod(defs.ConnectionStart, 0, {
+          versionMajor: 0,
+          versionMinor: 9,
+          serverProperties: {},
+          mechanisms: Buffer.from("PLAIN"),
+          locales: Buffer.from("en_US"),
+        });
+      }
+      let parsed;
+      while ((parsed = frame.parseFrame(rest, FRAME_MAX))) {
+        rest = parsed.rest;
+        accept(frame.decodeFrame(parsed));
+      }
+    }
+    sock.on("readable", go);
+    sock.on("error", () => {});
+  });
+  return server;
+}
+
+async function roundtrip(port, size) {
+  const expected = crypto.randomBytes(size);
+
+  {
+    const conn = await amqplib.connect(`amqp://127.0.0.1:${port}`);
+    const channel = await conn.createChannel();
+    await channel.assertQueue("q");
+    await channel.purgeQueue("q");
+    channel.sendToQueue("q", expected);
+    await channel.close();
+    await conn.close();
+  }
+
+  {
+    const conn = await amqplib.connect(`amqp://127.0.0.1:${port}`);
+    const channel = await conn.createChannel();
+    const msg = await channel.get("q");
+    await channel.close();
+    await conn.close();
+    if (!msg) throw new Error(`size=${size}: no message`);
+    if (msg.content.length !== size) throw new Error(`size=${size}: length ${msg.content.length} != ${size}`);
+    if (!msg.content.equals(expected)) throw new Error(`size=${size}: content mismatch`);
+  }
+}
+
+(async () => {
+  const queue = { content: null };
+  const server = fakeServer(queue);
+  await new Promise(r => server.listen(0, "127.0.0.1", r));
+  const port = server.address().port;
+  try {
+    for (const size of [100, 200_000]) {
+      await roundtrip(port, size);
+      console.log(`OK ${size}`);
+    }
+  } finally {
+    server.close();
+  }
+})();

--- a/test/js/third_party/amqplib/amqplib.test.ts
+++ b/test/js/third_party/amqplib/amqplib.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "path";
+
+// https://github.com/oven-sh/bun/issues/5627
+// amqplib fragments payloads larger than the negotiated frameMax across many
+// AMQP body frames and funnels them through an objectMode PassThrough into the
+// net.Socket (see amqplib/lib/mux.js). In older Bun versions the receive side
+// would see duplicated/interleaved bytes, tripping "Invalid frame" /
+// "Frame size exceeds frame max" in amqplib/lib/frame.js.
+test("amqplib round-trips large messages without frame corruption", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "amqplib-large-message-fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.split("\n").filter(Boolean)).toEqual(["OK 100", "OK 200000"]);
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/js/third_party/amqplib/package.json
+++ b/test/js/third_party/amqplib/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "amqplib-test",
+  "dependencies": {
+    "amqplib": "0.10.5"
+  }
+}

--- a/test/package.json
+++ b/test/package.json
@@ -32,6 +32,7 @@
     "@testing-library/react": "16.1.0",
     "@verdaccio/config": "6.0.0-6-next.76",
     "acorn": "8.15.0",
+    "amqplib": "0.10.5",
     "ansi-regex": "6.1.0",
     "astro": "5.5.5",
     "aws-cdk-lib": "2.148.0",


### PR DESCRIPTION
Closes #5627.

### Repro

Running [acuminous/amqplib-764](https://github.com/acuminous/amqplib-764) (`bun index.js 100000`) against RabbitMQ on Bun v1.1.13 throws `Invalid frame` / `Frame size exceeds frame max` at `amqplib/lib/frame.js:59`. The same program prints `OK` on Node.

### Cause and fix

amqplib fragments payloads larger than the negotiated `frameMax` (default 4096) into many body frames and funnels them through an objectMode `PassThrough` into the `net.Socket` via its `Mux` class, which drains the PassThrough on `"readable"` + `.read()` and calls `socket.write()` per frame. On the receive side amqplib reads the socket the same way (`"readable"` + `socket.read()`, then `Buffer.concat`).

This round trip corrupted data in older Bun: bytes from adjacent frames were duplicated/interleaved, so the `FRAME_END` octet landed at the wrong offset. Swapping `stream.PassThrough`/`Duplex` for the `readable-stream` package worked around it, pointing at the `node:net` / `node:stream` interaction.

No source change is needed here: bisecting across published releases shows the bug is present through **v1.1.34** and gone in **v1.1.35**, most likely fixed by the `node:net` compatibility work in #14933. On current `main`:

```
$ bun test/js/third_party/amqplib/amqplib-large-message-fixture.js
OK 100
OK 200000
```

The same fixture fails on v1.1.34 with the exact error from the issue:

```
error: Invalid frame
      at parseFrame (.../amqplib/lib/frame.js:59:15)
```

### What this PR adds

A minimal in-process AMQP 0.9.1 server (built on amqplib's own `lib/defs` / `lib/frame` codec, so no RabbitMQ needed) plus a test that drives the real `amqplib` client through a publish/get round trip over a TCP socket. The 200 KB payload at `frameMax=4096` is split across ~49 body frames and checked byte-for-byte on the way back, locking in both the send-side `Mux` path and the receive-side `"readable"`/`read()` path.

### Verification

| runtime | result |
| --- | --- |
| Node v26 | `OK 100` / `OK 200000` |
| Bun `main` (debug+ASAN) | pass, ~7s |
| Bun v1.1.35 | `OK 100` / `OK 200000` |
| Bun v1.1.34 | `Invalid frame` at `frame.js:59` |
| Bun v1.1.13 | `Invalid frame` at `frame.js:59` |

This PR is test-only; there is no `src/` diff because the underlying bug was fixed over a year ago. The fail-before gate will not apply here, so this needs a manual look.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 5 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/third_party/amqplib/amqplib.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/third_party/amqplib/amqplib.test.ts
bun test v1.4.0 (34eb92781)

test/js/third_party/amqplib/amqplib.test.ts:
(pass) amqplib round-trips large messages without frame corruption [6559.43ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [10.04s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bun.lock                                      |  11 ++
 .../amqplib/amqplib-large-message-fixture.js       | 164 +++++++++++++++++++++
 test/js/third_party/amqplib/amqplib.test.ts        |  24 +++
 test/js/third_party/amqplib/package.json           |   6 +
 test/package.json                                  |   1 +
 5 files changed, 206 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
test/bun.lock                                                 0      0      0
…js/third_party/amqplib/amqplib-large-message-fixture.js      0      6      0
test/js/third_party/amqplib/amqplib.test.ts                   0      2      0
test/js/third_party/amqplib/package.json                      0      2      0
test/package.json                                             1      2      0
```

</details>

<!-- robobun:evidence:end -->