### PR TITLE
inspector-frontend: guard isInsertionCaretInside call so Firefox survives reload

### DIFF
--- a/packages/bun-inspector-frontend/scripts/build.ts
+++ b/packages/bun-inspector-frontend/scripts/build.ts
@@ -1,12 +1,29 @@
 import { copyFileSync, mkdirSync, readdirSync, rmSync, statSync } from "fs";
 import { join } from "path";
 
-try {
-  const basePath = join(import.meta.dir, "../../../src/bun.js/WebKit/Source/WebInspectorUI/UserInterface");
+// Firefox compatibility patches applied to the bundled WebInspectorUI output.
+// Exported so it can be unit-tested without a full WebKit build.
+export function patchBundleForFirefox(jsText: string): string {
+  // WI._focusChanged is a capture-phase "focus" listener on document that calls
+  // event.target.isInsertionCaretInside(), an extension the inspector installs on
+  // Element.prototype. On reload Firefox can deliver this listener a focus event
+  // whose target is not an Element (https://github.com/oven-sh/bun/issues/16220),
+  // so the call throws and the whole UI fails to initialize. Bail out of the
+  // selection fixup when the target doesn't have the method; the createRange()
+  // path that follows it assumes an Element too.
+  return jsText.replace(
+    /if\((\w+)\.isInsertionCaretInside\(\)\)return/g,
+    'if(typeof $1.isInsertionCaretInside!=="function"||$1.isInsertionCaretInside())return',
+  );
+}
+
+async function main() {
+  const webkitPath = process.env.WEBKIT_PATH || join(import.meta.dir, "../../../vendor/WebKit");
+  const basePath = join(webkitPath, "Source/WebInspectorUI/UserInterface");
   const htmlPath = join(basePath, "Main.html");
   const backendCommands = join(
-    import.meta.dir,
-    "../../../src/bun.js/WebKit/WebKitBuild/Release/JavaScriptCore/DerivedSources/inspector/InspectorBackendCommands.js",
+    webkitPath,
+    "WebKitBuild/Release/JavaScriptCore/DerivedSources/inspector/InspectorBackendCommands.js",
   );
   const scriptsToBundle = [];
   const stylesToBundle = [];
@@ -117,6 +134,7 @@ try {
     outdir: "out",
     minify: true,
   });
+  const jsText = patchBundleForFirefox(await jsBundle.outputs[0].text());
   const jsFilename = "manifest-" + jsBundle.outputs[0].hash + ".js";
   // const cssBundle = await build({
   //   bundle: true,
@@ -144,7 +162,7 @@ try {
   // const cssFilename = "manifest-" + cssBundle.outputFiles[0].hash.replaceAll("/", "_") + ".css";
   htmlText = htmlText.replace(jsReplacementId, jsFilename);
   // htmlText = htmlText.replace(cssReplacementId, cssFilename);
-  await Bun.write(join(import.meta.dir, "out", jsFilename), jsBundle.outputs[0]);
+  await Bun.write(join(import.meta.dir, "out", jsFilename), jsText);
   // await Bun.write(join(import.meta.dir, "out", cssFilename), cssBundle.outputFiles[0].text);
   await Bun.write(join(import.meta.dir, "out", "index.html"), htmlText);
   await Bun.write(join(import.meta.dir, "out", "index.html"), htmlText);
@@ -165,7 +183,12 @@ try {
   }
 
   recursiveCopy(basePath, join(import.meta.dir, "out"));
-} catch (e) {
-  console.error("Failed to build. Please make sure you've ran `make jsc` locally.");
-  throw e;
+}
+
+if (import.meta.main) {
+  main().catch(e => {
+    console.error("Failed to build. Please make sure you've ran `make jsc` locally.");
+    console.error(e);
+    process.exit(1);
+  });
 }

--- a/packages/bun-inspector-frontend/scripts/build.ts
+++ b/packages/bun-inspector-frontend/scripts/build.ts
@@ -11,10 +11,17 @@ export function patchBundleForFirefox(jsText: string): string {
   // so the call throws and the whole UI fails to initialize. Bail out of the
   // selection fixup when the target doesn't have the method; the createRange()
   // path that follows it assumes an Element too.
-  return jsText.replace(
+  const out = jsText.replace(
     /if\((\w+)\.isInsertionCaretInside\(\)\)return/g,
     'if(typeof $1.isInsertionCaretInside!=="function"||$1.isInsertionCaretInside())return',
   );
+  if (out === jsText) {
+    throw new Error(
+      "Firefox isInsertionCaretInside patch did not apply: the minified shape of " +
+        "WI._focusChanged has changed. Update the pattern in patchBundleForFirefox.",
+    );
+  }
+  return out;
 }
 
 async function main() {
@@ -135,7 +142,7 @@ async function main() {
     minify: true,
   });
   const jsText = patchBundleForFirefox(await jsBundle.outputs[0].text());
-  const jsFilename = "manifest-" + jsBundle.outputs[0].hash + ".js";
+  const jsFilename = "manifest-" + Bun.hash(jsText).toString(36) + ".js";
   // const cssBundle = await build({
   //   bundle: true,
   //   minify: true,

--- a/test/regression/issue/16220.test.ts
+++ b/test/regression/issue/16220.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/16220
+//
+// debug.bun.sh is a bundled copy of WebKit's Web Inspector UI produced by
+// packages/bun-inspector-frontend/scripts/build.ts. The inspector installs a
+// capture-phase "focus" listener on document (WI._focusChanged) that calls
+// event.target.isInsertionCaretInside(), which the inspector defines only on
+// Element.prototype. When reloading the page in Firefox while the Console tab
+// is selected, the listener receives a focus event whose target is not an
+// Element, so the call throws and the UI fails to initialize.
+//
+// The build script post-processes the minified bundle to guard that call. We
+// can't run Firefox in CI, but we can verify the guard is applied and that the
+// guarded code survives a focus event whose target lacks the method.
+
+const buildScript = join(import.meta.dir, "../../../packages/bun-inspector-frontend/scripts/build.ts");
+
+// Tail of WI._focusChanged exactly as Bun.build({minify:true}) emits it from
+// WebKit's Source/WebInspectorUI/UserInterface/Base/Main.js (and as currently
+// deployed at https://debug.bun.sh/manifest-*.js).
+const minifiedFocusChanged =
+  "var I=window.getSelection();" +
+  "if(!I.isCollapsed)return;" +
+  "var E=N.target;" +
+  "if(E!==WI.currentFocusElement)WI.previousFocusElement=WI.currentFocusElement,WI.currentFocusElement=E;" +
+  "if(E.isInsertionCaretInside())return;" +
+  "var T=E.ownerDocument.createRange();" +
+  "T.setStart(E,0),T.setEnd(E,0),I.removeAllRanges(),I.addRange(T)";
+
+// Simulate the focus target Firefox delivers on reload: it has ownerDocument
+// like a Node but does not have the Element.prototype.isInsertionCaretInside
+// extension.
+function run(body: string) {
+  const window = {
+    getSelection: () => ({ isCollapsed: true, removeAllRanges() {}, addRange() {} }),
+  };
+  const WI = { currentFocusElement: null, previousFocusElement: null };
+  const N = {
+    target: {
+      ownerDocument: { createRange: () => ({ setStart() {}, setEnd() {} }) },
+      contains: () => false,
+    },
+  };
+  new Function("window", "WI", "N", body)(window, WI, N);
+}
+
+describe("debug.bun.sh Firefox reload crash", () => {
+  test("unpatched WI._focusChanged throws on a non-Element focus target (sanity)", () => {
+    expect(() => run(minifiedFocusChanged)).toThrow(/isInsertionCaretInside is not a function/);
+  });
+
+  test("inspector-frontend build script guards the isInsertionCaretInside call", async () => {
+    // build.ts exports patchBundleForFirefox and defers its top-level build to
+    // import.meta.main. The unfixed script ran its build at import time, so we
+    // check the export exists in the source before importing (in a subprocess)
+    // to avoid those side effects taking the test runner down on the fail-before
+    // path.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const path = ${JSON.stringify(buildScript)};
+         const src = await Bun.file(path).text();
+         if (!src.includes("export function patchBundleForFirefox")) {
+           console.error("build.ts does not export patchBundleForFirefox");
+           process.exit(1);
+         }
+         const { patchBundleForFirefox } = await import(path);
+         process.stdout.write(patchBundleForFirefox(${JSON.stringify(minifiedFocusChanged)}));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).not.toBe(minifiedFocusChanged);
+    expect(stdout).not.toContain("if(E.isInsertionCaretInside())");
+    expect(() => run(stdout)).not.toThrow();
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #16220.

## Repro

1. `bun --inspect-brk ./empty.ts`
2. Open the printed `https://debug.bun.sh/#...` URL in Firefox
3. Reload the page

```
TypeError: E.isInsertionCaretInside is not a function
    WI._focusChanged @ manifest-yr1khc1r.js:85:110934
    TextareaInput.prototype.focus @ codemirror.js:8770:25
    focus @ codemirror.js:7634:58
    ...
    WI.contentLoaded @ manifest-yr1khc1r.js:85:88809
```

The inspector UI never finishes initializing.

## Cause

WebKit's Web Inspector UI registers a capture-phase `focus` listener on `document` (`WI._focusChanged`, [Main.js](https://github.com/oven-sh/WebKit/blob/main/Source/WebInspectorUI/UserInterface/Base/Main.js)) and calls `event.target.isInsertionCaretInside()`, an extension it installs only on `Element.prototype` ([Utilities.js](https://github.com/oven-sh/WebKit/blob/main/Source/WebInspectorUI/UserInterface/Base/Utilities.js)).

On reload, `WI.contentLoaded` restores the previously selected tab from `WI._selectedTabIndexSetting`. When that is the Console tab, `ConsoleTabContentView.attached()` focuses the prompt, which calls CodeMirror's `focus()` (`window.focus(); this.display.input.focus()`). In Firefox the capture listener then receives a focus event whose target doesn't carry the `Element.prototype` extension, so the call throws and initialization stops. Chrome/Safari don't hit this.

## Fix

The debug.bun.sh bundle is produced by `packages/bun-inspector-frontend/scripts/build.ts`, which already injects a `scrollIntoViewIfNeeded` polyfill for Firefox. This PR adds a post-processing step there that rewrites the single call site to:

```js
if (typeof E.isInsertionCaretInside !== "function" || E.isInsertionCaretInside()) return;
```

so a focus target without the method short-circuits the selection fixup instead of throwing (the `ownerDocument.createRange()` path that follows it also assumes an Element). The replacement is a regex over the minified output so it's independent of the identifier the minifier picks. Verified by rebuilding the frontend locally: the patched bundle contains `if(typeof t.isInsertionCaretInside!=="function"||t.isInsertionCaretInside())return`.

The patch is exported as `patchBundleForFirefox()` so it can be unit-tested without a local WebKit release build, and the script body now runs only under `import.meta.main` so importing it is side-effect free. While here, the stale `src/bun.js/WebKit` path is updated to `vendor/WebKit` (overridable via `WEBKIT_PATH`) so the script can actually be run.

## Verification

`test/regression/issue/16220.test.ts` feeds the exact minified `WI._focusChanged` tail (as currently deployed at `debug.bun.sh/manifest-yr1khc1r.js`) through `patchBundleForFirefox` and evaluates the result against a focus target that lacks `isInsertionCaretInside`: the unpatched snippet throws, the patched one returns cleanly.

This only takes effect for users once the frontend is rebuilt and redeployed to debug.bun.sh.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/16220.test.ts"
bun test v1.4.0 (eba5d2a95)

test/regression/issue/16220.test.ts:
(pass) debug.bun.sh Firefox reload crash > unpatched WI._focusChanged throws on a non-Element focus target (sanity) [13.23ms]
75 |       stdout: "pipe",
76 |       stderr: "pipe",
77 |     });
78 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
79 | 
80 |     expect(stderr).toBe("");
                        ^
error: expect(received).toBe(expected)

- ""
+ "build.ts does not export patchBundleForFirefox
+ "

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/regression/issue/16220.test.ts:80:20)
(fail) debug.bun.sh Firefox reload crash > inspector-frontend build script guards the isInsertionCaretInside call [354.17ms]

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [2.63s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (0c4770d72)

test/regression/issue/16220.test.ts:
(pass) debug.bun.sh Firefox reload crash > unpatched WI._focusChanged throws on a non-Element focus target (sanity) [1.33ms]
75 |       stdout: "pipe",
76 |       stderr: "pipe",
77 |     });
78 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
79 | 
80 |     expect(stderr).toBe("");
                        ^
error: expect(received).toBe(expected)

- ""
+ "build.ts does not export patchBundleForFirefox
+ "

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/regression/issue/16220.test.ts:80:20)
(fail) debug.bun.sh Firefox reload crash > inspector-frontend build script guards the isInsertionCaretInside call [35.08ms]

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [219.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/16220.test.ts"
bun test v1.4.0 (eba5d2a95)

test/regression/issue/16220.test.ts:
(pass) debug.bun.sh Firefox reload crash > unpatched WI._focusChanged throws on a non-Element focus target (sanity) [11.48ms]
(pass) debug.bun.sh Firefox reload crash > inspector-frontend build script guards the isInsertionCaretInside call [1280.66ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [3.46s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 745ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 28s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.0-canary.1+eba5d2a95
[build] done
bun test v1.4.0-canary.1 (eba5d2a95)

test/regression/issue/16220.test.ts:
(pass) debug.bun.sh Firefox reload crash > unpatched WI._focusChanged throws on a non-Element focus target (sanity) [0.23ms]
(pass) debug.bun.sh Firefox reload crash > inspector-frontend build script guards the isInsertionCaretInside call [22.57ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-inspector-frontend/scripts/build.ts | 48 ++++++++++---
 test/regression/issue/16220.test.ts              | 86 ++++++++++++++++++++++++
 2 files changed, 125 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
packages/bun-inspector-frontend/scripts/build.ts      3      8      0
test/regression/issue/16220.test.ts                   1      4      0
```

</details>

<!-- robobun:evidence:end -->