### PR TITLE
bun patch: fix --commit path handling from workspace packages

### DIFF
--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -111,13 +111,9 @@ pub fn do_patch_commit(
             workspace_package_id,
             argument,
         ) {
-            // `bun patch` always leaves the editable copy as a real directory
-            // (any symlink is detached first). If the workspace-prefixed path
-            // is a symlink or missing but the argument taken relative to the
-            // workspace root is a real directory, that is where `bun patch`
-            // actually prepared the package, so diff that instead of the
-            // symlink (which `git diff --no-index` would record as a single
-            // mode-120000 file and then fail to apply).
+            // `prepare_patch` detaches symlinks, so a symlink at `rel_path` is
+            // not the prepared copy; fall back to the root-relative argument
+            // when that one is a real directory.
             if !is_real_dir_not_symlink(&rel_path) && is_real_dir_not_symlink(argument) {
                 argument
             } else {

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -111,9 +111,7 @@ pub fn do_patch_commit(
             workspace_package_id,
             argument,
         ) {
-            // `prepare_patch` detaches symlinks, so a symlink at `rel_path` is
-            // not the prepared copy; fall back to the root-relative argument
-            // when that one is a real directory.
+            // prepare_patch detaches symlinks; a symlink here means the prepared copy is at the root
             if !is_real_dir_not_symlink(&rel_path) && is_real_dir_not_symlink(argument) {
                 argument
             } else {

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -101,25 +101,36 @@ pub fn do_patch_commit(
         .get(&lockfile, manager.workspace_name_hash);
     let not_in_workspace_root = workspace_package_id != 0;
     // reshaped for borrowck — owned buffer kept separately so `argument` can borrow it
-    let argument_owned: Option<Box<[u8]>>;
+    let mut argument_owned: Option<Box<[u8]>> = None;
     let argument: &[u8] = if arg_kind == PatchArgKind::Path
         && not_in_workspace_root
-        && (!Platform::Posix.is_absolute(argument)
-            || (cfg!(windows) && !Platform::Windows.is_absolute(argument)))
+        && !Platform::AUTO.is_absolute(argument)
     {
         if let Some(rel_path) = path_argument_relative_to_root_workspace_package(
             &lockfile,
             workspace_package_id,
             argument,
         ) {
-            argument_owned = Some(rel_path);
-            argument_owned.as_deref().unwrap()
+            // `bun patch` always leaves the editable copy as a real directory
+            // (any symlink is detached first). If the workspace-prefixed path
+            // is a symlink or missing but the argument taken relative to the
+            // workspace root is a real directory, that is where `bun patch`
+            // actually prepared the package, so diff that instead of the
+            // symlink (which `git diff --no-index` would record as a single
+            // mode-120000 file and then fail to apply).
+            if !is_real_dir_not_symlink(&rel_path) && is_real_dir_not_symlink(argument) {
+                argument
+            } else {
+                argument_owned = Some(rel_path);
+                argument_owned.as_deref().unwrap()
+            }
         } else {
             argument
         }
     } else {
         argument
     };
+    let _ = &argument_owned;
 
     // Attempt to open the existing node_modules folder
     let root_node_modules: Dir = match sys::openat_os_path(
@@ -738,8 +749,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
     let argument_owned: Option<Box<[u8]>>;
     let argument: &[u8] = if arg_kind == PatchArgKind::Path
         && not_in_workspace_root
-        && (!Platform::Posix.is_absolute(argument)
-            || (cfg!(windows) && !Platform::Windows.is_absolute(argument)))
+        && !Platform::AUTO.is_absolute(argument)
     {
         if let Some(rel_path) = path_argument_relative_to_root_workspace_package(
             &manager.lockfile,
@@ -1029,6 +1039,42 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
     }
 
     Ok(())
+}
+
+fn is_real_dir_not_symlink(path: &[u8]) -> bool {
+    #[cfg(windows)]
+    let mut native_buf = PathBuffer::uninit();
+    #[cfg(windows)]
+    let native: &[u8] = {
+        if path.len() > native_buf.len() {
+            return false;
+        }
+        native_buf[0..path.len()].copy_from_slice(path);
+        let slice = &mut native_buf[0..path.len()];
+        resolve_path::posix_to_platform_in_place::<u8>(slice);
+        &*slice
+    };
+    #[cfg(not(windows))]
+    let native: &[u8] = path;
+
+    let Ok(mut p) = bun_paths::Path::<u8>::from(native) else {
+        return false;
+    };
+
+    #[cfg(windows)]
+    {
+        match sys::get_file_attributes(p.slice_z()) {
+            Some(attrs) => attrs.is_directory && !attrs.is_reparse_point,
+            None => false,
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        match sys::lstat(p.slice_z()) {
+            Ok(st) => sys::posix::s_isdir(st.st_mode as u32),
+            Err(_) => false,
+        }
+    }
 }
 
 fn detach_module_folder_from_shared_store(module_folder: &[u8]) {

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -299,6 +299,78 @@ describe("bun patch <pkg>", async () => {
       }
     });
 
+    // https://github.com/oven-sh/bun/issues/12200
+    // https://github.com/oven-sh/bun/issues/12882
+    describe("inside workspace package, committing with the path bun suggested", async () => {
+      const files = {
+        "package.json": JSON.stringify({
+          name: "root",
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+        packages: {
+          server: {
+            "package.json": JSON.stringify({
+              name: "server",
+              version: "1.0.0",
+              dependencies: { "is-odd": "3.0.1" },
+            }),
+          },
+        },
+      };
+
+      async function prepare(tempdir: string) {
+        const subdir = join(tempdir, "packages", "server");
+        await $`${bunExe()} i`.env(bunEnv).cwd(subdir);
+
+        const prep = await $`${bunExe()} patch is-odd`.env(bunEnv).cwd(subdir);
+        expect(prep.stderr.toString()).not.toContain("error");
+        const suggested = prep.stdout.toString().match(/bun patch --commit '([^']+)'/);
+        expect(suggested).not.toBeNull();
+        const absPath = suggested![1];
+        expect(absPath).toContain("node_modules");
+
+        await Bun.write(join(tempdir, "node_modules", "is-odd", "index.js"), "module.exports = () => 'patched';\n");
+        return { subdir, absPath };
+      }
+
+      async function check(tempdir: string, commit: ShellOutput) {
+        expect(commit.stderr.toString()).not.toContain("ENOENT");
+        expect(commit.stderr.toString()).not.toContain("error");
+        expect(commit.exitCode).toBe(0);
+
+        expect((await $`cat package.json`.cwd(tempdir).env(bunEnv).json()).patchedDependencies).toEqual({
+          "is-odd@3.0.1": "patches/is-odd@3.0.1.patch",
+        });
+        const patch = await Bun.file(join(tempdir, "patches", "is-odd@3.0.1.patch")).text();
+        expect(patch).not.toContain("new file mode 120000");
+        expect(patch).not.toContain("deleted file mode");
+        expect(patch).toContain("patched");
+      }
+
+      // On Windows the suggested path is a drive-letter absolute path like
+      // `C:\tmp\.../node_modules/is-odd`. Previously this was treated as
+      // relative and joined onto `packages/server/`, producing
+      // `packages\server\C:\...\package.json` → ENOENT.
+      test("absolute path", async () => {
+        await using tempdir = tempDir("patch-ws-abs", files);
+        const { subdir, absPath } = await prepare(String(tempdir));
+        const commit = await $`${bunExe()} patch --commit ${absPath}`.env(bunEnv).cwd(subdir).throws(false);
+        await check(String(tempdir), commit);
+      });
+
+      // With the isolated linker `packages/server/node_modules/is-odd` is a
+      // symlink into `.bun/`. `bun patch is-odd` placed the editable copy at
+      // the root `node_modules/is-odd`, so committing `node_modules/is-odd`
+      // from the subdir must diff the root copy, not the symlink.
+      test("relative node_modules/<pkg>", async () => {
+        await using tempdir = tempDir("patch-ws-rel", files);
+        const { subdir } = await prepare(String(tempdir));
+        const commit = await $`${bunExe()} patch --commit node_modules/is-odd`.env(bunEnv).cwd(subdir).throws(false);
+        await check(String(tempdir), commit);
+      });
+    });
+
     describe("inside ROOT workspace package", async () => {
       const args = [
         [

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -1,7 +1,8 @@
 import { $, ShellOutput } from "bun";
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { lstatSync } from "fs";
 import { bunEnv, bunExe, isASAN, tempDir } from "harness";
-import { join } from "path";
+import { isAbsolute, join, sep } from "path";
 
 const expectNoError = (o: ShellOutput) => expect(o.stderr.toString()).not.toContain("error");
 // const platformPath = (path: string) => (process.platform === "win32" ? path.replaceAll("/", sep) : path);
@@ -328,6 +329,7 @@ describe("bun patch <pkg>", async () => {
         const suggested = prep.stdout.toString().match(/bun patch --commit '([^']+)'/);
         expect(suggested).not.toBeNull();
         const absPath = suggested![1];
+        expect(isAbsolute(absPath.replaceAll("/", sep))).toBe(true);
         expect(absPath).toContain("node_modules");
 
         await Bun.write(join(tempdir, "node_modules", "is-odd", "index.js"), "module.exports = () => 'patched';\n");
@@ -339,7 +341,7 @@ describe("bun patch <pkg>", async () => {
         expect(commit.stderr.toString()).not.toContain("error");
         expect(commit.exitCode).toBe(0);
 
-        expect((await $`cat package.json`.cwd(tempdir).env(bunEnv).json()).patchedDependencies).toEqual({
+        expect((await Bun.file(join(tempdir, "package.json")).json()).patchedDependencies).toEqual({
           "is-odd@3.0.1": "patches/is-odd@3.0.1.patch",
         });
         const patch = await Bun.file(join(tempdir, "patches", "is-odd@3.0.1.patch")).text();
@@ -366,6 +368,7 @@ describe("bun patch <pkg>", async () => {
       test("relative node_modules/<pkg>", async () => {
         await using tempdir = tempDir("patch-ws-rel", files);
         const { subdir } = await prepare(String(tempdir));
+        expect(lstatSync(join(subdir, "node_modules", "is-odd")).isSymbolicLink()).toBe(true);
         const commit = await $`${bunExe()} patch --commit node_modules/is-odd`.env(bunEnv).cwd(subdir).throws(false);
         await check(String(tempdir), commit);
       });


### PR DESCRIPTION
Fixes #12200
Fixes #12882

## Repro

From inside a workspace package, `bun patch <pkg>` prints an absolute path and suggests running `bun patch --commit '<abs>/node_modules/<pkg>'` from the same directory. On current canary that suggested command fails in two different ways depending on platform:

**Windows** (reported in #12882, #12200):
```
PS Z:\repo\packages\server> bun patch is-odd
...
  bun patch --commit 'Z:\repo/node_modules/is-odd'

PS Z:\repo\packages\server> bun patch --commit 'Z:\repo/node_modules/is-odd'
ENOENT: No such file or directory: failed to read "packages\server\Z:\repo\node_modules\is-odd\package.json" (open)
```

**Linux/macOS/Windows**, isolated linker (now the default), if the user types the relative form instead:
```
$ cd packages/server
$ bun patch is-odd                         # editable copy lands at <root>/node_modules/is-odd
$ echo '// x' >> ../../node_modules/is-odd/index.js
$ bun patch --commit node_modules/is-odd
error: failed to parse patchfile: bad_file_mode
error: failed to patch package: is-odd@3.0.1
```

The written `patches/is-odd@3.0.1.patch` is garbage (records the `packages/server/node_modules/is-odd` symlink as a `mode 120000` file, plus every cache file as "deleted").

The original headline error from #12200, `EPERM: Operation not permitted (copyfile())` on cross-drive renames, no longer reproduces on current main; the EXDEV fallback in `renameat_concurrently` handles it. The recent "still broken in 1.3.x" comments on the issue are hitting the two failures above.

## Cause

`do_patch_commit` / `prepare_patch` rebase a relative path argument onto the invoking workspace package's prefix so that a path typed relative to cwd resolves from the workspace root. Two bugs in that rebasing:

1. The "is this already absolute" guard was
   ```rust
   !Platform::Posix.is_absolute(argument)
       || (cfg!(windows) && !Platform::Windows.is_absolute(argument))
   ```
   On Windows, for `C:\...`, `Posix.is_absolute` is `false`, so `!posix_abs` is `true` and the disjunction short-circuits. A drive-letter path gets joined onto `packages/<ws>/`. The intent was `&&` (De Morgan of "absolute in either sense").

2. With the isolated linker, `packages/<ws>/node_modules/<pkg>` is a symlink into `node_modules/.bun/`. `bun patch <name>` puts the editable copy at the *root* `node_modules/<pkg>` (a real directory, symlinks detached), so the rebased path points at the wrong place. `git diff --no-index` treats a symlink as a single-line file (mode 120000), and `git_diff_postprocess` cannot strip the prefixes, so the patch is unparseable.

## Fix

- Replace the guard with `!Platform::AUTO.is_absolute(argument)` in both `do_patch_commit` and `prepare_patch`. On POSIX this is `Platform::Posix` (unchanged); on Windows it is `Platform::Windows`, whose `is_absolute` already accepts `/`-rooted, `\`-rooted and drive-letter paths.
- In `do_patch_commit`, when the workspace-prefixed path is a symlink or missing but the argument taken root-relative is a real directory, use the root-relative path. `prepare_patch` always leaves a real directory, so a real directory at the root is where the editable copy actually is. `prepare_patch` itself is unchanged in this respect since it already detaches symlinks at whichever path it chooses.

## Verification

Two new tests under "inside workspace package, committing with the path bun suggested" in `test/cli/install/bun-patch.test.ts`, one feeding the printed absolute path back verbatim and one using `node_modules/is-odd` relative from the subdir.

Linux x64:
- `USE_SYSTEM_BUN=1`: `relative node_modules/<pkg>` fails with `bad_file_mode`; `absolute path` already passes (POSIX was unaffected)
- `bun bd test`: both pass; full `bun-patch.test.ts` 31/31 pass

Windows x64:
- `USE_SYSTEM_BUN=1`: both fail (`ENOENT: packages\server\C:\...` and `bad_file_mode`)
- `bun bd test`: both pass; full `bun-patch.test.ts` 31/31 pass

<details><summary>Windows fail-before</summary>

```
ENOENT: No such file or directory: failed to read "packages\server\C:\Users\azureuser\AppData\Local\Temp\patch-ws-abs_oeKec2\node_modules\is-odd\package.json" (open)
(fail) ... > absolute path

error: failed to parse patchfile: bad_file_mode
error: failed to patch package: is-odd@3.0.1
(fail) ... > relative node_modules/<pkg>
```
</details>

The `Platform::AUTO.is_absolute` change is the same fix as #35563; this PR additionally handles the isolated-linker symlink case that #35563 does not cover.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-patch.test.ts

<!-- robobun:evidence:end -->