### PR TITLE
cli(--filter): reap descendant tree on Windows via kill-on-close Job Object

### DIFF
--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -287,6 +287,12 @@ pub fn enable() {
     }
 }
 
+/// Windows arm: self-assign to a recursive kill-on-close Job Object. POSIX
+/// has no equivalent primitive (descendants are handled by the exit-time
+/// tree walk and per-child PDEATHSIG), so this is a no-op here.
+#[inline]
+pub fn ensure_kill_on_close_job() {}
+
 /// Register `EVFILT_PROC`/`NOTE_EXIT` for the original parent on the main
 /// event loop's kqueue. Called from `VirtualMachine.init` once the uws loop is
 /// up. macOS-only; no-op elsewhere and on subsequent calls.

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -287,9 +287,7 @@ pub fn enable() {
     }
 }
 
-/// Windows arm: self-assign to a recursive kill-on-close Job Object. POSIX
-/// has no equivalent primitive (descendants are handled by the exit-time
-/// tree walk and per-child PDEATHSIG), so this is a no-op here.
+/// Windows-only primitive; POSIX cleanup is the exit-time tree walk above.
 #[inline]
 pub fn ensure_kill_on_close_job() {}
 

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -111,6 +111,30 @@ pub mod parent_death_watchdog {
                 bun_core::w!("BUN_FEATURE_FLAG_NO_ORPHANS\0").as_ptr(),
                 bun_core::w!("1\0").as_ptr(),
             );
+            ensure_kill_on_close_job();
+            arm_parent_watch();
+        }
+    }
+
+    static JOB_ASSIGNED: AtomicBool = AtomicBool::new(false);
+
+    /// Self-assign to a kill-on-close Job Object with recursive membership
+    /// (no `SILENT_BREAKAWAY_OK`). Unlike libuv's global spawn Job, this one
+    /// propagates to every descendant regardless of how it was spawned, so a
+    /// `cmd.exe` / `.cmd` shim / node.exe link in the tree can't orphan what's
+    /// below it. Idempotent; the handle is leaked for the process lifetime so
+    /// `KILL_ON_JOB_CLOSE` only fires when this process actually exits.
+    ///
+    /// Called unconditionally from `bun --filter` (Windows) so Ctrl+C reaps the
+    /// whole tree, and from `enable()` for `--no-orphans`.
+    #[cold]
+    #[inline(never)]
+    pub fn ensure_kill_on_close_job() {
+        if JOB_ASSIGNED.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        // SAFETY: Win32 FFI; null args are documented-valid (anonymous Job).
+        unsafe {
             let job = windows::CreateJobObjectA(core::ptr::null_mut(), core::ptr::null());
             if !job.is_null() {
                 let mut jeli: windows::JOBOBJECT_EXTENDED_LIMIT_INFORMATION =
@@ -127,8 +151,6 @@ pub mod parent_death_watchdog {
                     windows::CloseHandle(job);
                 }
             }
-
-            arm_parent_watch();
         }
     }
 

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -118,15 +118,10 @@ pub mod parent_death_watchdog {
 
     static JOB_ASSIGNED: AtomicBool = AtomicBool::new(false);
 
-    /// Self-assign to a kill-on-close Job Object with recursive membership
-    /// (no `SILENT_BREAKAWAY_OK`). Unlike libuv's global spawn Job, this one
-    /// propagates to every descendant regardless of how it was spawned, so a
-    /// `cmd.exe` / `.cmd` shim / node.exe link in the tree can't orphan what's
-    /// below it. Idempotent; the handle is leaked for the process lifetime so
-    /// `KILL_ON_JOB_CLOSE` only fires when this process actually exits.
-    ///
-    /// Called unconditionally from `bun --filter` (Windows) so Ctrl+C reaps the
-    /// whole tree, and from `enable()` for `--no-orphans`.
+    /// Self-assign to a kill-on-close Job Object without `SILENT_BREAKAWAY_OK`,
+    /// so membership is inherited by every descendant (unlike libuv's spawn
+    /// Job). Idempotent; handle leaked for process lifetime. Used by
+    /// `--no-orphans` and unconditionally by `bun --filter`/`--parallel`.
     #[cold]
     #[inline(never)]
     pub fn ensure_kill_on_close_job() {

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -665,10 +665,8 @@ impl AbortHandler {
         // only necessary on Windows, as on posix we pass the SA_RESETHAND flag
         #[cfg(windows)]
         {
-            // Remove the handler we installed. `SetConsoleCtrlHandler(None, FALSE)`
-            // only clears the "ignore Ctrl+C" attribute; it does NOT unregister a
-            // previously-added routine, so the second Ctrl+C would still land in
-            // `windows_ctrl_handler` instead of the default handler.
+            // (None, FALSE) clears the ignore attribute; it does NOT unregister
+            // a handler routine — pass the address.
             let _ = bun_sys::c::SetConsoleCtrlHandler(
                 Some(Self::windows_ctrl_handler),
                 bun_sys::windows::FALSE,
@@ -878,11 +876,8 @@ pub(crate) fn run_scripts_with_filter(
         Some(unsafe { &mut *env_ptr }),
         None,
     );
-    // Windows: self-assign to a recursive kill-on-close Job Object so every
-    // descendant (including ones spawned through cmd.exe / .cmd shims that
-    // escape libuv's SILENT_BREAKAWAY job) is reaped when this process exits.
-    // Each script runs under CREATE_NO_WINDOW and so never receives the user's
-    // Ctrl+C directly; cleanup is entirely on us. POSIX: no-op.
+    // Windows: recursive kill-on-close Job so cmd.exe/.cmd-shim grandchildren
+    // (which escape libuv's SILENT_BREAKAWAY job) die with us. POSIX: no-op.
     bun_io::ParentDeathWatchdog::ensure_kill_on_close_job();
     // --no-orphans: register the macOS kqueue parent watch on this MiniEventLoop
     // (the VirtualMachine.init path is never reached for --filter). Linux is

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -665,8 +665,14 @@ impl AbortHandler {
         // only necessary on Windows, as on posix we pass the SA_RESETHAND flag
         #[cfg(windows)]
         {
-            // restores default Ctrl+C behavior
-            let _ = bun_sys::c::SetConsoleCtrlHandler(None, bun_sys::windows::FALSE);
+            // Remove the handler we installed. `SetConsoleCtrlHandler(None, FALSE)`
+            // only clears the "ignore Ctrl+C" attribute; it does NOT unregister a
+            // previously-added routine, so the second Ctrl+C would still land in
+            // `windows_ctrl_handler` instead of the default handler.
+            let _ = bun_sys::c::SetConsoleCtrlHandler(
+                Some(Self::windows_ctrl_handler),
+                bun_sys::windows::FALSE,
+            );
         }
     }
 }
@@ -872,6 +878,12 @@ pub(crate) fn run_scripts_with_filter(
         Some(unsafe { &mut *env_ptr }),
         None,
     );
+    // Windows: self-assign to a recursive kill-on-close Job Object so every
+    // descendant (including ones spawned through cmd.exe / .cmd shims that
+    // escape libuv's SILENT_BREAKAWAY job) is reaped when this process exits.
+    // Each script runs under CREATE_NO_WINDOW and so never receives the user's
+    // Ctrl+C directly; cleanup is entirely on us. POSIX: no-op.
+    bun_io::ParentDeathWatchdog::ensure_kill_on_close_job();
     // --no-orphans: register the macOS kqueue parent watch on this MiniEventLoop
     // (the VirtualMachine.init path is never reached for --filter). Linux is
     // already covered by prctl in enable() + linux_pdeathsig on each spawn.

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -810,9 +810,8 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
         Some(unsafe { &mut *env_ptr }),
         None,
     );
-    // Windows: self-assign to a recursive kill-on-close Job Object so every
-    // descendant (including ones spawned through cmd.exe / .cmd shims that
-    // escape libuv's SILENT_BREAKAWAY job) is reaped when this process exits.
+    // Windows: recursive kill-on-close Job so cmd.exe/.cmd-shim grandchildren
+    // (which escape libuv's SILENT_BREAKAWAY job) die with us. POSIX: no-op.
     bun_io::ParentDeathWatchdog::ensure_kill_on_close_job();
     // --no-orphans: register the macOS kqueue parent watch on this MiniEventLoop
     // (the VirtualMachine.init path is never reached for --parallel). Linux is

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -586,7 +586,10 @@ impl AbortHandler {
     pub(crate) fn uninstall() {
         #[cfg(windows)]
         {
-            let _ = bun_sys::windows::SetConsoleCtrlHandler(None, bun_sys::windows::FALSE);
+            let _ = bun_sys::windows::SetConsoleCtrlHandler(
+                Some(Self::windows_ctrl_handler),
+                bun_sys::windows::FALSE,
+            );
         }
     }
 }
@@ -807,6 +810,10 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
         Some(unsafe { &mut *env_ptr }),
         None,
     );
+    // Windows: self-assign to a recursive kill-on-close Job Object so every
+    // descendant (including ones spawned through cmd.exe / .cmd shims that
+    // escape libuv's SILENT_BREAKAWAY job) is reaped when this process exits.
+    bun_io::ParentDeathWatchdog::ensure_kill_on_close_job();
     // --no-orphans: register the macOS kqueue parent watch on this MiniEventLoop
     // (the VirtualMachine.init path is never reached for --parallel). Linux is
     // already covered by prctl in enable() + linux_pdeathsig on each spawn.

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { symlinkSync } from "node:fs";
+import { setTimeout as sleep } from "node:timers/promises";
 import { join } from "path";
 
 const cwd_root = tempDirWithFiles("testworkspace", {
@@ -662,3 +663,106 @@ describe("bun", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// #20319: on Windows, `bun --filter` spawns each script as `bun exec "<script>"`
+// with CREATE_NO_WINDOW, so the user's Ctrl+C never reaches the scripts and
+// cleanup is entirely on the filter parent. libuv's global spawn Job is
+// KILL_ON_CLOSE | SILENT_BREAKAWAY_OK, so membership only propagates one hop:
+// as soon as the tree contains a non-libuv spawner (cmd.exe, a `.cmd` bin shim,
+// node.exe), everything below it escapes and keeps its port bound after the
+// filter parent exits.
+//
+// Tree under test:
+//   test → `bun --filter` → `bun exec` → cmd.exe → leaf bun (long-running).
+// The leaf writes its pid to a file; the test kills the filter parent and polls
+// the leaf. Without a recursive kill-on-close Job on the filter parent, the
+// leaf survives.
+test.skipIf(!isWindows)(
+  "windows: --filter reaps the whole descendant tree when the parent exits (#20319)",
+  async () => {
+    function isAlive(pid: number): boolean {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+    async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (!isAlive(pid)) return true;
+        await sleep(25);
+      }
+      return !isAlive(pid);
+    }
+
+    using dir = tempDir("filter-win-cleanup", {
+      "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+      // .bat avoids cmd /c's quote-stripping around a quoted exe path + arg.
+      "packages/app/run.bat": `@"${bunExe()}" "%~dp0server.js"\r\n`,
+      "packages/app/server.js": `
+        require("fs").writeFileSync(process.env.PIDFILE, String(process.pid));
+        setInterval(() => {}, 1000);
+      `,
+      "packages/app/package.json": JSON.stringify({
+        name: "app",
+        scripts: { dev: "cmd /d /c run.bat" },
+      }),
+    });
+
+    const pidfile = join(String(dir), "leaf.pid");
+    // Unset NO_ORPHANS so the test exercises the --filter-specific Job rather
+    // than the opt-in env-var path CI may set globally.
+    const env: Record<string, string | undefined> = {
+      ...bunEnv,
+      PIDFILE: pidfile,
+      BUN_FEATURE_FLAG_NO_ORPHANS: undefined,
+      NO_COLOR: "1",
+    };
+
+    const filter = Bun.spawn({
+      cmd: [bunExe(), "--filter", "*", "dev"],
+      env,
+      cwd: String(dir),
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+
+    let leafPid = 0;
+    try {
+      const deadline = Date.now() + 15000;
+      while (leafPid === 0 && Date.now() < deadline) {
+        try {
+          const t = await Bun.file(pidfile).text();
+          if (t.length > 0) leafPid = Number(t.trim());
+        } catch {}
+        if (leafPid === 0) await sleep(25);
+      }
+      if (leafPid === 0) {
+        const stderr = await filter.stderr.text();
+        throw new Error(`leaf never wrote pidfile; stderr:\n${stderr}`);
+      }
+      expect(isAlive(leafPid)).toBe(true);
+
+      // TerminateProcess on the filter parent — same effect as the second
+      // Ctrl+C (default handler) or the first Ctrl+C's abort() path once the
+      // direct children have exited and filter calls Global::exit().
+      filter.kill("SIGKILL");
+      await filter.exited;
+
+      const died = await waitUntilDead(leafPid, 10000);
+      expect(died).toBe(true);
+    } finally {
+      filter.kill("SIGKILL");
+      await filter.exited;
+      if (leafPid > 0 && isAlive(leafPid)) {
+        try {
+          process.kill(leafPid, "SIGKILL");
+        } catch {}
+        await waitUntilDead(leafPid, 2000);
+      }
+    }
+  },
+  30000,
+);

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -664,105 +664,111 @@ describe("bun", () => {
   });
 });
 
-// #20319: on Windows, `bun --filter` spawns each script as `bun exec "<script>"`
-// with CREATE_NO_WINDOW, so the user's Ctrl+C never reaches the scripts and
-// cleanup is entirely on the filter parent. libuv's global spawn Job is
-// KILL_ON_CLOSE | SILENT_BREAKAWAY_OK, so membership only propagates one hop:
-// as soon as the tree contains a non-libuv spawner (cmd.exe, a `.cmd` bin shim,
-// node.exe), everything below it escapes and keeps its port bound after the
-// filter parent exits.
+// #20319: on Windows, `bun --filter` / `bun run --parallel` spawn each script
+// as `bun exec "<script>"` with CREATE_NO_WINDOW, so the user's Ctrl+C never
+// reaches the scripts and cleanup is entirely on the parent. libuv's global
+// spawn Job is KILL_ON_CLOSE | SILENT_BREAKAWAY_OK, so membership only
+// propagates one hop: as soon as the tree contains a non-libuv spawner
+// (cmd.exe, a `.cmd` bin shim, node.exe), everything below it escapes and keeps
+// its port bound after the parent exits.
 //
 // Tree under test:
-//   test → `bun --filter` → `bun exec` → cmd.exe → leaf bun (long-running).
-// The leaf writes its pid to a file; the test kills the filter parent and polls
-// the leaf. Without a recursive kill-on-close Job on the filter parent, the
-// leaf survives.
-test.skipIf(!isWindows)(
-  "windows: --filter reaps the whole descendant tree when the parent exits (#20319)",
-  async () => {
-    function isAlive(pid: number): boolean {
+//   test → bun parent → `bun exec` → cmd.exe → leaf bun (long-running).
+// The leaf writes its pid to a file; the test kills the parent and polls the
+// leaf. Without a recursive kill-on-close Job on the parent, the leaf survives.
+describe.skipIf(!isWindows).each([
+  { via: "--filter", argv: ["--filter", "*", "dev"] },
+  { via: "run --parallel", argv: ["run", "--parallel", "dev"] },
+])("windows: $via reaps the whole descendant tree when the parent exits (#20319)", ({ argv }) => {
+  test.concurrent(
+    "leaf dies",
+    async () => {
+      function isAlive(pid: number): boolean {
+        try {
+          process.kill(pid, 0);
+          return true;
+        } catch {
+          return false;
+        }
+      }
+      async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+          if (!isAlive(pid)) return true;
+          await sleep(25);
+        }
+        return !isAlive(pid);
+      }
+
+      using dir = tempDir("filter-win-cleanup", {
+        "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+        // .bat avoids cmd /c's quote-stripping around a quoted exe path + arg.
+        "packages/app/run.bat": `@"${bunExe()}" "%~dp0server.js"\r\n`,
+        "packages/app/server.js": `
+          require("fs").writeFileSync(process.env.PIDFILE, String(process.pid));
+          setInterval(() => {}, 1000);
+        `,
+        "packages/app/package.json": JSON.stringify({
+          name: "app",
+          scripts: { dev: "cmd /d /c run.bat" },
+        }),
+      });
+
+      const pidfile = join(String(dir), "leaf.pid");
+      // Unset NO_ORPHANS so the test exercises the unconditional Job rather
+      // than the opt-in env-var path CI may set globally.
+      const env: Record<string, string | undefined> = {
+        ...bunEnv,
+        PIDFILE: pidfile,
+        BUN_FEATURE_FLAG_NO_ORPHANS: undefined,
+        NO_COLOR: "1",
+      };
+
+      const parent = Bun.spawn({
+        cmd: [bunExe(), ...argv],
+        env,
+        cwd: join(String(dir), "packages", "app"),
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+
+      let leafPid = 0;
       try {
-        process.kill(pid, 0);
-        return true;
-      } catch {
-        return false;
+        const deadline = Date.now() + 15000;
+        while (leafPid === 0 && Date.now() < deadline) {
+          try {
+            const t = await Bun.file(pidfile).text();
+            if (t.length > 0) leafPid = Number(t.trim());
+          } catch {}
+          if (leafPid === 0) await sleep(25);
+        }
+        if (leafPid === 0) {
+          parent.kill("SIGKILL");
+          await parent.exited;
+          const stderr = await parent.stderr.text();
+          throw new Error(`leaf never wrote pidfile; stderr:\n${stderr}`);
+        }
+        expect(isAlive(leafPid)).toBe(true);
+
+        // TerminateProcess on the parent — same effect as the second Ctrl+C
+        // (default handler) or the first Ctrl+C's abort() path once the direct
+        // children have exited and the parent calls Global::exit().
+        parent.kill("SIGKILL");
+        await parent.exited;
+
+        const died = await waitUntilDead(leafPid, 10000);
+        expect(died).toBe(true);
+      } finally {
+        parent.kill("SIGKILL");
+        await parent.exited;
+        if (leafPid > 0 && isAlive(leafPid)) {
+          try {
+            process.kill(leafPid, "SIGKILL");
+          } catch {}
+          await waitUntilDead(leafPid, 2000);
+        }
       }
-    }
-    async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
-      const deadline = Date.now() + timeoutMs;
-      while (Date.now() < deadline) {
-        if (!isAlive(pid)) return true;
-        await sleep(25);
-      }
-      return !isAlive(pid);
-    }
-
-    using dir = tempDir("filter-win-cleanup", {
-      "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
-      // .bat avoids cmd /c's quote-stripping around a quoted exe path + arg.
-      "packages/app/run.bat": `@"${bunExe()}" "%~dp0server.js"\r\n`,
-      "packages/app/server.js": `
-        require("fs").writeFileSync(process.env.PIDFILE, String(process.pid));
-        setInterval(() => {}, 1000);
-      `,
-      "packages/app/package.json": JSON.stringify({
-        name: "app",
-        scripts: { dev: "cmd /d /c run.bat" },
-      }),
-    });
-
-    const pidfile = join(String(dir), "leaf.pid");
-    // Unset NO_ORPHANS so the test exercises the --filter-specific Job rather
-    // than the opt-in env-var path CI may set globally.
-    const env: Record<string, string | undefined> = {
-      ...bunEnv,
-      PIDFILE: pidfile,
-      BUN_FEATURE_FLAG_NO_ORPHANS: undefined,
-      NO_COLOR: "1",
-    };
-
-    const filter = Bun.spawn({
-      cmd: [bunExe(), "--filter", "*", "dev"],
-      env,
-      cwd: String(dir),
-      stdout: "ignore",
-      stderr: "pipe",
-    });
-
-    let leafPid = 0;
-    try {
-      const deadline = Date.now() + 15000;
-      while (leafPid === 0 && Date.now() < deadline) {
-        try {
-          const t = await Bun.file(pidfile).text();
-          if (t.length > 0) leafPid = Number(t.trim());
-        } catch {}
-        if (leafPid === 0) await sleep(25);
-      }
-      if (leafPid === 0) {
-        const stderr = await filter.stderr.text();
-        throw new Error(`leaf never wrote pidfile; stderr:\n${stderr}`);
-      }
-      expect(isAlive(leafPid)).toBe(true);
-
-      // TerminateProcess on the filter parent — same effect as the second
-      // Ctrl+C (default handler) or the first Ctrl+C's abort() path once the
-      // direct children have exited and filter calls Global::exit().
-      filter.kill("SIGKILL");
-      await filter.exited;
-
-      const died = await waitUntilDead(leafPid, 10000);
-      expect(died).toBe(true);
-    } finally {
-      filter.kill("SIGKILL");
-      await filter.exited;
-      if (leafPid > 0 && isAlive(leafPid)) {
-        try {
-          process.kill(leafPid, "SIGKILL");
-        } catch {}
-        await waitUntilDead(leafPid, 2000);
-      }
-    }
-  },
-  30000,
-);
+    },
+    30000,
+  );
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #20319
Fixes #10649
Fixes #18605

On Windows, `bun --filter '*' dev` spawns each workspace script as `bun.exe exec "<script>"` with `CREATE_NO_WINDOW`, so the user's Ctrl+C never reaches the scripts directly and cleanup is entirely on the filter parent.

libuv's global spawn Job Object is `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK`, so membership only propagates to processes libuv explicitly assigns. The moment the tree contains a non-libuv spawner (`cmd.exe`, a `.cmd` bin shim from `node_modules/.bin`, `node.exe` spawning workers, etc.), everything below it escapes. When the user presses Ctrl+C, `State::abort()` terminates the direct `bun exec` children, the filter parent exits, and the orphaned grandchild servers keep running with their ports bound.

### Reproduction

Workspace with `packages/app/package.json` → `"dev": "cmd /d /c run.bat"` → `bun server.js`. After `bun --filter '*' dev` and Ctrl+C:

```
pid 700 (bun --filter)
  pid 2784 (bun exec)
    pid 4132 (cmd.exe)
      pid 4272 (bun server.js)  ← survives
[driver] killing filter parent
[driver] server pids still alive: [ 4272 ]
[driver] port 45601 still bound: true
```

Setting `BUN_FEATURE_FLAG_NO_ORPHANS=1` (PR #34768) already fixed this via a recursive Job Object, but it's opt-in.

### Fix

`run_scripts_with_filter` (and `multi_run`) now self-assign the filter parent to a `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` Job Object **without** `SILENT_BREAKAWAY_OK` before spawning any scripts. Membership is inherited recursively (nested jobs, Win8+), so when the filter parent exits for any reason (first Ctrl+C → abort → `Global::exit`, second Ctrl+C → default handler → `ExitProcess`, or a crash), the kernel terminates every descendant.

The primitive is factored out of the Windows `parent_death_watchdog::enable()` path into `ensure_kill_on_close_job()` so `--no-orphans` and `--filter` share the same idempotent helper.

Also fixes `AbortHandler::uninstall()` on Windows: `SetConsoleCtrlHandler(None, FALSE)` only clears the "ignore Ctrl+C" attribute; it does not unregister a previously-added handler routine. Now passes the handler address with `Add = FALSE` so the second Ctrl+C actually reaches the default handler.

Does not fully address #21280: the primary scenario there is `bun run dev` (no `--filter`) wrapping `concurrently`, which goes through a different code path. The `--filter` variant the reporter also mentions is covered here.

## How did you verify your code works?

New Windows-only test in `test/cli/run/filter-workspace.test.ts` sets up `test → bun --filter → bun exec → cmd.exe → leaf bun`, waits for the leaf's pid, `TerminateProcess`es the filter parent, and polls the leaf.

- fails on `bun 1.4.0-canary.1+e532ad91f` (leaf survives)
- passes with this patch (leaf dies)
- existing `filter-workspace.test.ts` and `no-orphans.test.ts` pass on both Windows and Linux

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/filter-workspace.test.ts

<!-- robobun:evidence:end -->