### PR TITLE
install: preserve last registry path segment when URL has no trailing slash

### DIFF
--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -461,11 +461,9 @@ impl NetworkTask {
                 name
             };
 
-            // npm appends the package name as a new path segment whether or not
-            // the configured registry ends in "/"; WHATWG resolution would
-            // instead replace the last segment of a slash-less base. A query or
-            // fragment on the registry URL does not survive the join either way,
-            // so the "/" goes on the path, ahead of them.
+            // The registry is a directory: force a "/"-terminated base so the
+            // WHATWG join appends the name instead of replacing the last segment.
+            // The join discards a query/fragment anyway, so they are cut first.
             let registry_href = scope.url.href();
             let base_storage;
             let base: &[u8] = if strings::has_prefix_case_insensitive(registry_href, b"https://")
@@ -544,8 +542,8 @@ impl NetworkTask {
 
             {
                 let joined = URL::parse(&url_bytes);
-                // Same base the join used: a name like ".." must not be able to
-                // leave a slash-less registry path any more than a slash-terminated one.
+                // Confine against the same base the join used, so ".." cannot
+                // escape a slash-less registry path.
                 let registry = URL::parse(base);
                 let registry_dir_end =
                     strings::last_index_of_char(registry.pathname, b'/').map_or(0, |i| i + 1);

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -463,13 +463,21 @@ impl NetworkTask {
 
             // npm appends the package name as a new path segment whether or not
             // the configured registry ends in "/"; WHATWG resolution would
-            // instead replace the last segment of a slash-less base.
+            // instead replace the last segment of a slash-less base. A query or
+            // fragment on the registry URL does not survive the join either way,
+            // so the "/" goes on the path, ahead of them.
             let registry_href = scope.url.href();
             let base_storage;
-            let base: &[u8] = if strings::has_prefix_comptime(registry_href, b"https://")
-                || strings::has_prefix_comptime(registry_href, b"http://")
+            let base: &[u8] = if strings::has_prefix_case_insensitive(registry_href, b"https://")
+                || strings::has_prefix_case_insensitive(registry_href, b"http://")
             {
-                base_storage = [strings::without_trailing_slash(registry_href), b"/"].concat();
+                let path_end =
+                    strings::index_of_any(registry_href, b"?#").unwrap_or(registry_href.len());
+                base_storage = [
+                    strings::without_trailing_slash(&registry_href[..path_end]),
+                    b"/",
+                ]
+                .concat();
                 &base_storage
             } else {
                 registry_href
@@ -536,7 +544,9 @@ impl NetworkTask {
 
             {
                 let joined = URL::parse(&url_bytes);
-                let registry = scope.url.url();
+                // Same base the join used: a name like ".." must not be able to
+                // leave a slash-less registry path any more than a slash-terminated one.
+                let registry = URL::parse(base);
                 let registry_dir_end =
                     strings::last_index_of_char(registry.pathname, b'/').map_or(0, |i| i + 1);
                 let registry_dir = &registry.pathname[..registry_dir_end];

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -461,11 +461,25 @@ impl NetworkTask {
                 name
             };
 
+            // npm appends the package name as a new path segment whether or not
+            // the configured registry ends in "/"; WHATWG resolution would
+            // instead replace the last segment of a slash-less base.
+            let registry_href = scope.url.href();
+            let base_storage;
+            let base: &[u8] = if strings::has_prefix_comptime(registry_href, b"https://")
+                || strings::has_prefix_comptime(registry_href, b"http://")
+            {
+                base_storage = [strings::without_trailing_slash(registry_href), b"/"].concat();
+                &base_storage
+            } else {
+                registry_href
+            };
+
             // `OwnedString` derefs the WTF-backed result on scope exit —
             // covers both the
             // success path and the InvalidURL early returns below.
             let tmp = bun_core::OwnedString::new(bun_url::join(
-                &bun_core::String::borrow_utf8(scope.url.href()),
+                &bun_core::String::borrow_utf8(base),
                 &bun_core::String::borrow_utf8(encoded_name),
             ));
 

--- a/test/cli/install/bun-install-pathname-trailing-slash.test.ts
+++ b/test/cli/install/bun-install-pathname-trailing-slash.test.ts
@@ -64,7 +64,10 @@ describe.concurrent("registry path without trailing slash is preserved", () => {
   const registryPath = "/artifactory/api/npm/npm-stuff";
   const expectedPaths = [`${registryPath}/@scope%2fpkg`, `${registryPath}/react`];
 
-  async function install(configure: (dir: string, registry: string) => Promise<string[]>) {
+  async function install(
+    configure: (dir: string, registry: string) => Promise<string[]>,
+    options: { registry?: (registry: string) => string; dependencies?: Record<string, string> } = {},
+  ) {
     const paths: string[] = [];
     using server = Bun.serve({
       port: 0,
@@ -74,10 +77,16 @@ describe.concurrent("registry path without trailing slash is preserved", () => {
       },
     });
     const dir = tmpdirSync();
-    const args = await configure(dir, `http://${server.hostname}:${server.port}${registryPath}`);
+    const origin = `http://${server.hostname}:${server.port}`;
+    const registry = `${origin}${registryPath}`;
+    const args = await configure(dir, options.registry?.(registry) ?? registry);
     await Bun.write(
       join(dir, "package.json"),
-      JSON.stringify({ name: "test", version: "0.0.0", dependencies: { "react": "1.0.0", "@scope/pkg": "1.0.0" } }),
+      JSON.stringify({
+        name: "test",
+        version: "0.0.0",
+        dependencies: options.dependencies ?? { "react": "1.0.0", "@scope/pkg": "1.0.0" },
+      }),
     );
 
     await using proc = Bun.spawn({
@@ -89,7 +98,12 @@ describe.concurrent("registry path without trailing slash is preserved", () => {
       stdin: "ignore",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    return { paths: paths.sort(), stderr, exitCode };
+    return { paths: paths.sort(), stderr, exitCode, origin };
+  }
+
+  async function writeBunfig(dir: string, registry: string) {
+    await Bun.write(join(dir, "bunfig.toml"), Bun.TOML.stringify({ install: { registry } }));
+    return [];
   }
 
   test(".npmrc registry=", async () => {
@@ -103,10 +117,7 @@ describe.concurrent("registry path without trailing slash is preserved", () => {
   });
 
   test("bunfig.toml install.registry", async () => {
-    const { paths, exitCode } = await install(async (dir, registry) => {
-      await Bun.write(join(dir, "bunfig.toml"), Bun.TOML.stringify({ install: { registry } }));
-      return [];
-    });
+    const { paths, exitCode } = await install(writeBunfig);
     expect(paths).toEqual(expectedPaths);
     expect(exitCode).toBe(1);
   });
@@ -126,6 +137,31 @@ describe.concurrent("registry path without trailing slash is preserved", () => {
   test("--registry", async () => {
     const { paths, exitCode } = await install(async (_dir, registry) => ["--registry", registry]);
     expect(paths).toEqual(expectedPaths);
+    expect(exitCode).toBe(1);
+  });
+
+  // The scheme is case-insensitive, and the registry directory ends where the
+  // path does: a "/" inside the query is not a path separator.
+  test.each([
+    ["an uppercase scheme", (registry: string) => registry.replace("http://", "HTTP://")],
+    ["a query string", (registry: string) => `${registry}?path=a/b`],
+    ["a fragment", (registry: string) => `${registry}#npm`],
+    ["repeated trailing slashes", (registry: string) => `${registry}//`],
+  ])("registry URL with %s", async (_, registry) => {
+    const { paths, exitCode } = await install(writeBunfig, { registry });
+    expect(paths).toEqual(expectedPaths);
+    expect(exitCode).toBe(1);
+  });
+
+  // The manifest URL must stay under the registry path, and that check has to use
+  // the same slash-terminated base as the join: against the URL as written, the
+  // directory of ".../npm-stuff" is ".../npm/", which is exactly where ".." lands.
+  test("dependency name that resolves above the registry path is rejected", async () => {
+    const { paths, stderr, exitCode, origin } = await install(writeBunfig, { dependencies: { "..": "1.0.0" } });
+    expect(paths).toEqual([]);
+    expect(stderr).toContain(
+      `manifest URL "${origin}/artifactory/api/npm/" is not on registry "${origin}${registryPath}"`,
+    );
     expect(exitCode).toBe(1);
   });
 });

--- a/test/cli/install/bun-install-pathname-trailing-slash.test.ts
+++ b/test/cli/install/bun-install-pathname-trailing-slash.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tmpdirSync } from "harness";
 import { join } from "path";
 
@@ -54,4 +54,78 @@ test("custom registry doesn't have multiple trailing slashes in pathname", async
 
   expect(urls.length).toBe(1);
   expect(urls).toEqual([`http://${hostname}:${port}/prefixed-route/react`]);
+});
+
+// https://github.com/oven-sh/bun/issues/5368
+// npm appends the package name to the registry URL as a new path segment
+// whether or not the URL ends in "/". Bun resolved it as a relative URL, which
+// replaced the last segment of a registry path that had no trailing slash.
+describe.concurrent("registry path without trailing slash is preserved", () => {
+  const registryPath = "/artifactory/api/npm/npm-stuff";
+  const expectedPaths = [`${registryPath}/@scope%2fpkg`, `${registryPath}/react`];
+
+  async function install(configure: (dir: string, registry: string) => Promise<string[]>) {
+    const paths: string[] = [];
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        paths.push(new URL(req.url).pathname);
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const dir = tmpdirSync();
+    const args = await configure(dir, `http://${server.hostname}:${server.port}${registryPath}`);
+    await Bun.write(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "test", version: "0.0.0", dependencies: { "react": "1.0.0", "@scope/pkg": "1.0.0" } }),
+    );
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--no-cache", ...args],
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache") },
+      cwd: dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { paths: paths.sort(), stderr, exitCode };
+  }
+
+  test(".npmrc registry=", async () => {
+    const { paths, stderr, exitCode } = await install(async (dir, registry) => {
+      await Bun.write(join(dir, ".npmrc"), `registry=${registry}\n`);
+      return [];
+    });
+    expect(paths).toEqual(expectedPaths);
+    expect(stderr).toContain(`${registryPath}/react`);
+    expect(exitCode).toBe(1);
+  });
+
+  test("bunfig.toml install.registry", async () => {
+    const { paths, exitCode } = await install(async (dir, registry) => {
+      await Bun.write(join(dir, "bunfig.toml"), Bun.TOML.stringify({ install: { registry } }));
+      return [];
+    });
+    expect(paths).toEqual(expectedPaths);
+    expect(exitCode).toBe(1);
+  });
+
+  test("bunfig.toml install.scopes", async () => {
+    const { paths, exitCode } = await install(async (dir, registry) => {
+      await Bun.write(
+        join(dir, "bunfig.toml"),
+        Bun.TOML.stringify({ install: { registry, scopes: { scope: registry } } }),
+      );
+      return [];
+    });
+    expect(paths).toEqual(expectedPaths);
+    expect(exitCode).toBe(1);
+  });
+
+  test("--registry", async () => {
+    const { paths, exitCode } = await install(async (_dir, registry) => ["--registry", registry]);
+    expect(paths).toEqual(expectedPaths);
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/cli/install/bun-install-pathname-trailing-slash.test.ts
+++ b/test/cli/install/bun-install-pathname-trailing-slash.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
 let package_dir: string;
@@ -60,108 +60,124 @@ test("custom registry doesn't have multiple trailing slashes in pathname", async
 // npm appends the package name to the registry URL as a new path segment
 // whether or not the URL ends in "/". Bun resolved it as a relative URL, which
 // replaced the last segment of a registry path that had no trailing slash.
+//
+// Every registry below lives on one local server under a distinct path, so the
+// paths the server receives show which registry each request was built from.
+// Scoped registries let one `bun install` exercise several URL shapes at once;
+// each spawn is expensive under ASAN, so the cases are packed rather than split.
 describe.concurrent("registry path without trailing slash is preserved", () => {
-  const registryPath = "/artifactory/api/npm/npm-stuff";
-  const expectedPaths = [`${registryPath}/@scope%2fpkg`, `${registryPath}/react`];
-
-  async function install(
-    configure: (dir: string, registry: string) => Promise<string[]>,
-    options: { registry?: (registry: string) => string; dependencies?: Record<string, string> } = {},
-  ) {
+  function serve() {
     const paths: string[] = [];
-    using server = Bun.serve({
+    const server = Bun.serve({
       port: 0,
       fetch(req) {
         paths.push(new URL(req.url).pathname);
         return new Response("not found", { status: 404 });
       },
     });
-    const dir = tmpdirSync();
-    const origin = `http://${server.hostname}:${server.port}`;
-    const registry = `${origin}${registryPath}`;
-    const args = await configure(dir, options.registry?.(registry) ?? registry);
-    await Bun.write(
-      join(dir, "package.json"),
-      JSON.stringify({
-        name: "test",
-        version: "0.0.0",
-        dependencies: options.dependencies ?? { "react": "1.0.0", "@scope/pkg": "1.0.0" },
-      }),
-    );
+    return {
+      paths,
+      origin: `http://${server.hostname}:${server.port}`,
+      [Symbol.dispose]: () => server.stop(true),
+    };
+  }
 
+  function packageJson(...names: string[]) {
+    return JSON.stringify({
+      name: "test",
+      version: "0.0.0",
+      dependencies: Object.fromEntries(names.map(name => [name, "1.0.0"])),
+    });
+  }
+
+  async function install(cwd: string, ...args: string[]) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "install", "--no-cache", ...args],
-      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache") },
-      cwd: dir,
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(cwd, ".bun-cache") },
+      cwd,
       stdout: "ignore",
       stderr: "pipe",
       stdin: "ignore",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    return { paths: paths.sort(), stderr, exitCode, origin };
+    return { stderr, exitCode };
   }
 
-  async function writeBunfig(dir: string, registry: string) {
-    await Bun.write(join(dir, "bunfig.toml"), Bun.TOML.stringify({ install: { registry } }));
-    return [];
-  }
-
-  test(".npmrc registry=", async () => {
-    const { paths, stderr, exitCode } = await install(async (dir, registry) => {
-      await Bun.write(join(dir, ".npmrc"), `registry=${registry}\n`);
-      return [];
+  test(".npmrc registry= and @scope:registry=", async () => {
+    using registry = serve();
+    using dir = tempDir("no-trailing-slash-npmrc", {
+      ".npmrc": `registry=${registry.origin}/r/default\n@scoped:registry=${registry.origin}/r/scoped\n`,
+      "package.json": packageJson("react", "@scoped/pkg"),
     });
-    expect(paths).toEqual(expectedPaths);
-    expect(stderr).toContain(`${registryPath}/react`);
+
+    const { stderr, exitCode } = await install(String(dir));
+
+    expect(registry.paths.sort()).toEqual(["/r/default/react", "/r/scoped/@scoped%2fpkg"]);
+    expect(stderr).toContain("/r/default/react");
     expect(exitCode).toBe(1);
   });
 
-  test("bunfig.toml install.registry", async () => {
-    const { paths, exitCode } = await install(writeBunfig);
-    expect(paths).toEqual(expectedPaths);
-    expect(exitCode).toBe(1);
-  });
-
-  test("bunfig.toml install.scopes", async () => {
-    const { paths, exitCode } = await install(async (dir, registry) => {
-      await Bun.write(
-        join(dir, "bunfig.toml"),
-        Bun.TOML.stringify({ install: { registry, scopes: { scope: registry } } }),
-      );
-      return [];
+  // The scheme is case-insensitive, the registry directory ends where the path
+  // does (a "/" inside the query is not a separator), and any number of
+  // trailing slashes collapses to one.
+  test("bunfig.toml install.registry and install.scopes, in several URL shapes", async () => {
+    using registry = serve();
+    const { origin } = registry;
+    using dir = tempDir("no-trailing-slash-bunfig", {
+      "bunfig.toml": Bun.TOML.stringify({
+        install: {
+          registry: `${origin}/r/default`,
+          scopes: {
+            plain: `${origin}/r/plain`,
+            upper: `${origin.replace("http://", "HTTP://")}/r/upper`,
+            query: `${origin}/r/query?path=a/b`,
+            fragment: `${origin}/r/fragment#npm`,
+            slashes: `${origin}/r/slashes//`,
+          },
+        },
+      }),
+      "package.json": packageJson("react", "@plain/pkg", "@upper/pkg", "@query/pkg", "@fragment/pkg", "@slashes/pkg"),
     });
-    expect(paths).toEqual(expectedPaths);
+
+    const { exitCode } = await install(String(dir));
+
+    expect(registry.paths.sort()).toEqual([
+      "/r/default/react",
+      "/r/fragment/@fragment%2fpkg",
+      "/r/plain/@plain%2fpkg",
+      "/r/query/@query%2fpkg",
+      "/r/slashes/@slashes%2fpkg",
+      "/r/upper/@upper%2fpkg",
+    ]);
     expect(exitCode).toBe(1);
   });
 
   test("--registry", async () => {
-    const { paths, exitCode } = await install(async (_dir, registry) => ["--registry", registry]);
-    expect(paths).toEqual(expectedPaths);
+    using registry = serve();
+    using dir = tempDir("no-trailing-slash-flag", { "package.json": packageJson("react", "@scoped/pkg") });
+
+    const { exitCode } = await install(String(dir), "--registry", `${registry.origin}/r/default`);
+
+    expect(registry.paths.sort()).toEqual(["/r/default/@scoped%2fpkg", "/r/default/react"]);
     expect(exitCode).toBe(1);
   });
 
-  // The scheme is case-insensitive, and the registry directory ends where the
-  // path does: a "/" inside the query is not a path separator.
-  test.each([
-    ["an uppercase scheme", (registry: string) => registry.replace("http://", "HTTP://")],
-    ["a query string", (registry: string) => `${registry}?path=a/b`],
-    ["a fragment", (registry: string) => `${registry}#npm`],
-    ["repeated trailing slashes", (registry: string) => `${registry}//`],
-  ])("registry URL with %s", async (_, registry) => {
-    const { paths, exitCode } = await install(writeBunfig, { registry });
-    expect(paths).toEqual(expectedPaths);
-    expect(exitCode).toBe(1);
-  });
-
-  // The manifest URL must stay under the registry path, and that check has to use
-  // the same slash-terminated base as the join: against the URL as written, the
-  // directory of ".../npm-stuff" is ".../npm/", which is exactly where ".." lands.
+  // The manifest URL must stay under the registry path, and that check has to
+  // measure against the same slash-terminated base as the join: measured against
+  // the URL as written, the directory of ".../r/default" is ".../r/", which is
+  // exactly where ".." lands.
   test("dependency name that resolves above the registry path is rejected", async () => {
-    const { paths, stderr, exitCode, origin } = await install(writeBunfig, { dependencies: { "..": "1.0.0" } });
-    expect(paths).toEqual([]);
-    expect(stderr).toContain(
-      `manifest URL "${origin}/artifactory/api/npm/" is not on registry "${origin}${registryPath}"`,
-    );
+    using registry = serve();
+    const { origin } = registry;
+    using dir = tempDir("no-trailing-slash-dotdot", {
+      "bunfig.toml": Bun.TOML.stringify({ install: { registry: `${origin}/r/default` } }),
+      "package.json": packageJson(".."),
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+
+    expect(registry.paths).toEqual([]);
+    expect(stderr).toContain(`manifest URL "${origin}/r/" is not on registry "${origin}/r/default"`);
     expect(exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
Fixes #5368
Fixes #14017
Fixes #16185
Fixes #20373

Partially addresses #20593 (the trailing-slash half). The `.npmrc` vs `bunfig.toml` precedence half of #20593 (and #20390) is a separate behavior change and will go in its own PR.

Supersedes #32461 by @3w36zj6, which fixed the same join first; the query string and uppercase scheme handling and the confinement check below come from there (credited as co-author on d8d73bd).

### Problem

- A registry configured without a trailing slash loses its last path segment when Bun requests a manifest:
  ```ini
  registry=https://host/artifactory/api/npm/npm-stuff
  ```
  requests `https://host/artifactory/api/npm/lodash` (404). npm requests `.../npm-stuff/lodash`.
- Cause: `NetworkTask::for_manifest` (src/install/NetworkTask.rs) builds the URL with `bun_url::join(registry_href, name)`, which is WHATWG relative resolution: resolving `lodash` against `.../npm-stuff` replaces `npm-stuff`, the same way a browser resolves a relative link.
- Affects every way a registry can be configured (`.npmrc` `registry=` and `@scope:registry=`, `bunfig.toml` `install.registry` and `install.scopes`, `--registry`), since they all reach this one join.

### Fix

- At the join site only, build the base for `http(s)` registry URLs (scheme matched case-insensitively) as the href up to any `?`/`#`, trailing slashes stripped, plus `/`, so the join always appends a segment. A query or fragment never survives the join anyway, so cutting there only keeps the `/` on the path. The stored `Scope.url` is left exactly as written.
- The "manifest URL is on the registry" check a few lines down now parses that same base instead of the href as written. Measured against the as-written href, a slash-less registry's directory is one level up (`.../api/npm/` for `.../api/npm/npm-stuff`), which is where a name like `..` now resolves to, so it would have been let through; and a registry ending in `//` (works on main) would have been rejected, because the joined URL no longer starts with the `//` directory. With both sides using one base, a registry written without the slash behaves exactly like the same registry written with it, for the request path and for the check.
- Leaving the href alone matters: `cached_npm_package_folder_name_print` hashes the stored href into cache folder names for hostnames over 32 chars, so rewriting it would rename the cache folders of every package from a slash-less private registry and force re-downloads. Every other consumer (`build_url` for tarballs, `url_is_under_registry`, the manifest cache header, `url_hash`) already strips the slash itself. Non-http inputs are left untouched so the existing invalid-URL error messages still report what the user wrote.
- Verified: `test/cli/install/bun-install-pathname-trailing-slash.test.ts` records the exact paths one local server receives and covers, in four `bun install` runs: `.npmrc` (`registry=` plus `@scope:registry=`); `bunfig.toml` with a default registry and five scoped registries written as a plain URL, an uppercase scheme, a query string containing `/`, a fragment, and `//` (one install, six expected paths); `--registry`; and a `..` dependency, which must produce `manifest URL ".../r/" is not on registry` with no request sent. All four fail on main (the paths come back one segment short, and the `..` case reports `.../` since the join had already dropped the last segment) and pass with the branch. The `Registry URLs` table in `bun-install.test.ts` passes unchanged.

### Background

- The npm registry API is `<registry>/<name>` with the registry treated as a directory; npm's client concatenates, it does not URL-resolve.
- `bun_url::join` is the WHATWG URL resolver (same semantics as `new URL(rel, base)`), where a base without a trailing slash has its last segment treated as a file and replaced, and the base's query and fragment are dropped.
- The check in `for_manifest` exists because dependency names come from package.json files and from other packages' manifests, and the join interprets them as relative references (`..`, `\\host\x`): the joined URL has to stay on the registry's host and under its path before the request, which carries the scope's credentials, is sent. `bun_url::URL::parse` is Bun's lightweight component splitter used for that comparison; unlike `bun_url::join` it does not normalize its input, which is why the comparison has to be given the same base the join was.

