### PR TITLE
dns: fix RFC 8305 address-family interleave so blackholed IPv6 doesn't stall bun install

### DIFF
--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -299,6 +299,7 @@ export function getJS2NativeRust() {
   const handExported = new Set<string>([
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption",
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_newResolver",
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_getaddrinfoInterleaveForTesting",
   ]);
 
   const srcRoot = path.resolve(import.meta.dir, "..");

--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -299,7 +299,7 @@ export function getJS2NativeRust() {
   const handExported = new Set<string>([
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption",
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_newResolver",
-    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_getaddrinfoInterleaveForTesting",
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_seedCacheForTesting",
   ]);
 
   const srcRoot = path.resolve(import.meta.dir, "..");

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -467,16 +467,11 @@ export const stringsInternals = {
   ) => string,
 };
 
-export const dnsInternals = {
-  /**
-   * Feeds a synthetic getaddrinfo result with the given address families
-   * (4 | 6) through the connect-path result packing and returns
-   * `family * 1000 + originalIndex` in the order connections are attempted.
-   */
-  getaddrinfoInterleave: $newRustFunction("runtime/dns_jsc/dns.rs", "internal.getaddrinfoInterleaveForTesting", 1) as (
-    families: number[],
-  ) => number[],
-};
+/** Seed the connect-path DNS cache for `hostname` via the real `process_results` interleave; returns family order. */
+export const dnsCacheSeed = $newRustFunction("runtime/dns_jsc/dns.rs", "internal.seedCacheForTesting", 2) as (
+  hostname: string,
+  addresses: string[],
+) => number[];
 
 export const fetchH2Internals = {
   liveCounts: $newRustFunction("http/H2Client.rs", "TestingAPIs.liveCounts", 0) as () => {

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -467,6 +467,19 @@ export const stringsInternals = {
   ) => string,
 };
 
+export const dnsInternals = {
+  /**
+   * Feeds a synthetic getaddrinfo result with the given address families
+   * (4 | 6) through the connect-path result packing and returns
+   * `family * 1000 + originalIndex` in the order connections are attempted.
+   */
+  getaddrinfoInterleave: $newRustFunction(
+    "runtime/dns_jsc/dns.rs",
+    "internal.getaddrinfoInterleaveForTesting",
+    1,
+  ) as (families: number[]) => number[],
+};
+
 export const fetchH2Internals = {
   liveCounts: $newRustFunction("http/H2Client.rs", "TestingAPIs.liveCounts", 0) as () => {
     sessions: number;

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -473,11 +473,9 @@ export const dnsInternals = {
    * (4 | 6) through the connect-path result packing and returns
    * `family * 1000 + originalIndex` in the order connections are attempted.
    */
-  getaddrinfoInterleave: $newRustFunction(
-    "runtime/dns_jsc/dns.rs",
-    "internal.getaddrinfoInterleaveForTesting",
-    1,
-  ) as (families: number[]) => number[],
+  getaddrinfoInterleave: $newRustFunction("runtime/dns_jsc/dns.rs", "internal.getaddrinfoInterleaveForTesting", 1) as (
+    families: number[],
+  ) => number[],
 };
 
 export const fetchH2Internals = {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -3029,9 +3029,9 @@ pub mod internal {
         let hostname_z = bun::ZBox::from_bytes(hostname_slice.slice());
         let len = args[1].get_length(global)? as usize;
         if len == 0 || len > 64 {
-            return Err(global.throw_invalid_arguments(format_args!(
-                "addresses must have 1..=64 entries"
-            )));
+            return Err(
+                global.throw_invalid_arguments(format_args!("addresses must have 1..=64 entries"))
+            );
         }
 
         let mut addrs: Vec<SockaddrStorage> = (0..len).map(|_| bun_core::ffi::zeroed()).collect();

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2621,11 +2621,9 @@ pub mod internal {
         pub addr: SockaddrStorage,
     }
 
-    // Pack getaddrinfo results into a single allocation, interleaving address
-    // families (RFC 8305 §4): alternate between the resolver's first family
-    // and the other, preserving resolver order within each family, so a run of
-    // unroutable same-family addresses cannot occupy every concurrent connect
-    // attempt in usockets (CONCURRENT_CONNECTIONS = 4). See #4938 / #33278.
+    // Pack getaddrinfo results into one allocation with address families
+    // interleaved (RFC 8305 §4) so an unroutable family can never fill all
+    // CONCURRENT_CONNECTIONS parallel connect attempts. See #4938 / #33278.
     fn process_results(info: *mut AddrInfo) -> Box<[ResultEntry]> {
         let mut count: usize = 0;
         let mut n_first: usize = 0;
@@ -2650,18 +2648,13 @@ pub mod internal {
 
         let mut results: Box<[MaybeUninit<ResultEntry>]> = Box::new_uninit_slice(count);
 
-        // Copy results. The slot for the i-th entry of the first family is 2*i
-        // while the other family can still pair with it, then n_other+i for the
-        // surplus tail (and symmetrically 2*j+1 / n_first+j for the other
-        // family). This is a bijection over 0..count, so every MaybeUninit slot
-        // is written exactly once.
         let mut i_first: usize = 0;
         let mut i_other: usize = 0;
         info_ = info;
         while !info_.is_null() {
             // SAFETY: info_ is a valid addrinfo node (counted above); the slot
-            // mapping is a bijection over 0..count, so every results[i] is a
-            // MaybeUninit slot fully initialized exactly once.
+            // mapping is a bijection over 0..count so every MaybeUninit slot
+            // is fully initialized exactly once.
             unsafe {
                 let i = if (*info_).ai_family == first_family {
                     let i = i_first;
@@ -3019,44 +3012,61 @@ pub mod internal {
         Ok(object)
     }
 
-    /// `bun:internal-for-testing` probe for [`process_results`]: feeds a
-    /// synthetic getaddrinfo list with the given address families (4 or 6)
-    /// through the real packing path and returns `family * 1000 + originalIndex`
-    /// in connect-attempt order so tests can assert interleaving and stability.
-    pub(crate) fn getaddrinfo_interleave_for_testing(
+    /// `bun:internal-for-testing`: seed the connect-path DNS cache for `hostname`
+    /// by running `addresses` through the real [`process_results`] interleave and
+    /// storing the result, so a real `fetch()` / `Bun.connect()` consumes it.
+    pub(crate) fn seed_cache_for_testing(
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let families = frame.argument(0);
-        let len = families.get_length(global)? as usize;
+        let args = frame.arguments();
+        if args.len() < 2 || !args[0].is_string() || !args[1].is_array() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "expected (hostname: string, addresses: string[])"
+            )));
+        }
+        let hostname_slice = args[0].to_slice(global)?;
+        let hostname_z = bun::ZBox::from_bytes(hostname_slice.slice());
+        let len = args[1].get_length(global)? as usize;
+        if len == 0 || len > 64 {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "addresses must have 1..=64 entries"
+            )));
+        }
 
         let mut addrs: Vec<SockaddrStorage> = (0..len).map(|_| bun_core::ffi::zeroed()).collect();
         let mut nodes: Vec<AddrInfo> = (0..len).map(|_| bun_core::ffi::zeroed()).collect();
         for i in 0..len {
-            let family = families.get_index(global, i as u32)?.to_int32();
+            let addr_slice = args[1].get_index(global, i as u32)?.to_slice(global)?;
+            let addr_z = bun::ZBox::from_bytes(addr_slice.slice());
             let node = &mut nodes[i];
-            // Stash the original index in the port so the test can verify
-            // resolver order is preserved within each family.
-            match family {
-                4 => {
-                    // SAFETY: sockaddr_in fits in the zeroed sockaddr_storage.
-                    let sa = unsafe { &mut *(&raw mut addrs[i]).cast::<netc::sockaddr_in>() };
-                    sa.sin_family = netc::AF_INET as _;
-                    sa.sin_port = i as u16;
+            node.ai_socktype = netc::SOCK_STREAM;
+            // SAFETY: sockaddr_in/in6 fit in the zeroed sockaddr_storage and
+            // ares_inet_pton writes at most sizeof(in_addr)/sizeof(in6_addr).
+            unsafe {
+                let v4 = (&raw mut addrs[i]).cast::<netc::sockaddr_in>();
+                let v6 = (&raw mut addrs[i]).cast::<netc::sockaddr_in6>();
+                if c_ares::ares_inet_pton(
+                    netc::AF_INET,
+                    addr_z.as_ptr().cast::<c_char>(),
+                    (&raw mut (*v4).sin_addr).cast::<c_void>(),
+                ) > 0
+                {
+                    (*v4).sin_family = netc::AF_INET as _;
                     node.ai_family = netc::AF_INET;
                     node.ai_addrlen = size_of::<netc::sockaddr_in>() as _;
-                }
-                6 => {
-                    // SAFETY: sockaddr_in6 fits in the zeroed sockaddr_storage.
-                    let sa = unsafe { &mut *(&raw mut addrs[i]).cast::<netc::sockaddr_in6>() };
-                    sa.sin6_family = netc::AF_INET6 as _;
-                    sa.sin6_port = i as u16;
+                } else if c_ares::ares_inet_pton(
+                    netc::AF_INET6,
+                    addr_z.as_ptr().cast::<c_char>(),
+                    (&raw mut (*v6).sin6_addr).cast::<c_void>(),
+                ) > 0
+                {
+                    (*v6).sin6_family = netc::AF_INET6 as _;
                     node.ai_family = netc::AF_INET6;
                     node.ai_addrlen = size_of::<netc::sockaddr_in6>() as _;
-                }
-                other => {
+                } else {
                     return Err(global.throw_invalid_arguments(format_args!(
-                        "family must be 4 or 6, got {other}"
+                        "addresses[{i}] is not an IPv4 or IPv6 literal"
                     )));
                 }
             }
@@ -3068,35 +3078,38 @@ pub mod internal {
             unsafe { (*base.add(i)).ai_next = base.add(i + 1) };
         }
 
-        let results = process_results(if len == 0 {
-            ptr::null_mut()
-        } else {
-            nodes.as_mut_ptr()
-        });
+        let results = process_results(nodes.as_mut_ptr());
 
-        // Walk the rebuilt ai_next chain (not the slice) so the pointer fixup
-        // at the end of process_results is exercised too.
         let out = JSValue::create_empty_array(global, results.len())?;
-        let mut p: *const AddrInfo = if results.is_empty() {
-            ptr::null()
-        } else {
-            &raw const results[0].info
-        };
-        let mut idx: u32 = 0;
-        while !p.is_null() {
-            // SAFETY: p walks the ai_next chain inside the live `results` allocation.
-            let encoded = unsafe {
-                if (*p).ai_family == netc::AF_INET {
-                    4000 + i32::from((*(*p).ai_addr.cast::<netc::sockaddr_in>()).sin_port)
-                } else {
-                    6000 + i32::from((*(*p).ai_addr.cast::<netc::sockaddr_in6>()).sin6_port)
-                }
+        for (i, entry) in (0u32..).zip(results.iter()) {
+            let fam: i32 = if entry.info.ai_family == netc::AF_INET6 {
+                6
+            } else {
+                4
             };
-            out.put_index(global, idx, JSValue::js_number_from_int32(encoded))?;
-            idx += 1;
-            // SAFETY: as above.
-            p = unsafe { (*p).ai_next };
+            out.put_index(global, i, JSValue::js_number_from_int32(fam))?;
         }
+
+        let key = RequestKey::init(Some(hostname_z.as_zstr()), 0);
+        let req = Request::new(key.to_owned(), 0, GlobalCache::get_cache_timestamp());
+        // SAFETY: `req` is freshly heap-allocated and exclusively owned until
+        // `try_push` transfers it to the lock-guarded cache.
+        unsafe {
+            (*req).result_buf = Some(results);
+            let info = (*req)
+                .result_buf
+                .as_mut()
+                .and_then(|b| NonNull::new(b.as_mut_ptr()));
+            (*req).result = Some(RequestResult { info, err: 0 });
+        }
+        let mut guard = global_cache().lock();
+        if !guard.try_push(req) {
+            drop(guard);
+            Request::deinit(req);
+            return Err(global.throw_invalid_arguments(format_args!("DNS cache is full")));
+        }
+        DNS_CACHE_SIZE.store(guard.len, Ordering::Relaxed);
+        drop(guard);
         Ok(out)
     }
 
@@ -6214,6 +6227,6 @@ export_host_fn!(
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption"
 );
 export_host_fn!(
-    internal::getaddrinfo_interleave_for_testing,
-    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_getaddrinfoInterleaveForTesting"
+    internal::seed_cache_for_testing,
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_seedCacheForTesting"
 );

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2621,25 +2621,57 @@ pub mod internal {
         pub addr: SockaddrStorage,
     }
 
-    // re-order result to interleave ipv4 and ipv6 (also pack into a single allocation)
+    // Pack getaddrinfo results into a single allocation, interleaving address
+    // families (RFC 8305 §4): alternate between the resolver's first family
+    // and the other, preserving resolver order within each family, so a run of
+    // unroutable same-family addresses cannot occupy every concurrent connect
+    // attempt in usockets (CONCURRENT_CONNECTIONS = 4). See #4938 / #33278.
     fn process_results(info: *mut AddrInfo) -> Box<[ResultEntry]> {
         let mut count: usize = 0;
+        let mut n_first: usize = 0;
+        let first_family = if info.is_null() {
+            netc::AF_UNSPEC
+        } else {
+            // SAFETY: info is a live addrinfo node; freed by caller after we return.
+            unsafe { (*info).ai_family }
+        };
         let mut info_: *mut AddrInfo = info;
         while !info_.is_null() {
-            count += 1;
             // SAFETY: info_ walks the libc-allocated addrinfo list; freed by caller after we return.
-            info_ = unsafe { (*info_).ai_next };
+            unsafe {
+                count += 1;
+                if (*info_).ai_family == first_family {
+                    n_first += 1;
+                }
+                info_ = (*info_).ai_next;
+            }
         }
+        let n_other = count - n_first;
 
         let mut results: Box<[MaybeUninit<ResultEntry>]> = Box::new_uninit_slice(count);
 
-        // copy results
-        let mut i: usize = 0;
+        // Copy results. The slot for the i-th entry of the first family is 2*i
+        // while the other family can still pair with it, then n_other+i for the
+        // surplus tail (and symmetrically 2*j+1 / n_first+j for the other
+        // family). This is a bijection over 0..count, so every MaybeUninit slot
+        // is written exactly once.
+        let mut i_first: usize = 0;
+        let mut i_other: usize = 0;
         info_ = info;
         while !info_.is_null() {
-            // SAFETY: info_ is a valid addrinfo node (counted above); results[i] is a
-            // MaybeUninit slot we fully initialize in this iteration.
+            // SAFETY: info_ is a valid addrinfo node (counted above); the slot
+            // mapping is a bijection over 0..count, so every results[i] is a
+            // MaybeUninit slot fully initialized exactly once.
             unsafe {
+                let i = if (*info_).ai_family == first_family {
+                    let i = i_first;
+                    i_first += 1;
+                    if i < n_other { 2 * i } else { n_other + i }
+                } else {
+                    let j = i_other;
+                    i_other += 1;
+                    if j < n_first { 2 * j + 1 } else { n_first + j }
+                };
                 let entry = results[i].as_mut_ptr();
                 (*entry).info = *info_;
                 // Always initialize `addr`: assume_init() below requires every byte written.
@@ -2656,33 +2688,12 @@ pub mod internal {
                 } else {
                     (*entry).addr = bun_core::ffi::zeroed();
                 }
-                i += 1;
                 info_ = (*info_).ai_next;
             }
         }
 
         // SAFETY: every slot 0..count was written above
         let mut results: Box<[ResultEntry]> = unsafe { results.assume_init() };
-
-        // sort (interleave ipv4 and ipv6)
-        let mut want = netc::AF_INET6 as usize;
-        'outer: for idx in 0..count {
-            if results[idx].info.ai_family as usize == want {
-                continue;
-            }
-            for j in (idx + 1)..count {
-                if results[j].info.ai_family as usize == want {
-                    results.swap(idx, j);
-                    want = if want == netc::AF_INET6 as usize {
-                        netc::AF_INET as usize
-                    } else {
-                        netc::AF_INET6 as usize
-                    };
-                }
-            }
-            // the rest of the list is all one address family
-            break 'outer;
-        }
 
         // set up pointers
         for idx in 0..count {
@@ -3006,6 +3017,87 @@ pub mod internal {
             JSValue::js_number(GETADDRINFO_CALLS.load(Ordering::Relaxed) as f64),
         );
         Ok(object)
+    }
+
+    /// `bun:internal-for-testing` probe for [`process_results`]: feeds a
+    /// synthetic getaddrinfo list with the given address families (4 or 6)
+    /// through the real packing path and returns `family * 1000 + originalIndex`
+    /// in connect-attempt order so tests can assert interleaving and stability.
+    pub(crate) fn getaddrinfo_interleave_for_testing(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let families = frame.argument(0);
+        let len = families.get_length(global)? as usize;
+
+        let mut addrs: Vec<SockaddrStorage> = (0..len).map(|_| bun_core::ffi::zeroed()).collect();
+        let mut nodes: Vec<AddrInfo> = (0..len).map(|_| bun_core::ffi::zeroed()).collect();
+        for i in 0..len {
+            let family = families.get_index(global, i as u32)?.to_int32();
+            let node = &mut nodes[i];
+            // Stash the original index in the port so the test can verify
+            // resolver order is preserved within each family.
+            match family {
+                4 => {
+                    // SAFETY: sockaddr_in fits in the zeroed sockaddr_storage.
+                    let sa = unsafe { &mut *(&raw mut addrs[i]).cast::<netc::sockaddr_in>() };
+                    sa.sin_family = netc::AF_INET as _;
+                    sa.sin_port = i as u16;
+                    node.ai_family = netc::AF_INET;
+                    node.ai_addrlen = size_of::<netc::sockaddr_in>() as _;
+                }
+                6 => {
+                    // SAFETY: sockaddr_in6 fits in the zeroed sockaddr_storage.
+                    let sa = unsafe { &mut *(&raw mut addrs[i]).cast::<netc::sockaddr_in6>() };
+                    sa.sin6_family = netc::AF_INET6 as _;
+                    sa.sin6_port = i as u16;
+                    node.ai_family = netc::AF_INET6;
+                    node.ai_addrlen = size_of::<netc::sockaddr_in6>() as _;
+                }
+                other => {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "family must be 4 or 6, got {other}"
+                    )));
+                }
+            }
+            node.ai_addr = (&raw mut addrs[i]).cast::<Sockaddr>();
+        }
+        let base = nodes.as_mut_ptr();
+        for i in 0..len.saturating_sub(1) {
+            // SAFETY: i and i+1 are in-bounds; the Vec is never reallocated after this.
+            unsafe { (*base.add(i)).ai_next = base.add(i + 1) };
+        }
+
+        let results = process_results(if len == 0 {
+            ptr::null_mut()
+        } else {
+            nodes.as_mut_ptr()
+        });
+
+        // Walk the rebuilt ai_next chain (not the slice) so the pointer fixup
+        // at the end of process_results is exercised too.
+        let out = JSValue::create_empty_array(global, results.len())?;
+        let mut p: *const AddrInfo = if results.is_empty() {
+            ptr::null()
+        } else {
+            &raw const results[0].info
+        };
+        let mut idx: u32 = 0;
+        while !p.is_null() {
+            // SAFETY: p walks the ai_next chain inside the live `results` allocation.
+            let encoded = unsafe {
+                if (*p).ai_family == netc::AF_INET {
+                    4000 + i32::from((*(*p).ai_addr.cast::<netc::sockaddr_in>()).sin_port)
+                } else {
+                    6000 + i32::from((*(*p).ai_addr.cast::<netc::sockaddr_in6>()).sin6_port)
+                }
+            };
+            out.put_index(global, idx, JSValue::js_number_from_int32(encoded))?;
+            idx += 1;
+            // SAFETY: as above.
+            p = unsafe { (*p).ai_next };
+        }
+        Ok(out)
     }
 
     pub(crate) fn getaddrinfo(
@@ -6120,4 +6212,8 @@ export_host_fn!(
 export_host_fn!(
     Resolver::get_runtime_default_result_order_option,
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption"
+);
+export_host_fn!(
+    internal::getaddrinfo_interleave_for_testing,
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_getaddrinfoInterleaveForTesting"
 );

--- a/test/js/bun/dns/dns-interleave.test.ts
+++ b/test/js/bun/dns/dns-interleave.test.ts
@@ -49,7 +49,7 @@ async function run(body: string, timeoutMs = 10_000) {
   return { out, stderr, exitCode, signal: proc.signalCode };
 }
 
-describe("getaddrinfo interleave (RFC 8305)", () => {
+describe.concurrent("getaddrinfo interleave (RFC 8305)", () => {
   test("fetch() through a seeded 4xAAAA + 4xA entry connects via the interleaved order", async () => {
     const { out, stderr, exitCode, signal } = await run(/* js */ `
       using server = Bun.serve({ port: 0, fetch: () => new Response("ok") });

--- a/test/js/bun/dns/dns-interleave.test.ts
+++ b/test/js/bun/dns/dns-interleave.test.ts
@@ -1,0 +1,100 @@
+// The internal DNS cache (used by the usockets connect path for fetch(),
+// Bun.connect() and `bun install`) packs getaddrinfo results into a flat
+// array and is supposed to interleave address families (RFC 8305 §4) so that
+// the four parallel connection attempts usockets opens always cover both
+// families. registry.npmjs.org resolves to 12 AAAA + 12 A; on a dual-stack
+// host with blackholed IPv6, a broken interleave leaves all four initial
+// attempts on dead IPv6 and every manifest fetch stalls for ~100s waiting on
+// kernel SYN-retry exhaustion.
+//
+// https://github.com/oven-sh/bun/issues/4938
+// https://github.com/oven-sh/bun/issues/33278
+import { dnsInternals } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
+
+const { getaddrinfoInterleave } = dnsInternals;
+
+// Entries are encoded as family * 1000 + original resolver index.
+const families = (input: number[]) => getaddrinfoInterleave(input).map(e => Math.floor(e / 1000));
+const indices = (input: number[]) => getaddrinfoInterleave(input).map(e => e % 1000);
+
+describe("internal getaddrinfo interleave (RFC 8305)", () => {
+  test("registry.npmjs.org shape: 12 AAAA + 12 A puts IPv4 in the first batch", () => {
+    const input = [...Array(12).fill(6), ...Array(12).fill(4)];
+    const out = families(input);
+    expect(out.slice(0, 4)).toEqual([6, 4, 6, 4]);
+    expect(out).toEqual(Array(12).fill([6, 4]).flat());
+  });
+
+  test("AAAA-heavy result gets IPv4 into the first batch", () => {
+    // 4+ dead IPv6 ahead of one reachable IPv4. Without interleaving, the
+    // first CONCURRENT_CONNECTIONS (4) attempts are all IPv6.
+    const out = getaddrinfoInterleave([6, 6, 6, 6, 4]);
+    expect(out).toEqual([6000, 4004, 6001, 6002, 6003]);
+    expect(new Set(families([6, 6, 6, 6, 4]).slice(0, 4))).toEqual(new Set([4, 6]));
+  });
+
+  test("A-heavy result gets IPv6 into the first batch", () => {
+    expect(getaddrinfoInterleave([4, 4, 4, 4, 6])).toEqual([4000, 6004, 4001, 4002, 4003]);
+  });
+
+  test("first address stays first (respects OS RFC 6724 preference)", () => {
+    expect(families([6, 4, 4, 4])[0]).toBe(6);
+    expect(families([4, 6, 6, 6])[0]).toBe(4);
+  });
+
+  test("already-grouped input alternates fully", () => {
+    expect(getaddrinfoInterleave([6, 6, 6, 4, 4, 4])).toEqual([6000, 4003, 6001, 4004, 6002, 4005]);
+    expect(getaddrinfoInterleave([4, 4, 4, 6, 6, 6])).toEqual([4000, 6003, 4001, 6004, 4002, 6005]);
+  });
+
+  test("uneven counts: surplus family keeps resolver order at the tail", () => {
+    expect(getaddrinfoInterleave([6, 6, 6, 6, 4, 4])).toEqual([6000, 4004, 6001, 4005, 6002, 6003]);
+    expect(getaddrinfoInterleave([6, 4, 4, 4])).toEqual([6000, 4001, 4002, 4003]);
+  });
+
+  test("already-interleaved input is preserved", () => {
+    expect(getaddrinfoInterleave([6, 4, 6, 4])).toEqual([6000, 4001, 6002, 4003]);
+    expect(indices([4, 6, 4, 6])).toEqual([0, 1, 2, 3]);
+  });
+
+  test("single-family input is unchanged", () => {
+    expect(indices([6, 6, 6, 6])).toEqual([0, 1, 2, 3]);
+    expect(indices([4, 4, 4])).toEqual([0, 1, 2]);
+  });
+
+  test("relative order within each family is preserved", () => {
+    const out = getaddrinfoInterleave([6, 6, 6, 4, 4, 4]);
+    expect(out.filter(e => e >= 6000)).toEqual([6000, 6001, 6002]);
+    expect(out.filter(e => e < 6000)).toEqual([4003, 4004, 4005]);
+  });
+
+  test("empty and single-element inputs", () => {
+    expect(getaddrinfoInterleave([])).toEqual([]);
+    expect(getaddrinfoInterleave([4])).toEqual([4000]);
+    expect(getaddrinfoInterleave([6])).toEqual([6000]);
+  });
+
+  test("exhaustive: every dual-stack result has both families in the first four", () => {
+    // Whenever both families are present, the first min(4, n) slots must
+    // include both, and the output is a permutation of the input with
+    // resolver order preserved within each family.
+    for (let n = 2; n <= 8; n++) {
+      for (let mask = 0; mask < 1 << n; mask++) {
+        const input: number[] = [];
+        for (let i = 0; i < n; i++) input.push(mask & (1 << i) ? 6 : 4);
+        const out = getaddrinfoInterleave(input);
+        const outFamilies = out.map(e => Math.floor(e / 1000));
+        // permutation of the input
+        expect(outFamilies.toSorted()).toEqual(input.toSorted());
+        // stable within each family
+        expect(out.filter(e => e >= 6000)).toEqual(out.filter(e => e >= 6000).toSorted((a, b) => a - b));
+        expect(out.filter(e => e < 6000)).toEqual(out.filter(e => e < 6000).toSorted((a, b) => a - b));
+        if (!input.includes(4) || !input.includes(6)) continue;
+        // both families in the first connect batch
+        const head = new Set(outFamilies.slice(0, Math.min(4, n)));
+        expect({ input, head: [...head].sort() }).toEqual({ input, head: [4, 6] });
+      }
+    }
+  });
+});

--- a/test/js/bun/dns/dns-interleave.test.ts
+++ b/test/js/bun/dns/dns-interleave.test.ts
@@ -1,100 +1,198 @@
 // The internal DNS cache (used by the usockets connect path for fetch(),
-// Bun.connect() and `bun install`) packs getaddrinfo results into a flat
-// array and is supposed to interleave address families (RFC 8305 §4) so that
-// the four parallel connection attempts usockets opens always cover both
+// Bun.connect() and `bun install`) interleaves address families (RFC 8305 §4)
+// so the four parallel connection attempts usockets opens always cover both
 // families. registry.npmjs.org resolves to 12 AAAA + 12 A; on a dual-stack
-// host with blackholed IPv6, a broken interleave leaves all four initial
+// host with blackholed IPv6 a broken interleave leaves all four initial
 // attempts on dead IPv6 and every manifest fetch stalls for ~100s waiting on
 // kernel SYN-retry exhaustion.
 //
 // https://github.com/oven-sh/bun/issues/4938
 // https://github.com/oven-sh/bun/issues/33278
-import { dnsInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, isMusl } from "harness";
 
-const { getaddrinfoInterleave } = dnsInternals;
-
-// Entries are encoded as family * 1000 + original resolver index.
-const families = (input: number[]) => getaddrinfoInterleave(input).map(e => Math.floor(e / 1000));
-const indices = (input: number[]) => getaddrinfoInterleave(input).map(e => e % 1000);
-
-describe("internal getaddrinfo interleave (RFC 8305)", () => {
-  test("registry.npmjs.org shape: 12 AAAA + 12 A puts IPv4 in the first batch", () => {
-    const input = [...Array(12).fill(6), ...Array(12).fill(4)];
-    const out = families(input);
-    expect(out.slice(0, 4)).toEqual([6, 4, 6, 4]);
-    expect(out).toEqual(Array(12).fill([6, 4]).flat());
-  });
-
-  test("AAAA-heavy result gets IPv4 into the first batch", () => {
-    // 4+ dead IPv6 ahead of one reachable IPv4. Without interleaving, the
-    // first CONCURRENT_CONNECTIONS (4) attempts are all IPv6.
-    const out = getaddrinfoInterleave([6, 6, 6, 6, 4]);
-    expect(out).toEqual([6000, 4004, 6001, 6002, 6003]);
-    expect(new Set(families([6, 6, 6, 6, 4]).slice(0, 4))).toEqual(new Set([4, 6]));
-  });
-
-  test("A-heavy result gets IPv6 into the first batch", () => {
-    expect(getaddrinfoInterleave([4, 4, 4, 4, 6])).toEqual([4000, 6004, 4001, 4002, 4003]);
-  });
-
-  test("first address stays first (respects OS RFC 6724 preference)", () => {
-    expect(families([6, 4, 4, 4])[0]).toBe(6);
-    expect(families([4, 6, 6, 6])[0]).toBe(4);
-  });
-
-  test("already-grouped input alternates fully", () => {
-    expect(getaddrinfoInterleave([6, 6, 6, 4, 4, 4])).toEqual([6000, 4003, 6001, 4004, 6002, 4005]);
-    expect(getaddrinfoInterleave([4, 4, 4, 6, 6, 6])).toEqual([4000, 6003, 4001, 6004, 4002, 6005]);
-  });
-
-  test("uneven counts: surplus family keeps resolver order at the tail", () => {
-    expect(getaddrinfoInterleave([6, 6, 6, 6, 4, 4])).toEqual([6000, 4004, 6001, 4005, 6002, 6003]);
-    expect(getaddrinfoInterleave([6, 4, 4, 4])).toEqual([6000, 4001, 4002, 4003]);
-  });
-
-  test("already-interleaved input is preserved", () => {
-    expect(getaddrinfoInterleave([6, 4, 6, 4])).toEqual([6000, 4001, 6002, 4003]);
-    expect(indices([4, 6, 4, 6])).toEqual([0, 1, 2, 3]);
-  });
-
-  test("single-family input is unchanged", () => {
-    expect(indices([6, 6, 6, 6])).toEqual([0, 1, 2, 3]);
-    expect(indices([4, 4, 4])).toEqual([0, 1, 2]);
-  });
-
-  test("relative order within each family is preserved", () => {
-    const out = getaddrinfoInterleave([6, 6, 6, 4, 4, 4]);
-    expect(out.filter(e => e >= 6000)).toEqual([6000, 6001, 6002]);
-    expect(out.filter(e => e < 6000)).toEqual([4003, 4004, 4005]);
-  });
-
-  test("empty and single-element inputs", () => {
-    expect(getaddrinfoInterleave([])).toEqual([]);
-    expect(getaddrinfoInterleave([4])).toEqual([4000]);
-    expect(getaddrinfoInterleave([6])).toEqual([6000]);
-  });
-
-  test("exhaustive: every dual-stack result has both families in the first four", () => {
-    // Whenever both families are present, the first min(4, n) slots must
-    // include both, and the output is a permutation of the input with
-    // resolver order preserved within each family.
-    for (let n = 2; n <= 8; n++) {
-      for (let mask = 0; mask < 1 << n; mask++) {
-        const input: number[] = [];
-        for (let i = 0; i < n; i++) input.push(mask & (1 << i) ? 6 : 4);
-        const out = getaddrinfoInterleave(input);
-        const outFamilies = out.map(e => Math.floor(e / 1000));
-        // permutation of the input
-        expect(outFamilies.toSorted()).toEqual(input.toSorted());
-        // stable within each family
-        expect(out.filter(e => e >= 6000)).toEqual(out.filter(e => e >= 6000).toSorted((a, b) => a - b));
-        expect(out.filter(e => e < 6000)).toEqual(out.filter(e => e < 6000).toSorted((a, b) => a - b));
-        if (!input.includes(4) || !input.includes(6)) continue;
-        // both families in the first connect batch
-        const head = new Set(outFamilies.slice(0, Math.min(4, n)));
-        expect({ input, head: [...head].sort() }).toEqual({ input, head: [4, 6] });
-      }
+// The DNS cache is process-global and a failed connect evicts its entry, so
+// each scenario runs in its own process. Every test also does a real fetch()
+// through the seeded entry, which is consumed by usockets via
+// Bun__addrinfo_getRequestResult and start_connections().
+async function run(body: string, timeoutMs = 10_000) {
+  const fixture = /* js */ `
+    const { dnsCacheSeed } = require("bun:internal-for-testing");
+    if (typeof dnsCacheSeed !== "function") {
+      // A released binary without the hook must FAIL, not skip.
+      console.log(JSON.stringify({ ok: false, err: "dnsCacheSeed unavailable" }));
+      process.exit(0);
     }
+    ${body}
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: {
+      ...bunEnv,
+      HTTP_PROXY: undefined,
+      HTTPS_PROXY: undefined,
+      http_proxy: undefined,
+      https_proxy: undefined,
+    },
+    stderr: "pipe",
+    stdout: "pipe",
   });
+  const timer = setTimeout(() => proc.kill(), timeoutMs);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  clearTimeout(timer);
+  let out: any;
+  try {
+    out = JSON.parse(stdout.trim());
+  } catch {
+    out = { unparseableStdout: stdout };
+  }
+  return { out, stderr, exitCode, signal: proc.signalCode };
+}
+
+describe("getaddrinfo interleave (RFC 8305)", () => {
+  test("fetch() through a seeded 4xAAAA + 4xA entry connects via the interleaved order", async () => {
+    const { out, stderr, exitCode, signal } = await run(/* js */ `
+      using server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+      const port = server.port;
+      // Resolver order that used to defeat the old loop: all v6 first.
+      const order = dnsCacheSeed("he-grouped-" + port + ".test", [
+        "::1", "::1", "::1", "::1", "127.0.0.1", "127.0.0.1", "127.0.0.1", "127.0.0.1",
+      ]);
+      const res = await fetch("http://he-grouped-" + port + ".test:" + port + "/");
+      console.log(JSON.stringify({ ok: true, order, body: await res.text() }));
+      process.exit(0);
+    `);
+    expect({ out, stderr, exitCode, signal }).toEqual({
+      out: { ok: true, order: [6, 4, 6, 4, 6, 4, 6, 4], body: "ok" },
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+  });
+
+  test("registry.npmjs.org shape: 12 AAAA then 12 A puts IPv4 in the first batch", async () => {
+    const { out, stderr, exitCode, signal } = await run(/* js */ `
+      using server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+      const port = server.port;
+      const v6 = Array(12).fill("::1"), v4 = Array(12).fill("127.0.0.1");
+      const order = dnsCacheSeed("he-npm-" + port + ".test", [...v6, ...v4]);
+      const res = await fetch("http://he-npm-" + port + ".test:" + port + "/");
+      console.log(JSON.stringify({ ok: true, head: order.slice(0, 4), body: await res.text() }));
+      process.exit(0);
+    `);
+    expect({ out, stderr, exitCode, signal }).toEqual({
+      out: { ok: true, head: [6, 4, 6, 4], body: "ok" },
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+  });
+
+  test("resolver's first address stays first", async () => {
+    const { out, stderr, exitCode, signal } = await run(/* js */ `
+      using server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+      const port = server.port;
+      // v4-first input stays v4-first.
+      const order = dnsCacheSeed("he-v4first-" + port + ".test", [
+        "127.0.0.1", "127.0.0.1", "127.0.0.1", "127.0.0.1", "::1",
+      ]);
+      const res = await fetch("http://he-v4first-" + port + ".test:" + port + "/");
+      console.log(JSON.stringify({ ok: true, order, body: await res.text() }));
+      process.exit(0);
+    `);
+    expect({ out, stderr, exitCode, signal }).toEqual({
+      out: { ok: true, order: [4, 6, 4, 4, 4], body: "ok" },
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+  });
+
+  // End-to-end proof: with the first family blackholed (SYNs silently dropped,
+  // connect() stuck in EINPROGRESS until kernel SYN-retry exhaustion), fetch()
+  // must still succeed because the interleave put the other family in the
+  // first CONCURRENT_CONNECTIONS batch. Without the fix all four initial
+  // attempts are blackholed and the fetch hangs. The backlog-0 trick and
+  // 127.0.0.0/8-on-lo are Linux-specific; the raw setup dlopens glibc.
+  test.skipIf(!isLinux || isMusl)(
+    "fetch() succeeds when the first family is blackholed and only the other family is reachable",
+    async () => {
+      const { out, stderr, exitCode, signal } = await run(
+        /* js */ `
+        const { dlopen } = require("bun:ffi");
+        const libc = dlopen("libc.so.6", {
+          socket:   { args: ["int","int","int"],           returns: "int" },
+          bind:     { args: ["int","ptr","int"],           returns: "int" },
+          listen:   { args: ["int","int"],                 returns: "int" },
+          connect:  { args: ["int","ptr","int"],           returns: "int" },
+          close:    { args: ["int"],                       returns: "int" },
+          setsockopt:{args: ["int","int","int","ptr","int"],returns:"int" },
+        });
+        const AF_INET=2, SOCK_STREAM=1, SOCK_NONBLOCK=0o4000, SOL_SOCKET=1, SO_REUSEADDR=2;
+        function sockaddr_in(ip, port) {
+          const b = new Uint8Array(16);
+          new DataView(b.buffer).setUint16(0, AF_INET, true);
+          b[2] = (port>>8)&0xff; b[3] = port&0xff;
+          const o = ip.split(".").map(Number); b[4]=o[0]; b[5]=o[1]; b[6]=o[2]; b[7]=o[3];
+          return b;
+        }
+        const fds = [];
+        // listen(fd, 0) + fill the one-slot accept queue so further SYNs to
+        // ip:port are silently dropped (same EINPROGRESS a filtered network
+        // produces).
+        function blackhole(ip, port) {
+          const fd = libc.symbols.socket(AF_INET, SOCK_STREAM, 0);
+          if (fd < 0) throw new Error("socket() failed");
+          fds.push(fd);
+          const one = new Int32Array([1]);
+          libc.symbols.setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, one, 4);
+          if (libc.symbols.bind(fd, sockaddr_in(ip, port), 16) !== 0)
+            throw new Error("bind(" + ip + ":" + port + ") failed");
+          if (libc.symbols.listen(fd, 0) !== 0) throw new Error("listen() failed");
+          for (let i = 0; i < 8; i++) {
+            const c = libc.symbols.socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+            fds.push(c);
+            libc.symbols.connect(c, sockaddr_in(ip, port), 16);
+          }
+        }
+
+        using server = Bun.serve({ port: 0, hostname: "::1", fetch: () => new Response("ok via ::1") });
+        const port = server.port;
+        const dead = ["127.0.0.2","127.0.0.3","127.0.0.4","127.0.0.5"];
+        for (const ip of dead) blackhole(ip, port);
+
+        // Resolver returned 4 blackholed v4 first, then one reachable v6.
+        const host = "he-blackhole-" + port + ".test";
+        const order = dnsCacheSeed(host, [...dead, "::1"]);
+
+        const t0 = performance.now();
+        let result;
+        try {
+          const res = await fetch("http://" + host + ":" + port + "/", {
+            signal: AbortSignal.timeout(4000),
+          });
+          result = { ok: true, ms: Math.round(performance.now() - t0), order, body: await res.text() };
+        } catch (e) {
+          result = { ok: false, ms: Math.round(performance.now() - t0), order, err: e?.name ?? String(e) };
+        }
+        console.log(JSON.stringify(result));
+        for (const fd of fds) libc.symbols.close(fd);
+        process.exit(0);
+      `,
+        20_000,
+      );
+      // With the broken interleave the order is [4,4,4,4,6]: all four initial
+      // attempts sit in EINPROGRESS and the fetch aborts at 4s with
+      // TimeoutError. With the fix the order is [4,6,4,4,4]: ::1 is attempted
+      // in the first batch and connects immediately.
+      expect({ out, stderr, exitCode, signal }).toEqual({
+        out: { ok: true, ms: expect.any(Number), order: [4, 6, 4, 4, 4], body: "ok via ::1" },
+        stderr: expect.any(String),
+        exitCode: 0,
+        signal: null,
+      });
+      expect(out.ms).toBeLessThan(4000);
+    },
+    20_000,
+  );
 });


### PR DESCRIPTION
Fixes #4938. Fixes #33278. Fixes #29695. Fixes #25619.

Closes #33280,  Closes #32864 and Closes #29696 (the per-attempt connect timer in #32949 is orthogonal and left for a separate PR).

### What does this PR do?

On a dual-stack host where IPv6 is advertised but blackholed (Starlink, broken home routers, some corporate networks, Docker bridges), `bun install` stalls for ~75-130s per registry manifest fetch. `registry.npmjs.org` resolves to 12 AAAA + 12 A records; RFC 6724 sorts the AAAA records first, and `process_results()` in `src/runtime/dns_jsc/dns.rs` is supposed to interleave address families (RFC 8305 §4) before handing the list to usockets so the `CONCURRENT_CONNECTIONS = 4` parallel connect attempts cover both families.

The interleave loop has never worked:

```rust
let mut want = netc::AF_INET6 as usize;
'outer: for idx in 0..count {
    if results[idx].info.ai_family as usize == want {
        continue;   // never flips want
    }
    for j in (idx + 1)..count { ... }
    break 'outer;   // always breaks after first non-matching idx
}
```

`want` starts at hardcoded `AF_INET6` and only flips on a swap, so any list that *starts* with IPv6 (the failing shape) passes through unchanged. With `[12×v6, 12×v4]` the first four parallel connects are all blackholed IPv6 and the kernel retries SYNs until `tcp_syn_retries` is exhausted (~75s on macOS, ~127s on Linux), matching the 105.80s one reporter measured.

### Fix

Replace the post-copy swap with a closed-form interleave during the copy pass: alternate between the resolver's first family and the other, preserving resolver order within each family. The slot mapping is a bijection over `0..count`, so the existing `MaybeUninit`/`assume_init` invariant is unchanged and the broken swap loop is deleted.

Starting from the resolver's first family (rather than hardcoding v6) respects the OS's RFC 6724 policy: a v4-first result stays v4-first, and a user who set `precedence ::ffff:0:0/96 100` in `gai.conf` (the workaround several reporters used) still gets their preference.

With the interleave in place the first four attempts on a 12+12 result are `[v6, v4, v6, v4]`, so reachable IPv4 connects immediately even when every IPv6 address is blackholed.

### How did you verify your code works?

Added `dnsCacheSeed(hostname, addresses)` to `bun:internal-for-testing`. It builds a synthetic addrinfo linked list, runs it through the real `process_results()`, and stores the packed result on a `Request` in the global DNS cache the same way `after_result()` does. Every test in `test/js/bun/dns/dns-interleave.test.ts` then does a real `fetch()` to the seeded hostname, so `us_socket_group_connect` → `Bun__addrinfo_getRequestResult` → `start_connections()` consumes the exact interleaved list.

The Linux test is an end-to-end repro: 4 blackholed IPv4 listeners (backlog-0 with the accept queue filled, so SYNs are silently dropped and `connect()` sits in `EINPROGRESS`) followed by one reachable `::1`. With the interleave reverted to sequential order:

```
out: { ok: false, err: "TimeoutError", ms: 4022, order: [4, 4, 4, 4, 6] }
```

With the fix, `::1` is in slot 1 of the first batch and the fetch succeeds in ~1s:

```
out: { ok: true, body: "ok via ::1", ms: ..., order: [4, 6, 4, 4, 4] }
```

`rust:check-all` passes on all 10 targets.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/dns/dns-interleave.test.ts

<!-- robobun:evidence:end -->