### PR TITLE
HTMLRewriter: clamp unknown file-blob size so it does not overflow the preallocated-buffer hint

### DIFF
--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -332,9 +332,14 @@ impl<T: HTMLProcessorHandler, const VISIT_DOCUMENT_TAGS: bool>
         let settings = lol_html::Settings {
             element_content_handlers,
             encoding: lol_html::AsciiCompatibleEncoding::utf_8(),
-            memory_settings: lol_html::MemorySettings {
-                preallocated_parsing_buffer_size: (input.len() / 4).max(1024),
-                max_allowed_memory_usage: 1024 * 1024 * 10,
+            memory_settings: {
+                let max_allowed_memory_usage = 1024 * 1024 * 10;
+                lol_html::MemorySettings {
+                    // lol_html debug-asserts preallocated < max_allowed.
+                    preallocated_parsing_buffer_size: (input.len() / 4)
+                        .clamp(1024, max_allowed_memory_usage - 1),
+                    max_allowed_memory_usage,
+                }
             },
             strict: false,
             ..lol_html::Settings::new()

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -668,15 +668,21 @@ impl BufferOutputSink {
                 element_content_handlers,
                 document_content_handlers,
                 encoding: lol_html::AsciiCompatibleEncoding::utf_8(),
-                memory_settings: lol_html::MemorySettings {
-                    preallocated_parsing_buffer_size: if input_size as u64
-                        == webcore::blob::MAX_SIZE
-                    {
-                        1024
-                    } else {
-                        input_size.max(1024) as usize
-                    },
-                    max_allowed_memory_usage: u32::MAX as usize,
+                memory_settings: {
+                    let max_allowed_memory_usage = u32::MAX as usize;
+                    lol_html::MemorySettings {
+                        // lol_html debug-asserts preallocated < max_allowed, so
+                        // clamp. `MAX_SIZE` is the "unknown size" sentinel from
+                        // `Body::size()`; treat anything that large as unknown.
+                        preallocated_parsing_buffer_size: if input_size as u64
+                            >= webcore::blob::MAX_SIZE
+                        {
+                            1024
+                        } else {
+                            input_size.clamp(1024, max_allowed_memory_usage - 1)
+                        },
+                        max_allowed_memory_usage,
+                    }
                 },
                 strict: false,
                 enable_esi_tags: false,

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -669,11 +669,7 @@ impl BufferOutputSink {
                 document_content_handlers,
                 encoding: lol_html::AsciiCompatibleEncoding::utf_8(),
                 memory_settings: lol_html::MemorySettings {
-                    // lol_html debug-asserts preallocated < max_allowed.
-                    // `input_size` is `MAX_SIZE` for an unknown-size body and
-                    // is peer-supplied `Content-Length` for a fetched body, so
-                    // cap it; this buffer only holds the incomplete-token tail
-                    // between `write()` calls, not the whole document.
+                    // `input_size` may be unknown (`MAX_SIZE`) or peer-supplied; cap it.
                     preallocated_parsing_buffer_size: if input_size as u64
                         >= webcore::blob::MAX_SIZE
                     {

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -668,21 +668,20 @@ impl BufferOutputSink {
                 element_content_handlers,
                 document_content_handlers,
                 encoding: lol_html::AsciiCompatibleEncoding::utf_8(),
-                memory_settings: {
-                    let max_allowed_memory_usage = u32::MAX as usize;
-                    lol_html::MemorySettings {
-                        // lol_html debug-asserts preallocated < max_allowed, so
-                        // clamp. `MAX_SIZE` is the "unknown size" sentinel from
-                        // `Body::size()`; treat anything that large as unknown.
-                        preallocated_parsing_buffer_size: if input_size as u64
-                            >= webcore::blob::MAX_SIZE
-                        {
-                            1024
-                        } else {
-                            input_size.clamp(1024, max_allowed_memory_usage - 1)
-                        },
-                        max_allowed_memory_usage,
-                    }
+                memory_settings: lol_html::MemorySettings {
+                    // lol_html debug-asserts preallocated < max_allowed.
+                    // `input_size` is `MAX_SIZE` for an unknown-size body and
+                    // is peer-supplied `Content-Length` for a fetched body, so
+                    // cap it; this buffer only holds the incomplete-token tail
+                    // between `write()` calls, not the whole document.
+                    preallocated_parsing_buffer_size: if input_size as u64
+                        >= webcore::blob::MAX_SIZE
+                    {
+                        1024
+                    } else {
+                        input_size.clamp(1024, 64 * 1024)
+                    },
+                    max_allowed_memory_usage: u32::MAX as usize,
                 },
                 strict: false,
                 enable_esi_tags: false,

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -721,7 +721,10 @@ impl Value {
 
     pub fn size(&mut self) -> blob::SizeType {
         match self {
-            Value::Blob(b) => b.get_size_for_bindings() as blob::SizeType,
+            // `get_size_for_bindings()` returns `u64::MAX` for unknown size; map
+            // that to this module's "unknown" sentinel (`MAX_SIZE`). Zig used
+            // `@truncate(u52, …)` which did this implicitly.
+            Value::Blob(b) => b.get_size_for_bindings().min(blob::MAX_SIZE),
             Value::InternalBlob(b) => b.slice_const().len() as blob::SizeType,
             Value::WTFStringImpl(s) => wtf_impl(s).utf8_byte_length() as blob::SizeType,
             Value::Locked(l) => l.size_hint(),

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -721,9 +721,7 @@ impl Value {
 
     pub fn size(&mut self) -> blob::SizeType {
         match self {
-            // `get_size_for_bindings()` returns `u64::MAX` for unknown size; map
-            // that to this module's "unknown" sentinel (`MAX_SIZE`). Zig used
-            // `@truncate(u52, …)` which did this implicitly.
+            // Map `get_size_for_bindings()`'s `u64::MAX` "unknown" marker to `MAX_SIZE`.
             Value::Blob(b) => b.get_size_for_bindings().min(blob::MAX_SIZE),
             Value::InternalBlob(b) => b.slice_const().len() as blob::SizeType,
             Value::WTFStringImpl(s) => wtf_impl(s).utf8_byte_length() as blob::SizeType,

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -363,6 +363,18 @@ describe("HTMLRewriter", () => {
     expect(await output.text()).toBe("<div><blink>it worked!</blink></div>");
   });
 
+  it("(from file) rejects with ENOENT when the file does not exist", async () => {
+    const rewriter = new HTMLRewriter().on("div", { element() {} });
+    const missing = join(tmpdirSync(), "html-rewriter-does-not-exist.html");
+    const output = rewriter.transform(new Response(Bun.file(missing)));
+    const err = await output.text().then(
+      () => null,
+      e => e,
+    );
+    expect(err).not.toBeNull();
+    expect(err.code).toBe("ENOENT");
+  });
+
   it("supports attribute iterator", async () => {
     var rewriter = new HTMLRewriter();
     var expected = [


### PR DESCRIPTION
## Problem

In a debug build, transforming a `Response` that wraps a `Bun.file()` pointing at a missing (or otherwise unseekable) path panics inside lol_html:

```
panic: Total preallocated memory size should be less than `MemorySettings::max_allowed_memory_usage`.
<lol_html::memory::arena::Arena>::new
  vendor/lolhtml/src/memory/arena.rs:21
<bun_runtime::api::html_rewriter::BufferOutputSink>::init
  src/runtime/api/html_rewriter.rs:666
```

Repro:
```sh
bun bd -e 'await new HTMLRewriter().on("head",{element(){}}).transform(new Response(Bun.file("/nonexistent.html"))).text()'
```

Release builds reject with `ENOENT` because the check is a `debug_assert!`.

## Cause

`Blob::get_size_for_bindings()` returns `u64::MAX` to mean "size unknown". In Zig, `Body.Value.size()` applied `@truncate(u52, …)` so that value became `maxInt(u52) == Blob.max_size`, and HTMLRewriter's `input_size == Blob.max_size` sentinel check matched.

The Rust port widened `SizeType` to `u64` while keeping `MAX_SIZE = (1<<52)-1`. The truncation became a no-op `as u64` cast, so `Body::size()` now returns `u64::MAX`, the `== MAX_SIZE` check never matches, and `usize::MAX` flows into `preallocated_parsing_buffer_size` (with `max_allowed_memory_usage = u32::MAX`), tripping lol_html's assertion.

## Fix

- `Body::Value::size()` clamps `get_size_for_bindings()` to `MAX_SIZE`, restoring the Zig-era sentinel. (`get_size_for_bindings()` itself keeps returning `u64::MAX`; the C++ `Bun__Blob__getSizeForBindings` caller checks for that value.)
- `BufferOutputSink::init` caps `preallocated_parsing_buffer_size` at 64 KiB. `input_size` may be the peer-supplied `Content-Length` of a fetched response, and the buffer only holds the incomplete-token tail between `write()` calls, so there is no reason to let it scale to the full body size.
- `HTMLScanner::run` (the bundler's other `MemorySettings` site) clamps its `input.len() / 4` hint below `max_allowed_memory_usage` so a >=40 MiB HTML entry point no longer hits the same assertion.

## Test

Added a case next to the existing "(from file)" test that transforms a `Response(Bun.file(<missing>))` and asserts `.text()` rejects with `code === "ENOENT"`. Under `bun bd` without the src/ change this test aborts with the panic above; with it, the full `html-rewriter.test.js` suite (70 pass / 2 todo) and `bundler_html.test.ts` (22 pass) are green.

Found while investigating #16220 (unrelated to that issue).

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/workerd/html-rewriter.test.js
bun test v1.4.0 (6069d7c1c)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [21.21ms]
(pass) HTMLRewriter > error inside element handler [10.93ms]
(pass) HTMLRewriter > error inside element handler (string) [8.48ms]
(pass) HTMLRewriter > fast async error inside element handler [37.77ms]
(pass) HTMLRewriter > slow async error inside element handler [29.53ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [176.75ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [22.21ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [602.89ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .text() on the transformed response rejects [107.76ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .arrayBuffer() on the transformed response rejects [76.35ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .body on the t
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [0.17ms]
(pass) HTMLRewriter > error inside element handler [0.88ms]
(pass) HTMLRewriter > error inside element handler (string) [0.10ms]
(pass) HTMLRewriter > fast async error inside element handler [10.65ms]
(pass) HTMLRewriter > slow async error inside element handler [1.89ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [10.95ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [0.16ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [8.29ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .text() on the transformed response rejects [2.98ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .arrayBuffer() on the transformed response rejects [1.69ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .body on the transformed response is an errored stream [2.06ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > a read already pending on .body when the upstream f
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/workerd/html-rewriter.test.js
bun test v1.4.0 (6069d7c1c)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [12.35ms]
(pass) HTMLRewriter > error inside element handler [6.99ms]
(pass) HTMLRewriter > error inside element handler (string) [5.03ms]
(pass) HTMLRewriter > fast async error inside element handler [34.13ms]
(pass) HTMLRewriter > slow async error inside element handler [19.59ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [147.52ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [19.00ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [576.15ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .text() on the transformed response rejects [115.60ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .arrayBuffer() on the transformed response rejects [76.78ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .body on the tr
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     6069d7c1c3
  features     baseline

22 deps, 108 codegen, 1171 objects in 1940ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [14.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [3.00ms]
[3/1234] gen bindgenv2
[4/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[5/1234] gen .bind.ts → GeneratedBindings.cpp
[6/1234] gen ErrorCode+*.h
[7/1234] fetch zlib
[zlib] up to date
[8/1234] fetch picohttpparser
[picohttpparser] up to date
[9/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1234] fetch tinycc
[tinycc] up to date
[11/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/HTMLScanner.rs            | 11 ++++++++---
 src/runtime/api/html_rewriter.rs      |  5 +++--
 src/runtime/webcore/Body.rs           |  3 ++-
 test/js/workerd/html-rewriter.test.js | 12 ++++++++++++
 4 files changed, 25 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/bundler/HTMLScanner.rs                 1      1      0
src/runtime/api/html_rewriter.rs           4      4      0
src/runtime/webcore/Body.rs                5      2      0
test/js/workerd/html-rewriter.test.js      2      1      0
```

</details>

<!-- robobun:evidence:end -->