### PR TITLE
install(hoisted): defer nested skip until parent tree is installed

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -926,7 +926,8 @@ impl<'a> PackageInstaller<'a> {
                     self.node_modules.path = context.path;
                     self.current_tree_id = context.tree_id;
 
-                    const NEEDS_VERIFY: bool = false;
+                    // Re-verify: a parent reinstall may have deleted a deferred entry.
+                    const NEEDS_VERIFY: bool = true;
                     const IS_PENDING_PACKAGE_INSTALL: bool = true;
                     self.install_package_with_name_and_resolution::<NEEDS_VERIFY, IS_PENDING_PACKAGE_INSTALL>(
                         // This id might be different from the id used to enqueue the task. Important
@@ -1601,7 +1602,6 @@ impl<'a> PackageInstaller<'a> {
             || !NEEDS_VERIFY
             || remove_patch
             || !installer.verify(resolution, &self.root_node_modules_folder);
-        self.summary.skipped += (!needs_install) as u32;
 
         if needs_install {
             if resolution.tag.can_enqueue_install_task()
@@ -2220,6 +2220,27 @@ impl<'a> PackageInstaller<'a> {
                 }
             }
         } else {
+            // Same gate as the `needs_install` branch: a pending parent's
+            // `uninstall_before_install` would delete this verified package.
+            if !IS_PENDING_PACKAGE_INSTALL
+                && !Self::can_install_package_for_tree(
+                    &self.completed_trees,
+                    self.lockfile().buffers.trees.as_slice(),
+                    self.current_tree_id,
+                )
+            {
+                self.trees[self.current_tree_id as usize]
+                    .pending_installs
+                    .push(DependencyInstallContext {
+                        dependency_id,
+                        tree_id: self.current_tree_id,
+                        path: self.node_modules.path.clone(),
+                    });
+                return;
+            }
+
+            self.summary.skipped += 1;
+
             if self.bins[package_id as usize].tag != bin::Tag::None {
                 self.trees[self.current_tree_id as usize]
                     .binaries
@@ -2238,7 +2259,7 @@ impl<'a> PackageInstaller<'a> {
             };
 
             // `defer { destination_dir.close(); }` + `defer increment_tree_install_count`.
-            // No early returns in this branch, so manual calls at end are equivalent.
+            // No early returns after this point, so manual calls at end are equivalent.
 
             let dep = &self.lockfile().buffers.dependencies.as_slice()[dependency_id as usize];
             let dep_behavior = dep.behavior;

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -3439,6 +3439,146 @@ test("it should install with missing bun.lockb, node_modules, and/or cache", asy
 });
 
 describe("hoisting", async () => {
+  // https://github.com/oven-sh/bun/issues/7241
+  test("nested dependency is preserved when its parent is reinstalled from an empty cache", async () => {
+    // `one-fixed-dep@1.0.0` depends on `no-deps@1.0.0`. With `no-deps@2.0.0`
+    // at the root, `no-deps@1.0.0` is forced to nest under
+    // `node_modules/one-fixed-dep/node_modules/no-deps`.
+    await writeFile(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "one-fixed-dep": "1.0.0",
+          "no-deps": "2.0.0",
+        },
+      }),
+    );
+
+    await runBunInstall(env, packageDir);
+
+    const nestedPkg = join(packageDir, "node_modules", "one-fixed-dep", "node_modules", "no-deps", "package.json");
+    expect(await file(nestedPkg).json()).toMatchObject({ name: "no-deps", version: "1.0.0" });
+
+    // Simulate a CI build cache restore: node_modules survives, the install
+    // cache does not, and the parent package needs a reinstall.
+    await rm(join(packageDir, ".bun-cache"), { recursive: true, force: true });
+    await rm(join(packageDir, "node_modules", "one-fixed-dep", "package.json"));
+
+    // The nested child is still correct on disk. The bug was that the installer
+    // verified it before `one-fixed-dep` had finished re-downloading, marked it
+    // as done, and then the parent reinstall deleted `one-fixed-dep/` wholesale.
+    await runBunInstall(env, packageDir, { savesLockfile: false });
+
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      name: "no-deps",
+      version: "2.0.0",
+    });
+    expect(await file(join(packageDir, "node_modules", "one-fixed-dep", "package.json")).json()).toMatchObject({
+      name: "one-fixed-dep",
+      version: "1.0.0",
+    });
+    expect(await file(nestedPkg).json()).toMatchObject({
+      name: "no-deps",
+      version: "1.0.0",
+    });
+
+    const lockfile = parseLockfile(packageDir);
+    expect(lockfile).toMatchNodeModulesAt(packageDir);
+  });
+
+  // https://github.com/oven-sh/bun/issues/16968
+  test("nested dependency is preserved when its parent changes version via lockfile", async () => {
+    // has-bin-entries@1.0.0 and @2.0.0 both depend on no-deps@1.0.0. With
+    // no-deps@2.0.0 at the root, no-deps@1.0.0 nests under has-bin-entries.
+
+    // First produce the "after git pull" lockfile: has-bin-entries@2.0.0.
+    await writeFile(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: { "has-bin-entries": "2.0.0", "no-deps": "2.0.0" },
+      }),
+    );
+    await runBunInstall(env, packageDir);
+
+    const nested = join(packageDir, "node_modules", "has-bin-entries", "node_modules", "no-deps", "package.json");
+    expect(await file(nested).json()).toMatchObject({ name: "no-deps", version: "1.0.0" });
+
+    const savedLockb = await file(join(packageDir, "bun.lockb")).arrayBuffer();
+    const savedPkgJson = await file(packageJson).text();
+
+    // Now produce the "before git pull" on-disk state: has-bin-entries@1.0.0.
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    await rm(join(packageDir, "bun.lockb"), { force: true });
+    await writeFile(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: { "has-bin-entries": "1.0.0", "no-deps": "2.0.0" },
+      }),
+    );
+    await runBunInstall(env, packageDir);
+    expect(await file(join(packageDir, "node_modules", "has-bin-entries", "package.json")).json()).toMatchObject({
+      version: "1.0.0",
+    });
+    expect(await file(nested).json()).toMatchObject({ name: "no-deps", version: "1.0.0" });
+
+    // Simulate `git pull`: lockfile + package.json now say 2.0.0, node_modules is
+    // still at 1.0.0. Clear the cache so has-bin-entries@2.0.0 is downloaded
+    // during the install loop (the lockfile matches, so the resolve-phase
+    // prefetch is skipped).
+    await writeFile(join(packageDir, "bun.lockb"), new Uint8Array(savedLockb));
+    await writeFile(packageJson, savedPkgJson);
+    await rm(join(packageDir, ".bun-cache"), { recursive: true, force: true });
+
+    const { err } = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(err).not.toContain("Saved lockfile");
+
+    expect(await file(join(packageDir, "node_modules", "has-bin-entries", "package.json")).json()).toMatchObject({
+      version: "2.0.0",
+    });
+    expect(await file(nested).json()).toMatchObject({ name: "no-deps", version: "1.0.0" });
+
+    const lockfile = parseLockfile(packageDir);
+    expect(lockfile).toMatchNodeModulesAt(packageDir);
+  });
+
+  test("nested dependency deferred behind an unrelated root reinstall is skipped, not reinstalled", async () => {
+    await writeFile(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "one-fixed-dep": "1.0.0",
+          "no-deps": "2.0.0",
+        },
+      }),
+    );
+    await runBunInstall(env, packageDir);
+
+    const nested = join(packageDir, "node_modules", "one-fixed-dep", "node_modules", "no-deps", "package.json");
+    const { ino } = await lstat(nested);
+
+    // Only the root `no-deps@2.0.0` needs a reinstall. The nested
+    // `no-deps@1.0.0` is deferred until the root tree finishes, then must be
+    // re-verified and skipped rather than downloaded again.
+    await rm(join(packageDir, ".bun-cache"), { recursive: true, force: true });
+    await rm(join(packageDir, "node_modules", "no-deps", "package.json"));
+
+    const { out } = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(out).toContain("1 package installed");
+
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      name: "no-deps",
+      version: "2.0.0",
+    });
+    expect((await lstat(nested)).ino).toBe(ino);
+
+    const lockfile = parseLockfile(packageDir);
+    expect(lockfile).toMatchNodeModulesAt(packageDir);
+  });
+
   var tests: any = [
     {
       situation: "1.0.0 - 1.0.10 is in order",


### PR DESCRIPTION
Fixes #7241. Fixes #16968. Related: #24720.

## Problem

When `bun install` runs against a pre-existing `node_modules` (a restored CI build cache, or after `git pull` bumps a dependency) and the bun install cache is empty, a package `P` that needs a reinstall is queued for download, but the tree iterator keeps walking. If the nested `node_modules/P/node_modules/C` already holds the correct version of `C`, the installer verifies it, marks it as done, and moves on. When `P` finishes downloading, `uninstall_before_install` renames away all of `node_modules/P` (including `P/node_modules/C`) and installs `P` fresh. `C` is never revisited.

In #7241 this surfaces as:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in
  /vercel/path0/node_modules/estree-walker/package.json
    at Object.<anonymous> (/vercel/path0/node_modules/@vercel/nft/out/analyze.js:7:25)
```

because `@vercel/nft/node_modules/estree-walker@2.0.2` (CJS) is gone and Node resolves `require("estree-walker")` to the hoisted `estree-walker@3` (ESM-only). Every commenter on the issue reports the same workaround: redeploy without build cache.

In #16968 it surfaces as `Error: The service was stopped` from Vite, because `esbuild` is reinstalled after `bun add` and its nested platform package is wiped. Workaround there is the same: delete `node_modules` and reinstall.

## Cause

`install_package_with_name_and_resolution` already gates the `needs_install` branch on `can_install_package_for_tree` (defer until every parent tree has finished). The `!needs_install` skip branch had no such gate: it incremented the tree install count immediately, so the deferred-install machinery never saw it.

## Fix

Apply the same `can_install_package_for_tree` gate to the skip branch. When a parent is still pending, push the dependency to `pending_installs` instead of counting it as done. `install_available_packages` now drains with `NEEDS_VERIFY = true` so a deferred entry is re-verified against the disk state after its parents have settled: if the parent reinstall deleted it, it is installed; if it is still intact (its parent was skipped, or the pending root package was an unrelated sibling), it is skipped as before. `summary.skipped` moves past the gate so deferred entries are counted once.

## Tests

Three new tests in `hoisting` in `test/cli/install/bun-install-registry.test.ts`:

- `nested dependency is preserved when its parent is reinstalled from an empty cache` (#7241 shape): install `one-fixed-dep@1.0.0` + root `no-deps@2.0.0` so `no-deps@1.0.0` nests under `one-fixed-dep`; remove `.bun-cache` and the parent `package.json`; assert the nested copy survives. Fails on main with `ENOENT` on the nested `package.json`.
- `nested dependency is preserved when its parent changes version via lockfile` (#16968 shape): install `has-bin-entries@1.0.0` + root `no-deps@2.0.0`; swap in a lockfile that says `has-bin-entries@2.0.0` and clear the cache; assert the nested `no-deps@1.0.0` survives the parent's reinstall. Fails on main with `ENOENT`.
- `nested dependency deferred behind an unrelated root reinstall is skipped, not reinstalled`: same layout as the first, but only the root `no-deps@2.0.0` is made stale. The nested `no-deps@1.0.0` is deferred behind the root tree and must come back as a skip: stdout says `1 package installed` and the nested `package.json` keeps its inode. This pins the `NEEDS_VERIFY = true` on the drain path; with it set back to `false` this test prints `2 packages installed` while the other two still pass.

Full `bun-install-registry.test.ts` (233 pass, 0 fail) on the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->