### PR TITLE
resolver: auto-resolve extensions for wildcard exports/imports targets

### DIFF
--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1321,9 +1321,6 @@ pub enum Status {
     /// The package or module requested does not exist.
     ModuleNotFound,
 
-    /// The user just needs to add the missing extension
-    ModuleNotFoundMissingExtension,
-
     /// The resolved path corresponds to a directory, which is not a supported target for module imports.
     UnsupportedDirectoryImport,
 
@@ -2073,18 +2070,11 @@ impl<'a> ESModule<'a> {
                         };
                     }
 
-                    let status: Status = if strings::ends_with_char_or_is_zero_length(result, b'*')
-                        && strings::index_of_char(result, b'*').unwrap() as usize
-                            == result.len() - 1
-                    {
-                        Status::ExactEndsWithStar
-                    } else {
-                        Status::Exact
-                    };
+                    // Wildcard expansion: tag for `probe_wildcard_extensions` (oven-sh/bun#29679, #10001).
                     dedent!();
                     return Resolution {
                         path: Box::<[u8]>::from(result),
-                        status,
+                        status: Status::ExactEndsWithStar,
                     };
                 } else {
                     let parts2 = [package_url, str, subpath];

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3680,31 +3680,17 @@ impl<'a> Resolver<'a> {
                         let ends_with_star = esm_resolution.status == Status::ExactEndsWithStar;
                         esm_resolution.status = Status::ModuleNotFound;
 
-                        // Try to have a friendly error message if people forget the extension
-                        if ends_with_star {
-                            let buf = bufs!(load_as_file);
-                            buf[..base.len()].copy_from_slice(base);
-                            for ext in self.opts.ext_order_slice(extension_order).iter() {
-                                let ext: &[u8] = ext;
-                                let file_name = &mut buf[0..base.len() + ext.len()];
-                                file_name[base.len()..].copy_from_slice(ext);
-                                if entries.get(&file_name[..]).is_some() {
-                                    if let Some(debug) = self.debug_logs.as_mut() {
-                                        let parts = [package_json.name.as_ref(), package_subpath];
-                                        debug.add_note_fmt(format_args!(
-                                            "The import {} is missing the extension {}",
-                                            bstr::BStr::new(ResolvePath::join(
-                                                &parts,
-                                                bun_paths::Platform::AUTO
-                                            )),
-                                            bstr::BStr::new(ext)
-                                        ));
-                                    }
-                                    esm_resolution.status = Status::ModuleNotFoundMissingExtension;
-                                    let _ = ext;
-                                    break;
-                                }
-                            }
+                        if ends_with_star
+                            && self.probe_wildcard_extensions(
+                                entries,
+                                resolved_dir_info,
+                                package_json,
+                                base,
+                                extension_order,
+                                out,
+                            )
+                        {
+                            return MatchStatus::Success;
                         }
                         return MatchStatus::NotFound;
                     }
@@ -3715,6 +3701,18 @@ impl<'a> Resolver<'a> {
                     == Fs::file_system::EntryKind::Dir
                 {
                     let ends_with_star = esm_resolution.status == Status::ExactEndsWithStar;
+                    if ends_with_star
+                        && self.probe_wildcard_extensions(
+                            entries,
+                            resolved_dir_info,
+                            package_json,
+                            base,
+                            extension_order,
+                            out,
+                        )
+                    {
+                        return MatchStatus::Success;
+                    }
                     esm_resolution.status = Status::UnsupportedDirectoryImport;
 
                     // Try to have a friendly error message if people forget the "/index.js" suffix
@@ -3820,6 +3818,150 @@ impl<'a> Resolver<'a> {
             }
             _ => unreachable!(),
         }
+    }
+
+    /// Wildcard `exports`/`imports` target isn't a file: probe extensions like `load_as_file` does.
+    fn probe_wildcard_extensions<'e>(
+        &mut self,
+        entries: &'e Fs::file_system::DirEntry,
+        resolved_dir_info: DirInfoRef,
+        package_json: &PackageJSON,
+        base: &[u8],
+        extension_order: options::ExtOrder,
+        out: &mut MatchResult,
+    ) -> bool {
+        let rfs = self.rfs_ptr();
+
+        // Extensionless target (`"./*": "./dist/*"`): append extension_order (oven-sh/bun#29679).
+        if bun_paths::extension(base).is_empty() {
+            let buf = bufs!(load_as_file);
+            buf[..base.len()].copy_from_slice(base);
+            for ext in self.opts.ext_order_slice(extension_order).iter() {
+                let ext: &[u8] = ext;
+                let file_name = &mut buf[0..base.len() + ext.len()];
+                file_name[base.len()..].copy_from_slice(ext);
+                if let Some(ext_query) = entries.get(&file_name[..]) {
+                    // SAFETY: entries_mutex held; rfs points at the process-global RealFS.
+                    if unsafe { ext_query.entry().kind(rfs, self.store_fd) }
+                        == Fs::file_system::EntryKind::File
+                    {
+                        if let Some(debug) = self.debug_logs.as_mut() {
+                            debug.add_note_fmt(format_args!(
+                                "Resolved to \"{}\" by adding extension \"{}\"",
+                                bstr::BStr::new(file_name),
+                                bstr::BStr::new(ext)
+                            ));
+                        }
+                        self.build_wildcard_match(
+                            entries,
+                            resolved_dir_info,
+                            package_json,
+                            &ext_query,
+                            out,
+                        );
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // `.js`/`.jsx`/`.mjs` → `.ts`/`.tsx`/`.mts`: same rewrite as `load_as_file` (oven-sh/bun#10001).
+        if let Some(last_dot) = strings::last_index_of_char(base, b'.') {
+            let ext = &base[last_dot..];
+            let ts_exts: &[&[u8]] = if ext == b".js" || ext == b".jsx" {
+                &[b".ts", b".tsx", b".mts"]
+            } else if ext == b".mjs"
+                && (!FeatureFlags::DISABLE_AUTO_JS_TO_TS_IN_NODE_MODULES
+                    || !strings::path_contains_node_modules_folder(entries.dir))
+            {
+                &[b".mts"]
+            } else {
+                &[]
+            };
+
+            if !ts_exts.is_empty() {
+                let segment = &base[..last_dot];
+                let buf = bufs!(load_as_file);
+                buf[..segment.len()].copy_from_slice(segment);
+                for &replacement in ts_exts.iter() {
+                    let file_name = &mut buf[0..segment.len() + replacement.len()];
+                    file_name[segment.len()..].copy_from_slice(replacement);
+                    if let Some(ts_query) = entries.get(&file_name[..]) {
+                        // SAFETY: entries_mutex held; rfs points at the process-global RealFS.
+                        if unsafe { ts_query.entry().kind(rfs, self.store_fd) }
+                            == Fs::file_system::EntryKind::File
+                        {
+                            if let Some(debug) = self.debug_logs.as_mut() {
+                                debug.add_note_fmt(format_args!(
+                                    "Rewrote \"{}\" to \"{}\"",
+                                    bstr::BStr::new(base),
+                                    bstr::BStr::new(file_name)
+                                ));
+                            }
+                            self.build_wildcard_match(
+                                entries,
+                                resolved_dir_info,
+                                package_json,
+                                &ts_query,
+                                out,
+                            );
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
+    fn build_wildcard_match<'e>(
+        &mut self,
+        entries: &'e Fs::file_system::DirEntry,
+        resolved_dir_info: DirInfoRef,
+        package_json: &PackageJSON,
+        query: &crate::fs::EntryLookup<'e>,
+        out: &mut MatchResult,
+    ) {
+        let abs_path: &[u8] = {
+            if query.entry().abs_path.is_empty() {
+                let parts = [query.entry().dir, query.entry().base()];
+                let abs = self.fs_ref().abs_buf(&parts, bufs!(remap_path));
+                // SAFETY: EntryStore-owned slot; resolver mutex held. RHS fully
+                // evaluated before LHS `&mut Entry` is materialized.
+                unsafe { &mut *query.entry }.abs_path = Interned::from_static(
+                    self.fs_ref()
+                        .dirname_store
+                        .append_slice(abs)
+                        .expect("unreachable"),
+                );
+            }
+            query.entry().abs_path.as_bytes()
+        };
+        let module_type = if let Some(pkg) = resolved_dir_info.package_json() {
+            pkg.module_type
+        } else {
+            options::ModuleType::Unknown
+        };
+
+        *out = MatchResult {
+            path_pair: PathPair {
+                primary: Path::init_with_namespace(abs_path, b"file"),
+                secondary: None,
+            },
+            dirname_fd: entries.fd,
+            file_fd: query.entry().cache().fd,
+            dir_info: Some(resolved_dir_info),
+            is_node_module: true,
+            package_json: Some(
+                resolved_dir_info
+                    .package_json()
+                    .map(std::ptr::from_ref)
+                    .unwrap_or_else(|| std::ptr::from_ref(package_json)),
+            ),
+            module_type,
+            ..Default::default()
+        };
     }
 
     pub(crate) fn resolve_without_remapping(

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -1447,6 +1447,11 @@ describe("bundler", () => {
       stdout: "SUCCESS",
     },
   });
+  // Bun-specific: wildcard `exports` with an extensionless target now
+  // auto-resolves the extension (`.js`, `.mjs`, ...). Node.js and esbuild
+  // error here (this test is ported from esbuild, which is why it previously
+  // asserted a resolution error); Vite, webpack, and TypeScript's
+  // `moduleResolution: "bundler"` handle this shape. See oven-sh/bun#29679.
   itBundled("packagejson/ExportsNotExactMissingExtensionPattern", {
     files: {
       "/Users/user/project/src/entry.js": `import 'pkg1/foo/bar'`,
@@ -1459,8 +1464,8 @@ describe("bundler", () => {
       `,
       "/Users/user/project/node_modules/pkg1/dir/bar.js": `console.log('SUCCESS')`,
     },
-    bundleErrors: {
-      "/Users/user/project/src/entry.js": [`Could not resolve: "pkg1/foo/bar". Maybe you need to "bun install"?`],
+    run: {
+      stdout: "SUCCESS",
     },
   });
   itBundled("packagejson/ExportsExactMissingExtension", {

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1,5 +1,5 @@
 import { pathToFileURL } from "bun";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import { chmodSync, chownSync, mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, bunRun, isLinux, isMacOS, isWindows, joinP, tempDir, tempDirWithFiles } from "harness";
 import { join, resolve, sep } from "path";
@@ -1054,6 +1054,366 @@ it("resolves through many directories without corrupting the dir cache", async (
   expect(stderr).toBe("");
   expect(stdout).toBe(`${(N * (N - 1)) / 2}\n${3 + 77}\n`);
   expect(exitCode).toBe(0);
+}, 20_000);
+
+// ASAN builds print a warning on stderr that has nothing to do with resolution.
+function stripAsanWarning(stderr: string): string {
+  return stderr
+    .split("\n")
+    .filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+}
+
+async function runWildcardScript(dir: string, entry: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), entry],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr: stripAsanWarning(stderr), exitCode };
+}
+
+// https://github.com/oven-sh/bun/issues/29679
+// Packages like @modelcontextprotocol/sdk ship a wildcard `exports` entry
+// whose target has no extension, e.g. `"./*": { "import": "./dist/esm/*" }`.
+// Node.js requires the caller to write `pkg/foo.js` (with the extension).
+// Bun probes configured extensions so `pkg/foo` resolves to `./dist/esm/foo.js`.
+describe("wildcard exports with extensionless target", () => {
+  function makeFixture(extra: Record<string, string> = {}) {
+    return tempDir("wildcard-exports", {
+      "node_modules/wildcard-pkg/package.json": JSON.stringify({
+        name: "wildcard-pkg",
+        type: "module",
+        exports: {
+          ".": "./dist/esm/index.js",
+          "./exact": "./dist/esm/exact/index.js",
+          "./*": {
+            types: "./dist/esm/*.d.ts",
+            import: "./dist/esm/*",
+            require: "./dist/cjs/*",
+          },
+        },
+      }),
+      "node_modules/wildcard-pkg/dist/esm/index.js": "export const root = 'root';",
+      "node_modules/wildcard-pkg/dist/esm/exact/index.js": "export const exact = 'exact';",
+      "node_modules/wildcard-pkg/dist/esm/server/stdio.js": "export const stdio = 'stdio';",
+      "node_modules/wildcard-pkg/dist/esm/server/http.mjs": "export const http = 'http';",
+      "node_modules/wildcard-pkg/dist/cjs/server/stdio.js": "module.exports = { stdio: 'cjs-stdio' };",
+      ...extra,
+    });
+  }
+
+  test.concurrent("resolves import without extension to `.js`", async () => {
+    using dir = makeFixture({
+      "index.ts": `
+        import { stdio } from "wildcard-pkg/server/stdio";
+        console.log(stdio);
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
+      stdout: "stdio",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("resolves import without extension to `.mjs`", async () => {
+    using dir = makeFixture({
+      "index.ts": `
+        import { http } from "wildcard-pkg/server/http";
+        console.log(http);
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
+      stdout: "http",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("explicit `.js` extension still works", async () => {
+    using dir = makeFixture({
+      "index.ts": `
+        import { stdio } from "wildcard-pkg/server/stdio.js";
+        console.log(stdio);
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
+      stdout: "stdio",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("exact-key exports are not affected", async () => {
+    using dir = makeFixture({
+      "index.ts": `
+        import { exact } from "wildcard-pkg/exact";
+        console.log(exact);
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
+      stdout: "exact",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("truly missing subpath still errors", async () => {
+    using dir = makeFixture({
+      "index.ts": `
+        import { nope } from "wildcard-pkg/server/does-not-exist";
+        console.log(nope);
+      `,
+    });
+
+    const result = await runWildcardScript(String(dir), "index.ts");
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("Cannot find module");
+  });
+
+  test.concurrent("CJS require of extensionless wildcard target also resolves", async () => {
+    using dir = makeFixture({
+      "index.cjs": `
+        const { stdio } = require("wildcard-pkg/server/stdio");
+        console.log(stdio);
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "index.cjs")).toEqual({
+      stdout: "cjs-stdio",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // Regression guard: when the wildcard target already has an extension
+  // like `"./*": "./dist/*.js"`, a missing `foo.js` must not silently
+  // double-append to `foo.js.ts` / `foo.js.mjs` / etc. — the literal
+  // `.js`→`.ts` TypeScript rewrite is the only fallback that should run.
+  test.concurrent("explicit-extension wildcard target does not double-probe extensions", async () => {
+    using dir = tempDir("wildcard-explicit-ext", {
+      "node_modules/explicit-pkg/package.json": JSON.stringify({
+        name: "explicit-pkg",
+        type: "module",
+        exports: { "./*": "./dist/*.js" },
+      }),
+      // A sibling that a naive extension probe would grab.
+      "node_modules/explicit-pkg/dist/missing.js.mjs": "export const oops = 'nope';",
+      "index.ts": `
+        import { oops } from "explicit-pkg/missing";
+        console.log(oops);
+      `,
+    });
+
+    const result = await runWildcardScript(String(dir), "index.ts");
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("Cannot find module");
+  });
+
+  test.concurrent("resolves sibling `.js` when a same-named directory exists", async () => {
+    using dir = tempDir("wildcard-dir-sibling", {
+      "node_modules/dir-pkg/package.json": JSON.stringify({
+        name: "dir-pkg",
+        type: "module",
+        exports: { "./*": "./dist/*" },
+      }),
+      "node_modules/dir-pkg/dist/utils/helper.js": "export const helper = 'helper';",
+      "node_modules/dir-pkg/dist/utils.js": "export const utils = 'utils';",
+      "index.ts": `
+        import { utils } from "dir-pkg/utils";
+        console.log(utils);
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
+      stdout: "utils",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // https://github.com/oven-sh/bun/issues/6285
+  // typeorm ships `"./*.js": "./*.js"` ahead of `"./*": {"require": "./*.js",
+  // "import": "./*"}`. The ESM `import` condition maps `pkg/util/Foo` to
+  // `./util/Foo` with no extension, which must be probed to `.js` so
+  // `import "typeorm/util/StringUtils"` works the same as the CJS `require`.
+  test.concurrent("resolves typeorm-style `./*` with identity `import` target", async () => {
+    using dir = tempDir("wildcard-typeorm", {
+      "node_modules/typeorm-like/package.json": JSON.stringify({
+        name: "typeorm-like",
+        main: "./index.js",
+        exports: {
+          ".": "./index.js",
+          "./*.js": "./*.js",
+          "./*": { require: "./*.js", import: "./*" },
+        },
+      }),
+      "node_modules/typeorm-like/index.js": "module.exports = {};",
+      "node_modules/typeorm-like/util/StringUtils.js":
+        "module.exports.camelCase = s => s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());",
+      "index.ts": `
+        import { camelCase } from "typeorm-like/util/StringUtils";
+        console.log(camelCase("correct_output"));
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
+      stdout: "correctOutput",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/10001
+// Wildcard `imports`/`exports` that point at a `.js` target should also
+// pick up `.ts`/`.tsx`/`.mts` the same way Bun already does for plain
+// file loads (e.g. `import './foo.js'` finds `./foo.ts`). The rewrite
+// is gated on wildcard patterns only — users writing an explicit
+// `"./foo": "./foo.js"` target still get exactly what they asked for.
+describe("wildcard imports/exports with `.js` → `.ts` rewrite", () => {
+  test.concurrent("package.json `imports` wildcard with `.js` target resolves `.ts` file", async () => {
+    using dir = tempDir("wildcard-imports-ts", {
+      "package.json": JSON.stringify({
+        name: "imports-ts",
+        type: "module",
+        imports: {
+          "#app/*": "./app/*.js",
+        },
+      }),
+      "app/main.ts": `export const foo = "ts file";`,
+      "index.ts": `
+        import { foo } from "#app/main";
+        console.log(foo);
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
+      stdout: "ts file",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("`.mjs` target resolves `.mts` file", async () => {
+    using dir = tempDir("wildcard-mjs-mts", {
+      "package.json": JSON.stringify({
+        name: "mjs-pkg",
+        type: "module",
+        imports: {
+          "#src/*": "./src/*.mjs",
+        },
+      }),
+      "src/thing.mts": `export const thing = "mts file";`,
+      "index.ts": `
+        import { thing } from "#src/thing";
+        console.log(thing);
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
+      stdout: "mts file",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("`.jsx` target resolves `.tsx` file", async () => {
+    using dir = tempDir("wildcard-jsx-tsx", {
+      "package.json": JSON.stringify({
+        name: "jsx-pkg",
+        type: "module",
+        imports: {
+          "#components/*": "./components/*.jsx",
+        },
+      }),
+      "components/Button.tsx": `export const Button = "tsx file";`,
+      "index.ts": `
+        import { Button } from "#components/Button";
+        console.log(Button);
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
+      stdout: "tsx file",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("self-referencing `exports` wildcard with `.js` target resolves `.ts` file", async () => {
+    using dir = tempDir("wildcard-exports-self-ts", {
+      "package.json": JSON.stringify({
+        name: "self-pkg",
+        type: "module",
+        exports: {
+          "./*": "./src/*.js",
+        },
+      }),
+      "src/feature.ts": `export const feature = "ts feature";`,
+      "index.ts": `
+        import { feature } from "self-pkg/feature";
+        console.log(feature);
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
+      stdout: "ts feature",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("actual `.js` file takes precedence over `.ts`", async () => {
+    using dir = tempDir("wildcard-js-wins", {
+      "package.json": JSON.stringify({
+        name: "js-wins",
+        type: "module",
+        imports: {
+          "#app/*": "./app/*.js",
+        },
+      }),
+      "app/main.js": `export const src = "js file";`,
+      "app/main.ts": `export const src = "ts file";`,
+      "index.ts": `
+        import { src } from "#app/main";
+        console.log(src);
+      `,
+    });
+
+    expect(await runWildcardScript(String(dir), "index.ts")).toEqual({
+      stdout: "js file",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("exact (non-wildcard) `.js` target is not rewritten to `.ts`", async () => {
+    using dir = tempDir("exact-no-rewrite", {
+      "package.json": JSON.stringify({
+        name: "exact-pkg",
+        type: "module",
+        imports: { "#feature": "./src/feature.js" },
+      }),
+      "src/feature.ts": `export const feature = "ts feature";`,
+      "index.ts": `
+        import { feature } from "#feature";
+        console.log(feature);
+      `,
+    });
+
+    const result = await runWildcardScript(String(dir), "index.ts");
+    expect(result.stderr).toContain("Cannot find");
+    expect(result.exitCode).not.toBe(0);
+  });
 });
 
 it.skipIf(isWindows)("runs a script from a working directory nested 256 directories deep", async () => {


### PR DESCRIPTION
Fixes #29679.
Fixes #10001.

## Repro

Packages like `@modelcontextprotocol/sdk` ship an `exports` wildcard whose
target has no extension:

```json
"exports": {
  "./*": {
    "types": "./dist/esm/*.d.ts",
    "import": "./dist/esm/*",
    "require": "./dist/cjs/*"
  }
}
```

`import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio"`
expanded subpath `server/stdio` to `./dist/esm/server/stdio`, a file that
doesn't exist on disk (the file is `stdio.js`). Before this change Bun
errored `Cannot find module ...`, matching Node.js but breaking these
packages.

A closely related shape from #10001: wildcard `imports` with a `.js`
target that points at a `.ts` source:

```json
"imports": { "#app/*": "./app/*.js" }
```

With `app/main.ts` on disk, `import '#app/main'` failed for the same
reason: the substituted path (`./app/main.js`) wasn't a file and the
existing TypeScript rewrite (`.js` -> `.ts` from `load_as_file`) never ran.

## Cause

`resolve_target` in `src/resolver/package_json.rs` set
`ExactEndsWithStar` only when the substituted result literally ended with
`*`, true only when the subpath was empty. For non-empty subpaths the
status was `Exact`, which in `handle_esm_resolution` skipped any
extension probing.

## Fix

1. Always flag wildcard-pattern expansions as `ExactEndsWithStar` so the
   consumer knows the result came from a `"./*"`-style key.
2. New helper `probe_wildcard_extensions` runs when the pattern-expanded
   target isn't a file (called from both the miss arm and the Dir arm):
    - **Target has no extension** -> append the configured extension
      order (`.js`, `.mjs`, `.ts`, ...).
    - **Target ends with `.js`/`.jsx`/`.mjs`** -> swap for
      `.ts`/`.tsx`/`.mts`. Same rewrite `load_as_file` already does for
      plain file loads, with the same `node_modules` gating on the `.mjs`
      arm only (#5426).
3. Exact-key matches (`"./client": "./dist/esm/client/index.js"`) and
   non-wildcard `"./dir/"`-style keys are untouched.
4. Deletes the now-dead `Status::ModuleNotFoundMissingExtension` variant
   (its only setter was the hint loop this replaces).

## Comparison with other tools

Verified against Node.js 26.3.0, TypeScript 5.8.2, esbuild 0.28.1, webpack
5.99.5, and Vite 6.2.3:

| | extensionless (#29679) | `.js`→`.ts` (#10001) |
|---|---|---|
| Node.js | ❌ | ❌ |
| TypeScript `moduleResolution: "bundler"` | ❌ | ✅ |
| esbuild | ❌ | ✅ |
| webpack / enhanced-resolve | ✅ | ❌ |
| Vite | ✅ | ✅ |
| Bun (this PR) | ✅ | ✅ |

The `.js`→`.ts` rewrite (#10001) matches TypeScript, esbuild, and Vite; it is
also what Bun already does for plain relative imports via `load_as_file`. The
extensionless probe (#29679) matches webpack and Vite. Only Vite handles both.

## Verification

`#29679`:

```ts
import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio";
console.log(StdioServerTransport);
// [class StdioServerTransport]
```

`#10001`:

```ts
// package.json: "imports": { "#app/*": "./app/*.js" }
// app/main.ts:  export const foo = "ts file";
import { foo } from "#app/main";
console.log(foo);
// ts file
```

New test cases in `test/js/bun/resolve/resolve.test.ts` cover:

- Extensionless wildcard import resolves to `.js` target
- Extensionless wildcard import resolves to `.mjs` target
- Explicit `.js` extension still works
- Exact-key exports are unaffected
- Truly missing subpath still errors
- CJS `require()` resolves via the `require` condition
- Explicit-extension wildcard target does not double-probe
- Sibling `.js` resolves when a same-named directory exists
- `imports` wildcard with `.js` target resolves `.ts` file
- `.mjs` target resolves `.mts` file
- `.jsx` target resolves `.tsx` file
- Self-referencing `exports` wildcard with `.js` target resolves `.ts` file
- Real `.js` sibling wins over `.ts`
- Exact (non-wildcard) `.js` target is not rewritten to `.ts`

Also bumps the dir-cache stress test's timeout to 20s (it was already at
~4.9s/5s under debug+ASAN on main before these tests were added).
