### PR TITLE
install: keep a package below an ancestor whose version of its peer is out of range

### DIFF
--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1328,6 +1328,7 @@ impl Lockfile {
             late_bound_optional_peer: false,
             list: Default::default(),
             sort_buf: Default::default(),
+            peer_probes: Default::default(),
         };
 
         Tree::default().process_subtree(tree::ROOT_DEP_ID, tree::INVALID_ID, &mut builder)?;

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -446,9 +446,18 @@ pub struct Builder<'a, const METHOD: BuilderMethod> {
     pub(crate) late_bound_optional_peer: bool,
     pub(crate) manager: Option<&'a PackageManager>,
     pub(crate) sort_buf: Vec<DependencyID>,
+    /// Peers of the package currently being hoisted; see `Builder::begin_peer_probes`.
+    pub(crate) peer_probes: Vec<PeerProbe>,
     pub(crate) workspace_filters: &'a [WorkspaceFilter],
     pub(crate) install_root_dependencies: bool,
     pub(crate) packages_to_install: Option<&'a [PackageID]>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct PeerProbe {
+    dep_id: DependencyID,
+    /// A tree the package would still see if it stayed put holds an in-range version.
+    provided: bool,
 }
 
 pub struct BuilderEntry {
@@ -491,6 +500,115 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
 
     fn buf(&self) -> &[u8] {
         self.lockfile().buffers.string_bytes.as_slice()
+    }
+
+    /// Collects the required peers of `package_id`, about to be hoisted out of the package with `owner_deps`.
+    fn begin_peer_probes(&mut self, owner_deps: DependencyIDSlice, package_id: PackageID) {
+        self.peer_probes.clear();
+        if package_id == invalid_package_id {
+            return;
+        }
+
+        let lockfile_ref = self.lockfile;
+        let pkg_resolutions = lockfile_ref.get().packages.items_resolution();
+        match pkg_resolutions[package_id as usize].tag {
+            // Installed as a symlink, so a nested copy would resolve the same peers as the root copy.
+            crate::resolution::Tag::Workspace | crate::resolution::Tag::Symlink => return,
+            _ => {}
+        }
+
+        let buf = lockfile_ref.get().buffers.string_bytes.as_slice();
+        let deps = self.dependencies;
+        let pkg_deps = self.resolution_lists[package_id as usize];
+
+        'peers: for peer_dep_id in pkg_deps.begin()..pkg_deps.end() {
+            let peer = &deps[peer_dep_id as usize];
+            if !peer.behavior.is_peer()
+                || peer.behavior.is_optional_peer()
+                || peer.version.tag != crate::dependency::VersionTag::Npm
+            {
+                continue;
+            }
+
+            // A regular dependency on the same name is what gets installed next to the package.
+            for dep_id in pkg_deps.begin()..pkg_deps.end() {
+                let dep = &deps[dep_id as usize];
+                if dep.name_hash == peer.name_hash && !dep.behavior.is_peer() {
+                    continue 'peers;
+                }
+            }
+
+            // The owner's own copy of the peer, if it has one, is the one the package finds from here.
+            let owner_copy = (owner_deps.begin()..owner_deps.end())
+                .map(|dep_id| (&deps[dep_id as usize], self.resolutions[dep_id as usize]))
+                .find(|(dep, res_id)| {
+                    dep.name_hash == peer.name_hash
+                        && !dep.behavior.is_peer()
+                        && *res_id != invalid_package_id
+                })
+                .map(|(_, res_id)| {
+                    pkg_resolutions[res_id as usize].satisfies_dependency_version(
+                        &peer.version,
+                        buf,
+                        buf,
+                    )
+                });
+            let provided = match owner_copy {
+                Some(true) => true,
+                Some(false) => continue 'peers,
+                None => false,
+            };
+
+            self.peer_probes.push(PeerProbe {
+                dep_id: peer_dep_id,
+                provided,
+            });
+        }
+    }
+
+    /// True if `tree_id` holds an out-of-range version of a peer that staying put would resolve in range.
+    fn probe_peers(&mut self, tree_id: Id) -> bool {
+        let lockfile_ref = self.lockfile;
+        let lockfile = lockfile_ref.get();
+        let pkg_resolutions = lockfile.packages.items_resolution();
+        let buf = lockfile.buffers.string_bytes.as_slice();
+        let deps = self.dependencies;
+        let tree_deps = self.list.items_tree()[tree_id as usize]
+            .dependencies
+            .get(self.list.items_dependencies()[tree_id as usize].as_slice());
+
+        let mut i = 0;
+        while i < self.peer_probes.len() {
+            let probe = self.peer_probes[i];
+            let peer = &deps[probe.dep_id as usize];
+
+            let held = tree_deps
+                .iter()
+                .find(|&&dep_id| deps[dep_id as usize].name_hash == peer.name_hash)
+                .map(|&dep_id| self.resolutions[dep_id as usize])
+                .filter(|&res_id| res_id != invalid_package_id)
+                .map(|res_id| {
+                    pkg_resolutions[res_id as usize].satisfies_dependency_version(
+                        &peer.version,
+                        buf,
+                        buf,
+                    )
+                });
+
+            match held {
+                None => i += 1,
+                Some(true) => {
+                    self.peer_probes[i].provided = true;
+                    i += 1;
+                }
+                Some(false) if probe.provided => return true,
+                Some(false) => {
+                    self.peer_probes.swap_remove(i);
+                }
+            }
+        }
+
+        false
     }
 
     /// Flatten the multi-dimensional ArrayList of package IDs into a single easily serializable array
@@ -957,6 +1075,10 @@ impl Tree {
 
         // Tree is Copy — snapshot the fields we need so we don't hold a borrow of builder.list.
         let this: Tree = builder.list.items_tree()[self_id as usize];
+        if !AS_DEFINED && !builder.peer_probes.is_empty() && builder.probe_peers(self_id) {
+            return HoistDependencyResult::DependencyLoop; // 3
+        }
+
         // The loop body only reads through `builder`; the recursive call comes after the loop.
         let this_deps: &[DependencyID] = this
             .dependencies
@@ -1048,6 +1170,9 @@ impl Tree {
 
         // this dependency was not found in this tree, try hoisting or placing in the next parent
         if this.parent != INVALID_ID && this.id != hoist_root_id {
+            if AS_DEFINED {
+                builder.begin_peer_probes(input_dep_range, package_id);
+            }
             let id = Tree::hoist_dependency::<false, METHOD>(
                 this.parent,
                 hoist_root_id,

--- a/test/cli/install/hoist.test.ts
+++ b/test/cli/install/hoist.test.ts
@@ -1,5 +1,10 @@
-import { afterAll, beforeAll, test } from "bun:test";
-import { VerdaccioRegistry, bunEnv, runBunInstall } from "harness";
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { VerdaccioRegistry, bunEnv, pack, readdirSorted, runBunInstall } from "harness";
+import { exists, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+// Every test below runs `bun install` twice against the local registry.
+setDefaultTimeout(60_000);
 
 const registry = new VerdaccioRegistry();
 
@@ -27,4 +32,284 @@ test("should handle resolving optional peer from multiple instances of same pack
 
   // this shouldn't hit an assertion
   await runBunInstall(bunEnv, packageDir);
+});
+
+// https://github.com/oven-sh/bun/issues/20376
+describe.concurrent("peer dependencies decide how far a package hoists", () => {
+  async function version(...path: string[]) {
+    return (await Bun.file(join(...path, "package.json")).json()).version;
+  }
+
+  // Installs twice, once resolving from scratch and once from the bun.lock the first install wrote.
+  // The tests run concurrently and share packages, so each gets its own cache (the env var set by
+  // the CI runner would otherwise override the one in bunfig.toml).
+  async function installAndCheck(packageDir: string, check: () => Promise<void>) {
+    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache") };
+    await runBunInstall(env, packageDir);
+    await check();
+
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    const { err } = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(err).not.toContain("Saved lockfile");
+    await check();
+  }
+
+  test("stays next to the peer version it was resolved against", async () => {
+    // hoisting-peer-check-parent depends on { hoisting-peer-check-child: 1.0.0, no-deps: 2.0.0 }
+    // hoisting-peer-check-child has peerDependencies: { no-deps: 2.0.0 }
+    //
+    // The root pins no-deps@1.0.0, so no-deps@2.0.0 nests under the parent. The child has to nest
+    // with it: hoisted to the root, its `require("no-deps")` would find 1.0.0.
+    const { packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        "package.json": JSON.stringify({
+          name: "root",
+          dependencies: {
+            "no-deps": "1.0.0",
+            "hoisting-peer-check-parent": "1.0.0",
+          },
+        }),
+      },
+    });
+
+    const nodeModules = join(packageDir, "node_modules");
+    await installAndCheck(packageDir, async () => {
+      expect(await readdirSorted(join(nodeModules, "hoisting-peer-check-parent", "node_modules"))).toEqual([
+        "hoisting-peer-check-child",
+        "no-deps",
+      ]);
+      expect(await version(nodeModules, "no-deps")).toBe("1.0.0");
+      expect(await version(nodeModules, "hoisting-peer-check-parent", "node_modules", "no-deps")).toBe("2.0.0");
+    });
+  });
+
+  test("stays below a peer version provided further up than its own dependent", async () => {
+    // mismatched-peer-deps-lvl0 depends on lvl1 and has peerDependencies: { no-deps: <=1.1.0 }
+    // mismatched-peer-deps-lvl1 depends on lvl2 and has peerDependencies: { no-deps: <=1.0.1 }
+    // mismatched-peer-deps-lvl2 has peerDependencies: { no-deps: 1.0.0 }
+    //
+    // Only the workspace provides an in-range no-deps. lvl1 and lvl2 depend on nothing that does,
+    // but staying under lvl0 keeps the workspace's copy in reach; the root's 2.0.0 is out of range.
+    const { packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        "package.json": JSON.stringify({
+          name: "root",
+          workspaces: ["packages/*"],
+          dependencies: {
+            "no-deps": "2.0.0",
+          },
+        }),
+        "packages/app/package.json": JSON.stringify({
+          name: "app",
+          dependencies: {
+            "no-deps": "1.0.0",
+            "mismatched-peer-deps-lvl0": "1.0.0",
+          },
+        }),
+      },
+    });
+
+    const appModules = join(packageDir, "packages", "app", "node_modules");
+    const lvl0 = join(appModules, "mismatched-peer-deps-lvl0");
+    const lvl1 = join(lvl0, "node_modules", "mismatched-peer-deps-lvl1");
+    await installAndCheck(packageDir, async () => {
+      expect(await version(packageDir, "node_modules", "no-deps")).toBe("2.0.0");
+      expect(await readdirSorted(appModules)).toEqual(["mismatched-peer-deps-lvl0", "no-deps"]);
+      expect(await version(appModules, "no-deps")).toBe("1.0.0");
+      expect(await readdirSorted(join(lvl0, "node_modules"))).toEqual(["mismatched-peer-deps-lvl1"]);
+      expect(await readdirSorted(join(lvl1, "node_modules"))).toEqual(["mismatched-peer-deps-lvl2"]);
+    });
+  });
+
+  test("hoists past an out-of-range version when nothing below would satisfy the peer either", async () => {
+    // peer-deps-fixed has peerDependencies: { no-deps: ^1.0.0 }
+    //
+    // The root pins no-deps@2.0.0 and neither workspace that depends on peer-deps-fixed brings an
+    // in-range no-deps along, so a copy under each of them would still resolve the root's 2.0.0.
+    // One shared copy at the root, as before. (The third workspace only makes a 1.x exist in the
+    // lockfile, so the peer edge resolves to a package other than the root's.)
+    const { packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        "package.json": JSON.stringify({
+          name: "root",
+          workspaces: ["packages/*"],
+          dependencies: {
+            "no-deps": "2.0.0",
+          },
+        }),
+        "packages/a/package.json": JSON.stringify({
+          name: "a",
+          dependencies: { "peer-deps-fixed": "1.0.0" },
+        }),
+        "packages/b/package.json": JSON.stringify({
+          name: "b",
+          dependencies: { "peer-deps-fixed": "1.0.0" },
+        }),
+        "packages/c/package.json": JSON.stringify({
+          name: "c",
+          dependencies: { "no-deps": "1.0.0" },
+        }),
+      },
+    });
+
+    await installAndCheck(packageDir, async () => {
+      expect(await version(packageDir, "node_modules", "peer-deps-fixed")).toBe("1.0.0");
+      expect(await version(packageDir, "node_modules", "no-deps")).toBe("2.0.0");
+      expect(await exists(join(packageDir, "packages", "a", "node_modules"))).toBe(false);
+      expect(await exists(join(packageDir, "packages", "b", "node_modules"))).toBe(false);
+      expect(await readdirSorted(join(packageDir, "packages", "c", "node_modules"))).toEqual(["no-deps"]);
+    });
+  });
+
+  test("hoists when its own dependent installs an out-of-range copy of the peer", async () => {
+    // The a-dep tarball depends on { no-deps: 1.1.0, mismatched-peer-deps-lvl1 } and nests under
+    // the workspace because the root has another a-dep. Its no-deps@1.1.0 nests under it too, so
+    // that is what lvl1 (peer no-deps <=1.0.1) would find if it stayed there, not the workspace's
+    // 1.0.0. Out of range either way, so it hoists to the root like before.
+    const { packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        "package.json": JSON.stringify({
+          name: "root",
+          workspaces: ["packages/*"],
+          dependencies: {
+            "a-dep": "1.0.1",
+            "no-deps": "2.0.0",
+          },
+        }),
+        "packages/app/package.json": JSON.stringify({
+          name: "app",
+          dependencies: {
+            "a-dep": "file:../../a-dep/a-dep-9.0.0.tgz",
+            "no-deps": "1.0.0",
+          },
+        }),
+        "a-dep/package.json": JSON.stringify({
+          name: "a-dep",
+          version: "9.0.0",
+          dependencies: {
+            "mismatched-peer-deps-lvl1": "1.0.0",
+            "no-deps": "1.1.0",
+          },
+        }),
+      },
+    });
+    await pack(join(packageDir, "a-dep"), bunEnv);
+
+    const appModules = join(packageDir, "packages", "app", "node_modules");
+    await installAndCheck(packageDir, async () => {
+      expect(await version(packageDir, "node_modules", "mismatched-peer-deps-lvl1")).toBe("1.0.0");
+      expect(await version(appModules, "a-dep")).toBe("9.0.0");
+      expect(await readdirSorted(join(appModules, "a-dep", "node_modules"))).toEqual(["no-deps"]);
+      expect(await version(appModules, "a-dep", "node_modules", "no-deps")).toBe("1.1.0");
+    });
+  });
+
+  test("hoists when the version at the root satisfies the peer range", async () => {
+    // has-peer has peerDependencies: { peer-no-deps: ^1.0.0 }
+    // diff-peer-1 depends on { has-peer: 1.0.0, peer-no-deps: 1.0.0 }
+    // diff-peer-2 depends on { has-peer: 1.0.0, peer-no-deps: 1.0.1 }
+    //
+    // The peer edge resolves to 1.0.1, but the 1.0.0 that wins the root slot satisfies ^1.0.0 too,
+    // so both dependents share the has-peer at the root. Only peer-no-deps@1.0.1 nests.
+    const { packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        "package.json": JSON.stringify({
+          name: "root",
+          dependencies: {
+            "diff-peer-1": "1.0.0",
+            "diff-peer-2": "1.0.0",
+          },
+        }),
+      },
+    });
+
+    const nodeModules = join(packageDir, "node_modules");
+    await installAndCheck(packageDir, async () => {
+      expect(await version(nodeModules, "has-peer")).toBe("1.0.0");
+      expect(await version(nodeModules, "peer-no-deps")).toBe("1.0.0");
+      expect(await exists(join(nodeModules, "diff-peer-1", "node_modules"))).toBe(false);
+      expect(await readdirSorted(join(nodeModules, "diff-peer-2", "node_modules"))).toEqual(["peer-no-deps"]);
+      expect(await version(nodeModules, "diff-peer-2", "node_modules", "peer-no-deps")).toBe("1.0.1");
+    });
+  });
+
+  test("ignores a peer that the package also lists as a regular dependency", async () => {
+    // dup-peer lists no-deps@2.0.0 as both a dependency and a peer dependency. The regular
+    // dependency is what gets installed under it, so the root's no-deps@1.0.0 is no reason to
+    // keep dup-peer out of the root. (Registry manifests drop the duplicate peer edge; a tarball's
+    // package.json keeps it.)
+    const { packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        "package.json": JSON.stringify({
+          name: "root",
+          workspaces: ["packages/*"],
+          dependencies: {
+            "no-deps": "1.0.0",
+          },
+        }),
+        "packages/app/package.json": JSON.stringify({
+          name: "app",
+          dependencies: {
+            "dup-peer": "file:../../dup-peer/dup-peer-1.0.0.tgz",
+          },
+        }),
+        "dup-peer/package.json": JSON.stringify({
+          name: "dup-peer",
+          version: "1.0.0",
+          dependencies: { "no-deps": "2.0.0" },
+          peerDependencies: { "no-deps": "2.0.0" },
+        }),
+      },
+    });
+    await pack(join(packageDir, "dup-peer"), bunEnv);
+
+    const nodeModules = join(packageDir, "node_modules");
+    await installAndCheck(packageDir, async () => {
+      expect(await version(nodeModules, "no-deps")).toBe("1.0.0");
+      expect(await version(nodeModules, "dup-peer", "node_modules", "no-deps")).toBe("2.0.0");
+      expect(await exists(join(packageDir, "packages", "app", "node_modules"))).toBe(false);
+    });
+  });
+
+  test("never nests a workspace package", async () => {
+    // A workspace package installs as a symlink to its folder, so a nested link would still
+    // resolve the root's no-deps@1.0.0. Its peer range is no reason to add one.
+    const { packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        "package.json": JSON.stringify({
+          name: "root",
+          workspaces: ["packages/*"],
+          dependencies: {
+            "no-deps": "1.0.0",
+          },
+        }),
+        "packages/lib/package.json": JSON.stringify({
+          name: "lib",
+          version: "1.0.0",
+          peerDependencies: { "no-deps": "2.0.0" },
+        }),
+        "packages/app/package.json": JSON.stringify({
+          name: "app",
+          dependencies: {
+            "lib": "workspace:*",
+            "no-deps": "2.0.0",
+          },
+        }),
+      },
+    });
+
+    const nodeModules = join(packageDir, "node_modules");
+    await installAndCheck(packageDir, async () => {
+      expect(await version(nodeModules, "no-deps")).toBe("1.0.0");
+      expect(await version(nodeModules, "lib")).toBe("1.0.0");
+      expect(await readdirSorted(join(packageDir, "packages", "app", "node_modules"))).toEqual(["no-deps"]);
+    });
+  });
 });


### PR DESCRIPTION
### Problem

- With the hoisted linker, a package is hoisted (or deduplicated onto a copy) at an ancestor `node_modules` even when that ancestor holds a version of one of its peer dependencies that the peer range rejects, while the package that pulled it in has the right version nested next to itself. From the hoisted position `require(peer)` finds the wrong version, and when the peer is shared state between the two (`ajv` / `ajv-errors`) they end up with different module instances. Reported as #20376:
  ```
  SyntaxError: Unexpected token ':'
      at Ajv.compileSchema (.../@stoplight/spectral-core/node_modules/ajv/dist/compile/index.js:89:30)
  ```
- Smallest shape: root depends on `ajv@6` and `@stoplight/spectral-core`; spectral-core depends on `ajv@^8` and `ajv-errors`, and `ajv-errors` has `peerDependencies: { ajv: "^8" }`. `ajv@8` nests under spectral-core, but `ajv-errors` is hoisted to the root, next to `ajv@6`.
- Cause: `Tree::hoist_dependency` (`src/install/lockfile/Tree.rs`) only looks at whether an ancestor already holds an entry with the same name as the package being hoisted. The package's own peer edges are not consulted.

### Fix

- When `hoist_dependency` starts walking up from the directory a package was declared in, `Builder::begin_peer_probes` collects the package's required peers with an npm range (optional peers, `catalog:`/dist-tag/git peers, and peers the package also lists as a regular dependency are skipped; nothing is collected for workspace or `link:` packages, which install as symlinks). If the package that owns that directory has a regular dependency on the peer, that copy is the one the package finds from there, so the probe starts out `provided` when it is in range and is not created at all when it is not. Otherwise the probe starts out not provided.
- At every ancestor, `Builder::probe_peers` looks at the entry with the peer's name, if any. In range: the probe becomes `provided` (the package would still see that copy if it stayed put). Out of range: if the probe is `provided`, the hoist stops and the package is placed where it was declared (`DependencyLoop`, the existing result for a conflict); otherwise the probe is dropped, because a nested copy would resolve the same out-of-range version the hoisted copy does, so the layout stays what it is on main (one shared copy).
- Only version ranges and the resolutions of entries already placed in the tree are compared (`Resolution::satisfies_dependency_version`, the comparison the resolver binds peers with). The peer edge's own binding is never read: for required peers it is the highest in-range version anywhere in the lockfile, so comparing ids nested a copy whenever two in-range versions existed, and for non-npm ranges it is re-derived from the printed tree on reload, so a decision based on it would not survive a second install.
- The probe runs before the same-name match on purpose: when the root holds the package next to an out-of-range peer and a consumer provides an in-range one, deduplicating onto the root copy is the bug.
- Not covered: a peer-dependent package whose dependent was itself hoisted away from the provider (root `no-deps@1`, `outer -> { mid, no-deps@2 }`, `mid -> child` with a peer on `no-deps@2`). `mid` hoists to the root, so nothing `child` could stay below holds `no-deps@2`, and it is hoisted to the root and resolves `no-deps@1`, as on main. Placing it correctly means placing the peer next to it (peer-set placement), which this change does not attempt.
- Also known: the owner-copy seed in `begin_peer_probes` reads the owner's full edge list, so in the install-time tree an edge omitted by `--production` / `--omit` can seed a probe. Either direction only adds or skips a nested copy; the package never resolves a different version than it does on main, and the pass that writes `bun.lock` places every edge, so it is exact there. Left for a follow-up.
- No existing test expectation changes. New tests in `test/cli/install/hoist.test.ts` (run concurrently), each installing from scratch and again from the written `bun.lock`:
  - `stays next to the peer version it was resolved against`: the shape above on registry fixtures. Fails on main.
  - `stays below a peer version provided further up than its own dependent`: `mismatched-peer-deps-lvl0 -> lvl1 -> lvl2`, all with peers on `no-deps`, under a workspace that provides an in-range `no-deps` while the root pins an out-of-range one. Fails on main (all three are hoisted to the root).
  - `hoists past an out-of-range version when nothing below would satisfy the peer either`: root pins the peer out of range, a 1.x exists elsewhere in the lockfile, two workspaces depend on the package without providing the peer. One copy at the root; this is the shape the previous revision duplicated.
  - `hoists when its own dependent installs an out-of-range copy of the peer`: the dependent (a tarball kept under a workspace by a name clash at the root) nests an out-of-range `no-deps` under itself while the workspace above holds an in-range one; staying put would find the dependent's copy, so the package hoists as on main.
  - `hoists when the version at the root satisfies the peer range`: two in-range versions, the lower one at the root; the dependent stays shared. This is the shape an id comparison duplicated.
  - `ignores a peer that the package also lists as a regular dependency` (tarball, since `Package::from_npm` already drops that peer edge for registry packages) and `never nests a workspace package`.
- Verified on the reporter's repro and on the smallest shape with a script that resolves every required peer from the dependent's directory the way node does, and also checks that a package and the package depending on it resolve the peer to the same directory:

  | layout | out of range | split instances |
  | --- | --- | --- |
  | smallest shape, released bun | 2 | 2 |
  | smallest shape, this branch (fresh and from `bun.lock`) | 0 | 0 |
  | smallest shape, npm | 0 | 0 |
  | orval repro, released bun, from `bun.lock` | 0 | 5 |
  | orval repro, this branch (fresh and from `bun.lock`) | 0 | 0 |
  | orval repro, npm | 0 | 0 |

  On this branch the orval repro's `bun.lock` is unchanged by a second install and `orval` runs to completion. Also run with the debug build: `bun-install-registry.test.ts` (all), `bun-lock.test.ts`, `bun-workspaces.test.ts`, and the peer tests in `isolated-install.test.ts`.
- Rebased (squashed to one commit) after #36303 and #38333 rewrote `hoist_dependency`. Two mechanical adjustments: it no longer returns a `Result`, and since it now receives the declaring package's dependency range (`input_dep_range`), `begin_peer_probes` takes that directly instead of looking the owner up through the tree's `dependency_id`. The probe logic itself is unchanged from the reviewed revision; on the rebased main the two fixing tests still fail with this PR's `src/` changes reverted and all eight pass with them, and `bun-install-registry.test.ts`, `bun-lock.test.ts` and `bun-workspaces.test.ts` pass.

### Background

- The hoisted linker builds the `node_modules` layout from the resolved lockfile in `Tree.rs`. Each tree is one `node_modules` directory, built breadth first, so every ancestor is complete by the time a directory's own entries are placed. `hoist_dependency` walks from the directory a dependency was declared in (`AS_DEFINED`) up through its ancestors and either dedupes onto an entry with the same name, keeps walking, or, on a conflict, places the package back in the directory it was declared in.
- A peer dependency is a package the dependent expects to find next to itself rather than under itself. In the lockfile it is an edge like any other; for required peers the resolver binds it to the highest version in the lockfile that satisfies the range (`resolve_peer_dep_version_based` reproduces this on load), and optional, `*` and non-npm peers are bound to whatever ends up next to them. This change does not read those bindings.
- `hoist_dependency` has a root-dependency override: a peer edge that reaches a version pinned by the root `package.json` dedupes onto it even when the range rejects it. This PR does not change that; it is why nesting a package whose peer is provided nowhere below the root would change nothing, and why such conflicts are dropped.

Fixes #20376

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 11 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/hoist.test.ts
bun test v1.4.0 (725bf3fbc)

test/cli/install/hoist.test.ts:
(pass) should handle resolving optional peer from multiple instances of same package [306.16ms]
73 |       },
74 |     });
75 | 
76 |     const nodeModules = join(packageDir, "node_modules");
77 |     await installAndCheck(packageDir, async () => {
78 |       expect(await readdirSorted(join(nodeModules, "hoisting-peer-check-parent", "node_modules"))).toEqual([
                                                                                                        ^
error: expect(received).toEqual(expected)

  [
-   "hoisting-peer-check-child",
    "no-deps",
  ]

- Expected  - 1
+ Received  + 0

      at <anonymous> (/workspace/bun/test/cli/install/hoist.test.ts:78:100)
      at async installAndCheck (/workspace/bun/test/cli/install/hoist.test.ts:49:11)
      at async <anonymous> (/workspace/bun/test/cli/install/hoist.test.ts:77:11)
(fail) peer dependencies decide how far a package hoists > stays next to the peer version it was resolved against [
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (73f11e323)

test/cli/install/hoist.test.ts:
(pass) should handle resolving optional peer from multiple instances of same package [47.70ms]
(pass) peer dependencies decide how far a package hoists > ignores a peer that the package also lists as a regular dependency [58.68ms]
(pass) peer dependencies decide how far a package hoists > never nests a workspace package [58.62ms]
(pass) peer dependencies decide how far a package hoists > hoists past an out-of-range version when nothing below would satisfy the peer either [59.14ms]
(pass) peer dependencies decide how far a package hoists > hoists when its own dependent installs an out-of-range copy of the peer [60.55ms]
(pass) peer dependencies decide how far a package hoists > stays next to the peer version it was resolved against [61.20ms]
(pass) peer dependencies decide how far a package hoists > hoists when the version at the root satisfies the peer range [61.88ms]
(pass) peer dependencies decide how far a package hoists > stays below a peer version provided further up than its own dependent [62.43ms]

 8 pass
 0 fail
 171 expect() calls
Ran 8 tests across 1 file. [966.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/hoist.test.ts
bun test v1.4.0 (725bf3fbc)

test/cli/install/hoist.test.ts:
(pass) should handle resolving optional peer from multiple instances of same package [321.82ms]
(pass) peer dependencies decide how far a package hoists > stays next to the peer version it was resolved against [455.10ms]
(pass) peer dependencies decide how far a package hoists > hoists past an out-of-range version when nothing below would satisfy the peer either [497.31ms]
(pass) peer dependencies decide how far a package hoists > stays below a peer version provided further up than its own dependent [563.70ms]
(pass) peer dependencies decide how far a package hoists > hoists when the version at the root satisfies the peer range [544.48ms]
(pass) peer dependencies decide how far a package hoists > hoists when its own dependent installs an out-of-range copy of the peer [790.15ms]
(pass) peer dependencies decide how far a package hoists > never nests a workspace package [446.59ms]
(pass) peer dependencies decide how far a package hoists > ignores a
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 762ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/lockfile.rs        |   1 +
 src/install/lockfile/Tree.rs   | 125 ++++++++++++++++++
 test/cli/install/hoist.test.ts | 289 ++++++++++++++++++++++++++++++++++++++++-
 3 files changed, 413 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 4 passed · 2 rejected · iteration 11

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/install/lockfile.rs             4      1      0
src/install/lockfile/Tree.rs       18     19      0
test/cli/install/hoist.test.ts      5     12      0
```

</details>

<!-- robobun:evidence:end -->


