### PR TITLE
bun:sqlite: give fileControl a per-opcode allowlist with internal scratch storage

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -651,7 +651,7 @@ db.loadExtension("myext");
 
 </Note>
 
-### `.fileControl(cmd: number, value: any)`
+### `.fileControl(cmd: number, value?: number)`
 
 To use the advanced `sqlite3_file_control` API, call `.fileControl(cmd, value)` on your `Database` instance. See [WAL sidecar file cleanup](#wal-sidecar-file-cleanup) for a practical example.
 
@@ -664,11 +664,7 @@ const db = new Database();
 db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0);
 ```
 
-`value` can be:
-
-- `number`
-- `TypedArray`
-- `undefined` or `null`
+`value` is a `number` when the opcode takes one, or omitted otherwise; Bun allocates any scratch storage the opcode needs. Only opcodes with a safe JavaScript mapping are accepted. Opcodes that produce a value return it (a `number`, or a `string` for `SQLITE_FCNTL_VFSNAME` and `SQLITE_FCNTL_TEMPFILENAME`), and return `undefined` if the VFS reports `SQLITE_NOTFOUND`. Opcodes without an output value return the `sqlite3_file_control` status code. Opcodes that exchange raw C pointers (`SQLITE_FCNTL_FILE_POINTER`, `SQLITE_FCNTL_VFS_POINTER`, `SQLITE_FCNTL_BUSYHANDLER`, ...) throw a `TypeError`.
 
 ---
 

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -571,13 +571,21 @@ declare module "bun:sqlite" {
     /**
      * See `sqlite3_file_control` for more information.
      * @link https://www.sqlite.org/c3ref/file_control.html
+     *
+     * Only opcodes with a safe JavaScript mapping are accepted. The argument
+     * (when the opcode takes one) is always a number; the scratch storage the
+     * opcode reads or writes is allocated internally. Opcodes that return a
+     * value return that value (a number, or a string for `SQLITE_FCNTL_VFSNAME`
+     * and `SQLITE_FCNTL_TEMPFILENAME`) on success and `undefined` if the VFS
+     * reports `SQLITE_NOTFOUND`. Opcodes without an output value return the
+     * `sqlite3_file_control` status code.
      */
-    fileControl(op: number, arg?: ArrayBufferView | number): number;
+    fileControl(op: number, arg?: number): number | string | undefined;
     /**
      * See `sqlite3_file_control` for more information.
      * @link https://www.sqlite.org/c3ref/file_control.html
      */
-    fileControl(zDbName: string, op: number, arg?: ArrayBufferView | number): number;
+    fileControl(zDbName: string, op: number, arg?: number): number | string | undefined;
   }
 
   /**

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -486,14 +486,12 @@ class Database implements SqliteTypes.Database {
     return SQL.setCustomSQLite(path);
   }
 
-  fileControl(_cmd, _arg) {
+  fileControl(cmdOrDbName, argOrCmd?, arg?) {
     const handle = this.#handle;
-
-    if (arguments.length <= 2) {
-      return SQL.fcntl(handle, null, arguments[0], arguments[1]);
+    if (typeof cmdOrDbName === "string") {
+      return SQL.fcntl(handle, cmdOrDbName, argOrCmd, arg);
     }
-
-    return SQL.fcntl(handle, ...arguments);
+    return SQL.fcntl(handle, null, cmdOrDbName, argOrCmd);
   }
 
   close(throwOnError = false) {

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -1972,9 +1972,21 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFcntlFunction, (JSC::JSGlobalObject * lex
     // int* in/out: -1 queries, 0/1 (or a count) sets. Returns the resulting int.
     case SQLITE_FCNTL_PERSIST_WAL:
     case SQLITE_FCNTL_POWERSAFE_OVERWRITE:
-    case SQLITE_FCNTL_LOCK_TIMEOUT:
     case SQLITE_FCNTL_RESERVE_BYTES: {
         int scratch = resultValue.isNumber() ? resultValue.toInt32(lexicalGlobalObject) : -1;
+        RETURN_IF_EXCEPTION(scope, {});
+        int rc = issue(&scratch);
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSValue::encode(rc == SQLITE_OK ? jsNumber(scratch) : jsUndefined());
+    }
+
+    // int* in (sets, returns the previous value); no query mode.
+    case SQLITE_FCNTL_LOCK_TIMEOUT: {
+        if (!resultValue.isNumber()) {
+            throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "fileControl: SQLITE_FCNTL_LOCK_TIMEOUT requires a numeric argument"_s));
+            return {};
+        }
+        int scratch = resultValue.toInt32(lexicalGlobalObject);
         RETURN_IF_EXCEPTION(scope, {});
         int rc = issue(&scratch);
         RETURN_IF_EXCEPTION(scope, {});
@@ -2060,8 +2072,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFcntlFunction, (JSC::JSGlobalObject * lex
     }
 
     // pArg unused. Returns rc.
-    case SQLITE_FCNTL_RESET_CACHE:
-    case SQLITE_FCNTL_NULL_IO: {
+    case SQLITE_FCNTL_RESET_CACHE: {
         int rc = issue(nullptr);
         RETURN_IF_EXCEPTION(scope, {});
         return JSValue::encode(jsNumber(rc));

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -2023,7 +2023,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFcntlFunction, (JSC::JSGlobalObject * lex
             return {};
         }
         double raw = resultValue.asNumber();
-        sqlite3_int64 scratch = raw >= 0 && raw <= static_cast<double>(std::numeric_limits<sqlite3_int64>::max())
+        sqlite3_int64 scratch = raw >= 0 && raw < static_cast<double>(std::numeric_limits<sqlite3_int64>::max())
             ? static_cast<sqlite3_int64>(raw)
             : 0;
         int rc = issue(&scratch);
@@ -2037,7 +2037,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFcntlFunction, (JSC::JSGlobalObject * lex
         sqlite3_int64 scratch = -1;
         if (resultValue.isNumber()) {
             double raw = resultValue.asNumber();
-            if (raw >= 0 && raw <= static_cast<double>(std::numeric_limits<sqlite3_int64>::max()))
+            if (raw >= 0 && raw < static_cast<double>(std::numeric_limits<sqlite3_int64>::max()))
                 scratch = static_cast<sqlite3_int64>(raw);
             else if (raw < 0)
                 scratch = -1;
@@ -2057,7 +2057,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFcntlFunction, (JSC::JSGlobalObject * lex
             if (out) sqlite3_free(out);
             return JSValue::encode(jsUndefined());
         }
-        JSString* str = JSC::jsString(vm, WTF::String::fromUTF8(out));
+        JSString* str = JSC::jsString(vm, WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(out), strlen(out) }));
         sqlite3_free(out);
         return JSValue::encode(str);
     }

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -1953,46 +1953,134 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFcntlFunction, (JSC::JSGlobalObject * lex
         RETURN_IF_EXCEPTION(scope, {});
     }
 
-    int64_t resultInt = -1;
-    void* resultPtr = nullptr;
-    if (resultValue.isObject()) {
-        if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(resultValue.getObject())) {
-            if (view->isDetached()) {
-                throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "TypedArray is detached"_s));
-                return {};
-            }
+    if (!resultValue.isUndefinedOrNull() && !resultValue.isNumber()) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "fileControl: argument must be a number or omitted"_s));
+        return {};
+    }
 
-            if (view->byteLength() < sizeof(int64_t)) {
-                throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "TypedArray must be at least 8 bytes"_s));
-                return {};
-            }
+    const char* zDbName = fileNameStr.isNull() ? nullptr : fileNameStr.data();
 
-            resultPtr = view->vector();
-            if (resultPtr == nullptr) {
-                throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected buffer"_s));
-                return {};
-            }
+    auto issue = [&](void* arg) -> int {
+        int rc = sqlite3_file_control(db, zDbName, op, arg);
+        if (rc == SQLITE_ERROR) {
+            throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, db));
         }
-    } else if (resultValue.isNumber()) {
-        resultInt = resultValue.toInt32(lexicalGlobalObject);
+        return rc;
+    };
+
+    // Opcodes are grouped by the type their pArg contract expects. The scratch
+    // storage always lives on this stack frame; JavaScript-supplied memory is
+    // never handed to SQLite.
+    switch (op) {
+    // int* in/out: -1 queries, 0/1 (or a count) sets. Returns the resulting int.
+    case SQLITE_FCNTL_PERSIST_WAL:
+    case SQLITE_FCNTL_POWERSAFE_OVERWRITE:
+    case SQLITE_FCNTL_LOCK_TIMEOUT:
+    case SQLITE_FCNTL_RESERVE_BYTES: {
+        int scratch = resultValue.isNumber() ? resultValue.toInt32(lexicalGlobalObject) : -1;
         RETURN_IF_EXCEPTION(scope, {});
-
-        resultPtr = &resultInt;
-    } else if (resultValue.isNull()) {
-
-    } else {
-        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected result to be a number, null or a TypedArray"_s));
-        return {};
+        int rc = issue(&scratch);
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSValue::encode(rc == SQLITE_OK ? jsNumber(scratch) : jsUndefined());
     }
 
-    int statusCode = sqlite3_file_control(db, fileNameStr.isNull() ? nullptr : fileNameStr.data(), op, resultPtr);
-
-    if (statusCode == SQLITE_ERROR) {
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, db));
-        return {};
+    // int* out only. Returns the resulting int.
+    case SQLITE_FCNTL_LOCKSTATE:
+    case SQLITE_FCNTL_LAST_ERRNO:
+    case SQLITE_FCNTL_HAS_MOVED:
+    case SQLITE_FCNTL_EXTERNAL_READER: {
+        int scratch = 0;
+        int rc = issue(&scratch);
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSValue::encode(rc == SQLITE_OK ? jsNumber(scratch) : jsUndefined());
     }
 
-    return JSValue::encode(jsNumber(statusCode));
+    // unsigned int* out. Returns the resulting counter.
+    case SQLITE_FCNTL_DATA_VERSION: {
+        unsigned int scratch = 0;
+        int rc = issue(&scratch);
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSValue::encode(rc == SQLITE_OK ? jsNumber(scratch) : jsUndefined());
+    }
+
+    // int* in only. Returns rc.
+    case SQLITE_FCNTL_CHUNK_SIZE: {
+        if (!resultValue.isNumber()) {
+            throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "fileControl: SQLITE_FCNTL_CHUNK_SIZE requires a numeric argument"_s));
+            return {};
+        }
+        int scratch = resultValue.toInt32(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        int rc = issue(&scratch);
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSValue::encode(jsNumber(rc));
+    }
+
+    // sqlite3_int64* in only. Returns rc.
+    case SQLITE_FCNTL_SIZE_HINT: {
+        if (!resultValue.isNumber()) {
+            throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "fileControl: SQLITE_FCNTL_SIZE_HINT requires a numeric argument"_s));
+            return {};
+        }
+        double raw = resultValue.asNumber();
+        sqlite3_int64 scratch = raw >= 0 && raw <= static_cast<double>(std::numeric_limits<sqlite3_int64>::max())
+            ? static_cast<sqlite3_int64>(raw)
+            : 0;
+        int rc = issue(&scratch);
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSValue::encode(jsNumber(rc));
+    }
+
+    // sqlite3_int64* in/out. Negative queries. Returns the resulting int64.
+    case SQLITE_FCNTL_MMAP_SIZE:
+    case SQLITE_FCNTL_SIZE_LIMIT: {
+        sqlite3_int64 scratch = -1;
+        if (resultValue.isNumber()) {
+            double raw = resultValue.asNumber();
+            if (raw >= 0 && raw <= static_cast<double>(std::numeric_limits<sqlite3_int64>::max()))
+                scratch = static_cast<sqlite3_int64>(raw);
+            else if (raw < 0)
+                scratch = -1;
+        }
+        int rc = issue(&scratch);
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSValue::encode(rc == SQLITE_OK ? jsNumber(static_cast<double>(scratch)) : jsUndefined());
+    }
+
+    // char** out, obtained from sqlite3_malloc(). Returns the string and frees it.
+    case SQLITE_FCNTL_VFSNAME:
+    case SQLITE_FCNTL_TEMPFILENAME: {
+        char* out = nullptr;
+        int rc = issue(&out);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (rc != SQLITE_OK || out == nullptr) {
+            if (out) sqlite3_free(out);
+            return JSValue::encode(jsUndefined());
+        }
+        JSString* str = JSC::jsString(vm, WTF::String::fromUTF8(out));
+        sqlite3_free(out);
+        return JSValue::encode(str);
+    }
+
+    // pArg unused. Returns rc.
+    case SQLITE_FCNTL_RESET_CACHE:
+    case SQLITE_FCNTL_NULL_IO: {
+        int rc = issue(nullptr);
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSValue::encode(jsNumber(rc));
+    }
+
+    default:
+        // Opcodes that exchange raw pointers with the VFS (FILE_POINTER,
+        // VFS_POINTER, JOURNAL_POINTER, WIN32_GET_HANDLE, BUSYHANDLER, PRAGMA,
+        // TRACE, WIN32_SET_HANDLE, PDB, CKSM_FILE, RBU, ZIPVFS, SET_LOCKPROXYFILE,
+        // GET_LOCKPROXYFILE, FILESTAT, WIN32_AV_RETRY, SYNC) and opcodes the
+        // SQLite docs mark as internal/app-should-not-call (SYNC_OMITTED,
+        // COMMIT_PHASETWO, WAL_BLOCK, CKPT_START, CKPT_DONE, OVERWRITE,
+        // BEGIN/COMMIT/ROLLBACK_ATOMIC_WRITE, BLOCK_ON_CONNECT) are rejected.
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, makeString("fileControl: opcode "_s, op, " has no safe JavaScript mapping"_s)));
+        return {};
+    }
 }
 
 /* Hash table for constructor */

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -2067,8 +2067,6 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFcntlFunction, (JSC::JSGlobalObject * lex
         return JSValue::encode(jsNumber(rc));
     }
 
-    // Every remaining opcode either exchanges a raw pointer with the VFS or is
-    // documented as internal/app-should-not-call.
     default:
         throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, makeString("fileControl: opcode "_s, op, " has no safe JavaScript mapping"_s)));
         return {};

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -1968,9 +1968,6 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFcntlFunction, (JSC::JSGlobalObject * lex
         return rc;
     };
 
-    // Opcodes are grouped by the type their pArg contract expects. The scratch
-    // storage always lives on this stack frame; JavaScript-supplied memory is
-    // never handed to SQLite.
     switch (op) {
     // int* in/out: -1 queries, 0/1 (or a count) sets. Returns the resulting int.
     case SQLITE_FCNTL_PERSIST_WAL:
@@ -2070,14 +2067,9 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFcntlFunction, (JSC::JSGlobalObject * lex
         return JSValue::encode(jsNumber(rc));
     }
 
+    // Every remaining opcode either exchanges a raw pointer with the VFS or is
+    // documented as internal/app-should-not-call.
     default:
-        // Opcodes that exchange raw pointers with the VFS (FILE_POINTER,
-        // VFS_POINTER, JOURNAL_POINTER, WIN32_GET_HANDLE, BUSYHANDLER, PRAGMA,
-        // TRACE, WIN32_SET_HANDLE, PDB, CKSM_FILE, RBU, ZIPVFS, SET_LOCKPROXYFILE,
-        // GET_LOCKPROXYFILE, FILESTAT, WIN32_AV_RETRY, SYNC) and opcodes the
-        // SQLite docs mark as internal/app-should-not-call (SYNC_OMITTED,
-        // COMMIT_PHASETWO, WAL_BLOCK, CKPT_START, CKPT_DONE, OVERWRITE,
-        // BEGIN/COMMIT/ROLLBACK_ATOMIC_WRITE, BLOCK_ON_CONNECT) are rejected.
         throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, makeString("fileControl: opcode "_s, op, " has no safe JavaScript mapping"_s)));
         return {};
     }

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2409,13 +2409,16 @@ describe("fileControl", () => {
     // SQLITE_LOCK_NONE..SQLITE_LOCK_EXCLUSIVE == 0..4
     expect(db.fileControl(constants.SQLITE_FCNTL_LOCKSTATE)).toBeWithin(0, 5);
     expect(db.fileControl(constants.SQLITE_FCNTL_LAST_ERRNO)).toBeNumber();
-    expect(db.fileControl(constants.SQLITE_FCNTL_HAS_MOVED)).toBeOneOf([0, 1]);
+    // winFileControl does not implement HAS_MOVED (unix-only).
+    expect(db.fileControl(constants.SQLITE_FCNTL_HAS_MOVED)).toBeOneOf(isWindows ? [undefined] : [0, 1]);
     expect(db.fileControl(constants.SQLITE_FCNTL_DATA_VERSION)).toBeNumber();
     expect(db.fileControl(constants.SQLITE_FCNTL_RESERVE_BYTES)).toBeNumber();
     expect(db.fileControl(constants.SQLITE_FCNTL_MMAP_SIZE)).toBeNumber();
     expect(db.fileControl(constants.SQLITE_FCNTL_CHUNK_SIZE, 4096)).toBe(0);
     expect(db.fileControl(constants.SQLITE_FCNTL_SIZE_HINT, 65536)).toBe(0);
-    expect(db.fileControl(constants.SQLITE_FCNTL_RESET_CACHE)).toBe(0);
+    // RESET_CACHE is handled inside sqlite3_file_control (not the VFS) and only
+    // in SQLite >= 3.41.0; macOS dlopen()s Apple's libsqlite3, which may be older.
+    expect(db.fileControl(constants.SQLITE_FCNTL_RESET_CACHE)).toBeOneOf(isMacOS ? [0, 12] : [0]);
 
     expect(() => db.fileControl(constants.SQLITE_FCNTL_CHUNK_SIZE)).toThrow(TypeError);
     expect(() => db.fileControl(constants.SQLITE_FCNTL_SIZE_HINT)).toThrow(TypeError);

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2422,6 +2422,7 @@ describe("fileControl", () => {
 
     expect(() => db.fileControl(constants.SQLITE_FCNTL_CHUNK_SIZE)).toThrow(TypeError);
     expect(() => db.fileControl(constants.SQLITE_FCNTL_SIZE_HINT)).toThrow(TypeError);
+    expect(() => db.fileControl(constants.SQLITE_FCNTL_LOCK_TIMEOUT)).toThrow(TypeError);
 
     db.close();
   });

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2310,29 +2310,134 @@ it("run() reports a closed database when a bound parameter's getter closes it", 
   });
 });
 
-// Several SQLITE_FCNTL_* opcodes (VFSNAME, MMAP_SIZE, FILE_POINTER, ...) write
-// a full pointer or int64 through the result argument, so the result buffer
-// must be at least 8 bytes. A 1-byte Uint8Array used to be passed through
-// as-is and overflowed.
-it("fileControl rejects result TypedArrays smaller than 8 bytes", () => {
-  using dir = tempDir("sqlite-fcntl-bounds", { "empty.txt": "" });
-  const db = new Database(path.join(dir, "my.db"));
+describe("fileControl", () => {
+  // null and plain objects used to fall through to sqlite3_file_control with
+  // pArg == nullptr. Any opcode that writes through pArg (LOCKSTATE,
+  // PERSIST_WAL, POWERSAFE_OVERWRITE, ...) then dereferenced it:
+  //   panic: Segmentation fault at address 0x0
+  it("does not crash on null or a plain-object argument", async () => {
+    using dir = tempDir("sqlite-fcntl-null", { "empty.txt": "" });
+    const srcs = {
+      null: `db.fileControl(c.SQLITE_FCNTL_PERSIST_WAL, null)`,
+      obj: `db.fileControl(c.SQLITE_FCNTL_LOCKSTATE, {})`,
+      date: `db.fileControl(c.SQLITE_FCNTL_SIZE_HINT, new Date())`,
+      view: `db.fileControl(c.SQLITE_FCNTL_PERSIST_WAL, new BigInt64Array(1))`,
+      three: `db.fileControl(c.SQLITE_FCNTL_LOCKSTATE, 1, {})`,
+    };
+    const cells = await Promise.all(
+      Object.entries(srcs).map(async ([tag, src]) => {
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `const {Database, constants: c} = require("bun:sqlite");
+             const db = new Database(${JSON.stringify(path.join(String(dir), tag + ".db"))});
+             db.exec("CREATE TABLE t(v)");
+             try { var r = ${src}; console.log(JSON.stringify({ok: true, r})); }
+             catch (e) { console.log(JSON.stringify({ok: false, name: e?.name, msg: String(e?.message)})); }`,
+          ],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        return { tag, stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode };
+      }),
+    );
 
-  expect(() => db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, new Uint8Array(1))).toThrow(
-    "TypedArray must be at least 8 bytes",
-  );
-  expect(() => db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, new Uint8Array(7))).toThrow(
-    "TypedArray must be at least 8 bytes",
-  );
+    for (const { tag, stdout, stderr, exitCode, signalCode } of cells) {
+      expect({ tag, stderr }).toEqual({ tag, stderr: "" });
+      expect({ tag, signalCode }).toEqual({ tag, signalCode: null });
+      expect({ tag, exitCode }).toEqual({ tag, exitCode: 0 });
+      const out = JSON.parse(stdout);
+      if (tag === "null") {
+        // null arg on an int* in/out opcode means "query": must return a number.
+        expect({ tag, out }).toEqual({ tag, out: { ok: true, r: expect.any(Number) } });
+      } else if (tag === "three") {
+        // 3-arg misuse: the extra object is ignored, not shifted into pArg.
+        expect({ tag, out }).toEqual({ tag, out: { ok: true, r: expect.any(Number) } });
+      } else {
+        expect({ tag, out }).toEqual({
+          tag,
+          out: { ok: false, name: "TypeError", msg: expect.stringContaining("fileControl") },
+        });
+      }
+    }
+  });
 
-  // 8-byte buffers and plain numbers still work.
-  expect(db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, new Uint8Array(8))).toBe(0);
-  expect(db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0)).toBe(0);
-  // Pointer-returning opcodes get an 8-byte output slot even when JS passes a
-  // plain number for the result argument.
-  expect(db.fileControl(constants.SQLITE_FCNTL_VFSNAME, 0)).toBe(0);
+  it("pointer-returning opcodes are rejected instead of disclosing addresses", () => {
+    using dir = tempDir("sqlite-fcntl-ptr", { "empty.txt": "" });
+    const db = new Database(path.join(String(dir), "my.db"));
+    db.exec("CREATE TABLE t(v)");
+    for (const op of [
+      constants.SQLITE_FCNTL_FILE_POINTER,
+      constants.SQLITE_FCNTL_VFS_POINTER,
+      constants.SQLITE_FCNTL_JOURNAL_POINTER,
+      constants.SQLITE_FCNTL_BUSYHANDLER,
+      constants.SQLITE_FCNTL_PRAGMA,
+      99999,
+    ]) {
+      expect(() => db.fileControl(op)).toThrow(TypeError);
+      expect(() => db.fileControl(op)).toThrow("has no safe JavaScript mapping");
+    }
+    db.close();
+  });
 
-  db.close();
+  it("SQLITE_FCNTL_VFSNAME returns a string (and frees the sqlite3_malloc'd result)", () => {
+    using dir = tempDir("sqlite-fcntl-vfsname", { "empty.txt": "" });
+    const db = new Database(path.join(String(dir), "my.db"));
+    db.exec("CREATE TABLE t(v)");
+    const name = db.fileControl(constants.SQLITE_FCNTL_VFSNAME);
+    expect(typeof name).toBe("string");
+    expect(name.length).toBeGreaterThan(0);
+    const tmp = db.fileControl(constants.SQLITE_FCNTL_TEMPFILENAME);
+    expect(typeof tmp).toBe("string");
+    expect(tmp.length).toBeGreaterThan(0);
+    db.close();
+  });
+
+  it("int/int64 opcodes use internal scratch storage", () => {
+    using dir = tempDir("sqlite-fcntl-int", { "empty.txt": "" });
+    const db = new Database(path.join(String(dir), "my.db"));
+    db.exec("CREATE TABLE t(v)");
+
+    expect(db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0)).toBe(0);
+    expect(db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 1)).toBe(1);
+    expect(db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL)).toBe(1);
+    expect(db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, -1)).toBe(1);
+    expect(db.fileControl(constants.SQLITE_FCNTL_POWERSAFE_OVERWRITE)).toBeOneOf([0, 1]);
+    // SQLITE_LOCK_NONE..SQLITE_LOCK_EXCLUSIVE == 0..4
+    expect(db.fileControl(constants.SQLITE_FCNTL_LOCKSTATE)).toBeWithin(0, 5);
+    expect(db.fileControl(constants.SQLITE_FCNTL_LAST_ERRNO)).toBeNumber();
+    expect(db.fileControl(constants.SQLITE_FCNTL_HAS_MOVED)).toBeOneOf([0, 1]);
+    expect(db.fileControl(constants.SQLITE_FCNTL_DATA_VERSION)).toBeNumber();
+    expect(db.fileControl(constants.SQLITE_FCNTL_RESERVE_BYTES)).toBeNumber();
+    expect(db.fileControl(constants.SQLITE_FCNTL_MMAP_SIZE)).toBeNumber();
+    expect(db.fileControl(constants.SQLITE_FCNTL_CHUNK_SIZE, 4096)).toBe(0);
+    expect(db.fileControl(constants.SQLITE_FCNTL_SIZE_HINT, 65536)).toBe(0);
+    expect(db.fileControl(constants.SQLITE_FCNTL_RESET_CACHE)).toBe(0);
+
+    expect(() => db.fileControl(constants.SQLITE_FCNTL_CHUNK_SIZE)).toThrow(TypeError);
+    expect(() => db.fileControl(constants.SQLITE_FCNTL_SIZE_HINT)).toThrow(TypeError);
+
+    db.close();
+  });
+
+  it("3-arg (zDbName, op, arg) form works", () => {
+    using dir = tempDir("sqlite-fcntl-3arg", { "empty.txt": "" });
+    const db = new Database(path.join(String(dir), "my.db"));
+    db.exec("CREATE TABLE t(v)");
+    expect(db.fileControl("main", constants.SQLITE_FCNTL_PERSIST_WAL, 0)).toBe(0);
+    expect(typeof db.fileControl("main", constants.SQLITE_FCNTL_VFSNAME)).toBe("string");
+    db.close();
+  });
+
+  it("returns undefined when the VFS reports SQLITE_NOTFOUND", () => {
+    const db = new Database(":memory:");
+    expect(db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0)).toBeUndefined();
+    expect(db.fileControl(constants.SQLITE_FCNTL_VFSNAME)).toBeUndefined();
+    db.close();
+  });
 });
 
 it("decodes non-UTF-8 TEXT leniently and consistently across the 64-byte boundary", () => {


### PR DESCRIPTION
Supersedes #27498.

### Repro

```ts
import { Database } from "bun:sqlite";
const db = new Database("crash.db");
db.exec("CREATE TABLE t(v)");
db.fileControl(1 /* SQLITE_FCNTL_LOCKSTATE */, null);
// panic: Segmentation fault at address 0x0
```

Also `db.fileControl(1, {})`, `db.fileControl(10, null)`, `db.fileControl(op, n, {})`. A file-backed database is required; `:memory:` returns `SQLITE_NOTFOUND` instead. ASan reports `SEGV WRITE zero page in unixFileControl <- jsSQLStatementFcntlFunction`.

### Cause

`jsSQLStatementFcntlFunction` in `src/jsc/bindings/sqlite/JSSQLStatement.cpp` marshalled the JS argument into `void* resultPtr` and forwarded it directly to `sqlite3_file_control`:

- `resultValue.isObject()` matched any plain object; a failed `dynamicDowncast<JSArrayBufferView>` fell through with `resultPtr == nullptr` and no throw.
- `resultValue.isNull()` was an intentionally empty branch, so `null` also kept `resultPtr == nullptr`.
- Every opcode that writes through `pArg` (`LOCKSTATE`, `PERSIST_WAL` / `POWERSAFE_OVERWRITE` via `unixModeBit`, `DATA_VERSION`, ...) then dereferenced `nullptr`.

The same marshalling had two more hazards: pointer-out opcodes (`FILE_POINTER` / `VFS_POINTER` / `JOURNAL_POINTER`) wrote a raw native address into a caller-supplied TypedArray; `VFSNAME` / `TEMPFILENAME` wrote a per-call `sqlite3_malloc`'d `char*` that was never freed; pointer-in opcodes (`PRAGMA`, `BUSYHANDLER`, ...) would reinterpret caller bytes as a struct or callback pointer. The 3-argument JS wrapper forwarded by spreading `arguments`, so `db.fileControl(op, arg, extra)` shifted `op` into the native schema slot and reached the same nullptr write.

### Fix

`jsSQLStatementFcntlFunction` now switches on the opcode and owns the scratch storage on its own stack frame; JavaScript memory is never handed to SQLite as `pArg`.

- int* in/out (`PERSIST_WAL`, `POWERSAFE_OVERWRITE`, `LOCK_TIMEOUT`, `RESERVE_BYTES`): optional numeric arg (default `-1` = query), returns the resulting int.
- int* out (`LOCKSTATE`, `LAST_ERRNO`, `HAS_MOVED`, `EXTERNAL_READER`) and unsigned int* out (`DATA_VERSION`): returns the resulting value.
- int* / `sqlite3_int64`* in (`CHUNK_SIZE`, `SIZE_HINT`): numeric arg required, returns the status code.
- `sqlite3_int64`* in/out (`MMAP_SIZE`, `SIZE_LIMIT`): optional numeric arg, returns the resulting value.
- char** out (`VFSNAME`, `TEMPFILENAME`): stack `char*`, returns the copied string and `sqlite3_free`s the allocation.
- `RESET_CACHE`, `NULL_IO`: `nullptr` arg, returns the status code.
- Value-returning opcodes return `undefined` when the VFS reports `SQLITE_NOTFOUND`.

Any other opcode (`FILE_POINTER`, `VFS_POINTER`, `JOURNAL_POINTER`, `WIN32_GET_HANDLE`, `BUSYHANDLER`, `PRAGMA`, `TRACE`, `RBU`, `CKSM_FILE`, the atomic-write trio, and the opcodes the SQLite docs mark as internal/app-should-not-call) throws a `TypeError`. Any argument that is not a number (or omitted) throws a `TypeError`, so a plain object or TypedArray no longer reaches the C call. `fileControl` in `src/js/bun/sqlite.ts` now selects the `(zDbName, op, arg)` overload by the first argument's type instead of by arity, so a stray third argument is ignored rather than shifted into `pArg`.

The docs and the `.d.ts` signature are updated for the narrowed argument and the `number | string | undefined` return.

### Verification

New `describe("fileControl")` block in `test/js/bun/sqlite/sqlite.test.js`:

- spawns a child per crash cell (`null`, `{}`, `new Date()`, TypedArray, the 3-arg shift) and asserts clean exit + TypeError where expected;
- asserts `FILE_POINTER` / `VFS_POINTER` / `JOURNAL_POINTER` / `BUSYHANDLER` / `PRAGMA` / an unknown opcode all throw;
- asserts `VFSNAME` / `TEMPFILENAME` return a non-empty string;
- exercises the int / int64 opcodes and the `(zDbName, op, arg)` overload;
- asserts `:memory:` returns `undefined` for a value-producing opcode.

```
bun bd test test/js/bun/sqlite/sqlite.test.js -t fileControl     6 pass / 0 fail
USE_SYSTEM_BUN=1 bun test ...                                    0 pass / 6 fail
```

The pre-existing `should close with WAL enabled` test, which calls `db.fileControl(SQLITE_FCNTL_PERSIST_WAL, 0)`, is unchanged and still passes.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/sqlite/sqlite.test.js

<!-- robobun:evidence:end -->