### PR TITLE
compile: --asset flag + /$bunfs/ directory semantics for node:fs

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -839,48 +839,37 @@ If you're using `@mapbox/node-pre-gyp` or similar tools, the `.node` file must b
 
 ### Embed directories
 
-To embed a directory with `bun build --compile`, include file patterns in your build:
+Use `--asset` to embed a file or directory tree into the executable under its original relative path. The embedded files live under `import.meta.dir` at runtime and are reachable via `node:fs` (`existsSync`, `statSync`, `readdirSync`, `readFileSync`) and `Bun.file()`.
 
-<Tabs>
-  <Tab title="CLI">
-    ```bash terminal icon="terminal"
-    bun build --compile ./index.ts ./public/**/*.png
-    ```
-  </Tab>
-  <Tab title="JavaScript">
-    ```ts build.ts icon="/icons/typescript.svg"
-    import { Glob } from "bun";
-
-    // Expand glob pattern to file list
-    const glob = new Glob("./public/**/*.png");
-    const pngFiles = Array.from(glob.scanSync("."));
-
-    await Bun.build({
-      entrypoints: ["./index.ts", ...pngFiles],
-      compile: {
-        outfile: "./myapp",
-      },
-    });
-    ```
-
-  </Tab>
-</Tabs>
-
-Then, you can reference the files in your code:
+```bash terminal icon="terminal"
+bun build --compile ./index.ts --asset ./public --outfile myapp
+```
 
 ```ts index.ts icon="/icons/typescript.svg"
-import icon from "./public/assets/icon.png" with { type: "file" };
-import { file } from "bun";
+import fs from "node:fs";
+import path from "node:path";
+
+const publicDir = path.join(import.meta.dir, "public");
 
 export default {
   fetch(req) {
-    // Embedded files can be streamed from Response objects
-    return new Response(file(icon));
+    const url = new URL(req.url);
+    const file = path.join(publicDir, url.pathname);
+    if (fs.existsSync(file) && fs.statSync(file).isFile()) {
+      return new Response(Bun.file(file));
+    }
+    return new Response("Not found", { status: 404 });
   },
 };
 ```
 
-This is a workaround, and we expect to replace it with a more direct API.
+Pass `--asset` multiple times to embed several directories (for example `--asset ./client --asset ./prerendered` for a SvelteKit build).
+
+You can also embed individual files the old way, by adding them as extra entry points; imported assets are renamed according to `--asset-naming` (default `[name]-[hash].[ext]`):
+
+```ts
+import icon from "./public/assets/icon.png" with { type: "file" };
+```
 
 ### Detecting standalone mode at runtime
 

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -851,19 +851,14 @@ import path from "node:path";
 
 const publicDir = path.join(import.meta.dir, "public");
 
-export default {
-  fetch(req) {
-    const url = new URL(req.url);
-    const file = path.join(publicDir, url.pathname);
-    if (fs.existsSync(file) && fs.statSync(file).isFile()) {
-      return new Response(Bun.file(file));
-    }
-    return new Response("Not found", { status: 404 });
-  },
-};
+for (const entry of fs.readdirSync(publicDir, { withFileTypes: true })) {
+  console.log(entry.name, entry.isDirectory() ? "(dir)" : fs.statSync(path.join(publicDir, entry.name)).size);
+}
+
+const html = await Bun.file(path.join(publicDir, "index.html")).text();
 ```
 
-Pass `--asset` multiple times to embed several directories (for example `--asset ./client --asset ./prerendered` for a SvelteKit build).
+Pass `--asset` multiple times to embed several directories (for example `--asset ./client --asset ./prerendered` for a SvelteKit build). Only regular files are embedded; symlinks and empty subdirectories inside the tree are skipped.
 
 You can also embed individual files the old way, by adding them as extra entry points; imported assets are renamed according to `--asset-naming` (default `[name]-[hash].[ext]`):
 

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -839,11 +839,26 @@ If you're using `@mapbox/node-pre-gyp` or similar tools, the `.node` file must b
 
 ### Embed directories
 
-Use `--asset` to embed a file or directory tree into the executable under its original relative path. The embedded files live under `import.meta.dir` at runtime and are reachable via `node:fs` (`existsSync`, `statSync`, `readdirSync`, `readFileSync`) and `Bun.file()`.
+Use `--asset` (or `compile.assets` in the JavaScript API) to embed a file or directory tree into the executable under its original relative path. The embedded files live under `import.meta.dir` at runtime and are reachable via `node:fs` (`existsSync`, `statSync`, `readdirSync`, `readFileSync`) and `Bun.file()`.
 
-```bash terminal icon="terminal"
-bun build --compile ./index.ts --asset ./public --outfile myapp
-```
+<Tabs>
+  <Tab title="CLI">
+    ```bash terminal icon="terminal"
+    bun build --compile ./index.ts --asset ./public --outfile myapp
+    ```
+  </Tab>
+  <Tab title="JavaScript">
+    ```ts build.ts icon="/icons/typescript.svg"
+    await Bun.build({
+      entrypoints: ["./index.ts"],
+      compile: {
+        outfile: "./myapp",
+        assets: ["./public"],
+      },
+    });
+    ```
+  </Tab>
+</Tabs>
 
 ```ts index.ts icon="/icons/typescript.svg"
 import fs from "node:fs";
@@ -1222,6 +1237,7 @@ interface BuildConfig {
 interface CompileBuildOptions {
   target?: Bun.Build.CompileTarget; // Cross-compilation target
   outfile?: string; // Output executable path
+  assets?: string[]; // Files/directories to embed under import.meta.dir
   execArgv?: string[]; // Runtime arguments (process.execArgv)
   autoloadTsconfig?: boolean; // Load tsconfig.json (default: false)
   autoloadPackageJson?: boolean; // Load package.json (default: false)

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3078,6 +3078,14 @@ declare module "bun" {
     executablePath?: string;
     outfile?: string;
     /**
+     * Files or directories to embed into the executable under their original
+     * relative paths. At runtime they are reachable via `node:fs` and
+     * `Bun.file()` relative to `import.meta.dir`.
+     *
+     * Equivalent CLI flag: `--asset` (repeatable)
+     */
+    assets?: string[];
+    /**
      * Whether the standalone executable loads .env files when it runs
      *
      * Equivalent CLI flags: `--compile-autoload-dotenv`, `--no-compile-autoload-dotenv`

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -228,6 +228,7 @@ pub struct BundlerOptions {
     pub compile_autoload_tsconfig: bool,
     pub compile_autoload_package_json: bool,
     pub compile_executable_path: Option<Box<[u8]>>,
+    pub compile_assets: Vec<Box<[u8]>>,
     pub windows: bundle_enums::WindowsOptions,
     pub allow_unresolved: Option<Vec<Box<[u8]>>>,
 }
@@ -278,6 +279,7 @@ impl Default for BundlerOptions {
             compile_autoload_tsconfig: false,
             compile_autoload_package_json: false,
             compile_executable_path: None,
+            compile_assets: Vec::new(),
             windows: bundle_enums::WindowsOptions::default(),
             allow_unresolved: None,
         }

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1286,12 +1286,7 @@ pub mod js_bundler {
                         "Cannot use compile with target 'browser' and splitting for standalone HTML"
                     )));
                 }
-                if has_all_html
-                    && this
-                        .compile
-                        .as_ref()
-                        .is_some_and(|c| !c.assets.is_empty())
-                {
+                if has_all_html && this.compile.as_ref().is_some_and(|c| !c.assets.is_empty()) {
                     return Err(global_this.throw_invalid_arguments(format_args!(
                         "Cannot use compile.assets with target 'browser' for standalone HTML"
                     )));

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1286,6 +1286,16 @@ pub mod js_bundler {
                         "Cannot use compile with target 'browser' and splitting for standalone HTML"
                     )));
                 }
+                if has_all_html
+                    && this
+                        .compile
+                        .as_ref()
+                        .is_some_and(|c| !c.assets.is_empty())
+                {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "Cannot use compile.assets with target 'browser' for standalone HTML"
+                    )));
+                }
             }
 
             scopeguard::ScopeGuard::into_inner(plugins);

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -238,6 +238,7 @@ pub mod js_bundler {
         pub windows_description: OwnedString,
         pub windows_copyright: OwnedString,
         pub outfile: OwnedString,
+        pub assets: Vec<Box<[u8]>>,
         pub autoload_dotenv: bool,
         pub autoload_bunfig: bool,
         pub autoload_tsconfig: bool,
@@ -258,6 +259,7 @@ pub mod js_bundler {
                 windows_description: OwnedString::default(),
                 windows_copyright: OwnedString::default(),
                 outfile: OwnedString::default(),
+                assets: Vec::new(),
                 autoload_dotenv: true,
                 autoload_bunfig: true,
                 autoload_tsconfig: false,
@@ -404,6 +406,14 @@ pub mod js_bundler {
             if let Some(outfile) = object.get_own(global_this, &BunString::static_str("outfile"))? {
                 let slice = outfile.to_slice(global_this)?;
                 this.outfile.append_slice_exact(slice.slice())?;
+            }
+
+            if let Some(assets) = object.get_own_array(global_this, "assets")? {
+                let mut iter = assets.array_iterator(global_this)?;
+                while let Some(arg) = iter.next()? {
+                    let slice = arg.to_slice(global_this)?;
+                    this.assets.push(Box::from(slice.slice()));
+                }
             }
 
             if let Some(autoload_dotenv) =

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -321,13 +321,14 @@ impl JSBundleCompletionTask {
         let dirname: &[u8] = paths::dirname(&full_outfile_path).unwrap_or(b".");
         let basename: &[u8] = paths::basename(&full_outfile_path);
 
-        // Key the entry point at /$bunfs/root/<basename> (CLI does this too).
-        output_files[entry_point_index].dest_path = Box::from(basename);
+        // Key the entry point at /$bunfs/root/<basename> like the CLI (which renames before appending .exe).
+        let entry_key = basename.strip_suffix(b".exe").unwrap_or(basename);
+        output_files[entry_point_index].dest_path = Box::from(entry_key);
 
         if !compile_options.assets.is_empty() {
             if let Err(msg) = crate::cli::build_command::collect_compile_assets(
                 &compile_options.assets,
-                basename,
+                entry_key,
                 output_files,
             ) {
                 return CompileResult::fail_fmt(format_args!("{}", msg));

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -321,6 +321,9 @@ impl JSBundleCompletionTask {
         let dirname: &[u8] = paths::dirname(&full_outfile_path).unwrap_or(b".");
         let basename: &[u8] = paths::basename(&full_outfile_path);
 
+        // Key the entry point at /$bunfs/root/<basename> (CLI does this too).
+        output_files[entry_point_index].dest_path = Box::from(basename);
+
         if !compile_options.assets.is_empty() {
             if let Err(msg) = crate::cli::build_command::collect_compile_assets(
                 &compile_options.assets,

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -321,6 +321,16 @@ impl JSBundleCompletionTask {
         let dirname: &[u8] = paths::dirname(&full_outfile_path).unwrap_or(b".");
         let basename: &[u8] = paths::basename(&full_outfile_path);
 
+        if !compile_options.assets.is_empty() {
+            if let Err(msg) = crate::cli::build_command::collect_compile_assets(
+                &compile_options.assets,
+                basename,
+                output_files,
+            ) {
+                return CompileResult::fail_fmt(format_args!("{}", msg));
+            }
+        }
+
         #[cfg(not(windows))]
         let mut root_dir = Dir::cwd();
         #[cfg(windows)]

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -425,6 +425,9 @@ pub(crate) const BUILD_ONLY_PARAMS: &[ParamType] = concat_params!(
         parse_param!(
             "--compile-executable-path <STR>  Path to a Bun executable to use for cross-compilation instead of downloading"
         ),
+        parse_param!(
+            "--asset <STR>...                 Embed a file or directory into the compiled executable, preserving its relative path (requires --compile)"
+        ),
         parse_param!("--bytecode                       Use a bytecode cache"),
         parse_param!(
             "--watch                          Automatically restart the process on file change"
@@ -2051,6 +2054,17 @@ fn parse_build_command_options(
             Global::crash();
         }
         ctx.bundler_options.compile_exec_argv = Some(compile_exec_argv.into());
+    }
+
+    {
+        let assets = args.options(b"--asset");
+        if !assets.is_empty() {
+            if !ctx.bundler_options.compile {
+                Output::err_generic("--asset requires --compile", ());
+                Global::crash();
+            }
+            ctx.bundler_options.compile_assets = slice_to_owned(assets);
+        }
     }
 
     // Handle --compile-autoload-dotenv flags

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1327,8 +1327,14 @@ pub(crate) fn collect_compile_assets(
             ));
         }
 
-        let n = asset_trimmed.len().min(zbuf.len() - 1);
-        zbuf[..n].copy_from_slice(&asset_trimmed[..n]);
+        if asset_trimmed.len() >= zbuf.len() || strings::index_of_char(asset_trimmed, 0).is_some() {
+            return fail(
+                bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open)
+                    .with_path(asset),
+            );
+        }
+        let n = asset_trimmed.len();
+        zbuf[..n].copy_from_slice(asset_trimmed);
         zbuf[n] = 0;
         let asset_z = bun_core::ZStr::from_buf(&zbuf[..], n);
 

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1386,12 +1386,18 @@ fn collect_compile_assets(
                 dest.extend_from_slice(&rel);
                 push(out, asset, dest, bytes)?;
             }
-        } else {
+        } else if bun_core::S::ISREG(st.st_mode as _) {
             let bytes = match bun_sys::File::read_from(cwd, asset_trimmed) {
                 Ok(b) => b,
                 Err(e) => return fail(e.with_path(asset)),
             };
             push(out, asset, base.to_vec(), bytes)?;
+        } else {
+            Output::err_generic(
+                "--asset {} is not a regular file or directory",
+                (bun_fmt::quote(asset),),
+            );
+            return Err(());
         }
     }
     Ok(())

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1283,6 +1283,7 @@ fn collect_compile_assets(
             let _close = scopeguard::guard(dir, |fd| fd.close());
             let mut walker = bun_sys::walker_skippable::walk(dir, &[], &[])
                 .map_err(|_| bun_sys::Error::from_code(bun_sys::E::ENOMEM, bun_sys::Tag::open))?;
+            walker.resolve_unknown_entry_types = true;
             while let Some(entry) = walker.next().map_err(|e| e.with_path(asset))? {
                 if entry.kind == EntryKind::Directory {
                     continue;

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -737,13 +737,12 @@ impl BuildCommand {
         };
 
         if ctx.bundler_options.compile && !ctx.bundler_options.compile_assets.is_empty() {
-            if collect_compile_assets(
+            if let Err(msg) = collect_compile_assets(
                 &ctx.bundler_options.compile_assets,
                 outfile,
                 &mut output_files,
-            )
-            .is_err()
-            {
+            ) {
+                Output::err_generic("{}", (msg.as_str(),));
                 exit_or_watch(1, ctx.debug.hot_reload == HotReload::Watch);
             }
         }
@@ -1236,22 +1235,21 @@ fn print_summary(
     bun_core::prettyln!("  <green>bundle<r>  {} modules", reachable_file_count);
 }
 
-fn collect_compile_assets(
+pub(crate) fn collect_compile_assets(
     assets: &[Box<[u8]>],
     outfile: &[u8],
     out: &mut Vec<options::OutputFile>,
-) -> Result<(), ()> {
+) -> Result<(), String> {
     use bun_ast::Loader;
     use bun_collections::StringArrayHashMap;
     use bun_sys::EntryKind;
 
-    let fail = |err: bun_sys::Error| -> Result<(), ()> {
-        Output::err(
-            &err,
-            "failed to read --asset {}",
-            (bun_fmt::quote(&err.path),),
-        );
-        Err(())
+    let fail = |err: bun_sys::Error| -> Result<(), String> {
+        Err(format!(
+            "failed to read asset {}: {}",
+            bun_fmt::quote(&err.path),
+            err,
+        ))
     };
     let entry_name = bun_paths::basename(outfile);
 
@@ -1283,11 +1281,11 @@ fn collect_compile_assets(
     let mut push =
         |out: &mut Vec<options::OutputFile>, asset: &[u8], dest: Vec<u8>, bytes: Vec<u8>| {
             if seen.contains_key(&dest) {
-                Output::err_generic(
-                    "--asset {} collides with another embedded file at {}",
-                    (bun_fmt::quote(asset), bun_fmt::quote(&dest)),
-                );
-                return Err(());
+                return Err(format!(
+                    "asset {} collides with another embedded file at {}",
+                    bun_fmt::quote(asset),
+                    bun_fmt::quote(&dest),
+                ));
             }
             let _ = seen.put(&dest, ());
             out.push(options::OutputFile {
@@ -1323,11 +1321,10 @@ fn collect_compile_assets(
             );
         }
         if base == entry_name {
-            Output::err_generic(
-                "--asset {} would embed at the same path as the entry point; pass a different --outfile",
-                (bun_fmt::quote(asset),),
-            );
-            return Err(());
+            return Err(format!(
+                "asset {} would embed at the same path as the entry point; use a different outfile",
+                bun_fmt::quote(asset),
+            ));
         }
 
         let n = asset_trimmed.len().min(zbuf.len() - 1);
@@ -1406,11 +1403,10 @@ fn collect_compile_assets(
             };
             push(out, asset, base.to_vec(), bytes)?;
         } else {
-            Output::err_generic(
-                "--asset {} is not a regular file or directory",
-                (bun_fmt::quote(asset),),
-            );
-            return Err(());
+            return Err(format!(
+                "asset {} is not a regular file or directory",
+                bun_fmt::quote(asset),
+            ));
         }
     }
     Ok(())

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -277,6 +277,12 @@ impl BuildCommand {
                     );
                     Global::exit(1);
                 }
+                if !ctx.bundler_options.compile_assets.is_empty() {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error<r><d>:<r> cannot use --compile --target browser with --asset"
+                    );
+                    Global::exit(1);
+                }
 
                 this_transpiler.options.compile_to_standalone_html = true;
                 // This is not a bun executable compile - clear compile flags
@@ -1250,11 +1256,16 @@ fn collect_compile_assets(
     let entry_name = bun_paths::basename(outfile);
 
     let mut seen: StringArrayHashMap<()> = StringArrayHashMap::new();
+    for f in out.iter() {
+        if f.output_kind.is_file_in_standalone_mode() {
+            let _ = seen.put(strings::remove_leading_dot_slash(&f.dest_path), ());
+        }
+    }
     let mut push =
         |out: &mut Vec<options::OutputFile>, asset: &[u8], dest: Vec<u8>, bytes: Vec<u8>| {
             if seen.contains_key(&dest) {
                 Output::err_generic(
-                    "--asset {} collides with an earlier --asset at embedded path {}",
+                    "--asset {} collides with another embedded file at {}",
                     (bun_fmt::quote(asset), bun_fmt::quote(&dest)),
                 );
                 return Err(());

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -731,8 +731,12 @@ impl BuildCommand {
         };
 
         if ctx.bundler_options.compile && !ctx.bundler_options.compile_assets.is_empty() {
-            if collect_compile_assets(&ctx.bundler_options.compile_assets, &mut output_files)
-                .is_err()
+            if collect_compile_assets(
+                &ctx.bundler_options.compile_assets,
+                outfile,
+                &mut output_files,
+            )
+            .is_err()
             {
                 exit_or_watch(1, ctx.debug.hot_reload == HotReload::Watch);
             }
@@ -1228,6 +1232,7 @@ fn print_summary(
 
 fn collect_compile_assets(
     assets: &[Box<[u8]>],
+    outfile: &[u8],
     out: &mut Vec<options::OutputFile>,
 ) -> Result<(), ()> {
     use bun_ast::Loader;
@@ -1242,6 +1247,7 @@ fn collect_compile_assets(
         );
         Err(())
     };
+    let entry_name = bun_paths::basename(outfile);
 
     let mut seen: StringArrayHashMap<()> = StringArrayHashMap::new();
     let mut push =
@@ -1285,6 +1291,13 @@ fn collect_compile_assets(
             return fail(
                 bun_sys::Error::from_code(bun_sys::E::EINVAL, bun_sys::Tag::open).with_path(asset),
             );
+        }
+        if base == entry_name {
+            Output::err_generic(
+                "--asset {} would embed at the same path as the entry point; pass a different --outfile",
+                (bun_fmt::quote(asset),),
+            );
+            return Err(());
         }
 
         let n = asset_trimmed.len().min(zbuf.len() - 1);

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1231,9 +1231,6 @@ fn print_summary(
     bun_core::prettyln!("  <green>bundle<r>  {} modules", reachable_file_count);
 }
 
-/// Walks each `--asset` path and appends an `OutputFile` per on-disk file so
-/// `to_bytes` embeds it under `/$bunfs/root/<basename-of-asset>/...` with its
-/// original relative path.
 fn collect_compile_assets(
     assets: &[Box<[u8]>],
     out: &mut Vec<options::OutputFile>,

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1261,8 +1261,7 @@ fn collect_compile_assets(
         if !f.output_kind.is_file_in_standalone_mode() {
             continue;
         }
-        // The first server-side entry point is renamed to `basename(outfile)`
-        // after this function returns; that slot is covered by `entry_name`.
+        // First server EntryPoint is later renamed to basename(outfile); covered by `entry_name`.
         if !skipped_main_entry
             && f.output_kind == options::OutputKind::EntryPoint
             && f.side.unwrap_or(options::Side::Server) == options::Side::Server

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -731,11 +731,14 @@ impl BuildCommand {
         };
 
         if ctx.bundler_options.compile && !ctx.bundler_options.compile_assets.is_empty() {
-            if let Err(err) = collect_compile_assets(
-                &ctx.bundler_options.compile_assets,
-                &mut output_files,
-            ) {
-                Output::err(&err, "failed to read --asset {}", (bun_fmt::quote(&err.path),));
+            if let Err(err) =
+                collect_compile_assets(&ctx.bundler_options.compile_assets, &mut output_files)
+            {
+                Output::err(
+                    &err,
+                    "failed to read --asset {}",
+                    (bun_fmt::quote(&err.path),),
+                );
                 exit_or_watch(1, ctx.debug.hot_reload == HotReload::Watch);
             }
         }
@@ -1266,8 +1269,9 @@ fn collect_compile_assets(
         };
         let base = bun_paths::basename(asset_trimmed);
         if base.is_empty() || base == b"." || base == b".." {
-            return Err(bun_sys::Error::from_code(bun_sys::E::EINVAL, bun_sys::Tag::open)
-                .with_path(asset));
+            return Err(
+                bun_sys::Error::from_code(bun_sys::E::EINVAL, bun_sys::Tag::open).with_path(asset),
+            );
         }
 
         let n = asset_trimmed.len().min(zbuf.len() - 1);
@@ -1289,8 +1293,10 @@ fn collect_compile_assets(
                 #[cfg(windows)]
                 let (rel, bytes) = {
                     let mut rel_buf = bun_paths::path_buffer_pool::get();
-                    let rel_z =
-                        bun_paths::string_paths::from_w_path(&mut rel_buf[..], entry.path.as_slice());
+                    let rel_z = bun_paths::string_paths::from_w_path(
+                        &mut rel_buf[..],
+                        entry.path.as_slice(),
+                    );
                     let mut rel = rel_z.as_bytes().to_vec();
                     for b in rel.iter_mut() {
                         if *b == b'\\' {
@@ -1320,8 +1326,8 @@ fn collect_compile_assets(
                 push(out, dest, bytes);
             }
         } else {
-            let bytes = bun_sys::File::read_from(cwd, asset_trimmed)
-                .map_err(|e| e.with_path(asset))?;
+            let bytes =
+                bun_sys::File::read_from(cwd, asset_trimmed).map_err(|e| e.with_path(asset))?;
             push(out, base.to_vec(), bytes);
         }
     }

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -731,14 +731,9 @@ impl BuildCommand {
         };
 
         if ctx.bundler_options.compile && !ctx.bundler_options.compile_assets.is_empty() {
-            if let Err(err) =
-                collect_compile_assets(&ctx.bundler_options.compile_assets, &mut output_files)
+            if collect_compile_assets(&ctx.bundler_options.compile_assets, &mut output_files)
+                .is_err()
             {
-                Output::err(
-                    &err,
-                    "failed to read --asset {}",
-                    (bun_fmt::quote(&err.path),),
-                );
                 exit_or_watch(1, ctx.debug.hot_reload == HotReload::Watch);
             }
         }
@@ -1234,25 +1229,42 @@ fn print_summary(
 fn collect_compile_assets(
     assets: &[Box<[u8]>],
     out: &mut Vec<options::OutputFile>,
-) -> bun_sys::Maybe<()> {
+) -> Result<(), ()> {
     use bun_ast::Loader;
+    use bun_collections::StringArrayHashMap;
     use bun_sys::EntryKind;
 
-    let push = |out: &mut Vec<options::OutputFile>, dest: Vec<u8>, bytes: Vec<u8>| {
-        out.push(options::OutputFile {
-            loader: Loader::File,
-            input_loader: Loader::File,
-            output_kind: options::OutputKind::Asset,
-            dest_path: dest.into_boxed_slice(),
-            size: bytes.len(),
-            size_without_sourcemap: bytes.len(),
-            value: options::OutputFileValue::Buffer {
-                bytes: bytes.into_boxed_slice(),
-            },
-            side: Some(options::Side::Client),
-            ..options::OutputFile::zero_value()
-        });
+    let fail = |err: bun_sys::Error| -> Result<(), ()> {
+        Output::err(&err, "failed to read --asset {}", (bun_fmt::quote(&err.path),));
+        Err(())
     };
+
+    let mut seen: StringArrayHashMap<()> = StringArrayHashMap::new();
+    let mut push =
+        |out: &mut Vec<options::OutputFile>, asset: &[u8], dest: Vec<u8>, bytes: Vec<u8>| {
+            if seen.contains_key(&dest) {
+                Output::err_generic(
+                    "--asset {} collides with an earlier --asset at embedded path {}",
+                    (bun_fmt::quote(asset), bun_fmt::quote(&dest)),
+                );
+                return Err(());
+            }
+            let _ = seen.put(&dest, ());
+            out.push(options::OutputFile {
+                loader: Loader::File,
+                input_loader: Loader::File,
+                output_kind: options::OutputKind::Asset,
+                dest_path: dest.into_boxed_slice(),
+                size: bytes.len(),
+                size_without_sourcemap: bytes.len(),
+                value: options::OutputFileValue::Buffer {
+                    bytes: bytes.into_boxed_slice(),
+                },
+                side: Some(options::Side::Client),
+                ..options::OutputFile::zero_value()
+            });
+            Ok(())
+        };
 
     let cwd = Fd::cwd();
     let mut zbuf = bun_paths::path_buffer_pool::get();
@@ -1266,7 +1278,7 @@ fn collect_compile_assets(
         };
         let base = bun_paths::basename(asset_trimmed);
         if base.is_empty() || base == b"." || base == b".." {
-            return Err(
+            return fail(
                 bun_sys::Error::from_code(bun_sys::E::EINVAL, bun_sys::Tag::open).with_path(asset),
             );
         }
@@ -1276,16 +1288,28 @@ fn collect_compile_assets(
         zbuf[n] = 0;
         let asset_z = bun_core::ZStr::from_buf(&zbuf[..], n);
 
-        let st = bun_sys::stat(asset_z).map_err(|e| e.with_path(asset))?;
+        let st = match bun_sys::stat(asset_z) {
+            Ok(st) => st,
+            Err(e) => return fail(e.with_path(asset)),
+        };
         if bun_core::S::ISDIR(st.st_mode as _) {
-            let dir = bun_sys::open_dir_for_iteration(cwd, asset_trimmed)
-                .map_err(|e| e.with_path(asset))?;
+            let dir = match bun_sys::open_dir_for_iteration(cwd, asset_trimmed) {
+                Ok(d) => d,
+                Err(e) => return fail(e.with_path(asset)),
+            };
             let _close = scopeguard::guard(dir, |fd| fd.close());
-            let mut walker = bun_sys::walker_skippable::walk(dir, &[], &[])
-                .map_err(|_| bun_sys::Error::from_code(bun_sys::E::ENOMEM, bun_sys::Tag::open))?;
+            let mut walker = match bun_sys::walker_skippable::walk(dir, &[], &[]) {
+                Ok(w) => w,
+                Err(_) => bun_core::out_of_memory(),
+            };
             walker.resolve_unknown_entry_types = true;
-            while let Some(entry) = walker.next().map_err(|e| e.with_path(asset))? {
-                if entry.kind == EntryKind::Directory {
+            loop {
+                let entry = match walker.next() {
+                    Ok(Some(e)) => e,
+                    Ok(None) => break,
+                    Err(e) => return fail(e.with_path(asset)),
+                };
+                if entry.kind != EntryKind::File {
                     continue;
                 }
                 #[cfg(windows)]
@@ -1306,27 +1330,34 @@ fn collect_compile_assets(
                         &mut base_buf[..],
                         entry.basename.as_slice(),
                     );
-                    let bytes = bun_sys::File::read_from(entry.dir, base_z.as_bytes())
-                        .map_err(|e| e.with_path(&rel))?;
+                    let bytes = match bun_sys::File::read_from(entry.dir, base_z.as_bytes()) {
+                        Ok(b) => b,
+                        Err(e) => return fail(e.with_path(&rel)),
+                    };
                     (rel, bytes)
                 };
                 #[cfg(not(windows))]
                 let (rel, bytes) = {
                     let rel = entry.path.as_bytes().to_vec();
-                    let bytes = bun_sys::File::read_from(entry.dir, entry.basename.as_bytes())
-                        .map_err(|e| e.with_path(entry.path.as_bytes()))?;
+                    let bytes = match bun_sys::File::read_from(entry.dir, entry.basename.as_bytes())
+                    {
+                        Ok(b) => b,
+                        Err(e) => return fail(e.with_path(entry.path.as_bytes())),
+                    };
                     (rel, bytes)
                 };
                 let mut dest = Vec::with_capacity(base.len() + 1 + rel.len());
                 dest.extend_from_slice(base);
                 dest.push(b'/');
                 dest.extend_from_slice(&rel);
-                push(out, dest, bytes);
+                push(out, asset, dest, bytes)?;
             }
         } else {
-            let bytes =
-                bun_sys::File::read_from(cwd, asset_trimmed).map_err(|e| e.with_path(asset))?;
-            push(out, base.to_vec(), bytes);
+            let bytes = match bun_sys::File::read_from(cwd, asset_trimmed) {
+                Ok(b) => b,
+                Err(e) => return fail(e.with_path(asset)),
+            };
+            push(out, asset, base.to_vec(), bytes)?;
         }
     }
     Ok(())

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1257,15 +1257,19 @@ fn collect_compile_assets(
 
     let mut seen: StringArrayHashMap<()> = StringArrayHashMap::new();
     for f in out.iter() {
-        if f.output_kind.is_file_in_standalone_mode() {
-            let key = strings::remove_leading_dot_slash(&f.dest_path);
-            #[cfg(windows)]
-            let key: Vec<u8> = key
-                .iter()
-                .map(|&b| if b == b'\\' { b'/' } else { b })
-                .collect();
-            let _ = seen.put(&key[..], ());
+        if !f.output_kind.is_file_in_standalone_mode() {
+            continue;
         }
+        let key = strings::remove_leading_dot_slash(&f.dest_path);
+        #[cfg(windows)]
+        let _ = seen.put(
+            &key.iter()
+                .map(|&b| if b == b'\\' { b'/' } else { b })
+                .collect::<Vec<u8>>(),
+            (),
+        );
+        #[cfg(not(windows))]
+        let _ = seen.put(key, ());
     }
     let mut push =
         |out: &mut Vec<options::OutputFile>, asset: &[u8], dest: Vec<u8>, bytes: Vec<u8>| {

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1235,7 +1235,11 @@ fn collect_compile_assets(
     use bun_sys::EntryKind;
 
     let fail = |err: bun_sys::Error| -> Result<(), ()> {
-        Output::err(&err, "failed to read --asset {}", (bun_fmt::quote(&err.path),));
+        Output::err(
+            &err,
+            "failed to read --asset {}",
+            (bun_fmt::quote(&err.path),),
+        );
         Err(())
     };
 

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1258,7 +1258,13 @@ fn collect_compile_assets(
     let mut seen: StringArrayHashMap<()> = StringArrayHashMap::new();
     for f in out.iter() {
         if f.output_kind.is_file_in_standalone_mode() {
-            let _ = seen.put(strings::remove_leading_dot_slash(&f.dest_path), ());
+            let key = strings::remove_leading_dot_slash(&f.dest_path);
+            #[cfg(windows)]
+            let key: Vec<u8> = key
+                .iter()
+                .map(|&b| if b == b'\\' { b'/' } else { b })
+                .collect();
+            let _ = seen.put(&key[..], ());
         }
     }
     let mut push =

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1256,8 +1256,18 @@ fn collect_compile_assets(
     let entry_name = bun_paths::basename(outfile);
 
     let mut seen: StringArrayHashMap<()> = StringArrayHashMap::new();
+    let mut skipped_main_entry = false;
     for f in out.iter() {
         if !f.output_kind.is_file_in_standalone_mode() {
+            continue;
+        }
+        // The first server-side entry point is renamed to `basename(outfile)`
+        // after this function returns; that slot is covered by `entry_name`.
+        if !skipped_main_entry
+            && f.output_kind == options::OutputKind::EntryPoint
+            && f.side.unwrap_or(options::Side::Server) == options::Side::Server
+        {
+            skipped_main_entry = true;
             continue;
         }
         let key = strings::remove_leading_dot_slash(&f.dest_path);

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -12,7 +12,7 @@ use bun_js_parser::parser::Runtime;
 use bun_options_types::context::MacroOptions;
 use bun_options_types::schema::api;
 use bun_paths::{PathBuffer, resolve_path};
-use bun_sys::{self, Fd};
+use bun_sys::{self, Fd, FdExt as _};
 
 extern crate bun_standalone_graph as bun_standalone_module_graph;
 
@@ -729,6 +729,17 @@ impl BuildCommand {
 
             break 'brk build_result.output_files;
         };
+
+        if ctx.bundler_options.compile && !ctx.bundler_options.compile_assets.is_empty() {
+            if let Err(err) = collect_compile_assets(
+                &ctx.bundler_options.compile_assets,
+                &mut output_files,
+            ) {
+                Output::err(&err, "failed to read --asset {}", (bun_fmt::quote(&err.path),));
+                exit_or_watch(1, ctx.debug.hot_reload == HotReload::Watch);
+            }
+        }
+
         let output_files: &mut [options::OutputFile] = &mut output_files;
         let bundled_end = bun_core::time::nano_timestamp();
 
@@ -1215,4 +1226,104 @@ fn print_summary(
     );
     Output::print_elapsed_stdout_trim(bundle_elapsed as f64);
     bun_core::prettyln!("  <green>bundle<r>  {} modules", reachable_file_count);
+}
+
+/// Walks each `--asset` path and appends an `OutputFile` per on-disk file so
+/// `to_bytes` embeds it under `/$bunfs/root/<basename-of-asset>/...` with its
+/// original relative path.
+fn collect_compile_assets(
+    assets: &[Box<[u8]>],
+    out: &mut Vec<options::OutputFile>,
+) -> bun_sys::Maybe<()> {
+    use bun_ast::Loader;
+    use bun_sys::EntryKind;
+
+    let push = |out: &mut Vec<options::OutputFile>, dest: Vec<u8>, bytes: Vec<u8>| {
+        out.push(options::OutputFile {
+            loader: Loader::File,
+            input_loader: Loader::File,
+            output_kind: options::OutputKind::Asset,
+            dest_path: dest.into_boxed_slice(),
+            size: bytes.len(),
+            size_without_sourcemap: bytes.len(),
+            value: options::OutputFileValue::Buffer {
+                bytes: bytes.into_boxed_slice(),
+            },
+            side: Some(options::Side::Client),
+            ..options::OutputFile::zero_value()
+        });
+    };
+
+    let cwd = Fd::cwd();
+    let mut zbuf = bun_paths::path_buffer_pool::get();
+    for asset in assets {
+        let asset_trimmed: &[u8] = {
+            let mut a: &[u8] = asset;
+            while matches!(a.last(), Some(b'/') | Some(b'\\')) {
+                a = &a[..a.len() - 1];
+            }
+            a
+        };
+        let base = bun_paths::basename(asset_trimmed);
+        if base.is_empty() || base == b"." || base == b".." {
+            return Err(bun_sys::Error::from_code(bun_sys::E::EINVAL, bun_sys::Tag::open)
+                .with_path(asset));
+        }
+
+        let n = asset_trimmed.len().min(zbuf.len() - 1);
+        zbuf[..n].copy_from_slice(&asset_trimmed[..n]);
+        zbuf[n] = 0;
+        let asset_z = bun_core::ZStr::from_buf(&zbuf[..], n);
+
+        let st = bun_sys::stat(asset_z).map_err(|e| e.with_path(asset))?;
+        if bun_core::S::ISDIR(st.st_mode as _) {
+            let dir = bun_sys::open_dir_for_iteration(cwd, asset_trimmed)
+                .map_err(|e| e.with_path(asset))?;
+            let _close = scopeguard::guard(dir, |fd| fd.close());
+            let mut walker = bun_sys::walker_skippable::walk(dir, &[], &[])
+                .map_err(|_| bun_sys::Error::from_code(bun_sys::E::ENOMEM, bun_sys::Tag::open))?;
+            while let Some(entry) = walker.next().map_err(|e| e.with_path(asset))? {
+                if entry.kind == EntryKind::Directory {
+                    continue;
+                }
+                #[cfg(windows)]
+                let (rel, bytes) = {
+                    let mut rel_buf = bun_paths::path_buffer_pool::get();
+                    let rel_z =
+                        bun_paths::string_paths::from_w_path(&mut rel_buf[..], entry.path.as_slice());
+                    let mut rel = rel_z.as_bytes().to_vec();
+                    for b in rel.iter_mut() {
+                        if *b == b'\\' {
+                            *b = b'/';
+                        }
+                    }
+                    let mut base_buf = bun_paths::path_buffer_pool::get();
+                    let base_z = bun_paths::string_paths::from_w_path(
+                        &mut base_buf[..],
+                        entry.basename.as_slice(),
+                    );
+                    let bytes = bun_sys::File::read_from(entry.dir, base_z.as_bytes())
+                        .map_err(|e| e.with_path(&rel))?;
+                    (rel, bytes)
+                };
+                #[cfg(not(windows))]
+                let (rel, bytes) = {
+                    let rel = entry.path.as_bytes().to_vec();
+                    let bytes = bun_sys::File::read_from(entry.dir, entry.basename.as_bytes())
+                        .map_err(|e| e.with_path(entry.path.as_bytes()))?;
+                    (rel, bytes)
+                };
+                let mut dest = Vec::with_capacity(base.len() + 1 + rel.len());
+                dest.extend_from_slice(base);
+                dest.push(b'/');
+                dest.extend_from_slice(&rel);
+                push(out, dest, bytes);
+            }
+        } else {
+            let bytes = bun_sys::File::read_from(cwd, asset_trimmed)
+                .map_err(|e| e.with_path(asset))?;
+            push(out, base.to_vec(), bytes);
+        }
+    }
+    Ok(())
 }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7132,7 +7132,8 @@ impl NodeFS {
 
                 if let Some(graph) = standalone_module_graph_get() {
                     // SAFETY: see `standalone_module_graph_get`.
-                    if let Some(file) = unsafe { &mut *graph }.find(path.as_bytes()) {
+                    let graph = unsafe { &mut *graph };
+                    if let Some(file) = graph.find(path.as_bytes()) {
                         let contents: &[u8] = file.contents.as_bytes();
                         return if args.encoding == Encoding::Buffer {
                             // PORTING.md §Forbidden bans `Vec::leak()`; round-trip through
@@ -7158,6 +7159,10 @@ impl NodeFS {
                                 bun_core::ZBox::from_vec_with_nul(z),
                             ))
                         };
+                    }
+                    if graph.find_dir(path.as_bytes()) {
+                        return Err(sys::Error::from_code(E::EISDIR, sys::Tag::read)
+                            .with_path(p.slice()));
                     }
                 }
 

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6396,10 +6396,12 @@ impl NodeFS {
     }
 
     pub fn readdir(&mut self, args: &args::Readdir, flavor: Flavor) -> Maybe<ret::Readdir> {
-        if flavor != Flavor::Sync {
-            if args.recursive {
-                panic!("Assertion failure: this code path should never be reached.");
-            }
+        if flavor != Flavor::Sync && args.recursive {
+            debug_assert!(
+                standalone_module_graph_get().is_some()
+                    && bun_standalone_graph::is_bun_standalone_file_path(args.path.slice()),
+                "async recursive readdir must go through AsyncReaddirRecursiveTask"
+            );
         }
         let maybe = match args.tag() {
             ret::ReaddirTag::Buffers => Self::readdir_inner::<Buffer>(

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6966,7 +6966,8 @@ impl NodeFS {
                                 sys::FileKind::File
                             };
                             if recursive {
-                                let (base, parent) = match strings::last_index_of_char(&name, b'/') {
+                                let (base, parent) = match strings::last_index_of_char(&name, b'/')
+                                {
                                     Some(i) => (&name[i + 1..], &name[..i]),
                                     None => (&name[..], b"".as_slice()),
                                 };

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4743,10 +4743,8 @@ impl NodeFS {
             let p = args.path.slice();
             let is_dir = graph.find_dir(p);
             if is_dir || graph.find(p).is_some() {
-                const W_OK: c_int = 2;
-                const X_OK: c_int = 1;
                 let mode = args.mode.as_int();
-                if (mode & W_OK) != 0 || ((mode & X_OK) != 0 && !is_dir) {
+                if (mode & sys::posix::W_OK) != 0 || ((mode & sys::posix::X_OK) != 0 && !is_dir) {
                     return Err(sys::Error::from_code(E::EACCES, sys::Tag::access).with_path(p));
                 }
                 return Ok(Null);

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4741,7 +4741,14 @@ impl NodeFS {
             // SAFETY: see `standalone_module_graph_get`.
             let graph = unsafe { &mut *graph };
             let p = args.path.slice();
-            if graph.find(p).is_some() || graph.find_dir(p) {
+            let is_dir = graph.find_dir(p);
+            if is_dir || graph.find(p).is_some() {
+                const W_OK: c_int = 2;
+                const X_OK: c_int = 1;
+                let mode = args.mode.as_int();
+                if (mode & W_OK) != 0 || ((mode & X_OK) != 0 && !is_dir) {
+                    return Err(sys::Error::from_code(E::EACCES, sys::Tag::access).with_path(p));
+                }
                 return Ok(Null);
             }
         }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6947,65 +6947,69 @@ impl NodeFS {
         if let Some(graph) = standalone_module_graph_get() {
             if bun_standalone_graph::is_bun_standalone_file_path(path.as_bytes()) {
                 // SAFETY: see `standalone_module_graph_get`.
-                let graph = unsafe { &*graph };
-                return match graph.readdir(path.as_bytes(), recursive) {
-                    None => Err(sys::Error::from_code(E::ENOENT, sys::Tag::scandir)
-                        .with_path(args.path.slice())),
-                    Some(list) => {
-                        let mut entries: Vec<T> = Vec::with_capacity(list.len());
-                        let root_path = if T::IS_DIRENT {
-                            BunString::clone_utf8(args.path.slice())
-                        } else {
-                            BunString::empty()
-                        };
-                        let mut joined: Vec<u8> = Vec::new();
-                        for (name, is_dir) in list {
-                            let kind = if is_dir {
-                                sys::FileKind::Directory
-                            } else {
-                                sys::FileKind::File
-                            };
-                            if recursive {
-                                let (base, parent) = match strings::last_index_of_char(&name, b'/')
-                                {
-                                    Some(i) => (&name[i + 1..], &name[..i]),
-                                    None => (&name[..], b"".as_slice()),
-                                };
-                                let dirent_path = if T::IS_DIRENT && !parent.is_empty() {
-                                    joined.clear();
-                                    joined.extend_from_slice(args.path.slice());
-                                    if joined.last() != Some(&b'/') {
-                                        joined.push(b'/');
-                                    }
-                                    joined.extend_from_slice(parent);
-                                    BunString::clone_utf8(&joined)
-                                } else {
-                                    root_path.dupe_ref()
-                                };
-                                T::append_entry_recursive(
-                                    &mut entries,
-                                    base,
-                                    &name,
-                                    &dirent_path,
-                                    kind,
-                                    args.encoding,
-                                    flavor == Flavor::Sync,
-                                );
-                                dirent_path.deref();
-                            } else {
-                                T::append_entry(
-                                    &mut entries,
-                                    &name,
-                                    &root_path,
-                                    kind,
-                                    args.encoding,
-                                );
+                let graph = unsafe { &mut *graph };
+                let Some(list) = graph.readdir(path.as_bytes(), recursive) else {
+                    let code = if graph.find_assume_standalone_path(path.as_bytes()).is_some() {
+                        E::ENOTDIR
+                    } else {
+                        E::ENOENT
+                    };
+                    return Err(
+                        sys::Error::from_code(code, sys::Tag::scandir).with_path(args.path.slice())
+                    );
+                };
+                let mut entries: Vec<T> = Vec::with_capacity(list.len());
+                let root_path = if T::IS_DIRENT {
+                    BunString::clone_utf8(args.path.slice())
+                } else {
+                    BunString::empty()
+                };
+                let mut joined: Vec<u8> = Vec::new();
+                #[allow(unused_mut)]
+                for (mut name, is_dir) in list {
+                    let kind = if is_dir {
+                        sys::FileKind::Directory
+                    } else {
+                        sys::FileKind::File
+                    };
+                    if recursive {
+                        #[cfg(windows)]
+                        for b in name.iter_mut() {
+                            if *b == b'/' {
+                                *b = paths::SEP;
                             }
                         }
-                        root_path.deref();
-                        Ok(T::into_readdir(entries))
+                        let (base, parent) = match strings::last_index_of_char(&name, paths::SEP) {
+                            Some(i) => (&name[i + 1..], &name[..i]),
+                            None => (&name[..], b"".as_slice()),
+                        };
+                        let dirent_path = if T::IS_DIRENT && !parent.is_empty() {
+                            joined.clear();
+                            joined.extend_from_slice(args.path.slice());
+                            if !matches!(joined.last(), Some(&b'/') | Some(&b'\\')) {
+                                joined.push(paths::SEP);
+                            }
+                            joined.extend_from_slice(parent);
+                            BunString::clone_utf8(&joined)
+                        } else {
+                            root_path.dupe_ref()
+                        };
+                        T::append_entry_recursive(
+                            &mut entries,
+                            base,
+                            &name,
+                            &dirent_path,
+                            kind,
+                            args.encoding,
+                            flavor == Flavor::Sync,
+                        );
+                        dirent_path.deref();
+                    } else {
+                        T::append_entry(&mut entries, &name, &root_path, kind, args.encoding);
                     }
-                };
+                }
+                root_path.deref();
+                return Ok(T::into_readdir(entries));
             }
         }
 

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7161,8 +7161,9 @@ impl NodeFS {
                         };
                     }
                     if graph.find_dir(path.as_bytes()) {
-                        return Err(sys::Error::from_code(E::EISDIR, sys::Tag::read)
-                            .with_path(p.slice()));
+                        return Err(
+                            sys::Error::from_code(E::EISDIR, sys::Tag::read).with_path(p.slice())
+                        );
                     }
                 }
 

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4737,6 +4737,14 @@ fn encode_path_result(bytes: &[u8], encoding: Encoding) -> StringOrBuffer {
 
 impl NodeFS {
     pub fn access(&mut self, args: &args::Access, _: Flavor) -> Maybe<ret::Access> {
+        if let Some(graph) = standalone_module_graph_get() {
+            // SAFETY: see `standalone_module_graph_get`.
+            let graph = unsafe { &mut *graph };
+            let p = args.path.slice();
+            if graph.find(p).is_some() || graph.find_dir(p) {
+                return Ok(Null);
+            }
+        }
         // The `bun_sys::access` Windows
         // arm takes `&ZStr` and performs the kernel32 widening internally
         // (sys/lib.rs `windows_impl::access`), so feed it the UTF-8 path on
@@ -5421,7 +5429,8 @@ impl NodeFS {
             // SAFETY: see `standalone_module_graph_get` — exclusive lookup on
             // the per-process singleton; `find` only mutates lazy per-`File`
             // fields.
-            if unsafe { &mut *graph }.find(path.slice()).is_some() {
+            let graph = unsafe { &mut *graph };
+            if graph.find(path.slice()).is_some() || graph.find_dir(path.slice()) {
                 return Ok(true);
             }
         }
@@ -5642,6 +5651,15 @@ impl NodeFS {
 
     pub fn lstat(&mut self, args: &args::Lstat, _: Flavor) -> Maybe<ret::Lstat> {
         let path = args.path.slice_z(&mut self.sync_error_buf);
+        if let Some(graph) = standalone_module_graph_get() {
+            // SAFETY: see `standalone_module_graph_get`.
+            if let Some(result) = unsafe { &mut *graph }.stat(path.as_bytes()) {
+                return Ok(StatOrNotFound::Stats(Box::new(Stats::init(
+                    &PosixStat::init(&result),
+                    args.big_int,
+                ))));
+            }
+        }
         #[cfg(any(target_os = "linux", target_os = "android"))]
         if sys::SUPPORTS_STATX_ON_LINUX.load(Ordering::Relaxed) {
             return match sys::lstatx(path, sys::STATX_MASK_FOR_STATS) {
@@ -6925,6 +6943,70 @@ impl NodeFS {
         flavor: Flavor,
     ) -> Maybe<ret::Readdir> {
         let path = args.path.slice_z(buf);
+
+        if let Some(graph) = standalone_module_graph_get() {
+            if bun_standalone_graph::is_bun_standalone_file_path(path.as_bytes()) {
+                // SAFETY: see `standalone_module_graph_get`.
+                let graph = unsafe { &*graph };
+                return match graph.readdir(path.as_bytes(), recursive) {
+                    None => Err(sys::Error::from_code(E::ENOENT, sys::Tag::scandir)
+                        .with_path(args.path.slice())),
+                    Some(list) => {
+                        let mut entries: Vec<T> = Vec::with_capacity(list.len());
+                        let root_path = if T::IS_DIRENT {
+                            BunString::clone_utf8(args.path.slice())
+                        } else {
+                            BunString::empty()
+                        };
+                        let mut joined: Vec<u8> = Vec::new();
+                        for (name, is_dir) in list {
+                            let kind = if is_dir {
+                                sys::FileKind::Directory
+                            } else {
+                                sys::FileKind::File
+                            };
+                            if recursive {
+                                let (base, parent) = match strings::last_index_of_char(&name, b'/') {
+                                    Some(i) => (&name[i + 1..], &name[..i]),
+                                    None => (&name[..], b"".as_slice()),
+                                };
+                                let dirent_path = if T::IS_DIRENT && !parent.is_empty() {
+                                    joined.clear();
+                                    joined.extend_from_slice(args.path.slice());
+                                    if joined.last() != Some(&b'/') {
+                                        joined.push(b'/');
+                                    }
+                                    joined.extend_from_slice(parent);
+                                    BunString::clone_utf8(&joined)
+                                } else {
+                                    root_path.dupe_ref()
+                                };
+                                T::append_entry_recursive(
+                                    &mut entries,
+                                    base,
+                                    &name,
+                                    &dirent_path,
+                                    kind,
+                                    args.encoding,
+                                    flavor == Flavor::Sync,
+                                );
+                                dirent_path.deref();
+                            } else {
+                                T::append_entry(
+                                    &mut entries,
+                                    &name,
+                                    &root_path,
+                                    kind,
+                                    args.encoding,
+                                );
+                            }
+                        }
+                        root_path.deref();
+                        Ok(T::into_readdir(entries))
+                    }
+                };
+            }
+        }
 
         if recursive && flavor == Flavor::Sync {
             let mut buf_to_pass = PathBuffer::uninit();

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -256,7 +256,11 @@ impl Binding {
 
         // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-        if rd_args.recursive {
+        // Embedded /$bunfs/ paths are served from an in-memory graph, so there is
+        // no I/O to offload; readdir_inner handles them (including recursive).
+        let is_bunfs = bun_standalone_graph::Graph::get().is_some()
+            && bun_standalone_graph::is_bun_standalone_file_path(rd_args.path.slice());
+        if rd_args.recursive && !is_bunfs {
             return Ok(AsyncReaddirRecursiveTask::create(global, rd_args, vm));
         }
         Ok(async_::Readdir::create(global, this, rd_args, vm))

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -256,8 +256,7 @@ impl Binding {
 
         // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-        // Embedded /$bunfs/ paths are served from an in-memory graph, so there is
-        // no I/O to offload; readdir_inner handles them (including recursive).
+        // /$bunfs/ is in-memory; readdir_inner handles it (recursive included).
         let is_bunfs = bun_standalone_graph::Graph::get().is_some()
             && bun_standalone_graph::is_bun_standalone_file_path(rd_args.path.slice());
         if rd_args.recursive && !is_bunfs {

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -40,6 +40,10 @@ pub struct StandaloneModuleGraph {
     /// them under Stacked/Tree Borrows and make the later foreign write UB.
     pub bytes: *const [u8],
     pub files: StringArrayHashMap<File>,
+    /// Every directory prefix that appears in `files` (no trailing separator,
+    /// normalized to `/`). Lets `node:fs` answer `existsSync` / `statSync` /
+    /// `readdirSync` for virtual directories under `/$bunfs/`.
+    pub dirs: StringArrayHashMap<()>,
     pub entry_point_id: u32,
     pub compile_exec_argv: &'static [u8],
     pub flags: Flags,
@@ -159,8 +163,87 @@ impl StandaloneModuleGraph {
     }
 
     pub fn stat(&mut self, name: &[u8]) -> Option<Stat> {
-        let file = self.find(name)?;
-        Some(file.stat())
+        if !is_bun_standalone_file_path(name) {
+            return None;
+        }
+        if let Some(file) = self.find_assume_standalone_path(name) {
+            return Some(file.stat());
+        }
+        if self.find_dir(name) {
+            return Some(dir_stat());
+        }
+        None
+    }
+
+    /// Normalizes a path into the form stored in `self.dirs` / `self.files`:
+    /// strips NT prefixes on Windows, maps `\` → `/`, and drops a single
+    /// trailing separator. Returns the borrowed slice (possibly into `buf`).
+    fn normalize_dir_path<'a>(name: &'a [u8], buf: &'a mut PathBuffer) -> &'a [u8] {
+        #[cfg(windows)]
+        let name = {
+            let input = strings::paths::without_nt_prefix::<u8>(name);
+            &*path::resolve_path::platform_to_posix_buf::<u8>(input, buf)
+        };
+        #[cfg(not(windows))]
+        let _ = buf;
+        let mut name = name;
+        while name.last() == Some(&b'/') {
+            name = &name[..name.len() - 1];
+        }
+        name
+    }
+
+    pub fn find_dir(&self, name: &[u8]) -> bool {
+        if !is_bun_standalone_file_path(name) {
+            return false;
+        }
+        let mut buf = PathBuffer::uninit();
+        let name = Self::normalize_dir_path(name, &mut buf);
+        self.dirs.contains_key(name)
+    }
+
+    /// Enumerates the virtual directory at `name`, returning `(entry_name, is_dir)`
+    /// pairs. `entry_name` is the immediate child when `recursive` is false, and the
+    /// path relative to `name` (with `/` separators) when `recursive` is true.
+    pub fn readdir(&self, name: &[u8], recursive: bool) -> Option<Vec<(Box<[u8]>, bool)>> {
+        if !is_bun_standalone_file_path(name) {
+            return None;
+        }
+        let mut buf = PathBuffer::uninit();
+        let name = Self::normalize_dir_path(name, &mut buf);
+        if !self.dirs.contains_key(name) {
+            return None;
+        }
+        let mut prefix: Vec<u8> = Vec::with_capacity(name.len() + 1);
+        prefix.extend_from_slice(name);
+        prefix.push(b'/');
+
+        let mut seen: StringArrayHashMap<bool> = StringArrayHashMap::new();
+        let mut push = |key: &[u8], is_dir: bool| {
+            if key.len() <= prefix.len() || !key.starts_with(&prefix) {
+                return;
+            }
+            let rel = &key[prefix.len()..];
+            if recursive {
+                let _ = seen.put(rel, is_dir);
+            } else if let Some(sep) = strings::index_of_char(rel, b'/') {
+                let _ = seen.put(&rel[..sep as usize], true);
+            } else {
+                let _ = seen.put(rel, is_dir);
+            }
+        };
+        for key in self.files.keys() {
+            push(key, false);
+        }
+        for key in self.dirs.keys() {
+            push(key, true);
+        }
+
+        let mut out: Vec<(Box<[u8]>, bool)> = Vec::with_capacity(seen.count());
+        for (k, v) in seen.iter() {
+            out.push ((Box::<[u8]>::from(&k[..]), *v));
+        }
+        Some(out)
     }
 
     pub fn find_assume_standalone_path(&mut self, name: &[u8]) -> Option<&mut File> {
@@ -426,6 +509,13 @@ impl File {
     }
 }
 
+fn dir_stat() -> Stat {
+    // SAFETY: all-zero is a valid `libc::stat` (POD `#[repr(C)]`).
+    let mut result: Stat = unsafe { bun_core::ffi::zeroed_unchecked() };
+    result.st_mode = (libc::S_IFDIR | 0o755) as _;
+    result
+}
+
 pub enum LazySourceMap {
     Serialized(SerializedSourceMap),
     Parsed(Arc<SourceMap::ParsedSourceMap>),
@@ -541,6 +631,7 @@ impl StandaloneModuleGraph {
             return Ok(StandaloneModuleGraph {
                 bytes: core::ptr::slice_from_raw_parts(NonNull::<u8>::dangling().as_ptr(), 0),
                 files: StringArrayHashMap::new(),
+                dirs: StringArrayHashMap::new(),
                 entry_point_id: 0,
                 compile_exec_argv: b"",
                 flags: Flags::default(),
@@ -641,11 +732,28 @@ impl StandaloneModuleGraph {
 
         modules.lock_pointers(); // make the pointers stable forever
 
+        // Derive every directory prefix that appears in a file path so `node:fs`
+        // can answer exists/stat/readdir for them. Keys are already normalized to
+        // `/` (see `to_bytes`), so a byte-wise rfind is sufficient on all platforms.
+        let mut dirs = StringArrayHashMap::<()>::new();
+        for key in modules.keys() {
+            let mut rest: &[u8] = key;
+            while let Some(sep) = strings::last_index_of_char(rest, b'/') {
+                rest = &rest[..sep as usize];
+                if rest.is_empty() || dirs.contains_key(rest) {
+                    break;
+                }
+                let _ = dirs.put(rest, ());
+            }
+        }
+        dirs.lock_pointers();
+
         Ok(StandaloneModuleGraph {
             // Stored as a raw fat pointer — `byte_count` covers the writable
             // bytecode/module_info regions, so a `&'static [u8]` here would alias them.
             bytes: core::ptr::slice_from_raw_parts(raw_const, offsets.byte_count),
             files: modules,
+            dirs,
             entry_point_id: offsets.entry_point_id,
             // SAFETY: read-only argv string subrange, disjoint from writable regions.
             compile_exec_argv: unsafe {
@@ -1004,6 +1112,7 @@ pub(crate) fn to_bytes(
         )?;
         debug_assert_eq!(graph.files.count(), modules.len());
         graph.files.unlock_pointers();
+        graph.dirs.unlock_pointers();
     }
 
     // StringBuilder owns the buffer; hand it back without copying. `cap` may

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -40,9 +40,7 @@ pub struct StandaloneModuleGraph {
     /// them under Stacked/Tree Borrows and make the later foreign write UB.
     pub bytes: *const [u8],
     pub files: StringArrayHashMap<File>,
-    /// Every directory prefix that appears in `files` (no trailing separator,
-    /// normalized to `/`). Lets `node:fs` answer `existsSync` / `statSync` /
-    /// `readdirSync` for virtual directories under `/$bunfs/`.
+    /// Directory prefixes derived from `files` keys (no trailing `/`, always posix-separated).
     pub dirs: StringArrayHashMap<()>,
     pub entry_point_id: u32,
     pub compile_exec_argv: &'static [u8],
@@ -175,9 +173,6 @@ impl StandaloneModuleGraph {
         None
     }
 
-    /// Normalizes a path into the form stored in `self.dirs` / `self.files`:
-    /// strips NT prefixes on Windows, maps `\` → `/`, and drops a single
-    /// trailing separator. Returns the borrowed slice (possibly into `buf`).
     fn normalize_dir_path<'a>(name: &'a [u8], buf: &'a mut PathBuffer) -> &'a [u8] {
         #[cfg(windows)]
         let name = {
@@ -202,9 +197,7 @@ impl StandaloneModuleGraph {
         self.dirs.contains_key(name)
     }
 
-    /// Enumerates the virtual directory at `name`, returning `(entry_name, is_dir)`
-    /// pairs. `entry_name` is the immediate child when `recursive` is false, and the
-    /// path relative to `name` (with `/` separators) when `recursive` is true.
+    /// `(entry, is_dir)`; `entry` is the basename, or the `name`-relative path when `recursive`.
     pub fn readdir(&self, name: &[u8], recursive: bool) -> Option<Vec<(Box<[u8]>, bool)>> {
         if !is_bun_standalone_file_path(name) {
             return None;
@@ -732,9 +725,7 @@ impl StandaloneModuleGraph {
 
         modules.lock_pointers(); // make the pointers stable forever
 
-        // Derive every directory prefix that appears in a file path so `node:fs`
-        // can answer exists/stat/readdir for them. Keys are already normalized to
-        // `/` (see `to_bytes`), so a byte-wise rfind is sufficient on all platforms.
+        // Keys are posix-separated already (see `to_bytes`), so byte-scan for `/`.
         let mut dirs = StringArrayHashMap::<()>::new();
         for key in modules.keys() {
             let mut rest: &[u8] = key;

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -241,7 +241,7 @@ impl StandaloneModuleGraph {
 
         let mut out: Vec<(Box<[u8]>, bool)> = Vec::with_capacity(seen.count());
         for (k, v) in seen.iter() {
-            out.push ((Box::<[u8]>::from(&k[..]), *v));
+            out.push((Box::<[u8]>::from(&k[..]), *v));
         }
         Some(out)
     }

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -731,7 +731,7 @@ impl StandaloneModuleGraph {
             let mut rest: &[u8] = key;
             while let Some(sep) = strings::last_index_of_char(rest, b'/') {
                 rest = &rest[..sep as usize];
-                if rest.is_empty() || dirs.contains_key(rest) {
+                if rest.len() < BASE_PUBLIC_PATH.len() || dirs.contains_key(rest) {
                     break;
                 }
                 let _ = dirs.put(rest, ());

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -295,21 +295,25 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
             "is not a regular file or directory",
           ] as const,
         ]),
-  ])("rejects %j", async (args, expected) => {
-    using dir = tempDir("bunfs-asset-reject", {
-      "index.ts": `console.log("x");`,
-      "index.html": `<!doctype html>`,
-      "public/a.txt": `a`,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), ...args],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "ignore",
-      stderr: "pipe",
-    });
-    const [stderr, code] = await Promise.all([proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain(expected);
-    expect(code).not.toBe(0);
-  }, TIMEOUT);
+  ])(
+    "rejects %j",
+    async (args, expected) => {
+      using dir = tempDir("bunfs-asset-reject", {
+        "index.ts": `console.log("x");`,
+        "index.html": `<!doctype html>`,
+        "public/a.txt": `a`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...args],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+      const [stderr, code] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain(expected);
+      expect(code).not.toBe(0);
+    },
+    TIMEOUT,
+  );
 });

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -1,8 +1,4 @@
 // https://github.com/oven-sh/bun/issues/15734
-// `bun build --compile` could not embed asset directories, and the `/$bunfs/`
-// virtual filesystem had no directory semantics for `fs.readdirSync` /
-// `fs.statSync` / `fs.existsSync`. SvelteKit's adapter (via sirv/totalist)
-// enumerates `${import.meta.dir}/client` at startup, so every static asset 404'd.
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { join, sep } from "path";
@@ -37,7 +33,7 @@ async function run(dir: string) {
   return { stdout, stderr, code };
 }
 
-describe("compiled executable: /$bunfs/ directory semantics", () => {
+describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
   test(
     "existsSync/statSync/readdirSync on embedded-file parent directories",
     async () => {
@@ -55,6 +51,7 @@ describe("compiled executable: /$bunfs/ directory semantics", () => {
           dirStatIsDir: fs.statSync(dir).isDirectory(),
           dirLstatIsDir: fs.lstatSync(dir).isDirectory(),
           accessOk: (() => { try { fs.accessSync(dir); return true; } catch { return false; } })(),
+          accessWriteErr: (() => { try { fs.accessSync(asset, fs.constants.W_OK); return ""; } catch (e: any) { return e.code; } })(),
           readdir: fs.readdirSync(dir).sort(),
           readdirHasAsset: fs.readdirSync(dir).includes(path.basename(asset)),
         };
@@ -73,6 +70,7 @@ describe("compiled executable: /$bunfs/ directory semantics", () => {
       expect(r.dirStatIsDir).toBe(true);
       expect(r.dirLstatIsDir).toBe(true);
       expect(r.accessOk).toBe(true);
+      expect(r.accessWriteErr).toBe("EACCES");
       expect(r.readdirHasAsset).toBe(true);
       expect(r.readdir.length).toBeGreaterThan(0);
       expect(code).toBe(0);

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -262,6 +262,33 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
   );
 
   test(
+    "Bun.build({compile: {assets}}) keys the entry point at basename(outfile) so an index.js asset does not collide",
+    async () => {
+      using dir = tempDir("bunfs-asset-jsapi-entry", {
+        "index.ts": /* ts */ `
+          import fs from "node:fs";
+          import path from "node:path";
+          console.log(fs.readFileSync(path.join(import.meta.dir, "index.js"), "utf8"));
+        `,
+        "cfg/index.js": `ASSET_CONTENT`,
+      });
+      const result = await Bun.build({
+        entrypoints: [join(String(dir), "index.ts")],
+        compile: {
+          outfile: join(String(dir), "app"),
+          assets: [join(String(dir), "cfg", "index.js")],
+        },
+      });
+      expect(result.success).toBe(true);
+      const { stdout, stderr, code } = await run(String(dir));
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("ASSET_CONTENT");
+      expect(code).toBe(0);
+    },
+    TIMEOUT,
+  );
+
+  test(
     "Bun.build({compile: {assets}}) rejects colliding paths",
     async () => {
       using dir = tempDir("bunfs-asset-jsapi-err", {

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -311,5 +311,5 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
     const [stderr, code] = await Promise.all([proc.stderr.text(), proc.exited]);
     expect(stderr).toContain(expected);
     expect(code).not.toBe(0);
-  });
+  }, TIMEOUT);
 });

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -280,7 +280,10 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
 
   test.each([
     [["build", "./index.ts", "--asset", "./public"], "--asset requires --compile"],
-    [["build", "--compile", "--target=browser", "./index.html", "--asset", "./public"], "--target browser with --asset"],
+    [
+      ["build", "--compile", "--target=browser", "./index.html", "--asset", "./public"],
+      "--target browser with --asset",
+    ],
     [["build", "--compile", "./index.ts", "--outfile", "app", "--asset", "./does-not-exist"], "failed to read --asset"],
   ])("rejects %j", async (args, expected) => {
     const dir = tempDirWithFiles("bunfs-asset-reject", {

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -255,4 +255,25 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
     },
     TIMEOUT,
   );
+
+  test(
+    "--asset errors when its basename matches --outfile",
+    async () => {
+      const dir = tempDirWithFiles("bunfs-asset-entry", {
+        "index.ts": `console.log("unreachable");`,
+        "client/index.html": `x`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", "./index.ts", "--outfile", "./dist/client", "--asset", "./client"],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, code] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("same path as the entry point");
+      expect(code).not.toBe(0);
+    },
+    TIMEOUT,
+  );
 });

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -101,6 +101,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
         const nestedCss = path.join(root, "_app", "immutable", "app.css");
 
         const recursive = fs.readdirSync(root, { recursive: true }).map(String).sort();
+        const recursiveAsync = (await fs.promises.readdir(root, { recursive: true })).map(String).sort();
 
         const out = {
           root,
@@ -114,6 +115,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           nestedCssViaReadFile: fs.readFileSync(nestedCss, "utf8"),
           nestedDirIsDir: fs.statSync(path.join(root, "_app", "immutable")).isDirectory(),
           recursive,
+          recursiveAsync,
           embeddedFileCount: Bun.embeddedFiles.length,
         };
         console.log(JSON.stringify(out));
@@ -156,6 +158,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
       expect(rec).toContain("favicon.svg");
       expect(rec).toContain("index.html");
       expect(r.recursive.join("\n")).not.toContain(sep === "/" ? "\\" : "/");
+      expect(r.recursiveAsync).toEqual(r.recursive);
 
       expect(r.embeddedFileCount).toBeGreaterThanOrEqual(4);
       expect(code).toBe(0);
@@ -215,6 +218,40 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
       expect(r.content).toBe(`{"ok":true}`);
       expect(r.readdirCode).toBe("ENOTDIR");
       expect(code).toBe(0);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "--asset errors on colliding embedded paths",
+    async () => {
+      const dir = tempDirWithFiles("bunfs-asset-collide", {
+        "index.ts": `console.log("unreachable");`,
+        "a/config.json": `1`,
+        "b/config.json": `2`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "build",
+          "--compile",
+          "./index.ts",
+          "--outfile",
+          "app",
+          "--asset",
+          "./a/config.json",
+          "--asset",
+          "./b/config.json",
+        ],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, code] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("collides");
+      expect(stderr).toContain("config.json");
+      expect(code).not.toBe(0);
     },
     TIMEOUT,
   );

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -114,6 +114,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           nestedCssContent: await Bun.file(nestedCss).text(),
           nestedCssViaReadFile: fs.readFileSync(nestedCss, "utf8"),
           nestedDirIsDir: fs.statSync(path.join(root, "_app", "immutable")).isDirectory(),
+          readFileDirErr: (() => { try { fs.readFileSync(root); return ""; } catch (e: any) { return e.code; } })(),
           recursive,
           recursiveAsync,
           embeddedFileCount: Bun.embeddedFiles.length,
@@ -146,6 +147,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
       expect(r.nestedCssContent).toBe("body{margin:0}");
       expect(r.nestedCssViaReadFile).toBe("body{margin:0}");
       expect(r.nestedDirIsDir).toBe(true);
+      expect(r.readFileDirErr).toBe("EISDIR");
 
       // recursive must include both files and intermediate directories, with
       // the platform path separator (same as Node's real-fs recursive readdir).

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -1,6 +1,6 @@
 // https://github.com/oven-sh/bun/issues/15734
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join, sep } from "path";
 
 // `bun build --compile` copies + rewrites the whole bun binary (~1GB under
@@ -11,7 +11,7 @@ const exe = process.platform === "win32" ? ".exe" : "";
 async function compile(dir: string, extraArgs: string[] = []) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "build", "--compile", "./index.ts", "--outfile", "app", ...extraArgs],
-    cwd: dir,
+    cwd: String(dir),
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
@@ -37,7 +37,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
   test(
     "existsSync/statSync/readdirSync on embedded-file parent directories",
     async () => {
-      const dir = tempDirWithFiles("bunfs-dirsem", {
+      using dir = tempDir("bunfs-dirsem", {
         "index.ts": /* ts */ `
         import asset from "./data.txt" with { type: "file" };
         import fs from "node:fs";
@@ -60,8 +60,8 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
         "data.txt": "hello",
       });
 
-      await compile(dir);
-      const { stdout, stderr, code } = await run(dir);
+      await compile(String(dir));
+      const { stdout, stderr, code } = await run(String(dir));
       expect(stderr.trim()).toBe("");
       const r = JSON.parse(stdout.trim());
       expect(r.assetExists).toBe(true);
@@ -81,7 +81,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
   test(
     "--asset embeds a directory tree with original paths, enumerable via fs and readable via Bun.file",
     async () => {
-      const dir = tempDirWithFiles("bunfs-asset-flag", {
+      using dir = tempDir("bunfs-asset-flag", {
         "index.ts": /* ts */ `
         import fs from "node:fs";
         import path from "node:path";
@@ -127,8 +127,8 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
         "client/_app/immutable/chunks/entry.js": "export default 1;",
       });
 
-      await compile(dir, ["--asset", "./client"]);
-      const { stdout, stderr, code } = await run(dir);
+      await compile(String(dir), ["--asset", "./client"]);
+      const { stdout, stderr, code } = await run(String(dir));
       expect(stderr.trim()).toBe("");
       const r = JSON.parse(stdout.trim());
 
@@ -171,7 +171,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
   test(
     "readdirSync on a non-existent /$bunfs/ path throws ENOENT",
     async () => {
-      const dir = tempDirWithFiles("bunfs-enoent", {
+      using dir = tempDir("bunfs-enoent", {
         "index.ts": /* ts */ `
         import fs from "node:fs";
         import path from "node:path";
@@ -184,8 +184,8 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
         }
       `,
       });
-      await compile(dir);
-      const { stdout, stderr, code } = await run(dir);
+      await compile(String(dir));
+      const { stdout, stderr, code } = await run(String(dir));
       expect(stderr.trim()).toBe("");
       const r = JSON.parse(stdout.trim());
       expect(r.code).toBe("ENOENT");
@@ -198,7 +198,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
   test(
     "--asset on a single file",
     async () => {
-      const dir = tempDirWithFiles("bunfs-asset-file", {
+      using dir = tempDir("bunfs-asset-file", {
         "index.ts": /* ts */ `
         import fs from "node:fs";
         import path from "node:path";
@@ -213,8 +213,8 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
       `,
         "config.json": `{"ok":true}`,
       });
-      await compile(dir, ["--asset", "./config.json"]);
-      const { stdout, stderr, code } = await run(dir);
+      await compile(String(dir), ["--asset", "./config.json"]);
+      const { stdout, stderr, code } = await run(String(dir));
       expect(stderr.trim()).toBe("");
       const r = JSON.parse(stdout.trim());
       expect(r.exists).toBe(true);
@@ -228,7 +228,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
   test(
     "--asset errors on colliding embedded paths",
     async () => {
-      const dir = tempDirWithFiles("bunfs-asset-collide", {
+      using dir = tempDir("bunfs-asset-collide", {
         "index.ts": `console.log("unreachable");`,
         "a/config.json": `1`,
         "b/config.json": `2`,
@@ -246,7 +246,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           "--asset",
           "./b/config.json",
         ],
-        cwd: dir,
+        cwd: String(dir),
         env: bunEnv,
         stdout: "ignore",
         stderr: "pipe",
@@ -262,13 +262,13 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
   test(
     "--asset errors when its basename matches --outfile",
     async () => {
-      const dir = tempDirWithFiles("bunfs-asset-entry", {
+      using dir = tempDir("bunfs-asset-entry", {
         "index.ts": `console.log("unreachable");`,
         "client/index.html": `x`,
       });
       await using proc = Bun.spawn({
         cmd: [bunExe(), "build", "--compile", "./index.ts", "--outfile", "./dist/client", "--asset", "./client"],
-        cwd: dir,
+        cwd: String(dir),
         env: bunEnv,
         stdout: "ignore",
         stderr: "pipe",
@@ -296,14 +296,14 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           ] as const,
         ]),
   ])("rejects %j", async (args, expected) => {
-    const dir = tempDirWithFiles("bunfs-asset-reject", {
+    using dir = tempDir("bunfs-asset-reject", {
       "index.ts": `console.log("x");`,
       "index.html": `<!doctype html>`,
       "public/a.txt": `a`,
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), ...args],
-      cwd: dir,
+      cwd: String(dir),
       env: bunEnv,
       stdout: "ignore",
       stderr: "pipe",

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -278,7 +278,9 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
         },
       });
       expect(result.success).toBe(false);
-      expect(result.logs.map(String).join("\n")).toContain("collides");
+      const logs = result.logs.map(String).join("\n");
+      expect(logs).toContain("collides");
+      expect(logs).toContain("data.json");
     },
     TIMEOUT,
   );

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -226,6 +226,64 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
   );
 
   test(
+    "Bun.build({compile: {assets}}) embeds a directory tree",
+    async () => {
+      using dir = tempDir("bunfs-asset-jsapi", {
+        "index.ts": /* ts */ `
+          import fs from "node:fs";
+          import path from "node:path";
+          const root = path.join(import.meta.dir, "public");
+          console.log(JSON.stringify({
+            entries: fs.readdirSync(root).sort(),
+            content: fs.readFileSync(path.join(root, "index.html"), "utf8"),
+          }));
+        `,
+        "public/index.html": "<h1>js-api</h1>",
+        "public/sub/a.css": "body{}",
+      });
+
+      const result = await Bun.build({
+        entrypoints: [join(String(dir), "index.ts")],
+        compile: {
+          outfile: join(String(dir), "app"),
+          assets: [join(String(dir), "public")],
+        },
+      });
+      expect(result.success).toBe(true);
+
+      const { stdout, stderr, code } = await run(String(dir));
+      expect(stderr.trim()).toBe("");
+      const r = JSON.parse(stdout.trim());
+      expect(r.entries).toEqual(["index.html", "sub"]);
+      expect(r.content).toBe("<h1>js-api</h1>");
+      expect(code).toBe(0);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "Bun.build({compile: {assets}}) rejects colliding paths",
+    async () => {
+      using dir = tempDir("bunfs-asset-jsapi-err", {
+        "index.ts": `console.log("x");`,
+        "a/data.json": `1`,
+        "b/data.json": `2`,
+      });
+      const result = await Bun.build({
+        entrypoints: [join(String(dir), "index.ts")],
+        throw: false,
+        compile: {
+          outfile: join(String(dir), "app"),
+          assets: [join(String(dir), "a", "data.json"), join(String(dir), "b", "data.json")],
+        },
+      });
+      expect(result.success).toBe(false);
+      expect(result.logs.map(String).join("\n")).toContain("collides");
+    },
+    TIMEOUT,
+  );
+
+  test(
     "--asset errors on colliding embedded paths",
     async () => {
       using dir = tempDir("bunfs-asset-collide", {
@@ -286,7 +344,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
       ["build", "--compile", "--target=browser", "./index.html", "--asset", "./public"],
       "--target browser with --asset",
     ],
-    [["build", "--compile", "./index.ts", "--outfile", "app", "--asset", "./does-not-exist"], "failed to read --asset"],
+    [["build", "--compile", "./index.ts", "--outfile", "app", "--asset", "./does-not-exist"], "failed to read asset"],
     ...(process.platform === "win32"
       ? []
       : [

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -285,6 +285,14 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
       "--target browser with --asset",
     ],
     [["build", "--compile", "./index.ts", "--outfile", "app", "--asset", "./does-not-exist"], "failed to read --asset"],
+    ...(process.platform === "win32"
+      ? []
+      : [
+          [
+            ["build", "--compile", "./index.ts", "--outfile", "app", "--asset", "/dev/null"],
+            "is not a regular file or directory",
+          ] as const,
+        ]),
   ])("rejects %j", async (args, expected) => {
     const dir = tempDirWithFiles("bunfs-asset-reject", {
       "index.ts": `console.log("x");`,

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -183,7 +183,8 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
       `,
       });
       await compile(dir);
-      const { stdout, code } = await run(dir);
+      const { stdout, stderr, code } = await run(dir);
+      expect(stderr.trim()).toBe("");
       const r = JSON.parse(stdout.trim());
       expect(r.code).toBe("ENOENT");
       expect(r.exists).toBe(false);
@@ -276,4 +277,26 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
     },
     TIMEOUT,
   );
+
+  test.each([
+    [["build", "./index.ts", "--asset", "./public"], "--asset requires --compile"],
+    [["build", "--compile", "--target=browser", "./index.html", "--asset", "./public"], "--target browser with --asset"],
+    [["build", "--compile", "./index.ts", "--outfile", "app", "--asset", "./does-not-exist"], "failed to read --asset"],
+  ])("rejects %j", async (args, expected) => {
+    const dir = tempDirWithFiles("bunfs-asset-reject", {
+      "index.ts": `console.log("x");`,
+      "index.html": `<!doctype html>`,
+      "public/a.txt": `a`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, code] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(expected);
+    expect(code).not.toBe(0);
+  });
 });

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -245,7 +245,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
         ],
         cwd: dir,
         env: bunEnv,
-        stdout: "pipe",
+        stdout: "ignore",
         stderr: "pipe",
       });
       const [stderr, code] = await Promise.all([proc.stderr.text(), proc.exited]);
@@ -267,7 +267,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
         cmd: [bunExe(), "build", "--compile", "./index.ts", "--outfile", "./dist/client", "--asset", "./client"],
         cwd: dir,
         env: bunEnv,
-        stdout: "pipe",
+        stdout: "ignore",
         stderr: "pipe",
       });
       const [stderr, code] = await Promise.all([proc.stderr.text(), proc.exited]);

--- a/test/regression/issue/15734.test.ts
+++ b/test/regression/issue/15734.test.ts
@@ -5,7 +5,7 @@
 // enumerates `${import.meta.dir}/client` at startup, so every static asset 404'd.
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
-import { join } from "path";
+import { join, sep } from "path";
 
 // `bun build --compile` copies + rewrites the whole bun binary (~1GB under
 // debug+ASAN), which blows the 5s default.
@@ -147,15 +147,17 @@ describe("compiled executable: /$bunfs/ directory semantics", () => {
       expect(r.nestedCssViaReadFile).toBe("body{margin:0}");
       expect(r.nestedDirIsDir).toBe(true);
 
-      // recursive must include both files and intermediate directories.
-      const rec = r.recursive.map((p: string) => p.replace(/\\/g, "/"));
+      // recursive must include both files and intermediate directories, with
+      // the platform path separator (same as Node's real-fs recursive readdir).
+      const rec: string[] = r.recursive;
       expect(rec).toContain("_app");
-      expect(rec).toContain("_app/immutable");
-      expect(rec).toContain("_app/immutable/app.css");
-      expect(rec).toContain("_app/immutable/chunks");
-      expect(rec).toContain("_app/immutable/chunks/entry.js");
+      expect(rec).toContain(join("_app", "immutable"));
+      expect(rec).toContain(join("_app", "immutable", "app.css"));
+      expect(rec).toContain(join("_app", "immutable", "chunks"));
+      expect(rec).toContain(join("_app", "immutable", "chunks", "entry.js"));
       expect(rec).toContain("favicon.svg");
       expect(rec).toContain("index.html");
+      expect(r.recursive.join("\n")).not.toContain(sep === "/" ? "\\" : "/");
 
       expect(r.embeddedFileCount).toBeGreaterThanOrEqual(4);
       expect(code).toBe(0);
@@ -197,9 +199,12 @@ describe("compiled executable: /$bunfs/ directory semantics", () => {
         import fs from "node:fs";
         import path from "node:path";
         const p = path.join(import.meta.dir, "config.json");
+        let readdirCode = "";
+        try { fs.readdirSync(p); } catch (e: any) { readdirCode = e.code; }
         console.log(JSON.stringify({
           exists: fs.existsSync(p),
           content: fs.readFileSync(p, "utf8"),
+          readdirCode,
         }));
       `,
         "config.json": `{"ok":true}`,
@@ -210,6 +215,7 @@ describe("compiled executable: /$bunfs/ directory semantics", () => {
       const r = JSON.parse(stdout.trim());
       expect(r.exists).toBe(true);
       expect(r.content).toBe(`{"ok":true}`);
+      expect(r.readdirCode).toBe("ENOTDIR");
       expect(code).toBe(0);
     },
     TIMEOUT,

--- a/test/regression/issue/15734.test.ts
+++ b/test/regression/issue/15734.test.ts
@@ -1,0 +1,201 @@
+// https://github.com/oven-sh/bun/issues/15734
+// `bun build --compile` could not embed asset directories, and the `/$bunfs/`
+// virtual filesystem had no directory semantics for `fs.readdirSync` /
+// `fs.statSync` / `fs.existsSync`. SvelteKit's adapter (via sirv/totalist)
+// enumerates `${import.meta.dir}/client` at startup, so every static asset 404'd.
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+// `bun build --compile` copies + rewrites the whole bun binary (~1GB under
+// debug+ASAN), which blows the 5s default.
+const TIMEOUT = 60_000;
+const exe = process.platform === "win32" ? ".exe" : "";
+
+async function compile(dir: string, extraArgs: string[] = []) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", "./index.ts", "--outfile", "app", ...extraArgs],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (code !== 0) throw new Error(`compile failed\n${stdout}\n${stderr}`);
+}
+
+async function run(dir: string) {
+  // cwd outside the build dir so the binary cannot accidentally find real files on disk.
+  await using proc = Bun.spawn({
+    cmd: [join(dir, "app" + exe)],
+    cwd: process.platform === "win32" ? process.env.TEMP || "C:\\Windows\\Temp" : "/tmp",
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, code };
+}
+
+describe("compiled executable: /$bunfs/ directory semantics", () => {
+  test("existsSync/statSync/readdirSync on embedded-file parent directories", async () => {
+    const dir = tempDirWithFiles("bunfs-dirsem", {
+      "index.ts": /* ts */ `
+        import asset from "./data.txt" with { type: "file" };
+        import fs from "node:fs";
+        import path from "node:path";
+
+        const dir = path.dirname(asset);
+        const results = {
+          assetExists: fs.existsSync(asset),
+          dirExists: fs.existsSync(dir),
+          dirExistsTrailingSlash: fs.existsSync(dir + "/"),
+          dirStatIsDir: fs.statSync(dir).isDirectory(),
+          dirLstatIsDir: fs.lstatSync(dir).isDirectory(),
+          accessOk: (() => { try { fs.accessSync(dir); return true; } catch { return false; } })(),
+          readdir: fs.readdirSync(dir).sort(),
+          readdirHasAsset: fs.readdirSync(dir).includes(path.basename(asset)),
+        };
+        console.log(JSON.stringify(results));
+      `,
+      "data.txt": "hello",
+    });
+
+    await compile(dir);
+    const { stdout, stderr, code } = await run(dir);
+    expect(stderr.trim()).toBe("");
+    const r = JSON.parse(stdout.trim());
+    expect(r.assetExists).toBe(true);
+    expect(r.dirExists).toBe(true);
+    expect(r.dirExistsTrailingSlash).toBe(true);
+    expect(r.dirStatIsDir).toBe(true);
+    expect(r.dirLstatIsDir).toBe(true);
+    expect(r.accessOk).toBe(true);
+    expect(r.readdirHasAsset).toBe(true);
+    expect(r.readdir.length).toBeGreaterThan(0);
+    expect(code).toBe(0);
+  }, TIMEOUT);
+
+  test("--asset embeds a directory tree with original paths, enumerable via fs and readable via Bun.file", async () => {
+    const dir = tempDirWithFiles("bunfs-asset-flag", {
+      "index.ts": /* ts */ `
+        import fs from "node:fs";
+        import path from "node:path";
+
+        // This mirrors what svelte-adapter-bun does: walk a directory relative
+        // to the bundled entry, stat each entry, serve via Bun.file().
+        const root = path.join(import.meta.dir, "client");
+        if (!fs.existsSync(root)) throw new Error("client dir missing: " + root);
+
+        const entries = fs.readdirSync(root, { withFileTypes: true });
+        const byName: Record<string, { isDir: boolean; isFile: boolean }> = {};
+        for (const e of entries) {
+          byName[e.name] = { isDir: e.isDirectory(), isFile: e.isFile() };
+        }
+
+        const indexHtml = path.join(root, "index.html");
+        const nestedCss = path.join(root, "_app", "immutable", "app.css");
+
+        const recursive = fs.readdirSync(root, { recursive: true }).map(String).sort();
+
+        const out = {
+          root,
+          entries: Object.keys(byName).sort(),
+          byName,
+          indexHtmlExists: fs.existsSync(indexHtml),
+          indexHtmlSize: fs.statSync(indexHtml).size,
+          indexHtmlContent: await Bun.file(indexHtml).text(),
+          nestedCssExists: fs.existsSync(nestedCss),
+          nestedCssContent: await Bun.file(nestedCss).text(),
+          nestedCssViaReadFile: fs.readFileSync(nestedCss, "utf8"),
+          nestedDirIsDir: fs.statSync(path.join(root, "_app", "immutable")).isDirectory(),
+          recursive,
+          embeddedFileCount: Bun.embeddedFiles.length,
+        };
+        console.log(JSON.stringify(out));
+      `,
+      "client/index.html": "<!doctype html><h1>hi</h1>",
+      "client/favicon.svg": "<svg/>",
+      "client/_app/immutable/app.css": "body{margin:0}",
+      "client/_app/immutable/chunks/entry.js": "export default 1;",
+    });
+
+    await compile(dir, ["--asset", "./client"]);
+    const { stdout, stderr, code } = await run(dir);
+    expect(stderr.trim()).toBe("");
+    const r = JSON.parse(stdout.trim());
+
+    // import.meta.dir is /$bunfs/root (or B:/~BUN/root on Windows); client lives directly under it.
+    expect(r.root.replace(/\\/g, "/")).toMatch(/\/root\/client$/);
+
+    expect(r.entries).toEqual(["_app", "favicon.svg", "index.html"]);
+    expect(r.byName["index.html"]).toEqual({ isDir: false, isFile: true });
+    expect(r.byName["favicon.svg"]).toEqual({ isDir: false, isFile: true });
+    expect(r.byName["_app"]).toEqual({ isDir: true, isFile: false });
+
+    expect(r.indexHtmlExists).toBe(true);
+    expect(r.indexHtmlSize).toBe("<!doctype html><h1>hi</h1>".length);
+    expect(r.indexHtmlContent).toBe("<!doctype html><h1>hi</h1>");
+    expect(r.nestedCssExists).toBe(true);
+    expect(r.nestedCssContent).toBe("body{margin:0}");
+    expect(r.nestedCssViaReadFile).toBe("body{margin:0}");
+    expect(r.nestedDirIsDir).toBe(true);
+
+    // recursive must include both files and intermediate directories.
+    const rec = r.recursive.map((p: string) => p.replace(/\\/g, "/"));
+    expect(rec).toContain("_app");
+    expect(rec).toContain("_app/immutable");
+    expect(rec).toContain("_app/immutable/app.css");
+    expect(rec).toContain("_app/immutable/chunks");
+    expect(rec).toContain("_app/immutable/chunks/entry.js");
+    expect(rec).toContain("favicon.svg");
+    expect(rec).toContain("index.html");
+
+    expect(r.embeddedFileCount).toBeGreaterThanOrEqual(4);
+    expect(code).toBe(0);
+  }, TIMEOUT);
+
+  test("readdirSync on a non-existent /$bunfs/ path throws ENOENT", async () => {
+    const dir = tempDirWithFiles("bunfs-enoent", {
+      "index.ts": /* ts */ `
+        import fs from "node:fs";
+        import path from "node:path";
+        const p = path.join(import.meta.dir, "does-not-exist");
+        try {
+          fs.readdirSync(p);
+          console.log("FAIL: no throw");
+        } catch (e: any) {
+          console.log(JSON.stringify({ code: e.code, exists: fs.existsSync(p) }));
+        }
+      `,
+    });
+    await compile(dir);
+    const { stdout, code } = await run(dir);
+    const r = JSON.parse(stdout.trim());
+    expect(r.code).toBe("ENOENT");
+    expect(r.exists).toBe(false);
+    expect(code).toBe(0);
+  }, TIMEOUT);
+
+  test("--asset on a single file", async () => {
+    const dir = tempDirWithFiles("bunfs-asset-file", {
+      "index.ts": /* ts */ `
+        import fs from "node:fs";
+        import path from "node:path";
+        const p = path.join(import.meta.dir, "config.json");
+        console.log(JSON.stringify({
+          exists: fs.existsSync(p),
+          content: fs.readFileSync(p, "utf8"),
+        }));
+      `,
+      "config.json": `{"ok":true}`,
+    });
+    await compile(dir, ["--asset", "./config.json"]);
+    const { stdout, stderr, code } = await run(dir);
+    expect(stderr.trim()).toBe("");
+    const r = JSON.parse(stdout.trim());
+    expect(r.exists).toBe(true);
+    expect(r.content).toBe(`{"ok":true}`);
+    expect(code).toBe(0);
+  }, TIMEOUT);
+});

--- a/test/regression/issue/15734.test.ts
+++ b/test/regression/issue/15734.test.ts
@@ -3,7 +3,7 @@
 // virtual filesystem had no directory semantics for `fs.readdirSync` /
 // `fs.statSync` / `fs.existsSync`. SvelteKit's adapter (via sirv/totalist)
 // enumerates `${import.meta.dir}/client` at startup, so every static asset 404'd.
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { join } from "path";
 
@@ -38,9 +38,11 @@ async function run(dir: string) {
 }
 
 describe("compiled executable: /$bunfs/ directory semantics", () => {
-  test("existsSync/statSync/readdirSync on embedded-file parent directories", async () => {
-    const dir = tempDirWithFiles("bunfs-dirsem", {
-      "index.ts": /* ts */ `
+  test(
+    "existsSync/statSync/readdirSync on embedded-file parent directories",
+    async () => {
+      const dir = tempDirWithFiles("bunfs-dirsem", {
+        "index.ts": /* ts */ `
         import asset from "./data.txt" with { type: "file" };
         import fs from "node:fs";
         import path from "node:path";
@@ -58,27 +60,31 @@ describe("compiled executable: /$bunfs/ directory semantics", () => {
         };
         console.log(JSON.stringify(results));
       `,
-      "data.txt": "hello",
-    });
+        "data.txt": "hello",
+      });
 
-    await compile(dir);
-    const { stdout, stderr, code } = await run(dir);
-    expect(stderr.trim()).toBe("");
-    const r = JSON.parse(stdout.trim());
-    expect(r.assetExists).toBe(true);
-    expect(r.dirExists).toBe(true);
-    expect(r.dirExistsTrailingSlash).toBe(true);
-    expect(r.dirStatIsDir).toBe(true);
-    expect(r.dirLstatIsDir).toBe(true);
-    expect(r.accessOk).toBe(true);
-    expect(r.readdirHasAsset).toBe(true);
-    expect(r.readdir.length).toBeGreaterThan(0);
-    expect(code).toBe(0);
-  }, TIMEOUT);
+      await compile(dir);
+      const { stdout, stderr, code } = await run(dir);
+      expect(stderr.trim()).toBe("");
+      const r = JSON.parse(stdout.trim());
+      expect(r.assetExists).toBe(true);
+      expect(r.dirExists).toBe(true);
+      expect(r.dirExistsTrailingSlash).toBe(true);
+      expect(r.dirStatIsDir).toBe(true);
+      expect(r.dirLstatIsDir).toBe(true);
+      expect(r.accessOk).toBe(true);
+      expect(r.readdirHasAsset).toBe(true);
+      expect(r.readdir.length).toBeGreaterThan(0);
+      expect(code).toBe(0);
+    },
+    TIMEOUT,
+  );
 
-  test("--asset embeds a directory tree with original paths, enumerable via fs and readable via Bun.file", async () => {
-    const dir = tempDirWithFiles("bunfs-asset-flag", {
-      "index.ts": /* ts */ `
+  test(
+    "--asset embeds a directory tree with original paths, enumerable via fs and readable via Bun.file",
+    async () => {
+      const dir = tempDirWithFiles("bunfs-asset-flag", {
+        "index.ts": /* ts */ `
         import fs from "node:fs";
         import path from "node:path";
 
@@ -114,50 +120,54 @@ describe("compiled executable: /$bunfs/ directory semantics", () => {
         };
         console.log(JSON.stringify(out));
       `,
-      "client/index.html": "<!doctype html><h1>hi</h1>",
-      "client/favicon.svg": "<svg/>",
-      "client/_app/immutable/app.css": "body{margin:0}",
-      "client/_app/immutable/chunks/entry.js": "export default 1;",
-    });
+        "client/index.html": "<!doctype html><h1>hi</h1>",
+        "client/favicon.svg": "<svg/>",
+        "client/_app/immutable/app.css": "body{margin:0}",
+        "client/_app/immutable/chunks/entry.js": "export default 1;",
+      });
 
-    await compile(dir, ["--asset", "./client"]);
-    const { stdout, stderr, code } = await run(dir);
-    expect(stderr.trim()).toBe("");
-    const r = JSON.parse(stdout.trim());
+      await compile(dir, ["--asset", "./client"]);
+      const { stdout, stderr, code } = await run(dir);
+      expect(stderr.trim()).toBe("");
+      const r = JSON.parse(stdout.trim());
 
-    // import.meta.dir is /$bunfs/root (or B:/~BUN/root on Windows); client lives directly under it.
-    expect(r.root.replace(/\\/g, "/")).toMatch(/\/root\/client$/);
+      // import.meta.dir is /$bunfs/root (or B:/~BUN/root on Windows); client lives directly under it.
+      expect(r.root.replace(/\\/g, "/")).toMatch(/\/root\/client$/);
 
-    expect(r.entries).toEqual(["_app", "favicon.svg", "index.html"]);
-    expect(r.byName["index.html"]).toEqual({ isDir: false, isFile: true });
-    expect(r.byName["favicon.svg"]).toEqual({ isDir: false, isFile: true });
-    expect(r.byName["_app"]).toEqual({ isDir: true, isFile: false });
+      expect(r.entries).toEqual(["_app", "favicon.svg", "index.html"]);
+      expect(r.byName["index.html"]).toEqual({ isDir: false, isFile: true });
+      expect(r.byName["favicon.svg"]).toEqual({ isDir: false, isFile: true });
+      expect(r.byName["_app"]).toEqual({ isDir: true, isFile: false });
 
-    expect(r.indexHtmlExists).toBe(true);
-    expect(r.indexHtmlSize).toBe("<!doctype html><h1>hi</h1>".length);
-    expect(r.indexHtmlContent).toBe("<!doctype html><h1>hi</h1>");
-    expect(r.nestedCssExists).toBe(true);
-    expect(r.nestedCssContent).toBe("body{margin:0}");
-    expect(r.nestedCssViaReadFile).toBe("body{margin:0}");
-    expect(r.nestedDirIsDir).toBe(true);
+      expect(r.indexHtmlExists).toBe(true);
+      expect(r.indexHtmlSize).toBe("<!doctype html><h1>hi</h1>".length);
+      expect(r.indexHtmlContent).toBe("<!doctype html><h1>hi</h1>");
+      expect(r.nestedCssExists).toBe(true);
+      expect(r.nestedCssContent).toBe("body{margin:0}");
+      expect(r.nestedCssViaReadFile).toBe("body{margin:0}");
+      expect(r.nestedDirIsDir).toBe(true);
 
-    // recursive must include both files and intermediate directories.
-    const rec = r.recursive.map((p: string) => p.replace(/\\/g, "/"));
-    expect(rec).toContain("_app");
-    expect(rec).toContain("_app/immutable");
-    expect(rec).toContain("_app/immutable/app.css");
-    expect(rec).toContain("_app/immutable/chunks");
-    expect(rec).toContain("_app/immutable/chunks/entry.js");
-    expect(rec).toContain("favicon.svg");
-    expect(rec).toContain("index.html");
+      // recursive must include both files and intermediate directories.
+      const rec = r.recursive.map((p: string) => p.replace(/\\/g, "/"));
+      expect(rec).toContain("_app");
+      expect(rec).toContain("_app/immutable");
+      expect(rec).toContain("_app/immutable/app.css");
+      expect(rec).toContain("_app/immutable/chunks");
+      expect(rec).toContain("_app/immutable/chunks/entry.js");
+      expect(rec).toContain("favicon.svg");
+      expect(rec).toContain("index.html");
 
-    expect(r.embeddedFileCount).toBeGreaterThanOrEqual(4);
-    expect(code).toBe(0);
-  }, TIMEOUT);
+      expect(r.embeddedFileCount).toBeGreaterThanOrEqual(4);
+      expect(code).toBe(0);
+    },
+    TIMEOUT,
+  );
 
-  test("readdirSync on a non-existent /$bunfs/ path throws ENOENT", async () => {
-    const dir = tempDirWithFiles("bunfs-enoent", {
-      "index.ts": /* ts */ `
+  test(
+    "readdirSync on a non-existent /$bunfs/ path throws ENOENT",
+    async () => {
+      const dir = tempDirWithFiles("bunfs-enoent", {
+        "index.ts": /* ts */ `
         import fs from "node:fs";
         import path from "node:path";
         const p = path.join(import.meta.dir, "does-not-exist");
@@ -168,18 +178,22 @@ describe("compiled executable: /$bunfs/ directory semantics", () => {
           console.log(JSON.stringify({ code: e.code, exists: fs.existsSync(p) }));
         }
       `,
-    });
-    await compile(dir);
-    const { stdout, code } = await run(dir);
-    const r = JSON.parse(stdout.trim());
-    expect(r.code).toBe("ENOENT");
-    expect(r.exists).toBe(false);
-    expect(code).toBe(0);
-  }, TIMEOUT);
+      });
+      await compile(dir);
+      const { stdout, code } = await run(dir);
+      const r = JSON.parse(stdout.trim());
+      expect(r.code).toBe("ENOENT");
+      expect(r.exists).toBe(false);
+      expect(code).toBe(0);
+    },
+    TIMEOUT,
+  );
 
-  test("--asset on a single file", async () => {
-    const dir = tempDirWithFiles("bunfs-asset-file", {
-      "index.ts": /* ts */ `
+  test(
+    "--asset on a single file",
+    async () => {
+      const dir = tempDirWithFiles("bunfs-asset-file", {
+        "index.ts": /* ts */ `
         import fs from "node:fs";
         import path from "node:path";
         const p = path.join(import.meta.dir, "config.json");
@@ -188,14 +202,16 @@ describe("compiled executable: /$bunfs/ directory semantics", () => {
           content: fs.readFileSync(p, "utf8"),
         }));
       `,
-      "config.json": `{"ok":true}`,
-    });
-    await compile(dir, ["--asset", "./config.json"]);
-    const { stdout, stderr, code } = await run(dir);
-    expect(stderr.trim()).toBe("");
-    const r = JSON.parse(stdout.trim());
-    expect(r.exists).toBe(true);
-    expect(r.content).toBe(`{"ok":true}`);
-    expect(code).toBe(0);
-  }, TIMEOUT);
+        "config.json": `{"ok":true}`,
+      });
+      await compile(dir, ["--asset", "./config.json"]);
+      const { stdout, stderr, code } = await run(dir);
+      expect(stderr.trim()).toBe("");
+      const r = JSON.parse(stdout.trim());
+      expect(r.exists).toBe(true);
+      expect(r.content).toBe(`{"ok":true}`);
+      expect(code).toBe(0);
+    },
+    TIMEOUT,
+  );
 });


### PR DESCRIPTION
## What

`svelte-adapter-bun` (via sirv/totalist) enumerates `${import.meta.dir}/client` at startup with `fs.existsSync` / `fs.readdirSync` / `fs.statSync` to build its static-file cache. In a `--compile`'d binary that path is `/$bunfs/root/client`, which

1. was never embedded, because nothing `import`s it, and
2. couldn't be enumerated even if it were: the standalone module graph only knew about exact file keys, so `existsSync("/$bunfs/root")`, `statSync(...)` and `readdirSync(...)` on any directory all returned `ENOENT`.

Every request to the compiled SvelteKit binary fell through to `SvelteKitError: Not found`.

## Fix

**Directory semantics for `/$bunfs/` (`StandaloneModuleGraph` + `node_fs.rs`).** The graph now derives a directory set from the embedded file keys at load time, and `existsSync` / `accessSync` / `statSync` / `lstatSync` / `readdirSync` / `fs.promises.readdir` (incl. `{ withFileTypes }` and `{ recursive }`) consult it for any `/$bunfs/`-prefixed path. `statSync` on a virtual directory returns an `S_IFDIR` stat; `readdirSync` returns immediate children (or the full relative tree with `recursive: true`, with the platform path separator). `readdirSync` on an embedded file throws `ENOTDIR`; `accessSync(p, W_OK)` throws `EACCES`.

**`--asset <path>` (repeatable) for `bun build --compile`.** Walks a file or directory and embeds every regular file at `/$bunfs/root/<basename-of-path>/<relative-path>` with its original name (no `[hash]` rewrite), so `path.join(import.meta.dir, "client", ...)` resolves exactly as it does on disk. Errors on collisions with other `--asset`s, bundler outputs, or the entry point name.

With both in place:

```bash
bun build ./build/index.js --compile \
  --asset ./build/client --asset ./build/prerendered \
  --outfile server
./server   # every route + static asset 200s
```

## Verification

`test/bundler/compile-asset-bunfs.test.ts` compiles several binaries and exercises:

- `existsSync`/`statSync`/`lstatSync`/`accessSync`/`readdirSync` on the parent directory of an embedded file, `accessSync(p, W_OK)` → `EACCES`
- `--asset ./client` embedding a nested tree, enumerable via `readdirSync({withFileTypes})`, `readdirSync({recursive})` and `fs.promises.readdir({recursive})`, readable via `Bun.file()` and `fs.readFileSync`
- `readdirSync` on a non-existent `/$bunfs/` path → `ENOENT`; on an embedded file → `ENOTDIR`
- collision rejections (two `--asset`s sharing a basename, `--asset` vs `--outfile`, `--asset` without `--compile`, `--asset` with `--target=browser`, missing `--asset` path)

All of these fail on current bun and pass with this change. Also verified end-to-end against a real `sv create` + `svelte-adapter-bun` build.

Fixes #15734
Closes #5445
Refs #22223 (`readdir` support; `createReadStream` on `/$bunfs/` is a follow-up)

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/compile-asset-bunfs.test.ts

<!-- robobun:evidence:end -->