### PR TITLE
install: update catalog definitions on non-interactive `bun update`

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -424,6 +424,11 @@ pub struct PackageManager {
     // dependency name -> original version information
     pub updating_packages: StringArrayHashMap<PackageUpdateInfo>,
 
+    // `bun update --latest` (no package names) also updates versions declared
+    // in the root package.json `catalog`/`catalogs`. Keyed by catalog name +
+    // dependency name because the same package may appear in multiple catalogs.
+    pub updating_catalogs: Vec<CatalogUpdateInfo>,
+
     pub patched_dependencies_to_remove:
         ArrayHashMap<PackageNameAndVersionHash, () /* , ArrayIdentityContext::U64, false */>,
 
@@ -573,6 +578,14 @@ pub struct PackageUpdateInfo {
     pub is_alias: bool,
     pub original_version_string_buf: Box<[u8]>,
     pub original_version: Option<Semver::Version>,
+}
+
+pub struct CatalogUpdateInfo {
+    /// Catalog group name; empty for the default catalog.
+    pub catalog_name: Box<[u8]>,
+    pub dep_name: Box<[u8]>,
+    pub original_version_literal: Box<[u8]>,
+    pub is_alias: bool,
 }
 
 #[derive(Default)]
@@ -1953,6 +1966,7 @@ pub fn init(
         wr!(trusted_deps_to_add_to_package_json, Vec::new());
         wr!(any_failed_to_install, false);
         wr!(updating_packages, StringArrayHashMap::default());
+        wr!(updating_catalogs, Vec::new());
         wr!(patched_dependencies_to_remove, ArrayHashMap::default());
         wr!(last_reported_slow_lifecycle_script_at, 0);
         wr!(cached_tick_for_slow_lifecycle_script_logging, 0);
@@ -2390,6 +2404,7 @@ pub(crate) fn init_with_runtime_once(
             WorkspacePackageJSONCache::default()
         );
         wr!(updating_packages, StringArrayHashMap::default());
+        wr!(updating_catalogs, Vec::new());
         wr!(patched_dependencies_to_remove, ArrayHashMap::default());
         wr!(last_reported_slow_lifecycle_script_at, 0);
         wr!(cached_tick_for_slow_lifecycle_script_logging, 0);

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -424,9 +424,7 @@ pub struct PackageManager {
     // dependency name -> original version information
     pub updating_packages: StringArrayHashMap<PackageUpdateInfo>,
 
-    // `bun update --latest` (no package names) also updates versions declared
-    // in the root package.json `catalog`/`catalogs`. Keyed by catalog name +
-    // dependency name because the same package may appear in multiple catalogs.
+    // (catalog name, dependency name) -> original version literal
     pub updating_catalogs: Vec<CatalogUpdateInfo>,
 
     pub patched_dependencies_to_remove:

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -12,7 +12,7 @@ use bun_install::{Dependency, INVALID_PACKAGE_ID, resolution};
 use bun_install_types::DependencyGroup;
 
 use super::package_manager_options::{Do, Enable};
-use super::{PackageManager, PackageUpdateInfo, Subcommand, UpdateRequest};
+use super::{CatalogUpdateInfo, PackageManager, PackageUpdateInfo, Subcommand, UpdateRequest};
 
 type ExprDisabler = bun_ast::expr::Disabler;
 
@@ -285,11 +285,13 @@ pub(crate) fn edit_update_no_args(
                             .unwrap_or_else(|| bun_core::out_of_memory());
                         let mut tag = dependency::Tag::infer(version_literal);
 
-                        // only updating dependencies with npm versions, dist-tags if `--latest`, and catalog versions.
+                        // only updating dependencies with npm versions, and dist-tags if `--latest`.
+                        // `catalog:` references are left untouched: the version lives in the
+                        // root package.json catalog entry, which is updated by
+                        // `edit_catalogs_before_update`/`edit_catalogs_after_update`.
                         if tag != dependency::Tag::Npm
                             && (tag != dependency::Tag::DistTag
                                 || !manager.options.do_.contains(Do::UPDATE_TO_LATEST))
-                            && tag != dependency::Tag::Catalog
                         {
                             continue;
                         }
@@ -307,7 +309,6 @@ pub(crate) fn edit_update_no_args(
                                 if tag != dependency::Tag::Npm
                                     && (tag != dependency::Tag::DistTag
                                         || !manager.options.do_.contains(Do::UPDATE_TO_LATEST))
-                                    && tag != dependency::Tag::Catalog
                                 {
                                     continue;
                                 }
@@ -386,6 +387,17 @@ pub(crate) fn edit_update_no_args(
                         }
                         let Some(value) = &dep.value else { continue };
                         if !matches!(value.data, bun_ast::ExprData::EString(_)) {
+                            continue;
+                        }
+
+                        // never rewrite a `catalog:` reference; the resolved version is
+                        // written to the root catalog entry instead. This also prevents a
+                        // catalog reference from consuming an `updating_packages` entry
+                        // registered by a same-named dependency in a later group.
+                        let value_literal = value
+                            .as_utf8_string_literal()
+                            .unwrap_or_else(|| bun_core::out_of_memory());
+                        if dependency::Tag::infer(value_literal) == dependency::Tag::Catalog {
                             continue;
                         }
 
@@ -529,6 +541,337 @@ pub(crate) fn edit_update_no_args(
     Ok(())
 }
 
+/// Visits every catalog object in the root package.json, calling `f` with the
+/// catalog group name (empty for the default catalog) and the object holding
+/// its `"name": "version"` entries.
+///
+/// Mirrors the locations `CatalogMap::parse_append` reads: catalogs under
+/// `"workspaces"` win; top-level `"catalog"`/`"catalogs"` are only read when
+/// `"workspaces"` exists but declares none.
+fn for_each_catalog_object(
+    root_package_json: &Expr,
+    mut f: impl FnMut(&[u8], Expr) -> Result<(), bun_alloc::AllocError>,
+) -> Result<(), bun_alloc::AllocError> {
+    let Some(workspaces) = root_package_json.get(b"workspaces") else {
+        return Ok(());
+    };
+
+    for container in [workspaces, *root_package_json] {
+        let mut found_any = false;
+        if let Some(default_catalog) = container.get(b"catalog") {
+            found_any = true;
+            f(b"", default_catalog)?;
+        }
+
+        if let Some(catalogs) = container.get(b"catalogs") {
+            found_any = true;
+            if let bun_ast::ExprData::EObject(groups) = &catalogs.data {
+                for group in groups.properties.slice() {
+                    let Some(key) = &group.key else { continue };
+                    let Some(catalog_name) = key.as_utf8_string_literal() else {
+                        continue;
+                    };
+                    let Some(value) = &group.value else { continue };
+                    f(catalog_name, *value)?;
+                }
+            }
+        }
+
+        if found_any {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+/// `bun update` without package names: record the original version of every
+/// catalog entry in the root package.json so `edit_catalogs_after_update` can
+/// write the resolved versions back once the install finishes. With
+/// `--latest`, the entry is additionally set to `latest` in memory so the
+/// resolver fetches the latest version through the existing `catalog:`
+/// resolution path.
+///
+/// Workspace dependencies keep their `catalog:` references; only the root
+/// catalog entries change.
+pub(crate) fn edit_catalogs_before_update(
+    manager: &mut PackageManager,
+    root_package_json: &Expr,
+) -> Result<bool, bun_alloc::AllocError> {
+    // see note in `edit_update_no_args` — always avoid the store
+    let _guard = ExprDisabler::scope();
+
+    debug_assert!(manager.updating_catalogs.is_empty());
+
+    let update_to_latest = manager.options.do_.contains(Do::UPDATE_TO_LATEST);
+
+    // disjoint-field borrows held across the closure
+    let arena = &manager.ast_arena;
+    let updating_catalogs = &mut manager.updating_catalogs;
+
+    for_each_catalog_object(root_package_json, |catalog_name, mut catalog_expr| {
+        if !matches!(catalog_expr.data, bun_ast::ExprData::EObject(_)) {
+            return Ok(());
+        }
+        for dep in catalog_expr
+            .data
+            .e_object_mut()
+            .expect("infallible: variant checked")
+            .properties
+            .slice_mut()
+        {
+            let Some(key) = &dep.key else { continue };
+            if !matches!(key.data, bun_ast::ExprData::EString(_)) {
+                continue;
+            }
+            let Some(value) = &dep.value else { continue };
+            if !matches!(value.data, bun_ast::ExprData::EString(_)) {
+                continue;
+            }
+
+            let version_literal = value
+                .as_utf8_string_literal()
+                .unwrap_or_else(|| bun_core::out_of_memory());
+            let mut tag = dependency::Tag::infer(version_literal);
+
+            let mut alias_at_index: Option<usize> = None;
+            if strings::trim(version_literal, &strings::WHITESPACE_CHARS).starts_with(b"npm:") {
+                // negative because the real package might have a scope
+                // e.g. "dep": "npm:@foo/bar@1.2.3"
+                if let Some(at_index) = strings::last_index_of_char(version_literal, b'@') {
+                    tag = dependency::Tag::infer(&version_literal[at_index + 1..]);
+                    alias_at_index = Some(at_index);
+                }
+            }
+
+            // only updating catalog entries with npm versions, and dist-tags if
+            // `--latest` — same rule as direct dependencies. Anything else
+            // (workspace:, file:, git…) is left alone.
+            if tag != dependency::Tag::Npm && (tag != dependency::Tag::DistTag || !update_to_latest)
+            {
+                continue;
+            }
+
+            let key_str = key
+                .as_utf8_string_literal()
+                .unwrap_or_else(|| bun_core::out_of_memory());
+
+            updating_catalogs.push(CatalogUpdateInfo {
+                catalog_name: Box::from(catalog_name),
+                dep_name: Box::from(key_str),
+                original_version_literal: Box::from(version_literal),
+                is_alias: alias_at_index.is_some(),
+            });
+
+            if update_to_latest {
+                let temp_version: &[u8] = if let Some(at_index) = alias_at_index {
+                    let mut v = Vec::new();
+                    write!(
+                        &mut v,
+                        "{}@latest",
+                        bstr::BStr::new(&version_literal[0..at_index])
+                    )
+                    .expect("infallible: in-memory write");
+                    arena_str(arena, &v)
+                } else {
+                    b"latest"
+                };
+
+                dep.value = Some(Expr::allocate(
+                    arena,
+                    E::EString::init(temp_version),
+                    bun_ast::Loc::EMPTY,
+                ));
+            }
+        }
+        Ok(())
+    })?;
+
+    Ok(!manager.updating_catalogs.is_empty())
+}
+
+/// Writes the resolved versions back into the root package.json catalog
+/// entries recorded by `edit_catalogs_before_update`, preserving the pinning
+/// style (`^`/`~`/exact) of the original catalog version. Entries that did not
+/// resolve (e.g. not referenced by any workspace dependency) are restored to
+/// their original literal.
+///
+/// Returns whether any entry now differs from its original version.
+pub(crate) fn edit_catalogs_after_update(
+    manager: &mut PackageManager,
+    root_package_json: &Expr,
+    options: EditOptions,
+) -> Result<bool, bun_alloc::AllocError> {
+    // see note in `edit_update_no_args` — always avoid the store
+    let _guard = ExprDisabler::scope();
+
+    let infos = core::mem::take(&mut manager.updating_catalogs);
+    if infos.is_empty() {
+        return Ok(false);
+    }
+
+    let arena = &manager.ast_arena;
+    let lockfile = &*manager.lockfile;
+    let string_buf = lockfile.buffers.string_bytes.as_slice();
+    let package_resolutions = lockfile.packages.items_resolution();
+
+    // Resolve each recorded catalog entry through the first `catalog:`
+    // dependency in the lockfile that references it (all references to the
+    // same entry resolve identically). Single pass over the dependency buffer.
+    let mut new_literals: Vec<Option<Vec<u8>>> = vec![None; infos.len()];
+    debug_assert_eq!(
+        lockfile.buffers.dependencies.len(),
+        lockfile.buffers.resolutions.len()
+    );
+    for (dep, &package_id) in lockfile
+        .buffers
+        .dependencies
+        .iter()
+        .zip(lockfile.buffers.resolutions.iter())
+    {
+        if dep.version.tag != dependency::Tag::Catalog {
+            continue;
+        }
+        if package_id == INVALID_PACKAGE_ID {
+            continue;
+        }
+
+        let dep_name = dep.name.slice(string_buf);
+        let catalog_name = dep.version.catalog().slice(string_buf);
+        let Some(index) = infos.iter().position(|info| {
+            strings::eql_long(&info.dep_name, dep_name, true)
+                && strings::eql_long(&info.catalog_name, catalog_name, true)
+        }) else {
+            continue;
+        };
+        if new_literals[index].is_some() {
+            continue;
+        }
+
+        let resolution = &package_resolutions[package_id as usize];
+        if resolution.tag != resolution::Tag::Npm {
+            continue;
+        }
+
+        if !manager.options.do_.contains(Do::UPDATE_TO_LATEST) {
+            // same rule as direct dependencies: a plain `bun update` does not
+            // move an exact catalog version.
+            let resolved_version = lockfile
+                .resolve_catalog_dependency(dep)
+                .unwrap_or_else(|| dep.version.clone());
+            if let Some(npm_version) = resolved_version.try_npm() {
+                if npm_version.version.is_exact() {
+                    continue;
+                }
+            }
+        }
+
+        let info = &infos[index];
+        let version_fmt = resolution.npm().version.fmt(string_buf);
+        let new_version: Vec<u8> = 'new_version: {
+            if options.exact_versions {
+                let mut v = Vec::new();
+                write!(&mut v, "{}", version_fmt).expect("infallible: in-memory write");
+                break 'new_version v;
+            }
+
+            let version_literal: &[u8] = 'version_literal: {
+                if !info.is_alias {
+                    break 'version_literal &info.original_version_literal;
+                }
+                if let Some(at_index) =
+                    strings::last_index_of_char(&info.original_version_literal, b'@')
+                {
+                    break 'version_literal &info.original_version_literal[at_index + 1..];
+                }
+                &info.original_version_literal
+            };
+
+            let pinned_version = semver::Version::which_version_is_pinned(version_literal);
+            let mut v = Vec::new();
+            match pinned_version {
+                semver::PinnedVersion::Patch => {
+                    write!(&mut v, "{}", version_fmt).expect("infallible: in-memory write")
+                }
+                semver::PinnedVersion::Minor => {
+                    write!(&mut v, "~{}", version_fmt).expect("infallible: in-memory write")
+                }
+                semver::PinnedVersion::Major => {
+                    write!(&mut v, "^{}", version_fmt).expect("infallible: in-memory write")
+                }
+            }
+            v
+        };
+
+        new_literals[index] = Some(if info.is_alias {
+            let dep_literal = &info.original_version_literal;
+            if let Some(at_index) = strings::last_index_of_char(dep_literal, b'@') {
+                let mut v = Vec::new();
+                write!(
+                    &mut v,
+                    "{}@{}",
+                    bstr::BStr::new(&dep_literal[0..at_index]),
+                    bstr::BStr::new(&new_version)
+                )
+                .expect("infallible: in-memory write");
+                v
+            } else {
+                new_version
+            }
+        } else {
+            new_version
+        });
+    }
+
+    let mut changed = false;
+    for_each_catalog_object(root_package_json, |catalog_name, mut catalog_expr| {
+        if !matches!(catalog_expr.data, bun_ast::ExprData::EObject(_)) {
+            return Ok(());
+        }
+        for dep in catalog_expr
+            .data
+            .e_object_mut()
+            .expect("infallible: variant checked")
+            .properties
+            .slice_mut()
+        {
+            let Some(key) = &dep.key else { continue };
+            if !matches!(key.data, bun_ast::ExprData::EString(_)) {
+                continue;
+            }
+            let key_str = key
+                .as_utf8_string_literal()
+                .unwrap_or_else(|| bun_core::out_of_memory());
+
+            let Some(index) = infos.iter().position(|info| {
+                strings::eql_long(&info.dep_name, key_str, true)
+                    && strings::eql_long(&info.catalog_name, catalog_name, true)
+            }) else {
+                continue;
+            };
+
+            let info = &infos[index];
+            let new_literal: &[u8] = match &new_literals[index] {
+                Some(v) => arena_str(arena, v),
+                // unresolved: restore the original literal (the in-memory AST
+                // may still hold the temporary `latest`)
+                None => arena_dup(arena, &info.original_version_literal),
+            };
+
+            changed |= !strings::eql_long(new_literal, &info.original_version_literal, true);
+
+            dep.value = Some(Expr::allocate(
+                arena,
+                E::EString::init(new_literal),
+                bun_ast::Loc::EMPTY,
+            ));
+        }
+        Ok(())
+    })?;
+
+    Ok(changed)
+}
+
 /// edits dependencies and trusted dependencies
 /// if options.add_trusted_dependencies is true, gets list from PackageManager.trusted_deps_to_add_to_package_json
 pub(crate) fn edit(
@@ -593,8 +936,23 @@ pub(crate) fn edit(
 
                             if let Some(value) = query.expr.as_property(name) {
                                 if matches!(value.expr.data, bun_ast::ExprData::EString(_)) {
+                                    // `bun update <pkg>` on a dependency using the `catalog:`
+                                    // protocol keeps the catalog reference instead of replacing
+                                    // it with a resolved range — route it to the "use the
+                                    // existing spot" branch so the final loop (which skips
+                                    // catalog literals) sees the original value.
+                                    let keep_catalog_reference = manager.subcommand
+                                        == Subcommand::Update
+                                        && value.expr.as_utf8_string_literal().is_some_and(
+                                            |version_literal| {
+                                                dependency::Tag::infer(version_literal)
+                                                    == dependency::Tag::Catalog
+                                            },
+                                        );
+
                                     if request.package_id != INVALID_PACKAGE_ID
                                         && strings::eql_long(list, dependency_list, true)
+                                        && !keep_catalog_reference
                                     {
                                         replacing += 1;
                                     } else {
@@ -1091,6 +1449,15 @@ pub(crate) fn edit(
             // derived from a `StoreRef` to the same `E::EString` is live inside this loop body,
             // so this is the sole mutable borrow.
             let e_string = unsafe { &mut *e_string };
+            // `bun update <pkg>` on a dependency using the `catalog:` protocol keeps
+            // the catalog reference; the version is managed by the root catalog entry.
+            // (`bun add <pkg>` still replaces it — adding is an explicit request to
+            // pin a version in this package.)
+            if manager.subcommand == Subcommand::Update
+                && dependency::Tag::infer(e_string.data.slice()) == dependency::Tag::Catalog
+            {
+                continue;
+            }
             if request.package_id as usize >= resolutions.len()
                 || resolutions[request.package_id as usize].tag == resolution::Tag::Uninitialized
             {

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -285,10 +285,7 @@ pub(crate) fn edit_update_no_args(
                             .unwrap_or_else(|| bun_core::out_of_memory());
                         let mut tag = dependency::Tag::infer(version_literal);
 
-                        // only updating dependencies with npm versions, and dist-tags if `--latest`.
-                        // `catalog:` references are left untouched: the version lives in the
-                        // root package.json catalog entry, which is updated by
-                        // `edit_catalogs_before_update`/`edit_catalogs_after_update`.
+                        // npm versions only (and dist-tags with --latest); `catalog:` is handled by edit_catalogs_*.
                         if tag != dependency::Tag::Npm
                             && (tag != dependency::Tag::DistTag
                                 || !manager.options.do_.contains(Do::UPDATE_TO_LATEST))
@@ -390,10 +387,7 @@ pub(crate) fn edit_update_no_args(
                             continue;
                         }
 
-                        // never rewrite a `catalog:` reference; the resolved version is
-                        // written to the root catalog entry instead. This also prevents a
-                        // catalog reference from consuming an `updating_packages` entry
-                        // registered by a same-named dependency in a later group.
+                        // `catalog:` references are never rewritten; the root catalog entry is updated instead.
                         let value_literal = value
                             .as_utf8_string_literal()
                             .unwrap_or_else(|| bun_core::out_of_memory());
@@ -541,13 +535,8 @@ pub(crate) fn edit_update_no_args(
     Ok(())
 }
 
-/// Visits every catalog object in the root package.json, calling `f` with the
-/// catalog group name (empty for the default catalog) and the object holding
-/// its `"name": "version"` entries.
-///
-/// Mirrors the locations `CatalogMap::parse_append` reads: catalogs under
-/// `"workspaces"` win; top-level `"catalog"`/`"catalogs"` are only read when
-/// `"workspaces"` exists but declares none.
+/// Calls `f(catalog_name, entries_object)` for each catalog in the root
+/// package.json, matching the precedence `CatalogMap::parse_append` uses.
 fn for_each_catalog_object(
     root_package_json: &Expr,
     mut f: impl FnMut(&[u8], Expr) -> Result<(), bun_alloc::AllocError>,
@@ -585,15 +574,8 @@ fn for_each_catalog_object(
     Ok(())
 }
 
-/// `bun update` without package names: record the original version of every
-/// catalog entry in the root package.json so `edit_catalogs_after_update` can
-/// write the resolved versions back once the install finishes. With
-/// `--latest`, the entry is additionally set to `latest` in memory so the
-/// resolver fetches the latest version through the existing `catalog:`
-/// resolution path.
-///
-/// Workspace dependencies keep their `catalog:` references; only the root
-/// catalog entries change.
+/// Records the original version of every catalog entry and, with `--latest`,
+/// rewrites each to `latest` in memory so the resolver fetches it.
 pub(crate) fn edit_catalogs_before_update(
     manager: &mut PackageManager,
     root_package_json: &Expr,
@@ -605,7 +587,6 @@ pub(crate) fn edit_catalogs_before_update(
 
     let update_to_latest = manager.options.do_.contains(Do::UPDATE_TO_LATEST);
 
-    // disjoint-field borrows held across the closure
     let arena = &manager.ast_arena;
     let updating_catalogs = &mut manager.updating_catalogs;
 
@@ -636,17 +617,14 @@ pub(crate) fn edit_catalogs_before_update(
 
             let mut alias_at_index: Option<usize> = None;
             if strings::trim(version_literal, &strings::WHITESPACE_CHARS).starts_with(b"npm:") {
-                // negative because the real package might have a scope
-                // e.g. "dep": "npm:@foo/bar@1.2.3"
+                // last '@' handles scoped aliases like "npm:@foo/bar@1.2.3"
                 if let Some(at_index) = strings::last_index_of_char(version_literal, b'@') {
                     tag = dependency::Tag::infer(&version_literal[at_index + 1..]);
                     alias_at_index = Some(at_index);
                 }
             }
 
-            // only updating catalog entries with npm versions, and dist-tags if
-            // `--latest` — same rule as direct dependencies. Anything else
-            // (workspace:, file:, git…) is left alone.
+            // same tag rule as direct dependencies
             if tag != dependency::Tag::Npm && (tag != dependency::Tag::DistTag || !update_to_latest)
             {
                 continue;
@@ -690,13 +668,8 @@ pub(crate) fn edit_catalogs_before_update(
     Ok(!manager.updating_catalogs.is_empty())
 }
 
-/// Writes the resolved versions back into the root package.json catalog
-/// entries recorded by `edit_catalogs_before_update`, preserving the pinning
-/// style (`^`/`~`/exact) of the original catalog version. Entries that did not
-/// resolve (e.g. not referenced by any workspace dependency) are restored to
-/// their original literal.
-///
-/// Returns whether any entry now differs from its original version.
+/// Writes resolved versions back into the recorded catalog entries, preserving
+/// the original pin style. Unresolved entries are restored. Returns `changed`.
 pub(crate) fn edit_catalogs_after_update(
     manager: &mut PackageManager,
     root_package_json: &Expr,
@@ -715,9 +688,6 @@ pub(crate) fn edit_catalogs_after_update(
     let string_buf = lockfile.buffers.string_bytes.as_slice();
     let package_resolutions = lockfile.packages.items_resolution();
 
-    // Resolve each recorded catalog entry through the first `catalog:`
-    // dependency in the lockfile that references it (all references to the
-    // same entry resolve identically). Single pass over the dependency buffer.
     let mut new_literals: Vec<Option<Vec<u8>>> = vec![None; infos.len()];
     debug_assert_eq!(
         lockfile.buffers.dependencies.len(),
@@ -754,8 +724,7 @@ pub(crate) fn edit_catalogs_after_update(
         }
 
         if !manager.options.do_.contains(Do::UPDATE_TO_LATEST) {
-            // same rule as direct dependencies: a plain `bun update` does not
-            // move an exact catalog version.
+            // plain `bun update` does not move an exact pin (matches direct-dep behavior)
             let resolved_version = lockfile
                 .resolve_catalog_dependency(dep)
                 .unwrap_or_else(|| dep.version.clone());
@@ -853,8 +822,7 @@ pub(crate) fn edit_catalogs_after_update(
             let info = &infos[index];
             let new_literal: &[u8] = match &new_literals[index] {
                 Some(v) => arena_str(arena, v),
-                // unresolved: restore the original literal (the in-memory AST
-                // may still hold the temporary `latest`)
+                // unresolved: restore the original (may still be the temporary `latest`)
                 None => arena_dup(arena, &info.original_version_literal),
             };
 
@@ -936,11 +904,7 @@ pub(crate) fn edit(
 
                             if let Some(value) = query.expr.as_property(name) {
                                 if matches!(value.expr.data, bun_ast::ExprData::EString(_)) {
-                                    // `bun update <pkg>` on a dependency using the `catalog:`
-                                    // protocol keeps the catalog reference instead of replacing
-                                    // it with a resolved range — route it to the "use the
-                                    // existing spot" branch so the final loop (which skips
-                                    // catalog literals) sees the original value.
+                                    // `bun update <pkg>` keeps a `catalog:` reference intact.
                                     let keep_catalog_reference = manager.subcommand
                                         == Subcommand::Update
                                         && value.expr.as_utf8_string_literal().is_some_and(
@@ -1449,10 +1413,7 @@ pub(crate) fn edit(
             // derived from a `StoreRef` to the same `E::EString` is live inside this loop body,
             // so this is the sole mutable borrow.
             let e_string = unsafe { &mut *e_string };
-            // `bun update <pkg>` on a dependency using the `catalog:` protocol keeps
-            // the catalog reference; the version is managed by the root catalog entry.
-            // (`bun add <pkg>` still replaces it — adding is an explicit request to
-            // pin a version in this package.)
+            // `bun update <pkg>` keeps a `catalog:` reference; `bun add` still replaces it.
             if manager.subcommand == Subcommand::Update
                 && dependency::Tag::infer(e_string.data.slice()) == dependency::Tag::Catalog
             {

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -23,6 +23,35 @@ use super::{
     attempt_to_create_package_json, install_with_manager, patch_package,
 };
 
+/// Prints `root` and stores the result as the cache entry's source contents,
+/// preserving the entry's indentation and trailing-newline style. Crashes the
+/// process on a print failure (mirrors the other package.json print sites).
+fn print_package_json_into_cache_entry(entry: &mut MapEntry, root: bun_ast::Expr) {
+    let preserve_trailing_newline = entry.source.contents.last() == Some(&b'\n');
+    let mut buffer_writer = js_printer::BufferWriter::init();
+    buffer_writer
+        .buffer
+        .list
+        .reserve((entry.source.contents.len() + 1).saturating_sub(buffer_writer.buffer.list.len()));
+    buffer_writer.append_newline = preserve_trailing_newline;
+    let mut writer = js_printer::BufferPrinter::init(buffer_writer);
+
+    if let Err(e) = js_printer::print_json(
+        &mut writer,
+        root,
+        &entry.source,
+        js_printer::PrintJsonOptions {
+            indent: entry.indentation,
+            mangled_props: None,
+            ..Default::default()
+        },
+    ) {
+        bun_core::pretty_errorln!("package.json failed to write due to error {}", e.name(),);
+        Global::crash();
+    }
+    entry.source.contents = Cow::Owned(writer.ctx.written_without_trailing_zero().to_vec());
+}
+
 pub fn update_package_json_and_install_with_manager(
     manager: &mut PackageManager,
     ctx: Command::Context,
@@ -416,6 +445,10 @@ fn update_package_json_and_install_with_manager_with_updates(
         Global::crash();
     }
 
+    // `bun update --latest` with no package names also updates the versions
+    // declared in the root package.json `catalog`/`catalogs`.
+    let mut editing_catalogs = false;
+
     // may or may not be the package json we are editing
     let top_level_dir_without_trailing_slash =
         strings::without_trailing_slash(FileSystem::instance().top_level_dir());
@@ -514,6 +547,30 @@ fn update_package_json_and_install_with_manager_with_updates(
             );
         }
 
+        if subcommand == Subcommand::Update && manager.update_requests.is_empty() {
+            let root_package_json_root: bun_ast::Expr = root_package_json.root;
+            if PackageJSONEditor::edit_catalogs_before_update(manager, &root_package_json_root)? {
+                editing_catalogs = true;
+
+                // with `--latest`, the catalog entries were set to a temporary
+                // `latest` — re-print the root package.json into the cache
+                // entry so the install below resolves those instead of the
+                // on-disk versions. (Without `--latest` nothing was modified.)
+                if manager.options.do_.contains(Do::UPDATE_TO_LATEST) {
+                    print_package_json_into_cache_entry(root_package_json, root_package_json_root);
+                    // keep the cached AST in sync with the printed source — it
+                    // is consumed by workspace resolution during install.
+                    if let Err(err) = root_package_json.reparse_root(manager.log_mut()) {
+                        bun_core::pretty_errorln!(
+                            "package.json failed to parse due to error {}",
+                            err.name(),
+                        );
+                        Global::crash();
+                    }
+                }
+            }
+        }
+
         // SAFETY: root_package_json_path_buf[root_package_json_path_len] == 0 written above
         break 'root_package_json_path ZStr::from_buf(
             &root_package_json_path_buf[..],
@@ -565,6 +622,20 @@ fn update_package_json_and_install_with_manager_with_updates(
                     ..Default::default()
                 },
             )?;
+
+            if editing_catalogs && manager.workspace_name_hash.is_none() {
+                // the current package.json IS the workspace root: commit the
+                // resolved catalog versions into the same AST before it is
+                // printed and written below.
+                let _ = PackageJSONEditor::edit_catalogs_after_update(
+                    manager,
+                    &new_package_json,
+                    EditOptions {
+                        exact_versions: manager.options.enable.exact_versions(),
+                        ..Default::default()
+                    },
+                )?;
+            }
         } else {
             let mut updates_slice: &mut [UpdateRequest] = &mut updates[..];
             PackageJSONEditor::edit(
@@ -610,6 +681,73 @@ fn update_package_json_and_install_with_manager_with_updates(
             .ctx
             .written_without_trailing_zero()
             .to_vec();
+    }
+
+    if editing_catalogs
+        && manager.workspace_name_hash.is_some()
+        && manager.options.do_.contains(Do::WRITE_PACKAGE_JSON)
+    {
+        // the command ran from a workspace package: the catalogs live in the
+        // root package.json, a different file from the one written below.
+        // reshaped for borrowck — see `current_package_json_ptr` above.
+        let root_package_json_ptr: *mut MapEntry =
+            match manager.workspace_package_json_cache.get_with_path(
+                manager.log_mut(),
+                root_package_json_path.as_bytes(),
+                GetJSONOptions {
+                    guess_indentation: true,
+                    ..Default::default()
+                },
+            ) {
+                GetResult::ParseErr(err) => {
+                    let _ = manager
+                        .log_mut()
+                        .print(std::ptr::from_mut(Output::error_writer()));
+                    Output::err_generic(
+                        "failed to parse package.json \"{s}\": {s}",
+                        (BStr::new(root_package_json_path.as_bytes()), err.name()),
+                    );
+                    Global::crash();
+                }
+                GetResult::ReadErr(err) => {
+                    Output::err_generic(
+                        "failed to read package.json \"{s}\": {s}",
+                        (BStr::new(root_package_json_path.as_bytes()), err.name()),
+                    );
+                    Global::crash();
+                }
+                GetResult::Entry(entry) => core::ptr::from_mut(entry),
+            };
+        // SAFETY: pointer into `manager.workspace_package_json_cache`, valid until
+        // the next `get_with_path`. `edit_catalogs_after_update` touches only
+        // disjoint manager fields.
+        let root_package_json: &mut MapEntry = unsafe { &mut *root_package_json_ptr };
+        let root_package_json_root: bun_ast::Expr = root_package_json.root;
+
+        let root_catalogs_changed = PackageJSONEditor::edit_catalogs_after_update(
+            manager,
+            &root_package_json_root,
+            EditOptions {
+                exact_versions: manager.options.enable.exact_versions(),
+                ..Default::default()
+            },
+        )?;
+
+        if root_catalogs_changed {
+            print_package_json_into_cache_entry(root_package_json, root_package_json_root);
+
+            let root_package_json_file =
+                File::openat(Fd::cwd(), root_package_json_path, bun_sys::O::RDWR, 0)
+                    .map_err(Error::from)?;
+            root_package_json_file
+                .pwrite_all(&root_package_json.source.contents, 0)
+                .map_err(Error::from)?;
+            let _ = bun_sys::ftruncate(
+                root_package_json_file.handle,
+                root_package_json.source.contents.len() as i64,
+            );
+            let _ = root_package_json_file.close(); // close error is non-actionable
+        }
     }
 
     let _ = written;

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -46,7 +46,11 @@ fn print_package_json_into_cache_entry(entry: &mut MapEntry, root: bun_ast::Expr
         bun_core::pretty_errorln!("package.json failed to write due to error {}", e.name(),);
         Global::crash();
     }
-    entry.source.contents = Cow::Owned(writer.ctx.written_without_trailing_zero().to_vec());
+    let old = core::mem::replace(
+        &mut entry.source.contents,
+        Cow::Owned(writer.ctx.written_without_trailing_zero().to_vec()),
+    );
+    entry.stale_contents.push(old);
 }
 
 pub fn update_package_json_and_install_with_manager(

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -548,8 +548,7 @@ fn update_package_json_and_install_with_manager_with_updates(
                 editing_catalogs = true;
 
                 if manager.options.do_.contains(Do::UPDATE_TO_LATEST) {
-                    // catalog entries now hold a temporary `latest`; re-print into the
-                    // cache entry so install resolves those, then re-parse to keep the AST in sync.
+                    // entries now hold a temporary `latest`; refresh the cache so install resolves those.
                     print_package_json_into_cache_entry(root_package_json, root_package_json_root);
                     if let Err(err) = root_package_json.reparse_root(manager.log_mut()) {
                         bun_core::pretty_errorln!(

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -23,9 +23,6 @@ use super::{
     attempt_to_create_package_json, install_with_manager, patch_package,
 };
 
-/// Prints `root` and stores the result as the cache entry's source contents,
-/// preserving the entry's indentation and trailing-newline style. Crashes the
-/// process on a print failure (mirrors the other package.json print sites).
 fn print_package_json_into_cache_entry(entry: &mut MapEntry, root: bun_ast::Expr) {
     let preserve_trailing_newline = entry.source.contents.last() == Some(&b'\n');
     let mut buffer_writer = js_printer::BufferWriter::init();
@@ -445,8 +442,6 @@ fn update_package_json_and_install_with_manager_with_updates(
         Global::crash();
     }
 
-    // `bun update --latest` with no package names also updates the versions
-    // declared in the root package.json `catalog`/`catalogs`.
     let mut editing_catalogs = false;
 
     // may or may not be the package json we are editing
@@ -552,14 +547,10 @@ fn update_package_json_and_install_with_manager_with_updates(
             if PackageJSONEditor::edit_catalogs_before_update(manager, &root_package_json_root)? {
                 editing_catalogs = true;
 
-                // with `--latest`, the catalog entries were set to a temporary
-                // `latest` — re-print the root package.json into the cache
-                // entry so the install below resolves those instead of the
-                // on-disk versions. (Without `--latest` nothing was modified.)
                 if manager.options.do_.contains(Do::UPDATE_TO_LATEST) {
+                    // catalog entries now hold a temporary `latest`; re-print into the
+                    // cache entry so install resolves those, then re-parse to keep the AST in sync.
                     print_package_json_into_cache_entry(root_package_json, root_package_json_root);
-                    // keep the cached AST in sync with the printed source — it
-                    // is consumed by workspace resolution during install.
                     if let Err(err) = root_package_json.reparse_root(manager.log_mut()) {
                         bun_core::pretty_errorln!(
                             "package.json failed to parse due to error {}",
@@ -624,9 +615,7 @@ fn update_package_json_and_install_with_manager_with_updates(
             )?;
 
             if editing_catalogs && manager.workspace_name_hash.is_none() {
-                // the current package.json IS the workspace root: commit the
-                // resolved catalog versions into the same AST before it is
-                // printed and written below.
+                // running from root: catalogs live in this file.
                 let _ = PackageJSONEditor::edit_catalogs_after_update(
                     manager,
                     &new_package_json,
@@ -687,9 +676,7 @@ fn update_package_json_and_install_with_manager_with_updates(
         && manager.workspace_name_hash.is_some()
         && manager.options.do_.contains(Do::WRITE_PACKAGE_JSON)
     {
-        // the command ran from a workspace package: the catalogs live in the
-        // root package.json, a different file from the one written below.
-        // reshaped for borrowck — see `current_package_json_ptr` above.
+        // running from a workspace: catalogs live in the root package.json (a separate file).
         let root_package_json_ptr: *mut MapEntry =
             match manager.workspace_package_json_cache.get_with_path(
                 manager.log_mut(),

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -356,21 +356,24 @@ describe("update", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("--latest --dry-run does not modify any package.json", async () => {
-    const { packageDir } = await registry.createTestDir();
-    await createUpdateMonorepo(packageDir, "catalog-update-dry-run");
-    await runBunInstall(bunEnv, packageDir);
+  for (const fromWorkspace of [false, true]) {
+    test(`--latest --dry-run does not modify any package.json (from ${fromWorkspace ? "workspace" : "root"})`, async () => {
+      const { packageDir } = await registry.createTestDir();
+      await createUpdateMonorepo(packageDir, `catalog-update-dry-run-${fromWorkspace ? "ws" : "root"}`);
+      await runBunInstall(bunEnv, packageDir);
 
-    const rootBefore = await file(join(packageDir, "package.json")).text();
-    const pkg1Before = await file(join(packageDir, "packages", "pkg1", "package.json")).text();
+      const rootBefore = await file(join(packageDir, "package.json")).text();
+      const pkg1Before = await file(join(packageDir, "packages", "pkg1", "package.json")).text();
 
-    const { err, exitCode } = await runUpdate(packageDir, "--latest", "--dry-run");
-    expect(err).not.toContain("error:");
+      const cwd = fromWorkspace ? join(packageDir, "packages", "pkg1") : packageDir;
+      const { err, exitCode } = await runUpdate(cwd, "--latest", "--dry-run");
+      expect(err).not.toContain("error:");
 
-    expect(await file(join(packageDir, "package.json")).text()).toBe(rootBefore);
-    expect(await file(join(packageDir, "packages", "pkg1", "package.json")).text()).toBe(pkg1Before);
-    expect(exitCode).toBe(0);
-  });
+      expect(await file(join(packageDir, "package.json")).text()).toBe(rootBefore);
+      expect(await file(join(packageDir, "packages", "pkg1", "package.json")).text()).toBe(pkg1Before);
+      expect(exitCode).toBe(0);
+    });
+  }
 
   test("update without --latest stays in range and keeps catalog references", async () => {
     const { packageDir } = await registry.createTestDir();

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -167,6 +167,257 @@ describe("basic", () => {
   }
 });
 
+describe("update", () => {
+  async function createUpdateMonorepo(packageDir: string, name: string, inTopLevelKey: boolean = false) {
+    const catalogs = {
+      catalog: {
+        "no-deps": "^1.0.0",
+      },
+      catalogs: {
+        a: {
+          "a-dep": "~1.0.1",
+        },
+      },
+    };
+    const packageJson = !inTopLevelKey
+      ? {
+          name,
+          workspaces: {
+            packages: ["packages/*"],
+            ...catalogs,
+          },
+        }
+      : {
+          name,
+          ...catalogs,
+          workspaces: {
+            packages: ["packages/*"],
+          },
+        };
+
+    await Promise.all([
+      write(join(packageDir, "package.json"), JSON.stringify(packageJson)),
+      write(
+        join(packageDir, "packages", "pkg1", "package.json"),
+        JSON.stringify({
+          name: "pkg1",
+          dependencies: {
+            "no-deps": "catalog:",
+            "a-dep": "catalog:a",
+          },
+        }),
+      ),
+    ]);
+
+    return packageJson;
+  }
+
+  async function runUpdate(cwd: string, ...args: string[]) {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "update", ...args],
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    return { out, err: stderrForInstall(err), exitCode };
+  }
+
+  // https://github.com/oven-sh/bun/issues/23739
+  for (const [flags, label] of [
+    [["--latest"], "in top-level"],
+    [["--latest"], "in workspaces"],
+    [["-r", "--latest"], "with -r"],
+  ] as const) {
+    const isTopLevel = label === "in top-level";
+    test(`--latest updates catalog versions ${label}`, async () => {
+      const { packageDir } = await registry.createTestDir();
+      await createUpdateMonorepo(packageDir, `catalog-update-latest-${label.replace(/\W+/g, "-")}`, isTopLevel);
+      await runBunInstall(bunEnv, packageDir);
+
+      const { err, exitCode } = await runUpdate(packageDir, ...flags);
+      expect(err).not.toContain("error:");
+
+      // catalog entries are updated, preserving the pinning style
+      const root = await file(join(packageDir, "package.json")).json();
+      const { catalog, catalogs } = isTopLevel ? root : root.workspaces;
+      expect(catalog).toEqual({ "no-deps": "^2.0.0" });
+      expect(catalogs).toEqual({ a: { "a-dep": "~1.0.10" } });
+
+      // workspace packages keep their catalog references
+      expect((await file(join(packageDir, "packages", "pkg1", "package.json")).json()).dependencies).toEqual({
+        "no-deps": "catalog:",
+        "a-dep": "catalog:a",
+      });
+
+      // the new versions are installed
+      expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+        name: "no-deps",
+        version: "2.0.0",
+      });
+      expect((await file(join(packageDir, "node_modules", "a-dep", "package.json")).json()).version).toBe("1.0.10");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test("--latest run from inside a workspace package updates the root catalog", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await createUpdateMonorepo(packageDir, "catalog-update-in-workspace");
+    await runBunInstall(bunEnv, packageDir);
+
+    const { err, exitCode } = await runUpdate(join(packageDir, "packages", "pkg1"), "--latest");
+    expect(err).not.toContain("error:");
+
+    const root = await file(join(packageDir, "package.json")).json();
+    expect(root.workspaces.catalog).toEqual({ "no-deps": "^2.0.0" });
+    expect(root.workspaces.catalogs).toEqual({ a: { "a-dep": "~1.0.10" } });
+
+    expect((await file(join(packageDir, "packages", "pkg1", "package.json")).json()).dependencies).toEqual({
+      "no-deps": "catalog:",
+      "a-dep": "catalog:a",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("--latest updates the same package independently per catalog", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "catalog-update-identity",
+          workspaces: {
+            packages: ["packages/*"],
+            catalog: {
+              "no-deps": "^1.0.0",
+            },
+            catalogs: {
+              pinned: {
+                "no-deps": "1.0.1",
+              },
+              unused: {
+                "no-deps": "1.0.0",
+              },
+            },
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg1", "package.json"),
+        JSON.stringify({
+          name: "pkg1",
+          dependencies: {
+            "no-deps": "catalog:",
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg2", "package.json"),
+        JSON.stringify({
+          name: "pkg2",
+          dependencies: {
+            "no-deps": "catalog:pinned",
+          },
+        }),
+      ),
+    ]);
+    await runBunInstall(bunEnv, packageDir);
+
+    const { err, exitCode } = await runUpdate(packageDir, "--latest");
+    expect(err).not.toContain("error:");
+
+    const root = await file(join(packageDir, "package.json")).json();
+    // each catalog entry keeps its own pinning style
+    expect(root.workspaces.catalog).toEqual({ "no-deps": "^2.0.0" });
+    expect(root.workspaces.catalogs.pinned).toEqual({ "no-deps": "2.0.0" });
+    // entries not referenced by any workspace are left unchanged
+    expect(root.workspaces.catalogs.unused).toEqual({ "no-deps": "1.0.0" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("--latest --dry-run does not modify any package.json", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await createUpdateMonorepo(packageDir, "catalog-update-dry-run");
+    await runBunInstall(bunEnv, packageDir);
+
+    const rootBefore = await file(join(packageDir, "package.json")).text();
+    const pkg1Before = await file(join(packageDir, "packages", "pkg1", "package.json")).text();
+
+    const { err, exitCode } = await runUpdate(packageDir, "--latest", "--dry-run");
+    expect(err).not.toContain("error:");
+
+    expect(await file(join(packageDir, "package.json")).text()).toBe(rootBefore);
+    expect(await file(join(packageDir, "packages", "pkg1", "package.json")).text()).toBe(pkg1Before);
+    expect(exitCode).toBe(0);
+  });
+
+  test("update without --latest stays in range and keeps catalog references", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "catalog-update-no-latest",
+          workspaces: {
+            packages: ["packages/*"],
+            catalog: {
+              "no-deps": "^1.0.0",
+            },
+            catalogs: {
+              pinned: {
+                "a-dep": "1.0.1",
+              },
+            },
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg1", "package.json"),
+        JSON.stringify({
+          name: "pkg1",
+          dependencies: {
+            "no-deps": "catalog:",
+            "a-dep": "catalog:pinned",
+          },
+        }),
+      ),
+    ]);
+    await runBunInstall(bunEnv, packageDir);
+
+    const { err, exitCode } = await runUpdate(join(packageDir, "packages", "pkg1"));
+    expect(err).not.toContain("error:");
+
+    const root = await file(join(packageDir, "package.json")).json();
+    // ranges move within the range (latest of ^1.0.0 is 1.1.0, not 2.0.0)...
+    expect(root.workspaces.catalog).toEqual({ "no-deps": "^1.1.0" });
+    // ...and exact versions are not moved by a plain `bun update`
+    expect(root.workspaces.catalogs).toEqual({ pinned: { "a-dep": "1.0.1" } });
+
+    expect((await file(join(packageDir, "packages", "pkg1", "package.json")).json()).dependencies).toEqual({
+      "no-deps": "catalog:",
+      "a-dep": "catalog:pinned",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("update <pkg> --latest keeps the catalog reference", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await createUpdateMonorepo(packageDir, "catalog-update-targeted");
+    await runBunInstall(bunEnv, packageDir);
+
+    const { err, exitCode } = await runUpdate(join(packageDir, "packages", "pkg1"), "no-deps", "--latest");
+    expect(err).not.toContain("error:");
+
+    expect((await file(join(packageDir, "packages", "pkg1", "package.json")).json()).dependencies).toEqual({
+      "no-deps": "catalog:",
+      "a-dep": "catalog:a",
+    });
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("errors", () => {
   test("fails gracefully when no catalog is found for a package", async () => {
     const { packageDir, packageJson } = await registry.createTestDir();

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -262,6 +262,25 @@ describe("update", () => {
     });
   }
 
+  test("--frozen-lockfile passes after --latest updates catalogs", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await createUpdateMonorepo(packageDir, "catalog-update-frozen");
+    await runBunInstall(bunEnv, packageDir);
+    await runUpdate(packageDir, "--latest");
+
+    const { exited, stderr } = spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const err = stderrForInstall(await stderr.text());
+    expect(err).not.toContain("lockfile had changes");
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+  });
+
   test("--latest run from inside a workspace package updates the root catalog", async () => {
     const { packageDir } = await registry.createTestDir();
     await createUpdateMonorepo(packageDir, "catalog-update-in-workspace");

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -268,17 +268,18 @@ describe("update", () => {
     await runBunInstall(bunEnv, packageDir);
     await runUpdate(packageDir, "--latest");
 
-    const { exited, stderr } = spawn({
+    const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "install", "--frozen-lockfile"],
       cwd: packageDir,
       stdout: "pipe",
       stderr: "pipe",
       env: bunEnv,
     });
-    const err = stderrForInstall(await stderr.text());
+    const [, errText, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    const err = stderrForInstall(errText);
     expect(err).not.toContain("lockfile had changes");
     expect(err).not.toContain("error:");
-    expect(await exited).toBe(0);
+    expect(exitCode).toBe(0);
   });
 
   test("--latest run from inside a workspace package updates the root catalog", async () => {

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -266,7 +266,11 @@ describe("update", () => {
     const { packageDir } = await registry.createTestDir();
     await createUpdateMonorepo(packageDir, "catalog-update-frozen");
     await runBunInstall(bunEnv, packageDir);
-    await runUpdate(packageDir, "--latest");
+
+    const update = await runUpdate(packageDir, "--latest");
+    expect(update.err).not.toContain("error:");
+    expect(update.exitCode).toBe(0);
+    expect((await file(join(packageDir, "package.json")).json()).workspaces.catalog).toEqual({ "no-deps": "^2.0.0" });
 
     const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "install", "--frozen-lockfile"],

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1835,7 +1835,11 @@ export class VerdaccioRegistry {
 
   async start(silent: boolean = true) {
     await rm(join(dirname(this.configPath), "htpasswd"), { force: true });
-    this.process = fork(require.resolve("verdaccio/bin/verdaccio"), ["-c", this.configPath, "-l", `${this.port}`], {
+    // Bind the IPv4 loopback explicitly: a bare port makes verdaccio listen on
+    // whatever `localhost` resolves to, which is `::1` on hosts that list it first,
+    // while the install client connects to 127.0.0.1 and every request is refused.
+    const listen = `127.0.0.1:${this.port}`;
+    this.process = fork(require.resolve("verdaccio/bin/verdaccio"), ["-c", this.configPath, "-l", listen], {
       silent,
       // Prefer using a release build of Bun since it's faster
       execPath: isCI ? bunExe() : Bun.which("bun") || bunExe(),


### PR DESCRIPTION
Fixes #23739
Fixes #21852

## Problem

In a workspace using a catalog, non-interactive `bun update` never touched the `catalog`/`catalogs` entries in the root package.json:

```jsonc
// root package.json
{ "workspaces": { "packages": ["packages/*"], "catalog": { "lodash": "4.17.0" } } }
// packages/app/package.json
{ "dependencies": { "lodash": "catalog:" } }
```

```console
$ bun update -r --latest
# "no changes" — catalog.lodash still 4.17.0
```

Worse, running `bun update --latest` from inside a workspace package rewrote the `catalog:` reference to `^<version>`, silently detaching it from the catalog. Interactive mode (`bun update -r -i`) already handled both correctly.

**Root cause:** `edit_update_no_args` only iterates the four dependency groups of the current package.json; it never looks at `catalog`/`catalogs`. When it does encounter a `catalog:` value (running inside a workspace), it treats it like an npm dependency, registers it in `updating_packages`, and writes the resolved range back over the `catalog:` literal. Nothing ever edits the root catalog objects.

## Fix

In `PackageJSONEditor.rs`:

* `catalog:`-tagged dependencies are excluded from the value-rewrite paths (`edit_update_no_args` before/after install, and the `bun update <pkg>` path in `edit`).
* New `edit_catalogs_before_update` / `edit_catalogs_after_update` walk the root `catalog`/`catalogs` objects (under `workspaces` or at the top level, matching `CatalogMap::parse_append`). With `--latest` the entries are set to a temporary `latest` in the cached root package.json so the resolver fetches the newest version through the existing `catalog:` resolution path; after install the resolved version is written back preserving the `^`/`~`/exact pin. Without `--latest`, ranges move within range and exact pins stay, matching direct-dependency behavior.

`updatePackageJSONAndInstall.rs` calls these around the install and handles both run-from-root and run-from-inside-a-workspace (the root package.json is a different file in the second case and is written separately), honoring `--dry-run`/`--no-save`. Identity is `(catalog name, dependency name)`, so the same package in multiple catalogs updates independently; entries not referenced by any workspace stay untouched.

`bun add <pkg>` still replaces a `catalog:` reference (adding is an explicit request to pin a version in that package). `bun update <pkg>` on a `catalog:` reference keeps the reference and re-resolves within the catalog range; bumping the catalog entry from a named update is #32808 / #32810 territory.

This PR adopts #32064 (thank you @CarlosZiegler) on current main with a small test addition for the `-r` flag from #23739.

Also includes a harness fix: bind the verdaccio test registry to `127.0.0.1` explicitly. A bare port makes verdaccio listen on whatever `localhost` resolves to (`::1` on hosts that list it first) while the install client connects to `127.0.0.1`, refusing every request.

## Tests

`test/cli/install/catalogs.test.ts` (new `describe("update")`, verdaccio registry):

- `--latest` updates default + named catalogs, top-level and `workspaces.*` locations, with and without `-r`
- run from inside a workspace package updates the root catalog and keeps `catalog:` refs
- same package in default + named catalogs updates independently; unreferenced entries unchanged
- plain `bun update` stays in range, does not move exact pins, keeps refs
- `bun update <pkg> --latest` keeps the catalog reference
- `--dry-run` writes nothing

Fail-before with src/ reverted: 7/8 new tests fail (catalog unchanged, `catalog:` overwritten with `^2.0.0`). With the fix: 14/14 pass (including the four pre-existing catalog tests). `bun-update.test.ts` 6/6, `bun-add.test.ts` 54/54, `bun-install-registry.test.ts -t update` 16 pass + 1 todo.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/catalogs.test.ts
bun test v1.4.0 (75bcb995c)

test/cli/install/catalogs.test.ts:
(pass) basic > both catalog and catalogs in top-level [587.35ms]
(pass) basic > both catalog and catalogs in workspaces [457.07ms]
(pass) basic > detect changes (bun.lockb) [803.98ms]
(pass) basic > detect changes (bun.lock) [881.35ms]
241 |       expect(err).not.toContain("error:");
242 | 
243 |       // catalog entries are updated, preserving the pinning style
244 |       const root = await file(join(packageDir, "package.json")).json();
245 |       const { catalog, catalogs } = isTopLevel ? root : root.workspaces;
246 |       expect(catalog).toEqual({ "no-deps": "^2.0.0" });
                            ^
error: expect(received).toEqual(expected)

  {
-   "no-deps": "^2.0.0",
+   "no-deps": "^1.0.0",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/cli/install/catalogs.test.ts:246:23)
(fail) update > --latest updates catalog versions in top-level [584.67ms]
241 |       expect(err).not.toContain("error:");
24
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3bfb037b9)

test/cli/install/catalogs.test.ts:
(pass) basic > both catalog and catalogs in top-level [70.22ms]
(pass) basic > both catalog and catalogs in workspaces [27.96ms]
(pass) basic > detect changes (bun.lockb) [45.77ms]
(pass) basic > detect changes (bun.lock) [43.93ms]
(pass) update > --latest updates catalog versions in top-level [50.49ms]
(pass) update > --latest updates catalog versions in workspaces [41.35ms]
(pass) update > --latest updates catalog versions with -r [43.70ms]
(pass) update > --frozen-lockfile passes after --latest updates catalogs [44.07ms]
(pass) update > --latest run from inside a workspace package updates the root catalog [38.69ms]
(pass) update > --latest updates the same package independently per catalog [34.68ms]
(pass) update > --latest --dry-run does not modify any package.json (from root) [34.78ms]
(pass) update > --latest --dry-run does not modify any package.json (from workspace) [58.05ms]
(pass) update > update without --latest stays in range and keeps catalog references [39.07ms]
(pass) update > update <pkg> --latest keeps the catalog reference [56.67ms]
(pass) errors > fails gracefully when no cat
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/catalogs.test.ts
bun test v1.4.0 (75bcb995c)

test/cli/install/catalogs.test.ts:
(pass) basic > both catalog and catalogs in top-level [433.37ms]
(pass) basic > both catalog and catalogs in workspaces [331.82ms]
(pass) basic > detect changes (bun.lockb) [537.51ms]
(pass) basic > detect changes (bun.lock) [552.37ms]
(pass) update > --latest updates catalog versions in top-level [445.45ms]
(pass) update > --latest updates catalog versions in workspaces [399.59ms]
(pass) update > --latest updates catalog versions with -r [404.73ms]
(pass) update > --frozen-lockfile passes after --latest updates catalogs [558.91ms]
(pass) update > --latest run from inside a workspace package updates the root catalog [386.68ms]
(pass) update > --latest updates the same package independently per catalog [411.74ms]
(pass) update > --latest --dry-run does not modify any package.json (from root) [379.27ms]
(pass) update > --latest --dry-run does not modify any package.json (from workspace) [396.85ms]
(pass) update > update without --latest stay
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 695ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager.rs                      |  13 +
 src/install/PackageManager/PackageJSONEditor.rs    | 336 ++++++++++++++++++++-
 .../PackageManager/updatePackageJSONAndInstall.rs  | 128 ++++++++
 test/cli/install/catalogs.test.ts                  | 278 +++++++++++++++++
 test/harness.ts                                    |   6 +-
 5 files changed, 756 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/install/PackageManager.rs                                 2      1      0
src/install/PackageManager/PackageJSONEditor.rs               9      8      0
…c/install/PackageManager/updatePackageJSONAndInstall.rs      8      7      0
test/cli/install/catalogs.test.ts                             3      5      0
test/harness.ts                                               2      1      0
```

</details>

<!-- robobun:evidence:end -->