### PR TITLE
sql(mysql): default CLIENT_MULTI_STATEMENTS off, add `multipleStatements` option

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -630,6 +630,10 @@ const sql = new SQL({
   //   cert: "path/to/cert.pem",
   // },
 
+  // Allow semicolon-separated statements in sql.unsafe() / .simple().
+  // Off by default so a string injection cannot escalate to stacked queries.
+  multipleStatements: false,
+
   // Callbacks
   onconnect: client => {
     console.log("Connected to MySQL");
@@ -1226,10 +1230,13 @@ const [users, orders, products] = await Promise.all([
 
 #### Multiple Result Sets
 
-MySQL can return multiple result sets from multi-statement queries:
+MySQL can return multiple result sets from multi-statement queries. Because stacked queries amplify the impact of SQL injection, `CLIENT_MULTI_STATEMENTS` is not advertised by default; opt in per connection with `multipleStatements: true` (the same option name `mysql2` uses):
 
 ```ts
-const mysql = new SQL("mysql://user:pass@localhost/mydb");
+const mysql = new SQL({
+  url: "mysql://user:pass@localhost/mydb",
+  multipleStatements: true,
+});
 
 // Multi-statement queries with simple() method
 const multiResults = await mysql`
@@ -1237,6 +1244,8 @@ const multiResults = await mysql`
   SELECT * FROM orders WHERE user_id = 1;
 `.simple();
 ```
+
+Stored procedures that return multiple result sets work regardless of this option: `CLIENT_MULTI_RESULTS` stays enabled.
 
 #### Character Sets & Collations
 

--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -389,6 +389,18 @@ declare module "bun" {
        * @default false
        */
       allowPublicKeyRetrieval?: boolean | undefined;
+
+      /**
+       * MySQL only. Advertise `CLIENT_MULTI_STATEMENTS` in the handshake so a
+       * single `sql.unsafe()` / `.simple()` string may contain multiple
+       * semicolon-separated statements. Disabled by default as defence in
+       * depth: with it off, a string injection that reaches the text protocol
+       * cannot escalate to stacked queries. `CLIENT_MULTI_RESULTS` remains
+       * enabled regardless, so stored procedures that return multiple result
+       * sets keep working.
+       * @default false
+       */
+      multipleStatements?: boolean | undefined;
     }
 
     /**

--- a/src/js/internal/sql/mysql.ts
+++ b/src/js/internal/sql/mysql.ts
@@ -108,6 +108,7 @@ export interface MySQLDotZig {
     maxLifetime: number,
     useUnnamedPreparedStatements: boolean,
     allowPublicKeyRetrieval: boolean,
+    multipleStatements: boolean,
   ) => $ZigGeneratedClasses.MySQLConnection;
   createQuery: (
     sql: string,

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -838,7 +838,8 @@ function closeNT(onClose: (err: Error) => void, err: Error | null) {
  * Resolves the password (which may be a function and/or a promise) and calls
  * the driver's native createConnection with the normalized pool options.
  * Extra trailing arguments past `useUnnamedPreparedStatements` (MySQL's
- * `allowPublicKeyRetrieval`) are ignored by drivers that don't take them.
+ * `allowPublicKeyRetrieval`, `multipleStatements`) are ignored by drivers
+ * that don't take them.
  */
 async function createPooledConnectionHandle<ConnectionHandle>(
   nativeCreateConnection: (...args: any[]) => ConnectionHandle,
@@ -860,6 +861,7 @@ async function createPooledConnectionHandle<ConnectionHandle>(
     prepare = true,
     path,
     allowPublicKeyRetrieval = false,
+    multipleStatements = false,
   } = options;
 
   let password: Bun.MaybePromise<string> | string | undefined | (() => Bun.MaybePromise<string>) = options.password;
@@ -894,6 +896,7 @@ async function createPooledConnectionHandle<ConnectionHandle>(
       maxLifetime,
       !prepare,
       !!allowPublicKeyRetrieval,
+      !!multipleStatements,
     );
   } catch (e) {
     // defer so the callback never runs while the adapter is still filling
@@ -2061,6 +2064,7 @@ function parseOptions(
     tls,
     prepare,
     allowPublicKeyRetrieval: options.allowPublicKeyRetrieval === true,
+    multipleStatements: options.multipleStatements === true,
     bigint,
     sslMode,
     query,

--- a/src/sql/mysql/Capabilities.rs
+++ b/src/sql/mysql/Capabilities.rs
@@ -116,13 +116,9 @@ impl Capabilities {
             CLIENT_CONNECT_WITH_DB: has_db_name,
             CLIENT_DEPRECATE_EOF: true,
             CLIENT_SSL: ssl,
-            // Defence in depth: off by default so a string injection that
-            // reaches COM_QUERY cannot escalate to stacked queries. Opted in
-            // via the `multipleStatements` connection option (mirrors mysql2,
-            // go-sql-driver/mysql, mysqlclient). CLIENT_MULTI_RESULTS stays
-            // on unconditionally so stored procedures that return multiple
-            // result sets keep working.
+            // Opt-in (`multipleStatements`): off by default so COM_QUERY injection can't stack queries.
             CLIENT_MULTI_STATEMENTS: multiple_statements,
+            // Always on so stored procedures can return multiple result sets.
             CLIENT_MULTI_RESULTS: true,
             ..Default::default()
         }

--- a/src/sql/mysql/Capabilities.rs
+++ b/src/sql/mysql/Capabilities.rs
@@ -104,7 +104,11 @@ impl Capabilities {
         Self::from_int(self.to_int() & other.to_int())
     }
 
-    pub fn get_default_capabilities(ssl: bool, has_db_name: bool) -> Capabilities {
+    pub fn get_default_capabilities(
+        ssl: bool,
+        has_db_name: bool,
+        multiple_statements: bool,
+    ) -> Capabilities {
         Capabilities {
             CLIENT_PROTOCOL_41: true,
             CLIENT_PLUGIN_AUTH: true,
@@ -112,7 +116,13 @@ impl Capabilities {
             CLIENT_CONNECT_WITH_DB: has_db_name,
             CLIENT_DEPRECATE_EOF: true,
             CLIENT_SSL: ssl,
-            CLIENT_MULTI_STATEMENTS: true,
+            // Defence in depth: off by default so a string injection that
+            // reaches COM_QUERY cannot escalate to stacked queries. Opted in
+            // via the `multipleStatements` connection option (mirrors mysql2,
+            // go-sql-driver/mysql, mysqlclient). CLIENT_MULTI_RESULTS stays
+            // on unconditionally so stored procedures that return multiple
+            // result sets keep working.
+            CLIENT_MULTI_STATEMENTS: multiple_statements,
             CLIENT_MULTI_RESULTS: true,
             ..Default::default()
         }

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -516,6 +516,7 @@ impl JSMySQLConnection {
         // MySQL doesn't support unnamed prepared statements
         let _ = use_unnamed_prepared_statements;
         let allow_public_key_retrieval = callframe.argument(15).to_boolean();
+        let multiple_statements = callframe.argument(16).to_boolean();
 
         // Ownership transferred into `ptr.connection`; disarm the errdefer so the
         // connect-fail `ptr.deref()` is the sole cleanup path from here on.
@@ -537,6 +538,7 @@ impl JSMySQLConnection {
                 secure,
                 args.ssl_mode,
                 allow_public_key_retrieval,
+                multiple_statements,
             )),
             auto_flusher: JsCell::new(AutoFlusher::default()),
             idle_timeout_interval_ms: u32::try_from(idle_timeout).expect("int cast"),

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -87,6 +87,7 @@ pub struct MySQLConnection {
     tls_status: TLSStatus,
     ssl_mode: SSLMode,
     allow_public_key_retrieval: bool,
+    multiple_statements: bool,
     flags: ConnectionFlags,
 }
 
@@ -119,6 +120,7 @@ impl Default for MySQLConnection {
             tls_status: TLSStatus::None,
             ssl_mode: SSLMode::Disable,
             allow_public_key_retrieval: false,
+            multiple_statements: false,
             flags: ConnectionFlags::default(),
         }
     }
@@ -139,6 +141,7 @@ impl MySQLConnection {
         secure: Option<*mut SslCtx>,
         ssl_mode: SSLMode,
         allow_public_key_retrieval: bool,
+        multiple_statements: bool,
     ) -> Self {
         Self {
             database,
@@ -153,6 +156,7 @@ impl MySQLConnection {
             secure,
             ssl_mode,
             allow_public_key_retrieval,
+            multiple_statements,
             tls_status: if ssl_mode != SSLMode::Disable {
                 TLSStatus::Pending
             } else {
@@ -644,6 +648,7 @@ impl MySQLConnection {
         self.capabilities = Capabilities::get_default_capabilities(
             self.ssl_mode != SSLMode::Disable,
             !self.database.is_empty(),
+            self.multiple_statements,
         )
         .intersect(handshake.capability_flags);
 

--- a/test/js/sql/sql-mysql-multi-statements.test.ts
+++ b/test/js/sql/sql-mysql-multi-statements.test.ts
@@ -1,0 +1,97 @@
+// Fault-injection test: requires a server that refuses / drops / sends malformed
+// frames, which a healthy container will not do on demand. DO NOT COPY THIS
+// PATTERN — anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import {
+  listeningServer,
+  MYSQL_CLIENT_CONNECT_WITH_DB,
+  MYSQL_CLIENT_MULTI_RESULTS,
+  MYSQL_CLIENT_MULTI_STATEMENTS,
+  MYSQL_DEFAULT_CAPABILITIES,
+  mysqlHandshakeV10,
+  mysqlOkPacket,
+  mysqlReadPackets,
+} from "./wire-frames";
+
+// The mock server advertises CLIENT_MULTI_STATEMENTS so the client is free to
+// request it. CLIENT_CONNECT_WITH_DB is also advertised so the client can send
+// the database name inline rather than issuing a COM_INIT_DB afterwards.
+const SERVER_CAPABILITIES =
+  MYSQL_DEFAULT_CAPABILITIES |
+  MYSQL_CLIENT_CONNECT_WITH_DB |
+  MYSQL_CLIENT_MULTI_STATEMENTS |
+  MYSQL_CLIENT_MULTI_RESULTS;
+
+async function captureHandshakeCapabilities(options: Bun.SQL.Options): Promise<number> {
+  const captured = Promise.withResolvers<number>();
+  const greeting = mysqlHandshakeV10({ capabilities: SERVER_CAPABILITIES });
+
+  const { port, server } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let seen = false;
+    socket.write(greeting);
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (seen) return;
+        seen = true;
+        // HandshakeResponse41 starts with the client's Int<4> capability flags.
+        captured.resolve(payload.readUInt32LE(0));
+        socket.write(mysqlOkPacket(seq + 1));
+      });
+    });
+    socket.on("error", () => {});
+  });
+
+  try {
+    await using sql = new SQL({
+      adapter: "mysql",
+      hostname: "127.0.0.1",
+      port,
+      username: "root",
+      password: "pw",
+      database: "db",
+      max: 1,
+      ...options,
+    });
+    await sql.connect();
+    return await captured.promise;
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}
+
+test("MySQL: CLIENT_MULTI_STATEMENTS is not advertised by default", async () => {
+  const caps = await captureHandshakeCapabilities({});
+  // Stacked-query support must be opt-in: every mainstream MySQL client
+  // (mysql2, go-sql-driver/mysql, mysqlclient) defaults it off so a
+  // single-statement injection cannot escalate to arbitrary stacked
+  // statements. CLIENT_MULTI_RESULTS stays on so stored procedures that
+  // return multiple result sets keep working.
+  expect({
+    CLIENT_MULTI_STATEMENTS: !!(caps & MYSQL_CLIENT_MULTI_STATEMENTS),
+    CLIENT_MULTI_RESULTS: !!(caps & MYSQL_CLIENT_MULTI_RESULTS),
+  }).toEqual({
+    CLIENT_MULTI_STATEMENTS: false,
+    CLIENT_MULTI_RESULTS: true,
+  });
+});
+
+test("MySQL: multipleStatements: true advertises CLIENT_MULTI_STATEMENTS", async () => {
+  const caps = await captureHandshakeCapabilities({ multipleStatements: true } as Bun.SQL.Options);
+  expect({
+    CLIENT_MULTI_STATEMENTS: !!(caps & MYSQL_CLIENT_MULTI_STATEMENTS),
+    CLIENT_MULTI_RESULTS: !!(caps & MYSQL_CLIENT_MULTI_RESULTS),
+  }).toEqual({
+    CLIENT_MULTI_STATEMENTS: true,
+    CLIENT_MULTI_RESULTS: true,
+  });
+});
+
+test("MySQL: multipleStatements: false does not advertise CLIENT_MULTI_STATEMENTS", async () => {
+  const caps = await captureHandshakeCapabilities({ multipleStatements: false } as Bun.SQL.Options);
+  expect(!!(caps & MYSQL_CLIENT_MULTI_STATEMENTS)).toBe(false);
+});

--- a/test/js/sql/sql-mysql.auth.test.ts
+++ b/test/js/sql/sql-mysql.auth.test.ts
@@ -43,6 +43,7 @@ describeWithContainer(
         await using sql = new SQL({
           url: getUrl(),
           max: 1,
+          multipleStatements: true,
         });
 
         await sql`DROP USER IF EXISTS caching@'%';`.simple();
@@ -78,7 +79,7 @@ describeWithContainer(
     // client's scramble; any prior successful full auth is what warms the server cache.
     test("caching_sha2_password fast auth (warm server-side auth cache)", async () => {
       {
-        await using admin = new SQL({ url: getUrl(), max: 1 });
+        await using admin = new SQL({ url: getUrl(), max: 1, multipleStatements: true });
         await admin`DROP USER IF EXISTS fastauth@'%';`.simple();
         await admin`CREATE USER fastauth@'%' IDENTIFIED WITH caching_sha2_password BY 'bunbun';
               GRANT ALL PRIVILEGES ON bun_sql_test.* TO fastauth@'%';`.simple();

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -1003,7 +1003,7 @@ if (isDockerEnabled()) {
         });
 
         test("simple query with multiple statements", async () => {
-          await using sql = new SQL({ ...getOptions(), max: 1 });
+          await using sql = new SQL({ ...getOptions(), max: 1, multipleStatements: true });
           const result = await sql`select 1 as x;select 2 as x`.simple();
           expect(result).toBeDefined();
           expect(result.length).toEqual(2);
@@ -1012,12 +1012,25 @@ if (isDockerEnabled()) {
         });
 
         test("simple query using unsafe with multiple statements", async () => {
-          await using sql = new SQL({ ...getOptions(), max: 1 });
+          await using sql = new SQL({ ...getOptions(), max: 1, multipleStatements: true });
           const result = await sql.unsafe("select 1 as x;select 2 as x");
           expect(result).toBeDefined();
           expect(result.length).toEqual(2);
           expect(result[0][0].x).toEqual(1);
           expect(result[1][0].x).toEqual(2);
+        });
+
+        test("multiple statements are rejected by default", async () => {
+          // CLIENT_MULTI_STATEMENTS is not advertised unless multipleStatements: true,
+          // so the server parses the whole string as one statement and reports a
+          // syntax error at the semicolon.
+          await using sql = new SQL({ ...getOptions(), max: 1 });
+          const err = await sql.unsafe("select 1 as x;select 2 as x").then(
+            () => null,
+            e => e,
+          );
+          expect(err).not.toBeNull();
+          expect(err.errno).toBe(1064); // ER_PARSE_ERROR
         });
 
         test("only allows one statement", async () => {

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -261,9 +261,12 @@ export async function pgMinimalReadyServer(): Promise<{ port: number; server: ne
 // ---------------------------------------------------------------------------
 
 // Capability flags — page_protocol_basic_capability_flags.html (subset used by the mocks).
+export const MYSQL_CLIENT_CONNECT_WITH_DB = 1 << 3;
 export const MYSQL_CLIENT_PROTOCOL_41 = 1 << 9;
 export const MYSQL_CLIENT_SSL = 1 << 11;
 export const MYSQL_CLIENT_SECURE_CONNECTION = 1 << 15;
+export const MYSQL_CLIENT_MULTI_STATEMENTS = 1 << 16;
+export const MYSQL_CLIENT_MULTI_RESULTS = 1 << 17;
 export const MYSQL_CLIENT_PLUGIN_AUTH = 1 << 19;
 export const MYSQL_CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 1 << 21;
 export const MYSQL_CLIENT_DEPRECATE_EOF = 1 << 24;


### PR DESCRIPTION
## What

The MySQL client advertised `CLIENT_MULTI_STATEMENTS` (bit 16) in every handshake with no way to opt out. A wire capture against a mock server shows the flag in the client's `HandshakeResponse41` on the default configuration:

```
client capability flags = 0x11b8208, CLIENT_MULTI_STATEMENTS = true
```

With that flag on, any string injection that reaches the `COM_QUERY` text protocol (`sql.unsafe(str)` / `.simple()`, dynamic identifiers, migration runners) escalates from a single-statement injection to arbitrary stacked queries. Every mainstream MySQL client (`mysql2`, `go-sql-driver/mysql`, `mysqlclient`) defaults this off for exactly this reason.

## Fix

- `Capabilities::get_default_capabilities` now takes a `multiple_statements: bool` and only sets `CLIENT_MULTI_STATEMENTS` when it is `true`.
- New `multipleStatements?: boolean` option on `Bun.SQL.Options` (MySQL only, default `false`), plumbed JS -> `createConnection` positional arg -> `MySQLConnection::init` -> handshake.
- `CLIENT_MULTI_RESULTS` stays on unconditionally so stored procedures that return multiple result sets keep working. The tagged-template path is unaffected since interpolated values travel as bound `COM_STMT_EXECUTE` params.

## Tests

`test/js/sql/sql-mysql-multi-statements.test.ts` runs a mock server that captures the client's `HandshakeResponse41` capability flags:

- default config: `CLIENT_MULTI_STATEMENTS` is **not** advertised, `CLIENT_MULTI_RESULTS` still is
- `multipleStatements: true`: flag is advertised
- `multipleStatements: false`: flag is not advertised

Existing multi-statement tests in `sql-mysql.test.ts` / `sql-mysql.auth.test.ts` now pass `multipleStatements: true`, and a new container test asserts that the server rejects stacked queries with `ER_PARSE_ERROR` on the default config.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql-multi-statements.test.ts test/js/sql/sql-mysql.auth.test.ts test/js/sql/sql-mysql.test.ts
bun test v1.4.0 (54b1d0f6b)

test/js/sql/sql-mysql.auth.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (split framing) [587.20ms]
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (coalesced framing) [159.06ms]
(pass) caching_sha2_password scramble hashes the double-SHA256 before the nonce [124.52ms]

test/js/sql/sql-mysql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory

test/js/sql/sql-mysql-multi-statements.test.ts:
72 |   // statements. CLIENT_MULTI_RESULTS stays on so
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (e1950dcb4)

test/js/sql/sql-mysql.auth.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (split framing) [20.09ms]
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (coalesced framing) [2.38ms]
(pass) caching_sha2_password scramble hashes the double-SHA256 before the nonce [6.15ms]

test/js/sql/sql-mysql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory

test/js/sql/sql-mysql-multi-statements.test.ts:
(pass) MySQL: CLIENT_MULTI_STATEMENTS is not advertised by default [3.86ms]
(pass) MySQL: multipleStatements: true advertises CLIENT_MULTI_STATEMENTS [1.69ms]
(pass) MySQL: multipleStatements: false does not advertise CLIENT_MULTI_STATEMENTS [1.61ms]

 6 pass
 0 fail
 7 expect() calls
Ran 6 tes
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql-multi-statements.test.ts test/js/sql/sql-mysql.auth.test.ts test/js/sql/sql-mysql.test.ts
bun test v1.4.0 (54b1d0f6b)

test/js/sql/sql-mysql.auth.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (split framing) [586.12ms]
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (coalesced framing) [159.59ms]
(pass) caching_sha2_password scramble hashes the double-SHA256 before the nonce [119.91ms]

test/js/sql/sql-mysql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory

test/js/sql/sql-mysql-multi-statements.test.ts:
(pass) MySQL: CLIENT_MULTI_STATEMENTS is not advertise
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 709ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/23] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/23] gen JS modules (bundle-modules)
Preprocess modules (9033ms)
Bundle modules (49ms)
Postprocesss modules (235ms)
Bundle Functions (764ms)
Generate Code (31ms)

[10.13s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compil
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/sql.mdx                           | 13 +++-
 packages/bun-types/sql.d.ts                    | 12 ++++
 src/js/internal/sql/mysql.ts                   |  1 +
 src/js/internal/sql/shared.ts                  |  6 +-
 src/sql/mysql/Capabilities.rs                  | 10 ++-
 src/sql_jsc/mysql/JSMySQLConnection.rs         |  2 +
 src/sql_jsc/mysql/MySQLConnection.rs           |  5 ++
 test/js/sql/sql-mysql-multi-statements.test.ts | 97 ++++++++++++++++++++++++++
 test/js/sql/sql-mysql.auth.test.ts             |  3 +-
 test/js/sql/sql-mysql.test.ts                  | 17 ++++-
 test/js/sql/wire-frames.ts                     |  3 +
 11 files changed, 161 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
docs/runtime/sql.mdx                                2      1      0
packages/bun-types/sql.d.ts                         1      1      0
src/js/internal/sql/mysql.ts                        1      1      0
src/js/internal/sql/shared.ts                       1      2      0
src/sql/mysql/Capabilities.rs                       2      3      0
src/sql_jsc/mysql/JSMySQLConnection.rs              2      1      0
src/sql_jsc/mysql/MySQLConnection.rs                2      1      0
test/js/sql/sql-mysql-multi-statements.test.ts      0      1      0
test/js/sql/sql-mysql.auth.test.ts                  1      1      0
test/js/sql/sql-mysql.test.ts                       1      1      0
test/js/sql/wire-frames.ts                          1      1      0
```

</details>

<!-- robobun:evidence:end -->