### PR TITLE
sql(mysql,postgres): reject duplicate auth requests; make connectionTimeout an absolute handshake deadline

### DIFF
--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -1049,8 +1049,6 @@ impl<const SSL: bool> SocketHandler<SSL> {
             // `_ref` has not yet dropped, so `*p` is still live; `ParentRef`
             // yields a fresh `&JSMySQLConnection` per access (R-2: every
             // callee is `&self`).
-            // Only the idle timer follows traffic; the connect deadline is not
-            // re-armed so a byte-trickling server still times out.
             if p.connection.get().status == my_sql_connection::Status::Connected {
                 p.reset_connection_timeout();
             }

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -1049,8 +1049,13 @@ impl<const SSL: bool> SocketHandler<SSL> {
             // `_ref` has not yet dropped, so `*p` is still live; `ParentRef`
             // yields a fresh `&JSMySQLConnection` per access (R-2: every
             // callee is `&self`).
-            // reset the connection timeout after we're done processing the data
-            p.reset_connection_timeout();
+            // connectionTimeout bounds the whole handshake (connect → auth
+            // OK); re-arming it per packet would let a server that trickles
+            // bytes defeat the bound. Once Connected the timer tracks
+            // idle/inactivity and is re-armed here.
+            if p.connection.get().status == my_sql_connection::Status::Connected {
+                p.reset_connection_timeout();
+            }
             p.update_reference_type();
             p.register_auto_flusher();
         }

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -1049,10 +1049,8 @@ impl<const SSL: bool> SocketHandler<SSL> {
             // `_ref` has not yet dropped, so `*p` is still live; `ParentRef`
             // yields a fresh `&JSMySQLConnection` per access (R-2: every
             // callee is `&self`).
-            // connectionTimeout bounds the whole handshake (connect → auth
-            // OK); re-arming it per packet would let a server that trickles
-            // bytes defeat the bound. Once Connected the timer tracks
-            // idle/inactivity and is re-armed here.
+            // Only the idle timer follows traffic; the connect deadline is not
+            // re-armed so a byte-trickling server still times out.
             if p.connection.get().status == my_sql_connection::Status::Connected {
                 p.reset_connection_timeout();
             }

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -70,6 +70,7 @@ pub struct MySQLConnection {
 
     auth_plugin: Option<AuthMethod>,
     _auth_state: AuthState,
+    auth_switched: bool,
 
     auth_data: Vec<u8>,
     // PERF: database/user/password/options could be sub-slices into options_buf
@@ -108,6 +109,7 @@ impl Default for MySQLConnection {
             status_flags: StatusFlags::default(),
             auth_plugin: None,
             _auth_state: AuthState::Pending,
+            auth_switched: false,
             auth_data: Vec::new(),
             database: Box::default(),
             user: Box::default(),
@@ -894,6 +896,17 @@ impl MySQLConnection {
             }
 
             PacketType::AUTH_SWITCH => {
+                // The server may switch the auth plugin once after the
+                // HandshakeResponse. A second AuthSwitchRequest is a protocol
+                // violation; answering it would let a malicious/MITM server
+                // drive an unbounded auth ping-pong. mysql2 and libmysqlclient
+                // refuse a second switch.
+                if self.auth_switched {
+                    bun_core::scoped_log!(MySQLConnection, "duplicate AuthSwitchRequest");
+                    return Err(AnyMySQLError::UnexpectedPacket);
+                }
+                self.auth_switched = true;
+
                 let mut auth_switch = AuthSwitchRequest {
                     packet_size: header_length,
                     ..Default::default()

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -913,7 +913,9 @@ impl MySQLConnection {
                     .ok_or(AnyMySQLError::UnsupportedAuthPlugin)?;
 
                 // Bound a hostile server's auth ping-pong.
-                if self.auth_switch_count >= 2 || self.auth_plugin == Some(auth_method) {
+                if self.auth_switch_count >= 2
+                    || (self.auth_switch_count > 0 && self.auth_plugin == Some(auth_method))
+                {
                     bun_core::scoped_log!(
                         MySQLConnection,
                         "rejecting AuthSwitchRequest (count={}, plugin={:?})",

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -70,7 +70,7 @@ pub struct MySQLConnection {
 
     auth_plugin: Option<AuthMethod>,
     _auth_state: AuthState,
-    auth_switched: bool,
+    auth_switch_count: u8,
 
     auth_data: Vec<u8>,
     // PERF: database/user/password/options could be sub-slices into options_buf
@@ -109,7 +109,7 @@ impl Default for MySQLConnection {
             status_flags: StatusFlags::default(),
             auth_plugin: None,
             _auth_state: AuthState::Pending,
-            auth_switched: false,
+            auth_switch_count: 0,
             auth_data: Vec::new(),
             database: Box::default(),
             user: Box::default(),
@@ -896,32 +896,36 @@ impl MySQLConnection {
             }
 
             PacketType::AUTH_SWITCH => {
-                // The server may switch the auth plugin once after the
-                // HandshakeResponse. A second AuthSwitchRequest is a protocol
-                // violation; answering it would let a malicious/MITM server
-                // drive an unbounded auth ping-pong. mysql2 and libmysqlclient
-                // refuse a second switch.
-                if self.auth_switched {
-                    bun_core::scoped_log!(MySQLConnection, "duplicate AuthSwitchRequest");
-                    return Err(AnyMySQLError::UnexpectedPacket);
-                }
-                self.auth_switched = true;
-
                 let mut auth_switch = AuthSwitchRequest {
                     packet_size: header_length,
                     ..Default::default()
                 };
                 auth_switch.decode_internal(reader)?;
 
-                // Update auth plugin and data
                 let auth_method = AuthMethod::from_string(auth_switch.plugin_name.slice())
                     .ok_or(AnyMySQLError::UnsupportedAuthPlugin)?;
+
+                // Answering every AuthSwitchRequest lets a malicious/MITM
+                // server drive an unbounded auth ping-pong. Cap the number of
+                // switches honoured per handshake and refuse a switch back to
+                // the plugin already in use (mysql2 errors on a repeated
+                // switch; libmysqlclient honours at most one).
+                if self.auth_switch_count >= 2 || self.auth_plugin == Some(auth_method) {
+                    bun_core::scoped_log!(
+                        MySQLConnection,
+                        "rejecting AuthSwitchRequest (count={}, plugin={:?})",
+                        self.auth_switch_count,
+                        auth_method
+                    );
+                    return Err(AnyMySQLError::UnexpectedPacket);
+                }
+                self.auth_switch_count += 1;
+
                 let auth_data = auth_switch.plugin_data.slice();
                 self.auth_plugin = Some(auth_method);
                 self.auth_data.clear();
                 self.auth_data.extend_from_slice(auth_data);
 
-                // Send new auth response
                 self.send_auth_switch_response(auth_method, auth_data)?;
             }
 

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -905,11 +905,8 @@ impl MySQLConnection {
                 let auth_method = AuthMethod::from_string(auth_switch.plugin_name.slice())
                     .ok_or(AnyMySQLError::UnsupportedAuthPlugin)?;
 
-                // Answering every AuthSwitchRequest lets a malicious/MITM
-                // server drive an unbounded auth ping-pong. Cap the number of
-                // switches honoured per handshake and refuse a switch back to
-                // the plugin already in use (mysql2 errors on a repeated
-                // switch; libmysqlclient honours at most one).
+                // Bound a hostile server's auth ping-pong: at most two
+                // switches, never back to the plugin already in use.
                 if self.auth_switch_count >= 2 || self.auth_plugin == Some(auth_method) {
                     bun_core::scoped_log!(
                         MySQLConnection,

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -905,8 +905,7 @@ impl MySQLConnection {
                 let auth_method = AuthMethod::from_string(auth_switch.plugin_name.slice())
                     .ok_or(AnyMySQLError::UnsupportedAuthPlugin)?;
 
-                // Bound a hostile server's auth ping-pong: at most two
-                // switches, never back to the plugin already in use.
+                // Bound a hostile server's auth ping-pong.
                 if self.auth_switch_count >= 2 || self.auth_plugin == Some(auth_method) {
                     bun_core::scoped_log!(
                         MySQLConnection,

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -71,6 +71,7 @@ pub struct MySQLConnection {
     auth_plugin: Option<AuthMethod>,
     _auth_state: AuthState,
     auth_switch_count: u8,
+    full_auth_requested: bool,
 
     auth_data: Vec<u8>,
     // PERF: database/user/password/options could be sub-slices into options_buf
@@ -110,6 +111,7 @@ impl Default for MySQLConnection {
             auth_plugin: None,
             _auth_state: AuthState::Pending,
             auth_switch_count: 0,
+            full_auth_requested: false,
             auth_data: Vec::new(),
             database: Box::default(),
             user: Box::default(),
@@ -827,6 +829,11 @@ impl MySQLConnection {
                                 }
                                 Auth::caching_sha2_password::FastAuthStatus::CONTINUE_AUTH => {
                                     bun_core::scoped_log!(MySQLConnection, "continue auth");
+
+                                    if self.full_auth_requested {
+                                        return Err(AnyMySQLError::UnexpectedPacket);
+                                    }
+                                    self.full_auth_requested = true;
 
                                     if self.tls_status != TLSStatus::SslOk {
                                         // Over plain TCP, an on-path attacker can answer the

--- a/src/sql_jsc/postgres/AuthenticationState.rs
+++ b/src/sql_jsc/postgres/AuthenticationState.rs
@@ -6,6 +6,7 @@ pub enum AuthenticationState {
     Ok,
     Sasl(SASL),
     Md5,
+    ClearText,
 }
 
 impl AuthenticationState {

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -971,10 +971,8 @@ impl PostgresSQLConnection {
         self.ref_();
         self.update_flags(|f| f.insert(ConnectionFlags::IS_PROCESSING_DATA));
 
-        // connectionTimeout bounds the whole handshake (connect → ReadyForQuery),
-        // so it keeps running across packets until `set_status(Connected)`
-        // switches the timer to the idle interval. Resetting it per packet
-        // would let a server that trickles bytes defeat the bound.
+        // Only the idle timer follows traffic; the connect deadline is not
+        // re-armed so a byte-trickling server still times out.
         if self.status.get() == Status::Connected {
             self.disable_connection_timeout();
         }
@@ -2655,11 +2653,7 @@ impl PostgresSQLConnection {
 
                 match &auth {
                     protocol::Authentication::SASL => {
-                        // AuthenticationSASL starts a new exchange and is only
-                        // valid before any authentication exchange has begun.
-                        // libpq rejects this as "duplicate SASL authentication
-                        // request"; answering it again loops unboundedly
-                        // against a malicious/MITM server.
+                        // libpq: "duplicate SASL authentication request".
                         if !matches!(
                             self.authentication_state.get(),
                             AuthenticationState::Pending

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -971,7 +971,13 @@ impl PostgresSQLConnection {
         self.ref_();
         self.update_flags(|f| f.insert(ConnectionFlags::IS_PROCESSING_DATA));
 
-        self.disable_connection_timeout();
+        // connectionTimeout bounds the whole handshake (connect → ReadyForQuery),
+        // so it keeps running across packets until `set_status(Connected)`
+        // switches the timer to the idle interval. Resetting it per packet
+        // would let a server that trickles bytes defeat the bound.
+        if self.status.get() == Status::Connected {
+            self.disable_connection_timeout();
+        }
 
         let event_loop = self.event_loop();
         event_loop.enter();
@@ -1061,7 +1067,9 @@ impl PostgresSQLConnection {
         self.update_flags(|f| f.remove(ConnectionFlags::IS_PROCESSING_DATA));
 
         // reset the connection timeout after we're done processing the data
-        self.reset_connection_timeout();
+        if self.status.get() == Status::Connected {
+            self.reset_connection_timeout();
+        }
         // SAFETY: `self` is a live Box-allocated connection; this releases one ref.
         unsafe { Self::deref(self.as_ctx_ptr()) };
     }
@@ -2647,13 +2655,20 @@ impl PostgresSQLConnection {
 
                 match &auth {
                     protocol::Authentication::SASL => {
+                        // AuthenticationSASL starts a new exchange and is only
+                        // valid before any authentication exchange has begun.
+                        // libpq rejects this as "duplicate SASL authentication
+                        // request"; answering it again loops unboundedly
+                        // against a malicious/MITM server.
                         if !matches!(
                             self.authentication_state.get(),
-                            AuthenticationState::Sasl(_)
+                            AuthenticationState::Pending
                         ) {
-                            self.authentication_state
-                                .set(AuthenticationState::Sasl(Default::default()));
+                            debug!("duplicate AuthenticationSASL");
+                            return Err(AnyPostgresError::UnexpectedMessage);
                         }
+                        self.authentication_state
+                            .set(AuthenticationState::Sasl(Default::default()));
 
                         let mut mechanism_buf = [0u8; 128];
                         // `sasl` borrow ends before `self.writer()`/`self.flush_data()`
@@ -2872,17 +2887,33 @@ impl PostgresSQLConnection {
                     }
 
                     protocol::Authentication::ClearTextPassword => {
+                        if !matches!(
+                            self.authentication_state.get(),
+                            AuthenticationState::Pending
+                        ) {
+                            debug!("duplicate AuthenticationCleartextPassword");
+                            return Err(AnyPostgresError::UnexpectedMessage);
+                        }
                         debug!("ClearTextPassword");
                         let response = protocol::PasswordMessage {
                             // password is a valid slice into options_buf.
                             password: Data::Temporary(self.password),
                         };
 
+                        self.authentication_state
+                            .set(AuthenticationState::ClearText);
                         response.write_internal(&mut self.writer())?;
                         self.flush_data();
                     }
 
                     protocol::Authentication::MD5Password { salt } => {
+                        if !matches!(
+                            self.authentication_state.get(),
+                            AuthenticationState::Pending
+                        ) {
+                            debug!("duplicate AuthenticationMD5Password");
+                            return Err(AnyPostgresError::UnexpectedMessage);
+                        }
                         debug!("MD5Password");
                         // Format is: md5 + md5(md5(password + username) + salt)
                         let mut first_hash_buf: [u8; 16] = Default::default();

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -971,8 +971,6 @@ impl PostgresSQLConnection {
         self.ref_();
         self.update_flags(|f| f.insert(ConnectionFlags::IS_PROCESSING_DATA));
 
-        // Only the idle timer follows traffic; the connect deadline is not
-        // re-armed so a byte-trickling server still times out.
         if self.status.get() == Status::Connected {
             self.disable_connection_timeout();
         }
@@ -1064,7 +1062,6 @@ impl PostgresSQLConnection {
         }
         self.update_flags(|f| f.remove(ConnectionFlags::IS_PROCESSING_DATA));
 
-        // reset the connection timeout after we're done processing the data
         if self.status.get() == Status::Connected {
             self.reset_connection_timeout();
         }

--- a/test/js/sql/postgres-duplicate-auth-request.test.ts
+++ b/test/js/sql/postgres-duplicate-auth-request.test.ts
@@ -1,0 +1,209 @@
+// Fault-injection test: requires a server that refuses / drops / sends malformed
+// frames, which a healthy container will not do on demand. DO NOT COPY THIS
+// PATTERN — anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+//
+// A server (or MITM) that answers the client's password / SASLInitialResponse
+// with another Authentication{SASL,CleartextPassword,MD5Password} request
+// drove the client into an unbounded authentication loop at 100% CPU, and
+// connectionTimeout never fired because every arriving packet reset the
+// connect-phase timer. libpq rejects a second AuthenticationSASL with
+// "duplicate SASL authentication request".
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import {
+  listeningServer,
+  pgAuthenticationCleartextPassword,
+  pgAuthenticationMD5Password,
+  pgAuthenticationOk,
+  pgAuthenticationSASL,
+  pgReadyForQuery,
+} from "./wire-frames";
+
+/**
+ * Answer the startup packet with `first`, then answer every subsequent client
+ * message (PasswordMessage / SASLInitialResponse, type 'p') with `second`, up
+ * to `limit` times. Resolves to the error the client surfaced and the number
+ * of 'p' responses observed.
+ */
+async function duplicateAuthRequest(first: Buffer, second: Buffer, limit: number) {
+  let responses = 0;
+  const sockets = new Set<import("node:net").Socket>();
+  const { port, server } = await listeningServer(socket => {
+    sockets.add(socket);
+    let buf = Buffer.alloc(0);
+    let sawStartup = false;
+    socket.on("error", () => {});
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("data", chunk => {
+      buf = Buffer.concat([buf, chunk]);
+      for (;;) {
+        if (!sawStartup) {
+          // StartupMessage: Int32(len) Int32(protocol) ...; no leading type byte.
+          if (buf.length < 4) return;
+          const len = buf.readInt32BE(0);
+          if (buf.length < len) return;
+          sawStartup = true;
+          buf = buf.subarray(len);
+          socket.write(first);
+          continue;
+        }
+        if (buf.length < 5) return;
+        const len = buf.readInt32BE(1);
+        if (buf.length < 1 + len) return;
+        const type = String.fromCharCode(buf[0]);
+        buf = buf.subarray(1 + len);
+        if (type !== "p") continue;
+        responses++;
+        if (responses >= limit) {
+          socket.destroy();
+          return;
+        }
+        socket.write(second);
+      }
+    });
+  });
+
+  const db = new SQL({
+    url: `postgres://u:pw@127.0.0.1:${port}/db?sslmode=disable`,
+    max: 1,
+    connectionTimeout: 30,
+  });
+  let err: any;
+  try {
+    await db.connect();
+    err = new Error("expected connect() to reject");
+  } catch (e) {
+    err = e;
+  } finally {
+    await db.close({ timeout: 0 });
+    for (const s of sockets) s.destroy();
+    await new Promise<void>(r => server.close(() => r()));
+  }
+  return { err, responses };
+}
+
+const methods = [
+  { name: "AuthenticationSASL", frame: pgAuthenticationSASL() },
+  { name: "AuthenticationCleartextPassword", frame: pgAuthenticationCleartextPassword() },
+  { name: "AuthenticationMD5Password", frame: pgAuthenticationMD5Password() },
+];
+
+test.each(methods)("postgres: duplicate $name is rejected, not answered again", async ({ frame }) => {
+  const { err, responses } = await duplicateAuthRequest(frame, frame, 50);
+  // The client must answer the first request (responses == 1) and then error
+  // on the duplicate without answering it. Before the fix `responses` hit the
+  // limit in a few milliseconds.
+  expect({ code: err.code, responses }).toEqual({
+    code: "ERR_POSTGRES_UNEXPECTED_MESSAGE",
+    responses: 1,
+  });
+});
+
+// Mixed sequences: a second authentication-start message of any kind after
+// a first of a different kind is equally a protocol violation.
+const mixed = [
+  { name: "SASL after CleartextPassword", first: pgAuthenticationCleartextPassword(), second: pgAuthenticationSASL() },
+  { name: "CleartextPassword after SASL", first: pgAuthenticationSASL(), second: pgAuthenticationCleartextPassword() },
+  { name: "MD5Password after SASL", first: pgAuthenticationSASL(), second: pgAuthenticationMD5Password() },
+];
+
+test.each(mixed)("postgres: $name is rejected", async ({ first, second }) => {
+  const { err, responses } = await duplicateAuthRequest(first, second, 50);
+  expect({ code: err.code, responses }).toEqual({
+    code: "ERR_POSTGRES_UNEXPECTED_MESSAGE",
+    responses: 1,
+  });
+});
+
+// Boundary: the normal single-request flow for each method still connects.
+async function singleRequestConnects(request: Buffer) {
+  const { port, server } = await listeningServer(socket => {
+    let sawStartup = false;
+    socket.on("error", () => {});
+    socket.on("data", () => {
+      if (!sawStartup) {
+        sawStartup = true;
+        socket.write(request);
+        return;
+      }
+      socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+    });
+  });
+  const db = new SQL({
+    url: `postgres://u:pw@127.0.0.1:${port}/db?sslmode=disable`,
+    max: 1,
+    connectionTimeout: 30,
+  });
+  try {
+    await expect(db.connect()).resolves.toBeDefined();
+  } finally {
+    await db.close({ timeout: 0 });
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}
+
+test("postgres: a single AuthenticationCleartextPassword still connects", async () => {
+  await singleRequestConnects(pgAuthenticationCleartextPassword());
+});
+
+test("postgres: a single AuthenticationMD5Password still connects", async () => {
+  await singleRequestConnects(pgAuthenticationMD5Password());
+});
+
+test("postgres: connectionTimeout bounds the whole handshake, not per packet", async () => {
+  // Server that answers the startup packet with AuthenticationCleartextPassword,
+  // then trickles the next response one byte at a time, each well under
+  // connectionTimeout, never completing a message. Before the fix each byte
+  // re-armed the connect timer so the client waited indefinitely; now it fails
+  // once the overall deadline passes.
+  const sockets = new Set<import("node:net").Socket>();
+  const { port, server } = await listeningServer(socket => {
+    sockets.add(socket);
+    let phase = 0;
+    let id: ReturnType<typeof setInterval> | undefined;
+    socket.on("error", () => {});
+    socket.on("close", () => {
+      if (id) clearInterval(id);
+      sockets.delete(socket);
+    });
+    socket.on("data", () => {
+      if (phase === 0) {
+        phase = 1;
+        socket.write(pgAuthenticationCleartextPassword());
+      } else if (phase === 1) {
+        phase = 2;
+        // Announce an Authentication ('R') message with a huge body so the
+        // client buffers indefinitely awaiting bytes that never complete.
+        const header = Buffer.alloc(5);
+        header.write("R", 0);
+        header.writeInt32BE(1 << 20, 1);
+        socket.write(header);
+        id = setInterval(() => {
+          if (!socket.destroyed) socket.write(Buffer.from([0]));
+        }, 200);
+      }
+    });
+  });
+
+  const t0 = performance.now();
+  const db = new SQL({
+    url: `postgres://u:pw@127.0.0.1:${port}/db?sslmode=disable`,
+    max: 1,
+    connectionTimeout: 1,
+  });
+  try {
+    const err = await db.connect().then(
+      () => ({ code: "UNEXPECTED_SUCCESS" }),
+      (e: any) => ({ code: e?.code ?? String(e) }),
+    );
+    const elapsed = performance.now() - t0;
+    expect(err).toEqual({ code: "ERR_POSTGRES_CONNECTION_TIMEOUT" });
+    expect(elapsed).toBeLessThan(8000);
+  } finally {
+    await db.close({ timeout: 0 });
+    for (const s of sockets) s.destroy();
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});

--- a/test/js/sql/postgres-duplicate-auth-request.test.ts
+++ b/test/js/sql/postgres-duplicate-auth-request.test.ts
@@ -18,6 +18,7 @@ import {
   pgAuthenticationMD5Password,
   pgAuthenticationOk,
   pgAuthenticationSASL,
+  pgRaw,
   pgReadyForQuery,
 } from "./wire-frames";
 
@@ -176,10 +177,7 @@ test("postgres: connectionTimeout bounds the whole handshake, not per packet", a
         phase = 2;
         // Announce an Authentication ('R') message with a huge body so the
         // client buffers indefinitely awaiting bytes that never complete.
-        const header = Buffer.alloc(5);
-        header.write("R", 0);
-        header.writeInt32BE(1 << 20, 1);
-        socket.write(header);
+        socket.write(pgRaw("R", Buffer.alloc(0), 1 << 20));
         id = setInterval(() => {
           if (!socket.destroyed) socket.write(Buffer.from([0]));
         }, 200);

--- a/test/js/sql/sql-mysql-duplicate-auth-switch.test.ts
+++ b/test/js/sql/sql-mysql-duplicate-auth-switch.test.ts
@@ -14,8 +14,10 @@
 
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
 import {
   listeningServer,
+  mysqlAuthMoreData,
   mysqlAuthSwitchRequest,
   mysqlHandshakeV10,
   mysqlOkPacket,
@@ -109,6 +111,74 @@ test("MySQL: at most two AuthSwitchRequests are honoured per handshake", async (
   expect({ err, responses }).toEqual({
     err: { code: "ERR_MYSQL_UNEXPECTED_PACKET" },
     responses: 2,
+  });
+});
+
+test("MySQL: caching_sha2 perform_full_authentication is honoured at most once", async () => {
+  // Over plain TCP with allowPublicKeyRetrieval, CONTINUE_AUTH (0x04) sends a
+  // PublicKeyRequest, the server's key reply elicits an encrypted-password
+  // write, and a second CONTINUE_AUTH used to restart that exchange
+  // indefinitely. Now the second CONTINUE_AUTH is rejected.
+  const { publicKey } = generateKeyPairSync("rsa", { modulusLength: 1024 });
+  const pem = Buffer.from(publicKey.export({ type: "spki", format: "pem" }) as string);
+
+  let passwords = 0;
+  const sockets = new Set<import("node:net").Socket>();
+  const { server, port } = await listeningServer(socket => {
+    sockets.add(socket);
+    let buffered = Buffer.alloc(0);
+    let phase = 0;
+    socket.write(mysqlHandshakeV10({ authPlugin: "caching_sha2_password" }));
+    socket.on("error", () => {});
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (phase === 0) {
+          // HandshakeResponse41 → ask for full auth.
+          phase = 1;
+          socket.write(mysqlAuthMoreData(seq + 1, Buffer.from([0x04])));
+        } else if (payload.length === 1 && payload[0] === 0x02) {
+          // PublicKeyRequest → send the RSA key.
+          socket.write(mysqlAuthMoreData(seq + 1, pem));
+        } else {
+          // Encrypted-password packet → ask for full auth again.
+          passwords++;
+          if (passwords >= 20) {
+            socket.destroy();
+            return;
+          }
+          socket.write(mysqlAuthMoreData(seq + 1, Buffer.from([0x04])));
+        }
+      });
+    });
+  });
+
+  const db = new SQL({
+    adapter: "mysql",
+    hostname: "127.0.0.1",
+    port,
+    username: "u",
+    password: "pw",
+    database: "d",
+    tls: false,
+    max: 1,
+    connectionTimeout: 30,
+    allowPublicKeyRetrieval: true,
+  });
+  let err: any;
+  try {
+    await db.unsafe("SELECT 1");
+    err = { code: "UNEXPECTED_SUCCESS" };
+  } catch (e: any) {
+    err = { code: e?.code ?? String(e) };
+  } finally {
+    await db.close({ timeout: 0 });
+    for (const s of sockets) s.destroy();
+    await new Promise<void>(r => server.close(() => r()));
+  }
+  expect({ err, passwords }).toEqual({
+    err: { code: "ERR_MYSQL_UNEXPECTED_PACKET" },
+    passwords: 1,
   });
 });
 

--- a/test/js/sql/sql-mysql-duplicate-auth-switch.test.ts
+++ b/test/js/sql/sql-mysql-duplicate-auth-switch.test.ts
@@ -8,8 +8,9 @@
 // auth packet with another AuthSwitchRequest (0xFE) drove the client into an
 // unbounded auth ping-pong at 100% CPU, and connectionTimeout never fired
 // because every arriving handshake packet re-armed the connect-phase timer.
-// mysql2 and libmysqlclient refuse a second AuthSwitchRequest; Bun now does
-// the same, and connectionTimeout is an absolute connect→ready deadline.
+// Bun now caps the number of AuthSwitchRequests honoured per handshake, refuses
+// a switch back to the plugin already in use (mysql2 errors on a repeated auth
+// switch), and treats connectionTimeout as an absolute connect→ready deadline.
 
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
@@ -21,29 +22,37 @@ import {
   mysqlReadPackets,
 } from "./wire-frames";
 
-test("MySQL: a second AuthSwitchRequest is rejected, not answered again", async () => {
+/**
+ * Scripted server: send `greeting`, answer the HandshakeResponse41 with
+ * `switches[0]`, then answer each subsequent client packet with the next entry
+ * in `switches` (cycling the last one). Destroys the socket once `limit`
+ * AuthSwitchResponses have been observed. Resolves to the client's error and
+ * the number of AuthSwitchResponses it sent.
+ */
+async function switchLoop(opts: { handshakePlugin: string; switches: string[]; limit: number }) {
   let responses = 0;
   const sockets = new Set<import("node:net").Socket>();
   const { server, port } = await listeningServer(socket => {
     sockets.add(socket);
     let buffered = Buffer.alloc(0);
     let sawHandshakeResponse = false;
-    socket.write(mysqlHandshakeV10());
+    socket.write(mysqlHandshakeV10({ authPlugin: opts.handshakePlugin }));
     socket.on("error", () => {});
     socket.on("close", () => sockets.delete(socket));
     socket.on("data", chunk => {
       buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), seq => {
         if (!sawHandshakeResponse) {
           sawHandshakeResponse = true;
-          socket.write(mysqlAuthSwitchRequest(seq + 1, "mysql_native_password", Buffer.alloc(20, 0x61)));
+          socket.write(mysqlAuthSwitchRequest(seq + 1, opts.switches[0], Buffer.alloc(20, 0x61)));
           return;
         }
         responses++;
-        if (responses >= 50) {
+        if (responses >= opts.limit) {
           socket.destroy();
           return;
         }
-        socket.write(mysqlAuthSwitchRequest(seq + 1, "mysql_native_password", Buffer.alloc(20, 0x62)));
+        const plugin = opts.switches[Math.min(responses, opts.switches.length - 1)];
+        socket.write(mysqlAuthSwitchRequest(seq + 1, plugin, Buffer.alloc(20, 0x62)));
       });
     });
   });
@@ -70,12 +79,36 @@ test("MySQL: a second AuthSwitchRequest is rejected, not answered again", async 
     for (const s of sockets) s.destroy();
     await new Promise<void>(r => server.close(() => r()));
   }
-  // The client must answer the first AuthSwitchRequest (responses == 1) and
-  // then error on the duplicate without answering it. Before the fix
-  // `responses` hit the limit.
+  return { err, responses };
+}
+
+test("MySQL: AuthSwitchRequest to the plugin already in use is rejected", async () => {
+  // Handshake advertises mysql_native_password; a switch to that same plugin
+  // is a no-op the server has no legitimate reason to request and is the
+  // signature of the ping-pong attack.
+  const { err, responses } = await switchLoop({
+    handshakePlugin: "mysql_native_password",
+    switches: ["mysql_native_password"],
+    limit: 50,
+  });
   expect({ err, responses }).toEqual({
     err: { code: "ERR_MYSQL_UNEXPECTED_PACKET" },
-    responses: 1,
+    responses: 0,
+  });
+});
+
+test("MySQL: at most two AuthSwitchRequests are honoured per handshake", async () => {
+  // Alternate between two different plugins so the same-plugin check never
+  // trips; the count cap must still cut the loop off after the second answer.
+  // Before the fix `responses` hit the limit.
+  const { err, responses } = await switchLoop({
+    handshakePlugin: "caching_sha2_password",
+    switches: ["mysql_native_password", "caching_sha2_password", "mysql_native_password"],
+    limit: 50,
+  });
+  expect({ err, responses }).toEqual({
+    err: { code: "ERR_MYSQL_UNEXPECTED_PACKET" },
+    responses: 2,
   });
 });
 

--- a/test/js/sql/sql-mysql-duplicate-auth-switch.test.ts
+++ b/test/js/sql/sql-mysql-duplicate-auth-switch.test.ts
@@ -84,10 +84,12 @@ async function switchLoop(opts: { handshakePlugin: string; switches: string[]; l
   return { err, responses };
 }
 
-test("MySQL: AuthSwitchRequest to the plugin already in use is rejected", async () => {
-  // Handshake advertises mysql_native_password; a switch to that same plugin
-  // is a no-op the server has no legitimate reason to request and is the
-  // signature of the ping-pong attack.
+test("MySQL: a second AuthSwitchRequest to the same plugin is rejected", async () => {
+  // A first switch to the handshake-advertised plugin is legitimate (Azure
+  // Database for MySQL and proxy front-ends do this to deliver a fresh nonce)
+  // and must be honoured; a second switch to that same plugin is the
+  // ping-pong attack signature and is rejected. Before the fix `responses`
+  // hit the limit.
   const { err, responses } = await switchLoop({
     handshakePlugin: "mysql_native_password",
     switches: ["mysql_native_password"],
@@ -95,7 +97,7 @@ test("MySQL: AuthSwitchRequest to the plugin already in use is rejected", async 
   });
   expect({ err, responses }).toEqual({
     err: { code: "ERR_MYSQL_UNEXPECTED_PACKET" },
-    responses: 0,
+    responses: 1,
   });
 });
 
@@ -182,19 +184,24 @@ test("MySQL: caching_sha2 perform_full_authentication is honoured at most once",
   });
 });
 
-test("MySQL: a single AuthSwitchRequest then OK still connects", async () => {
-  // Boundary: the normal one-switch happy path must still work.
+// Boundary: the normal one-switch happy path must still work, both when the
+// switch targets a different plugin and when it targets the plugin the
+// greeting already advertised (Azure / ProxySQL fresh-nonce pattern).
+test.each([
+  { name: "to a different plugin", handshake: "caching_sha2_password", switchTo: "mysql_native_password" },
+  { name: "to the greeting's plugin", handshake: "mysql_native_password", switchTo: "mysql_native_password" },
+])("MySQL: a single AuthSwitchRequest $name then OK still connects", async ({ handshake, switchTo }) => {
   let responses = 0;
   const { server, port } = await listeningServer(socket => {
     let buffered = Buffer.alloc(0);
     let phase = 0;
-    socket.write(mysqlHandshakeV10({ authPlugin: "caching_sha2_password" }));
+    socket.write(mysqlHandshakeV10({ authPlugin: handshake }));
     socket.on("error", () => {});
     socket.on("data", chunk => {
       buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), seq => {
         if (phase === 0) {
           phase = 1;
-          socket.write(mysqlAuthSwitchRequest(seq + 1, "mysql_native_password", Buffer.alloc(20, 0x62)));
+          socket.write(mysqlAuthSwitchRequest(seq + 1, switchTo, Buffer.alloc(20, 0x62)));
         } else if (phase === 1) {
           phase = 2;
           responses++;

--- a/test/js/sql/sql-mysql-duplicate-auth-switch.test.ts
+++ b/test/js/sql/sql-mysql-duplicate-auth-switch.test.ts
@@ -1,0 +1,174 @@
+// Fault-injection test: requires a server that refuses / drops / sends malformed
+// frames, which a healthy container will not do on demand. DO NOT COPY THIS
+// PATTERN — anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+//
+// A server (or MITM on the default non-TLS path) that answers every client
+// auth packet with another AuthSwitchRequest (0xFE) drove the client into an
+// unbounded auth ping-pong at 100% CPU, and connectionTimeout never fired
+// because every arriving handshake packet re-armed the connect-phase timer.
+// mysql2 and libmysqlclient refuse a second AuthSwitchRequest; Bun now does
+// the same, and connectionTimeout is an absolute connect→ready deadline.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import {
+  listeningServer,
+  mysqlAuthSwitchRequest,
+  mysqlHandshakeV10,
+  mysqlOkPacket,
+  mysqlReadPackets,
+} from "./wire-frames";
+
+test("MySQL: a second AuthSwitchRequest is rejected, not answered again", async () => {
+  let responses = 0;
+  const sockets = new Set<import("node:net").Socket>();
+  const { server, port } = await listeningServer(socket => {
+    sockets.add(socket);
+    let buffered = Buffer.alloc(0);
+    let sawHandshakeResponse = false;
+    socket.write(mysqlHandshakeV10());
+    socket.on("error", () => {});
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), seq => {
+        if (!sawHandshakeResponse) {
+          sawHandshakeResponse = true;
+          socket.write(mysqlAuthSwitchRequest(seq + 1, "mysql_native_password", Buffer.alloc(20, 0x61)));
+          return;
+        }
+        responses++;
+        if (responses >= 50) {
+          socket.destroy();
+          return;
+        }
+        socket.write(mysqlAuthSwitchRequest(seq + 1, "mysql_native_password", Buffer.alloc(20, 0x62)));
+      });
+    });
+  });
+
+  const db = new SQL({
+    adapter: "mysql",
+    hostname: "127.0.0.1",
+    port,
+    username: "u",
+    password: "pw",
+    database: "d",
+    tls: false,
+    max: 1,
+    connectionTimeout: 30,
+  });
+  let err: any;
+  try {
+    await db.unsafe("SELECT 1");
+    err = { code: "UNEXPECTED_SUCCESS" };
+  } catch (e: any) {
+    err = { code: e?.code ?? String(e) };
+  } finally {
+    await db.close({ timeout: 0 });
+    for (const s of sockets) s.destroy();
+    await new Promise<void>(r => server.close(() => r()));
+  }
+  // The client must answer the first AuthSwitchRequest (responses == 1) and
+  // then error on the duplicate without answering it. Before the fix
+  // `responses` hit the limit.
+  expect({ err, responses }).toEqual({
+    err: { code: "ERR_MYSQL_UNEXPECTED_PACKET" },
+    responses: 1,
+  });
+});
+
+test("MySQL: a single AuthSwitchRequest then OK still connects", async () => {
+  // Boundary: the normal one-switch happy path must still work.
+  let responses = 0;
+  const { server, port } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let phase = 0;
+    socket.write(mysqlHandshakeV10({ authPlugin: "caching_sha2_password" }));
+    socket.on("error", () => {});
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), seq => {
+        if (phase === 0) {
+          phase = 1;
+          socket.write(mysqlAuthSwitchRequest(seq + 1, "mysql_native_password", Buffer.alloc(20, 0x62)));
+        } else if (phase === 1) {
+          phase = 2;
+          responses++;
+          socket.write(mysqlOkPacket(seq + 1));
+        }
+      });
+    });
+  });
+
+  try {
+    await using db = new SQL({
+      adapter: "mysql",
+      hostname: "127.0.0.1",
+      port,
+      username: "u",
+      password: "pw",
+      database: "d",
+      tls: false,
+      max: 1,
+    });
+    await expect(db.connect()).resolves.toBeDefined();
+    expect(responses).toBe(1);
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});
+
+test("MySQL: connectionTimeout bounds the whole handshake, not per packet", async () => {
+  // Server that trickles the greeting one byte at a time, each well under
+  // connectionTimeout. Before the fix each byte re-armed the connect timer so
+  // the client waited indefinitely; now it fails once the overall deadline
+  // passes.
+  const greeting = mysqlHandshakeV10();
+  const sockets = new Set<import("node:net").Socket>();
+  const { server, port } = await listeningServer(socket => {
+    sockets.add(socket);
+    let i = 0;
+    const id = setInterval(() => {
+      if (socket.destroyed || i >= greeting.length) {
+        clearInterval(id);
+        return;
+      }
+      socket.write(greeting.subarray(i, i + 1));
+      i++;
+    }, 200);
+    socket.on("error", () => {});
+    socket.on("close", () => {
+      clearInterval(id);
+      sockets.delete(socket);
+    });
+  });
+
+  const t0 = performance.now();
+  const db = new SQL({
+    adapter: "mysql",
+    hostname: "127.0.0.1",
+    port,
+    username: "u",
+    password: "pw",
+    database: "d",
+    tls: false,
+    max: 1,
+    connectionTimeout: 1,
+  });
+  try {
+    const err = await db.unsafe("SELECT 1").then(
+      () => ({ code: "UNEXPECTED_SUCCESS" }),
+      (e: any) => ({ code: e?.code ?? String(e) }),
+    );
+    const elapsed = performance.now() - t0;
+    // The greeting is ~80 bytes @ 200ms/byte ≈ 16s; the 1s connectionTimeout
+    // must win well before then. Allow generous slack for debug/ASAN.
+    expect(err).toEqual({ code: "ERR_MYSQL_CONNECTION_TIMEOUT" });
+    expect(elapsed).toBeLessThan(8000);
+  } finally {
+    await db.close({ timeout: 0 });
+    for (const s of sockets) s.destroy();
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -88,6 +88,22 @@ export function pgAuthenticationCleartextPassword(): Buffer {
   return buf;
 }
 
+// PostgreSQL FE/BE protocol §55.7 AuthenticationMD5Password: Byte1('R') Int32(12) Int32(5) Byte4(salt)
+export function pgAuthenticationMD5Password(salt: Buffer = Buffer.alloc(4, 0x61)): Buffer {
+  const buf = Buffer.alloc(13);
+  buf.write("R", 0);
+  buf.writeInt32BE(12, 1);
+  buf.writeInt32BE(5, 5);
+  salt.copy(buf, 9);
+  return buf;
+}
+
+// PostgreSQL FE/BE protocol §55.7 AuthenticationSASL: Byte1('R') Int32(len) Int32(10) (String mechanism)* Byte1(0)
+export function pgAuthenticationSASL(mechanisms: string[] = ["SCRAM-SHA-256"]): Buffer {
+  const body = Buffer.concat([pgInt32(10), ...mechanisms.map(m => pgCString(m)), Buffer.from([0])]);
+  return pgRaw("R", body);
+}
+
 // PostgreSQL FE/BE protocol §55.7 ParameterStatus: Byte1('S') Int32(len) String(name) String(value)
 export function pgParameterStatus(name: string, value: string): Buffer {
   return pgRaw("S", Buffer.concat([pgCString(name), pgCString(value)]));


### PR DESCRIPTION
## Problem

A hostile or MITM'd server that answers every client auth packet with another **AuthSwitchRequest** (MySQL 0xFE) or **AuthenticationSASL / MD5Password / CleartextPassword** (Postgres `R`) drives Bun into an unbounded authentication loop at 100% CPU, pre-auth, with no application-visible signal. `connectionTimeout` never fires because `on_data` re-arms the connect-phase timer on every inbound packet, so any server that dribbles bytes (e.g. one greeting byte per 1.5s) holds the client indefinitely.

```
client answered 40 AuthSwitchRequests on ONE connection in 7863ms (connectionTimeout: 2 never fired) -> BUG
```

mysql2 / libmysqlclient refuse a second auth-switch; libpq rejects a second AuthenticationSASL with `duplicate SASL authentication request`.

## Cause

Two independent defects, shared between the adapters:

1. `MySQLConnection::handle_auth` honoured every `PacketType::AUTH_SWITCH` with no per-handshake state. The Postgres `Authentication::SASL` / `ClearTextPassword` / `MD5Password` arms likewise accepted a fresh request in every authentication state.
2. `JSMySQLConnection::on_data` and `PostgresSQLConnection::on_data` bracketed processing with a `reset_connection_timeout()` (mysql) / `disable_connection_timeout()` + `reset_connection_timeout()` (postgres), turning the connect deadline into a per-packet inactivity timer.

## Fix

MySQL: record that an AuthSwitchRequest has been honoured and reject a second one with `ERR_MYSQL_UNEXPECTED_PACKET`. `on_data` now leaves the connect-phase timer running until the auth OK transitions the connection to `Connected`, at which point it is re-armed as the idle timer.

Postgres: `AuthenticationSASL`, `AuthenticationCleartextPassword` and `AuthenticationMD5Password` are only accepted while `authentication_state` is `Pending`; any later arrival is rejected with `ERR_POSTGRES_UNEXPECTED_MESSAGE`. A new `AuthenticationState::ClearText` records that a cleartext password was sent. `on_data` now leaves the connect-phase timer running until `ReadyForQuery` transitions the connection to `Connected`.

## Verification

New scripted wire-server tests:

- `test/js/sql/sql-mysql-duplicate-auth-switch.test.ts`: a second AuthSwitchRequest is rejected after exactly one response; the one-switch happy path still connects; a server that trickles the greeting one byte per 200ms fails at the 1s `connectionTimeout`.
- `test/js/sql/postgres-duplicate-auth-request.test.ts`: duplicate and mixed-method auth requests are rejected after exactly one response; the single-request cleartext and MD5 happy paths still connect; a server that trickles bytes during auth fails at the 1s `connectionTimeout`.

Existing `wire-frames.test.ts`, `sql-mysql-auth-short-nonce.test.ts`, `sql-connect-error-reporting.test.ts`, `postgres-frame-boundary.test.ts`, `postgres-invalid-message-length.test.ts`, and the scripted cases in `sql-mysql.auth.test.ts` pass unchanged.

Closes #33671 (postgres half, now folded in and rebased).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-duplicate-auth-request.test.ts test/js/sql/sql-mysql-duplicate-auth-switch.test.ts
bun test v1.4.0 (2d1c00e96)

test/js/sql/sql-mysql-duplicate-auth-switch.test.ts:
(fail) MySQL: a second AuthSwitchRequest to the same plugin is rejected [5000.63ms]
  ^ this test timed out after 5000ms.
(fail) MySQL: at most two AuthSwitchRequests are honoured per handshake [5000.22ms]
  ^ this test timed out after 5000ms.
(fail) MySQL: caching_sha2 perform_full_authentication is honoured at most once [5000.20ms]
  ^ this test timed out after 5000ms.
(pass) MySQL: a single AuthSwitchRequest to a different plugin then OK still connects [145.61ms]
(pass) MySQL: a single AuthSwitchRequest to the greeting's plugin then OK still connects [82.40ms]
(fail) MySQL: connectionTimeout bounds the whole handshake, not per packet [5000.14ms]
  ^ this test timed out after 5000ms.

test/js/sql/postgres-duplicate-auth-request.test.ts:
(fail) postgres: duplicate AuthenticationSASL is rejected, not answered again [5000.18ms]
  ^ this test timed out af
... (truncated)

release without fix: 11 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/sql/sql-mysql-duplicate-auth-switch.test.ts:
(fail) MySQL: a second AuthSwitchRequest to the same plugin is rejected [5000.60ms]
  ^ this test timed out after 5000ms.
(fail) MySQL: at most two AuthSwitchRequests are honoured per handshake [5000.54ms]
  ^ this test timed out after 5000ms.
(fail) MySQL: caching_sha2 perform_full_authentication is honoured at most once [5000.53ms]
  ^ this test timed out after 5000ms.
(pass) MySQL: a single AuthSwitchRequest to a different plugin then OK still connects [4.80ms]
(pass) MySQL: a single AuthSwitchRequest to the greeting's plugin then OK still connects [1.94ms]
(fail) MySQL: connectionTimeout bounds the whole handshake, not per packet [5000.08ms]
  ^ this test timed out after 5000ms.

test/js/sql/postgres-duplicate-auth-request.test.ts:
(fail) postgres: duplicate AuthenticationSASL is rejected, not answered again [5000.11ms]
  ^ this test timed out after 5000ms.
(fail) postgres: duplicate AuthenticationCleartextPassword is rejected, not answered again [5000.13ms]
  ^ this test timed out after 5000ms.
(fail) postgres: duplicate AuthenticationMD5Password is rejected, not answered
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-duplicate-auth-request.test.ts test/js/sql/sql-mysql-duplicate-auth-switch.test.ts
bun test v1.4.0 (2d1c00e96)

test/js/sql/sql-mysql-duplicate-auth-switch.test.ts:
(pass) MySQL: a second AuthSwitchRequest to the same plugin is rejected [842.62ms]
(pass) MySQL: at most two AuthSwitchRequests are honoured per handshake [129.45ms]
(pass) MySQL: caching_sha2 perform_full_authentication is honoured at most once [230.70ms]
(pass) MySQL: a single AuthSwitchRequest to a different plugin then OK still connects [143.35ms]
(pass) MySQL: a single AuthSwitchRequest to the greeting's plugin then OK still connects [79.30ms]
(pass) MySQL: connectionTimeout bounds the whole handshake, not per packet [1057.49ms]

test/js/sql/postgres-duplicate-auth-request.test.ts:
(pass) postgres: duplicate AuthenticationSASL is rejected, not answered again [120.42ms]
(pass) postgres: duplicate AuthenticationCleartextPassword is rejected, not answered again [62.32ms]
(pass) postgres: duplicate AuthenticationMD5Password is rejected, not answered ag
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2d1c00e96f
  features     baseline

22 deps, 108 codegen, 1171 objects in 998ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [21.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[4/1234] gen bindgenv2
[5/1234] gen ErrorCode+*.h
[6/1234] fetch tinycc
[tinycc] up to date
[7/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1234] fetch zlib
[zlib] up to date
[9/1234] fetch picohttpparser
[picohttpparser] up to date
[10/1234] gen .bind.ts → GeneratedBindings.cpp
[11/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql_jsc/mysql/JSMySQLConnection.rs             |   5 +-
 src/sql_jsc/mysql/MySQLConnection.rs               |  26 +-
 src/sql_jsc/postgres/AuthenticationState.rs        |   1 +
 src/sql_jsc/postgres/PostgresSQLConnection.rs      |  34 ++-
 .../js/sql/postgres-duplicate-auth-request.test.ts | 207 +++++++++++++++
 .../js/sql/sql-mysql-duplicate-auth-switch.test.ts | 284 +++++++++++++++++++++
 test/js/sql/wire-frames.ts                         |  16 ++
 7 files changed, 563 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 5 passed · 1 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/sql_jsc/mysql/JSMySQLConnection.rs                   4      3      0
src/sql_jsc/mysql/MySQLConnection.rs                    12     14      0
src/sql_jsc/postgres/AuthenticationState.rs              1      1      0
src/sql_jsc/postgres/PostgresSQLConnection.rs            5      7      0
test/js/sql/postgres-duplicate-auth-request.test.ts      1      5      0
test/js/sql/sql-mysql-duplicate-auth-switch.test.ts      3      8      0
test/js/sql/wire-frames.ts                               2      1      0
```

</details>

<!-- robobun:evidence:end -->