### PR TITLE
test(net): drop 100ms setTimeout race from the net.Server listen tests

### DIFF
--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -18,13 +18,8 @@ describe("net.createServer listen", () => {
     done();
   });
 
-  // These tests formerly armed `setTimeout(closeAndFail, 100)` as a secondary
-  // deadline. After #36175 reordered the serial phase to overlap with the
-  // docker-service prestart, the alpine lane saw the 100ms timer fire before
-  // `'listening'` (the timer was measuring scheduling contention, not listen()).
-  // The test runner already bounds each test, so the extra timer only added a
-  // flake surface. A real listen failure still reaches done() via the 'error'
-  // listener below.
+  // No secondary setTimeout deadline: the test runner already bounds each test,
+  // and a real listen failure reaches done() via the 'error' listener below.
   const failOnError = (server: Server, done: (err?: unknown) => void) => (err: unknown) => {
     server.close();
     done(err);

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -18,18 +18,23 @@ describe("net.createServer listen", () => {
     done();
   });
 
+  // These tests formerly armed `setTimeout(closeAndFail, 100)` as a secondary
+  // deadline. After #36175 reordered the serial phase to overlap with the
+  // docker-service prestart, the alpine lane saw the 100ms timer fire before
+  // `'listening'` (the timer was measuring scheduling contention, not listen()).
+  // The test runner already bounds each test, so the extra timer only added a
+  // flake surface. A real listen failure still reaches done() via the 'error'
+  // listener below.
+  const failOnError = (server: Server, done: (err?: unknown) => void) => (err: unknown) => {
+    server.close();
+    done(err);
+  };
+
   it("should listen on IPv6 by default", done => {
-    const { mustCall, mustNotCall } = createCallCheckCtx(done);
+    const { mustCall } = createCallCheckCtx(done);
 
     const server: Server = createServer();
-    let timeout: Timer;
-    const closeAndFail = () => {
-      clearTimeout(timeout);
-      server.close();
-      mustNotCall()();
-    };
-    server.on("error", closeAndFail);
-    timeout = setTimeout(closeAndFail, 100);
+    server.on("error", failOnError(server, done));
 
     server.listen(
       0,
@@ -46,18 +51,10 @@ describe("net.createServer listen", () => {
   });
 
   it("should listen on IPv4", done => {
-    const { mustCall, mustNotCall } = createCallCheckCtx(done);
+    const { mustCall } = createCallCheckCtx(done);
 
     const server: Server = createServer();
-
-    let timeout: Timer;
-    const closeAndFail = () => {
-      clearTimeout(timeout);
-      server.close();
-      mustNotCall()();
-    };
-    server.on("error", closeAndFail);
-    timeout = setTimeout(closeAndFail, 100);
+    server.on("error", failOnError(server, done));
 
     server.listen(
       0,
@@ -75,73 +72,45 @@ describe("net.createServer listen", () => {
   });
 
   it("should call listening", done => {
-    const { mustCall, mustNotCall } = createCallCheckCtx(done);
+    const { mustCall } = createCallCheckCtx(done);
 
     const server: Server = createServer();
 
-    let timeout: Timer;
-    const closeAndFail = () => {
-      clearTimeout(timeout);
-      server.close();
-      mustNotCall()();
-    };
-
-    server.on("error", closeAndFail).on(
+    server.on("error", failOnError(server, done)).on(
       "listening",
       mustCall(() => {
-        clearTimeout(timeout);
         server.close();
         done();
       }),
     );
 
-    timeout = setTimeout(closeAndFail, 100);
-
     server.listen(0, "0.0.0.0");
   });
 
   it("should provide listening property", done => {
-    const { mustCall, mustNotCall } = createCallCheckCtx(done);
+    const { mustCall } = createCallCheckCtx(done);
 
     const server: Server = createServer();
     expect(server.listening).toBeFalse();
 
-    let timeout: Timer;
-    const closeAndFail = () => {
-      clearTimeout(timeout);
-      server.close();
-      mustNotCall()();
-    };
-
-    server.on("error", closeAndFail).on(
+    server.on("error", failOnError(server, done)).on(
       "listening",
       mustCall(() => {
         expect(server.listening).toBeTrue();
-        clearTimeout(timeout);
         server.close();
         expect(server.listening).toBeFalse();
         done();
       }),
     );
 
-    timeout = setTimeout(closeAndFail, 100);
-
     server.listen(0, "0.0.0.0");
   });
 
   it("should listen on localhost", done => {
-    const { mustCall, mustNotCall } = createCallCheckCtx(done);
+    const { mustCall } = createCallCheckCtx(done);
 
     const server: Server = createServer();
-
-    let timeout: Timer;
-    const closeAndFail = () => {
-      clearTimeout(timeout);
-      server.close();
-      mustNotCall()();
-    };
-    server.on("error", closeAndFail);
-    timeout = setTimeout(closeAndFail, 100);
+    server.on("error", failOnError(server, done));
 
     server.listen(
       0,
@@ -159,18 +128,10 @@ describe("net.createServer listen", () => {
   });
 
   it("should listen on localhost", done => {
-    const { mustCall, mustNotCall } = createCallCheckCtx(done);
+    const { mustCall } = createCallCheckCtx(done);
 
     const server: Server = createServer();
-
-    let timeout: Timer;
-    const closeAndFail = () => {
-      clearTimeout(timeout);
-      server.close();
-      mustNotCall()();
-    };
-    server.on("error", closeAndFail);
-    timeout = setTimeout(closeAndFail, 100);
+    server.on("error", failOnError(server, done));
 
     server.listen(
       0,
@@ -186,18 +147,10 @@ describe("net.createServer listen", () => {
   });
 
   it("should listen without port or host", done => {
-    const { mustCall, mustNotCall } = createCallCheckCtx(done);
+    const { mustCall } = createCallCheckCtx(done);
 
     const server: Server = createServer();
-
-    let timeout: Timer;
-    const closeAndFail = () => {
-      clearTimeout(timeout);
-      server.close();
-      mustNotCall()();
-    };
-    server.on("error", closeAndFail);
-    timeout = setTimeout(closeAndFail, 100);
+    server.on("error", failOnError(server, done));
 
     server.listen(
       mustCall(() => {
@@ -213,18 +166,10 @@ describe("net.createServer listen", () => {
   });
 
   it("should listen on unix domain socket", done => {
-    const { mustCall, mustNotCall } = createCallCheckCtx(done);
+    const { mustCall } = createCallCheckCtx(done);
 
     const server: Server = createServer();
-
-    let timeout: Timer;
-    const closeAndFail = () => {
-      clearTimeout(timeout);
-      server.close();
-      mustNotCall()();
-    };
-    server.on("error", closeAndFail);
-    timeout = setTimeout(closeAndFail, 100);
+    server.on("error", failOnError(server, done));
 
     server.listen(
       socket_domain,
@@ -238,17 +183,10 @@ describe("net.createServer listen", () => {
   });
 
   it("should bind IPv4 0.0.0.0 when listen on 0.0.0.0, issue#7355", done => {
-    const { mustCall, mustNotCall } = createCallCheckCtx(done);
+    const { mustCall } = createCallCheckCtx(done);
 
     const server: Server = createServer();
-    let timeout: Timer;
-    const closeAndFail = () => {
-      clearTimeout(timeout);
-      server.close();
-      mustNotCall()();
-    };
-    server.on("error", closeAndFail);
-    timeout = setTimeout(closeAndFail, 100);
+    server.on("error", failOnError(server, done));
 
     server.listen(
       0,


### PR DESCRIPTION
### What does this PR do?

Fixes `test/js/node/net/node-net-server.test.ts > should listen on unix domain socket` going red on the alpine 3.23 lanes since #36175 (seen on main builds 84293, 84503, 84549, 84601 and ~60 branch builds).

Every test in the `net.createServer listen` block armed `setTimeout(closeAndFail, 100)` next to `server.listen()`. That timer was never testing `listen()` itself: `Bun.listen` binds synchronously and `'listening'` is scheduled via `setTimeout(emitListeningNextTick, 1, this)`, so the 100 ms race was against the test process's own scheduling latency. The runner already bounds each test, so the extra timer only added a flake surface (and hid the real error behind `function should not have been called`).

#36175 didn't touch `net` or this file, but it moved the allowlisted files into a single batch, so the handful of remaining serial files (this one is in `excludeFiles`) now run much earlier in the shard. On alpine that lands while the docker-service coordinator is still bringing up the mysql containers in the background:

```
t=233226  [9/282] node-net-server.test.ts
t=233436  ✗ should listen on unix domain socket [144.58ms]   ← 100 ms timer fired
t=234907  coordinator: mysql_native_password ready           ← docker init finished 1.5 s later
t=242361  [attempt #2] node-net-server.test.ts  21 pass      ← same file green once docker is idle
```

(from build 84601, alpine 3.23 x64 shard `019fab6d-27b7-4c39`)

### Change

Remove the 100 ms `setTimeout(closeAndFail, ...)` from the nine listen tests and route `server.on('error', ...)` to `done(err)` so a real bind failure reports its actual error. Same assertions, same code paths (`listen()` → `'listening'` → `server.address()` checks); only the hand-rolled deadline that duplicated the test runner's timeout is gone. The 500 ms timers in the `events` block are untouched; they guard real client↔server round trips, have `is_done` guards, and haven't flaked.

### How did you verify your code works?

- `bun bd test test/js/node/net/node-net-server.test.ts` → 21 pass / 0 fail.
- Reproduced the race locally by running the file under background CPU+disk load (4× `yes`, 2 GB `dd`): with the old timer the listen block failed 1/5 runs at `function should not have been called`; with this change 5/5 runs pass under the same load (including a 246 ms `'listening'` that would have tripped the old 100 ms timer).

`node-tls-server.test.ts` has the same 100 ms pattern and is also a serial `excludeFiles` entry; happy to fold it in here if preferred, but it hasn't been observed red so I kept this scoped to the reported file.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/net/node-net-server.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/net/node-net-server.test.ts
bun test v1.4.0 (6b920f8b9)

test/js/node/net/node-net-server.test.ts:
(pass) net.createServer listen > should throw when no port or path when using options [27.65ms]
(pass) net.createServer listen > should listen on IPv6 by default [153.42ms]
(pass) net.createServer listen > should listen on IPv4 [26.37ms]
(pass) net.createServer listen > should call listening [19.34ms]
(pass) net.createServer listen > should provide listening property [22.93ms]
(pass) net.createServer listen > should listen on localhost [17.90ms]
(pass) net.createServer listen > should listen on localhost [17.45ms]
(pass) net.createServer listen > should listen without port or host [24.19ms]
(pass) net.createServer listen > should listen on unix domain socket [19.40ms]
(pass) net.createServer listen > should bind IPv4 0.0.0.0 when listen on 0.0.0.0, issue#7355 [31.32ms]
(pass) net.createServer events > should receive data [159.16ms]
(pass) net.createServer events > should call end [155.39ms]
(pass) net.createServer events > should call close [19.65ms]
(pass) net.createServer events > should call connection and drop [70.90ms]
(pass) net.createServer events > should error on an invalid port [23.08ms]
(pass) net.createServer events > should call abort with signal [25.98ms]
(pass) net.createServer events > should echo data [111.91ms]
(pass) net.createServer events > #8374 [72.98ms]
(pass) accepted socket event-loop hold matches Node (per-connection KeepAlive) > server.stop() + accepted socket.unref() lets the process exit [318.84ms]
(pass) accepted socket event-loop hold matches Node (per-connection KeepAlive) > server.unref() alone does not drop a ref'd accepted connection's hold [1548.16ms]
(pass) accepted socket event-loop hold matches Node (per-connection KeepAlive) > half-open accepted sockets after peer FIN do not busy-poll the event loop (Windows AFD DISCONNECT) [4
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/net/node-net-server.test.ts | 117 +++++++------------------------
 1 file changed, 25 insertions(+), 92 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
test/js/node/net/node-net-server.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->