### PR TITLE
Bun.serve: validate per-method route values like top-level route values

### DIFF
--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -970,8 +970,11 @@ impl ServerConfig {
                                 }
                             } else {
                                 let ty_str = function.js_type_string(global).to_slice(global);
-                                let received: &[u8] =
-                                    if function.is_null() { b"null" } else { ty_str.slice() };
+                                let received: &[u8] = if function.is_null() {
+                                    b"null"
+                                } else {
+                                    ty_str.slice()
+                                };
                                 return Err(global.throw_invalid_arguments(format_args!(
                                     "Invalid value for route {} method {}: received {}. Expected a function, Response, HTMLBundle, BunFile, or false.",
                                     bun_fmt::quote(&path),

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -921,10 +921,17 @@ impl ServerConfig {
                     for method in METHODS {
                         let method_name = bun_core::String::static_(method.as_str());
                         if let Some(function) = value.get_own(global, &method_name)? {
+                            if function.is_undefined() {
+                                continue;
+                            }
                             if !found {
                                 validate_route_name(global, &path)?;
                             }
                             found = true;
+
+                            if function == JSValue::FALSE {
+                                continue;
+                            }
 
                             if function.is_callable() {
                                 let callback = function.with_async_context_if_needed(global);
@@ -962,6 +969,12 @@ impl ServerConfig {
                                 if method == Method::HEAD {
                                     has_head_route = true;
                                 }
+                            } else {
+                                return Err(global.throw_invalid_arguments(format_args!(
+                                    "Invalid value for route {} method {}. Expected a function, Response, HTMLBundle, BunFile, or false.",
+                                    bun_fmt::quote(&path),
+                                    method.as_str(),
+                                )));
                             }
                         }
                     }

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -924,7 +924,13 @@ impl ServerConfig {
                         if let Some(function) = value.get_own(global, &method_name)? {
                             found = true;
 
-                            if function.is_undefined() || function == JSValue::FALSE {
+                            if function.is_undefined() {
+                                continue;
+                            }
+                            if function == JSValue::FALSE {
+                                if method == Method::HEAD {
+                                    has_head_route = true;
+                                }
                                 continue;
                             }
                             if !route_name_validated {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -914,6 +914,7 @@ impl ServerConfig {
                         Method::TRACE,
                     ];
                     let mut found = false;
+                    let mut route_name_validated = false;
                     // HEAD must behave like GET without a body (RFC 9110 section 9.3.2),
                     // so a route object with a GET handler and no HEAD entry also answers HEAD.
                     let mut derived_head_route: Option<UserRouteBuilder> = None;
@@ -921,16 +922,14 @@ impl ServerConfig {
                     for method in METHODS {
                         let method_name = bun_core::String::static_(method.as_str());
                         if let Some(function) = value.get_own(global, &method_name)? {
-                            if function.is_undefined() {
-                                continue;
-                            }
-                            if !found {
-                                validate_route_name(global, &path)?;
-                            }
                             found = true;
 
-                            if function == JSValue::FALSE {
+                            if function.is_undefined() || function == JSValue::FALSE {
                                 continue;
+                            }
+                            if !route_name_validated {
+                                validate_route_name(global, &path)?;
+                                route_name_validated = true;
                             }
 
                             if function.is_callable() {
@@ -970,10 +969,14 @@ impl ServerConfig {
                                     has_head_route = true;
                                 }
                             } else {
+                                let ty_str = function.js_type_string(global).to_slice(global);
+                                let received: &[u8] =
+                                    if function.is_null() { b"null" } else { ty_str.slice() };
                                 return Err(global.throw_invalid_arguments(format_args!(
-                                    "Invalid value for route {} method {}. Expected a function, Response, HTMLBundle, BunFile, or false.",
+                                    "Invalid value for route {} method {}: received {}. Expected a function, Response, HTMLBundle, BunFile, or false.",
                                     bun_fmt::quote(&path),
                                     method.as_str(),
+                                    bstr::BStr::new(received),
                                 )));
                             }
                         }

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -236,6 +236,31 @@ describe("implicit HEAD for per-method route objects", () => {
     expect(get.status).toBe(200);
   });
 
+  test("HEAD: false suppresses the GET-derived HEAD route", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/x": {
+          GET: () => new Response("get-body"),
+          // @ts-expect-error - false is an explicit per-method disable
+          HEAD: false,
+        },
+      },
+      fetch: req => new Response(null, { status: 299, headers: { "x-from": "fetch", "x-method": req.method } }),
+    });
+
+    const head = await fetch(new URL("/x", server.url), { method: "HEAD" });
+    expect({ status: head.status, from: head.headers.get("x-from"), method: head.headers.get("x-method") }).toEqual({
+      status: 299,
+      from: "fetch",
+      method: "HEAD",
+    });
+
+    const get = await fetch(new URL("/x", server.url));
+    expect(await get.text()).toBe("get-body");
+    expect(get.status).toBe(200);
+  });
+
   test("a static Response for another method does not capture HEAD away from GET", async () => {
     await using server = Bun.serve({
       port: 0,

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -742,13 +742,13 @@ it("throws a validation error when passing invalid routes", () => {
 
 describe("per-method route value validation", () => {
   it.each([
-    ["null", null],
-    ["number", 42],
-    ["string", "str"],
-    ["plain object", {}],
-    ["array", [1, 2]],
-    ["true", true],
-  ])("throws when a method value is %s", (_, value) => {
+    ["null", null, "null"],
+    ["number", 42, "number"],
+    ["string", "str", "string"],
+    ["plain object", {}, "object"],
+    ["array", [1, 2], "object"],
+    ["true", true, "boolean"],
+  ])("throws when a method value is %s", (_, value, received) => {
     expect(() => {
       Bun.serve({
         port: 0,
@@ -756,7 +756,9 @@ describe("per-method route value validation", () => {
         routes: { "/x": { GET: value, POST: () => new Response("ok") } },
         fetch: () => new Response("fallback"),
       });
-    }).toThrow('Invalid value for route "/x" method GET');
+    }).toThrow(
+      `Invalid value for route "/x" method GET: received ${received}. Expected a function, Response, HTMLBundle, BunFile, or false.`,
+    );
   });
 
   it.each([
@@ -780,6 +782,20 @@ describe("per-method route value validation", () => {
       get: { status: 299, body: "fallback" },
       post: { status: 200, body: "post-ok" },
     });
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["false", false],
+  ])("accepts a lone { GET: %s } without falling through to the top-level validator", async (_, value) => {
+    await using server = Bun.serve({
+      port: 0,
+      // @ts-expect-error - testing runtime acceptance
+      routes: { "/x": { GET: value } },
+      fetch: () => new Response("fallback", { status: 299 }),
+    });
+    const res = await fetch(new URL("/x", server.url));
+    expect({ status: res.status, body: await res.text() }).toEqual({ status: 299, body: "fallback" });
   });
 
   it("still accepts a Response as a method value", async () => {

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -740,6 +740,57 @@ it("throws a validation error when passing invalid routes", () => {
   `);
 });
 
+describe("per-method route value validation", () => {
+  it.each([
+    ["null", null],
+    ["number", 42],
+    ["string", "str"],
+    ["plain object", {}],
+    ["array", [1, 2]],
+    ["true", true],
+  ])("throws when a method value is %s", (_, value) => {
+    expect(() => {
+      Bun.serve({
+        port: 0,
+        // @ts-expect-error - testing invalid input
+        routes: { "/x": { GET: value, POST: () => new Response("ok") } },
+        fetch: () => new Response("fallback"),
+      });
+    }).toThrow('Invalid value for route "/x" method GET');
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["false", false],
+  ])("accepts %s as a method value (skips that method)", async (_, value) => {
+    await using server = Bun.serve({
+      port: 0,
+      // @ts-expect-error - testing runtime acceptance
+      routes: { "/x": { GET: value, POST: () => new Response("post-ok") } },
+      fetch: () => new Response("fallback", { status: 299 }),
+    });
+    const [g, p] = await Promise.all([
+      fetch(new URL("/x", server.url)),
+      fetch(new URL("/x", server.url), { method: "POST" }),
+    ]);
+    expect({ get: { status: g.status, body: await g.text() }, post: { status: p.status, body: await p.text() } }).toEqual({
+      get: { status: 299, body: "fallback" },
+      post: { status: 200, body: "post-ok" },
+    });
+  });
+
+  it("still accepts a Response as a method value", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: { "/x": { GET: new Response("static-get") } },
+      fetch: () => new Response("fallback"),
+    });
+    const res = await fetch(new URL("/x", server.url));
+    expect(await res.text()).toBe("static-get");
+    expect(res.status).toBe(200);
+  });
+});
+
 it("throws a validation error when routes object is empty and fetch is not specified", async () => {
   expect(() =>
     Bun.serve({

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -773,7 +773,10 @@ describe("per-method route value validation", () => {
       fetch(new URL("/x", server.url)),
       fetch(new URL("/x", server.url), { method: "POST" }),
     ]);
-    expect({ get: { status: g.status, body: await g.text() }, post: { status: p.status, body: await p.text() } }).toEqual({
+    expect({
+      get: { status: g.status, body: await g.text() },
+      post: { status: p.status, body: await p.text() },
+    }).toEqual({
       get: { status: 299, body: "fallback" },
       post: { status: 200, body: "post-ok" },
     });


### PR DESCRIPTION
## What

`Bun.serve({ routes })` validates top-level route values: `{ "/x": 42 }` throws a `TypeError` at registration. The same invalid value nested inside a method object was accepted silently, leaving that method dead (falls through to `fetch` or 404) with no error at registration or request time.

```js
Bun.serve({ routes: { "/x": 42 } });                          // throws
Bun.serve({ routes: { "/x": { GET: 42, POST: handler } } });  // accepted, GET is dead
```

The realistic face of this is a typo'd handler import, e.g. `{ GET: handlers.getUsr }`, producing a route that silently never runs.

## Why

The per-method loop in `ServerConfig::from_js` set `found = true` for any own method key before checking the value type. A value that was neither callable nor a valid `AnyRoute` fell out of the `if`/`else if` without an `else`, and `found = true` then suppressed the top-level validator. Panic/top-frame signature: `Invalid value for route "/x" method GET`.

## Fix

Per-method values now match top-level semantics:

- `undefined` skips the key (same as top-level `"/x": undefined`)
- `false` marks the object as a method map without registering a handler (documented disable)
- anything else that is not a callable or a valid static route throws `Invalid value for route "<path>" method <METHOD>. Expected a function, Response, HTMLBundle, BunFile, or false.`

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/bun/http/bun-serve-routes.test.ts -t "per-method route value validation"
  6 fail (null/number/string/object/array/true accepted silently)

bun bd test test/js/bun/http/bun-serve-routes.test.ts
  64 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-routes.test.ts
bun test v1.4.0 (2c84eecb7)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [25.19ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [17.55ms]
(pass) path parameters > handles encoded parameters [8.57ms]
(pass) path parameters > handles unicode parameters [13.46ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [376.50ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [53.18ms]
(pass) HTTP methods > GET request [24.82ms]
(pass) HTTP methods > POST request [5.46ms]
(pass) HTTP methods > PUT request [10.76ms]
(pass) HTTP methods > DELETE request [4.73ms]
(pass) HTTP methods > PATCH request [3.71ms]
(pass) HTTP methods > OPTIONS request [9.83ms]
(pass) HTTP methods > HEAD request [5.64ms]
(pass) implicit HEAD for per-method route objects > HEAD is served by the GET handler when no HEAD handler is declared [59.42ms]
(pass) impli
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (9356b6a24)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [1.37ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [0.31ms]
(pass) path parameters > handles encoded parameters [0.14ms]
(pass) path parameters > handles unicode parameters [0.15ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [5.55ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [0.73ms]
(pass) HTTP methods > GET request [1.06ms]
(pass) HTTP methods > POST request [0.14ms]
(pass) HTTP methods > PUT request [0.08ms]
(pass) HTTP methods > DELETE request [0.07ms]
(pass) HTTP methods > PATCH request [0.07ms]
(pass) HTTP methods > OPTIONS request [0.07ms]
(pass) HTTP methods > HEAD request [0.10ms]
(pass) implicit HEAD for per-method route objects > HEAD is served by the GET handler when no HEAD handler is declared [1.20ms]
(pass) implicit HEAD for per-method route objects > HEAD does not 404 when there is no later route to fall through to [0.79ms]
(pass) implicit HEAD for per-method route objects > the GET 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-routes.test.ts
bun test v1.4.0 (2c84eecb7)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [22.90ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [10.06ms]
(pass) path parameters > handles encoded parameters [13.51ms]
(pass) path parameters > handles unicode parameters [7.35ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [365.80ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [51.35ms]
(pass) HTTP methods > GET request [23.04ms]
(pass) HTTP methods > POST request [4.84ms]
(pass) HTTP methods > PUT request [3.86ms]
(pass) HTTP methods > DELETE request [12.60ms]
(pass) HTTP methods > PATCH request [4.19ms]
(pass) HTTP methods > OPTIONS request [10.30ms]
(pass) HTTP methods > HEAD request [5.05ms]
(pass) implicit HEAD for per-method route objects > HEAD is served by the GET handler when no HEAD handler is declared [50.34ms]
(pass) impl
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 698ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 20s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.0-canary.1+2c84eecb7
[build] done
bun test v1.4.0-canary.1 (2c84eecb7)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [1.50ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [0.28ms]
(pass) path parameters > handles encoded parameters [0.14ms]
(pass) path parameters > handles unicode param
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/ServerConfig.rs        | 29 +++++++++-
 test/js/bun/http/bun-serve-routes.test.ts | 95 +++++++++++++++++++++++++++++++
 2 files changed, 122 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/server/ServerConfig.rs             5      6      0
test/js/bun/http/bun-serve-routes.test.ts      4      4      0
```

</details>

<!-- robobun:evidence:end -->