### PR TITLE
worker: expose self.close() and self.name on the Web Worker global

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -597,6 +597,10 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
                 globalObject->m_processEnvObject.set(vm, globalObject, Bun::createSharedEnvironmentVariablesMap(globalObject).getObject());
             }
 
+            // DedicatedWorkerGlobalScope members that only exist inside a worker.
+            globalObject->putDirect(vm, vm.propertyNames->name, jsString(vm, options.name.isolatedCopy()), PropertyAttribute::ReadOnly | 0);
+            globalObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "close"_s), 0, WebCore::jsFunctionWorkerGlobalScopeClose, ImplementationVisibility::Public, NoIntrinsic, 0);
+
             // Ensure that the TerminationException singleton is constructed. Workers need this so
             // that we can request their termination from another thread. For the main thread, we
             // can delay this until we are actually requesting termination (until and unless we ever

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -597,9 +597,12 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
                 globalObject->m_processEnvObject.set(vm, globalObject, Bun::createSharedEnvironmentVariablesMap(globalObject).getObject());
             }
 
-            // DedicatedWorkerGlobalScope members that only exist inside a worker.
-            globalObject->putDirect(vm, vm.propertyNames->name, jsString(vm, options.name.isolatedCopy()), PropertyAttribute::ReadOnly | 0);
-            globalObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "close"_s), 0, WebCore::jsFunctionWorkerGlobalScopeClose, ImplementationVisibility::Public, NoIntrinsic, 0);
+            if (options.kind == WebCore::WorkerOptions::Kind::Web) {
+                // DedicatedWorkerGlobalScope members. Not installed for node:worker_threads
+                // workers, whose globalThis matches the main thread.
+                globalObject->putDirect(vm, vm.propertyNames->name, jsString(vm, options.name.isolatedCopy()), PropertyAttribute::ReadOnly | 0);
+                globalObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "close"_s), 0, WebCore::jsFunctionWorkerGlobalScopeClose, ImplementationVisibility::Public, NoIntrinsic, 0);
+            }
 
             // Ensure that the TerminationException singleton is constructed. Workers need this so
             // that we can request their termination from another thread. For the main thread, we

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -598,8 +598,7 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
             }
 
             if (options.kind == WebCore::WorkerOptions::Kind::Web) {
-                // DedicatedWorkerGlobalScope members. Not installed for node:worker_threads
-                // workers, whose globalThis matches the main thread.
+                // DedicatedWorkerGlobalScope members (node:worker_threads keeps the main-thread global shape).
                 globalObject->putDirect(vm, vm.propertyNames->name, jsString(vm, options.name.isolatedCopy()), PropertyAttribute::ReadOnly | 0);
                 globalObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "close"_s), 0, WebCore::jsFunctionWorkerGlobalScopeClose, ImplementationVisibility::Public, NoIntrinsic, 0);
             }

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -42,6 +42,7 @@
 extern "C" void Bun__Process__emitWarning(Zig::GlobalObject*, JSC::EncodedJSValue warning, JSC::EncodedJSValue type, JSC::EncodedJSValue code, JSC::EncodedJSValue ctor);
 
 extern "C" void Bun__eventLoop__incrementRefConcurrently(void* bunVM, int delta);
+extern "C" bool WebWorker__isCloseRequested(void* bunVM);
 
 namespace WebCore {
 
@@ -187,8 +188,8 @@ void MessagePort::flushQueuedMessagesBeforeClose()
         if (!message)
             break;
         dispatchOneMessage(*context, WTF::move(*message));
-        if (globalObject->drainMicrotasks())
-            break; // termination pending
+        if (globalObject->drainMicrotasks() || WebWorker__isCloseRequested(globalObject->bunVM()))
+            break; // termination pending, or self.close() asked us to stop
     }
 }
 

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -13,6 +13,8 @@
 #include "ScriptExecutionContext.h"
 #include <wtf/Locker.h>
 
+extern "C" bool WebWorker__isCloseRequested(void* bunVM);
+
 namespace WebCore {
 
 MessagePortPipe::~MessagePortPipe() = default;
@@ -167,8 +169,8 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
         // Node's MakeCallback wraps each emit in an InternalCallbackScope,
         // which drains nextTick + microtasks on exit; match that so
         // queueMicrotask(cb) inside onmessage runs before the next message.
-        if (globalObject->drainMicrotasks())
-            break; // termination pending
+        if (globalObject->drainMicrotasks() || WebWorker__isCloseRequested(globalObject->bunVM()))
+            break; // termination pending, or self.close() asked us to stop
 
         // Listeners may have been removed mid-drain (port.off()); pause like the
         // pre-loop check instead of dispatching the rest to zero listeners.

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -96,6 +96,9 @@ void WebWorker__releaseParentPollRef(void* worker);
 // Free the native WebWorker struct. Called from ~Worker.
 void WebWorker__destroy(void* worker);
 
+// Has self.close() been called inside this worker's VM?
+bool WebWorker__isCloseRequested(void* bunVM);
+
 } // extern "C"
 // -------------------------------------------------------------------------------------------------
 
@@ -308,12 +311,14 @@ static inline bool drainInbox(Worker::MessageInbox& inbox, Zig::GlobalObject* gl
 
             auto ports = MessagePort::entanglePorts(context, WTF::move(message.transferredPorts));
             auto event = MessageEvent::create(*context.jsGlobalObject(), message.message.releaseNonNull(), nullptr, WTF::move(ports));
-            dispatch(event.event);
+            bool keepGoing = dispatch(event.event);
 
-            if (globalObject->drainMicrotasks()) {
-                // Termination pending. Drop the rest — dispatch is a no-op
-                // once m_terminateRequested is set (drainToParent), and the
-                // worker thread is tearing down (drainToWorker).
+            if (globalObject->drainMicrotasks() || !keepGoing) {
+                // Termination pending, or the receiver asked us to stop
+                // (drainToWorker: self.close() inside the handler). Drop the
+                // rest — dispatch is a no-op once m_terminateRequested is set
+                // (drainToParent), and the worker thread is tearing down
+                // (drainToWorker).
                 return false;
             }
         }
@@ -340,6 +345,7 @@ void Worker::drainToWorker(ScriptExecutionContext& context)
     }
     bool reschedule = drainInbox(m_toWorker, globalObject, context, [&](Event& event) {
         globalObject->globalEventScope->dispatchEvent(event);
+        return !WebWorker__isCloseRequested(globalObject->bunVM());
     });
     if (reschedule) {
         ScriptExecutionContext::postTaskTo(m_clientIdentifier, [protectedThis = Ref { *this }](ScriptExecutionContext& ctx) {
@@ -358,6 +364,7 @@ void Worker::drainToParent(ScriptExecutionContext& context)
     }
     bool reschedule = drainInbox(m_toParent, globalObject, context, [&](Event& event) {
         dispatchEvent(event);
+        return true;
     });
     if (reschedule) {
         postTaskToParent([protectedThis = Ref { *this }](ScriptExecutionContext& c) {

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -314,11 +314,8 @@ static inline bool drainInbox(Worker::MessageInbox& inbox, Zig::GlobalObject* gl
             bool keepGoing = dispatch(event.event);
 
             if (globalObject->drainMicrotasks() || !keepGoing) {
-                // Termination pending, or the receiver asked us to stop
-                // (drainToWorker: self.close() inside the handler). Drop the
-                // rest — dispatch is a no-op once m_terminateRequested is set
-                // (drainToParent), and the worker thread is tearing down
-                // (drainToWorker).
+                // Termination pending, or the receiver's self.close() asked us
+                // to stop. Drop the rest: dispatch is a no-op past this point.
                 return false;
             }
         }

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -748,6 +748,7 @@ extern "C" void WebWorker__dispatchError(Zig::GlobalObject* globalObject, Worker
 }
 
 extern "C" WebCore::Worker* WebWorker__getParentWorker(void* bunVM);
+extern "C" void WebWorker__requestClose(void* bunVM);
 
 JSC_DEFINE_HOST_FUNCTION(jsReceiveMessageOnPort, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
@@ -950,6 +951,17 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionPostMessage,
 
     worker->enqueueToParent(MessageWithMessagePorts { serialized.releaseReturnValue(), disentangledPorts.releaseReturnValue() });
 
+    return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionWorkerGlobalScopeClose,
+    (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame*))
+{
+    Zig::GlobalObject* globalObject = dynamicDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    if (!globalObject) [[unlikely]]
+        return JSValue::encode(jsUndefined());
+
+    WebWorker__requestClose(globalObject->bunVM());
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -311,9 +311,9 @@ static inline bool drainInbox(Worker::MessageInbox& inbox, Zig::GlobalObject* gl
 
             auto ports = MessagePort::entanglePorts(context, WTF::move(message.transferredPorts));
             auto event = MessageEvent::create(*context.jsGlobalObject(), message.message.releaseNonNull(), nullptr, WTF::move(ports));
-            bool keepGoing = dispatch(event.event);
+            dispatch(event.event);
 
-            if (globalObject->drainMicrotasks() || !keepGoing) {
+            if (globalObject->drainMicrotasks() || WebWorker__isCloseRequested(globalObject->bunVM())) {
                 // Termination pending, or the receiver's self.close() asked us
                 // to stop. Drop the rest: dispatch is a no-op past this point.
                 return false;
@@ -342,7 +342,6 @@ void Worker::drainToWorker(ScriptExecutionContext& context)
     }
     bool reschedule = drainInbox(m_toWorker, globalObject, context, [&](Event& event) {
         globalObject->globalEventScope->dispatchEvent(event);
-        return !WebWorker__isCloseRequested(globalObject->bunVM());
     });
     if (reschedule) {
         ScriptExecutionContext::postTaskTo(m_clientIdentifier, [protectedThis = Ref { *this }](ScriptExecutionContext& ctx) {
@@ -361,7 +360,6 @@ void Worker::drainToParent(ScriptExecutionContext& context)
     }
     bool reschedule = drainInbox(m_toParent, globalObject, context, [&](Event& event) {
         dispatchEvent(event);
-        return true;
     });
     if (reschedule) {
         postTaskToParent([protectedThis = Ref { *this }](ScriptExecutionContext& c) {

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -211,5 +211,6 @@ private:
 JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject);
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionPostMessage);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionWorkerGlobalScopeClose);
 
 } // namespace WebCore

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1158,13 +1158,9 @@ impl EventLoop {
             .expect("worker is not initialized");
         match promise.status() {
             PromiseStatus::Pending => {
-                while !worker.has_requested_terminate()
-                    && promise.status() == PromiseStatus::Pending
-                {
+                while !worker.should_exit_loop() && promise.status() == PromiseStatus::Pending {
                     self.tick();
-                    if !worker.has_requested_terminate()
-                        && promise.status() == PromiseStatus::Pending
-                    {
+                    if !worker.should_exit_loop() && promise.status() == PromiseStatus::Pending {
                         // Unsettled top-level await: the loop has drained but the
                         // entry module's evaluation promise is still pending. Stop
                         // waiting so the worker can exit (node uses exit code 13).

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -127,12 +127,9 @@ pub struct WebWorker {
     /// (`exit`). The worker loop polls this between ticks.
     requested_terminate: AtomicBool,
 
-    /// Set by `self.close()` on the worker thread. The event loop polls this
-    /// alongside `requested_terminate` so it exits after the current task.
-    /// Separate from `requested_terminate` so that `notify_need_termination`
-    /// and `terminate_all_and_wait` (which skip arming the TerminationException
-    /// when `requested_terminate` is already set) still interrupt a worker that
-    /// has called `close()` and then entered a long synchronous section.
+    /// Set by `self.close()` on the worker thread. Kept separate from
+    /// `requested_terminate` so a later `terminate()` still arms the
+    /// TerminationException (its setter early-returns when that flag is set).
     close_requested: AtomicBool,
 
     /// The worker's `jsc.VirtualMachine`, or null before `startVM()` / after
@@ -411,12 +408,9 @@ pub(crate) extern "C" fn WebWorker__getParentWorker(vm: &VirtualMachine) -> *mut
         .unwrap_or(core::ptr::null_mut())
 }
 
-/// `self.close()` inside the worker (DedicatedWorkerGlobalScope.close()).
-/// Worker-thread only. Sets the closing flag so the event loop exits after the
-/// current task completes. Unlike `exit()`, this does not arm the
-/// TerminationException, so the script that called `close()` runs to its
-/// synchronous completion. Uses a separate flag from `requested_terminate` so a
-/// later `terminate()` still arms the trap.
+/// `self.close()` inside the worker. Worker-thread only. Sets `close_requested`
+/// so the event loop exits after the current task; does not arm the
+/// TerminationException, so the calling script runs to completion.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn WebWorker__requestClose(vm: &VirtualMachine) {
     if let Some(worker) = vm.worker_ref() {

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -403,6 +403,19 @@ pub(crate) extern "C" fn WebWorker__getParentWorker(vm: &VirtualMachine) -> *mut
         .unwrap_or(core::ptr::null_mut())
 }
 
+/// `self.close()` inside the worker (DedicatedWorkerGlobalScope.close()).
+/// Worker-thread only. Sets the closing flag so the event loop exits after the
+/// current task completes. Unlike `exit()`, this does not arm the
+/// TerminationException, so the script that called `close()` runs to its
+/// synchronous completion.
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn WebWorker__requestClose(vm: &VirtualMachine) {
+    if let Some(worker) = vm.worker_ref() {
+        worker.exit_called.store(true, Ordering::Relaxed);
+        let _ = worker.set_requested_terminate();
+    }
+}
+
 impl WebWorker {
     pub fn has_requested_terminate(&self) -> bool {
         self.requested_terminate.load(Ordering::Acquire)

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -418,6 +418,12 @@ pub(crate) extern "C" fn WebWorker__requestClose(vm: &VirtualMachine) {
     }
 }
 
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn WebWorker__isCloseRequested(vm: &VirtualMachine) -> bool {
+    vm.worker_ref()
+        .is_some_and(|w| w.close_requested.load(Ordering::Relaxed))
+}
+
 impl WebWorker {
     pub fn has_requested_terminate(&self) -> bool {
         self.requested_terminate.load(Ordering::Acquire)
@@ -1168,7 +1174,9 @@ impl WebWorker {
         // `cpp_worker` is the opaque C++-owned handle round-tripped via `safe fn`;
         // `vm.global()` yields the live `&JSGlobalObject` published in start_vm.
         WebWorker__dispatchOnline(self.cpp_worker, vm.global());
-        WebWorker__fireEarlyMessages(self.cpp_worker, vm.global());
+        if !self.should_exit_loop() {
+            WebWorker__fireEarlyMessages(self.cpp_worker, vm.global());
+        }
         self.set_status(Status::Running);
 
         // don't run the GC if we don't actually need to

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -127,6 +127,14 @@ pub struct WebWorker {
     /// (`exit`). The worker loop polls this between ticks.
     requested_terminate: AtomicBool,
 
+    /// Set by `self.close()` on the worker thread. The event loop polls this
+    /// alongside `requested_terminate` so it exits after the current task.
+    /// Separate from `requested_terminate` so that `notify_need_termination`
+    /// and `terminate_all_and_wait` (which skip arming the TerminationException
+    /// when `requested_terminate` is already set) still interrupt a worker that
+    /// has called `close()` and then entered a long synchronous section.
+    close_requested: AtomicBool,
+
     /// The worker's `jsc.VirtualMachine`, or null before `startVM()` / after
     /// `shutdown()` nulls it. Lives inside `arena`. `vm_lock` must be held for
     /// any cross-thread read (see header comment).
@@ -407,18 +415,25 @@ pub(crate) extern "C" fn WebWorker__getParentWorker(vm: &VirtualMachine) -> *mut
 /// Worker-thread only. Sets the closing flag so the event loop exits after the
 /// current task completes. Unlike `exit()`, this does not arm the
 /// TerminationException, so the script that called `close()` runs to its
-/// synchronous completion.
+/// synchronous completion. Uses a separate flag from `requested_terminate` so a
+/// later `terminate()` still arms the trap.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn WebWorker__requestClose(vm: &VirtualMachine) {
     if let Some(worker) = vm.worker_ref() {
-        worker.exit_called.store(true, Ordering::Relaxed);
-        let _ = worker.set_requested_terminate();
+        worker.close_requested.store(true, Ordering::Relaxed);
     }
 }
 
 impl WebWorker {
     pub fn has_requested_terminate(&self) -> bool {
         self.requested_terminate.load(Ordering::Acquire)
+    }
+
+    /// `terminate()` / `process.exit()` / `self.close()`: any of the ways the
+    /// event loop has been asked to stop after the current task.
+    pub fn should_exit_loop(&self) -> bool {
+        self.requested_terminate.load(Ordering::Acquire)
+            || self.close_requested.load(Ordering::Relaxed)
     }
 
     /// Raw read of the `vm` cell. Worker-thread-only callers (which are also
@@ -577,6 +592,7 @@ impl WebWorker {
             live_next: Cell::new(core::ptr::null_mut()),
             live_prev: Cell::new(core::ptr::null_mut()),
             requested_terminate: AtomicBool::new(false),
+            close_requested: AtomicBool::new(false),
             vm: Cell::new(core::ptr::null_mut()),
             vm_lock: Mutex::new(),
             parent_poll_ref: JsCell::new(KeepAlive::init()),
@@ -1171,31 +1187,33 @@ impl WebWorker {
 
         // Always do a first tick so we call CppTask without delay after
         // dispatchOnline.
-        vm.as_mut().tick();
-
-        while vm.is_event_loop_alive() {
+        if !self.should_exit_loop() {
             vm.as_mut().tick();
-            if self.has_requested_terminate() {
-                break;
-            }
-            vm.as_mut().auto_tick_active();
-            if self.has_requested_terminate() {
-                break;
+
+            while vm.is_event_loop_alive() {
+                vm.as_mut().tick();
+                if self.should_exit_loop() {
+                    break;
+                }
+                vm.as_mut().auto_tick_active();
+                if self.should_exit_loop() {
+                    break;
+                }
             }
         }
 
         log!(
             "[{}] before exit {}",
             self.execution_context_id,
-            if self.has_requested_terminate() {
+            if self.should_exit_loop() {
                 "(terminated)"
             } else {
                 "(event loop dead)"
             }
         );
 
-        // Only emit 'beforeExit' on a natural drain, not on terminate().
-        if !self.has_requested_terminate() {
+        // Only emit 'beforeExit' on a natural drain, not on terminate() / close().
+        if !self.should_exit_loop() {
             // TODO: is this able to allow the event loop to continue?
             vm.as_mut().on_before_exit();
         }

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1150,7 +1150,9 @@ impl WebWorker {
                     // would clobber a process.on('exit') change to process.exitCode.
                     return self.shutdown();
                 }
-            } else if status == jsc::js_promise::Status::Pending {
+            } else if status == jsc::js_promise::Status::Pending
+                && !self.close_requested.load(Ordering::Relaxed)
+            {
                 // Unsettled top-level await (loop drained, entry promise still
                 // pending): node exits the worker with code 13, but only if the
                 // user hasn't set a nonzero process.exitCode.
@@ -1159,7 +1161,7 @@ impl WebWorker {
                 }
                 self.flush_logs(vm);
                 return self.shutdown();
-            } else {
+            } else if status == jsc::js_promise::Status::Fulfilled {
                 let _ = (*promise).result(vm.jsc_vm());
             }
         }

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -404,20 +404,27 @@ describe("web worker", () => {
     const messages: any[] = [];
     worker.addEventListener("message", e => messages.push(e.data));
     worker.onerror = e => messages.push("error: " + e.message);
-    await once(worker, "close");
+    const [close] = await once(worker, "close");
     expect(messages).toEqual(["closing"]);
+    expect(close.code).toBe(0);
   });
 
-  test("self.close() from onmessage drops the rest of the batch", async () => {
-    const src = `self.onmessage = e => { postMessage(e.data); if (e.data === 0) self.close(); };`;
-    const worker = new Worker("data:text/javascript," + encodeURIComponent(src));
-    await once(worker, "open");
-    for (let i = 0; i < 5; i++) worker.postMessage(i);
-    const messages: any[] = [];
-    worker.addEventListener("message", e => messages.push(e.data));
-    await once(worker, "close");
-    expect(messages).toEqual([0]);
-  });
+  for (const defer of ["sync", "microtask"] as const) {
+    test(`self.close() from onmessage (${defer}) drops the rest of the batch`, async () => {
+      const call = defer === "sync" ? "self.close()" : "queueMicrotask(() => self.close())";
+      const src = `self.onmessage = e => { postMessage(e.data); if (e.data === 0) ${call}; };`;
+      const worker = new Worker("data:text/javascript," + encodeURIComponent(src));
+      worker.onerror = e => {
+        throw e.message ?? e;
+      };
+      await once(worker, "open");
+      for (let i = 0; i < 5; i++) worker.postMessage(i);
+      const messages: any[] = [];
+      worker.addEventListener("message", e => messages.push(e.data));
+      await once(worker, "close");
+      expect(messages).toEqual([0]);
+    });
+  }
 
   test("close and name are not defined on the main-thread global", () => {
     expect("close" in globalThis).toBe(false);

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -375,6 +375,16 @@ describe("web worker", () => {
     expect("close" in globalThis).toBe(false);
     expect("name" in globalThis).toBe(false);
   });
+
+  test("close and name are not defined in a node:worker_threads worker", async () => {
+    const worker = new wt.Worker(
+      `require("worker_threads").parentPort.postMessage({ close: "close" in globalThis, name: "name" in globalThis })`,
+      { eval: true, name: "nw" },
+    );
+    const [msg] = await once(worker, "message");
+    await worker.terminate();
+    expect(msg).toEqual({ close: false, name: false });
+  });
 });
 
 // TODO: move to node:worker_threads tests directory

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -424,6 +424,22 @@ describe("web worker", () => {
     });
   }
 
+  test("self.close() from a MessagePort onmessage drops the rest of the batch", async () => {
+    const src = `
+      const { port1, port2 } = new MessageChannel();
+      port1.onmessage = e => { postMessage(e.data); if (e.data === 0) self.close(); };
+      self.onmessage = () => { for (let i = 0; i < 5; i++) port2.postMessage(i); };
+    `;
+    const worker = new Worker("data:text/javascript," + encodeURIComponent(src));
+    const errored = new Promise<never>((_, r) => (worker.onerror = e => r(e.message ?? e)));
+    await Promise.race([once(worker, "open"), errored]);
+    worker.postMessage("go");
+    const messages: any[] = [];
+    worker.addEventListener("message", e => messages.push(e.data));
+    await Promise.race([once(worker, "close"), errored]);
+    expect(messages).toEqual([0]);
+  });
+
   test("close and name are not defined on the main-thread global", () => {
     expect("close" in globalThis).toBe(false);
     expect("name" in globalThis).toBe(false);

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -336,22 +336,29 @@ describe("web worker", () => {
     });
   });
 
+  async function messageOrError(worker: Worker) {
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    worker.onmessage = e => resolve(e.data);
+    worker.onerror = e => reject(e.message ?? e);
+    try {
+      return await promise;
+    } finally {
+      worker.terminate();
+    }
+  }
+
   test("self.name reflects the name option", async () => {
     const worker = new Worker(
       "data:text/javascript," +
         encodeURIComponent(`postMessage({ name: self.name, global: globalThis.name, type: typeof self.name });`),
       { name: "wanted-name" },
     );
-    const [e] = await once(worker, "message");
-    worker.terminate();
-    expect(e.data).toEqual({ name: "wanted-name", global: "wanted-name", type: "string" });
+    expect(await messageOrError(worker)).toEqual({ name: "wanted-name", global: "wanted-name", type: "string" });
   });
 
   test("self.name defaults to the empty string", async () => {
     const worker = new Worker("data:text/javascript," + encodeURIComponent(`postMessage(self.name);`));
-    const [e] = await once(worker, "message");
-    worker.terminate();
-    expect(e.data).toBe("");
+    expect(await messageOrError(worker)).toBe("");
   });
 
   test("self.close() ends the worker after the current task", async () => {
@@ -369,6 +376,26 @@ describe("web worker", () => {
 
     expect(messages).toEqual([{ closeType: "function", name: "closer", afterClose: "reached" }]);
     expect(close.code).toBe(0);
+  });
+
+  test("terminate() still interrupts after self.close()", async () => {
+    const src = `self.close(); postMessage("closing"); while (true) {}`;
+    const worker = new Worker("data:text/javascript," + encodeURIComponent(src));
+    // messageOrError resolves on "closing" and then calls worker.terminate();
+    // the worker is in the infinite loop by then, so terminate() must arm the
+    // TerminationException for the close event to ever fire.
+    expect(await messageOrError(worker)).toBe("closing");
+    const [close] = await once(worker, "close");
+    expect(typeof close.code).toBe("number");
+  });
+
+  test("self.close() followed by a top-level throw still reports the error", async () => {
+    const src = `self.close(); throw new Error("boom");`;
+    const worker = new Worker("data:text/javascript," + encodeURIComponent(src));
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    worker.onerror = e => resolve(e.message);
+    worker.addEventListener("close", e => reject(new Error(`closed (${e.code}) without error event`)));
+    expect(await promise).toContain("boom");
   });
 
   test("close and name are not defined on the main-thread global", () => {

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -335,6 +335,46 @@ describe("web worker", () => {
       expect(err.error).toBe(null);
     });
   });
+
+  test("self.name reflects the name option", async () => {
+    const worker = new Worker(
+      "data:text/javascript," +
+        encodeURIComponent(`postMessage({ name: self.name, global: globalThis.name, type: typeof self.name });`),
+      { name: "wanted-name" },
+    );
+    const [e] = await once(worker, "message");
+    worker.terminate();
+    expect(e.data).toEqual({ name: "wanted-name", global: "wanted-name", type: "string" });
+  });
+
+  test("self.name defaults to the empty string", async () => {
+    const worker = new Worker("data:text/javascript," + encodeURIComponent(`postMessage(self.name);`));
+    const [e] = await once(worker, "message");
+    worker.terminate();
+    expect(e.data).toBe("");
+  });
+
+  test("self.close() ends the worker after the current task", async () => {
+    const src = `
+      const r = { closeType: typeof self.close, name: self.name };
+      try { self.close(); r.afterClose = "reached"; } catch (e) { r.afterClose = "THROW " + e.constructor.name; }
+      postMessage(r);
+      setTimeout(() => postMessage({ late: true }), 0);
+    `;
+    const worker = new Worker("data:text/javascript," + encodeURIComponent(src), { name: "closer" });
+
+    const messages: any[] = [];
+    worker.addEventListener("message", e => messages.push(e.data));
+    const [close] = await once(worker, "close");
+
+    expect(messages).toEqual([{ closeType: "function", name: "closer", afterClose: "reached" }]);
+    expect(close.code).toBe(0);
+  });
+
+  test("close and name are not defined on the main-thread global", () => {
+    expect("close" in globalThis).toBe(false);
+    expect("name" in globalThis).toBe(false);
+  });
 });
 
 // TODO: move to node:worker_threads tests directory

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -386,7 +386,7 @@ describe("web worker", () => {
     // TerminationException for the close event to ever fire.
     expect(await messageOrError(worker)).toBe("closing");
     const [close] = await once(worker, "close");
-    expect(typeof close.code).toBe("number");
+    expect([0, 1]).toContain(close.code);
   });
 
   test("self.close() followed by a top-level throw still reports the error", async () => {

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -398,6 +398,27 @@ describe("web worker", () => {
     expect(await promise).toContain("boom");
   });
 
+  test("self.close() during top-level await with a live handle exits", async () => {
+    const src = `setInterval(() => postMessage("tick"), 1e6); self.close(); postMessage("closing"); await new Promise(() => {});`;
+    const worker = new Worker("data:text/javascript," + encodeURIComponent(src));
+    const messages: any[] = [];
+    worker.addEventListener("message", e => messages.push(e.data));
+    worker.onerror = e => messages.push("error: " + e.message);
+    await once(worker, "close");
+    expect(messages).toEqual(["closing"]);
+  });
+
+  test("self.close() from onmessage drops the rest of the batch", async () => {
+    const src = `self.onmessage = e => { postMessage(e.data); if (e.data === 0) self.close(); };`;
+    const worker = new Worker("data:text/javascript," + encodeURIComponent(src));
+    await once(worker, "open");
+    for (let i = 0; i < 5; i++) worker.postMessage(i);
+    const messages: any[] = [];
+    worker.addEventListener("message", e => messages.push(e.data));
+    await once(worker, "close");
+    expect(messages).toEqual([0]);
+  });
+
   test("close and name are not defined on the main-thread global", () => {
     expect("close" in globalThis).toBe(false);
     expect("name" in globalThis).toBe(false);

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -414,14 +414,12 @@ describe("web worker", () => {
       const call = defer === "sync" ? "self.close()" : "queueMicrotask(() => self.close())";
       const src = `self.onmessage = e => { postMessage(e.data); if (e.data === 0) ${call}; };`;
       const worker = new Worker("data:text/javascript," + encodeURIComponent(src));
-      worker.onerror = e => {
-        throw e.message ?? e;
-      };
-      await once(worker, "open");
+      const errored = new Promise<never>((_, r) => (worker.onerror = e => r(e.message ?? e)));
+      await Promise.race([once(worker, "open"), errored]);
       for (let i = 0; i < 5; i++) worker.postMessage(i);
       const messages: any[] = [];
       worker.addEventListener("message", e => messages.push(e.data));
-      await once(worker, "close");
+      await Promise.race([once(worker, "close"), errored]);
       expect(messages).toEqual([0]);
     });
   }


### PR DESCRIPTION
## What does this PR do?

Inside a Web `Worker`, `self.close()` was missing (`TypeError: self.close is not a function`) and `self.name` was `undefined` even when the worker was constructed with `{ name: "..." }`.

```js
const src = `
const r = { closeType: typeof self.close, name: self.name };
try { self.close(); r.closeCall = 'ok'; } catch (e) { r.closeCall = 'THROW ' + e.constructor.name; }
postMessage(r);`;
const w = new Worker(URL.createObjectURL(new Blob([src], { type: 'text/javascript' })), { name: 'wanted-name' });
w.onmessage = (e) => { console.log(JSON.stringify(e.data)); w.terminate();
  process.exit(e.data.closeType === 'function' && e.data.name === 'wanted-name' ? 0 : 86); };
```

Before: `{"closeType":"undefined","closeCall":"THROW TypeError"}`, exit 86.
After: `{"closeType":"function","name":"wanted-name","closeCall":"ok"}`, exit 0.

## How?

Both are installed on the worker global in `initializeWorker`, gated on `WorkerOptions::Kind::Web` so `node:worker_threads` workers and the main thread are unchanged.

- `self.name` is a read-only string copied from the parsed `name` option (empty string when unset).
- `self.close()` calls a new `WebWorker__requestClose` FFI which sets the worker's closing flag so the event loop exits after the current task. Unlike `process.exit()` it does not arm the `TerminationException`, so the script that called `close()` runs to synchronous completion and can still `postMessage` before the worker shuts down, matching `DedicatedWorkerGlobalScope.close()`.

## How did you verify?

`bun bd test test/js/web/workers/worker.test.ts` (30 pass). New tests cover: `self.name` with and without the option, `self.close()` letting the current task finish and suppressing later tasks, and that neither property appears on the main-thread or `node:worker_threads` global.

Fixes #29186
Fixes #23114
Fixes #6646

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/worker.test.ts
bun test v1.4.0 (ecfa7a5d3)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [18.89ms]
(pass) web worker > preload > string [160.71ms]
(pass) web worker > preload > array of 2 strings [156.51ms]
(pass) web worker > preload > array of string [147.42ms]
(pass) web worker > preload > error in preload doesn't crash parent [131.18ms]
(pass) web worker > worker [133.84ms]
(pass) web worker > worker-env [158.70ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [1088.00ms]
(pass) web worker > worker-env with a lot of properties [367.81ms]
(pass) web worker > argv / execArgv defaults [149.78ms]
(pass) web worker > argv / execArgv options [172.12ms]
(pass) web worker > sending 50 messages should just work [184.19ms]
(pass) web worker > worker with event listeners doesn't close event loop [570.22ms]
(pass) web worker > worker with event listeners doesn't close event loop 2 [564.73ms]
(pass) web worker > worker with process.exit [198.93ms]
(pass) web
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3a9bfd5f3)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [0.24ms]
(pass) web worker > preload > string [3.47ms]
(pass) web worker > preload > array of 2 strings [3.59ms]
(pass) web worker > preload > array of string [2.90ms]
(pass) web worker > preload > error in preload doesn't crash parent [2.61ms]
(pass) web worker > worker [1.97ms]
(pass) web worker > worker-env [3.43ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [19.36ms]
(pass) web worker > worker-env with a lot of properties [5.41ms]
(pass) web worker > argv / execArgv defaults [2.32ms]
(pass) web worker > argv / execArgv options [3.12ms]
(pass) web worker > sending 50 messages should just work [3.56ms]
(pass) web worker > worker with event listeners doesn't close event loop [13.59ms]
(pass) web worker > worker with event listeners doesn't close event loop 2 [19.26ms]
(pass) web worker > worker with process.exit [14.50ms]
(pass) web worker > worker event > is fired with the right object [0.21ms]
(pass) web worker > error event > is fired with a string of the error [5.27ms]
(pass) web worker > self.name reflects th
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/worker.test.ts
bun test v1.4.0 (ecfa7a5d3)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [11.93ms]
(pass) web worker > preload > string [161.32ms]
(pass) web worker > preload > array of 2 strings [156.16ms]
(pass) web worker > preload > array of string [148.12ms]
(pass) web worker > preload > error in preload doesn't crash parent [131.33ms]
(pass) web worker > worker [149.17ms]
(pass) web worker > worker-env [157.93ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [1028.30ms]
(pass) web worker > worker-env with a lot of properties [342.95ms]
(pass) web worker > argv / execArgv defaults [153.39ms]
(pass) web worker > argv / execArgv options [153.67ms]
(pass) web worker > sending 50 messages should just work [177.00ms]
(pass) web worker > worker with event listeners doesn't close event loop [631.10ms]
(pass) web worker > worker with event listeners doesn't close event loop 2 [560.08ms]
(pass) web worker > worker with process.exit [208.56ms]
(pass) web
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 745ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/13] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[2/13] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[3/13] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[4/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[5/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[6/13] gen cpp.rs (cppbind)
[7/13] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[7/13] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ZigGlobalObject.cpp         |   6 ++
 src/jsc/bindings/webcore/MessagePort.cpp     |   5 +-
 src/jsc/bindings/webcore/MessagePortPipe.cpp |   6 +-
 src/jsc/bindings/webcore/Worker.cpp          |  22 ++++-
 src/jsc/bindings/webcore/Worker.h            |   1 +
 src/jsc/event_loop.rs                        |   8 +-
 src/jsc/web_worker.rs                        |  65 +++++++++++----
 test/js/web/workers/worker.test.ts           | 119 +++++++++++++++++++++++++++
 8 files changed, 203 insertions(+), 29 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/bindings/ZigGlobalObject.cpp              5      5      0
src/jsc/bindings/webcore/MessagePort.cpp          1      2      0
src/jsc/bindings/webcore/MessagePortPipe.cpp      1      2      0
src/jsc/bindings/webcore/Worker.cpp               7     10      0
src/jsc/bindings/webcore/Worker.h                 3      1      0
src/jsc/event_loop.rs                             1      1      0
src/jsc/web_worker.rs                            14     13      0
test/js/web/workers/worker.test.ts                8      9      0
```

</details>

<!-- robobun:evidence:end -->