### PR TITLE
event_loop: yield worker/port message drains to the next iteration so a postMessage flood can't starve timers/poll

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1043,6 +1043,7 @@ impl VirtualMachine {
             && ((active as usize)
                 + self.active_tasks
                 + el.tasks.readable_length()
+                + el.next_iteration_tasks.len()
                 + (el.has_pending_refs() as usize)
                 > 0)
     }

--- a/src/jsc/bindings/ScriptExecutionContext.cpp
+++ b/src/jsc/bindings/ScriptExecutionContext.cpp
@@ -283,6 +283,12 @@ void ScriptExecutionContext::postTask(Function<void(ScriptExecutionContext&)>&& 
     auto* task = new EventLoopTask(WTF::move(lambda));
     static_cast<Zig::GlobalObject*>(m_globalObject)->queueTask(task);
 }
+
+void ScriptExecutionContext::postTaskNextIteration(Function<void(ScriptExecutionContext&)>&& lambda)
+{
+    auto* task = new EventLoopTask(WTF::move(lambda));
+    static_cast<Zig::GlobalObject*>(m_globalObject)->queueTaskNextIteration(task);
+}
 // Executes the task on context's thread asynchronously.
 void ScriptExecutionContext::postTask(EventLoopTask* task)
 {

--- a/src/jsc/bindings/ScriptExecutionContext.h
+++ b/src/jsc/bindings/ScriptExecutionContext.h
@@ -112,6 +112,10 @@ public:
     void postTaskConcurrently(Function<void(ScriptExecutionContext&)>&& lambda);
     // Executes the task on context's thread asynchronously.
     void postTask(Function<void(ScriptExecutionContext&)>&& lambda);
+    // Executes the task on this context's thread on the *next* event-loop
+    // iteration (after I/O poll and due timers). Must be called on this
+    // context's own thread.
+    void postTaskNextIteration(Function<void(ScriptExecutionContext&)>&& lambda);
     // Executes the task on context's thread asynchronously.
     void postTask(EventLoopTask* task);
 

--- a/src/jsc/bindings/ScriptExecutionContext.h
+++ b/src/jsc/bindings/ScriptExecutionContext.h
@@ -112,9 +112,7 @@ public:
     void postTaskConcurrently(Function<void(ScriptExecutionContext&)>&& lambda);
     // Executes the task on context's thread asynchronously.
     void postTask(Function<void(ScriptExecutionContext&)>&& lambda);
-    // Executes the task on this context's thread on the *next* event-loop
-    // iteration (after I/O poll and due timers). Must be called on this
-    // context's own thread.
+    // Same-thread only. Runs on the next event-loop iteration (after I/O poll + due timers).
     void postTaskNextIteration(Function<void(ScriptExecutionContext&)>&& lambda);
     // Executes the task on context's thread asynchronously.
     void postTask(EventLoopTask* task);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3386,6 +3386,7 @@ extern "C" void JSGlobalObject__clearTerminationException(JSC::JSGlobalObject* g
 }
 
 extern "C" void Bun__queueTask(JSC::JSGlobalObject*, WebCore::EventLoopTask* task);
+extern "C" void Bun__queueTaskNextIteration(JSC::JSGlobalObject*, WebCore::EventLoopTask* task);
 extern "C" void Bun__queueTaskConcurrently(JSC::JSGlobalObject*, WebCore::EventLoopTask* task);
 extern "C" [[ZIG_EXPORT(check_slow)]] void Bun__performTask(Zig::GlobalObject* globalObject, WebCore::EventLoopTask* task)
 {
@@ -3415,6 +3416,11 @@ RefPtr<Performance> GlobalObject::performance()
 void GlobalObject::queueTask(WebCore::EventLoopTask* task)
 {
     Bun__queueTask(this, task);
+}
+
+void GlobalObject::queueTaskNextIteration(WebCore::EventLoopTask* task)
+{
+    Bun__queueTaskNextIteration(this, task);
 }
 
 void GlobalObject::queueTaskConcurrently(WebCore::EventLoopTask* task)

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -180,6 +180,9 @@ public:
     WebCore::ScriptExecutionContext* scriptExecutionContext() const;
 
     void queueTask(WebCore::EventLoopTask* task);
+    // Runs the task on the next event-loop iteration, after the current
+    // tick's task-drain loop, the I/O poll, and due timers.
+    void queueTaskNextIteration(WebCore::EventLoopTask* task);
     void queueTaskConcurrently(WebCore::EventLoopTask* task);
 
     JSDOMStructureMap& structures() WTF_REQUIRES_LOCK(m_gcLock) { return m_structures; }

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -180,8 +180,6 @@ public:
     WebCore::ScriptExecutionContext* scriptExecutionContext() const;
 
     void queueTask(WebCore::EventLoopTask* task);
-    // Runs the task on the next event-loop iteration, after the current
-    // tick's task-drain loop, the I/O poll, and due timers.
     void queueTaskNextIteration(WebCore::EventLoopTask* task);
     void queueTaskConcurrently(WebCore::EventLoopTask* task);
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -174,9 +174,11 @@ void MessagePort::flushQueuedMessagesBeforeClose()
     if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) != ScriptExecutionStatus::Running)
         return;
 
-    // Cap iterations like drainAndDispatch() so a 'message' handler re-injecting
-    // into this closing port (via its entangled peer) can't starve the loop.
-    size_t limit = std::max<size_t>(MessagePortPipe::queuedCount(m_pipe->state(m_side)), 1000);
+    // One-shot terminal flush before close(): anything left after `limit` is
+    // dropped by m_pipe->close(), so unlike drainAndDispatch() this doesn't
+    // cap at kDrainPerTurnCap. The floor bounds a handler re-injecting into
+    // this closing port via its entangled peer.
+    size_t limit = std::max<size_t>(MessagePortPipe::queuedCount(m_pipe->state(m_side)), MessagePortPipe::kDrainPerTurnCap);
     for (size_t i = 0; i < limit; ++i) {
         // A handler (or a microtask it queued) may have transferred this port; the
         // remaining inbox now belongs to the new owner. drainAndDispatch()'s

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -93,7 +93,6 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
     // Messages are popped one at a time under the lock, so if the handler
     // transfers this port (pipe->detach clears `s.port`/`Attached`) the
     // remaining inbox stays buffered for the new owner.
-    static constexpr size_t kMessageDrainPerTurnCap = 1024;
     auto& s = m_sides[side];
 
     RefPtr<MessagePort> port;
@@ -113,7 +112,7 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
             s.state.store(st & ~DrainScheduled, std::memory_order_release);
             return;
         }
-        limit = std::min<size_t>(s.inbox.size(), kMessageDrainPerTurnCap);
+        limit = std::min<size_t>(s.inbox.size(), kDrainPerTurnCap);
     }
 
     // All 'message' listeners removed: the port is paused. Leave the inbox buffered

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -87,9 +87,8 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
     // Mirrors Node's MessagePort::OnMessage (src/node_messaging.cc): one
     // drain task processes a bounded batch, draining microtasks between each
     // delivery so queueMicrotask/Promise callbacks observe messages one at a
-    // time, but without a separate posted task per message. The per-turn
-    // limit is a fixed cap so a fast sender can't starve the event loop;
-    // anything beyond it waits for the next loop iteration.
+    // time, but without a separate posted task per message. Anything beyond
+    // the fixed per-turn cap waits for the next loop iteration.
     //
     // Messages are popped one at a time under the lock, so if the handler
     // transfers this port (pipe->detach clears `s.port`/`Attached`) the
@@ -180,13 +179,7 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
     }
 
     if (rescheduleCtx) {
-        // Limit exhausted with messages still queued. Resume on the NEXT
-        // event-loop iteration: `tick()` drains tasks queued by tasks, so an
-        // ordinary post (scheduleDrain -> postTaskTo -> concurrent queue)
-        // would re-run this drain inside the same tick and starve timers,
-        // immediates and I/O forever under a same-thread ping-pong. Node
-        // yields the same way here (TriggerAsync in MessagePort::OnMessage).
-        // We are on `rescheduleCtx`'s thread (== expectedCtx, checked above).
+        // Next-iteration so timers/poll get a turn; scheduleDrain would re-run inside the same tick.
         context->postTaskNextIteration([pipe = Ref { *this }, side, ctxId = rescheduleCtx](ScriptExecutionContext&) {
             pipe->drainAndDispatch(side, ctxId);
         });

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -85,16 +85,16 @@ void MessagePortPipe::scheduleDrain(uint8_t side, ScriptExecutionContextIdentifi
 void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdentifier expectedCtx)
 {
     // Mirrors Node's MessagePort::OnMessage (src/node_messaging.cc): one
-    // drain task processes the whole inbox in a loop, draining microtasks
-    // between each delivery so queueMicrotask/Promise callbacks observe
-    // messages one at a time, but without a separate posted task per
-    // message. The per-invocation limit is max(initial queue size, 1000)
-    // — enough to amortize the uv_async-style reschedule cost, capped so a
-    // fast sender can't starve the event loop indefinitely.
+    // drain task processes a bounded batch, draining microtasks between each
+    // delivery so queueMicrotask/Promise callbacks observe messages one at a
+    // time, but without a separate posted task per message. The per-turn
+    // limit is a fixed cap so a fast sender can't starve the event loop;
+    // anything beyond it waits for the next loop iteration.
     //
     // Messages are popped one at a time under the lock, so if the handler
     // transfers this port (pipe->detach clears `s.port`/`Attached`) the
     // remaining inbox stays buffered for the new owner.
+    static constexpr size_t kMessageDrainPerTurnCap = 1024;
     auto& s = m_sides[side];
 
     RefPtr<MessagePort> port;
@@ -114,7 +114,7 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
             s.state.store(st & ~DrainScheduled, std::memory_order_release);
             return;
         }
-        limit = std::max<size_t>(s.inbox.size(), 1000);
+        limit = std::min<size_t>(s.inbox.size(), kMessageDrainPerTurnCap);
     }
 
     // All 'message' listeners removed: the port is paused. Leave the inbox buffered
@@ -179,8 +179,18 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
         }
     }
 
-    if (rescheduleCtx)
-        scheduleDrain(side, rescheduleCtx);
+    if (rescheduleCtx) {
+        // Limit exhausted with messages still queued. Resume on the NEXT
+        // event-loop iteration: `tick()` drains tasks queued by tasks, so an
+        // ordinary post (scheduleDrain -> postTaskTo -> concurrent queue)
+        // would re-run this drain inside the same tick and starve timers,
+        // immediates and I/O forever under a same-thread ping-pong. Node
+        // yields the same way here (TriggerAsync in MessagePort::OnMessage).
+        // We are on `rescheduleCtx`'s thread (== expectedCtx, checked above).
+        context->postTaskNextIteration([pipe = Ref { *this }, side, ctxId = rescheduleCtx](ScriptExecutionContext&) {
+            pipe->drainAndDispatch(side, ctxId);
+        });
+    }
 }
 
 std::optional<MessageWithMessagePorts> MessagePortPipe::takeOne(uint8_t side)

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -35,6 +35,9 @@ using ScriptExecutionContextIdentifier = uint32_t;
 
 class MessagePortPipe final : public ThreadSafeRefCounted<MessagePortPipe> {
 public:
+    // Shared per-turn message drain cap for drainAndDispatch and Worker::drainInbox.
+    static constexpr size_t kDrainPerTurnCap = 1024;
+
     static Ref<MessagePortPipe> create() { return adoptRef(*new MessagePortPipe); }
     ~MessagePortPipe();
 

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -12,9 +12,10 @@
 // task on the receiving context. The drain task loops, popping one message at
 // a time under the lock and dispatching it, draining microtasks between each
 // (matching Node's MakeCallback / InternalCallbackScope behavior), up to
-// max(initial-queue-size, 1000) iterations before yielding back to the event
-// loop. Messages stay in the inbox until the instant they are dispatched, so
-// a port transferred mid-loop carries the remaining queue to the new owner.
+// kDrainPerTurnCap messages per turn; anything beyond that yields to the next
+// event-loop iteration so a sustained sender can't starve timers/poll.
+// Messages stay in the inbox until the instant they are dispatched, so a port
+// transferred mid-loop carries the remaining queue to the new owner.
 //
 // The Web API semantics (start(), close(), transfer, event dispatch) live in
 // MessagePort; this class knows nothing about EventTarget or JS.

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -268,18 +268,16 @@ void Worker::enqueueToParent(MessageWithMessagePorts&& message)
 }
 
 // Shared drain loop for the two inboxes. Mirrors MessagePortPipe's
-// drainAndDispatch: one task drains up to kMessageDrainPerTurnCap messages,
-// running microtasks between each so queueMicrotask/Promise callbacks observe
-// messages one at a time, then yields to the next loop iteration if more
-// remain so a sustained sender can't starve timers/poll.
+// drainAndDispatch: one task drains up to MessagePortPipe::kDrainPerTurnCap
+// messages, running microtasks between each so queueMicrotask/Promise
+// callbacks observe messages one at a time, then yields to the next loop
+// iteration if more remain so a sustained sender can't starve timers/poll.
 //
 // Unlike MessagePortPipe, Worker sides never transfer, so we don't need to
 // re-check port identity each iteration — which lets us swap the whole inbox
 // into a local deque under the lock and dispatch without contending with the
 // sender. A sustained producer (e.g. a tight postMessage loop) would otherwise
 // make every per-message pop a contended acquire.
-static constexpr size_t kMessageDrainPerTurnCap = 1024;
-
 template<typename Dispatch>
 static inline bool drainInbox(Worker::MessageInbox& inbox, Zig::GlobalObject* globalObject, ScriptExecutionContext& context, Dispatch&& dispatch)
 {
@@ -291,7 +289,7 @@ static inline bool drainInbox(Worker::MessageInbox& inbox, Zig::GlobalObject* gl
             inbox.drainScheduled.store(false, std::memory_order_relaxed);
             return false;
         }
-        limit = std::min<size_t>(inbox.queue.size(), kMessageDrainPerTurnCap);
+        limit = std::min<size_t>(inbox.queue.size(), MessagePortPipe::kDrainPerTurnCap);
         batch = std::exchange(inbox.queue, {});
     }
 

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -295,12 +295,14 @@ static inline bool drainInbox(Worker::MessageInbox& inbox, Zig::GlobalObject* gl
 
     while (!batch.isEmpty()) {
         if (limit-- == 0) {
-            // Yield to the rest of the event loop. Return the undrained
-            // tail to the front of the inbox so it stays ahead of
-            // anything enqueued concurrently; caller reschedules.
+            // Yield to the rest of the event loop. Put the undrained tail
+            // back ahead of anything the sender enqueued during dispatch:
+            // swap so inbox.queue holds the large old tail, then append the
+            // few arrivals — O(arrivals), not O(backlog), under the lock.
             Locker locker { inbox.lock };
+            std::swap(inbox.queue, batch);
             while (!batch.isEmpty())
-                inbox.queue.prepend(batch.takeLast());
+                inbox.queue.append(batch.takeFirst());
             return true;
         }
         auto message = batch.takeFirst();

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -268,12 +268,10 @@ void Worker::enqueueToParent(MessageWithMessagePorts&& message)
 }
 
 // Shared drain loop for the two inboxes. Mirrors MessagePortPipe's
-// drainAndDispatch: one task drains a bounded batch, running microtasks
-// between each message so queueMicrotask/Promise callbacks observe messages
-// one at a time, then yields and reschedules on the NEXT event-loop iteration
-// if more remain. The per-turn cap is fixed: when the sender outruns the
-// receiver the inbox is the backpressure buffer, and a cap that grows with it
-// (max(size, 1000)) never yields to timers/poll.
+// drainAndDispatch: one task drains up to kMessageDrainPerTurnCap messages,
+// running microtasks between each so queueMicrotask/Promise callbacks observe
+// messages one at a time, then yields to the next loop iteration if more
+// remain so a sustained sender can't starve timers/poll.
 //
 // Unlike MessagePortPipe, Worker sides never transfer, so we don't need to
 // re-check port identity each iteration — which lets us swap the whole inbox
@@ -346,11 +344,7 @@ void Worker::drainToWorker(ScriptExecutionContext& context)
         globalObject->globalEventScope->dispatchEvent(event);
     });
     if (reschedule) {
-        // Budget spent with messages left. Resume on the next loop iteration
-        // so this thread's timers, immediates and I/O get a turn; an ordinary
-        // post would re-run inside the same tick's drain-until-empty task
-        // loop and a sustained sender would starve them forever. `context` is
-        // the worker thread's own context (we are running on it).
+        // Next-iteration so this thread's timers/poll get a turn; postTaskTo would re-run in the same tick.
         context.postTaskNextIteration([protectedThis = Ref { *this }](ScriptExecutionContext& ctx) {
             protectedThis->drainToWorker(ctx);
         });
@@ -369,8 +363,6 @@ void Worker::drainToParent(ScriptExecutionContext& context)
         dispatchEvent(event);
     });
     if (reschedule) {
-        // Same yield as drainToWorker: this runs on the parent thread, so
-        // `context` is the parent context this drain task was dispatched on.
         context.postTaskNextIteration([protectedThis = Ref { *this }](ScriptExecutionContext& c) {
             protectedThis->drainToParent(c);
         });

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -295,41 +295,38 @@ static inline bool drainInbox(Worker::MessageInbox& inbox, Zig::GlobalObject* gl
         batch = std::exchange(inbox.queue, {});
     }
 
-    while (true) {
-        while (!batch.isEmpty()) {
-            if (limit-- == 0) {
-                // Yield to the rest of the event loop. Return the undrained
-                // tail to the front of the inbox so it stays ahead of
-                // anything enqueued concurrently; caller reschedules.
-                Locker locker { inbox.lock };
-                while (!batch.isEmpty())
-                    inbox.queue.prepend(batch.takeLast());
-                return true;
-            }
-            auto message = batch.takeFirst();
-
-            auto ports = MessagePort::entanglePorts(context, WTF::move(message.transferredPorts));
-            auto event = MessageEvent::create(*context.jsGlobalObject(), message.message.releaseNonNull(), nullptr, WTF::move(ports));
-            dispatch(event.event);
-
-            if (globalObject->drainMicrotasks()) {
-                // Termination pending. Drop the rest — dispatch is a no-op
-                // once m_terminateRequested is set (drainToParent), and the
-                // worker thread is tearing down (drainToWorker).
-                return false;
-            }
+    while (!batch.isEmpty()) {
+        if (limit-- == 0) {
+            // Yield to the rest of the event loop. Return the undrained
+            // tail to the front of the inbox so it stays ahead of
+            // anything enqueued concurrently; caller reschedules.
+            Locker locker { inbox.lock };
+            while (!batch.isEmpty())
+                inbox.queue.prepend(batch.takeLast());
+            return true;
         }
+        auto message = batch.takeFirst();
 
-        // Batch exhausted — see if more arrived while we were dispatching.
-        Locker locker { inbox.lock };
-        if (inbox.queue.isEmpty()) {
-            inbox.drainScheduled.store(false, std::memory_order_relaxed);
+        auto ports = MessagePort::entanglePorts(context, WTF::move(message.transferredPorts));
+        auto event = MessageEvent::create(*context.jsGlobalObject(), message.message.releaseNonNull(), nullptr, WTF::move(ports));
+        dispatch(event.event);
+
+        if (globalObject->drainMicrotasks()) {
+            // Termination pending. Drop the rest — dispatch is a no-op
+            // once m_terminateRequested is set (drainToParent), and the
+            // worker thread is tearing down (drainToWorker).
             return false;
         }
-        if (limit == 0)
-            return true; // budget spent; caller reschedules
-        batch = std::exchange(inbox.queue, {});
     }
+
+    // Batch exhausted (limit == batch.size() ≤ cap). Anything that arrived
+    // while dispatching waits for the next loop iteration.
+    Locker locker { inbox.lock };
+    if (inbox.queue.isEmpty()) {
+        inbox.drainScheduled.store(false, std::memory_order_relaxed);
+        return false;
+    }
+    return true;
 }
 
 void Worker::drainToWorker(ScriptExecutionContext& context)

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -268,16 +268,20 @@ void Worker::enqueueToParent(MessageWithMessagePorts&& message)
 }
 
 // Shared drain loop for the two inboxes. Mirrors MessagePortPipe's
-// drainAndDispatch (and Node's MessagePort::OnMessage): one task drains up to
-// max(initial queue size, 1000) messages, running microtasks between each so
-// queueMicrotask/Promise callbacks observe messages one at a time, then
-// yields and reschedules if more remain.
+// drainAndDispatch: one task drains a bounded batch, running microtasks
+// between each message so queueMicrotask/Promise callbacks observe messages
+// one at a time, then yields and reschedules on the NEXT event-loop iteration
+// if more remain. The per-turn cap is fixed: when the sender outruns the
+// receiver the inbox is the backpressure buffer, and a cap that grows with it
+// (max(size, 1000)) never yields to timers/poll.
 //
 // Unlike MessagePortPipe, Worker sides never transfer, so we don't need to
 // re-check port identity each iteration — which lets us swap the whole inbox
 // into a local deque under the lock and dispatch without contending with the
 // sender. A sustained producer (e.g. a tight postMessage loop) would otherwise
 // make every per-message pop a contended acquire.
+static constexpr size_t kMessageDrainPerTurnCap = 1024;
+
 template<typename Dispatch>
 static inline bool drainInbox(Worker::MessageInbox& inbox, Zig::GlobalObject* globalObject, ScriptExecutionContext& context, Dispatch&& dispatch)
 {
@@ -289,7 +293,7 @@ static inline bool drainInbox(Worker::MessageInbox& inbox, Zig::GlobalObject* gl
             inbox.drainScheduled.store(false, std::memory_order_relaxed);
             return false;
         }
-        limit = std::max<size_t>(inbox.queue.size(), 1000);
+        limit = std::min<size_t>(inbox.queue.size(), kMessageDrainPerTurnCap);
         batch = std::exchange(inbox.queue, {});
     }
 
@@ -342,7 +346,12 @@ void Worker::drainToWorker(ScriptExecutionContext& context)
         globalObject->globalEventScope->dispatchEvent(event);
     });
     if (reschedule) {
-        ScriptExecutionContext::postTaskTo(m_clientIdentifier, [protectedThis = Ref { *this }](ScriptExecutionContext& ctx) {
+        // Budget spent with messages left. Resume on the next loop iteration
+        // so this thread's timers, immediates and I/O get a turn; an ordinary
+        // post would re-run inside the same tick's drain-until-empty task
+        // loop and a sustained sender would starve them forever. `context` is
+        // the worker thread's own context (we are running on it).
+        context.postTaskNextIteration([protectedThis = Ref { *this }](ScriptExecutionContext& ctx) {
             protectedThis->drainToWorker(ctx);
         });
     }
@@ -360,7 +369,9 @@ void Worker::drainToParent(ScriptExecutionContext& context)
         dispatchEvent(event);
     });
     if (reschedule) {
-        postTaskToParent([protectedThis = Ref { *this }](ScriptExecutionContext& c) {
+        // Same yield as drainToWorker: this runs on the parent thread, so
+        // `context` is the parent context this drain task was dispatched on.
+        context.postTaskNextIteration([protectedThis = Ref { *this }](ScriptExecutionContext& c) {
             protectedThis->drainToParent(c);
         });
     }

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -69,6 +69,16 @@ pub struct EventLoop {
     pub immediate_tasks: Vec<*mut ()>,
     pub next_immediate_tasks: Vec<*mut ()>,
 
+    /// Tasks that must not run until the *next* event-loop iteration, after
+    /// `tick()` has returned and the outer loop has polled I/O and fired due
+    /// timers. Promoted into `tasks` at `tick()` entry only, so a task queued
+    /// here from inside the current tick cannot be picked up by that tick's
+    /// drain-until-empty loop. This is Node's `uv_async_send` yield in
+    /// `MessagePort::OnMessage`: a batch-limit reschedule runs on the next
+    /// iteration instead of back-to-back, so a sustained sender can't starve
+    /// timers, immediates and I/O.
+    pub next_iteration_tasks: Vec<Task>,
+
     pub concurrent_tasks: ConcurrentQueue,
     // BACKREF — `*JSGlobalObject` owned by the VM; outlives this EventLoop.
     pub global: Option<NonNull<JSGlobalObject>>,
@@ -114,6 +124,7 @@ impl Default for EventLoop {
             tasks: Queue::init(),
             immediate_tasks: Vec::new(),
             next_immediate_tasks: Vec::new(),
+            next_iteration_tasks: Vec::new(),
             concurrent_tasks: ConcurrentQueue::default(),
             global: None,
             virtual_machine: None,
@@ -621,6 +632,11 @@ impl EventLoop {
         jsc::mark_binding();
         crate::top_scope!(scope, self.global_ref());
         self.entered_event_loop_count += 1;
+        // Promote next-iteration tasks queued by the previous tick. Entry-only:
+        // anything deferred from inside this tick lands in the next one.
+        for task in self.next_iteration_tasks.drain(..) {
+            let _ = self.tasks.write_item(task);
+        }
         // The scope/counter cleanup is inlined at each return site below (a
         // scopeguard closure would alias `&mut self`).
 
@@ -681,6 +697,12 @@ impl EventLoop {
 
     pub fn enqueue_task(&mut self, task: Task) {
         let _ = self.tasks.write_item(task);
+    }
+
+    /// Queue `task` for the next event-loop iteration (see
+    /// `next_iteration_tasks`). JS-thread only.
+    pub fn enqueue_task_next_iteration(&mut self, task: Task) {
+        self.next_iteration_tasks.push(task);
     }
 
     /// Drain `concurrent_tasks` without running them and `delete` any
@@ -747,6 +769,11 @@ impl EventLoop {
     /// definer can't safely dispatch every `AnyTask` callback at shutdown.
     pub fn release_queued_tasks_for_shutdown(&mut self) {
         self.drop_concurrent_cpp_tasks();
+        // Never-promoted next-iteration tasks get the same per-tag reclaim as
+        // ordinary queued tasks.
+        for task in self.next_iteration_tasks.drain(..) {
+            let _ = self.tasks.write_item(task);
+        }
         let mut requeue: Vec<bun_event_loop::Task> = Vec::new();
         while let Some(task) = self.tasks.read_item() {
             // SAFETY: tag-specific release (drops JSC handles while the VM is

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -823,6 +823,7 @@ impl EventLoop {
         for task in requeue {
             let _ = self.tasks.write_item(task);
         }
+        self.next_iteration_tasks = Vec::new();
         let pending = core::mem::take(&mut self.immediate_tasks);
         let next = core::mem::take(&mut self.next_immediate_tasks);
         if !pending.is_empty() || !next.is_empty() {

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -69,14 +69,10 @@ pub struct EventLoop {
     pub immediate_tasks: Vec<*mut ()>,
     pub next_immediate_tasks: Vec<*mut ()>,
 
-    /// Tasks that must not run until the *next* event-loop iteration, after
-    /// `tick()` has returned and the outer loop has polled I/O and fired due
-    /// timers. Promoted into `tasks` at `tick()` entry only, so a task queued
-    /// here from inside the current tick cannot be picked up by that tick's
-    /// drain-until-empty loop. This is Node's `uv_async_send` yield in
-    /// `MessagePort::OnMessage`: a batch-limit reschedule runs on the next
-    /// iteration instead of back-to-back, so a sustained sender can't starve
-    /// timers, immediates and I/O.
+    /// Tasks deferred to the next event-loop iteration. Promoted into `tasks`
+    /// at `tick()` entry only, so a task queued here from inside the current
+    /// tick runs after the outer loop has polled I/O and fired due timers
+    /// (the `uv_async` yield node's MessagePort drain relies on).
     pub next_iteration_tasks: Vec<Task>,
 
     pub concurrent_tasks: ConcurrentQueue,
@@ -632,8 +628,7 @@ impl EventLoop {
         jsc::mark_binding();
         crate::top_scope!(scope, self.global_ref());
         self.entered_event_loop_count += 1;
-        // Promote next-iteration tasks queued by the previous tick. Entry-only:
-        // anything deferred from inside this tick lands in the next one.
+        // Entry-only: deferrals from inside this tick land in the next one.
         for task in self.next_iteration_tasks.drain(..) {
             let _ = self.tasks.write_item(task);
         }
@@ -699,8 +694,7 @@ impl EventLoop {
         let _ = self.tasks.write_item(task);
     }
 
-    /// Queue `task` for the next event-loop iteration (see
-    /// `next_iteration_tasks`). JS-thread only.
+    /// See `next_iteration_tasks`. JS-thread only.
     pub fn enqueue_task_next_iteration(&mut self, task: Task) {
         self.next_iteration_tasks.push(task);
     }
@@ -769,8 +763,6 @@ impl EventLoop {
     /// definer can't safely dispatch every `AnyTask` callback at shutdown.
     pub fn release_queued_tasks_for_shutdown(&mut self) {
         self.drop_concurrent_cpp_tasks();
-        // Never-promoted next-iteration tasks get the same per-tag reclaim as
-        // ordinary queued tasks.
         for task in self.next_iteration_tasks.drain(..) {
             let _ = self.tasks.write_item(task);
         }

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -113,9 +113,7 @@ pub fn queue_task(global: &JSGlobalObject, task: *mut crate::cpp_task::CppTask) 
         .enqueue_task(Task::init(task));
 }
 
-/// Like `Bun__queueTask`, but the task runs on the *next* event-loop
-/// iteration, after the current tick's drain-until-empty loop has returned and
-/// the outer loop has polled I/O and fired due timers. JS-thread only.
+/// `Bun__queueTask` variant that defers to the next event-loop iteration. JS-thread only.
 // HOST_EXPORT(Bun__queueTaskNextIteration, c)
 pub fn queue_task_next_iteration(global: &JSGlobalObject, task: *mut crate::cpp_task::CppTask) {
     crate::mark_binding!();

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -113,6 +113,18 @@ pub fn queue_task(global: &JSGlobalObject, task: *mut crate::cpp_task::CppTask) 
         .enqueue_task(Task::init(task));
 }
 
+/// Like `Bun__queueTask`, but the task runs on the *next* event-loop
+/// iteration, after the current tick's drain-until-empty loop has returned and
+/// the outer loop has polled I/O and fired due timers. JS-thread only.
+// HOST_EXPORT(Bun__queueTaskNextIteration, c)
+pub fn queue_task_next_iteration(global: &JSGlobalObject, task: *mut crate::cpp_task::CppTask) {
+    crate::mark_binding!();
+    global
+        .bun_vm()
+        .event_loop_mut()
+        .enqueue_task_next_iteration(Task::init(task));
+}
+
 // HOST_EXPORT(Bun__reportUnhandledError, c)
 pub fn report_unhandled_error(global: &JSGlobalObject, value: JSValue) -> JSValue {
     crate::mark_binding!();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -914,7 +914,9 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
     unsafe { (*el).tick_immediate_tasks(vm) };
     #[cfg(windows)]
-    if !unsafe { &*el }.immediate_tasks.is_empty() {
+    if !unsafe { &*el }.immediate_tasks.is_empty()
+        || !unsafe { &*el }.next_iteration_tasks.is_empty()
+    {
         // SAFETY: `el` is the live per-thread event loop.
         unsafe { (*el).wakeup() };
     }
@@ -1073,7 +1075,9 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
     // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
     unsafe { (*el).tick_immediate_tasks(vm) };
     #[cfg(windows)]
-    if !unsafe { &*el }.immediate_tasks.is_empty() {
+    if !unsafe { &*el }.immediate_tasks.is_empty()
+        || !unsafe { &*el }.next_iteration_tasks.is_empty()
+    {
         // SAFETY: `el` is the live per-thread event loop.
         unsafe { (*el).wakeup() };
     }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -977,7 +977,8 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
         // `tickImmediateTasks` swaps `next_immediate_tasks` in, so this
         // reflects next-tick immediates (queued during the drain above).
         // SAFETY: `el` is the live per-thread event loop.
-        let has_pending_immediate = !unsafe { &*el }.immediate_tasks.is_empty();
+        let has_pending_immediate = !unsafe { &*el }.immediate_tasks.is_empty()
+            || !unsafe { &*el }.next_iteration_tasks.is_empty();
         // Fold the QUIC deadline into the poll timeout.
         // SAFETY: `loop_` is the live per-thread uws loop.
         let quic_next_tick_us = unsafe {
@@ -1112,7 +1113,8 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
 
     {
         // SAFETY: `el` is the live per-thread event loop.
-        let has_pending_immediate = !unsafe { &*el }.immediate_tasks.is_empty();
+        let has_pending_immediate = !unsafe { &*el }.immediate_tasks.is_empty()
+            || !unsafe { &*el }.next_iteration_tasks.is_empty();
         // SAFETY: `loop_` is the live per-thread uws loop.
         let quic_next_tick_us = unsafe {
             let ild = &(*loop_).internal_loop_data;

--- a/test/js/web/workers/message-port-pipe.test.ts
+++ b/test/js/web/workers/message-port-pipe.test.ts
@@ -7,6 +7,35 @@ import { receiveMessageOnPort } from "node:worker_threads";
 // and thread-safety under concurrent channel churn.
 
 describe("MessagePort pipe", () => {
+  test("self-feeding onmessage loop yields to timers/immediates", async () => {
+    // port1's handler posts via port2 back to port1, so port1's drain keeps
+    // finding more in its inbox. The drain must hit its per-batch limit and
+    // reschedule on the NEXT event-loop iteration so setTimeout/setImmediate
+    // get a turn; if it re-runs in the same tick the loop never yields.
+    // Deterministic: single-threaded, no wall-clock dependency.
+    const script = `
+      const { port1, port2 } = new MessageChannel();
+      let count = 0, fired = false;
+      port1.onmessage = () => {
+        if (count++ === 0) {
+          setTimeout(() => { fired = true; }, 0);
+          setImmediate(() => { fired = true; });
+        }
+        if (fired) { console.log(JSON.stringify({ count })); process.exit(0); }
+        if (count > 10000) { console.log(JSON.stringify({ count, STARVED: true })); process.exit(1); }
+        port2.postMessage(0);
+      };
+      port2.postMessage(0);
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout.trim());
+    expect(out.STARVED).toBeUndefined();
+    expect(out.count).toBeLessThan(10000);
+    expect(exitCode).toBe(0);
+  });
+
   test("microtasks run between message events (task-source semantics)", async () => {
     const { port1, port2 } = new MessageChannel();
     const order: string[] = [];

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -247,7 +247,7 @@ describe("web worker", () => {
           console.log(JSON.stringify({ recv, fired }));
           process.exit(0);
         }
-        if (Date.now() - t0 > 5000) {
+        if (Date.now() - t0 > 2000) {
           console.log(JSON.stringify({ recv, fired, STARVED: true }));
           process.exit(1);
         }
@@ -268,7 +268,7 @@ describe("web worker", () => {
       immediate: "number",
     });
     expect(exitCode).toBe(0);
-  }, 10_000);
+  });
 
   test("sending 50 messages should just work", done => {
     const worker = new Worker(new URL("worker-fixture-many-messages.js", import.meta.url).href, {});

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -226,15 +226,13 @@ describe("web worker", () => {
     expect(process.execArgv).toEqual(original_execArgv);
   });
 
-  test(
-    "sustained worker postMessage flood doesn't starve parent timers/immediates",
-    async () => {
-      // A worker running a tight `for(;;) postMessage()` loop must not prevent
-      // the parent's setTimeout/setImmediate from firing. Cross-thread message
-      // delivery is a bounded task per event-loop turn in Node and browsers.
-      // The worker waits for "go" so the parent is already in its event loop
-      // when the flood starts and the first drain sees a bounded inbox.
-      const script = `
+  test("sustained worker postMessage flood doesn't starve parent timers/immediates", async () => {
+    // A worker running a tight `for(;;) postMessage()` loop must not prevent
+    // the parent's setTimeout/setImmediate from firing. Cross-thread message
+    // delivery is a bounded task per event-loop turn in Node and browsers.
+    // The worker waits for "go" so the parent is already in its event loop
+    // when the flood starts and the first drain sees a bounded inbox.
+    const script = `
       let recv = 0, t0 = 0;
       const fired = {};
       const workerSrc = "onmessage = () => { for (;;) postMessage(0); };";
@@ -256,23 +254,21 @@ describe("web worker", () => {
       };
       w.postMessage("go");
     `;
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", script],
-        env: bunEnv,
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      const out = JSON.parse(stdout.trim());
-      expect({ STARVED: out.STARVED, timer: typeof out.fired.timer, immediate: typeof out.fired.immediate }).toEqual({
-        STARVED: undefined,
-        timer: "number",
-        immediate: "number",
-      });
-      expect(exitCode).toBe(0);
-    },
-    10_000,
-  );
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout.trim());
+    expect({ STARVED: out.STARVED, timer: typeof out.fired.timer, immediate: typeof out.fired.immediate }).toEqual({
+      STARVED: undefined,
+      timer: "number",
+      immediate: "number",
+    });
+    expect(exitCode).toBe(0);
+  }, 10_000);
 
   test("sending 50 messages should just work", done => {
     const worker = new Worker(new URL("worker-fixture-many-messages.js", import.meta.url).href, {});

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -226,6 +226,54 @@ describe("web worker", () => {
     expect(process.execArgv).toEqual(original_execArgv);
   });
 
+  test(
+    "sustained worker postMessage flood doesn't starve parent timers/immediates",
+    async () => {
+      // A worker running a tight `for(;;) postMessage()` loop must not prevent
+      // the parent's setTimeout/setImmediate from firing. Cross-thread message
+      // delivery is a bounded task per event-loop turn in Node and browsers.
+      // The worker waits for "go" so the parent is already in its event loop
+      // when the flood starts and the first drain sees a bounded inbox.
+      const script = `
+      let recv = 0, t0 = 0;
+      const fired = {};
+      const workerSrc = "onmessage = () => { for (;;) postMessage(0); };";
+      const w = new Worker(URL.createObjectURL(new Blob([workerSrc], { type: "text/javascript" })));
+      w.onmessage = () => {
+        if (++recv === 1) {
+          t0 = Date.now();
+          setTimeout(() => { fired.timer = Date.now() - t0; }, 100);
+          setImmediate(() => { fired.immediate = Date.now() - t0; });
+        }
+        if ("timer" in fired && "immediate" in fired) {
+          console.log(JSON.stringify({ recv, fired }));
+          process.exit(0);
+        }
+        if (Date.now() - t0 > 5000) {
+          console.log(JSON.stringify({ recv, fired, STARVED: true }));
+          process.exit(1);
+        }
+      };
+      w.postMessage("go");
+    `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      const out = JSON.parse(stdout.trim());
+      expect({ STARVED: out.STARVED, timer: typeof out.fired.timer, immediate: typeof out.fired.immediate }).toEqual({
+        STARVED: undefined,
+        timer: "number",
+        immediate: "number",
+      });
+      expect(exitCode).toBe(0);
+    },
+    10_000,
+  );
+
   test("sending 50 messages should just work", done => {
     const worker = new Worker(new URL("worker-fixture-many-messages.js", import.meta.url).href, {});
 


### PR DESCRIPTION
A worker running a tight `for(;;) postMessage()` loop starves the parent event loop: timers, `setImmediate` and TCP accept never run while messages keep arriving. One worker is enough.

```js
let recv = 0, t0 = 0; const seen = {};
const w = new Worker(URL.createObjectURL(new Blob(["for (;;) postMessage('m');"], { type: "text/javascript" })));
w.onmessage = () => {
  if (++recv === 1) { t0 = Date.now(); setTimeout(() => { seen.timer50ms = Date.now() - t0; }, 50); setImmediate(() => { seen.setImmediate = Date.now() - t0; }); }
  if (recv >= 2_000_000) { console.log(JSON.stringify({ messages: recv, ms: Date.now() - t0, fired: seen, TIMER_STARVED: !("timer50ms" in seen) })); process.exit(); }
};
```

Before: `{"messages":2000000,"ms":1507,"fired":{},"TIMER_STARVED":true}`. Node v26 under the same flood interleaves fairly (setImmediate ~20 ms, 50 ms timer ~110 ms).

### Cause

`Worker::drainToParent` / `MessagePortPipe::drainAndDispatch` already cap each drain at `max(inbox.size(), 1000)` and reschedule when the cap is hit, but the reschedule goes through `postTaskTo` -> `postTaskConcurrently` -> the parent's concurrent task queue, and `EventLoop::tick()` calls `tick_concurrent()` inside its `while tick_with_count() > 0` loop. The reschedule is promoted and runs in the same `tick()`, so `tick()` never returns to `auto_tick` (`jsc_hooks.rs`), which is the only place immediates, the I/O poll (TCP accept) and `drain_timers` run. The `max(size, 1000)` cap also grows with the backlog when the sender outruns the receiver, so even the first batch can be arbitrarily long.

### Fix

- `EventLoop` gains a `next_iteration_tasks` lane, promoted into `tasks` once at `tick()` entry (never inside the drain loop). Exposed to C++ as `ScriptExecutionContext::postTaskNextIteration` via `Bun__queueTaskNextIteration`. Folded into `is_event_loop_alive`, the `has_pending_immediate` poll-deadline check in `auto_tick` / `auto_tick_active`, and `release_queued_tasks_for_shutdown` so shutdown reclaims any task left parked there.
- The reschedule legs in `Worker::drainToParent`, `Worker::drainToWorker` and `MessagePortPipe::drainAndDispatch` post via that lane instead of `postTaskTo`.
- The per-turn cap is now a fixed `min(size, 1024)` so the inbox acts as the backpressure buffer and each loop iteration dispatches a bounded slice.

This is Node's model: `uv_async` fires once per loop iteration and `MessagePort::OnMessage` drains what was queued when the callback started, so timers and poll run between drains.

### Tests

- `message-port-pipe.test.ts` "self-feeding onmessage loop yields to timers/immediates": same-thread port whose handler posts back to itself; deterministic (single-threaded, message-count bounded). Fails on main at count>10000 with `STARVED: true`; with the fix setTimeout(0) and setImmediate both fire within a few batches.
- `worker.test.ts` "sustained worker postMessage flood doesn't starve parent timers/immediates": the reported cross-thread scenario. Fails on main with `STARVED: true`; with the fix the 100 ms timer and setImmediate both fire under the flood.

Regression sweep on the debug build: `worker.test.ts` 26/26, `message-port-pipe.test.ts` 14/14, `worker_threads.test.ts` 91/91, `message-channel.test.ts` 17/17.

The same next-iteration primitive is on `claude/node-v26-hang-fixes` (#35538) for the node parallel test; this applies it standalone to main with the fixed cap and the cross-thread worker coverage.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 14 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/message-port-pipe.test.ts test/js/web/workers/worker.test.ts
bun test v1.4.0 (b933785b2)

test/js/web/workers/message-port-pipe.test.ts:
29 |     `;
30 |     await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stderr: "pipe" });
31 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
32 |     expect(stderr).toBe("");
33 |     const out = JSON.parse(stdout.trim());
34 |     expect(out.STARVED).toBeUndefined();
                             ^
error: expect(received).toBeUndefined()

Received: true

      at <anonymous> (/workspace/bun/test/js/web/workers/message-port-pipe.test.ts:34:25)
(fail) MessagePort pipe > self-feeding onmessage loop yields to timers/immediates [1925.89ms]
(pass) MessagePort pipe > microtasks run between message events (task-source semantics) [22.34ms]
(pass) MessagePort pipe > messages buffered before start() are delivered on start() [8.21ms]
(pass) MessagePort pipe > receiveMessageOnPort pops in FIFO order [125
... (truncated)

release without fix: 3 skipped
bun test v1.4.0-canary.1 (7596e5cb6)

test/js/web/workers/message-port-pipe.test.ts:
(pass) MessagePort pipe > self-feeding onmessage loop yields to timers/immediates [7.33ms]
(pass) MessagePort pipe > microtasks run between message events (task-source semantics) [0.26ms]
(pass) MessagePort pipe > messages buffered before start() are delivered on start() [0.12ms]
(pass) MessagePort pipe > receiveMessageOnPort pops in FIFO order [0.70ms]
(pass) MessagePort pipe > close() inside onmessage handler still delivers already-queued messages [0.20ms]
(pass) MessagePort pipe > messages queued on a port follow it across transfer [0.24ms]
(pass) MessagePort pipe > same-context re-attach inside handler: inbox follows new wrapper [0.22ms]
(pass) MessagePort pipe > chained transfer delivers through every hop [0.23ms]
(pass) MessagePort pipe > objectTypeCounts drop after close + GC; peer-open pins listening port [21.22ms]
(pass) MessagePort pipe > port dropped in transit does not pin its peer [10.28ms]
(skip) MessagePort pipe > concurrent MessageChannel creation across workers is race-free
(skip) MessagePort pipe > burst of postMessage across threads delivers every message in order
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/message-port-pipe.test.ts test/js/web/workers/worker.test.ts
bun test v1.4.0 (b933785b2)

test/js/web/workers/message-port-pipe.test.ts:
(pass) MessagePort pipe > self-feeding onmessage loop yields to timers/immediates [319.84ms]
(pass) MessagePort pipe > microtasks run between message events (task-source semantics) [15.65ms]
(pass) MessagePort pipe > messages buffered before start() are delivered on start() [8.24ms]
(pass) MessagePort pipe > receiveMessageOnPort pops in FIFO order [127.03ms]
(pass) MessagePort pipe > close() inside onmessage handler still delivers already-queued messages [12.54ms]
(pass) MessagePort pipe > messages queued on a port follow it across transfer [26.65ms]
(pass) MessagePort pipe > same-context re-attach inside handler: inbox follows new wrapper [11.61ms]
(pass) MessagePort pipe > chained transfer delivers through every hop [17.67ms]
(pass) MessagePort pipe > objectTypeCounts drop after close + GC; peer-open pins listening port [1531.49ms]
(pass) MessagePort pipe > port dropped in transi
... (truncated)

release with fix: 3 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 701ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/120] gen cpp.rs (cppbind)
[2/120] gen generated_host_exports.rs
generated_host_exports.rs: 95 exports (host=3, lazy=10, generic=82, rust=0); 240 extern-C blocks audited
[2/120] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs                     |  1 +
 src/jsc/bindings/ScriptExecutionContext.cpp   |  6 +++
 src/jsc/bindings/ScriptExecutionContext.h     |  2 +
 src/jsc/bindings/ZigGlobalObject.cpp          |  6 +++
 src/jsc/bindings/ZigGlobalObject.h            |  1 +
 src/jsc/bindings/webcore/MessagePort.cpp      |  8 +--
 src/jsc/bindings/webcore/MessagePortPipe.cpp  | 20 ++++----
 src/jsc/bindings/webcore/MessagePortPipe.h    | 10 ++--
 src/jsc/bindings/webcore/Worker.cpp           | 74 +++++++++++++--------------
 src/jsc/event_loop.rs                         | 20 ++++++++
 src/jsc/virtual_machine_exports.rs            | 10 ++++
 src/runtime/jsc_hooks.rs                      | 14 +++--
 test/js/web/workers/message-port-pipe.test.ts | 29 +++++++++++
 test/js/web/workers/worker.test.ts            | 44 ++++++++++++++++
 14 files changed, 189 insertions(+), 56 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/jsc/VirtualMachine.rs                          2      1      0
src/jsc/bindings/ScriptExecutionContext.cpp        1      1      0
src/jsc/bindings/ScriptExecutionContext.h          4      4      0
src/jsc/bindings/ZigGlobalObject.cpp               2      2      0
src/jsc/bindings/ZigGlobalObject.h                 4      4      0
src/jsc/bindings/webcore/MessagePort.cpp           2      1      0
src/jsc/bindings/webcore/MessagePortPipe.cpp       6      5      0
src/jsc/bindings/webcore/MessagePortPipe.h         2      2      0
src/jsc/bindings/webcore/Worker.cpp                8      9      0
src/jsc/event_loop.rs                              8     10      0
src/jsc/virtual_machine_exports.rs                 4      4      0
src/runtime/jsc_hooks.rs                           3      3      0
test/js/web/workers/message-port-pipe.test.ts      1      1      0
test/js/web/workers/worker.test.ts                 2      5      0
```

</details>

<!-- robobun:evidence:end -->