### PR TITLE
ptr: fix ref-count derives under `cargo test --release --doc`

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -78,3 +78,14 @@ jobs:
         env:
           BUN_CODEGEN_DIR: ${{ github.workspace }}/build/debug/codegen
         run: bun run rust:clippy
+
+      - name: cargo test --release --doc
+        # Guards against cfg(debug_assertions) skew between the ref-count
+        # derive macros and bun_ptr: rustdoc compiles the crate-under-test
+        # with debug_assertions on even under --release, while deps are built
+        # release. bun_ptr's doctest on the derive re-exports is the minimal
+        # reproducer (fails with E0407/E0405 if the derive emits cfg-gated
+        # items).
+        env:
+          BUN_CODEGEN_DIR: ${{ github.workspace }}/build/debug/codegen
+        run: bun run rust:doctest-release

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "rust:check": "cargo check --workspace --keep-going",
     "rust:check-all": "bun scripts/rust-check-all.ts",
     "rust:clippy": "cargo clippy --workspace --no-deps --keep-going",
+    "rust:doctest-release": "cargo test --release --doc -p bun_ptr",
     "rust:miri": "bun scripts/rust-miri.ts",
     "rust:timings": "bun scripts/rust-timings.ts",
     "codegen:string-maps": "for f in src/**/*.string-map.ts; do bun src/codegen/generate-string-map.ts \"$f\" \"${f%.string-map.ts}.generated.rs\"; done",

--- a/src/bun_core_macros/lib.rs
+++ b/src/bun_core_macros/lib.rs
@@ -368,8 +368,6 @@ pub fn derive_cell_ref_counted(input: TokenStream) -> TokenStream {
                     0,
                 );
             }
-            // `rc_debug_data`: `AnyRefCounted`'s default (no-op) is correct for
-            // `CellRefCounted` types — they carry no `DebugData` field.
         }
         // Inherent forwarders so callers don't need the trait in scope.
         impl #impl_g #name #ty_g #where_g {

--- a/src/bun_core_macros/lib.rs
+++ b/src/bun_core_macros/lib.rs
@@ -368,11 +368,8 @@ pub fn derive_cell_ref_counted(input: TokenStream) -> TokenStream {
                     0,
                 );
             }
-            #[cfg(debug_assertions)]
-            #[inline]
-            unsafe fn rc_debug_data(_this: *mut Self) -> *mut dyn ::bun_ptr::ref_count::DebugDataOps {
-                ::bun_ptr::ref_count::noop_debug_data()
-            }
+            // `rc_debug_data`: `AnyRefCounted`'s default (no-op) is correct for
+            // `CellRefCounted` types — they carry no `DebugData` field.
         }
         // Inherent forwarders so callers don't need the trait in scope.
         impl #impl_g #name #ty_g #where_g {
@@ -471,7 +468,6 @@ pub fn derive_thread_safe_ref_counted(input: TokenStream) -> TokenStream {
                         .assert_no_refs()
                 }
             }
-            #[cfg(debug_assertions)]
             #[inline]
             unsafe fn rc_debug_data(this: *mut Self) -> *mut dyn ::bun_ptr::ref_count::DebugDataOps {
                 // SAFETY: caller contract — `this` points to a live Self.

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -45,6 +45,21 @@ pub use ref_count::{
 // Derive macros — same names as the traits (separate namespace). The derives
 // expand to `::bun_ptr::…` paths, so this crate is the canonical re-export
 // point: `#[derive(bun_ptr::CellRefCounted)]`.
+//
+/// ```
+/// // Regression guard: under `cargo test --release --doc`, rustdoc compiles
+/// // this snippet with `cfg(debug_assertions)` ON but links it against a
+/// // release (`debug_assertions` OFF) `bun_ptr`. The derives must therefore
+/// // not emit anything that only exists in `bun_ptr` under
+/// // `#[cfg(debug_assertions)]`. Previously this failed with
+/// //   E0407 `rc_debug_data` is not a member of trait `AnyRefCounted`
+/// //   E0405 cannot find trait `DebugDataOps`
+/// #[derive(bun_ptr::CellRefCounted)]
+/// struct Cell { ref_count: core::cell::Cell<u32> }
+/// #[derive(bun_ptr::ThreadSafeRefCounted)]
+/// struct Atomic { ref_count: bun_ptr::ThreadSafeRefCount<Atomic> }
+/// let _ = core::mem::size_of::<(Cell, Atomic)>();
+/// ```
 pub use bun_core_macros::{CellRefCounted, RefCounted, ThreadSafeRefCounted};
 
 pub mod parent_ref;

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -47,13 +47,7 @@ pub use ref_count::{
 // point: `#[derive(bun_ptr::CellRefCounted)]`.
 //
 /// ```
-/// // Regression guard: under `cargo test --release --doc`, rustdoc compiles
-/// // this snippet with `cfg(debug_assertions)` ON but links it against a
-/// // release (`debug_assertions` OFF) `bun_ptr`. The derives must therefore
-/// // not emit anything that only exists in `bun_ptr` under
-/// // `#[cfg(debug_assertions)]`. Previously this failed with
-/// //   E0407 `rc_debug_data` is not a member of trait `AnyRefCounted`
-/// //   E0405 cannot find trait `DebugDataOps`
+/// // `cargo test --release --doc` cfg-skew guard (see AnyRefCounted::rc_debug_data).
 /// #[derive(bun_ptr::CellRefCounted)]
 /// struct Cell { ref_count: core::cell::Cell<u32> }
 /// #[derive(bun_ptr::ThreadSafeRefCounted)]

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -1011,8 +1011,7 @@ struct TrackedDeref;
 // ──────────────────────────────────────────────────────────────────────────
 
 /// Dyn-safe surface of `DebugData<Count>` so `RefPtr<T>` can interact with it
-/// without knowing whether `Count` is `Cell<u32>` or `AtomicU32`. Unconditional
-/// for the same reason as [`AnyRefCounted::rc_debug_data`].
+/// without knowing whether `Count` is `Cell<u32>` or `AtomicU32`.
 pub trait DebugDataOps {
     fn assert_valid_dyn(&self);
     fn acquire(&mut self, return_address: usize) -> TrackedRefId;

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -656,11 +656,6 @@ impl DebugDataOps for NoopDebugData {
 
 #[doc(hidden)]
 pub fn noop_debug_data() -> *mut dyn DebugDataOps {
-    // Per-call leaked stub — `RefPtr` only calls `acquire`/`release` on it,
-    // both of which are no-ops, so a shared static would also be sound; but
-    // `*mut dyn` from a `static mut` is unergonomic. Debug-only.
-    // SAFETY: NonNull::dangling is fine here? No — `RefPtr` derefs it.
-    // Use a thread-local static to avoid per-ref allocation.
     thread_local! {
         static NOOP: core::cell::UnsafeCell<NoopDebugData> =
             const { core::cell::UnsafeCell::new(NoopDebugData) };

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -147,10 +147,22 @@ pub trait AnyRefCounted: Sized {
     /// `this` must point to a live `Self`.
     unsafe fn rc_assert_no_refs(this: *const Self);
 
-    #[cfg(debug_assertions)]
+    /// Debug-build ref-tracking hook for [`RefPtr`]. Returns a no-op stub by
+    /// default; hosts with a real [`DebugData`] override it. All call sites
+    /// are themselves `#[cfg(debug_assertions)]`, so the default is dead code
+    /// in release — but the method and [`DebugDataOps`] are declared
+    /// unconditionally so the derive macros' emitted impls type-check when the
+    /// deriving crate and `bun_ptr` disagree on `cfg(debug_assertions)` (as
+    /// they do under `cargo test --release --doc`, where rustdoc compiles the
+    /// crate-under-test with debug assertions on against release-built deps).
+    ///
     /// # Safety
     /// `this` must point to a live `Self`.
-    unsafe fn rc_debug_data(this: *mut Self) -> *mut dyn DebugDataOps;
+    #[inline]
+    unsafe fn rc_debug_data(this: *mut Self) -> *mut dyn DebugDataOps {
+        let _ = this;
+        noop_debug_data()
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -370,10 +382,18 @@ impl<T: RefCounted> AnyRefCounted for T {
         // SAFETY: caller contract — `this` points to a live T
         unsafe { (*T::get_ref_count(this.cast_mut())).assert_no_refs() }
     }
-    #[cfg(debug_assertions)]
+    #[inline]
     unsafe fn rc_debug_data(this: *mut Self) -> *mut dyn DebugDataOps {
-        // SAFETY: caller contract — `this` points to a live T
-        unsafe { &raw mut (*T::get_ref_count(this)).debug }
+        let _ = this;
+        #[cfg(debug_assertions)]
+        {
+            // SAFETY: caller contract — `this` points to a live T
+            unsafe { &raw mut (*T::get_ref_count(this)).debug }
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            noop_debug_data()
+        }
     }
 }
 
@@ -516,11 +536,17 @@ impl<T: ThreadSafeRefCounted> ThreadSafeRefCount<T> {
     /// Type-erased accessor for the embedded debug tracker. Exposed (rather
     /// than the private `debug` field) so `#[derive(ThreadSafeRefCounted)]`
     /// can emit [`AnyRefCounted::rc_debug_data`] from outside this crate.
-    #[cfg(debug_assertions)]
     #[doc(hidden)]
     #[inline]
     pub fn debug_data_ptr(&mut self) -> *mut dyn DebugDataOps {
-        &raw mut self.debug
+        #[cfg(debug_assertions)]
+        {
+            &raw mut self.debug
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            noop_debug_data()
+        }
     }
 
     // `getRefCount` / `is_ref_count` / `ref_count_options` — see
@@ -621,11 +647,9 @@ pub unsafe trait CellRefCounted: Sized {
 /// No-op [`DebugDataOps`] for [`CellRefCounted`] types — they carry no
 /// `DebugData` field, so [`RefPtr`]'s acquire/release tracking degrades to
 /// a stub.
-#[cfg(debug_assertions)]
 #[doc(hidden)]
 pub struct NoopDebugData;
 
-#[cfg(debug_assertions)]
 impl DebugDataOps for NoopDebugData {
     fn assert_valid_dyn(&self) {}
     fn acquire(&mut self, _return_address: usize) -> TrackedRefId {
@@ -634,7 +658,6 @@ impl DebugDataOps for NoopDebugData {
     fn release(&mut self, _id: TrackedRefId, _return_address: usize) {}
 }
 
-#[cfg(debug_assertions)]
 #[doc(hidden)]
 pub fn noop_debug_data() -> *mut dyn DebugDataOps {
     // Per-call leaked stub — `RefPtr` only calls `acquire`/`release` on it,
@@ -977,7 +1000,6 @@ struct TrackedRef;
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct TrackedRefId(u32);
 
-#[cfg(debug_assertions)]
 impl TrackedRefId {
     #[inline]
     const fn new(n: u32) -> Self {
@@ -994,7 +1016,14 @@ struct TrackedDeref;
 
 /// Dyn-safe surface of `DebugData<Count>` so `RefPtr<T>` can interact with it
 /// without knowing whether `Count` is `Cell<u32>` or `AtomicU32`.
-#[cfg(debug_assertions)]
+///
+/// Declared unconditionally (not `#[cfg(debug_assertions)]`) so that
+/// `#[derive(CellRefCounted)]` / `#[derive(ThreadSafeRefCounted)]` expansions
+/// — which name this trait in the emitted `AnyRefCounted::rc_debug_data`
+/// signature — type-check even when the deriving crate's
+/// `cfg(debug_assertions)` differs from `bun_ptr`'s (see the note on
+/// [`AnyRefCounted::rc_debug_data`]). Only [`NoopDebugData`] implements it in
+/// release builds; the real [`DebugData`] storage stays debug-only.
 pub trait DebugDataOps {
     fn assert_valid_dyn(&self);
     fn acquire(&mut self, return_address: usize) -> TrackedRefId;

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -147,14 +147,10 @@ pub trait AnyRefCounted: Sized {
     /// `this` must point to a live `Self`.
     unsafe fn rc_assert_no_refs(this: *const Self);
 
-    /// Debug-build ref-tracking hook for [`RefPtr`]. Returns a no-op stub by
-    /// default; hosts with a real [`DebugData`] override it. All call sites
-    /// are themselves `#[cfg(debug_assertions)]`, so the default is dead code
-    /// in release — but the method and [`DebugDataOps`] are declared
-    /// unconditionally so the derive macros' emitted impls type-check when the
-    /// deriving crate and `bun_ptr` disagree on `cfg(debug_assertions)` (as
-    /// they do under `cargo test --release --doc`, where rustdoc compiles the
-    /// crate-under-test with debug assertions on against release-built deps).
+    /// Debug-build ref-tracking hook for [`RefPtr`]; no-op by default. Declared
+    /// unconditionally (with [`DebugDataOps`]) so derive-macro output type-checks
+    /// when a deriving crate and `bun_ptr` disagree on `cfg(debug_assertions)`,
+    /// as under `cargo test --release --doc`.
     ///
     /// # Safety
     /// `this` must point to a live `Self`.
@@ -1015,15 +1011,8 @@ struct TrackedDeref;
 // ──────────────────────────────────────────────────────────────────────────
 
 /// Dyn-safe surface of `DebugData<Count>` so `RefPtr<T>` can interact with it
-/// without knowing whether `Count` is `Cell<u32>` or `AtomicU32`.
-///
-/// Declared unconditionally (not `#[cfg(debug_assertions)]`) so that
-/// `#[derive(CellRefCounted)]` / `#[derive(ThreadSafeRefCounted)]` expansions
-/// — which name this trait in the emitted `AnyRefCounted::rc_debug_data`
-/// signature — type-check even when the deriving crate's
-/// `cfg(debug_assertions)` differs from `bun_ptr`'s (see the note on
-/// [`AnyRefCounted::rc_debug_data`]). Only [`NoopDebugData`] implements it in
-/// release builds; the real [`DebugData`] storage stays debug-only.
+/// without knowing whether `Count` is `Cell<u32>` or `AtomicU32`. Unconditional
+/// for the same reason as [`AnyRefCounted::rc_debug_data`].
 pub trait DebugDataOps {
     fn assert_valid_dyn(&self);
     fn acquire(&mut self, return_address: usize) -> TrackedRefId;

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2614,11 +2614,6 @@ impl bun_ptr::AnyRefCounted for NodeHTTPResponse {
         // SAFETY: caller contract — `this` is live.
         debug_assert_eq!(unsafe { (*this).ref_count.get() }, 0);
     }
-    #[cfg(debug_assertions)]
-    #[inline]
-    unsafe fn rc_debug_data(_this: *mut Self) -> *mut dyn bun_ptr::ref_count::DebugDataOps {
-        bun_ptr::ref_count::noop_debug_data()
-    }
 }
 
 /// # Safety

--- a/test/internal/rust-refcount-derive-release-doctest.test.ts
+++ b/test/internal/rust-refcount-derive-release-doctest.test.ts
@@ -25,8 +25,7 @@ const codegenDir = join(repoRoot, "build", "debug", "codegen");
 // applying -p, and test-only CI lanes run a prebuilt binary without
 // vendor/lolhtml or the codegen tree on disk.
 const workspaceResolvable =
-  existsSync(join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
-  existsSync(join(codegenDir, "build_options.rs"));
+  existsSync(join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) && existsSync(join(codegenDir, "build_options.rs"));
 
 test.skipIf(!cargo || !workspaceResolvable)(
   "cargo test --release --doc -p bun_http compiles the ref-count derives",

--- a/test/internal/rust-refcount-derive-release-doctest.test.ts
+++ b/test/internal/rust-refcount-derive-release-doctest.test.ts
@@ -19,13 +19,14 @@ import { join } from "node:path";
 
 const cargo = which("cargo");
 const repoRoot = join(import.meta.dir, "..", "..");
+const codegenDir = join(repoRoot, "build", "debug", "codegen");
 // Same prerequisite check as rust-windows-sys-link.test.ts / linear-fifo.test.ts:
 // cargo parses the whole workspace manifest (including path deps) before
 // applying -p, and test-only CI lanes run a prebuilt binary without
 // vendor/lolhtml or the codegen tree on disk.
 const workspaceResolvable =
   existsSync(join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
-  existsSync(join(repoRoot, "build", "debug", "codegen", "build_options.rs"));
+  existsSync(join(codegenDir, "build_options.rs"));
 
 test.skipIf(!cargo || !workspaceResolvable)(
   "cargo test --release --doc -p bun_http compiles the ref-count derives",
@@ -33,7 +34,7 @@ test.skipIf(!cargo || !workspaceResolvable)(
     await using proc = Bun.spawn({
       cmd: [cargo!, "test", "--locked", "--release", "--doc", "-p", "bun_http", "--quiet"],
       cwd: repoRoot,
-      env: { ...process.env, CARGO_TERM_COLOR: "never" },
+      env: { ...process.env, CARGO_TERM_COLOR: "never", BUN_CODEGEN_DIR: codegenDir },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/internal/rust-refcount-derive-release-doctest.test.ts
+++ b/test/internal/rust-refcount-derive-release-doctest.test.ts
@@ -1,0 +1,50 @@
+// Under `cargo test --release --doc`, cargo builds dependencies (including
+// bun_ptr) with the release profile (cfg(debug_assertions) off), but rustdoc
+// compiles the crate-under-test with cfg(debug_assertions) on. The
+// CellRefCounted / ThreadSafeRefCounted derive macros previously emitted an
+// `rc_debug_data` override gated on the *deriving* crate's
+// cfg(debug_assertions), so every derive site in bun_http (and any other
+// consumer) failed to compile under rustdoc's release doctest harness with
+//   E0407 method `rc_debug_data` is not a member of trait `AnyRefCounted`
+//   E0405 cannot find trait `DebugDataOps` in module `::bun_ptr::ref_count`
+// even though the dev-profile doctests and the plain release lib build were
+// fine. CI never ran release-profile doctests, so this was invisible.
+//
+// This test drives that exact configuration against bun_http (the crate the
+// report was filed against) so the profile skew stays covered end to end.
+import { which } from "bun";
+import { expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const cargo = which("cargo");
+const repoRoot = join(import.meta.dir, "..", "..");
+// Same prerequisite check as rust-windows-sys-link.test.ts / linear-fifo.test.ts:
+// cargo parses the whole workspace manifest (including path deps) before
+// applying -p, and test-only CI lanes run a prebuilt binary without
+// vendor/lolhtml or the codegen tree on disk.
+const workspaceResolvable =
+  existsSync(join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
+  existsSync(join(repoRoot, "build", "debug", "codegen", "build_options.rs"));
+
+test.skipIf(!cargo || !workspaceResolvable)(
+  "cargo test --release --doc -p bun_http compiles the ref-count derives",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [cargo!, "test", "--locked", "--release", "--doc", "-p", "bun_http", "--quiet"],
+      cwd: repoRoot,
+      env: { ...process.env, CARGO_TERM_COLOR: "never" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) {
+      // Surface the rustc diagnostic so the gate/CI log shows the real error.
+      console.error(stderr || stdout);
+    }
+    expect(stderr).not.toContain("is not a member of trait");
+    expect(stderr).not.toContain("cannot find trait `DebugDataOps`");
+    expect(exitCode).toBe(0);
+  },
+  120_000,
+);


### PR DESCRIPTION
## Repro

```
cargo test --release --doc -p bun_http
```

fails on `main` with 5× `E0407: method 'rc_debug_data' is not a member of trait '::bun_ptr::AnyRefCounted'` + 5× `E0405: cannot find trait 'DebugDataOps' in module '::bun_ptr::ref_count'` at each `#[derive(bun_ptr::CellRefCounted)]` / `#[derive(bun_ptr::ThreadSafeRefCounted)]` site (`h2_client/ClientSession.rs`, `h3_client/ClientSession.rs`, `HTTPContext.rs`, `ProxyTunnel.rs`, `ThreadSafeStreamBuffer.rs`). Dev-profile doctests and the plain release lib build are fine.

## Cause

Under `cargo test --release --doc`, cargo builds dependencies (including `bun_ptr`) with the release profile (`debug_assertions` off), but rustdoc compiles the crate-under-test with `cfg(debug_assertions)` **on**. `AnyRefCounted::rc_debug_data` and `DebugDataOps` in `bun_ptr` were `#[cfg(debug_assertions)]`-gated, and the derive macros emitted their `rc_debug_data` override under the same cfg evaluated in the **deriving** crate. The two sides disagreed: the impl side kept the method, the trait side had dropped it.

## Fix

Make the trait surface the derives reference profile-agnostic:

- `AnyRefCounted::rc_debug_data` is always declared, with a default no-op body (`noop_debug_data()`).
- `DebugDataOps`, `NoopDebugData`, `noop_debug_data()`, `TrackedRefId::new` and `ThreadSafeRefCount::debug_data_ptr()` are always defined (no-op in release).
- The `DebugData` storage struct itself and all `RefPtr` call sites stay `#[cfg(debug_assertions)]`, so release builds carry no extra state and the no-op accessors are dead code.
- `#[derive(CellRefCounted)]` drops its `rc_debug_data` emission entirely (the trait default is exactly the no-op it was emitting).
- `#[derive(ThreadSafeRefCounted)]` drops the `#[cfg(debug_assertions)]` on its `rc_debug_data` emission; `debug_data_ptr()` now exists in both profiles.

The derives no longer emit any `#[cfg(debug_assertions)]` and reference only always-present items.

## Verification

```
cargo test --release --doc -p bun_ptr -p bun_http   # now passes
cargo test --doc -p bun_ptr                         # dev still passes
cargo clippy -p bun_ptr -p bun_http --release       # clean
cargo clippy -p bun_ptr -p bun_http                 # clean
bun bd                                              # links
```

Added a doctest on the `bun_ptr` derive re-exports that uses both derives; under `cargo test --release --doc -p bun_ptr` this reproduces the exact E0407/E0405 on `main` and passes with the fix. Wired that command into the Clippy workflow via a new `rust:doctest-release` script so the configuration stays covered (bun_ptr release deps build in a few seconds, so the CI cost is negligible).

Found while running a release-profile cross-crate dead-code analysis (#36184); reproduces on `main` independently of that PR.

<!-- robobun:evidence:begin -->

---

**[decide:dep]** gate passed · iteration 2 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/rust-refcount-derive-release-doctest.test.ts
bun test v1.4.0 (befb6a2dc)

test/internal/rust-refcount-derive-release-doctest.test.ts:
error[E0407]: method `rc_debug_data` is not a member of trait `::bun_ptr::AnyRefCounted`
  --> src/http/h2_client/ClientSession.rs:34:10
   |
34 | #[derive(bun_ptr::CellRefCounted)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `::bun_ptr::AnyRefCounted`
   |
   = note: this error originates in the derive macro `bun_ptr::CellRefCounted` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0407]: method `rc_debug_data` is not a member of trait `::bun_ptr::AnyRefCounted`
  --> src/http/h3_client/ClientSession.rs:23:10
   |
23 | #[derive(bun_ptr::CellRefCounted)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `::bun_ptr::AnyRefCounted`
   |
   = note: this error originates in the derive macro `bun_ptr::CellRefCounted` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0407]: method `rc_debug_data` is not a member of trait `::bun_
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (08ac44d3c)

test/internal/rust-refcount-derive-release-doctest.test.ts:
error[E0407]: method `rc_debug_data` is not a member of trait `::bun_ptr::AnyRefCounted`
  --> src/http/h2_client/ClientSession.rs:34:10
   |
34 | #[derive(bun_ptr::CellRefCounted)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `::bun_ptr::AnyRefCounted`
   |
   = note: this error originates in the derive macro `bun_ptr::CellRefCounted` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0407]: method `rc_debug_data` is not a member of trait `::bun_ptr::AnyRefCounted`
  --> src/http/h3_client/ClientSession.rs:23:10
   |
23 | #[derive(bun_ptr::CellRefCounted)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `::bun_ptr::AnyRefCounted`
   |
   = note: this error originates in the derive macro `bun_ptr::CellRefCounted` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0407]: method `rc_debug_data` is not a member of trait `::bun_ptr::AnyRefCounted`
  --> src/http/HTTPContext.rs:25:10
   |
25 | #[derive(bun_ptr::CellRefCounted)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `::bun_ptr::AnyRefCoun
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/rust-refcount-derive-release-doctest.test.ts
bun test v1.4.0 (befb6a2dc)

test/internal/rust-refcount-derive-release-doctest.test.ts:
(pass) cargo test --release --doc -p bun_http compiles the ref-count derives [9817.37ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [11.81s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 699ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_core_macros v0.0.0 (/workspace/bun/src/bun_core_macros)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.github/workflows/clippy.yml                       | 11 +++++
 package.json                                       |  1 +
 src/bun_core_macros/lib.rs                         |  6 ---
 src/ptr/lib.rs                                     |  9 ++++
 src/ptr/ref_count.rs                               | 46 ++++++++++++--------
 src/runtime/server/NodeHTTPResponse.rs             |  5 ---
 .../rust-refcount-derive-release-doctest.test.ts   | 50 ++++++++++++++++++++++
 7 files changed, 100 insertions(+), 28 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
.github/workflows/clippy.yml                                  1      1      0
package.json                                                  1      1      0
src/bun_core_macros/lib.rs                                    3      4      0
src/ptr/lib.rs                                                3      3      0
src/ptr/ref_count.rs                                          5     12      0
src/runtime/server/NodeHTTPResponse.rs                        1      1      0
…t/internal/rust-refcount-derive-release-doctest.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->