### PR TITLE
Bun.file: resolve relative paths against cwd at construction

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2178,7 +2178,8 @@ declare module "bun" {
      */
     lastModified: number;
     /**
-     * The name or path of the file, as specified in the constructor.
+     * The name or path of the file. Relative paths are resolved against
+     * `process.cwd()` at the time `Bun.file()` is called.
      */
     readonly name?: string;
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4367,8 +4367,20 @@ pub extern "C" fn Blob__dupe(this: &Blob) -> *mut Blob {
     Blob::new(this.dupe_with_content_type(true))
 }
 
+/// Default `filename` for `FormData.append(name, blob)`. For a file-backed
+/// blob the store holds an absolute path, so emit only the basename to avoid
+/// leaking the cwd in `Content-Disposition` (matches browser `<input>` / RFC
+/// 7578 §4.2). `File`/`S3` names set explicitly by the user pass through.
 #[unsafe(no_mangle)]
 pub extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
+    if let Some(store) = this.store.get().as_deref() {
+        if let store::Data::File(file) = &store.data {
+            if let PathOrFileDescriptor::Path(path) = &file.pathlike {
+                return BunString::from_bytes(bun_paths::basename(path.slice()));
+            }
+            return BunString::empty();
+        }
+    }
     if let Some(filename) = this.get_file_name() {
         return BunString::from_bytes(filename);
     }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3743,7 +3743,32 @@ impl BlobExt for Blob {
                     }
                 }
 
-                path_or_fd.to_thread_safe();
+                // Resolve relative paths against the current working directory
+                // now, at construction time. The BunFile is a long-lived handle
+                // whose reads happen later; keeping the raw relative string and
+                // resolving at read time means a `process.chdir()` in between
+                // silently retargets the handle to a different file.
+                let slice = path_or_fd.path().slice();
+                let resolved = if !slice.is_empty() && !bun_paths::is_absolute(slice) {
+                    let mut buf = bun_paths::path_buffer_pool::get();
+                    let cwd = global_this.bun_vm().top_level_dir();
+                    bun_paths::resolve_path::join_abs_string_buf_checked::<
+                        bun_paths::platform::Auto,
+                    >(cwd, &mut buf[..], &[slice])
+                    .map(|abs| {
+                        bun_core::handle_oom(bun_ptr::cow_slice::CowSlice::init_dupe(abs))
+                    })
+                } else {
+                    None
+                };
+                match resolved {
+                    Some(abs) => {
+                        *path_or_fd = PathOrFileDescriptor::Path(
+                            crate::webcore::node_types::PathLike::String(abs),
+                        );
+                    }
+                    None => path_or_fd.to_thread_safe(),
+                }
                 core::mem::replace(
                     path_or_fd,
                     PathOrFileDescriptor::Path(crate::webcore::node_types::PathLike::String(

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3743,11 +3743,8 @@ impl BlobExt for Blob {
                     }
                 }
 
-                // Resolve relative paths against the current working directory
-                // now, at construction time. The BunFile is a long-lived handle
-                // whose reads happen later; keeping the raw relative string and
-                // resolving at read time means a `process.chdir()` in between
-                // silently retargets the handle to a different file.
+                // Resolve relative paths now so a later `process.chdir()`
+                // cannot retarget this handle's reads.
                 let slice = path_or_fd.path().slice();
                 let resolved = if !slice.is_empty() && !bun_paths::is_absolute(slice) {
                     let mut buf = bun_paths::path_buffer_pool::get();

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4367,15 +4367,12 @@ pub extern "C" fn Blob__dupe(this: &Blob) -> *mut Blob {
     Blob::new(this.dupe_with_content_type(true))
 }
 
-/// Default `filename` for `FormData.append(name, blob)`. For a file-backed
-/// blob the store holds an absolute path, so emit only the basename to avoid
-/// leaking the cwd in `Content-Disposition` (matches browser `<input>` / RFC
-/// 7578 §4.2). `File`/`S3` names set explicitly by the user pass through.
 #[unsafe(no_mangle)]
 pub extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
     if let Some(store) = this.store.get().as_deref() {
         if let store::Data::File(file) = &store.data {
             if let PathOrFileDescriptor::Path(path) = &file.pathlike {
+                // FormData default filename: basename only (RFC 7578 4.2).
                 return BunString::from_bytes(bun_paths::basename(path.slice()));
             }
             return BunString::empty();

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1022,7 +1022,7 @@ for (let credentials of allCredentials) {
             expect.unreachable();
           } catch (e: any) {
             expect(e?.code).toBe("ENOENT");
-            expect(e?.path).toBe("./do-not-exist.txt");
+            expect(e?.path).toBe(path.resolve("./do-not-exist.txt"));
             expect(e?.syscall).toBe("open");
           }
         });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1786,7 +1786,7 @@ describe("s3 multipart upload id validation", () => {
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      env: { ...bunEnv, http_proxy: undefined, HTTP_PROXY: undefined, https_proxy: undefined, HTTPS_PROXY: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -195,3 +195,15 @@ test("Bun.file(relativePath) resolves against cwd at construction, not at read t
   });
   expect(exitCode).toBe(0);
 });
+
+test("FormData.append(name, Bun.file(path)) sends only the basename as filename", async () => {
+  using dir = tempDir("bun-file-formdata", {
+    "upload.csv": "a,b,c\n",
+  });
+
+  const fd = new FormData();
+  fd.append("f", Bun.file(join(String(dir), "upload.csv")));
+  const body = await new Request("http://x", { method: "POST", body: fd }).text();
+  const m = body.match(/filename="([^"]*)"/);
+  expect(m?.[1]).toBe("upload.csv");
+});

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -155,3 +155,43 @@ test("Bun.file().json() with UTF-8 BOM does not free an interior pointer", async
   });
   expect(exitCode).toBe(0);
 });
+
+test("Bun.file(relativePath) resolves against cwd at construction, not at read time", async () => {
+  using dir = tempDir("bun-file-relcwd", {
+    "a/rel.txt": "FROM-A",
+    "b/rel.txt": "FROM-B",
+    "b/only-b.txt": "ONLY-B",
+    "run.ts": `
+      import fs from "node:fs";
+      import path from "node:path";
+      const root = process.argv[2];
+      process.chdir(path.join(root, "a"));
+      const f = Bun.file("rel.txt");
+      const g = Bun.file("only-b.txt");
+      process.chdir(path.join(root, "b"));
+      console.log(JSON.stringify({
+        text: await f.text(),
+        nameIsAbsolute: path.isAbsolute(f.name),
+        nameResolves: fs.realpathSync(f.name) === fs.realpathSync(path.join(root, "a", "rel.txt")),
+        exists: await g.exists(),
+      }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(String(dir), "run.ts"), String(dir)],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    text: "FROM-A",
+    nameIsAbsolute: true,
+    nameResolves: true,
+    exists: false,
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

`Bun.file("rel.txt")` kept the raw relative string and resolved it against `process.cwd()` at consumption time rather than construction time. A `process.chdir()` between construction and the first read silently retargeted the handle to a different file, and `.name` stayed `"rel.txt"` so nothing on the object recorded which file was actually read. `.size`, `.exists()`, and `.stat()` resolved late the same way.

```js
fs.writeFileSync(root + "/a/rel.txt", "FROM-A");
fs.writeFileSync(root + "/b/rel.txt", "FROM-B");
process.chdir(root + "/a");
const f = Bun.file("rel.txt");      // constructed while cwd = a
process.chdir(root + "/b");
await f.text();                      // "FROM-B"  (silently retargeted)
f.name;                              // "rel.txt" (still relative)
```

Node's `fs.openAsBlob("rel.txt")` captures file identity at call time and rejects a changed target rather than silently reading another file.

## Fix

Resolve relative paths to absolute in `find_or_create_file_from_path` at construction time, using `join_abs_string_buf_checked` against `top_level_dir` (the same pattern `fs.watch` and `Bun.mmapFile` use). Absolute paths, `s3://` URLs, `/$bunfs/` virtual paths, file descriptors, and empty paths pass through unchanged. Paths whose joined length would exceed `PATH_MAX` keep the original relative form and fail at open time with `ENAMETOOLONG` as before (rather than panicking on the buffer write).

`.name` now returns the resolved absolute path for relative inputs. `..` in a relative path is normalized lexically (matching `path.resolve()` / `fs.watch` / `Bun.mmapFile`).

Since the store now holds an absolute path, `Blob__getFileNameString` (the FormData default `filename` for `append(name, blob)` / `set(name, blob)`) emits `basename(path)` for file-backed blobs so the cwd is not leaked in `Content-Disposition`. This also fixes the pre-existing case where `Bun.file(absolutePath)` sent the full path on the wire. Names from `new File([...], name)` and S3 keys are unchanged.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/util/bun-file.test.ts -t "resolves against cwd"
(fail) ... text: "FROM-B", nameIsAbsolute: false, exists: true

$ bun bd test test/js/bun/util/bun-file.test.ts
(pass) Bun.file(relativePath) resolves against cwd at construction, not at read time
(pass) FormData.append(name, Bun.file(path)) sends only the basename as filename
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 286 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3.test.ts" test/js/bun/util/bun-file.test.ts
bun test v1.4.0 (54570c5bf)

test/js/bun/s3/s3.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(skip) R2 > s3 > fetch > bucket in path > should download file via fetch GET
(skip) R2 > s3 > fetch > bucket in path > should download range
(skip) R2 > s3 > fetch > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > fetch > bucket in path > should check if a key does not exist
(skip) R2 > s3 > fetch > bucket in path > should be able to set content-type
(skip) R2 > s3 > fetch > bucket in path > should be able to upload large files
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download file via Bun.s3().text()
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range with 0 offset
(skip) R2 > s3 > Bun.S3Clien
... (truncated)

release without fix: 286 skipped
bun test v1.4.0-canary.1 (f46a4b90e)

test/js/bun/s3/s3.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(skip) R2 > s3 > fetch > bucket in path > should download file via fetch GET
(skip) R2 > s3 > fetch > bucket in path > should download range
(skip) R2 > s3 > fetch > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > fetch > bucket in path > should check if a key does not exist
(skip) R2 > s3 > fetch > bucket in path > should be able to set content-type
(skip) R2 > s3 > fetch > bucket in path > should be able to upload large files
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download file via Bun.s3().text()
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range with 0 offset
(skip) R2 > s3 > Bun.S3Client > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > Bun.S3Client > bucket in path > should check if a key does not exist
(skip) R2 > s3 > Bun.S3Client > 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 286 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3.test.ts" test/js/bun/util/bun-file.test.ts
bun test v1.4.0 (54570c5bf)

test/js/bun/s3/s3.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(skip) R2 > s3 > fetch > bucket in path > should download file via fetch GET
(skip) R2 > s3 > fetch > bucket in path > should download range
(skip) R2 > s3 > fetch > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > fetch > bucket in path > should check if a key does not exist
(skip) R2 > s3 > fetch > bucket in path > should be able to set content-type
(skip) R2 > s3 > fetch > bucket in path > should be able to upload large files
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download file via Bun.s3().text()
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range with 0 offset
(skip) R2 > s3 > Bun.S3Clien
... (truncated)

release with fix: 286 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 935ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/bun.d.ts       |  3 ++-
 src/runtime/webcore/Blob.rs       | 33 ++++++++++++++++++++++++-
 test/js/bun/s3/s3.test.ts         |  4 +--
 test/js/bun/util/bun-file.test.ts | 52 +++++++++++++++++++++++++++++++++++++++
 4 files changed, 88 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
packages/bun-types/bun.d.ts            1      1      0
src/runtime/webcore/Blob.rs           12      6      0
test/js/bun/s3/s3.test.ts              3      2      0
test/js/bun/util/bun-file.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->