### PR TITLE
Bun.serve: honour per-method false as a negative route

### DIFF
--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -585,7 +585,7 @@ declare module "bun" {
       [Path in R]:
         | BaseRouteValue
         | Handler<BunRequest<Path>, Server<WebSocketData>, Response>
-        | Partial<Record<HTTPMethod, Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Response>>;
+        | Partial<Record<HTTPMethod, Handler<BunRequest<Path>, Server<WebSocketData>, Response> | BaseRouteValue>>;
     };
 
     type RoutesWithUpgrade<WebSocketData, R extends string> = {
@@ -593,7 +593,10 @@ declare module "bun" {
         | BaseRouteValue
         | Handler<BunRequest<Path>, Server<WebSocketData>, Response | undefined | void>
         | Partial<
-            Record<HTTPMethod, Handler<BunRequest<Path>, Server<WebSocketData>, Response | undefined | void> | Response>
+            Record<
+              HTTPMethod,
+              Handler<BunRequest<Path>, Server<WebSocketData>, Response | undefined | void> | BaseRouteValue
+            >
           >;
     };
 

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -64,7 +64,7 @@ pub struct ServerConfig {
     pub had_routes_object: bool,
 
     pub static_routes: Vec<StaticRouteEntry>,
-    pub negative_routes: Vec<ZBox>,
+    pub negative_routes: Vec<NegativeRoute>,
     pub user_routes_to_build: Vec<UserRouteBuilder>,
 
     pub bake: Option<crate::bake::UserOptions>,
@@ -153,7 +153,7 @@ impl ServerConfig {
         cost += self.id.len();
         cost += self.base_uri.len();
         for route in self.negative_routes.iter() {
-            cost += route.as_bytes().len();
+            cost += route.path.as_bytes().len();
         }
 
         cost
@@ -169,6 +169,14 @@ pub struct RouteDeclaration {
 pub enum RouteMethod {
     Any,
     Specific(Method),
+}
+
+/// A `false` route value: register the path (or one method at the path) so it
+/// dispatches to the default handler ladder instead of being caught by a
+/// wildcard route.
+pub struct NegativeRoute {
+    pub path: ZBox,
+    pub method: RouteMethod,
 }
 
 impl Default for RouteDeclaration {
@@ -889,8 +897,10 @@ impl ServerConfig {
                 if value == JSValue::FALSE {
                     // Appends a sentinel NUL without rejecting interior NULs
                     // (which already passed `is_all_ascii`).
-                    let duped = ZBox::from_bytes(&*path);
-                    args.negative_routes.push(duped);
+                    args.negative_routes.push(NegativeRoute {
+                        path: ZBox::from_bytes(&*path),
+                        method: RouteMethod::Any,
+                    });
                     continue;
                 }
 
@@ -937,6 +947,10 @@ impl ServerConfig {
                                 if method == Method::HEAD {
                                     has_head_route = true;
                                 }
+                                args.negative_routes.push(NegativeRoute {
+                                    path: ZBox::from_bytes(&*path),
+                                    method: RouteMethod::Specific(method),
+                                });
                                 continue;
                             }
 

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -185,6 +185,11 @@ pub struct StaticRouteEntry {
     pub path: Box<[u8]>,
     pub route: AnyRoute,
     pub method: MethodOptional,
+    /// Set when the per-method route object this entry came from also declared
+    /// `HEAD` (as a handler, a static value, or `false`). `apply_static_route`
+    /// uses it to skip the implicit GET→HEAD registration so the sibling
+    /// declaration is not displaced.
+    pub skip_implicit_head: bool,
 }
 
 impl StaticRouteEntry {
@@ -299,6 +304,7 @@ impl ServerConfig {
             path: Box::<[u8]>::from(path),
             route,
             method,
+            skip_implicit_head: false,
         });
         Ok(())
     }
@@ -918,6 +924,7 @@ impl ServerConfig {
                     // so a route object with a GET handler and no HEAD entry also answers HEAD.
                     let mut derived_head_route: Option<UserRouteBuilder> = None;
                     let mut has_head_route = false;
+                    let static_routes_start = init_ctx.user_routes.len();
                     for method in METHODS {
                         let method_name = bun_core::String::static_(method.as_str());
                         if let Some(function) = value.get_own(global, &method_name)? {
@@ -925,6 +932,13 @@ impl ServerConfig {
                                 validate_route_name(global, &path)?;
                             }
                             found = true;
+
+                            if function == JSValue::FALSE {
+                                if method == Method::HEAD {
+                                    has_head_route = true;
+                                }
+                                continue;
+                            }
 
                             if function.is_callable() {
                                 let callback = function.with_async_context_if_needed(global);
@@ -958,6 +972,7 @@ impl ServerConfig {
                                     path: Box::<[u8]>::from(&*path),
                                     route: html_route,
                                     method: http_method::Optional::Method(method_set),
+                                    skip_implicit_head: false,
                                 });
                                 if method == Method::HEAD {
                                     has_head_route = true;
@@ -966,6 +981,13 @@ impl ServerConfig {
                         }
                     }
 
+                    if has_head_route {
+                        for entry in &mut init_ctx.user_routes[static_routes_start..] {
+                            if *entry.path == *path {
+                                entry.skip_implicit_head = true;
+                            }
+                        }
+                    }
                     if let Some(builder) = derived_head_route {
                         if !has_head_route {
                             args.user_routes_to_build.push(builder);
@@ -1014,6 +1036,7 @@ impl ServerConfig {
                     path,
                     route,
                     method: http_method::Optional::Any,
+                    skip_implicit_head: false,
                 });
             }
 

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -171,9 +171,7 @@ pub enum RouteMethod {
     Specific(Method),
 }
 
-/// A `false` route value: register the path (or one method at the path) so it
-/// dispatches to the default handler ladder instead of being caught by a
-/// wildcard route.
+/// A `false` route value: claim the path (or one method) for the default handler.
 pub struct NegativeRoute {
     pub path: ZBox,
     pub method: RouteMethod,
@@ -193,10 +191,7 @@ pub struct StaticRouteEntry {
     pub path: Box<[u8]>,
     pub route: AnyRoute,
     pub method: MethodOptional,
-    /// Set when the per-method route object this entry came from also declared
-    /// `HEAD` (as a handler, a static value, or `false`). `apply_static_route`
-    /// uses it to skip the implicit GET→HEAD registration so the sibling
-    /// declaration is not displaced.
+    /// The path's per-method route object declared `HEAD`, so don't derive one.
     pub skip_implicit_head: bool,
 }
 
@@ -933,6 +928,7 @@ impl ServerConfig {
                     // HEAD must behave like GET without a body (RFC 9110 section 9.3.2),
                     // so a route object with a GET handler and no HEAD entry also answers HEAD.
                     let mut derived_head_route: Option<UserRouteBuilder> = None;
+                    let mut derived_head_negative = false;
                     let mut has_head_route = false;
                     let static_routes_start = init_ctx.user_routes.len();
                     for method in METHODS {
@@ -944,8 +940,10 @@ impl ServerConfig {
                             found = true;
 
                             if function == JSValue::FALSE {
-                                if method == Method::HEAD {
-                                    has_head_route = true;
+                                match method {
+                                    Method::HEAD => has_head_route = true,
+                                    Method::GET => derived_head_negative = true,
+                                    _ => {}
                                 }
                                 args.negative_routes.push(NegativeRoute {
                                     path: ZBox::from_bytes(&*path),
@@ -1001,10 +999,15 @@ impl ServerConfig {
                                 entry.skip_implicit_head = true;
                             }
                         }
-                    }
-                    if let Some(builder) = derived_head_route {
-                        if !has_head_route {
+                    } else {
+                        if let Some(builder) = derived_head_route {
                             args.user_routes_to_build.push(builder);
+                        }
+                        if derived_head_negative {
+                            args.negative_routes.push(NegativeRoute {
+                                path: ZBox::from_bytes(&*path),
+                                method: RouteMethod::Specific(Method::HEAD),
+                            });
                         }
                     }
 

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2270,16 +2270,30 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         } else {
             trampoline::on_404::<SSL, DEBUG>
         };
-        for route_path in self.config.negative_routes.iter() {
-            let p = route_path.as_bytes();
-            app.head(p, Some(negative_h1), self_ptr.cast());
-            app.any(p, Some(negative_h1), self_ptr.cast());
-            if Self::HAS_H3 {
-                if let Some(h3_app) = self.h3_app {
-                    // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
-                    let h3_app = bun_opaque::opaque_deref_mut(h3_app);
-                    h3_app.head(p, self_ptr, Self::on_h3_request);
-                    h3_app.any(p, self_ptr, Self::on_h3_request);
+        for route in self.config.negative_routes.iter() {
+            let p = route.path.as_bytes();
+            match route.method {
+                server_config::RouteMethod::Any => {
+                    app.head(p, Some(negative_h1), self_ptr.cast());
+                    app.any(p, Some(negative_h1), self_ptr.cast());
+                    if Self::HAS_H3 {
+                        if let Some(h3_app) = self.h3_app {
+                            // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
+                            let h3_app = bun_opaque::opaque_deref_mut(h3_app);
+                            h3_app.head(p, self_ptr, Self::on_h3_request);
+                            h3_app.any(p, self_ptr, Self::on_h3_request);
+                        }
+                    }
+                }
+                server_config::RouteMethod::Specific(m) => {
+                    app.method(m, p, Some(negative_h1), self_ptr.cast());
+                    if Self::HAS_H3 {
+                        if let Some(h3_app) = self.h3_app {
+                            // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
+                            bun_opaque::opaque_deref_mut(h3_app)
+                                .method(m, p, self_ptr, Self::on_h3_request);
+                        }
+                    }
                 }
             }
         }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2327,10 +2327,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
             // An explicit HEAD handler route must stay the HEAD handler for its
             // path: uWS keeps the last registration for a method and path, and
-            // static routes register after user routes. `skip_implicit_head`
-            // carries the same signal for sibling per-method declarations that
-            // the callable-route scan cannot see (a static `HEAD` value or
-            // `HEAD: false`).
+            // static routes register after user routes.
             let path_has_user_head_route = entry.skip_implicit_head
                 || self
                     .user_routes

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2290,8 +2290,12 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     if Self::HAS_H3 {
                         if let Some(h3_app) = self.h3_app {
                             // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
-                            bun_opaque::opaque_deref_mut(h3_app)
-                                .method(m, p, self_ptr, Self::on_h3_request);
+                            bun_opaque::opaque_deref_mut(h3_app).method(
+                                m,
+                                p,
+                                self_ptr,
+                                Self::on_h3_request,
+                            );
                         }
                     }
                 }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2309,9 +2309,13 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
             // An explicit HEAD handler route must stay the HEAD handler for its
             // path: uWS keeps the last registration for a method and path, and
-            // static routes register after user routes.
-            let path_has_user_head_route =
-                self.user_routes
+            // static routes register after user routes. `skip_implicit_head`
+            // carries the same signal for sibling per-method declarations that
+            // the callable-route scan cannot see (a static `HEAD` value or
+            // `HEAD: false`).
+            let path_has_user_head_route = entry.skip_implicit_head
+                || self
+                    .user_routes
                     .iter()
                     .any(|route| match &route.route.method {
                         server_config::RouteMethod::Specific(method) => {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -619,6 +619,7 @@ impl AnyRoute {
             path: builder.into_boxed_slice(),
             route,
             method: methods,
+            skip_implicit_head: false,
         });
         Ok(None)
     }

--- a/test/integration/bun-types/fixture/serve.ts
+++ b/test/integration/bun-types/fixture/serve.ts
@@ -84,3 +84,18 @@ const s4 = Bun.serve({
     },
   },
 });
+
+Bun.serve({
+  routes: {
+    "/static-per-method": {
+      GET: new Response("static"),
+      HEAD: false,
+      POST: req => {
+        expectType(req.params).is<{}>();
+        return new Response("ok");
+      },
+    },
+    "/top-level-false": false,
+  },
+  fetch: () => new Response("fallback"),
+});

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -243,10 +243,7 @@ describe("implicit HEAD for per-method route objects", () => {
     test("sends HEAD to fetch instead of deriving it from GET", async () => {
       await using server = Bun.serve({
         port: 0,
-        routes: {
-          // @ts-expect-error - false is the per-method disable
-          "/x": { GET: makeGet(), HEAD: false },
-        },
+        routes: { "/x": { GET: makeGet(), HEAD: false } },
         fetch: req => new Response(null, { status: 299, headers: { "x-from": "fetch", "x-method": req.method } }),
       });
 
@@ -264,7 +261,6 @@ describe("implicit HEAD for per-method route objects", () => {
     test("sends HEAD to 404 when there is no fetch handler", async () => {
       await using server = Bun.serve({
         port: 0,
-        // @ts-expect-error - false is the per-method disable
         routes: { "/x": { GET: makeGet(), HEAD: false } },
       });
 
@@ -280,11 +276,40 @@ describe("implicit HEAD for per-method route objects", () => {
     });
   });
 
+  test("HEAD: false routes HEAD to the default handler past a /* sibling, like a top-level false", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/per-method": { GET: new Response("g"), HEAD: false },
+        "/top-level": false,
+        "/*": new Response("star-body", { headers: { "x-from": "star" } }),
+      },
+      fetch: req => new Response(null, { status: 299, headers: { "x-from": "fetch", "x-method": req.method } }),
+    });
+
+    const [perMethod, topLevel, getPerMethod, other] = await Promise.all([
+      fetch(new URL("/per-method", server.url), { method: "HEAD" }),
+      fetch(new URL("/top-level", server.url), { method: "HEAD" }),
+      fetch(new URL("/per-method", server.url)),
+      fetch(new URL("/elsewhere", server.url), { method: "HEAD" }),
+    ]);
+    expect({
+      perMethod: { status: perMethod.status, from: perMethod.headers.get("x-from") },
+      topLevel: { status: topLevel.status, from: topLevel.headers.get("x-from") },
+      getPerMethod: { status: getPerMethod.status, body: await getPerMethod.text() },
+      other: { status: other.status, from: other.headers.get("x-from") },
+    }).toEqual({
+      perMethod: { status: 299, from: "fetch" },
+      topLevel: { status: 299, from: "fetch" },
+      getPerMethod: { status: 200, body: "g" },
+      other: { status: 200, from: "star" },
+    });
+  });
+
   test("HEAD: false on one path does not affect the implicit HEAD on another", async () => {
     await using server = Bun.serve({
       port: 0,
       routes: {
-        // @ts-expect-error - false is the per-method disable
         "/a": { GET: new Response("a-body"), HEAD: false },
         "/b": { GET: new Response("b-body") },
       },

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -306,6 +306,32 @@ describe("implicit HEAD for per-method route objects", () => {
     });
   });
 
+  test("GET: false derives a negative HEAD past a /* sibling (RFC 9110 symmetry)", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/x": { GET: false },
+        "/y": { GET: false, HEAD: new Response(null, { headers: { "x-from": "own-head" } }) },
+        "/*": new Response("star", { headers: { "x-from": "star" } }),
+      },
+      fetch: req => new Response(null, { status: 299, headers: { "x-from": "fetch", "x-method": req.method } }),
+    });
+
+    const [gx, hx, gy, hy] = await Promise.all([
+      fetch(new URL("/x", server.url)),
+      fetch(new URL("/x", server.url), { method: "HEAD" }),
+      fetch(new URL("/y", server.url)),
+      fetch(new URL("/y", server.url), { method: "HEAD" }),
+    ]);
+    expect({
+      x: { get: gx.headers.get("x-from"), head: hx.headers.get("x-from") },
+      y: { get: gy.headers.get("x-from"), head: hy.headers.get("x-from") },
+    }).toEqual({
+      x: { get: "fetch", head: "fetch" },
+      y: { get: "fetch", head: "own-head" },
+    });
+  });
+
   test("HEAD: false on one path does not affect the implicit HEAD on another", async () => {
     await using server = Bun.serve({
       port: 0,

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -236,6 +236,71 @@ describe("implicit HEAD for per-method route objects", () => {
     expect(get.status).toBe(200);
   });
 
+  describe.each([
+    ["callable GET", () => () => new Response("get-body")],
+    ["static Response GET", () => new Response("get-body")],
+  ])("HEAD: false alongside a %s", (_, makeGet) => {
+    test("sends HEAD to fetch instead of deriving it from GET", async () => {
+      await using server = Bun.serve({
+        port: 0,
+        routes: {
+          // @ts-expect-error - false is the per-method disable
+          "/x": { GET: makeGet(), HEAD: false },
+        },
+        fetch: req => new Response(null, { status: 299, headers: { "x-from": "fetch", "x-method": req.method } }),
+      });
+
+      const head = await fetch(new URL("/x", server.url), { method: "HEAD" });
+      const g = await fetch(new URL("/x", server.url));
+      expect({
+        head: { status: head.status, from: head.headers.get("x-from"), method: head.headers.get("x-method") },
+        get: { status: g.status, body: await g.text() },
+      }).toEqual({
+        head: { status: 299, from: "fetch", method: "HEAD" },
+        get: { status: 200, body: "get-body" },
+      });
+    });
+
+    test("sends HEAD to 404 when there is no fetch handler", async () => {
+      await using server = Bun.serve({
+        port: 0,
+        // @ts-expect-error - false is the per-method disable
+        routes: { "/x": { GET: makeGet(), HEAD: false } },
+      });
+
+      const head = await fetch(new URL("/x", server.url), { method: "HEAD" });
+      const g = await fetch(new URL("/x", server.url));
+      expect({
+        head: { status: head.status },
+        get: { status: g.status, body: await g.text() },
+      }).toEqual({
+        head: { status: 404 },
+        get: { status: 200, body: "get-body" },
+      });
+    });
+  });
+
+  test("HEAD: false on one path does not affect the implicit HEAD on another", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        // @ts-expect-error - false is the per-method disable
+        "/a": { GET: new Response("a-body"), HEAD: false },
+        "/b": { GET: new Response("b-body") },
+      },
+      fetch: () => new Response(null, { status: 299 }),
+    });
+
+    const [ha, hb] = await Promise.all([
+      fetch(new URL("/a", server.url), { method: "HEAD" }),
+      fetch(new URL("/b", server.url), { method: "HEAD" }),
+    ]);
+    expect({ a: ha.status, b: { status: hb.status, len: hb.headers.get("content-length") } }).toEqual({
+      a: 299,
+      b: { status: 200, len: String("b-body".length) },
+    });
+  });
+
   test("a static Response for another method does not capture HEAD away from GET", async () => {
     await using server = Bun.serve({
       port: 0,


### PR DESCRIPTION
## What

A top-level route value of `false` registers the path with the default handler ladder (node http → `fetch` → 404), so it falls through past any `/*` wildcard. The per-method form was silently ignored:

```js
Bun.serve({
  routes: {
    "/x": { GET: new Response("static-get-body"), HEAD: false },
    "/*": new Response("catch-all"),
  },
  fetch: req => new Response(null, { status: 299, headers: { "x-from": "fetch" } }),
});
// HEAD /x -> 200 from the static GET route (expected 299 from fetch)
```

This held for both callable and static per-method `GET` values.

## Why

The per-method parse loop in `ServerConfig::from_js` recorded nothing for a `false` value (`AnyRoute::from_js` returns `None` for it), so `has_head_route` stayed `false` and:

- a callable `GET` still pushed `derived_head_route` as a HEAD handler;
- a static `GET` (`Response`/`BunFile`/`HTMLBundle`) had `apply_static_route` register an implicit HEAD, because `path_has_user_head_route` only scans callable `user_routes`;
- nothing was registered for the `false` method itself, so a `/*` sibling would capture the request instead of `fetch`.

Panic/top-frame signature: `{ GET: Response, HEAD: false }` served HEAD from the static GET route.

## Fix

- `NegativeRoute { path, method }` replaces `Vec<ZBox>` so one list covers top-level `false` (`RouteMethod::Any`) and per-method `false` (`RouteMethod::Specific`). Step 4 of route registration now registers either `head + any` or the single method with the default-handler ladder.
- A per-method `false` for `HEAD` sets `has_head_route`, which already suppresses `derived_head_route` for a callable `GET`. A per-method `false` for `GET` stages a derived negative `HEAD` so RFC 9110 symmetry holds past a `/*` sibling; an explicit `HEAD` entry still takes precedence.
- `StaticRouteEntry.skip_implicit_head` is set on the static entries pushed for the same path once `has_head_route` is known after the per-method loop. Step 5 folds it into `path_has_user_head_route` so `apply_static_route` does not re-register HEAD on top of step 4's negative registration. The flag is also set for an explicit static or callable `HEAD` sibling, so a static `GET` no longer relies on registration order to stay out of its way.
- `serve.d.ts`: the per-method value is widened from `Response` to `BaseRouteValue` (`Response | false | HTMLBundle | BunFile`), matching what the runtime already accepts.

RFC 9110 §9.3.2 still holds everywhere else: a per-method `GET` without an explicit `HEAD` answers HEAD.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/bun/http/bun-serve-routes.test.ts -t "implicit HEAD"
  7 fail, 9 pass (the 9 existing tests unchanged)

bun bd test test/js/bun/http/bun-serve-routes.test.ts
  62 pass, 0 fail

bun bd test test/js/bun/http/bun-serve-static.test.ts test/js/bun/http/bun-serve-file.test.ts
  149 pass

bun test test/integration/bun-types/bun-types.test.ts
  14 pass
```

Related: #36311 (adds validation for per-method values; overlaps on the `false` branch in the parse loop).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-routes.test.ts
bun test v1.4.0 (362224cc7)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [23.03ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [9.46ms]
(pass) path parameters > handles encoded parameters [14.14ms]
(pass) path parameters > handles unicode parameters [7.01ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [356.81ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [48.28ms]
(pass) HTTP methods > GET request [22.71ms]
(pass) HTTP methods > POST request [4.73ms]
(pass) HTTP methods > PUT request [3.94ms]
(pass) HTTP methods > DELETE request [14.05ms]
(pass) HTTP methods > PATCH request [4.30ms]
(pass) HTTP methods > OPTIONS request [10.94ms]
(pass) HTTP methods > HEAD request [4.77ms]
(pass) implicit HEAD for per-method route objects > HEAD is served by the GET handler when no HEAD handler is declared [49.45ms]
(pass) impli
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (df4f71b37)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [1.68ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [0.74ms]
(pass) path parameters > handles encoded parameters [0.17ms]
(pass) path parameters > handles unicode parameters [0.17ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [5.65ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [0.81ms]
(pass) HTTP methods > GET request [1.24ms]
(pass) HTTP methods > POST request [0.11ms]
(pass) HTTP methods > PUT request [0.11ms]
(pass) HTTP methods > DELETE request [0.09ms]
(pass) HTTP methods > PATCH request [0.09ms]
(pass) HTTP methods > OPTIONS request [0.09ms]
(pass) HTTP methods > HEAD request [0.07ms]
(pass) implicit HEAD for per-method route objects > HEAD is served by the GET handler when no HEAD handler is declared [1.11ms]
(pass) implicit HEAD for per-method route objects > HEAD does not 404 when there is no later route to fall through to [0.71ms]
(pass) implicit HEAD for per-method route objects > the GET 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-routes.test.ts
bun test v1.4.0 (362224cc7)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [23.14ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [9.47ms]
(pass) path parameters > handles encoded parameters [12.13ms]
(pass) path parameters > handles unicode parameters [6.96ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [350.34ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [47.55ms]
(pass) HTTP methods > GET request [21.97ms]
(pass) HTTP methods > POST request [4.60ms]
(pass) HTTP methods > PUT request [4.23ms]
(pass) HTTP methods > DELETE request [10.43ms]
(pass) HTTP methods > PATCH request [3.97ms]
(pass) HTTP methods > OPTIONS request [3.28ms]
(pass) HTTP methods > HEAD request [8.77ms]
(pass) implicit HEAD for per-method route objects > HEAD is served by the GET handler when no HEAD handler is declared [44.56ms]
(pass) implic
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 768ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/serve.d.ts               |   7 +-
 src/runtime/server/ServerConfig.rs          |  52 +++++++++++--
 src/runtime/server/mod.rs                   |  43 ++++++++---
 src/runtime/server/server_body.rs           |   1 +
 test/integration/bun-types/fixture/serve.ts |  15 ++++
 test/js/bun/http/bun-serve-routes.test.ts   | 116 ++++++++++++++++++++++++++++
 6 files changed, 214 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
packages/bun-types/serve.d.ts                    1      1      0
src/runtime/server/ServerConfig.rs               8     16      0
src/runtime/server/mod.rs                        5      3      0
src/runtime/server/server_body.rs                5      1      0
test/integration/bun-types/fixture/serve.ts      1      1      0
test/js/bun/http/bun-serve-routes.test.ts        2      7      0
```

</details>

<!-- robobun:evidence:end -->