### PR TITLE
ShadowRealm: cache importValue module in its own realm under require(esm)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+export const WEBKIT_VERSION = "autobuild-preview-pr-371-4e9f0037";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/shadow.test.js
+++ b/test/js/bun/jsc/shadow.test.js
@@ -1,4 +1,5 @@
 import { expect, it } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 it("shadow realm works", () => {
   const red = new ShadowRealm();
@@ -7,4 +8,45 @@ it("shadow realm works", () => {
   const result = red.evaluate("globalThis.someValue = 2;");
   expect(globalThis.someValue).toBe(1);
   expect(result).toBe(2);
+});
+
+// require(esm) drives the module loader through a VM-wide synchronous queue.
+// Reactions from a ShadowRealm's own module loader that fire during that drain
+// must be replayed against the ShadowRealm's registry, not the caller's; if
+// they aren't, the first importValue registers the module in the wrong realm
+// and the second importValue loads a fresh copy instead of the cached one.
+it("importValue caches modules in the ShadowRealm when kicked off under require(esm)", async () => {
+  using dir = tempDir("shadow-realm-sync-queue", {
+    "counter.mjs": `let n = 0; export const getCounter = () => n++;`,
+    "trigger.mjs": `
+      import url from "node:url";
+      import path from "node:path";
+      const mod = url.pathToFileURL(path.join(import.meta.dirname, "counter.mjs")).href;
+      const realm = new ShadowRealm();
+      const first = realm.importValue(mod, "getCounter");
+      export { realm, first, mod };
+    `,
+    "entry.cjs": `
+      const { realm, first, mod } = require("./trigger.mjs");
+      (async () => {
+        const a = await first;
+        const b = await realm.importValue(mod, "getCounter");
+        const { getCounter: outer } = await import(mod);
+        console.log(JSON.stringify({ a0: a(), b0: b(), b1: b(), outer: outer() }));
+      })().catch(e => { console.error(e); process.exit(1); });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  // a and b must share module state inside the ShadowRealm; the outer realm's
+  // import of the same specifier must be a separate instance.
+  expect(JSON.parse(stdout.trim())).toEqual({ a0: 0, b0: 1, b1: 2, outer: 0 });
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem

`require(esm)` drives JSC's module loader through a VM-wide synchronous queue (`vm.m_synchronousModuleQueue`). If a `ShadowRealm.importValue` starts while that queue is active (e.g. from the top level of the required ESM), the ShadowRealm's module-loader reactions are diverted to the queue and then replayed against the caller's `globalObject` instead of the ShadowRealm's. The module is registered in the main realm's module map, so:

- the second `importValue` for the same specifier loads a fresh instance instead of the cached one, and
- a later `import()` in the outer realm sees the ShadowRealm's instance.

```js
// trigger.mjs  (evaluated under loadModuleSync)
const realm = new ShadowRealm();
const first = realm.importValue(counterHref, "getCounter");
export { realm, first };

// entry.cjs
const { realm, first } = require("./trigger.mjs");
const a = await first;
const b = await realm.importValue(counterHref, "getCounter");
a(); // 0
b(); // 0, should be 1 (same module)
(await import(counterHref)).getCounter(); // 1, should be 0 (different realm)
```

#34121 wraps every CommonJS entry load in the same queue, which makes Node's `test/parallel/test-shadow-realm-module.js` fail there.

### Cause

`JSModuleLoader::drainSynchronousModuleQueue` passes its caller's `globalObject` to `runInternalMicrotask` for every queued task. The four diversion points in `JSPromise.cpp` all have the reaction's own realm in scope (it is exactly what `queueMicrotask` would have used) but do not store it on `SynchronousModuleTask`.

### Fix

JavaScriptCore side: oven-sh/WebKit#371 stores the realm on `SynchronousModuleTask`, replays against it in the drain loop (including the exception-path `queueMicrotask`), and marks it in `VM::visitAggregateImpl`.

This PR bumps `WEBKIT_VERSION` to that PR's preview build (parent is the currently pinned `549170099`, so nothing else rides along) and adds a regression test.

### Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/jsc/shadow.test.js
(fail) importValue caches modules in the ShadowRealm when kicked off under require(esm)
  {
    "a0": 0,
-   "b0": 1,
-   "b1": 2,
-   "outer": 0,
+   "b0": 0,
+   "b1": 1,
+   "outer": 1,
  }
```

With the fix (local WebKit build):

```
(pass) shadow realm works
(pass) importValue caches modules in the ShadowRealm when kicked off under require(esm)
```

Also ran `test/parallel/test-shadow-realm-module.js` and the `require-esm-*` sync-queue tests; all pass.

Unblocks #34121 for `test-shadow-realm-module.js`.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/shadow.test.js'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/shadow.test.js
bun test v1.4.0 (64028c747)

test/js/bun/jsc/shadow.test.js:
(pass) shadow realm works [46.91ms]
(pass) importValue caches modules in the ShadowRealm when kicked off under require(esm) [593.39ms]

 2 pass
 0 fail
 5 expect() calls
Ran 2 tests across 1 file. [2.75s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts   |  2 +-
 test/js/bun/jsc/shadow.test.js | 42 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 43 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
scripts/build/deps/webkit.ts        3      2      0
test/js/bun/jsc/shadow.test.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->