### PR TITLE
node:events: make errorMonitor an unregistered Symbol

### DIFF
--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -47,7 +47,7 @@ const kCapture = Symbol("kCapture");
 // writes `undefined` instead of `delete`, keeping one shared JSC Structure
 // so the (StructureID, name)-keyed megamorphic cache stays hot.
 const kShapeMode = Symbol("shapeMode");
-const kErrorMonitor = SymbolFor("events.errorMonitor");
+const kErrorMonitor = Symbol("events.errorMonitor");
 const kMaxEventTargetListeners = Symbol("events.maxEventTargetListeners");
 const kMaxEventTargetListenersWarned = Symbol("events.maxEventTargetListenersWarned");
 const kWatermarkData = SymbolFor("nodejs.watermarkData");

--- a/src/node-fallbacks/events.js
+++ b/src/node-fallbacks/events.js
@@ -9,7 +9,7 @@
 const SymbolFor = Symbol.for;
 
 const kCapture = Symbol("kCapture");
-const kErrorMonitor = SymbolFor("events.errorMonitor");
+const kErrorMonitor = Symbol("events.errorMonitor");
 const kMaxEventTargetListeners = Symbol("events.maxEventTargetListeners");
 const kMaxEventTargetListenersWarned = Symbol("events.maxEventTargetListenersWarned");
 const kRejection = SymbolFor("nodejs.rejection");

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -706,6 +706,30 @@ describe("EventEmitter error handling", () => {
 
     expect(handled).toBe(true);
   });
+
+  test("errorMonitor is an unregistered Symbol (node parity)", () => {
+    const registered = Symbol.for("events.errorMonitor");
+    expect({
+      sameAsSymbolFor: EventEmitter.errorMonitor === registered,
+      keyFor: Symbol.keyFor(EventEmitter.errorMonitor),
+      description: EventEmitter.errorMonitor.description,
+    }).toEqual({
+      sameAsSymbolFor: false,
+      keyFor: undefined,
+      description: "events.errorMonitor",
+    });
+
+    const ee = new EventEmitter();
+    let fired = false;
+    ee.on(registered, () => (fired = true));
+    expect(() => ee.emit("error", new Error("boom"))).toThrow("boom");
+    expect(fired).toBe(false);
+
+    const ee2 = new EventEmitter();
+    ee2.on(EventEmitter.errorMonitor, () => {});
+    ee2.on(registered, () => {});
+    expect(ee2.listenerCount(EventEmitter.errorMonitor)).toBe(1);
+  });
 });
 
 describe("EventEmitter captureRejections", () => {


### PR DESCRIPTION
### What does this PR do?

Node creates `events.errorMonitor` with `Symbol('events.errorMonitor')`, a unique unregistered symbol. Bun was using `Symbol.for('events.errorMonitor')`, which put it in the global symbol registry.

Consequence: any listener added under `Symbol.for('events.errorMonitor')` (a bundled copy of `node:events`, a polyfill, cross-realm code, or a name collision) became the real error monitor in Bun: it fired on every `'error'` emit and was counted by `listenerCount(errorMonitor)`. In Node that listener is an ordinary event that never fires for `'error'`. It also leaked the identity into the global registry (`Symbol.keyFor(events.errorMonitor)` returned a string in Bun, `undefined` in Node).

### Repro

```js
import { EventEmitter, errorMonitor } from 'node:events';
const S = Symbol.for('events.errorMonitor');
const r = { sameAsSymbolFor: errorMonitor === S, keyFor: Symbol.keyFor(errorMonitor) ?? 'not-registered' };
const ee = new EventEmitter();
ee.on(S, (e) => { r.symbolForListenerFired = 'yes:' + e.message; });
try { ee.emit('error', new Error('boom')); r.threw = false; } catch (e) { r.threw = true; }
r.symbolForListenerFired ??= 'no';
const ee2 = new EventEmitter();
ee2.on(errorMonitor, () => {}); ee2.on(S, () => {});
r.listenerCount_errorMonitor = ee2.listenerCount(errorMonitor);
console.log(JSON.stringify(r));
```

Node v26.3.0:
```
{"sameAsSymbolFor":false,"keyFor":"not-registered","threw":true,"symbolForListenerFired":"no","listenerCount_errorMonitor":1}
```

Bun before:
```
{"sameAsSymbolFor":true,"keyFor":"events.errorMonitor","symbolForListenerFired":"yes:boom","threw":true,"listenerCount_errorMonitor":2}
```

### Fix

`src/js/node/events.ts`: `SymbolFor("events.errorMonitor")` -> `Symbol("events.errorMonitor")`, matching [Node's definition](https://github.com/nodejs/node/blob/main/lib/events.js).

The other `SymbolFor` uses in that block (`nodejs.rejection`, `nodejs.watermarkData`) are correctly registered in Node and were left alone.

### How did you verify your code works?

- `USE_SYSTEM_BUN=1 bun test test/js/node/events/event-emitter.test.ts -t "errorMonitor is an unregistered Symbol"` fails
- `bun bd test test/js/node/events/event-emitter.test.ts` passes (76/76)

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/events/event-emitter.test.ts
bun test v1.4.0 (875c8ed86)

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [4.25ms]
(pass) node:events > once [70.83ms]
(pass) node:events > once (abort) [22.72ms]
(pass) node:events > once (two events in same tick) [38.47ms]
(pass) node:events > once removes the listener afterwards [60.71ms]
(pass) node:events > once is an async function [2.17ms]
(pass) node:events > once with already-aborted signal rejects (not a synchronous throw) [9.50ms]
(pass) node:events > once with invalid options.signal rejects (not a synchronous throw) [17.40ms]
(pass) node:events > once with non-object options rejects (not a synchronous throw) [8.42ms]
(pass) EventEmitter > getEventListeners [9.34ms]
(pass) EventEmitter > constructor [5.89ms]
(pass) EventEmitter > removeAllListeners() [11.66ms]
(pass) EventEmitter > removeAllListeners(type) [5.53ms]
(pass) EventEmitter > emit > different tick [4.31ms]
(pass) EventEmitter > emit > async microtask before [6.35ms]
(pass) EventEmi
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (1a0b1e62b)

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [0.03ms]
(pass) node:events > once [1.89ms]
(pass) node:events > once (abort) [0.35ms]
(pass) node:events > once (two events in same tick) [10.34ms]
(pass) node:events > once removes the listener afterwards [0.69ms]
(pass) node:events > once is an async function [0.02ms]
(pass) node:events > once with already-aborted signal rejects (not a synchronous throw) [0.41ms]
(pass) node:events > once with invalid options.signal rejects (not a synchronous throw) [0.21ms]
(pass) node:events > once with non-object options rejects (not a synchronous throw) [0.07ms]
(pass) EventEmitter > getEventListeners [0.09ms]
(pass) EventEmitter > constructor [0.05ms]
(pass) EventEmitter > removeAllListeners() [0.32ms]
(pass) EventEmitter > removeAllListeners(type) [0.06ms]
(pass) EventEmitter > emit > different tick [0.05ms]
(pass) EventEmitter > emit > async microtask before [0.07ms]
(pass) EventEmitter > emit > async microtask after [0.05ms]
(pass) EventEmitter > emit > same tick [0.03ms]
(pass) EventEmitter > emit > setTimeout task [1.20ms]
(pass) EventEmitter > em
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/events/event-emitter.test.ts
bun test v1.4.0 (875c8ed86)

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [2.83ms]
(pass) node:events > once [43.16ms]
(pass) node:events > once (abort) [12.50ms]
(pass) node:events > once (two events in same tick) [29.19ms]
(pass) node:events > once removes the listener afterwards [36.23ms]
(pass) node:events > once is an async function [1.58ms]
(pass) node:events > once with already-aborted signal rejects (not a synchronous throw) [9.20ms]
(pass) node:events > once with invalid options.signal rejects (not a synchronous throw) [14.87ms]
(pass) node:events > once with non-object options rejects (not a synchronous throw) [5.03ms]
(pass) EventEmitter > getEventListeners [5.84ms]
(pass) EventEmitter > constructor [4.40ms]
(pass) EventEmitter > removeAllListeners() [13.31ms]
(pass) EventEmitter > removeAllListeners(type) [5.22ms]
(pass) EventEmitter > emit > different tick [4.22ms]
(pass) EventEmitter > emit > async microtask before [6.58ms]
(pass) EventEmi
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 819ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen node-fallbacks/*.js
[2/22] gen JS modules (bundle-modules)
Preprocess modules (10018ms)
Bundle modules (79ms)
Postprocesss modules (47ms)
Bundle Functions (858ms)
Generate Code (30ms)

[11.06s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/events.ts                     |  2 +-
 src/node-fallbacks/events.js              |  2 +-
 test/js/node/events/event-emitter.test.ts | 24 ++++++++++++++++++++++++
 3 files changed, 26 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/events.ts                          1      1      0
src/node-fallbacks/events.js                   1      1      0
test/js/node/events/event-emitter.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->