### PR TITLE
node:fs: deliver ENAMETOOLONG via the callback with per-op syscall/path

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7661,16 +7661,12 @@ impl NodeFS {
     ) -> Maybe<ret::Realpath> {
         #[cfg(windows)]
         {
+            let path = args
+                .path
+                .slice_z_sys(&mut self.sync_error_buf, sys::Tag::realpath)?;
             let mut req = UvFsReq::new();
             let rc = unsafe {
-                uv::uv_fs_realpath(
-                    bun_io::Loop::get(),
-                    &mut *req,
-                    args.path
-                        .slice_z_sys(&mut self.sync_error_buf, sys::Tag::realpath)?
-                        .as_ptr(),
-                    None,
-                )
+                uv::uv_fs_realpath(bun_io::Loop::get(), &mut *req, path.as_ptr(), None)
             };
             if let Some(errno) = rc.errno() {
                 return Err(sys::Error {
@@ -8182,14 +8178,15 @@ impl NodeFS {
     pub fn utimes(&mut self, args: &args::Utimes, _: Flavor) -> Maybe<ret::Utimes> {
         #[cfg(windows)]
         {
+            let path = args
+                .path
+                .slice_z_sys(&mut self.sync_error_buf, sys::Tag::utime)?;
             let mut req = UvFsReq::new();
             let rc = unsafe {
                 uv::uv_fs_utime(
                     bun_io::Loop::get(),
                     &mut *req,
-                    args.path
-                        .slice_z_sys(&mut self.sync_error_buf, sys::Tag::utime)?
-                        .as_ptr(),
+                    path.as_ptr(),
                     args.atime,
                     args.mtime,
                     None,
@@ -8222,14 +8219,15 @@ impl NodeFS {
     pub fn lutimes(&mut self, args: &args::Lutimes, _: Flavor) -> Maybe<ret::Lutimes> {
         #[cfg(windows)]
         {
+            let path = args
+                .path
+                .slice_z_sys(&mut self.sync_error_buf, sys::Tag::lutime)?;
             let mut req = UvFsReq::new();
             let rc = unsafe {
                 uv::uv_fs_lutime(
                     bun_io::Loop::get(),
                     &mut *req,
-                    args.path
-                        .slice_z_sys(&mut self.sync_error_buf, sys::Tag::lutime)?
-                        .as_ptr(),
+                    path.as_ptr(),
                     args.atime,
                     args.mtime,
                     None,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4744,7 +4744,8 @@ impl NodeFS {
         let path: &ZStr = if args.path.slice().is_empty() {
             ZStr::EMPTY
         } else {
-            args.path.slice_z(&mut self.sync_error_buf)
+            args.path
+                .slice_z_sys(&mut self.sync_error_buf, sys::Tag::access)?
         };
         match Syscall::access(path, args.mode.as_int()) {
             Err(err) => Err(err.with_path(args.path.slice())),
@@ -4763,7 +4764,7 @@ impl NodeFS {
                 Ok(())
             }
             PathOrFileDescriptor::Path(path_) => {
-                let path = path_.slice_z(&mut self.sync_error_buf);
+                let path = path_.slice_z_sys(&mut self.sync_error_buf, sys::Tag::open)?;
                 let fd = Syscall::open(path, FileSystemFlags::A.as_int(), args.mode)?;
                 let _close = scopeguard::guard(fd, |fd| fd.close());
                 while !data.is_empty() {
@@ -4984,8 +4985,14 @@ impl NodeFS {
         {
             let mut src_buf = PathBuffer::uninit();
             let mut dest_buf = PathBuffer::uninit();
-            let src = args.src.slice_z(&mut src_buf);
-            let dest = args.dest.slice_z(&mut dest_buf);
+            let src = args
+                .src
+                .slice_z_sys(&mut src_buf, sys::Tag::copyfile)
+                .map_err(|e| e.with_path_dest(args.src.slice(), args.dest.slice()))?;
+            let dest = args
+                .dest
+                .slice_z_sys(&mut dest_buf, sys::Tag::copyfile)
+                .map_err(|e| e.with_path_dest(args.src.slice(), args.dest.slice()))?;
 
             if args.mode.is_force_clone() {
                 // https://www.manpagez.com/man/2/clonefile/
@@ -5084,8 +5091,14 @@ impl NodeFS {
         {
             let mut src_buf = PathBuffer::uninit();
             let mut dest_buf = PathBuffer::uninit();
-            let src = args.src.slice_z(&mut src_buf);
-            let dest = args.dest.slice_z(&mut dest_buf);
+            let src = args
+                .src
+                .slice_z_sys(&mut src_buf, sys::Tag::copyfile)
+                .map_err(|e| e.with_path_dest(args.src.slice(), args.dest.slice()))?;
+            let dest = args
+                .dest
+                .slice_z_sys(&mut dest_buf, sys::Tag::copyfile)
+                .map_err(|e| e.with_path_dest(args.src.slice(), args.dest.slice()))?;
 
             if args.mode.is_force_clone() {
                 return Err(sys::Error {
@@ -5196,8 +5209,14 @@ impl NodeFS {
         {
             let mut src_buf = PathBuffer::uninit();
             let mut dest_buf = PathBuffer::uninit();
-            let src = args.src.slice_z(&mut src_buf);
-            let dest = args.dest.slice_z(&mut dest_buf);
+            let src = args
+                .src
+                .slice_z_sys(&mut src_buf, sys::Tag::copyfile)
+                .map_err(|e| e.with_path_dest(args.src.slice(), args.dest.slice()))?;
+            let dest = args
+                .dest
+                .slice_z_sys(&mut dest_buf, sys::Tag::copyfile)
+                .map_err(|e| e.with_path_dest(args.src.slice(), args.dest.slice()))?;
 
             let src_fd = Syscall::open(src, sys::O::RDONLY, 0o644)?;
             let _close_src = scopeguard::guard(src_fd, |fd| fd.close());
@@ -5443,7 +5462,8 @@ impl NodeFS {
         #[cfg(windows)]
         {
             return match Syscall::chown(
-                args.path.slice_z(&mut self.sync_error_buf),
+                args.path
+                    .slice_z_sys(&mut self.sync_error_buf, sys::Tag::chown)?,
                 args.uid,
                 args.gid,
             ) {
@@ -5453,13 +5473,17 @@ impl NodeFS {
         }
         #[cfg(not(windows))]
         {
-            let path = args.path.slice_z(&mut self.sync_error_buf);
+            let path = args
+                .path
+                .slice_z_sys(&mut self.sync_error_buf, sys::Tag::chown)?;
             Syscall::chown(path, args.uid, args.gid)
         }
     }
 
     pub fn chmod(&mut self, args: &args::Chmod, _: Flavor) -> Maybe<ret::Chmod> {
-        let path = args.path.slice_z(&mut self.sync_error_buf);
+        let path = args
+            .path
+            .slice_z_sys(&mut self.sync_error_buf, sys::Tag::chmod)?;
         #[cfg(windows)]
         {
             return match Syscall::chmod(path, args.mode) {
@@ -5600,7 +5624,9 @@ impl NodeFS {
         }
         #[cfg(not(any(windows, target_os = "android")))]
         {
-            let path = args.path.slice_z(&mut self.sync_error_buf);
+            let path = args
+                .path
+                .slice_z_sys(&mut self.sync_error_buf, sys::Tag::lchmod)?;
             match Syscall::lchmod(path, args.mode) {
                 Err(err) => Err(err.with_path(args.path.slice())),
                 Ok(_) => Ok(()),
@@ -5611,7 +5637,9 @@ impl NodeFS {
     pub fn lchown(&mut self, args: &args::LChown, _: Flavor) -> Maybe<ret::Lchown> {
         // On Windows `Syscall::lchown` routes through uv_fs_lchown, which is
         // a no-op success, matching Node.
-        let path = args.path.slice_z(&mut self.sync_error_buf);
+        let path = args
+            .path
+            .slice_z_sys(&mut self.sync_error_buf, sys::Tag::lchown)?;
         match Syscall::lchown(path, args.uid, args.gid) {
             Err(err) => Err(err.with_path(args.path.slice())),
             Ok(_) => Ok(()),
@@ -5620,8 +5648,14 @@ impl NodeFS {
 
     pub fn link(&mut self, args: &args::Link, _: Flavor) -> Maybe<ret::Link> {
         let mut to_buf = PathBuffer::uninit();
-        let from = args.old_path.slice_z(&mut self.sync_error_buf);
-        let to = args.new_path.slice_z(&mut to_buf);
+        let from = args
+            .old_path
+            .slice_z_sys(&mut self.sync_error_buf, sys::Tag::link)
+            .map_err(|e| e.with_path_dest(args.old_path.slice(), args.new_path.slice()))?;
+        let to = args
+            .new_path
+            .slice_z_sys(&mut to_buf, sys::Tag::link)
+            .map_err(|e| e.with_path_dest(args.old_path.slice(), args.new_path.slice()))?;
         #[cfg(windows)]
         {
             return match Syscall::link(from, to) {
@@ -5641,7 +5675,9 @@ impl NodeFS {
     }
 
     pub fn lstat(&mut self, args: &args::Lstat, _: Flavor) -> Maybe<ret::Lstat> {
-        let path = args.path.slice_z(&mut self.sync_error_buf);
+        let path = args
+            .path
+            .slice_z_sys(&mut self.sync_error_buf, sys::Tag::lstat)?;
         #[cfg(any(target_os = "linux", target_os = "android"))]
         if sys::SUPPORTS_STATX_ON_LINUX.load(Ordering::Relaxed) {
             return match sys::lstatx(path, sys::STATX_MASK_FOR_STATS) {
@@ -5689,7 +5725,9 @@ impl NodeFS {
 
     // Node doesn't absolute the path so we don't have to either
     pub fn mkdir_non_recursive(&mut self, args: &args::Mkdir) -> Maybe<ret::Mkdir> {
-        let path = args.path.slice_z(&mut self.sync_error_buf);
+        let path = args
+            .path
+            .slice_z_sys(&mut self.sync_error_buf, sys::Tag::mkdir)?;
         match Syscall::mkdir(path, args.mode) {
             Ok(_) => Ok(StringOrUndefined::None),
             Err(err) => Err(err.with_path(args.path.slice())),
@@ -5975,7 +6013,15 @@ impl NodeFS {
     pub fn mkdtemp(&mut self, args: &args::MkdirTemp, _: Flavor) -> Maybe<ret::Mkdtemp> {
         let prefix_buf = &mut self.sync_error_buf;
         let prefix_slice = args.prefix.slice();
-        let len = prefix_slice.len().min(prefix_buf.len().saturating_sub(7));
+        let len = prefix_slice.len();
+        if len + 7 > prefix_buf.len() {
+            return Err(sys::Error {
+                errno: E::ENAMETOOLONG as _,
+                syscall: sys::Tag::mkdtemp,
+                path: prefix_slice.into(),
+                ..Default::default()
+            });
+        }
         if len > 0 {
             prefix_buf[..len].copy_from_slice(&prefix_slice[..len]);
         }
@@ -6039,7 +6085,8 @@ impl NodeFS {
             // SAFETY: literal is NUL-terminated; len excludes the sentinel.
             ZStr::from_static(b"\\\\.\\NUL\0")
         } else {
-            args.path.slice_z(&mut self.sync_error_buf)
+            args.path
+                .slice_z_sys(&mut self.sync_error_buf, sys::Tag::open)?
         };
         match Syscall::open(path, args.flags.as_int(), args.mode) {
             Err(err) => Err(err.with_path(args.path.slice())),
@@ -6924,7 +6971,7 @@ impl NodeFS {
         recursive: bool,
         flavor: Flavor,
     ) -> Maybe<ret::Readdir> {
-        let path = args.path.slice_z(buf);
+        let path = args.path.slice_z_sys(buf, sys::Tag::scandir)?;
 
         if recursive && flavor == Flavor::Sync {
             let mut buf_to_pass = PathBuffer::uninit();
@@ -7032,7 +7079,7 @@ impl NodeFS {
         let path_is_path = matches!(args.path, PathOrFileDescriptor::Path(_));
         let fd_maybe_windows: FD = match &args.path {
             PathOrFileDescriptor::Path(p) => {
-                let path = p.slice_z(&mut self.sync_error_buf);
+                let path = p.slice_z_sys(&mut self.sync_error_buf, sys::Tag::open)?;
 
                 if let Some(graph) = standalone_module_graph_get() {
                     // SAFETY: see `standalone_module_graph_get`.
@@ -7392,6 +7439,14 @@ impl NodeFS {
     ) -> Maybe<ret::WriteFile> {
         let fd = match &args.file {
             PathOrFileDescriptor::Path(p) => {
+                if p.slice().len() >= paths::MAX_PATH_BYTES {
+                    return Err(sys::Error {
+                        errno: E::ENAMETOOLONG as _,
+                        syscall: sys::Tag::open,
+                        path: p.slice().into(),
+                        ..Default::default()
+                    });
+                }
                 let path = p.slice_z_with_force_copy::<true>(pathbuf);
                 // O_TRUNC is dropped on purpose: keeping the existing blocks
                 // allocated makes rewriting a large file cheaper, and the resize
@@ -7528,7 +7583,7 @@ impl NodeFS {
     pub fn readlink(&mut self, args: &args::Readlink, _: Flavor) -> Maybe<ret::Readlink> {
         let mut outbuf = PathBuffer::uninit();
         let inbuf = &mut self.sync_error_buf;
-        let path = args.path.slice_z(inbuf);
+        let path = args.path.slice_z_sys(inbuf, sys::Tag::readlink)?;
         // PORT: `Syscall` (= `sys_uv` on Windows) returns the link slice
         // directly there but `usize` on POSIX. `bun_sys::readlink` is the
         // length-normalised wrapper on every platform.
@@ -7591,7 +7646,9 @@ impl NodeFS {
                 uv::uv_fs_realpath(
                     bun_io::Loop::get(),
                     &mut *req,
-                    args.path.slice_z(&mut self.sync_error_buf).as_ptr(),
+                    args.path
+                        .slice_z_sys(&mut self.sync_error_buf, sys::Tag::realpath)?
+                        .as_ptr(),
                     None,
                 )
             };
@@ -7694,8 +7751,14 @@ impl NodeFS {
     pub fn rename(&mut self, args: &args::Rename, _: Flavor) -> Maybe<ret::Rename> {
         let from_buf = &mut self.sync_error_buf;
         let mut to_buf = PathBuffer::uninit();
-        let from = args.old_path.slice_z(from_buf);
-        let to = args.new_path.slice_z(&mut to_buf);
+        let from = args
+            .old_path
+            .slice_z_sys(from_buf, sys::Tag::rename)
+            .map_err(|e| e.with_path_dest(args.old_path.slice(), args.new_path.slice()))?;
+        let to = args
+            .new_path
+            .slice_z_sys(&mut to_buf, sys::Tag::rename)
+            .map_err(|e| e.with_path_dest(args.old_path.slice(), args.new_path.slice()))?;
         match Syscall::rename(from, to) {
             Ok(result) => Ok(result),
             Err(err) => Err(err.with_path_dest(args.old_path.slice(), args.new_path.slice())),
@@ -7712,7 +7775,10 @@ impl NodeFS {
             // slice_z so the path already carries a drive letter, the same way
             // existsSync/statSync/unlinkSync see it.
             #[cfg(windows)]
-            let resolved = args.path.slice_z(&mut self.sync_error_buf).as_bytes();
+            let resolved = args
+                .path
+                .slice_z_sys(&mut self.sync_error_buf, sys::Tag::rmdir)?
+                .as_bytes();
             #[cfg(not(windows))]
             let resolved = args.path.slice();
             if let Err(err) = zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::Directory)
@@ -7725,9 +7791,12 @@ impl NodeFS {
             }
             return Ok(());
         }
+        let path = args
+            .path
+            .slice_z_sys(&mut self.sync_error_buf, sys::Tag::rmdir)?;
         #[cfg(windows)]
         {
-            return match Syscall::rmdir(args.path.slice_z(&mut self.sync_error_buf)) {
+            return match Syscall::rmdir(path) {
                 Err(err) => Err(err.with_path(args.path.slice())),
                 Ok(result) => Ok(result),
             };
@@ -7735,7 +7804,7 @@ impl NodeFS {
         // SAFETY: path is NUL-terminated by slice_z; rmdir(2) is the libc FFI
         #[cfg(not(windows))]
         Maybe::<ret::Rmdir>::errno_sys_p(
-            unsafe { libc::rmdir(args.path.slice_z(&mut self.sync_error_buf).as_ptr().cast()) },
+            unsafe { libc::rmdir(path.as_ptr().cast()) },
             sys::Tag::rmdir,
             args.path.slice(),
         )
@@ -7750,7 +7819,10 @@ impl NodeFS {
             // drive prepended before reaching the dt_* / Syscall::*at helpers,
             // which do not do that themselves.
             #[cfg(windows)]
-            let resolved = args.path.slice_z(&mut self.sync_error_buf).as_bytes();
+            let resolved = args
+                .path
+                .slice_z_sys(&mut self.sync_error_buf, sys::Tag::lstat)?
+                .as_bytes();
             #[cfg(not(windows))]
             let resolved = args.path.slice();
             if let Err(err) = zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::File) {
@@ -7773,7 +7845,9 @@ impl NodeFS {
             return Ok(());
         }
 
-        let dest = args.path.slice_z(&mut self.sync_error_buf);
+        let dest = args
+            .path
+            .slice_z_sys(&mut self.sync_error_buf, sys::Tag::lstat)?;
         // The original implementation mapped the unlink/rmdir error through a
         // *narrow* table to an errno, defaulting to `EFAULT`. We go straight to
         // `bun_sys::unlink`/`libc::rmdir` (raw errno), so route the result
@@ -7819,14 +7893,19 @@ impl NodeFS {
     }
 
     pub fn statfs(&mut self, args: &args::StatFS, _: Flavor) -> Maybe<ret::StatFS> {
-        match Syscall::statfs(args.path.slice_z(&mut self.sync_error_buf)) {
+        let path = args
+            .path
+            .slice_z_sys(&mut self.sync_error_buf, sys::Tag::statfs)?;
+        match Syscall::statfs(path) {
             Ok(result) => Ok(ret::StatFS::init(&result, args.big_int)),
             Err(err) => Err(err),
         }
     }
 
     pub fn stat(&mut self, args: &args::Stat, _: Flavor) -> Maybe<ret::Stat> {
-        let path = args.path.slice_z(&mut self.sync_error_buf);
+        let path = args
+            .path
+            .slice_z_sys(&mut self.sync_error_buf, sys::Tag::stat)?;
         if let Some(graph) = standalone_module_graph_get() {
             // SAFETY: see `standalone_module_graph_get`.
             if let Some(result) = unsafe { &mut *graph }.stat(path.as_bytes()) {
@@ -7880,6 +7959,18 @@ impl NodeFS {
 
             let target_path = args.target_path.slice();
             let new_path = args.new_path.slice();
+            // Bound both paths before the fixed-size buffer copies below.
+            if target_path.len() >= paths::MAX_PATH_BYTES
+                || new_path.len() >= paths::MAX_PATH_BYTES
+            {
+                return Err(sys::Error {
+                    errno: E::ENAMETOOLONG as _,
+                    syscall: sys::Tag::symlink,
+                    path: target_path.into(),
+                    dest: new_path.into(),
+                    ..Default::default()
+                });
+            }
             // Note: to_buf and sync_error_buf hold intermediate states, but the
             // ending state is:
             //    - new_path is in &sync_error_buf
@@ -7956,7 +8047,11 @@ impl NodeFS {
             };
             return match Syscall::symlink_uv(
                 processed_target,
-                args.new_path.slice_z(&mut to_buf),
+                args.new_path
+                    .slice_z_sys(&mut to_buf, sys::Tag::symlink)
+                    .map_err(|e| {
+                        e.with_path_dest(args.target_path.slice(), args.new_path.slice())
+                    })?,
                 match resolved_link_type {
                     ResolvedLinkType::File => 0,
                     ResolvedLinkType::Dir => UV_FS_SYMLINK_DIR,
@@ -7971,8 +8066,12 @@ impl NodeFS {
         }
         #[cfg(not(windows))]
         match Syscall::symlink(
-            args.target_path.slice_z(&mut self.sync_error_buf),
-            args.new_path.slice_z(&mut to_buf),
+            args.target_path
+                .slice_z_sys(&mut self.sync_error_buf, sys::Tag::symlink)
+                .map_err(|e| e.with_path_dest(args.target_path.slice(), args.new_path.slice()))?,
+            args.new_path
+                .slice_z_sys(&mut to_buf, sys::Tag::symlink)
+                .map_err(|e| e.with_path_dest(args.target_path.slice(), args.new_path.slice()))?,
         ) {
             Ok(result) => Ok(result),
             Err(err) => Err(err.with_path_dest(args.target_path.slice(), args.new_path.slice())),
@@ -7984,13 +8083,10 @@ impl NodeFS {
         // rather than `try_from().unwrap()`-panicking
         // on a hostile `> i64::MAX` value.
         let len_i64 = (len & ((1u64 << 63) - 1)) as i64;
+        let path_z = path.slice_z_sys(&mut self.sync_error_buf, sys::Tag::open)?;
         #[cfg(windows)]
         {
-            let file = sys::open(
-                path.slice_z(&mut self.sync_error_buf),
-                sys::O::WRONLY | flags,
-                0o644,
-            );
+            let file = sys::open(path_z, sys::O::WRONLY | flags, 0o644);
             let Ok(fd) = file else {
                 let Err(e) = file else { unreachable!() };
                 return Err(sys::Error {
@@ -8011,12 +8107,7 @@ impl NodeFS {
             let _ = flags;
             // SAFETY: path is NUL-terminated by slice_z; truncate(2) is the libc FFI
             Maybe::<ret::Truncate>::errno_sys_p(
-                unsafe {
-                    libc::truncate(
-                        path.slice_z(&mut self.sync_error_buf).as_ptr().cast(),
-                        len_i64,
-                    )
-                },
+                unsafe { libc::truncate(path_z.as_ptr().cast(), len_i64) },
                 sys::Tag::truncate,
                 path.slice(),
             )
@@ -8035,9 +8126,12 @@ impl NodeFS {
     }
 
     pub fn unlink(&mut self, args: &args::Unlink, _: Flavor) -> Maybe<ret::Unlink> {
+        let path = args
+            .path
+            .slice_z_sys(&mut self.sync_error_buf, sys::Tag::unlink)?;
         #[cfg(windows)]
         {
-            return match Syscall::unlink(args.path.slice_z(&mut self.sync_error_buf)) {
+            return match Syscall::unlink(path) {
                 Err(err) => Err(err.with_path(args.path.slice())),
                 Ok(result) => Ok(result),
             };
@@ -8045,7 +8139,7 @@ impl NodeFS {
         // SAFETY: path is NUL-terminated by slice_z; unlink(2) is the libc FFI
         #[cfg(not(windows))]
         Maybe::<ret::Unlink>::errno_sys_p(
-            unsafe { libc::unlink(args.path.slice_z(&mut self.sync_error_buf).as_ptr().cast()) },
+            unsafe { libc::unlink(path.as_ptr().cast()) },
             sys::Tag::unlink,
             args.path.slice(),
         )
@@ -8056,30 +8150,15 @@ impl NodeFS {
         debug_assert!(flavor == Flavor::Sync);
         // `create_stat_watcher` consumes `args` (the `PathLike` is moved into
         // the new `StatWatcher`); capture what the error path needs first.
-        // `BackRef` is `Copy` — copy out so the borrow detaches from `args`.
-        let global_this = args.global_this;
         let path: Vec<u8> = args.path.slice().to_vec();
         match args.create_stat_watcher() {
             Ok(watcher) => Ok(watcher),
-            Err(err) => {
-                let mut buf = Vec::new();
-                use std::io::Write as _;
-                let _ = write!(
-                    &mut buf,
-                    "Failed to watch file {}",
-                    bun_core::fmt::QuotedFormatter { text: &path }
-                );
-                let _ = global_this.throw_value(
-                    bun_jsc::SystemError {
-                        message: BunString::init(&buf[..]).into(),
-                        code: BunString::init(err.name()).into(),
-                        path: BunString::init(path.as_slice()).into(),
-                        ..Default::default()
-                    }
-                    .to_error_instance(&global_this),
-                );
-                Ok(JSValue::UNDEFINED)
-            }
+            Err(err) => Err(sys::Error {
+                errno: map_anyerror_to_errno(&err) as _,
+                syscall: sys::Tag::watch,
+                path: path.into_boxed_slice(),
+                ..Default::default()
+            }),
         }
     }
 
@@ -8095,7 +8174,9 @@ impl NodeFS {
                 uv::uv_fs_utime(
                     bun_io::Loop::get(),
                     &mut *req,
-                    args.path.slice_z(&mut self.sync_error_buf).as_ptr(),
+                    args.path
+                        .slice_z_sys(&mut self.sync_error_buf, sys::Tag::utime)?
+                        .as_ptr(),
                     args.atime,
                     args.mtime,
                     None,
@@ -8114,7 +8195,8 @@ impl NodeFS {
         }
         #[cfg(not(windows))]
         match Syscall::utimens(
-            args.path.slice_z(&mut self.sync_error_buf),
+            args.path
+                .slice_z_sys(&mut self.sync_error_buf, sys::Tag::utime)?,
             to_sys_time_like(args.atime),
             to_sys_time_like(args.mtime),
         ) {
@@ -8132,7 +8214,9 @@ impl NodeFS {
                 uv::uv_fs_lutime(
                     bun_io::Loop::get(),
                     &mut *req,
-                    args.path.slice_z(&mut self.sync_error_buf).as_ptr(),
+                    args.path
+                        .slice_z_sys(&mut self.sync_error_buf, sys::Tag::lutime)?
+                        .as_ptr(),
                     args.atime,
                     args.mtime,
                     None,
@@ -8151,7 +8235,8 @@ impl NodeFS {
         }
         #[cfg(not(windows))]
         match Syscall::lutimens(
-            args.path.slice_z(&mut self.sync_error_buf),
+            args.path
+                .slice_z_sys(&mut self.sync_error_buf, sys::Tag::lutime)?,
             to_sys_time_like(args.atime),
             to_sys_time_like(args.mtime),
         ) {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -682,9 +682,7 @@ mod _async_tasks {
             self.global_object.get()
         }
 
-        /// Skip the libuv round-trip: store `err` and enqueue `run_from_js_thread`
-        /// directly so the promise rejects on the next tick (same path the
-        /// Writev empty-bufs arm uses for its early `Ok`).
+        /// Reject `task.promise` on the next tick without dispatching to libuv.
         fn complete_early_err(task: &mut Self, err: sys::Error) -> JSValue {
             task.result = Err(err);
             let task_ptr: *mut Self = task;

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7960,8 +7960,7 @@ impl NodeFS {
             let target_path = args.target_path.slice();
             let new_path = args.new_path.slice();
             // Bound both paths before the fixed-size buffer copies below.
-            if target_path.len() >= paths::MAX_PATH_BYTES
-                || new_path.len() >= paths::MAX_PATH_BYTES
+            if target_path.len() >= paths::MAX_PATH_BYTES || new_path.len() >= paths::MAX_PATH_BYTES
             {
                 return Err(sys::Error {
                     errno: E::ENAMETOOLONG as _,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -682,6 +682,19 @@ mod _async_tasks {
             self.global_object.get()
         }
 
+        /// Skip the libuv round-trip: store `err` and enqueue `run_from_js_thread`
+        /// directly so the promise rejects on the next tick (same path the
+        /// Writev empty-bufs arm uses for its early `Ok`).
+        fn complete_early_err(task: &mut Self, err: sys::Error) -> JSValue {
+            task.result = Err(err);
+            let task_ptr: *mut Self = task;
+            task.global_object()
+                .bun_vm()
+                .event_loop_mut()
+                .enqueue_task(Task::init(task_ptr));
+            task.promise.value()
+        }
+
         pub fn create(
             global_object: &JSGlobalObject,
             binding: &Binding,
@@ -737,8 +750,13 @@ mod _async_tasks {
                         // scratch path buffer; the borrow is held only across the
                         // libuv enqueue below (which copies `path` internally) and
                         // never across a JS re-entry point.
-                        args.path
-                            .slice_z(unsafe { &mut binding.node_fs.get_mut().sync_error_buf })
+                        match args.path.slice_z_sys(
+                            unsafe { &mut binding.node_fs.get_mut().sync_error_buf },
+                            sys::Tag::open,
+                        ) {
+                            Ok(p) => p,
+                            Err(err) => return Self::complete_early_err(task, err),
+                        }
                     };
                     let mut flags: c_int = args.flags.as_int();
                     flags = uv::O::from_bun_o(flags);
@@ -899,9 +917,13 @@ mod _async_tasks {
                     let args: &args::StatFS = args_as!(args::StatFS);
                     // SAFETY (R-2): single-JS-thread `JsCell` projection; held only
                     // across the libuv enqueue (copies `path` internally).
-                    let path = args
-                        .path
-                        .slice_z(unsafe { &mut binding.node_fs.get_mut().sync_error_buf });
+                    let path = match args.path.slice_z_sys(
+                        unsafe { &mut binding.node_fs.get_mut().sync_error_buf },
+                        sys::Tag::statfs,
+                    ) {
+                        Ok(p) => p,
+                        Err(err) => return Self::complete_early_err(task, err),
+                    };
                     // SAFETY: libuv copies `path` internally before return.
                     let rc = unsafe {
                         uv::uv_fs_statfs(
@@ -7774,13 +7796,10 @@ impl NodeFS {
             // "/tmp/foo" into a nonexistent NT name (ENOENT). Pre-resolve with
             // slice_z so the path already carries a drive letter, the same way
             // existsSync/statSync/unlinkSync see it.
-            #[cfg(windows)]
             let resolved = args
                 .path
                 .slice_z_sys(&mut self.sync_error_buf, sys::Tag::rmdir)?
                 .as_bytes();
-            #[cfg(not(windows))]
-            let resolved = args.path.slice();
             if let Err(err) = zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::Directory)
             {
                 let mut errno: E = map_anyerror_to_errno(&err);
@@ -7818,13 +7837,10 @@ impl NodeFS {
             // Windows so rooted-but-driveless paths ("/tmp/foo") get the cwd
             // drive prepended before reaching the dt_* / Syscall::*at helpers,
             // which do not do that themselves.
-            #[cfg(windows)]
             let resolved = args
                 .path
                 .slice_z_sys(&mut self.sync_error_buf, sys::Tag::lstat)?
                 .as_bytes();
-            #[cfg(not(windows))]
-            let resolved = args.path.slice();
             if let Err(err) = zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::File) {
                 if matches!(err, crate::Error::FileNotFound) {
                     if args.force {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7665,9 +7665,8 @@ impl NodeFS {
                 .path
                 .slice_z_sys(&mut self.sync_error_buf, sys::Tag::realpath)?;
             let mut req = UvFsReq::new();
-            let rc = unsafe {
-                uv::uv_fs_realpath(bun_io::Loop::get(), &mut *req, path.as_ptr(), None)
-            };
+            let rc =
+                unsafe { uv::uv_fs_realpath(bun_io::Loop::get(), &mut *req, path.as_ptr(), None) };
             if let Some(errno) = rc.errno() {
                 return Err(sys::Error {
                     errno,

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -1019,8 +1019,14 @@ impl StatWatcher {
         // (`FileSystem::init` runs before any JS module loads).
         let top_level_dir = fs::FileSystem::get().top_level_dir;
         let parts: [&[u8]; 1] = [slice];
-        let file_path =
-            Path::join_abs_string_buf::<platform::Auto>(top_level_dir, &mut buf[..], &parts);
+        let buf_len = buf.len();
+        let Some(file_path) = Path::join_abs_string_buf_checked::<platform::Auto>(
+            top_level_dir,
+            &mut buf[..buf_len - 1],
+            &parts,
+        ) else {
+            return Err(crate::Error::NameTooLong);
+        };
 
         // allocSentinel + memcpy → owned NUL-terminated copy (ZBox)
         let alloc_file_path = ZBox::from_bytes(file_path);

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1077,6 +1077,9 @@ impl PathLikeExt for PathLike {
         #[cfg(windows)]
         {
             let s = self.slice();
+            if s.len() >= MAX_PATH_BYTES {
+                return Err(NameTooLong);
+            }
             let mut b = bun_paths::path_buffer_pool::get();
             // RAII guard puts back on Drop.
 
@@ -1843,6 +1846,21 @@ impl PathOrBlob {
         args: &mut ArgumentsSlice,
     ) -> JsResult<PathOrBlob> {
         if let Some(path) = PathOrFileDescriptor::from_js(ctx, args)? {
+            if let PathOrFileDescriptor::Path(ref p) = path {
+                let s = p.slice();
+                if s.len() >= MAX_PATH_BYTES && !s.starts_with(b"s3://") {
+                    return Err(ctx.throw_value(
+                        bun_sys::Error {
+                            errno: bun_sys::E::ENAMETOOLONG as _,
+                            syscall: bun_sys::Tag::open,
+                            path: s.into(),
+                            ..Default::default()
+                        }
+                        .to_system_error()
+                        .to_error_instance(ctx),
+                    ));
+                }
+            }
             return Ok(PathOrBlob::Path(path));
         }
 

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -856,6 +856,19 @@ pub trait PathLikeExt {
     fn slice_z<'a>(&'a self, buf: &'a mut PathBuffer) -> &'a ZStr
     where
         Self: Sized;
+    /// [`Self::slice_z`] for `node:fs` syscall dispatch: when the path would
+    /// not fit `PathBuffer` (which is `PATH_MAX` bytes on POSIX), return the
+    /// `ENAMETOOLONG` the kernel would have returned, tagged with the caller's
+    /// syscall and carrying the full path. This is what lets `fs.stat(big, cb)`
+    /// deliver the error via `cb` (the check happens in dispatch, not in
+    /// argument parsing) and with `err.syscall`/`err.path` populated.
+    fn slice_z_sys<'a>(
+        &'a self,
+        buf: &'a mut PathBuffer,
+        syscall: bun_sys::Tag,
+    ) -> bun_sys::Maybe<&'a ZStr>
+    where
+        Self: Sized;
     fn slice_w<'a>(&'a self, buf: &'a mut WPathBuffer) -> Result<&'a WStr, NameTooLong>
     where
         Self: Sized;
@@ -1019,6 +1032,24 @@ impl PathLikeExt for PathLike {
     }
 
     #[inline]
+    fn slice_z_sys<'a>(
+        &'a self,
+        buf: &'a mut PathBuffer,
+        syscall: bun_sys::Tag,
+    ) -> bun_sys::Maybe<&'a ZStr> {
+        let sliced = self.slice();
+        if sliced.len() >= MAX_PATH_BYTES {
+            return Err(bun_sys::Error {
+                errno: bun_sys::E::ENAMETOOLONG as _,
+                syscall,
+                path: sliced.into(),
+                ..Default::default()
+            });
+        }
+        Ok(self.slice_z_with_force_copy::<false>(buf))
+    }
+
+    #[inline]
     fn slice_w<'a>(&'a self, buf: &'a mut WPathBuffer) -> Result<&'a WStr, NameTooLong> {
         let sliced = self.slice();
         if !strings::fits_in_wide_path_buffer(sliced) {
@@ -1035,6 +1066,9 @@ impl PathLikeExt for PathLike {
         }
         #[cfg(not(windows))]
         {
+            if self.slice().len() >= MAX_PATH_BYTES {
+                return Err(NameTooLong);
+            }
             Ok(self.slice_z_with_force_copy::<false>(buf))
         }
     }
@@ -1122,6 +1156,9 @@ impl PathLikeExt for PathLike {
 
         #[cfg(not(windows))]
         {
+            if self.slice().len() >= MAX_PATH_BYTES {
+                return Err(NameTooLong);
+            }
             Ok(self.slice_z_with_force_copy::<false>(buf))
         }
     }
@@ -1245,9 +1282,6 @@ impl PathLikeExt for PathLike {
             let sliced = str.to_thread_safe_slice();
             let sliced = scopeguard::guard(sliced, |s| s.deinit());
 
-            // Validate the UTF-8 byte length after conversion, since the path
-            // will be stored in a fixed-size PathBuffer.
-            Valid::path_string_length(sliced.slice().len(), global)?;
             Valid::path_null_bytes(sliced.slice(), global)?;
 
             let mut sliced = scopeguard::ScopeGuard::into_inner(sliced);
@@ -1261,9 +1295,6 @@ impl PathLikeExt for PathLike {
             let sliced = str.to_slice();
             let sliced = scopeguard::guard(sliced, |s| s.deinit());
 
-            // Validate the UTF-8 byte length after conversion, since the path
-            // will be stored in a fixed-size PathBuffer.
-            Valid::path_string_length(sliced.slice().len(), global)?;
             Valid::path_null_bytes(sliced.slice(), global)?;
 
             let mut sliced = scopeguard::ScopeGuard::into_inner(sliced);
@@ -1291,39 +1322,13 @@ impl PathLikeExt for PathLike {
 pub struct Valid;
 
 impl Valid {
-    pub fn path_string_length(len: usize, ctx: &JSGlobalObject) -> JsResult<()> {
-        match len {
-            // Exclusive: `PathBuffer` is `[u8; MAX_PATH_BYTES]` and
-            // `slice_z_with_force_copy` needs `len + NUL ≤ MAX_PATH_BYTES`.
-            0..MAX_PATH_BYTES => Ok(()),
-            _ => {
-                let mut system_error =
-                    bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open)
-                        .to_system_error();
-                system_error.syscall = bun_core::String::DEAD.into();
-                Err(ctx.throw_value(system_error.to_error_instance(ctx)))
-            }
-        }
-    }
-
     pub fn path_buffer(buffer: &Buffer, ctx: &JSGlobalObject) -> JsResult<()> {
-        let slice = buffer.slice();
-        match slice.len() {
-            0 => {
-                Err(ctx
-                    .throw_invalid_arguments(format_args!("Invalid path buffer: can't be empty")))
-            }
-            // Exclusive: `PathBuffer` is `[u8; MAX_PATH_BYTES]` and
-            // `slice_z_with_force_copy` needs `len + NUL ≤ MAX_PATH_BYTES`.
-            1..MAX_PATH_BYTES => Ok(()),
-            _ => {
-                let mut system_error =
-                    bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open)
-                        .to_system_error();
-                system_error.syscall = bun_core::String::DEAD.into();
-                Err(ctx.throw_value(system_error.to_error_instance(ctx)))
-            }
+        if buffer.slice().is_empty() {
+            return Err(
+                ctx.throw_invalid_arguments(format_args!("Invalid path buffer: can't be empty"))
+            );
         }
+        Ok(())
     }
 
     pub fn path_null_bytes(slice: &[u8], global: &JSGlobalObject) -> JsResult<()> {

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -856,12 +856,8 @@ pub trait PathLikeExt {
     fn slice_z<'a>(&'a self, buf: &'a mut PathBuffer) -> &'a ZStr
     where
         Self: Sized;
-    /// [`Self::slice_z`] for `node:fs` syscall dispatch: when the path would
-    /// not fit `PathBuffer` (which is `PATH_MAX` bytes on POSIX), return the
-    /// `ENAMETOOLONG` the kernel would have returned, tagged with the caller's
-    /// syscall and carrying the full path. This is what lets `fs.stat(big, cb)`
-    /// deliver the error via `cb` (the check happens in dispatch, not in
-    /// argument parsing) and with `err.syscall`/`err.path` populated.
+    /// Fallible [`Self::slice_z`]: returns `ENAMETOOLONG` tagged with
+    /// `syscall` and the full path when the path would not fit `PathBuffer`.
     fn slice_z_sys<'a>(
         &'a self,
         buf: &'a mut PathBuffer,

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -9,6 +9,7 @@ use crate::bake::dev_server::DevServer;
 use crate::bake::framework_router as FrameworkRouter;
 use crate::bake::{self as bake};
 use crate::node::types::PathLikeExt as _;
+use bun_jsc::SysErrorJsc as _;
 use crate::webcore::BlobExt;
 use crate::webcore::body::Value as BodyValue;
 use crate::webcore::fetch as Fetch;
@@ -546,11 +547,18 @@ impl AnyRoute {
             return Ok(None);
         };
         let mut path_string = BunString::from_js(path_js, init_ctx.global)?;
-        let mut path = Node::PathOrFileDescriptor::Path(Node::PathLike::from_bun_string(
-            init_ctx.global,
-            &mut path_string,
-            false,
-        )?);
+        let path_like = Node::PathLike::from_bun_string(init_ctx.global, &mut path_string, false)?;
+        if path_like.slice().len() >= bun_paths::MAX_PATH_BYTES {
+            let err = bun_sys::Error {
+                errno: bun_sys::E::ENAMETOOLONG as _,
+                syscall: bun_sys::Tag::open,
+                path: path_like.slice().into(),
+                ..Default::default()
+            };
+            path_string.deref();
+            return Err(init_ctx.global.throw_value(err.to_js(init_ctx.global)));
+        }
+        let mut path = Node::PathOrFileDescriptor::Path(path_like);
         // NOTE: `from_bun_string` clones
         // the bytes (or bumps the WTF ref) into the PathLike payload, so we can
         // release the source ref immediately — `bun_core::String` has no `Drop`.

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -9,7 +9,6 @@ use crate::bake::dev_server::DevServer;
 use crate::bake::framework_router as FrameworkRouter;
 use crate::bake::{self as bake};
 use crate::node::types::PathLikeExt as _;
-use bun_jsc::SysErrorJsc as _;
 use crate::webcore::BlobExt;
 use crate::webcore::body::Value as BodyValue;
 use crate::webcore::fetch as Fetch;
@@ -23,6 +22,7 @@ use bun_core::{Output, fmt as bun_fmt};
 use bun_core::{String as BunString, ZigString, strings};
 use bun_http::{self as http, Method, MimeType};
 use bun_jsc::Debugger::DebuggerId;
+use bun_jsc::SysErrorJsc as _;
 use bun_jsc::ZigStringJsc as _;
 use bun_jsc::uuid::UUID;
 use bun_jsc::{

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5712,11 +5712,8 @@ pub fn construct_bun_file(
             // clone the path (`path` drops at scope exit).
             return S3File::construct_internal_js(global_object, p.clone(), options);
         }
-        // Filesystem blobs copy the path into a fixed-size PathBuffer at every
-        // syscall boundary (`slice_z`); reject here so an over-long path fails
-        // with ENAMETOOLONG instead of later truncating to "" and yielding
-        // ENOENT. S3 paths above are keys, not filesystem paths, so they skip
-        // this.
+        // `slice_z` at the syscall boundaries silently truncates an over-long
+        // path to ""; fail here with ENAMETOOLONG instead of ENOENT later.
         if p.slice().len() >= bun_paths::MAX_PATH_BYTES {
             return Err(global_object.throw_value(
                 bun_sys::Error {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5712,6 +5712,22 @@ pub fn construct_bun_file(
             // clone the path (`path` drops at scope exit).
             return S3File::construct_internal_js(global_object, p.clone(), options);
         }
+        // Filesystem blobs copy the path into a fixed-size PathBuffer at every
+        // syscall boundary (`slice_z`); reject here so an over-long path fails
+        // with ENAMETOOLONG instead of later truncating to "" and yielding
+        // ENOENT. S3 paths above are keys, not filesystem paths, so they skip
+        // this.
+        if p.slice().len() >= bun_paths::MAX_PATH_BYTES {
+            return Err(global_object.throw_value(
+                bun_sys::Error {
+                    errno: bun_sys::E::ENAMETOOLONG as _,
+                    syscall: bun_sys::Tag::open,
+                    path: p.slice().into(),
+                    ..Default::default()
+                }
+                .to_js(global_object),
+            ));
+        }
     }
     // The sync path took no `protect()`, so `Drop for PathOrFileDescriptor`
     // suffices to release `path`.

--- a/test/js/node/fs/fs-path-length.test.ts
+++ b/test/js/node/fs/fs-path-length.test.ts
@@ -290,6 +290,31 @@ describe("over-PATH_MAX path goes to the callback with full error identity (#256
     });
   });
 
+  // watch / watchFile are synchronous and don't fit the callback-form table.
+  // Node's watchFile never throws for a nonexistent/over-long path (it polls),
+  // so only assert that Bun throws a well-formed error rather than panicking.
+  for (const [name, fn] of [
+    ["watch", (p: string) => fs.watch(p, () => {})],
+    ["watchFile", (p: string) => fs.watchFile(p, () => {})],
+  ] as const) {
+    it(`fs.${name} reports ENAMETOOLONG with syscall=watch and path`, () => {
+      let err!: NodeJS.ErrnoException;
+      try {
+        fn(BIG);
+        expect.unreachable();
+      } catch (e) {
+        err = e as NodeJS.ErrnoException;
+      } finally {
+        if (name === "watchFile") fs.unwatchFile(BIG);
+      }
+      expect({ code: err.code, syscall: err.syscall, hasPath: "path" in err }).toEqual({
+        code: "ENAMETOOLONG",
+        syscall: "watch",
+        hasPath: true,
+      });
+    });
+  }
+
   it("callback form with a Buffer path delivers via the callback", async () => {
     const { sync, cb } = await viaCallback(fs.stat, Buffer.from(BIG));
     expect({ sync: sync?.code, cb: cb?.code, syscall: cb?.syscall }).toEqual({

--- a/test/js/node/fs/fs-path-length.test.ts
+++ b/test/js/node/fs/fs-path-length.test.ts
@@ -273,6 +273,7 @@ describe("over-PATH_MAX path goes to the callback with full error identity (#256
     ["statfs", fs.statfs, [BIG], "statfs"],
     ["truncate", fs.truncate, [BIG], "open"],
     ["mkdtemp", fs.mkdtemp, [BIG], "mkdtemp"],
+    ["rm (recursive)", fs.rm, [BIG, { recursive: true }], "lstat"],
   ] as const;
 
   describe.each(ops)("fs.%s", (_name, fn, args, syscall) => {
@@ -351,6 +352,21 @@ describe("over-PATH_MAX path goes to the callback with full error identity (#256
     expect({ code: err.code, syscall: err.syscall, hasPath: "path" in err }).toEqual({
       code: "ENAMETOOLONG",
       syscall: "stat",
+      hasPath: true,
+    });
+  });
+
+  it("Bun.file() throws ENAMETOOLONG with syscall/path for an over-PATH_MAX path", () => {
+    let err!: NodeJS.ErrnoException;
+    try {
+      Bun.file(BIG);
+      expect.unreachable();
+    } catch (e) {
+      err = e as NodeJS.ErrnoException;
+    }
+    expect({ code: err.code, syscall: err.syscall, hasPath: "path" in err }).toEqual({
+      code: "ENAMETOOLONG",
+      syscall: "open",
       hasPath: true,
     });
   });

--- a/test/js/node/fs/fs-path-length.test.ts
+++ b/test/js/node/fs/fs-path-length.test.ts
@@ -213,19 +213,13 @@ describe.if(isWindows)("path length validation against UTF-16 conversion buffers
   });
 });
 
-// https://github.com/oven-sh/bun/issues/7760
-//
-// A path over PATH_MAX is an OS-level error, not a programmer error: Node.js
-// performs no length pre-check and lets the kernel return ENAMETOOLONG, so the
-// error reaches the callback (never throws synchronously) and carries the
-// per-operation `syscall` plus the full `path`. Bun pre-checked the length
-// during argument parsing, threw synchronously from every callback/promise
-// form, and built the error with no `syscall`, no `path`, and a message that
-// hard-coded `open` regardless of which operation was called. The check now
-// happens at dispatch (where the syscall name is known) and returns a
-// `bun_sys::Error`, so it flows through the same async path as every other
-// kernel error.
-describe("over-PATH_MAX path goes to the callback with full error identity (#7760)", () => {
+// https://github.com/oven-sh/bun/issues/25659
+// A path over PATH_MAX is an OS-level error, not a programmer error: in Node
+// it reaches the callback (never a synchronous throw) and the error carries
+// the per-operation `syscall` plus the full `path`. Bun pre-checked the
+// length during argument parsing and threw synchronously with no `syscall`,
+// no `path`, and a message that hard-coded `open`.
+describe("over-PATH_MAX path goes to the callback with full error identity (#25659)", () => {
   // Longer than PATH_MAX on every platform (Windows MAX_PATH_BYTES ≈ 98302).
   const BIG = Buffer.alloc(100_000, "a").toString();
 

--- a/test/js/node/fs/fs-path-length.test.ts
+++ b/test/js/node/fs/fs-path-length.test.ts
@@ -356,20 +356,25 @@ describe("over-PATH_MAX path goes to the callback with full error identity (#256
     });
   });
 
-  it("Bun.file() throws ENAMETOOLONG with syscall/path for an over-PATH_MAX path", () => {
-    let err!: NodeJS.ErrnoException;
-    try {
-      Bun.file(BIG);
-      expect.unreachable();
-    } catch (e) {
-      err = e as NodeJS.ErrnoException;
-    }
-    expect({ code: err.code, syscall: err.syscall, hasPath: "path" in err }).toEqual({
-      code: "ENAMETOOLONG",
-      syscall: "open",
-      hasPath: true,
+  for (const [name, fn] of [
+    ["Bun.file()", () => Bun.file(BIG)],
+    ["Bun.write() destination", () => Bun.write(BIG, "x")],
+  ] as const) {
+    it(`${name} throws ENAMETOOLONG with syscall/path for an over-PATH_MAX path`, () => {
+      let err!: NodeJS.ErrnoException;
+      try {
+        fn();
+        expect.unreachable();
+      } catch (e) {
+        err = e as NodeJS.ErrnoException;
+      }
+      expect({ code: err.code, syscall: err.syscall, hasPath: "path" in err }).toEqual({
+        code: "ENAMETOOLONG",
+        syscall: "open",
+        hasPath: true,
+      });
     });
-  });
+  }
 
   it("type errors and null-byte paths still throw synchronously (matches node)", async () => {
     // ERR_INVALID_ARG_TYPE: wrong path type

--- a/test/js/node/fs/fs-path-length.test.ts
+++ b/test/js/node/fs/fs-path-length.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { isLinux, isMacOS, isPosix, isWindows } from "harness";
 import fs from "node:fs";
+import fsp from "node:fs/promises";
 
 // On POSIX systems, MAX_PATH_BYTES is 4096.
 // Path validation must account for the actual UTF-8 byte length of strings,
@@ -209,5 +210,142 @@ describe.if(isWindows)("path length validation against UTF-16 conversion buffers
     const segment = Buffer.alloc(600, "\u4e00").toString();
     const p = "C:\\" + Array(150).fill(segment).join("\\");
     expect(() => fs.copyFileSync(p, "copy-file-dest-does-not-matter.txt")).toThrow("ENOENT");
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/7760
+//
+// A path over PATH_MAX is an OS-level error, not a programmer error: Node.js
+// performs no length pre-check and lets the kernel return ENAMETOOLONG, so the
+// error reaches the callback (never throws synchronously) and carries the
+// per-operation `syscall` plus the full `path`. Bun pre-checked the length
+// during argument parsing, threw synchronously from every callback/promise
+// form, and built the error with no `syscall`, no `path`, and a message that
+// hard-coded `open` regardless of which operation was called. The check now
+// happens at dispatch (where the syscall name is known) and returns a
+// `bun_sys::Error`, so it flows through the same async path as every other
+// kernel error.
+describe("over-PATH_MAX path goes to the callback with full error identity (#7760)", () => {
+  // Longer than PATH_MAX on every platform (Windows MAX_PATH_BYTES ≈ 98302).
+  const BIG = Buffer.alloc(100_000, "a").toString();
+
+  async function viaCallback<A extends unknown[]>(
+    fn: (...a: [...A, (err: NodeJS.ErrnoException | null) => void]) => void,
+    ...a: A
+  ) {
+    const { promise, resolve } = Promise.withResolvers<{
+      sync: NodeJS.ErrnoException | undefined;
+      cb: NodeJS.ErrnoException | null | undefined;
+    }>();
+    let cb: NodeJS.ErrnoException | null | undefined;
+    try {
+      fn(...a, (err: NodeJS.ErrnoException | null) => {
+        cb = err;
+        resolve({ sync: undefined, cb });
+      });
+    } catch (e) {
+      resolve({ sync: e as NodeJS.ErrnoException, cb });
+    }
+    return promise;
+  }
+
+  // [callback fn, args, expected err.syscall]
+  const ops = [
+    ["stat", fs.stat, [BIG], "stat"],
+    ["lstat", fs.lstat, [BIG], "lstat"],
+    ["open", fs.open, [BIG, "r"], "open"],
+    ["readdir", fs.readdir, [BIG], "scandir"],
+    ["mkdir", fs.mkdir, [BIG], "mkdir"],
+    ["unlink", fs.unlink, [BIG], "unlink"],
+    ["access", fs.access, [BIG], "access"],
+    ["readFile", fs.readFile, [BIG], "open"],
+    ["writeFile", fs.writeFile, [BIG, "x"], "open"],
+    ["appendFile", fs.appendFile, [BIG, "x"], "open"],
+    ["readlink", fs.readlink, [BIG], "readlink"],
+    ["rmdir", fs.rmdir, [BIG], "rmdir"],
+    ["chmod", fs.chmod, [BIG, 0o644], "chmod"],
+    ["chown", fs.chown, [BIG, 0, 0], "chown"],
+    ["lchown", fs.lchown, [BIG, 0, 0], "lchown"],
+    ["utimes", fs.utimes, [BIG, 0, 0], "utime"],
+    ["lutimes", fs.lutimes, [BIG, 0, 0], "lutime"],
+    ["rename (src)", fs.rename, [BIG, "x"], "rename"],
+    ["rename (dest)", fs.rename, ["x", BIG], "rename"],
+    ["link (src)", fs.link, [BIG, "x"], "link"],
+    ["link (dest)", fs.link, ["x", BIG], "link"],
+    ["copyFile (src)", fs.copyFile, [BIG, "x"], "copyfile"],
+    ["copyFile (dest)", fs.copyFile, ["x", BIG], "copyfile"],
+    ["symlink (target)", fs.symlink, [BIG, "x"], "symlink"],
+    ["symlink (path)", fs.symlink, ["x", BIG], "symlink"],
+    ["statfs", fs.statfs, [BIG], "statfs"],
+    ["truncate", fs.truncate, [BIG], "open"],
+    ["mkdtemp", fs.mkdtemp, [BIG], "mkdtemp"],
+  ] as const;
+
+  describe.each(ops)("fs.%s", (_name, fn, args, syscall) => {
+    it.concurrent("delivers ENAMETOOLONG via the callback", async () => {
+      const { sync, cb } = await viaCallback(fn as any, ...(args as unknown[]));
+      expect({ sync: sync?.code, cb: cb?.code }).toEqual({ sync: undefined, cb: "ENAMETOOLONG" });
+    });
+    it.concurrent("error carries the caller's syscall and the path", async () => {
+      const { cb } = await viaCallback(fn as any, ...(args as unknown[]));
+      expect({ code: cb?.code, syscall: cb?.syscall, hasPath: "path" in (cb ?? {}) }).toEqual({
+        code: "ENAMETOOLONG",
+        syscall,
+        hasPath: true,
+      });
+    });
+  });
+
+  it("callback form with a Buffer path delivers via the callback", async () => {
+    const { sync, cb } = await viaCallback(fs.stat, Buffer.from(BIG));
+    expect({ sync: sync?.code, cb: cb?.code, syscall: cb?.syscall }).toEqual({
+      sync: undefined,
+      cb: "ENAMETOOLONG",
+      syscall: "stat",
+    });
+  });
+
+  it("sync form error carries syscall/path (not hardcoded 'open')", () => {
+    let err!: NodeJS.ErrnoException;
+    try {
+      fs.statSync(BIG);
+      expect.unreachable();
+    } catch (e) {
+      err = e as NodeJS.ErrnoException;
+    }
+    expect({ code: err.code, syscall: err.syscall, hasPath: "path" in err }).toEqual({
+      code: "ENAMETOOLONG",
+      syscall: "stat",
+      hasPath: true,
+    });
+    expect(err.message).toStartWith("ENAMETOOLONG: name too long, stat '");
+  });
+
+  it("promise form rejects with syscall/path", async () => {
+    let err!: NodeJS.ErrnoException;
+    try {
+      await fsp.stat(BIG);
+      expect.unreachable();
+    } catch (e) {
+      err = e as NodeJS.ErrnoException;
+    }
+    expect({ code: err.code, syscall: err.syscall, hasPath: "path" in err }).toEqual({
+      code: "ENAMETOOLONG",
+      syscall: "stat",
+      hasPath: true,
+    });
+  });
+
+  it("type errors and null-byte paths still throw synchronously (matches node)", async () => {
+    // ERR_INVALID_ARG_TYPE: wrong path type
+    {
+      const { sync, cb } = await viaCallback(fs.stat as any, 123 as any);
+      expect({ sync: sync?.code, cb }).toEqual({ sync: "ERR_INVALID_ARG_TYPE", cb: undefined });
+    }
+    // ERR_INVALID_ARG_VALUE: null byte in path
+    {
+      const { sync, cb } = await viaCallback(fs.stat, "foo\0bar");
+      expect({ sync: sync?.code, cb }).toEqual({ sync: "ERR_INVALID_ARG_VALUE", cb: undefined });
+    }
   });
 });

--- a/test/js/node/fs/fs-path-length.test.ts
+++ b/test/js/node/fs/fs-path-length.test.ts
@@ -359,6 +359,10 @@ describe("over-PATH_MAX path goes to the callback with full error identity (#256
   for (const [name, fn] of [
     ["Bun.file()", () => Bun.file(BIG)],
     ["Bun.write() destination", () => Bun.write(BIG, "x")],
+    [
+      "Bun.serve HTMLImportManifest path",
+      () => Bun.serve({ port: 0, routes: { "/": { index: "x", files: [{ path: BIG, headers: {} }] } } as any }),
+    ],
   ] as const) {
     it(`${name} throws ENAMETOOLONG with syscall/path for an over-PATH_MAX path`, () => {
       let err!: NodeJS.ErrnoException;


### PR DESCRIPTION
Fixes #25659.

## What

For a path whose byte length exceeds `PATH_MAX`, the `node:fs` callback APIs (`stat`, `open`, `readdir`, `mkdir`, `unlink`, `access`, `readFile`, `writeFile`, `readlink`, `rmdir`, `chmod`, `chown`, `utimes`, `rename`, `link`, `symlink`, `copyFile`, `statfs`, `truncate`, `mkdtemp`, ...) threw `ENAMETOOLONG` **synchronously** at the call site and never invoked the callback. The thrown error carried no `syscall`, no `path`, and its message hard-coded `open` regardless of which operation was called.

Node.js performs no length pre-check: it passes the path to the kernel, which returns `ENAMETOOLONG`, and the error reaches the callback with the per-operation `syscall` name (`stat`, `scandir`, `mkdir`, ...) and the full `path`.

## Repro

```js
import fs from "node:fs";
const BIG = "a".repeat(5000);
try {
  fs.stat(BIG, err => console.log("cb", err.code, err.syscall, "path" in err));
} catch (e) {
  console.log("SYNC", e.code, e.syscall, "path" in e);
}
```

Before: `SYNC ENAMETOOLONG undefined false` (message `ENAMETOOLONG: name too long, open`)
After (matches node): `cb ENAMETOOLONG stat true`

## Cause

The length guard lived in `Valid::path_string_length` / `Valid::path_buffer`, called from `PathLike::from_js` during argument parsing. Any failure there is a synchronous host-function throw; `run_async` in `node_fs_binding.rs` returns it before the `AsyncFSTask` is created, so the callback wrapper's `.then(..., callback)` is never reached. The guard also built its error with a hard-coded `Tag::open` and cleared `syscall`, so even the sync form's error had no identity.

## Fix

Move the length check out of argument parsing and into dispatch, where the syscall name is known and the result is a `Maybe<R>`:

- Drop the `MAX_PATH_BYTES` check from `Valid::path_string_length` / `Valid::path_buffer` (null-byte and empty-buffer checks stay; those are programmer errors that Node also throws synchronously).
- Add `PathLike::slice_z_sys(buf, syscall) -> bun_sys::Maybe<&ZStr>`, which returns `Err(sys::Error { ENAMETOOLONG, syscall, path })` when the path would not fit `PathBuffer`, and otherwise forwards to `slice_z`.
- Switch every `NodeFS::<op>` from `slice_z(buf)` to `slice_z_sys(buf, Tag::<op>)?`. The `?` on a `Maybe`-returning method routes the error through the existing `AsyncFSTask` rejection path (async) or the `run_sync` throw path (sync), with `syscall` and `path` populated.

Related fixes in the same area:

- `os_path` / `os_path_kernel32` now report `NameTooLong` on POSIX when the path would overflow `PathBuffer` (previously only the Windows arm checked).
- `mkdtemp` no longer silently truncates an over-long prefix; it returns `ENAMETOOLONG` with `syscall: "mkdtemp"` and the prefix as `path`.
- `StatWatcher::init` uses the checked path join (the unchecked join became reachable once `from_js` stopped rejecting over-long paths) and `NodeFS::watch_file` returns the error as a `sys::Error` instead of throwing inside a `Maybe::Ok`, which tripped JSC's unexpected-exception assertion.

## Verification

`test/js/node/fs/fs-path-length.test.ts` gains a describe covering 28 callback ops × two assertions (delivery via callback; `{code, syscall, path}` shape), plus Buffer-path, sync-form and promise-form identity checks, and a sanity check that type/null-byte errors still throw synchronously.

With `USE_SYSTEM_BUN=1`: 59 of the 60 new assertions fail (`{sync: "ENAMETOOLONG", cb: undefined}` / `{syscall: undefined, hasPath: false}`).
With this change: all 71 pass; `fs.test.ts` (429), `cp.test.ts` / `promises.test.js` / `fs-mkdir.test.ts` (97), `fs.watch.test.ts` (42) unchanged; `rust:check-all` green on all 10 targets.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs-path-length.test.ts

<!-- robobun:evidence:end -->
