### PR TITLE
bundler: don't panic on unterminated naming template placeholders

### DIFF
--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2263,6 +2263,7 @@ fn path_template_print_tolerates_malformed_brackets() {
     assert_eq!(run(b"a[b"), b"a[b");
     assert_eq!(run(b"foo["), b"foo[");
     assert_eq!(run(b"["), b"[");
+    assert_eq!(run(b"]"), b"]");
     assert_eq!(run(b""), b"");
     // No change to well-formed templates.
     assert_eq!(run(b"[dir]/[name].[ext]"), b"D/N.E");
@@ -2285,6 +2286,7 @@ fn path_template_print_tolerates_malformed_brackets() {
         Some((1, b"[b.js".as_slice()))
     );
     assert_eq!(find_unterminated_placeholder(b""), None);
+    assert_eq!(find_unterminated_placeholder(b"]"), None);
     assert_eq!(find_unterminated_placeholder(b"[dir]/[name].[ext]"), None);
     assert_eq!(find_unterminated_placeholder(b"[foo]-[name].[ext]"), None);
 }

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2268,10 +2268,22 @@ fn path_template_print_tolerates_malformed_brackets() {
     assert_eq!(run(b"[dir]/[name].[ext]"), b"D/N.E");
 
     // The up-front validator agrees with the printer on what is unterminated.
-    assert_eq!(find_unterminated_placeholder(b"[name"), Some((0, b"[name".as_slice())));
-    assert_eq!(find_unterminated_placeholder(b"foo["), Some((3, b"[".as_slice())));
-    assert_eq!(find_unterminated_placeholder(b"[name]-[ext"), Some((7, b"[ext".as_slice())));
-    assert_eq!(find_unterminated_placeholder(b"a[b.js"), Some((1, b"[b.js".as_slice())));
+    assert_eq!(
+        find_unterminated_placeholder(b"[name"),
+        Some((0, b"[name".as_slice()))
+    );
+    assert_eq!(
+        find_unterminated_placeholder(b"foo["),
+        Some((3, b"[".as_slice()))
+    );
+    assert_eq!(
+        find_unterminated_placeholder(b"[name]-[ext"),
+        Some((7, b"[ext".as_slice()))
+    );
+    assert_eq!(
+        find_unterminated_placeholder(b"a[b.js"),
+        Some((1, b"[b.js".as_slice()))
+    );
     assert_eq!(find_unterminated_placeholder(b""), None);
     assert_eq!(find_unterminated_placeholder(b"[dir]/[name].[ext]"), None);
     assert_eq!(find_unterminated_placeholder(b"[foo]-[name].[ext]"), None);

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2085,8 +2085,7 @@ pub(crate) fn path_template_needs(data: &[u8], field: PlaceholderField) -> bool 
     strings::contains(data, needle)
 }
 
-/// `Some((byte_index_of_open_bracket, &template[byte_index..]))` when a `[`
-/// has no matching `]` (same depth-counting as [`path_template_print`]).
+/// `Some((index_of_open_bracket, &template[index..]))` when a `[` has no matching `]`.
 pub fn find_unterminated_placeholder(template: &[u8]) -> Option<(usize, &[u8])> {
     let mut remain = template;
     while let Some(j) = strings::index_of_char(remain, b'[') {

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2085,6 +2085,39 @@ pub(crate) fn path_template_needs(data: &[u8], field: PlaceholderField) -> bool 
     strings::contains(data, needle)
 }
 
+/// Returns `Some((byte_index, tail))` when `template` contains a `[` with no
+/// matching `]`, where `byte_index` is the position of that `[` and `tail` is
+/// the slice from that `[` to the end. Balanced templates return `None`.
+///
+/// The scan mirrors [`path_template_print`]'s depth-counting so the two agree
+/// on what is "unterminated".
+pub fn find_unterminated_placeholder(template: &[u8]) -> Option<(usize, &[u8])> {
+    let mut remain = template;
+    while let Some(j) = strings::index_of_char(remain, b'[') {
+        let j = j as usize;
+        let open_at = template.len() - remain.len() + j;
+        remain = &remain[j + 1..];
+        let mut count: isize = 1;
+        let mut close: Option<usize> = None;
+        for (idx, c) in remain.iter().enumerate() {
+            count += match *c {
+                b'[' => 1,
+                b']' => -1,
+                _ => 0,
+            };
+            if count == 0 {
+                close = Some(idx);
+                break;
+            }
+        }
+        let Some(end) = close else {
+            return Some((open_at, &template[open_at..]));
+        };
+        remain = &remain[end + 1..];
+    }
+    None
+}
+
 // Shared body for PathTemplate::print / PathTemplateConst::print (D064).
 // Writes raw path bytes via a byte-writer free fn (not `core::fmt::Display`).
 pub(crate) fn path_template_print<W: bun_io::Write>(
@@ -2240,6 +2273,15 @@ fn path_template_print_tolerates_malformed_brackets() {
     assert_eq!(run(b""), b"");
     // No change to well-formed templates.
     assert_eq!(run(b"[dir]/[name].[ext]"), b"D/N.E");
+
+    // The up-front validator agrees with the printer on what is unterminated.
+    assert_eq!(find_unterminated_placeholder(b"[name"), Some((0, b"[name".as_slice())));
+    assert_eq!(find_unterminated_placeholder(b"foo["), Some((3, b"[".as_slice())));
+    assert_eq!(find_unterminated_placeholder(b"[name]-[ext"), Some((7, b"[ext".as_slice())));
+    assert_eq!(find_unterminated_placeholder(b"a[b.js"), Some((1, b"[b.js".as_slice())));
+    assert_eq!(find_unterminated_placeholder(b""), None);
+    assert_eq!(find_unterminated_placeholder(b"[dir]/[name].[ext]"), None);
+    assert_eq!(find_unterminated_placeholder(b"[foo]-[name].[ext]"), None);
 }
 
 impl PathTemplate {

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2102,11 +2102,6 @@ pub(crate) fn path_template_print<W: bun_io::Write>(
         let j = j as usize;
         PathTemplate::write_replacing_slashes_on_windows(writer, &remain[0..j])?;
         remain = &remain[j + 1..];
-        if remain.is_empty() {
-            // TODO: throw error
-            writer.write_all(b"[")?;
-            break;
-        }
 
         let mut count: isize = 1;
         let mut end_len: usize = remain.len();
@@ -2119,16 +2114,26 @@ pub(crate) fn path_template_print<W: bun_io::Write>(
 
             if count == 0 {
                 end_len = idx;
-                debug_assert!(end_len <= remain.len());
+                debug_assert!(end_len < remain.len());
                 break;
             }
+        }
+
+        if count != 0 {
+            // No matching `]` exists: the `[` and everything after it is literal.
+            // `remain` is written after the loop.
+            writer.write_all(b"[")?;
+            break;
         }
 
         let placeholder = &remain[0..end_len];
 
         let Some(field) = PLACEHOLDER_MAP.get(placeholder).copied() else {
+            // Unknown placeholder: keep `[placeholder]` verbatim in the output.
+            writer.write_all(b"[")?;
             PathTemplate::write_replacing_slashes_on_windows(writer, placeholder)?;
-            remain = &remain[end_len..];
+            writer.write_all(b"]")?;
+            remain = &remain[end_len + 1..];
             continue;
         };
 
@@ -2208,6 +2213,33 @@ fn write_sanitized_parent_dirs_rewrites_every_dotdot_segment() {
     // POSIX: `\` is an ordinary filename byte, not a separator.
     #[cfg(not(windows))]
     assert_eq!(run(br"weird\dir/x.js"), br"weird\dir/x.js");
+}
+
+#[cfg(test)]
+#[test]
+fn path_template_print_tolerates_malformed_brackets() {
+    fn run(template: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        path_template_print(&mut out, template, b"D", b"N", b"E", Some(0), b"T", false).unwrap();
+        out
+    }
+    // A known placeholder name with no closing `]` must not slice past the end
+    // (used to panic with "range start index 5 out of range for slice of length 4").
+    assert_eq!(run(b"[name"), b"[name");
+    assert_eq!(run(b"[dir"), b"[dir");
+    assert_eq!(run(b"[hash"), b"[hash");
+    assert_eq!(run(b"[ext"), b"[ext");
+    assert_eq!(run(b"[target"), b"[target");
+    // A closed placeholder before the unterminated one is still substituted.
+    assert_eq!(run(b"[name]-[ext"), b"N-[ext");
+    // Unknown placeholders and stray brackets pass through untouched.
+    assert_eq!(run(b"[foo]-[name].[ext]"), b"[foo]-N.E");
+    assert_eq!(run(b"a[b"), b"a[b");
+    assert_eq!(run(b"foo["), b"foo[");
+    assert_eq!(run(b"["), b"[");
+    assert_eq!(run(b""), b"");
+    // No change to well-formed templates.
+    assert_eq!(run(b"[dir]/[name].[ext]"), b"D/N.E");
 }
 
 impl PathTemplate {

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2085,12 +2085,8 @@ pub(crate) fn path_template_needs(data: &[u8], field: PlaceholderField) -> bool 
     strings::contains(data, needle)
 }
 
-/// Returns `Some((byte_index, tail))` when `template` contains a `[` with no
-/// matching `]`, where `byte_index` is the position of that `[` and `tail` is
-/// the slice from that `[` to the end. Balanced templates return `None`.
-///
-/// The scan mirrors [`path_template_print`]'s depth-counting so the two agree
-/// on what is "unterminated".
+/// `Some((byte_index_of_open_bracket, &template[byte_index..]))` when a `[`
+/// has no matching `]` (same depth-counting as [`path_template_print`]).
 pub fn find_unterminated_placeholder(template: &[u8]) -> Option<(usize, &[u8])> {
     let mut remain = template;
     while let Some(j) = strings::index_of_char(remain, b'[') {
@@ -2153,8 +2149,7 @@ pub(crate) fn path_template_print<W: bun_io::Write>(
         }
 
         if count != 0 {
-            // No matching `]` exists: the `[` and everything after it is literal.
-            // `remain` is written after the loop.
+            // No matching `]`: emit `[` and fall through to write `remain` literally.
             writer.write_all(b"[")?;
             break;
         }
@@ -2256,8 +2251,7 @@ fn path_template_print_tolerates_malformed_brackets() {
         path_template_print(&mut out, template, b"D", b"N", b"E", Some(0), b"T", false).unwrap();
         out
     }
-    // A known placeholder name with no closing `]` must not slice past the end
-    // (used to panic with "range start index 5 out of range for slice of length 4").
+    // Unterminated known placeholder: used to slice one past the end.
     assert_eq!(run(b"[name"), b"[name");
     assert_eq!(run(b"[dir"), b"[dir");
     assert_eq!(run(b"[hash"), b"[hash");

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -998,11 +998,11 @@ pub mod js_bundler {
                         buf.into_boxed_slice()
                     }
                 };
-                let validate = |key: &str, s: &[u8]| -> JsResult<()> {
+                let validate = |option: &str, s: &[u8]| -> JsResult<()> {
                     if let Some((pos, tail)) = options::find_unterminated_placeholder(s) {
                         return Err(global_this.throw_invalid_arguments(format_args!(
-                            "naming.{}: unterminated \"{}\" placeholder (missing \"]\") at position {}",
-                            key,
+                            "{}: unterminated \"{}\" placeholder (missing \"]\") at position {}",
+                            option,
                             bstr::BStr::new(tail),
                             pos,
                         )));
@@ -1011,25 +1011,25 @@ pub mod js_bundler {
                 };
                 if naming.is_string() {
                     if let Some(slice) = config.get_optional_slice(global_this, b"naming")? {
-                        validate("entry", slice.slice())?;
+                        validate("naming", slice.slice())?;
                         this.names.entry_point.data = with_dot_slash(slice.slice());
                         drop(slice);
                     }
                 } else if naming.is_object() {
                     if let Some(slice) = naming.get_optional_slice(global_this, b"entry")? {
-                        validate("entry", slice.slice())?;
+                        validate("naming.entry", slice.slice())?;
                         this.names.entry_point.data = with_dot_slash(slice.slice());
                         drop(slice);
                     }
 
                     if let Some(slice) = naming.get_optional_slice(global_this, b"chunk")? {
-                        validate("chunk", slice.slice())?;
+                        validate("naming.chunk", slice.slice())?;
                         this.names.chunk.data = with_dot_slash(slice.slice());
                         drop(slice);
                     }
 
                     if let Some(slice) = naming.get_optional_slice(global_this, b"asset")? {
-                        validate("asset", slice.slice())?;
+                        validate("naming.asset", slice.slice())?;
                         this.names.asset.data = with_dot_slash(slice.slice());
                         drop(slice);
                     }

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -998,23 +998,38 @@ pub mod js_bundler {
                         buf.into_boxed_slice()
                     }
                 };
+                let validate = |key: &str, s: &[u8]| -> JsResult<()> {
+                    if let Some((pos, tail)) = options::find_unterminated_placeholder(s) {
+                        return Err(global_this.throw_invalid_arguments(format_args!(
+                            "naming.{}: unterminated \"{}\" placeholder (missing \"]\") at position {}",
+                            key,
+                            bstr::BStr::new(tail),
+                            pos,
+                        )));
+                    }
+                    Ok(())
+                };
                 if naming.is_string() {
                     if let Some(slice) = config.get_optional_slice(global_this, b"naming")? {
+                        validate("entry", slice.slice())?;
                         this.names.entry_point.data = with_dot_slash(slice.slice());
                         drop(slice);
                     }
                 } else if naming.is_object() {
                     if let Some(slice) = naming.get_optional_slice(global_this, b"entry")? {
+                        validate("entry", slice.slice())?;
                         this.names.entry_point.data = with_dot_slash(slice.slice());
                         drop(slice);
                     }
 
                     if let Some(slice) = naming.get_optional_slice(global_this, b"chunk")? {
+                        validate("chunk", slice.slice())?;
                         this.names.chunk.data = with_dot_slash(slice.slice());
                         drop(slice);
                     }
 
                     if let Some(slice) = naming.get_optional_slice(global_this, b"asset")? {
+                        validate("asset", slice.slice())?;
                         this.names.asset.data = with_dot_slash(slice.slice());
                         drop(slice);
                     }

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2362,19 +2362,30 @@ fn parse_build_command_options(
         ctx.bundler_options.code_splitting = true;
     }
 
-    if let Some(entry_naming) = args.option(b"--entry-naming") {
-        ctx.bundler_options.entry_naming =
-            strings::concat(&[b"./", strings::remove_leading_dot_slash(entry_naming)]);
-    }
-
-    if let Some(chunk_naming) = args.option(b"--chunk-naming") {
-        ctx.bundler_options.chunk_naming =
-            strings::concat(&[b"./", strings::remove_leading_dot_slash(chunk_naming)]);
-    }
-
-    if let Some(asset_naming) = args.option(b"--asset-naming") {
-        ctx.bundler_options.asset_naming =
-            strings::concat(&[b"./", strings::remove_leading_dot_slash(asset_naming)]);
+    for (flag, slot) in [
+        (
+            b"--entry-naming".as_slice(),
+            &mut ctx.bundler_options.entry_naming,
+        ),
+        (
+            b"--chunk-naming".as_slice(),
+            &mut ctx.bundler_options.chunk_naming,
+        ),
+        (
+            b"--asset-naming".as_slice(),
+            &mut ctx.bundler_options.asset_naming,
+        ),
+    ] {
+        if let Some(value) = args.option(flag) {
+            if let Some((pos, tail)) = options::find_unterminated_placeholder(value) {
+                Output::err_generic(
+                    "{}: unterminated \"{}\" placeholder (missing \"]\") at position {}",
+                    (BStr::new(flag), BStr::new(tail), pos),
+                );
+                Global::exit(1);
+            }
+            *slot = strings::concat(&[b"./", strings::remove_leading_dot_slash(value)]);
+        }
     }
 
     if args.flag(b"--server-components") {

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -324,4 +324,65 @@ describe("bundler", () => {
     },
     run: { stdout: "1" },
   });
+  // https://github.com/oven-sh/bun/issues/7810
+  // An unterminated known placeholder ("[name" with no closing "]") used to
+  // panic the whole process with "range start index N out of range" because the
+  // known-placeholder branch advanced one byte past the end of the template.
+  // Run via the CLI backend so a regression crashes the spawned `bun build`,
+  // not the test runner.
+  for (const unterminated of ["[name", "[dir", "[ext", "[hash", "[target"]) {
+    itBundled(`naming/UnterminatedPlaceholderPanic/${unterminated.slice(1)}`, {
+      backend: "cli",
+      files: {
+        "/src/entry.js": `console.log(1);`,
+      },
+      root: "/src",
+      entryNaming: unterminated,
+      entryPointsRaw: ["./src/entry.js"],
+      onAfterBundle(api) {
+        api.assertFileExists(`/out/${unterminated}`);
+      },
+    });
+  }
+  itBundled("naming/UnterminatedAfterValidPlaceholder", {
+    backend: "cli",
+    files: {
+      "/src/entry.js": `console.log(1);`,
+    },
+    root: "/src",
+    entryNaming: "[name]-[hash.js",
+    entryPointsRaw: ["./src/entry.js"],
+    onAfterBundle(api) {
+      api.assertFileExists("/out/entry-[hash.js");
+    },
+    run: { file: "/out/entry-[hash.js", stdout: "1" },
+  });
+  // A `[` with no matching `]`, and an unknown `[placeholder]`, are kept as
+  // literal bytes in the output path rather than being silently dropped.
+  itBundled("naming/UnknownPlaceholderIsLiteral", {
+    backend: "cli",
+    files: {
+      "/src/entry.js": `console.log(1);`,
+    },
+    root: "/src",
+    entryNaming: "[nonexistent]-[name].[ext]",
+    entryPointsRaw: ["./src/entry.js"],
+    onAfterBundle(api) {
+      api.assertFileExists("/out/[nonexistent]-entry.js");
+    },
+    run: { file: "/out/[nonexistent]-entry.js", stdout: "1" },
+  });
+  itBundled("naming/StrayOpenBracketIsLiteral", {
+    backend: "cli",
+    files: {
+      "/src/entry.js": `console.log(1);`,
+    },
+    root: "/src",
+    entryNaming: "a[b.js",
+    entryPointsRaw: ["./src/entry.js"],
+    onAfterBundle(api) {
+      api.assertFileExists("/out/a[b.js");
+    },
+    run: { file: "/out/a[b.js", stdout: "1" },
+  });
 });

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -375,7 +375,12 @@ describe("bundler", () => {
 
 // Bun.build({ naming: "[name" }) used to SIGABRT; validation now rejects it.
 describe("bundler", () => {
-  for (const naming of [`"[name"`, `{ chunk: "[name]-[hash" }`, `{ asset: "pre[post" }`]) {
+  for (const [naming, option] of [
+    [`"[name"`, "naming"],
+    [`{ entry: "[dir]/[name" }`, "naming.entry"],
+    [`{ chunk: "[name]-[hash" }`, "naming.chunk"],
+    [`{ asset: "pre[post" }`, "naming.asset"],
+  ] as const) {
     test(`naming/UnterminatedPlaceholderAPI ${naming}`, async () => {
       using dir = tempDir("naming-unterminated", {
         "e.ts": `console.log("hi");`,
@@ -397,8 +402,7 @@ describe("bundler", () => {
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
-      expect(stdout).toContain("SURVIVED");
-      expect(stdout).toContain(`unterminated "[`);
+      expect(stdout).toContain(`${option}: unterminated "[`);
       expect(stdout).toContain(`(missing "]")`);
       expect(exitCode).toBe(0);
     });

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -396,7 +396,7 @@ describe("bundler", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).not.toContain("panic:");
+      expect(stderr).toBe("");
       expect(stdout).toContain("SURVIVED");
       expect(stdout).toContain(`unterminated "[`);
       expect(stdout).toContain(`(missing "]")`);

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -1,4 +1,5 @@
-import { describe } from "bun:test";
+import { describe, test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { ESBUILD, itBundled } from "./expectBundled";
 
 describe("bundler", () => {
@@ -327,11 +328,11 @@ describe("bundler", () => {
   // https://github.com/oven-sh/bun/issues/7810
   // An unterminated known placeholder ("[name" with no closing "]") used to
   // panic the whole process with "range start index N out of range" because the
-  // known-placeholder branch advanced one byte past the end of the template.
-  // Run via the CLI backend so a regression crashes the spawned `bun build`,
-  // not the test runner.
-  for (const unterminated of ["[name", "[dir", "[ext", "[hash", "[target"]) {
-    itBundled(`naming/UnterminatedPlaceholderPanic/${unterminated.slice(1)}`, {
+  // known-placeholder branch in path_template_print advanced one byte past the
+  // end of the template. Run via the CLI backend so a regression crashes the
+  // spawned `bun build`, not the test runner.
+  for (const unterminated of ["[name", "[dir", "[ext", "[hash", "[target", "a[b.js", "[name]-[hash.js"]) {
+    itBundled(`naming/UnterminatedPlaceholder/${unterminated}`, {
       backend: "cli",
       files: {
         "/src/entry.js": `console.log(1);`,
@@ -339,26 +340,13 @@ describe("bundler", () => {
       root: "/src",
       entryNaming: unterminated,
       entryPointsRaw: ["./src/entry.js"],
-      onAfterBundle(api) {
-        api.assertFileExists(`/out/${unterminated}`);
+      bundleErrors: {
+        "<bun>": [`--entry-naming: unterminated "[`],
       },
     });
   }
-  itBundled("naming/UnterminatedAfterValidPlaceholder", {
-    backend: "cli",
-    files: {
-      "/src/entry.js": `console.log(1);`,
-    },
-    root: "/src",
-    entryNaming: "[name]-[hash.js",
-    entryPointsRaw: ["./src/entry.js"],
-    onAfterBundle(api) {
-      api.assertFileExists("/out/entry-[hash.js");
-    },
-    run: { file: "/out/entry-[hash.js", stdout: "1" },
-  });
-  // A `[` with no matching `]`, and an unknown `[placeholder]`, are kept as
-  // literal bytes in the output path rather than being silently dropped.
+  // An unknown `[placeholder]` with a matching `]` is kept as literal bytes in
+  // the output path rather than being silently dropped.
   itBundled("naming/UnknownPlaceholderIsLiteral", {
     backend: "cli",
     files: {
@@ -372,17 +360,38 @@ describe("bundler", () => {
     },
     run: { file: "/out/[nonexistent]-entry.js", stdout: "1" },
   });
-  itBundled("naming/StrayOpenBracketIsLiteral", {
-    backend: "cli",
-    files: {
-      "/src/entry.js": `console.log(1);`,
-    },
-    root: "/src",
-    entryNaming: "a[b.js",
-    entryPointsRaw: ["./src/entry.js"],
-    onAfterBundle(api) {
-      api.assertFileExists("/out/a[b.js");
-    },
-    run: { file: "/out/a[b.js", stdout: "1" },
-  });
+});
+
+// Same repro via the JS API: Bun.build({ naming: "[name" }) used to SIGABRT
+// the process (see #7810), so run it in a subprocess. After the fix the config
+// parser rejects the template up front with a catchable error.
+describe("bundler", () => {
+  for (const naming of [`"[name"`, `{ chunk: "[name]-[hash" }`, `{ asset: "pre[post" }`]) {
+    test(`naming/UnterminatedPlaceholderAPI ${naming}`, async () => {
+      using dir = tempDir("naming-unterminated", {
+        "e.ts": `console.log("hi");`,
+        "build.ts": `
+          try {
+            await Bun.build({ entrypoints: ["./e.ts"], outdir: "./out", throw: false, naming: ${naming} });
+            console.log("SURVIVED no-error");
+          } catch (e) {
+            console.log("SURVIVED", String(e));
+          }
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("panic:");
+      expect(stdout).toContain("SURVIVED");
+      expect(stdout).toContain(`unterminated "[`);
+      expect(stdout).toContain(`(missing "]")`);
+      expect(exitCode).toBe(0);
+    });
+  }
 });

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { ESBUILD, itBundled } from "./expectBundled";
 

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -325,12 +325,7 @@ describe("bundler", () => {
     },
     run: { stdout: "1" },
   });
-  // https://github.com/oven-sh/bun/issues/7810
-  // An unterminated known placeholder ("[name" with no closing "]") used to
-  // panic the whole process with "range start index N out of range" because the
-  // known-placeholder branch in path_template_print advanced one byte past the
-  // end of the template. Run via the CLI backend so a regression crashes the
-  // spawned `bun build`, not the test runner.
+  // Unterminated `[` used to panic path_template_print; CLI backend isolates the crash.
   for (const unterminated of ["[name", "[dir", "[ext", "[hash", "[target", "a[b.js", "[name]-[hash.js"]) {
     itBundled(`naming/UnterminatedPlaceholder/${unterminated}`, {
       backend: "cli",
@@ -345,8 +340,24 @@ describe("bundler", () => {
       },
     });
   }
-  // An unknown `[placeholder]` with a matching `]` is kept as literal bytes in
-  // the output path rather than being silently dropped.
+  for (const [opt, flag] of [
+    ["chunkNaming", "--chunk-naming"],
+    ["assetNaming", "--asset-naming"],
+  ] as const) {
+    itBundled(`naming/UnterminatedPlaceholder/${flag}`, {
+      backend: "cli",
+      files: {
+        "/src/entry.js": `console.log(1);`,
+      },
+      root: "/src",
+      [opt]: "[name]-[hash",
+      entryPointsRaw: ["./src/entry.js"],
+      bundleErrors: {
+        "<bun>": [`${flag}: unterminated "[hash"`],
+      },
+    });
+  }
+  // An unknown `[placeholder]` is kept verbatim in the output path.
   itBundled("naming/UnknownPlaceholderIsLiteral", {
     backend: "cli",
     files: {
@@ -362,9 +373,7 @@ describe("bundler", () => {
   });
 });
 
-// Same repro via the JS API: Bun.build({ naming: "[name" }) used to SIGABRT
-// the process (see #7810), so run it in a subprocess. After the fix the config
-// parser rejects the template up front with a catchable error.
+// Bun.build({ naming: "[name" }) used to SIGABRT; validation now rejects it.
 describe("bundler", () => {
   for (const naming of [`"[name"`, `{ chunk: "[name]-[hash" }`, `{ asset: "pre[post" }`]) {
     test(`naming/UnterminatedPlaceholderAPI ${naming}`, async () => {


### PR DESCRIPTION
## Repro

```js
await Bun.build({ entrypoints: ["e.ts"], throw: false, naming: "[name" });
```

```
panic: range start index 5 out of range for slice of length 4
oh no: Bun has crashed.
```

Same from the CLI via `--entry-naming='[name'`, and for any of `[dir` / `[ext` / `[hash` / `[target` appearing at the tail of `naming` or `naming.{entry,chunk,asset}`. `throw: false` does not help since the panic aborts the whole process.

## Cause

`path_template_print` in `src/bundler/options.rs` scans for a matching `]` and records its index in `end_len`. When none is found, `end_len` stays at `remain.len()`. If the text between `[` and the end of the string happens to be a known placeholder name, the known-placeholder branch then advances with `remain = &remain[end_len + 1..]`, one past the end.

The unknown-placeholder branch used `&remain[end_len..]` so it did not panic, but it wrote the placeholder text without the `[` it had already consumed, so `"a[b"` became `"ab"` and `"[foo]-[name].[ext]"` became `"foo]-index.js"`.

## Fix

**Validate up front.** `options::find_unterminated_placeholder` scans a template with the same depth-counting as the printer and returns the position of any `[` with no matching `]`. The `Bun.build` config parser (`JSBundler.rs`) calls it for `naming` / `naming.{entry,chunk,asset}` and throws `ERR_INVALID_ARG_TYPE` with the placeholder text and byte position; the CLI flag parser (`Arguments.rs`) does the same for `--entry-naming` / `--chunk-naming` / `--asset-naming` and exits 1.

```
error: --entry-naming: unterminated "[name" placeholder (missing "]") at position 0
```

**Make the printer total.** In `path_template_print`, after the bracket scan, if no matching `]` was found (`count != 0`), write the `[` back and treat the remainder as literal text. For an unknown `[placeholder]` with a matching `]`, write `[placeholder]` verbatim and advance past the `]` (esbuild keeps unknown placeholders as-is). The known-placeholder branch's `end_len + 1` advance is now only reached when `end_len < remain.len()`. The old `remain.is_empty()` special case is subsumed and removed.

## Tests

`test/bundler/bundler_naming.test.ts` (all via subprocess so a regression crashes the spawned process, not the test runner):

- CLI `--entry-naming`: `[name`, `[dir`, `[ext`, `[hash`, `[target`, `a[b.js`, `[name]-[hash.js` each rejected with the `--entry-naming: unterminated ...` error; on main these either SIGABRT or silently write a wrong filename.
- CLI `--chunk-naming` / `--asset-naming`: rejected with the matching flag name in the error.
- CLI: `[nonexistent]-[name].[ext]` passes validation and writes `[nonexistent]-entry.js` (unknown placeholder kept literal); on main it writes `nonexistent]-entry.js`.
- API: `Bun.build` with `naming: "[name"`, `naming: { chunk: "[name]-[hash" }`, `naming: { asset: "pre[post" }` each reject with a catchable `naming.*: unterminated ...` error; on main the first panics and the other two succeed.

Plus a `#[cfg(test)]` unit test in `options.rs` covering the printer's literal fallback and the validator directly.

Fail-before: 13/13 fail on bun 1.3.14. Pass-after: 24 pass / 3 pre-existing todo on the debug build; `bun-build-api.test.ts -t naming|hash` green.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 failed, 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_naming.test.ts
bun test v1.4.0 (e64f28124)

test/bundler/bundler_naming.test.ts:
(pass) bundler > naming/EntryNamingCollission [462.26ms]
(pass) bundler > naming/ImplicitOutbase1 [651.47ms]
(pass) bundler > naming/ImplicitOutbase2 [896.35ms]
(pass) bundler > naming/EntryNamingTemplate1 [921.28ms]
(todo) bundler > naming/EntryNamingTemplate2
(pass) bundler > naming/AssetNaming [345.94ms]
(pass) bundler > naming/AssetNamingMkdir [353.87ms]
(pass) bundler > naming/AssetNamingDir [352.42ms]
(todo) bundler > naming/AssetNoOverwrite
(pass) bundler > naming/AssetFileLoaderPath1 [86.13ms]
ENOENT opening root directory "/tmp/bun-build-tests/bun-wIfU1j/naming/NonexistantRoot/lib"

(pass) bundler > naming/NonexistantRoot [143.23ms]
(todo) bundler > naming/EntrypointOutsideOfRoot
(pass) bundler > naming/WithPathTraversal [913.22ms]
(pass) bundler > naming/NonAsciiSourceFilenameSymbol [366.91ms]
969 |       ]);
970 |       const stdout = Buffer.from(stdoutBytes);
971 |       const stderr = Buffer.from(stderrBytes);
972 |       
... (truncated)

release without fix: 1 failed, 3 skipped
bun test v1.4.0-canary.1 (3f83e96c5)

test/bundler/bundler_naming.test.ts:
(pass) bundler > naming/EntryNamingCollission [12.46ms]
(pass) bundler > naming/ImplicitOutbase1 [16.92ms]
(pass) bundler > naming/ImplicitOutbase2 [23.25ms]
(pass) bundler > naming/EntryNamingTemplate1 [20.99ms]
(todo) bundler > naming/EntryNamingTemplate2
(pass) bundler > naming/AssetNaming [8.71ms]
(pass) bundler > naming/AssetNamingMkdir [9.31ms]
(pass) bundler > naming/AssetNamingDir [8.39ms]
(todo) bundler > naming/AssetNoOverwrite
(pass) bundler > naming/AssetFileLoaderPath1 [3.16ms]
ENOENT opening root directory "/tmp/bun-build-tests/bun-owj1VU/naming/NonexistantRoot/lib"

(pass) bundler > naming/NonexistantRoot [2.14ms]
(todo) bundler > naming/EntrypointOutsideOfRoot
(pass) bundler > naming/WithPathTraversal [20.37ms]
(pass) bundler > naming/NonAsciiSourceFilenameSymbol [9.63ms]
(pass) bundler > naming/UnterminatedPlaceholder/[name [2.02ms]
(pass) bundler > naming/UnterminatedPlaceholder/[dir [1.71ms]
(pass) bundler > naming/UnterminatedPlaceholder/[ext [1.62ms]
(pass) bundler > naming/UnterminatedPlaceholder/[hash [2.12ms]
(pass) bundler > naming/UnterminatedPlaceholder/[target [2.0
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_naming.test.ts
bun test v1.4.0 (e64f28124)

test/bundler/bundler_naming.test.ts:
(pass) bundler > naming/EntryNamingCollission [489.90ms]
(pass) bundler > naming/ImplicitOutbase1 [651.15ms]
(pass) bundler > naming/ImplicitOutbase2 [899.76ms]
(pass) bundler > naming/EntryNamingTemplate1 [882.45ms]
(todo) bundler > naming/EntryNamingTemplate2
(pass) bundler > naming/AssetNaming [343.03ms]
(pass) bundler > naming/AssetNamingMkdir [356.95ms]
(pass) bundler > naming/AssetNamingDir [353.70ms]
(todo) bundler > naming/AssetNoOverwrite
(pass) bundler > naming/AssetFileLoaderPath1 [84.49ms]
ENOENT opening root directory "/tmp/bun-build-tests/bun-p1PawH/naming/NonexistantRoot/lib"

(pass) bundler > naming/NonexistantRoot [144.49ms]
(todo) bundler > naming/EntrypointOutsideOfRoot
(pass) bundler > naming/WithPathTraversal [893.44ms]
(pass) bundler > naming/NonAsciiSourceFilenameSymbol [369.22ms]
(pass) bundler > naming/UnterminatedPlaceholder/[name [441.27ms]
(pass) bundler > naming/UnterminatedPlaceholder/[dir [128.82ms]
(pass
... (truncated)

release with fix: 3 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 657ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/options.rs              | 95 ++++++++++++++++++++++++++++++++++---
 src/runtime/api/JSBundler.rs        | 15 ++++++
 src/runtime/cli/Arguments.rs        | 37 ++++++++++-----
 test/bundler/bundler_naming.test.ts | 85 ++++++++++++++++++++++++++++++++-
 4 files changed, 211 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/bundler/options.rs                   4     11      0
src/runtime/api/JSBundler.rs             2      2      0
src/runtime/cli/Arguments.rs             3      2      0
test/bundler/bundler_naming.test.ts      4      9      0
```

</details>

<!-- robobun:evidence:end -->