### PR TITLE
JSSink: skip JS onClose/onPull when the VM has a pending termination

### DIFF
--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -662,11 +662,7 @@ void JS${controllerName}::detach() {
     if (readableStream.value() && onClose.value()) {
         JSC::JSGlobalObject *globalObject = this->globalObject();
         auto& vm = globalObject->vm();
-        // Worker shutdown stops every Bun.serve() and tears down in-flight response
-        // sinks while the sticky TerminationException is already set on the VM;
-        // re-entering JS here trips executeCallImpl's assertNoException(). The
-        // onClose hook only exists to transition the direct ReadableStream's
-        // state, which is moot once the VM is going away.
+        // Re-entering JS on a terminated worker trips executeCallImpl's assertNoException().
         if (vm.hasPendingTerminationException()) [[unlikely]]
             return;
         auto scope = DECLARE_THROW_SCOPE(vm);
@@ -980,9 +976,7 @@ extern "C" void ${name}__onReady(JSC::EncodedJSValue controllerValue, JSC::Encod
         return;
     JSC::JSGlobalObject *globalObject = controller->globalObject();
     auto& vm = globalObject->vm();
-    // See detach(): worker.terminate() mid-stream leaves the sticky
-    // TerminationException pending, so re-entering JS here aborts on
-    // executeCallImpl's assertNoException().
+    // Re-entering JS on a terminated worker trips executeCallImpl's assertNoException().
     if (vm.hasPendingTerminationException()) [[unlikely]]
         return;
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1011,9 +1005,7 @@ extern "C" void ${name}__onClose(JSC::EncodedJSValue controllerValue, JSC::Encod
     controller->m_onClose.clear();
     JSC::JSGlobalObject* globalObject = controller->globalObject();
     auto& vm = globalObject->vm();
-    // See detach(): worker.terminate() mid-stream leaves the sticky
-    // TerminationException pending, so re-entering JS here aborts on
-    // executeCallImpl's assertNoException().
+    // Re-entering JS on a terminated worker trips executeCallImpl's assertNoException().
     if (vm.hasPendingTerminationException()) [[unlikely]]
         return;
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -661,7 +661,15 @@ void JS${controllerName}::detach() {
 
     if (readableStream.value() && onClose.value()) {
         JSC::JSGlobalObject *globalObject = this->globalObject();
-        auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+        auto& vm = globalObject->vm();
+        // Worker shutdown stops every Bun.serve() and tears down in-flight response
+        // sinks while the sticky TerminationException is already set on the VM;
+        // re-entering JS here trips executeCallImpl's assertNoException(). The
+        // onClose hook only exists to transition the direct ReadableStream's
+        // state, which is moot once the VM is going away.
+        if (vm.hasPendingTerminationException()) [[unlikely]]
+            return;
+        auto scope = DECLARE_THROW_SCOPE(vm);
         JSC::MarkedArgumentBuffer arguments;
         arguments.append(readableStream.value());
         arguments.append(jsUndefined());
@@ -971,7 +979,13 @@ extern "C" void ${name}__onReady(JSC::EncodedJSValue controllerValue, JSC::Encod
     if (!function)
         return;
     JSC::JSGlobalObject *globalObject = controller->globalObject();
-    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    auto& vm = globalObject->vm();
+    // See detach(): worker.terminate() mid-stream leaves the sticky
+    // TerminationException pending, so re-entering JS here aborts on
+    // executeCallImpl's assertNoException().
+    if (vm.hasPendingTerminationException()) [[unlikely]]
+        return;
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(controller);
     arguments.append(JSC::JSValue::decode(amt));
@@ -996,7 +1010,13 @@ extern "C" void ${name}__onClose(JSC::EncodedJSValue controllerValue, JSC::Encod
     // only call close once
     controller->m_onClose.clear();
     JSC::JSGlobalObject* globalObject = controller->globalObject();
-    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    auto& vm = globalObject->vm();
+    // See detach(): worker.terminate() mid-stream leaves the sticky
+    // TerminationException pending, so re-entering JS here aborts on
+    // executeCallImpl's assertNoException().
+    if (vm.hasPendingTerminationException()) [[unlikely]]
+        return;
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSC::MarkedArgumentBuffer arguments;
     auto readableStream = controller->m_weakReadableStream.get();

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -275,6 +275,9 @@ impl<T: JsSinkAbi> SinkSignal<T> {
             // `simulateThrow()`.
             // TODO: this should be got from a parameter / properly propagate exception upwards.
             let global = ::bun_jsc::virtual_machine::VirtualMachine::get().global();
+            if global.has_exception() {
+                return;
+            }
             let _ =
                 ::bun_jsc::call_check_slow(global, || T::on_close_extern(cpp, JSValue::UNDEFINED));
         }
@@ -289,6 +292,9 @@ impl<T: JsSinkAbi> SinkSignal<T> {
             // own); see `close` above. Same wrapper.
             // TODO: this should be got from a parameter / properly propagate exception upwards.
             let global = ::bun_jsc::virtual_machine::VirtualMachine::get().global();
+            if global.has_exception() {
+                return;
+            }
             let _ = ::bun_jsc::call_check_slow(global, || {
                 T::on_ready_extern(cpp, JSValue::UNDEFINED, JSValue::UNDEFINED)
             });

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -183,8 +183,10 @@ test.skipIf(!isASAN)(
 // via AsyncContextFrame::call while the VM's sticky TerminationException is
 // still pending, tripping Interpreter::executeCallImpl's
 // scope.assertNoException() and SIGABRTing the whole process. Release WebKit
-// compiles that ASSERT out, so this is debug/ASAN only. Three cells cover the
-// sink classes and stream shapes the shutdown drain reaches.
+// compiles that ASSERT out, so this is debug/ASAN only. Two cells cover
+// HTTPResponseSink and HTTPSResponseSink; the type:"direct" shape hits a
+// separate pre-existing VMTraps::deferTerminationSlow assert and is tracked
+// separately.
 describe.skipIf(!isDebug)(
   "terminate() while Bun.serve is streaming a ReadableStream body does not trip assertNoException()",
   () => {

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -200,7 +200,7 @@ test.skipIf(!isDebug)(
           '    await Bun.sleep(0);' +
           '  } })); } });' +
           'require("node:worker_threads").parentPort.postMessage(server.port);';
-        for (let i = 0; i < 8; i++) {
+        for (let i = 0; i < ${rounds}; i++) {
           const w = new Worker(src, { eval: true });
           const port = await new Promise(r => w.once("message", r));
           const res = await fetch("http://127.0.0.1:" + port + "/");
@@ -220,7 +220,7 @@ test.skipIf(!isDebug)(
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).not.toContain("ASSERTION FAILED");
+    expect(stderr).toBe("");
     expect(stdout).toBe("survived\n");
     expect(exitCode).toBe(0);
   },

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -176,3 +176,53 @@ test.skipIf(!isASAN)(
   },
   timeout,
 );
+
+// Regression: Bun.serve() inside a worker, streaming a JS ReadableStream body,
+// then worker.terminate() mid-stream. Worker shutdown stops the server which
+// tears down the in-flight HTTPResponseSink and fires its JS onClose/onPull
+// hook via AsyncContextFrame::call while the VM's sticky TerminationException
+// is still pending, tripping Interpreter::executeCallImpl's
+// scope.assertNoException() and SIGABRTing the whole process. Release WebKit
+// compiles that ASSERT out, so this is debug/ASAN only.
+test.skipIf(!isDebug)(
+  "terminate() while Bun.serve is streaming a ReadableStream body does not trip assertNoException()",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const src = 'const server = Bun.serve({ port: 0, fetch() { let i = 0;' +
+          '  return new Response(new ReadableStream({ async pull(c) {' +
+          '    c.enqueue(new Uint8Array(8192).fill(i++));' +
+          '    if (i > 20000) c.close();' +
+          '    await Bun.sleep(0);' +
+          '  } })); } });' +
+          'require("node:worker_threads").parentPort.postMessage(server.port);';
+        for (let i = 0; i < 8; i++) {
+          const w = new Worker(src, { eval: true });
+          const port = await new Promise(r => w.once("message", r));
+          const res = await fetch("http://127.0.0.1:" + port + "/");
+          const rd = res.body.getReader();
+          await rd.read();
+          const done = new Promise(r => w.once("exit", r));
+          w.terminate();
+          await done;
+          rd.cancel().catch(() => {});
+        }
+        console.log("survived");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("ASSERTION FAILED");
+    expect(stdout).toBe("survived\n");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -209,7 +209,7 @@ test.skipIf(!isDebug)(
           const done = new Promise(r => w.once("exit", r));
           w.terminate();
           await done;
-          rd.cancel().catch(() => {});
+          await rd.cancel().catch(() => {});
         }
         console.log("survived");
       `,

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug, tls } from "harness";
 import { join } from "path";
 
 // Worker VM startup/teardown is much slower under debug and/or ASAN; these
@@ -179,50 +179,81 @@ test.skipIf(!isASAN)(
 
 // Regression: Bun.serve() inside a worker, streaming a JS ReadableStream body,
 // then worker.terminate() mid-stream. Worker shutdown stops the server which
-// tears down the in-flight HTTPResponseSink and fires its JS onClose/onPull
-// hook via AsyncContextFrame::call while the VM's sticky TerminationException
-// is still pending, tripping Interpreter::executeCallImpl's
+// tears down the in-flight HTTP(S)ResponseSink and fires its JS onClose hook
+// via AsyncContextFrame::call while the VM's sticky TerminationException is
+// still pending, tripping Interpreter::executeCallImpl's
 // scope.assertNoException() and SIGABRTing the whole process. Release WebKit
-// compiles that ASSERT out, so this is debug/ASAN only.
-test.skipIf(!isDebug)(
+// compiles that ASSERT out, so this is debug/ASAN only. Three cells cover the
+// sink classes and stream shapes the shutdown drain reaches.
+describe.skipIf(!isDebug)(
   "terminate() while Bun.serve is streaming a ReadableStream body does not trip assertNoException()",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        const { Worker } = require("node:worker_threads");
-        const src = 'const server = Bun.serve({ port: 0, fetch() { let i = 0;' +
-          '  return new Response(new ReadableStream({ async pull(c) {' +
-          '    c.enqueue(new Uint8Array(8192).fill(i++));' +
-          '    if (i > 20000) c.close();' +
-          '    await Bun.sleep(0);' +
-          '  } })); } });' +
-          'require("node:worker_threads").parentPort.postMessage(server.port);';
-        for (let i = 0; i < ${rounds}; i++) {
-          const w = new Worker(src, { eval: true });
-          const port = await new Promise(r => w.once("message", r));
-          const res = await fetch("http://127.0.0.1:" + port + "/");
-          const rd = res.body.getReader();
-          await rd.read();
-          const done = new Promise(r => w.once("exit", r));
-          w.terminate();
-          await done;
-          await rd.cancel().catch(() => {});
-        }
-        console.log("survived");
-      `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+  () => {
+    async function runCell(
+      workerBody: string,
+      scheme: "http" | "https",
+      fetchOpts: string,
+      workerData?: Record<string, string>,
+    ) {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const { Worker } = require("node:worker_threads");
+          const workerData = ${JSON.stringify(workerData ?? {})};
+          const src = ${JSON.stringify(workerBody)};
+          for (let i = 0; i < ${rounds}; i++) {
+            const w = new Worker(src, { eval: true, workerData });
+            const port = await new Promise(r => w.once("message", r));
+            const res = await fetch("${scheme}://127.0.0.1:" + port + "/", ${fetchOpts});
+            const rd = res.body.getReader();
+            await rd.read();
+            const done = new Promise(r => w.once("exit", r));
+            w.terminate();
+            await done;
+            await rd.cancel().catch(() => {});
+          }
+          console.log("survived");
+        `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("survived\n");
+      expect(exitCode).toBe(0);
+    }
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toBe("survived\n");
-    expect(exitCode).toBe(0);
+    const pullBody =
+      "let i = 0;" +
+      "return new Response(new ReadableStream({ async pull(c) {" +
+      "  c.enqueue(new Uint8Array(8192).fill(i++));" +
+      "  if (i > 20000) c.close();" +
+      "  await Bun.sleep(0);" +
+      "} }));";
+    const httpWorker =
+      "const server = Bun.serve({ port: 0, fetch() {" +
+      pullBody +
+      "} });" +
+      "require('node:worker_threads').parentPort.postMessage(server.port);";
+    const httpsWorker =
+      "const { workerData } = require('node:worker_threads');" +
+      "const server = Bun.serve({ port: 0, tls: { cert: workerData.cert, key: workerData.key }, fetch() {" +
+      pullBody +
+      "} });" +
+      "require('node:worker_threads').parentPort.postMessage(server.port);";
+
+    test.concurrent("http (HTTPResponseSink)", () => runCell(httpWorker, "http", "{}"), timeout);
+    test.concurrent(
+      "https (HTTPSResponseSink)",
+      () =>
+        runCell(httpsWorker, "https", "{ tls: { rejectUnauthorized: false } }", {
+          cert: tls.cert,
+          key: tls.key,
+        }),
+      timeout,
+    );
   },
-  timeout,
 );


### PR DESCRIPTION
## What

A Worker running `Bun.serve()` with a streamed `ReadableStream` body, terminated mid-stream, SIGABRTs the whole process on assertion-enabled builds:

```
ASSERTION FAILED: !exception()
ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

Stack: `assertNoException` ← `Interpreter::executeCallImpl` ← `executeBoundCall` ← `JSC::call` ← `AsyncContextFrame::call` ← `HTTPResponseSink__onClose`, aborting thread "Worker". The same holds for `HTTPSResponseSink__onClose` over a TLS listener.

## Repro

```js
const { Worker } = require("node:worker_threads");
const src = 'const server = Bun.serve({ port: 0, fetch() { let i = 0;' +
  '  return new Response(new ReadableStream({ async pull(c) {' +
  '    c.enqueue(new Uint8Array(8192).fill(i++)); if (i > 20000) c.close(); await Bun.sleep(0); } })); } });' +
  'require("node:worker_threads").parentPort.postMessage(server.port);';
for (let i = 0; i < 8; i++) {
  const w = new Worker(src, { eval: true });
  const port = await new Promise(r => w.once("message", r));
  const res = await fetch("http://127.0.0.1:" + port + "/");
  const rd = res.body.getReader();
  await rd.read();
  const done = new Promise(r => w.once("exit", r));
  w.terminate();
  await done;
  await rd.cancel().catch(() => {});
}
console.log("survived");
```

Under `bun bd` this aborts on the first iteration 8/8. Release builds survive (the `ASSERT` is compiled out).

## Cause

`worker.terminate()` sets the sticky `TerminationException` on the worker VM. Worker shutdown (`web_worker.rs` `close_all_socket_groups`) then stops every `Bun.serve()`, which aborts in-flight responses: `RequestContext` → `HTTPServerWritable::abort` → `signal.close(None)` → `SinkSignal` close thunk → generated `HTTP(S)ResponseSink__onClose`, which re-enters JS via `AsyncContextFrame::call` → `JSC::profiledCall` → `executeCallImpl`. `executeCallImpl` opens with `scope.assertNoException()`, and the already-pending termination exception trips it.

None of `__onClose`, `__onReady`, or the controller's `detach()` (all generated by `generate-jssink.ts`, shared by all 6 sink classes) checked for a pending exception before calling into JS.

## Fix

- `generate-jssink.ts`: guard `detach()`, `__onClose`, and `__onReady` with `vm.hasPendingTerminationException()` before `AsyncContextFrame::call`, matching the pattern in `Worker.cpp` / `NodeTimerObject.cpp` / `JSDOMPromiseDeferred.cpp`. `detach()`'s native cleanup (nulling `m_sinkPtr`, `Bun__onSinkDestroyed`, `controllerDetached`) still runs; only the JS onClose is skipped, which only exists to transition the direct `ReadableStream`'s JS-visible state and is moot once the VM is shutting down.
- `Sink.rs`: add a `global.has_exception()` early-return in the `SinkSignal` `close` / `ready` vtable thunks, mirroring the idiom in `WebSocketServerContext.rs` / `socket/Handlers.rs`. Short-circuits before the `call_check_slow` scope is constructed. The Rust `JSSink::detach` is left alone because it must still clear the signal, unprotect the cell, and run the C++ native cleanup; the C++ `detach()` guard handles that path.

The `type:"direct"` body cell was also tried but hits a separate pre-existing assert on main (`VMTraps::deferTerminationSlow`'s `hasTerminationRequest()` check, rooted at `web_worker.rs` shutdown clearing the request flag but not the sticky exception before `close_all_socket_groups`); that is tracked separately. `BunStreamSource.cpp`'s `readDirectStreamCloseImpl` has the same shape (pre-call no termination check at the `sinkController.end()` / `cancel()` calls) but is unreproduced; also left for a separate change.

## Verification

- `bun bd test test/js/web/workers/worker-terminate-lifetime.test.ts -t "does not trip assertNoException"`: both cells (http `HTTPResponseSink`, https `HTTPSResponseSink`) fail on main (`ASSERTION FAILED: !exception()`, exit 134, first iteration every run), pass with fix (~13s concurrent).
- `test/js/bun/http/serve-direct-readable-stream.test.ts`: 13 pass (direct-stream onClose path unchanged for the non-terminating case).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->