### PR TITLE
runtime + --no-bundle: implement base64/dataurl loaders

### DIFF
--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -124,7 +124,10 @@ impl Loader {
     }
 
     pub fn handles_empty_file(self) -> bool {
-        matches!(self, Loader::Wasm | Loader::File | Loader::Text)
+        matches!(
+            self,
+            Loader::Wasm | Loader::File | Loader::Text | Loader::Base64 | Loader::Dataurl
+        )
     }
 
     // `to_mime_type` / `from_mime_type` stay in bun_http_types as extension

--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -233,6 +233,8 @@ impl Loader {
     pub fn side_effects(self) -> SideEffects {
         match self {
             Loader::Text
+            | Loader::Base64
+            | Loader::Dataurl
             | Loader::Json
             | Loader::Jsonc
             | Loader::Toml

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1425,14 +1425,19 @@ impl<'a> Transpiler<'a> {
             // `read_file_with_allocator` strips/transcodes BOMs; the raw-binary
             // loaders need the file bytes verbatim.
             if matches!(loader, options::Loader::Base64 | options::Loader::Dataurl) {
+                let publish_fd = this_parse.file_fd_ptr.is_some();
                 let read = match file_descriptor {
                     Some(fd) => bun_sys::lseek(fd, 0, libc::SEEK_SET)
                         .and_then(|_| bun_sys::File::borrow(&fd).read_to_end())
-                        .map(|b| (fd, b)),
+                        .map(|b| (Some(fd), b)),
                     None => bun_sys::File::openat(FD::cwd(), path.text, bun_sys::O::RDONLY, 0)
                         .and_then(|f| {
                             let body = f.read_to_end()?;
-                            Ok((f.into_raw(), body))
+                            // Only disarm Drop when the caller owns the fd
+                            // (runtime watcher via `file_fd_ptr`); otherwise
+                            // let `f` close itself here.
+                            let fd = publish_fd.then(|| f.into_raw());
+                            Ok((fd, body))
                         }),
                 };
                 let (fd, body) = match read {
@@ -1450,8 +1455,8 @@ impl<'a> Transpiler<'a> {
                         return None;
                     }
                 };
-                input_fd = Some(fd);
-                if let Some(file_fd_ptr) = this_parse.file_fd_ptr.take() {
+                input_fd = fd;
+                if let (Some(fd), Some(file_fd_ptr)) = (fd, this_parse.file_fd_ptr.take()) {
                     *file_fd_ptr = fd;
                 }
                 source_backing = resolver::cache::Contents::from(body);

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1786,6 +1786,16 @@ impl<'a> Transpiler<'a> {
             options::Loader::Text => {
                 return parse_text_loader(source, loader, input_fd, source_backing, arena);
             }
+            options::Loader::Base64 | options::Loader::Dataurl => {
+                return parse_base64_or_dataurl_loader(
+                    source,
+                    loader,
+                    input_fd,
+                    source_backing,
+                    arena,
+                    &path,
+                );
+            }
             options::Loader::Md => {
                 return parse_md_loader(source, loader, input_fd, source_backing, arena, log);
             }
@@ -1804,8 +1814,6 @@ impl<'a> Transpiler<'a> {
             options::Loader::Css => {}
             options::Loader::File
             | options::Loader::Napi
-            | options::Loader::Base64
-            | options::Loader::Dataurl
             | options::Loader::Bunsh
             | options::Loader::Sqlite
             | options::Loader::SqliteEmbedded
@@ -2083,6 +2091,57 @@ fn parse_text_loader<'a>(
         bun_ast::E::EString::init(&source.contents),
         bun_ast::Loc::EMPTY,
     );
+    let stmt = bun_ast::Stmt::alloc(
+        bun_ast::S::ExportDefault {
+            value: bun_ast::StmtOrExpr::Expr(expr),
+            default_name: bun_ast::LocRef {
+                loc: bun_ast::Loc::default(),
+                ref_: bun_ast::Ref::NONE,
+            },
+        },
+        bun_ast::Loc { start: 0 },
+    );
+    let stmts = bun_ast::StoreSlice::new_mut(arena.alloc_slice_copy(&[stmt]));
+    let parts: Box<[bun_ast::Part]> = Box::new([bun_ast::Part {
+        stmts,
+        ..Default::default()
+    }]);
+
+    return Some(ParseResult {
+        ast: bun_ast::Ast::from_parts(parts, arena),
+        source: source.clone(),
+        loader,
+        input_fd,
+        already_bundled: AlreadyBundled::None,
+        pending_imports: Default::default(),
+        runtime_transpiler_cache: None,
+        empty: false,
+        source_contents_backing: source_backing,
+    });
+}
+
+#[cold]
+#[inline(never)]
+fn parse_base64_or_dataurl_loader<'a>(
+    source: &bun_ast::Source,
+    loader: options::Loader,
+    input_fd: Option<FD>,
+    source_backing: resolver::cache::Contents,
+    arena: &'a Arena,
+    path: &bun_paths::fs::Path<'static>,
+) -> Option<ParseResult<'a>> {
+    use bun_resolver::data_url::DataURL;
+    let contents = &source.contents;
+    let encoded: Vec<u8> = if matches!(loader, options::Loader::Base64) {
+        bun_base64::encode_alloc(contents)
+    } else {
+        let mime = DataURL::guess_mime_type(path.text, contents);
+        DataURL::encode_string_as_shortest_data_url(&mime, contents)
+    };
+    // SAFETY: ARENA — `arena` outlives the returned `ParseResult.ast` (the AST
+    // crate's `Str` convention erases `'bump` to `'static` for `E::String.data`).
+    let encoded: &'static [u8] = unsafe { bun_ptr::detach_lifetime(arena.alloc_slice_copy(&encoded)) };
+    let expr = bun_ast::Expr::init(bun_ast::E::EString::init(encoded), bun_ast::Loc::EMPTY);
     let stmt = bun_ast::Stmt::alloc(
         bun_ast::S::ExportDefault {
             value: bun_ast::StmtOrExpr::Expr(expr),
@@ -2846,6 +2905,8 @@ impl<'a> Transpiler<'a> {
             | options::Loader::Yaml
             | options::Loader::Json5
             | options::Loader::Text
+            | options::Loader::Base64
+            | options::Loader::Dataurl
             | options::Loader::Md => {
                 // borrowck — `parse` consumes `&mut self`, so capture
                 // the option fields needed for `ParseOptions` first.
@@ -2940,9 +3001,6 @@ impl<'a> Transpiler<'a> {
                 output_file.value = crate::output_file::Value::Buffer {
                     bytes: writer.ctx.written().to_vec().into_boxed_slice(),
                 };
-            }
-            options::Loader::Dataurl | options::Loader::Base64 => {
-                bun_core::Output::panic(format_args!("TODO: dataurl, base64"));
             }
             options::Loader::Css => {
                 match self.build_css_output(

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2140,7 +2140,8 @@ fn parse_base64_or_dataurl_loader<'a>(
     };
     // SAFETY: ARENA — `arena` outlives the returned `ParseResult.ast` (the AST
     // crate's `Str` convention erases `'bump` to `'static` for `E::String.data`).
-    let encoded: &'static [u8] = unsafe { bun_ptr::detach_lifetime(arena.alloc_slice_copy(&encoded)) };
+    let encoded: &'static [u8] =
+        unsafe { bun_ptr::detach_lifetime(arena.alloc_slice_copy(&encoded)) };
     let expr = bun_ast::Expr::init(bun_ast::E::EString::init(encoded), bun_ast::Loc::EMPTY);
     let stmt = bun_ast::Stmt::alloc(
         bun_ast::S::ExportDefault {

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2166,7 +2166,10 @@ fn parse_base64_or_dataurl_loader<'a>(
     let encoded: Vec<u8> = if matches!(loader, options::Loader::Base64) {
         bun_base64::encode_alloc(contents)
     } else {
-        let mime = DataURL::guess_mime_type(path.text, contents);
+        let mime = match DataURL::parse(path.text) {
+            Ok(Some(u)) if !u.mime_type.is_empty() => u.mime_type.to_vec(),
+            _ => DataURL::guess_mime_type(path.text, contents),
+        };
         DataURL::encode_string_as_shortest_data_url(&mime, contents)
     };
     // SAFETY: ARENA — `arena` outlives the returned `ParseResult.ast` (the AST

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1427,11 +1427,16 @@ impl<'a> Transpiler<'a> {
             if matches!(loader, options::Loader::Base64 | options::Loader::Dataurl) {
                 let read = match file_descriptor {
                     Some(fd) => bun_sys::lseek(fd, 0, libc::SEEK_SET)
-                        .and_then(|_| bun_sys::File::borrow(&fd).read_to_end()),
-                    None => bun_sys::File::read_from(FD::cwd(), path.text),
+                        .and_then(|_| bun_sys::File::borrow(&fd).read_to_end())
+                        .map(|b| (fd, b)),
+                    None => bun_sys::File::openat(FD::cwd(), path.text, bun_sys::O::RDONLY, 0)
+                        .and_then(|f| {
+                            let body = f.read_to_end()?;
+                            Ok((f.into_raw(), body))
+                        }),
                 };
-                let body = match read {
-                    Ok(b) => b,
+                let (fd, body) = match read {
+                    Ok(v) => v,
                     Err(err) => {
                         let _ = log.add_error_fmt(
                             None,
@@ -1445,6 +1450,10 @@ impl<'a> Transpiler<'a> {
                         return None;
                     }
                 };
+                input_fd = Some(fd);
+                if let Some(file_fd_ptr) = this_parse.file_fd_ptr.take() {
+                    *file_fd_ptr = fd;
+                }
                 source_backing = resolver::cache::Contents::from(body);
                 // SAFETY: `source_backing` outlives every read through
                 // `source.contents` (moved into the returned `ParseResult`).

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1433,9 +1433,6 @@ impl<'a> Transpiler<'a> {
                     None => bun_sys::File::openat(FD::cwd(), path.text, bun_sys::O::RDONLY, 0)
                         .and_then(|f| {
                             let body = f.read_to_end()?;
-                            // Only disarm Drop when the caller owns the fd
-                            // (runtime watcher via `file_fd_ptr`); otherwise
-                            // let `f` close itself here.
                             let fd = publish_fd.then(|| f.into_raw());
                             Ok((fd, body))
                         }),

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1422,6 +1422,37 @@ impl<'a> Transpiler<'a> {
                 break 'brk bun_ast::Source::init_path_string(path.text, contents);
             }
 
+            // `read_file_with_allocator` strips/transcodes BOMs; the raw-binary
+            // loaders need the file bytes verbatim.
+            if matches!(loader, options::Loader::Base64 | options::Loader::Dataurl) {
+                let read = match file_descriptor {
+                    Some(fd) => bun_sys::lseek(fd, 0, libc::SEEK_SET)
+                        .and_then(|_| bun_sys::File::borrow(&fd).read_to_end()),
+                    None => bun_sys::File::read_from(FD::cwd(), path.text),
+                };
+                let body = match read {
+                    Ok(b) => b,
+                    Err(err) => {
+                        let _ = log.add_error_fmt(
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            format_args!(
+                                "{} reading \"{}\"",
+                                bstr::BStr::new(err.name()),
+                                bstr::BStr::new(path.text),
+                            ),
+                        );
+                        return None;
+                    }
+                };
+                source_backing = resolver::cache::Contents::from(body);
+                // SAFETY: `source_backing` outlives every read through
+                // `source.contents` (moved into the returned `ParseResult`).
+                let contents: &'static [u8] =
+                    unsafe { bun_ptr::detach_lifetime_ref::<[u8]>(source_backing.as_slice()) };
+                break 'brk bun_ast::Source::init_path_string(path.text, contents);
+            }
+
             // Thread
             // `this_parse.arena` (the per-call `MimallocArena` from
             // `RuntimeTranspilerStore`) so the source bytes land in the

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3982,7 +3982,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         break;
                     }
                 }
-            } else if loader == options::Loader::File || loader == options::Loader::Text {
+            } else if matches!(
+                loader,
+                options::Loader::File
+                    | options::Loader::Text
+                    | options::Loader::Base64
+                    | options::Loader::Dataurl
+                    | options::Loader::Md
+            ) {
                 // arena-owned `StoreSlice<ClauseItem>` valid for parser 'a.
                 for item in stmt.items.iter() {
                     // `ClauseItem.alias` is an arena-owned `StoreStr` valid for 'a.

--- a/src/resolver/data_url.rs
+++ b/src/resolver/data_url.rs
@@ -170,10 +170,7 @@ impl<'a> DataURL<'a> {
         bun_http_types::MimeType::MimeType::init(self.mime_type, false, None)
     }
 
-    /// Derive the MIME type string for a `data:` URL from the file extension,
-    /// falling back to a whatwg binary-byte content sniff when the extension
-    /// is unknown. `text/*` types without an explicit charset are suffixed
-    /// with `;charset=utf-8` (esbuild parity).
+    /// MIME type for a `data:` URL: by extension, else a binary-byte sniff.
     pub fn guess_mime_type(path: &[u8], contents: &[u8]) -> Vec<u8> {
         let ext = strings::trim_leading_char(bun_paths::extension(path), b'.');
         if let Some(mime) = bun_http_types::MimeType::by_extension_no_default(ext) {

--- a/src/resolver/data_url.rs
+++ b/src/resolver/data_url.rs
@@ -173,6 +173,15 @@ impl<'a> DataURL<'a> {
     /// MIME type for a `data:` URL: by extension, else a binary-byte sniff.
     pub fn guess_mime_type(path: &[u8], contents: &[u8]) -> Vec<u8> {
         let ext = strings::trim_leading_char(bun_paths::extension(path), b'.');
+        let mut lower = [0u8; 32];
+        let ext: &[u8] = if ext.len() <= lower.len() {
+            for (i, &b) in ext.iter().enumerate() {
+                lower[i] = b.to_ascii_lowercase();
+            }
+            &lower[..ext.len()]
+        } else {
+            ext
+        };
         if let Some(mime) = bun_http_types::MimeType::by_extension_no_default(ext) {
             let value = &*mime.value;
             if strings::has_prefix_comptime(value, b"text/")

--- a/src/resolver/data_url.rs
+++ b/src/resolver/data_url.rs
@@ -170,6 +170,37 @@ impl<'a> DataURL<'a> {
         bun_http_types::MimeType::MimeType::init(self.mime_type, false, None)
     }
 
+    /// Derive the MIME type string for a `data:` URL from the file extension,
+    /// falling back to a whatwg binary-byte content sniff when the extension
+    /// is unknown. `text/*` types without an explicit charset are suffixed
+    /// with `;charset=utf-8` (esbuild parity).
+    pub fn guess_mime_type(path: &[u8], contents: &[u8]) -> Vec<u8> {
+        let ext = strings::trim_leading_char(bun_paths::extension(path), b'.');
+        if let Some(mime) = bun_http_types::MimeType::by_extension_no_default(ext) {
+            let value = &*mime.value;
+            if strings::has_prefix_comptime(value, b"text/")
+                && !strings::contains(value, b"charset")
+            {
+                let mut v = Vec::with_capacity(value.len() + b";charset=utf-8".len());
+                v.extend_from_slice(value);
+                v.extend_from_slice(b";charset=utf-8");
+                return v;
+            }
+            return value.to_vec();
+        }
+        // https://mimesniff.spec.whatwg.org/#binary-data-byte
+        let n = contents.len().min(512);
+        let binary = !strings::is_valid_utf8(contents)
+            || contents[..n]
+                .iter()
+                .any(|&b| matches!(b, 0x00..=0x08 | 0x0B | 0x0E..=0x1A | 0x1C..=0x1F));
+        if binary {
+            b"application/octet-stream".to_vec()
+        } else {
+            b"text/plain;charset=utf-8".to_vec()
+        }
+    }
+
     /// Decodes the data from the data URL. Always returns an owned slice.
     pub fn decode_data(&self) -> Result<Vec<u8>, DecodeDataError> {
         let percent_decoded_owned: Option<Vec<u8>> = PercentEncoding::decode_unstrict(self.data)?;

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2126,6 +2126,8 @@ fn transpile_source_code_inner(
         | L::Yaml
         | L::Json5
         | L::Text
+        | L::Base64
+        | L::Dataurl
         | L::Md => {
             // `bun_ast::ASTMemoryAllocator::Scope`.
             let mut _ast_scope = bun_ast::ast_memory_allocator::Scope::default();

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -355,6 +355,9 @@ describe("base64 / dataurl", () => {
     { type: "base64", file: "png.png", contents: Buffer.from("89504e470d0a1a0a", "hex"), expected: "iVBORw0KGgo=" },
     { type: "base64", file: "bin.foo", contents: Buffer.from([0x00, 0xff, 0x80, 0x7f]), expected: "AP+Afw==" },
     { type: "base64", file: "empty.foo", contents: "", expected: "" },
+    { type: "base64", file: "u16.foo", contents: Buffer.from([0xff, 0xfe, 0x41, 0x00]), expected: "//5BAA==" },
+    { type: "base64", file: "u8.foo", contents: Buffer.from([0xef, 0xbb, 0xbf, 0x41]), expected: "77u/QQ==" },
+    { type: "dataurl", file: "style.css", contents: "ABC", expected: "data:text/css;charset=utf-8,ABC" },
     { type: "dataurl", file: "text.foo", contents: "ABC", expected: "data:text/plain;charset=utf-8,ABC" },
     {
       type: "dataurl",
@@ -399,21 +402,19 @@ describe("base64 / dataurl", () => {
     });
   }
 
-  for (const loader of ["base64", "dataurl"] as const) {
-    test.concurrent(`bun build --no-bundle --loader .bin:${loader}`, async () => {
-      using dir = tempDir("no-bundle-b64", {
-        "entry.bin": loader === "base64" ? "ABC" : Buffer.from("89504e470d0a1a0a", "hex"),
-      });
+  for (const [loader, contents, expected] of [
+    ["base64", "ABC", `export default "QUJD";`],
+    ["base64", Buffer.from([0xff, 0xfe, 0x41, 0x00]), `export default "//5BAA==";`],
+    ["dataurl", Buffer.from("89504e470d0a1a0a", "hex"), `export default "data:image/png;base64,iVBORw0KGgo=";`],
+  ] as const) {
+    test.concurrent(`bun build --no-bundle --loader .png:${loader} (${expected})`, async () => {
+      using dir = tempDir("no-bundle-b64", { "entry.png": contents });
       const { stdout, stderr, exitCode } = await run(
-        [bunExe(), "build", "--no-bundle", "--loader", `.bin:${loader}`, "entry.bin"],
+        [bunExe(), "build", "--no-bundle", "--loader", `.png:${loader}`, "entry.png"],
         String(dir),
       );
       expect(stderr).toBe("");
-      expect(stdout).toContain(
-        loader === "base64"
-          ? `export default "QUJD";`
-          : `export default "data:application/octet-stream;base64,iVBORw0KGgo=";`,
-      );
+      expect(stdout).toContain(expected);
       expect(exitCode).toBe(0);
     });
   }

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -1,4 +1,4 @@
-import { bunExe, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import * as path from "path";
 
 const loaders = ["js", "jsx", "ts", "tsx", "json", "jsonc", "toml", "yaml", "text", "sqlite", "file"];
@@ -339,6 +339,82 @@ describe("other loaders do not crash", () => {
   for (const skipped_loader of other_loaders_do_not_crash) {
     test(skipped_loader, async () => {
       await compileAndTest(`export const a = "demo";`);
+    });
+  }
+});
+
+describe("base64 / dataurl", () => {
+  async function run(cmd: string[], dir: string) {
+    await using proc = Bun.spawn({ cmd, env: bunEnv, cwd: dir, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const cases = [
+    { type: "base64", file: "text.foo", contents: "ABC", expected: "QUJD" },
+    { type: "base64", file: "png.png", contents: Buffer.from("89504e470d0a1a0a", "hex"), expected: "iVBORw0KGgo=" },
+    { type: "base64", file: "bin.foo", contents: Buffer.from([0x00, 0xff, 0x80, 0x7f]), expected: "AP+Afw==" },
+    { type: "base64", file: "empty.foo", contents: "", expected: "" },
+    { type: "dataurl", file: "text.foo", contents: "ABC", expected: "data:text/plain;charset=utf-8,ABC" },
+    {
+      type: "dataurl",
+      file: "png.png",
+      contents: Buffer.from("89504e470d0a1a0a", "hex"),
+      expected: "data:image/png;base64,iVBORw0KGgo=",
+    },
+    {
+      type: "dataurl",
+      file: "bin.foo",
+      contents: Buffer.from([0x00, 0xff, 0x80, 0x7f]),
+      expected: "data:application/octet-stream;base64,AP+Afw==",
+    },
+    { type: "dataurl", file: "empty.foo", contents: "", expected: "data:text/plain;charset=utf-8," },
+  ] as const;
+
+  for (const form of ["static", "dynamic"] as const) {
+    test.concurrent(`runtime import attribute (${form})`, async () => {
+      // One file per (type, payload) pair: the runtime module cache is keyed by
+      // resolved path, so importing the same file with two different `type`
+      // attributes returns the first-loaded module for both.
+      const files: Record<string, string | Buffer> = {};
+      const stmts: string[] = [];
+      const wants: Record<string, string> = {};
+      for (const [i, c] of cases.entries()) {
+        files[`${i}-${c.file}`] = c.contents;
+        stmts.push(
+          form === "static"
+            ? `import v${i} from "./${i}-${c.file}" with { type: "${c.type}" };`
+            : `const v${i} = (await import("./${i}-${c.file}", { with: { type: "${c.type}" } })).default;`,
+        );
+        wants[`v${i}`] = c.expected;
+      }
+      files["entry.ts"] =
+        stmts.join("\n") + `\nconsole.log(JSON.stringify({ ${cases.map((_, i) => `v${i}`).join(", ")} }));`;
+
+      using dir = tempDir("import-attributes-b64", files);
+      const { stdout, stderr, exitCode } = await run([bunExe(), "entry.ts"], String(dir));
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(wants);
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  for (const loader of ["base64", "dataurl"] as const) {
+    test.concurrent(`bun build --no-bundle --loader .bin:${loader}`, async () => {
+      using dir = tempDir("no-bundle-b64", {
+        "entry.bin": loader === "base64" ? "ABC" : Buffer.from("89504e470d0a1a0a", "hex"),
+      });
+      const { stdout, stderr, exitCode } = await run(
+        [bunExe(), "build", "--no-bundle", "--loader", `.bin:${loader}`, "entry.bin"],
+        String(dir),
+      );
+      expect(stderr).toBe("");
+      expect(stdout).toContain(
+        loader === "base64"
+          ? `export default "QUJD";`
+          : `export default "data:application/octet-stream;base64,iVBORw0KGgo=";`,
+      );
+      expect(exitCode).toBe(0);
     });
   }
 });

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -358,6 +358,12 @@ describe("base64 / dataurl", () => {
     { type: "base64", file: "u16.foo", contents: Buffer.from([0xff, 0xfe, 0x41, 0x00]), expected: "//5BAA==" },
     { type: "base64", file: "u8.foo", contents: Buffer.from([0xef, 0xbb, 0xbf, 0x41]), expected: "77u/QQ==" },
     { type: "dataurl", file: "style.css", contents: "ABC", expected: "data:text/css;charset=utf-8,ABC" },
+    {
+      type: "dataurl",
+      file: "IMG.PNG",
+      contents: Buffer.from("89504e470d0a1a0a", "hex"),
+      expected: "data:image/png;base64,iVBORw0KGgo=",
+    },
     { type: "dataurl", file: "text.foo", contents: "ABC", expected: "data:text/plain;charset=utf-8,ABC" },
     {
       type: "dataurl",
@@ -418,6 +424,25 @@ describe("base64 / dataurl", () => {
       expect(exitCode).toBe(0);
     });
   }
+
+  test.concurrent("data: URL specifier preserves its declared MIME", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      [
+        bunExe(),
+        "-e",
+        `import png from "data:image/png;base64,iVBORw0KGgo=" with { type: "dataurl" };
+         import b64 from "data:application/json,ABC" with { type: "base64" };
+         console.log(JSON.stringify({ png, b64 }));`,
+      ],
+      process.cwd(),
+    );
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      png: "data:image/png;base64,iVBORw0KGgo=",
+      b64: "QUJD",
+    });
+    expect(exitCode).toBe(0);
+  });
 });
 
 describe("?raw", () => {

--- a/test/js/bun/resolve/import-empty.test.js
+++ b/test/js/bun/resolve/import-empty.test.js
@@ -75,8 +75,6 @@ it("importing empty file returns module with path as default export", async () =
   const other_types = [
     "wasm",
     // "napi", // marked unreachable in src/jsc/ModuleLoader.zig:1956:22
-    "base64",
-    "dataurl",
   ];
 
   for (const type of other_types) {
@@ -84,6 +82,18 @@ it("importing empty file returns module with path as default export", async () =
 
     const empty_file_module = await import("./empty-file", { with: { type } });
     expect(empty_file_module.default).toEqual(empty_file_path);
+  }
+});
+
+it("importing empty base64/dataurl file returns the encoded empty string", async () => {
+  for (const [type, expected] of [
+    ["base64", ""],
+    ["dataurl", "data:text/plain;charset=utf-8,"],
+  ]) {
+    delete require.cache[require.resolve(`./empty-file`)];
+
+    const empty_file_module = await import("./empty-file", { with: { type } });
+    expect(empty_file_module.default).toEqual(expected);
   }
 });
 


### PR DESCRIPTION
### Problem

Two non-bundler code paths don't handle the `base64` and `dataurl` loaders:

**Runtime** (`bun script.ts`): importing a file with `with { type: "base64" }` or `with { type: "dataurl" }` falls through to the file-loader arm in `transpile_source_code_inner` and silently exports the resolved path string instead of the encoded bytes:

```sh
$ printf 'ABC' > f.png
$ bun -e 'import x from "./f.png" with {type:"base64"}; console.log(x)'
/tmp/f.png          # expected: QUJD
```

**`bun build --no-bundle`**: hits an explicit `panic: TODO: dataurl, base64` in `build_with_resolve_result_eager`:

```sh
$ bun build --no-bundle --loader .bin:base64 entry.bin
panic: TODO: dataurl, base64
```

Both are pre-existing; #36327 implements these loaders in the bundler's `ParseTask::get_ast` but that path is not reached for runtime imports or `--no-bundle`.

### Fix

Route `Loader::Base64` and `Loader::Dataurl` through the existing parse/print path, the same way `Loader::Text` and `Loader::Md` already flow:

- `jsc_hooks.rs::transpile_source_code_inner`: add both to the JS-like match arm (falls through to the `Text`/`Md` branch of every inner switch; `parse_maybe_return_file_only` reads the file).
- `transpiler.rs::build_with_resolve_result_eager`: add both to the JS-like arm, delete the panic arm.
- `transpiler.rs::parse_maybe_return_file_only_allow_shared_buffer`: route to a new `parse_base64_or_dataurl_loader` (modeled on `parse_text_loader`) that emits `export default "<encoded>"` via `bun_base64::encode_alloc` / `DataURL::encode_string_as_shortest_data_url`.
- `loader.rs::handles_empty_file`: add both so an empty input yields `""` / `data:<mime>,` rather than an empty module.
- `data_url.rs`: add `DataURL::guess_mime_type` (extension lookup with a whatwg binary-byte content sniff for unknown extensions, `;charset=utf-8` suffix for `text/*`). Shared so it can also serve the bundler path.

esbuild with the same inputs:

```
--loader:.foo=base64   "ABC"        ->  "QUJD"
--loader:.foo=dataurl  "ABC"        ->  "data:text/plain;charset=utf-8,ABC"
--loader:.png=dataurl  <png magic>  ->  "data:image/png;base64,iVBORw0KGgo="
```

### Verification

New tests in `test/js/bun/import-attributes/import-attributes.test.ts` cover static import, dynamic `import()`, and `bun build --no-bundle --loader`, for text / known-extension binary / unknown-extension binary / empty inputs.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/import-attributes/import-attributes.test.ts test/js/bun/resolve/import-empty.test.js
bun test v1.4.0 (d1cb34735)

test/js/bun/resolve/import-empty.test.js:
(pass) importing empty text file returns empty string [25.78ms]
(pass) importing empty file with type file returns it path [6.25ms]
(pass) importing empty css file returns an empty object [6.04ms]
(pass) importing empty html file returns HTMLBundle with its path [6.16ms]
(pass) importing empty js like file returns empty module [40.45ms]
(pass) importing empty json file throws JSON Parse error [10.69ms]
(pass) importing empty jsonc/toml file returns module with empty object as default export [13.68ms]
(pass) importing empty file returns module with path as default export [9.01ms]
91 |     ["dataurl", "data:text/plain;charset=utf-8,"],
92 |   ]) {
93 |     delete require.cache[require.resolve(`./empty-file`)];
94 | 
95 |     const empty_file_module = await import("./empty-file", { with: { type } });
96 |     expect(empty_file_module.default).toEqual(expected);
            
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (cda921fb6)

test/js/bun/resolve/import-empty.test.js:
(pass) importing empty text file returns empty string [1.28ms]
(pass) importing empty file with type file returns it path [0.10ms]
(pass) importing empty css file returns an empty object [0.08ms]
(pass) importing empty html file returns HTMLBundle with its path [0.08ms]
(pass) importing empty js like file returns empty module [2.62ms]
(pass) importing empty json file throws JSON Parse error [0.33ms]
(pass) importing empty jsonc/toml file returns module with empty object as default export [0.31ms]
(pass) importing empty file returns module with path as default export [0.14ms]
(pass) importing empty base64/dataurl file returns the encoded empty string [0.29ms]
(pass) importing empty sqlite files returns database object [0.75ms]

test/js/bun/import-attributes/import-attributes.test.ts:
(pass) javascript [129.09ms]
(pass) typescript [115.96ms]
(pass) json [108.63ms]
(pass) jsonc [116.20ms]
(pass) toml [102.04ms]
(pass) yaml [97.66ms]
(pass) tsconfig.json is assumed jsonc [38.96ms]
(pass) other loaders do not crash > webassembly [86.36ms]
(pass) other loaders do not crash > does_not_exist [11
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/import-attributes/import-attributes.test.ts test/js/bun/resolve/import-empty.test.js
bun test v1.4.0 (d1cb34735)

test/js/bun/resolve/import-empty.test.js:
(pass) importing empty text file returns empty string [25.37ms]
(pass) importing empty file with type file returns it path [6.39ms]
(pass) importing empty css file returns an empty object [6.02ms]
(pass) importing empty html file returns HTMLBundle with its path [6.63ms]
(pass) importing empty js like file returns empty module [55.64ms]
(pass) importing empty json file throws JSON Parse error [11.74ms]
(pass) importing empty jsonc/toml file returns module with empty object as default export [15.98ms]
(pass) importing empty file returns module with path as default export [9.63ms]
(pass) importing empty base64/dataurl file returns the encoded empty string [17.12ms]
(pass) importing empty sqlite files returns database object [28.11ms]

test/js/bun/import-attributes/import-attributes.test.ts:
(pass) javascript [1534.55ms]
(pass) typescript [1323.99ms]
(pass) json [1244.42ms]
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 700ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/loader.rs                                  |   7 +-
 src/bundler/transpiler.rs                          | 114 ++++++++++++++++++++-
 src/js_parser/p.rs                                 |   9 +-
 src/resolver/data_url.rs                           |  37 +++++++
 src/runtime/jsc_hooks.rs                           |   2 +
 .../import-attributes/import-attributes.test.ts    | 104 ++++++++++++++++++-
 test/js/bun/resolve/import-empty.test.js           |  14 ++-
 7 files changed, 277 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/ast/loader.rs                                            2      2      0
src/bundler/transpiler.rs                                   12     12      0
src/js_parser/p.rs                                           1      1      0
src/resolver/data_url.rs                                     5      3      0
src/runtime/jsc_hooks.rs                                     6      1      0
test/js/bun/import-attributes/import-attributes.test.ts      4     11      0
test/js/bun/resolve/import-empty.test.js                     1      1      0
```

</details>

<!-- robobun:evidence:end -->