### PR TITLE
http: return owning HTTPResponseMetadata from send_sync instead of leaking it

### DIFF
--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -601,7 +601,12 @@ fn send_sync_callback(
     if let Some(mut real) = async_http.real {
         // SAFETY: `real` outlives the HTTP-thread copy by construction.
         let real = unsafe { real.as_mut() };
-        real.response = async_http.response;
+        // Do not copy `response` back: it is a bitwise alias of
+        // `metadata.response`, whose buffers are freed when the caller drops
+        // the `HTTPResponseMetadata` returned by `send_sync`, so a stored copy
+        // would dangle. No sync caller reads `real.response`; they use the
+        // returned value.
+        real.response = None;
         real.err = async_http.err;
         real.elapsed = async_http.elapsed;
         real.response_buffer = async_http.response_buffer;
@@ -616,7 +621,7 @@ fn send_sync_callback(
 }
 
 impl<'a> AsyncHTTP<'a> {
-    pub fn send_sync(&mut self) -> crate::Result<picohttp::Response<'static>> {
+    pub fn send_sync(&mut self) -> crate::Result<crate::HTTPResponseMetadata> {
         crate::http_thread::init(&Default::default());
 
         // Note: `Box::leak` is forbidden (PORTING.md §Forbidden);
@@ -646,11 +651,11 @@ impl<'a> AsyncHTTP<'a> {
             // a network error rather than panicking on network-driven state.
             return Err(crate::Error::ConnectionClosed);
         };
-        // The returned `Response` borrows `metadata.owned_buf` (status text +
-        // header slices); suppress Drop so the borrowed buffer outlives the
-        // call. `send_sync` is one-shot CLI.
-        let metadata = core::mem::ManuallyDrop::new(metadata);
-        Ok(metadata.response)
+        // `metadata.response` borrows `metadata.owned_buf` (status text +
+        // header slices), so hand the whole metadata to the caller. Its
+        // `Deref` exposes the inner `Response`, and `Drop` reclaims the
+        // buffers when the caller is done.
+        Ok(metadata)
     }
 
     // ──────────────────────────────────────────────────────────────────────

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -601,11 +601,8 @@ fn send_sync_callback(
     if let Some(mut real) = async_http.real {
         // SAFETY: `real` outlives the HTTP-thread copy by construction.
         let real = unsafe { real.as_mut() };
-        // Do not copy `response` back: it is a bitwise alias of
-        // `metadata.response`, whose buffers are freed when the caller drops
-        // the `HTTPResponseMetadata` returned by `send_sync`, so a stored copy
-        // would dangle. No sync caller reads `real.response`; they use the
-        // returned value.
+        // `response` aliases the metadata `send_sync` hands to the caller; a
+        // stored copy would dangle once that metadata is dropped.
         real.response = None;
         real.err = async_http.err;
         real.elapsed = async_http.elapsed;
@@ -651,10 +648,6 @@ impl<'a> AsyncHTTP<'a> {
             // a network error rather than panicking on network-driven state.
             return Err(crate::Error::ConnectionClosed);
         };
-        // `metadata.response` borrows `metadata.owned_buf` (status text +
-        // header slices), so hand the whole metadata to the caller. Its
-        // `Deref` exposes the inner `Response`, and `Drop` reclaims the
-        // buffers when the caller is done.
         Ok(metadata)
     }
 

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -130,15 +130,9 @@ impl Default for HTTPResponseMetadata {
     }
 }
 
-// `send_sync` returns the whole metadata so the borrowed `Response` cannot
-// outlive its backing buffers; callers that only read `Response` fields go
-// through this `Deref` and stay unchanged.
-//
-// CAUTION: the `Response` is typed `'static` but its status text and header
-// slices actually borrow the sibling `owned_buf` (and the leaked headers
-// slice) that `Drop` frees. The borrow checker cannot stop a slice obtained
-// via `res.headers.get(..)` from escaping the metadata's scope, so keep all
-// such borrows strictly inside it.
+// Lets `send_sync` callers keep reading `Response` fields. CAUTION: the target
+// is typed `'static` but its slices borrow the sibling `owned_buf` / header
+// slice that `Drop` frees; do not let a slice escape the metadata's scope.
 impl core::ops::Deref for HTTPResponseMetadata {
     type Target = bun_picohttp::Response<'static>;
 

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -130,6 +130,23 @@ impl Default for HTTPResponseMetadata {
     }
 }
 
+// `send_sync` returns the whole metadata so the borrowed `Response` cannot
+// outlive its backing buffers; callers that only read `Response` fields go
+// through this `Deref` and stay unchanged.
+//
+// CAUTION: the `Response` is typed `'static` but its status text and header
+// slices actually borrow the sibling `owned_buf` (and the leaked headers
+// slice) that `Drop` frees. The borrow checker cannot stop a slice obtained
+// via `res.headers.get(..)` from escaping the metadata's scope, so keep all
+// such borrows strictly inside it.
+impl core::ops::Deref for HTTPResponseMetadata {
+    type Target = bun_picohttp::Response<'static>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.response
+    }
+}
+
 impl Drop for HTTPResponseMetadata {
     // `owned_buf` is freed by
     // `Box`'s own Drop; `response.headers.list` was `Box::leak`'d in

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -130,14 +130,25 @@ impl Default for HTTPResponseMetadata {
     }
 }
 
-// Lets `send_sync` callers keep reading `Response` fields. CAUTION: the target
-// is typed `'static` but its slices borrow the sibling `owned_buf` / header
-// slice that `Drop` frees; do not let a slice escape the metadata's scope.
-impl core::ops::Deref for HTTPResponseMetadata {
-    type Target = bun_picohttp::Response<'static>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.response
+impl HTTPResponseMetadata {
+    /// Accessors tied to `&self`: `response` is typed `'static` but its slices
+    /// borrow the sibling `owned_buf` / header slice that `Drop` frees, so
+    /// hand out reborrows that cannot outlive this metadata.
+    #[inline]
+    pub fn status_code(&self) -> u32 {
+        self.response.status_code
+    }
+    #[inline]
+    pub fn status_text(&self) -> &[u8] {
+        self.response.status
+    }
+    #[inline]
+    pub fn header(&self, name: &[u8]) -> Option<&[u8]> {
+        self.response.headers.get(name)
+    }
+    #[inline]
+    pub fn header_if_other_is_absent(&self, name: &[u8], other: &[u8]) -> Option<&[u8]> {
+        self.response.headers.get_if_other_is_absent(name, other)
     }
 }
 

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -176,15 +176,12 @@ pub fn whoami(manager: &mut PackageManager) -> Result<Vec<u8>, WhoamiError> {
         }
     };
 
-    if res.status_code >= 400 {
+    if res.status_code() >= 400 {
         const OTP_RESPONSE: bool = false;
         response_error::<OTP_RESPONSE>(&req, &res, None, &mut response_buf)?;
     }
 
-    if let Some(notice) = res
-        .headers
-        .get_if_other_is_absent(b"npm-notice", b"x-local-cache")
-    {
+    if let Some(notice) = res.header_if_other_is_absent(b"npm-notice", b"x-local-cache") {
         Output::print_error("\n");
         bun_core::note!("{}", bstr::BStr::new(notice));
         Output::flush();
@@ -221,7 +218,7 @@ pub fn whoami(manager: &mut PackageManager) -> Result<Vec<u8>, WhoamiError> {
 
 pub fn response_error<const OTP_RESPONSE: bool>(
     req: &AsyncHTTP,
-    res: &picohttp::Response,
+    res: &bun_http::HTTPResponseMetadata,
     // `<name>@<version>`
     pkg_id: Option<(&[u8], &[u8])>,
     response_body: &mut MutableString,
@@ -246,13 +243,13 @@ pub fn response_error<const OTP_RESPONSE: bool>(
 
     bun_core::pretty_errorln!(
         "\n<red>{}<r>{}{}: {}\n",
-        res.status_code,
-        if !res.status.is_empty() { " " } else { "" },
-        bstr::BStr::new(&res.status),
+        res.status_code(),
+        if !res.status_text().is_empty() { " " } else { "" },
+        bstr::BStr::new(res.status_text()),
         bun_fmt::redacted_npm_url(req.url.href),
     );
 
-    if res.status_code == 404
+    if res.status_code() == 404
         && let Some((package_name, package_version)) = pkg_id
     {
         bun_core::pretty_errorln!(
@@ -262,7 +259,7 @@ pub fn response_error<const OTP_RESPONSE: bool>(
         );
     } else if let Some(msg) = &message {
         if OTP_RESPONSE {
-            if res.status_code == 401
+            if res.status_code() == 401
                 && strings::contains(
                     msg,
                     b"You must provide a one-time pass. Upgrade your client to npm@latest in order to use 2FA.",

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -244,7 +244,11 @@ pub fn response_error<const OTP_RESPONSE: bool>(
     bun_core::pretty_errorln!(
         "\n<red>{}<r>{}{}: {}\n",
         res.status_code(),
-        if !res.status_text().is_empty() { " " } else { "" },
+        if !res.status_text().is_empty() {
+            " "
+        } else {
+            ""
+        },
         bstr::BStr::new(res.status_text()),
         bun_fmt::redacted_npm_url(req.url.href),
     );

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -493,10 +493,10 @@ fn send_audit_request(
         }
     };
 
-    if res.status_code >= 400 {
+    if res.status_code() >= 400 {
         bun_core::pretty_errorln!(
             "<red>error<r>: audit request failed (status {})",
-            res.status_code
+            res.status_code()
         );
         Global::crash();
     }

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1970,7 +1970,7 @@ impl Example {
 
         let response = async_http.send_sync()?;
 
-        match response.status_code {
+        match response.status_code() {
             404 => return Err(crate::Error::GitHubRepositoryNotFound),
             403 => return Err(crate::Error::HTTPForbidden),
             429 => return Err(crate::Error::HTTPTooManyRequests),
@@ -1979,7 +1979,7 @@ impl Example {
             _ => return Err(crate::Error::HTTPError),
         }
 
-        let content_type: &[u8] = response.headers.get(b"content-type").unwrap_or(b"");
+        let content_type: &[u8] = response.header(b"content-type").unwrap_or(b"");
         let is_expected_content_type = content_type == b"application/x-gzip";
 
         if !is_expected_content_type {
@@ -2074,7 +2074,7 @@ impl Example {
 
         let mut response = async_http.send_sync()?;
 
-        match response.status_code {
+        match response.status_code() {
             404 => return Err(crate::Error::ExampleNotFound),
             403 => return Err(crate::Error::HTTPForbidden),
             429 => return Err(crate::Error::HTTPTooManyRequests),
@@ -2172,12 +2172,12 @@ impl Example {
 
         refresher.maybe_refresh();
 
-        if response.status_code != 200 {
+        if response.status_code() != 200 {
             progress.end();
             refresher.refresh();
             bun_core::pretty_errorln!(
                 "Error fetching tarball: <r><red>{}<r>",
-                response.status_code,
+                response.status_code(),
             );
             Global::exit(1);
         }
@@ -2233,10 +2233,10 @@ impl Example {
             }
         };
 
-        if response.status_code != 200 {
+        if response.status_code() != 200 {
             bun_core::pretty_errorln!(
                 "<r><red>{} {}<r> fetching examples :( ",
-                response.status_code,
+                response.status_code(),
                 bstr::BStr::new(mutable.list.as_slice()),
             );
             Global::exit(1);

--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -134,7 +134,7 @@ pub(crate) fn view(
         }
     };
 
-    if res.status_code >= 400 {
+    if res.status_code() >= 400 {
         npm::response_error::<false>(&req, &res, Some((name, version)), &mut response_buf)?;
     }
 

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -852,7 +852,7 @@ impl PublishCommand {
         let Ok(res) = req.send_sync() else {
             return false;
         };
-        if res.status_code != 200 {
+        if res.status_code() != 200 {
             return false;
         }
 
@@ -985,14 +985,14 @@ impl PublishCommand {
             }
         };
 
-        match res.status_code {
+        match res.status_code() {
             400..=u32::MAX => {
                 let prompt_for_otp = 'prompt_for_otp: {
-                    if res.status_code != 401 {
+                    if res.status_code() != 401 {
                         break 'prompt_for_otp false;
                     }
 
-                    if let Some(www_authenticate) = res.headers.get(b"www-authenticate") {
+                    if let Some(www_authenticate) = res.header(b"www-authenticate") {
                         let mut iter = strings::split(www_authenticate, b",");
                         while let Some(part) = iter.next() {
                             let trimmed = strings::trim(part, &strings::WHITESPACE_CHARS);
@@ -1032,9 +1032,8 @@ impl PublishCommand {
 
                 // https://github.com/npm/cli/blob/534ad7789e5c61f579f44d782bdd18ea3ff1ee20/node_modules/npm-registry-fetch/lib/check-response.js#L14
                 // ignore if x-local-cache exists
-                if let Some(notice) = res
-                    .headers
-                    .get_if_other_is_absent(b"npm-notice", b"x-local-cache")
+                if let Some(notice) =
+                    res.header_if_other_is_absent(b"npm-notice", b"x-local-cache")
                 {
                     Output::print_error(format_args!("\n"));
                     bun_core::note!("{}", bstr::BStr::new(notice));
@@ -1082,7 +1081,7 @@ impl PublishCommand {
                     }
                 };
 
-                match otp_res.status_code {
+                match otp_res.status_code() {
                     400..=u32::MAX => {
                         Npm::response_error::<true>(
                             &otp_req,
@@ -1094,9 +1093,8 @@ impl PublishCommand {
                     _ => {
                         // https://github.com/npm/cli/blob/534ad7789e5c61f579f44d782bdd18ea3ff1ee20/node_modules/npm-registry-fetch/lib/check-response.js#L14
                         // ignore if x-local-cache exists
-                        if let Some(notice) = otp_res
-                            .headers
-                            .get_if_other_is_absent(b"npm-notice", b"x-local-cache")
+                        if let Some(notice) =
+                            otp_res.header_if_other_is_absent(b"npm-notice", b"x-local-cache")
                         {
                             Output::print_error(format_args!("\n"));
                             bun_core::note!("{}", bstr::BStr::new(notice));
@@ -1301,11 +1299,11 @@ impl PublishCommand {
                         }
                     };
 
-                    match res.status_code {
+                    match res.status_code() {
                         202 => {
                             // retry
                             let nanoseconds: u64 = 'nanoseconds: {
-                                if let Some(retry) = res.headers.get(b"retry-after") {
+                                if let Some(retry) = res.header(b"retry-after") {
                                     'default: {
                                         let trimmed =
                                             strings::trim(retry, &strings::WHITESPACE_CHARS);
@@ -1359,9 +1357,8 @@ impl PublishCommand {
 
                             // https://github.com/npm/cli/blob/534ad7789e5c61f579f44d782bdd18ea3ff1ee20/node_modules/npm-registry-fetch/lib/check-response.js#L14
                             // ignore if x-local-cache exists
-                            if let Some(notice) = res
-                                .headers
-                                .get_if_other_is_absent(b"npm-notice", b"x-local-cache")
+                            if let Some(notice) =
+                                res.header_if_other_is_absent(b"npm-notice", b"x-local-cache")
                             {
                                 Output::print_error(format_args!("\n"));
                                 bun_core::note!("{}", bstr::BStr::new(notice));

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -1032,8 +1032,7 @@ impl PublishCommand {
 
                 // https://github.com/npm/cli/blob/534ad7789e5c61f579f44d782bdd18ea3ff1ee20/node_modules/npm-registry-fetch/lib/check-response.js#L14
                 // ignore if x-local-cache exists
-                if let Some(notice) =
-                    res.header_if_other_is_absent(b"npm-notice", b"x-local-cache")
+                if let Some(notice) = res.header_if_other_is_absent(b"npm-notice", b"x-local-cache")
                 {
                     Output::print_error(format_args!("\n"));
                     bun_core::note!("{}", bstr::BStr::new(notice));

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -280,7 +280,7 @@ impl UpgradeCommand {
         }
         let response = async_http.send_sync()?;
 
-        match response.status_code {
+        match response.status_code() {
             404 => return Err(crate::Error::HTTP404),
             403 => return Err(crate::Error::HTTPForbidden),
             429 => return Err(crate::Error::HTTPTooManyRequests),
@@ -673,7 +673,7 @@ impl UpgradeCommand {
 
             let response = async_http.send_sync()?;
 
-            match response.status_code {
+            match response.status_code() {
                 404 => {
                     if use_canary {
                         bun_core::pretty_errorln!(

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1575,7 +1575,7 @@ pub(crate) fn download_to_path(
             let send_result = async_http.send_sync();
 
             progress.end();
-            let status_code = send_result?.status_code as u16;
+            let status_code = send_result?.status_code() as u16;
 
             match status_code {
                 404 => {

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -419,9 +419,9 @@ test.skipIf(!isASAN)(
       stderr: "pipe",
       stdin: "ignore",
     });
-    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe("leakpkg");
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("clone_metadata");
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "leakpkg", exitCode: 0 });
     // Timeout: a detected leak makes llvm-symbolizer load the full DWARF of the
     // test binary before the assertion above can run; the no-leak path is < 1s.
   },

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -270,11 +270,11 @@ describe.concurrent("bun info", () => {
 
     it("should handle scoped packages", async () => {
       const testDir = await setupTest();
-      const { output, error, code } = await runCommand([bunExe(), "pm", "view", "@types/node"], testDir);
+      const { output, error, code } = await runCommand([bunExe(), "pm", "view", "@types/semver"], testDir);
 
       expect(code).toBe(0);
       expect(error).toBe("");
-      expect(output).toContain("@types/node@");
+      expect(output).toContain("@types/semver@");
       expect(output).toContain("TypeScript definitions");
     });
 

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -1,6 +1,7 @@
 import { spawn } from "bun";
 import { describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tempDirWithFiles } from "harness";
+import { join } from "node:path";
 
 describe.concurrent("bun info", () => {
   let i = 0;
@@ -371,13 +372,9 @@ describe.concurrent("bun info", () => {
   });
 });
 
-// `send_sync` used to wrap the returned HTTPResponseMetadata in ManuallyDrop,
-// leaking the cloned response-header buffer and its backing string storage on
-// every sync CLI request. LSan's default conservative scan only catches it when
-// no idle thread happens to park with a stale pointer in a callee-saved
-// register, so exclude registers as roots to make the check deterministic and
-// look for the clone_metadata allocation site. A local registry keeps this
-// hermetic.
+// LSan's default conservative scan only flags the `send_sync` response-metadata
+// leak when no idle thread parks with a stale pointer in a callee-saved
+// register; excluding registers as roots makes the check deterministic.
 test.skipIf(!isASAN)(
   "bun info does not leak the sync response metadata",
   async () => {
@@ -413,7 +410,7 @@ test.skipIf(!isASAN)(
         HTTP_PROXY: "",
         HTTPS_PROXY: "",
         ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
-        LSAN_OPTIONS: "use_registers=0:print_suppressions=0",
+        LSAN_OPTIONS: `use_registers=0:print_suppressions=0:suppressions=${join(import.meta.dirname, "../../leaksan.supp")}`,
       },
       stdout: "pipe",
       stderr: "pipe",

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
-import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { describe, expect, it, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, tempDirWithFiles } from "harness";
 
 describe.concurrent("bun info", () => {
   let i = 0;
@@ -370,3 +370,56 @@ describe.concurrent("bun info", () => {
     });
   });
 });
+
+// `send_sync` used to wrap the returned HTTPResponseMetadata in ManuallyDrop,
+// leaking the cloned response-header buffer and its backing string storage on
+// every sync CLI request. LSan's default conservative scan only catches it when
+// no idle thread happens to park with a stale pointer in a callee-saved
+// register, so exclude registers as roots to make the check deterministic and
+// look for the clone_metadata allocation site. A local registry keeps this
+// hermetic.
+test.skipIf(!isASAN)("bun info does not leak the sync response metadata", async () => {
+  const manifest = JSON.stringify({
+    name: "leakpkg",
+    "dist-tags": { latest: "0.0.1" },
+    versions: {
+      "0.0.1": {
+        name: "leakpkg",
+        version: "0.0.1",
+        dist: { tarball: "http://localhost/leakpkg-0.0.1.tgz", shasum: "0".repeat(40) },
+      },
+    },
+    time: { "0.0.1": "2020-01-01T00:00:00.000Z" },
+  });
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(manifest, { headers: { "content-type": "application/json" } });
+    },
+  });
+  const dir = tempDirWithFiles("bun-info-lsan", {
+    "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
+    "bunfig.toml": `[install]\nregistry = "http://localhost:${server.port}/"\n`,
+  });
+  await using proc = spawn({
+    cmd: [bunExe(), "info", "leakpkg", "name"],
+    cwd: dir,
+    env: {
+      ...bunEnv,
+      http_proxy: "",
+      https_proxy: "",
+      HTTP_PROXY: "",
+      HTTPS_PROXY: "",
+      ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1",
+      LSAN_OPTIONS: "use_registers=0:exitcode=0:print_suppressions=0",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout.trim()).toBe("leakpkg");
+  expect(stderr).not.toContain("clone_metadata");
+  // Timeout: a detected leak makes llvm-symbolizer load the full DWARF of the
+  // test binary before the assertion above can run; the no-leak path is < 1s.
+}, 30_000);

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -378,48 +378,52 @@ describe.concurrent("bun info", () => {
 // register, so exclude registers as roots to make the check deterministic and
 // look for the clone_metadata allocation site. A local registry keeps this
 // hermetic.
-test.skipIf(!isASAN)("bun info does not leak the sync response metadata", async () => {
-  const manifest = JSON.stringify({
-    name: "leakpkg",
-    "dist-tags": { latest: "0.0.1" },
-    versions: {
-      "0.0.1": {
-        name: "leakpkg",
-        version: "0.0.1",
-        dist: { tarball: "http://localhost/leakpkg-0.0.1.tgz", shasum: "0".repeat(40) },
+test.skipIf(!isASAN)(
+  "bun info does not leak the sync response metadata",
+  async () => {
+    const manifest = JSON.stringify({
+      name: "leakpkg",
+      "dist-tags": { latest: "0.0.1" },
+      versions: {
+        "0.0.1": {
+          name: "leakpkg",
+          version: "0.0.1",
+          dist: { tarball: "http://localhost/leakpkg-0.0.1.tgz", shasum: "0".repeat(40) },
+        },
       },
-    },
-    time: { "0.0.1": "2020-01-01T00:00:00.000Z" },
-  });
-  await using server = Bun.serve({
-    port: 0,
-    fetch() {
-      return new Response(manifest, { headers: { "content-type": "application/json" } });
-    },
-  });
-  const dir = tempDirWithFiles("bun-info-lsan", {
-    "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
-    "bunfig.toml": `[install]\nregistry = "http://localhost:${server.port}/"\n`,
-  });
-  await using proc = spawn({
-    cmd: [bunExe(), "info", "leakpkg", "name"],
-    cwd: dir,
-    env: {
-      ...bunEnv,
-      http_proxy: "",
-      https_proxy: "",
-      HTTP_PROXY: "",
-      HTTPS_PROXY: "",
-      ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1",
-      LSAN_OPTIONS: "use_registers=0:exitcode=0:print_suppressions=0",
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-    stdin: "ignore",
-  });
-  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout.trim()).toBe("leakpkg");
-  expect(stderr).not.toContain("clone_metadata");
-  // Timeout: a detected leak makes llvm-symbolizer load the full DWARF of the
-  // test binary before the assertion above can run; the no-leak path is < 1s.
-}, 30_000);
+      time: { "0.0.1": "2020-01-01T00:00:00.000Z" },
+    });
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(manifest, { headers: { "content-type": "application/json" } });
+      },
+    });
+    const dir = tempDirWithFiles("bun-info-lsan", {
+      "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
+      "bunfig.toml": `[install]\nregistry = "http://localhost:${server.port}/"\n`,
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "info", "leakpkg", "name"],
+      cwd: dir,
+      env: {
+        ...bunEnv,
+        http_proxy: "",
+        https_proxy: "",
+        HTTP_PROXY: "",
+        HTTPS_PROXY: "",
+        ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1",
+        LSAN_OPTIONS: "use_registers=0:exitcode=0:print_suppressions=0",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("leakpkg");
+    expect(stderr).not.toContain("clone_metadata");
+    // Timeout: a detected leak makes llvm-symbolizer load the full DWARF of the
+    // test binary before the assertion above can run; the no-leak path is < 1s.
+  },
+  30_000,
+);

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -412,16 +412,19 @@ test.skipIf(!isASAN)(
         https_proxy: "",
         HTTP_PROXY: "",
         HTTPS_PROXY: "",
-        ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1",
-        LSAN_OPTIONS: "use_registers=0:exitcode=0:print_suppressions=0",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: "use_registers=0:print_suppressions=0",
       },
       stdout: "pipe",
       stderr: "pipe",
       stdin: "ignore",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).not.toContain("clone_metadata");
-    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "leakpkg", exitCode: 0 });
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "leakpkg",
+      stderr: expect.not.stringContaining("LeakSanitizer: detected memory leaks"),
+      exitCode: 0,
+    });
     // Timeout: a detected leak makes llvm-symbolizer load the full DWARF of the
     // test binary before the assertion above can run; the no-leak path is < 1s.
   },


### PR DESCRIPTION
## Problem

`test/cli/install/bun-info.test.ts` (and its sibling `bun-audit.test.ts`) started aborting on the `:debian: 13 x64-asan` PR lane with a LeakSanitizer report after #36175 landed (observed on builds 84674 / 84751 / 84815 / 84881):

```
==19020==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 512 byte(s) in 1 object(s) allocated from:
    ...
    #16 in <bun_http::HTTPClient>::clone_metadata src/http/lib.rs:3977:13
    #17 in handle_on_data_headers<true> src/http/lib.rs:3761:14
    ...
    #26 in <bun_http::http_thread::HttpThread>::process_events
```

## Cause

`AsyncHTTP::send_sync` wrapped the terminal `HTTPResponseMetadata` in `ManuallyDrop` and returned the inner `picohttp::Response<'static>`:

```rust
let metadata = core::mem::ManuallyDrop::new(metadata);
Ok(metadata.response)
```

This was carried over from the Zig port (the original `sendSync` returned the bare `Response` and never `deinit`'d the metadata). It leaks two heap allocations per call: the `Box<[Header]>` leaked via `heap::release` in `clone_metadata`, and the `StringBuilder`-owned `owned_buf` that holds status text / header names / header values. Every sync CLI request goes through this path: `bun info` / `bun pm view`, `bun audit`, `bun publish` (up to four times with the OTP retry), `bun upgrade`, `bun create`, and `build --compile`'s target download.

LSan's default scan is conservative, treating stacks and registers of every thread as roots. The only live reference to the leaked header slice after the command returns is the `Response` alias stored in `real.response` by `send_sync_callback`, and that lives on a frame already below the main thread's SP when `Global::exit` runs the leak check. Whether LSan still sees it depends on whether a thread happened to park in epoll / a futex with a stale pointer to the slice in a callee-saved register. On the x64-asan PR lane it stopped being hidden after #36175; locally it stays hidden unless registers are excluded as roots. A fix for this leak already exists on the `farm/3977ed4f/linux-arm64-asan-ci` branch (7f1803a094) and in #36173; this PR extracts just the leak fix to unblock the x64-asan lane.

## Fix

Return the owning `HTTPResponseMetadata` from `send_sync`. Accessor methods (`status_code()`, `status_text()`, `header()`, `header_if_other_is_absent()`) hand out reborrows tied to `&self` so borrowck enforces that no slice escapes the metadata's scope; the inner `Response` is typed `'static` but its slices borrow the sibling `owned_buf` / header slice that `Drop` frees. Callers switch from `res.status_code` / `res.headers.get(..)` to the accessor form. `npm::response_error` now takes `&HTTPResponseMetadata` directly. `send_sync_callback` writes `real.response = None` instead of copying the alias back into the caller's `AsyncHTTP`, since that stored copy would dangle once the returned metadata is dropped and no sync caller reads `self.response`.

## Test

Added an ASAN-gated case to `bun-info.test.ts` that runs `bun info` against a local `Bun.serve` registry with `LSAN_OPTIONS=use_registers=0` so the leak is observed deterministically, and asserts a combined `{ stdout, stderr, exitCode }` result with LSan's default non-zero exit left intact.

```
# fail-before (src/ reverted to main, debug build)
(fail) bun info does not leak the sync response metadata [5307ms]
  SUMMARY: AddressSanitizer: 206 byte(s) leaked in 2 allocation(s).

# pass-after
bun bd test test/cli/install/bun-info.test.ts
 20 pass  0 fail  (new leak test: 223ms)

bun bd test test/cli/install/bun-audit.test.ts     # 16 pass
bun bd test test/cli/install/bun-create.test.ts    # 19 pass
bun bd test test/cli/install/bun-upgrade.test.ts   #  8 pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-info.test.ts
bun test v1.4.0 (8f0ef4772)

test/cli/install/bun-info.test.ts:
(pass) bun info > bun info (main command) > should display package info for latest version [359.12ms]
(pass) bun info > bun info (main command) > should handle missing arguments [346.80ms]
(pass) bun info > bun info (main command) > should display package info for specific version [402.47ms]
(pass) bun info > bun pm view (alias) > should display package info for latest version [380.58ms]
(pass) bun info > bun info (main command) > should display specific property [484.38ms]
(pass) bun info > bun pm view (alias) > should display package info for specific version [380.99ms]
(pass) bun info > bun pm view (alias) > should display nested property [324.88ms]
(pass) bun info > bun pm view (alias) > should handle non-existent package [297.70ms]
(pass) bun info > bun pm view (alias) > should display specific property [1379.12ms]
(pass) bun info > bun pm view (alias) > should output JSON format with --json flag [1356.80ms]
(pass) bun info > bun pm v
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (b4544d053)

test/cli/install/bun-info.test.ts:
(pass) bun info > bun info (main command) > should display package info for latest version [69.02ms]
(pass) bun info > bun info (main command) > should handle missing arguments [68.71ms]
(pass) bun info > bun pm view (alias) > should handle non-existent package [62.61ms]
(pass) bun info > bun pm view (alias) > should display package info for latest version [71.24ms]
(pass) bun info > bun pm view (alias) > should display nested property [69.87ms]
(pass) bun info > bun pm view (alias) > should handle . [61.86ms]
(pass) bun info > bun info (main command) > should display package info for specific version [75.65ms]
(pass) bun info > bun info (main command) > should display specific property [77.38ms]
(pass) bun info > bun pm view (alias) > should output JSON format with --json flag [78.60ms]
(pass) bun info > bun pm view (alias) > versions[0] should work [71.64ms]
(pass) bun info > bun pm view (alias) > versions should work [75.43ms]
(pass) bun info > bun pm view (alias) > should handle dist-tags like latest [74.19ms]
(pass) bun info > bun pm view (alias) > should handle version ranges [78.07ms]
(p
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-info.test.ts
bun test v1.4.0 (8f0ef4772)

test/cli/install/bun-info.test.ts:
(pass) bun info > bun info (main command) > should display package info for latest version [349.74ms]
(pass) bun info > bun info (main command) > should display package info for specific version [468.60ms]
(pass) bun info > bun info (main command) > should display specific property [469.69ms]
(pass) bun info > bun info (main command) > should handle missing arguments [475.25ms]
(pass) bun info > bun pm view (alias) > should display package info for latest version [506.84ms]
(pass) bun info > bun pm view (alias) > should display package info for specific version [460.48ms]
(pass) bun info > bun pm view (alias) > should display nested property [392.82ms]
(pass) bun info > bun pm view (alias) > should display specific property [507.04ms]
(pass) bun info > bun pm view (alias) > should handle non-existent package [458.13ms]
(pass) bun info > bun pm view (alias) > should output JSON format with --json flag [575.15ms]
(pass) bun info > bun pm vie
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1113ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_collections v0.0.0 (/workspace/bun/src/collections)
[1m[92m   Compiling[0m bun_p
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/AsyncHTTP.rs                         | 12 +++--
 src/http/lib.rs                               | 22 +++++++++
 src/install/npm.rs                            | 23 +++++-----
 src/runtime/cli/audit_command.rs              |  4 +-
 src/runtime/cli/create_command.rs             | 14 +++---
 src/runtime/cli/pm_view_command.rs            |  2 +-
 src/runtime/cli/publish_command.rs            | 28 +++++-------
 src/runtime/cli/upgrade_command.rs            |  4 +-
 src/standalone_graph/StandaloneModuleGraph.rs |  2 +-
 test/cli/install/bun-info.test.ts             | 65 +++++++++++++++++++++++++--
 10 files changed, 125 insertions(+), 51 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/http/AsyncHTTP.rs                              5      6      0
src/http/lib.rs                                    5      4      0
src/install/npm.rs                                 0      0      0
src/runtime/cli/audit_command.rs                   1      0      0
src/runtime/cli/create_command.rs                  2      0      0
src/runtime/cli/pm_view_command.rs                 2      0      0
src/runtime/cli/publish_command.rs                 2      0      0
src/runtime/cli/upgrade_command.rs                 1      0      0
src/standalone_graph/StandaloneModuleGraph.rs      1      0      0
test/cli/install/bun-info.test.ts                  6     11      0
```

</details>

<!-- robobun:evidence:end -->