### PR TITLE
webstreams: hold the native-source adapter's controller as a WriteBarrier

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -38,7 +38,6 @@
 #include <JavaScriptCore/SourceCode.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
-#include <JavaScriptCore/WeakInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -51,13 +50,6 @@ const ClassInfo JSNativeStreamSourceAdapter::s_info = { "NativeStreamSourceAdapt
 JSNativeStreamSourceAdapter::JSNativeStreamSourceAdapter(VM& vm, Structure* structure)
     : Base(vm, structure)
 {
-}
-
-JSNativeStreamSourceAdapter::~JSNativeStreamSourceAdapter() = default;
-
-void JSNativeStreamSourceAdapter::destroy(JSCell* cell)
-{
-    static_cast<JSNativeStreamSourceAdapter*>(cell)->JSNativeStreamSourceAdapter::~JSNativeStreamSourceAdapter();
 }
 
 void JSNativeStreamSourceAdapter::finishCreation(VM& vm)
@@ -98,6 +90,7 @@ void JSNativeStreamSourceAdapter::visitChildrenImpl(JSCell* cell, Visitor& visit
     visitor.appendHidden(thisObject->m_pendingView);
     visitor.appendHidden(thisObject->m_closer);
     visitor.appendHidden(thisObject->m_drainValue);
+    visitor.appendHidden(thisObject->m_controller);
 }
 
 DEFINE_VISIT_CHILDREN(JSNativeStreamSourceAdapter);
@@ -111,6 +104,7 @@ void JSNativeStreamSourceAdapter::analyzeHeap(JSCell* cell, HeapAnalyzer& analyz
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_pendingView, "pendingView"_s);
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_closer, "closer"_s);
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_drainValue, "drainValue"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_controller, "controller"_s);
 }
 
 const ClassInfo JSDirectSinkCloseState::s_info = { "DirectSinkCloseState"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDirectSinkCloseState) };
@@ -454,6 +448,7 @@ static void nativeSourceSever(JSGlobalObject* globalObject, JSNativeStreamSource
 static void nativeSourceCallClose(JSC::VM& vm, JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter)
 {
     auto* controller = adapter->m_controller.get();
+    adapter->m_controller.clear();
     if (controller && readableStreamDefaultControllerCanCloseOrEnqueue(controller)) {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         if (adapter->m_textMode)
@@ -671,7 +666,7 @@ JSValue nativeSourceStart(JSGlobalObject* globalObject, JSReadableStreamDefaultC
     if (!drainValue.isEmpty()) {
         adapter->m_drainValue.clear();
         if (!adapter->m_controller)
-            adapter->m_controller = JSC::Weak<JSReadableStreamDefaultController>(controller);
+            adapter->m_controller.set(vm, adapter, controller);
         if (adapter->m_textMode) {
             if (auto* drainView = dynamicDowncast<JSC::JSArrayBufferView>(drainValue))
                 nativeEnqueueTextChunk(globalObject, controller, adapter->m_textState, drainView->span(), /* flush */ false);
@@ -687,7 +682,7 @@ static JSPromise* nativeSourcePullImpl(JSC::VM& vm, JSGlobalObject* globalObject
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (!adapter->m_controller)
-        adapter->m_controller = JSC::Weak<JSReadableStreamDefaultController>(controller);
+        adapter->m_controller.set(vm, adapter, controller);
 
     JSObject* handle = adapter->m_handle.get();
     if (!handle || adapter->m_closed) {
@@ -776,6 +771,7 @@ JSPromise* nativeSourceCancel(JSGlobalObject* globalObject, JSReadableStreamDefa
     {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         adapter->m_pendingView.clear();
+        adapter->m_controller.clear();
         if (JSObject* handle = adapter->m_handle.get())
             invokeNativeHandleCancel(vm, globalObject, handle, reason);
         if (!catchScope.exception())

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -39,7 +39,6 @@
 #include <JavaScriptCore/SourceCode.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
-#include <JavaScriptCore/WeakInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -436,6 +435,7 @@ static void nativeSourceSever(JSGlobalObject* globalObject, JSNativeStreamSource
 static void nativeSourceCallClose(JSC::VM& vm, JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter)
 {
     auto* controller = adapter->controller();
+    adapter->clearController(vm);
     if (controller && readableStreamDefaultControllerCanCloseOrEnqueue(controller)) {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         if (adapter->m_textMode)
@@ -758,6 +758,7 @@ JSPromise* nativeSourceCancel(JSGlobalObject* globalObject, JSReadableStreamDefa
     {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         adapter->clearPendingView(vm);
+        adapter->clearController(vm);
         if (JSObject* handle = adapter->handle())
             invokeNativeHandleCancel(vm, globalObject, handle, reason);
         if (!catchScope.exception())

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/JSArrayBufferView.h>
 #include <JavaScriptCore/JSBoundFunction.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/JSInternalFieldObjectImplInlines.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/JSTypedArrays.h>
 #include <JavaScriptCore/Microtask.h>
@@ -38,6 +39,7 @@
 #include <JavaScriptCore/SourceCode.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
+#include <JavaScriptCore/WeakInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -55,6 +57,9 @@ JSNativeStreamSourceAdapter::JSNativeStreamSourceAdapter(VM& vm, Structure* stru
 void JSNativeStreamSourceAdapter::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
+    auto values = initialValues();
+    for (unsigned i = 0; i < numberOfInternalFields; ++i)
+        Base::internalField(i).set(vm, this, values[i]);
     ASSERT(inherits(info()));
 }
 
@@ -86,11 +91,6 @@ void JSNativeStreamSourceAdapter::visitChildrenImpl(JSCell* cell, Visitor& visit
     auto* thisObject = uncheckedDowncast<JSNativeStreamSourceAdapter>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.appendHidden(thisObject->m_handle);
-    visitor.appendHidden(thisObject->m_pendingView);
-    visitor.appendHidden(thisObject->m_closer);
-    visitor.appendHidden(thisObject->m_drainValue);
-    visitor.appendHidden(thisObject->m_controller);
 }
 
 DEFINE_VISIT_CHILDREN(JSNativeStreamSourceAdapter);
@@ -100,11 +100,11 @@ void JSNativeStreamSourceAdapter::analyzeHeap(JSCell* cell, HeapAnalyzer& analyz
     auto* thisObject = uncheckedDowncast<JSNativeStreamSourceAdapter>(cell);
     auto& vm = cell->vm();
     Base::analyzeHeap(cell, analyzer);
-    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_handle, "handle"_s);
-    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_pendingView, "pendingView"_s);
-    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_closer, "closer"_s);
-    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_drainValue, "drainValue"_s);
-    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_controller, "controller"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->internalField(JSNativeStreamSourceAdapter::Field::Handle), "handle"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->internalField(JSNativeStreamSourceAdapter::Field::PendingView), "pendingView"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->internalField(JSNativeStreamSourceAdapter::Field::Closer), "closer"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->internalField(JSNativeStreamSourceAdapter::Field::DrainValue), "drainValue"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->internalField(JSNativeStreamSourceAdapter::Field::Controller), "controller"_s);
 }
 
 const ClassInfo JSDirectSinkCloseState::s_info = { "DirectSinkCloseState"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDirectSinkCloseState) };
@@ -391,9 +391,9 @@ static void clearStreamControllerSlots(JSReadableStream* stream)
 static void nativeStorePendingView(JSC::VM& vm, JSNativeStreamSourceAdapter* adapter, JSValue newView)
 {
     if (JSObject* object = newView.getObject())
-        adapter->m_pendingView.set(vm, adapter, object);
+        adapter->setPendingView(vm, object);
     else
-        adapter->m_pendingView.clear();
+        adapter->clearPendingView(vm);
 }
 
 // Text mode: decode `bytes` against `state` and enqueue the resulting string
@@ -417,7 +417,7 @@ static void nativeEnqueueTextChunk(JSGlobalObject* globalObject, JSReadableStrea
 static bool nativeCloserFlag(JSC::VM& vm, JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* closer = uncheckedDowncast<JSArray>(adapter->m_closer.get());
+    auto* closer = uncheckedDowncast<JSArray>(adapter->closer());
     JSValue flag = closer->getIndex(globalObject, 0);
     RETURN_IF_EXCEPTION(scope, false);
     return flag.toBoolean(globalObject);
@@ -427,7 +427,7 @@ static bool nativeCloserFlag(JSC::VM& vm, JSGlobalObject* globalObject, JSNative
 static void nativeSourceSever(JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter)
 {
     auto& vm = getVM(globalObject);
-    if (JSObject* handle = adapter->m_handle.get()) {
+    if (JSObject* handle = adapter->handle()) {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         PutPropertySlot onCloseSlot(handle, false);
         handle->methodTable()->put(handle, globalObject, builtinNames(vm).onClosePublicName(), jsUndefined(), onCloseSlot);
@@ -440,15 +440,14 @@ static void nativeSourceSever(JSGlobalObject* globalObject, JSNativeStreamSource
                 return;
         }
     }
-    adapter->m_handle.clear();
-    adapter->m_pendingView.clear();
+    adapter->clearHandle(vm);
+    adapter->clearPendingView(vm);
 }
 
 // The queued callClose job body: close the controller if the consumer is still alive, then sever.
 static void nativeSourceCallClose(JSC::VM& vm, JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter)
 {
-    auto* controller = adapter->m_controller.get();
-    adapter->m_controller.clear();
+    auto* controller = adapter->controller();
     if (controller && readableStreamDefaultControllerCanCloseOrEnqueue(controller)) {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         if (adapter->m_textMode)
@@ -490,14 +489,14 @@ static JSC::JSUint8Array* nativeGetInternalBuffer(JSC::VM& vm, JSGlobalObject* g
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     const size_t chunkSize = adapter->m_chunkSize;
-    if (JSObject* pending = adapter->m_pendingView.get()) {
+    if (JSObject* pending = adapter->pendingView()) {
         auto* view = uncheckedDowncast<JSC::JSUint8Array>(pending);
         if (!view->isDetached() && view->possiblySharedBuffer() && view->possiblySharedBuffer()->byteLength() >= chunkSize)
             return view;
     }
     auto* fresh = JSC::JSUint8Array::create(globalObject, globalObject->typedArrayStructure(JSC::TypeUint8, false), chunkSize);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    adapter->m_pendingView.set(vm, adapter, fresh);
+    adapter->setPendingView(vm, fresh);
     return fresh;
 }
 
@@ -626,16 +625,16 @@ void materializeNativeSource(JSGlobalObject* globalObject, JSReadableStream* str
     }
 
     auto* adapter = WebCore::JSNativeStreamSourceAdapter::create(vm, runtime->nativeStreamSourceAdapterStructure(domGlobalObject));
-    adapter->m_handle.set(vm, adapter, handle);
+    adapter->setHandle(vm, handle);
     adapter->m_textMode = stream->m_nativeTextMode;
     adapter->m_chunkSize = std::max(static_cast<size_t>(chunkSize), autoAllocateChunkSize);
     auto* closer = JSC::constructEmptyArray(globalObject, nullptr, 1);
     RETURN_IF_EXCEPTION(scope, );
     closer->putDirectIndex(globalObject, 0, jsBoolean(false));
     RETURN_IF_EXCEPTION(scope, );
-    adapter->m_closer.set(vm, adapter, closer);
+    adapter->setCloser(vm, closer);
     if (!drainValue.isUndefined())
-        adapter->m_drainValue.set(vm, adapter, drainValue);
+        adapter->setDrainValue(vm, drainValue);
 
     auto* onCloseBound = createBoundHandler(globalObject, runtime->boundOnNativeSourceClose(), adapter);
     RETURN_IF_EXCEPTION(scope, );
@@ -662,11 +661,11 @@ JSValue nativeSourceStart(JSGlobalObject* globalObject, JSReadableStreamDefaultC
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* adapter = uncheckedDowncast<JSNativeStreamSourceAdapter>(controller->m_algorithms.algorithmContext.get());
-    JSValue drainValue = adapter->m_drainValue.get();
-    if (!drainValue.isEmpty()) {
-        adapter->m_drainValue.clear();
-        if (!adapter->m_controller)
-            adapter->m_controller.set(vm, adapter, controller);
+    JSValue drainValue = adapter->drainValue();
+    if (!drainValue.isUndefined()) {
+        adapter->clearDrainValue(vm);
+        if (!adapter->controller())
+            adapter->setController(vm, controller);
         if (adapter->m_textMode) {
             if (auto* drainView = dynamicDowncast<JSC::JSArrayBufferView>(drainValue))
                 nativeEnqueueTextChunk(globalObject, controller, adapter->m_textState, drainView->span(), /* flush */ false);
@@ -681,10 +680,10 @@ JSValue nativeSourceStart(JSGlobalObject* globalObject, JSReadableStreamDefaultC
 static JSPromise* nativeSourcePullImpl(JSC::VM& vm, JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter, JSReadableStreamDefaultController* controller)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (!adapter->m_controller)
-        adapter->m_controller.set(vm, adapter, controller);
+    if (!adapter->controller())
+        adapter->setController(vm, controller);
 
-    JSObject* handle = adapter->m_handle.get();
+    JSObject* handle = adapter->handle();
     if (!handle || adapter->m_closed) {
         adapter->m_closed = true;
         scheduleNativeSourceCallClose(globalObject, adapter);
@@ -693,11 +692,11 @@ static JSPromise* nativeSourcePullImpl(JSC::VM& vm, JSGlobalObject* globalObject
         return nullptr;
     }
 
-    auto* closer = uncheckedDowncast<JSArray>(adapter->m_closer.get());
+    auto* closer = uncheckedDowncast<JSArray>(adapter->closer());
     closer->putDirectIndex(globalObject, 0, jsBoolean(false));
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    if (JSObject* pendingObject = adapter->m_pendingView.get()) {
+    if (JSObject* pendingObject = adapter->pendingView()) {
         MarkedArgumentBuffer noArgs;
         JSValue drained = invokeMethod(vm, globalObject, handle, builtinNames(vm).drainPublicName(), noArgs);
         RETURN_IF_EXCEPTION(scope, nullptr);
@@ -735,7 +734,7 @@ static JSPromise* nativeSourcePullImpl(JSC::VM& vm, JSGlobalObject* globalObject
     RETURN_IF_EXCEPTION(scope, nullptr);
     nativeStorePendingView(vm, adapter, newView);
     if (adapter->m_closed)
-        adapter->m_pendingView.clear();
+        adapter->clearPendingView(vm);
     return nullptr;
 }
 
@@ -770,9 +769,8 @@ JSPromise* nativeSourceCancel(JSGlobalObject* globalObject, JSReadableStreamDefa
     JSValue thrown;
     {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        adapter->m_pendingView.clear();
-        adapter->m_controller.clear();
-        if (JSObject* handle = adapter->m_handle.get())
+        adapter->clearPendingView(vm);
+        if (JSObject* handle = adapter->handle())
             invokeNativeHandleCancel(vm, globalObject, handle, reason);
         if (!catchScope.exception())
             nativeSourceSever(globalObject, adapter);
@@ -815,7 +813,7 @@ JSPromise* cancelPendingNativeSource(JSGlobalObject* globalObject, JSReadableStr
 // The [bound-convention] onDrain body: a dead consumer drops the chunk.
 static void nativeSourceOnDrain(JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter, JSValue chunk)
 {
-    auto* controller = adapter->m_controller.get();
+    auto* controller = adapter->controller();
     if (!controller)
         return;
     if (adapter->m_textMode) {
@@ -830,7 +828,7 @@ static void nativeSourceOnDrain(JSGlobalObject* globalObject, JSNativeStreamSour
 static void nativeSourceOnClose(JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter)
 {
     adapter->m_closed = true;
-    if (adapter->m_controller.get())
+    if (adapter->controller())
         scheduleNativeSourceCallClose(globalObject, adapter);
     nativeSourceSever(globalObject, adapter);
 }
@@ -838,9 +836,9 @@ static void nativeSourceOnClose(JSGlobalObject* globalObject, JSNativeStreamSour
 static void nativeSourcePullFulfilled(JSC::VM& vm, JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter, JSValue result)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* controller = adapter->m_controller.get();
+    auto* controller = adapter->controller();
     JSC::JSUint8Array* view = nullptr;
-    if (JSObject* pendingObject = adapter->m_pendingView.get())
+    if (JSObject* pendingObject = adapter->pendingView())
         view = uncheckedDowncast<JSC::JSUint8Array>(pendingObject);
     bool isClosed = nativeCloserFlag(vm, globalObject, adapter);
     RETURN_IF_EXCEPTION(scope, );
@@ -848,16 +846,16 @@ static void nativeSourcePullFulfilled(JSC::VM& vm, JSGlobalObject* globalObject,
     RETURN_IF_EXCEPTION(scope, );
     nativeStorePendingView(vm, adapter, newView);
     if (adapter->m_closed)
-        adapter->m_pendingView.clear();
+        adapter->clearPendingView(vm);
 }
 
 static void nativeSourcePullRejected(JSC::VM& vm, JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter, JSValue error)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    adapter->m_pendingView.clear();
+    adapter->clearPendingView(vm);
     adapter->m_closed = true;
-    auto* controller = adapter->m_controller.get();
-    adapter->m_controller.clear();
+    auto* controller = adapter->controller();
+    adapter->clearController(vm);
     if (controller) {
         readableStreamDefaultControllerError(globalObject, controller, error);
         RETURN_IF_EXCEPTION(scope, );
@@ -1637,7 +1635,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onNativePullFulfilled, (JSGlobalObj
     }
     // Boundary: an internal decode failure errors the stream instead of escaping.
     if (!thrown.isEmpty()) {
-        if (auto* controller = adapter->m_controller.get()) {
+        if (auto* controller = adapter->controller()) {
             readableStreamDefaultControllerError(globalObject, controller, thrown);
             RETURN_IF_EXCEPTION(scope, {});
         }

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -95,18 +95,6 @@ void JSNativeStreamSourceAdapter::visitChildrenImpl(JSCell* cell, Visitor& visit
 
 DEFINE_VISIT_CHILDREN(JSNativeStreamSourceAdapter);
 
-void JSNativeStreamSourceAdapter::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
-{
-    auto* thisObject = uncheckedDowncast<JSNativeStreamSourceAdapter>(cell);
-    auto& vm = cell->vm();
-    Base::analyzeHeap(cell, analyzer);
-    analyzeBarrierEdge(vm, analyzer, cell, thisObject->internalField(JSNativeStreamSourceAdapter::Field::Handle), "handle"_s);
-    analyzeBarrierEdge(vm, analyzer, cell, thisObject->internalField(JSNativeStreamSourceAdapter::Field::PendingView), "pendingView"_s);
-    analyzeBarrierEdge(vm, analyzer, cell, thisObject->internalField(JSNativeStreamSourceAdapter::Field::Closer), "closer"_s);
-    analyzeBarrierEdge(vm, analyzer, cell, thisObject->internalField(JSNativeStreamSourceAdapter::Field::DrainValue), "drainValue"_s);
-    analyzeBarrierEdge(vm, analyzer, cell, thisObject->internalField(JSNativeStreamSourceAdapter::Field::Controller), "controller"_s);
-}
-
 const ClassInfo JSDirectSinkCloseState::s_info = { "DirectSinkCloseState"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDirectSinkCloseState) };
 
 JSDirectSinkCloseState::JSDirectSinkCloseState(VM& vm, Structure* structure)

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.h
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.h
@@ -46,11 +46,8 @@ public:
     // the drain value returned by handle.start()/drain(), enqueued by the Native
     // startAlgorithm and then cleared.
     JSC::WriteBarrier<JSC::Unknown> m_drainValue;
-    // Visited: with the adapter queued as a reaction context (onNativePull*), this edge
-    // keeps the controller (and the whole downstream consumer graph) rooted across
-    // FetchTasklet's Strong release. Cleared by nativeSourceSever on every terminal path;
-    // controller->algorithmContext is cleared by readableStreamDefaultControllerClearAlgorithms,
-    // so the abandoned case is an ordinary intra-heap cycle.
+    // Visited (roots the consumer graph while the adapter is a queued reaction
+    // context); cleared on every terminal path.
     JSC::WriteBarrier<JSReadableStreamDefaultController> m_controller;
     // adaptive chunk size (256 KiB default, doubled once up to 2 MiB).
     size_t m_chunkSize { 0 };

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.h
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.h
@@ -2,35 +2,28 @@
 // NativeReadableStreamSource JS class. Its .cpp also owns materializeNativeSource and the
 // SourceKind::Native pull/cancel/start algorithm arms.
 //
-// DESTRUCTIBLE: it owns a JSC::Weak (a non-trivially-destructible member).
-// The Weak member is THE one sanctioned JSC::Weak in the whole subsystem: a STRONG back-edge
-// would let Rust's external Strong root on the native handle pin the entire abandoned JS
-// consumer graph forever.
-// Internal cell: no prototype, no constructor, never exposed to JS.
+// Internal cell: no prototype, no constructor, never exposed to JS. Non-destructible.
 #pragma once
 
 #include "root.h"
 #include "StreamsForward.h"
 
 #include "JSReadableStreamDefaultController.h"
-#include <JavaScriptCore/JSDestructibleObject.h>
-#include <JavaScriptCore/Weak.h>
+#include <JavaScriptCore/JSObject.h>
 
 namespace WebCore {
 
-class JSNativeStreamSourceAdapter final : public JSC::JSDestructibleObject {
+class JSNativeStreamSourceAdapter final : public JSC::JSNonFinalObject {
 public:
-    using Base = JSC::JSDestructibleObject;
+    using Base = JSC::JSNonFinalObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags;
-    static constexpr JSC::DestructionMode needsDestruction = JSC::NeedsDestruction;
+    static constexpr JSC::DestructionMode needsDestruction = JSC::DoesNotNeedDestruction;
 
     static JSNativeStreamSourceAdapter* create(JSC::VM&, JSC::Structure*);
-    static void destroy(JSC::JSCell*);
     static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue prototype);
 
     DECLARE_INFO;
-    // visitChildrenImpl MUST visit: m_handle, m_pendingView, m_closer, m_drainValue.
-    // m_controller is a JSC::Weak and MUST NOT be visited (that is the whole point).
+    // visitChildrenImpl MUST visit: m_handle, m_pendingView, m_closer, m_drainValue, m_controller.
     DECLARE_VISIT_CHILDREN;
     static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
@@ -53,9 +46,12 @@ public:
     // the drain value returned by handle.start()/drain(), enqueued by the Native
     // startAlgorithm and then cleared.
     JSC::WriteBarrier<JSC::Unknown> m_drainValue;
-    // THE ONE SANCTIONED JSC::Weak in the subsystem. Null-check EVERY read: null ⇒ the JS
-    // consumer side was collected ⇒ drop the data / no-op. Assigned lazily — never eagerly.
-    JSC::Weak<JSReadableStreamDefaultController> m_controller;
+    // Visited: with the adapter queued as a reaction context (onNativePull*), this edge
+    // keeps the controller (and the whole downstream consumer graph) rooted across
+    // FetchTasklet's Strong release. Cleared by nativeSourceSever on every terminal path;
+    // controller->algorithmContext is cleared by readableStreamDefaultControllerClearAlgorithms,
+    // so the abandoned case is an ordinary intra-heap cycle.
+    JSC::WriteBarrier<JSReadableStreamDefaultController> m_controller;
     // adaptive chunk size (256 KiB default, doubled once up to 2 MiB).
     size_t m_chunkSize { 0 };
     // #hasResized — the one-shot chunk-size adaptation already happened.
@@ -68,7 +64,6 @@ public:
 
 private:
     JSNativeStreamSourceAdapter(JSC::VM&, JSC::Structure*);
-    ~JSNativeStreamSourceAdapter();
     void finishCreation(JSC::VM&);
 };
 

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.h
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.h
@@ -50,7 +50,6 @@ public:
 
     DECLARE_INFO;
     DECLARE_VISIT_CHILDREN;
-    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.h
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.h
@@ -2,28 +2,53 @@
 // NativeReadableStreamSource JS class. Its .cpp also owns materializeNativeSource and the
 // SourceKind::Native pull/cancel/start algorithm arms.
 //
-// Internal cell: no prototype, no constructor, never exposed to JS. Non-destructible.
+// Internal cell: no prototype, no constructor, never exposed to JS.
 #pragma once
 
 #include "root.h"
 #include "StreamsForward.h"
 
 #include "JSReadableStreamDefaultController.h"
-#include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/JSCast.h>
+#include <JavaScriptCore/JSInternalFieldObjectImpl.h>
 
 namespace WebCore {
 
-class JSNativeStreamSourceAdapter final : public JSC::JSNonFinalObject {
+class JSNativeStreamSourceAdapter final : public JSC::JSInternalFieldObjectImpl<5> {
 public:
-    using Base = JSC::JSNonFinalObject;
+    using Base = JSC::JSInternalFieldObjectImpl<5>;
     static constexpr unsigned StructureFlags = Base::StructureFlags;
     static constexpr JSC::DestructionMode needsDestruction = JSC::DoesNotNeedDestruction;
+
+    enum class Field : uint32_t {
+        // JS{Blob,File,Bytes}InternalReadableStreamSource; cleared on every terminal path.
+        Handle = 0,
+        // `$data`: the unfilled tail Uint8Array reused across pulls.
+        PendingView,
+        // `#closer`: a per-instance length-1 JSArray the native pull writes EOF into (#29787).
+        Closer,
+        // handle.start()/drain() result, enqueued by the Native startAlgorithm then cleared.
+        DrainValue,
+        // Visited (roots the consumer graph while the adapter is a queued reaction
+        // context); cleared on every terminal path.
+        Controller,
+    };
+
+    static std::array<JSC::JSValue, numberOfInternalFields> initialValues()
+    {
+        return { { JSC::jsUndefined(), JSC::jsUndefined(), JSC::jsUndefined(), JSC::jsUndefined(), JSC::jsUndefined() } };
+    }
 
     static JSNativeStreamSourceAdapter* create(JSC::VM&, JSC::Structure*);
     static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue prototype);
 
+    static size_t allocationSize(Checked<size_t> inlineCapacity)
+    {
+        ASSERT_UNUSED(inlineCapacity, inlineCapacity == 0U);
+        return sizeof(JSNativeStreamSourceAdapter);
+    }
+
     DECLARE_INFO;
-    // visitChildrenImpl MUST visit: m_handle, m_pendingView, m_closer, m_drainValue, m_controller.
     DECLARE_VISIT_CHILDREN;
     static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
@@ -36,19 +61,26 @@ public:
     }
     static JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM&);
 
-    // the JS{Blob,File,Bytes}InternalReadableStreamSource handle cell. CLEARED (with
-    // handle.onClose/onDrain and m_pendingView) on all three terminal paths.
-    JSC::WriteBarrier<JSC::JSObject> m_handle;
-    // `$data`: the unfilled tail Uint8Array reused across pulls.
-    JSC::WriteBarrier<JSC::JSObject> m_pendingView;
-    // `#closer`: a per-instance length-1 JSArray the native pull writes EOF into (#29787).
-    JSC::WriteBarrier<JSC::JSObject> m_closer;
-    // the drain value returned by handle.start()/drain(), enqueued by the Native
-    // startAlgorithm and then cleared.
-    JSC::WriteBarrier<JSC::Unknown> m_drainValue;
-    // Visited (roots the consumer graph while the adapter is a queued reaction
-    // context); cleared on every terminal path.
-    JSC::WriteBarrier<JSReadableStreamDefaultController> m_controller;
+    const JSC::WriteBarrier<JSC::Unknown>& internalField(Field field) const { return Base::internalField(static_cast<uint32_t>(field)); }
+    JSC::WriteBarrier<JSC::Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
+
+    JSC::JSObject* handle() const { return internalField(Field::Handle).get().getObject(); }
+    JSC::JSObject* pendingView() const { return internalField(Field::PendingView).get().getObject(); }
+    JSC::JSObject* closer() const { return internalField(Field::Closer).get().getObject(); }
+    JSC::JSValue drainValue() const { return internalField(Field::DrainValue).get(); }
+    JSReadableStreamDefaultController* controller() const { return dynamicDowncast<JSReadableStreamDefaultController>(internalField(Field::Controller).get()); }
+
+    void setHandle(JSC::VM& vm, JSC::JSValue v) { internalField(Field::Handle).set(vm, this, v); }
+    void setPendingView(JSC::VM& vm, JSC::JSValue v) { internalField(Field::PendingView).set(vm, this, v); }
+    void setCloser(JSC::VM& vm, JSC::JSValue v) { internalField(Field::Closer).set(vm, this, v); }
+    void setDrainValue(JSC::VM& vm, JSC::JSValue v) { internalField(Field::DrainValue).set(vm, this, v); }
+    void setController(JSC::VM& vm, JSReadableStreamDefaultController* c) { internalField(Field::Controller).set(vm, this, c); }
+
+    void clearHandle(JSC::VM& vm) { internalField(Field::Handle).set(vm, this, JSC::jsUndefined()); }
+    void clearPendingView(JSC::VM& vm) { internalField(Field::PendingView).set(vm, this, JSC::jsUndefined()); }
+    void clearDrainValue(JSC::VM& vm) { internalField(Field::DrainValue).set(vm, this, JSC::jsUndefined()); }
+    void clearController(JSC::VM& vm) { internalField(Field::Controller).set(vm, this, JSC::jsUndefined()); }
+
     // adaptive chunk size (256 KiB default, doubled once up to 2 MiB).
     size_t m_chunkSize { 0 };
     // #hasResized — the one-shot chunk-size adaptation already happened.

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -540,7 +540,7 @@ void readableStreamReaderGenericRelease(JSGlobalObject* globalObject, JSReadable
         // Bun: drop the native handle's event-loop ref when its consumer releases the lock.
         if (stream->m_nativePtr && controller->m_algorithms.kind == SourceKind::Native) {
             const auto* adapter = uncheckedDowncast<WebCore::JSNativeStreamSourceAdapter>(controller->m_algorithms.algorithmContext.get());
-            if (auto* handle = adapter->m_handle.get()) {
+            if (auto* handle = adapter->handle()) {
                 JSValue updateRef = handle->getIfPropertyExists(globalObject, builtinNames(vm).updateRefPublicName());
                 RETURN_IF_EXCEPTION(scope, void());
                 if (updateRef && updateRef.isCallable()) {

--- a/test/js/web/streams/pipeTo-shutdown-gc.test.ts
+++ b/test/js/web/streams/pipeTo-shutdown-gc.test.ts
@@ -56,7 +56,7 @@ const script = `
     setTimeout(() => ac.abort(new Error("iter-abort")), 3);
     // preventAbort=false: source error -> AbortDestination shutdown arm
     resp.body.pipeTo(makeSink(), { signal: ac.signal }).catch(() => {});
-    // No await: drop resp / ws so only the internal pipe graph roots them.
+    // No await: drop resp so only the internal pipe graph roots the body stream.
   }
 
   for (let iter = 0; iter < 8; iter++) {

--- a/test/js/web/streams/pipeTo-shutdown-gc.test.ts
+++ b/test/js/web/streams/pipeTo-shutdown-gc.test.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN } from "harness";
+
+// Regression guard for a use-after-GC in pipeTo's native shutdown path.
+// JSNativeStreamSourceAdapter::m_controller was a JSC::Weak<>, so an adapter
+// queued as a microtask reaction context did not root the controller. When a
+// socket error rejected the native pull promise and FetchTasklet released its
+// Strong<>s before the microtask drain, a GC in between could leave the whole
+// consumer graph (controller -> stream -> reader -> pipe op -> destination ->
+// writer -> readyPromise) white. The subsequent onNativePullRejected errored
+// the stream through a stale Weak read, cascading into a deferred pipe
+// shutdown that called writableStreamAbort on a corpse destination and
+// dereferenced a swept readyPromise (RELEASE_ASSERT in JSObject::realm();
+// silent heap write on builds without the assert).
+//
+// The crash is timing-dependent (observed ~1/3 under a fault-injected tracer
+// replay; 0/1800 under best-effort in-memory GC storms). This test exercises
+// the shape (native body source, socket fault mid-stream, fire-and-forget
+// pipeTo under collectContinuously, AbortDestination shutdown arm) as a
+// regression surface, not a deterministic reproducer.
+
+const script = `
+  "use strict";
+  const net = require("node:net");
+
+  let connId = 0;
+  const server = net.createServer(sock => {
+    const id = connId++;
+    sock.on("error", () => {});
+    sock.write(
+      "HTTP/1.1 200 OK\\r\\n" +
+        "Content-Type: application/octet-stream\\r\\n" +
+        "Transfer-Encoding: chunked\\r\\n" +
+        "Connection: close\\r\\n" +
+        "\\r\\n",
+    );
+    sock.write("3\\r\\nabc\\r\\n");
+    setTimeout(() => {
+      try {
+        sock.write("3\\r\\ndef\\r\\n");
+      } catch {}
+      setTimeout(() => {
+        try {
+          // socket fault: abrupt destroy mid-chunk (no terminating 0\\r\\n)
+          sock.write("5\\r\\ngh");
+          sock.destroy();
+        } catch {}
+      }, 1);
+    }, 1);
+  });
+
+  await new Promise(r => server.listen(0, r));
+  const url = "http://127.0.0.1:" + server.address().port + "/";
+
+  function makeSink() {
+    return new WritableStream(
+      { write() {}, close() {}, abort() {} },
+      new CountQueuingStrategy({ highWaterMark: 0 }),
+    );
+  }
+
+  async function once(i) {
+    let resp;
+    try {
+      resp = await fetch(url);
+    } catch {
+      return;
+    }
+    const ac = new AbortController();
+    setTimeout(() => ac.abort(new Error("iter-abort")), 3);
+    // preventAbort=false: source error -> AbortDestination shutdown arm
+    resp.body.pipeTo(makeSink(), { signal: ac.signal }).catch(() => {});
+    // No await: drop resp / ws so only the internal pipe graph roots them.
+  }
+
+  for (let iter = 0; iter < 8; iter++) {
+    const batch = [];
+    for (let i = 0; i < 40; i++) batch.push(once(i));
+    await Promise.all(batch);
+    for (let k = 0; k < 6; k++) {
+      Bun.gc(true);
+      await Bun.sleep(1);
+    }
+  }
+  server.close();
+  for (let k = 0; k < 6; k++) {
+    Bun.gc(true);
+    await Bun.sleep(1);
+  }
+  console.log("OK");
+`;
+
+test(
+  "abandoned pipeTo over a faulting native body does not re-enter a swept pipe graph",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, BUN_JSC_collectContinuously: "1" },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "OK", stderr: "", exitCode: 0 });
+  },
+  isASAN ? 90_000 : 30_000,
+);

--- a/test/js/web/streams/pipeTo-shutdown-gc.test.ts
+++ b/test/js/web/streams/pipeTo-shutdown-gc.test.ts
@@ -1,23 +1,11 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
 
-// Regression guard for a use-after-GC in pipeTo's native shutdown path.
-// JSNativeStreamSourceAdapter::m_controller was a JSC::Weak<>, so an adapter
-// queued as a microtask reaction context did not root the controller. When a
-// socket error rejected the native pull promise and FetchTasklet released its
-// Strong<>s before the microtask drain, a GC in between could leave the whole
-// consumer graph (controller -> stream -> reader -> pipe op -> destination ->
-// writer -> readyPromise) white. The subsequent onNativePullRejected errored
-// the stream through a stale Weak read, cascading into a deferred pipe
-// shutdown that called writableStreamAbort on a corpse destination and
-// dereferenced a swept readyPromise (RELEASE_ASSERT in JSObject::realm();
-// silent heap write on builds without the assert).
-//
-// The crash is timing-dependent (observed ~1/3 under a fault-injected tracer
-// replay; 0/1800 under best-effort in-memory GC storms). This test exercises
-// the shape (native body source, socket fault mid-stream, fire-and-forget
-// pipeTo under collectContinuously, AbortDestination shutdown arm) as a
-// regression surface, not a deterministic reproducer.
+// Regression surface for a use-after-GC observed in pipeTo's native shutdown
+// path (RELEASE_ASSERT in JSObject::realm() from a swept readyPromise). The
+// crash only reproduced under a fault-injected tracer replay; this exercises
+// the same shape (native body source, socket fault mid-stream, fire-and-forget
+// pipeTo, AbortDestination shutdown arm) under collectContinuously.
 
 const script = `
   "use strict";

--- a/test/js/web/streams/pipeTo-shutdown-gc.test.ts
+++ b/test/js/web/streams/pipeTo-shutdown-gc.test.ts
@@ -23,9 +23,7 @@ const script = `
   "use strict";
   const net = require("node:net");
 
-  let connId = 0;
   const server = net.createServer(sock => {
-    const id = connId++;
     sock.on("error", () => {});
     sock.write(
       "HTTP/1.1 200 OK\\r\\n" +
@@ -59,7 +57,7 @@ const script = `
     );
   }
 
-  async function once(i) {
+  async function once() {
     let resp;
     try {
       resp = await fetch(url);
@@ -75,7 +73,7 @@ const script = `
 
   for (let iter = 0; iter < 8; iter++) {
     const batch = [];
-    for (let i = 0; i < 40; i++) batch.push(once(i));
+    for (let i = 0; i < 40; i++) batch.push(once());
     await Promise.all(batch);
     for (let k = 0; k < 6; k++) {
       Bun.gc(true);

--- a/test/js/web/streams/pipeTo-shutdown-gc.test.ts
+++ b/test/js/web/streams/pipeTo-shutdown-gc.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows } from "harness";
 
 // Regression surface for a use-after-GC observed in pipeTo's native shutdown
 // path (RELEASE_ASSERT in JSObject::realm() from a swept readyPromise). The
@@ -81,7 +81,9 @@ test(
   async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", script],
-      env: { ...bunEnv, BUN_JSC_collectContinuously: "1" },
+      // collectContinuously is prohibitively slow on Windows CI; the script's
+      // explicit Bun.gc(true) storms retain coverage there.
+      env: { ...bunEnv, ...(isWindows ? {} : { BUN_JSC_collectContinuously: "1" }) },
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);


### PR DESCRIPTION
`JSNativeStreamSourceAdapter::m_controller` was a `JSC::Weak<JSReadableStreamDefaultController>`. When the native pull promise is rejected (socket fault on a fetch body) the adapter is queued as the `onNativePullRejected` reaction context, which roots the **adapter** but not the **controller**: the adapter's only edge to it was the `Weak`. `FetchTasklet` releases both native `Strong<>`s to the body stream before that microtask drains, so a GC in between can leave the entire consumer graph (`controller -> stream -> reader -> pipe op -> destination -> writer -> readyPromise`) white. The subsequent error cascade then enqueues the pipe's writes-drained shutdown deferral against a corpse `op`, and `performPipeShutdownAction(AbortDestination)` dereferences a swept `readyPromise`:

```
ASSERTION FAILED: result   JSObject.h(583) JSGlobalObject *JSC::JSObject::realm() const
#5  JSC::JSObject::realm()
#6  JSC::JSPromise::rejectPromise
#7  JSC::JSPromise::reject
#8  Bun::WebStreams::writableStreamDefaultWriterEnsureReadyPromiseRejected
#9  Bun::WebStreams::writableStreamStartErroring
#10 Bun::WebStreams::writableStreamAbort
#11 WebCore::performPipeShutdownAction (AbortDestination)
#12 WebCore::JSStreamPipeToOperation::onWritesFinishedForShutdown
```

On builds without the assert the same path is a silent write into freed/reused promise memory.

## Fix

Hold `m_controller` as a visited internal field so a queued adapter roots the controller directly. The edge is cleared on every terminal path (`nativeSourcePullRejected`, `nativeSourceCallClose`, `nativeSourceCancel`); `controller->algorithmContext` is cleared by `readableStreamDefaultControllerClearAlgorithms`, so the abandoned case is an ordinary intra-heap cycle mark-sweep collects. `NewSource::this_jsvalue` is only `Strong` during FileReader I/O, where pinning the consumer graph is the correct behavior anyway.

With the `Weak` gone the adapter no longer needs a destructor, so it is now a `JSInternalFieldObjectImpl<5>`: the five JSValue members (handle, pendingView, closer, drainValue, controller) are internal fields visited by the base class, with typed accessors at call sites. The scalar members (chunkSize, flag bitfield, text-decode state) stay as plain members.

## Verification

`native-source-onclose-leak.test.ts` (the partial-read + `releaseLock` abandonment tests for Blob/fetch/File sources) continues to pass, confirming the cycle does not pin. `streams.test.js`, `pipeTo-signal-leak.test.ts`, `compression.test.ts`, `blob.test.ts` all pass.

The crash itself is 0/1800 standalone; it reproduces ~1/3 only under a fault-injected tracer replay. `pipeTo-shutdown-gc.test.ts` exercises the shape (native body source, socket fault mid-stream, fire-and-forget `pipeTo` under `collectContinuously`, `AbortDestination` shutdown arm) as a regression surface.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/streams/pipeTo-shutdown-gc.test.ts

<!-- robobun:evidence:end -->