### PR TITLE
shell(mv): fall back to copy+unlink when rename() returns EXDEV

### DIFF
--- a/src/bun_core/result.rs
+++ b/src/bun_core/result.rs
@@ -145,6 +145,7 @@ pub mod coreutils_error_map {
         "EPROTONOSUPPORT" => "Protocol not supported",
         "ESOCKTNOSUPPORT" => "Socket type not supported",
         "EOPNOTSUPP" => "Operation not supported",
+        "ENOTSUP" => "Operation not supported",
         "EPFNOSUPPORT" => "Protocol family not supported",
         "EAFNOSUPPORT" => "Address family not supported by protocol",
         "EADDRINUSE" => "Address already in use",

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -520,13 +520,18 @@ impl ShellMvBatchedTask {
         }
 
         if bun_sys::S::ISDIR(mode) {
-            // Create writable/searchable so children can be written; the source
-            // mode is stamped via fchmod once the tree is in place.
-            let created = match bun_sys::mkdirat(dst_dir, dst, (mode & 0o7777) | 0o700) {
-                Ok(()) => true,
-                Err(e) if e.get_errno() == bun_sys::E::EEXIST => false,
+            // 0o700 so children can be written into a dest whose source mode
+            // is e.g. 0o500; the real mode is stamped via fchmod below.
+            match bun_sys::mkdirat(dst_dir, dst, (mode & 0o7777) | 0o700) {
+                Ok(()) => {}
+                Err(e) if e.get_errno() == bun_sys::E::EEXIST => {
+                    // Same-device renameat() onto a non-empty dir fails with
+                    // ENOTEMPTY; match that instead of silently merging.
+                    bun_sys::rmdirat(dst_dir, dst)?;
+                    bun_sys::mkdirat(dst_dir, dst, (mode & 0o7777) | 0o700)?;
+                }
                 Err(e) => return Err(e),
-            };
+            }
             let src_fd = shell_openat(src_dir, src, bun_sys::O::RDONLY | bun_sys::O::DIRECTORY, 0)?;
             let dst_fd =
                 match shell_openat(dst_dir, dst, bun_sys::O::RDONLY | bun_sys::O::DIRECTORY, 0) {
@@ -536,12 +541,13 @@ impl ShellMvBatchedTask {
                         return Err(e);
                     }
                 };
-            let mut iter = bun_sys::dir_iterator::iterate(src_fd);
+            // Boxed: `WrappedIterator` embeds an 8 KB inline readdir buffer.
+            let mut iter = Box::new(bun_sys::dir_iterator::iterate(src_fd));
+            let mut nbuf = bun_paths::path_buffer_pool::get();
             let result: Result<(), bun_sys::Error> = loop {
                 match iter.next() {
                     Ok(Some(entry)) => {
                         let name = entry.name.slice_u8();
-                        let mut nbuf = bun_paths::path_buffer_pool::get();
                         if name.len() >= bun_paths::MAX_PATH_BYTES {
                             break Err(bun_sys::Error::from_code(
                                 bun_sys::E::ENAMETOOLONG,
@@ -559,13 +565,22 @@ impl ShellMvBatchedTask {
                     Err(e) => break Err(e),
                 }
             };
-            if created && result.is_ok() {
+            if result.is_ok() {
                 let _ = bun_sys::fchmod(dst_fd, mode & 0o7777);
             }
             closefd(dst_fd);
             closefd(src_fd);
             result?;
             return bun_sys::rmdirat(src_dir, src);
+        }
+
+        if !bun_sys::S::ISREG(mode) {
+            // Opening a FIFO O_RDONLY without O_NONBLOCK blocks forever; refuse
+            // special files rather than hang the worker thread.
+            return Err(bun_sys::Error::from_code(
+                bun_sys::E::ENOTSUP,
+                bun_sys::Tag::rename,
+            ));
         }
 
         let in_fd = bun_sys::openat(src_dir, src, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0)?;

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -527,8 +527,7 @@ impl ShellMvBatchedTask {
                 Err(e) if e.get_errno() == bun_sys::E::EEXIST => {}
                 Err(e) => return Err(e),
             }
-            let src_fd =
-                shell_openat(src_dir, src, bun_sys::O::RDONLY | bun_sys::O::DIRECTORY, 0)?;
+            let src_fd = shell_openat(src_dir, src, bun_sys::O::RDONLY | bun_sys::O::DIRECTORY, 0)?;
             let dst_fd =
                 match shell_openat(dst_dir, dst, bun_sys::O::RDONLY | bun_sys::O::DIRECTORY, 0) {
                     Ok(fd) => fd,
@@ -552,9 +551,7 @@ impl ShellMvBatchedTask {
                         nbuf[..name.len()].copy_from_slice(name);
                         nbuf[name.len()] = 0;
                         let name_z = ZStr::from_buf(&nbuf[..], name.len());
-                        if let Err(e) =
-                            Self::move_across_devices(src_fd, name_z, dst_fd, name_z)
-                        {
+                        if let Err(e) = Self::move_across_devices(src_fd, name_z, dst_fd, name_z) {
                             break Err(e);
                         }
                     }

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -467,7 +467,7 @@ impl ShellMvBatchedTask {
             return;
         }
         // Rename single entry to a new path (target was not a directory).
-        if let Err(e) = bun_sys::renameat(this.cwd, &this.sources[0], this.cwd, &this.target) {
+        if let Err(e) = Self::do_rename(this.cwd, &this.sources[0], this.cwd, &this.target) {
             this.err = Some(if e.get_errno() == bun_sys::E::ENOTDIR {
                 e.with_path(this.target.as_bytes())
             } else {
@@ -475,6 +475,126 @@ impl ShellMvBatchedTask {
             });
         }
         // Bounce-back is posted by `shell_task_trampoline`.
+    }
+
+    /// `renameat()` with a POSIX `mv` cross-device fallback: on EXDEV the
+    /// source hierarchy is duplicated at the destination and then removed.
+    fn do_rename(
+        src_dir: bun_sys::Fd,
+        src: &ZStr,
+        dst_dir: bun_sys::Fd,
+        dst: &ZStr,
+    ) -> Result<(), bun_sys::Error> {
+        match bun_sys::renameat(src_dir, src, dst_dir, dst) {
+            Err(e) if e.get_errno() == bun_sys::E::EXDEV => {
+                Self::move_across_devices(src_dir, src, dst_dir, dst)
+                    .map_err(|e| e.with_path(src.as_bytes()))
+            }
+            r => r,
+        }
+    }
+
+    /// EXDEV fallback: copy the source to the destination, then remove the
+    /// source. The source is only removed once the copy has fully succeeded.
+    fn move_across_devices(
+        src_dir: bun_sys::Fd,
+        src: &ZStr,
+        dst_dir: bun_sys::Fd,
+        dst: &ZStr,
+    ) -> Result<(), bun_sys::Error> {
+        let st = bun_sys::lstatat(src_dir, src)?;
+        let mode = st.st_mode as bun_core::Mode;
+
+        if bun_sys::S::ISLNK(mode) {
+            let mut buf = bun_paths::path_buffer_pool::get();
+            let n = bun_sys::readlinkat(src_dir, src, &mut buf[..])?;
+            if n >= bun_paths::MAX_PATH_BYTES {
+                return Err(bun_sys::Error::from_code(
+                    bun_sys::E::ENAMETOOLONG,
+                    bun_sys::Tag::readlink,
+                ));
+            }
+            buf[n] = 0;
+            let target = ZStr::from_buf(&buf[..], n);
+            let _ = bun_sys::unlinkat(dst_dir, dst);
+            bun_sys::symlinkat(target, dst_dir, dst)?;
+            return bun_sys::unlinkat(src_dir, src);
+        }
+
+        if bun_sys::S::ISDIR(mode) {
+            match bun_sys::mkdirat(dst_dir, dst, mode & 0o7777) {
+                Ok(()) => {}
+                Err(e) if e.get_errno() == bun_sys::E::EEXIST => {}
+                Err(e) => return Err(e),
+            }
+            let src_fd =
+                shell_openat(src_dir, src, bun_sys::O::RDONLY | bun_sys::O::DIRECTORY, 0)?;
+            let dst_fd =
+                match shell_openat(dst_dir, dst, bun_sys::O::RDONLY | bun_sys::O::DIRECTORY, 0) {
+                    Ok(fd) => fd,
+                    Err(e) => {
+                        closefd(src_fd);
+                        return Err(e);
+                    }
+                };
+            let mut iter = bun_sys::dir_iterator::iterate(src_fd);
+            let result: Result<(), bun_sys::Error> = loop {
+                match iter.next() {
+                    Ok(Some(entry)) => {
+                        let name = entry.name.slice_u8();
+                        let mut nbuf = bun_paths::path_buffer_pool::get();
+                        if name.len() >= bun_paths::MAX_PATH_BYTES {
+                            break Err(bun_sys::Error::from_code(
+                                bun_sys::E::ENAMETOOLONG,
+                                bun_sys::Tag::rename,
+                            ));
+                        }
+                        nbuf[..name.len()].copy_from_slice(name);
+                        nbuf[name.len()] = 0;
+                        let name_z = ZStr::from_buf(&nbuf[..], name.len());
+                        if let Err(e) =
+                            Self::move_across_devices(src_fd, name_z, dst_fd, name_z)
+                        {
+                            break Err(e);
+                        }
+                    }
+                    Ok(None) => break Ok(()),
+                    Err(e) => break Err(e),
+                }
+            };
+            closefd(dst_fd);
+            closefd(src_fd);
+            result?;
+            return bun_sys::rmdirat(src_dir, src);
+        }
+
+        let in_fd = bun_sys::openat(src_dir, src, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0)?;
+        let out_fd = match bun_sys::openat(
+            dst_dir,
+            dst,
+            bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC | bun_sys::O::CLOEXEC,
+            mode & 0o7777,
+        ) {
+            Ok(fd) => fd,
+            Err(e) => {
+                closefd(in_fd);
+                return Err(e);
+            }
+        };
+        let _ = bun_sys::preallocate_file(out_fd.native(), 0, st.st_size as _);
+        let copied = bun_sys::copy_file(in_fd, out_fd);
+        #[cfg(unix)]
+        if copied.is_ok() {
+            let _ = bun_sys::fchmod(out_fd, mode & 0o7777);
+            let _ = bun_sys::fchown(out_fd, st.st_uid as _, st.st_gid as _);
+        }
+        closefd(out_fd);
+        closefd(in_fd);
+        if let Err(e) = copied {
+            let _ = bun_sys::unlinkat(dst_dir, dst);
+            return Err(e);
+        }
+        bun_sys::unlinkat(src_dir, src)
     }
 
     /// `renameat(cwd, src, target_fd, basename(src))`. A free fn over the
@@ -498,7 +618,7 @@ impl ShellMvBatchedTask {
         }
         buf[len] = 0;
         let path_in_dir = ZStr::from_buf(buf.as_slice(), len);
-        bun_sys::renameat(cwd, src, target_fd, path_in_dir).map_err(|e| {
+        Self::do_rename(cwd, src, target_fd, path_in_dir).map_err(|e| {
             // Surface `target/basename(src)` as the failing path.
             let joined = resolve_path::join_z::<bun_paths::platform::Auto>(&[target, base]);
             e.with_path(joined.as_bytes())

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -520,11 +520,13 @@ impl ShellMvBatchedTask {
         }
 
         if bun_sys::S::ISDIR(mode) {
-            match bun_sys::mkdirat(dst_dir, dst, mode & 0o7777) {
-                Ok(()) => {}
-                Err(e) if e.get_errno() == bun_sys::E::EEXIST => {}
+            // Create writable/searchable so children can be written; the source
+            // mode is stamped via fchmod once the tree is in place.
+            let created = match bun_sys::mkdirat(dst_dir, dst, (mode & 0o7777) | 0o700) {
+                Ok(()) => true,
+                Err(e) if e.get_errno() == bun_sys::E::EEXIST => false,
                 Err(e) => return Err(e),
-            }
+            };
             let src_fd = shell_openat(src_dir, src, bun_sys::O::RDONLY | bun_sys::O::DIRECTORY, 0)?;
             let dst_fd =
                 match shell_openat(dst_dir, dst, bun_sys::O::RDONLY | bun_sys::O::DIRECTORY, 0) {
@@ -557,6 +559,9 @@ impl ShellMvBatchedTask {
                     Err(e) => break Err(e),
                 }
             };
+            if created && result.is_ok() {
+                let _ = bun_sys::fchmod(dst_fd, mode & 0o7777);
+            }
             closefd(dst_fd);
             closefd(src_fd);
             result?;

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -572,6 +572,8 @@ impl ShellMvBatchedTask {
                 }
             };
             if result.is_ok() {
+                #[cfg(unix)]
+                let _ = bun_sys::fchown(dst_fd, st.st_uid as _, st.st_gid as _);
                 let _ = bun_sys::fchmod(dst_fd, mode & 0o7777);
             }
             closefd(dst_fd);
@@ -607,8 +609,9 @@ impl ShellMvBatchedTask {
         let copied = bun_sys::copy_file(in_fd, out_fd);
         #[cfg(unix)]
         if copied.is_ok() {
-            let _ = bun_sys::fchmod(out_fd, mode & 0o7777);
+            // `fchown` first: Linux clears S_ISUID/S_ISGID on chown.
             let _ = bun_sys::fchown(out_fd, st.st_uid as _, st.st_gid as _);
+            let _ = bun_sys::fchmod(out_fd, mode & 0o7777);
         }
         closefd(out_fd);
         closefd(in_fd);

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -503,6 +503,14 @@ impl ShellMvBatchedTask {
         let st = bun_sys::lstatat(src_dir, src)?;
         let mode = st.st_mode as bun_core::Mode;
 
+        // Bind mounts can alias one inode through two vfsmounts (renameat()
+        // still returns EXDEV); treat same-inode as the POSIX rename() no-op.
+        if let Ok(dst_st) = bun_sys::lstatat(dst_dir, dst) {
+            if st.st_dev == dst_st.st_dev && st.st_ino == dst_st.st_ino {
+                return Ok(());
+            }
+        }
+
         if bun_sys::S::ISLNK(mode) {
             let mut buf = bun_paths::path_buffer_pool::get();
             let n = bun_sys::readlinkat(src_dir, src, &mut buf[..])?;
@@ -520,13 +528,11 @@ impl ShellMvBatchedTask {
         }
 
         if bun_sys::S::ISDIR(mode) {
-            // 0o700 so children can be written into a dest whose source mode
-            // is e.g. 0o500; the real mode is stamped via fchmod below.
+            // `| 0o700` so children can be written even when the source mode is read-only; restored via `fchmod` below.
             match bun_sys::mkdirat(dst_dir, dst, (mode & 0o7777) | 0o700) {
                 Ok(()) => {}
                 Err(e) if e.get_errno() == bun_sys::E::EEXIST => {
-                    // Same-device renameat() onto a non-empty dir fails with
-                    // ENOTEMPTY; match that instead of silently merging.
+                    // Refuse to merge into a non-empty dest (matches same-device `ENOTEMPTY`).
                     bun_sys::rmdirat(dst_dir, dst)?;
                     bun_sys::mkdirat(dst_dir, dst, (mode & 0o7777) | 0o700)?;
                 }
@@ -575,8 +581,7 @@ impl ShellMvBatchedTask {
         }
 
         if !bun_sys::S::ISREG(mode) {
-            // Opening a FIFO O_RDONLY without O_NONBLOCK blocks forever; refuse
-            // special files rather than hang the worker thread.
+            // Opening a FIFO `O_RDONLY` without `O_NONBLOCK` would block forever.
             return Err(bun_sys::Error::from_code(
                 bun_sys::E::ENOTSUP,
                 bun_sys::Tag::rename,
@@ -584,6 +589,8 @@ impl ShellMvBatchedTask {
         }
 
         let in_fd = bun_sys::openat(src_dir, src, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0)?;
+        // Unlink first so a symlink-at-dest isn't followed by `O_TRUNC`; also avoids ETXTBUSY.
+        let _ = bun_sys::unlinkat(dst_dir, dst);
         let out_fd = match bun_sys::openat(
             dst_dir,
             dst,

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -505,129 +505,90 @@ impl ShellMvBatchedTask {
         dst_dir: bun_sys::Fd,
         dst: &ZStr,
     ) -> Result<(), bun_sys::Error> {
+        use bun_sys::{Dir, E, File, O, S, Tag};
+
         let st = bun_sys::lstatat(src_dir, src)?;
         let mode = st.st_mode as bun_core::Mode;
 
         // Bind mounts can alias one inode through two vfsmounts (renameat()
         // still returns EXDEV); treat same-inode as the POSIX rename() no-op.
-        if let Ok(dst_st) = bun_sys::lstatat(dst_dir, dst) {
-            if st.st_dev == dst_st.st_dev && st.st_ino == dst_st.st_ino {
+        if let Ok(d) = bun_sys::lstatat(dst_dir, dst) {
+            if st.st_dev == d.st_dev && st.st_ino == d.st_ino {
                 return Ok(());
             }
         }
 
-        if bun_sys::S::ISLNK(mode) {
+        if S::ISLNK(mode) {
             let mut buf = bun_paths::path_buffer_pool::get();
             let n = bun_sys::readlinkat(src_dir, src, &mut buf[..])?;
             if n >= bun_paths::MAX_PATH_BYTES {
-                return Err(bun_sys::Error::from_code(
-                    bun_sys::E::ENAMETOOLONG,
-                    bun_sys::Tag::readlink,
-                ));
+                return Err(bun_sys::Error::from_code(E::ENAMETOOLONG, Tag::readlink));
             }
             buf[n] = 0;
-            let target = ZStr::from_buf(&buf[..], n);
             let _ = bun_sys::unlinkat(dst_dir, dst);
-            bun_sys::symlinkat(target, dst_dir, dst)?;
+            bun_sys::symlinkat(ZStr::from_buf(&buf[..], n), dst_dir, dst)?;
             return bun_sys::unlinkat(src_dir, src);
         }
 
-        if bun_sys::S::ISDIR(mode) {
+        if S::ISDIR(mode) {
             // `| 0o700` so children can be written even when the source mode is read-only; restored via `fchmod` below.
-            match bun_sys::mkdirat(dst_dir, dst, (mode & 0o7777) | 0o700) {
-                Ok(()) => {}
-                Err(e) if e.get_errno() == bun_sys::E::EEXIST => {
-                    // Refuse to merge into a non-empty dest (matches same-device `ENOTEMPTY`).
-                    bun_sys::rmdirat(dst_dir, dst)?;
-                    bun_sys::mkdirat(dst_dir, dst, (mode & 0o7777) | 0o700)?;
+            if let Err(e) = bun_sys::mkdirat(dst_dir, dst, (mode & 0o7777) | 0o700) {
+                if e.get_errno() != E::EEXIST {
+                    return Err(e);
                 }
-                Err(e) => return Err(e),
+                // Refuse to merge into a non-empty dest (matches same-device `ENOTEMPTY`).
+                bun_sys::rmdirat(dst_dir, dst)?;
+                bun_sys::mkdirat(dst_dir, dst, (mode & 0o7777) | 0o700)?;
             }
-            let src_fd = shell_openat(src_dir, src, bun_sys::O::RDONLY | bun_sys::O::DIRECTORY, 0)?;
-            let dst_fd =
-                match shell_openat(dst_dir, dst, bun_sys::O::RDONLY | bun_sys::O::DIRECTORY, 0) {
-                    Ok(fd) => fd,
-                    Err(e) => {
-                        closefd(src_fd);
-                        return Err(e);
-                    }
-                };
+            let sd = Dir::from_fd(shell_openat(src_dir, src, O::RDONLY | O::DIRECTORY, 0)?);
+            let dd = Dir::from_fd(shell_openat(dst_dir, dst, O::RDONLY | O::DIRECTORY, 0)?);
             // Boxed: `WrappedIterator` embeds an 8 KB inline readdir buffer.
-            let mut iter = Box::new(bun_sys::dir_iterator::iterate(src_fd));
+            let mut iter = Box::new(bun_sys::dir_iterator::iterate(sd.fd()));
             let mut nbuf = bun_paths::path_buffer_pool::get();
-            let result: Result<(), bun_sys::Error> = loop {
-                match iter.next() {
-                    Ok(Some(entry)) => {
-                        let name = entry.name.slice_u8();
-                        if name.len() >= bun_paths::MAX_PATH_BYTES {
-                            break Err(bun_sys::Error::from_code(
-                                bun_sys::E::ENAMETOOLONG,
-                                bun_sys::Tag::rename,
-                            ));
-                        }
-                        nbuf[..name.len()].copy_from_slice(name);
-                        nbuf[name.len()] = 0;
-                        let name_z = ZStr::from_buf(&nbuf[..], name.len());
-                        if let Err(e) = Self::move_across_devices(src_fd, name_z, dst_fd, name_z) {
-                            break Err(e);
-                        }
-                    }
-                    Ok(None) => break Ok(()),
-                    Err(e) => break Err(e),
+            while let Some(entry) = iter.next()? {
+                let name = entry.name.slice_u8();
+                if name.len() >= bun_paths::MAX_PATH_BYTES {
+                    return Err(bun_sys::Error::from_code(E::ENAMETOOLONG, Tag::rename));
                 }
-            };
-            if result.is_ok() {
-                #[cfg(unix)]
-                let _ = bun_sys::fchown(dst_fd, st.st_uid as _, st.st_gid as _);
-                let _ = bun_sys::fchmod(dst_fd, mode & 0o7777);
+                nbuf[..name.len()].copy_from_slice(name);
+                nbuf[name.len()] = 0;
+                let name_z = ZStr::from_buf(&nbuf[..], name.len());
+                Self::move_across_devices(sd.fd(), name_z, dd.fd(), name_z)?;
             }
-            closefd(dst_fd);
-            closefd(src_fd);
-            result?;
+            #[cfg(unix)]
+            let _ = bun_sys::fchown(dd.fd(), st.st_uid as _, st.st_gid as _);
+            let _ = bun_sys::fchmod(dd.fd(), mode & 0o7777);
+            drop((sd, dd));
             return bun_sys::rmdirat(src_dir, src);
         }
 
-        if !bun_sys::S::ISREG(mode) {
+        if !S::ISREG(mode) {
             // Opening a FIFO `O_RDONLY` without `O_NONBLOCK` would block forever.
-            return Err(bun_sys::Error::from_code(
-                bun_sys::E::ENOTSUP,
-                bun_sys::Tag::rename,
-            ));
+            return Err(bun_sys::Error::from_code(E::ENOTSUP, Tag::rename));
         }
 
-        let in_fd = bun_sys::openat(src_dir, src, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0)?;
+        let in_ = File::openat(src_dir, src.as_bytes(), O::RDONLY | O::CLOEXEC, 0)?;
         // Unlink first so a symlink-at-dest isn't followed by `O_TRUNC`; also avoids ETXTBUSY.
         let _ = bun_sys::unlinkat(dst_dir, dst);
-        let out_fd = match bun_sys::openat(
+        let out = File::openat(
             dst_dir,
-            dst,
-            bun_sys::O::WRONLY
-                | bun_sys::O::CREAT
-                | bun_sys::O::TRUNC
-                | bun_sys::O::CLOEXEC
-                | bun_sys::O::NOFOLLOW,
+            dst.as_bytes(),
+            O::WRONLY | O::CREAT | O::TRUNC | O::CLOEXEC | O::NOFOLLOW,
             mode & 0o7777,
-        ) {
-            Ok(fd) => fd,
-            Err(e) => {
-                closefd(in_fd);
-                return Err(e);
-            }
-        };
-        let _ = bun_sys::preallocate_file(out_fd.native(), 0, st.st_size as _);
-        let copied = bun_sys::copy_file(in_fd, out_fd);
-        #[cfg(unix)]
-        if copied.is_ok() {
-            // `fchown` first: Linux clears S_ISUID/S_ISGID on chown.
-            let _ = bun_sys::fchown(out_fd, st.st_uid as _, st.st_gid as _);
-            let _ = bun_sys::fchmod(out_fd, mode & 0o7777);
-        }
-        closefd(out_fd);
-        closefd(in_fd);
-        if let Err(e) = copied {
+        )?;
+        let _ = bun_sys::preallocate_file(out.fd().native(), 0, st.st_size as _);
+        if let Err(e) = bun_sys::copy_file(in_.fd(), out.fd()) {
+            drop(out);
             let _ = bun_sys::unlinkat(dst_dir, dst);
             return Err(e);
         }
+        #[cfg(unix)]
+        {
+            // `fchown` first: Linux clears S_ISUID/S_ISGID on chown.
+            let _ = bun_sys::fchown(out.fd(), st.st_uid as _, st.st_gid as _);
+            let _ = bun_sys::fchmod(out.fd(), mode & 0o7777);
+        }
+        drop((in_, out));
         bun_sys::unlinkat(src_dir, src)
     }
 

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -477,8 +477,7 @@ impl ShellMvBatchedTask {
         // Bounce-back is posted by `shell_task_trampoline`.
     }
 
-    /// `renameat()` with a POSIX `mv` cross-device fallback: on EXDEV the
-    /// source hierarchy is duplicated at the destination and then removed.
+    /// `renameat()`, falling through to [`Self::move_across_devices`] on EXDEV.
     fn do_rename(
         src_dir: bun_sys::Fd,
         src: &ZStr,
@@ -494,8 +493,7 @@ impl ShellMvBatchedTask {
         }
     }
 
-    /// EXDEV fallback: copy the source to the destination, then remove the
-    /// source. The source is only removed once the copy has fully succeeded.
+    /// EXDEV fallback: copy `src` to `dst`, then (only on success) remove `src`.
     fn move_across_devices(
         src_dir: bun_sys::Fd,
         src: &ZStr,

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -486,8 +486,13 @@ impl ShellMvBatchedTask {
     ) -> Result<(), bun_sys::Error> {
         match bun_sys::renameat(src_dir, src, dst_dir, dst) {
             Err(e) if e.get_errno() == bun_sys::E::EXDEV => {
-                Self::move_across_devices(src_dir, src, dst_dir, dst)
-                    .map_err(|e| e.with_path(src.as_bytes()))
+                Self::move_across_devices(src_dir, src, dst_dir, dst).map_err(|e| {
+                    if e.path.is_empty() {
+                        e.with_path(src.as_bytes())
+                    } else {
+                        e
+                    }
+                })
             }
             r => r,
         }
@@ -596,7 +601,11 @@ impl ShellMvBatchedTask {
         let out_fd = match bun_sys::openat(
             dst_dir,
             dst,
-            bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC | bun_sys::O::CLOEXEC,
+            bun_sys::O::WRONLY
+                | bun_sys::O::CREAT
+                | bun_sys::O::TRUNC
+                | bun_sys::O::CLOEXEC
+                | bun_sys::O::NOFOLLOW,
             mode & 0o7777,
         ) {
             Ok(fd) => fd,

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -2,6 +2,9 @@ import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
 import { isPosix } from "harness";
 import {
+  accessSync,
+  chmodSync,
+  constants,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -70,9 +73,11 @@ describe("mv", async () => {
     function findCrossDeviceDir(): string | undefined {
       if (!isPosix) return undefined;
       const refDev = statSync(tmp).dev;
-      for (const candidate of ["/dev/shm", "/tmp", "/run"]) {
+      for (const candidate of ["/dev/shm", "/tmp"]) {
         try {
-          if (statSync(candidate).dev !== refDev) return candidate;
+          if (statSync(candidate).dev === refDev) continue;
+          accessSync(candidate, constants.W_OK | constants.X_OK);
+          return candidate;
         } catch {}
       }
       return undefined;
@@ -97,12 +102,14 @@ describe("mv", async () => {
         const srcFile = join(src, "f.txt");
         const dstFile = join(dst, "f.txt");
         writeFileSync(srcFile, "payload\n");
+        chmodSync(srcFile, 0o640);
 
         const r = await $`mv ${srcFile} ${dstFile}`.quiet();
         expect(r.stderr.toString()).toBe("");
         expect(r.exitCode).toBe(0);
         expect(existsSync(srcFile)).toBe(false);
         expect(readFileSync(dstFile, "utf8")).toBe("payload\n");
+        expect(statSync(dstFile).mode & 0o777).toBe(0o640);
       } finally {
         rmSync(src, { recursive: true, force: true });
         rmSync(dst, { recursive: true, force: true });

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -1,9 +1,18 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, readlinkSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { isPosix } from "harness";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "path";
-import { isPosix } from "harness";
 import { createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const TestBuilder = createTestBuilder(import.meta.path);

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -6,6 +6,7 @@ import {
   chmodSync,
   constants,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   readlinkSync,
@@ -142,7 +143,7 @@ describe("mv", async () => {
         const r = await $`mv ${srcLink} ${dst}`.quiet();
         expect(r.stderr.toString()).toBe("");
         expect(r.exitCode).toBe(0);
-        expect(existsSync(srcLink)).toBe(false);
+        expect(lstatSync(srcLink, { throwIfNoEntry: false })).toBeUndefined();
         expect(readlinkSync(join(dst, "link"))).toBe("does-not-exist");
       } finally {
         rmSync(src, { recursive: true, force: true });
@@ -164,6 +165,43 @@ describe("mv", async () => {
         expect(existsSync(srcDir)).toBe(false);
         expect(readFileSync(join(dst, "tree", "a.txt"), "utf8")).toBe("A\n");
         expect(readFileSync(join(dst, "tree", "sub", "b.txt"), "utf8")).toBe("B\n");
+      } finally {
+        rmSync(src, { recursive: true, force: true });
+        rmSync(dst, { recursive: true, force: true });
+      }
+    });
+
+    test.skipIf(skip)("directory onto non-empty directory across devices fails", async () => {
+      const [src, dst] = crossDevicePair("notempty");
+      try {
+        const srcDir = join(src, "d");
+        mkdirSync(srcDir);
+        writeFileSync(join(srcDir, "f.txt"), "new\n");
+        mkdirSync(join(dst, "d"));
+        writeFileSync(join(dst, "d", "f.txt"), "precious\n");
+
+        const r = await $`mv ${srcDir} ${dst}`.quiet();
+        expect(r.stderr.toString()).toContain("not empty");
+        expect(r.exitCode).not.toBe(0);
+        expect(readFileSync(join(dst, "d", "f.txt"), "utf8")).toBe("precious\n");
+        expect(readFileSync(join(srcDir, "f.txt"), "utf8")).toBe("new\n");
+      } finally {
+        rmSync(src, { recursive: true, force: true });
+        rmSync(dst, { recursive: true, force: true });
+      }
+    });
+
+    test.skipIf(skip)("FIFO across devices fails fast", async () => {
+      const [src, dst] = crossDevicePair("fifo");
+      try {
+        const fifo = join(src, "pipe");
+        const { exitCode: mk } = Bun.spawnSync({ cmd: ["mkfifo", fifo] });
+        expect(mk).toBe(0);
+
+        const r = await $`mv ${fifo} ${dst}`.quiet();
+        expect(r.exitCode).not.toBe(0);
+        expect(lstatSync(fifo).isFIFO()).toBe(true);
+        expect(lstatSync(join(dst, "pipe"), { throwIfNoEntry: false })).toBeUndefined();
       } finally {
         rmSync(src, { recursive: true, force: true });
         rmSync(dst, { recursive: true, force: true });

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -199,6 +199,7 @@ describe("mv", async () => {
         expect(mk).toBe(0);
 
         const r = await $`mv ${fifo} ${dst}`.quiet();
+        expect(r.stderr.toString()).toContain("not supported");
         expect(r.exitCode).not.toBe(0);
         expect(lstatSync(fifo).isFIFO()).toBe(true);
         expect(lstatSync(join(dst, "pipe"), { throwIfNoEntry: false })).toBeUndefined();

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -1,6 +1,9 @@
 import { $ } from "bun";
-import { describe, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, readlinkSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "path";
+import { isPosix } from "harness";
 import { createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const TestBuilder = createTestBuilder(import.meta.path);
@@ -49,4 +52,106 @@ describe("mv", async () => {
     .exitCode(20 /* ENOTDIR */)
     .stderr("mv: a: Not a directory\n")
     .runAsTest("move dir -> file fails");
+
+  // POSIX `mv` must fall back to copy+unlink when `rename()` returns EXDEV
+  // (source and destination on different filesystems). Requires a writable
+  // mount on a different device from the harness temp dir.
+  describe("cross-device (EXDEV)", () => {
+    const tmp = tmpdir();
+    function findCrossDeviceDir(): string | undefined {
+      if (!isPosix) return undefined;
+      const refDev = statSync(tmp).dev;
+      for (const candidate of ["/dev/shm", "/tmp", "/run"]) {
+        try {
+          if (statSync(candidate).dev !== refDev) return candidate;
+        } catch {}
+      }
+      return undefined;
+    }
+    const other = findCrossDeviceDir();
+    const skip = other === undefined;
+
+    function crossDevicePair(name: string): [src: string, dst: string] {
+      const base = `bun-mv-xdev-${process.pid}-${name}`;
+      const a = join(tmp, base);
+      const b = join(other!, base);
+      for (const d of [a, b]) {
+        rmSync(d, { recursive: true, force: true });
+        mkdirSync(d, { recursive: true });
+      }
+      return [a, b];
+    }
+
+    test.skipIf(skip)("file -> file across devices", async () => {
+      const [src, dst] = crossDevicePair("file");
+      try {
+        const srcFile = join(src, "f.txt");
+        const dstFile = join(dst, "f.txt");
+        writeFileSync(srcFile, "payload\n");
+
+        const r = await $`mv ${srcFile} ${dstFile}`.quiet();
+        expect(r.stderr.toString()).toBe("");
+        expect(r.exitCode).toBe(0);
+        expect(existsSync(srcFile)).toBe(false);
+        expect(readFileSync(dstFile, "utf8")).toBe("payload\n");
+      } finally {
+        rmSync(src, { recursive: true, force: true });
+        rmSync(dst, { recursive: true, force: true });
+      }
+    });
+
+    test.skipIf(skip)("file -> directory across devices", async () => {
+      const [src, dst] = crossDevicePair("into-dir");
+      try {
+        const srcFile = join(src, "g.txt");
+        writeFileSync(srcFile, "into-dir\n");
+
+        const r = await $`mv ${srcFile} ${dst}`.quiet();
+        expect(r.stderr.toString()).toBe("");
+        expect(r.exitCode).toBe(0);
+        expect(existsSync(srcFile)).toBe(false);
+        expect(readFileSync(join(dst, "g.txt"), "utf8")).toBe("into-dir\n");
+      } finally {
+        rmSync(src, { recursive: true, force: true });
+        rmSync(dst, { recursive: true, force: true });
+      }
+    });
+
+    test.skipIf(skip)("symlink across devices", async () => {
+      const [src, dst] = crossDevicePair("symlink");
+      try {
+        const srcLink = join(src, "link");
+        symlinkSync("does-not-exist", srcLink);
+
+        const r = await $`mv ${srcLink} ${dst}`.quiet();
+        expect(r.stderr.toString()).toBe("");
+        expect(r.exitCode).toBe(0);
+        expect(existsSync(srcLink)).toBe(false);
+        expect(readlinkSync(join(dst, "link"))).toBe("does-not-exist");
+      } finally {
+        rmSync(src, { recursive: true, force: true });
+        rmSync(dst, { recursive: true, force: true });
+      }
+    });
+
+    test.skipIf(skip)("directory tree across devices", async () => {
+      const [src, dst] = crossDevicePair("tree");
+      try {
+        const srcDir = join(src, "tree");
+        mkdirSync(join(srcDir, "sub"), { recursive: true });
+        writeFileSync(join(srcDir, "a.txt"), "A\n");
+        writeFileSync(join(srcDir, "sub", "b.txt"), "B\n");
+
+        const r = await $`mv ${srcDir} ${dst}`.quiet();
+        expect(r.stderr.toString()).toBe("");
+        expect(r.exitCode).toBe(0);
+        expect(existsSync(srcDir)).toBe(false);
+        expect(readFileSync(join(dst, "tree", "a.txt"), "utf8")).toBe("A\n");
+        expect(readFileSync(join(dst, "tree", "sub", "b.txt"), "utf8")).toBe("B\n");
+      } finally {
+        rmSync(src, { recursive: true, force: true });
+        rmSync(dst, { recursive: true, force: true });
+      }
+    });
+  });
 });


### PR DESCRIPTION
## What

The Bun Shell `mv` builtin called `renameat()` with no cross-device fallback, so any move between filesystems (project dir to `/tmp` tmpfs, docker volume, bind mount) failed with `Invalid cross-device link`, left the source untouched, and surfaced the raw errno (18) as the exit code. POSIX and coreutils `mv` both fall back to copy-then-remove on EXDEV.

## Repro

```js
// cwd on a different filesystem than the destination (e.g. root fs vs tmpfs)
import { $ } from "bun";
import { writeFileSync, existsSync, statSync, mkdirSync } from "node:fs";
mkdirSync("box", { recursive: true });
writeFileSync("box/f.txt", "payload\n");
console.log("different devices:", statSync("box").dev !== statSync("/dev/shm").dev);
const r = await $`mv box/f.txt /dev/shm/f.txt`.throws(false).quiet();
console.log(r.exitCode, r.stderr.toString().trim());
// before: 18  mv: box/f.txt: Invalid cross-device link
// after:  0
```

## Cause

Both `mv` code paths were a bare `bun_sys::renameat()` with no EXDEV branch:

* `src/runtime/shell/builtin/mv.rs:470` single-entry rename
* `src/runtime/shell/builtin/mv.rs:501` `move_in_dir`

## Fix

`ShellMvBatchedTask::do_rename` wraps `renameat()` and, on `E::EXDEV`, calls `move_across_devices`, which runs on the existing worker thread:

* **regular files**: mirrors `bun_sys::move_file_z_with_handle`. `openat` the source `RDONLY`, `openat` the destination `O_WRONLY|O_CREAT|O_TRUNC` with the source mode, `preallocate_file` (best-effort), `bun_sys::copy_file` (ficlone / `copy_file_range` / `sendfile` fast path), `fchmod`/`fchown` from the source stat, then `unlinkat` the source. A failed copy unlinks the partial destination and surfaces the copy errno; the source is never touched until the copy completes (unlike `move_file_z_slow`, which unlinks first).
* **symlinks**: `readlinkat` the target, `symlinkat` at the destination, `unlinkat` source.
* **directories**: `mkdirat` the destination, walk the source with `bun_sys::dir_iterator` and recurse per entry, `rmdirat` the now-empty source on success.

All work stays inside `run_from_thread_pool`; no new `MvState` variant and no async cp/rm task plumbing. The directory walk reuses the same `bun_sys::copy_file` primitive per file, so it keeps the kernel fast-path; the trade-off is that a cross-device directory tree copies serially on one worker thread rather than fanning out through `ShellAsyncCpTask`.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/bun/shell/commands/mv.test.ts
  6 pass, 4 fail  (all four EXDEV cases: Invalid cross-device link)

bun bd test test/js/bun/shell/commands/mv.test.ts
  10 pass, 0 fail

bun bd test test/js/bun/shell/bunshell.test.ts
  414 pass, 0 fail

bun run rust:check-all
  10 ok, 0 failed
```

The new cross-device tests skip when no second filesystem is available (macOS CI, any host where `/dev/shm`, `/tmp`, `/run` share a device with `os.tmpdir()`).

Fixes #12394

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/commands/mv.test.ts
bun test v1.4.0 (8173f3a0f)

test/js/bun/shell/commands/mv.test.ts:
(pass) mv > move file -> file [107.26ms]
a
(pass) mv > move single file into a directory [27.20ms]
c
b
a
(pass) mv > move multiple files into a directory [32.37ms]
mv: does_not_exist/: No such file or directory
(pass) mv > fails if destination folder does not exist [7.14ms]
inside_bar
foo
bar/foo:
inside_foo
(pass) mv > move dir -> dir [18.35ms]
mv: a: Not a directory
(pass) mv > move dir -> file fails [28.73ms]
104 |         const dstFile = join(dst, "f.txt");
105 |         writeFileSync(srcFile, "payload\n");
106 |         chmodSync(srcFile, 0o640);
107 | 
108 |         const r = await $`mv ${srcFile} ${dstFile}`.quiet();
109 |         expect(r.stderr.toString()).toBe("");
                                          ^
error: expect(received).toBe(expected)

- ""
+ "mv: /tmp/bun-mv-xdev-174668-file/f.txt: Invalid cross-device link
+ "

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/bun/shell/commands/m
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (309719322)

test/js/bun/shell/commands/mv.test.ts:
(pass) mv > move file -> file [1.90ms]
a
(pass) mv > move single file into a directory [1.14ms]
c
b
a
(pass) mv > move multiple files into a directory [0.44ms]
mv: does_not_exist/: No such file or directory
(pass) mv > fails if destination folder does not exist [0.15ms]
inside_bar
foo
bar/foo:
inside_foo
(pass) mv > move dir -> dir [0.65ms]
mv: a: Not a directory
(pass) mv > move dir -> file fails [0.95ms]
(pass) mv > cross-device (EXDEV) > file -> file across devices [1.33ms]
(pass) mv > cross-device (EXDEV) > file -> directory across devices [0.84ms]
(pass) mv > cross-device (EXDEV) > symlink across devices [1.44ms]
(pass) mv > cross-device (EXDEV) > directory tree across devices [1.15ms]
(pass) mv > cross-device (EXDEV) > directory onto non-empty directory across devices fails [0.82ms]
(pass) mv > cross-device (EXDEV) > FIFO across devices fails fast [2.23ms]

 12 pass
 0 fail
 50 expect() calls
Ran 12 tests across 1 file. [205.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/commands/mv.test.ts
bun test v1.4.0 (8173f3a0f)

test/js/bun/shell/commands/mv.test.ts:
(pass) mv > move file -> file [102.93ms]
a
(pass) mv > move single file into a directory [23.22ms]
c
b
a
(pass) mv > move multiple files into a directory [27.04ms]
mv: does_not_exist/: No such file or directory
(pass) mv > fails if destination folder does not exist [20.51ms]
inside_bar
foo
bar/foo:
inside_foo
(pass) mv > move dir -> dir [30.49ms]
mv: a: Not a directory
(pass) mv > move dir -> file fails [14.72ms]
(pass) mv > cross-device (EXDEV) > file -> file across devices [40.04ms]
(pass) mv > cross-device (EXDEV) > file -> directory across devices [30.70ms]
(pass) mv > cross-device (EXDEV) > symlink across devices [27.60ms]
(pass) mv > cross-device (EXDEV) > directory tree across devices [32.96ms]
(pass) mv > cross-device (EXDEV) > directory onto non-empty directory across devices fails [32.42ms]
(pass) mv > cross-device (EXDEV) > FIFO across devices fails fast [45.77ms]

 12 pass
 0 fail
 50 expect() calls
Ran 12 tests across 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     8173f3a0fa
  features     baseline

22 deps, 108 codegen, 1171 objects in 785ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1233] install /workspace/bun
bun install v1.4.0-canary.1 (309719322)

Checked 124 installs across 170 packages (no changes) [9.00ms]
[2/1233] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (309719322)

Checked 1 install across 2 packages (no changes) [7.00ms]
[3/1233] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (309719322)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[4/1233] gen ErrorCode+*.h
[5/1233] gen bindgenv2
[6/1233] fetch picohttpparser
[picohttpparser] up to date
[7/1233] fetch zlib
[zlib] up to date
[8/1233] fetch tinycc
[tinycc] up to date
[9/1232] gen .bind.ts → GeneratedBindings.cpp
[10/1232] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1232] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/result.rs                |   1 +
 src/runtime/shell/builtin/mv.rs       | 158 ++++++++++++++++++++++++++++++++-
 test/js/bun/shell/commands/mv.test.ts | 162 +++++++++++++++++++++++++++++++++-
 3 files changed, 318 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/bun_core/result.rs                     1      1      0
src/runtime/shell/builtin/mv.rs           10     17      0
test/js/bun/shell/commands/mv.test.ts      5     11      0
```

</details>

<!-- robobun:evidence:end -->