### PR TITLE
ci(build): keep waiting for build-cpp while a retry is queued instead of bailing on a stale errored outcome

### DIFF
--- a/scripts/build/ci.ts
+++ b/scripts/build/ci.ts
@@ -638,7 +638,8 @@ export async function waitForStepOutcome(stepKey: string, pollMs = 3000): Promis
   const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
   const get = (attr: string) => {
     const r = spawnSync("buildkite-agent", ["step", "get", attr, "--step", stepKey], { encoding: "utf8" });
-    return { ok: !r.error && r.status === 0, out: (r.stdout ?? "").trim(), err: (r.stderr ?? "").trim() };
+    if (r.error) throw new BuildError(`Failed to spawn buildkite-agent`, { cause: r.error });
+    return { ok: r.status === 0, out: (r.stdout ?? "").trim(), err: (r.stderr ?? "").trim() };
   };
   const start = Date.now();
   const deadlineMs = 60 * 60 * 1000;

--- a/scripts/build/ci.ts
+++ b/scripts/build/ci.ts
@@ -600,6 +600,19 @@ function runAsync(argv: string[], cwd: string): Promise<void> {
   });
 }
 
+/** One `buildkite-agent step get <attr>` read. */
+export interface StepGetResult {
+  ok: boolean;
+  out: string;
+  err: string;
+}
+
+function agentStepGet(stepKey: string, attr: string): StepGetResult {
+  const r = spawnSync("buildkite-agent", ["step", "get", attr, "--step", stepKey], { encoding: "utf8" });
+  if (r.error) throw new BuildError(`Failed to spawn buildkite-agent`, { cause: r.error });
+  return { ok: r.status === 0, out: (r.stdout ?? "").trim(), err: (r.stderr ?? "").trim() };
+}
+
 /**
  * Poll `buildkite-agent step get` until `<stepKey>` reaches a terminal state.
  * Returns on "passed"; throws on a terminal failure so the caller exits 1 with
@@ -608,46 +621,36 @@ function runAsync(argv: string[], cwd: string): Promise<void> {
  *
  * `outcome` alone is not enough: Buildkite reports the last *completed* job's
  * outcome, so an earlier attempt that errored/expired reads as `errored` even
- * while an automatic or manual retry is queued or running. `state` tracks the
- * latest job (it's what depends_on gates on), so a failure outcome is only
- * believed once `state` is terminal too. See build 84838: windows-x64-build-bun
- * bailed on `outcome: errored [0s]` while windows-x64-build-cpp's retry was
- * sitting in the queue.
+ * while an automatic or manual retry is queued or running. `state` is the
+ * step-level state (`ready`/`running`/`failing`/`finished`/…, distinct from
+ * REST's job states; see https://buildkite.com/docs/agent/v3/cli-step), so a
+ * failure outcome is only believed once `state` is terminal too. Build 84838's
+ * windows-x64-build-bun bailed on `outcome: errored [0s]` while
+ * windows-x64-build-cpp's retry was still queued; build 85043's linux-aarch64
+ * logged the expected `state=running` → `state=finished`.
  *
- * Exported for test/internal/ci-sibling-wait.test.ts; pollMs is only for that
- * test (CI keeps the default 3s).
+ * Exported for test/internal/ci-sibling-wait.test.ts; `opts` is the test seam.
  */
-export async function waitForStepOutcome(stepKey: string, pollMs = 3000): Promise<void> {
+export async function waitForStepOutcome(
+  stepKey: string,
+  opts: { pollMs?: number; get?: (stepKey: string, attr: string) => StepGetResult } = {},
+): Promise<void> {
+  const { pollMs = 3000, get = agentStepGet } = opts;
   const failedOutcome = new Set(["hard_failed", "soft_failed", "errored", "canceled", "cancelled"]);
-  // Job states that mean "a retry is in flight / the step isn't done". Anything
-  // in this set keeps the poll going even when `outcome` already shows a
-  // failure from an earlier attempt. Unknown values fall through to the
-  // outcome check, preserving the pre-retry-aware behaviour.
-  const liveState = new Set([
-    "pending",
-    "waiting",
-    "blocked",
-    "unblocked",
-    "limiting",
-    "limited",
-    "scheduled",
-    "assigned",
-    "accepted",
-    "running",
-  ]);
+  // `step get state` returns step states, not job states. The terminal ones per
+  // Buildkite's glossary are `finished`/`canceled`/`ignored`; everything else
+  // (`waiting_for_dependencies`/`ready`/`running`/`failing`, or a value we
+  // haven't seen) means a job for this step may still produce a pass. An empty
+  // `state` falls back to outcome-only (the pre-retry-aware behaviour).
+  const terminalState = new Set(["finished", "canceled", "cancelled", "ignored"]);
   const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
-  const get = (attr: string) => {
-    const r = spawnSync("buildkite-agent", ["step", "get", attr, "--step", stepKey], { encoding: "utf8" });
-    if (r.error) throw new BuildError(`Failed to spawn buildkite-agent`, { cause: r.error });
-    return { ok: r.status === 0, out: (r.stdout ?? "").trim(), err: (r.stderr ?? "").trim() };
-  };
   const start = Date.now();
   const deadlineMs = 60 * 60 * 1000;
   let last = "";
   let terminalReads = 0;
   console.log(`Waiting for ${stepKey} to finish...`);
   for (;;) {
-    const outcome = get("outcome");
+    const outcome = get(stepKey, "outcome");
     if (!outcome.ok) {
       if (outcome.err !== last) {
         console.log(`  buildkite-agent step get outcome failed: ${outcome.err}`);
@@ -659,9 +662,7 @@ export async function waitForStepOutcome(stepKey: string, pollMs = 3000): Promis
       await sleep(pollMs);
       continue;
     }
-    // `state` is advisory: if the agent/API doesn't return it, fall back to
-    // outcome-only (the original behaviour).
-    const state = get("state");
+    const state = get(stepKey, "state");
     const stateVal = state.ok ? state.out : "";
     const display = `${outcome.out || "(none)"}${stateVal ? ` / state=${stateVal}` : ""}`;
     if (display !== last) {
@@ -670,11 +671,11 @@ export async function waitForStepOutcome(stepKey: string, pollMs = 3000): Promis
       last = display;
     }
     if (outcome.out === "passed") return;
-    if (failedOutcome.has(outcome.out) && !liveState.has(stateVal)) {
-      // Two consecutive terminal reads before giving up: a retry job is
-      // created ~1s after its predecessor finishes, so a single poll can land
-      // in the gap where attempt N is `expired` and attempt N+1 isn't
-      // `scheduled` yet.
+    const stateIsTerminal = stateVal === "" || terminalState.has(stateVal);
+    if (failedOutcome.has(outcome.out) && stateIsTerminal) {
+      // Two consecutive terminal reads before giving up: a retry job appears
+      // ~1s after its predecessor ends, so a single poll can see `finished`
+      // before the step goes back to `ready` for the retry.
       if (++terminalReads >= 2) {
         throw new BuildError(`Sibling step ${stepKey} ${outcome.out} — nothing to link`, {
           hint: `See the ${stepKey} job for the real error; this step only downloads its artifacts.`,

--- a/scripts/build/ci.ts
+++ b/scripts/build/ci.ts
@@ -609,7 +609,9 @@ export interface StepGetResult {
 
 function agentStepGet(stepKey: string, attr: string): StepGetResult {
   const r = spawnSync("buildkite-agent", ["step", "get", attr, "--step", stepKey], { encoding: "utf8" });
-  if (r.error) throw new BuildError(`Failed to spawn buildkite-agent`, { cause: r.error });
+  if (r.error) {
+    throw new BuildError(`Failed to spawn buildkite-agent step get ${attr} --step ${stepKey}`, { cause: r.error });
+  }
   return { ok: r.status === 0, out: (r.stdout ?? "").trim(), err: (r.stderr ?? "").trim() };
 }
 
@@ -663,15 +665,20 @@ export async function waitForStepOutcome(
       continue;
     }
     const state = get(stepKey, "state");
-    const stateVal = state.ok ? state.out : "";
-    const display = `${outcome.out || "(none)"}${stateVal ? ` / state=${stateVal}` : ""}`;
+    const stateVal = state.ok ? state.out : `<${state.err || "error"}>`;
+    const display = `${outcome.out || "(none)"} / state=${stateVal || "(none)"}`;
     if (display !== last) {
       const elapsed = Math.round((Date.now() - start) / 1000);
       console.log(`  ${stepKey} outcome=${display} [${elapsed}s]`);
       last = display;
     }
     if (outcome.out === "passed") return;
-    const stateIsTerminal = stateVal === "" || terminalState.has(stateVal);
+    // A successful-but-empty `state` falls back to outcome-only (pre-change
+    // behaviour). A FAILED `state` read is not evidence of anything — the
+    // outcome read in this same iteration worked, so the agent and API are
+    // reachable; treat it as non-terminal rather than let a flaky second call
+    // undo the retry-awareness this poll exists for.
+    const stateIsTerminal = state.ok && (state.out === "" || terminalState.has(state.out));
     if (failedOutcome.has(outcome.out) && stateIsTerminal) {
       // Two consecutive terminal reads before giving up: a retry job appears
       // ~1s after its predecessor ends, so a single poll can see `finished`

--- a/scripts/build/ci.ts
+++ b/scripts/build/ci.ts
@@ -503,9 +503,8 @@ function makeZip(cfg: Config, name: string, files: string[]): string {
  * after download.
  *
  * rust-and-link runs in parallel with build-cpp (no depends_on), so it
- * POLLS `buildkite-agent step get outcome` for the cpp step until it passes
- * before attempting the download. link-only has depends_on and skips the
- * poll.
+ * POLLS `buildkite-agent step get` for the cpp step until it passes before
+ * attempting the download. link-only has depends_on and skips the poll.
  *
  * Call BEFORE ninja — the downloaded files are ninja's link inputs.
  */
@@ -602,53 +601,93 @@ function runAsync(argv: string[], cwd: string): Promise<void> {
 }
 
 /**
- * Poll `buildkite-agent step get outcome --step <key>` until the step
- * reaches a terminal state. Returns on "passed"; throws on any failure
- * outcome so the caller exits 1 with a message that points at the real
- * failing step (rather than a downstream "artifact not found").
+ * Poll `buildkite-agent step get` until `<stepKey>` reaches a terminal state.
+ * Returns on "passed"; throws on a terminal failure so the caller exits 1 with
+ * a message that points at the real failing step (rather than a downstream
+ * "artifact not found").
+ *
+ * `outcome` alone is not enough: Buildkite reports the last *completed* job's
+ * outcome, so an earlier attempt that errored/expired reads as `errored` even
+ * while an automatic or manual retry is queued or running. `state` tracks the
+ * latest job (it's what depends_on gates on), so a failure outcome is only
+ * believed once `state` is terminal too. See build 84838: windows-x64-build-bun
+ * bailed on `outcome: errored [0s]` while windows-x64-build-cpp's retry was
+ * sitting in the queue.
+ *
+ * Exported for test/internal/ci-sibling-wait.test.ts; pollMs is only for that
+ * test (CI keeps the default 3s).
  */
-async function waitForStepOutcome(stepKey: string): Promise<void> {
-  const failed = new Set(["hard_failed", "soft_failed", "errored", "canceled", "cancelled"]);
+export async function waitForStepOutcome(stepKey: string, pollMs = 3000): Promise<void> {
+  const failedOutcome = new Set(["hard_failed", "soft_failed", "errored", "canceled", "cancelled"]);
+  // Job states that mean "a retry is in flight / the step isn't done". Anything
+  // in this set keeps the poll going even when `outcome` already shows a
+  // failure from an earlier attempt. Unknown values fall through to the
+  // outcome check, preserving the pre-retry-aware behaviour.
+  const liveState = new Set([
+    "pending",
+    "waiting",
+    "blocked",
+    "unblocked",
+    "limiting",
+    "limited",
+    "scheduled",
+    "assigned",
+    "accepted",
+    "running",
+  ]);
   const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+  const get = (attr: string) => {
+    const r = spawnSync("buildkite-agent", ["step", "get", attr, "--step", stepKey], { encoding: "utf8" });
+    return { ok: !r.error && r.status === 0, out: (r.stdout ?? "").trim(), err: (r.stderr ?? "").trim() };
+  };
   const start = Date.now();
   const deadlineMs = 60 * 60 * 1000;
   let last = "";
+  let terminalReads = 0;
   console.log(`Waiting for ${stepKey} to finish...`);
   for (;;) {
-    const result = spawnSync("buildkite-agent", ["step", "get", "outcome", "--step", stepKey], { encoding: "utf8" });
-    if (result.error) {
-      throw new BuildError(`Failed to spawn buildkite-agent`, { cause: result.error });
-    }
-    if (result.status !== 0) {
-      const err = (result.stderr ?? "").trim();
-      if (err !== last) {
-        console.log(`  buildkite-agent step get exited ${result.status}: ${err}`);
-        last = err;
+    const outcome = get("outcome");
+    if (!outcome.ok) {
+      if (outcome.err !== last) {
+        console.log(`  buildkite-agent step get outcome failed: ${outcome.err}`);
+        last = outcome.err;
       }
       if (Date.now() - start > deadlineMs) {
-        throw new BuildError(`buildkite-agent step get kept failing for ${stepKey}`, { hint: err });
+        throw new BuildError(`buildkite-agent step get kept failing for ${stepKey}`, { hint: outcome.err });
       }
-      await sleep(3000);
+      await sleep(pollMs);
       continue;
     }
-    const outcome = (result.stdout ?? "").trim();
-    if (outcome !== last) {
+    // `state` is advisory: if the agent/API doesn't return it, fall back to
+    // outcome-only (the original behaviour).
+    const state = get("state");
+    const stateVal = state.ok ? state.out : "";
+    const display = `${outcome.out || "(none)"}${stateVal ? ` / state=${stateVal}` : ""}`;
+    if (display !== last) {
       const elapsed = Math.round((Date.now() - start) / 1000);
-      console.log(`  ${stepKey} outcome: ${outcome || "(running)"} [${elapsed}s]`);
-      last = outcome;
+      console.log(`  ${stepKey} outcome=${display} [${elapsed}s]`);
+      last = display;
     }
-    if (outcome === "passed") return;
-    if (failed.has(outcome)) {
-      throw new BuildError(`Sibling step ${stepKey} ${outcome} — nothing to link`, {
-        hint: `See the ${stepKey} job for the real error; this step only downloads its artifacts.`,
-      });
+    if (outcome.out === "passed") return;
+    if (failedOutcome.has(outcome.out) && !liveState.has(stateVal)) {
+      // Two consecutive terminal reads before giving up: a retry job is
+      // created ~1s after its predecessor finishes, so a single poll can land
+      // in the gap where attempt N is `expired` and attempt N+1 isn't
+      // `scheduled` yet.
+      if (++terminalReads >= 2) {
+        throw new BuildError(`Sibling step ${stepKey} ${outcome.out} — nothing to link`, {
+          hint: `See the ${stepKey} job for the real error; this step only downloads its artifacts.`,
+        });
+      }
+    } else {
+      terminalReads = 0;
     }
     if (Date.now() - start > deadlineMs) {
       throw new BuildError(`Timed out after 60m waiting for ${stepKey}`, {
         hint: `${stepKey} never reached a terminal outcome; check that job for a hang.`,
       });
     }
-    await sleep(3000);
+    await sleep(pollMs);
   }
 }
 

--- a/test/internal/ci-sibling-wait.test.ts
+++ b/test/internal/ci-sibling-wait.test.ts
@@ -13,19 +13,19 @@
 import { describe, expect, test } from "bun:test";
 import { waitForStepOutcome, type StepGetResult } from "../../scripts/build/ci.ts";
 
+type Read = string | { ok: false; err: string };
+const fail = (err: string): Read => ({ ok: false, err });
+
 /** Drive `waitForStepOutcome` through a canned sequence of `outcome`/`state` reads. */
-function run(script: ReadonlyArray<{ outcome: string; state: string } | { ok: false; err: string }>) {
+function run(script: ReadonlyArray<{ outcome: Read; state: Read }>) {
   let i = 0;
-  const get = (_stepKey: string, attr: string): StepGetResult => {
+  const get = (_stepKey: string, attr: "outcome" | "state"): StepGetResult => {
     const entry = script[Math.min(i, script.length - 1)]!;
-    // One poll = outcome then state; advance on state so both reads see the same entry.
-    if (attr === "state") i++;
-    if ("ok" in entry) {
-      // A transient agent failure: the poll retries without reading `state`.
-      if (attr === "outcome") i++;
-      return { ok: false, out: "", err: entry.err };
-    }
-    return { ok: true, out: entry[attr as "outcome" | "state"], err: "" };
+    const v = entry[attr];
+    // One poll is `outcome` then (if outcome was ok) `state`; advance after the
+    // last read in the poll so both reads see the same entry.
+    if (attr === "state" || (attr === "outcome" && typeof v !== "string")) i++;
+    return typeof v === "string" ? { ok: true, out: v, err: "" } : { ok: false, out: "", err: v.err };
   };
   return waitForStepOutcome("linux-x64-build-cpp", { pollMs: 0, get });
 }
@@ -90,7 +90,7 @@ describe.concurrent("waitForStepOutcome", () => {
   });
 
   test("falls back to outcome when state is unavailable", async () => {
-    // An empty/unavailable state must not mask a real failure.
+    // A successful-but-empty state must not mask a real failure.
     await expect(
       run([
         { outcome: "errored", state: "" },
@@ -99,9 +99,20 @@ describe.concurrent("waitForStepOutcome", () => {
     ).rejects.toThrow("linux-x64-build-cpp errored");
   });
 
-  test("retries a transient agent error", async () => {
+  test("treats a failed state read as non-terminal", async () => {
+    // `outcome` read in the same poll succeeded, so the agent is up; a flaky
+    // `state` read must not count as a terminal observation.
     await run([
-      { ok: false, err: "transient 502" },
+      { outcome: "errored", state: fail("502 Bad Gateway") },
+      { outcome: "errored", state: fail("502 Bad Gateway") },
+      { outcome: "errored", state: "ready" },
+      { outcome: "passed", state: "finished" },
+    ]);
+  });
+
+  test("retries a transient agent error on outcome", async () => {
+    await run([
+      { outcome: fail("transient 502"), state: "n/a" },
       { outcome: "passed", state: "finished" },
     ]);
   });

--- a/test/internal/ci-sibling-wait.test.ts
+++ b/test/internal/ci-sibling-wait.test.ts
@@ -11,7 +11,7 @@
  * two apart.
  */
 import { describe, expect, test } from "bun:test";
-import { isWindows, tempDir } from "harness";
+import { bunExe, isWindows, tempDir } from "harness";
 import { chmodSync } from "node:fs";
 import { join } from "node:path";
 import { waitForStepOutcome } from "../../scripts/build/ci.ts";
@@ -37,7 +37,7 @@ n=0
 if [ "$attr" = "state" ]; then
   echo $((n+1)) > "$AGENT_DIR/calls"
 fi
-node -e '
+exec "$BUN_EXE" -e '
   const s = require(process.env.AGENT_DIR + "/script.json");
   const i = Math.min(+process.argv[1], s.length - 1);
   process.stdout.write(s[i][process.argv[2]] ?? "");
@@ -45,16 +45,17 @@ node -e '
 `,
   });
   chmodSync(join(String(dir), "buildkite-agent"), 0o755);
-  const prevPath = process.env.PATH;
-  const prevDir = process.env.AGENT_DIR;
-  process.env.PATH = `${dir}:${prevPath}`;
+  const prev = { PATH: process.env.PATH, AGENT_DIR: process.env.AGENT_DIR, BUN_EXE: process.env.BUN_EXE };
+  process.env.PATH = `${dir}:${prev.PATH}`;
   process.env.AGENT_DIR = String(dir);
+  process.env.BUN_EXE = bunExe();
   try {
     return await fn();
   } finally {
-    process.env.PATH = prevPath;
-    if (prevDir === undefined) delete process.env.AGENT_DIR;
-    else process.env.AGENT_DIR = prevDir;
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
   }
 }
 

--- a/test/internal/ci-sibling-wait.test.ts
+++ b/test/internal/ci-sibling-wait.test.ts
@@ -2,134 +2,107 @@
  * Unit tests for the build-bun → build-cpp sibling poll in
  * scripts/build/ci.ts::waitForStepOutcome().
  *
- * The poll runs inside CI's rust-and-link step, so it can only be exercised by
- * putting a fake `buildkite-agent` on PATH that plays back a canned sequence of
- * `step get outcome` / `step get state` responses. The regression these tests
- * pin down: Buildkite's `outcome` attribute reports the last *completed* job,
- * so an earlier attempt that expired in the queue reads as `errored` even while
- * a retry is scheduled or running. The poll must look at `state` to tell the
- * two apart.
+ * Buildkite's `step get outcome` reports the last *completed* job, so an
+ * earlier attempt that expired in the queue reads as `errored` even while a
+ * retry is queued or running. The poll must consult `step get state` (the
+ * step-level state: `ready`/`running`/`failing`/`finished`/…) and only give up
+ * once that is terminal too. Build 85043's linux-aarch64-build-bun logged
+ * `state=running` → `state=finished`, which is the vocabulary these fixtures
+ * use.
  */
 import { describe, expect, test } from "bun:test";
-import { bunExe, isWindows, tempDir } from "harness";
-import { chmodSync } from "node:fs";
-import { join } from "node:path";
-import { waitForStepOutcome } from "../../scripts/build/ci.ts";
+import { waitForStepOutcome, type StepGetResult } from "../../scripts/build/ci.ts";
 
-/**
- * Install a fake `buildkite-agent` that serves `step get outcome|state` from
- * `script[i]` on the i-th poll (clamped to the last entry), and run `fn` with
- * it on PATH. `waitForStepOutcome` issues one `outcome` read then one `state`
- * read per poll, so each script entry is consumed once per poll.
- */
-async function withFakeAgent<T>(script: Array<{ outcome: string; state: string }>, fn: () => Promise<T>): Promise<T> {
-  using dir = tempDir("fake-bk-agent", {
-    "script.json": JSON.stringify(script),
-    // The real binary is Go; this stub only needs to honour
-    // `step get <attr> --step <key>` and count polls.
-    "buildkite-agent": `#!/usr/bin/env bash
-set -euo pipefail
-attr="\${3:-}"
-n=0
-[ -f "$AGENT_DIR/calls" ] && n=$(cat "$AGENT_DIR/calls")
-# One poll = outcome then state; advance the script cursor on state so both
-# reads in a poll see the same entry.
-if [ "$attr" = "state" ]; then
-  echo $((n+1)) > "$AGENT_DIR/calls"
-fi
-exec "$BUN_EXE" -e '
-  const s = require(process.env.AGENT_DIR + "/script.json");
-  const i = Math.min(+process.argv[1], s.length - 1);
-  process.stdout.write(s[i][process.argv[2]] ?? "");
-' "$n" "$attr"
-`,
-  });
-  chmodSync(join(String(dir), "buildkite-agent"), 0o755);
-  const prev = { PATH: process.env.PATH, AGENT_DIR: process.env.AGENT_DIR, BUN_EXE: process.env.BUN_EXE };
-  process.env.PATH = `${dir}:${prev.PATH}`;
-  process.env.AGENT_DIR = String(dir);
-  process.env.BUN_EXE = bunExe();
-  try {
-    return await fn();
-  } finally {
-    for (const [k, v] of Object.entries(prev)) {
-      if (v === undefined) delete process.env[k];
-      else process.env[k] = v;
+/** Drive `waitForStepOutcome` through a canned sequence of `outcome`/`state` reads. */
+function run(script: ReadonlyArray<{ outcome: string; state: string } | { ok: false; err: string }>) {
+  let i = 0;
+  const get = (_stepKey: string, attr: string): StepGetResult => {
+    const entry = script[Math.min(i, script.length - 1)]!;
+    // One poll = outcome then state; advance on state so both reads see the same entry.
+    if (attr === "state") i++;
+    if ("ok" in entry) {
+      // A transient agent failure: the poll retries without reading `state`.
+      if (attr === "outcome") i++;
+      return { ok: false, out: "", err: entry.err };
     }
-  }
+    return { ok: true, out: entry[attr as "outcome" | "state"], err: "" };
+  };
+  return waitForStepOutcome("linux-x64-build-cpp", { pollMs: 0, get });
 }
 
-// The fake agent is a bash script; the Windows CI lane never runs the
-// rust-and-link poll anyway (all build steps are linux-hosted).
-describe.skipIf(isWindows)("waitForStepOutcome", () => {
+describe.concurrent("waitForStepOutcome", () => {
   test("resolves once the sibling passes", async () => {
-    await withFakeAgent(
-      [
-        { outcome: "", state: "running" },
-        { outcome: "passed", state: "passed" },
-      ],
-      () => waitForStepOutcome("linux-x64-build-cpp", 5),
-    );
+    await run([
+      { outcome: "", state: "running" },
+      { outcome: "passed", state: "finished" },
+    ]);
   });
 
   test("keeps polling while a retry is queued after an earlier error", async () => {
     // Build 84838: attempt 1 expired (outcome=errored), attempt 2 sat in the
-    // queue (state=scheduled). The old outcome-only poll bailed at index 0.
-    await withFakeAgent(
-      [
-        { outcome: "errored", state: "scheduled" },
-        { outcome: "errored", state: "scheduled" },
-        { outcome: "errored", state: "running" },
-        { outcome: "passed", state: "passed" },
-      ],
-      () => waitForStepOutcome("windows-x64-build-cpp", 5),
-    );
+    // queue. The old outcome-only poll bailed at index 0.
+    await run([
+      { outcome: "errored", state: "ready" },
+      { outcome: "errored", state: "ready" },
+      { outcome: "errored", state: "running" },
+      { outcome: "passed", state: "finished" },
+    ]);
+  });
+
+  test("keeps polling through state=failing", async () => {
+    // `failing` is a documented non-terminal step state (a job failed but the
+    // step has not settled); a retry can still turn it around.
+    await run([
+      { outcome: "errored", state: "failing" },
+      { outcome: "errored", state: "failing" },
+      { outcome: "errored", state: "running" },
+      { outcome: "passed", state: "finished" },
+    ]);
+  });
+
+  test("keeps polling through an unknown state value", async () => {
+    // A state we have not enumerated must not be mistaken for terminal; the
+    // 60 min deadline still bounds the wait.
+    await run([
+      { outcome: "errored", state: "limiting" },
+      { outcome: "errored", state: "limiting" },
+      { outcome: "passed", state: "finished" },
+    ]);
   });
 
   test("tolerates the gap between one attempt finishing and its retry appearing", async () => {
     // A retry job is created ~1s after its predecessor ends, so one poll can
-    // land on a terminal state before the next attempt is scheduled.
-    await withFakeAgent(
-      [
-        { outcome: "errored", state: "expired" },
-        { outcome: "errored", state: "scheduled" },
-        { outcome: "passed", state: "passed" },
-      ],
-      () => waitForStepOutcome("darwin-x64-build-cpp", 5),
-    );
+    // land on state=finished before the next attempt takes it back to ready.
+    await run([
+      { outcome: "errored", state: "finished" },
+      { outcome: "errored", state: "ready" },
+      { outcome: "passed", state: "finished" },
+    ]);
   });
 
   test("throws once the sibling is terminally failed with no retry in flight", async () => {
-    const err = await withFakeAgent(
-      [
-        { outcome: "hard_failed", state: "failed" },
-        { outcome: "hard_failed", state: "failed" },
-      ],
-      () =>
-        waitForStepOutcome("linux-x64-build-cpp", 5).then(
-          () => null,
-          e => e as Error,
-        ),
-    );
-    expect(err).not.toBeNull();
-    expect(String(err)).toContain("linux-x64-build-cpp hard_failed");
+    await expect(
+      run([
+        { outcome: "hard_failed", state: "finished" },
+        { outcome: "hard_failed", state: "finished" },
+      ]),
+    ).rejects.toThrow("linux-x64-build-cpp hard_failed");
   });
 
   test("falls back to outcome when state is unavailable", async () => {
-    // `step get state` predates some agent versions returning it; an empty
-    // state must not mask a real failure.
-    const err = await withFakeAgent(
-      [
+    // An empty/unavailable state must not mask a real failure.
+    await expect(
+      run([
         { outcome: "errored", state: "" },
         { outcome: "errored", state: "" },
-      ],
-      () =>
-        waitForStepOutcome("linux-x64-build-cpp", 5).then(
-          () => null,
-          e => e as Error,
-        ),
-    );
-    expect(err).not.toBeNull();
-    expect(String(err)).toContain("errored");
+      ]),
+    ).rejects.toThrow("linux-x64-build-cpp errored");
+  });
+
+  test("retries a transient agent error", async () => {
+    await run([
+      { ok: false, err: "transient 502" },
+      { outcome: "passed", state: "finished" },
+    ]);
   });
 });

--- a/test/internal/ci-sibling-wait.test.ts
+++ b/test/internal/ci-sibling-wait.test.ts
@@ -104,7 +104,11 @@ describe.skipIf(isWindows)("waitForStepOutcome", () => {
         { outcome: "hard_failed", state: "failed" },
         { outcome: "hard_failed", state: "failed" },
       ],
-      () => waitForStepOutcome("linux-x64-build-cpp", 5).then(() => null, e => e as Error),
+      () =>
+        waitForStepOutcome("linux-x64-build-cpp", 5).then(
+          () => null,
+          e => e as Error,
+        ),
     );
     expect(err).not.toBeNull();
     expect(String(err)).toContain("linux-x64-build-cpp hard_failed");
@@ -118,7 +122,11 @@ describe.skipIf(isWindows)("waitForStepOutcome", () => {
         { outcome: "errored", state: "" },
         { outcome: "errored", state: "" },
       ],
-      () => waitForStepOutcome("linux-x64-build-cpp", 5).then(() => null, e => e as Error),
+      () =>
+        waitForStepOutcome("linux-x64-build-cpp", 5).then(
+          () => null,
+          e => e as Error,
+        ),
     );
     expect(err).not.toBeNull();
     expect(String(err)).toContain("errored");

--- a/test/internal/ci-sibling-wait.test.ts
+++ b/test/internal/ci-sibling-wait.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for the build-bun → build-cpp sibling poll in
+ * scripts/build/ci.ts::waitForStepOutcome().
+ *
+ * The poll runs inside CI's rust-and-link step, so it can only be exercised by
+ * putting a fake `buildkite-agent` on PATH that plays back a canned sequence of
+ * `step get outcome` / `step get state` responses. The regression these tests
+ * pin down: Buildkite's `outcome` attribute reports the last *completed* job,
+ * so an earlier attempt that expired in the queue reads as `errored` even while
+ * a retry is scheduled or running. The poll must look at `state` to tell the
+ * two apart.
+ */
+import { describe, expect, test } from "bun:test";
+import { isWindows, tempDir } from "harness";
+import { chmodSync } from "node:fs";
+import { join } from "node:path";
+import { waitForStepOutcome } from "../../scripts/build/ci.ts";
+
+/**
+ * Install a fake `buildkite-agent` that serves `step get outcome|state` from
+ * `script[i]` on the i-th poll (clamped to the last entry), and run `fn` with
+ * it on PATH. `waitForStepOutcome` issues one `outcome` read then one `state`
+ * read per poll, so each script entry is consumed once per poll.
+ */
+async function withFakeAgent<T>(script: Array<{ outcome: string; state: string }>, fn: () => Promise<T>): Promise<T> {
+  using dir = tempDir("fake-bk-agent", {
+    "script.json": JSON.stringify(script),
+    // The real binary is Go; this stub only needs to honour
+    // `step get <attr> --step <key>` and count polls.
+    "buildkite-agent": `#!/usr/bin/env bash
+set -euo pipefail
+attr="\${3:-}"
+n=0
+[ -f "$AGENT_DIR/calls" ] && n=$(cat "$AGENT_DIR/calls")
+# One poll = outcome then state; advance the script cursor on state so both
+# reads in a poll see the same entry.
+if [ "$attr" = "state" ]; then
+  echo $((n+1)) > "$AGENT_DIR/calls"
+fi
+node -e '
+  const s = require(process.env.AGENT_DIR + "/script.json");
+  const i = Math.min(+process.argv[1], s.length - 1);
+  process.stdout.write(s[i][process.argv[2]] ?? "");
+' "$n" "$attr"
+`,
+  });
+  chmodSync(join(String(dir), "buildkite-agent"), 0o755);
+  const prevPath = process.env.PATH;
+  const prevDir = process.env.AGENT_DIR;
+  process.env.PATH = `${dir}:${prevPath}`;
+  process.env.AGENT_DIR = String(dir);
+  try {
+    return await fn();
+  } finally {
+    process.env.PATH = prevPath;
+    if (prevDir === undefined) delete process.env.AGENT_DIR;
+    else process.env.AGENT_DIR = prevDir;
+  }
+}
+
+// The fake agent is a bash script; the Windows CI lane never runs the
+// rust-and-link poll anyway (all build steps are linux-hosted).
+describe.skipIf(isWindows)("waitForStepOutcome", () => {
+  test("resolves once the sibling passes", async () => {
+    await withFakeAgent(
+      [
+        { outcome: "", state: "running" },
+        { outcome: "passed", state: "passed" },
+      ],
+      () => waitForStepOutcome("linux-x64-build-cpp", 5),
+    );
+  });
+
+  test("keeps polling while a retry is queued after an earlier error", async () => {
+    // Build 84838: attempt 1 expired (outcome=errored), attempt 2 sat in the
+    // queue (state=scheduled). The old outcome-only poll bailed at index 0.
+    await withFakeAgent(
+      [
+        { outcome: "errored", state: "scheduled" },
+        { outcome: "errored", state: "scheduled" },
+        { outcome: "errored", state: "running" },
+        { outcome: "passed", state: "passed" },
+      ],
+      () => waitForStepOutcome("windows-x64-build-cpp", 5),
+    );
+  });
+
+  test("tolerates the gap between one attempt finishing and its retry appearing", async () => {
+    // A retry job is created ~1s after its predecessor ends, so one poll can
+    // land on a terminal state before the next attempt is scheduled.
+    await withFakeAgent(
+      [
+        { outcome: "errored", state: "expired" },
+        { outcome: "errored", state: "scheduled" },
+        { outcome: "passed", state: "passed" },
+      ],
+      () => waitForStepOutcome("darwin-x64-build-cpp", 5),
+    );
+  });
+
+  test("throws once the sibling is terminally failed with no retry in flight", async () => {
+    const err = await withFakeAgent(
+      [
+        { outcome: "hard_failed", state: "failed" },
+        { outcome: "hard_failed", state: "failed" },
+      ],
+      () => waitForStepOutcome("linux-x64-build-cpp", 5).then(() => null, e => e as Error),
+    );
+    expect(err).not.toBeNull();
+    expect(String(err)).toContain("linux-x64-build-cpp hard_failed");
+  });
+
+  test("falls back to outcome when state is unavailable", async () => {
+    // `step get state` predates some agent versions returning it; an empty
+    // state must not mask a real failure.
+    const err = await withFakeAgent(
+      [
+        { outcome: "errored", state: "" },
+        { outcome: "errored", state: "" },
+      ],
+      () => waitForStepOutcome("linux-x64-build-cpp", 5).then(() => null, e => e as Error),
+    );
+    expect(err).not.toBeNull();
+    expect(String(err)).toContain("errored");
+  });
+});


### PR DESCRIPTION
## What broke

Build-bun steps across ~40 builds (84714 onward, including main #84716) failed with

```
Waiting for windows-x64-build-cpp to finish...
  windows-x64-build-cpp outcome: errored [0s]
error: Sibling step windows-x64-build-cpp errored — nothing to link
```

even though the sibling build-cpp step later passed on retry. First seen in build 84838 (reported from #31737).

## Cause

`rust-and-link` (introduced in #34782) runs build-bun in parallel with build-cpp and polls `buildkite-agent step get outcome --step <target>-build-cpp` before downloading the C++ archive. Under last night's load spike the c8g.4xlarge queue backed up past Buildkite's 60-minute scheduled-job expiry, so many build-cpp jobs expired without ever being assigned an agent and were then retried.

`step get outcome` reports the result of the last *completed* job for a step. With a prior attempt expired and a retry still queued or running, it returns `errored`, and `waitForStepOutcome()` treated that as terminal:

```
# build 84838, windows-x64-build-bun attempt 2 (07:01:40 - 07:04:25)
# windows-x64-build-cpp attempt 1 expired 06:06:22; attempt 2 was queued
# (runnable 06:06:21, not yet started) when this poll ran.
windows-x64-build-cpp outcome: errored [0s]
```

So retrying a build-cpp job did nothing for a concurrently running build-bun, and a retried build-bun would bail immediately on its first poll.

## Fix

Poll `state` alongside `outcome`. `step get state` returns the step-level state (`ready`/`running`/`failing`/`finished`/..., a different vocabulary from the REST API's job states; see the [agent CLI docs](https://buildkite.com/docs/agent/v3/cli-step)), so a failed `outcome` is only acted on once `state` is in the terminal set `{finished, canceled, ignored}`. Any other state, including values we haven't enumerated, keeps the poll going; an empty/unavailable `state` falls back to the original outcome-only behaviour. Two consecutive terminal reads are required before giving up, covering the ~1 s window between an attempt finishing and its retry job appearing.

The genuine-failure fast path is preserved: a build-cpp that hard-fails with no retry reports `state=finished` on two consecutive polls and build-bun still exits within ~3 s of that.

## Verification

Observed in this PR's own CI (build 85043, linux-aarch64-build-bun):

```
Waiting for linux-aarch64-build-cpp to finish...
  linux-aarch64-build-cpp outcome=(none) / state=running [0s]
  linux-aarch64-build-cpp outcome=passed / state=finished [6s]
```

`test/internal/ci-sibling-wait.test.ts` drives `waitForStepOutcome()` through an injected `step get` seam (no subprocess, runs on all hosts) and covers: pass, errored-while-retry-queued (`state=ready`), `state=failing`, an unrecognised state, the finished->ready transition gap, terminal hard-fail, `state` unavailable, and a transient agent error.

The underlying c8g.4xlarge backlog is a capacity issue (525 build-cpp jobs expired over ~3 h at a median 92 min queue wait); that is not addressed here, but with this change the retry path works through it instead of cascading into build-bun failures.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/internal/ci-sibling-wait.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/internal/ci-sibling-wait.test.ts
bun test v1.4.0 (3897ad168)

test/internal/ci-sibling-wait.test.ts:
Waiting for linux-x64-build-cpp to finish...
  linux-x64-build-cpp outcome=(none) / state=running [0s]
Waiting for linux-x64-build-cpp to finish...
  linux-x64-build-cpp outcome=errored / state=ready [0s]
Waiting for linux-x64-build-cpp to finish...
  linux-x64-build-cpp outcome=errored / state=failing [0s]
Waiting for linux-x64-build-cpp to finish...
  linux-x64-build-cpp outcome=errored / state=limiting [0s]
Waiting for linux-x64-build-cpp to finish...
  linux-x64-build-cpp outcome=errored / state=finished [0s]
  linux-x64-build-cpp outcome=passed / state=finished [0s]
(pass) waitForStepOutcome > resolves once the sibling passes [67.51ms]
Waiting for linux-x64-build-cpp to finish...
  linux-x64-build-cpp outcome=hard_failed / state=finished [0s]
  linux-x64-build-cpp outcome=errored / state=ready [0s]
  linux-x64-build-cpp outcome=errored / state=running [0s]
  linux-x64-build-cpp outcome=errored / state=running [0s]
  linux-x64-build-cpp outcome=passed / state=finished [0s]
  linux-x64-build-cpp outcome=passed / state=finished [0s]
  linux-x64-build-cpp outcome=passed / state=finished [0s]
(pass) waitForStepOutcome > throws once the sibling is terminally failed with no retry in flight [12.79ms]
Waiting for linux-x64-build-cpp to finish...
  linux-x64-build-cpp outcome=errored / state=(none) [0s]
  linux-x64-build-cpp outcome=passed / state=finished [0s]
(pass) waitForStepOutcome > falls back to outcome when state is unavailable [17.21ms]
Waiting for linux-x64-build-cpp to finish...
  linux-x64-build-cpp outcome=errored / state=<502 Bad Gateway> [0s]
(pass) waitForStepOutcome > keeps polling through an unknown state value [50.42ms]
Waiting for linux-x64-build-cpp to finish...
  buildkite-agent step get outcome failed: transient 502
(pass) waitForStepOutcome > tolerates t
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/ci.ts                   | 108 +++++++++++++++++++++---------
 test/internal/ci-sibling-wait.test.ts | 119 ++++++++++++++++++++++++++++++++++
 2 files changed, 197 insertions(+), 30 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
scripts/build/ci.ts                        4     12      0
test/internal/ci-sibling-wait.test.ts      2      7      0
```

</details>

<!-- robobun:evidence:end -->