### PR TITLE
worker: survive terminate() while Bun.serve is streaming a type:"direct" body

### DIFF
--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -118,10 +118,6 @@ impl VM {
         JSC__VM__notifyNeedTermination(self)
     }
 
-    pub(crate) fn clear_has_termination_request(&self) {
-        crate::cpp::JSC__VM__clearHasTerminationRequest(self)
-    }
-
     #[track_caller]
     pub fn throw_error(&self, global_object: &JSGlobalObject, value: JSValue) -> JsError {
         crate::validation_scope!(scope, global_object);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3230,24 +3230,9 @@ uint8_t GlobalObject::drainMicrotasks()
     auto& vm = this->vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    // Each `return 1` below observes the TerminationException still pending.
-    // The outermost VMEntryScope that raised it has already run
-    // executeEntryScopeServicesOnExit(), which clears hasTerminationRequest()
-    // while leaving the exception in place. Re-set the flag so JSC's
-    // DeferTermination invariant (hasPendingTerminationException() implies
-    // hasTerminationRequest(); see VMTraps::deferTerminationSlow) holds for a
-    // caller that does not consult the return value and proceeds to touch a
-    // LazyProperty (LazyPropertyInlines.h callFunc opens
-    // DeferTerminationForAWhile unconditionally). setHasTerminationRequest()
-    // is idempotent.
-    auto returnTerminated = [&]() -> uint8_t {
-        vm.setHasTerminationRequest();
-        return 1;
-    };
-
     if (auto* exception = scope.exception()) [[unlikely]] {
         if (vm.isTerminationException(exception)) [[unlikely]] {
-            return returnTerminated();
+            return 1;
         }
 
 #if ASSERT_ENABLED
@@ -3269,7 +3254,7 @@ uint8_t GlobalObject::drainMicrotasks()
         nextTickQueue->drain(vm, this);
         if (auto* exception = scope.exception()) {
             if (vm.isTerminationException(exception)) {
-                return returnTerminated();
+                return 1;
             }
             (void)scope.tryClearException();
             this->reportUncaughtExceptionAtEventLoop(this, exception);
@@ -3279,7 +3264,7 @@ uint8_t GlobalObject::drainMicrotasks()
     vm.drainMicrotasks();
     if (auto* exception = scope.exception()) {
         if (vm.isTerminationException(exception)) {
-            return returnTerminated();
+            return 1;
         }
         (void)scope.tryClearException();
         this->reportUncaughtExceptionAtEventLoop(this, exception);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3230,9 +3230,24 @@ uint8_t GlobalObject::drainMicrotasks()
     auto& vm = this->vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
+    // Each `return 1` below observes the TerminationException still pending.
+    // The outermost VMEntryScope that raised it has already run
+    // executeEntryScopeServicesOnExit(), which clears hasTerminationRequest()
+    // while leaving the exception in place. Re-set the flag so JSC's
+    // DeferTermination invariant (hasPendingTerminationException() implies
+    // hasTerminationRequest(); see VMTraps::deferTerminationSlow) holds for a
+    // caller that does not consult the return value and proceeds to touch a
+    // LazyProperty (LazyPropertyInlines.h callFunc opens
+    // DeferTerminationForAWhile unconditionally). setHasTerminationRequest()
+    // is idempotent.
+    auto returnTerminated = [&]() -> uint8_t {
+        vm.setHasTerminationRequest();
+        return 1;
+    };
+
     if (auto* exception = scope.exception()) [[unlikely]] {
         if (vm.isTerminationException(exception)) [[unlikely]] {
-            return 1;
+            return returnTerminated();
         }
 
 #if ASSERT_ENABLED
@@ -3254,7 +3269,7 @@ uint8_t GlobalObject::drainMicrotasks()
         nextTickQueue->drain(vm, this);
         if (auto* exception = scope.exception()) {
             if (vm.isTerminationException(exception)) {
-                return 1;
+                return returnTerminated();
             }
             (void)scope.tryClearException();
             this->reportUncaughtExceptionAtEventLoop(this, exception);
@@ -3264,7 +3279,7 @@ uint8_t GlobalObject::drainMicrotasks()
     vm.drainMicrotasks();
     if (auto* exception = scope.exception()) {
         if (vm.isTerminationException(exception)) {
-            return 1;
+            return returnTerminated();
         }
         (void)scope.tryClearException();
         this->reportUncaughtExceptionAtEventLoop(this, exception);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4924,11 +4924,6 @@ bool JSC__VM__isTerminationException(JSC::VM* vm, JSC::Exception* exception)
 }
 
 [[ZIG_EXPORT(nothrow)]]
-void JSC__VM__clearHasTerminationRequest(JSC::VM* vm)
-{
-    vm->clearHasTerminationRequest();
-}
-[[ZIG_EXPORT(nothrow)]]
 bool JSC__VM__hasTerminationRequest(JSC::VM* vm)
 {
     return vm->hasTerminationRequest();

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1243,18 +1243,14 @@ impl WebWorker {
             // SAFETY: vm_ptr valid; unpublished above under vm_lock, so no
             // other thread can dereference it now — `&mut` is exclusive.
             let vm = unsafe { &mut *vm_ptr };
-            // terminate() set the JSC termination flag to interrupt running JS;
-            // clear both the request flag and the already-thrown
-            // TerminationException so process.on('exit') handlers and
-            // close_all_socket_groups' on_close callbacks can re-enter JS.
-            // Clearing only the flag would leave the sticky exception pending,
-            // and JSC's DeferTermination scope asserts
-            // `hasTerminationRequest()` whenever a termination exception is
-            // pending (VMTraps::deferTerminationSlow). teardownJSCVM re-sets
-            // the flag for the JSC VM teardown.
-            vm.global().clear_termination_exception();
             vm.is_shutting_down = true;
+            // dispatchExitInternal's termination guard skips process.on('exit')
+            // on terminate() (node semantics), so the pending
+            // TerminationException may stay in place across on_exit.
             vm.on_exit();
+            // Now clear it so close_all_socket_groups' on_close callbacks can
+            // re-enter JS. teardownJSCVM re-sets the flag for the VM teardown.
+            vm.global().clear_termination_exception();
             if let Some(hooks) = runtime_hooks() {
                 (hooks.cron_clear_all_teardown)(vm);
                 // Drain `TimeoutObject`s from this worker's timer heap before

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1244,9 +1244,15 @@ impl WebWorker {
             // other thread can dereference it now — `&mut` is exclusive.
             let vm = unsafe { &mut *vm_ptr };
             // terminate() set the JSC termination flag to interrupt running JS;
-            // clear it so process.on('exit') handlers can run. teardownJSCVM
-            // re-sets it for the JSC VM teardown.
-            vm.jsc_vm().clear_has_termination_request();
+            // clear both the request flag and the already-thrown
+            // TerminationException so process.on('exit') handlers and
+            // close_all_socket_groups' on_close callbacks can re-enter JS.
+            // Clearing only the flag would leave the sticky exception pending,
+            // and JSC's DeferTermination scope asserts
+            // `hasTerminationRequest()` whenever a termination exception is
+            // pending (VMTraps::deferTerminationSlow). teardownJSCVM re-sets
+            // the flag for the JSC VM teardown.
+            vm.global().clear_termination_exception();
             vm.is_shutting_down = true;
             vm.on_exit();
             if let Some(hooks) = runtime_hooks() {

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1244,12 +1244,9 @@ impl WebWorker {
             // other thread can dereference it now — `&mut` is exclusive.
             let vm = unsafe { &mut *vm_ptr };
             vm.is_shutting_down = true;
-            // dispatchExitInternal's termination guard skips process.on('exit')
-            // on terminate() (node semantics), so the pending
-            // TerminationException may stay in place across on_exit.
+            // on_exit first: dispatchExitInternal skips 'exit' on terminate (node semantics).
             vm.on_exit();
-            // Now clear it so close_all_socket_groups' on_close callbacks can
-            // re-enter JS. teardownJSCVM re-sets the flag for the VM teardown.
+            // Cleared here so close_all_socket_groups can re-enter JS; teardownJSCVM re-sets it.
             vm.global().clear_termination_exception();
             if let Some(hooks) = runtime_hooks() {
                 (hooks.cron_clear_all_teardown)(vm);

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2129,6 +2129,23 @@ where
                 stream_log!("returned a promise");
                 this.drain_microtasks();
 
+                // A worker terminate() arriving while drain_microtasks() was
+                // driving the stream's async pull leaves the
+                // TerminationException pending here. Every branch below would
+                // then re-enter JS (NativePromiseContext lazy-init /
+                // then_with_value / handle_resolve_stream /
+                // handle_reject_stream), tripping JSC's DeferTermination or
+                // executeCallImpl assertNoException under debug/ASAN. The
+                // worker is shutting down, so the sink already in `this.sink`
+                // is torn down by the server abort path during
+                // close_all_socket_groups; nothing to wire up.
+                if global_this.has_exception() {
+                    response_stream.sink.on_first_write = None;
+                    response_stream.sink.ctx = None;
+                    this.flags.set_has_marked_pending(true);
+                    return;
+                }
+
                 // `MarkHandled` matters for the Rejected arm: the promise
                 // settled before any reaction was attached, so without the
                 // flag the VM would report it as an unhandled rejection even

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2129,16 +2129,9 @@ where
                 stream_log!("returned a promise");
                 this.drain_microtasks();
 
-                // A worker terminate() arriving while drain_microtasks() was
-                // driving the stream's async pull leaves the
-                // TerminationException pending here. Every branch below would
-                // then re-enter JS (NativePromiseContext lazy-init /
-                // then_with_value / handle_resolve_stream /
-                // handle_reject_stream), tripping JSC's DeferTermination or
-                // executeCallImpl assertNoException under debug/ASAN. The
-                // worker is shutting down, so the sink already in `this.sink`
-                // is torn down by the server abort path during
-                // close_all_socket_groups; nothing to wire up.
+                // worker.terminate() landing inside drain_microtasks leaves the
+                // TerminationException pending; every branch below re-enters
+                // JS. Leave the sink on `this` for the server abort path.
                 if global_this.has_exception() {
                     response_stream.sink.on_first_write = None;
                     response_stream.sink.ctx = None;
@@ -2695,6 +2688,13 @@ where
         request_value.ensure_still_alive();
         response_value.ensure_still_alive();
         ctx.drain_microtasks();
+
+        // Same guard as do_render_stream: worker.terminate() landing inside the
+        // drain leaves the TerminationException pending, and the paths below
+        // re-enter JS.
+        if this.global_this().has_exception() {
+            return;
+        }
 
         if ctx.is_aborted_or_ended() {
             return;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2129,9 +2129,7 @@ where
                 stream_log!("returned a promise");
                 this.drain_microtasks();
 
-                // worker.terminate() landing inside drain_microtasks leaves the
-                // TerminationException pending; every branch below re-enters
-                // JS. Leave the sink on `this` for the server abort path.
+                // terminate() inside the drain leaves a pending TerminationException; every branch below re-enters JS.
                 if global_this.has_exception() {
                     response_stream.sink.on_first_write = None;
                     response_stream.sink.ctx = None;
@@ -2689,9 +2687,7 @@ where
         response_value.ensure_still_alive();
         ctx.drain_microtasks();
 
-        // Same guard as do_render_stream: worker.terminate() landing inside the
-        // drain leaves the TerminationException pending, and the paths below
-        // re-enter JS.
+        // Same as do_render_stream: terminate() inside the drain leaves a pending TerminationException.
         if this.global_this().has_exception() {
             return;
         }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1313,6 +1313,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     needs_to_drain = false;
                     // SAFETY: `vm` is the process-static VirtualMachine.
                     unsafe { (*vm).drain_microtasks() };
+                    // Same as RequestContext::on_response: terminate() inside the drain leaves a pending TerminationException.
+                    if global.has_exception() {
+                        strong_promise.deinit();
+                        break 'brk HttpResult::Success;
+                    }
                     status = promise.status();
                 }
 

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -24,7 +24,7 @@ const timeout = slow ? 60_000 : 20_000;
 // leaving the sticky exception in place for the same class of assert. Both
 // asserts are debug/ASAN-only; release builds compile them out.
 test.skipIf(!isDebug)(
-  "terminate() while Bun.serve is streaming a type:\"direct\" body does not trip DeferTermination / assertNoException",
+  'terminate() while Bun.serve is streaming a type:"direct" body does not trip DeferTermination / assertNoException',
   async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -20,10 +20,10 @@ const timeout = slow ? 60_000 : 20_000;
 // DeferTerminationForAWhile scope, asserting hasTerminationRequest() in
 // VMTraps::deferTerminationSlow, and (b) re-entered JS via then_with_value,
 // asserting !exception() in executeCallImpl. Separately, WebWorker::shutdown
-// cleared only the request flag before on_exit / close_all_socket_groups,
-// leaving the sticky exception in place for the same class of assert. Both
-// asserts are debug/ASAN-only; release builds compile them out.
-test.skipIf(!isDebug)(
+// cleared only the request flag before close_all_socket_groups, leaving the
+// sticky exception in place for the same class of assert. Both asserts are
+// compiled out outside debug/ASAN builds.
+test.skipIf(!(isDebug || isASAN))(
   'terminate() while Bun.serve is streaming a type:"direct" body does not trip DeferTermination / assertNoException',
   async () => {
     await using proc = Bun.spawn({

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -11,6 +11,63 @@ const rounds = slow ? 4 : 8;
 const perRound = slow ? 12 : 32;
 const timeout = slow ? 60_000 : 20_000;
 
+// Regression: Bun.serve() inside a worker streaming a type:"direct" body,
+// then worker.terminate() mid-stream. drain_microtasks() drives the async
+// pull loop; when the termination trap fires inside it, the outermost
+// VMEntryScope's executeEntryScopeServicesOnExit clears hasTerminationRequest
+// while the TerminationException stays pending. do_render_stream then kept
+// going and (a) lazy-initialized NativePromiseContextStructure inside a
+// DeferTerminationForAWhile scope, asserting hasTerminationRequest() in
+// VMTraps::deferTerminationSlow, and (b) re-entered JS via then_with_value,
+// asserting !exception() in executeCallImpl. Separately, WebWorker::shutdown
+// cleared only the request flag before on_exit / close_all_socket_groups,
+// leaving the sticky exception in place for the same class of assert. Both
+// asserts are debug/ASAN-only; release builds compile them out.
+test.skipIf(!isDebug)(
+  "terminate() while Bun.serve is streaming a type:\"direct\" body does not trip DeferTermination / assertNoException",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const src = 'const server = Bun.serve({ port: 0, fetch() {' +
+          '  return new Response(new ReadableStream({ type: "direct", async pull(ctrl) {' +
+          '    for (let i = 0; i < 20000; i++) {' +
+          '      ctrl.write(new Uint8Array(8192).fill(i));' +
+          '      await ctrl.flush();' +
+          '    }' +
+          '    ctrl.close();' +
+          '  }, cancel() {} }));' +
+          '} });' +
+          'require("node:worker_threads").parentPort.postMessage(server.port);';
+        for (let i = 0; i < ${rounds}; i++) {
+          const w = new Worker(src, { eval: true });
+          const port = await new Promise(r => w.once("message", r));
+          const res = await fetch("http://127.0.0.1:" + port + "/");
+          const rd = res.body.getReader();
+          await rd.read();
+          const done = new Promise(r => w.once("exit", r));
+          w.terminate();
+          await done;
+          await rd.cancel().catch(() => {});
+        }
+        console.log("survived");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("survived\n");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);
+
 // Regression: `new Worker(url, { ref: false })` was silently ignored — the
 // Zig-side `user_keep_alive` field was set from it but never read, and the
 // parent keep-alive was taken unconditionally in `create()`. `.unref()` after

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -68,6 +68,89 @@ test.skipIf(!(isDebug || isASAN))(
   timeout,
 );
 
+// Sibling of the above: on_response's drain_microtasks() driving an async
+// fetch handler that never yields past `await 1`. Same DeferTermination /
+// assertNoException pair, same fix shape.
+test.skipIf(!(isDebug || isASAN))(
+  "terminate() while Bun.serve's async fetch is looping in drain_microtasks does not trip DeferTermination",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const sab = new SharedArrayBuffer(4);
+        const flag = new Int32Array(sab);
+        const src = 'const { workerData } = require("node:worker_threads");' +
+          'const flag = new Int32Array(workerData.sab);' +
+          'const server = Bun.serve({ port: 0, async fetch() {' +
+          '  for (;;) { Atomics.add(flag, 0, 1); await 1; }' +
+          '} });' +
+          'require("node:worker_threads").parentPort.postMessage(server.port);';
+        for (let i = 0; i < ${rounds}; i++) {
+          Atomics.store(flag, 0, 0);
+          const w = new Worker(src, { eval: true, workerData: { sab } });
+          const port = await new Promise(r => w.once("message", r));
+          const ac = new AbortController();
+          fetch("http://127.0.0.1:" + port + "/", { signal: ac.signal }).catch(() => {});
+          while (Atomics.load(flag, 0) < 100) await Bun.sleep(0);
+          const done = new Promise(r => w.once("exit", r));
+          w.terminate();
+          await done;
+          ac.abort();
+        }
+        console.log("survived");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("survived\n");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);
+
+// Node skips the worker's process.on('exit') listeners on worker.terminate().
+// WebWorker::shutdown must leave the TerminationException in place across
+// on_exit so dispatchExitInternal's guard trips; clearing it earlier would let
+// the handler run.
+test("process.on('exit') does not fire on worker.terminate()", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { Worker } = require("node:worker_threads");
+      const sab = new SharedArrayBuffer(4);
+      const counter = new Int32Array(sab);
+      const src = 'const { workerData, parentPort } = require("node:worker_threads");' +
+        'const counter = new Int32Array(workerData.sab);' +
+        'process.on("exit", () => Atomics.add(counter, 0, 1));' +
+        'parentPort.postMessage("ready");' +
+        'setInterval(() => {}, 100000);';
+      const w = new Worker(src, { eval: true, workerData: { sab } });
+      await new Promise(r => w.once("message", r));
+      const done = new Promise(r => w.once("exit", r));
+      w.terminate();
+      await done;
+      console.log("exitCalls=" + Atomics.load(counter, 0));
+    `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("exitCalls=0\n");
+  expect(exitCode).toBe(0);
+});
+
 // Regression: `new Worker(url, { ref: false })` was silently ignored — the
 // Zig-side `user_keep_alive` field was set from it but never read, and the
 // parent keep-alive was taken unconditionally in `create()`. `.unref()` after

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -70,7 +70,11 @@ test.skipIf(!(isDebug || isASAN))(
 
 // Sibling of the above: on_response's drain_microtasks() driving an async
 // fetch handler that never yields past `await 1`. Same DeferTermination /
-// assertNoException pair, same fix shape.
+// assertNoException pair, same fix shape. Also asserts Node's
+// "process.on('exit') is skipped on terminate()" when terminate lands while
+// JS is on the stack (sab[1] stays 0): in that state the NeedTermination trap
+// has already been consumed, so only the sticky TerminationException guards
+// dispatchExitInternal; clearing it before on_exit would let the handler run.
 test.skipIf(!(isDebug || isASAN))(
   "terminate() while Bun.serve's async fetch is looping in drain_microtasks does not trip DeferTermination",
   async () => {
@@ -80,16 +84,18 @@ test.skipIf(!(isDebug || isASAN))(
         "-e",
         `
         const { Worker } = require("node:worker_threads");
-        const sab = new SharedArrayBuffer(4);
+        const sab = new SharedArrayBuffer(8);
         const flag = new Int32Array(sab);
         const src = 'const { workerData } = require("node:worker_threads");' +
           'const flag = new Int32Array(workerData.sab);' +
+          'process.on("exit", () => Atomics.add(flag, 1, 1));' +
           'const server = Bun.serve({ port: 0, async fetch() {' +
           '  for (;;) { Atomics.add(flag, 0, 1); await 1; }' +
           '} });' +
           'require("node:worker_threads").parentPort.postMessage(server.port);';
         for (let i = 0; i < ${rounds}; i++) {
           Atomics.store(flag, 0, 0);
+          Atomics.store(flag, 1, 0);
           const w = new Worker(src, { eval: true, workerData: { sab } });
           const port = await new Promise(r => w.once("message", r));
           const ac = new AbortController();
@@ -99,6 +105,7 @@ test.skipIf(!(isDebug || isASAN))(
           w.terminate();
           await done;
           ac.abort();
+          if (Atomics.load(flag, 1) !== 0) throw new Error("process.on('exit') fired on terminate");
         }
         console.log("survived");
       `,
@@ -115,11 +122,11 @@ test.skipIf(!(isDebug || isASAN))(
   timeout,
 );
 
-// Node skips the worker's process.on('exit') listeners on worker.terminate().
-// WebWorker::shutdown must leave the TerminationException in place across
-// on_exit so dispatchExitInternal's guard trips; clearing it earlier would let
-// the handler run.
-test("process.on('exit') does not fire on worker.terminate()", async () => {
+// Node skips the worker's process.on('exit') listeners on worker.terminate()
+// when the worker is idle (the NeedTermination trap bit is still armed here,
+// so this is the simpler half of the invariant; the mid-JS half is checked in
+// the async-fetch test above).
+test("process.on('exit') does not fire on worker.terminate() when idle", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -122,6 +122,51 @@ test.skipIf(!(isDebug || isASAN))(
   timeout,
 );
 
+// Same again for the node:http-compat path (on_node_http_request_with_upgrade_ctx).
+test.skipIf(!(isDebug || isASAN))(
+  "terminate() while a node:http server's async handler is looping in drain_microtasks does not trip DeferTermination",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const sab = new SharedArrayBuffer(4);
+        const flag = new Int32Array(sab);
+        const src = 'const { workerData } = require("node:worker_threads");' +
+          'const flag = new Int32Array(workerData.sab);' +
+          'const http = require("node:http");' +
+          'const server = http.createServer(async (req, res) => {' +
+          '  for (;;) { Atomics.add(flag, 0, 1); await 1; }' +
+          '}).listen(0, () => require("node:worker_threads").parentPort.postMessage(server.address().port));';
+        for (let i = 0; i < ${rounds}; i++) {
+          Atomics.store(flag, 0, 0);
+          const w = new Worker(src, { eval: true, workerData: { sab } });
+          const port = await new Promise(r => w.once("message", r));
+          const ac = new AbortController();
+          fetch("http://127.0.0.1:" + port + "/", { signal: ac.signal }).catch(() => {});
+          while (Atomics.load(flag, 0) < 100) await Bun.sleep(0);
+          const done = new Promise(r => w.once("exit", r));
+          w.terminate();
+          await done;
+          ac.abort();
+        }
+        console.log("survived");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("survived\n");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);
+
 // Node skips the worker's process.on('exit') listeners on worker.terminate()
 // when the worker is idle (the NeedTermination trap bit is still armed here,
 // so this is the simpler half of the invariant; the mid-JS half is checked in


### PR DESCRIPTION
## What

A Worker running `Bun.serve()` that streams a `type:"direct"` `ReadableStream` body, terminated mid-stream, SIGABRTs debug/ASAN builds with:

```
ASSERTION FAILED: vm.hasTerminationRequest()
vendor/WebKit/Source/JavaScriptCore/runtime/VMTraps.cpp(539) : void JSC::VMTraps::deferTerminationSlow(DeferAction)
```

Release builds are unaffected (the `ASSERT` is compiled out). Deterministic on main, first iteration every run. The same assert also fires for an async `fetch()` handler that spins on `await` when terminated mid-drain.

## Repro

```js
const { Worker } = require("node:worker_threads");
const src = "const server = Bun.serve({ port: 0, fetch() {" +
  "return new Response(new ReadableStream({ type: 'direct', async pull(ctrl) {" +
  "  for (let i = 0; i < 20000; i++) { ctrl.write(new Uint8Array(8192).fill(i)); await ctrl.flush(); }" +
  "  ctrl.close();" +
  "}, cancel() {} }));" +
  "} });" +
  "require('node:worker_threads').parentPort.postMessage(server.port);";
for (let i = 0; i < 4; i++) {
  const w = new Worker(src, { eval: true });
  const port = await new Promise(r => w.once("message", r));
  const res = await fetch("http://127.0.0.1:" + port + "/");
  const rd = res.body.getReader();
  await rd.read();
  const done = new Promise(r => w.once("exit", r));
  w.terminate();
  await done;
  await rd.cancel().catch(() => {});
}
console.log("survived");
```

## Cause

`do_render_stream` calls `assign_to_stream` (which kicks off the direct stream's async `pull`), then `drain_microtasks()` to drive the `await ctrl.flush()` continuations. When `terminate()` lands cross-thread during that drain:

1. `VMTraps::handleTraps` sets `hasTerminationRequest` and throws the `TerminationException`.
2. The microtask's outermost `VMEntryScope` destructor runs `executeEntryScopeServicesOnExit()`, which clears `hasTerminationRequest` (the `NeedTermination` trap bit has been consumed) but leaves `m_exception` pointing at the termination exception.
3. `GlobalObject::drainMicrotasks` observes the pending termination and returns `1`; `RequestContext::drain_microtasks` discards that.
4. `do_render_stream` continues into the Pending branch and calls `NativePromiseContext::create`. That is the first touch of `m_NativePromiseContextStructure`, so `LazyProperty::callFunc` runs and opens a `DeferTerminationForAWhile` scope. `VMTraps::deferTerminationSlow` sees `hasPendingTerminationException()` true and asserts `hasTerminationRequest()`, which is now false.

With the lazy-init assert avoided, the very next step (`then_with_value` → `JSC::profiledCall`) trips `executeCallImpl`'s `scope.assertNoException()` for the same reason. `on_response` has the identical `drain_microtasks()` → `NativePromiseContext::create` → `then_with_value` sequence for an async `fetch()` handler.

Separately, `WebWorker::shutdown` called `clear_has_termination_request()` before `on_exit()`, which was a no-op in practice (the `dispatchExitInternal` termination guard still tripped on the pending exception, matching Node's "skip `process.on('exit')` on terminate"), and left the sticky exception in place for `close_all_socket_groups`' on_close callbacks to re-enter JS against.

## Fix

- `RequestContext::do_render_stream`, `RequestContext::on_response`, and `on_node_http_request_with_upgrade_ctx` (the node:http-compat twin): after `drain_microtasks()`, if an exception is pending (only the `TerminationException` survives the drain), return instead of continuing into paths that re-enter JS. Worker shutdown's `close_all_socket_groups` aborts the response and tears the sink down.
- `WebWorker::shutdown`: drop the no-op `clear_has_termination_request()` before `on_exit()` and instead call `clear_termination_exception()` (clears both the flag and the pending exception) *after* `on_exit()`, so `dispatchExitInternal` still skips `process.on('exit')` on terminate (Node semantics) while `close_all_socket_groups`' on_close callbacks can re-enter JS.
- Delete the now-unused `VM::clear_has_termination_request` wrapper and its `JSC__VM__clearHasTerminationRequest` FFI shim.

#36331 fixes the sibling `assertNoException` face for the non-direct stream path at the `HTTP(S)ResponseSink__onClose`/`__onReady`/`detach` sites; this PR covers the `type:"direct"`, async-handler, and node:http-compat paths at `do_render_stream`/`on_response`/`on_node_http_request_with_upgrade_ctx` and at shutdown.

## Verification

- New `type:"direct"` cell in `worker-terminate-lifetime.test.ts`: fails on main with the `deferTerminationSlow` assert (first iteration, 5/5), passes with the fix (5/5).
- New async-`fetch()` cell: same assert on main, passes with the fix; also asserts `process.on('exit')` is skipped (sab[1] stays 0), which fails if `clear_termination_exception()` is moved back before `on_exit()`.
- New idle-terminate cell: `process.on('exit')` is skipped when `terminate()` lands while the worker is parked (Node compat; the trap-bit path).
- `test/js/bun/http/serve-direct-readable-stream.test.ts`: 13 pass.
- `serve-stream-body-error.test.ts`, `serve-error-handler-stream.test.ts`, `async-iterator-stream.test.ts`, `serve-async-stream-client-abort.test.ts`: 121 pass.
- `test/js/node/worker_threads/worker_threads.test.ts`: 91 pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->
