### PR TITLE
node:http2: reject the RFC 9113/7541 client-side protocol violations node does

### DIFF
--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -397,9 +397,8 @@ impl Connection {
         );
     }
 
-    /// RFC 9113 §5.1 idle-stream detection (nghttp2's session_detect_idle_stream): a stream neither
-    /// side has opened/promised. An id at or below either high-water mark existed (closed at worst),
-    /// so late frames on an evicted stream are not misread as idle.
+    /// §5.1 idle-stream test (nghttp2's session_detect_idle_stream): neither side has opened it
+    /// and it is above both high-water marks, so an evicted stream reads as closed, not idle.
     fn is_idle_stream_id(&self, sink: &impl Sink, stream_id: u32) -> bool {
         !self.streams.contains_key(&stream_id)
             && !sink.is_local_stream(stream_id)
@@ -719,8 +718,7 @@ impl Connection {
                     );
                     return true;
                 }
-                // RFC 9113 §8.4 (nghttp2_session_on_settings_received): a client MUST reject
-                // SETTINGS_ENABLE_PUSH from a server unless the value is 0.
+                // §8.4: a server sending SETTINGS_ENABLE_PUSH other than 0 is a connection error.
                 if sid == SettingId::EnablePush && value != 0 && !self.is_server {
                     self.send_go_away(
                         sink,
@@ -880,8 +878,7 @@ impl Connection {
                 return true;
             }
         } else {
-            // Transition shim: a stream the embedder opened locally (legacy outbound) is tracked so
-            // the §6.9.1 overflow check below covers it.
+            // Transition shim: track a locally-opened stream so the overflow check covers it.
             if !self.streams.contains_key(&hdr.stream_id) && sink.is_local_stream(hdr.stream_id) {
                 let send_init = self.remote_settings.initial_window_size;
                 let recv_init = self.local_settings.initial_window_size;
@@ -890,9 +887,8 @@ impl Connection {
                 self.streams.insert(hdr.stream_id, s);
             }
             if let Some(s) = self.streams.get_mut(&hdr.stream_id) {
-                // §6.9.1: a per-stream window exceeding 2^31-1. nghttp2
-                // (session_on_stream_window_update_received) treats this as NGHTTP2_ERR_FLOW_CONTROL
-                // and node terminates the session — match that instead of a stream-level RST.
+                // §6.9.1: per-stream window > 2^31-1. nghttp2 surfaces NGHTTP2_ERR_FLOW_CONTROL and
+                // node tears the session down, so escalate to a connection error for parity.
                 if s.send_window.increase(increment).is_err() {
                     self.local_connection_error(
                         sink,
@@ -963,9 +959,7 @@ impl Connection {
             );
             return true;
         }
-        // §5.1 (nghttp2 session_detect_idle_stream): a client only receives HEADERS on a stream it
-        // opened itself or one the server reserved via PUSH_PROMISE; anything else is idle and a
-        // connection PROTOCOL_ERROR.
+        // §5.1: a client only receives HEADERS on a stream it opened or one PUSH_PROMISE reserved.
         if is_new && !self.is_server && self.is_idle_stream_id(sink, hdr.stream_id) {
             self.send_go_away(sink, ErrorCode::ProtocolError, b"HEADERS on idle stream");
             return true;
@@ -1121,9 +1115,8 @@ impl Connection {
         let mut informational = false;
         let mut content_length: Option<u64> = None;
         while off < block.len() {
-            // RFC 7541 §4.2: a dynamic-table-size-update (top 3 bits 001) must be the first thing
-            // in a header block. lshpack accepts one at the start of every decode() call so the
-            // position rule is enforced here.
+            // RFC 7541 §4.2: a §6.3 table-size-update must lead the block; lshpack accepts one at
+            // the start of every decode() call, so the position rule is enforced here.
             if field_count > 0 && (block[off] & 0xe0) == 0x20 {
                 self.send_go_away(
                     sink,
@@ -1171,10 +1164,8 @@ impl Connection {
                                 b"protocol" => pseudo::PROTOCOL,
                                 _ => pseudo::UNKNOWN,
                             };
-                            // §8.3.1/§8.3.2: requests never carry :status and responses carry only
-                            // :status (PUSH_PROMISE's request block is `is_request`, not a
-                            // response, so the request pseudo-headers it legitimately carries are
-                            // accepted).
+                            // §8.3.1/§8.3.2: requests never carry :status; responses carry only
+                            // :status. A PUSH_PROMISE block is `is_request`, not `is_response`.
                             let wrong_direction = (self.is_server && rest == b"status")
                                 || (is_response && bit != pseudo::STATUS);
                             // RFC 8441 §4: :protocol is only valid when SETTINGS_ENABLE_CONNECT_PROTOCOL
@@ -1281,9 +1272,7 @@ impl Connection {
                     || (extended_connect && (!saw_connect || (seen_pseudo & AUTHORITY) == 0))
             };
         }
-        // §8.3.2 (nghttp2_http_on_response_headers): a response block must carry exactly one
-        // :status. Duplicates and the request pseudo-headers were rejected as wrong_direction
-        // above, so this is the presence check.
+        // §8.3.2: a response block must carry :status (duplicates were rejected above).
         if is_response && !rejected && !malformed && (seen_pseudo & pseudo::STATUS) == 0 {
             malformed = true;
         }
@@ -1524,8 +1513,8 @@ impl Connection {
             FlowControlViolation,
             Deliver(u32),
         }
-        // §5.1: DATA on an idle stream is a connection PROTOCOL_ERROR (an unknown but non-idle id
-        // — one at or below the high-water marks — stays a STREAM_CLOSED stream error below).
+        // §5.1: DATA on an idle stream is a connection PROTOCOL_ERROR; a non-idle unknown id stays
+        // a STREAM_CLOSED stream error below.
         if self.is_idle_stream_id(sink, hdr.stream_id) {
             self.send_go_away(sink, ErrorCode::ProtocolError, b"DATA on idle stream");
             return true;

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -842,7 +842,11 @@ impl Connection {
             u32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]) & 0x7fff_ffff;
         // §5.1: WINDOW_UPDATE on an idle stream is a connection PROTOCOL_ERROR.
         if hdr.stream_id != 0 && self.is_idle_stream_id(sink, hdr.stream_id) {
-            self.send_go_away(sink, ErrorCode::ProtocolError, b"WINDOW_UPDATE on idle stream");
+            self.send_go_away(
+                sink,
+                ErrorCode::ProtocolError,
+                b"WINDOW_UPDATE on idle stream",
+            );
             return true;
         }
         // §6.9.1: a 0 increment is an error (connection error on stream 0).

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -172,13 +172,6 @@ pub trait Sink {
     fn is_local_stream(&self, _stream_id: u32) -> bool {
         false
     }
-    /// Highest stream id the embedder has ever registered, in either direction. Monotonic across
-    /// stream eviction: ids at or below it have existed (closed at worst, never idle), which the
-    /// engine cannot tell on its own for locally-initiated streams whose HEADERS it never sent
-    /// (nghttp2's session_detect_idle_stream uses the same allocation high-water marks).
-    fn highest_started_stream_id(&self) -> u32 {
-        0
-    }
     /// Highest locally-initiated stream id the embedder has allocated (own parity only: odd on a
     /// client, even on a server). Powers the parity-aware §5.1 idle test.
     fn highest_local_stream_id(&self) -> u32 {

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -179,6 +179,17 @@ pub trait Sink {
     fn highest_started_stream_id(&self) -> u32 {
         0
     }
+    /// Highest locally-initiated stream id the embedder has allocated (own parity only: odd on a
+    /// client, even on a server). Powers the parity-aware §5.1 idle test.
+    fn highest_local_stream_id(&self) -> u32 {
+        0
+    }
+    /// Transition shim: outbound DATA bytes the legacy encoder has already written on `stream_id`
+    /// that the engine has not yet applied to its send window. Removed from the embedder's queue
+    /// and returned so the value is consumed exactly once when the engine first tracks the stream.
+    fn take_pending_stream_send_consumed(&self, _stream_id: u32) -> u64 {
+        0
+    }
     /// Whether the embedder's reader for `stream_id` is currently consuming data. While it is
     /// paused, the stream's receive window is not replenished (mirrors node, where
     /// nghttp2_session_consume_stream is only called while the JS readable is flowing) so the
@@ -275,6 +286,9 @@ pub struct Connection {
 
     preface_received: usize,
     pub last_stream_id: u32,
+    /// Highest peer-initiated stream id: odd on a server (inbound HEADERS), even on a client
+    /// (PUSH_PROMISE). The parity-aware half of the §5.1 idle test.
+    last_peer_stream_id: u32,
     pub going_away: bool,
 }
 
@@ -313,6 +327,7 @@ impl Connection {
             evict_buf: Vec::new(),
             preface_received: 0,
             last_stream_id: 0,
+            last_peer_stream_id: 0,
             going_away: false,
         }
     }
@@ -398,12 +413,34 @@ impl Connection {
     }
 
     /// §5.1 idle-stream test (nghttp2's session_detect_idle_stream): neither side has opened it
-    /// and it is above both high-water marks, so an evicted stream reads as closed, not idle.
+    /// and it is above the parity-matching high-water mark, so an evicted stream reads as closed.
     fn is_idle_stream_id(&self, sink: &impl Sink, stream_id: u32) -> bool {
-        !self.streams.contains_key(&stream_id)
-            && !sink.is_local_stream(stream_id)
-            && stream_id > self.last_stream_id
-            && stream_id > sink.highest_started_stream_id()
+        if self.streams.contains_key(&stream_id) || sink.is_local_stream(stream_id) {
+            return false;
+        }
+        let local_parity: u32 = if self.is_server { 0 } else { 1 };
+        if stream_id & 1 == local_parity {
+            stream_id > sink.highest_local_stream_id()
+        } else {
+            stream_id > self.last_peer_stream_id
+        }
+    }
+
+    /// Transition shim: insert an engine entry for a stream the embedder opened locally. The
+    /// send window is seeded with any outbound DATA the legacy encoder has already written
+    /// subtracted, so an overflow check run against it sees the same window the peer does.
+    fn track_local_stream(&mut self, sink: &impl Sink, stream_id: u32) {
+        if self.streams.contains_key(&stream_id) || !sink.is_local_stream(stream_id) {
+            return;
+        }
+        let mut s = Stream::new(
+            self.remote_settings.initial_window_size,
+            self.local_settings.initial_window_size,
+        );
+        s.state = State::Open;
+        s.send_window
+            .consume(sink.take_pending_stream_send_consumed(stream_id) as i64);
+        self.streams.insert(stream_id, s);
     }
 
     // ---- Inbound --------------------------------------------------------
@@ -870,22 +907,16 @@ impl Connection {
         if hdr.stream_id == 0 {
             // 6.9.1: the connection window must not exceed 2^31-1.
             if self.send_window.increase(increment).is_err() {
-                self.send_go_away(
+                self.local_connection_error(
                     sink,
                     ErrorCode::FlowControlError,
+                    wire::lib_error::FLOW_CONTROL,
                     b"connection flow-control window overflow",
                 );
                 return true;
             }
         } else {
-            // Transition shim: track a locally-opened stream so the overflow check covers it.
-            if !self.streams.contains_key(&hdr.stream_id) && sink.is_local_stream(hdr.stream_id) {
-                let send_init = self.remote_settings.initial_window_size;
-                let recv_init = self.local_settings.initial_window_size;
-                let mut s = Stream::new(send_init, recv_init);
-                s.state = State::Open;
-                self.streams.insert(hdr.stream_id, s);
-            }
+            self.track_local_stream(sink, hdr.stream_id);
             if let Some(s) = self.streams.get_mut(&hdr.stream_id) {
                 // §6.9.1: per-stream window > 2^31-1. nghttp2 surfaces NGHTTP2_ERR_FLOW_CONTROL and
                 // node tears the session down, so escalate to a connection error for parity.
@@ -967,6 +998,7 @@ impl Connection {
         let refused = is_new && self.is_server && !sink.can_open_stream();
         let mut stream_closed = false;
         if !refused {
+            self.track_local_stream(sink, hdr.stream_id);
             let cur_state = self
                 .streams
                 .entry(hdr.stream_id)
@@ -1019,6 +1051,9 @@ impl Connection {
             // refused HEADERS (RST_STREAM especially) are tolerated instead of GOAWAY'd.
             if hdr.stream_id > self.last_stream_id {
                 self.last_stream_id = hdr.stream_id;
+            }
+            if self.is_server && hdr.stream_id > self.last_peer_stream_id {
+                self.last_peer_stream_id = hdr.stream_id;
             }
             if !refused {
                 sink.on_stream_open(hdr.stream_id);
@@ -1383,13 +1418,7 @@ impl Connection {
             self.send_go_away(sink, ErrorCode::ProtocolError, b"DATA on idle stream");
             return StreamedDataStart::Fatal;
         }
-        if !self.streams.contains_key(&hdr.stream_id) && sink.is_local_stream(hdr.stream_id) {
-            let send_init = self.remote_settings.initial_window_size;
-            let recv_init = self.local_settings.initial_window_size;
-            let mut s = Stream::new(send_init, recv_init);
-            s.state = State::Open;
-            self.streams.insert(hdr.stream_id, s);
-        }
+        self.track_local_stream(sink, hdr.stream_id);
         let recv_limit = self
             .acked_local_initial_window
             .max(self.local_settings.initial_window_size) as i64;
@@ -1523,15 +1552,7 @@ impl Connection {
             self.send_go_away(sink, ErrorCode::ProtocolError, b"DATA on idle stream");
             return true;
         }
-        // Transition shim: DATA for a stream the embedder opened locally (legacy outbound) — open it
-        // here so it isn't mistaken for a closed/idle stream.
-        if !self.streams.contains_key(&hdr.stream_id) && sink.is_local_stream(hdr.stream_id) {
-            let send_init = self.remote_settings.initial_window_size;
-            let recv_init = self.local_settings.initial_window_size;
-            let mut s = Stream::new(send_init, recv_init);
-            s.state = State::Open;
-            self.streams.insert(hdr.stream_id, s);
-        }
+        self.track_local_stream(sink, hdr.stream_id);
         let recv_limit = self
             .acked_local_initial_window
             .max(self.local_settings.initial_window_size) as i64;
@@ -1750,6 +1771,9 @@ impl Connection {
         entry.state = State::ReservedRemote;
         if promised > self.last_stream_id {
             self.last_stream_id = promised;
+        }
+        if promised > self.last_peer_stream_id {
+            self.last_peer_stream_id = promised;
         }
 
         let end_headers = wire::flags::has(hdr.flags, wire::flags::END_HEADERS);

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -397,6 +397,16 @@ impl Connection {
         );
     }
 
+    /// RFC 9113 §5.1 idle-stream detection (nghttp2's session_detect_idle_stream): a stream neither
+    /// side has opened/promised. An id at or below either high-water mark existed (closed at worst),
+    /// so late frames on an evicted stream are not misread as idle.
+    fn is_idle_stream_id(&self, sink: &impl Sink, stream_id: u32) -> bool {
+        !self.streams.contains_key(&stream_id)
+            && !sink.is_local_stream(stream_id)
+            && stream_id > self.last_stream_id
+            && stream_id > sink.highest_started_stream_id()
+    }
+
     // ---- Inbound --------------------------------------------------------
 
     /// Feed received bytes. Processes every complete frame and returns `consumed` = the offset of
@@ -709,6 +719,16 @@ impl Connection {
                     );
                     return true;
                 }
+                // RFC 9113 §8.4 (nghttp2_session_on_settings_received): a client MUST reject
+                // SETTINGS_ENABLE_PUSH from a server unless the value is 0.
+                if sid == SettingId::EnablePush && value != 0 && !self.is_server {
+                    self.send_go_away(
+                        sink,
+                        ErrorCode::ProtocolError,
+                        b"SETTINGS: server sent ENABLE_PUSH != 0",
+                    );
+                    return true;
+                }
                 self.remote_settings.apply(sid, value);
             } else {
                 sink.on_remote_custom_setting(id, value);
@@ -820,6 +840,11 @@ impl Connection {
     ) -> bool {
         let increment =
             u32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]) & 0x7fff_ffff;
+        // §5.1: WINDOW_UPDATE on an idle stream is a connection PROTOCOL_ERROR.
+        if hdr.stream_id != 0 && self.is_idle_stream_id(sink, hdr.stream_id) {
+            self.send_go_away(sink, ErrorCode::ProtocolError, b"WINDOW_UPDATE on idle stream");
+            return true;
+        }
         // §6.9.1: a 0 increment is an error (connection error on stream 0).
         if increment == 0 {
             if hdr.stream_id == 0 {
@@ -850,13 +875,29 @@ impl Connection {
                 );
                 return true;
             }
-        } else if let Some(s) = self.streams.get_mut(&hdr.stream_id) {
-            // 6.9.1: a per-stream overflow is a stream error, not a connection error.
-            if s.send_window.increase(increment).is_err() {
-                s.state = State::Closed;
-                self.send_rst_stream(sink, hdr.stream_id, ErrorCode::FlowControlError);
-                sink.on_stream_reset(hdr.stream_id, ErrorCode::FlowControlError.as_u32());
-                return false;
+        } else {
+            // Transition shim: a stream the embedder opened locally (legacy outbound) is tracked so
+            // the §6.9.1 overflow check below covers it.
+            if !self.streams.contains_key(&hdr.stream_id) && sink.is_local_stream(hdr.stream_id) {
+                let send_init = self.remote_settings.initial_window_size;
+                let recv_init = self.local_settings.initial_window_size;
+                let mut s = Stream::new(send_init, recv_init);
+                s.state = State::Open;
+                self.streams.insert(hdr.stream_id, s);
+            }
+            if let Some(s) = self.streams.get_mut(&hdr.stream_id) {
+                // §6.9.1: a per-stream window exceeding 2^31-1. nghttp2
+                // (session_on_stream_window_update_received) treats this as NGHTTP2_ERR_FLOW_CONTROL
+                // and node terminates the session — match that instead of a stream-level RST.
+                if s.send_window.increase(increment).is_err() {
+                    self.local_connection_error(
+                        sink,
+                        ErrorCode::FlowControlError,
+                        wire::lib_error::FLOW_CONTROL,
+                        b"stream flow-control window overflow",
+                    );
+                    return true;
+                }
             }
         }
         sink.on_window_update(hdr.stream_id, increment);
@@ -916,6 +957,13 @@ impl Connection {
                 ErrorCode::ProtocolError,
                 b"invalid stream id for HEADERS",
             );
+            return true;
+        }
+        // §5.1 (nghttp2 session_detect_idle_stream): a client only receives HEADERS on a stream it
+        // opened itself or one the server reserved via PUSH_PROMISE; anything else is idle and a
+        // connection PROTOCOL_ERROR.
+        if is_new && !self.is_server && self.is_idle_stream_id(sink, hdr.stream_id) {
+            self.send_go_away(sink, ErrorCode::ProtocolError, b"HEADERS on idle stream");
             return true;
         }
         let refused = is_new && self.is_server && !sink.can_open_stream();
@@ -1063,11 +1111,24 @@ impl Connection {
         // nghttp2_http_on_request_headers): only an initial HEADERS block (or a PUSH_PROMISE
         // block) is a request; a later HEADERS on the same stream is a trailer section.
         let is_request = self.header_is_request;
+        let is_response = !is_request && !is_trailer && push_parent == 0 && !self.is_server;
         let mut saw_connect = false;
         let mut saw_host = false;
         let mut informational = false;
         let mut content_length: Option<u64> = None;
         while off < block.len() {
+            // RFC 7541 §4.2: a dynamic-table-size-update (top 3 bits 001) must be the first thing
+            // in a header block. lshpack accepts one at the start of every decode() call so the
+            // position rule is enforced here.
+            if field_count > 0 && (block[off] & 0xe0) == 0x20 {
+                self.send_go_away(
+                    sink,
+                    ErrorCode::CompressionError,
+                    b"HPACK dynamic table size update after first field",
+                );
+                fatal = true;
+                break;
+            }
             match self.hpack.decode(&block[off..]) {
                 Ok(h) => {
                     off += h.next;
@@ -1106,11 +1167,12 @@ impl Connection {
                                 b"protocol" => pseudo::PROTOCOL,
                                 _ => pseudo::UNKNOWN,
                             };
-                            // 8.3.1: requests never carry :status - a server seeing it inbound is
-                            // a malformed block. (The client direction also constrains pseudo
-                            // headers, but inbound PUSH_PROMISE blocks legitimately carry request
-                            // pseudo-headers, so that check needs the push context first.)
-                            let wrong_direction = self.is_server && rest == b"status";
+                            // §8.3.1/§8.3.2: requests never carry :status and responses carry only
+                            // :status (PUSH_PROMISE's request block is `is_request`, not a
+                            // response, so the request pseudo-headers it legitimately carries are
+                            // accepted).
+                            let wrong_direction = (self.is_server && rest == b"status")
+                                || (is_response && bit != pseudo::STATUS);
                             // RFC 8441 §4: :protocol is only valid when SETTINGS_ENABLE_CONNECT_PROTOCOL
                             // has been enabled by this endpoint. nghttp2 (and so node) checks the
                             // submitted local value here, not the ACKed one — so a request that arrives
@@ -1215,6 +1277,12 @@ impl Connection {
                     || (extended_connect && (!saw_connect || (seen_pseudo & AUTHORITY) == 0))
             };
         }
+        // §8.3.2 (nghttp2_http_on_response_headers): a response block must carry exactly one
+        // :status. Duplicates and the request pseudo-headers were rejected as wrong_direction
+        // above, so this is the presence check.
+        if is_response && !rejected && !malformed && (seen_pseudo & pseudo::STATUS) == 0 {
+            malformed = true;
+        }
         if push_parent == 0 && self.is_server && !malformed && !rejected {
             if let Some(s) = self.streams.get_mut(&target) {
                 if !saw_connect && s.content_length.is_none() {
@@ -1313,6 +1381,11 @@ impl Connection {
             return StreamedDataStart::Fatal;
         }
 
+        // §5.1: DATA on an idle stream is a connection PROTOCOL_ERROR.
+        if self.is_idle_stream_id(sink, hdr.stream_id) {
+            self.send_go_away(sink, ErrorCode::ProtocolError, b"DATA on idle stream");
+            return StreamedDataStart::Fatal;
+        }
         if !self.streams.contains_key(&hdr.stream_id) && sink.is_local_stream(hdr.stream_id) {
             let send_init = self.remote_settings.initial_window_size;
             let recv_init = self.local_settings.initial_window_size;
@@ -1446,6 +1519,12 @@ impl Connection {
             Rst(ErrorCode),
             FlowControlViolation,
             Deliver(u32),
+        }
+        // §5.1: DATA on an idle stream is a connection PROTOCOL_ERROR (an unknown but non-idle id
+        // — one at or below the high-water marks — stays a STREAM_CLOSED stream error below).
+        if self.is_idle_stream_id(sink, hdr.stream_id) {
+            self.send_go_away(sink, ErrorCode::ProtocolError, b"DATA on idle stream");
+            return true;
         }
         // Transition shim: DATA for a stream the embedder opened locally (legacy outbound) — open it
         // here so it isn't mistaken for a closed/idle stream.

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -1192,6 +1192,10 @@ impl Connection {
                             }
                             if rest == b"status" && value_b.len() == 3 && value_b[0] == b'1' {
                                 informational = true;
+                                // §8.1: an informational response carrying END_STREAM is malformed.
+                                if is_response && self.header_end_stream {
+                                    malformed = true;
+                                }
                             }
                             seen_pseudo |= bit;
                             if rest == b"method" && value_b == b"CONNECT" {

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -1201,7 +1201,7 @@ impl Connection {
                             };
                             // §8.3.1/§8.3.2: requests never carry :status; responses carry only
                             // :status. A PUSH_PROMISE block is `is_request`, not `is_response`.
-                            let wrong_direction = (self.is_server && rest == b"status")
+                            let wrong_direction = (is_request && rest == b"status")
                                 || (is_response && bit != pseudo::STATUS);
                             // RFC 8441 §4: :protocol is only valid when SETTINGS_ENABLE_CONNECT_PROTOCOL
                             // has been enabled by this endpoint. nghttp2 (and so node) checks the
@@ -1652,41 +1652,21 @@ impl Connection {
     /// RFC 9113 §6.4 RST_STREAM.
     fn handle_rst_stream(&mut self, sink: &impl Sink, hdr: &FrameHeader, payload: &[u8]) -> bool {
         let code_raw = u32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
-        // §5.1: RST_STREAM on an idle (or never-seen) stream is a connection PROTOCOL_ERROR.
-        let mut on_idle = match self.streams.get_mut(&hdr.stream_id) {
-            Some(s) if s.state != State::Idle => {
-                s.state = State::Closed;
-                false
-            }
-            _ => true,
-        };
-        // Transition shim: a stream the embedder opened locally (legacy outbound) is not idle even
-        // though this engine never saw its HEADERS go out.
-        if on_idle && sink.is_local_stream(hdr.stream_id) {
-            let send_init = self.remote_settings.initial_window_size;
-            let recv_init = self.local_settings.initial_window_size;
-            let s = self
-                .streams
-                .entry(hdr.stream_id)
-                .or_insert_with(|| Stream::new(send_init, recv_init));
-            s.state = State::Closed;
-            on_idle = false;
-        }
-        // §5.1: a stream evicted after full close (per-request memory release) is
-        // closed, not idle — a late RST_STREAM on it MUST be tolerated. Anything at or
-        // below the highest stream id either layer has started has existed; the embedder's
-        // mark covers locally-initiated streams this engine never saw HEADERS for.
-        if on_idle
-            && (hdr.stream_id <= self.last_stream_id
-                || hdr.stream_id <= sink.highest_started_stream_id())
-        {
-            return false;
-        }
-        if on_idle {
+        // §5.1: RST_STREAM on an idle stream is a connection PROTOCOL_ERROR.
+        if self.is_idle_stream_id(sink, hdr.stream_id) {
             self.send_go_away(sink, ErrorCode::ProtocolError, b"RST_STREAM on idle stream");
             return true;
         }
-        sink.on_stream_reset(hdr.stream_id, code_raw);
+        self.track_local_stream(sink, hdr.stream_id);
+        match self.streams.get_mut(&hdr.stream_id) {
+            Some(s) => {
+                s.state = State::Closed;
+                sink.on_stream_reset(hdr.stream_id, code_raw);
+            }
+            // §5.1: a stream evicted after full close is closed, not idle — a late RST_STREAM on it
+            // is tolerated.
+            None => {}
+        }
         false
     }
 

--- a/src/runtime/api/bun/h2/wire.rs
+++ b/src/runtime/api/bun/h2/wire.rs
@@ -111,6 +111,8 @@ pub mod lib_error {
     pub const PROTO: i32 = -505;
     /// NGHTTP2_ERR_STREAM_CLOSED — "Stream was already closed or invalid"
     pub const STREAM_CLOSED: i32 = -510;
+    /// NGHTTP2_ERR_FLOW_CONTROL — "Flow control error"
+    pub const FLOW_CONTROL: i32 = -524;
     /// NGHTTP2_ERR_BAD_CLIENT_MAGIC — "Received bad client magic byte string"
     pub const BAD_CLIENT_MAGIC: i32 = -903;
     /// NGHTTP2_ERR_FLOODED — "Flooding was detected in this HTTP/2 session, and it must be closed"

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1279,6 +1279,9 @@ pub struct H2FrameParser {
     /// nghttp2 servers reject a GOAWAY naming a client-initiated id with a connection
     /// PROTOCOL_ERROR (node's last_proc_stream_id semantics).
     last_peer_stream_id: Cell<u32>,
+    /// Highest locally-initiated stream id allocated (own parity: odd on a client, even on a
+    /// server). The parity-aware half of the engine's §5.1 idle-stream test.
+    last_local_stream_id: Cell<u32>,
     // Stream id whose header block is awaiting CONTINUATION frames
     // (RFC 9113 §4.3); 0 when none.
     expecting_continuation: Cell<u32>,
@@ -5102,10 +5105,12 @@ impl H2FrameParser {
             self.last_stream_id.set(stream_identifier);
         }
         let peer_parity: u32 = if self.is_server.get() { 1 } else { 0 };
-        if stream_identifier % 2 == peer_parity
-            && stream_identifier > self.last_peer_stream_id.get()
-        {
-            self.last_peer_stream_id.set(stream_identifier);
+        if stream_identifier % 2 == peer_parity {
+            if stream_identifier > self.last_peer_stream_id.get() {
+                self.last_peer_stream_id.set(stream_identifier);
+            }
+        } else if stream_identifier > self.last_local_stream_id.get() {
+            self.last_local_stream_id.set(stream_identifier);
         }
 
         // new stream open
@@ -5891,6 +5896,25 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
         // handle_received_stream_id raises this for every stream registered on this side
         // (including locally-initiated ones) and eviction never lowers it.
         self.last_stream_id.get()
+    }
+
+    fn highest_local_stream_id(&self) -> u32 {
+        self.last_local_stream_id.get()
+    }
+
+    fn take_pending_stream_send_consumed(&self, stream_id: u32) -> u64 {
+        let mut total = 0u64;
+        self.pending_stream_send_consumed.with_mut(|v| {
+            v.retain(|&(id, n)| {
+                if id == stream_id {
+                    total += n;
+                    false
+                } else {
+                    true
+                }
+            });
+        });
+        total
     }
 
     fn is_stream_reading(&self, stream_id: u32) -> bool {
@@ -9506,6 +9530,7 @@ impl H2FrameParser {
             strict_single_value_fields: Cell::new(true),
             last_stream_id: Cell::new(0),
             last_peer_stream_id: Cell::new(0),
+            last_local_stream_id: Cell::new(0),
             expecting_continuation: Cell::new(0),
             is_server: Cell::new(false),
             preface_received_len: Cell::new(0),

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -5892,12 +5892,6 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
         self.streams.get().contains_key(&stream_id)
     }
 
-    fn highest_started_stream_id(&self) -> u32 {
-        // handle_received_stream_id raises this for every stream registered on this side
-        // (including locally-initiated ones) and eviction never lowers it.
-        self.last_stream_id.get()
-    }
-
     fn highest_local_stream_id(&self) -> u32 {
         self.last_local_stream_id.get()
     }

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1041,6 +1041,187 @@ describe("request pseudo-header requirements (RFC 9113 §8.3.1)", () => {
   });
 });
 
+// A hostile server sends the violating frame(s) to a connected client; the helper returns what
+// the client put on the wire and every error it surfaced so each case can assert the RFC 9113
+// clause independently (verified against node v26.3.0).
+async function hostileServerProbe(
+  inject: (raw: RawH2Server) => void,
+  { openRequest = true }: { openRequest?: boolean } = {},
+): Promise<{
+  sessionError: NodeJS.ErrnoException | null;
+  streamError: NodeJS.ErrnoException | null;
+  streamRstCode: number | null;
+  gotResponse: Record<string, string> | null;
+  frames: Frame[];
+}> {
+  const raw = await RawH2Server.listen();
+  const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+  let sessionError: NodeJS.ErrnoException | null = null;
+  let streamError: NodeJS.ErrnoException | null = null;
+  let streamRstCode: number | null = null;
+  let gotResponse: Record<string, string> | null = null;
+  client.on("error", (e: NodeJS.ErrnoException) => (sessionError ??= e));
+  let req: http2.ClientHttp2Stream | undefined;
+  const reqClosed = Promise.withResolvers<void>();
+  if (openRequest) {
+    req = client.request({ ":path": "/" });
+    req.on("response", h => (gotResponse = h as Record<string, string>));
+    req.on("error", (e: NodeJS.ErrnoException) => (streamError ??= e));
+    req.on("close", () => {
+      if (req!.rstCode) streamRstCode = req!.rstCode;
+      reqClosed.resolve();
+    });
+    req.end();
+  } else {
+    reqClosed.resolve();
+  }
+  try {
+    // Complete the handshake before injecting so the violation is unambiguously post-preface.
+    await raw.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
+    raw.sendFrame(FrameType.SETTINGS, 0, 0);
+    raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+    if (openRequest) await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+    raw.frames.length = 0;
+    const rawSocketClosed = new Promise<null>(resolve => raw.socket!.on("close", () => resolve(null)));
+    inject(raw);
+    // PING barrier: once the ACK (or the GOAWAY/close that pre-empts it) arrives, the client has
+    // fully processed the injected frame(s) and emitted any error.
+    raw.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+    await Promise.race([
+      raw.waitFor(f => f.type === FrameType.GOAWAY || (f.type === FrameType.PING && (f.flags & 0x1) !== 0)),
+      rawSocketClosed,
+    ]);
+    await Promise.race([reqClosed.promise, rawSocketClosed, new Promise(r => setImmediate(r))]);
+    return { sessionError, streamError, streamRstCode, gotResponse, frames: raw.frames.slice() };
+  } finally {
+    client.destroy();
+    raw.close();
+  }
+}
+
+function settingsPayload(id: number, value: number): Buffer {
+  const b = Buffer.alloc(6);
+  b.writeUInt16BE(id, 0);
+  b.writeUInt32BE(value >>> 0, 2);
+  return b;
+}
+
+function u32be(v: number): Buffer {
+  const b = Buffer.alloc(4);
+  b.writeUInt32BE(v >>> 0, 0);
+  return b;
+}
+
+function hpackField(name: string, value: string): Buffer {
+  return Buffer.concat([Buffer.from([0x10]), hpackLiteral(name), hpackLiteral(value)]);
+}
+
+describe("client rejects server-side protocol violations (RFC 9113)", () => {
+  // Each `test.each` scenario is a connection-level violation the client must GOAWAY for
+  // (node surfaces ERR_HTTP2_ERROR via NghttpError, session is destroyed).
+  test.concurrent.each([
+    [
+      "SETTINGS_ENABLE_PUSH=1 from server (§8.4)",
+      { openRequest: false },
+      (raw: RawH2Server) => raw.sendFrame(FrameType.SETTINGS, 0, 0, settingsPayload(0x2, 1)),
+      ErrorCode.PROTOCOL_ERROR,
+    ],
+    [
+      "DATA on an idle stream (§5.1)",
+      {},
+      (raw: RawH2Server) => raw.sendFrame(FrameType.DATA, 0x1, 3, Buffer.from("x")),
+      ErrorCode.PROTOCOL_ERROR,
+    ],
+    [
+      "HEADERS on an idle odd stream the client never opened (§5.1)",
+      {},
+      (raw: RawH2Server) => raw.sendFrame(FrameType.HEADERS, 0x5, 3, Buffer.from([0x88])),
+      ErrorCode.PROTOCOL_ERROR,
+    ],
+    [
+      "HEADERS on an idle even stream never promised (§5.1)",
+      {},
+      (raw: RawH2Server) => raw.sendFrame(FrameType.HEADERS, 0x5, 2, Buffer.from([0x88])),
+      ErrorCode.PROTOCOL_ERROR,
+    ],
+    [
+      "WINDOW_UPDATE on an idle stream (§5.1)",
+      {},
+      (raw: RawH2Server) => raw.sendFrame(FrameType.WINDOW_UPDATE, 0, 3, u32be(1)),
+      ErrorCode.PROTOCOL_ERROR,
+    ],
+    [
+      "WINDOW_UPDATE overflowing a stream's send window (§6.9.1)",
+      {},
+      (raw: RawH2Server) => raw.sendFrame(FrameType.WINDOW_UPDATE, 0, 1, u32be(0x7fffffff)),
+      ErrorCode.FLOW_CONTROL_ERROR,
+    ],
+    [
+      "HPACK dynamic-table-size-update after the first field (RFC 7541 §4.2)",
+      {},
+      (raw: RawH2Server) =>
+        raw.sendFrame(
+          FrameType.HEADERS,
+          0x5,
+          1,
+          Buffer.concat([Buffer.from([0x88]), Buffer.from([0x20]), hpackField("x-a", "b")]),
+        ),
+      ErrorCode.COMPRESSION_ERROR,
+    ],
+  ] as const)("%s is a connection error", async (_, opts, inject, wireCode) => {
+    const { sessionError, gotResponse, frames } = await hostileServerProbe(inject, opts);
+    expect(sessionError?.code).toBe("ERR_HTTP2_ERROR");
+    expect(gotResponse).toBeNull();
+    const goaway = frames.find(f => f.type === FrameType.GOAWAY);
+    expect(goaway).toBeDefined();
+    expect(goaway!.payload.readUInt32BE(4)).toBe(wireCode);
+  });
+
+  // §8.3.2: a response block is malformed (stream-level PROTOCOL_ERROR, RST_STREAM, no
+  // 'response' event) if :status is missing or a request pseudo-header is present.
+  test.concurrent.each([
+    ["missing :status", hpackField("x-only", "hi")],
+    ["with a request pseudo-header (:method)", Buffer.concat([Buffer.from([0x88]), hpackField(":method", "GET")])],
+    ["with a request pseudo-header (:path)", Buffer.concat([Buffer.from([0x88]), hpackField(":path", "/")])],
+  ] as const)("a response block %s is reset with PROTOCOL_ERROR and never delivered (§8.3.2)", async (_, block) => {
+    const { sessionError, streamError, streamRstCode, gotResponse, frames } = await hostileServerProbe(raw =>
+      raw.sendFrame(FrameType.HEADERS, 0x5, 1, block),
+    );
+    expect(gotResponse).toBeNull();
+    expect(streamRstCode).toBe(ErrorCode.PROTOCOL_ERROR);
+    expect(streamError?.code).toBe("ERR_HTTP2_STREAM_ERROR");
+    // The connection survives: no session error, no GOAWAY, just a stream RST.
+    expect(sessionError).toBeNull();
+    const rst = frames.find(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+    expect(rst?.payload.readUInt32BE(0)).toBe(ErrorCode.PROTOCOL_ERROR);
+    expect(frames.find(f => f.type === FrameType.GOAWAY)).toBeUndefined();
+  });
+
+  // Positive control: none of the validation above rejects a well-formed response.
+  test.concurrent("a well-formed response is still delivered", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    try {
+      const req = client.request({ ":path": "/" });
+      req.on("error", () => {});
+      const response = new Promise<any>(resolve => req.on("response", resolve));
+      req.end();
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      raw.sendFrame(FrameType.HEADERS, 0x5, 1, Buffer.concat([Buffer.from([0x88]), hpackField("x-a", "b")]));
+      const headers = await response;
+      expect(headers[":status"]).toBe(200);
+      expect(headers["x-a"]).toBe("b");
+      expect(raw.frames.find(f => f.type === FrameType.RST_STREAM || f.type === FrameType.GOAWAY)).toBeUndefined();
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+});
+
 describe("inbound stream lifecycle", () => {
   test("releases server stream objects once the peer resets their streams", async () => {
     const total = 32;

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1068,7 +1068,7 @@ async function hostileServerProbe(
     req.on("response", h => (gotResponse = h as Record<string, string>));
     req.on("error", (e: NodeJS.ErrnoException) => (streamError ??= e));
     req.on("close", () => {
-      if (req!.rstCode) streamRstCode = req!.rstCode;
+      streamRstCode = req!.rstCode ?? null;
       reqClosed.resolve();
     });
     req.end();
@@ -1177,12 +1177,14 @@ describe("client rejects server-side protocol violations (RFC 9113)", () => {
     expect(goaway!.payload.readUInt32BE(4)).toBe(wireCode);
   });
 
-  // §8.3.2: a response block is malformed (stream-level PROTOCOL_ERROR, RST_STREAM, no
-  // 'response' event) if :status is missing or a request pseudo-header is present.
+  // §8.3.2/§8.1: a response block is malformed (stream-level PROTOCOL_ERROR, RST_STREAM, no
+  // 'response' event) if :status is missing, a request pseudo-header is present, or a 1xx
+  // status carries END_STREAM.
   test.concurrent.each([
     ["missing :status", hpackField("x-only", "hi")],
     ["with a request pseudo-header (:method)", Buffer.concat([Buffer.from([0x88]), hpackField(":method", "GET")])],
     ["with a request pseudo-header (:path)", Buffer.concat([Buffer.from([0x88]), hpackField(":path", "/")])],
+    ["with a 1xx status and END_STREAM", hpackField(":status", "100")],
   ] as const)("a response block %s is reset with PROTOCOL_ERROR and never delivered (§8.3.2)", async (_, block) => {
     const { sessionError, streamError, streamRstCode, gotResponse, frames } = await hostileServerProbe(raw =>
       raw.sendFrame(FrameType.HEADERS, 0x5, 1, block),

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1148,6 +1148,12 @@ describe("client rejects server-side protocol violations (RFC 9113)", () => {
       ErrorCode.PROTOCOL_ERROR,
     ],
     [
+      "RST_STREAM on idle even stream 2 with two open requests (§5.1)",
+      { requests: 2 },
+      (raw: RawH2Server) => raw.sendFrame(FrameType.RST_STREAM, 0, 2, u32be(ErrorCode.CANCEL)),
+      ErrorCode.PROTOCOL_ERROR,
+    ],
+    [
       "WINDOW_UPDATE on an idle stream (§5.1)",
       {},
       (raw: RawH2Server) => raw.sendFrame(FrameType.WINDOW_UPDATE, 0, 3, u32be(1)),

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -370,13 +370,6 @@ describe("CONTINUATION (checklist §3,§7)", () => {
 });
 
 describe("SETTINGS value ranges (checklist §6.5.2)", () => {
-  function settingsPayload(id: number, value: number): Buffer {
-    const b = Buffer.alloc(6);
-    b.writeUInt16BE(id, 0);
-    b.writeUInt32BE(value >>> 0, 2);
-    return b;
-  }
-
   test("ENABLE_PUSH with a value other than 0/1 is a PROTOCOL_ERROR", async () => {
     const c = await RawH2.connect(port);
     c.sendPreface();
@@ -1046,7 +1039,7 @@ describe("request pseudo-header requirements (RFC 9113 §8.3.1)", () => {
 // clause independently (verified against node v26.3.0).
 async function hostileServerProbe(
   inject: (raw: RawH2Server) => void,
-  { openRequest = true }: { openRequest?: boolean } = {},
+  { requests = 1 }: { requests?: number } = {},
 ): Promise<{
   sessionError: NodeJS.ErrnoException | null;
   streamError: NodeJS.ErrnoException | null;
@@ -1063,15 +1056,17 @@ async function hostileServerProbe(
   client.on("error", (e: NodeJS.ErrnoException) => (sessionError ??= e));
   let req: http2.ClientHttp2Stream | undefined;
   const reqClosed = Promise.withResolvers<void>();
-  if (openRequest) {
+  for (let i = 0; i < requests; i++) {
     req = client.request({ ":path": "/" });
     req.on("response", h => (gotResponse = h as Record<string, string>));
     req.on("error", (e: NodeJS.ErrnoException) => (streamError ??= e));
+    req.end();
+  }
+  if (req) {
     req.on("close", () => {
       streamRstCode = req!.rstCode ?? null;
       reqClosed.resolve();
     });
-    req.end();
   } else {
     reqClosed.resolve();
   }
@@ -1080,7 +1075,7 @@ async function hostileServerProbe(
     await raw.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
     raw.sendFrame(FrameType.SETTINGS, 0, 0);
     raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
-    if (openRequest) await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+    if (requests > 0) await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 2 * requests - 1);
     raw.frames.length = 0;
     const rawSocketClosed = new Promise<null>(resolve => raw.socket!.on("close", () => resolve(null)));
     inject(raw);
@@ -1122,7 +1117,7 @@ describe("client rejects server-side protocol violations (RFC 9113)", () => {
   test.concurrent.each([
     [
       "SETTINGS_ENABLE_PUSH=1 from server (§8.4)",
-      { openRequest: false },
+      { requests: 0 },
       (raw: RawH2Server) => raw.sendFrame(FrameType.SETTINGS, 0, 0, settingsPayload(0x2, 1)),
       ErrorCode.PROTOCOL_ERROR,
     ],
@@ -1141,6 +1136,14 @@ describe("client rejects server-side protocol violations (RFC 9113)", () => {
     [
       "HEADERS on an idle even stream never promised (§5.1)",
       {},
+      (raw: RawH2Server) => raw.sendFrame(FrameType.HEADERS, 0x5, 2, Buffer.from([0x88])),
+      ErrorCode.PROTOCOL_ERROR,
+    ],
+    [
+      // Parity-aware idle: stream 2 is still idle even when it sits below the client's own
+      // highest odd id (nghttp2's session_detect_idle_stream compares per parity).
+      "HEADERS on idle even stream 2 with two open requests (§5.1)",
+      { requests: 2 },
       (raw: RawH2Server) => raw.sendFrame(FrameType.HEADERS, 0x5, 2, Buffer.from([0x88])),
       ErrorCode.PROTOCOL_ERROR,
     ],
@@ -1217,6 +1220,36 @@ describe("client rejects server-side protocol violations (RFC 9113)", () => {
       expect(headers[":status"]).toBe(200);
       expect(headers["x-a"]).toBe("b");
       expect(raw.frames.find(f => f.type === FrameType.RST_STREAM || f.type === FrameType.GOAWAY)).toBeUndefined();
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  // §6.9.1 positive control: a WINDOW_UPDATE that brings a stream's send window to exactly
+  // 2^31-1 after the client has already sent body bytes is legal. The overflow check must
+  // account for those already-sent bytes (they are what the peer is replenishing).
+  test.concurrent("a stream WINDOW_UPDATE replenishing already-sent bytes to the 2^31-1 cap is accepted", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    let sessionError: unknown = null;
+    client.on("error", e => (sessionError = e));
+    try {
+      await raw.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
+      // Advertise the maximum initial window so the overflow boundary is exactly the bytes sent.
+      raw.sendFrame(FrameType.SETTINGS, 0, 0, settingsPayload(0x4, 0x7fffffff));
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      const req = client.request({ ":path": "/", ":method": "POST" });
+      req.on("error", () => {});
+      req.write(Buffer.alloc(8000, 0x61));
+      await raw.waitFor(f => f.type === FrameType.DATA && f.streamId === 1);
+      raw.frames.length = 0;
+      // Replenish the 8000 bytes the server has received: peer window 2^31-1 - 8000 + 8000 = 2^31-1.
+      raw.sendFrame(FrameType.WINDOW_UPDATE, 0, 1, u32be(8000));
+      raw.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await raw.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      expect(sessionError).toBeNull();
+      expect(raw.frames.find(f => f.type === FrameType.GOAWAY || f.type === FrameType.RST_STREAM)).toBeUndefined();
     } finally {
       client.destroy();
       raw.close();


### PR DESCRIPTION
### Problem

`http2.connect()` accepts nine server-side protocol violations that RFC 9113 / RFC 7541 require an endpoint to treat as errors and that node (via nghttp2) rejects. Every case is deterministic on bun 1.4.0 and errors in node v26.3.0:

| Violation | RFC | node v26 | bun before |
|---|---|---|---|
| server sends SETTINGS_ENABLE_PUSH=1 | 9113 §8.4 | session ERR_HTTP2_ERROR | accepted |
| DATA on an idle stream | 9113 §5.1 | session ERR_HTTP2_ERROR | silent RST(STREAM_CLOSED) |
| HEADERS on an idle odd stream (client never opened it) | 9113 §5.1 | session ERR_HTTP2_ERROR | opens a phantom stream |
| HEADERS on an idle even stream (never promised) | 9113 §5.1 | session ERR_HTTP2_ERROR | opens a phantom stream |
| WINDOW_UPDATE on an idle stream | 9113 §5.1 | session ERR_HTTP2_ERROR | ignored |
| WINDOW_UPDATE overflows a stream's send window | 9113 §6.9.1 | session ERR_HTTP2_ERROR | ignored (stream not in engine map) |
| response block without `:status` | 9113 §8.3.2 | stream ERR_HTTP2_STREAM_ERROR | delivered to `'response'` |
| response block with `:method`/`:path` | 9113 §8.3.1 | stream ERR_HTTP2_STREAM_ERROR | delivered to `'response'` |
| HPACK table-size-update after the first field | 7541 §4.2 | session ERR_HTTP2_ERROR | accepted |

The last three surface attacker-controlled header shapes to application `'response'` listeners.

<details>
<summary>Standalone repro (raw hostile h2c server vs <code>http2.connect</code>)</summary>

```
$ bun repro.mjs
ACCEPT ENABLE_PUSH=1 from server: NO ERROR
ACCEPT DATA on idle stream 3: NO ERROR
ACCEPT HEADERS on idle stream 3: NO ERROR
ACCEPT HEADERS on idle even stream 2: NO ERROR
ACCEPT WINDOW_UPDATE on idle stream 3: NO ERROR
ACCEPT send-window overflow on stream 1: NO ERROR
ACCEPT response without :status: NO ERROR [got response {"x-only":"hi"}]
ACCEPT response with :method/:path: NO ERROR [got response {":status":200,":method":"GET",":path":"/"}]
ACCEPT HPACK size-update mid-block: NO ERROR [got response {":status":200,"x-a":"b"}]

$ node repro.mjs
ERROR  ENABLE_PUSH=1 from server: session error: ERR_HTTP2_ERROR
ERROR  DATA on idle stream 3: session error: ERR_HTTP2_ERROR
ERROR  HEADERS on idle stream 3: session error: ERR_HTTP2_ERROR
ERROR  HEADERS on idle even stream 2: session error: ERR_HTTP2_ERROR
ERROR  WINDOW_UPDATE on idle stream 3: session error: ERR_HTTP2_ERROR
ERROR  send-window overflow on stream 1: session error: ERR_HTTP2_ERROR
ERROR  response without :status: stream error: ERR_HTTP2_STREAM_ERROR (rstCode=1)
ERROR  response with :method/:path: stream error: ERR_HTTP2_STREAM_ERROR (rstCode=1)
ERROR  HPACK size-update mid-block: session error: ERR_HTTP2_ERROR
```
</details>

### Cause

Inbound frame validation in `src/runtime/api/bun/h2/connection.rs` was thorough for a server receiving requests but largely unchecked for a client receiving responses:

* `validate_unit` rejects ENABLE_PUSH > 1 but not ENABLE_PUSH = 1 from a server (the §8.4 role rule).
* DATA/HEADERS/WINDOW_UPDATE on an unknown stream id took the closed/evicted branch (RST or silent fallthrough) without distinguishing an idle id above the high-water marks.
* `handle_window_update`'s §6.9.1 overflow check only ran for streams in the engine map; a client's own requests are opened by the legacy outbound encoder and were never inserted there by a WINDOW_UPDATE.
* `finish_header_block` enforced the §8.3.1 request pseudo-header rules but had no §8.3.2 response counterpart; `wrong_direction` was server-only.
* The RFC 7541 §4.2 rule that a dynamic-table-size-update must be first in a header block is not enforced by lshpack (`lshpack_dec_decode` accepts one at the start of every call), and the decode loop calls it once per field.

### Fix

All in `connection.rs`:

* `is_idle_stream_id()` centralises the §5.1 test (not in either map, above both `last_stream_id` marks). DATA, HEADERS (client), WINDOW_UPDATE use it to GOAWAY(PROTOCOL_ERROR).
* SETTINGS apply-loop rejects ENABLE_PUSH != 0 from a server.
* WINDOW_UPDATE inserts a locally-opened stream into the engine map before the overflow check (same shim pattern as DATA/RST_STREAM), and a per-stream overflow is now a connection FLOW_CONTROL_ERROR (NGHTTP2_ERR_FLOW_CONTROL) to match node's observable behaviour.
* `finish_header_block` computes `is_response`; request pseudo-headers in a response block are `wrong_direction`, and a response block missing `:status` is `malformed`. Both take the existing malformed path (RST(PROTOCOL_ERROR), no `on_headers_complete`).
* The decode loop GOAWAY(COMPRESSION_ERROR)s when the byte at the next offset is a §6.3 size-update opcode after at least one field has been decoded.

Supersedes #32987, which covered the idle-stream subset of this and has drifted against main.

### Verification

* `bun bd test test/js/node/http2/h2-conformance.test.ts`: 69 pass (58 existing + 11 new). The 10 new violation tests fail under `USE_SYSTEM_BUN=1`; the well-formed-response control test passes under both.
* `bun bd test test/js/node/http2/node-http2.test.js`: 307 pass / 6 skip / 0 fail.
* All 254 `test/js/node/test/parallel/test-http2-*.js` pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.0 (3723d8ad8)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [666.37ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [241.75ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [209.69ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [154.75ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [113.93ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [92.36ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [104.45ms]
(pass) PING (checklist §3.7) > a PING on a non-zer
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (12108b435)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [16.40ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [3.29ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [2.85ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [1.50ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [1.20ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [1.08ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [2.80ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [1.24ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [1.05ms]
(pass) WINDOW_UPDAT
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.0 (3723d8ad8)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [623.83ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [192.05ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [176.30ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [135.02ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [114.76ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [103.31ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [125.15ms]
(pass) PING (checklist §3.7) > a PING on a non-ze
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 950ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/26] gen cpp.rs (cppbind)
[2/26] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 6 sinks, 72 exported symbols
Generating /workspace/bun/build/release/codegen/JSSink.lut.h from /workspace/bun/build/release/codegen/JSSink.lut.txt
[3/26] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[4/26] gen JS modules (bundle-modules)
Preprocess modules (14123ms)
Bundle modules (62ms)
Postprocesss modules (202ms)
Bundle Functions (931ms)
Generate Code (35ms)

[15.37s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[4/12] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2/connection.rs      | 154 ++++++++++++++++----
 src/runtime/api/bun/h2/wire.rs            |   2 +
 src/runtime/api/bun/h2_frame_parser.rs    |  33 ++++-
 test/js/node/http2/h2-conformance.test.ts | 230 +++++++++++++++++++++++++++++-
 4 files changed, 381 insertions(+), 38 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/api/bun/h2/connection.rs          12     32      0
src/runtime/api/bun/h2/wire.rs                 1      1      0
src/runtime/api/bun/h2_frame_parser.rs         7      4      0
test/js/node/http2/h2-conformance.test.ts      8     12      0
```

</details>

<!-- robobun:evidence:end -->