### PR TITLE
test(websocket): speed up websocket-upgrade.test.ts and fix swallowed assertions

### DIFF
--- a/test/js/web/websocket/websocket-upgrade.test.ts
+++ b/test/js/web/websocket/websocket-upgrade.test.ts
@@ -1,70 +1,77 @@
-import { serve } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 describe("WebSocket upgrade", () => {
   // https://github.com/oven-sh/bun/issues/2896
   // BUN_CONFIG_WS_HANDSHAKE_TIMEOUT=1: uSockets sweeps every 4 s, so the
-  // effective delay is ~4-8 s, hence the 30 s test budget.
-  test("fails the handshake when the server never responds", async () => {
-    const script = `
-      const net = require("node:net");
-      const srv = net.createServer(() => {});
-      srv.listen(0, "127.0.0.1", () => {
-        const port = srv.address().port;
-        const ws = new WebSocket("ws://127.0.0.1:" + port + "/");
-        const events = [];
-        ws.onopen = () => events.push("open");
-        ws.onerror = () => events.push("error");
-        ws.onclose = (e) => {
-          events.push("close:" + e.code);
-          console.log(JSON.stringify(events));
-          srv.close();
-        };
-      });
+  // effective delay is ~4-8 s, hence the 30 s test budget. The child uses
+  // Bun.listen instead of node:net to avoid ~800 ms of module load in debug.
+  test.concurrent(
+    "fails the handshake when the server never responds",
+    async () => {
+      const script = `
+      const srv = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+      const ws = new WebSocket("ws://127.0.0.1:" + srv.port + "/");
+      const events = [];
+      ws.onopen = () => events.push("open");
+      ws.onerror = () => events.push("error");
+      ws.onclose = (e) => {
+        events.push("close:" + e.code);
+        console.log(JSON.stringify(events));
+        srv.stop(true);
+      };
     `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: { ...bunEnv, BUN_CONFIG_WS_HANDSHAKE_TIMEOUT: "1" },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(JSON.parse(stdout.trim())).toEqual(["error", "close:1006"]);
-    expect(exitCode).toBe(0);
-  }, 30_000);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: { ...bunEnv, BUN_CONFIG_WS_HANDSHAKE_TIMEOUT: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout.trim())).toEqual(["error", "close:1006"]);
+      expect(exitCode).toBe(0);
+    },
+    30_000,
+  );
 
-  test("should send correct upgrade headers", async () => {
-    const server = serve({
+  test.concurrent("sends the expected upgrade request headers", async () => {
+    const received = Promise.withResolvers<{ upgraded: boolean; headers: Record<string, string> }>();
+    await using server = Bun.serve({
       hostname: "127.0.0.1",
       port: 0,
       fetch(request, server) {
-        expect(server.upgrade(request)).toBeTrue();
-        const { headers } = request;
-        expect(headers.get("connection")).toBe("upgrade");
-        expect(headers.get("upgrade")).toBe("websocket");
-        expect(headers.get("sec-websocket-version")).toBe("13");
-        expect(headers.get("sec-websocket-key")).toBeString();
-        expect(headers.get("host")).toBe(`127.0.0.1:${server.port}`);
-        return;
-        // FIXME: types gets annoyed if this is not here
-        return new Response();
+        const headers = Object.fromEntries(request.headers);
+        const upgraded = server.upgrade(request);
+        received.resolve({ upgraded, headers });
+        if (upgraded) return;
+        return new Response("upgrade failed", { status: 500 });
       },
       websocket: {
         open(ws) {
-          // FIXME: double-free issue
-          // ws.close();
-          server.stop();
+          ws.close();
         },
-        message(ws, message) {},
+        message() {},
       },
     });
-    await new Promise((resolve, reject) => {
-      const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
-      ws.addEventListener("open", resolve);
-      ws.addEventListener("error", reject);
-      ws.addEventListener("close", reject);
+
+    const opened = Promise.withResolvers<void>();
+    const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
+    ws.addEventListener("open", () => opened.resolve());
+    ws.addEventListener("error", opened.reject);
+    await opened.promise;
+
+    const { upgraded, headers } = await received.promise;
+    expect(upgraded).toBe(true);
+    expect(headers).toEqual({
+      connection: "Upgrade",
+      host: `127.0.0.1:${server.port}`,
+      "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
+      "sec-websocket-key": expect.stringMatching(/^[A-Za-z0-9+/]{22}==$/),
+      "sec-websocket-version": "13",
+      upgrade: "websocket",
     });
+
+    ws.close();
   });
 });


### PR DESCRIPTION
## Summary

`test/js/web/websocket/websocket-upgrade.test.ts` was flagged as slow on darwin aarch64 (8s wall time in build #84540). While most of that is the irreducible 4s uSockets timeout-sweep granularity, there were a couple of real seconds to reclaim, and one of the two tests turned out to be silently broken.

## Header test was not asserting anything

The `should send correct upgrade headers` test called `expect()` inside the `fetch` handler *after* `server.upgrade()` had already returned true:

```js
fetch(request, server) {
  expect(server.upgrade(request)).toBeTrue();      // passes, 101 sent
  expect(headers.get("connection")).toBe("upgrade"); // throws: actual is "Upgrade"
  expect(headers.get("upgrade")).toBe("websocket");  // never runs
  // ...
}
```

The first header assertion compared `Connection` against `"upgrade"` while Bun actually sends `"Upgrade"`, so it threw. But because `upgrade()` had already succeeded, the throw was swallowed and the WebSocket opened anyway; the client's `open` resolved the test promise and the test passed. `bun bd test` on main reports "5 expect() calls" for the file; the last four in this test never executed.

Fixed by capturing the headers in the handler and asserting them in the test body via a single `toEqual` over the full header set (including `Sec-WebSocket-Extensions` and the base64 shape of `Sec-WebSocket-Key`, which weren't checked before). Also dropped two 2023-era FIXME comments: the fetch-return-type workaround is obsolete now that the `websocket` overload allows `void`, and `ws.close()` inside `open()` no longer double-frees under ASAN.

## Speedup

The handshake-timeout test (for the #35167 regression) spawned a child that started a `node:net` server which accepts the TCP connection and never responds. Loading `node:net` costs ~800ms in a debug+ASAN child. Switched to `Bun.listen`, which serves the same purpose (accept, never respond) without the module-load cost.

Both tests are now `test.concurrent`.

| | before | after |
|---|---|---|
| handshake-timeout test | 5162ms | 4303ms |
| header test | 37ms | 44ms |
| file (debug+ASAN, linux x64) | **7.25s** | **6.4s** |

The remaining ~4.3s is the uSockets `LIBUS_TIMEOUT_GRANULARITY` (4s) plus child startup; that floor can't be lowered without changing the timeout-sweep tick rate itself.

## Verification

```
$ bun bd test test/js/web/websocket/websocket-upgrade.test.ts
(pass) WebSocket upgrade > sends the expected upgrade request headers [44.14ms]
(pass) WebSocket upgrade > fails the handshake when the server never responds [4303.39ms]
 2 pass
 0 fail
 5 expect() calls
Ran 2 tests across 1 file. [6.41s]
```

The handshake-timeout test still fails on a build without the #35167 fix (verified against 1498d7b77: times out at 30s).

This overlaps with the test-file changes in #33525, which moved the `upgrade()` call after the header reads for the same reason; this PR goes further by moving the assertions out of the handler entirely.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/websocket/websocket-upgrade.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/websocket/websocket-upgrade.test.ts
bun test v1.4.0 (28e8256f8)

test/js/web/websocket/websocket-upgrade.test.ts:
(pass) WebSocket upgrade > sends the expected upgrade request headers [44.07ms]
(pass) WebSocket upgrade > fails the handshake when the server never responds [4310.36ms]

 2 pass
 0 fail
 5 expect() calls
Ran 2 tests across 1 file. [6.44s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/websocket/websocket-upgrade.test.ts | 107 +++++++++++++-----------
 1 file changed, 57 insertions(+), 50 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
test/js/web/websocket/websocket-upgrade.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->