### PR TITLE
asan: default allow_user_segv_handler=1 so wasm shared memory works

### DIFF
--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -74,6 +74,10 @@ pub extern "C" fn __asan_default_options() -> *const core::ffi::c_char {
     //   JSC's conservative GC scan and `StackBounds::contains` see them.
     // detect_leaks=0: off by default (Linux defaults it on); CI opts in via
     //   ASAN_OPTIONS with a suppressions file.
+    // allow_user_segv_handler=1: JSC's wasm fault handler needs its own
+    //   SIGSEGV/SIGBUS sigaction. JSC also string-matches this flag in
+    //   getenv("ASAN_OPTIONS") before enabling the handler; JSCInitialize
+    //   mirrors it into the env var for that check.
     //
     // Do NOT add `symbolize=0`
     // here — LSAN's function-name suppression matching (`test/leaksan.supp`)
@@ -81,7 +85,7 @@ pub extern "C" fn __asan_default_options() -> *const core::ffi::c_char {
     // `leak:uws_create_app` silently stops matching and CI reports the
     // suppressed allocations as leaks. If local debug crashes feel slow to
     // print, set `ASAN_OPTIONS=symbolize=0` in your shell instead.
-    c"detect_stack_use_after_return=0:detect_leaks=0".as_ptr()
+    c"detect_stack_use_after_return=0:detect_leaks=0:allow_user_segv_handler=1".as_ptr()
 }
 
 /// LSAN built-in suppressions, merged with whatever `LSAN_OPTIONS=suppressions=`

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -75,7 +75,7 @@ pub extern "C" fn __asan_default_options() -> *const core::ffi::c_char {
     // detect_leaks=0: off by default (Linux defaults it on); CI opts in via
     //   ASAN_OPTIONS with a suppressions file.
     // allow_user_segv_handler=1: permit JSC's wasm SIGSEGV fault handler;
-    //   JSCInitialize mirrors it into the env var for JSC's getenv check.
+    //   bun_jsc::initialize mirrors it into the env var for JSC's getenv check.
     //
     // Do NOT add `symbolize=0`
     // here — LSAN's function-name suppression matching (`test/leaksan.supp`)

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -74,9 +74,8 @@ pub extern "C" fn __asan_default_options() -> *const core::ffi::c_char {
     //   JSC's conservative GC scan and `StackBounds::contains` see them.
     // detect_leaks=0: off by default (Linux defaults it on); CI opts in via
     //   ASAN_OPTIONS with a suppressions file.
-    // allow_user_segv_handler=1: let JSC install its wasm SIGSEGV fault
-    //   handler (JSCInitialize also mirrors this into the env var for JSC's
-    //   ASAN_OPTIONS string check).
+    // allow_user_segv_handler=1: permit JSC's wasm SIGSEGV fault handler;
+    //   JSCInitialize mirrors it into the env var for JSC's getenv check.
     //
     // Do NOT add `symbolize=0`
     // here — LSAN's function-name suppression matching (`test/leaksan.supp`)

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -74,10 +74,9 @@ pub extern "C" fn __asan_default_options() -> *const core::ffi::c_char {
     //   JSC's conservative GC scan and `StackBounds::contains` see them.
     // detect_leaks=0: off by default (Linux defaults it on); CI opts in via
     //   ASAN_OPTIONS with a suppressions file.
-    // allow_user_segv_handler=1: JSC's wasm fault handler needs its own
-    //   SIGSEGV/SIGBUS sigaction. JSC also string-matches this flag in
-    //   getenv("ASAN_OPTIONS") before enabling the handler; JSCInitialize
-    //   mirrors it into the env var for that check.
+    // allow_user_segv_handler=1: let JSC install its wasm SIGSEGV fault
+    //   handler (JSCInitialize also mirrors this into the env var for JSC's
+    //   ASAN_OPTIONS string check).
     //
     // Do NOT add `symbolize=0`
     // here — LSAN's function-name suppression matching (`test/leaksan.supp`)

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -293,26 +293,11 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         std::set_terminate([]() { Zig__GlobalObject__onCrash(); });
         WTF::initializeMainThread();
 
-#if ASAN_ENABLED && OS(LINUX)
-        // JSC gates useWasmFaultSignalHandler (wasm shared memory) on this flag
-        // in getenv("ASAN_OPTIONS"); mirror __asan_default_options() so it's seen.
-        {
-            const char* asanOptions = getenv("ASAN_OPTIONS");
-            if (!asanOptions || !*asanOptions) {
-                setenv("ASAN_OPTIONS", "allow_user_segv_handler=1", 1);
-            } else if (!strstr(asanOptions, "allow_user_segv_handler=") && !strstr(asanOptions, "handle_segv=0")) {
-                size_t n = strlen(asanOptions);
-                char* merged = static_cast<char*>(malloc(n + sizeof(":allow_user_segv_handler=1")));
-                memcpy(merged, asanOptions, n);
-                memcpy(merged + n, ":allow_user_segv_handler=1", sizeof(":allow_user_segv_handler=1"));
-                setenv("ASAN_OPTIONS", merged, 1);
-                free(merged);
-            }
-        }
-#endif
-
         // Use JSC::initialize with a callback to set Options during initialization.
         // The callback runs BEFORE IPInt::initialize() so we can configure WASM options early.
+        // Under ASAN+Linux, JSC's notifyOptionsChanged() gates useWasmFaultSignalHandler
+        // on ASAN_OPTIONS containing allow_user_segv_handler=1; bun_jsc::initialize()
+        // supplies that default before capturing envp.
         JSC::initialize([&] {
             JSC::Options::useWasm() = true;
             JSC::Options::useJIT() = true;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -294,10 +294,8 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         WTF::initializeMainThread();
 
 #if ASAN_ENABLED && OS(LINUX)
-        // JSC's notifyOptionsChanged() clears useWasmFaultSignalHandler (and with
-        // it WebAssembly shared memory) unless getenv("ASAN_OPTIONS") contains
-        // this flag. __asan_default_options() already sets it for the runtime;
-        // mirror it into the env var. Leave an explicit user value alone.
+        // JSC gates useWasmFaultSignalHandler (wasm shared memory) on this flag
+        // in getenv("ASAN_OPTIONS"); mirror __asan_default_options() so it's seen.
         {
             const char* asanOptions = getenv("ASAN_OPTIONS");
             if (!asanOptions || !*asanOptions) {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -293,11 +293,34 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         std::set_terminate([]() { Zig__GlobalObject__onCrash(); });
         WTF::initializeMainThread();
 
+#if ASAN_ENABLED && OS(LINUX)
+        // JSC's notifyOptionsChanged() string-matches getenv("ASAN_OPTIONS") for
+        // "allow_user_segv_handler=1" (or "handle_segv=0") and otherwise disables
+        // useWasmFaultSignalHandler, which in turn makes WebAssembly.Memory
+        // silently ignore {shared:true}. __asan_default_options() already opts
+        // the runtime in; mirror it into the env var so JSC's check sees it. A
+        // value explicitly containing "allow_user_segv_handler=" is left alone
+        // so a caller can still force it off.
+        {
+            const char* asanOptions = getenv("ASAN_OPTIONS");
+            if (!asanOptions || !*asanOptions) {
+                setenv("ASAN_OPTIONS", "allow_user_segv_handler=1", 1);
+            } else if (!strstr(asanOptions, "allow_user_segv_handler=") && !strstr(asanOptions, "handle_segv=0")) {
+                size_t n = strlen(asanOptions);
+                char* merged = static_cast<char*>(malloc(n + sizeof(":allow_user_segv_handler=1")));
+                memcpy(merged, asanOptions, n);
+                memcpy(merged + n, ":allow_user_segv_handler=1", sizeof(":allow_user_segv_handler=1"));
+                setenv("ASAN_OPTIONS", merged, 1);
+                free(merged);
+            }
+        }
+#endif
+
         // Use JSC::initialize with a callback to set Options during initialization.
         // The callback runs BEFORE IPInt::initialize() so we can configure WASM options early.
-        // Under ASAN+Linux, JSC's notifyOptionsChanged() already disables
-        // useWasmFaultSignalHandler/FastMemory when ASAN_OPTIONS lacks
-        // allow_user_segv_handler=1, so we don't force it off here.
+        // Under ASAN+Linux, JSC's notifyOptionsChanged() gates
+        // useWasmFaultSignalHandler/FastMemory on ASAN_OPTIONS containing
+        // allow_user_segv_handler=1; the setenv above supplies that default.
         JSC::initialize([&] {
             JSC::Options::useWasm() = true;
             JSC::Options::useJIT() = true;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -294,13 +294,10 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         WTF::initializeMainThread();
 
 #if ASAN_ENABLED && OS(LINUX)
-        // JSC's notifyOptionsChanged() string-matches getenv("ASAN_OPTIONS") for
-        // "allow_user_segv_handler=1" (or "handle_segv=0") and otherwise disables
-        // useWasmFaultSignalHandler, which in turn makes WebAssembly.Memory
-        // silently ignore {shared:true}. __asan_default_options() already opts
-        // the runtime in; mirror it into the env var so JSC's check sees it. A
-        // value explicitly containing "allow_user_segv_handler=" is left alone
-        // so a caller can still force it off.
+        // JSC's notifyOptionsChanged() clears useWasmFaultSignalHandler (and with
+        // it WebAssembly shared memory) unless getenv("ASAN_OPTIONS") contains
+        // this flag. __asan_default_options() already sets it for the runtime;
+        // mirror it into the env var. Leave an explicit user value alone.
         {
             const char* asanOptions = getenv("ASAN_OPTIONS");
             if (!asanOptions || !*asanOptions) {
@@ -318,9 +315,6 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
 
         // Use JSC::initialize with a callback to set Options during initialization.
         // The callback runs BEFORE IPInt::initialize() so we can configure WASM options early.
-        // Under ASAN+Linux, JSC's notifyOptionsChanged() gates
-        // useWasmFaultSignalHandler/FastMemory on ASAN_OPTIONS containing
-        // allow_user_segv_handler=1; the setenv above supplies that default.
         JSC::initialize([&] {
             JSC::Options::useWasm() = true;
             JSC::Options::useJIT() = true;

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -596,8 +596,7 @@ fn mirror_asan_segv_handler_into_env() -> AsanOptionsRestore {
         let mut original = Vec::with_capacity(bytes.len() + 1);
         original.extend_from_slice(bytes);
         original.push(0);
-        let mut merged =
-            Vec::with_capacity(bytes.len() + b":allow_user_segv_handler=1\0".len());
+        let mut merged = Vec::with_capacity(bytes.len() + b":allow_user_segv_handler=1\0".len());
         merged.extend_from_slice(bytes);
         merged.extend_from_slice(if bytes.is_empty() {
             b"allow_user_segv_handler=1\0"

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -534,7 +534,7 @@ pub fn initialize(eval_mode: bool) {
     // `bun_analytics`.
     bun_core::analytics::Features::jsc_inc();
     #[cfg(all(bun_asan, target_os = "linux"))]
-    mirror_asan_segv_handler_into_env();
+    let restore = mirror_asan_segv_handler_into_env();
     let env = bun_sys::environ();
     // One-shot eval invocations (`bun -e ...` / `bun --print ...`) exit before
     // any long-running event loop; tell JSC to skip the worker threads it
@@ -552,39 +552,80 @@ pub fn initialize(eval_mode: bool) {
             one_shot,
         )
     };
+    #[cfg(all(bun_asan, target_os = "linux"))]
+    restore_asan_options(restore);
+}
+
+/// What [`restore_asan_options`] should do once JSC has read `ASAN_OPTIONS`.
+#[cfg(all(bun_asan, target_os = "linux"))]
+enum AsanOptionsRestore {
+    Unchanged,
+    Unset,
+    Value(Vec<u8>),
 }
 
 /// JSC's `notifyOptionsChanged()` clears `useWasmFaultSignalHandler` (and with
 /// it WebAssembly shared memory) unless `getenv("ASAN_OPTIONS")` contains
 /// `allow_user_segv_handler=1`. `__asan_default_options()` already opts the
-/// runtime in; mirror it into the env var so JSC's check passes. Runs before
-/// `bun_sys::environ()` is captured so the `envp` slice passed to C++ reflects
-/// the final environ array.
+/// runtime in; mirror it into the env var for the duration of JSC init so that
+/// check passes, then let the caller restore the original value so
+/// `process.env` and child-process inheritance stay as the user set them. Runs
+/// before `bun_sys::environ()` is captured so the `envp` slice passed to C++
+/// reflects the mutated `environ` array.
 #[cfg(all(bun_asan, target_os = "linux"))]
 #[cold]
-fn mirror_asan_segv_handler_into_env() {
+fn mirror_asan_segv_handler_into_env() -> AsanOptionsRestore {
     use core::ffi::CStr;
     // SAFETY: single-threaded at this point (before JSC init spawns anything).
     unsafe {
         let cur = libc::getenv(c"ASAN_OPTIONS".as_ptr());
-        if cur.is_null() || *cur == 0 {
+        if cur.is_null() {
             libc::setenv(
                 c"ASAN_OPTIONS".as_ptr(),
                 c"allow_user_segv_handler=1".as_ptr(),
                 1,
             );
-            return;
+            return AsanOptionsRestore::Unset;
         }
-        let cur = CStr::from_ptr(cur).to_bytes();
-        if bun_core::strings::contains(cur, b"allow_user_segv_handler=")
-            || bun_core::strings::contains(cur, b"handle_segv=0")
+        let bytes = CStr::from_ptr(cur).to_bytes();
+        if bun_core::strings::contains(bytes, b"allow_user_segv_handler=")
+            || bun_core::strings::contains(bytes, b"handle_segv=0")
         {
-            return;
+            return AsanOptionsRestore::Unchanged;
         }
-        let mut merged = Vec::with_capacity(cur.len() + b":allow_user_segv_handler=1\0".len());
-        merged.extend_from_slice(cur);
-        merged.extend_from_slice(b":allow_user_segv_handler=1\0");
+        let mut original = Vec::with_capacity(bytes.len() + 1);
+        original.extend_from_slice(bytes);
+        original.push(0);
+        let mut merged =
+            Vec::with_capacity(bytes.len() + b":allow_user_segv_handler=1\0".len());
+        merged.extend_from_slice(bytes);
+        merged.extend_from_slice(if bytes.is_empty() {
+            b"allow_user_segv_handler=1\0"
+        } else {
+            b":allow_user_segv_handler=1\0"
+        });
         libc::setenv(c"ASAN_OPTIONS".as_ptr(), merged.as_ptr().cast(), 1);
+        AsanOptionsRestore::Value(original)
+    }
+}
+
+/// Restore `ASAN_OPTIONS` after `JSCInitialize` has returned (and is no longer
+/// reading the `envp` slice). `setenv`-overwrite and `unsetenv` do not realloc
+/// `environ`, so this does not invalidate any borrow the caller may still hold.
+#[cfg(all(bun_asan, target_os = "linux"))]
+#[cold]
+fn restore_asan_options(restore: AsanOptionsRestore) {
+    // SAFETY: still single-threaded; JSC's threads start on first VM creation.
+    unsafe {
+        match restore {
+            AsanOptionsRestore::Unchanged => {}
+            AsanOptionsRestore::Unset => {
+                libc::unsetenv(c"ASAN_OPTIONS".as_ptr());
+            }
+            AsanOptionsRestore::Value(v) => {
+                libc::setenv(c"ASAN_OPTIONS".as_ptr(), v.as_ptr().cast(), 1);
+            }
+        }
     }
 }
 

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -533,6 +533,8 @@ pub fn initialize(eval_mode: bool) {
     // The counter lives in `bun_core` so this crate doesn't depend on
     // `bun_analytics`.
     bun_core::analytics::Features::jsc_inc();
+    #[cfg(all(bun_asan, target_os = "linux"))]
+    mirror_asan_segv_handler_into_env();
     let env = bun_sys::environ();
     // One-shot eval invocations (`bun -e ...` / `bun --print ...`) exit before
     // any long-running event loop; tell JSC to skip the worker threads it
@@ -550,6 +552,40 @@ pub fn initialize(eval_mode: bool) {
             one_shot,
         )
     };
+}
+
+/// JSC's `notifyOptionsChanged()` clears `useWasmFaultSignalHandler` (and with
+/// it WebAssembly shared memory) unless `getenv("ASAN_OPTIONS")` contains
+/// `allow_user_segv_handler=1`. `__asan_default_options()` already opts the
+/// runtime in; mirror it into the env var so JSC's check passes. Runs before
+/// `bun_sys::environ()` is captured so the `envp` slice passed to C++ reflects
+/// the final environ array.
+#[cfg(all(bun_asan, target_os = "linux"))]
+#[cold]
+fn mirror_asan_segv_handler_into_env() {
+    use core::ffi::CStr;
+    // SAFETY: single-threaded at this point (before JSC init spawns anything).
+    unsafe {
+        let cur = libc::getenv(c"ASAN_OPTIONS".as_ptr());
+        if cur.is_null() || *cur == 0 {
+            libc::setenv(
+                c"ASAN_OPTIONS".as_ptr(),
+                c"allow_user_segv_handler=1".as_ptr(),
+                1,
+            );
+            return;
+        }
+        let cur = CStr::from_ptr(cur).to_bytes();
+        if bun_core::strings::contains(cur, b"allow_user_segv_handler=")
+            || bun_core::strings::contains(cur, b"handle_segv=0")
+        {
+            return;
+        }
+        let mut merged = Vec::with_capacity(cur.len() + b":allow_user_segv_handler=1\0".len());
+        merged.extend_from_slice(cur);
+        merged.extend_from_slice(b":allow_user_segv_handler=1\0");
+        libc::setenv(c"ASAN_OPTIONS".as_ptr(), merged.as_ptr().cast(), 1);
+    }
 }
 
 /// Whether this process was launched as `bun -e <code>` / `bun --eval <code>` /

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -533,27 +533,35 @@ pub fn initialize(eval_mode: bool) {
     // The counter lives in `bun_core` so this crate doesn't depend on
     // `bun_analytics`.
     bun_core::analytics::Features::jsc_inc();
-    #[cfg(all(bun_asan, target_os = "linux"))]
-    let restore = mirror_asan_segv_handler_into_env();
-    let env = bun_sys::environ();
-    // One-shot eval invocations (`bun -e ...` / `bun --print ...`) exit before
-    // any long-running event loop; tell JSC to skip the worker threads it
-    // otherwise spawns eagerly at VM creation (see `JSCInitialize`).
-    let one_shot = is_one_shot_eval_invocation();
-    // SAFETY: `env` borrows the libc `environ` global for the duration of the
-    // call; `on_jsc_invalid_env_var` is `extern "C"` and only reads the (ptr,len)
-    // it is handed. JSCInitialize is called exactly once at startup.
-    unsafe {
-        JSCInitialize(
-            env.as_ptr(),
-            env.len(),
-            on_jsc_invalid_env_var,
-            eval_mode,
-            one_shot,
-        )
-    };
-    #[cfg(all(bun_asan, target_os = "linux"))]
-    restore_asan_options(restore);
+    // Bundler WorkPool threads (Macro::init, CachedBytecode, RegularExpression)
+    // each call this off the main thread; the C++ `std::call_once` only guards
+    // the FFI body, so serialize the Rust-side env read/write here too.
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        #[cfg(all(bun_asan, target_os = "linux"))]
+        let restore = mirror_asan_segv_handler_into_env();
+        let env = bun_sys::environ();
+        // One-shot eval invocations (`bun -e ...` / `bun --print ...`) exit
+        // before any long-running event loop; tell JSC to skip the worker
+        // threads it otherwise spawns eagerly at VM creation (see
+        // `JSCInitialize`).
+        let one_shot = is_one_shot_eval_invocation();
+        // SAFETY: `env` borrows the libc `environ` global for the duration of
+        // the call; `on_jsc_invalid_env_var` is `extern "C"` and only reads the
+        // (ptr,len) it is handed. Runs under `Once::call_once` so no other
+        // entrant is mutating `environ` concurrently.
+        unsafe {
+            JSCInitialize(
+                env.as_ptr(),
+                env.len(),
+                on_jsc_invalid_env_var,
+                eval_mode,
+                one_shot,
+            )
+        };
+        #[cfg(all(bun_asan, target_os = "linux"))]
+        restore_asan_options(restore);
+    });
 }
 
 /// What [`restore_asan_options`] should do once JSC has read `ASAN_OPTIONS`.
@@ -576,7 +584,7 @@ enum AsanOptionsRestore {
 #[cold]
 fn mirror_asan_segv_handler_into_env() -> AsanOptionsRestore {
     use core::ffi::CStr;
-    // SAFETY: single-threaded at this point (before JSC init spawns anything).
+    // SAFETY: serialized by `initialize`'s `Once::call_once`.
     unsafe {
         let cur = libc::getenv(c"ASAN_OPTIONS".as_ptr());
         if cur.is_null() {
@@ -614,7 +622,7 @@ fn mirror_asan_segv_handler_into_env() -> AsanOptionsRestore {
 #[cfg(all(bun_asan, target_os = "linux"))]
 #[cold]
 fn restore_asan_options(restore: AsanOptionsRestore) {
-    // SAFETY: still single-threaded; JSC's threads start on first VM creation.
+    // SAFETY: serialized by `initialize`'s `Once::call_once`.
     unsafe {
         match restore {
             AsanOptionsRestore::Unchanged => {}

--- a/test/js/bun/wasm/wasm-memory-shared.test.ts
+++ b/test/js/bun/wasm/wasm-memory-shared.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isLinux } from "harness";
 
 const script = `

--- a/test/js/bun/wasm/wasm-memory-shared.test.ts
+++ b/test/js/bun/wasm/wasm-memory-shared.test.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, isASAN, isLinux } from "harness";
+
+const script = `
+  const m = new WebAssembly.Memory({ initial: 1, maximum: 8, shared: true });
+  const tag = Object.prototype.toString.call(m.buffer);
+  const view = new Int32Array(m.buffer);
+  m.grow(2);
+  let maxRequiredError = "none";
+  try {
+    new WebAssembly.Memory({ initial: 1, shared: true });
+  } catch (e) {
+    maxRequiredError = e?.constructor?.name;
+  }
+  console.log(JSON.stringify({
+    tag,
+    grownByteLength: m.buffer.byteLength,
+    oldViewLength: view.length,
+    oldViewDetached: view.buffer.byteLength === 0,
+    maxRequiredError,
+  }));
+`;
+
+const expected = {
+  tag: "[object SharedArrayBuffer]",
+  grownByteLength: 196608,
+  oldViewLength: 16384,
+  oldViewDetached: false,
+  maxRequiredError: "TypeError",
+};
+
+test("WebAssembly.Memory shared:true yields a SharedArrayBuffer", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual(expected);
+  expect(exitCode).toBe(0);
+});
+
+// JSC gates useWasmFaultSignalHandler on a substring of getenv("ASAN_OPTIONS")
+// under ASAN+Linux. When the env var is unset (or set without the flag),
+// WebAssembly.Memory must not silently drop {shared:true}; the binary should
+// enable the handler on its own.
+test.skipIf(!(isASAN && isLinux))(
+  "WebAssembly.Memory shared:true works on ASAN builds without ASAN_OPTIONS in env",
+  async () => {
+    for (const override of [undefined, "detect_leaks=0"]) {
+      const env: Record<string, string | undefined> = { ...bunEnv, ASAN_OPTIONS: override };
+      if (override === undefined) delete env.ASAN_OPTIONS;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(expected);
+      expect(exitCode).toBe(0);
+    }
+  },
+);

--- a/test/js/bun/wasm/wasm-memory-shared.test.ts
+++ b/test/js/bun/wasm/wasm-memory-shared.test.ts
@@ -18,6 +18,7 @@ const script = `
     oldViewLength: view.length,
     oldViewDetached: view.buffer.byteLength === 0,
     maxRequiredError,
+    asanOptions: process.env.ASAN_OPTIONS ?? null,
   }));
 `;
 
@@ -38,14 +39,14 @@ test("WebAssembly.Memory shared:true yields a SharedArrayBuffer", async () => {
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual(expected);
+  expect(JSON.parse(stdout)).toEqual({ ...expected, asanOptions: bunEnv.ASAN_OPTIONS ?? null });
   expect(exitCode).toBe(0);
 });
 
 // JSC gates useWasmFaultSignalHandler on a substring of getenv("ASAN_OPTIONS")
 // under ASAN+Linux. When the env var is unset (or set without the flag),
 // WebAssembly.Memory must not silently drop {shared:true}; the binary should
-// enable the handler on its own.
+// enable the handler on its own without leaking into process.env.
 test.skipIf(!(isASAN && isLinux))(
   "WebAssembly.Memory shared:true works on ASAN builds without ASAN_OPTIONS in env",
   async () => {
@@ -60,7 +61,7 @@ test.skipIf(!(isASAN && isLinux))(
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual(expected);
+      expect(JSON.parse(stdout)).toEqual({ ...expected, asanOptions: override ?? null });
       expect(exitCode).toBe(0);
     }
   },


### PR DESCRIPTION
## Problem

On ASAN+Linux builds, `new WebAssembly.Memory({initial, maximum, shared: true})` silently returns a memory whose `.buffer` is a plain detachable `ArrayBuffer` instead of a `SharedArrayBuffer`. No error is raised, Atomics refuse to operate on the buffer, and `{shared:true}` without `maximum` no longer throws.

```js
const m = new WebAssembly.Memory({ initial: 1, maximum: 8, shared: true });
Object.prototype.toString.call(m.buffer);
// release:   [object SharedArrayBuffer]
// bun-asan:  [object ArrayBuffer]   (silent degrade)
```

Observed on release-asan fleet builds; stock release and Node are correct.

## Cause

JSC's `Options::notifyOptionsChanged()` has, under `ASAN_ENABLED && OS(LINUX)`:

```cpp
const char* asanOptions = getenv("ASAN_OPTIONS");
bool okToUseWasmFastMemory = asanOptions
    && (strstr(asanOptions, "allow_user_segv_handler=1") || strstr(asanOptions, "handle_segv=0"));
if (!okToUseWasmFastMemory)
    Options::useWasmFaultSignalHandler() = false;
```

and `WebAssemblyMemoryConstructor::createMemoryFromDescriptor` only reads the `shared` descriptor field when `useWasmFaultSignalHandler()` is true, so the option falling off makes `shared:true` a no-op.

Bun's `__asan_default_options()` returns `detect_stack_use_after_return=0:detect_leaks=0` (no `allow_user_segv_handler`), and JSC only inspects the env var, not the compiled-in defaults. The CI test runner and `test/harness.ts` already set `ASAN_OPTIONS=allow_user_segv_handler=1:...` externally, so CI never observed this; direct `bun-asan`/`bun-debug` invocations (fuzz fleet, local repro) did.

## Fix

* Add `allow_user_segv_handler=1` to `__asan_default_options()` so ASAN actually permits JSC's SIGSEGV handler.
* In `bun_jsc::initialize()` (under `cfg(all(bun_asan, target_os = "linux"))`), mirror the flag into `ASAN_OPTIONS` before `bun_sys::environ()` is captured, so JSC's string check passes and the `envp` slice handed to `JSCInitialize` already reflects the final `environ` array. An explicit `allow_user_segv_handler=` in the caller's env is left untouched so it can still be forced off.

Both paths are compile-time gated to ASAN builds; release is unaffected.

## Verification

`test/js/bun/wasm/wasm-memory-shared.test.ts` spawns a child with `ASAN_OPTIONS` absent/stripped and asserts the buffer is a `SharedArrayBuffer`, the pre-grow view stays live, and `{shared:true}` without `maximum` throws `TypeError`. Fails on ASAN before, passes after.

## Follow-up

The constructor silently dropping `shared:true` when `useWasmFaultSignalHandler` is off (instead of throwing, as the wasm module parser already does) is upstream JSC behaviour; worth tightening in oven-sh/WebKit separately.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/wasm/wasm-memory-shared.test.ts

<!-- robobun:evidence:end -->