### PR TITLE
create: stop deleting the destination directory for local templates

### DIFF
--- a/docs/runtime/templating/create.mdx
+++ b/docs/runtime/templating/create.mdx
@@ -245,14 +245,14 @@ IF GitHub repo
 ELSE IF local template
 
 1. Open local template folder
-2. Delete destination directory recursively
-3. Copy files recursively using the fastest system calls available (on macOS, `fcopyfile`; on Linux, `copy_file_range`). Do not copy or traverse into the `node_modules` folder if it exists (this alone makes it faster than `cp`)
+2. Copy files recursively using the fastest system calls available (on macOS, `fcopyfile`; on Linux, `copy_file_range`). Do not copy or traverse into the `node_modules` folder if it exists (this alone makes it faster than `cp`)
+   - If files would be overwritten, warn and exit unless `--force` is passed
 
-4. Parse the `package.json` (again!), update `name` to be `${basename(destination)}`, remove the `bun-create` section from the `package.json` and save the updated `package.json` to disk.
-5. Run any tasks defined in `"bun-create": { "preinstall" }`
-6. Run `bun install` unless `--no-install` is passed OR no dependencies are in package.json
-7. Run any tasks defined in `"bun-create": { "postinstall" }`
-8. Run `git init; git add -A .; git commit -am "Initial Commit";`
+3. Parse the `package.json` (again!), update `name` to be `${basename(destination)}`, remove the `bun-create` section from the `package.json` and save the updated `package.json` to disk.
+4. Run any tasks defined in `"bun-create": { "preinstall" }`
+5. Run `bun install` unless `--no-install` is passed OR no dependencies are in package.json
+6. Run any tasks defined in `"bun-create": { "postinstall" }`
+7. Run `git init; git add -A .; git commit -am "Initial Commit";`
    - Rename `gitignore` to `.gitignore`. npm strips `.gitignore` files from published packages.
    - If there are dependencies, this runs in a separate thread concurrently while node_modules are being installed
    - Using libgit2 if available was tested and performed 3x slower in microbenchmarks

--- a/docs/runtime/templating/create.mdx
+++ b/docs/runtime/templating/create.mdx
@@ -150,7 +150,7 @@ Bun then:
 
 ## From a local template
 
-Like remote templates, `bun create` with a local template refuses to overwrite existing files in the destination folder unless the `--force` flag is passed.
+Like remote templates, `bun create` with a local template refuses to overwrite existing files in the destination folder unless the `--force` flag is passed. `README.md` and `.gitignore` are the exception: they never count as conflicts and are replaced by the template's versions.
 
 You can define custom templates on your local file system. Put them in one of the following directories:
 

--- a/docs/runtime/templating/create.mdx
+++ b/docs/runtime/templating/create.mdx
@@ -150,10 +150,7 @@ Bun then:
 
 ## From a local template
 
-<Warning>
-  Unlike remote templates, running `bun create` with a local template deletes the entire destination folder if it
-  already exists.
-</Warning>
+Like remote templates, `bun create` with a local template refuses to overwrite existing files in the destination folder unless the `--force` flag is passed.
 
 You can define custom templates on your local file system. Put them in one of the following directories:
 

--- a/docs/runtime/templating/create.mdx
+++ b/docs/runtime/templating/create.mdx
@@ -253,6 +253,7 @@ ELSE IF local template
 5. Run `bun install` unless `--no-install` is passed OR no dependencies are in package.json
 6. Run any tasks defined in `"bun-create": { "postinstall" }`
 7. Run `git init; git add -A .; git commit -am "Initial Commit";`
+   - Skipped if `${destination}/.git` already exists, leaving the existing repository untouched
    - Rename `gitignore` to `.gitignore`. npm strips `.gitignore` files from published packages.
    - If there are dependencies, this runs in a separate thread concurrently while node_modules are being installed
    - Using libgit2 if available was tested and performed 3x slower in microbenchmarks

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -653,8 +653,7 @@ impl CreateCommand {
 
                     let mut conflicts: Vec<Vec<bun_paths::OSPathChar>> = Vec::new();
                     while let Some(entry) = scan_walker.next()? {
-                        // POSIX no-follow: a symlink is never classified as its
-                        // target (Windows classifies reparse points by target).
+                        // POSIX no-follow; Windows classifies reparse points by target.
                         #[cfg(not(windows))]
                         let existing_kind = bun_sys::lstatat(existing_destination.fd, entry.path)
                             .map(|st| bun_sys::kind_from_mode(st.st_mode as _));

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -44,8 +44,14 @@ static BUN_PATH_BUF: bun_core::RacyCell<PathBuffer> = bun_core::RacyCell::new(Pa
 // Elements must be `&OSPathSlice` because `OSPathSlice` itself is unsized.
 #[cfg(not(windows))]
 const SKIP_DIRS: &[&OSPathSlice] = &[b"node_modules", b".git"];
+// `.git` as a file is a worktree/submodule pointer; never scan or copy it.
 #[cfg(not(windows))]
-const SKIP_FILES: &[&OSPathSlice] = &[b"package-lock.json", b"yarn.lock", b"pnpm-lock.yaml"];
+const SKIP_FILES: &[&OSPathSlice] = &[
+    b"package-lock.json",
+    b"yarn.lock",
+    b"pnpm-lock.yaml",
+    b".git",
+];
 #[cfg(windows)]
 const SKIP_DIRS: &[&OSPathSlice] = &[bun_core::w!("node_modules"), bun_core::w!(".git")];
 #[cfg(windows)]
@@ -53,6 +59,7 @@ const SKIP_FILES: &[&OSPathSlice] = &[
     bun_core::w!("package-lock.json"),
     bun_core::w!("yarn.lock"),
     bun_core::w!("pnpm-lock.yaml"),
+    bun_core::w!(".git"),
 ];
 
 const NEVER_CONFLICT: &[&[u8]] = &[b"README.md", b"gitignore", b".gitignore", b".git/"];
@@ -950,26 +957,14 @@ impl CreateCommand {
         {
             let parent_dir = bun_sys::Dir::open(destination)?;
             if template_has_gitignore {
-                #[cfg(windows)]
-                {
-                    let _ = parent_dir.copy_file(
-                        b"gitignore",
-                        &parent_dir,
-                        b".gitignore",
-                        Default::default(),
-                    );
-                }
-                #[cfg(not(windows))]
-                {
-                    let _ = bun_sys::linkat(
-                        parent_dir.fd(),
-                        bun_core::zstr!("gitignore"),
-                        parent_dir.fd(),
-                        bun_core::zstr!(".gitignore"),
-                    );
-                }
-
-                let _ = bun_sys::unlinkat(&parent_dir, bun_core::zstr!("gitignore"));
+                // rename replaces an existing .gitignore; linkat would fail
+                // with EEXIST and silently drop the template's version.
+                let _ = bun_sys::renameat(
+                    parent_dir.fd(),
+                    bun_core::zstr!("gitignore"),
+                    parent_dir.fd(),
+                    bun_core::zstr!(".gitignore"),
+                );
             }
             if template_has_npmignore {
                 let _ = bun_sys::unlinkat(&parent_dir, bun_core::zstr!(".npmignore"));

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -641,32 +641,45 @@ impl CreateCommand {
 
                     let mut conflicts: Vec<Vec<bun_paths::OSPathChar>> = Vec::new();
                     while let Some(entry) = scan_walker.next()? {
-                        if entry.kind != bun_sys::FileKind::File {
-                            continue;
-                        }
-
                         #[cfg(not(windows))]
-                        let exists = bun_sys::exists_at(existing_destination.fd, entry.path);
+                        let existing_kind =
+                            bun_sys::exists_at_type(existing_destination.fd, entry.path);
                         #[cfg(windows)]
-                        let exists = bun_sys::exists_at_type_w(
+                        let existing_kind = bun_sys::exists_at_type_w(
                             existing_destination.fd,
                             entry.path.as_slice(),
-                        )
-                        .is_ok();
-                        if !exists {
+                        );
+                        let Ok(existing_kind) = existing_kind else {
                             continue;
+                        };
+
+                        match entry.kind {
+                            // Any existing entry at a template file path would
+                            // be overwritten.
+                            bun_sys::FileKind::File => {}
+                            // A directory only conflicts when the destination
+                            // has a non-directory in its place; merging into an
+                            // existing directory is fine.
+                            bun_sys::FileKind::Directory => {
+                                if existing_kind == bun_sys::ExistsAtType::Directory {
+                                    continue;
+                                }
+                            }
+                            _ => continue,
                         }
 
-                        #[cfg(not(windows))]
-                        let never_conflict = NEVER_CONFLICT
-                            .iter()
-                            .any(|p| strings::eql(entry.path.as_bytes(), p));
-                        #[cfg(windows)]
-                        let never_conflict = NEVER_CONFLICT
-                            .iter()
-                            .any(|p| strings::eql_comptime_utf16(entry.path.as_slice(), p));
-                        if never_conflict {
-                            continue;
+                        if entry.kind == bun_sys::FileKind::File {
+                            #[cfg(not(windows))]
+                            let never_conflict = NEVER_CONFLICT
+                                .iter()
+                                .any(|p| strings::eql(entry.path.as_bytes(), p));
+                            #[cfg(windows)]
+                            let never_conflict = NEVER_CONFLICT
+                                .iter()
+                                .any(|p| strings::eql_comptime_utf16(entry.path.as_slice(), p));
+                            if never_conflict {
+                                continue;
+                            }
                         }
 
                         #[cfg(not(windows))]

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -338,6 +338,11 @@ impl CreateCommand {
 
         let mut package_json_contents: MutableString = MutableString::default();
         let mut package_json_file: Option<bun_sys::File> = None;
+        // The post-copy cleanup renames `gitignore` and removes `.npmignore`.
+        // Local templates set these from the template's contents so files the
+        // user already had are left alone; tarballs keep the old behavior.
+        let mut template_has_gitignore = true;
+        let mut template_has_npmignore = true;
 
         if example_tag != ExampleTag::LocalFolder {
             if create_options.verbose {
@@ -600,6 +605,11 @@ impl CreateCommand {
                     }
                 };
 
+                template_has_gitignore =
+                    bun_sys::exists_at(template_dir.fd, bun_core::zstr!("gitignore"));
+                template_has_npmignore =
+                    bun_sys::exists_at(template_dir.fd, bun_core::zstr!(".npmignore"));
+
                 let existing_destination = if create_options.overwrite {
                     None
                 } else {
@@ -649,8 +659,34 @@ impl CreateCommand {
                             existing_destination.fd,
                             entry.path.as_slice(),
                         );
-                        let Ok(existing_kind) = existing_kind else {
-                            continue;
+                        let existing_kind = match existing_kind {
+                            Ok(k) => k,
+                            // ENOTDIR: a parent component is a file, which the
+                            // scan already records as a conflict for that
+                            // component.
+                            Err(err)
+                                if matches!(
+                                    err.get_errno(),
+                                    bun_sys::E::ENOENT | bun_sys::E::ENOTDIR
+                                ) =>
+                            {
+                                continue;
+                            }
+                            Err(err) => {
+                                node.end();
+                                progress.refresh();
+
+                                #[cfg(not(windows))]
+                                let entry_path: &[u8] = entry.path.as_bytes();
+                                #[cfg(windows)]
+                                let entry_path: &[u16] = entry.path.as_slice();
+                                pretty_errorln!(
+                                    "<r><red>{}<r>: checking {}",
+                                    bstr::BStr::new(err.name()),
+                                    bun_core::fmt::fmt_os_path(entry_path, Default::default()),
+                                );
+                                Global::exit(1);
+                            }
                         };
 
                         let conflicting = match entry.kind {
@@ -859,27 +895,31 @@ impl CreateCommand {
 
         {
             let parent_dir = bun_sys::Dir::open(destination)?;
-            #[cfg(windows)]
-            {
-                let _ = parent_dir.copy_file(
-                    b"gitignore",
-                    &parent_dir,
-                    b".gitignore",
-                    Default::default(),
-                );
-            }
-            #[cfg(not(windows))]
-            {
-                let _ = bun_sys::linkat(
-                    parent_dir.fd(),
-                    bun_core::zstr!("gitignore"),
-                    parent_dir.fd(),
-                    bun_core::zstr!(".gitignore"),
-                );
-            }
+            if template_has_gitignore {
+                #[cfg(windows)]
+                {
+                    let _ = parent_dir.copy_file(
+                        b"gitignore",
+                        &parent_dir,
+                        b".gitignore",
+                        Default::default(),
+                    );
+                }
+                #[cfg(not(windows))]
+                {
+                    let _ = bun_sys::linkat(
+                        parent_dir.fd(),
+                        bun_core::zstr!("gitignore"),
+                        parent_dir.fd(),
+                        bun_core::zstr!(".gitignore"),
+                    );
+                }
 
-            let _ = bun_sys::unlinkat(&parent_dir, bun_core::zstr!("gitignore"));
-            let _ = bun_sys::unlinkat(&parent_dir, bun_core::zstr!(".npmignore"));
+                let _ = bun_sys::unlinkat(&parent_dir, bun_core::zstr!("gitignore"));
+            }
+            if template_has_npmignore {
+                let _ = bun_sys::unlinkat(&parent_dir, bun_core::zstr!(".npmignore"));
+            }
         }
 
         let mut start_command: &[u8] = b"bun dev";

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -960,8 +960,7 @@ impl CreateCommand {
         {
             let parent_dir = bun_sys::Dir::open(destination)?;
             if template_has_gitignore {
-                // rename replaces an existing .gitignore; linkat fails EEXIST.
-                // Only a directory can block the rename; --force clears it.
+                // rename replaces files; only a directory blocks it (--force clears it).
                 if create_options.overwrite
                     && bun_sys::directory_exists_at(
                         parent_dir.fd(),

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -653,9 +653,7 @@ impl CreateCommand {
 
                     let mut conflicts: Vec<Vec<bun_paths::OSPathChar>> = Vec::new();
                     while let Some(entry) = scan_walker.next()? {
-                        // No-follow: a destination symlink counts as the link
-                        // itself, so it conflicts (or is unlinked by --force)
-                        // instead of being written through.
+                        // No-follow: a symlink is never classified as its target.
                         #[cfg(not(windows))]
                         let existing_kind = bun_sys::lstatat(existing_destination.fd, entry.path)
                             .map(|st| bun_sys::kind_from_mode(st.st_mode as _));

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -746,7 +746,11 @@ impl CreateCommand {
                             continue;
                         }
 
-                        if entry.kind == bun_sys::FileKind::File {
+                        // The bypass only applies when the copy can actually
+                        // overwrite: a directory in the way still conflicts.
+                        if entry.kind == bun_sys::FileKind::File
+                            && existing_kind != bun_sys::ExistsAtType::Directory
+                        {
                             #[cfg(not(windows))]
                             let never_conflict = NEVER_CONFLICT
                                 .iter()

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -600,73 +600,101 @@ impl CreateCommand {
                     }
                 };
 
-                if !create_options.overwrite
-                    && let Ok(existing_destination) = bun_sys::Dir::open(destination)
-                {
-                    // Walk a separate handle: the walker consumes the fd's
-                    // directory stream, and `template_dir` is walked again
-                    // below for the copy.
-                    if let Ok(scan_dir) = bun_sys::Dir::open(abs_template_path) {
-                        let mut scan_walker =
-                            bun_sys::walker_skippable::walk(scan_dir.fd, SKIP_FILES, SKIP_DIRS)?;
-
-                        let mut conflicts: Vec<Vec<bun_paths::OSPathChar>> = Vec::new();
-                        while let Some(entry) = scan_walker.next()? {
-                            if entry.kind != bun_sys::FileKind::File {
-                                continue;
-                            }
-
-                            #[cfg(not(windows))]
-                            let exists = bun_sys::exists_at(existing_destination.fd, entry.path);
-                            #[cfg(windows)]
-                            let exists = bun_sys::exists_at_type_w(
-                                existing_destination.fd,
-                                entry.path.as_slice(),
-                            )
-                            .is_ok();
-                            if !exists {
-                                continue;
-                            }
-
-                            #[cfg(not(windows))]
-                            let never_conflict = NEVER_CONFLICT
-                                .iter()
-                                .any(|p| strings::eql(entry.path.as_bytes(), p));
-                            #[cfg(windows)]
-                            let never_conflict = NEVER_CONFLICT
-                                .iter()
-                                .any(|p| strings::eql_comptime_utf16(entry.path.as_slice(), p));
-                            if never_conflict {
-                                continue;
-                            }
-
-                            #[cfg(not(windows))]
-                            conflicts.push(entry.path.as_bytes().to_vec());
-                            #[cfg(windows)]
-                            conflicts.push(entry.path.as_slice().to_vec());
-                        }
-
-                        if !conflicts.is_empty() {
+                let existing_destination = if create_options.overwrite {
+                    None
+                } else {
+                    match bun_sys::Dir::open(destination) {
+                        Ok(d) => Some(d),
+                        Err(err) if err.get_errno() == bun_sys::E::ENOENT => None,
+                        Err(err) => {
                             node.end();
                             progress.refresh();
 
                             pretty_errorln!(
-                                "<r>\n<red>error<r><d>: <r>The directory <b><blue>{}<r>/ contains files that could conflict:\n\n",
-                                bstr::BStr::new(bun_paths::basename(destination)),
+                                "<r><red>{}<r>: opening dir {}",
+                                bstr::BStr::new(err.name()),
+                                bstr::BStr::new(destination),
                             );
-                            for path in &conflicts {
-                                pretty_errorln!(
-                                    "<r>  {}",
-                                    bun_core::fmt::fmt_os_path(path.as_slice(), Default::default())
-                                );
-                            }
+                            Global::exit(1);
+                        }
+                    }
+                };
+                if let Some(existing_destination) = existing_destination {
+                    // The walker consumes the fd's directory stream, so the
+                    // copy below needs its own handle on the template.
+                    let scan_dir = match bun_sys::Dir::open(abs_template_path) {
+                        Ok(d) => d,
+                        Err(err) => {
+                            node.end();
+                            progress.refresh();
 
                             pretty_errorln!(
-                                "<r>\n<d>To copy {} anyway, use --force<r>",
+                                "<r><red>{}<r>: opening dir {}",
+                                bstr::BStr::new(err.name()),
                                 bstr::BStr::new(template),
                             );
                             Global::exit(1);
                         }
+                    };
+                    let mut scan_walker =
+                        bun_sys::walker_skippable::walk(scan_dir.fd, SKIP_FILES, SKIP_DIRS)?;
+
+                    let mut conflicts: Vec<Vec<bun_paths::OSPathChar>> = Vec::new();
+                    while let Some(entry) = scan_walker.next()? {
+                        if entry.kind != bun_sys::FileKind::File {
+                            continue;
+                        }
+
+                        #[cfg(not(windows))]
+                        let exists = bun_sys::exists_at(existing_destination.fd, entry.path);
+                        #[cfg(windows)]
+                        let exists = bun_sys::exists_at_type_w(
+                            existing_destination.fd,
+                            entry.path.as_slice(),
+                        )
+                        .is_ok();
+                        if !exists {
+                            continue;
+                        }
+
+                        #[cfg(not(windows))]
+                        let never_conflict = NEVER_CONFLICT
+                            .iter()
+                            .any(|p| strings::eql(entry.path.as_bytes(), p));
+                        #[cfg(windows)]
+                        let never_conflict = NEVER_CONFLICT
+                            .iter()
+                            .any(|p| strings::eql_comptime_utf16(entry.path.as_slice(), p));
+                        if never_conflict {
+                            continue;
+                        }
+
+                        #[cfg(not(windows))]
+                        conflicts.push(entry.path.as_bytes().to_vec());
+                        #[cfg(windows)]
+                        conflicts.push(entry.path.as_slice().to_vec());
+                    }
+
+                    if !conflicts.is_empty() {
+                        node.end();
+                        progress.refresh();
+
+                        pretty_errorln!(
+                            "<r>\n<red>error<r><d>: <r>The directory <b><blue>{}<r>/ contains files that could conflict:\n\n",
+                            bstr::BStr::new(bun_paths::basename(destination)),
+                        );
+                        for path in &conflicts {
+                            pretty_errorln!(
+                                "<r>  {}",
+                                bun_core::fmt::fmt_os_path(path.as_slice(), Default::default())
+                            );
+                        }
+
+                        pretty_errorln!(
+                            "<r>\n<d>To copy {} anyway, use --force<r>",
+                            bstr::BStr::new(template),
+                        );
+                        Global::exit(1);
                     }
                 }
 

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -653,14 +653,21 @@ impl CreateCommand {
 
                     let mut conflicts: Vec<Vec<bun_paths::OSPathChar>> = Vec::new();
                     while let Some(entry) = scan_walker.next()? {
+                        // No-follow: a destination symlink counts as the link
+                        // itself, so it conflicts (or is unlinked by --force)
+                        // instead of being written through.
                         #[cfg(not(windows))]
-                        let existing_kind =
-                            bun_sys::exists_at_type(existing_destination.fd, entry.path);
+                        let existing_kind = bun_sys::lstatat(existing_destination.fd, entry.path)
+                            .map(|st| bun_sys::kind_from_mode(st.st_mode as _));
                         #[cfg(windows)]
                         let existing_kind = bun_sys::exists_at_type_w(
                             existing_destination.fd,
                             entry.path.as_slice(),
-                        );
+                        )
+                        .map(|k| match k {
+                            bun_sys::ExistsAtType::Directory => bun_sys::FileKind::Directory,
+                            bun_sys::ExistsAtType::File => bun_sys::FileKind::File,
+                        });
                         let existing_kind = match existing_kind {
                             Ok(k) => k,
                             // ENOTDIR: a parent component is a file, already a conflict.
@@ -692,16 +699,16 @@ impl CreateCommand {
                         if create_options.overwrite {
                             let mismatch = match entry.kind {
                                 bun_sys::FileKind::File => {
-                                    existing_kind == bun_sys::ExistsAtType::Directory
+                                    existing_kind != bun_sys::FileKind::File
                                 }
                                 bun_sys::FileKind::Directory => {
-                                    existing_kind != bun_sys::ExistsAtType::Directory
+                                    existing_kind != bun_sys::FileKind::Directory
                                 }
                                 _ => false,
                             };
                             if mismatch {
                                 #[cfg(not(windows))]
-                                let removed = if existing_kind == bun_sys::ExistsAtType::Directory {
+                                let removed = if existing_kind == bun_sys::FileKind::Directory {
                                     existing_destination.delete_tree(entry.path.as_bytes())
                                 } else {
                                     bun_sys::unlinkat(&existing_destination, entry.path)
@@ -712,7 +719,7 @@ impl CreateCommand {
                                         Vec::new(),
                                         entry.path.as_slice(),
                                     );
-                                    if existing_kind == bun_sys::ExistsAtType::Directory {
+                                    if existing_kind == bun_sys::FileKind::Directory {
                                         existing_destination.delete_tree(&utf8)
                                     } else {
                                         utf8.push(0);
@@ -745,7 +752,7 @@ impl CreateCommand {
                             bun_sys::FileKind::File => true,
                             // Merging into an existing directory is fine.
                             bun_sys::FileKind::Directory => {
-                                existing_kind != bun_sys::ExistsAtType::Directory
+                                existing_kind != bun_sys::FileKind::Directory
                             }
                             _ => false,
                         };
@@ -753,9 +760,9 @@ impl CreateCommand {
                             continue;
                         }
 
-                        // A directory in the way conflicts even for these names.
+                        // A directory or symlink in the way conflicts even for these names.
                         if entry.kind == bun_sys::FileKind::File
-                            && existing_kind != bun_sys::ExistsAtType::Directory
+                            && existing_kind == bun_sys::FileKind::File
                         {
                             #[cfg(not(windows))]
                             let never_conflict = NEVER_CONFLICT

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1232,9 +1232,7 @@ impl CreateCommand {
 
         // git add/commit on a pre-existing repo would sweep the user's files in.
         let has_existing_git_repo = bun_sys::Dir::open(destination)
-            .map(|d| {
-                bun_sys::directory_exists_at(d.fd, bun_core::zstr!(".git")).unwrap_or(false)
-            })
+            .map(|d| bun_sys::directory_exists_at(d.fd, bun_core::zstr!(".git")).unwrap_or(false))
             .unwrap_or(false);
 
         if !create_options.skip_git && !has_existing_git_repo {

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -696,9 +696,7 @@ impl CreateCommand {
 
                         if create_options.overwrite {
                             let mismatch = match entry.kind {
-                                bun_sys::FileKind::File => {
-                                    existing_kind != bun_sys::FileKind::File
-                                }
+                                bun_sys::FileKind::File => existing_kind != bun_sys::FileKind::File,
                                 bun_sys::FileKind::Directory => {
                                     existing_kind != bun_sys::FileKind::Directory
                                 }

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -653,7 +653,8 @@ impl CreateCommand {
 
                     let mut conflicts: Vec<Vec<bun_paths::OSPathChar>> = Vec::new();
                     while let Some(entry) = scan_walker.next()? {
-                        // No-follow: a symlink is never classified as its target.
+                        // POSIX no-follow: a symlink is never classified as its
+                        // target (Windows classifies reparse points by target).
                         #[cfg(not(windows))]
                         let existing_kind = bun_sys::lstatat(existing_destination.fd, entry.path)
                             .map(|st| bun_sys::kind_from_mode(st.st_mode as _));

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1309,7 +1309,7 @@ impl CreateCommand {
                     bun_sys::exists_at_type(d.fd, bun_core::zstr!(".git")),
                     Err(ref err) if err.get_errno() == bun_sys::E::ENOENT
                 ),
-                Err(_) => false,
+                Err(_) => true,
             };
         }
 

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -608,9 +608,7 @@ impl CreateCommand {
                 template_has_npmignore =
                     bun_sys::exists_at(template_dir.fd, bun_core::zstr!(".npmignore"));
 
-                // With --force the scan still runs: it removes entries whose
-                // kind mismatches the template's, which O_TRUNC/mkdir cannot
-                // overwrite.
+                // Under --force the scan removes kind-mismatched entries instead.
                 let existing_destination = match bun_sys::Dir::open(destination) {
                     Ok(d) => Some(d),
                     Err(err) if err.get_errno() == bun_sys::E::ENOENT => None,

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -961,12 +961,18 @@ impl CreateCommand {
             let parent_dir = bun_sys::Dir::open(destination)?;
             if template_has_gitignore {
                 // rename replaces an existing .gitignore; linkat fails EEXIST.
-                let _ = bun_sys::renameat(
+                if let Err(err) = bun_sys::renameat(
                     parent_dir.fd(),
                     bun_core::zstr!("gitignore"),
                     parent_dir.fd(),
                     bun_core::zstr!(".gitignore"),
-                );
+                ) {
+                    pretty_errorln!(
+                        "<r><red>{}<r>: renaming gitignore to .gitignore",
+                        bstr::BStr::new(err.name()),
+                    );
+                    Global::exit(1);
+                }
             }
             if template_has_npmignore {
                 let _ = bun_sys::unlinkat(&parent_dir, bun_core::zstr!(".npmignore"));

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -746,8 +746,7 @@ impl CreateCommand {
                             continue;
                         }
 
-                        // The bypass only applies when the copy can actually
-                        // overwrite: a directory in the way still conflicts.
+                        // A directory in the way conflicts even for these names.
                         if entry.kind == bun_sys::FileKind::File
                             && existing_kind != bun_sys::ExistsAtType::Directory
                         {

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -961,6 +961,22 @@ impl CreateCommand {
             let parent_dir = bun_sys::Dir::open(destination)?;
             if template_has_gitignore {
                 // rename replaces an existing .gitignore; linkat fails EEXIST.
+                // Only a directory can block the rename; --force clears it.
+                if create_options.overwrite
+                    && bun_sys::directory_exists_at(
+                        parent_dir.fd(),
+                        bun_core::zstr!(".gitignore"),
+                    )
+                    .unwrap_or(false)
+                {
+                    if let Err(err) = parent_dir.delete_tree(b".gitignore") {
+                        pretty_errorln!(
+                            "<r><red>{}<r>: removing .gitignore",
+                            bstr::BStr::new(err.name()),
+                        );
+                        Global::exit(1);
+                    }
+                }
                 if let Err(err) = bun_sys::renameat(
                     parent_dir.fd(),
                     bun_core::zstr!("gitignore"),

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -973,17 +973,22 @@ impl CreateCommand {
                         Global::exit(1);
                     }
                 }
-                if let Err(err) = bun_sys::renameat(
+                match bun_sys::renameat(
                     parent_dir.fd(),
                     bun_core::zstr!("gitignore"),
                     parent_dir.fd(),
                     bun_core::zstr!(".gitignore"),
                 ) {
-                    pretty_errorln!(
-                        "<r><red>{}<r>: renaming gitignore to .gitignore",
-                        bstr::BStr::new(err.name()),
-                    );
-                    Global::exit(1);
+                    Ok(()) => {}
+                    // Tarballs default the flag on; nothing to rename is fine.
+                    Err(ref err) if err.get_errno() == bun_sys::E::ENOENT => {}
+                    Err(err) => {
+                        pretty_errorln!(
+                            "<r><red>{}<r>: renaming gitignore to .gitignore",
+                            bstr::BStr::new(err.name()),
+                        );
+                        Global::exit(1);
+                    }
                 }
             }
             if template_has_npmignore {

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -608,23 +608,22 @@ impl CreateCommand {
                 template_has_npmignore =
                     bun_sys::exists_at(template_dir.fd, bun_core::zstr!(".npmignore"));
 
-                let existing_destination = if create_options.overwrite {
-                    None
-                } else {
-                    match bun_sys::Dir::open(destination) {
-                        Ok(d) => Some(d),
-                        Err(err) if err.get_errno() == bun_sys::E::ENOENT => None,
-                        Err(err) => {
-                            node.end();
-                            progress.refresh();
+                // With --force the scan still runs: it removes entries whose
+                // kind mismatches the template's, which O_TRUNC/mkdir cannot
+                // overwrite.
+                let existing_destination = match bun_sys::Dir::open(destination) {
+                    Ok(d) => Some(d),
+                    Err(err) if err.get_errno() == bun_sys::E::ENOENT => None,
+                    Err(err) => {
+                        node.end();
+                        progress.refresh();
 
-                            pretty_errorln!(
-                                "<r><red>{}<r>: opening dir {}",
-                                bstr::BStr::new(err.name()),
-                                bstr::BStr::new(destination),
-                            );
-                            Global::exit(1);
-                        }
+                        pretty_errorln!(
+                            "<r><red>{}<r>: opening dir {}",
+                            bstr::BStr::new(err.name()),
+                            bstr::BStr::new(destination),
+                        );
+                        Global::exit(1);
                     }
                 };
                 if let Some(existing_destination) = existing_destination {
@@ -684,6 +683,62 @@ impl CreateCommand {
                                 Global::exit(1);
                             }
                         };
+
+                        if create_options.overwrite {
+                            let mismatch = match entry.kind {
+                                bun_sys::FileKind::File => {
+                                    existing_kind == bun_sys::ExistsAtType::Directory
+                                }
+                                bun_sys::FileKind::Directory => {
+                                    existing_kind != bun_sys::ExistsAtType::Directory
+                                }
+                                _ => false,
+                            };
+                            if mismatch {
+                                #[cfg(not(windows))]
+                                let removed = if existing_kind == bun_sys::ExistsAtType::Directory
+                                {
+                                    existing_destination.delete_tree(entry.path.as_bytes())
+                                } else {
+                                    bun_sys::unlinkat(&existing_destination, entry.path)
+                                };
+                                #[cfg(windows)]
+                                let removed = {
+                                    let mut utf8 = bun_core::strings::convert_utf16_to_utf8(
+                                        Vec::new(),
+                                        entry.path.as_slice(),
+                                    );
+                                    if existing_kind == bun_sys::ExistsAtType::Directory {
+                                        existing_destination.delete_tree(&utf8)
+                                    } else {
+                                        utf8.push(0);
+                                        bun_sys::unlinkat(
+                                            &existing_destination,
+                                            bun_core::ZStr::from_slice_with_nul(&utf8),
+                                        )
+                                    }
+                                };
+                                if let Err(err) = removed {
+                                    node.end();
+                                    progress.refresh();
+
+                                    #[cfg(not(windows))]
+                                    let entry_path: &[u8] = entry.path.as_bytes();
+                                    #[cfg(windows)]
+                                    let entry_path: &[u16] = entry.path.as_slice();
+                                    pretty_errorln!(
+                                        "<r><red>{}<r>: removing {}",
+                                        bstr::BStr::new(err.name()),
+                                        bun_core::fmt::fmt_os_path(
+                                            entry_path,
+                                            Default::default()
+                                        ),
+                                    );
+                                    Global::exit(1);
+                                }
+                            }
+                            continue;
+                        }
 
                         let conflicting = match entry.kind {
                             bun_sys::FileKind::File => true,

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1279,12 +1279,20 @@ impl CreateCommand {
         let user_skipped_install = create_options.skip_install;
         create_options.skip_install = create_options.skip_install || !has_dependencies;
 
-        // git add/commit on a pre-existing repo would sweep the user's files in.
-        let has_existing_git_repo = bun_sys::Dir::open(destination)
-            .map(|d| bun_sys::directory_exists_at(d.fd, bun_core::zstr!(".git")).unwrap_or(false))
-            .unwrap_or(false);
+        // git add/commit on a pre-existing repo would sweep the user's files
+        // in. `.git` may be a file (worktrees, submodules), so any entry kind
+        // counts, and a failed check skips git rather than committing.
+        if !create_options.skip_git {
+            create_options.skip_git = match bun_sys::Dir::open(destination) {
+                Ok(d) => !matches!(
+                    bun_sys::exists_at_type(d.fd, bun_core::zstr!(".git")),
+                    Err(ref err) if err.get_errno() == bun_sys::E::ENOENT
+                ),
+                Err(_) => false,
+            };
+        }
 
-        if !create_options.skip_git && !has_existing_git_repo {
+        if !create_options.skip_git {
             if !create_options.skip_install {
                 GitHandler::spawn(destination, path_env, create_options.verbose);
             } else {

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -653,19 +653,16 @@ impl CreateCommand {
                             continue;
                         };
 
-                        match entry.kind {
-                            // Any existing entry at a template file path would
-                            // be overwritten.
-                            bun_sys::FileKind::File => {}
-                            // A directory only conflicts when the destination
-                            // has a non-directory in its place; merging into an
-                            // existing directory is fine.
+                        let conflicting = match entry.kind {
+                            bun_sys::FileKind::File => true,
+                            // Merging into an existing directory is fine.
                             bun_sys::FileKind::Directory => {
-                                if existing_kind == bun_sys::ExistsAtType::Directory {
-                                    continue;
-                                }
+                                existing_kind != bun_sys::ExistsAtType::Directory
                             }
-                            _ => continue,
+                            _ => false,
+                        };
+                        if !conflicting {
+                            continue;
                         }
 
                         if entry.kind == bun_sys::FileKind::File {

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -957,8 +957,7 @@ impl CreateCommand {
         {
             let parent_dir = bun_sys::Dir::open(destination)?;
             if template_has_gitignore {
-                // rename replaces an existing .gitignore; linkat would fail
-                // with EEXIST and silently drop the template's version.
+                // rename replaces an existing .gitignore; linkat fails EEXIST.
                 let _ = bun_sys::renameat(
                     parent_dir.fd(),
                     bun_core::zstr!("gitignore"),

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -694,8 +694,7 @@ impl CreateCommand {
                             };
                             if mismatch {
                                 #[cfg(not(windows))]
-                                let removed = if existing_kind == bun_sys::ExistsAtType::Directory
-                                {
+                                let removed = if existing_kind == bun_sys::ExistsAtType::Directory {
                                     existing_destination.delete_tree(entry.path.as_bytes())
                                 } else {
                                     bun_sys::unlinkat(&existing_destination, entry.path)
@@ -727,10 +726,7 @@ impl CreateCommand {
                                     pretty_errorln!(
                                         "<r><red>{}<r>: removing {}",
                                         bstr::BStr::new(err.name()),
-                                        bun_core::fmt::fmt_os_path(
-                                            entry_path,
-                                            Default::default()
-                                        ),
+                                        bun_core::fmt::fmt_os_path(entry_path, Default::default()),
                                     );
                                     Global::exit(1);
                                 }

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1279,9 +1279,7 @@ impl CreateCommand {
         let user_skipped_install = create_options.skip_install;
         create_options.skip_install = create_options.skip_install || !has_dependencies;
 
-        // git add/commit on a pre-existing repo would sweep the user's files
-        // in. `.git` may be a file (worktrees, submodules), so any entry kind
-        // counts, and a failed check skips git rather than committing.
+        // Any .git entry counts (worktrees use a file); check errors skip git.
         if !create_options.skip_git {
             create_options.skip_git = match bun_sys::Dir::open(destination) {
                 Ok(d) => !matches!(

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -338,9 +338,7 @@ impl CreateCommand {
 
         let mut package_json_contents: MutableString = MutableString::default();
         let mut package_json_file: Option<bun_sys::File> = None;
-        // The post-copy cleanup renames `gitignore` and removes `.npmignore`.
-        // Local templates set these from the template's contents so files the
-        // user already had are left alone; tarballs keep the old behavior.
+        // Gate the post-copy gitignore/.npmignore cleanup on template contents.
         let mut template_has_gitignore = true;
         let mut template_has_npmignore = true;
 
@@ -661,9 +659,7 @@ impl CreateCommand {
                         );
                         let existing_kind = match existing_kind {
                             Ok(k) => k,
-                            // ENOTDIR: a parent component is a file, which the
-                            // scan already records as a conflict for that
-                            // component.
+                            // ENOTDIR: a parent component is a file, already a conflict.
                             Err(err)
                                 if matches!(
                                     err.get_errno(),

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -800,9 +800,16 @@ impl CreateCommand {
                     &mut template_path_buf,
                 )?;
 
-                package_json_file = destination_dir
-                    .open_file(b"package.json", bun_sys::O::RDWR, 0)
-                    .ok();
+                // Only a template-derived package.json may be rewritten below;
+                // a template without one must leave the user's file untouched.
+                package_json_file =
+                    if bun_sys::exists_at(template_dir.fd, bun_core::zstr!("package.json")) {
+                        destination_dir
+                            .open_file(b"package.json", bun_sys::O::RDWR, 0)
+                            .ok()
+                    } else {
+                        None
+                    };
 
                 'read_package_json: {
                     if let Some(ref pkg) = package_json_file {
@@ -1224,7 +1231,15 @@ impl CreateCommand {
         let user_skipped_install = create_options.skip_install;
         create_options.skip_install = create_options.skip_install || !has_dependencies;
 
-        if !create_options.skip_git {
+        // `git add`/`git commit` on a pre-existing repository would sweep the
+        // user's files into a new commit.
+        let has_existing_git_repo = bun_sys::Dir::open(destination)
+            .map(|d| {
+                bun_sys::directory_exists_at(d.fd, bun_core::zstr!(".git")).unwrap_or(false)
+            })
+            .unwrap_or(false);
+
+        if !create_options.skip_git && !has_existing_git_repo {
             if !create_options.skip_install {
                 GitHandler::spawn(destination, path_env, create_options.verbose);
             } else {

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -800,8 +800,7 @@ impl CreateCommand {
                     &mut template_path_buf,
                 )?;
 
-                // Only a template-derived package.json may be rewritten below;
-                // a template without one must leave the user's file untouched.
+                // A template without package.json must leave the user's file untouched.
                 package_json_file =
                     if bun_sys::exists_at(template_dir.fd, bun_core::zstr!("package.json")) {
                         destination_dir
@@ -1231,8 +1230,7 @@ impl CreateCommand {
         let user_skipped_install = create_options.skip_install;
         create_options.skip_install = create_options.skip_install || !has_dependencies;
 
-        // `git add`/`git commit` on a pre-existing repository would sweep the
-        // user's files into a new commit.
+        // git add/commit on a pre-existing repo would sweep the user's files in.
         let has_existing_git_repo = bun_sys::Dir::open(destination)
             .map(|d| {
                 bun_sys::directory_exists_at(d.fd, bun_core::zstr!(".git")).unwrap_or(false)

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -962,11 +962,8 @@ impl CreateCommand {
             if template_has_gitignore {
                 // rename replaces files; only a directory blocks it (--force clears it).
                 if create_options.overwrite
-                    && bun_sys::directory_exists_at(
-                        parent_dir.fd(),
-                        bun_core::zstr!(".gitignore"),
-                    )
-                    .unwrap_or(false)
+                    && bun_sys::directory_exists_at(parent_dir.fd(), bun_core::zstr!(".gitignore"))
+                        .unwrap_or(false)
                 {
                     if let Err(err) = parent_dir.delete_tree(b".gitignore") {
                         pretty_errorln!(

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -600,7 +600,76 @@ impl CreateCommand {
                     }
                 };
 
-                let _ = bun_sys::delete_tree_absolute(destination);
+                if !create_options.overwrite
+                    && let Ok(existing_destination) = bun_sys::Dir::open(destination)
+                {
+                    // Walk a separate handle: the walker consumes the fd's
+                    // directory stream, and `template_dir` is walked again
+                    // below for the copy.
+                    if let Ok(scan_dir) = bun_sys::Dir::open(abs_template_path) {
+                        let mut scan_walker =
+                            bun_sys::walker_skippable::walk(scan_dir.fd, SKIP_FILES, SKIP_DIRS)?;
+
+                        let mut conflicts: Vec<Vec<bun_paths::OSPathChar>> = Vec::new();
+                        while let Some(entry) = scan_walker.next()? {
+                            if entry.kind != bun_sys::FileKind::File {
+                                continue;
+                            }
+
+                            #[cfg(not(windows))]
+                            let exists = bun_sys::exists_at(existing_destination.fd, entry.path);
+                            #[cfg(windows)]
+                            let exists = bun_sys::exists_at_type_w(
+                                existing_destination.fd,
+                                entry.path.as_slice(),
+                            )
+                            .is_ok();
+                            if !exists {
+                                continue;
+                            }
+
+                            #[cfg(not(windows))]
+                            let never_conflict = NEVER_CONFLICT
+                                .iter()
+                                .any(|p| strings::eql(entry.path.as_bytes(), p));
+                            #[cfg(windows)]
+                            let never_conflict = NEVER_CONFLICT
+                                .iter()
+                                .any(|p| strings::eql_comptime_utf16(entry.path.as_slice(), p));
+                            if never_conflict {
+                                continue;
+                            }
+
+                            #[cfg(not(windows))]
+                            conflicts.push(entry.path.as_bytes().to_vec());
+                            #[cfg(windows)]
+                            conflicts.push(entry.path.as_slice().to_vec());
+                        }
+
+                        if !conflicts.is_empty() {
+                            node.end();
+                            progress.refresh();
+
+                            pretty_errorln!(
+                                "<r>\n<red>error<r><d>: <r>The directory <b><blue>{}<r>/ contains files that could conflict:\n\n",
+                                bstr::BStr::new(bun_paths::basename(destination)),
+                            );
+                            for path in &conflicts {
+                                pretty_errorln!(
+                                    "<r>  {}",
+                                    bun_core::fmt::fmt_os_path(path.as_slice(), Default::default())
+                                );
+                            }
+
+                            pretty_errorln!(
+                                "<r>\n<d>To copy {} anyway, use --force<r>",
+                                bstr::BStr::new(template),
+                            );
+                            Global::exit(1);
+                        }
+                    }
+                }
+
                 let destination_dir__ = match bun_sys::Fd::cwd().make_open_path(destination) {
                     Ok(d) => d,
                     Err(err) => {

--- a/test/cli/create/__snapshots__/create-jsx.test.ts.snap
+++ b/test/cli/create/__snapshots__/create-jsx.test.ts.snap
@@ -256,3 +256,35 @@ exports[`development: false shadcn/ui dev server 2`] = `
 <div id="root"><div class="min-h-screen bg-gradient-to-b from-background to-slate-900"><div class="container mx-auto px-4 py-16"><section class="text-center mb-16 space-y-6"><span data-slot="badge" class="inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&amp;>svg]:size-3 gap-1 [&amp;>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-auto border-transparent bg-secondary text-secondary-foreground [a&amp;]:hover:bg-secondary/90 mb-2">New in Bun*.*.*</span><h1 class="text-4xl md:text-6xl font-bold tracking-tight">From Component to App in<span class="text-primary"> Seconds</span></h1><p class="text-xl text-muted-foreground max-w-2xl mx-auto">Start a complete dev server from a single React component. No config needed.</p><div class="flex flex-wrap justify-center gap-4 pt-4"><button data-slot="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 h-10 rounded-md px-6 has-[>svg]:px-4 min-w-[140px]">Get Started</button><button data-slot="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground h-10 rounded-md px-6 has-[>svg]:px-4 min-w-[140px]">Documentation</button></div></section><div data-slot="card" class="text-card-foreground flex flex-col gap-6 rounded-xl border shadow-sm bg-slate-900 p-6 mb-16"><div class="overflow-x-auto"><pre class="text-green-400 text-sm md:text-base"><code>$ bun create ./MyComponent.tsx<br>📦 Installing dependencies...<br>🔍 Detected Tailwind CSS<br>🎨 Detected shadcn/ui<br>✨ Dev server running at http://localhost:3000</code></pre></div></div><section class="grid md:grid-cols-3 gap-8 mb-16"><div data-slot="card" class="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border shadow-sm p-6 hover:shadow-lg transition-shadow duration-200"><div class="flex items-center gap-2 mb-4"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-primary shrink-0"><path d="M21.801 10A10 10 0 1 1 17 3.335"></path><path d="m9 11 3 3L22 4"></path></svg><h3 class="font-semibold text-lg">Auto Dependencies</h3></div><p class="text-muted-foreground">Automatically detects and installs required dependencies for your component</p></div><div data-slot="card" class="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border shadow-sm p-6 hover:shadow-lg transition-shadow duration-200"><div class="flex items-center gap-2 mb-4"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-primary shrink-0"><path d="M21.801 10A10 10 0 1 1 17 3.335"></path><path d="m9 11 3 3L22 4"></path></svg><h3 class="font-semibold text-lg">Tool Detection</h3></div><p class="text-muted-foreground">Seamlessly integrates with Tailwind CSS, shadcn/ui, and other popular tools</p></div><div data-slot="card" class="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border shadow-sm p-6 hover:shadow-lg transition-shadow duration-200"><div class="flex items-center gap-2 mb-4"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-primary shrink-0"><path d="M21.801 10A10 10 0 1 1 17 3.335"></path><path d="m9 11 3 3L22 4"></path></svg><h3 class="font-semibold text-lg">Zero Config</h3></div><p class="text-muted-foreground">No setup required. Start developing instantly with hot reload enabled</p></div></section><section class="text-center"><div data-slot="card" class="text-card-foreground flex flex-col gap-6 rounded-xl border shadow-sm p-8 bg-primary/5 border-primary/10"><h2 class="text-2xl md:text-3xl font-bold mb-4">Ready to streamline your React development?</h2><p class="text-muted-foreground mb-6">Get started with Bun's powerful component development workflow today.</p><button data-slot="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 h-10 rounded-md px-6 has-[>svg]:px-4 min-w-[160px]">Install Bun</button></div></section></div></div></div>
 </body></html>"
 `;
+
+exports[`development: true react spa (no tailwind) (unnamed) 1`] = `""`;
+
+exports[`development: true react spa (no tailwind) (unnamed) 2`] = `
+"create  index.build.ts     build
+create  index.css          css
+create  index.html         html
+create  index.client.tsx   bun
+create  package.json       npm
+📦 Auto-installing 6 detected dependencies
+$ bun --only-missing install -- classnames react-dom@19 react@19
+bun add *.*.*
+installed classnames@*.*.*
+installed react-dom@*.*.*
+installed react@*.*.*
+4 packages installed [*ms]
+$ bun --only-missing add -d @types/bun @types/react@19 @types/react-dom@19
+bun add *.*.*
+installed @types/bun@*.*.*
+installed @types/react@*.*.*
+installed @types/react-dom@*.*.*
+7 packages installed [*ms]
+--------------------------------
+✨ React project configured
+Development - frontend dev server with hot reload
+bun dev
+Production - build optimized assets
+bun run build
+Happy bunning! 🐇
+Bun v*.*.* dev server ready in *.** ms
+url: http://[SERVER_URL]/"
+`;

--- a/test/cli/create/__snapshots__/create-jsx.test.ts.snap
+++ b/test/cli/create/__snapshots__/create-jsx.test.ts.snap
@@ -256,35 +256,3 @@ exports[`development: false shadcn/ui dev server 2`] = `
 <div id="root"><div class="min-h-screen bg-gradient-to-b from-background to-slate-900"><div class="container mx-auto px-4 py-16"><section class="text-center mb-16 space-y-6"><span data-slot="badge" class="inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&amp;>svg]:size-3 gap-1 [&amp;>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-auto border-transparent bg-secondary text-secondary-foreground [a&amp;]:hover:bg-secondary/90 mb-2">New in Bun*.*.*</span><h1 class="text-4xl md:text-6xl font-bold tracking-tight">From Component to App in<span class="text-primary"> Seconds</span></h1><p class="text-xl text-muted-foreground max-w-2xl mx-auto">Start a complete dev server from a single React component. No config needed.</p><div class="flex flex-wrap justify-center gap-4 pt-4"><button data-slot="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 h-10 rounded-md px-6 has-[>svg]:px-4 min-w-[140px]">Get Started</button><button data-slot="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground h-10 rounded-md px-6 has-[>svg]:px-4 min-w-[140px]">Documentation</button></div></section><div data-slot="card" class="text-card-foreground flex flex-col gap-6 rounded-xl border shadow-sm bg-slate-900 p-6 mb-16"><div class="overflow-x-auto"><pre class="text-green-400 text-sm md:text-base"><code>$ bun create ./MyComponent.tsx<br>📦 Installing dependencies...<br>🔍 Detected Tailwind CSS<br>🎨 Detected shadcn/ui<br>✨ Dev server running at http://localhost:3000</code></pre></div></div><section class="grid md:grid-cols-3 gap-8 mb-16"><div data-slot="card" class="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border shadow-sm p-6 hover:shadow-lg transition-shadow duration-200"><div class="flex items-center gap-2 mb-4"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-primary shrink-0"><path d="M21.801 10A10 10 0 1 1 17 3.335"></path><path d="m9 11 3 3L22 4"></path></svg><h3 class="font-semibold text-lg">Auto Dependencies</h3></div><p class="text-muted-foreground">Automatically detects and installs required dependencies for your component</p></div><div data-slot="card" class="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border shadow-sm p-6 hover:shadow-lg transition-shadow duration-200"><div class="flex items-center gap-2 mb-4"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-primary shrink-0"><path d="M21.801 10A10 10 0 1 1 17 3.335"></path><path d="m9 11 3 3L22 4"></path></svg><h3 class="font-semibold text-lg">Tool Detection</h3></div><p class="text-muted-foreground">Seamlessly integrates with Tailwind CSS, shadcn/ui, and other popular tools</p></div><div data-slot="card" class="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border shadow-sm p-6 hover:shadow-lg transition-shadow duration-200"><div class="flex items-center gap-2 mb-4"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-primary shrink-0"><path d="M21.801 10A10 10 0 1 1 17 3.335"></path><path d="m9 11 3 3L22 4"></path></svg><h3 class="font-semibold text-lg">Zero Config</h3></div><p class="text-muted-foreground">No setup required. Start developing instantly with hot reload enabled</p></div></section><section class="text-center"><div data-slot="card" class="text-card-foreground flex flex-col gap-6 rounded-xl border shadow-sm p-8 bg-primary/5 border-primary/10"><h2 class="text-2xl md:text-3xl font-bold mb-4">Ready to streamline your React development?</h2><p class="text-muted-foreground mb-6">Get started with Bun's powerful component development workflow today.</p><button data-slot="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 h-10 rounded-md px-6 has-[>svg]:px-4 min-w-[160px]">Install Bun</button></div></section></div></div></div>
 </body></html>"
 `;
-
-exports[`development: true react spa (no tailwind) (unnamed) 1`] = `""`;
-
-exports[`development: true react spa (no tailwind) (unnamed) 2`] = `
-"create  index.build.ts     build
-create  index.css          css
-create  index.html         html
-create  index.client.tsx   bun
-create  package.json       npm
-📦 Auto-installing 6 detected dependencies
-$ bun --only-missing install -- classnames react-dom@19 react@19
-bun add *.*.*
-installed classnames@*.*.*
-installed react-dom@*.*.*
-installed react@*.*.*
-4 packages installed [*ms]
-$ bun --only-missing add -d @types/bun @types/react@19 @types/react-dom@19
-bun add *.*.*
-installed @types/bun@*.*.*
-installed @types/react@*.*.*
-installed @types/react-dom@*.*.*
-7 packages installed [*ms]
---------------------------------
-✨ React project configured
-Development - frontend dev server with hot reload
-bun dev
-Production - build optimized assets
-bun run build
-Happy bunning! 🐇
-Bun v*.*.* dev server ready in *.** ms
-url: http://[SERVER_URL]/"
-`;

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -207,6 +207,28 @@ test.concurrent("bun create from local template does not run git when .git is a 
   expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
 });
 
+test.concurrent("bun create from local template flags a directory named README.md as a conflict", async () => {
+  using dir = tempDir("create-local-readme-dir", {
+    "templates/mytpl/README.md": "template readme",
+    "proj/README.md/index.md": "user file inside dir",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", "."],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+
+  expect(await Bun.file(join(String(dir), "proj", "README.md", "index.md")).text()).toBe("user file inside dir");
+  expect({ exitCode, stderr }).toEqual({
+    exitCode: 1,
+    stderr: expect.stringContaining("contains files that could conflict"),
+  });
+});
+
 test.concurrent("bun create from local template with --force replaces kind-mismatched entries", async () => {
   using dir = tempDir("create-local-force-mismatch", {
     "templates/mytpl/sub/nested.txt": "template nested",

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -13,6 +13,10 @@ test.concurrent("bun create from local template preserves unrelated files in des
     "templates/mytpl/tpl.txt": "template file",
     "proj/important.txt": "IMPORTANT DATA",
     "proj/subdir/data.txt": "more data",
+    // post-copy cleanup must not remove these when the template has no
+    // gitignore/.npmignore of its own
+    "proj/.npmignore": "my npmignore",
+    "proj/gitignore": "file literally named gitignore",
   });
 
   await using proc = Bun.spawn({
@@ -27,6 +31,8 @@ test.concurrent("bun create from local template preserves unrelated files in des
   expect(await Bun.file(join(String(dir), "proj", "important.txt")).text()).toBe("IMPORTANT DATA");
   expect(await Bun.file(join(String(dir), "proj", "subdir", "data.txt")).text()).toBe("more data");
   expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
+  expect(await Bun.file(join(String(dir), "proj", ".npmignore")).text()).toBe("my npmignore");
+  expect(await Bun.file(join(String(dir), "proj", "gitignore")).text()).toBe("file literally named gitignore");
   expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
 });
 

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { symlinkSync } from "node:fs";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { symlinkSync } from "node:fs";
 import { join } from "path";
 
 // https://github.com/oven-sh/bun/issues/36341
@@ -281,28 +281,32 @@ test.skipIf(isWindows).concurrent("bun create treats a destination symlink as a 
   });
 });
 
-test.skipIf(isWindows).concurrent("bun create with --force replaces a destination symlink instead of writing through it", async () => {
-  using dir = tempDir("create-local-symlink-force", {
-    "templates/mytpl/sub/nested.txt": "template nested",
-    "elsewhere/data.txt": "outside data",
-    "proj/placeholder.txt": "x",
-  });
-  symlinkSync(join(String(dir), "elsewhere"), join(String(dir), "proj", "sub"));
+test
+  .skipIf(isWindows)
+  .concurrent("bun create with --force replaces a destination symlink instead of writing through it", async () => {
+    using dir = tempDir("create-local-symlink-force", {
+      "templates/mytpl/sub/nested.txt": "template nested",
+      "elsewhere/data.txt": "outside data",
+      "proj/placeholder.txt": "x",
+    });
+    symlinkSync(join(String(dir), "elsewhere"), join(String(dir), "proj", "sub"));
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "create", "mytpl", ".", "--force"],
-    env: createEnv(join(String(dir), "templates")),
-    cwd: join(String(dir), "proj"),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "create", "mytpl", ".", "--force"],
+      env: createEnv(join(String(dir), "templates")),
+      cwd: join(String(dir), "proj"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
 
-  // the link target must stay untouched; sub becomes a real directory
-  expect(await Array.fromAsync(new Bun.Glob("*").scan({ cwd: join(String(dir), "elsewhere") }))).toEqual(["data.txt"]);
-  expect(await Bun.file(join(String(dir), "proj", "sub", "nested.txt")).text()).toBe("template nested");
-  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
-});
+    // the link target must stay untouched; sub becomes a real directory
+    expect(await Array.fromAsync(new Bun.Glob("*").scan({ cwd: join(String(dir), "elsewhere") }))).toEqual([
+      "data.txt",
+    ]);
+    expect(await Bun.file(join(String(dir), "proj", "sub", "nested.txt")).text()).toBe("template nested");
+    expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
+  });
 
 test.concurrent("bun create from local template flags a directory named README.md as a conflict", async () => {
   using dir = tempDir("create-local-readme-dir", {

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -27,8 +27,7 @@ test.concurrent("bun create from local template preserves unrelated files in des
   expect(await Bun.file(join(String(dir), "proj", "important.txt")).text()).toBe("IMPORTANT DATA");
   expect(await Bun.file(join(String(dir), "proj", "subdir", "data.txt")).text()).toBe("more data");
   expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
-  expect(stderr).not.toContain("error");
-  expect(exitCode).toBe(0);
+  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
 });
 
 test.concurrent("bun create from local template refuses to overwrite conflicting files without --force", async () => {
@@ -46,10 +45,12 @@ test.concurrent("bun create from local template refuses to overwrite conflicting
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
 
-  expect(stderr).toContain("contains files that could conflict");
   expect(stderr).toContain("index.ts");
   expect(await Bun.file(join(String(dir), "proj", "index.ts")).text()).toBe("my version");
-  expect(exitCode).toBe(1);
+  expect({ exitCode, stderr }).toEqual({
+    exitCode: 1,
+    stderr: expect.stringContaining("contains files that could conflict"),
+  });
 });
 
 test.concurrent("bun create from local template overwrites conflicting files with --force", async () => {
@@ -71,8 +72,7 @@ test.concurrent("bun create from local template overwrites conflicting files wit
   expect(await Bun.file(join(String(dir), "proj", "index.ts")).text()).toBe("template version");
   // --force overwrites conflicts but must not delete unrelated files
   expect(await Bun.file(join(String(dir), "proj", "keep.txt")).text()).toBe("keep me");
-  expect(stderr).not.toContain("error");
-  expect(exitCode).toBe(0);
+  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
 });
 
 test.concurrent("bun create from local template into existing named directory preserves its files", async () => {
@@ -92,8 +92,7 @@ test.concurrent("bun create from local template into existing named directory pr
 
   expect(await Bun.file(join(String(dir), "dest", "keep.txt")).text()).toBe("keep me");
   expect(await Bun.file(join(String(dir), "dest", "tpl.txt")).text()).toBe("template file");
-  expect(stderr).not.toContain("error");
-  expect(exitCode).toBe(0);
+  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
 });
 
 test.concurrent("bun create from local template ignores README.md and .gitignore conflicts", async () => {
@@ -114,7 +113,9 @@ test.concurrent("bun create from local template ignores README.md and .gitignore
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
 
-  expect(stderr).not.toContain("contains files that could conflict");
   expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
-  expect(exitCode).toBe(0);
+  expect({ exitCode, stderr }).toEqual({
+    exitCode: 0,
+    stderr: expect.not.stringContaining("contains files that could conflict"),
+  });
 });

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -5,7 +5,13 @@ import { join } from "path";
 // https://github.com/oven-sh/bun/issues/36341
 
 function createEnv(templatesDir: string) {
-  return { ...bunEnv, BUN_CREATE_DIR: templatesDir };
+  return {
+    ...bunEnv,
+    BUN_CREATE_DIR: templatesDir,
+    // The conflict path exits via Global::exit; LSan's conservative scan
+    // flags in-flight CLI allocations at that point and aborts with 134.
+    ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+  };
 }
 
 test.concurrent("bun create from local template preserves unrelated files in destination", async () => {
@@ -127,6 +133,52 @@ test.concurrent("bun create from local template ignores README.md and .gitignore
     exitCode: 0,
     stderr: expect.not.stringContaining("contains files that could conflict"),
   });
+});
+
+test.concurrent("bun create from local template leaves the user's package.json alone when the template has none", async () => {
+  const userPackageJson = JSON.stringify({ name: "mine", version: "9.9.9" });
+  using dir = tempDir("create-local-pkgjson", {
+    "templates/mytpl/tpl.txt": "template file",
+    "proj/package.json": userPackageJson,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", ".", "--no-install"],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+
+  expect(await Bun.file(join(String(dir), "proj", "package.json")).text()).toBe(userPackageJson);
+  expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
+  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
+});
+
+test.concurrent("bun create from local template does not run git in a pre-existing repository", async () => {
+  using dir = tempDir("create-local-git", {
+    "templates/mytpl/tpl.txt": "template file",
+    "proj/.git/KEEP.txt": "keep",
+    "proj/existing.txt": "user file",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", "."],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+
+  expect(await Bun.file(join(String(dir), "proj", ".git", "KEEP.txt")).text()).toBe("keep");
+  // git init/add/commit must not have touched the pre-existing repo
+  expect(await Array.fromAsync(new Bun.Glob("*").scan({ cwd: join(String(dir), "proj", ".git"), dot: true }))).toEqual(
+    ["KEEP.txt"],
+  );
+  expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
+  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
 });
 
 test.concurrent("bun create from local template refuses when a template directory collides with a file", async () => {

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -3,10 +3,6 @@ import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 // https://github.com/oven-sh/bun/issues/36341
-// `bun create <local-template> <dest>` used to `rm -rf` the destination
-// before copying, silently destroying pre-existing files (including the
-// entire cwd when dest was "."). It must preserve unrelated files and
-// refuse to overwrite conflicting ones unless --force is passed.
 
 function createEnv(templatesDir: string) {
   return { ...bunEnv, BUN_CREATE_DIR: templatesDir };
@@ -26,7 +22,7 @@ test.concurrent("bun create from local template preserves unrelated files in des
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
 
   expect(await Bun.file(join(String(dir), "proj", "important.txt")).text()).toBe("IMPORTANT DATA");
   expect(await Bun.file(join(String(dir), "proj", "subdir", "data.txt")).text()).toBe("more data");
@@ -48,7 +44,7 @@ test.concurrent("bun create from local template refuses to overwrite conflicting
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
 
   expect(stderr).toContain("contains files that could conflict");
   expect(stderr).toContain("index.ts");
@@ -70,7 +66,7 @@ test.concurrent("bun create from local template overwrites conflicting files wit
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
 
   expect(await Bun.file(join(String(dir), "proj", "index.ts")).text()).toBe("template version");
   // --force overwrites conflicts but must not delete unrelated files
@@ -92,7 +88,7 @@ test.concurrent("bun create from local template into existing named directory pr
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
 
   expect(await Bun.file(join(String(dir), "dest", "keep.txt")).text()).toBe("keep me");
   expect(await Bun.file(join(String(dir), "dest", "tpl.txt")).text()).toBe("template file");
@@ -116,7 +112,7 @@ test.concurrent("bun create from local template ignores README.md and .gitignore
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
 
   expect(stderr).not.toContain("contains files that could conflict");
   expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -208,6 +208,50 @@ test.concurrent("bun create from local template does not run git when .git is a 
   expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
 });
 
+test.concurrent("bun create skips a template's .git worktree pointer file even with --force", async () => {
+  using dir = tempDir("create-local-tpl-git-file", {
+    "templates/mytpl/.git": "gitdir: /somewhere/else/.git/worktrees/mytpl",
+    "templates/mytpl/tpl.txt": "template file",
+    "proj/.git/KEEP.txt": "keep",
+    "proj/keep.txt": "keep me",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", ".", "--force"],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+
+  // the destination repo must not be replaced by the template's pointer file
+  expect(await Bun.file(join(String(dir), "proj", ".git", "KEEP.txt")).text()).toBe("keep");
+  expect(await Bun.file(join(String(dir), "proj", "keep.txt")).text()).toBe("keep me");
+  expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
+  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
+});
+
+test.concurrent("bun create from local template replaces an existing .gitignore via the gitignore convention", async () => {
+  using dir = tempDir("create-local-gitignore-rename", {
+    "templates/mytpl/gitignore": "node_modules",
+    "proj/.gitignore": "dist",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", "."],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+
+  expect(await Bun.file(join(String(dir), "proj", ".gitignore")).text()).toBe("node_modules");
+  expect(await Bun.file(join(String(dir), "proj", "gitignore")).exists()).toBe(false);
+  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
+});
+
 test.concurrent("bun create from local template flags a directory named README.md as a conflict", async () => {
   using dir = tempDir("create-local-readme-dir", {
     "templates/mytpl/README.md": "template readme",

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -308,6 +308,28 @@ test
     expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
   });
 
+test.concurrent("bun create reports a failed gitignore rename instead of claiming success", async () => {
+  using dir = tempDir("create-local-gitignore-dir", {
+    "templates/mytpl/gitignore": "node_modules",
+    "proj/.gitignore/inner.txt": "keep",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", "."],
+    env: createEnv(join(String(dir), "templates"), { expectConflictExit: true }),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+
+  expect(await Bun.file(join(String(dir), "proj", ".gitignore", "inner.txt")).text()).toBe("keep");
+  expect({ exitCode, stderr }).toEqual({
+    exitCode: 1,
+    stderr: expect.stringContaining("renaming gitignore to .gitignore"),
+  });
+});
+
 test.concurrent("bun create from local template flags a directory named README.md as a conflict", async () => {
   using dir = tempDir("create-local-readme-dir", {
     "templates/mytpl/README.md": "template readme",

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -201,9 +201,7 @@ test.concurrent("bun create from local template does not run git when .git is a 
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
 
   // the worktree pointer file must survive untouched
-  expect(await Bun.file(join(String(dir), "proj", ".git")).text()).toBe(
-    "gitdir: /somewhere/else/.git/worktrees/proj",
-  );
+  expect(await Bun.file(join(String(dir), "proj", ".git")).text()).toBe("gitdir: /somewhere/else/.git/worktrees/proj");
   expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
   expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
 });

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -4,14 +4,14 @@ import { join } from "path";
 
 // https://github.com/oven-sh/bun/issues/36341
 
-function createEnv(templatesDir: string) {
-  return {
-    ...bunEnv,
-    BUN_CREATE_DIR: templatesDir,
+function createEnv(templatesDir: string, opts: { expectConflictExit?: boolean } = {}) {
+  const env: Record<string, string | undefined> = { ...bunEnv, BUN_CREATE_DIR: templatesDir };
+  if (opts.expectConflictExit) {
     // The conflict path exits via Global::exit; LSan's conservative scan
     // flags in-flight CLI allocations at that point and aborts with 134.
-    ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
-  };
+    env.ASAN_OPTIONS = [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":");
+  }
+  return env;
 }
 
 test.concurrent("bun create from local template preserves unrelated files in destination", async () => {
@@ -50,7 +50,7 @@ test.concurrent("bun create from local template refuses to overwrite conflicting
 
   await using proc = Bun.spawn({
     cmd: [bunExe(), "create", "mytpl", "."],
-    env: createEnv(join(String(dir), "templates")),
+    env: createEnv(join(String(dir), "templates"), { expectConflictExit: true }),
     cwd: join(String(dir), "proj"),
     stdout: "pipe",
     stderr: "pipe",
@@ -199,11 +199,12 @@ test.concurrent("bun create from local template does not run git when .git is a 
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+  const [stderr, exitCode, stdout] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
 
   // the worktree pointer file must survive untouched
   expect(await Bun.file(join(String(dir), "proj", ".git")).text()).toBe("gitdir: /somewhere/else/.git/worktrees/proj");
   expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
+  expect(stdout).not.toContain("local git repository was created");
   expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
 });
 
@@ -215,7 +216,7 @@ test.concurrent("bun create from local template flags a directory named README.m
 
   await using proc = Bun.spawn({
     cmd: [bunExe(), "create", "mytpl", "."],
-    env: createEnv(join(String(dir), "templates")),
+    env: createEnv(join(String(dir), "templates"), { expectConflictExit: true }),
     cwd: join(String(dir), "proj"),
     stdout: "pipe",
     stderr: "pipe",
@@ -261,7 +262,7 @@ test.concurrent("bun create from local template refuses when a template director
 
   await using proc = Bun.spawn({
     cmd: [bunExe(), "create", "mytpl", "."],
-    env: createEnv(join(String(dir), "templates")),
+    env: createEnv(join(String(dir), "templates"), { expectConflictExit: true }),
     cwd: join(String(dir), "proj"),
     stdout: "pipe",
     stderr: "pipe",

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -184,6 +184,30 @@ test.concurrent("bun create from local template does not run git in a pre-existi
   expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
 });
 
+test.concurrent("bun create from local template does not run git when .git is a worktree file", async () => {
+  using dir = tempDir("create-local-git-file", {
+    "templates/mytpl/tpl.txt": "template file",
+    "proj/.git": "gitdir: /somewhere/else/.git/worktrees/proj",
+    "proj/existing.txt": "user file",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", "."],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+
+  // the worktree pointer file must survive untouched
+  expect(await Bun.file(join(String(dir), "proj", ".git")).text()).toBe(
+    "gitdir: /somewhere/else/.git/worktrees/proj",
+  );
+  expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
+  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
+});
+
 test.concurrent("bun create from local template with --force replaces kind-mismatched entries", async () => {
   using dir = tempDir("create-local-force-mismatch", {
     "templates/mytpl/sub/nested.txt": "template nested",

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "bun:test";
+import { join } from "path";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/36341
+// `bun create <local-template> <dest>` used to `rm -rf` the destination
+// before copying, silently destroying pre-existing files (including the
+// entire cwd when dest was "."). It must preserve unrelated files and
+// refuse to overwrite conflicting ones unless --force is passed.
+
+function createEnv(templatesDir: string) {
+  return { ...bunEnv, BUN_CREATE_DIR: templatesDir };
+}
+
+test.concurrent("bun create from local template preserves unrelated files in destination", async () => {
+  using dir = tempDir("create-local-preserve", {
+    "templates/mytpl/tpl.txt": "template file",
+    "proj/important.txt": "IMPORTANT DATA",
+    "proj/subdir/data.txt": "more data",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", "."],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(await Bun.file(join(String(dir), "proj", "important.txt")).text()).toBe("IMPORTANT DATA");
+  expect(await Bun.file(join(String(dir), "proj", "subdir", "data.txt")).text()).toBe("more data");
+  expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
+  expect(stderr).not.toContain("error");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("bun create from local template refuses to overwrite conflicting files without --force", async () => {
+  using dir = tempDir("create-local-conflict", {
+    "templates/mytpl/index.ts": "template version",
+    "proj/index.ts": "my version",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", "."],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("contains files that could conflict");
+  expect(stderr).toContain("index.ts");
+  expect(await Bun.file(join(String(dir), "proj", "index.ts")).text()).toBe("my version");
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("bun create from local template overwrites conflicting files with --force", async () => {
+  using dir = tempDir("create-local-force", {
+    "templates/mytpl/index.ts": "template version",
+    "proj/index.ts": "my version",
+    "proj/keep.txt": "keep me",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", ".", "--force"],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(await Bun.file(join(String(dir), "proj", "index.ts")).text()).toBe("template version");
+  // --force overwrites conflicts but must not delete unrelated files
+  expect(await Bun.file(join(String(dir), "proj", "keep.txt")).text()).toBe("keep me");
+  expect(stderr).not.toContain("error");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("bun create from local template into existing named directory preserves its files", async () => {
+  using dir = tempDir("create-local-named", {
+    "templates/mytpl/tpl.txt": "template file",
+    "dest/keep.txt": "keep me",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", "dest"],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(await Bun.file(join(String(dir), "dest", "keep.txt")).text()).toBe("keep me");
+  expect(await Bun.file(join(String(dir), "dest", "tpl.txt")).text()).toBe("template file");
+  expect(stderr).not.toContain("error");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("bun create from local template ignores README.md and .gitignore conflicts", async () => {
+  using dir = tempDir("create-local-never-conflict", {
+    "templates/mytpl/README.md": "template readme",
+    "templates/mytpl/.gitignore": "node_modules",
+    "templates/mytpl/tpl.txt": "template file",
+    "proj/README.md": "my readme",
+    "proj/.gitignore": "dist",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", "."],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("contains files that could conflict");
+  expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -173,7 +173,7 @@ test.concurrent("bun create from local template does not run git in a pre-existi
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+  const [stderr, exitCode, stdout] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
 
   expect(await Bun.file(join(String(dir), "proj", ".git", "KEEP.txt")).text()).toBe("keep");
   // git init/add/commit must not have touched the pre-existing repo
@@ -181,6 +181,7 @@ test.concurrent("bun create from local template does not run git in a pre-existi
     "KEEP.txt",
   ]);
   expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
+  expect(stdout).not.toContain("local git repository was created");
   expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
 });
 

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -184,6 +184,30 @@ test.concurrent("bun create from local template does not run git in a pre-existi
   expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
 });
 
+test.concurrent("bun create from local template with --force replaces kind-mismatched entries", async () => {
+  using dir = tempDir("create-local-force-mismatch", {
+    "templates/mytpl/sub/nested.txt": "template nested",
+    "templates/mytpl/blocker": "template blocker file",
+    "proj/sub": "file named sub",
+    "proj/blocker/inner.txt": "user nested",
+    "proj/keep.txt": "keep me",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", ".", "--force"],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+
+  expect(await Bun.file(join(String(dir), "proj", "sub", "nested.txt")).text()).toBe("template nested");
+  expect(await Bun.file(join(String(dir), "proj", "blocker")).text()).toBe("template blocker file");
+  expect(await Bun.file(join(String(dir), "proj", "keep.txt")).text()).toBe("keep me");
+  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
+});
+
 test.concurrent("bun create from local template refuses when a template directory collides with a file", async () => {
   using dir = tempDir("create-local-dir-conflict", {
     "templates/mytpl/sub/nested.txt": "template nested",

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -232,25 +232,28 @@ test.concurrent("bun create skips a template's .git worktree pointer file even w
   expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
 });
 
-test.concurrent("bun create from local template replaces an existing .gitignore via the gitignore convention", async () => {
-  using dir = tempDir("create-local-gitignore-rename", {
-    "templates/mytpl/gitignore": "node_modules",
-    "proj/.gitignore": "dist",
-  });
+test.concurrent(
+  "bun create from local template replaces an existing .gitignore via the gitignore convention",
+  async () => {
+    using dir = tempDir("create-local-gitignore-rename", {
+      "templates/mytpl/gitignore": "node_modules",
+      "proj/.gitignore": "dist",
+    });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "create", "mytpl", "."],
-    env: createEnv(join(String(dir), "templates")),
-    cwd: join(String(dir), "proj"),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "create", "mytpl", "."],
+      env: createEnv(join(String(dir), "templates")),
+      cwd: join(String(dir), "proj"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
 
-  expect(await Bun.file(join(String(dir), "proj", ".gitignore")).text()).toBe("node_modules");
-  expect(await Bun.file(join(String(dir), "proj", "gitignore")).exists()).toBe(false);
-  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
-});
+    expect(await Bun.file(join(String(dir), "proj", ".gitignore")).text()).toBe("node_modules");
+    expect(await Bun.file(join(String(dir), "proj", "gitignore")).exists()).toBe(false);
+    expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
+  },
+);
 
 test.concurrent("bun create from local template flags a directory named README.md as a conflict", async () => {
   using dir = tempDir("create-local-readme-dir", {

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -330,6 +330,27 @@ test.concurrent("bun create reports a failed gitignore rename instead of claimin
   });
 });
 
+test.concurrent("bun create with --force replaces a directory blocking the gitignore rename", async () => {
+  using dir = tempDir("create-local-gitignore-dir-force", {
+    "templates/mytpl/gitignore": "node_modules",
+    "proj/.gitignore/inner.txt": "old",
+    "proj/keep.txt": "keep me",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", ".", "--force"],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+
+  expect(await Bun.file(join(String(dir), "proj", ".gitignore")).text()).toBe("node_modules");
+  expect(await Bun.file(join(String(dir), "proj", "keep.txt")).text()).toBe("keep me");
+  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
+});
+
 test.concurrent("bun create from local template flags a directory named README.md as a conflict", async () => {
   using dir = tempDir("create-local-readme-dir", {
     "templates/mytpl/README.md": "template readme",

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -135,26 +135,29 @@ test.concurrent("bun create from local template ignores README.md and .gitignore
   });
 });
 
-test.concurrent("bun create from local template leaves the user's package.json alone when the template has none", async () => {
-  const userPackageJson = JSON.stringify({ name: "mine", version: "9.9.9" });
-  using dir = tempDir("create-local-pkgjson", {
-    "templates/mytpl/tpl.txt": "template file",
-    "proj/package.json": userPackageJson,
-  });
+test.concurrent(
+  "bun create from local template leaves the user's package.json alone when the template has none",
+  async () => {
+    const userPackageJson = JSON.stringify({ name: "mine", version: "9.9.9" });
+    using dir = tempDir("create-local-pkgjson", {
+      "templates/mytpl/tpl.txt": "template file",
+      "proj/package.json": userPackageJson,
+    });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "create", "mytpl", ".", "--no-install"],
-    env: createEnv(join(String(dir), "templates")),
-    cwd: join(String(dir), "proj"),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "create", "mytpl", ".", "--no-install"],
+      env: createEnv(join(String(dir), "templates")),
+      cwd: join(String(dir), "proj"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
 
-  expect(await Bun.file(join(String(dir), "proj", "package.json")).text()).toBe(userPackageJson);
-  expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
-  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
-});
+    expect(await Bun.file(join(String(dir), "proj", "package.json")).text()).toBe(userPackageJson);
+    expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
+    expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
+  },
+);
 
 test.concurrent("bun create from local template does not run git in a pre-existing repository", async () => {
   using dir = tempDir("create-local-git", {
@@ -174,9 +177,9 @@ test.concurrent("bun create from local template does not run git in a pre-existi
 
   expect(await Bun.file(join(String(dir), "proj", ".git", "KEEP.txt")).text()).toBe("keep");
   // git init/add/commit must not have touched the pre-existing repo
-  expect(await Array.fromAsync(new Bun.Glob("*").scan({ cwd: join(String(dir), "proj", ".git"), dot: true }))).toEqual(
-    ["KEEP.txt"],
-  );
+  expect(await Array.fromAsync(new Bun.Glob("*").scan({ cwd: join(String(dir), "proj", ".git"), dot: true }))).toEqual([
+    "KEEP.txt",
+  ]);
   expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
   expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
 });

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { symlinkSync } from "node:fs";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 // https://github.com/oven-sh/bun/issues/36341
@@ -254,6 +255,54 @@ test.concurrent(
     expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
   },
 );
+
+test.skipIf(isWindows).concurrent("bun create treats a destination symlink as a conflict, not its target", async () => {
+  using dir = tempDir("create-local-symlink", {
+    "templates/mytpl/sub/nested.txt": "template nested",
+    "elsewhere/data.txt": "outside data",
+    "proj/placeholder.txt": "x",
+  });
+  symlinkSync(join(String(dir), "elsewhere"), join(String(dir), "proj", "sub"));
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", "."],
+    env: createEnv(join(String(dir), "templates"), { expectConflictExit: true }),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+
+  // nothing may be written through the link
+  expect(await Array.fromAsync(new Bun.Glob("*").scan({ cwd: join(String(dir), "elsewhere") }))).toEqual(["data.txt"]);
+  expect({ exitCode, stderr }).toEqual({
+    exitCode: 1,
+    stderr: expect.stringContaining("contains files that could conflict"),
+  });
+});
+
+test.skipIf(isWindows).concurrent("bun create with --force replaces a destination symlink instead of writing through it", async () => {
+  using dir = tempDir("create-local-symlink-force", {
+    "templates/mytpl/sub/nested.txt": "template nested",
+    "elsewhere/data.txt": "outside data",
+    "proj/placeholder.txt": "x",
+  });
+  symlinkSync(join(String(dir), "elsewhere"), join(String(dir), "proj", "sub"));
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", ".", "--force"],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+
+  // the link target must stay untouched; sub becomes a real directory
+  expect(await Array.fromAsync(new Bun.Glob("*").scan({ cwd: join(String(dir), "elsewhere") }))).toEqual(["data.txt"]);
+  expect(await Bun.file(join(String(dir), "proj", "sub", "nested.txt")).text()).toBe("template nested");
+  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.not.stringContaining("error") });
+});
 
 test.concurrent("bun create from local template flags a directory named README.md as a conflict", async () => {
   using dir = tempDir("create-local-readme-dir", {

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -114,8 +114,34 @@ test.concurrent("bun create from local template ignores README.md and .gitignore
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
 
   expect(await Bun.file(join(String(dir), "proj", "tpl.txt")).text()).toBe("template file");
+  // never-conflict files are replaced by the template's versions
+  expect(await Bun.file(join(String(dir), "proj", "README.md")).text()).toBe("template readme");
+  expect(await Bun.file(join(String(dir), "proj", ".gitignore")).text()).toBe("node_modules");
   expect({ exitCode, stderr }).toEqual({
     exitCode: 0,
     stderr: expect.not.stringContaining("contains files that could conflict"),
+  });
+});
+
+test.concurrent("bun create from local template refuses when a template directory collides with a file", async () => {
+  using dir = tempDir("create-local-dir-conflict", {
+    "templates/mytpl/sub/nested.txt": "template nested",
+    "proj/sub": "I am a file named sub",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "mytpl", "."],
+    env: createEnv(join(String(dir), "templates")),
+    cwd: join(String(dir), "proj"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+
+  expect(stderr).toContain("sub");
+  expect(await Bun.file(join(String(dir), "proj", "sub")).text()).toBe("I am a file named sub");
+  expect({ exitCode, stderr }).toEqual({
+    exitCode: 1,
+    stderr: expect.stringContaining("contains files that could conflict"),
   });
 });

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { join } from "path";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
 
 // https://github.com/oven-sh/bun/issues/36341
 // `bun create <local-template> <dest>` used to `rm -rf` the destination

--- a/test/cli/create/create-local-template.test.ts
+++ b/test/cli/create/create-local-template.test.ts
@@ -256,6 +256,8 @@ test.concurrent(
   },
 );
 
+// Windows classifies reparse points by target kind, so the no-follow refusal
+// does not apply there; creating symlinks also needs elevation on Windows.
 test.skipIf(isWindows).concurrent("bun create treats a destination symlink as a conflict, not its target", async () => {
   using dir = tempDir("create-local-symlink", {
     "templates/mytpl/sub/nested.txt": "template nested",
@@ -281,6 +283,7 @@ test.skipIf(isWindows).concurrent("bun create treats a destination symlink as a 
   });
 });
 
+// See the Windows note on the previous symlink test.
 test
   .skipIf(isWindows)
   .concurrent("bun create with --force replaces a destination symlink instead of writing through it", async () => {


### PR DESCRIPTION
### What does this PR do?

Fixes #36341. Fixes #27948.

`bun create <template> <dest>` with a local-folder template (one resolved from `.bun-create/` or `$BUN_CREATE_DIR`) deleted the entire destination directory tree before copying, with no conflict check and no `--force` requirement. With `bun create mytpl .` this silently wiped the user's current working directory:

```console
$ echo "IMPORTANT DATA" > important.txt
$ BUN_CREATE_DIR=/path/to/templates bun create mytpl .
Copying files...
Created mytpl project successfully
$ ls
tpl.txt        # important.txt is gone
```

This is not a 1.4 regression: 1.3.14 behaves identically (the reporter's bisect did not hold up). The remote/tarball template path already refuses to overwrite conflicting files without `--force`; only the local-folder path nuked the destination.

### Fix

In the `ExampleTag::LocalFolder` branch of `create_command.rs`, remove the `delete_tree_absolute(destination)` call. If the destination already exists and `--force` was not passed, walk the template and refuse with the tarball path's "contains files that could conflict" error when any template file already exists in the destination (`README.md`/`.gitignore` excluded via the existing `NEVER_CONFLICT` list). With `--force`, conflicting files are overwritten and unrelated files are preserved, matching the tarball path's semantics. The copy itself already opens with `O_CREAT | O_TRUNC` (`CopyFileW` with overwrite on Windows), so the delete was never needed for a clean copy.

The conflict scan walks a separately opened handle because the walker consumes the directory fd's stream and the copy walks the template again.

Also updates `docs/runtime/templating/create.mdx`: the warning documenting the destructive delete is replaced with the new conflict semantics.

### Verification

New tests in `test/cli/create/create-local-template.test.ts` cover: `.` destination preserving unrelated files, conflict refusal without `--force`, overwrite-but-preserve with `--force`, existing named directory, and the never-conflict names.

With released bun, 4 of 5 fail (files destroyed, no conflict error); with this change, all 5 pass:

```
(pass) bun create from local template preserves unrelated files in destination
(pass) bun create from local template refuses to overwrite conflicting files without --force
(pass) bun create from local template overwrites conflicting files with --force
(pass) bun create from local template ignores README.md and .gitignore conflicts
(pass) bun create from local template into existing named directory preserves its files
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 10 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/create/create-local-template.test.ts

<!-- robobun:evidence:end -->