### PR TITLE
test(harness): make VerdaccioRegistry.stop() actually terminate the process

### DIFF
--- a/test/cli/install/verdaccio-registry-lifecycle.test.ts
+++ b/test/cli/install/verdaccio-registry-lifecycle.test.ts
@@ -1,0 +1,33 @@
+import { afterAll, expect, test } from "bun:test";
+import { VerdaccioRegistry } from "harness";
+import { once } from "node:events";
+
+let registry: VerdaccioRegistry | undefined;
+
+afterAll(() => {
+  if (registry?.process && registry.process.exitCode === null && registry.process.signalCode === null) {
+    registry.process.kill("SIGKILL");
+  }
+});
+
+// stop() previously called kill(0), which only probes for liveness and left the
+// forked verdaccio running after every test file that used it.
+test("VerdaccioRegistry.stop() terminates the forked process", async () => {
+  registry = new VerdaccioRegistry();
+  await registry.start();
+
+  const child = registry.process!;
+  expect(child.pid).toBeGreaterThan(0);
+  expect(() => process.kill(child.pid!, 0)).not.toThrow();
+
+  const exited = once(child, "exit");
+  registry.stop();
+
+  const result = await Promise.race([
+    exited.then(() => "exited" as const),
+    Bun.sleep(3000).then(() => "still running" as const),
+  ]);
+
+  expect(result).toBe("exited");
+  expect(child.killed).toBe(true);
+});

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1826,6 +1826,7 @@ export class VerdaccioRegistry {
   configPath: string;
   packagesPath: string;
   users: Record<string, string> = {};
+  #stopped = false;
 
   constructor(opts?: { configPath?: string; packagesPath?: string; verbose?: boolean }) {
     this.port = randomPort();
@@ -1857,6 +1858,7 @@ export class VerdaccioRegistry {
     });
 
     this.process.on("exit", (code, signal) => {
+      if (this.#stopped) return;
       if (code !== 0) {
         console.error(`Verdaccio exited with code ${code} and signal ${signal}`);
       } else {
@@ -1878,8 +1880,9 @@ export class VerdaccioRegistry {
   }
 
   stop() {
+    this.#stopped = true;
     rmSync(join(dirname(this.configPath), "htpasswd"), { force: true });
-    this.process?.kill(0);
+    this.process?.kill();
   }
 
   /**

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1835,6 +1835,7 @@ export class VerdaccioRegistry {
   }
 
   async start(silent: boolean = true) {
+    this.#stopped = false;
     await rm(join(dirname(this.configPath), "htpasswd"), { force: true });
     this.process = fork(require.resolve("verdaccio/bin/verdaccio"), ["-c", this.configPath, "-l", `${this.port}`], {
       silent,


### PR DESCRIPTION
## Problem

`VerdaccioRegistry.stop()` in `test/harness.ts` calls `this.process?.kill(0)`. In Node's `child_process` API, passing signal `0` to `kill()` only probes whether the process exists; it does not send a signal. As a result, the forked verdaccio process survives every `afterAll()` teardown and leaks for the rest of the test run.

This was introduced in #16540, which changed `kill()` to `kill(0)`.

## Reproduction

```ts
const registry = new VerdaccioRegistry();
await registry.start();
registry.stop();
// registry.process is still running
```

Observed in practice as stacks of stale `verdaccio` processes after running install test files locally.

## Fix

Call `kill()` with no argument so the default `SIGTERM` is sent, restoring the pre-#16540 behavior. Now that the process actually exits on teardown, the `exit` listener would log `Verdaccio exited with code null and signal SIGTERM` for every test file; a `#stopped` flag suppresses that message when the exit was initiated by `stop()`, keeping normal teardown quiet while still surfacing unexpected mid-test crashes.

## Verification

New test `test/cli/install/verdaccio-registry-lifecycle.test.ts` starts a registry, calls `stop()`, and asserts the child's `exit` event fires.

Before the fix:
```
error: expect(received).toBe(expected)
Expected: "exited"
Received: "still running"
```

After: passes in ~1s, `ps` shows no lingering verdaccio.

Note: the change is entirely under `test/`, so the automated fail-before check (which stashes `src/`) cannot distinguish before/after. The fail-before output above was captured by reverting `kill()` back to `kill(0)` with the new test in place.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/install/verdaccio-registry-lifecycle.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/install/verdaccio-registry-lifecycle.test.ts
bun test v1.4.0 (d652713ce)

test/cli/install/verdaccio-registry-lifecycle.test.ts:
(pass) VerdaccioRegistry.stop() terminates the forked process [968.93ms]

 1 pass
 0 fail
 4 expect() calls
Ran 1 test across 1 file. [3.06s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../install/verdaccio-registry-lifecycle.test.ts   | 33 ++++++++++++++++++++++
 test/harness.ts                                    |  6 +++-
 2 files changed, 38 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
test/cli/install/verdaccio-registry-lifecycle.test.ts      1      3      0
test/harness.ts                                            4      6      0
```

</details>

<!-- robobun:evidence:end -->