### PR TITLE
diagnostics_channel: preserve callback return value in TracingChannel.traceCallback

### DIFF
--- a/src/js/node/diagnostics_channel.ts
+++ b/src/js/node/diagnostics_channel.ts
@@ -303,7 +303,21 @@ class TracingChannel {
     return done;
   }
 
+  get hasSubscribers() {
+    return (
+      this.start?.hasSubscribers ||
+      this.end?.hasSubscribers ||
+      this.asyncStart?.hasSubscribers ||
+      this.asyncEnd?.hasSubscribers ||
+      this.error?.hasSubscribers
+    );
+  }
+
   traceSync(fn, context = {}, thisArg, ...args) {
+    if (!this.hasSubscribers) {
+      return fn.$apply(thisArg, args);
+    }
+
     const { start, end, error } = this;
 
     return start.runStores(context, () => {
@@ -322,6 +336,10 @@ class TracingChannel {
   }
 
   tracePromise(fn, context = {}, thisArg, ...args) {
+    if (!this.hasSubscribers) {
+      return fn.$apply(thisArg, args);
+    }
+
     const { start, end, asyncStart, asyncEnd, error } = this;
 
     function reject(err) {
@@ -360,6 +378,10 @@ class TracingChannel {
   }
 
   traceCallback(fn, position = -1, context = {}, thisArg, ...args) {
+    if (!this.hasSubscribers) {
+      return fn.$apply(thisArg, args);
+    }
+
     const { start, end, asyncStart, asyncEnd, error } = this;
 
     function wrappedCallback(err, res) {
@@ -371,7 +393,7 @@ class TracingChannel {
       }
 
       // Using runStores here enables manual context failure recovery
-      asyncStart.runStores(context, () => {
+      return asyncStart.runStores(context, () => {
         try {
           if (callback) {
             return callback.$apply(this, arguments);

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -346,13 +346,13 @@ describe("TracingChannel", () => {
 
   test("hasSubscribers reflects a subscriber on any sub-channel", () => {
     const tc = tracingChannel("tc-hasSubscribers");
-    expect(tc.hasSubscribers).toBeFalsy();
+    expect(tc.hasSubscribers).toBeFalse();
     for (const name of ["start", "end", "asyncStart", "asyncEnd", "error"] as const) {
       const handler = () => {};
       tc[name].subscribe(handler);
-      expect(tc.hasSubscribers).toBeTruthy();
+      expect(tc.hasSubscribers).toBeTrue();
       tc[name].unsubscribe(handler);
-      expect(tc.hasSubscribers).toBeFalsy();
+      expect(tc.hasSubscribers).toBeFalse();
     }
   });
 
@@ -385,7 +385,7 @@ describe("TracingChannel", () => {
 
   test("traceSync/tracePromise/traceCallback are pure passthrough with no subscribers", async () => {
     const tc = tracingChannel("tc-nosub-passthrough");
-    expect(tc.hasSubscribers).toBeFalsy();
+    expect(tc.hasSubscribers).toBeFalse();
 
     const calls: unknown[][] = [];
     const fn = function (this: unknown, ...args: unknown[]) {

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -1,7 +1,7 @@
 import { gc } from "bun";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { AsyncLocalStorage } from "node:async_hooks";
-import { channel, Channel, hasSubscribers, subscribe, unsubscribe } from "node:diagnostics_channel";
+import { channel, Channel, hasSubscribers, subscribe, tracingChannel, unsubscribe } from "node:diagnostics_channel";
 
 describe("Channel", () => {
   // test-diagnostics-channel-has-subscribers.js
@@ -343,6 +343,72 @@ describe("TracingChannel", () => {
   // Port tests from:
   // https://github.com/search?q=repo%3Anodejs%2Fnode+test-diagnostics-channel+AND+%2Ftracing%2F&type=code
   test.todo("TODO");
+
+  test("hasSubscribers reflects a subscriber on any sub-channel", () => {
+    const tc = tracingChannel("tc-hasSubscribers");
+    expect(tc.hasSubscribers).toBeFalsy();
+    for (const name of ["start", "end", "asyncStart", "asyncEnd", "error"] as const) {
+      const handler = () => {};
+      tc[name].subscribe(handler);
+      expect(tc.hasSubscribers).toBeTruthy();
+      tc[name].unsubscribe(handler);
+      expect(tc.hasSubscribers).toBeFalsy();
+    }
+  });
+
+  test("traceCallback preserves the wrapped callback's return value", () => {
+    const tc = tracingChannel("tc-cb-return");
+    const events: string[] = [];
+    const handlers = {
+      start: () => events.push("start"),
+      end: () => events.push("end"),
+      asyncStart: () => events.push("asyncStart"),
+      asyncEnd: () => events.push("asyncEnd"),
+      error: () => events.push("error"),
+    };
+    tc.subscribe(handlers);
+
+    const api = (a: number, cb: (err: null, v: number) => number) => cb(null, a * 2);
+    const cb = (_err: null, v: number) => v * 2;
+
+    const untraced = api(10.5, cb);
+    const traced = tc.traceCallback(api, -1, {}, null, 10.5, cb);
+
+    expect({ untraced, traced, events }).toEqual({
+      untraced: 42,
+      traced: 42,
+      events: ["start", "asyncStart", "asyncEnd", "end"],
+    });
+
+    tc.unsubscribe(handlers);
+  });
+
+  test("traceSync/tracePromise/traceCallback are pure passthrough with no subscribers", async () => {
+    const tc = tracingChannel("tc-nosub-passthrough");
+    expect(tc.hasSubscribers).toBeFalsy();
+
+    const calls: unknown[][] = [];
+    const fn = function (this: unknown, ...args: unknown[]) {
+      calls.push([this, ...args]);
+      return args[0];
+    };
+    const thisArg = { tag: "t" };
+    const ctx = {};
+
+    expect(tc.traceSync(fn, ctx, thisArg, "sync")).toBe("sync");
+    // traceCallback must not validate the callback arg when nothing is subscribed
+    expect(tc.traceCallback(fn, -1, ctx, thisArg, "cb", "not-a-function")).toBe("cb");
+    const p = tc.tracePromise(fn, ctx, thisArg, Promise.resolve("p"));
+    expect(await p).toBe("p");
+
+    expect(calls).toEqual([
+      [thisArg, "sync"],
+      [thisArg, "cb", "not-a-function"],
+      [thisArg, p],
+    ]);
+    // context must not be populated when nothing is subscribed
+    expect(ctx).toEqual({});
+  });
 });
 
 const mocks = new Map();


### PR DESCRIPTION
## Problem

`TracingChannel.traceCallback` wraps the user's callback to publish `asyncStart`/`asyncEnd`, but the wrapper called `asyncStart.runStores(...)` without `return`ing it. The callback's return value was dropped, so any API whose callback return value matters (middleware `next()` chains that await the callback's promise, status-returning callbacks) behaved differently only when traced.

```js
import dc from "node:diagnostics_channel";
const api = (a, cb) => cb(null, a * 2);
const cb  = (e, v) => v * 2;
const t = dc.tracingChannel("tcb-ret");
t.subscribe({ start(){}, end(){}, asyncStart(){}, asyncEnd(){}, error(){} });
console.log(api(10.5, cb), t.traceCallback(api, -1, {}, null, 10.5, cb));
// node:       42 42
// bun before: 42 undefined
```

This also held with zero subscribers because Bun had no `hasSubscribers` short-circuit: `traceCallback` always validated and wrapped the callback. Node is a pure passthrough when nothing is subscribed (it does not even run `validateFunction` on the callback arg).

## Fix

- `wrappedCallback` now `return`s `asyncStart.runStores(...)` so the user callback's return value flows through.
- Added `TracingChannel.prototype.hasSubscribers` (checks all five sub-channels) and an `if (!this.hasSubscribers) return fn.apply(thisArg, args)` fast path to `traceSync`, `tracePromise`, and `traceCallback`, matching Node.

Event order (`start`, `asyncStart`, `asyncEnd`, `end`) is unchanged.

## Verification

New tests in `test/js/node/diagnostics_channel/diagnostics_channel.test.ts` cover the callback return value (with subscribers), the `hasSubscribers` getter, and the no-subscriber passthrough (including that `traceCallback` does not validate the callback arg when unsubscribed). All assertions were cross-checked against Node v26.3.0. The existing `test/js/node/test/parallel/test-diagnostics-channel-tracing-channel-*.js` suite continues to pass.

Fixes #27805

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/diagnostics_channel/diagnostics_channel.test.ts
bun test v1.4.0 (d7298cbfd)

test/js/node/diagnostics_channel/diagnostics_channel.test.ts:
(pass) Channel > can have subscribers [22.45ms]
(pass) Channel > can have symbol as name [14.92ms]
(pass) Channel > does not throw when unsubscribed [9.71ms]
(pass) Channel > can publish and subscribe [13.66ms]
(pass) Channel > can publish and subscribe using object [10.54ms]
(todo) Channel > can handle subscriber errors
(todo) Channel > can use bind store
(pass) Channel > references are not leaked [289.51ms]
(todo) TracingChannel > TODO
344 |   // https://github.com/search?q=repo%3Anodejs%2Fnode+test-diagnostics-channel+AND+%2Ftracing%2F&type=code
345 |   test.todo("TODO");
346 | 
347 |   test("hasSubscribers reflects a subscriber on any sub-channel", () => {
348 |     const tc = tracingChannel("tc-hasSubscribers");
349 |     expect(tc.hasSubscribers).toBeFalse();
                                    ^
error: expect(received).toBeFalse()

Received: undefined

      at <anonymous> (/work
... (truncated)

release without fix: 3 failed, 3 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/diagnostics_channel/diagnostics_channel.test.ts:
(pass) Channel > can have subscribers [0.34ms]
(pass) Channel > can have symbol as name [0.32ms]
(pass) Channel > does not throw when unsubscribed [0.17ms]
(pass) Channel > can publish and subscribe [0.20ms]
(pass) Channel > can publish and subscribe using object [0.17ms]
(todo) Channel > can handle subscriber errors
(todo) Channel > can use bind store
(pass) Channel > references are not leaked [4.71ms]
(todo) TracingChannel > TODO
344 |   // https://github.com/search?q=repo%3Anodejs%2Fnode+test-diagnostics-channel+AND+%2Ftracing%2F&type=code
345 |   test.todo("TODO");
346 | 
347 |   test("hasSubscribers reflects a subscriber on any sub-channel", () => {
348 |     const tc = tracingChannel("tc-hasSubscribers");
349 |     expect(tc.hasSubscribers).toBeFalse();
                                    ^
error: expect(received).toBeFalse()

Received: undefined

      at <anonymous> (/workspace/bun/test/js/node/diagnostics_channel/diagnostics_channel.test.ts:349:31)
(fail) TracingChannel > hasSubscribers reflects a subscriber on any sub-channel [0.35ms]
372 |     const cb = (_
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/diagnostics_channel/diagnostics_channel.test.ts
bun test v1.4.0 (d7298cbfd)

test/js/node/diagnostics_channel/diagnostics_channel.test.ts:
(pass) Channel > can have subscribers [23.87ms]
(pass) Channel > can have symbol as name [15.31ms]
(pass) Channel > does not throw when unsubscribed [10.09ms]
(pass) Channel > can publish and subscribe [13.86ms]
(pass) Channel > can publish and subscribe using object [10.81ms]
(todo) Channel > can handle subscriber errors
(todo) Channel > can use bind store
(pass) Channel > references are not leaked [288.38ms]
(todo) TracingChannel > TODO
(pass) TracingChannel > hasSubscribers reflects a subscriber on any sub-channel [16.41ms]
(pass) TracingChannel > traceCallback preserves the wrapped callback's return value [29.75ms]
(pass) TracingChannel > traceSync/tracePromise/traceCallback are pure passthrough with no subscribers [17.70ms]

 9 pass
 3 todo
 0 fail
 50 expect() calls
Ran 12 tests across 1 file. [2.53s]
__F:0:S:3

release with fix: 3 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 671ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (9137ms)
Bundle modules (35ms)
Postprocesss modules (25ms)
Bundle Functions (725ms)
Generate Code (20ms)

[9.95s] Bundled "src/js" for production
  2571 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/diagnostics_channel.ts                 | 24 +++++++-
 .../diagnostics_channel.test.ts                    | 68 +++++++++++++++++++++-
 2 files changed, 90 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/node/diagnostics_channel.ts                            3      3      0
…js/node/diagnostics_channel/diagnostics_channel.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->