### PR TITLE
test(node:http): deflake numeric-header.test.ts

### DIFF
--- a/test/js/node/http/numeric-header.test.ts
+++ b/test/js/node/http/numeric-header.test.ts
@@ -1,41 +1,47 @@
 import { describe, expect, test } from "bun:test";
-import { createServer } from "http";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 
 describe("HTTP numeric headers", () => {
   test("should handle numeric header names", async () => {
+    let received: { byString: unknown; byNumber: unknown; hasKey: boolean } | undefined;
+
+    // Capture header values in the handler and assert after the response
+    // completes so a failed assertion surfaces as a test failure instead of a
+    // hung fetch (res.end() would otherwise never run).
     const server = createServer((req, res) => {
-      // Get the custom header value
-      expect(req.headers["1234"]).toBe("Hello from client!");
-      expect("1234" in req.headers).toBe(true);
-      expect(req.headers[1234]).toBe("Hello from client!");
-
-      const customHeader = req.headers["1234"];
-
-      // Send response with the header value
+      received = {
+        byString: req.headers["1234"],
+        byNumber: req.headers[1234],
+        hasKey: "1234" in req.headers,
+      };
       res.writeHead(200, { "Content-Type": "text/plain" });
-      res.end(`Received header value: ${customHeader}`);
+      res.end(`Received header value: ${req.headers["1234"]}`);
     });
 
-    // Start server on random port
-    const port = await new Promise<number>(resolve => {
-      server.listen(0, () => {
-        const address = server.address();
-        if (address && typeof address === "object") {
-          resolve(address.port);
-        }
+    server.listen(0, "127.0.0.1");
+    try {
+      await once(server, "listening");
+      const { port } = server.address() as AddressInfo;
+
+      const response = await fetch(`http://127.0.0.1:${port}/`, {
+        headers: {
+          "1234": "Hello from client!",
+          "Connection": "close",
+        },
       });
-    });
+      const data = await response.text();
 
-    // Make fetch request to the server
-    const response = await fetch(`http://localhost:${port}/`, {
-      headers: {
-        "1234": "Hello from client!",
-      },
-    });
-
-    const data = await response.text();
-    expect(data).toBe("Received header value: Hello from client!");
-
-    server.close();
+      expect(received).toEqual({
+        byString: "Hello from client!",
+        byNumber: "Hello from client!",
+        hasKey: true,
+      });
+      expect(data).toBe("Received header value: Hello from client!");
+    } finally {
+      server.closeAllConnections();
+      server.close();
+    }
   });
 });


### PR DESCRIPTION
Deflakes \`test/js/node/http/numeric-header.test.ts\`, which timed out in the parallel batch on Debian 13 x64 and aarch64 \`test-bun\` lanes while passing when run alone.

### Cause

The request handler called \`expect()\` before \`res.end()\`:

\`\`\`ts
const server = createServer((req, res) => {
  expect(req.headers["1234"]).toBe("Hello from client!"); // throws on mismatch
  ...
  res.end(...); // never reached on throw
});
\`\`\`

If the assertion throws, \`res.end()\` is never called, so the client \`fetch\` hangs until the 5s test timeout instead of failing fast. The test also listened without a host and fetched \`localhost\`, and the listen promise had no rejection path, so any listen error would also hang.

### Fix

- Capture header values in the handler and assert them after the response completes, so a mismatch is a normal assertion failure instead of a timeout.
- Bind and connect on \`127.0.0.1\` explicitly and send \`Connection: close\`.
- Use \`await once(server, "listening")\` so listen errors reject.
- Close the server (and any open connections) in a \`finally\` block.

### Verification

- \`bun bd test test/js/node/http/numeric-header.test.ts\`: pass
- 10 parallel debug runs: 10/10 pass
- 20 parallel release runs: 20/20 pass

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/http/numeric-header.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/http/numeric-header.test.ts
bun test v1.4.0 (971676e80)

test/js/node/http/numeric-header.test.ts:
(pass) HTTP numeric headers > should handle numeric header names [499.32ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [3.28s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/http/numeric-header.test.ts | 64 +++++++++++++++++---------------
 1 file changed, 35 insertions(+), 29 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
test/js/node/http/numeric-header.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->