### PR TITLE
node:fs: reject cp/cpSync when a symlink-aliased dest resolves into src

### DIFF
--- a/src/js/internal/fs/cp-sync.ts
+++ b/src/js/internal/fs/cp-sync.ts
@@ -11,12 +11,13 @@ const {
   mkdirSync,
   readdirSync,
   readlinkSync,
+  realpathSync,
   statSync,
   symlinkSync,
   unlinkSync,
   utimesSync,
 } = require("node:fs");
-const { dirname, isAbsolute, join, parse, resolve, sep } = require("node:path");
+const { basename, dirname, isAbsolute, join, parse, resolve, sep } = require("node:path");
 
 const { EEXIST, EISDIR, EINVAL, ENOTDIR } = $processBindingConstants.os.errno;
 
@@ -224,27 +225,72 @@ function getStatsSync(src, dest, opts) {
   return { srcStat, destStat };
 }
 
+// Resolve `p` through symlinks. If `p` (or a trailing portion of it) does not
+// exist yet, resolve the deepest existing ancestor and rejoin the missing tail
+// so the result names where `p` would land once created. Any non-ENOENT error
+// falls back to path.resolve; this is a guard, not the copy itself.
+function resolveExistingRealpathSync(p) {
+  let current = resolve(p);
+  const tail: string[] = [];
+  for (;;) {
+    try {
+      current = realpathSync(current);
+      break;
+    } catch (err: any) {
+      if (err?.code !== "ENOENT") return resolve(p);
+      const parent = dirname(current);
+      if (parent === current) break;
+      tail.push(basename(current));
+      current = parent;
+    }
+  }
+  let i = tail.length;
+  while (i > 0) current = join(current, tail[--i]);
+  return current;
+}
+
 function checkParentPathsSync(src, srcStat, dest) {
+  // The string isSrcSubdir check in checkPaths and the inode walk below both
+  // miss a destination reached through a symlink that resolves into a
+  // subdirectory of src: the string check sees the alias, and the inode walk
+  // only matches src itself. Resolve both sides through symlinks and repeat
+  // the prefix check on the real locations so the recursion cannot copy src
+  // back into itself.
+  if (srcStat.isDirectory()) {
+    const resolvedSrc = resolveExistingRealpathSync(src);
+    const resolvedDest = resolveExistingRealpathSync(dest);
+    if (isSrcSubdir(resolvedSrc, resolvedDest)) {
+      throw fsCpEinvalError({
+        message: `cannot copy ${src} to a subdirectory of self ${dest}`,
+        path: dest,
+        syscall: "cp",
+        errno: EINVAL,
+        code: "EINVAL",
+      });
+    }
+  }
   const srcParent = resolve(dirname(src));
-  const destParent = resolve(dirname(dest));
-  if (destParent === srcParent || destParent === parse(destParent).root) return;
-  let destStat;
-  try {
-    destStat = statSync(destParent, { bigint: true });
-  } catch (err: any) {
-    if (err.code === "ENOENT") return;
-    throw err;
+  let destParent = resolve(dirname(dest));
+  for (;;) {
+    if (destParent === srcParent || destParent === parse(destParent).root) return;
+    let destStat;
+    try {
+      destStat = statSync(destParent, { bigint: true });
+    } catch (err: any) {
+      if (err.code === "ENOENT") return;
+      throw err;
+    }
+    if (areIdentical(srcStat, destStat)) {
+      throw fsCpEinvalError({
+        message: `cannot copy ${src} to a subdirectory of self ${dest}`,
+        path: dest,
+        syscall: "cp",
+        errno: EINVAL,
+        code: "EINVAL",
+      });
+    }
+    destParent = resolve(dirname(destParent));
   }
-  if (areIdentical(srcStat, destStat)) {
-    throw fsCpEinvalError({
-      message: `cannot copy ${src} to a subdirectory of self ${dest}`,
-      path: dest,
-      syscall: "cp",
-      errno: EINVAL,
-      code: "EINVAL",
-    });
-  }
-  return checkParentPathsSync(src, srcStat, destParent);
 }
 
 // The native recursive copy (a single clonefile() on macOS) copies symlinks

--- a/src/js/internal/fs/cp-sync.ts
+++ b/src/js/internal/fs/cp-sync.ts
@@ -225,8 +225,6 @@ function getStatsSync(src, dest, opts) {
   return { srcStat, destStat };
 }
 
-// realpath(p), walking up past ENOENT and rejoining the missing tail so the
-// result names where p would land once created.
 function resolveExistingRealpathSync(p) {
   let current = resolve(p);
   const tail: string[] = [];
@@ -248,8 +246,6 @@ function resolveExistingRealpathSync(p) {
 }
 
 function checkParentPathsSync(src, srcStat, dest) {
-  // isSrcSubdir compares path strings and the inode walk below only matches
-  // src itself, so repeat the prefix check on realpath-resolved locations.
   if (srcStat.isDirectory()) {
     const resolvedSrc = resolveExistingRealpathSync(src);
     const resolvedDest = resolveExistingRealpathSync(dest);

--- a/src/js/internal/fs/cp-sync.ts
+++ b/src/js/internal/fs/cp-sync.ts
@@ -225,10 +225,8 @@ function getStatsSync(src, dest, opts) {
   return { srcStat, destStat };
 }
 
-// Resolve `p` through symlinks. If `p` (or a trailing portion of it) does not
-// exist yet, resolve the deepest existing ancestor and rejoin the missing tail
-// so the result names where `p` would land once created. Any non-ENOENT error
-// falls back to path.resolve; this is a guard, not the copy itself.
+// realpath(p), walking up past ENOENT and rejoining the missing tail so the
+// result names where p would land once created.
 function resolveExistingRealpathSync(p) {
   let current = resolve(p);
   const tail: string[] = [];
@@ -250,12 +248,8 @@ function resolveExistingRealpathSync(p) {
 }
 
 function checkParentPathsSync(src, srcStat, dest) {
-  // The string isSrcSubdir check in checkPaths and the inode walk below both
-  // miss a destination reached through a symlink that resolves into a
-  // subdirectory of src: the string check sees the alias, and the inode walk
-  // only matches src itself. Resolve both sides through symlinks and repeat
-  // the prefix check on the real locations so the recursion cannot copy src
-  // back into itself.
+  // isSrcSubdir compares path strings and the inode walk below only matches
+  // src itself, so repeat the prefix check on realpath-resolved locations.
   if (srcStat.isDirectory()) {
     const resolvedSrc = resolveExistingRealpathSync(src);
     const resolvedDest = resolveExistingRealpathSync(dest);

--- a/src/js/internal/fs/cp.ts
+++ b/src/js/internal/fs/cp.ts
@@ -91,10 +91,8 @@ function getStats(src, dest, opts) {
   ]);
 }
 
-// Resolve `p` through symlinks. If `p` (or a trailing portion of it) does not
-// exist yet, resolve the deepest existing ancestor and rejoin the missing tail
-// so the result names where `p` would land once created. Any non-ENOENT error
-// falls back to path.resolve; this is a guard, not the copy itself.
+// realpath(p), walking up past ENOENT and rejoining the missing tail so the
+// result names where p would land once created.
 async function resolveExistingRealpath(p) {
   let current = resolve(p);
   const tail: string[] = [];
@@ -116,12 +114,8 @@ async function resolveExistingRealpath(p) {
 }
 
 async function checkParentPaths(src, srcStat, dest) {
-  // The string isSrcSubdir check in checkPaths and the inode walk below both
-  // miss a destination reached through a symlink that resolves into a
-  // subdirectory of src: the string check sees the alias, and the inode walk
-  // only matches src itself. Resolve both sides through symlinks and repeat
-  // the prefix check on the real locations so the recursion cannot copy src
-  // back into itself.
+  // isSrcSubdir compares path strings and the inode walk below only matches
+  // src itself, so repeat the prefix check on realpath-resolved locations.
   if (srcStat.isDirectory()) {
     const resolvedSrc = await resolveExistingRealpath(src);
     const resolvedDest = await resolveExistingRealpath(dest);

--- a/src/js/internal/fs/cp.ts
+++ b/src/js/internal/fs/cp.ts
@@ -22,12 +22,13 @@ const {
   opendir,
   readdir,
   readlink,
+  realpath,
   stat,
   symlink,
   unlink,
   utimes,
 } = require("node:fs/promises");
-const { dirname, isAbsolute, join, parse, resolve } = require("node:path");
+const { basename, dirname, isAbsolute, join, parse, resolve } = require("node:path");
 
 const PromisePrototypeThen = $Promise.prototype.$then;
 const PromiseReject = Promise.$reject;
@@ -90,33 +91,76 @@ function getStats(src, dest, opts) {
   ]);
 }
 
-// Recursively check if dest parent is a subdirectory of src.
+// Resolve `p` through symlinks. If `p` (or a trailing portion of it) does not
+// exist yet, resolve the deepest existing ancestor and rejoin the missing tail
+// so the result names where `p` would land once created. Any non-ENOENT error
+// falls back to path.resolve; this is a guard, not the copy itself.
+async function resolveExistingRealpath(p) {
+  let current = resolve(p);
+  const tail: string[] = [];
+  for (;;) {
+    try {
+      current = await realpath(current);
+      break;
+    } catch (err: any) {
+      if (err?.code !== "ENOENT") return resolve(p);
+      const parent = dirname(current);
+      if (parent === current) break;
+      tail.push(basename(current));
+      current = parent;
+    }
+  }
+  let i = tail.length;
+  while (i > 0) current = join(current, tail[--i]);
+  return current;
+}
+
+// Check if dest parent is a subdirectory of src.
 // It works for all file types including symlinks since it
 // checks the src and dest inodes. It starts from the deepest
 // parent and stops once it reaches the src parent or the root path.
 async function checkParentPaths(src, srcStat, dest) {
+  // The string isSrcSubdir check in checkPaths and the inode walk below both
+  // miss a destination reached through a symlink that resolves into a
+  // subdirectory of src: the string check sees the alias, and the inode walk
+  // only matches src itself. Resolve both sides through symlinks and repeat
+  // the prefix check on the real locations so the recursion cannot copy src
+  // back into itself.
+  if (srcStat.isDirectory()) {
+    const resolvedSrc = await resolveExistingRealpath(src);
+    const resolvedDest = await resolveExistingRealpath(dest);
+    if (isSrcSubdir(resolvedSrc, resolvedDest)) {
+      throw fsCpEinvalError({
+        message: `cannot copy ${src} to a subdirectory of self ${dest}`,
+        path: dest,
+        syscall: "cp",
+        errno: EINVAL,
+        code: "EINVAL",
+      });
+    }
+  }
   const srcParent = resolve(dirname(src));
-  const destParent = resolve(dirname(dest));
-  if (destParent === srcParent || destParent === parse(destParent).root) {
-    return;
+  let destParent = resolve(dirname(dest));
+  for (;;) {
+    if (destParent === srcParent || destParent === parse(destParent).root) return;
+    let destStat;
+    try {
+      destStat = await stat(destParent, { bigint: true });
+    } catch (err: any) {
+      if (err.code === "ENOENT") return;
+      throw err;
+    }
+    if (areIdentical(srcStat, destStat)) {
+      throw fsCpEinvalError({
+        message: `cannot copy ${src} to a subdirectory of self ${dest}`,
+        path: dest,
+        syscall: "cp",
+        errno: EINVAL,
+        code: "EINVAL",
+      });
+    }
+    destParent = resolve(dirname(destParent));
   }
-  let destStat;
-  try {
-    destStat = await stat(destParent, { bigint: true });
-  } catch (err: any) {
-    if (err.code === "ENOENT") return;
-    throw err;
-  }
-  if (areIdentical(srcStat, destStat)) {
-    throw fsCpEinvalError({
-      message: `cannot copy ${src} to a subdirectory of self ${dest}`,
-      path: dest,
-      syscall: "cp",
-      errno: EINVAL,
-      code: "EINVAL",
-    });
-  }
-  return checkParentPaths(src, srcStat, destParent);
 }
 
 // The native recursive copy (a single clonefile() on macOS) copies symlinks

--- a/src/js/internal/fs/cp.ts
+++ b/src/js/internal/fs/cp.ts
@@ -115,10 +115,6 @@ async function resolveExistingRealpath(p) {
   return current;
 }
 
-// Check if dest parent is a subdirectory of src.
-// It works for all file types including symlinks since it
-// checks the src and dest inodes. It starts from the deepest
-// parent and stops once it reaches the src parent or the root path.
 async function checkParentPaths(src, srcStat, dest) {
   // The string isSrcSubdir check in checkPaths and the inode walk below both
   // miss a destination reached through a symlink that resolves into a

--- a/src/js/internal/fs/cp.ts
+++ b/src/js/internal/fs/cp.ts
@@ -91,8 +91,6 @@ function getStats(src, dest, opts) {
   ]);
 }
 
-// realpath(p), walking up past ENOENT and rejoining the missing tail so the
-// result names where p would land once created.
 async function resolveExistingRealpath(p) {
   let current = resolve(p);
   const tail: string[] = [];
@@ -114,8 +112,6 @@ async function resolveExistingRealpath(p) {
 }
 
 async function checkParentPaths(src, srcStat, dest) {
-  // isSrcSubdir compares path strings and the inode walk below only matches
-  // src itself, so repeat the prefix check on realpath-resolved locations.
   if (srcStat.isDirectory()) {
     const resolvedSrc = await resolveExistingRealpath(src);
     const resolvedDest = await resolveExistingRealpath(dest);

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -405,6 +405,55 @@ for (const [name, copy] of impls) {
       assertContent(basename + "/result/a.dir/c.txt", "c");
     });
 
+    // The "copy to a subdirectory of self" guard is a path-string prefix check,
+    // so a destination reached through a symlink that points into the source
+    // tree defeats it and the walker re-enters src on every level until
+    // ENAMETOOLONG, leaving a deep garbage subtree behind. checkParentPaths
+    // now realpath-resolves both sides before comparing.
+    test("rejects symlink-aliased dest that resolves into src", async () => {
+      using dir = tempDir("cp-alias-subdir", {
+        "src/sub/.keep": "",
+      });
+      const base = String(dir);
+      const src = join(base, "src");
+      fs.symlinkSync(join(src, "sub"), join(base, "alias"), "junction");
+      // Long component so the unfixed recursion hits ENAMETOOLONG in a handful
+      // of levels instead of hundreds.
+      const destName = Buffer.alloc(200, "d").toString();
+
+      const err = await copyShouldThrow(src, join(base, "alias", destName), { recursive: true });
+      expect(err.code).toBe("ERR_FS_CP_EINVAL");
+      expect(fs.readdirSync(join(src, "sub"))).toEqual([".keep"]);
+    });
+
+    test("rejects symlink-aliased dest with missing intermediate directories", async () => {
+      using dir = tempDir("cp-alias-deep", {
+        "src/sub/.keep": "",
+      });
+      const base = String(dir);
+      const src = join(base, "src");
+      fs.symlinkSync(join(src, "sub"), join(base, "alias"), "junction");
+      const destName = Buffer.alloc(200, "d").toString();
+
+      const err = await copyShouldThrow(src, join(base, "alias", "a", "b", destName), { recursive: true });
+      expect(err.code).toBe("ERR_FS_CP_EINVAL");
+      expect(fs.readdirSync(join(src, "sub"))).toEqual([".keep"]);
+    });
+
+    // Negative control: a symlinked dest that lands outside src must still
+    // copy normally.
+    test("allows symlink-aliased dest that resolves outside src", async () => {
+      using dir = tempDir("cp-alias-outside", {
+        "src/file.txt": "payload",
+        "other/.keep": "",
+      });
+      const base = String(dir);
+      fs.symlinkSync(join(base, "other"), join(base, "alias"), "junction");
+
+      await copy(join(base, "src"), join(base, "alias", "copy"), { recursive: true });
+      expect(fs.readFileSync(join(base, "other", "copy", "file.txt"), "utf8")).toBe("payload");
+    });
+
     test.if(process.platform === "win32")("should not throw EBUSY when copying the same file on windows", async () => {
       await using basename = tempDir("cp", {
         "hey": "hi",

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -440,6 +440,20 @@ for (const [name, copy] of impls) {
       expect(fs.readdirSync(join(src, "sub"))).toEqual([".keep"]);
     });
 
+    test("rejects relative-symlink-aliased dest that resolves into src", async () => {
+      using dir = tempDir("cp-alias-rel", {
+        "src/sub/.keep": "",
+      });
+      const base = String(dir);
+      const src = join(base, "src");
+      fs.symlinkSync(join("src", "sub"), join(base, "alias"), "junction");
+      const destName = Buffer.alloc(200, "d").toString();
+
+      const err = await copyShouldThrow(src, join(base, "alias", destName), { recursive: true });
+      expect(err.code).toBe("ERR_FS_CP_EINVAL");
+      expect(fs.readdirSync(join(src, "sub"))).toEqual([".keep"]);
+    });
+
     // Negative control: a symlinked dest that lands outside src must still
     // copy normally.
     test("allows symlink-aliased dest that resolves outside src", async () => {
@@ -452,6 +466,21 @@ for (const [name, copy] of impls) {
 
       await copy(join(base, "src"), join(base, "alias", "copy"), { recursive: true });
       expect(fs.readFileSync(join(base, "other", "copy", "file.txt"), "utf8")).toBe("payload");
+    });
+
+    // Negative control: dest reached through a symlink to src's parent lands
+    // as a sibling of src, not inside it; the realpath comparison must not
+    // over-reject this.
+    test("allows symlink-aliased dest that resolves to a sibling of src", async () => {
+      using dir = tempDir("cp-alias-sibling", {
+        "src/file.txt": "payload",
+      });
+      const base = fs.realpathSync(String(dir));
+      fs.symlinkSync(base, join(base, "plink"), "junction");
+
+      await copy(join(base, "src"), join(base, "plink", "pcopy"), { recursive: true });
+      expect(fs.readFileSync(join(base, "pcopy", "file.txt"), "utf8")).toBe("payload");
+      expect(fs.readdirSync(join(base, "src"))).toEqual(["file.txt"]);
     });
 
     test.if(process.platform === "win32")("should not throw EBUSY when copying the same file on windows", async () => {


### PR DESCRIPTION
### What does this PR do?

`fs.cpSync` / `fs.cp` / `fs.promises.cp` guard against copying a directory into a subdirectory of itself, but the guard can be walked past with a symlink:

```js
import fs from "node:fs"; import path from "node:path"; import os from "node:os";
const base = fs.mkdtempSync(path.join(os.tmpdir(), "cpalias-"));
const src = path.join(base, "src"); fs.mkdirSync(path.join(src, "sub"), { recursive: true });
fs.writeFileSync(path.join(src, "file.txt"), "payload\n");
const alias = path.join(base, "alias"); fs.symlinkSync(path.join(src, "sub"), alias); // alias -> src/sub
fs.cpSync(src, path.join(alias, "copy"), { recursive: true });
```

`alias/copy` resolves to `src/sub/copy`, which is inside `src`, so every recursion level re-enters the growing source tree. The copy writes a ~900-level-deep garbage subtree into `src` until `ENAMETOOLONG`, leaving the source polluted. With real files in the tree each level re-copies the growing subtree (disk-fill class).

The plain-string case (`cpSync(src, src + "/sub/copy")`) is rejected correctly; only the symlink-aliased destination slips through.

### Cause

Two checks are supposed to catch this:

* `isSrcSubdir(src, dest)` in `checkPaths` is a path-string prefix comparison, so it sees `src` vs `alias/copy` and finds no overlap.
* `checkParentPaths` walks `dest`'s path-string ancestors and compares each by inode to `srcStat`. It follows symlinks for the stat itself, but only matches the `src` directory: a symlink into a *subdirectory* of `src` has a different inode, and the walk stops at `dirname(src)` before ever reaching `src`.

Node.js shares the defect (its async `promises.cp` recurses identically; its C++ `cpSync` throws an uncaught `std::filesystem::filesystem_error`).

### Fix

`checkParentPaths` / `checkParentPathsSync` now resolve both `src` and `dest` through symlinks and repeat the `isSrcSubdir` prefix check on the real locations. Since `dest` may not exist yet, the resolver walks up past `ENOENT` to the deepest existing ancestor, realpaths that, and rejoins the missing tail, so the check sees where `dest` would actually land once created. The existing inode walk is kept (converted to a loop) for bind-mount cases realpath cannot see.

The check runs once per top-level `cp` call (not per directory entry), so the added cost is two `realpath` calls.

### Verification

```
plain-string dest: ERR_FS_CP_EINVAL
symlink-aliased dest: ERR_FS_CP_EINVAL
source tree now has 3 nodes (was 3)
```

* `test/js/node/fs/cp.test.ts`: 53 pass, 0 fail (6 new)
* all 76 vendored `test/js/node/test/parallel/test-fs-cp-*`: pass
* `test/js/node/fs/cp-symlink-target.test.ts`: 2 pass

Related but distinct from #33448, which addresses symlink resolution for the src/dest *identity* check; that change does not touch `isSrcSubdir` or `checkParentPaths`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/cp.test.ts

<!-- robobun:evidence:end -->