### PR TITLE
jsc: let worker.terminate() preempt pure-Wasm loops

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "171babe26c3b330ac0263d1bed3550571908c838";
+export const WEBKIT_VERSION = "autobuild-preview-pr-372-a50d1e50";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/workers/worker-terminate-wasm-loop.test.ts
+++ b/test/js/web/workers/worker-terminate-wasm-loop.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression: worker.terminate() could not preempt a Worker running a pure
+// WebAssembly loop (no JS re-entry). VM::notifyNeedTermination() poisons the
+// trap-aware soft stack limit, but the Wasm tiers only checked it at function
+// prologues, never at loop back-edges, so `loop { br 0 }` spun forever and the
+// terminate() promise never settled. JS loops and Wasm loops that call an
+// imported JS function per iteration were already preemptible because they hit
+// a JS-side trap check.
+
+// (module (func (export "spin") (loop (br 0))))
+const PURE = new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2, 1, 0, 7, 8, 1, 4, 115, 112, 105, 110, 0, 0, 10, 9, 1, 7, 0, 3,
+  64, 12, 0, 11, 11,
+]);
+// (module (import "e" "tick" (func)) (func (export "spin") (loop (call 0) (br 0))))
+const CALL = new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 2, 10, 1, 1, 101, 4, 116, 105, 99, 107, 0, 0, 3, 2, 1, 0, 7, 8, 1, 4,
+  115, 112, 105, 110, 0, 1, 10, 11, 1, 9, 0, 3, 64, 16, 0, 12, 0, 11, 11,
+]);
+
+function workerSourceFor(kind: "js" | "wasm" | "wasmcall"): string {
+  if (kind === "js") {
+    return `require("worker_threads").parentPort.postMessage("go"); for(;;){}`;
+  }
+  const bytes = kind === "wasm" ? PURE : CALL;
+  const imports = kind === "wasm" ? "undefined" : "{ e: { tick() {} } }";
+  return `
+    const { parentPort } = require("worker_threads");
+    const bytes = Buffer.from(${JSON.stringify(Buffer.from(bytes).toString("base64"))}, "base64");
+    const inst = new WebAssembly.Instance(new WebAssembly.Module(bytes), ${imports});
+    parentPort.postMessage("go");
+    inst.exports.spin();
+  `;
+}
+
+async function runCase(kind: "js" | "wasm" | "wasmcall", warmMs: number, capMs: number) {
+  const body = `
+    import { Worker } from "node:worker_threads";
+    const w = new Worker(${JSON.stringify(workerSourceFor(kind))}, { eval: true });
+    let exited = -1;
+    w.on("exit", code => { exited = code; });
+    await new Promise((resolve, reject) => { w.on("message", resolve); w.on("error", reject); });
+    // Let the loop tier up past IPInt before terminate(); once spin() is entered there is no
+    // observable readiness signal (a pure Wasm loop has no JS re-entry to postMessage from).
+    await new Promise(r => setTimeout(r, ${warmMs}));
+    const t0 = performance.now();
+    const outcome = await Promise.race([
+      w.terminate().then(code => ({ terminated: true, code })),
+      new Promise(r => setTimeout(() => r({ terminated: false }), ${capMs})),
+    ]);
+    const dt = Math.round(performance.now() - t0);
+    console.log(JSON.stringify({ ...outcome, dt, exited }));
+    process.exit(0);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", body],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout.trim());
+  expect(exitCode).toBe(0);
+  return result;
+}
+
+describe.concurrent("worker.terminate() preempts infinite loops", () => {
+  for (const kind of ["js", "wasmcall", "wasm"] as const) {
+    test(
+      kind,
+      async () => {
+        const warm = kind === "wasm" ? 300 : 100;
+        // cap must be long enough for debug+ASAN to settle but short enough that
+        // the unfixed pure-wasm hang (never terminates) is clearly distinguished.
+        const { terminated, code, exited } = await runCase(kind, warm, 8000);
+        expect({ terminated, code, exited }).toEqual({ terminated: true, code: 1, exited: 1 });
+      },
+      20_000,
+    );
+  }
+});


### PR DESCRIPTION
## Problem

A Worker running a WebAssembly function whose body is a tight loop with no JS re-entry (e.g. `(loop (br 0))`) cannot be preempted by `worker.terminate()`: the promise never settles, no `exit` event fires, and the thread spins at 100% CPU until the process dies. JS `for(;;){}` and Wasm loops that call an imported JS function per iteration are already preemptible because they reach a JS-side trap check; Node terminates all three shapes in a few ms.

```
$ bun repro.mjs
js       -> terminated(code 1) 3ms
wasmcall -> terminated(code 1) 196ms
wasm     -> HUNG >15s 15001ms
```

Any host that isolates untrusted or third-party Wasm in a Worker cannot reclaim a spinning module: the worker is unkillable and burns a core forever. Since the worker-lifetime rework (#37075) joined worker teardown, the blast radius is larger: a parent worker calling `process.exit()` while a descendant spins in Wasm now wedges the whole process instead of exiting.

## Cause

Root cause is in JavaScriptCore, not Bun's worker plumbing. `VM::notifyNeedTermination()` fires `VMTraps::NeedTermination` -> `StackManager::requestStop()` sets `m_trapAwareSoftStackLimit` on every registered `Mirror` (including each `JSWebAssemblyInstance`'s `m_stackMirror`) to `UINTPTR_MAX`. The only Wasm-side consumer of that field was the IPInt function prologue; BBQ/OMG prologues read the non-trap-aware `m_softStackLimit`, and no tier reads it at loop back-edges. The `VMTraps::SignalSender` path only patches JS DFG/FTL CodeBlocks. A pure-Wasm loop therefore never observes the termination request.

## Fix

The JSC change is in oven-sh/WebKit#372: add a trap-aware stack-limit poll at each Wasm loop head (IPInt / BBQ / OMG). One load + one predicted-not-taken branch per back-edge; the slow path services the trap under a probe so non-termination async traps (NeedStopTheWorld / NeedWatchdogCheck / NeedDebuggerBreak) resume the loop with all live state preserved, and termination unwinds via `ExceptionType::Termination`. That PR is now rebased onto fork main `78d45d3184` (one commit ahead of the `171babe26c` this repo currently pins), so the bump stays a single commit.

This PR bumps `WEBKIT_VERSION` to the oven-sh/WebKit#372 preview build (`autobuild-preview-pr-372-a50d1e50`, full 38-asset matrix published) and adds `test/js/web/workers/worker-terminate-wasm-loop.test.ts`, which spawns three workers (JS loop, Wasm loop calling a JS import, pure Wasm loop) and asserts `terminate()` resolves with `{terminated: true, code: 1, exited: 1}` for each.

## Verification

Built bun main (`9008ae7ab`) against the rebased WebKit branch as a local WebKit (linux x64, debug+ASAN):

- `worker.terminate()` on the pure-Wasm loop resolves (exit event fires, process exits); unpatched hangs forever
- the new test passes 3/3 (`js` / `wasmcall` / `wasm`)
- nested tree: main -> worker -> worker spinning in pure Wasm, middle worker calls `process.exit(5)`: exits cleanly 3/3; on current main this never exits
- `wasm-streaming.test.ts` (33) and `bun-build-compile-wasm.test.ts` pass; `worker.test.ts` shows the same 3 timing-sensitive failures as an unpatched debug build of the same tree (pre-existing)

Merge sequencing: (1) oven-sh/WebKit#372 merges, (2) repin `WEBKIT_VERSION` here to the merged 40-hex sha, (3) merge this PR. The preview pin is CI-only.

Note: the fix is entirely in the vendored WebKit (via `WEBKIT_VERSION`), so the src-stash fail-before check is not mechanically applicable here; `USE_SYSTEM_BUN=1 bun test` on the new test file demonstrates the fail-before (`wasm -> HUNG`).

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 2 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/workers/worker-terminate-wasm-loop.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/workers/worker-terminate-wasm-loop.test.ts
bun test v1.4.0 (b16dd4cdb)

test/js/web/workers/worker-terminate-wasm-loop.test.ts:
(pass) worker.terminate() preempts infinite loops > js [2819.36ms]
(pass) worker.terminate() preempts infinite loops > wasmcall [2802.64ms]
(pass) worker.terminate() preempts infinite loops > wasm [2995.33ms]

 3 pass
 0 fail
 9 expect() calls
Ran 3 tests across 1 file. [5.42s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |  2 +-
 .../web/workers/worker-terminate-wasm-loop.test.ts | 84 ++++++++++++++++++++++
 2 files changed, 85 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
scripts/build/deps/webkit.ts                                1      3      0
test/js/web/workers/worker-terminate-wasm-loop.test.ts      0      4      0
```

</details>

<!-- robobun:evidence:end -->