### PR TITLE
fetch/WebSocket: reject wrong-typed proxy values instead of silently going direct

### DIFF
--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -67,6 +67,7 @@
 #include "JSDOMURL.h"
 #include "headers.h"
 #include "ObjectBindings.h"
+#include "../ErrorCode.h"
 
 namespace WebCore {
 using namespace JSC;
@@ -300,10 +301,12 @@ static inline JSC::EncodedJSValue constructJSWebSocket3(JSGlobalObject* lexicalG
                     JSC::JSObject* proxyOptions = proxyValue.getObject();
                     auto proxyUrlValue = Bun::getOwnPropertyIfExists(globalObject, proxyOptions, PropertyName(Identifier::fromString(vm, "url"_s)));
                     RETURN_IF_EXCEPTION(throwScope, {});
-                    if (proxyUrlValue && !proxyUrlValue.isUndefinedOrNull()) {
-                        proxyUrl = convert<IDLUSVString>(*lexicalGlobalObject, proxyUrlValue);
-                        RETURN_IF_EXCEPTION(throwScope, {});
+                    if (!proxyUrlValue || proxyUrlValue.isUndefinedOrNull()) {
+                        return Bun::throwError(lexicalGlobalObject, throwScope, Bun::ErrorCode::ERR_INVALID_ARG_TYPE,
+                            "WebSocket proxy must be a string, URL, or an object with a \"url\" property."_s);
                     }
+                    proxyUrl = convert<IDLUSVString>(*lexicalGlobalObject, proxyUrlValue);
+                    RETURN_IF_EXCEPTION(throwScope, {});
 
                     auto proxyHeadersValue = Bun::getOwnPropertyIfExists(globalObject, proxyOptions, builtinnames.headersPublicName());
                     RETURN_IF_EXCEPTION(throwScope, {});
@@ -324,6 +327,9 @@ static inline JSC::EncodedJSValue constructJSWebSocket3(JSGlobalObject* lexicalG
                             RETURN_IF_EXCEPTION(throwScope, {});
                         }
                     }
+                } else {
+                    return Bun::throwError(lexicalGlobalObject, throwScope, Bun::ErrorCode::ERR_INVALID_ARG_TYPE,
+                        "WebSocket proxy must be a string, URL, or an object with a \"url\" property."_s);
                 }
             }
         }

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -67,7 +67,7 @@
 #include "JSDOMURL.h"
 #include "headers.h"
 #include "ObjectBindings.h"
-#include "../ErrorCode.h"
+#include "ErrorCode.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1002,13 +1002,18 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         for obj in objects_to_try {
             if !obj.is_empty() {
                 if let Some(proxy_arg) = obj.get(global_this, "proxy")? {
+                    // `null` and the empty string are explicit "no proxy" sentinels.
+                    if proxy_arg.is_null()
+                        || (proxy_arg.is_string() && proxy_arg.get_length(ctx)? == 0)
+                    {
+                        break 'extract_proxy url_proxy_buffer;
+                    }
                     // A URL instance has no `.url` own property, so the `{url, headers}`
                     // branch below would silently ignore it. Treat it as its href here.
                     let is_url_instance =
                         bun_jsc::DOMURL::cast_(proxy_arg, global_this.vm()).is_some();
                     // Handle string format: proxy: "http://proxy.example.com:8080"
-                    if is_url_instance || (proxy_arg.is_string() && proxy_arg.get_length(ctx)? > 0)
-                    {
+                    if is_url_instance || proxy_arg.is_string() {
                         // `href_from_js` returns a +1 WTFStringImpl ref; `bun_core::String`
                         // is `Copy` with no `Drop`, so wrap in `OwnedString` for scope-exit
                         // deref (mirrors `defer href.deref()` in fetch.zig).
@@ -1043,7 +1048,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         break 'extract_proxy buffer;
                     }
                     // Handle object format: proxy: { url: "http://proxy.example.com:8080", headers?: Headers }
-                    // If the proxy object doesn't have a 'url' property, ignore it.
                     if proxy_arg.is_object() {
                         // Get the URL from the proxy object
                         if let Some(proxy_url_arg) = proxy_arg.get(global_this, "url")? {
@@ -1111,6 +1115,21 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                             }
                         }
                     }
+                    // Fall through: a value that is neither a URL string, a `URL`
+                    // instance, nor a `{url}` object. Fail closed rather than
+                    // silently connecting directly to the origin.
+                    let err = ctx.to_type_error(
+                        jsc::ErrorCode::INVALID_ARG_TYPE,
+                        format_args!(
+                            "fetch() proxy must be a string, URL, or an object with a \"url\" property."
+                        ),
+                    );
+                    return Ok(
+                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                            global_this,
+                            err,
+                        ),
+                    );
                 }
 
                 if global_this.has_exception() {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1115,9 +1115,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                             }
                         }
                     }
-                    // Fall through: a value that is neither a URL string, a `URL`
-                    // instance, nor a `{url}` object. Fail closed rather than
-                    // silently connecting directly to the origin.
                     let err = ctx.to_type_error(
                         jsc::ErrorCode::INVALID_ARG_TYPE,
                         format_args!(

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -461,6 +461,55 @@ describe("proxy option validation", () => {
       expect(await response.text()).toBe("shape-check");
     }
   });
+
+  test("WebSocket: rejects wrong-typed values instead of silently going direct", async () => {
+    let directHit = false;
+    await using origin = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("no", { status: 400 });
+      },
+      websocket: {
+        open(ws) {
+          directHit = true;
+          ws.close();
+        },
+        message() {},
+      },
+    });
+
+    const invalid: Array<[string, unknown]> = [
+      ["number", 42],
+      ["array", [httpProxyServer.url]],
+      ["boolean true", true],
+      ["boolean false", false],
+      ["object without url", { headers: {} }],
+      ["object with null url", { url: null }],
+    ];
+    for (const [label, value] of invalid) {
+      expect(() => new WebSocket(`ws://127.0.0.1:${origin.port}/`, { proxy: value } as any), label).toThrowError(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+        }),
+      );
+    }
+    expect(directHit).toBe(false);
+
+    // null / empty string / undefined remain the "no proxy" sentinels: the
+    // constructor must not throw and the socket must reach the origin directly.
+    for (const value of [null, "", undefined]) {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      const ws = new WebSocket(`ws://127.0.0.1:${origin.port}/`, { proxy: value } as any);
+      ws.onopen = () => ws.close();
+      ws.onclose = () => resolve();
+      ws.onerror = () => resolve();
+      await promise;
+    }
+    expect(directHit).toBe(true);
+  });
 });
 
 /**

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -380,6 +380,89 @@ test("unsupported protocol", async () => {
   );
 });
 
+// https://github.com/oven-sh/bun/issues/8150
+// A malformed proxy *string* already rejects with ERR_INVALID_ARG_VALUE, but a
+// wrong-typed proxy *value* (number/array/boolean/object without `url`) used to
+// be silently ignored so the request went direct to the origin.
+describe("proxy option validation", () => {
+  test("rejects wrong-typed values instead of silently going direct", async () => {
+    const hits: string[] = [];
+    await using origin = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: req => {
+        hits.push(new URL(req.url).pathname);
+        return new Response("DIRECT");
+      },
+    });
+
+    const invalid: Array<[string, unknown]> = [
+      ["number", 42],
+      ["array", [httpProxyServer.url]],
+      ["boolean true", true],
+      ["boolean false", false],
+      ["object without url", { headers: {} }],
+      ["object with typo'd key", { proxyUrl: httpProxyServer.url }],
+      ["object with null url", { url: null }],
+    ];
+    for (const [label, value] of invalid) {
+      await expect(
+        fetch(`${origin.url}/${encodeURIComponent(label)}`, { proxy: value as any }),
+        label,
+      ).rejects.toThrowError(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+        }),
+      );
+    }
+    // The malformed-string and bad-url-in-object paths must keep failing closed.
+    for (const value of ["http//x", { url: 42 }]) {
+      await expect(fetch(`${origin.url}/bad-value`, { proxy: value as any })).rejects.toThrowError(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_VALUE",
+        }),
+      );
+    }
+    // None of the rejected shapes may have reached the origin.
+    expect(hits).toEqual([]);
+  });
+
+  test("null / empty string / undefined mean 'no proxy'", async () => {
+    const hits: string[] = [];
+    await using origin = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: req => {
+        hits.push(new URL(req.url).pathname);
+        return new Response("DIRECT");
+      },
+    });
+
+    for (const [label, value] of [
+      ["null", null],
+      ["empty", ""],
+      ["undef", undefined],
+    ] as const) {
+      const res = await fetch(`${origin.url}/${label}`, { proxy: value as any });
+      expect(await res.text()).toBe("DIRECT");
+    }
+    expect(hits).toEqual(["/null", "/empty", "/undef"]);
+  });
+
+  test("valid string / URL / {url} shapes still route through the proxy", async () => {
+    for (const value of [httpProxyServer.url, new URL(httpProxyServer.url), { url: httpProxyServer.url }]) {
+      const response = await fetch(httpServer.url, {
+        method: "POST",
+        proxy: value as any,
+        body: "shape-check",
+      });
+      expect(await response.text()).toBe("shape-check");
+    }
+  });
+});
+
 /**
  * Creates an HTTP proxy server that captures Proxy-Authorization headers.
  * The server forwards requests to their destination and pipes responses back.
@@ -1454,32 +1537,27 @@ describe.concurrent("proxy object format with headers", () => {
     }
   });
 
-  test("proxy object without url is ignored (regression #25413)", async () => {
-    // When proxy object doesn't have a 'url' property, it should be ignored
-    // This ensures compatibility with libraries that pass URL objects as proxy
-    const response = await fetch(httpServer.url, {
-      method: "GET",
-      proxy: {
-        headers: { "X-Test": "value" },
-      } as any,
-      keepalive: false,
-    });
-    expect(response.ok).toBe(true);
-    expect(response.status).toBe(200);
+  test("proxy object without url throws (was silently ignored for #25413)", async () => {
+    // #25413 was caused by the old node:http → native fetch() shim passing a
+    // junk object here; that shim no longer exists, so fail closed rather than
+    // silently connecting direct to the origin.
+    await expect(
+      fetch(httpServer.url, {
+        method: "GET",
+        proxy: { headers: { "X-Test": "value" } } as any,
+        keepalive: false,
+      }),
+    ).rejects.toThrowError(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
   });
 
-  test("proxy object with null url is ignored (regression #25413)", async () => {
-    // When proxy.url is null, the proxy object should be ignored
-    const response = await fetch(httpServer.url, {
-      method: "GET",
-      proxy: {
-        url: null,
-        headers: { "X-Test": "value" },
-      } as any,
-      keepalive: false,
-    });
-    expect(response.ok).toBe(true);
-    expect(response.status).toBe(200);
+  test("proxy object with null url throws (was silently ignored for #25413)", async () => {
+    await expect(
+      fetch(httpServer.url, {
+        method: "GET",
+        proxy: { url: null, headers: { "X-Test": "value" } } as any,
+        keepalive: false,
+      }),
+    ).rejects.toThrowError(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
   });
 
   test("proxy object with empty string url throws error", async () => {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -380,10 +380,6 @@ test("unsupported protocol", async () => {
   );
 });
 
-// https://github.com/oven-sh/bun/issues/8150
-// A malformed proxy *string* already rejects with ERR_INVALID_ARG_VALUE, but a
-// wrong-typed proxy *value* (number/array/boolean/object without `url`) used to
-// be silently ignored so the request went direct to the origin.
 describe("proxy option validation", () => {
   test("rejects wrong-typed values instead of silently going direct", async () => {
     const hits: string[] = [];

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -463,7 +463,7 @@ describe("proxy option validation", () => {
   });
 
   test("WebSocket: rejects wrong-typed values instead of silently going direct", async () => {
-    let directHit = false;
+    let directHits = 0;
     await using origin = Bun.serve({
       port: 0,
       hostname: "127.0.0.1",
@@ -473,7 +473,7 @@ describe("proxy option validation", () => {
       },
       websocket: {
         open(ws) {
-          directHit = true;
+          directHits++;
           ws.close();
         },
         message() {},
@@ -496,19 +496,19 @@ describe("proxy option validation", () => {
         }),
       );
     }
-    expect(directHit).toBe(false);
+    expect(directHits).toBe(0);
 
     // null / empty string / undefined remain the "no proxy" sentinels: the
     // constructor must not throw and the socket must reach the origin directly.
     for (const value of [null, "", undefined]) {
-      const { promise, resolve } = Promise.withResolvers<void>();
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
       const ws = new WebSocket(`ws://127.0.0.1:${origin.port}/`, { proxy: value } as any);
       ws.onopen = () => ws.close();
       ws.onclose = () => resolve();
-      ws.onerror = () => resolve();
+      ws.onerror = ev => reject(new Error(`proxy: ${JSON.stringify(value)} errored: ${(ev as ErrorEvent).message}`));
       await promise;
     }
-    expect(directHit).toBe(true);
+    expect(directHits).toBe(3);
   });
 });
 

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -451,7 +451,11 @@ describe("proxy option validation", () => {
     expect(hits).toEqual(["/null", "/empty", "/undef"]);
   });
 
-  test("valid string / URL / {url} shapes still route through the proxy", async () => {
+  test("valid string / URL / {url} shapes are accepted (not rejected by validation)", async () => {
+    // Proxy routing for each shape is covered by the matrix tests and the
+    // "proxy as URL instance ..." / "proxy object with url string ..." tests
+    // elsewhere in this file; this check only guards against the new
+    // ERR_INVALID_ARG_TYPE validation over-rejecting valid shapes.
     for (const value of [httpProxyServer.url, new URL(httpProxyServer.url), { url: httpProxyServer.url }]) {
       const response = await fetch(httpServer.url, {
         method: "POST",


### PR DESCRIPTION
## What

`fetch(url, { proxy })` and `new WebSocket(url, { proxy })` with a wrong-typed `proxy` value (number, array, boolean, object without a `url` property) were silently ignored and the request went **direct** to the origin. A malformed proxy *string* already rejects with `TypeError: fetch() proxy URL is invalid` (`ERR_INVALID_ARG_VALUE`), so the string path fails closed but the type-mismatch path failed open.

```js
const origin = Bun.serve({ port: 0, fetch: () => new Response("DIRECT") });
await fetch(origin.url, { proxy: 42 });              // before: went DIRECT; now: rejects
await fetch(origin.url, { proxy: [proxyUrl] });      // before: went DIRECT; now: rejects
await fetch(origin.url, { proxy: true });            // before: went DIRECT; now: rejects
await fetch(origin.url, { proxy: { proxyUrl } });    // before: went DIRECT; now: rejects (no "url" key)
await fetch(origin.url, { proxy: "http//x" });       // unchanged: rejects (ERR_INVALID_ARG_VALUE)
new WebSocket(wsUrl, { proxy: 42 });                 // before: connected DIRECT; now: throws
```

A program that ends up with a non-string proxy value (config split into an array, `{url}` mistyped as `{proxyUrl}`, `parseInt` on a port, a truthy flag) silently loses its proxy and connects straight to the origin.

## Cause

`'extract_proxy` in `src/runtime/webcore/fetch.rs` and `constructJSWebSocket3` in `src/jsc/bindings/webcore/JSWebSocket.cpp` both check for a string/`URL` instance, then an object with a `url` property, then **fall through with no error**, leaving the proxy unset.

## Fix

After the string/URL and `{url}` branches, any remaining value rejects with `ERR_INVALID_ARG_TYPE`. `null` and the empty string are treated as explicit "no proxy" sentinels and short-circuit before validation (unchanged observable behavior; `undefined` is already filtered).

### Supersedes the #25413 workaround

PR #25414 made objects without `url` silently ignored because the old `node:http` shim called native `fetch()` with a junk object as `proxy` (#25413). That shim no longer exists: `_http_client.ts` uses raw sockets and never calls native `fetch()` with a `proxy` option. The two regression tests asserting the old ignore behavior are updated to expect the new `TypeError`.

## Verification

New tests in `test/js/bun/http/proxy.test.ts` under `proxy option validation`:

- `rejects wrong-typed values instead of silently going direct`: 7 invalid shapes reject with `ERR_INVALID_ARG_TYPE`, the 2 existing bad-value shapes keep rejecting with `ERR_INVALID_ARG_VALUE`, and the origin server records zero hits.
- `null / empty string / undefined mean 'no proxy'`: still resolve and hit the origin directly.
- `valid string / URL / {url} shapes are accepted (not rejected by validation)`: non-regression smoke test.
- `WebSocket: rejects wrong-typed values instead of silently going direct`: the WebSocket constructor throws `ERR_INVALID_ARG_TYPE` for the same 6 invalid shapes, and `null`/`""`/`undefined` still connect direct.

With `src/` stashed the first and last tests fail; with the fix, all 72 tests in the file pass.
