### PR TITLE
install: honor --recursive/--filter in non-interactive bun update; re-resolve every named-update target

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -665,6 +665,16 @@ pub struct UpdateTargetWorkspace {
     pub name: Box<[u8]>,
 }
 
+impl UpdateTargetWorkspace {
+    /// Root is unique, so `is_root` alone identifies it; members match by hash then name.
+    pub fn matches(&self, is_root: bool, name_hash: PackageNameHash, name: &[u8]) -> bool {
+        if self.is_root || is_root {
+            return self.is_root && is_root;
+        }
+        self.name_hash == name_hash && &*self.name == name
+    }
+}
+
 #[derive(Default)]
 pub enum TrackInstalledBin {
     #[default]

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -407,7 +407,7 @@ pub struct PackageManager {
     pub updating_catalogs: Vec<CatalogUpdateInfo>,
 
     // `bun update -r`/`--filter`: workspaces whose deps update. None = cwd only.
-    pub(crate) update_target_workspaces: Option<Box<[(PackageNameHash, Box<[u8]>)]>>,
+    pub(crate) update_target_workspaces: Option<Box<[UpdateTargetWorkspace]>>,
 
     pub(crate) patched_dependencies_to_remove:
         ArrayHashMap<PackageNameAndVersionHash, () /* , ArrayIdentityContext::U64, false */>,
@@ -657,6 +657,12 @@ pub struct CatalogUpdateInfo {
     pub dep_name: Box<[u8]>,
     pub original_version_literal: Box<[u8]>,
     pub is_alias: bool,
+}
+
+pub struct UpdateTargetWorkspace {
+    pub is_root: bool,
+    pub name_hash: PackageNameHash,
+    pub name: Box<[u8]>,
 }
 
 #[derive(Default)]

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -406,6 +406,9 @@ pub struct PackageManager {
     // (catalog name, dependency name) -> original version literal
     pub updating_catalogs: Vec<CatalogUpdateInfo>,
 
+    // `bun update -r`/`--filter`: workspaces whose deps update. None = cwd only.
+    pub(crate) update_target_workspaces: Option<Box<[(PackageNameHash, Box<[u8]>)]>>,
+
     pub(crate) patched_dependencies_to_remove:
         ArrayHashMap<PackageNameAndVersionHash, () /* , ArrayIdentityContext::U64, false */>,
 
@@ -544,6 +547,97 @@ impl WorkspaceFilter {
         } else {
             WorkspaceFilter::Name(buf)
         })
+    }
+
+    /// Every workspace (root included), filtered by `filter_patterns` (empty = all).
+    pub fn select_workspaces(
+        lockfile: &crate::Lockfile,
+        filter_patterns: &[&[u8]],
+        original_cwd: &[u8],
+    ) -> Vec<PackageID> {
+        use crate::lockfile::package::PackageColumns as _;
+
+        let packages = lockfile.packages.slice();
+        let pkg_names = packages.items_name();
+        let pkg_resolutions = packages.items_resolution();
+        let string_buf = lockfile.buffers.string_bytes.as_slice();
+
+        let mut ids: Vec<PackageID> = Vec::new();
+        for (pkg_id, res) in pkg_resolutions.iter().enumerate() {
+            if res.tag == crate::resolution::Tag::Workspace
+                || res.tag == crate::resolution::Tag::Root
+            {
+                ids.push(pkg_id as PackageID);
+            }
+        }
+
+        if filter_patterns.is_empty() {
+            return ids;
+        }
+
+        let mut path_buf = PathBuffer::uninit();
+        let converted_filters: Vec<WorkspaceFilter> = filter_patterns
+            .iter()
+            .map(|filter| {
+                bun_core::handle_oom(WorkspaceFilter::init(filter, original_cwd, &mut path_buf.0))
+            })
+            .collect();
+
+        let top_level_dir = FileSystem::instance().top_level_dir();
+
+        let has_positive = converted_filters.iter().any(|f| match f {
+            WorkspaceFilter::All => true,
+            WorkspaceFilter::Path(p) | WorkspaceFilter::Name(p) => p.first() != Some(&b'!'),
+        });
+
+        let mut i = 0;
+        while i < ids.len() {
+            let pkg_id = ids[i];
+            let mut matched = !has_positive;
+            for filter in &converted_filters {
+                let (pattern, subject): (&[u8], &[u8]) = match filter {
+                    WorkspaceFilter::All => {
+                        matched = true;
+                        continue;
+                    }
+                    WorkspaceFilter::Path(pattern) => {
+                        if pattern.is_empty() {
+                            continue;
+                        }
+                        let res = &pkg_resolutions[pkg_id as usize];
+                        let res_path: &[u8] = match res.tag {
+                            crate::resolution::Tag::Workspace => res.workspace().slice(string_buf),
+                            crate::resolution::Tag::Root => top_level_dir,
+                            _ => unreachable!(),
+                        };
+                        let abs = resolve_path::join_abs_string_buf::<platform::Posix>(
+                            top_level_dir,
+                            &mut path_buf.0,
+                            &[res_path],
+                        );
+                        (pattern, strings::without_trailing_slash(abs))
+                    }
+                    WorkspaceFilter::Name(pattern) => {
+                        (pattern, pkg_names[pkg_id as usize].slice(string_buf))
+                    }
+                };
+                if pattern.first() == Some(&b'!') {
+                    if bun_glob::r#match(&pattern[1..], subject).matches() {
+                        matched = false;
+                        break;
+                    }
+                } else if bun_glob::r#match(pattern, subject).matches() {
+                    matched = true;
+                }
+            }
+            if matched {
+                i += 1;
+            } else {
+                ids.swap_remove(i);
+            }
+        }
+
+        ids
     }
 }
 
@@ -1945,6 +2039,7 @@ pub fn init(
         wr!(any_failed_to_install, false);
         wr!(updating_packages, StringArrayHashMap::default());
         wr!(updating_catalogs, Vec::new());
+        wr!(update_target_workspaces, None);
         wr!(patched_dependencies_to_remove, ArrayHashMap::default());
         wr!(last_reported_slow_lifecycle_script_at, 0);
         wr!(cached_tick_for_slow_lifecycle_script_logging, 0);
@@ -2383,6 +2478,7 @@ fn init_with_runtime_once(
         );
         wr!(updating_packages, StringArrayHashMap::default());
         wr!(updating_catalogs, Vec::new());
+        wr!(update_target_workspaces, None);
         wr!(patched_dependencies_to_remove, ArrayHashMap::default());
         wr!(last_reported_slow_lifecycle_script_at, 0);
         wr!(cached_tick_for_slow_lifecycle_script_logging, 0);

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1,4 +1,4 @@
-use bun_collections::VecExt;
+use bun_collections::{StringArrayHashMap, VecExt};
 use std::io::Write as _;
 
 use bun_ast as js_ast;
@@ -9,7 +9,7 @@ use bun_semver as semver;
 use bun_install::dependency::{self, TagExt as _};
 use bun_install::lockfile::package::PackageColumns as _;
 use bun_install::{Dependency, INVALID_PACKAGE_ID, resolution};
-use bun_install_types::DependencyGroup;
+use bun_install_types::{DependencyGroup, PackageNameHash};
 
 use super::package_manager_options::{Do, Enable};
 use super::{CatalogUpdateInfo, PackageManager, PackageUpdateInfo, Subcommand, UpdateRequest};
@@ -245,16 +245,31 @@ pub(crate) fn edit_update_no_args(
     current_package_json: &mut Expr,
     options: EditOptions,
 ) -> Result<(), bun_alloc::AllocError> {
+    edit_update_no_args_in(
+        &manager.lockfile,
+        &manager.ast_arena,
+        &mut manager.updating_packages,
+        manager.workspace_name_hash,
+        manager.options.do_.contains(Do::UPDATE_TO_LATEST),
+        current_package_json,
+        options,
+    )
+}
+
+/// Split-borrow variant: callers holding a `&mut` to another `PackageManager` field can use this.
+pub(crate) fn edit_update_no_args_in(
+    lockfile: &crate::Lockfile,
+    arena: &bun_alloc::Arena,
+    updating_packages: &mut StringArrayHashMap<PackageUpdateInfo>,
+    workspace_name_hash: Option<PackageNameHash>,
+    update_to_latest: bool,
+    current_package_json: &mut Expr,
+    options: EditOptions,
+) -> Result<(), bun_alloc::AllocError> {
     // using data store is going to result in undefined memory issues as
     // the store is cleared in some workspace situations. the solution
     // is to always avoid the store
     let _guard = ExprDisabler::scope();
-
-    // Process-lifetime arena for AST
-    // nodes that must outlive `Expr.Data.Store.reset()`. See `PackageManager.ast_arena`.
-    // `arena` is a disjoint-field borrow held across
-    // the `&mut manager.updating_packages` accesses below.
-    let arena = &manager.ast_arena;
 
     for group in DEPENDENCY_GROUPS {
         let group_str = group.prop;
@@ -287,8 +302,7 @@ pub(crate) fn edit_update_no_args(
 
                         // npm versions only (and dist-tags with --latest); `catalog:` is handled by edit_catalogs_*.
                         if tag != dependency::Tag::Npm
-                            && (tag != dependency::Tag::DistTag
-                                || !manager.options.do_.contains(Do::UPDATE_TO_LATEST))
+                            && (tag != dependency::Tag::DistTag || !update_to_latest)
                         {
                             continue;
                         }
@@ -304,8 +318,7 @@ pub(crate) fn edit_update_no_args(
                             {
                                 tag = dependency::Tag::infer(&version_literal[at_index + 1..]);
                                 if tag != dependency::Tag::Npm
-                                    && (tag != dependency::Tag::DistTag
-                                        || !manager.options.do_.contains(Do::UPDATE_TO_LATEST))
+                                    && (tag != dependency::Tag::DistTag || !update_to_latest)
                                 {
                                     continue;
                                 }
@@ -315,9 +328,9 @@ pub(crate) fn edit_update_no_args(
 
                         let key_str = key.as_utf8_string_literal().expect("unreachable");
                         // Capture the literal as an owned
-                        // copy before borrowing `manager.updating_packages` mutably.
+                        // copy before borrowing `updating_packages` mutably.
                         let version_literal_owned = Box::<[u8]>::from(version_literal);
-                        let entry = manager.updating_packages.get_or_put(key_str)?;
+                        let entry = updating_packages.get_or_put(key_str)?;
 
                         // If a dependency is present in more than one dependency group, only one of it's versions
                         // will be updated. The group is determined by the order of `dependency_groups`, the same
@@ -333,7 +346,7 @@ pub(crate) fn edit_update_no_args(
                             original_version: None,
                         };
 
-                        if manager.options.do_.contains(Do::UPDATE_TO_LATEST) {
+                        if update_to_latest {
                             // is it an aliased package
                             let temp_version: &[u8] = if let Some(at_index) = alias_at_index {
                                 let mut v = Vec::new();
@@ -356,10 +369,9 @@ pub(crate) fn edit_update_no_args(
                         }
                     }
                 } else {
-                    let lockfile = &*manager.lockfile;
                     let string_buf = lockfile.buffers.string_bytes.as_slice();
                     let workspace_package_id =
-                        lockfile.get_workspace_package_id(manager.workspace_name_hash);
+                        lockfile.get_workspace_package_id(workspace_name_hash);
                     let packages = lockfile.packages.slice();
                     let resolutions = packages.items_resolution();
                     let deps = packages.items_dependencies()[workspace_package_id as usize];
@@ -402,9 +414,7 @@ pub(crate) fn edit_update_no_args(
                         'updated: {
                             // fetchSwapRemove because we want to update the first dependency with a matching
                             // name, or none at all
-                            if let Some(entry) =
-                                manager.updating_packages.fetch_swap_remove(key_str)
-                            {
+                            if let Some(entry) = updating_packages.fetch_swap_remove(key_str) {
                                 let is_alias = entry.value.is_alias;
                                 let dep_name = &*entry.key;
                                 debug_assert_eq!(
@@ -434,9 +444,7 @@ pub(crate) fn edit_update_no_args(
                                     if let Some(npm_version) = resolved_version.try_npm() {
                                         // It's possible we inserted a dependency that won't update (version is an exact version).
                                         // If we find one, skip to keep the original version literal.
-                                        if !manager.options.do_.contains(Do::UPDATE_TO_LATEST)
-                                            && npm_version.version.is_exact()
-                                        {
+                                        if !update_to_latest && npm_version.version.is_exact() {
                                             break 'updated;
                                         }
                                     }

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -20,9 +20,9 @@ use crate::lockfile::PackageIndexEntry;
 use crate::lockfile::package::Package;
 use crate::lockfile_real as Lockfile;
 use crate::package_manager_real::{
-    self, FailFn, PackageManager, SuccessFn, TaskCallbackList, determine_preinstall_state,
-    get_cache_directory, get_preinstall_state, get_temporary_directory, run_tasks,
-    set_preinstall_state,
+    self, FailFn, PackageManager, SuccessFn, TaskCallbackList, UpdateRequest,
+    determine_preinstall_state, get_cache_directory, get_preinstall_state, get_temporary_directory,
+    run_tasks, set_preinstall_state,
 };
 use crate::package_manager_task as Task;
 use crate::patch_install::EnqueueAfterState;
@@ -1970,22 +1970,32 @@ fn get_or_put_resolved_package_with_find_result(
 ) -> crate::Result<Option<ResolvedPackageResult>> {
     // reshaped for borrowck — `is_root_dependency(&self, &mut PackageManager, …)`
     // borrows `this.lockfile` and `this` at once. Split via raw root.
-    let should_update = {
-        let this_ptr: *mut PackageManager = this;
-        // SAFETY: `is_root_dependency` reads `manager.root_dependency_list` /
-        // `manager.workspace_package_json_cache` only — disjoint from
-        // `manager.lockfile`.
-        this.to_update
-            // Update direct deps of the current workspace; catalogs are root-scoped.
-            && (dependency.version.tag == dependency::version::Tag::Catalog
+    let should_update = this.to_update
+        && if !this.update_requests.is_empty() {
+            // `bun update <name>`: every `<name>` slot, else other resolutions stay pinned.
+            UpdateRequest::contains_name(
+                &this.update_requests,
+                dependency.name_hash,
+                dependency
+                    .name
+                    .slice(this.lockfile.buffers.string_bytes.as_slice()),
+            )
+        } else if let Some(targets) = this.update_target_workspaces.as_deref() {
+            // `bun update -r`/`--filter`: direct deps of the selected workspaces; catalogs are root-scoped.
+            dependency.version.tag == dependency::version::Tag::Catalog
+                || this
+                    .lockfile
+                    .is_dependency_of_workspace_in(targets, dependency_id)
+        } else {
+            // Bare `bun update`: direct deps of the cwd workspace; catalogs are root-scoped.
+            let this_ptr: *mut PackageManager = this;
+            // SAFETY: `is_root_dependency` reads `manager.root_dependency_list` /
+            // `manager.workspace_package_json_cache` only — disjoint from
+            // `manager.lockfile`.
+            dependency.version.tag == dependency::version::Tag::Catalog
                 || unsafe { &*(*this_ptr).lockfile }
-                    .is_root_dependency(unsafe { &mut *this_ptr }, dependency_id))
-            // no need to do a look up if update requests are empty (`bun update` with no args)
-            && (this.update_requests.is_empty()
-                || this.updating_packages.contains(
-                    dependency.name.slice(this.lockfile.buffers.string_bytes.as_slice()),
-                ))
-    };
+                    .is_root_dependency(unsafe { &mut *this_ptr }, dependency_id)
+        };
 
     // Was this package already allocated? Let's reuse the existing one.
     //
@@ -2372,7 +2382,32 @@ fn get_or_put_resolved_package(
             };
             let manifest: &Npm::PackageManifest = manifest;
 
+            // `bun update -r/--filter --latest`: resolve targeted workspaces' npm deps by dist-tag `latest`.
+            let latest_for_target = matches!(
+                dependency.version.tag,
+                dependency::version::Tag::Npm | dependency::version::Tag::DistTag
+            ) && version.tag == dependency.version.tag
+                && {
+                    let buf = this.lockfile.buffers.string_bytes.as_slice();
+                    version.literal.eql(dependency.version.literal, buf, buf)
+                }
+                && this.to_update
+                && this.update_requests.is_empty()
+                && this
+                    .options
+                    .do_
+                    .contains(crate::package_manager::options::Do::UPDATE_TO_LATEST)
+                && this.update_target_workspaces.as_deref().is_some_and(|t| {
+                    this.lockfile
+                        .is_dependency_of_workspace_in(t, dependency_id)
+                });
+
             let version_result: Npm::FindVersionResult = match version.tag {
+                _ if latest_for_target => manifest.find_by_dist_tag_with_filter(
+                    b"latest",
+                    this.options.minimum_release_age_ms,
+                    this.options.minimum_release_age_excludes,
+                ),
                 // SAFETY: `version.tag` discriminates the union arm.
                 dependency::version::Tag::DistTag => manifest.find_by_dist_tag_with_filter(
                     this.lockfile.str(&version.dist_tag().tag),

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -654,6 +654,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
         _ => dependency.name_hash,
     };
 
+    let mut version_was_replaced = true;
     let version: dependency::Version = 'version: {
         if dependency.version.tag == dependency::version::Tag::Npm {
             if let Some(aliased) = this.known_npm_aliases.get(&name_hash) {
@@ -746,6 +747,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
 
         // explicit copy here due to `dependency.version` becoming undefined
         // when `getOrPutResolvedPackageWithFindResult` is called and resizes the list.
+        version_was_replaced = false;
         break 'version dependency.version.clone();
     };
     let mut loaded_manifest: Option<Npm::PackageManifest> = None;
@@ -761,6 +763,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     name,
                     dependency,
                     &version,
+                    version_was_replaced,
                     dependency.behavior,
                     id,
                     resolution,
@@ -1360,6 +1363,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 name,
                 dependency,
                 &version,
+                version_was_replaced,
                 dependency.behavior,
                 id,
                 resolution,
@@ -2173,6 +2177,7 @@ fn get_or_put_resolved_package(
     name: SemverString,
     dependency: &Dependency,
     version: &dependency::Version,
+    version_was_replaced: bool,
     behavior: Behavior,
     dependency_id: DependencyID,
     resolution: PackageID,
@@ -2383,14 +2388,11 @@ fn get_or_put_resolved_package(
             let manifest: &Npm::PackageManifest = manifest;
 
             // `bun update -r/--filter --latest`: resolve targeted workspaces' npm deps by dist-tag `latest`.
-            let latest_for_target = matches!(
-                dependency.version.tag,
-                dependency::version::Tag::Npm | dependency::version::Tag::DistTag
-            ) && version.tag == dependency.version.tag
-                && {
-                    let buf = this.lockfile.buffers.string_bytes.as_slice();
-                    version.literal.eql(dependency.version.literal, buf, buf)
-                }
+            let latest_for_target = !version_was_replaced
+                && matches!(
+                    version.tag,
+                    dependency::version::Tag::Npm | dependency::version::Tag::DistTag
+                )
                 && this.to_update
                 && this.update_requests.is_empty()
                 && this

--- a/src/install/PackageManager/UpdateRequest.rs
+++ b/src/install/PackageManager/UpdateRequest.rs
@@ -70,6 +70,18 @@ fn anchor_cli_bytes(b: Box<[u8]>) -> &'static [u8] {
 }
 
 impl UpdateRequest {
+    /// Is `name` one of the `bun update <name>` targets? `false` for a bare `bun update`.
+    #[inline]
+    pub fn contains_name(
+        requests: &[UpdateRequest],
+        name_hash: PackageNameHash,
+        name: &[u8],
+    ) -> bool {
+        requests
+            .iter()
+            .any(|r| r.name_hash == name_hash && (r.name.is_empty() || r.name == name))
+    }
+
     /// Borrow the backing string buffer.
     ///
     /// SAFETY for callers: the buffer this points into (leaked CLI input, or

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -36,8 +36,8 @@ use bun_install_types::NodeLinker::NodeLinker;
 // to avoid one giant `impl PackageManager` block.
 use crate::package_manager_real::run_tasks::{RunTasksCallbacks, run_tasks};
 use crate::package_manager_real::{
-    enqueue_dependency_list, enqueue_dependency_with_main, enqueue_patch_task_pre, save_lockfile,
-    setup_global_dir, update_lockfile_if_needed, write_yarn_lock,
+    UpdateRequest, enqueue_dependency_list, enqueue_dependency_with_main, enqueue_patch_task_pre,
+    save_lockfile, setup_global_dir, update_lockfile_if_needed, write_yarn_lock,
 };
 
 use super::security_scanner;
@@ -523,6 +523,34 @@ pub fn install_with_manager(
                                 false,
                             ) {
                                 add_dependency_error(manager, &dep, err);
+                            }
+                        }
+                    }
+
+                    // `bun update <name>`: drop and re-enqueue every `<name>` slot, not just root-level.
+                    if manager.to_update && !manager.update_requests.is_empty() {
+                        let dependencies_len = manager.lockfile.buffers.dependencies.len();
+                        for dependency_i in 0..dependencies_len {
+                            let dependency =
+                                manager.lockfile.buffers.dependencies[dependency_i].clone();
+                            if UpdateRequest::contains_name(
+                                &manager.update_requests,
+                                dependency.name_hash,
+                                dependency
+                                    .name
+                                    .slice(manager.lockfile.buffers.string_bytes.as_slice()),
+                            ) {
+                                manager.lockfile.buffers.resolutions[dependency_i] =
+                                    invalid_package_id;
+                                if let Err(err) = enqueue_dependency_with_main(
+                                    manager,
+                                    dependency_i as u32,
+                                    &dependency,
+                                    invalid_package_id,
+                                    false,
+                                ) {
+                                    add_dependency_error(manager, &dependency, err);
+                                }
                             }
                         }
                     }

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -975,10 +975,7 @@ fn write_resolved_versions_to_targets(
         };
         let hash = pkg_name_hashes[pkg_id];
         let name = pkg_names[pkg_id].slice(manager.lockfile.buffers.string_bytes.as_slice());
-        if !targets
-            .iter()
-            .any(|t| t.is_root == is_root && t.name_hash == hash && &*t.name == name)
-        {
+        if !targets.iter().any(|t| t.matches(is_root, hash, name)) {
             continue;
         }
         let mut path_buf = PathBuffer::uninit();

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -19,7 +19,7 @@ use super::command_line_arguments::CommandLineArguments;
 use super::package_json_editor as PackageJSONEditor;
 use super::update_request::Array as UpdateRequestArray;
 use super::{
-    Command, PackageManager, PatchCommitResult, Subcommand, UpdateRequest,
+    Command, PackageManager, PatchCommitResult, Subcommand, UpdateRequest, WorkspaceFilter,
     attempt_to_create_package_json, install_with_manager, patch_package,
 };
 
@@ -150,6 +150,58 @@ fn update_package_json_and_install_with_manager_with_updates(
                 .print(std::ptr::from_mut(Output::error_writer()));
         }
         Global::crash();
+    }
+
+    if subcommand == Subcommand::Update
+        && updates.is_empty()
+        && (manager.options.do_.recursive() || !manager.options.filter_patterns.is_empty())
+        && manager.options.do_.load_lockfile()
+    {
+        match manager.load_lockfile_from_cwd::<true>() {
+            crate::lockfile::LoadResult::Ok(_) => {}
+            crate::lockfile::LoadResult::NotFound => {
+                if log_level != LogLevel::Silent {
+                    Output::err_generic("missing lockfile, nothing to update", ());
+                }
+                Global::crash();
+            }
+            crate::lockfile::LoadResult::Err(cause) => {
+                if log_level != LogLevel::Silent {
+                    let what: &str = match cause.step {
+                        crate::lockfile::LoadStep::OpenFile => "open",
+                        crate::lockfile::LoadStep::ReadFile => "read",
+                        crate::lockfile::LoadStep::ParseFile => "parse",
+                        crate::lockfile::LoadStep::Migrating => "migrate",
+                    };
+                    Output::err_generic("failed to {s} lockfile: {s}", (what, cause.value.name()));
+                    if manager.log_mut().has_errors() {
+                        let _ = manager
+                            .log_mut()
+                            .print(std::ptr::from_mut(Output::error_writer()));
+                    }
+                }
+                Global::crash();
+            }
+        }
+        let selected = WorkspaceFilter::select_workspaces(
+            &manager.lockfile,
+            manager.options.filter_patterns,
+            original_cwd,
+        );
+        let name_hashes = manager.lockfile.packages.items_name_hash();
+        let names = manager.lockfile.packages.items_name();
+        let sbuf = manager.lockfile.buffers.string_bytes.as_slice();
+        manager.update_target_workspaces = Some(
+            selected
+                .iter()
+                .map(|&id| {
+                    (
+                        name_hashes[id as usize],
+                        Box::from(names[id as usize].slice(sbuf)),
+                    )
+                })
+                .collect(),
+        );
     }
 
     // reshaped for borrowck — `get_with_path` returns `&mut MapEntry`
@@ -352,7 +404,8 @@ fn update_package_json_and_install_with_manager_with_updates(
                 // `edit` may shrink the slice.
                 let new_len = updates_slice.len();
                 updates.truncate(new_len);
-            } else if subcommand == Subcommand::Update {
+            } else if subcommand == Subcommand::Update && manager.update_target_workspaces.is_none()
+            {
                 PackageJSONEditor::edit_update_no_args(
                     manager,
                     &mut current_package_json_root,
@@ -546,7 +599,17 @@ fn update_package_json_and_install_with_manager_with_updates(
             );
         }
 
-        if subcommand == Subcommand::Update && manager.update_requests.is_empty() {
+        let root_is_targeted = manager.update_target_workspaces.as_deref().is_none_or(|t| {
+            let h = manager.lockfile.packages.items_name_hash()[0];
+            let n = manager.lockfile.packages.items_name()[0]
+                .slice(manager.lockfile.buffers.string_bytes.as_slice());
+            t.iter().any(|(th, tn)| *th == h && &**tn == n)
+        });
+
+        if subcommand == Subcommand::Update
+            && manager.update_requests.is_empty()
+            && root_is_targeted
+        {
             let root_package_json_root: bun_ast::Expr = root_package_json.root;
             if PackageJSONEditor::edit_catalogs_before_update(manager, &root_package_json_root)? {
                 editing_catalogs = true;
@@ -608,16 +671,21 @@ fn update_package_json_and_install_with_manager_with_updates(
             };
 
         if updates.is_empty() {
-            PackageJSONEditor::edit_update_no_args(
-                manager,
-                &mut new_package_json,
-                EditOptions {
-                    exact_versions: manager.options.enable.exact_versions(),
-                    ..Default::default()
-                },
-            )?;
+            if manager.update_target_workspaces.is_none() {
+                PackageJSONEditor::edit_update_no_args(
+                    manager,
+                    &mut new_package_json,
+                    EditOptions {
+                        exact_versions: manager.options.enable.exact_versions(),
+                        ..Default::default()
+                    },
+                )?;
+            }
 
-            if editing_catalogs && manager.workspace_name_hash.is_none() {
+            if editing_catalogs
+                && manager.workspace_name_hash.is_none()
+                && manager.update_target_workspaces.is_none()
+            {
                 // running from root: catalogs live in this file.
                 let _ = PackageJSONEditor::edit_catalogs_after_update(
                     manager,
@@ -676,10 +744,10 @@ fn update_package_json_and_install_with_manager_with_updates(
     }
 
     if editing_catalogs
-        && manager.workspace_name_hash.is_some()
+        && (manager.workspace_name_hash.is_some() || manager.update_target_workspaces.is_some())
         && manager.options.do_.contains(Do::WRITE_PACKAGE_JSON)
     {
-        // running from a workspace: catalogs live in the root package.json (a separate file).
+        // running from a workspace, or with -r/--filter: catalogs live in the root package.json.
         let root_package_json_ptr: *mut MapEntry =
             match manager.workspace_package_json_cache.get_with_path(
                 manager.log_mut(),
@@ -726,21 +794,31 @@ fn update_package_json_and_install_with_manager_with_updates(
         if root_catalogs_changed {
             print_package_json_into_cache_entry(root_package_json, root_package_json_root);
 
-            let root_package_json_file =
-                File::openat(Fd::cwd(), root_package_json_path, bun_sys::O::RDWR, 0)
+            // the targets loop below writes root (with deps + catalogs) in one pass.
+            if manager.update_target_workspaces.is_none() {
+                let root_package_json_file =
+                    File::openat(Fd::cwd(), root_package_json_path, bun_sys::O::RDWR, 0)
+                        .map_err(Error::from)?;
+                root_package_json_file
+                    .pwrite_all(&root_package_json.source.contents, 0)
                     .map_err(Error::from)?;
-            root_package_json_file
-                .pwrite_all(&root_package_json.source.contents, 0)
-                .map_err(Error::from)?;
-            let _ = bun_sys::ftruncate(
-                root_package_json_file.handle,
-                root_package_json.source.contents.len() as i64,
-            );
-            let _ = root_package_json_file.close(); // close error is non-actionable
+                let _ = bun_sys::ftruncate(
+                    root_package_json_file.handle,
+                    root_package_json.source.contents.len() as i64,
+                );
+                let _ = root_package_json_file.close(); // close error is non-actionable
+            }
         }
     }
 
     let _ = written;
+
+    if let Some(targets) = manager.update_target_workspaces.take() {
+        if manager.options.do_.contains(Do::WRITE_PACKAGE_JSON) {
+            write_resolved_versions_to_targets(manager, &targets)?;
+        }
+        return Ok(());
+    }
 
     if manager.options.do_.contains(Do::WRITE_PACKAGE_JSON) {
         let (source, path): (&[u8], &ZStr) =
@@ -868,6 +946,102 @@ fn update_package_json_and_install_with_manager_with_updates(
         }
     }
 
+    Ok(())
+}
+
+fn write_resolved_versions_to_targets(
+    manager: &mut PackageManager,
+    targets: &[(crate::PackageNameHash, Box<[u8]>)],
+) -> Result<(), Error> {
+    let top_level = strings::without_trailing_slash(FileSystem::instance().top_level_dir());
+    let update_to_latest = manager.options.do_.contains(Do::UPDATE_TO_LATEST);
+    let exact_versions = manager.options.enable.exact_versions();
+    let log = manager.log_mut();
+    let mut any_failed = false;
+
+    for (hash, name) in targets {
+        let pkg_id = manager.lockfile.get_workspace_package_id(Some(*hash));
+        if manager.lockfile.packages.items_name_hash()[pkg_id as usize] != *hash {
+            continue;
+        }
+        let res = manager.lockfile.packages.items_resolution()[pkg_id as usize];
+        let ws_name_hash = if res.tag == crate::resolution::Tag::Root {
+            None
+        } else {
+            Some(*hash)
+        };
+        let rel: &[u8] = if res.tag == crate::resolution::Tag::Workspace {
+            res.workspace()
+                .slice(manager.lockfile.buffers.string_bytes.as_slice())
+        } else {
+            b""
+        };
+        let mut path_buf = PathBuffer::uninit();
+        let path: &[u8] = bun_paths::resolve_path::join_abs_string_buf::<
+            bun_paths::resolve_path::platform::Auto,
+        >(top_level, &mut path_buf.0, &[rel, b"package.json"]);
+
+        let entry = match manager.workspace_package_json_cache.get_with_path(
+            log,
+            path,
+            GetJSONOptions {
+                guess_indentation: true,
+                ..Default::default()
+            },
+        ) {
+            GetResult::Entry(e) => e,
+            GetResult::ParseErr(err) | GetResult::ReadErr(err) => {
+                Output::err_generic(
+                    "failed to read/parse package.json for workspace '{s}': {s}",
+                    (bstr::BStr::new(name), err.name()),
+                );
+                any_failed = true;
+                continue;
+            }
+        };
+
+        let mut ast = entry.root;
+        let mut updating = bun_collections::StringArrayHashMap::default();
+        PackageJSONEditor::edit_update_no_args_in(
+            &manager.lockfile,
+            &manager.ast_arena,
+            &mut updating,
+            ws_name_hash,
+            update_to_latest,
+            &mut ast,
+            EditOptions {
+                exact_versions: true,
+                before_install: true,
+                ..Default::default()
+            },
+        )?;
+        PackageJSONEditor::edit_update_no_args_in(
+            &manager.lockfile,
+            &manager.ast_arena,
+            &mut updating,
+            ws_name_hash,
+            update_to_latest,
+            &mut ast,
+            EditOptions {
+                exact_versions,
+                ..Default::default()
+            },
+        )?;
+
+        print_package_json_into_cache_entry(entry, ast);
+        let mut path_zbuf = PathBuffer::uninit();
+        let path_z = bun_paths::resolve_path::z(path, &mut path_zbuf);
+        if let Err(err) = File::write_file(Fd::cwd(), path_z, &entry.source.contents) {
+            Output::err_generic(
+                "failed to write package.json for workspace '{s}': {s}",
+                (bstr::BStr::new(name), bstr::BStr::new(err.name())),
+            );
+            any_failed = true;
+        }
+    }
+    if any_failed {
+        Global::exit(1);
+    }
     Ok(())
 }
 

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -959,23 +959,26 @@ fn write_resolved_versions_to_targets(
     let log = manager.log_mut();
     let mut any_failed = false;
 
-    for (hash, name) in targets {
-        let pkg_id = manager.lockfile.get_workspace_package_id(Some(*hash));
-        if manager.lockfile.packages.items_name_hash()[pkg_id as usize] != *hash {
+    let packages = manager.lockfile.packages.slice();
+    let pkg_resolutions = packages.items_resolution();
+    let pkg_name_hashes = packages.items_name_hash();
+    let pkg_names = packages.items_name();
+    for pkg_id in 0..packages.len() {
+        let res = pkg_resolutions[pkg_id];
+        let (ws_name_hash, rel): (Option<crate::PackageNameHash>, &[u8]) = match res.tag {
+            crate::resolution::Tag::Root => (None, b""),
+            crate::resolution::Tag::Workspace => (
+                Some(pkg_name_hashes[pkg_id]),
+                res.workspace()
+                    .slice(manager.lockfile.buffers.string_bytes.as_slice()),
+            ),
+            _ => continue,
+        };
+        let hash = pkg_name_hashes[pkg_id];
+        let name = pkg_names[pkg_id].slice(manager.lockfile.buffers.string_bytes.as_slice());
+        if !targets.iter().any(|(h, n)| *h == hash && &**n == name) {
             continue;
         }
-        let res = manager.lockfile.packages.items_resolution()[pkg_id as usize];
-        let ws_name_hash = if res.tag == crate::resolution::Tag::Root {
-            None
-        } else {
-            Some(*hash)
-        };
-        let rel: &[u8] = if res.tag == crate::resolution::Tag::Workspace {
-            res.workspace()
-                .slice(manager.lockfile.buffers.string_bytes.as_slice())
-        } else {
-            b""
-        };
         let mut path_buf = PathBuffer::uninit();
         let path: &[u8] = bun_paths::resolve_path::join_abs_string_buf::<
             bun_paths::resolve_path::platform::Auto,

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -190,15 +190,15 @@ fn update_package_json_and_install_with_manager_with_updates(
         );
         let name_hashes = manager.lockfile.packages.items_name_hash();
         let names = manager.lockfile.packages.items_name();
+        let resolutions = manager.lockfile.packages.items_resolution();
         let sbuf = manager.lockfile.buffers.string_bytes.as_slice();
         manager.update_target_workspaces = Some(
             selected
                 .iter()
-                .map(|&id| {
-                    (
-                        name_hashes[id as usize],
-                        Box::from(names[id as usize].slice(sbuf)),
-                    )
+                .map(|&id| super::UpdateTargetWorkspace {
+                    is_root: resolutions[id as usize].tag == crate::resolution::Tag::Root,
+                    name_hash: name_hashes[id as usize],
+                    name: Box::from(names[id as usize].slice(sbuf)),
                 })
                 .collect(),
         );
@@ -599,12 +599,10 @@ fn update_package_json_and_install_with_manager_with_updates(
             );
         }
 
-        let root_is_targeted = manager.update_target_workspaces.as_deref().is_none_or(|t| {
-            let h = manager.lockfile.packages.items_name_hash()[0];
-            let n = manager.lockfile.packages.items_name()[0]
-                .slice(manager.lockfile.buffers.string_bytes.as_slice());
-            t.iter().any(|(th, tn)| *th == h && &**tn == n)
-        });
+        let root_is_targeted = manager
+            .update_target_workspaces
+            .as_deref()
+            .is_none_or(|t| t.iter().any(|w| w.is_root));
 
         if subcommand == Subcommand::Update
             && manager.update_requests.is_empty()
@@ -951,7 +949,7 @@ fn update_package_json_and_install_with_manager_with_updates(
 
 fn write_resolved_versions_to_targets(
     manager: &mut PackageManager,
-    targets: &[(crate::PackageNameHash, Box<[u8]>)],
+    targets: &[super::UpdateTargetWorkspace],
 ) -> Result<(), Error> {
     let top_level = strings::without_trailing_slash(FileSystem::instance().top_level_dir());
     let update_to_latest = manager.options.do_.contains(Do::UPDATE_TO_LATEST);
@@ -965,6 +963,7 @@ fn write_resolved_versions_to_targets(
     let pkg_names = packages.items_name();
     for pkg_id in 0..packages.len() {
         let res = pkg_resolutions[pkg_id];
+        let is_root = res.tag == crate::resolution::Tag::Root;
         let (ws_name_hash, rel): (Option<crate::PackageNameHash>, &[u8]) = match res.tag {
             crate::resolution::Tag::Root => (None, b""),
             crate::resolution::Tag::Workspace => (
@@ -976,7 +975,10 @@ fn write_resolved_versions_to_targets(
         };
         let hash = pkg_name_hashes[pkg_id];
         let name = pkg_names[pkg_id].slice(manager.lockfile.buffers.string_bytes.as_slice());
-        if !targets.iter().any(|(h, n)| *h == hash && &**n == name) {
+        if !targets
+            .iter()
+            .any(|t| t.is_root == is_root && t.name_hash == hash && &*t.name == name)
+        {
             continue;
         }
         let mut path_buf = PathBuffer::uninit();

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -863,6 +863,22 @@ impl Lockfile {
         self.packages.items_dependencies()[root_id as usize].contains(id)
     }
 
+    /// Is `id` a direct dependency of one of the `targets` workspaces (by name-hash then name)?
+    pub fn is_dependency_of_workspace_in(
+        &self,
+        targets: &[(PackageNameHash, Box<[u8]>)],
+        id: DependencyID,
+    ) -> bool {
+        let pkg_id = self.get_workspace_pkg_if_workspace_dep(id);
+        if pkg_id == invalid_package_id {
+            return false;
+        }
+        let hash = self.packages.items_name_hash()[pkg_id as usize];
+        let name =
+            self.packages.items_name()[pkg_id as usize].slice(self.buffers.string_bytes.as_slice());
+        targets.iter().any(|(h, n)| *h == hash && &**n == name)
+    }
+
     /// Is this a direct dependency of any workspace (including workspace root)?
     /// TODO make this faster by caching the workspace package ids
     pub(crate) fn is_workspace_dependency(&self, id: DependencyID) -> bool {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -878,9 +878,7 @@ impl Lockfile {
         let hash = self.packages.items_name_hash()[pkg_id as usize];
         let name =
             self.packages.items_name()[pkg_id as usize].slice(self.buffers.string_bytes.as_slice());
-        targets
-            .iter()
-            .any(|t| t.is_root == is_root && t.name_hash == hash && &*t.name == name)
+        targets.iter().any(|t| t.matches(is_root, hash, name))
     }
 
     /// Is this a direct dependency of any workspace (including workspace root)?

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -863,20 +863,24 @@ impl Lockfile {
         self.packages.items_dependencies()[root_id as usize].contains(id)
     }
 
-    /// Is `id` a direct dependency of one of the `targets` workspaces (by name-hash then name)?
+    /// Is `id` a direct dependency of one of the `targets` workspaces?
     pub fn is_dependency_of_workspace_in(
         &self,
-        targets: &[(PackageNameHash, Box<[u8]>)],
+        targets: &[crate::package_manager::UpdateTargetWorkspace],
         id: DependencyID,
     ) -> bool {
         let pkg_id = self.get_workspace_pkg_if_workspace_dep(id);
         if pkg_id == invalid_package_id {
             return false;
         }
+        let is_root =
+            self.packages.items_resolution()[pkg_id as usize].tag == crate::resolution::Tag::Root;
         let hash = self.packages.items_name_hash()[pkg_id as usize];
         let name =
             self.packages.items_name()[pkg_id as usize].slice(self.buffers.string_bytes.as_slice());
-        targets.iter().any(|(h, n)| *h == hash && &**n == name)
+        targets
+            .iter()
+            .any(|t| t.is_root == is_root && t.name_hash == hash && &*t.name == name)
     }
 
     /// Is this a direct dependency of any workspace (including workspace root)?

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1351,14 +1351,13 @@ impl Diff {
             ) {
                 if let Some(updates) = update_requests {
                     if updates.is_empty()
-                        || 'brk: {
-                            for request in updates {
-                                if from_dep.name_hash == request.name_hash {
-                                    break 'brk true;
-                                }
-                            }
-                            false
-                        }
+                        || UpdateRequest::contains_name(
+                            updates,
+                            from_dep.name_hash,
+                            from_dep
+                                .name
+                                .slice(from_lockfile.buffers.string_bytes.as_slice()),
+                        )
                     {
                         // Listed as to be updated
                         summary.update += 1;
@@ -1491,8 +1490,12 @@ impl Diff {
             // preserved. Same gate as the `Dependency::eql == true` branch
             // above.
             let is_explicit_update_target = matches!(update_requests, Some(updates)
-                if updates.is_empty()
-                    || updates.iter().any(|r| r.name_hash == from_dep.name_hash));
+            if updates.is_empty()
+                || UpdateRequest::contains_name(
+                    updates,
+                    from_dep.name_hash,
+                    from_dep.name.slice(from_lockfile.buffers.string_bytes.as_slice()),
+                ));
             if !is_explicit_update_target {
                 if let Some(mapping) = id_mapping.as_deref_mut() {
                     let from_res_id = from_resolutions[i];

--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -13,8 +13,6 @@ use bun_install::package_manager::{
     LogLevel, ManifestLoad, Subcommand, WorkspaceFilter, populate_manifest_cache,
 };
 use bun_install::{CommandLineArguments, DependencyID, PackageID, PackageManager, resolution};
-use bun_paths::{self as path, PathBuffer};
-use bun_resolver::fs::FileSystem;
 use bun_wyhash::hash;
 
 use crate::Command;
@@ -163,21 +161,17 @@ impl OutdatedCommand {
         original_cwd: &[u8],
         manager: &mut PackageManager,
     ) -> crate::Result<()> {
-        if !manager.options.filter_patterns.is_empty() {
-            let filters = manager.options.filter_patterns;
-            let workspace_pkg_ids = Self::find_matching_workspaces(original_cwd, manager, filters);
+        if !manager.options.filter_patterns.is_empty() || manager.options.do_.recursive() {
+            let workspace_pkg_ids = WorkspaceFilter::select_workspaces(
+                &manager.lockfile,
+                manager.options.filter_patterns,
+                original_cwd,
+            );
             populate_manifest_cache::populate_manifest_cache(
                 manager,
                 populate_manifest_cache::Packages::Ids(&workspace_pkg_ids),
             )?;
             Self::print_outdated_info_table::<ENABLE_ANSI_COLORS>(manager, &workspace_pkg_ids, true)
-        } else if manager.options.do_.recursive() {
-            let all_workspaces = Self::get_all_workspaces(manager);
-            populate_manifest_cache::populate_manifest_cache(
-                manager,
-                populate_manifest_cache::Packages::Ids(&all_workspaces),
-            )?;
-            Self::print_outdated_info_table::<ENABLE_ANSI_COLORS>(manager, &all_workspaces, true)
         } else {
             let root_pkg_id = manager
                 .root_package_id
@@ -192,118 +186,6 @@ impl OutdatedCommand {
             )?;
             Self::print_outdated_info_table::<ENABLE_ANSI_COLORS>(manager, &ids, false)
         }
-    }
-
-    fn get_all_workspaces(manager: &PackageManager) -> Vec<PackageID> {
-        let lockfile = &manager.lockfile;
-        let packages = lockfile.packages.slice();
-        let pkg_resolutions = packages.items_resolution();
-
-        let mut workspace_pkg_ids: Vec<PackageID> = Vec::new();
-        for (pkg_id, resolution) in pkg_resolutions.iter().enumerate() {
-            if resolution.tag != resolution::Tag::Workspace
-                && resolution.tag != resolution::Tag::Root
-            {
-                continue;
-            }
-            workspace_pkg_ids.push(pkg_id as PackageID);
-        }
-        workspace_pkg_ids
-    }
-
-    fn find_matching_workspaces(
-        original_cwd: &[u8],
-        manager: &PackageManager,
-        filters: &[&[u8]],
-    ) -> Vec<PackageID> {
-        let lockfile = &manager.lockfile;
-        let packages = lockfile.packages.slice();
-        let pkg_names = packages.items_name();
-        let pkg_resolutions = packages.items_resolution();
-        let string_buf = lockfile.buffers.string_bytes.as_slice();
-
-        let mut workspace_pkg_ids: Vec<PackageID> = Vec::new();
-        for (pkg_id, resolution) in pkg_resolutions.iter().enumerate() {
-            if resolution.tag != resolution::Tag::Workspace
-                && resolution.tag != resolution::Tag::Root
-            {
-                continue;
-            }
-            workspace_pkg_ids.push(pkg_id as PackageID);
-        }
-
-        let mut path_buf = PathBuffer::uninit();
-
-        let converted_filters: Vec<WorkspaceFilter> = filters
-            .iter()
-            .map(|filter| {
-                bun_core::handle_oom(WorkspaceFilter::init(filter, original_cwd, &mut path_buf.0))
-            })
-            .collect();
-        // `defer { filter.deinit(allocator); allocator.free(...) }` — implicit via Drop.
-
-        // SAFETY: `FileSystem::init` runs during `PackageManager::init` so the
-        // process-singleton is populated.
-        let top_level_dir = FileSystem::get().top_level_dir;
-
-        // move all matched workspaces to front of array
-        let mut i: usize = 0;
-        while i < workspace_pkg_ids.len() {
-            let workspace_pkg_id = workspace_pkg_ids[i];
-
-            let matched = 'matched: {
-                for filter in &converted_filters {
-                    match filter {
-                        WorkspaceFilter::Path(pattern) => {
-                            if pattern.is_empty() {
-                                continue;
-                            }
-                            let res = &pkg_resolutions[workspace_pkg_id as usize];
-                            let res_path: &[u8] = match res.tag {
-                                resolution::Tag::Workspace => {
-                                    // Borrow the field in-place so the returned slice (which may
-                                    // point into the inline small-string storage) stays valid.
-                                    res.workspace().slice(string_buf)
-                                }
-                                resolution::Tag::Root => top_level_dir,
-                                _ => unreachable!(),
-                            };
-
-                            let abs_res_path = path::resolve_path::join_abs_string_buf::<
-                                path::platform::Posix,
-                            >(
-                                top_level_dir, &mut path_buf.0, &[res_path]
-                            );
-
-                            if !glob::r#match(
-                                pattern,
-                                strings::without_trailing_slash(abs_res_path),
-                            )
-                            .matches()
-                            {
-                                break 'matched false;
-                            }
-                        }
-                        WorkspaceFilter::Name(pattern) => {
-                            let name = pkg_names[workspace_pkg_id as usize].slice(string_buf);
-                            if !glob::r#match(pattern, name).matches() {
-                                break 'matched false;
-                            }
-                        }
-                        WorkspaceFilter::All => {}
-                    }
-                }
-                true
-            };
-
-            if matched {
-                i += 1;
-            } else {
-                workspace_pkg_ids.swap_remove(i);
-            }
-        }
-
-        workspace_pkg_ids
     }
 
     fn group_catalog_dependencies(

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -8,7 +8,6 @@ use bstr::BStr;
 use bun_alloc::Arena as Bump;
 use bun_collections::StringHashMap;
 use bun_core::{Global, Output};
-use bun_glob as glob;
 use bun_install::dependency::{self, Behavior};
 use bun_install::lockfile::package::PackageColumns as _;
 use bun_install::lockfile::{LoadResult, LoadStep};
@@ -544,20 +543,22 @@ impl UpdateInteractiveCommand {
             }
         }
 
-        let workspace_pkg_ids: Vec<PackageID> = if !manager.options.filter_patterns.is_empty() {
-            let filters = manager.options.filter_patterns;
-            Self::find_matching_workspaces(original_cwd, manager, filters)
-        } else if manager.options.do_.recursive() {
-            Self::get_all_workspaces(manager)
-        } else {
-            let root_pkg_id = manager
-                .root_package_id
-                .get(&manager.lockfile, manager.workspace_name_hash);
-            if root_pkg_id == INVALID_PACKAGE_ID {
-                return Ok(());
-            }
-            vec![root_pkg_id]
-        };
+        let workspace_pkg_ids: Vec<PackageID> =
+            if !manager.options.filter_patterns.is_empty() || manager.options.do_.recursive() {
+                WorkspaceFilter::select_workspaces(
+                    &manager.lockfile,
+                    manager.options.filter_patterns,
+                    original_cwd,
+                )
+            } else {
+                let root_pkg_id = manager
+                    .root_package_id
+                    .get(&manager.lockfile, manager.workspace_name_hash);
+                if root_pkg_id == INVALID_PACKAGE_ID {
+                    return Ok(());
+                }
+                vec![root_pkg_id]
+            };
 
         populate_manifest_cache::populate_manifest_cache(
             manager,
@@ -729,113 +730,6 @@ impl UpdateInteractiveCommand {
             }
         }
         Ok(())
-    }
-
-    fn get_all_workspaces(manager: &PackageManager) -> Vec<PackageID> {
-        let lockfile = &manager.lockfile;
-        let packages = lockfile.packages.slice();
-        let pkg_resolutions = packages.items_resolution();
-
-        let mut workspace_pkg_ids: Vec<PackageID> = Vec::new();
-        for (pkg_id, resolution) in pkg_resolutions.iter().enumerate() {
-            if resolution.tag != resolution::Tag::Workspace
-                && resolution.tag != resolution::Tag::Root
-            {
-                continue;
-            }
-            workspace_pkg_ids.push(pkg_id as PackageID);
-        }
-        workspace_pkg_ids
-    }
-
-    fn find_matching_workspaces(
-        original_cwd: &[u8],
-        manager: &PackageManager,
-        filters: &[&[u8]],
-    ) -> Vec<PackageID> {
-        let lockfile = &manager.lockfile;
-        let packages = lockfile.packages.slice();
-        let pkg_names = packages.items_name();
-        let pkg_resolutions = packages.items_resolution();
-        let string_buf = lockfile.buffers.string_bytes.as_slice();
-
-        let mut workspace_pkg_ids: Vec<PackageID> = Vec::new();
-        for (pkg_id, resolution) in pkg_resolutions.iter().enumerate() {
-            if resolution.tag != resolution::Tag::Workspace
-                && resolution.tag != resolution::Tag::Root
-            {
-                continue;
-            }
-            workspace_pkg_ids.push(pkg_id as PackageID);
-        }
-
-        let mut path_buf = PathBuffer::uninit();
-
-        let converted_filters: Vec<WorkspaceFilter> = filters
-            .iter()
-            .map(|filter| {
-                WorkspaceFilter::init(filter, original_cwd, &mut path_buf.0).expect("OOM")
-            })
-            .collect();
-        // `defer { filter.deinit(allocator); allocator.free(...) }` — implicit via Drop.
-
-        // SAFETY: `FileSystem::init` ran during `PackageManager::init`.
-        let top_level_dir = FileSystem::get().top_level_dir;
-
-        // move all matched workspaces to front of array
-        let mut i: usize = 0;
-        while i < workspace_pkg_ids.len() {
-            let workspace_pkg_id = workspace_pkg_ids[i];
-
-            let matched = 'matched: {
-                for filter in &converted_filters {
-                    match filter {
-                        WorkspaceFilter::Path(pattern) => {
-                            if pattern.is_empty() {
-                                continue;
-                            }
-                            let res = &pkg_resolutions[workspace_pkg_id as usize];
-                            let res_path: &[u8] = match res.tag {
-                                resolution::Tag::Workspace => res.workspace().slice(string_buf),
-                                resolution::Tag::Root => top_level_dir,
-                                _ => unreachable!(),
-                            };
-
-                            let abs_res_path = path::resolve_path::join_abs_string_buf::<
-                                path::platform::Posix,
-                            >(
-                                top_level_dir, &mut path_buf.0, &[res_path]
-                            );
-
-                            if !glob::r#match(
-                                pattern,
-                                strings::without_trailing_slash(abs_res_path),
-                            )
-                            .matches()
-                            {
-                                break 'matched false;
-                            }
-                        }
-                        WorkspaceFilter::Name(pattern) => {
-                            let name = pkg_names[workspace_pkg_id as usize].slice(string_buf);
-                            if !glob::r#match(pattern, name).matches() {
-                                break 'matched false;
-                            }
-                        }
-                        WorkspaceFilter::All => {}
-                    }
-                }
-                true
-            };
-
-            if matched {
-                i += 1;
-            } else {
-                workspace_pkg_ids.swap_remove(i);
-            }
-        }
-
-        workspace_pkg_ids
     }
 
     fn group_catalog_dependencies(

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -1148,6 +1148,132 @@ it("--recursive preserves each member's pin style independently", async () => {
 });
 
 // https://github.com/oven-sh/bun/issues/23507
+it("--filter with a scoped glob (@scope/*) targets only those members", async () => {
+  await setupWorkspaces(
+    { dependencies: { baz: "~0.0.3" } },
+    {
+      "scope-a": { name: "@scope/a", dependencies: { baz: "~0.0.3" } },
+      "scope-b": { name: "@scope/b", dependencies: { baz: "~0.0.3" } },
+      "other": { dependencies: { baz: "~0.0.3" } },
+    },
+  );
+  await runUpdate(["--filter", "@scope/*"]);
+  expect({
+    root: (await file(join(package_dir, "package.json")).json()).dependencies.baz,
+    a: (await pkgJson("scope-a")).dependencies.baz,
+    b: (await pkgJson("scope-b")).dependencies.baz,
+    other: (await pkgJson("other")).dependencies.baz,
+  }).toEqual({ root: "~0.0.3", a: "~0.0.5", b: "~0.0.5", other: "~0.0.3" });
+});
+
+// https://github.com/oven-sh/bun/issues/23507
+it("--recursive --latest does not bypass a root overrides entry for a member's dep", async () => {
+  await setupWorkspaces(
+    { overrides: { baz: "0.0.3" } },
+    { "pkg-a": { dependencies: { baz: "^0.0.3" } } },
+  );
+  await runUpdate(["--recursive", "--latest"]);
+  // The override pins baz to 0.0.3; --latest must not resolve past it.
+  expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toMatchObject({
+    version: "0.0.3",
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/23507
+it("--recursive --no-save updates node_modules but not any package.json", async () => {
+  await setupWorkspaces({}, { "pkg-a": { dependencies: { baz: "~0.0.3" } } });
+  const aBefore = await file(join(package_dir, "packages", "pkg-a", "package.json")).text();
+  await runUpdate(["--recursive", "--no-save"]);
+  expect(await file(join(package_dir, "packages", "pkg-a", "package.json")).text()).toBe(aBefore);
+  expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toMatchObject({
+    version: "0.0.5",
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/23507
+it("--recursive is idempotent: a second run changes nothing", async () => {
+  await setupWorkspaces(
+    { dependencies: { baz: "~0.0.3" } },
+    { "pkg-a": { dependencies: { baz: "~0.0.3" } } },
+  );
+  await runUpdate(["--recursive"]);
+  const rootAfter = await file(join(package_dir, "package.json")).json();
+  const aAfter = await pkgJson("pkg-a");
+  expect(aAfter.dependencies.baz).toBe("~0.0.5");
+  await runUpdate(["--recursive"]);
+  expect(await file(join(package_dir, "package.json")).json()).toEqual(rootAfter);
+  expect(await pkgJson("pkg-a")).toEqual(aAfter);
+});
+
+it("--filter matching nothing writes no package.json", async () => {
+  await setupWorkspaces(
+    { dependencies: { baz: "~0.0.3" } },
+    { "pkg-a": { dependencies: { baz: "~0.0.3" } } },
+  );
+  const rootBefore = await file(join(package_dir, "package.json")).text();
+  const aBefore = await file(join(package_dir, "packages", "pkg-a", "package.json")).text();
+  await runUpdate(["--filter", "does-not-exist"]);
+  expect(await file(join(package_dir, "package.json")).text()).toBe(rootBefore);
+  expect(await file(join(package_dir, "packages", "pkg-a", "package.json")).text()).toBe(aBefore);
+});
+
+it("--recursive tolerates a member with no dependency groups", async () => {
+  await setupWorkspaces(
+    { dependencies: { baz: "~0.0.3" } },
+    { empty: { version: "1.0.0" }, "pkg-a": { dependencies: { baz: "~0.0.3" } } },
+  );
+  await runUpdate(["--recursive"]);
+  expect((await pkgJson("pkg-a")).dependencies.baz).toBe("~0.0.5");
+  expect(await pkgJson("empty")).toEqual({ name: "empty", version: "1.0.0" });
+});
+
+// https://github.com/oven-sh/bun/issues/23507
+it("--recursive updates only one group when a member lists the same dep in two groups", async () => {
+  await setupWorkspaces(
+    {},
+    { "pkg-a": { dependencies: { baz: "~0.0.3" }, devDependencies: { baz: "~0.0.3" } } },
+  );
+  await runUpdate(["--recursive"]);
+  const a = await pkgJson("pkg-a");
+  // Matches the existing single-workspace behavior: only one group's entry is rewritten.
+  expect([a.dependencies.baz, a.devDependencies.baz].sort()).toEqual(["~0.0.3", "~0.0.5"]);
+});
+
+// https://github.com/oven-sh/bun/issues/23507
+it("--recursive with multiple workspace globs fans out to every matched directory", async () => {
+  setHandler(dummyRegistry([], { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "root", private: true, workspaces: ["apps/*", "packages/*"] }),
+  );
+  for (const [dir, name] of [
+    ["apps", "app-a"],
+    ["packages", "pkg-a"],
+  ] as const) {
+    await mkdir(join(package_dir, dir, name), { recursive: true });
+    await writeFile(
+      join(package_dir, dir, name, "package.json"),
+      JSON.stringify({ name, dependencies: { baz: "~0.0.3" } }),
+    );
+  }
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    const [err, code] = await Promise.all([stderr.text(), exited]);
+    expect(err).not.toContain("error:");
+    expect(code).toBe(0);
+  }
+  await runUpdate(["--recursive"]);
+  expect((await file(join(package_dir, "apps", "app-a", "package.json")).json()).dependencies.baz).toBe("~0.0.5");
+  expect((await file(join(package_dir, "packages", "pkg-a", "package.json")).json()).dependencies.baz).toBe("~0.0.5");
+});
+
+// https://github.com/oven-sh/bun/issues/23507
 it("bun outdated -r is empty after bun update -r --latest", async () => {
   await setupWorkspaces(
     { dependencies: { baz: "~0.0.3" } },

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -1168,10 +1168,7 @@ it("--filter with a scoped glob (@scope/*) targets only those members", async ()
 
 // https://github.com/oven-sh/bun/issues/23507
 it("--recursive --latest does not bypass a root overrides entry for a member's dep", async () => {
-  await setupWorkspaces(
-    { overrides: { baz: "0.0.3" } },
-    { "pkg-a": { dependencies: { baz: "^0.0.3" } } },
-  );
+  await setupWorkspaces({ overrides: { baz: "0.0.3" } }, { "pkg-a": { dependencies: { baz: "^0.0.3" } } });
   await runUpdate(["--recursive", "--latest"]);
   // The override pins baz to 0.0.3; --latest must not resolve past it.
   expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toMatchObject({
@@ -1192,10 +1189,7 @@ it("--recursive --no-save updates node_modules but not any package.json", async 
 
 // https://github.com/oven-sh/bun/issues/23507
 it("--recursive is idempotent: a second run changes nothing", async () => {
-  await setupWorkspaces(
-    { dependencies: { baz: "~0.0.3" } },
-    { "pkg-a": { dependencies: { baz: "~0.0.3" } } },
-  );
+  await setupWorkspaces({ dependencies: { baz: "~0.0.3" } }, { "pkg-a": { dependencies: { baz: "~0.0.3" } } });
   await runUpdate(["--recursive"]);
   const rootAfter = await file(join(package_dir, "package.json")).json();
   const aAfter = await pkgJson("pkg-a");
@@ -1206,10 +1200,7 @@ it("--recursive is idempotent: a second run changes nothing", async () => {
 });
 
 it("--filter matching nothing writes no package.json", async () => {
-  await setupWorkspaces(
-    { dependencies: { baz: "~0.0.3" } },
-    { "pkg-a": { dependencies: { baz: "~0.0.3" } } },
-  );
+  await setupWorkspaces({ dependencies: { baz: "~0.0.3" } }, { "pkg-a": { dependencies: { baz: "~0.0.3" } } });
   const rootBefore = await file(join(package_dir, "package.json")).text();
   const aBefore = await file(join(package_dir, "packages", "pkg-a", "package.json")).text();
   await runUpdate(["--filter", "does-not-exist"]);
@@ -1229,10 +1220,7 @@ it("--recursive tolerates a member with no dependency groups", async () => {
 
 // https://github.com/oven-sh/bun/issues/23507
 it("--recursive updates only one group when a member lists the same dep in two groups", async () => {
-  await setupWorkspaces(
-    {},
-    { "pkg-a": { dependencies: { baz: "~0.0.3" }, devDependencies: { baz: "~0.0.3" } } },
-  );
+  await setupWorkspaces({}, { "pkg-a": { dependencies: { baz: "~0.0.3" }, devDependencies: { baz: "~0.0.3" } } });
   await runUpdate(["--recursive"]);
   const a = await pkgJson("pkg-a");
   // Matches the existing single-workspace behavior: only one group's entry is rewritten.

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -1167,14 +1167,16 @@ it("--filter with a scoped glob (@scope/*) targets only those members", async ()
 });
 
 // https://github.com/oven-sh/bun/issues/23507
-it("--recursive --latest does not bypass a root overrides entry for a member's dep", async () => {
-  await setupWorkspaces({ overrides: { baz: "0.0.3" } }, { "pkg-a": { dependencies: { baz: "^0.0.3" } } });
-  await runUpdate(["--recursive", "--latest"]);
-  // The override pins baz to 0.0.3; --latest must not resolve past it.
-  expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toMatchObject({
-    version: "0.0.3",
+for (const depLiteral of ["^0.0.3", "0.0.3"]) {
+  it(`--recursive --latest does not bypass a root overrides entry (member dep literal ${depLiteral})`, async () => {
+    await setupWorkspaces({ overrides: { baz: "0.0.3" } }, { "pkg-a": { dependencies: { baz: depLiteral } } });
+    await runUpdate(["--recursive", "--latest"]);
+    // The override pins baz to 0.0.3; --latest must not resolve past it.
+    expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toMatchObject({
+      version: "0.0.3",
+    });
   });
-});
+}
 
 // https://github.com/oven-sh/bun/issues/23507
 it("--recursive --no-save updates node_modules but not any package.json", async () => {

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -1012,6 +1012,167 @@ it("--filter with a negated pattern updates everything except the excluded works
   expect(root.dependencies.baz).toBe("~0.0.5");
 });
 
+async function setupWorkspaces(
+  root: object,
+  members: Record<string, object>,
+  versions: Record<string, object> = { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" },
+) {
+  setHandler(dummyRegistry([], versions));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "root", private: true, workspaces: ["packages/*"], ...root }),
+  );
+  for (const [name, body] of Object.entries(members)) {
+    await mkdir(join(package_dir, "packages", name), { recursive: true });
+    await writeFile(join(package_dir, "packages", name, "package.json"), JSON.stringify({ name, ...body }));
+  }
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "install", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const [err, code] = await Promise.all([stderr.text(), exited]);
+  expect(err).not.toContain("error:");
+  expect(code).toBe(0);
+}
+
+async function runUpdate(args: string[], cwd = package_dir) {
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", ...args, "--linker=hoisted"],
+    cwd,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const [err, code] = await Promise.all([stderr.text(), exited]);
+  expect(err).not.toContain("error:");
+  expect(code).toBe(0);
+}
+
+const pkgJson = (name: string) => file(join(package_dir, "packages", name, "package.json")).json();
+
+// https://github.com/oven-sh/bun/issues/23507
+for (const group of ["dependencies", "devDependencies", "optionalDependencies"] as const) {
+  it(`--recursive --latest updates a member's ${group}`, async () => {
+    await setupWorkspaces({}, { "pkg-a": { [group]: { baz: "0.0.3" } } });
+    await runUpdate(["--recursive", "--latest"]);
+    expect((await pkgJson("pkg-a"))[group]).toEqual({ baz: "0.0.5" });
+  });
+}
+
+// https://github.com/oven-sh/bun/issues/23507
+it("--recursive --latest updates an npm: aliased dep in a member, preserving the alias", async () => {
+  await setupWorkspaces({}, { "pkg-a": { dependencies: { aliased: "npm:baz@0.0.3" } } });
+  await runUpdate(["--recursive", "--latest"]);
+  expect((await pkgJson("pkg-a")).dependencies).toEqual({ aliased: "npm:baz@0.0.5" });
+});
+
+// https://github.com/oven-sh/bun/issues/23507
+it("--recursive does not rewrite workspace: protocol references between members", async () => {
+  await setupWorkspaces(
+    {},
+    {
+      "pkg-a": { version: "1.0.0", dependencies: { baz: "~0.0.3" } },
+      "pkg-b": { dependencies: { "pkg-a": "workspace:*", baz: "~0.0.3" } },
+    },
+  );
+  await runUpdate(["--recursive"]);
+  expect((await pkgJson("pkg-b")).dependencies).toEqual({ "pkg-a": "workspace:*", baz: "~0.0.5" });
+  expect((await pkgJson("pkg-a")).dependencies).toEqual({ baz: "~0.0.5" });
+});
+
+// https://github.com/oven-sh/bun/issues/23507
+it("--recursive from inside a member updates siblings and root", async () => {
+  await setupWorkspaces(
+    { dependencies: { baz: "~0.0.3" } },
+    {
+      "pkg-a": { dependencies: { baz: "~0.0.3" } },
+      "pkg-b": { dependencies: { baz: "~0.0.3" } },
+    },
+  );
+  await runUpdate(["--recursive"], join(package_dir, "packages", "pkg-a"));
+  expect({
+    root: (await file(join(package_dir, "package.json")).json()).dependencies.baz,
+    a: (await pkgJson("pkg-a")).dependencies.baz,
+    b: (await pkgJson("pkg-b")).dependencies.baz,
+  }).toEqual({ root: "~0.0.5", a: "~0.0.5", b: "~0.0.5" });
+});
+
+// https://github.com/oven-sh/bun/issues/23507
+it("--filter with a glob plus a negation scopes to the matched set minus the exclusion", async () => {
+  await setupWorkspaces(
+    { dependencies: { baz: "~0.0.3" } },
+    {
+      "pkg-a": { dependencies: { baz: "~0.0.3" } },
+      "pkg-b": { dependencies: { baz: "~0.0.3" } },
+      "pkg-c": { dependencies: { baz: "~0.0.3" } },
+    },
+  );
+  await runUpdate(["--filter", "pkg-*", "--filter", "!pkg-c"]);
+  expect({
+    root: (await file(join(package_dir, "package.json")).json()).dependencies.baz,
+    a: (await pkgJson("pkg-a")).dependencies.baz,
+    b: (await pkgJson("pkg-b")).dependencies.baz,
+    c: (await pkgJson("pkg-c")).dependencies.baz,
+  }).toEqual({ root: "~0.0.3", a: "~0.0.5", b: "~0.0.5", c: "~0.0.3" });
+});
+
+// https://github.com/oven-sh/bun/issues/23507
+it("--recursive --dry-run writes no workspace package.json", async () => {
+  await setupWorkspaces(
+    { dependencies: { baz: "~0.0.3" } },
+    { "pkg-a": { dependencies: { baz: "~0.0.3" } } },
+  );
+  const rootBefore = await file(join(package_dir, "package.json")).text();
+  const aBefore = await file(join(package_dir, "packages", "pkg-a", "package.json")).text();
+  await runUpdate(["--recursive", "--latest", "--dry-run"]);
+  expect(await file(join(package_dir, "package.json")).text()).toBe(rootBefore);
+  expect(await file(join(package_dir, "packages", "pkg-a", "package.json")).text()).toBe(aBefore);
+});
+
+// https://github.com/oven-sh/bun/issues/23507
+it("--recursive preserves each member's pin style independently", async () => {
+  await setupWorkspaces(
+    {},
+    {
+      "pkg-a": { dependencies: { baz: "^0.0.3" } },
+      "pkg-b": { dependencies: { baz: "~0.0.3" } },
+      "pkg-c": { dependencies: { baz: "0.0.3" } },
+    },
+  );
+  await runUpdate(["--recursive", "--latest"]);
+  expect({
+    a: (await pkgJson("pkg-a")).dependencies.baz,
+    b: (await pkgJson("pkg-b")).dependencies.baz,
+    c: (await pkgJson("pkg-c")).dependencies.baz,
+  }).toEqual({ a: "^0.0.5", b: "~0.0.5", c: "0.0.5" });
+});
+
+// https://github.com/oven-sh/bun/issues/23507
+it("bun outdated -r is empty after bun update -r --latest", async () => {
+  await setupWorkspaces(
+    { dependencies: { baz: "~0.0.3" } },
+    {
+      "pkg-a": { dependencies: { baz: "~0.0.3" } },
+      "pkg-b": { devDependencies: { baz: "0.0.3" } },
+    },
+  );
+  await runUpdate(["--recursive", "--latest"]);
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "outdated", "--recursive"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  expect(err).not.toContain("error:");
+  expect(out).not.toContain("baz");
+  expect(code).toBe(0);
+});
+
 it("should print UTF-8 arrows correctly with colors enabled", async () => {
   const urls: string[] = [];
   const registry = {

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -1,8 +1,8 @@
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
 import { access, mkdir, readFile, rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted, toBeValidBin, toHaveBins } from "harness";
-import { join } from "path";
+import { bunExe, bunEnv as env, pack, readdirSorted, toBeValidBin, toHaveBins } from "harness";
+import { basename, join } from "path";
 import {
   dummyAfterAll,
   dummyAfterEach,
@@ -483,6 +483,535 @@ it("should support --recursive flag", async () => {
   expect(out + err).toMatch(/bun update|missing lockfile|nothing to update/);
 });
 
+// https://github.com/oven-sh/bun/issues/33176
+it("--recursive updates dependencies and peerDependencies in workspace members", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "root", private: true, workspaces: ["packages/*"] }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await mkdir(join(package_dir, "packages", "pkg-b"), { recursive: true });
+  // Same dependency name in two workspaces, one as a regular dep and one as a
+  // peer dep, so the update must fan out to both members and handle each
+  // workspace's dependency groups independently.
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "~0.0.3" } }),
+  );
+  await writeFile(
+    join(package_dir, "packages", "pkg-b", "package.json"),
+    JSON.stringify({ name: "pkg-b", peerDependencies: { baz: "~0.0.3" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--recursive", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  const b = await file(join(package_dir, "packages", "pkg-b", "package.json")).json();
+  expect(a.dependencies.baz).toBe("~0.0.5");
+  expect(b.peerDependencies.baz).toBe("~0.0.5");
+});
+
+// https://github.com/oven-sh/bun/issues/33176
+it("--recursive --latest updates workspace members to the latest version", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "root", private: true, workspaces: ["packages/*"] }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  // Exact pin below latest: only `--latest` moves it, so this also proves the
+  // member goes through the `--latest` path rather than range-constrained update.
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "0.0.3" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--recursive", "--latest", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  expect(a.dependencies.baz).toBe("0.0.5");
+});
+
+// https://github.com/oven-sh/bun/issues/33176
+it("--filter updates only matching workspaces, leaving siblings and root untouched", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      dependencies: { baz: "~0.0.3" },
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await mkdir(join(package_dir, "packages", "pkg-b"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "~0.0.3" } }),
+  );
+  await writeFile(
+    join(package_dir, "packages", "pkg-b", "package.json"),
+    JSON.stringify({ name: "pkg-b", dependencies: { baz: "~0.0.3" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--filter", "pkg-a", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const root = await file(join(package_dir, "package.json")).json();
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  const b = await file(join(package_dir, "packages", "pkg-b", "package.json")).json();
+  expect(a.dependencies.baz).toBe("~0.0.5");
+  // Unmatched workspace and the root are left untouched.
+  expect(b.dependencies.baz).toBe("~0.0.3");
+  expect(root.dependencies.baz).toBe("~0.0.3");
+});
+
+// Multiple `--filter` patterns select the union of matches (any positive), minus negations.
+it("--filter with multiple patterns selects the union of matching workspaces", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      dependencies: { baz: "~0.0.3" },
+    }),
+  );
+  for (const n of ["pkg-a", "pkg-b", "pkg-c"]) {
+    await mkdir(join(package_dir, "packages", n), { recursive: true });
+    await writeFile(
+      join(package_dir, "packages", n, "package.json"),
+      JSON.stringify({ name: n, dependencies: { baz: "~0.0.3" } }),
+    );
+  }
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--filter", "pkg-a", "--filter", "pkg-b", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  expect({
+    root: (await file(join(package_dir, "package.json")).json()).dependencies.baz,
+    a: (await file(join(package_dir, "packages", "pkg-a", "package.json")).json()).dependencies.baz,
+    b: (await file(join(package_dir, "packages", "pkg-b", "package.json")).json()).dependencies.baz,
+    c: (await file(join(package_dir, "packages", "pkg-c", "package.json")).json()).dependencies.baz,
+  }).toEqual({ root: "~0.0.3", a: "~0.0.5", b: "~0.0.5", c: "~0.0.3" });
+});
+
+// https://github.com/oven-sh/bun/issues/33176
+// `bun update <name>` re-resolves every `<name>` entry in the lockfile, but
+// only the cwd package.json is rewritten. Named updates don't fan the
+// package.json edit out to members.
+it("named update with --recursive rewrites only the cwd package.json", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      dependencies: { baz: "~0.0.3" },
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "~0.0.3" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "baz", "--recursive", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const root = await file(join(package_dir, "package.json")).json();
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  expect(root.dependencies.baz).toBe("~0.0.5");
+  // Named updates do not fan the package.json edit out to members.
+  expect(a.dependencies.baz).toBe("~0.0.3");
+});
+
+// https://github.com/oven-sh/bun/issues/33176
+// A workspace member's `catalog:` reference must survive `bun update`: the
+// version lives in the root catalog, not inline in the member.
+it("--recursive preserves a workspace member's catalog: reference", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      catalog: { baz: "^0.0.3" },
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "catalog:" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--recursive", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const root = await file(join(package_dir, "package.json")).json();
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  // The member keeps the catalog reference; the catalog definition is unchanged.
+  expect(a.dependencies.baz).toBe("catalog:");
+  expect(root.catalog.baz).toBe("^0.0.3");
+});
+
+// `--filter` excluding root must not touch the root package.json (catalogs included),
+// so the lockfile stays consistent with the on-disk root.
+it("--filter excluding root leaves root (and its catalog) untouched", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  const rootJson = JSON.stringify({
+    name: "root",
+    private: true,
+    workspaces: ["packages/*"],
+    catalog: { baz: "^0.0.3" },
+    dependencies: { baz: "^0.0.3" },
+  });
+  await writeFile(join(package_dir, "package.json"), rootJson);
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "catalog:" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--filter", "pkg-a", "--latest", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  // Root is not a `--filter pkg-a` target; nothing in its package.json changes.
+  expect(await file(join(package_dir, "package.json")).text()).toBe(rootJson);
+  expect((await file(join(package_dir, "packages", "pkg-a", "package.json")).json()).dependencies.baz).toBe("catalog:");
+  // pkg-a's `catalog:` dep stays within the catalog range; `--latest` must not bypass it.
+  expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toMatchObject({
+    version: "0.0.3",
+  });
+
+  // A subsequent frozen-lockfile install must pass (no catalog drift vs. lockfile).
+  const frozen = spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(frozen.stderr).text()).not.toContain("error:");
+  expect(await frozen.exited).toBe(0);
+});
+
+// `-r` from inside a member must write root's catalog and direct deps in one
+// pass (the member-commit path carries both).
+it("--recursive --latest from a member updates root's catalog and direct deps together", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      catalog: { baz: "^0.0.3" },
+      dependencies: { baz: "^0.0.3" },
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "catalog:" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--recursive", "--latest", "--linker=hoisted"],
+    cwd: join(package_dir, "packages", "pkg-a"),
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const root = await file(join(package_dir, "package.json")).json();
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  expect(root.dependencies.baz).toBe("^0.0.5");
+  expect(root.catalog.baz).toBe("^0.0.5");
+  expect(a.dependencies.baz).toBe("catalog:");
+});
+
+// https://github.com/oven-sh/bun/issues/33176
+it("--filter with a path targets only the matching workspace", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      dependencies: { baz: "~0.0.3" },
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await mkdir(join(package_dir, "packages", "pkg-b"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "~0.0.3" } }),
+  );
+  await writeFile(
+    join(package_dir, "packages", "pkg-b", "package.json"),
+    JSON.stringify({ name: "pkg-b", dependencies: { baz: "~0.0.3" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--filter", "./packages/pkg-a", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const root = await file(join(package_dir, "package.json")).json();
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  const b = await file(join(package_dir, "packages", "pkg-b", "package.json")).json();
+  expect(a.dependencies.baz).toBe("~0.0.5");
+  expect(b.dependencies.baz).toBe("~0.0.3");
+  expect(root.dependencies.baz).toBe("~0.0.3");
+});
+
+// https://github.com/oven-sh/bun/issues/33176
+it("--filter with a negated pattern updates everything except the excluded workspace", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      dependencies: { baz: "~0.0.3" },
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await mkdir(join(package_dir, "packages", "pkg-b"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "~0.0.3" } }),
+  );
+  await writeFile(
+    join(package_dir, "packages", "pkg-b", "package.json"),
+    JSON.stringify({ name: "pkg-b", dependencies: { baz: "~0.0.3" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--filter", "!pkg-a", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const root = await file(join(package_dir, "package.json")).json();
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  const b = await file(join(package_dir, "packages", "pkg-b", "package.json")).json();
+  // `!pkg-a` excludes pkg-a but keeps the root and sibling members.
+  expect(a.dependencies.baz).toBe("~0.0.3");
+  expect(b.dependencies.baz).toBe("~0.0.5");
+  expect(root.dependencies.baz).toBe("~0.0.5");
+});
+
 it("should print UTF-8 arrows correctly with colors enabled", async () => {
   const urls: string[] = [];
   const registry = {
@@ -526,4 +1055,155 @@ it("should print UTF-8 arrows correctly with colors enabled", async () => {
   // double-encoded UTF-8 (each byte of the arrow re-encoded as Latin-1)
   expect(out).not.toContain("â");
   expect(await exited2).toBe(0);
+});
+
+// Unlike `dummyRegistry`, this serves a distinct manifest per package name,
+// packing a real tarball for each version into `tgzDir`.
+async function perNameRegistry(
+  tgzDir: string,
+  manifests: Record<string, { versions: Record<string, { dependencies?: Record<string, string> }>; latest: string }>,
+) {
+  for (const [name, { versions }] of Object.entries(manifests)) {
+    for (const [version, extra] of Object.entries(versions)) {
+      const staging = join(tgzDir, ".staging", `${name}-${version}`);
+      await mkdir(staging, { recursive: true });
+      await writeFile(join(staging, "package.json"), JSON.stringify({ name, version, ...extra }));
+      await pack(staging, env, "--destination", tgzDir);
+    }
+  }
+  return (request: Request) => {
+    const url = request.url;
+    if (url.endsWith(".tgz")) return new Response(file(join(tgzDir, basename(url))));
+    const name = url.slice(url.indexOf("/", root_url.length) + 1);
+    const entry = manifests[name];
+    if (!entry) return new Response("not found", { status: 404 });
+    const versions: Record<string, object> = {};
+    for (const [version, extra] of Object.entries(entry.versions)) {
+      versions[version] = { name, version, dist: { tarball: `${url}-${version}.tgz` }, ...extra };
+    }
+    return new Response(JSON.stringify({ name, versions, "dist-tags": { latest: entry.latest } }));
+  };
+}
+
+async function runInPackageDir(...args: string[]) {
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), ...args],
+    cwd: package_dir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  expect(err).not.toContain("error:");
+  expect(exitCode).toBe(0);
+  return out;
+}
+
+// The set of `shared@<version>` resolutions in the text lockfile.
+async function lockedSharedResolutions() {
+  const lock = await file(join(package_dir, "bun.lock")).text();
+  return [...new Set(lock.match(/"shared@[\d.]+"/g))].sort();
+}
+
+async function writePerNameBunfig() {
+  await writeFile(
+    join(package_dir, "bunfig.toml"),
+    `[install]\ncache = false\nregistry = "${root_url}/"\nsaveTextLockfile = true\nlinker = "hoisted"\n`,
+  );
+}
+
+// `bun update <name>` must re-resolve every dependency on `<name>` in the
+// lockfile, each within its own version range, including a workspace whose
+// range resolves to a different version than the current workspace's.
+it("should update every resolution of a named package across workspaces", async () => {
+  setHandler(
+    await perNameRegistry(join(package_dir, ".tarballs"), {
+      shared: { versions: { "1.0.0": {}, "1.1.0": {}, "2.0.0": {} }, latest: "2.0.0" },
+    }),
+  );
+  await writePerNameBunfig();
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "root", workspaces: ["packages/*"], dependencies: { shared: "^2.0.0" } }),
+  );
+  const pkgOneJson = join(package_dir, "packages", "pkg-one", "package.json");
+  await mkdir(join(package_dir, "packages", "pkg-one"), { recursive: true });
+  await writeFile(pkgOneJson, JSON.stringify({ name: "pkg-one", version: "1.0.0", dependencies: { shared: "1.0.0" } }));
+  await runInPackageDir("install");
+
+  // Widen pkg-one's range. A plain install keeps its stale 1.0.0 because the
+  // previously resolved package still satisfies the new range.
+  await writeFile(
+    pkgOneJson,
+    JSON.stringify({ name: "pkg-one", version: "1.0.0", dependencies: { shared: "^1.0.0" } }),
+  );
+  await runInPackageDir("install");
+  expect(await lockedSharedResolutions()).toEqual(['"shared@1.0.0"', '"shared@2.0.0"']);
+
+  // root's ^2.0.0 is already at 2.0.0; pkg-one's ^1.0.0 must move to 1.1.0.
+  await runInPackageDir("update", "shared");
+  expect(await lockedSharedResolutions()).toEqual(['"shared@1.1.0"', '"shared@2.0.0"']);
+  expect(
+    await file(join(package_dir, "packages", "pkg-one", "node_modules", "shared", "package.json")).json(),
+  ).toMatchObject({ version: "1.1.0" });
+
+  // The update reached a fixpoint: running it again is a no-op.
+  await runInPackageDir("update", "shared");
+  expect(await lockedSharedResolutions()).toEqual(['"shared@1.1.0"', '"shared@2.0.0"']);
+});
+
+// The same invariant one level deeper: a dependency on `<name>` owned by a
+// preserved parent package must also re-enter the resolve queue.
+it("should update transitive resolutions of a named package", async () => {
+  setHandler(
+    await perNameRegistry(join(package_dir, ".tarballs"), {
+      shared: { versions: { "1.0.0": {}, "1.1.0": {} }, latest: "1.1.0" },
+      "dep-x": { versions: { "1.0.0": { dependencies: { shared: "^1.0.0" } } }, latest: "1.0.0" },
+    }),
+  );
+  await writePerNameBunfig();
+  // dep-x@1.0.0 depends on shared@^1.0.0, which dedupes onto the root's
+  // exact shared@1.0.0 at install time.
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "root", dependencies: { shared: "1.0.0", "dep-x": "^1.0.0" } }),
+  );
+  await runInPackageDir("install");
+  expect(await lockedSharedResolutions()).toEqual(['"shared@1.0.0"']);
+
+  // The root's exact `1.0.0` cannot move; dep-x's `^1.0.0` must move to 1.1.0.
+  await runInPackageDir("update", "shared");
+  expect(await lockedSharedResolutions()).toEqual(['"shared@1.0.0"', '"shared@1.1.0"']);
+  expect(
+    await file(join(package_dir, "node_modules", "dep-x", "node_modules", "shared", "package.json")).json(),
+  ).toMatchObject({ version: "1.1.0" });
+});
+
+// `<name>` appears only transitively: nothing in any package.json depends on
+// it directly. `bun update <name>` promotes it to a direct dependency of the
+// invoking package.json, and the transitive slot must re-resolve too.
+it("should update a resolution reachable only through a transitive dependency", async () => {
+  const tgzDir = join(package_dir, ".tarballs");
+  const depX = { "dep-x": { versions: { "1.0.0": { dependencies: { shared: "^1.0.0" } } }, latest: "1.0.0" } };
+  // Only shared@1.0.0 exists when the lockfile is created.
+  setHandler(await perNameRegistry(tgzDir, { ...depX, shared: { versions: { "1.0.0": {} }, latest: "1.0.0" } }));
+  await writePerNameBunfig();
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "root", dependencies: { "dep-x": "^1.0.0" } }),
+  );
+  await runInPackageDir("install");
+  expect(await lockedSharedResolutions()).toEqual(['"shared@1.0.0"']);
+
+  // shared@1.1.0 is published after the lockfile pinned 1.0.0.
+  setHandler(
+    await perNameRegistry(tgzDir, { ...depX, shared: { versions: { "1.0.0": {}, "1.1.0": {} }, latest: "1.1.0" } }),
+  );
+
+  // Both the new root entry and dep-x's `^1.0.0` must land on 1.1.0.
+  await runInPackageDir("update", "shared");
+  expect(await file(join(package_dir, "package.json")).json()).toMatchObject({
+    dependencies: { "dep-x": "^1.0.0", shared: "^1.1.0" },
+  });
+  expect(await lockedSharedResolutions()).toEqual(['"shared@1.1.0"']);
 });

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -1121,10 +1121,7 @@ it("--filter with a glob plus a negation scopes to the matched set minus the exc
 
 // https://github.com/oven-sh/bun/issues/23507
 it("--recursive --dry-run writes no workspace package.json", async () => {
-  await setupWorkspaces(
-    { dependencies: { baz: "~0.0.3" } },
-    { "pkg-a": { dependencies: { baz: "~0.0.3" } } },
-  );
+  await setupWorkspaces({ dependencies: { baz: "~0.0.3" } }, { "pkg-a": { dependencies: { baz: "~0.0.3" } } });
   const rootBefore = await file(join(package_dir, "package.json")).text();
   const aBefore = await file(join(package_dir, "packages", "pkg-a", "package.json")).text();
   await runUpdate(["--recursive", "--latest", "--dry-run"]);


### PR DESCRIPTION
Closes #33182 and #32947 on top of current main (which already has #36304 for catalogs).

Fixes #23507
Fixes #33176
Fixes #29357

Closes #33182, Closes #32947, Closes #32064.

## Problem

`bun update --recursive --latest` in a monorepo only rewrote the root/cwd `package.json`. Workspace members were left untouched and `bun outdated -r` kept reporting them forever. `--recursive` and `--filter` were parsed into `PackageManagerOptions` but never read by the non-interactive update path.

Separately, `bun update <name>` only treated `<name>` as an update target when it was a direct dependency of the invoking workspace; another workspace's or a transitive parent's resolution of `<name>` stayed pinned.

## Fix

**`bun update --recursive` / `--filter` (no named packages):**
- Resolve the target workspace set from the lockfile via `WorkspaceFilter::select_workspaces` (union of positive patterns minus negations, shared with `bun outdated` / `update -i`). Error if no lockfile exists (matching `bun outdated`).
- Store `update_target_workspaces` on the manager as `(name_hash, name)` pairs so the install-time gate (`should_update` in `get_or_put_resolved_package_with_find_result`) re-resolves dependencies of every selected workspace, not just the cwd; membership is checked by hash then name.
- Under `--latest`, the manifest lookup in `get_or_put_resolved_package` uses dist-tag `latest` for an npm dep of a targeted workspace whose version was not already substituted by a `catalog:` or `overrides` entry, so members' deps resolve to latest without rewriting their package.json beforehand.
- After install, one loop writes resolved versions to each selected workspace's package.json via `edit_update_no_args_in` (a split-borrow variant that takes `&Lockfile` / `&Arena` / `&mut map` instead of `&mut PackageManager`, so no raw pointers are added). `catalog:` references are preserved; catalog editing only runs when root is a selected target.

**`bun update <name>`:**
- `should_update` treats every dependency whose name matches a request as an update target, wherever it sits in the graph.
- `install_with_manager` walks the dependency buffer, drops the resolution of every matching slot, and re-enqueues it (same shape as the `overrides_changed` pass).

**`WorkspaceFilter::select_workspaces`** is extracted once and called from `bun outdated`, `bun update -i`, and this path, replacing three local copies; this also fixes `bun outdated --filter a --filter b` which previously returned nothing (the copies ANDed filters instead of taking the union).

## Tests

`test/cli/install/bun-update.test.ts` (in-process registry):

- `--recursive` updates a member's `dependencies` and another's `peerDependencies`
- `--recursive --latest` bumps a member's exact-pinned dependency
- `--filter <name>` / `--filter ./path` / `--filter !name` / `--filter a --filter b` select the expected workspaces
- `--filter <member> --latest` leaves root (catalog + deps) byte-for-byte unchanged; the member's `catalog:` dep stays within the catalog range; a subsequent `--frozen-lockfile` passes
- `--recursive --latest` from inside a member updates root's catalog and direct deps together
- `bun update <name>` re-resolves every resolution across workspaces, including transitives reached only through a preserved parent

11 of the new tests fail on the released binary (`USE_SYSTEM_BUN=1`); all 19 pass with this fix. No regressions in `catalogs.test.ts` (16), `bun-install-registry.test.ts -t outdated` (16), `-t update` (16), `bun-workspaces.test.ts` (63), `bun-add.test.ts` (54), `overrides.test.ts` (7).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 26 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-update.test.ts
bun test v1.4.0 (59a9d71ed)

test/cli/install/bun-update.test.ts:
(pass) should update to latest version of dependency (~) [494.02ms]
(pass) should update to latest versions of dependencies (~) [432.44ms]
(pass) lockfile should not be modified when there are no version changes, issue#5888 [1219.02ms]
(pass) should support catalog versions in update [214.35ms]
(pass) should support --recursive flag [267.39ms]
528 |   expect(await new Response(stderr).text()).not.toContain("error:");
529 |   expect(await exited).toBe(0);
530 | 
531 |   const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
532 |   const b = await file(join(package_dir, "packages", "pkg-b", "package.json")).json();
533 |   expect(a.dependencies.baz).toBe("~0.0.5");
                                   ^
error: expect(received).toBe(expected)

Expected: "~0.0.5"
Received: "~0.0.3"

      at <anonymous> (/workspace/bun/test/cli/install/bun-update.test.ts:533:30)
(fail) --recursive updates dependencies and peerD
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (f18eaa16a)

test/cli/install/bun-update.test.ts:
(pass) should update to latest version of dependency (~) [18.09ms]
(pass) should update to latest versions of dependencies (~) [11.16ms]
(pass) lockfile should not be modified when there are no version changes, issue#5888 [24.89ms]
(pass) should support catalog versions in update [4.46ms]
(pass) should support --recursive flag [3.88ms]
(pass) --recursive updates dependencies and peerDependencies in workspace members [8.69ms]
(pass) --recursive --latest updates workspace members to the latest version [12.55ms]
(pass) --filter updates only matching workspaces, leaving siblings and root untouched [11.43ms]
(pass) --filter with multiple patterns selects the union of matching workspaces [12.59ms]
(pass) named update with --recursive rewrites only the cwd package.json [10.12ms]
(pass) --recursive preserves a workspace member's catalog: reference [12.40ms]
(pass) --filter excluding root leaves root (and its catalog) untouched [12.86ms]
(pass) --recursive --latest from a member updates root's catalog and direct deps together [9.18ms]
(pass) --filter with a path targets only the matching workspace [10
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-update.test.ts
bun test v1.4.0 (59a9d71ed)

test/cli/install/bun-update.test.ts:
(pass) should update to latest version of dependency (~) [497.76ms]
(pass) should update to latest versions of dependencies (~) [429.20ms]
(pass) lockfile should not be modified when there are no version changes, issue#5888 [1218.81ms]
(pass) should support catalog versions in update [193.91ms]
(pass) should support --recursive flag [236.04ms]
(pass) --recursive updates dependencies and peerDependencies in workspace members [388.99ms]
(pass) --recursive --latest updates workspace members to the latest version [386.47ms]
(pass) --filter updates only matching workspaces, leaving siblings and root untouched [376.64ms]
(pass) --filter with multiple patterns selects the union of matching workspaces [396.43ms]
(pass) named update with --recursive rewrites only the cwd package.json [376.78ms]
(pass) --recursive preserves a workspace member's catalog: reference [380.53ms]
(pass) --filter excluding root leaves root (and its catalog) untouched [
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 686ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (9052ms)
Bundle modules (52ms)
Postprocesss modules (207ms)
Bundle Functions (693ms)
Generate Code (34ms)

[10.05s] Bundled "src/js" for production
  2569 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager.rs                      | 112 +++
 src/install/PackageManager/PackageJSONEditor.rs    |  54 +-
 .../PackageManager/PackageManagerEnqueue.rs        |  73 +-
 src/install/PackageManager/UpdateRequest.rs        |  12 +
 src/install/PackageManager/install_with_manager.rs |  32 +-
 .../PackageManager/updatePackageJSONAndInstall.rs  | 224 ++++-
 src/install/lockfile.rs                            |  18 +
 src/install/lockfile/Package.rs                    |  23 +-
 src/runtime/cli/outdated_command.rs                | 130 +--
 src/runtime/cli/update_interactive_command.rs      | 138 +--
 test/cli/install/bun-update.test.ts                | 958 ++++++++++++++++++++-
 11 files changed, 1449 insertions(+), 325 deletions(-)
```

</details>

**gate history** · 12 passed · 0 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/install/PackageManager.rs                                12     12      0
src/install/PackageManager/PackageJSONEditor.rs               8      7      0
src/install/PackageManager/PackageManagerEnqueue.rs          15     13      0
src/install/PackageManager/UpdateRequest.rs                   3      4      0
src/install/PackageManager/install_with_manager.rs            4      5      0
…c/install/PackageManager/updatePackageJSONAndInstall.rs     34     39      0
src/install/lockfile.rs                                       7      5      0
src/install/lockfile/Package.rs                               1      1      0
src/runtime/cli/outdated_command.rs                           2      3      0
src/runtime/cli/update_interactive_command.rs                 5      3      0
test/cli/install/bun-update.test.ts                           8     10      0
```

</details>

<!-- robobun:evidence:end -->