### PR TITLE
Bump WebKit: omit dayPeriod from Intl.DateTimeFormat resolvedOptions for bare 12-hour patterns

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "34c01d13391e00c06862a3d2c5b7fff350ac87e0";
+export const WEBKIT_VERSION = "autobuild-preview-pr-373-0c1a9be2";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -86,6 +86,43 @@ describe("Intl.NumberFormat", () => {
 // ---------------------------------------------------------------------------
 
 describe("Intl.DateTimeFormat", () => {
+  test("resolvedOptions() omits dayPeriod for a bare 12-hour pattern", () => {
+    // The AM/PM marker ('a' in the ICU pattern) is governed by hourCycle/hour12,
+    // not the dayPeriod option. A 12-hour formatter that never asked for dayPeriod
+    // must not report one, and round-tripping resolvedOptions() must reproduce the
+    // same output. https://tc39.es/ecma402/#sec-initializedatetimeformat
+    const t = Date.UTC(2026, 0, 1, 10, 5);
+    const opts = { timeZone: "UTC", hour: "numeric", minute: "2-digit" } as const;
+    const a = new Intl.DateTimeFormat("en-US", opts);
+    const ro = a.resolvedOptions();
+    const b = new Intl.DateTimeFormat("en-US", ro);
+    expect({
+      dayPeriod: ro.dayPeriod,
+      hourCycle: ro.hourCycle,
+      original: a.format(t),
+      roundTrip: b.format(t),
+    }).toEqual({
+      dayPeriod: undefined,
+      hourCycle: "h12",
+      original: "10:05 AM",
+      roundTrip: "10:05 AM",
+    });
+
+    expect(
+      new Intl.DateTimeFormat("en-US", { timeZone: "UTC", hour: "2-digit", hourCycle: "h11" }).resolvedOptions()
+        .dayPeriod,
+    ).toBeUndefined();
+
+    // When dayPeriod *is* requested it must still be reported.
+    expect(
+      new Intl.DateTimeFormat("en-US", { timeZone: "UTC", hour: "numeric", dayPeriod: "long" }).resolvedOptions()
+        .dayPeriod,
+    ).toBe("long");
+
+    // formatToParts still labels the AM/PM marker as type "dayPeriod" (ECMA-402 Table 16).
+    expect(a.formatToParts(t).find(p => p.value === "AM")?.type).toBe("dayPeriod");
+  });
+
   snapshotIf("default", () => {
     const out: Record<string, string> = {};
     for (const loc of LOCALES) out[loc] = new Intl.DateTimeFormat(loc, { timeZone: "UTC" }).format(0);


### PR DESCRIPTION
Bumps `WEBKIT_VERSION` to pick up [oven-sh/WebKit#373](https://github.com/oven-sh/WebKit/pull/373).

### Problem

Any `Intl.DateTimeFormat` component formatter that resolves to a 12-hour cycle (`hour` with h11/h12, `hour12: true`, or a 12-hour locale default) reports `resolvedOptions().dayPeriod === "short"` even though no `dayPeriod` option was passed and the output contains no flexible day period. Feeding `resolvedOptions()` back into the constructor (the ECMA-402 round-trip idiom) then genuinely requests `dayPeriod`, so the same time formats differently:

```js
const t = Date.UTC(2026, 0, 1, 10, 5);
const a = new Intl.DateTimeFormat("en-US", { timeZone: "UTC", hour: "numeric", minute: "2-digit" });
const ro = a.resolvedOptions();
const b = new Intl.DateTimeFormat("en-US", ro);
console.log(ro.dayPeriod, a.format(t), b.format(t));
// bun : "short"   "10:05 AM"  "10:05 in the morning"
// node: undefined "10:05 AM"  "10:05 AM"
```

h23/h24 and the `timeStyle` path are unaffected.

### Cause

`IntlDateTimeFormat::setFormatsFromPattern` in JSC maps the resolved ICU pattern back into the fields that `resolvedOptions()` reports. It was treating `'a'` (the AM/PM marker, emitted whenever the resolved hour cycle is h11/h12) the same as `'b'`/`'B'` (the flexible day-period fields that the ECMA-402 `dayPeriod` option actually requests). `buildSkeleton` maps `dayPeriod` back to `'B'`, so the round-trip swaps the AM/PM marker for a flexible day period.

### Fix

`'a'` no longer populates `m_dayPeriod`; only `'b'`/`'B'` do. `m_dayPeriod` is read exclusively by `resolvedOptions()`, so `formatToParts` (which maps `UDAT_AM_PM_FIELD` to the `"dayPeriod"` part type independently) is unaffected. This matches V8.

### Verification

New test in `test/js/web/intl/intl.test.ts` covers the undefined `dayPeriod`, the round-trip equality, the explicit-`dayPeriod` case still being reported, and the `formatToParts` part type.

### Also in this range (oven-sh/WebKit 34c01d1339..)

Nothing else; oven-sh/WebKit#373 is directly on top of the current `WEBKIT_VERSION`.

> [!NOTE]
> `WEBKIT_VERSION` currently points at the preview tag `autobuild-preview-pr-373-0c1a9be2` while oven-sh/WebKit#373 is open. It will be switched to the merged main sha before this lands.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->