### PR TITLE
Intl.NumberFormat: fix percent formatRange scaling twice on approximately path

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "34c01d13391e00c06862a3d2c5b7fff350ac87e0";
+export const WEBKIT_VERSION = "autobuild-preview-pr-374-9cfb1f57";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-374-9cfb1f57";
+export const WEBKIT_VERSION = "autobuild-preview-pr-374-46c558e6";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -79,6 +79,45 @@ describe("Intl.NumberFormat", () => {
     }
     expect(out).toMatchSnapshot();
   });
+
+  // ICU-23110: with style:"percent", formatRange/formatRangeToParts collapsing to
+  // ~single-value applied scale/100 twice (0.5 → "~5,000%" instead of "~50%").
+  // Assert the numeric parts match format() exactly; the approximatelySign /
+  // literal decorations are locale-shaped and covered by the string check.
+  describe("style:'percent' formatRange identity (ICU-23110)", () => {
+    const numeric = (parts: Intl.NumberFormatPart[]) =>
+      parts
+        .filter(p => p.type !== "approximatelySign" && p.type !== "literal")
+        .map(p => `${p.type}:${p.value}`);
+
+    test.each(["en", "de", "ja", "ar"])("%s", loc => {
+      const nf = new Intl.NumberFormat(loc, { style: "percent" });
+      for (const [a, b] of [
+        [0.5, 0.5],
+        [0.5, 0.500001],
+        [0.145, 0.145],
+      ] as const) {
+        const single = nf.format(a);
+        const range = nf.formatRange(a, b);
+        // The collapsed range is format(a) with a locale-specific "approximately" affix.
+        expect({ a, b, range }.range).toContain(single);
+        expect({ a, b, parts: numeric(nf.formatRangeToParts(a, b)) }.parts).toEqual(numeric(nf.formatToParts(a)));
+      }
+      // Distinct endpoints must still render as a range.
+      expect(nf.formatRange(0.5, 0.6)).toContain(nf.format(0.6));
+    });
+
+    test("BigInt and string inputs", () => {
+      const nf = new Intl.NumberFormat("en", { style: "percent" });
+      expect(numeric(nf.formatRangeToParts(5n, 5n))).toEqual(numeric(nf.formatToParts(5n)));
+      expect(numeric(nf.formatRangeToParts("0.5", "0.5"))).toEqual(numeric(nf.formatToParts("0.5")));
+    });
+
+    test("compact notation", () => {
+      const nf = new Intl.NumberFormat("en", { style: "percent", notation: "compact" });
+      expect(nf.formatRange(15, 15)).toContain(nf.format(15));
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -96,10 +96,9 @@ describe("Intl.NumberFormat", () => {
         [0.145, 0.145],
       ] as const) {
         const single = nf.format(a);
-        const range = nf.formatRange(a, b);
         // The collapsed range is format(a) with a locale-specific "approximately" affix.
-        expect({ a, b, range }.range).toContain(single);
-        expect({ a, b, parts: numeric(nf.formatRangeToParts(a, b)) }.parts).toEqual(numeric(nf.formatToParts(a)));
+        expect({ a, b, range: nf.formatRange(a, b) }).toEqual({ a, b, range: expect.stringContaining(single) });
+        expect({ a, b, parts: numeric(nf.formatRangeToParts(a, b)) }).toEqual({ a, b, parts: numeric(nf.formatToParts(a)) });
       }
       // Distinct endpoints must still render as a range.
       expect(nf.formatRange(0.5, 0.6)).toContain(nf.format(0.6));

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -98,7 +98,11 @@ describe("Intl.NumberFormat", () => {
         const single = nf.format(a);
         // The collapsed range is format(a) with a locale-specific "approximately" affix.
         expect({ a, b, range: nf.formatRange(a, b) }).toEqual({ a, b, range: expect.stringContaining(single) });
-        expect({ a, b, parts: numeric(nf.formatRangeToParts(a, b)) }).toEqual({ a, b, parts: numeric(nf.formatToParts(a)) });
+        expect({ a, b, parts: numeric(nf.formatRangeToParts(a, b)) }).toEqual({
+          a,
+          b,
+          parts: numeric(nf.formatToParts(a)),
+        });
       }
       // Distinct endpoints must still render as a range.
       expect(nf.formatRange(0.5, 0.6)).toContain(nf.format(0.6));

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -86,9 +86,7 @@ describe("Intl.NumberFormat", () => {
   // literal decorations are locale-shaped and covered by the string check.
   describe("style:'percent' formatRange identity (ICU-23110)", () => {
     const numeric = (parts: Intl.NumberFormatPart[]) =>
-      parts
-        .filter(p => p.type !== "approximatelySign" && p.type !== "literal")
-        .map(p => `${p.type}:${p.value}`);
+      parts.filter(p => p.type !== "approximatelySign" && p.type !== "literal").map(p => `${p.type}:${p.value}`);
 
     test.each(["en", "de", "ja", "ar"])("%s", loc => {
       const nf = new Intl.NumberFormat(loc, { style: "percent" });


### PR DESCRIPTION
## Problem

With `style: "percent"`, `Intl.NumberFormat.prototype.formatRange` (and `formatRangeToParts`) applies the ×100 scale twice whenever the range collapses to a single approximate value (equal endpoints, or endpoints that round to the same formatted number):

```js
for (const loc of ["en", "de", "ja"]) {
  const nf = new Intl.NumberFormat(loc, { style: "percent" });
  console.log(loc, nf.format(0.5), nf.formatRange(0.5, 0.5), nf.formatRange(0.5, 0.500001), nf.formatRange(0.5, 0.6));
}
// bun : en 50% ~5,000% ~5,000% 50% – 60%   |  de ≈5.000 %  |  ja 約5,000%
// node: en 50% ~50%    ~50%    50% – 60%   |  de ≈50 %     |  ja 約50%
```

Reproduces in every locale and through every input path (double, BigInt, string); compact notation shows the same ×100 (`formatRange(15, 15)` → `~150K%`, Node `~1.5K%`). Distinct ranges, `style: "unit" / "currency" / "decimal"` collapses, and macOS are all correct.

## Cause

[ICU-23110](https://unicode-org.atlassian.net/browse/ICU-23110). `NumberRangeFormatterImpl::format` calls `formatterImpl1.preProcess(data.quantity1, ...)` (which applies the skeleton's `scale/100`), then on the `UNUM_IDENTITY_FALLBACK_APPROXIMATELY` path hands the already-scaled `data.quantity1` to `formatApproximately`, which calls `fApproximatelyFormatter.preProcess(data.quantity1, ...)` again. The intervening `resetExponent()` only clears compact/scientific exponent state, not the multiplier, so 0.5 → 50 → 5000.

JSC builds the range formatter from the same skeleton as `format()` (`" percent scale/100"`) and passes raw inputs to `unumrf_formatDoubleRange` / `unumrf_formatDecimalRange`, which is also what V8 does. Node is correct only because it ships ICU ≥ 78. Bun bundles ICU 75.1 on Linux/musl/Android/FreeBSD and 73.2 on Windows; macOS links Apple's `libicucore`, which already renders correctly.

## Fix

**oven-sh/WebKit#374** backports unicode-org/icu@757be359 (first released in ICU 78.1) as a build-time patch applied in every Dockerfile that builds ICU. The patch takes a copy of `data.quantity1` before the first `preProcess` and feeds that copy to `formatApproximately`, so the approximately formatter starts from the original quantity.

This PR:
- bumps `WEBKIT_VERSION` to that PR's preview build;
- adds coverage in `test/js/web/intl/intl.test.ts`: for `en`/`de`/`ja`/`ar`, the numeric parts of `formatRangeToParts(a, a)` must equal `formatToParts(a)`, and the collapsed range string must contain `format(a)`. Covers double, BigInt, string, and compact-notation inputs, plus a distinct-range sanity check.

## Verification

Built ICU 75.1 with and without the backport and drove `unumrf_formatDoubleRange` directly:

```
                        unpatched       patched
formatRange(0.5, 0.5)   ~5,000%         ~50%
formatRange(0.5, 0.6)   50% – 60%       50% – 60%
formatRange(15, 15)     ~150,000%       ~1,500%
```

The new test block:
- fails on the current WebKit prebuilt (`Expected to contain: "50%"` / `Received: "~5,000%"`, all four locales, BigInt/string/compact);
- passes on Node (ICU 78.3) and on macOS (Apple ICU 74.2).

Note: the automated fail-before/fail-after gate does not apply here because the code change is a prebuilt-dependency bump (`scripts/build/deps/webkit.ts`), not `src/**`; the WebKit preview build is what makes the new tests pass. This PR's CI build step will fail until the oven-sh/WebKit#374 preview release (`autobuild-preview-pr-374-9cfb1f57`) is published; once it merges the `WEBKIT_VERSION` here will be updated to the resulting autobuild sha.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->