### PR TITLE
test: use port 0 in bun-audit.test.ts mock registry server

### DIFF
--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -18,6 +18,7 @@ let server: Bun.Server;
 
 beforeAll(() => {
   server = Bun.serve({
+    port: 0,
     fetch: async req => {
       const body = await gunzipJsonRequest(req);
 
@@ -34,7 +35,7 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  server.stop();
+  server?.stop();
 });
 
 function doAuditTest(


### PR DESCRIPTION
The `beforeAll` `Bun.serve()` call in `test/cli/install/bun-audit.test.ts` had no port specified, so it defaulted to 3000. When another test in the same parallel batch already held port 3000, `beforeAll` threw:

```
Failed to start server. Is port 3000 in use?
```

and `afterAll` then threw on `server.stop()` because `server` was never assigned:

```
undefined is not an object (evaluating 'server.stop')
```

Seen on debian 13 aarch64 (test-bun) in the parallel batch; passes when run alone.

Fix: use `port: 0` for an ephemeral port, and optional-chain `server?.stop()` so a future `beforeAll` failure doesn't get masked by the `afterAll` crash.

Verified locally by occupying port 3000 and running the test: fails before this change with the exact errors above, passes after (16/16).