### PR TITLE
Intl.DurationFormat: per-unit numeric style forces minutes/seconds display

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "34c01d13391e00c06862a3d2c5b7fff350ac87e0";
+export const WEBKIT_VERSION = "autobuild-preview-pr-375-8394b80f";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -185,6 +185,65 @@ describe("Intl.ListFormat", () => {
   });
 });
 
+describe("Intl.DurationFormat", () => {
+  // https://tc39.es/ecma402/#sec-getdurationunitoptions step 3.b.i: when a
+  // unit's style is left undefined and the previous unit resolved to
+  // "numeric"/"2-digit", minutes and seconds must default their *display* to
+  // "always" (only other units default to "auto"). Without this, {hours:"numeric"}
+  // formatted {hours:1} as "1" instead of "1:00:00".
+  describe("per-unit numeric style forces minutes/seconds display", () => {
+    test("resolvedOptions()", () => {
+      const pick = (o: Intl.ResolvedDurationFormatOptions) => ({
+        minutes: o.minutes,
+        minutesDisplay: o.minutesDisplay,
+        seconds: o.seconds,
+        secondsDisplay: o.secondsDisplay,
+        milliseconds: o.milliseconds,
+        millisecondsDisplay: o.millisecondsDisplay,
+      });
+      // hours:"numeric" -> minutes/seconds inherit 2-digit + display:"always";
+      // milliseconds inherits numeric but keeps display:"auto" (not minute/second).
+      expect(pick(new Intl.DurationFormat("en", { hours: "numeric" }).resolvedOptions())).toEqual({
+        minutes: "2-digit",
+        minutesDisplay: "always",
+        seconds: "2-digit",
+        secondsDisplay: "always",
+        milliseconds: "numeric",
+        millisecondsDisplay: "auto",
+      });
+      expect(pick(new Intl.DurationFormat("en", { hours: "2-digit" }).resolvedOptions())).toEqual({
+        minutes: "2-digit",
+        minutesDisplay: "always",
+        seconds: "2-digit",
+        secondsDisplay: "always",
+        milliseconds: "numeric",
+        millisecondsDisplay: "auto",
+      });
+      // minutes:"numeric" -> only seconds is forced.
+      const ro = new Intl.DurationFormat("en", { minutes: "numeric" }).resolvedOptions();
+      expect({ seconds: ro.seconds, secondsDisplay: ro.secondsDisplay }).toEqual({
+        seconds: "2-digit",
+        secondsDisplay: "always",
+      });
+    });
+
+    test("format()", () => {
+      const fmt = (opts: Intl.DurationFormatOptions, d: Intl.DurationInput) =>
+        new Intl.DurationFormat("en", opts).format(d);
+      expect(fmt({ hours: "numeric" }, { hours: 1 })).toBe("1:00:00");
+      expect(fmt({ hours: "numeric" }, { hours: 0 })).toBe("0:00:00");
+      expect(fmt({ hours: "2-digit" }, { hours: 1 })).toBe("01:00:00");
+      expect(fmt({ hours: "numeric", minutes: "numeric" }, { minutes: 5 })).toBe("0:05:00");
+      expect(fmt({ minutes: "numeric" }, { minutes: 5 })).toBe("5:00");
+      expect(fmt({ minutes: "2-digit" }, { minutes: 5 })).toBe("05:00");
+      // style:"digital" already behaved this way; the two spellings must agree.
+      expect(fmt({ style: "digital" }, { minutes: 5 })).toBe("0:05:00");
+      // An explicit {minutesDisplay:"auto"} still suppresses zero units.
+      expect(fmt({ hours: "numeric", minutesDisplay: "auto", secondsDisplay: "auto" }, { hours: 1 })).toBe("1");
+    });
+  });
+});
+
 describe("Intl.RelativeTimeFormat", () => {
   snapshotIf("format across locales", () => {
     const out: Record<string, string[]> = {};


### PR DESCRIPTION
Depends on oven-sh/WebKit#375 (the load-bearing fix). This PR bumps `WEBKIT_VERSION` to that PR's preview build and adds regression coverage; it will switch to the merged main sha before landing.

## Repro

```js
const DF = Intl.DurationFormat;
console.log(new DF("en", { hours: "numeric" }).format({ hours: 1 }));
console.log(new DF("en", { minutes: "numeric" }).format({ minutes: 5 }));
console.log(new DF("en", { style: "digital" }).format({ minutes: 5 }));
const o = new DF("en", { hours: "numeric" }).resolvedOptions();
console.log(o.minutesDisplay, o.secondsDisplay, o.millisecondsDisplay);
// bun : "1"       | "5"    | "0:05:00" | "auto"   "auto"   "auto"
// node: "1:00:00" | "5:00" | "0:05:00" | "always" "always" "auto"
```

## Cause

ECMA-402 `GetDurationUnitOptions` step 3.b.i: when a unit's style option is undefined, `baseStyle` is not `"digital"`, and the previous unit resolved to `"numeric"`/`"2-digit"`, `displayDefault` stays `"always"` for `"minutes"` and `"seconds"` (only other units get `"auto"`). JSC's `intlDurationUnitOptions` set `displayDefault = Auto` unconditionally in that branch and only rewrote the inherited style to `Numeric`, so minutes and seconds inherited the correct `"2-digit"` style but the wrong `"auto"` display. The `{style:"digital"}` branch directly above it already handled this correctly, which is why the two spellings disagreed.

## Fix

oven-sh/WebKit#375 splits the non-digital `else` branch so the `prevStyle` numeric/2-digit case guards `displayDefault = Auto` behind `unit != Minute && unit != Second`, matching the digital branch.

## Verification

Compiled the patched `IntlDurationFormat.cpp` against `vendor/WebKit` at `34c01d1339` and replaced the standalone `IntlDurationFormat.cpp.o` (the file is `@no-unify`) in the prebuilt `libJavaScriptCore.a`, then relinked:

```
(pass) Intl.DurationFormat > per-unit numeric style forces minutes/seconds display > resolvedOptions()
(pass) Intl.DurationFormat > per-unit numeric style forces minutes/seconds display > format()
 33 pass / 0 fail
```

Both tests fail against the current release (`USE_SYSTEM_BUN=1`). Checked 20 format/resolvedOptions cases against Node v26.3.0; all match, including the unchanged paths (`{style:"digital"}`, explicit `minutesDisplay:"auto"`, the `RangeError` on style conflicts, and `millisecondsDisplay` staying `"auto"`).

> [!NOTE]
> `WEBKIT_VERSION` currently points at `autobuild-preview-pr-375-8394b80f`. Before merging, bump it to the `autobuild-<sha>` of the merge commit once oven-sh/WebKit#375 lands.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->