### PR TITLE
prompt()/confirm(): return typed input when stdin closes without a newline

### DIFF
--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -338,8 +338,7 @@ pub mod prompt {
             input.push(second);
         }
 
-        // Read until '\n', growing 2048 -> 4096 -> unbounded. EOF ends the
-        // response with the bytes read so far; only EOF-before-first-byte is null.
+        // EOF before '\n' yields the bytes read so far; only EOF-before-first-byte (above) is null.
         'read: {
             match read_until_delimiter_array_list_append_assume_capacity(
                 &mut *reader,

--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -126,9 +126,9 @@ fn confirm(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         }
         b'y' | b'Y' => {
             let Ok(next_byte) = reader.take_byte() else {
-                // They may have said yes, but the stdin is invalid.
-
-                return Ok(JSValue::FALSE);
+                // EOF after 'y' with no newline (e.g. `printf y | bun ...`) is a
+                // completed positive response, not an abort.
+                return Ok(JSValue::TRUE);
             };
 
             if next_byte == b'\n' {
@@ -138,7 +138,7 @@ fn confirm(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
             } else if next_byte == b'\r' {
                 // Check Windows style
                 let Ok(second_byte) = reader.take_byte() else {
-                    return Ok(JSValue::FALSE);
+                    return Ok(JSValue::TRUE);
                 };
                 if second_byte == b'\n' {
                     return Ok(JSValue::TRUE);
@@ -320,12 +320,15 @@ pub mod prompt {
             //    that the user responded with.
             return Ok(default);
         } else if first_byte == b'\r' {
-            let Ok(second) = reader.read_byte() else {
-                return Ok(JSValue::NULL);
-            };
-            second_byte = Some(second);
-            if second == b'\n' {
-                return Ok(default);
+            match reader.read_byte() {
+                Ok(second) => {
+                    if second == b'\n' {
+                        return Ok(default);
+                    }
+                    second_byte = Some(second);
+                }
+                // Bare CR followed by EOF: treat as an empty response, same as CRLF.
+                Err(_) => return Ok(default),
             }
         }
 
@@ -340,40 +343,35 @@ pub mod prompt {
         // buffer of size 2048. If that is too small, then increase the buffer
         // size to 4096. If that is too small, then just dynamically allocate
         // the rest.
-        if let Err(e) = read_until_delimiter_array_list_append_assume_capacity(
-            &mut *reader,
-            &mut input,
-            b'\n',
-            2048,
-        ) {
-            if !matches!(e, ReadError::StreamTooLong) {
-                // 8. Let result be null if the user aborts, or otherwise the string
-                //    that the user responded with.
-                return Ok(JSValue::NULL);
+        //
+        // Reaching EOF before a newline is a completed response (the bytes read
+        // so far), not an abort: `printf answer | bun` and a TTY user typing
+        // text then Ctrl-D both produce this shape. Only EOF before the first
+        // byte (handled above) returns null.
+        'read: {
+            match read_until_delimiter_array_list_append_assume_capacity(
+                &mut *reader,
+                &mut input,
+                b'\n',
+                2048,
+            ) {
+                Ok(()) | Err(ReadError::Io) => break 'read,
+                Err(ReadError::StreamTooLong) => {}
             }
 
             input.ensure_total_capacity(4096);
 
-            if let Err(e2) = read_until_delimiter_array_list_append_assume_capacity(
+            match read_until_delimiter_array_list_append_assume_capacity(
                 &mut *reader,
                 &mut input,
                 b'\n',
                 4096,
             ) {
-                if !matches!(e2, ReadError::StreamTooLong) {
-                    // 8. Let result be null if the user aborts, or otherwise the string
-                    //    that the user responded with.
-                    return Ok(JSValue::NULL);
-                }
-
-                if read_until_delimiter_array_list_infinity(&mut *reader, &mut input, b'\n')
-                    .is_err()
-                {
-                    // 8. Let result be null if the user aborts, or otherwise the string
-                    //    that the user responded with.
-                    return Ok(JSValue::NULL);
-                }
+                Ok(()) | Err(ReadError::Io) => break 'read,
+                Err(ReadError::StreamTooLong) => {}
             }
+
+            let _ = read_until_delimiter_array_list_infinity(&mut *reader, &mut input, b'\n');
         }
 
         if !input.is_empty() && input[input.len() - 1] == b'\r' {
@@ -381,7 +379,6 @@ pub mod prompt {
         }
 
         debug_assert!(!input.is_empty());
-        debug_assert!(input[input.len() - 1] != b'\r');
 
         // 8. Let result be null if the user aborts, or otherwise the string
         //    that the user responded with.

--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -126,8 +126,7 @@ fn confirm(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         }
         b'y' | b'Y' => {
             let Ok(next_byte) = reader.take_byte() else {
-                // EOF after 'y' with no newline (e.g. `printf y | bun ...`) is a
-                // completed positive response, not an abort.
+                // EOF after 'y' is a completed "yes", not an abort.
                 return Ok(JSValue::TRUE);
             };
 
@@ -339,15 +338,8 @@ pub mod prompt {
             input.push(second);
         }
 
-        // All of this code basically just first tries to load the input into a
-        // buffer of size 2048. If that is too small, then increase the buffer
-        // size to 4096. If that is too small, then just dynamically allocate
-        // the rest.
-        //
-        // Reaching EOF before a newline is a completed response (the bytes read
-        // so far), not an abort: `printf answer | bun` and a TTY user typing
-        // text then Ctrl-D both produce this shape. Only EOF before the first
-        // byte (handled above) returns null.
+        // Read until '\n', growing 2048 -> 4096 -> unbounded. EOF ends the
+        // response with the bytes read so far; only EOF-before-first-byte is null.
         'read: {
             match read_until_delimiter_array_list_append_assume_capacity(
                 &mut *reader,

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -1,5 +1,5 @@
 import { spawn } from "bun";
-import { expect, it, test } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isMacOS, isWindows, withoutAggressiveGC } from "harness";
 
 test("exists", () => {
@@ -350,6 +350,73 @@ test("confirm (no) windows newline", async () => {
   await proc.exited;
 
   expect(await proc.stderr.text()).toBe("No\n");
+});
+
+// prompt()/confirm() must treat EOF after some input as a completed response,
+// not as an abort. This is what `printf ans | bun`, `echo -n ans | bun`, and a
+// TTY user typing then pressing Ctrl-D all produce.
+describe.concurrent("prompt()/confirm() with unterminated stdin (EOF before newline)", () => {
+  async function runPrompt(stdin, src) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdin: Buffer.from(stdin),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.each([
+    ["answer", '"answer"'],
+    ["answer\n", '"answer"'],
+    ["answer\r\n", '"answer"'],
+    ["answer\r", '"answer"'],
+    ["hello world", '"hello world"'],
+  ])("prompt() with stdin %j returns %s", async (stdin, expected) => {
+    const { stderr, exitCode } = await runPrompt(stdin, 'console.error(JSON.stringify(prompt("Q?")))');
+    expect(stderr).toBe(expected + "\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.each([
+    ["", "null"],
+    ["\n", '"DEF"'],
+    ["\r\n", '"DEF"'],
+    ["\r", '"DEF"'],
+    ["x", '"x"'],
+  ])("prompt() with default, stdin %j returns %s", async (stdin, expected) => {
+    const { stderr, exitCode } = await runPrompt(stdin, 'console.error(JSON.stringify(prompt("Q?", "DEF")))');
+    expect(stderr).toBe(expected + "\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("prompt() with a long unterminated line returns the full line", async () => {
+    // Crosses the 2048 and 4096 internal buffer thresholds.
+    const { stderr, exitCode } = await runPrompt(
+      Buffer.alloc(5000, "A"),
+      'const r = prompt("Q?"); console.error(JSON.stringify({ len: r?.length ?? null, ok: r === Buffer.alloc(5000, "A").toString() }))',
+    );
+    expect(JSON.parse(stderr)).toEqual({ len: 5000, ok: true });
+    expect(exitCode).toBe(0);
+  });
+
+  test.each([
+    ["y", "Yes"],
+    ["Y", "Yes"],
+    ["y\r", "Yes"],
+    ["n", "No"],
+    ["", "No"],
+    ["yes", "No"],
+  ])("confirm() with stdin %j returns %s", async (stdin, expected) => {
+    const { stderr, exitCode } = await runPrompt(
+      stdin,
+      'console.error(confirm("Q?") ? "Yes" : "No")',
+    );
+    expect(stderr).toBe(expected + "\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 test("globalThis.self = 123 works", () => {

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -410,10 +410,7 @@ describe.concurrent("prompt()/confirm() with unterminated stdin (EOF before newl
     ["", "No"],
     ["yes", "No"],
   ])("confirm() with stdin %j returns %s", async (stdin, expected) => {
-    const { stderr, exitCode } = await runPrompt(
-      stdin,
-      'console.error(confirm("Q?") ? "Yes" : "No")',
-    );
+    const { stderr, exitCode } = await runPrompt(stdin, 'console.error(confirm("Q?") ? "Yes" : "No")');
     expect(stderr).toBe(expected + "\n");
     expect(exitCode).toBe(0);
   });


### PR DESCRIPTION
## What

`prompt()` discarded the accumulated input buffer and returned `null` whenever stdin reached EOF before a `\n`. `confirm()` did the same, returning `false` for `y` + EOF. This is exactly the shape produced by `printf`, `echo -n`, shell heredocs without a trailing newline, and a TTY user typing text then pressing Ctrl-D.

```console
$ printf 'answer' | bun -e 'console.log(JSON.stringify(prompt("Q?")))'
Q? null                                 # before
Q? "answer"                             # after

$ printf 'y' | bun -e 'console.log(confirm("Q?"))'
Q? [y/N] false                          # before
Q? [y/N] true                           # after

$ head -c 1048576 /dev/zero | tr '\0' A | bun -e 'console.log(prompt("?")?.length)'
? undefined                             # before: 1 MiB of input discarded
? 1048576                               # after
```

Every line reader in this space (Node `readline`, Bun's own `for await (const line of console)`, POSIX `read`) yields the unterminated final line. The HTML spec's `null` return is for the user *aborting* the dialog, not for a completed response that happens to lack a trailing newline.

## Cause

Every EOF path in `src/runtime/webcore/prompt.rs` returned `NULL` / `FALSE` and dropped the partially-filled buffer: the read-until-`\n` helpers map `read_byte()`'s `EndOfStream` to `ReadError::Io`, and the caller treated that as an abort at all three buffer-size tiers.

## Fix

- `prompt()`: on EOF inside the read loop, fall through and return the accumulated bytes. Only EOF before the first byte still returns `null`. A bare CR before EOF is treated as an empty response (returns the `default`), same as CRLF. The three-tier read was restructured as a labeled block with explicit `match` arms so EOF and newline both exit to the same result path.
- `confirm()`: EOF immediately after `y`/`Y` (or `y\r`) is a completed positive response.
- Removed a `debug_assert!(input[last] != b'\r')` that already did not hold for inputs with consecutive CRs (e.g. `\r\r\n`); it only strips one trailing `\r`.

## Verification

Tests added to `test/js/web/web-globals.test.js` next to the existing `confirm()` tests: unterminated and terminated variants for `prompt()`, `prompt()` with a default, a 5000-byte unterminated line crossing the 2048 and 4096 internal buffer thresholds, and `confirm()` `y`/`Y`/`y\r`/`n`/empty/`yes` at EOF.

```
USE_SYSTEM_BUN=1 bun test test/js/web/web-globals.test.js -t "unterminated stdin"  # 9 fail, 8 pass
bun bd          test test/js/web/web-globals.test.js -t "unterminated stdin"       # 17 pass
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/web-globals.test.js

<!-- robobun:evidence:end -->