### PR TITLE
test(svelte): deflake client-side dev server test

### DIFF
--- a/test/integration/svelte/client-side.test.ts
+++ b/test/integration/svelte/client-side.test.ts
@@ -1,9 +1,13 @@
 import { Subprocess } from "bun";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tmpdirSync } from "harness";
 import { promises as fs, statSync } from "node:fs";
 import path from "node:path";
 
 const fixturePath = (...segs: string[]): string => path.join(import.meta.dirname, "fixtures", ...segs);
+
+// Running the real Svelte compiler (in-process Bun.build and via the spawned
+// dev server) takes ~8-11s under debug+ASAN; the workload can't be shrunk.
+const svelteCompileTimeout = isDebug || isASAN ? 30_000 : undefined;
 
 beforeAll(async () => {
   const pluginDir = path.resolve(import.meta.dirname, "..", "..", "..", "packages", "bun-plugin-svelte");
@@ -35,7 +39,7 @@ describe("generating client-side code", () => {
     } finally {
       await fs.rm(outdir, { force: true, recursive: true });
     }
-  }, 30_000);
+  }, svelteCompileTimeout);
 
   describe("Using Svelte components in Bun's dev server", () => {
     let server: Subprocess<"ignore", "pipe", "inherit">;
@@ -78,6 +82,6 @@ describe("generating client-side code", () => {
       expect(body).toContain("<title>Svelte App</title>");
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toMatch("text/html");
-    }, 30_000);
+    }, svelteCompileTimeout);
   });
 });

--- a/test/integration/svelte/client-side.test.ts
+++ b/test/integration/svelte/client-side.test.ts
@@ -38,18 +38,42 @@ describe("generating client-side code", () => {
   });
 
   describe("Using Svelte components in Bun's dev server", () => {
-    let server: Subprocess;
+    let server: Subprocess<"ignore", "pipe", "pipe">;
+    let baseUrl: string;
 
     beforeAll(async () => {
-      server = Bun.spawn([bunExe(), "./index.html"], {
+      server = Bun.spawn({
+        cmd: [bunExe(), "./index.html", "--port=0", "--hostname=127.0.0.1"],
         env: {
           ...bunEnv,
           NODE_ENV: "development",
         },
         cwd: fixturePath("app"),
-        stdio: ["ignore", "inherit", "inherit"],
+        stdio: ["ignore", "pipe", "pipe"],
       });
-      await Bun.sleep(500);
+
+      const decoder = new TextDecoder();
+      let text = "";
+      const reader = server.stdout.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (value) text += decoder.decode(value, { stream: true });
+          const match = text.match(/http:\/\/127\.0\.0\.1:\d+\//);
+          if (match) {
+            baseUrl = match[0];
+            break;
+          }
+          if (done) break;
+        }
+      } finally {
+        reader.releaseLock();
+      }
+
+      if (!baseUrl) {
+        const stderr = await server.stderr.text();
+        throw new Error("dev server did not print a URL.\nstdout: " + text + "\nstderr: " + stderr);
+      }
     });
 
     afterAll(() => {
@@ -57,8 +81,9 @@ describe("generating client-side code", () => {
     });
 
     it("serves the app", async () => {
-      const response = await fetch("http://localhost:3000");
-      await console.log(await response.text());
+      const response = await fetch(baseUrl);
+      const body = await response.text();
+      expect(body).toContain("<title>Svelte App</title>");
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toMatch("text/html");
     });

--- a/test/integration/svelte/client-side.test.ts
+++ b/test/integration/svelte/client-side.test.ts
@@ -38,7 +38,7 @@ describe("generating client-side code", () => {
   }, 30_000);
 
   describe("Using Svelte components in Bun's dev server", () => {
-    let server: Subprocess<"ignore", "pipe", "pipe">;
+    let server: Subprocess<"ignore", "pipe", "inherit">;
     let baseUrl: string;
 
     beforeAll(async () => {
@@ -49,30 +49,22 @@ describe("generating client-side code", () => {
           NODE_ENV: "development",
         },
         cwd: fixturePath("app"),
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: ["ignore", "pipe", "inherit"],
       });
 
       const decoder = new TextDecoder();
       let text = "";
-      const reader = server.stdout.getReader();
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (value) text += decoder.decode(value, { stream: true });
-          const match = text.match(/http:\/\/127\.0\.0\.1:\d+\//);
-          if (match) {
-            baseUrl = match[0];
-            break;
-          }
-          if (done) break;
+      for await (const chunk of server.stdout) {
+        text += decoder.decode(chunk, { stream: true });
+        const match = text.match(/http:\/\/127\.0\.0\.1:\d+\//);
+        if (match) {
+          baseUrl = match[0];
+          break;
         }
-      } finally {
-        reader.releaseLock();
       }
 
       if (!baseUrl) {
-        const stderr = await server.stderr.text();
-        throw new Error("dev server did not print a URL.\nstdout: " + text + "\nstderr: " + stderr);
+        throw new Error("dev server did not print a URL.\nstdout: " + text);
       }
     });
 

--- a/test/integration/svelte/client-side.test.ts
+++ b/test/integration/svelte/client-side.test.ts
@@ -16,26 +16,30 @@ beforeAll(async () => {
 });
 
 describe("generating client-side code", () => {
-  test("Bundling Svelte components", async () => {
-    const outdir = tmpdirSync("bun-svelte-client-side");
-    const { SveltePlugin } = await import("bun-plugin-svelte");
-    try {
-      const result = await Bun.build({
-        entrypoints: [fixturePath("app/index.ts")],
-        outdir,
-        sourcemap: "inline",
-        minify: true,
-        target: "browser",
-        plugins: [SveltePlugin({ development: true })],
-      });
-      expect(result.success).toBeTrue();
+  test(
+    "Bundling Svelte components",
+    async () => {
+      const outdir = tmpdirSync("bun-svelte-client-side");
+      const { SveltePlugin } = await import("bun-plugin-svelte");
+      try {
+        const result = await Bun.build({
+          entrypoints: [fixturePath("app/index.ts")],
+          outdir,
+          sourcemap: "inline",
+          minify: true,
+          target: "browser",
+          plugins: [SveltePlugin({ development: true })],
+        });
+        expect(result.success).toBeTrue();
 
-      const entrypoint = result.outputs.find(o => o.kind === "entry-point");
-      expect(entrypoint).toBeDefined();
-    } finally {
-      await fs.rm(outdir, { force: true, recursive: true });
-    }
-  });
+        const entrypoint = result.outputs.find(o => o.kind === "entry-point");
+        expect(entrypoint).toBeDefined();
+      } finally {
+        await fs.rm(outdir, { force: true, recursive: true });
+      }
+    },
+    30_000,
+  );
 
   describe("Using Svelte components in Bun's dev server", () => {
     let server: Subprocess<"ignore", "pipe", "pipe">;
@@ -80,12 +84,16 @@ describe("generating client-side code", () => {
       server?.kill();
     });
 
-    it("serves the app", async () => {
-      const response = await fetch(baseUrl);
-      const body = await response.text();
-      expect(body).toContain("<title>Svelte App</title>");
-      expect(response.status).toBe(200);
-      expect(response.headers.get("content-type")).toMatch("text/html");
-    });
+    it(
+      "serves the app",
+      async () => {
+        const response = await fetch(baseUrl);
+        const body = await response.text();
+        expect(body).toContain("<title>Svelte App</title>");
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toMatch("text/html");
+      },
+      30_000,
+    );
   });
 });

--- a/test/integration/svelte/client-side.test.ts
+++ b/test/integration/svelte/client-side.test.ts
@@ -20,26 +20,30 @@ beforeAll(async () => {
 });
 
 describe("generating client-side code", () => {
-  test("Bundling Svelte components", async () => {
-    const outdir = tmpdirSync("bun-svelte-client-side");
-    const { SveltePlugin } = await import("bun-plugin-svelte");
-    try {
-      const result = await Bun.build({
-        entrypoints: [fixturePath("app/index.ts")],
-        outdir,
-        sourcemap: "inline",
-        minify: true,
-        target: "browser",
-        plugins: [SveltePlugin({ development: true })],
-      });
-      expect(result.success).toBeTrue();
+  test(
+    "Bundling Svelte components",
+    async () => {
+      const outdir = tmpdirSync("bun-svelte-client-side");
+      const { SveltePlugin } = await import("bun-plugin-svelte");
+      try {
+        const result = await Bun.build({
+          entrypoints: [fixturePath("app/index.ts")],
+          outdir,
+          sourcemap: "inline",
+          minify: true,
+          target: "browser",
+          plugins: [SveltePlugin({ development: true })],
+        });
+        expect(result.success).toBeTrue();
 
-      const entrypoint = result.outputs.find(o => o.kind === "entry-point");
-      expect(entrypoint).toBeDefined();
-    } finally {
-      await fs.rm(outdir, { force: true, recursive: true });
-    }
-  }, svelteCompileTimeout);
+        const entrypoint = result.outputs.find(o => o.kind === "entry-point");
+        expect(entrypoint).toBeDefined();
+      } finally {
+        await fs.rm(outdir, { force: true, recursive: true });
+      }
+    },
+    svelteCompileTimeout,
+  );
 
   describe("Using Svelte components in Bun's dev server", () => {
     let server: Subprocess<"ignore", "pipe", "inherit">;
@@ -76,12 +80,16 @@ describe("generating client-side code", () => {
       server?.kill();
     });
 
-    it("serves the app", async () => {
-      const response = await fetch(baseUrl);
-      const body = await response.text();
-      expect(body).toContain("<title>Svelte App</title>");
-      expect(response.status).toBe(200);
-      expect(response.headers.get("content-type")).toMatch("text/html");
-    }, svelteCompileTimeout);
+    it(
+      "serves the app",
+      async () => {
+        const response = await fetch(baseUrl);
+        const body = await response.text();
+        expect(body).toContain("<title>Svelte App</title>");
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toMatch("text/html");
+      },
+      svelteCompileTimeout,
+    );
   });
 });

--- a/test/integration/svelte/client-side.test.ts
+++ b/test/integration/svelte/client-side.test.ts
@@ -16,30 +16,26 @@ beforeAll(async () => {
 });
 
 describe("generating client-side code", () => {
-  test(
-    "Bundling Svelte components",
-    async () => {
-      const outdir = tmpdirSync("bun-svelte-client-side");
-      const { SveltePlugin } = await import("bun-plugin-svelte");
-      try {
-        const result = await Bun.build({
-          entrypoints: [fixturePath("app/index.ts")],
-          outdir,
-          sourcemap: "inline",
-          minify: true,
-          target: "browser",
-          plugins: [SveltePlugin({ development: true })],
-        });
-        expect(result.success).toBeTrue();
+  test("Bundling Svelte components", async () => {
+    const outdir = tmpdirSync("bun-svelte-client-side");
+    const { SveltePlugin } = await import("bun-plugin-svelte");
+    try {
+      const result = await Bun.build({
+        entrypoints: [fixturePath("app/index.ts")],
+        outdir,
+        sourcemap: "inline",
+        minify: true,
+        target: "browser",
+        plugins: [SveltePlugin({ development: true })],
+      });
+      expect(result.success).toBeTrue();
 
-        const entrypoint = result.outputs.find(o => o.kind === "entry-point");
-        expect(entrypoint).toBeDefined();
-      } finally {
-        await fs.rm(outdir, { force: true, recursive: true });
-      }
-    },
-    30_000,
-  );
+      const entrypoint = result.outputs.find(o => o.kind === "entry-point");
+      expect(entrypoint).toBeDefined();
+    } finally {
+      await fs.rm(outdir, { force: true, recursive: true });
+    }
+  }, 30_000);
 
   describe("Using Svelte components in Bun's dev server", () => {
     let server: Subprocess<"ignore", "pipe", "pipe">;
@@ -84,16 +80,12 @@ describe("generating client-side code", () => {
       server?.kill();
     });
 
-    it(
-      "serves the app",
-      async () => {
-        const response = await fetch(baseUrl);
-        const body = await response.text();
-        expect(body).toContain("<title>Svelte App</title>");
-        expect(response.status).toBe(200);
-        expect(response.headers.get("content-type")).toMatch("text/html");
-      },
-      30_000,
-    );
+    it("serves the app", async () => {
+      const response = await fetch(baseUrl);
+      const body = await response.text();
+      expect(body).toContain("<title>Svelte App</title>");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toMatch("text/html");
+    }, 30_000);
   });
 });

--- a/test/regression/issue/19661.test.ts
+++ b/test/regression/issue/19661.test.ts
@@ -37,8 +37,8 @@ test("server version", async () => {
       },
     });
 
-  // will start the server on default port 3000
-  const server = Bun.serve({
+  await using server = Bun.serve({
+    port: 0,
     fetch(req) {
       return new Response(stream());
     },


### PR DESCRIPTION
## What

`test/integration/svelte/client-side.test.ts` "serves the app" flakes in the parallel batch:

```
✗ serves the app
The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()
```

It passes when run alone.

## Why

The test spawned the dev server with no port (default 3000), waited a fixed `Bun.sleep(500)`, then fetched `http://localhost:3000`. In the parallel batch either something else is on 3000 or 500ms is not enough under load for the server to be ready.

`test/regression/issue/19661.test.ts` was one such neighbour: it calls `Bun.serve({...})` with no port (binds 3000) and never stops the server.

## Fix

- Spawn the dev server with `--port=0 --hostname=127.0.0.1` and read the printed URL from stdout before fetching, instead of sleeping.
- Assert on the response body so a stray server answering on that port would fail the test rather than pass silently.
- Give `19661.test.ts` `port: 0` and `await using` so it stops holding a fixed port.

## Verification

```
# 5 sequential runs
$ for i in 1 2 3 4 5; do bun test test/integration/svelte/client-side.test.ts; done
2 pass / 0 fail (x5)

# 4 concurrent runs (simulating the parallel batch)
$ (bun test ... & bun test ... & bun test ... & bun test ... & wait)
1 pass / 0 fail (x4)

# debug build (CI timeout)
$ bun bd test --timeout=90000 test/integration/svelte/client-side.test.ts
2 pass / 0 fail

$ bun bd test test/regression/issue/19661.test.ts
2 pass / 0 fail
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/integration/svelte/client-side.test.ts' 'test/regression/issue/19661.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/integration/svelte/client-side.test.ts "test/regression/issue/19661.test.ts"
bun test v1.4.0 (566a65cd6)

test/regression/issue/19661.test.ts:
(pass) ReadableStream [51.33ms]
(pass) server version [40.86ms]

test/integration/svelte/client-side.test.ts:
(pass) generating client-side code > Bundling Svelte components [8203.58ms]
Bundled page in 2330ms: index.html
(pass) generating client-side code > Using Svelte components in Bun's dev server > serves the app [10883.49ms]

 4 pass
 0 fail
 7 expect() calls
Ran 4 tests across 2 files. [21.82s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/integration/svelte/client-side.test.ts | 89 +++++++++++++++++++----------
 test/regression/issue/19661.test.ts         |  4 +-
 2 files changed, 61 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 5 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
test/integration/svelte/client-side.test.ts      5      8      0
test/regression/issue/19661.test.ts              1      1      0
```

</details>

<!-- robobun:evidence:end -->