### PR TITLE
http: honor Connection: close on non-2xx responses

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4898,12 +4898,8 @@ impl<'a> HTTPClient<'a> {
                     location = header.value();
                 }
                 h if h == hash_header_const(b"Connection") => {
-                    // RFC 9112 §9.6: `Connection: close` means the sender will
-                    // close after this response; status code is irrelevant. The
-                    // old 2xx-only guard dates from when keep-alive defaulted
-                    // off and the block only handled `keep-alive`; with the
-                    // default now on, gating `close` on 2xx pools a socket the
-                    // server (or relaying proxy) is closing after a 4xx/5xx.
+                    // `close` applies on any status (RFC 9112 §9.6); only an
+                    // explicit `keep-alive` is gated on a 2xx success.
                     if bun_core::strings::eql_case_insensitive_ascii_check_length(
                         header.value(),
                         b"close",

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4898,19 +4898,24 @@ impl<'a> HTTPClient<'a> {
                     location = header.value();
                 }
                 h if h == hash_header_const(b"Connection") => {
-                    if response.status_code >= 200 && response.status_code <= 299 {
-                        // HTTP headers are case-insensitive (RFC 7230)
-                        if bun_core::strings::eql_case_insensitive_ascii_check_length(
-                            header.value(),
-                            b"close",
-                        ) {
-                            self.state.flags.allow_keepalive = false;
-                        } else if bun_core::strings::eql_case_insensitive_ascii_check_length(
+                    // RFC 9112 §9.6: `Connection: close` means the sender will
+                    // close after this response; status code is irrelevant. The
+                    // old 2xx-only guard dates from when keep-alive defaulted
+                    // off and the block only handled `keep-alive`; with the
+                    // default now on, gating `close` on 2xx pools a socket the
+                    // server (or relaying proxy) is closing after a 4xx/5xx.
+                    if bun_core::strings::eql_case_insensitive_ascii_check_length(
+                        header.value(),
+                        b"close",
+                    ) {
+                        self.state.flags.allow_keepalive = false;
+                    } else if (200..=299).contains(&response.status_code)
+                        && bun_core::strings::eql_case_insensitive_ascii_check_length(
                             header.value(),
                             b"keep-alive",
-                        ) {
-                            self.state.flags.allow_keepalive = true;
-                        }
+                        )
+                    {
+                        self.state.flags.allow_keepalive = true;
                     }
                 }
                 h if h == hash_header_const(b"Last-Modified") => {

--- a/test/js/bun/http/proxy-stress-protocol.test.ts
+++ b/test/js/bun/http/proxy-stress-protocol.test.ts
@@ -52,10 +52,7 @@ afterAll(async () => {
 
 describe("early reply during upload", () => {
   async function makeEarlyReplyOrigin(status: number, after: number, withTls: boolean) {
-    const sockets = new Set<net.Socket>();
     const handler = (sock: net.Socket) => {
-      sockets.add(sock);
-      sock.on("close", () => sockets.delete(sock));
       sock.on("error", () => {});
       let got = 0;
       let replied = false;
@@ -64,14 +61,7 @@ describe("early reply during upload", () => {
         if (!replied && got >= after) {
           replied = true;
           const reply = `HTTP/1.1 ${status} Nope\r\nContent-Length: 5\r\nConnection: close\r\n\r\nearly`;
-          // Keep the socket open after replying: the client is still
-          // mid-upload, and if we end here the proxy relays the FIN and
-          // closes the client leg while ~1MB of body is still in flight.
-          // bun's next on_writable then observes a shut-down socket before
-          // it has read this response and fails with ConnectionClosed
-          // (ECONNRESET). The client closes after reading Connection: close,
-          // which tears down the proxy→origin leg.
-          sock.write(reply);
+          sock.write(reply, () => sock.end());
         }
       });
     };
@@ -81,15 +71,11 @@ describe("early reply during upload", () => {
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
     const port = (server.address() as net.AddressInfo).port;
-    const close = () => {
-      server.close();
-      for (const s of sockets) s.destroy();
-    };
     return {
       url: `${withTls ? "https" : "http"}://localhost:${port}`,
       port,
-      close,
-      [Symbol.asyncDispose]: async () => close(),
+      close: () => server.close(),
+      [Symbol.asyncDispose]: async () => server.close(),
     };
   }
 

--- a/test/js/bun/http/proxy-stress-protocol.test.ts
+++ b/test/js/bun/http/proxy-stress-protocol.test.ts
@@ -52,7 +52,10 @@ afterAll(async () => {
 
 describe("early reply during upload", () => {
   async function makeEarlyReplyOrigin(status: number, after: number, withTls: boolean) {
+    const sockets = new Set<net.Socket>();
     const handler = (sock: net.Socket) => {
+      sockets.add(sock);
+      sock.on("close", () => sockets.delete(sock));
       sock.on("error", () => {});
       let got = 0;
       let replied = false;
@@ -61,7 +64,14 @@ describe("early reply during upload", () => {
         if (!replied && got >= after) {
           replied = true;
           const reply = `HTTP/1.1 ${status} Nope\r\nContent-Length: 5\r\nConnection: close\r\n\r\nearly`;
-          sock.write(reply, () => sock.end());
+          // Keep the socket open after replying: the client is still
+          // mid-upload, and if we end here the proxy relays the FIN and
+          // closes the client leg while ~1MB of body is still in flight.
+          // bun's next on_writable then observes a shut-down socket before
+          // it has read this response and fails with ConnectionClosed
+          // (ECONNRESET). The client closes after reading Connection: close,
+          // which tears down the proxy→origin leg.
+          sock.write(reply);
         }
       });
     };
@@ -71,11 +81,15 @@ describe("early reply during upload", () => {
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
     const port = (server.address() as net.AddressInfo).port;
+    const close = () => {
+      server.close();
+      for (const s of sockets) s.destroy();
+    };
     return {
       url: `${withTls ? "https" : "http"}://localhost:${port}`,
       port,
-      close: () => server.close(),
-      [Symbol.asyncDispose]: async () => server.close(),
+      close,
+      [Symbol.asyncDispose]: async () => close(),
     };
   }
 

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -80,7 +80,7 @@ test("fetch does not reuse a pooled TLS connection for a request with a differen
 // so the pool can't leak into other tests. The server here keeps the socket
 // open and answers every request on it, so the connection count is exactly
 // how many times bun dialed (pooled reuse => 1, correct => 4).
-test.each([200, 400, 413, 500])("a %d response with Connection: close is not pooled", async status => {
+test.concurrent.each([200, 400, 413, 500])("a %d response with Connection: close is not pooled", async status => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -80,14 +80,12 @@ test("fetch does not reuse a pooled TLS connection for a request with a differen
 // so the pool can't leak into other tests. The server here keeps the socket
 // open and answers every request on it, so the connection count is exactly
 // how many times bun dialed (pooled reuse => 1, correct => 4).
-test.each([200, 400, 413, 500])(
-  "a %d response with Connection: close is not pooled",
-  async status => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
+test.each([200, 400, 413, 500])("a %d response with Connection: close is not pooled", async status => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
         import net from "node:net";
         let connections = 0;
         const server = net.createServer(sock => {
@@ -114,20 +112,19 @@ test.each([200, 400, 413, 500])(
         console.log(JSON.stringify({ statuses, connections }));
         process.exit(0);
         `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
-    expect({ result, exitCode }).toEqual({
-      result: { statuses: [status, status, status, status], connections: 4 },
-      exitCode: 0,
-    });
-  },
-);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+  expect({ result, exitCode }).toEqual({
+    result: { statuses: [status, status, status, status], connections: 4 },
+    exitCode: 0,
+  });
+});
 
 // A reused keep-alive connection reset during a streaming PUT must reject with
 // ECONNRESET, not retry: the stream body is already consumed, and the retry

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -73,6 +73,62 @@ test("fetch does not reuse a pooled TLS connection for a request with a differen
   expect(plain).not.toBe(overrideA);
 });
 
+// RFC 9112 §9.6: a server's `Connection: close` applies regardless of status
+// code. Previously bun only honored it for 2xx, so a 4xx/5xx with
+// `Connection: close` was pooled; a concurrent fetch that picked the pooled
+// socket before the server's FIN landed failed with ECONNRESET. Subprocess
+// so the pool can't leak into other tests. The server here keeps the socket
+// open and answers every request on it, so the connection count is exactly
+// how many times bun dialed (pooled reuse => 1, correct => 4).
+test.each([200, 400, 413, 500])(
+  "a %d response with Connection: close is not pooled",
+  async status => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import net from "node:net";
+        let connections = 0;
+        const server = net.createServer(sock => {
+          connections++;
+          sock.on("error", () => {});
+          let buf = "";
+          sock.on("data", d => {
+            buf += d.toString("latin1");
+            while (buf.includes("\\r\\n\\r\\n")) {
+              buf = buf.slice(buf.indexOf("\\r\\n\\r\\n") + 4);
+              sock.write("HTTP/1.1 ${status} X\\r\\nContent-Length: 2\\r\\nConnection: close\\r\\n\\r\\nok");
+            }
+          });
+        });
+        server.listen(0, "127.0.0.1");
+        await new Promise(r => server.on("listening", r));
+        const url = "http://127.0.0.1:" + server.address().port + "/";
+        const statuses = [];
+        for (let i = 0; i < 4; i++) {
+          const res = await fetch(url, { keepalive: true });
+          statuses.push(res.status);
+          await res.text();
+        }
+        console.log(JSON.stringify({ statuses, connections }));
+        process.exit(0);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+    expect({ result, exitCode }).toEqual({
+      result: { statuses: [status, status, status, status], connections: 4 },
+      exitCode: 0,
+    });
+  },
+);
+
 // A reused keep-alive connection reset during a streaming PUT must reject with
 // ECONNRESET, not retry: the stream body is already consumed, and the retry
 // panicked in send_initial_request_payload. Subprocess: the panic aborts the process.


### PR DESCRIPTION
Fixes the flake in `test/js/bun/http/proxy-stress-protocol.test.ts` `early reply during upload`, seen on debian 13 x64-asan:

```
error: The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()
  path: "http://localhost:45859/",
 errno: 0,
  code: "ECONNRESET"
✗ early reply during upload > https-proxy → http-origin, 500 after 1KB of a 1MB upload
```

## Cause

The response `Connection` header was only applied when the status code was 2xx:

```rust
h if h == hash_header_const(b"Connection") => {
    if response.status_code >= 200 && response.status_code <= 299 {
        if ...eql...(header.value(), b"close") {
            self.state.flags.allow_keepalive = false;
        }
        ...
```

That guard dates from 2b45c8dffe when keep-alive defaulted off and this block only handled `Connection: keep-alive` (opt in on 2xx success). Once the default flipped to keep-alive on, the same guard started meaning "ignore `Connection: close` on 4xx/5xx", so a 413/500 carrying `Connection: close` left `allow_keepalive` true and the socket was released into the pool.

In the flaky test: origin replies `500 / Connection: close` after 1KB of a 1MB upload and ends; the proxy relays the reply and the FIN. bun parses the reply, pools the socket (because 500 skipped the `close` check, and the 1MB body already fit in the loopback send buffer so `request_side_drained` was true), and a concurrent early-reply test sharing the same `sharedHttpsProxy` picks the about-to-die socket from the pool. Absolute-form proxy connections are keyed on the proxy URL alone, so the three `https-proxy → http-origin` variants all draw from the same pool entry.

With `BUN_DEBUG_fetch=1` under concurrency:

```
[fetch] progressUpdate true
[fetch] release socket        <- pooled despite Connection: close on a 500
[fetch] done
...
[fetch] Closed  http://localhost:34835/   <- next fetch on that pooled socket
```

## Fix

Honor `Connection: close` for every status code (RFC 9112 section 9.6: "A client that receives a 'close' connection option MUST cease sending requests on that connection"). The 2xx guard is kept only for the explicit `Connection: keep-alive` case.

The earlier test-side workaround (keeping the origin socket open) is reverted; the original `sock.end()` is realistic server behavior and is now handled correctly.

## Verification

Standalone stress repro (https-proxy to http-origin early-reply, `keepalive: true`, 24 concurrent x 300 iterations, debug+ASAN):

| | before | after |
|---|---|---|
| origin `sock.end()` (as in the test) | 91/300 ECONNRESET | 0/300 |
| `keepalive: false` | 0/300 | 0/300 |

- `bun bd test test/js/web/fetch/fetch-keepalive.test.ts`: new `a {200,400,413,500} response with Connection: close is not pooled` cases fail before (`connections: 1` for 4xx/5xx) and pass after (`connections: 4`)
- `bun bd test test/js/bun/http/proxy-stress-protocol.test.ts`: 102 pass, 20/20 iterations under ASAN
- All other `proxy-stress-*.test.ts` files pass
