### PR TITLE
test(node-http): deflake node-http-agent-tls-options Node.js compat step

### DIFF
--- a/test/js/node/http/node-http-agent-tls-options.test.mts
+++ b/test/js/node/http/node-http-agent-tls-options.test.mts
@@ -683,9 +683,15 @@ if (typeof Bun !== "undefined") {
 
       const testFile = fileURLToPath(import.meta.url);
 
+      // Run the file directly rather than via `node --test`: the runner mode
+      // forks a second node process for the file, and under CI's parallel
+      // batch that extra process frequently fails uv_thread_create (EAGAIN)
+      // at startup. A direct run uses one process and still exits non-zero on
+      // any node:test failure. The pool-size knobs keep Node's V8 and libuv
+      // worker pools minimal for the same reason.
       await using proc = Bun.spawn({
-        cmd: [node, "--test", testFile],
-        env: bunEnv,
+        cmd: [node, "--v8-pool-size=1", testFile],
+        env: { ...bunEnv, UV_THREADPOOL_SIZE: "2" },
         stdout: "pipe",
         stderr: "pipe",
       });


### PR DESCRIPTION
`node-http-agent-tls-options.test.mts` was showing up as "failed in the parallel batch; passed alone" on the Linux lanes.

### Repro

Running 20 copies of the file concurrently (the parallel bucket width on a 16-core Linux runner is 15):

```
Interrupted while still running:
  test/js/node/http/node-http-agent-tls-options.test.mts (263s)
```

Every failure is the `Node.js compatibility > all tests pass in Node.js` step. Two shapes:

```
error: Node.js tests failed with code 134
  #  node_platform.cc:109
  #  Assertion failed: (0) == (uv_thread_create(t.get(), start_thread, this))
```

and the per-test watchdog firing after the Node child never exits.

### Cause

The step launched `node --test <this file>`. In runner mode Node forks a second process to execute the file, so the check costs two Node processes on top of the Bun workers already in flight. Under parallel-batch load one of those processes hits `uv_thread_create` → `EAGAIN` during V8 platform init and either aborts (exit 134/1) or leaves the parent waiting until the watchdog kills it. On the asan lane the per-test watchdog is 270 s, so the 4-minute batch idle timeout tripped first and the whole bucket was interrupted.

### Fix

Run the file with `node <file>` instead of `node --test <file>`: node:test sets a non-zero exit code without the runner flag, and it keeps the check to a single process. Also cap Node's V8 (`--v8-pool-size=1`) and libuv (`UV_THREADPOOL_SIZE=2`) worker pools, which are not needed for the handful of TLS handshakes the file performs.

### Verification

20 concurrent copies, 3 rounds each:

| | before | after |
| --- | --- | --- |
| round 1 | 16/20 | 20/20 |
| round 2 | 14/20 | 20/20 |
| round 3 | 10/20 | 20/20 |

`bun bd test test/js/node/http/node-http-agent-tls-options.test.mts` passes.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->