### PR TITLE
ws: emit 'Unexpected server response: <code>' to error-only listeners

### DIFF
--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -429,10 +429,6 @@ class BunWebSocket extends EventEmitter {
           once,
         );
       } else if (event === "error") {
-        // Arm the handshake bridge so #onHandshake can emit the ws-style
-        // "Unexpected server response: <code>" error for an error-only
-        // subscriber; #unexpectedResponseEmitted then suppresses the native
-        // "Expected 101" follow-up below.
         this.#ensureHandshakeListener();
         this.#ws.addEventListener(
           "error",

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -356,15 +356,20 @@ class BunWebSocket extends EventEmitter {
 
   #onHandshake(data) {
     const { statusCode, statusMessage, rawHeaders, body } = data;
-    const res = makeHandshakeResponse(statusCode, statusMessage, rawHeaders, statusCode === 101 ? null : body);
     if (statusCode === 101) {
-      this.emit("upgrade", res);
+      if (this.listenerCount("upgrade") > 0) {
+        this.emit("upgrade", makeHandshakeResponse(statusCode, statusMessage, rawHeaders, null));
+      }
       return;
     }
     if (this.listenerCount("unexpected-response") > 0) {
       this.#unexpectedResponseEmitted = true;
       this.#unexpectedResponseHandled = true;
-      this.emit("unexpected-response", this.#getSyntheticRequest(), res);
+      this.emit(
+        "unexpected-response",
+        this.#getSyntheticRequest(),
+        makeHandshakeResponse(statusCode, statusMessage, rawHeaders, body),
+      );
     } else if (this.listenerCount("error") > 0) {
       this.#unexpectedResponseEmitted = true;
       this.emit("error", new Error("Unexpected server response: " + statusCode));
@@ -424,6 +429,11 @@ class BunWebSocket extends EventEmitter {
           once,
         );
       } else if (event === "error") {
+        // Arm the handshake bridge so #onHandshake can emit the ws-style
+        // "Unexpected server response: <code>" error for an error-only
+        // subscriber; #unexpectedResponseEmitted then suppresses the native
+        // "Expected 101" follow-up below.
+        this.#ensureHandshakeListener();
         this.#ws.addEventListener(
           "error",
           err => {

--- a/test/js/first_party/ws/ws-upgrade-events.test.ts
+++ b/test/js/first_party/ws/ws-upgrade-events.test.ts
@@ -81,28 +81,41 @@ test.concurrent("ws emits 'unexpected-response' with status, headers and body on
   expect(exitCode).toBe(0);
 });
 
-// Diverges from real ws: with no 'unexpected-response' listener, real ws emits
-// "Unexpected server response: 503". Bun's shim only registers the native
-// handshake listener when the user subscribes to 'upgrade'/'unexpected-response',
-// so the unmodified native error surfaces instead.
-test.concurrent("ws emits native 'error' on non-101 when no 'unexpected-response' listener", async () => {
+// With no 'unexpected-response' listener, real ws emits
+// "Unexpected server response: <code>" to on('error'). Subscribing to 'error'
+// now arms the handshake bridge so the ws-style message is delivered whether
+// or not the user also subscribed to 'upgrade'.
+test.concurrent("ws on('error') gets 'Unexpected server response: <code>' on non-101 with no other listeners", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
     const { WebSocket } = require("ws");
 
-    const server = createServer(s =>
-      s.once("data", () => s.end("HTTP/1.1 503 Service Unavailable\\r\\n\\r\\n")),
-    ).listen(0, "127.0.0.1");
+    const server = createServer(s => {
+      s.once("data", () => s.end("HTTP/1.1 503 Service Unavailable\\r\\n\\r\\n"));
+      s.on("error", () => {});
+    }).listen(0, "127.0.0.1");
     await once(server, "listening");
 
-    const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
-    const [err] = await once(ws, "error");
-    console.log(/Expected 101/.test(err.message) ? "got native 101 error" : "unexpected: " + err.message);
+    async function runOne(armUpgrade) {
+      const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+      if (armUpgrade) ws.on("upgrade", () => {});
+      const messages = [];
+      ws.on("error", err => messages.push(err.message));
+      await once(ws, "close").catch(() => {});
+      return { count: messages.length, first: messages[0] };
+    }
+
+    const errorOnly = await runOne(false);
+    const withUpgrade = await runOne(true);
+    console.log(JSON.stringify({ errorOnly, withUpgrade }));
     server.close();
     process.exit(0);
   `);
-  expect(stdout).toMatchInlineSnapshot(`"got native 101 error"`);
+  // Both paths deliver the same ws-style error exactly once.
+  expect(stdout).toMatchInlineSnapshot(
+    `"{"errorOnly":{"count":1,"first":"Unexpected server response: 503"},"withUpgrade":{"count":1,"first":"Unexpected server response: 503"}}"`,
+  );
   expect(exitCode).toBe(0);
 });
 
@@ -497,7 +510,10 @@ test.concurrent(
     const h = () => { count++; };
     ws.addEventListener("error", h);
     ws.addEventListener("error", h); // duplicate — must be a no-op
-    await once(ws, "close").catch(() => {});
+    // Wait for the native close via addEventListener so no EventEmitter 'error'
+    // listener is added (which would arm the handshake bridge and resolve
+    // early on the synthetic error, before the native error reaches h).
+    await new Promise(resolve => ws.addEventListener("close", resolve, { once: true }));
     server.close();
     try { ws.terminate(); } catch {}
     // removeEventListener must fully detach (no leaked wrapper left behind).

--- a/test/js/first_party/ws/ws-upgrade-events.test.ts
+++ b/test/js/first_party/ws/ws-upgrade-events.test.ts
@@ -85,8 +85,10 @@ test.concurrent("ws emits 'unexpected-response' with status, headers and body on
 // "Unexpected server response: <code>" to on('error'). Subscribing to 'error'
 // now arms the handshake bridge so the ws-style message is delivered whether
 // or not the user also subscribed to 'upgrade'.
-test.concurrent("ws on('error') gets 'Unexpected server response: <code>' on non-101 with no other listeners", async () => {
-  const { stdout, exitCode } = await run(/* js */ `
+test.concurrent(
+  "ws on('error') gets 'Unexpected server response: <code>' on non-101 with no other listeners",
+  async () => {
+    const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
     const { WebSocket } = require("ws");
@@ -112,12 +114,13 @@ test.concurrent("ws on('error') gets 'Unexpected server response: <code>' on non
     server.close();
     process.exit(0);
   `);
-  // Both paths deliver the same ws-style error exactly once.
-  expect(stdout).toMatchInlineSnapshot(
-    `"{"errorOnly":{"count":1,"first":"Unexpected server response: 503"},"withUpgrade":{"count":1,"first":"Unexpected server response: 503"}}"`,
-  );
-  expect(exitCode).toBe(0);
-});
+    // Both paths deliver the same ws-style error exactly once.
+    expect(stdout).toMatchInlineSnapshot(
+      `"{"errorOnly":{"count":1,"first":"Unexpected server response: 503"},"withUpgrade":{"count":1,"first":"Unexpected server response: 503"}}"`,
+    );
+    expect(exitCode).toBe(0);
+  },
+);
 
 test.concurrent("ws emits 'upgrade' with headers before 'open' on 101", async () => {
   const { stdout, exitCode } = await run(/* js */ `


### PR DESCRIPTION
Follow-up to #36272.

## Repro

```js
const { createServer } = require("node:net");
const { WebSocket } = require("ws");
const srv = createServer(s => {
  s.on("data", () => s.end("HTTP/1.1 403 Forbidden\r\nContent-Length: 2\r\n\r\nno"));
  s.on("error", () => {});
});
srv.listen(0, "127.0.0.1", async () => {
  const url = "ws://127.0.0.1:" + srv.address().port;
  const run = arm => new Promise(res => {
    const ws = new WebSocket(url);
    if (arm) ws.on("upgrade", () => {});
    ws.on("error", e => res(e.message));
  });
  console.log("error-only :", await run(false));
  console.log("+ upgrade  :", await run(true));
  srv.close();
});
```

Before:
```
error-only : WebSocket connection to 'ws://127.0.0.1:.../' failed: Expected 101 status code
+ upgrade  : Unexpected server response: 403
```

After (matches npm `ws`):
```
error-only : Unexpected server response: 403
+ upgrade  : Unexpected server response: 403
```

## Cause

`#onHandshake` has the branch that emits `new Error("Unexpected server response: " + statusCode)` to EventEmitter `'error'` listeners, but the native `'handshake'` listener that drives it was only armed from `#onOrOnce`/`#armNativeBridge`/`addEventListener` for `'upgrade'` and `'unexpected-response'`. Subscribing to `'error'` never armed it, so the native "Expected 101 status code" error surfaced instead.

## Fix

Arm `#ensureHandshakeListener()` in the `event === "error"` branch of `#onOrOnce`. The native client dispatches `'handshake'` before the non-101 error (`WebSocketUpgradeClient::process_websocket_upgrade_response` calls `dispatch_handshake` then `process_response`), so the existing `#unexpectedResponseEmitted` guard in the error bridge suppresses the follow-up and the handler fires exactly once.

`#onHandshake` now also skips building the synthetic `IncomingMessage` when there is no `'upgrade'` / `'unexpected-response'` listener, so an error-only subscriber does not pay that allocation on every successful 101.

## Verification

`bun bd test test/js/first_party/ws/ws-upgrade-events.test.ts`: 13 pass.
`bun bd test test/js/first_party/ws/ws.test.ts`: 45 pass.

Fail-before (src/ stashed):
```
Expected: "{"errorOnly":{"count":1,"first":"Unexpected server response: 503"},"withUpgrade":{"count":1,"first":"Unexpected server response: 503"}}"
Received: "{"errorOnly":{"count":1,"first":"WebSocket connection to 'ws://127.0.0.1:40501/' failed: Expected 101 status code"},"withUpgrade":{"count":1,"first":"Unexpected server response: 503"}}"
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/ws/ws-upgrade-events.test.ts
bun test v1.4.0 (6a75a682e)

test/js/first_party/ws/ws-upgrade-events.test.ts:
(pass) ws on/addListener/prepend*/addEventListener for upgrade/unexpected-response emit no warning [1891.71ms]
113 |     console.log(JSON.stringify({ errorOnly, withUpgrade }));
114 |     server.close();
115 |     process.exit(0);
116 |   `);
117 |     // Both paths deliver the same ws-style error exactly once.
118 |     expect(stdout).toMatchInlineSnapshot(
                         ^
error: expect(received).toMatchInlineSnapshot(expected)

Expected: "{"errorOnly":{"count":1,"first":"Unexpected server response: 503"},"withUpgrade":{"count":1,"first":"Unexpected server response: 503"}}"
Received: "{"errorOnly":{"count":1,"first":"WebSocket connection to 'ws://127.0.0.1:34687/' failed: Expected 101 status code"},"withUpgrade":{"count":1,"first":"Unexpected server response: 503"}}"

      at <anonymous> (/workspace/bun/test/js/first_party/ws/ws-upgrade-events.test.ts:118:20)
(fail) ws on('error') gets 'Unexpected
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (8e56e7f92)

test/js/first_party/ws/ws-upgrade-events.test.ts:
(pass) ws on/addListener/prepend*/addEventListener for upgrade/unexpected-response emit no warning [39.22ms]
(pass) ws microtask queued in 'upgrade' handler observes readyState OPEN [41.52ms]
(pass) ws on('error') fires once (not twice) for a non-101 with no 'unexpected-response' listener [37.13ms]
(pass) ws still delivers the native error to addEventListener/onerror when there is no 'unexpected-response' listener [38.03ms]
(pass) ws 'unexpected-response' coalesces duplicate headers like Node IncomingMessage [41.33ms]
(pass) ws emits 'unexpected-response' with status, headers and body on non-101 [48.32ms]
(pass) ws 'unexpected-response' fires for addListener / prependListener / addEventListener [43.51ms]
(pass) ws emits 'upgrade' with headers before 'open' on 101 [53.60ms]
(pass) ws error handlers each fire once when on('error') and addEventListener/onerror are mixed [47.79ms]
(pass) ws suppresses the native error after 'unexpected-response' across on/addEventListener/onerror [51.49ms]
(pass) ws on('error') gets 'Unexpected server response: <code>' on non-101 with no other listen
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/ws/ws-upgrade-events.test.ts
bun test v1.4.0 (6a75a682e)

test/js/first_party/ws/ws-upgrade-events.test.ts:
(pass) ws on/addListener/prepend*/addEventListener for upgrade/unexpected-response emit no warning [1866.76ms]
(pass) ws on('error') gets 'Unexpected server response: <code>' on non-101 with no other listeners [2201.31ms]
(pass) ws emits 'upgrade' with headers before 'open' on 101 [2462.39ms]
(pass) ws microtask queued in 'upgrade' handler observes readyState OPEN [2467.75ms]
(pass) ws emits 'unexpected-response' with status, headers and body on non-101 [2535.13ms]
(pass) ws 'unexpected-response' coalesces duplicate headers like Node IncomingMessage [2453.26ms]
(pass) ws 'unexpected-response' fires for addListener / prependListener / addEventListener [2366.72ms]
(pass) ws on('error') fires once (not twice) for a non-101 with no 'unexpected-response' listener [2190.26ms]
(pass) ws still delivers the native error to addEventListener/onerror when there is no 'unexpected-response' listener [2269.03ms]
(pass) ws su
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 718ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/28] gen cpp.rs (cppbind)
[2/28] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[3/28] gen JS modules (bundle-modules)
Preprocess modules (9367ms)
Bundle modules (56ms)
Postprocesss modules (278ms)
Bundle Functions (1030ms)
Generate Code (36ms)

[10.79s] Bundled "src/js" for production
  2569 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[3/24] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/thirdparty/ws.js                          | 12 ++++--
 test/js/first_party/ws/ws-upgrade-events.test.ts | 51 ++++++++++++++++--------
 2 files changed, 44 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/js/thirdparty/ws.js                               2      4      0
test/js/first_party/ws/ws-upgrade-events.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->