### PR TITLE
test(node:http): shrink pinned-write payload to 8MB and run concurrently

### DIFF
--- a/test/js/node/http/node-http-pinned-write.test.ts
+++ b/test/js/node/http/node-http-pinned-write.test.ts
@@ -6,10 +6,11 @@ import http from "node:http";
 import type { AddressInfo } from "node:net";
 import net from "node:net";
 
-// Large enough to overflow both the 16KB cork buffer and the kernel send
-// buffer on every platform (Windows loopback auto-tuning can absorb several
-// MB), so the native write reports backpressure and the tail is held.
-const CHUNK_SIZE = 64 * 1024 * 1024;
+// Large enough to overflow the 16KB cork buffer plus the Linux/macOS loopback
+// kernel send buffer, so the native write reports backpressure and the tail is
+// held. Windows loopback auto-tuning can absorb the whole payload, so the pin
+// assertions are skipped there; the other tests check byte-delivery only.
+const CHUNK_SIZE = 8 * 1024 * 1024;
 
 const PATTERN_256 = Buffer.from(Array.from({ length: 256 }, (_, i) => i));
 const PATTERN_64_HIGH = Buffer.from(Array.from({ length: 64 }, (_, i) => 0xc0 + i));
@@ -22,7 +23,7 @@ function sha1(buf: Uint8Array): string {
   return createHash("sha1").update(buf).digest("hex");
 }
 
-describe("node:http large Buffer writes are sent zero-copy", () => {
+describe.concurrent("node:http large Buffer writes are sent zero-copy", () => {
   // Winsock auto-tunes its send buffer on loopback and will absorb the whole
   // payload in one nonblocking send(), so the pinned-tail state is never
   // reached on Windows (the bytes go straight to the kernel instead). The
@@ -245,9 +246,7 @@ describe("node:http large Buffer writes are sent zero-copy", () => {
     });
   });
 
-  // 8 MB overflows the Linux/macOS loopback send+recv buffers with a paused
-  // client while keeping the spill + drain under the default test timeout.
-  const RESIZABLE_CHUNK_SIZE = 8 * 1024 * 1024;
+  const RESIZABLE_CHUNK_SIZE = CHUNK_SIZE;
   const resizableChild = (afterWrite: string) => `
     const http = require("node:http");
     const net = require("node:net");


### PR DESCRIPTION
The `node:http large Buffer writes are sent zero-copy` tests in `test/js/node/http/node-http-pinned-write.test.ts` timed out in the `--parallel` CI batch:

```
test/js/node/http/node-http-pinned-write.test.ts - 5 failing in the parallel batch (450.13s)
✗ Content-Length (non-chunked) path delivers the exact bytes - test timed out
✗ a second write before drain is ordered after the pending tail - test timed out
✗ large string writes (latin1 ascii, utf8 encoding) are held by reference - test timed out
✗ large string writes with latin1 encoding deliver the exact bytes - test timed out
✗ a second write before drain releases the pin on the first buffer - test timed out
```

## Cause

`CHUNK_SIZE` was 64MB (128MB for the double-write tests). In the parallel batch that much loopback traffic and `Buffer.alloc`/`sha1` work, under ASAN and alongside many other files, pushed each test past the timeout.

## Change

- `CHUNK_SIZE` 64MB → 8MB. `res.write()` is synchronous, so the client cannot drain before it returns; the backpressure threshold is the server's kernel send buffer. 8MB overflows the Linux/macOS loopback send buffer (measured pin threshold ~4MB here; the existing `RESIZABLE_CHUNK_SIZE` tests already used 8MB for the same reason).
- `describe` → `describe.concurrent` so the subprocess tests overlap with the in-process ones.

The node:http server socket's fd is not reachable from JS (`res.socket._handle` is null; the native `us_socket_t*` is behind a private `Symbol(handle)` on `JSNodeHTTPServerSocket` with no fd getter), and setting the client's `SO_RCVBUF` via `setSocketOptions` does not lower the threshold for the first write since the server's send buffer is what fills first. So the payload size, not a socket option, is the lever here.

The pin assertion (`detachedWhilePending === false`) was already `skipIf(isWindows)`; the other tests assert byte-delivery correctness and pass whether or not the pin engages.

## Verification

- debug+ASAN: 9 pass, wall time 15.6s → 7.7s; the five failing tests drop from 350-670ms to 120-200ms each in isolation
- 15/15 iterations under debug+ASAN, 0 failures
- Windows x64 (system bun): 6 pass, 3 skip, 0 fail, 263ms

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->