### PR TITLE
install: re-resolve catalog references on plain `bun update` from the workspace root

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1976,9 +1976,7 @@ fn get_or_put_resolved_package_with_find_result(
         // `manager.workspace_package_json_cache` only — disjoint from
         // `manager.lockfile`.
         this.to_update
-            // If updating, only update packages in the current workspace.
-            // `catalog:` references live in workspace packages but the catalog
-            // definition is root-level, so they re-resolve regardless of cwd.
+            // Update direct deps of the current workspace; catalogs are root-scoped.
             && (dependency.version.tag == dependency::version::Tag::Catalog
                 || unsafe { &*(*this_ptr).lockfile }
                     .is_root_dependency(unsafe { &mut *this_ptr }, dependency_id))

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1976,9 +1976,12 @@ fn get_or_put_resolved_package_with_find_result(
         // `manager.workspace_package_json_cache` only — disjoint from
         // `manager.lockfile`.
         this.to_update
-            // If updating, only update packages in the current workspace
-            && unsafe { &*(*this_ptr).lockfile }
-                .is_root_dependency(unsafe { &mut *this_ptr }, dependency_id)
+            // If updating, only update packages in the current workspace.
+            // `catalog:` references live in workspace packages but the catalog
+            // definition is root-level, so they re-resolve regardless of cwd.
+            && (dependency.version.tag == dependency::version::Tag::Catalog
+                || unsafe { &*(*this_ptr).lockfile }
+                    .is_root_dependency(unsafe { &mut *this_ptr }, dependency_id))
             // no need to do a look up if update requests are empty (`bun update` with no args)
             && (this.update_requests.is_empty()
                 || this.updating_packages.contains(

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -380,6 +380,75 @@ describe("update", () => {
     });
   }
 
+  for (const args of [[], ["-r"]] as const) {
+    test(`update without --latest from root moves catalogs within range (${args.join(" ") || "no args"})`, async () => {
+      // The lockfile pins no-deps@1.0.0 (as if 1.1.0 was published after install).
+      // `bun update` from the workspace root must re-resolve catalog references
+      // within range the same as a direct dependency would be.
+      const { packageDir } = await registry.createTestDir();
+      const url = registry.registryUrl();
+      await Promise.all([
+        write(
+          join(packageDir, "package.json"),
+          JSON.stringify({
+            name: "catalog-update-from-root",
+            workspaces: {
+              packages: ["packages/*"],
+              catalog: { "no-deps": "^1.0.0" },
+            },
+          }),
+        ),
+        write(
+          join(packageDir, "packages", "pkg1", "package.json"),
+          JSON.stringify({
+            name: "pkg1",
+            dependencies: { "no-deps": "catalog:" },
+          }),
+        ),
+        write(
+          join(packageDir, "bun.lock"),
+          JSON.stringify({
+            lockfileVersion: 1,
+            configVersion: 1,
+            workspaces: {
+              "": { name: "catalog-update-from-root" },
+              "packages/pkg1": { name: "pkg1", dependencies: { "no-deps": "catalog:" } },
+            },
+            catalog: { "no-deps": "^1.0.0" },
+            packages: {
+              "no-deps": [
+                "no-deps@1.0.0",
+                `${url}no-deps/-/no-deps-1.0.0.tgz`,
+                {},
+                "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw==",
+              ],
+              "pkg1": ["pkg1@workspace:packages/pkg1"],
+            },
+          }),
+        ),
+      ]);
+
+      const { err, exitCode } = await runUpdate(packageDir, ...args);
+      expect(err).not.toContain("error:");
+
+      const root = await file(join(packageDir, "package.json")).json();
+      expect(root.workspaces.catalog).toEqual({ "no-deps": "^1.1.0" });
+
+      expect((await file(join(packageDir, "packages", "pkg1", "package.json")).json()).dependencies).toEqual({
+        "no-deps": "catalog:",
+      });
+      expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+        name: "no-deps",
+        version: "1.1.0",
+      });
+
+      const lock = await file(join(packageDir, "bun.lock")).text();
+      expect(lock).toContain("no-deps@1.1.0");
+      expect(lock).not.toContain("no-deps@1.0.0");
+      expect(exitCode).toBe(0);
+    });
+  }
+
   test("update without --latest stays in range and keeps catalog references", async () => {
     const { packageDir } = await registry.createTestDir();
     await Promise.all([


### PR DESCRIPTION
Follow-up to #36304.

## Problem

`bun update` / `bun update -r` (no `--latest`) is a no-op for catalog entries when run from the workspace root: a catalog entry `^1.0.0` locked to 1.0.0 stays on 1.0.0 after 1.5.0 is published, while a direct dependency with the identical range moves to 1.5.0. Only `--latest` bumps catalogs.

```
# root package.json: workspaces.catalog = { "dep": "^1.0.0" }
# packages/app/package.json: dependencies = { "dep": "catalog:" }
# lockfile: dep@1.0.0, registry now has dep@1.5.0

bun update            # -> "no changes", catalog stays ^1.0.0, dep@1.0.0
bun update -r         # -> "no changes"
bun update -r --latest # -> catalog -> ^1.5.0 (works)
```

The only existing non-`--latest` test ran update from inside the workspace package, where this already worked.

## Cause

`get_or_put_resolved_package_with_find_result` gates re-resolution on `is_root_dependency(dependency_id)`, i.e. "is this a direct dependency of the package in cwd". A `catalog:` reference lives in a workspace package, so when running from the root it fails that check, `should_update` is false, and `get_package_id` dedupes onto the locked version instead of taking the manifest's best match. With `--latest` the catalog text is rewritten to `latest` before install, which trips `catalogs_changed` and clears the resolution, bypassing the dedupe.

(Separately, `-r` is not read anywhere in the non-interactive resolve path, so it is equivalent to no flag here; that's #36360 / #33182.)

## Fix

In `should_update`, treat a `catalog:` reference (`dependency.version.tag == Catalog`) as eligible for re-resolution regardless of cwd. Catalog definitions are a root-level concept shared across workspaces; re-resolving them matches what #36304 already does for the package.json rewrite in `edit_catalogs_after_update`.

## Tests

New in `test/cli/install/catalogs.test.ts`: writes a lockfile pinning `no-deps@1.0.0` with a catalog range `^1.0.0` (the registry has 1.1.0), runs `bun update` / `bun update -r` from the root, asserts the catalog is rewritten to `^1.1.0`, `node_modules/no-deps` is 1.1.0, and the lockfile no longer contains `no-deps@1.0.0`.

Fail-before (release canary):
```
(fail) update > update without --latest from root moves catalogs within range (no args)
(fail) update > update without --latest from root moves catalogs within range (-r)
  expected catalog { "no-deps": "^1.1.0" }, received { "no-deps": "^1.0.0" }
```

With fix: `catalogs.test.ts` 18/18, `bun-update.test.ts` 6/6, `bun-install-registry.test.ts -t update` 16 pass + 1 todo, `bun-workspaces.test.ts` 63/63, `bun-add.test.ts` 54/54, `bun-lock.test.ts` 13/13.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/catalogs.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/104] gen ErrorCode+*.h
[2/45] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[3/45] gen cpp.rs (cppbind)
[4/45] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 6 sinks, 72 exported symbols
Generating /workspace/bun/build/debug/codegen/JSSink.lut.h from /workspace/bun/build/debug/codegen/JSSink.lut.txt
[5/45] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[6/45] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (fcf284975)

test/cli/install/catalogs.test.ts:
(pass) basic > both catalog and catalogs in top-level [42.17ms]
(pass) basic > both catalog and catalogs in workspaces [16.31ms]
(pass) basic > detect changes (bun.lockb) [23.66ms]
(pass) basic > detect changes (bun.lock) [24.12ms]
(pass) update > --latest updates catalog versions in top-level [18.41ms]
(pass) update > --latest updates catalog versions in workspaces [19.24ms]
(pass) update > --latest updates catalog versions with -r [19.63ms]
(pass) update > --frozen-lockfile passes after --latest updates catalogs [22.89ms]
(pass) update > --latest run from inside a workspace package updates the root catalog [17.98ms]
(pass) update > --latest updates the same package independently per catalog [19.11ms]
(pass) update > --latest --dry-run does not modify any package.json (from root) [18.94ms]
(pass) update > --latest --dry-run does not modify any package.json (from workspace) [16.02ms]
(pass) update > update without --latest from root moves catalogs within range (no args) [7.38ms]
(pass) update > update without --latest from root moves catalogs within range (-r) [6.06ms]
(pass) update > update wi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/catalogs.test.ts
bun test v1.4.0 (02dc29569)

test/cli/install/catalogs.test.ts:
(pass) basic > both catalog and catalogs in top-level [409.47ms]
(pass) basic > both catalog and catalogs in workspaces [333.92ms]
(pass) basic > detect changes (bun.lockb) [519.80ms]
(pass) basic > detect changes (bun.lock) [509.54ms]
(pass) update > --latest updates catalog versions in top-level [406.88ms]
(pass) update > --latest updates catalog versions in workspaces [372.94ms]
(pass) update > --latest updates catalog versions with -r [378.63ms]
(pass) update > --frozen-lockfile passes after --latest updates catalogs [544.80ms]
(pass) update > --latest run from inside a workspace package updates the root catalog [445.30ms]
(pass) update > --latest updates the same package independently per catalog [390.07ms]
(pass) update > --latest --dry-run does not modify any package.json (from root) [382.96ms]
(pass) update > --latest --dry-run does not modify any package.json (from workspace) [362.05ms]
(pass) update > update without --latest from
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 630ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/82] gen ErrorCode+*.h
[2/37] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[3/37] gen cpp.rs (cppbind)
[4/37] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 6 sinks, 72 exported symbols
Generating /workspace/bun/build/release/codegen/JSSink.lut.h from /workspace/bun/build/release/codegen/JSSink.lut.txt
[5/37] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[6/37] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspac
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../PackageManager/PackageManagerEnqueue.rs        |  7 ++-
 test/cli/install/catalogs.test.ts                  | 69 ++++++++++++++++++++++
 2 files changed, 73 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/install/PackageManager/PackageManagerEnqueue.rs      9      4      0
test/cli/install/catalogs.test.ts                        1      3      0
```

</details>

<!-- robobun:evidence:end -->