### PR TITLE
test(fetch): drain server socket so body-mixin-errors close() doesn't hang

### DIFF
--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -31,6 +31,10 @@ describe("body-mixin-errors", () => {
   async function withTruncatedBodyServer<T>(fn: (url: string) => Promise<T>): Promise<T> {
     const body = Buffer.alloc(1000, "x").toString();
     const server = net.createServer(socket => {
+      // Drain the inbound request so 'end' can fire once the client closes;
+      // otherwise server.close() below waits on a paused socket with buffered
+      // data forever (Node behaves the same way).
+      socket.resume();
       socket.end(`HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 100000\r\n\r\n${body}`);
     });
     server.listen(0, "127.0.0.1");


### PR DESCRIPTION
Fixes `test/js/web/fetch/body-mixin-errors.test.ts` timing out on main since 8afcd4b45d (#35855).

### What broke

Seven subtests time out at 90s on every platform (build [85316](https://buildkite.com/bun/bun/builds/85316), [85322](https://buildkite.com/bun/bun/builds/85322)), while all 45 `expect()` calls run. The assertions were fine; the timeout is the awaited `server.close()` in the helper's `finally` block.

### Cause

The `withTruncatedBodyServer` helper does `net.createServer(socket => socket.end(response))` and never reads the inbound HTTP request. #35855 passed its own CI (build [82038](https://buildkite.com/bun/bun/builds/82038)) because at the time Bun auto-destroyed a server-accepted socket one `setImmediate` after peer FIN when it still held unread data with no reader. #36332 removed that auto-destroy to match Node, so now the server socket stays paused with the GET request buffered, `'end'` never fires, and `server.close()` waits on that connection forever. #36332 and #35855 landed within an hour of each other and neither saw the other in CI.

Node.js behaves the same way:

```js
const server = net.createServer(s =>
  s.end("HTTP/1.1 200 OK\r\nContent-Length: 100000\r\n\r\n" + "x".repeat(1000))
).listen(0, "127.0.0.1");
await once(server, "listening");
const r = await fetch(`http://127.0.0.1:${server.address().port}/`);
await r.text().catch(() => {});
await new Promise(res => server.close(res));   // <-- never resolves in Node v26
```

### Fix

Add `socket.resume()` in the handler so the request bytes drain, `'end'` fires after the client closes, and the normal `allowHalfOpen=false` teardown closes the socket. This is test setup only and does not touch what the tests assert.

### Verification

```
bun bd test test/js/web/fetch/body-mixin-errors.test.ts
 9 pass  0 fail  45 expect() calls  [2.9s]
```

Same 45 `expect()` calls before and after. With #35855's `src/` changes reverted the patched test still fails 7/9 on the `toBeInstanceOf(TypeError)` / `bodyUsed` assertions, so it continues to cover the behaviour #35855 fixed.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/fetch/body-mixin-errors.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/fetch/body-mixin-errors.test.ts
bun test v1.4.0 (259a2f263)

test/js/web/fetch/body-mixin-errors.test.ts:
(pass) body-mixin-errors > should throw TypeError when body already used on Response [13.15ms]
(pass) body-mixin-errors > should throw TypeError when body already used on Request [8.20ms]
(pass) body-mixin-errors > fetch: truncated body read rejects with TypeError and marks body used [508.18ms]
(pass) body-mixin-errors > fetch: body that failed before any reader call is still consumed by the first read [408.96ms]
(pass) body-mixin-errors > fetch: reading .body directly marks body used when the stream errors [404.73ms]
(pass) body-mixin-errors > fetch: truncated body arrayBuffer() marks body used [399.12ms]
(pass) body-mixin-errors > fetch: truncated body bytes() marks body used [406.66ms]
(pass) body-mixin-errors > fetch: truncated body blob() marks body used [86.10ms]
(pass) body-mixin-errors > fetch: truncated body json() marks body used [71.00ms]

 9 pass
 0 fail
 45 expect() calls
Ran 9 tests across 1 file. [2.83s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/fetch/body-mixin-errors.test.ts | 4 ++++
 1 file changed, 4 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
test/js/web/fetch/body-mixin-errors.test.ts      1      1      0
```

</details>

**self-review** · no surviving concerns

19 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->