### PR TITLE
install: sync bun.lock catalog with package.json on bun update

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -584,9 +584,7 @@ pub struct CatalogUpdateInfo {
     pub dep_name: Box<[u8]>,
     pub original_version_literal: Box<[u8]>,
     pub is_alias: bool,
-    /// The literal `bun update` resolved, computed once in
-    /// `Lockfile::preprocess_updating_catalogs` and applied to both
-    /// `lockfile.catalogs` and package.json. `None` keeps the original.
+    /// Set by `Lockfile::preprocess_updating_catalogs`; `None` keeps the original.
     pub resolved_version_literal: Option<Box<[u8]>>,
 }
 

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -584,6 +584,10 @@ pub struct CatalogUpdateInfo {
     pub dep_name: Box<[u8]>,
     pub original_version_literal: Box<[u8]>,
     pub is_alias: bool,
+    /// The literal `bun update` resolved, computed once in
+    /// `Lockfile::preprocess_updating_catalogs` and applied to both
+    /// `lockfile.catalogs` and package.json. `None` keeps the original.
+    pub resolved_version_literal: Option<Box<[u8]>>,
 }
 
 #[derive(Default)]

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -639,6 +639,7 @@ pub(crate) fn edit_catalogs_before_update(
                 dep_name: Box::from(key_str),
                 original_version_literal: Box::from(version_literal),
                 is_alias: alias_at_index.is_some(),
+                resolved_version_literal: None,
             });
 
             if update_to_latest {
@@ -673,7 +674,7 @@ pub(crate) fn edit_catalogs_before_update(
 pub(crate) fn edit_catalogs_after_update(
     manager: &mut PackageManager,
     root_package_json: &Expr,
-    options: EditOptions,
+    _options: EditOptions,
 ) -> Result<bool, bun_alloc::AllocError> {
     // see note in `edit_update_no_args` — always avoid the store
     let _guard = ExprDisabler::scope();
@@ -684,113 +685,6 @@ pub(crate) fn edit_catalogs_after_update(
     }
 
     let arena = &manager.ast_arena;
-    let lockfile = &*manager.lockfile;
-    let string_buf = lockfile.buffers.string_bytes.as_slice();
-    let package_resolutions = lockfile.packages.items_resolution();
-
-    let mut new_literals: Vec<Option<Vec<u8>>> = vec![None; infos.len()];
-    debug_assert_eq!(
-        lockfile.buffers.dependencies.len(),
-        lockfile.buffers.resolutions.len()
-    );
-    for (dep, &package_id) in lockfile
-        .buffers
-        .dependencies
-        .iter()
-        .zip(lockfile.buffers.resolutions.iter())
-    {
-        if dep.version.tag != dependency::Tag::Catalog {
-            continue;
-        }
-        if package_id == INVALID_PACKAGE_ID {
-            continue;
-        }
-
-        let dep_name = dep.name.slice(string_buf);
-        let catalog_name = dep.version.catalog().slice(string_buf);
-        let Some(index) = infos.iter().position(|info| {
-            strings::eql_long(&info.dep_name, dep_name, true)
-                && strings::eql_long(&info.catalog_name, catalog_name, true)
-        }) else {
-            continue;
-        };
-        if new_literals[index].is_some() {
-            continue;
-        }
-
-        let resolution = &package_resolutions[package_id as usize];
-        if resolution.tag != resolution::Tag::Npm {
-            continue;
-        }
-
-        if !manager.options.do_.contains(Do::UPDATE_TO_LATEST) {
-            // plain `bun update` does not move an exact pin (matches direct-dep behavior)
-            let resolved_version = lockfile
-                .resolve_catalog_dependency(dep)
-                .unwrap_or_else(|| dep.version.clone());
-            if let Some(npm_version) = resolved_version.try_npm() {
-                if npm_version.version.is_exact() {
-                    continue;
-                }
-            }
-        }
-
-        let info = &infos[index];
-        let version_fmt = resolution.npm().version.fmt(string_buf);
-        let new_version: Vec<u8> = 'new_version: {
-            if options.exact_versions {
-                let mut v = Vec::new();
-                write!(&mut v, "{}", version_fmt).expect("infallible: in-memory write");
-                break 'new_version v;
-            }
-
-            let version_literal: &[u8] = 'version_literal: {
-                if !info.is_alias {
-                    break 'version_literal &info.original_version_literal;
-                }
-                if let Some(at_index) =
-                    strings::last_index_of_char(&info.original_version_literal, b'@')
-                {
-                    break 'version_literal &info.original_version_literal[at_index + 1..];
-                }
-                &info.original_version_literal
-            };
-
-            let pinned_version = semver::Version::which_version_is_pinned(version_literal);
-            let mut v = Vec::new();
-            match pinned_version {
-                semver::PinnedVersion::Patch => {
-                    write!(&mut v, "{}", version_fmt).expect("infallible: in-memory write")
-                }
-                semver::PinnedVersion::Minor => {
-                    write!(&mut v, "~{}", version_fmt).expect("infallible: in-memory write")
-                }
-                semver::PinnedVersion::Major => {
-                    write!(&mut v, "^{}", version_fmt).expect("infallible: in-memory write")
-                }
-            }
-            v
-        };
-
-        new_literals[index] = Some(if info.is_alias {
-            let dep_literal = &info.original_version_literal;
-            if let Some(at_index) = strings::last_index_of_char(dep_literal, b'@') {
-                let mut v = Vec::new();
-                write!(
-                    &mut v,
-                    "{}@{}",
-                    bstr::BStr::new(&dep_literal[0..at_index]),
-                    bstr::BStr::new(&new_version)
-                )
-                .expect("infallible: in-memory write");
-                v
-            } else {
-                new_version
-            }
-        } else {
-            new_version
-        });
-    }
 
     let mut changed = false;
     for_each_catalog_object(root_package_json, |catalog_name, mut catalog_expr| {
@@ -820,9 +714,12 @@ pub(crate) fn edit_catalogs_after_update(
             };
 
             let info = &infos[index];
-            let new_literal: &[u8] = match &new_literals[index] {
+            // `Lockfile::preprocess_updating_catalogs` resolved this literal
+            // together with the lockfile's catalog map, so package.json and
+            // bun.lock always agree. `None` restores the original (may still
+            // be the temporary `latest`).
+            let new_literal: &[u8] = match &info.resolved_version_literal {
                 Some(v) => arena_str(arena, v),
-                // unresolved: restore the original (may still be the temporary `latest`)
                 None => arena_dup(arena, &info.original_version_literal),
             };
 

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -713,10 +713,7 @@ pub(crate) fn edit_catalogs_after_update(
             };
 
             let info = &infos[index];
-            // `Lockfile::preprocess_updating_catalogs` resolved this literal
-            // together with the lockfile's catalog map, so package.json and
-            // bun.lock always agree. `None` restores the original (may still
-            // be the temporary `latest`).
+            // `Lockfile::preprocess_updating_catalogs` wrote the same literal into bun.lock.
             let new_literal: &[u8] = match &info.resolved_version_literal {
                 Some(v) => arena_str(arena, v),
                 None => arena_dup(arena, &info.original_version_literal),

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -674,7 +674,6 @@ pub(crate) fn edit_catalogs_before_update(
 pub(crate) fn edit_catalogs_after_update(
     manager: &mut PackageManager,
     root_package_json: &Expr,
-    _options: EditOptions,
 ) -> Result<bool, bun_alloc::AllocError> {
     // see note in `edit_update_no_args` — always avoid the store
     let _guard = ExprDisabler::scope();

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -619,14 +619,7 @@ fn update_package_json_and_install_with_manager_with_updates(
 
             if editing_catalogs && manager.workspace_name_hash.is_none() {
                 // running from root: catalogs live in this file.
-                let _ = PackageJSONEditor::edit_catalogs_after_update(
-                    manager,
-                    &new_package_json,
-                    EditOptions {
-                        exact_versions: manager.options.enable.exact_versions(),
-                        ..Default::default()
-                    },
-                )?;
+                let _ = PackageJSONEditor::edit_catalogs_after_update(manager, &new_package_json)?;
             }
         } else {
             let mut updates_slice: &mut [UpdateRequest] = &mut updates[..];
@@ -714,14 +707,8 @@ fn update_package_json_and_install_with_manager_with_updates(
         let root_package_json: &mut MapEntry = unsafe { &mut *root_package_json_ptr };
         let root_package_json_root: bun_ast::Expr = root_package_json.root;
 
-        let root_catalogs_changed = PackageJSONEditor::edit_catalogs_after_update(
-            manager,
-            &root_package_json_root,
-            EditOptions {
-                exact_versions: manager.options.enable.exact_versions(),
-                ..Default::default()
-            },
-        )?;
+        let root_catalogs_changed =
+            PackageJSONEditor::edit_catalogs_after_update(manager, &root_package_json_root)?;
 
         if root_catalogs_changed {
             print_package_json_into_cache_entry(root_package_json, root_package_json_root);

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -855,8 +855,6 @@ impl Lockfile {
         Ok(())
     }
 
-    /// Rewrite `old.catalogs` with the resolved literal for each catalog entry
-    /// `bun update` touched, so the saved lockfile matches package.json.
     fn preprocess_updating_catalogs(
         old: &mut Lockfile,
         manager: &mut PackageManager,
@@ -1367,8 +1365,6 @@ fn clean_preprocess_updating_catalogs_cold(
     Lockfile::preprocess_updating_catalogs(old, manager, exact_versions)
 }
 
-/// Resolved npm version with the entry's original `^`/`~`/exact pin and
-/// `npm:<name>@` alias prefix preserved (exact under `--save-exact`).
 pub fn format_catalog_update_literal(
     resolution: &Resolution,
     string_buf: &[u8],

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -966,17 +966,20 @@ impl Lockfile {
             ) else {
                 continue;
             };
-            let group = old
-                .catalogs
-                .get_or_put_group(string_builder.string_bytes.as_slice(), catalog_name)?;
             let buf = string_builder.string_bytes.as_slice();
             let ctx = bun_semver::string::ArrayHashContext {
                 arg_buf: buf,
                 existing_buf: buf,
             };
-            let entry = group.get_or_put_adapted(&dep_name, &ctx)?;
-            if entry.found_existing {
-                entry.value_ptr.version = version;
+            let group = if info.catalog_name.is_empty() {
+                &mut old.catalogs.default
+            } else if let Some(i) = old.catalogs.groups.get_index_adapted(&catalog_name, &ctx) {
+                &mut old.catalogs.groups.values_mut()[i]
+            } else {
+                continue;
+            };
+            if let Some(i) = group.get_index_adapted(&dep_name, &ctx) {
+                group.values_mut()[i].version = version;
             }
         }
         string_builder.clamp();

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -855,11 +855,8 @@ impl Lockfile {
         Ok(())
     }
 
-    /// `bun update` with catalogs records each catalog entry it edits in
-    /// `manager.updating_catalogs`; with `--latest` the entry is rewritten to
-    /// `latest` before resolution. Compute the resolved literal for each entry
-    /// and write it into `old.catalogs` so the saved lockfile matches the
-    /// package.json `edit_catalogs_after_update` will write.
+    /// Rewrite `old.catalogs` with the resolved literal for each catalog entry
+    /// `bun update` touched, so the saved lockfile matches package.json.
     fn preprocess_updating_catalogs(
         old: &mut Lockfile,
         manager: &mut PackageManager,
@@ -923,12 +920,9 @@ impl Lockfile {
             }
         }
 
-        // Split-borrow: `string_builder!` only takes `old.buffers.string_bytes`
-        // + `old.string_pool`, leaving `old.catalogs` free.
         let mut string_builder = string_builder!(old);
         for info in infos.iter() {
-            // Unresolved entries are left as-is; with `--latest` they still hold
-            // the temporary `latest`, so restore the original literal.
+            // Unresolved: restore the original (`--latest` left `latest`).
             let new_literal = info
                 .resolved_version_literal
                 .as_deref()
@@ -1373,10 +1367,8 @@ fn clean_preprocess_updating_catalogs_cold(
     Lockfile::preprocess_updating_catalogs(old, manager, exact_versions)
 }
 
-/// Version literal a catalog entry is rewritten to after `bun update`:
-/// the resolved npm version with the entry's original `^`/`~`/exact pin
-/// preserved (or exact under `--save-exact`), and the `npm:<name>@` prefix
-/// kept for alias entries.
+/// Resolved npm version with the entry's original `^`/`~`/exact pin and
+/// `npm:<name>@` alias prefix preserved (exact under `--save-exact`).
 pub fn format_catalog_update_literal(
     resolution: &Resolution,
     string_buf: &[u8],

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1365,7 +1365,7 @@ fn clean_preprocess_updating_catalogs_cold(
     Lockfile::preprocess_updating_catalogs(old, manager, exact_versions)
 }
 
-pub fn format_catalog_update_literal(
+fn format_catalog_update_literal(
     resolution: &Resolution,
     string_buf: &[u8],
     info: &CatalogUpdateInfo,

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -29,7 +29,8 @@ use crate::config_version::ConfigVersion;
 use crate::migration;
 use crate::package_manager::WorkspaceFilter;
 use crate::package_manager_real::{
-    Options as PackageManagerOptions, options::LogLevel, populate_manifest_cache,
+    CatalogUpdateInfo, Options as PackageManagerOptions, options::Do, options::LogLevel,
+    populate_manifest_cache,
 };
 use crate::resolution_real::{self as resolution, Resolution};
 use crate::string_builder;
@@ -854,6 +855,135 @@ impl Lockfile {
         Ok(())
     }
 
+    /// `bun update` with catalogs records each catalog entry it edits in
+    /// `manager.updating_catalogs`; with `--latest` the entry is rewritten to
+    /// `latest` before resolution. Compute the resolved literal for each entry
+    /// and write it into `old.catalogs` so the saved lockfile matches the
+    /// package.json `edit_catalogs_after_update` will write.
+    fn preprocess_updating_catalogs(
+        old: &mut Lockfile,
+        manager: &mut PackageManager,
+        exact_versions: bool,
+    ) -> Result<(), BunError> {
+        let update_to_latest = manager.options.do_.contains(Do::UPDATE_TO_LATEST);
+        let mut infos = core::mem::take(&mut manager.updating_catalogs);
+
+        {
+            let string_buf = old.buffers.string_bytes.as_slice();
+            let package_resolutions = old.packages.items_resolution();
+            let packages_len = old.packages.len();
+            debug_assert_eq!(
+                old.buffers.dependencies.len(),
+                old.buffers.resolutions.len()
+            );
+            for (dep, &package_id) in old
+                .buffers
+                .dependencies
+                .iter()
+                .zip(old.buffers.resolutions.iter())
+            {
+                if dep.version.tag != dependency::Tag::Catalog {
+                    continue;
+                }
+                if package_id as usize >= packages_len {
+                    continue;
+                }
+                let resolution = &package_resolutions[package_id as usize];
+                if resolution.tag != ResolutionTag::Npm {
+                    continue;
+                }
+
+                let dep_name = dep.name.slice(string_buf);
+                let catalog_name = dep.version.catalog().slice(string_buf);
+                let Some(info) = infos.iter_mut().find(|info| {
+                    strings::eql_long(&info.dep_name, dep_name, true)
+                        && strings::eql_long(&info.catalog_name, catalog_name, true)
+                }) else {
+                    continue;
+                };
+                if info.resolved_version_literal.is_some() {
+                    continue;
+                }
+
+                if !update_to_latest {
+                    let Some(catalog_dep) = old.catalogs.get(old, *dep.version.catalog(), dep.name)
+                    else {
+                        continue;
+                    };
+                    if let Some(npm_version) = catalog_dep.version.try_npm() {
+                        if npm_version.version.is_exact() {
+                            continue;
+                        }
+                    }
+                }
+
+                let new_literal =
+                    format_catalog_update_literal(resolution, string_buf, info, exact_versions);
+                info.resolved_version_literal = Some(new_literal.into_boxed_slice());
+            }
+        }
+
+        // Split-borrow: `string_builder!` only takes `old.buffers.string_bytes`
+        // + `old.string_pool`, leaving `old.catalogs` free.
+        let mut string_builder = string_builder!(old);
+        for info in infos.iter() {
+            // Unresolved entries are left as-is; with `--latest` they still hold
+            // the temporary `latest`, so restore the original literal.
+            let new_literal = info
+                .resolved_version_literal
+                .as_deref()
+                .unwrap_or(&info.original_version_literal);
+            if new_literal.len() >= SemverString::MAX_INLINE_LEN {
+                string_builder.cap += new_literal.len();
+            }
+            if info.catalog_name.len() >= SemverString::MAX_INLINE_LEN {
+                string_builder.cap += info.catalog_name.len();
+            }
+            if info.dep_name.len() >= SemverString::MAX_INLINE_LEN {
+                string_builder.cap += info.dep_name.len();
+            }
+        }
+        string_builder.allocate()?;
+
+        for info in infos.iter() {
+            let new_literal = info
+                .resolved_version_literal
+                .as_deref()
+                .unwrap_or(&info.original_version_literal);
+            let catalog_name = string_builder.append::<SemverString>(&info.catalog_name);
+            let dep_name = string_builder.append::<SemverString>(&info.dep_name);
+            let external_version = string_builder.append::<ExternalString>(new_literal);
+            let sliced = external_version
+                .value
+                .sliced(string_builder.string_bytes.as_slice());
+            let Some(version) = dependency::parse(
+                dep_name,
+                SemverStringBuilder::string_hash(&info.dep_name),
+                sliced.slice,
+                &sliced,
+                None,
+                &mut *manager,
+            ) else {
+                continue;
+            };
+            let group = old
+                .catalogs
+                .get_or_put_group(string_builder.string_bytes.as_slice(), catalog_name)?;
+            let buf = string_builder.string_bytes.as_slice();
+            let ctx = bun_semver::string::ArrayHashContext {
+                arg_buf: buf,
+                existing_buf: buf,
+            };
+            let entry = group.get_or_put_adapted(&dep_name, &ctx)?;
+            if entry.found_existing {
+                entry.value_ptr.version = version;
+            }
+        }
+        string_builder.clamp();
+        manager.updating_catalogs = infos;
+        Ok(())
+    }
+
     pub fn resolve_catalog_dependency(&self, dep: &Dependency) -> Option<DependencyVersion> {
         if dep.version.tag != dependency::Tag::Catalog {
             return Some(dep.version.clone());
@@ -990,6 +1120,10 @@ impl Lockfile {
 
         if !updates.is_empty() {
             clean_preprocess_update_requests_cold(old, manager, updates, exact_versions)?;
+        }
+
+        if !manager.updating_catalogs.is_empty() {
+            clean_preprocess_updating_catalogs_cold(old, manager, exact_versions)?;
         }
 
         // Caller owns the new lockfile; return `Box<Lockfile>` so Drop reclaims
@@ -1224,6 +1358,77 @@ fn clean_preprocess_update_requests_cold(
     exact_versions: bool,
 ) -> Result<(), BunError> {
     Lockfile::preprocess_update_requests(old, manager, updates, exact_versions)
+}
+
+#[cold]
+#[inline(never)]
+fn clean_preprocess_updating_catalogs_cold(
+    old: &mut Lockfile,
+    manager: &mut PackageManager,
+    exact_versions: bool,
+) -> Result<(), BunError> {
+    Lockfile::preprocess_updating_catalogs(old, manager, exact_versions)
+}
+
+/// Version literal a catalog entry is rewritten to after `bun update`:
+/// the resolved npm version with the entry's original `^`/`~`/exact pin
+/// preserved (or exact under `--save-exact`), and the `npm:<name>@` prefix
+/// kept for alias entries.
+pub fn format_catalog_update_literal(
+    resolution: &Resolution,
+    string_buf: &[u8],
+    info: &CatalogUpdateInfo,
+    exact_versions: bool,
+) -> Vec<u8> {
+    let version_fmt = resolution.npm().version.fmt(string_buf);
+    let new_version: Vec<u8> = 'new_version: {
+        if exact_versions {
+            let mut v = Vec::new();
+            write!(&mut v, "{}", version_fmt).expect("infallible: in-memory write");
+            break 'new_version v;
+        }
+
+        let version_literal: &[u8] = 'version_literal: {
+            if !info.is_alias {
+                break 'version_literal &info.original_version_literal;
+            }
+            if let Some(at_index) =
+                strings::last_index_of_char(&info.original_version_literal, b'@')
+            {
+                break 'version_literal &info.original_version_literal[at_index + 1..];
+            }
+            &info.original_version_literal
+        };
+
+        let mut v = Vec::new();
+        match Semver::Version::which_version_is_pinned(version_literal) {
+            Semver::PinnedVersion::Patch => {
+                write!(&mut v, "{}", version_fmt).expect("infallible: in-memory write")
+            }
+            Semver::PinnedVersion::Minor => {
+                write!(&mut v, "~{}", version_fmt).expect("infallible: in-memory write")
+            }
+            Semver::PinnedVersion::Major => {
+                write!(&mut v, "^{}", version_fmt).expect("infallible: in-memory write")
+            }
+        }
+        v
+    };
+
+    if info.is_alias {
+        if let Some(at_index) = strings::last_index_of_char(&info.original_version_literal, b'@') {
+            let mut v = Vec::new();
+            write!(
+                &mut v,
+                "{}@{}",
+                bstr::BStr::new(&info.original_version_literal[0..at_index]),
+                bstr::BStr::new(&new_version)
+            )
+            .expect("infallible: in-memory write");
+            return v;
+        }
+    }
+    new_version
 }
 
 #[cold]

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -272,6 +272,14 @@ describe("update", () => {
     expect(update.exitCode).toBe(0);
     expect((await file(join(packageDir, "package.json")).json()).workspaces.catalog).toEqual({ "no-deps": "^2.0.0" });
 
+    // bun.lock's catalog maps must match package.json: the temporary `latest`
+    // used to drive resolution must not be persisted.
+    const lock = await file(join(packageDir, "bun.lock")).text();
+    const catalogSection = lock.slice(lock.indexOf('"catalog":'), lock.indexOf('"packages":'));
+    expect(catalogSection).toContain('"no-deps": "^2.0.0"');
+    expect(catalogSection).toContain('"a-dep": "~1.0.10"');
+    expect(catalogSection).not.toContain('"latest"');
+
     const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "install", "--frozen-lockfile"],
       cwd: packageDir,
@@ -284,6 +292,72 @@ describe("update", () => {
     expect(err).not.toContain("lockfile had changes");
     expect(err).not.toContain("error:");
     expect(exitCode).toBe(0);
+  });
+
+  for (const fromWorkspace of [false, true]) {
+    test(`--frozen-lockfile works offline after --latest updates catalogs (from ${fromWorkspace ? "workspace" : "root"})`, async () => {
+      const { packageDir } = await registry.createTestDir();
+      await createUpdateMonorepo(packageDir, `catalog-update-offline-${fromWorkspace ? "ws" : "root"}`);
+      await runBunInstall(bunEnv, packageDir);
+
+      const cwd = fromWorkspace ? join(packageDir, "packages", "pkg1") : packageDir;
+      const update = await runUpdate(cwd, "--latest");
+      expect(update.err).not.toContain("error:");
+      expect(update.exitCode).toBe(0);
+
+      // Point the registry at a closed port so any attempt to re-resolve the
+      // catalog entries over the network fails. With package.json and bun.lock
+      // in sync and node_modules warm, frozen-lockfile must not touch the network.
+      await write(
+        join(packageDir, "bunfig.toml"),
+        `[install]\ncache = "${join(packageDir, ".bun-cache").replaceAll("\\", "\\\\")}"\nregistry = "http://127.0.0.1:1"\n`,
+      );
+
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install", "--frozen-lockfile"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
+      });
+      const [, errText, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      const err = stderrForInstall(errText);
+      expect(err).not.toContain("failed to resolve");
+      expect(err).not.toContain("lockfile had changes");
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test("bun.lock catalog matches package.json after update without --latest", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "catalog-update-lock-sync",
+          workspaces: {
+            packages: ["packages/*"],
+            catalog: { "no-deps": "^1.0.0" },
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg1", "package.json"),
+        JSON.stringify({ name: "pkg1", dependencies: { "no-deps": "catalog:" } }),
+      ),
+    ]);
+    await runBunInstall(bunEnv, packageDir);
+
+    const { err, exitCode } = await runUpdate(packageDir);
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    const root = await file(join(packageDir, "package.json")).json();
+    expect(root.workspaces.catalog).toEqual({ "no-deps": "^1.1.0" });
+    const lock = await file(join(packageDir, "bun.lock")).text();
+    const catalogSection = lock.slice(lock.indexOf('"catalog":'), lock.indexOf('"packages":'));
+    expect(catalogSection).toContain('"no-deps": "^1.1.0"');
   });
 
   test("--latest run from inside a workspace package updates the root catalog", async () => {


### PR DESCRIPTION
Follow-up to #36304.

## Problem

`bun update --latest` in a catalog workspace rewrote each catalog entry to the placeholder `"latest"` in memory so the resolver would fetch the newest version, then wrote the resolved range (e.g. `^2.0.0`) back to `package.json` after install. But the lockfile is saved inside `install_with_manager`, before the write-back runs, so `bun.lock`'s `catalog`/`catalogs` maps persisted the temporary `"latest"`. Without `--latest`, the same ordering left the stale pre-update range in the lockfile.

```jsonc
// package.json after bun update --latest
"catalog": { "no-deps": "^2.0.0" }
// bun.lock
"catalog": { "no-deps": "latest" }
```

From then on the two files disagree on every catalog entry, so the next `bun install` (including `--frozen-lockfile`) re-resolves them over the network and fails when the registry is unreachable:

```
error: no-deps@catalog: failed to resolve
```

## Fix

Compute each catalog entry's resolved literal once, before the lockfile is cloned and saved. `Lockfile::preprocess_updating_catalogs` (called from `clean_with_logger`, mirroring `preprocess_update_requests`) walks `manager.updating_catalogs`, formats the resolved version with the entry's original `^`/`~`/exact pin, stores it on `CatalogUpdateInfo`, and rewrites `old.catalogs` in place so the saved `bun.lock` carries the resolved range. `edit_catalogs_after_update` then writes the same precomputed literal to `package.json`, so the two files cannot diverge. Unresolved entries (no workspace references them, or they resolve to a non-npm target) are restored to their original literal in both places.

## Tests

`test/cli/install/catalogs.test.ts` gains three cases (fail before, pass after):
- `bun.lock`'s catalog maps contain the resolved ranges, not `"latest"`, after `bun update --latest`
- `bun install --frozen-lockfile` succeeds with the registry pointed at a closed port after `bun update --latest` (from root and from inside a workspace)
- after a plain `bun update`, `bun.lock`'s catalog matches the range written to `package.json`

All 19 `catalogs.test.ts`, 6 `bun-update.test.ts`, and 19 `bun-install-registry.test.ts -t 'update|catalog|frozen'` cases pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/catalogs.test.ts
bun test v1.4.0 (8cbde11cc)

test/cli/install/catalogs.test.ts:
(pass) basic > both catalog and catalogs in top-level [450.39ms]
(pass) basic > both catalog and catalogs in workspaces [348.91ms]
(pass) basic > detect changes (bun.lockb) [545.71ms]
(pass) basic > detect changes (bun.lock) [509.33ms]
(pass) update > --latest updates catalog versions in top-level [434.46ms]
(pass) update > --latest updates catalog versions in workspaces [403.96ms]
(pass) update > --latest updates catalog versions with -r [421.36ms]
274 | 
275 |     // bun.lock's catalog maps must match package.json: the temporary `latest`
276 |     // used to drive resolution must not be persisted.
277 |     const lock = await file(join(packageDir, "bun.lock")).text();
278 |     const catalogSection = lock.slice(lock.indexOf('"catalog":'), lock.indexOf('"packages":'));
279 |     expect(catalogSection).toContain('"no-deps": "^2.0.0"');
                                 ^
error: expect(received).toContain(expected)

Expected to contain: "\"n
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (8ad21d479)

test/cli/install/catalogs.test.ts:
(pass) basic > both catalog and catalogs in top-level [81.96ms]
(pass) basic > both catalog and catalogs in workspaces [19.23ms]
(pass) basic > detect changes (bun.lockb) [31.16ms]
(pass) basic > detect changes (bun.lock) [34.74ms]
(pass) update > --latest updates catalog versions in top-level [27.41ms]
(pass) update > --latest updates catalog versions in workspaces [23.98ms]
(pass) update > --latest updates catalog versions with -r [25.29ms]
(pass) update > --frozen-lockfile passes after --latest updates catalogs [25.14ms]
(pass) update > --frozen-lockfile works offline after --latest updates catalogs (from root) [30.39ms]
(pass) update > --frozen-lockfile works offline after --latest updates catalogs (from workspace) [32.09ms]
(pass) update > bun.lock catalog matches package.json after update without --latest [21.58ms]
(pass) update > --latest run from inside a workspace package updates the root catalog [22.83ms]
(pass) update > --latest updates the same package independently per catalog [32.40ms]
(pass) update > --latest --dry-run does not modify any package.json (from root) [29.88ms]
(pass)
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/catalogs.test.ts
bun test v1.4.0 (8cbde11cc)

test/cli/install/catalogs.test.ts:
(pass) basic > both catalog and catalogs in top-level [444.87ms]
(pass) basic > both catalog and catalogs in workspaces [372.68ms]
(pass) basic > detect changes (bun.lockb) [567.25ms]
(pass) basic > detect changes (bun.lock) [555.95ms]
(pass) update > --latest updates catalog versions in top-level [466.86ms]
(pass) update > --latest updates catalog versions in workspaces [409.22ms]
(pass) update > --latest updates catalog versions with -r [730.80ms]
(pass) update > --frozen-lockfile passes after --latest updates catalogs [561.93ms]
(pass) update > --frozen-lockfile works offline after --latest updates catalogs (from root) [579.11ms]
(pass) update > --frozen-lockfile works offline after --latest updates catalogs (from workspace) [583.64ms]
(pass) update > bun.lock catalog matches package.json after update without --latest [414.11ms]
(pass) update > --latest run from inside a workspace package updates the root catalog [403.80ms]
(pass) updat
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 732ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager.rs                      |   2 +
 src/install/PackageManager/PackageJSONEditor.rs    | 113 +-----------
 .../PackageManager/updatePackageJSONAndInstall.rs  |  19 +-
 src/install/lockfile.rs                            | 198 ++++++++++++++++++++-
 test/cli/install/catalogs.test.ts                  |  74 ++++++++
 5 files changed, 279 insertions(+), 127 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/install/PackageManager.rs                                 2      3      0
src/install/PackageManager/PackageJSONEditor.rs               4      5      0
…c/install/PackageManager/updatePackageJSONAndInstall.rs      3      2      0
src/install/lockfile.rs                                       9     15      0
test/cli/install/catalogs.test.ts                             1      3      0
```

</details>

<!-- robobun:evidence:end -->