### PR TITLE
bun build --compile: only write .map sidecar for --sourcemap=external

### DIFF
--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -243,6 +243,7 @@ pub mod js_bundler {
         pub autoload_bunfig: bool,
         pub autoload_tsconfig: bool,
         pub autoload_package_json: bool,
+        pub sourcemap_sidecar: bool,
     }
 
     impl Default for CompileOptions {
@@ -264,6 +265,7 @@ pub mod js_bundler {
                 autoload_bunfig: true,
                 autoload_tsconfig: false,
                 autoload_package_json: false,
+                sourcemap_sidecar: false,
             }
         }
     }
@@ -1202,6 +1204,9 @@ pub mod js_bundler {
                     // When using --compile, only `external` sourcemaps work, as we do not
                     // look at the source map comment. Override any other sourcemap type.
                     if this.source_map != options::SourceMapOption::None {
+                        // Only write a .map sidecar when the user asked for it.
+                        compile.sourcemap_sidecar =
+                            this.source_map == options::SourceMapOption::External;
                         this.source_map = options::SourceMapOption::External;
                     }
 

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -444,6 +444,7 @@ impl JSBundleCompletionTask {
             let keep_this = if i == entry_point_index {
                 true
             } else if matches!(result, CompileResult::Success)
+                && compile_options.sourcemap_sidecar
                 && output_files[i].output_kind == OutputKind::Sourcemap
                 && matches!(output_files[i].value, OutputFileValue::Buffer { .. })
             {

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -310,14 +310,10 @@ impl BuildCommand {
                 // comment. After validating the user's choice, secretly
                 // override it. (Standalone HTML builds keep the user's choice
                 // because browsers do read the comment.)
-                //
-                // Remember whether the user explicitly asked for `external`
-                // before this override so the post-compile sidecar write only
-                // happens when it was requested. Otherwise the embedded map is
-                // sufficient and a stray `<entry>.js.map` on disk is unwanted.
-                compile_sourcemap_sidecar =
-                    this_transpiler.options.source_map == options::SourceMapOption::External;
                 if this_transpiler.options.source_map != options::SourceMapOption::None {
+                    // Only write a .map sidecar when the user asked for it.
+                    compile_sourcemap_sidecar =
+                        this_transpiler.options.source_map == options::SourceMapOption::External;
                     this_transpiler.options.source_map = options::SourceMapOption::External;
                 }
 

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -246,6 +246,7 @@ impl BuildCommand {
 
         this_transpiler.options.bytecode = ctx.bundler_options.bytecode;
         let mut was_renamed_from_index = false;
+        let mut compile_sourcemap_sidecar = false;
 
         if ctx.bundler_options.compile {
             if ctx.bundler_options.transform_only {
@@ -309,6 +310,13 @@ impl BuildCommand {
                 // comment. After validating the user's choice, secretly
                 // override it. (Standalone HTML builds keep the user's choice
                 // because browsers do read the comment.)
+                //
+                // Remember whether the user explicitly asked for `external`
+                // before this override so the post-compile sidecar write only
+                // happens when it was requested. Otherwise the embedded map is
+                // sufficient and a stray `<entry>.js.map` on disk is unwanted.
+                compile_sourcemap_sidecar =
+                    this_transpiler.options.source_map == options::SourceMapOption::External;
                 if this_transpiler.options.source_map != options::SourceMapOption::None {
                     this_transpiler.options.source_map = options::SourceMapOption::External;
                 }
@@ -580,7 +588,6 @@ impl BuildCommand {
         let opt_minify_syntax = this_transpiler.options.minify_syntax;
         let opt_public_path: Box<[u8]> = this_transpiler.options.public_path.clone();
         let opt_output_format = this_transpiler.options.output_format;
-        let opt_source_map = this_transpiler.options.source_map;
         let opt_transform_only = this_transpiler.options.transform_only;
         let env_ptr = this_transpiler.env;
 
@@ -931,7 +938,7 @@ impl BuildCommand {
 
                 // Write external sourcemap files next to the compiled executable.
                 // With --splitting, there can be multiple .map files (one per chunk).
-                if opt_source_map == options::SourceMapOption::External {
+                if compile_sourcemap_sidecar {
                     for f in output_files.iter() {
                         if f.output_kind == options::OutputKind::Sourcemap
                             && matches!(f.value, options::OutputFileValue::Buffer { .. })

--- a/test/bundler/bun-build-compile-sourcemap.test.ts
+++ b/test/bundler/bun-build-compile-sourcemap.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
 import { readdirSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 describe("Bun.build compile with sourcemap", () => {
@@ -221,54 +221,47 @@ export function greet() {
     ["--sourcemap=inline", false],
     ["--sourcemap=external", true],
   ])("CLI: --compile %s", (flag, expectSidecar) => {
-    test.concurrent(
-      expectSidecar ? "writes a .map sidecar" : "does not write a .map sidecar",
-      async () => {
-        using dir = tempDir(`build-compile-cli-sourcemap-${flag.replace(/[^a-z]/gi, "")}`, {
-          "thr.ts": 'function f() {\n  throw new Error("x");\n}\nf();\n',
-        });
-        const outfile = join(String(dir), "app");
+    test.concurrent(expectSidecar ? "writes a .map sidecar" : "does not write a .map sidecar", async () => {
+      using dir = tempDir(`build-compile-cli-sourcemap-${flag.replace(/[^a-z]/gi, "")}`, {
+        "thr.ts": 'function f() {\n  throw new Error("x");\n}\nf();\n',
+      });
+      const outfile = join(String(dir), "app");
 
-        await using build = Bun.spawn({
-          cmd: [bunExe(), "build", "--compile", "thr.ts", "--outfile", outfile, flag],
-          env: bunEnv,
-          cwd: String(dir),
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [, buildStderr, buildExit] = await Promise.all([
-          build.stdout.text(),
-          build.stderr.text(),
-          build.exited,
-        ]);
-        expect(buildStderr).toBe("");
-        expect(buildExit).toBe(0);
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", "thr.ts", "--outfile", outfile, flag],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, buildStderr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+      expect(buildStderr).toBe("");
+      expect(buildExit).toBe(0);
 
-        const mapFiles = readdirSync(String(dir)).filter(name => name.endsWith(".map"));
-        if (expectSidecar) {
-          expect(mapFiles.length).toBe(1);
-          const map = JSON.parse(await Bun.file(join(String(dir), mapFiles[0])).text());
-          expect(map.version).toBe(3);
-        } else {
-          expect(mapFiles).toEqual([]);
-        }
+      const mapFiles = readdirSync(String(dir)).filter(name => name.endsWith(".map"));
+      if (expectSidecar) {
+        expect(mapFiles.length).toBe(1);
+        const map = JSON.parse(await Bun.file(join(String(dir), mapFiles[0])).text());
+        expect(map.version).toBe(3);
+      } else {
+        expect(mapFiles).toEqual([]);
+      }
 
-        // The embedded sourcemap should resolve the stack regardless of
-        // whether a sidecar was written.
-        const exe = process.platform === "win32" ? `${outfile}.exe` : outfile;
-        await using run = Bun.spawn({
-          cmd: [exe],
-          env: bunEnv,
-          cwd: String(dir),
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [, runStderr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
-        expect(runStderr).toContain("thr.ts");
-        expect(runStderr).not.toMatch(/(\$bunfs|~BUN)\/root\//);
-        expect(runExit).not.toBe(0);
-      },
-    );
+      // The embedded sourcemap should resolve the stack regardless of
+      // whether a sidecar was written.
+      const exe = process.platform === "win32" ? `${outfile}.exe` : outfile;
+      await using run = Bun.spawn({
+        cmd: [exe],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, runStderr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+      expect(runStderr).toContain("thr.ts");
+      expect(runStderr).not.toMatch(/(\$bunfs|~BUN)\/root\//);
+      expect(runExit).not.toBe(0);
+    });
   });
 
   test("compile with --outfile subdir/myapp writes .map next to executable", async () => {

--- a/test/bundler/bun-build-compile-sourcemap.test.ts
+++ b/test/bundler/bun-build-compile-sourcemap.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { readdirSync } from "fs";
 import { join } from "path";
 
 describe("Bun.build compile with sourcemap", () => {
@@ -208,6 +209,66 @@ export function greet() {
 
     expect(stdout).toContain("hello from lazy module");
     expect(exitCode).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/8341
+  // `--compile --sourcemap[=inline|linked]` used to write an <entry>.js.map
+  // sidecar even though the map is embedded in the executable. Only
+  // `--sourcemap=external` should emit a sidecar.
+  describe.each([
+    ["--sourcemap", false],
+    ["--sourcemap=linked", false],
+    ["--sourcemap=inline", false],
+    ["--sourcemap=external", true],
+  ])("CLI: --compile %s", (flag, expectSidecar) => {
+    test.concurrent(
+      expectSidecar ? "writes a .map sidecar" : "does not write a .map sidecar",
+      async () => {
+        using dir = tempDir(`build-compile-cli-sourcemap-${flag.replace(/[^a-z]/gi, "")}`, {
+          "thr.ts": 'function f() {\n  throw new Error("x");\n}\nf();\n',
+        });
+        const outfile = join(String(dir), "app");
+
+        await using build = Bun.spawn({
+          cmd: [bunExe(), "build", "--compile", "thr.ts", "--outfile", outfile, flag],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [, buildStderr, buildExit] = await Promise.all([
+          build.stdout.text(),
+          build.stderr.text(),
+          build.exited,
+        ]);
+        expect(buildStderr).toBe("");
+        expect(buildExit).toBe(0);
+
+        const mapFiles = readdirSync(String(dir)).filter(name => name.endsWith(".map"));
+        if (expectSidecar) {
+          expect(mapFiles.length).toBe(1);
+          const map = JSON.parse(await Bun.file(join(String(dir), mapFiles[0])).text());
+          expect(map.version).toBe(3);
+        } else {
+          expect(mapFiles).toEqual([]);
+        }
+
+        // The embedded sourcemap should resolve the stack regardless of
+        // whether a sidecar was written.
+        const exe = process.platform === "win32" ? `${outfile}.exe` : outfile;
+        await using run = Bun.spawn({
+          cmd: [exe],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [, runStderr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+        expect(runStderr).toContain("thr.ts");
+        expect(runStderr).not.toMatch(/(\$bunfs|~BUN)\/root\//);
+        expect(runExit).not.toBe(0);
+      },
+    );
   });
 
   test("compile with --outfile subdir/myapp writes .map next to executable", async () => {

--- a/test/bundler/bun-build-compile-sourcemap.test.ts
+++ b/test/bundler/bun-build-compile-sourcemap.test.ts
@@ -216,6 +216,52 @@ export function greet() {
   // sidecar even though the map is embedded in the executable. Only
   // `--sourcemap=external` should emit a sidecar.
   describe.each([
+    [true, false],
+    ["linked", false],
+    ["inline", false],
+    ["external", true],
+  ] as const)("JS API: compile with sourcemap: %p", (sourcemap, expectSidecar) => {
+    test(expectSidecar ? "writes a .map sidecar" : "does not write a .map sidecar", async () => {
+      using dir = tempDir(`build-compile-jsapi-sourcemap-${sourcemap}`, {
+        "thr.ts": 'function f() {\n  throw new Error("x");\n}\nf();\n',
+      });
+      const outfile = join(String(dir), "app");
+
+      const result = await Bun.build({
+        entrypoints: [join(String(dir), "thr.ts")],
+        compile: { outfile },
+        sourcemap,
+      });
+      expect(result.success).toBe(true);
+
+      const mapFiles = readdirSync(String(dir)).filter(name => name.endsWith(".map"));
+      const sourcemapOutputs = result.outputs.filter(o => o.kind === "sourcemap");
+      if (expectSidecar) {
+        expect(mapFiles.length).toBe(1);
+        expect(sourcemapOutputs.length).toBe(1);
+        const map = JSON.parse(await Bun.file(join(String(dir), mapFiles[0])).text());
+        expect(map.version).toBe(3);
+      } else {
+        expect(mapFiles).toEqual([]);
+        expect(sourcemapOutputs).toEqual([]);
+      }
+
+      const exe = process.platform === "win32" ? `${outfile}.exe` : outfile;
+      await using run = Bun.spawn({
+        cmd: [exe],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, runStderr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+      expect(runStderr).toContain("thr.ts");
+      expect(runStderr).not.toMatch(/(\$bunfs|~BUN)\/root\//);
+      expect(runExit).not.toBe(0);
+    });
+  });
+
+  describe.each([
     ["--sourcemap", false],
     ["--sourcemap=linked", false],
     ["--sourcemap=inline", false],


### PR DESCRIPTION
Closes #8341

## Repro

```console
$ printf 'function f(){throw new Error("x")}\nf()\n' > thr.ts
$ bun build --compile thr.ts --outfile app --sourcemap
$ ls
app  thr.js.map  thr.ts           # <- thr.js.map is dead weight
$ rm thr.js.map && ./app
error: x
      at f (thr.ts:1:20)          # <- stack still resolves; map is embedded
```

`--sourcemap`, `=inline`, `=linked`, and `=external` all produced a byte-identical executable and all wrote the sidecar. The sidecar is named after the entry (`<entry>.js.map`), so it can clobber a project's own map file sitting next to the outfile. `Bun.build({ compile: true, sourcemap: 'inline' | 'linked' | true })` had the same behavior.

## Cause

Both the CLI (`build_command.rs`) and the JS API (`JSBundler.rs`) force `source_map = External` for the executable compile path so the standalone module graph receives the map as a separate `OutputFile` to embed (the runtime does not read `//# sourceMappingURL`). The post-compile sidecar write then checked the post-override value, so it was true whenever any sourcemap mode was set.

## Fix

Record whether the user's original choice was `external` before the override runs, and gate the sidecar write on that in both paths. `--sourcemap` / `=inline` / `=linked` (and `sourcemap: true | 'inline' | 'linked'`) now embed only; `=external` / `'external'` still writes the `.map` next to the executable.

## Verification

New parameterized tests in `test/bundler/bun-build-compile-sourcemap.test.ts` cover both entry points: a CLI block over all four flag spellings and a JS API block over `true`/`'linked'`/`'inline'`/`'external'`. Each asserts no `.map` in the output dir for non-external modes, exactly one for external, and that the embedded map still resolves `thr.ts` in the thrown stack. 6/8 new cases fail on main, 17/17 pass with the fix.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-compile-sourcemap.test.ts

<!-- robobun:evidence:end -->