### PR TITLE
bun test --isolate: deactivate leaked fake timers between files

### DIFF
--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1648,20 +1648,20 @@ pub(crate) fn close_isolation_handles(vm: &mut VirtualMachine) {
     let _ = vm.event_loop_mut().drain_microtasks();
     // Fake-timer state lives in the per-thread `timer::All`, not the JS
     // global, so a file that leaves it active routes every later file's
-    // `setTimeout` into the never-driven fake heap.
+    // `setTimeout` into the never-driven fake heap. Leave the heap itself
+    // intact: `swap_global_for_test_isolation` runs `cancel_all_timeout_objects`
+    // next, which walks both heaps and releases `TimeoutObject` pins and
+    // `AbortSignalTimeout` cycle refs at a point where no user JS can touch
+    // the outgoing signals.
     {
         let all = timer_all();
         // SAFETY: `state` is non-null so `timer_all()` is non-null; single
         // JS thread, no re-entry while we hold the field borrow.
         if !all.is_null() && unsafe { (*all).fake_timers.is_active() } {
             let global = vm.global();
-            // SAFETY: as above; `deactivate` only touches `fake_timers` and
-            // the `CURRENT_TIME` static.
-            let pinned = unsafe { (*all).fake_timers.deactivate(global) };
-            let vm_ptr: *mut VirtualMachine = vm;
-            for p in pinned {
-                timer::TimerObjectInternals::release_heap_pin(p, vm_ptr);
-            }
+            // SAFETY: as above; only touches `fake_timers.active` and the
+            // `CURRENT_TIME` static.
+            unsafe { (*all).fake_timers.reset_for_isolation(global) };
         }
     }
     loop {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1646,6 +1646,24 @@ pub(crate) fn close_isolation_handles(vm: &mut VirtualMachine) {
     // handles when it runs. Drain first so they land in the registry before
     // it empties — matches the swap's own drain-before-teardown ordering.
     let _ = vm.event_loop_mut().drain_microtasks();
+    // Fake-timer state lives in the per-thread `timer::All`, not the JS
+    // global, so a file that leaves it active routes every later file's
+    // `setTimeout` into the never-driven fake heap.
+    {
+        let all = timer_all();
+        // SAFETY: `state` is non-null so `timer_all()` is non-null; single
+        // JS thread, no re-entry while we hold the field borrow.
+        if !all.is_null() && unsafe { (*all).fake_timers.is_active() } {
+            let global = vm.global();
+            // SAFETY: as above; `deactivate` only touches `fake_timers` and
+            // the `CURRENT_TIME` static.
+            let pinned = unsafe { (*all).fake_timers.deactivate(global) };
+            let vm_ptr: *mut VirtualMachine = vm;
+            for p in pinned {
+                timer::TimerObjectInternals::release_heap_pin(p, vm_ptr);
+            }
+        }
+    }
     loop {
         // SAFETY: live boxed per-thread `RuntimeState`; the borrow ends before
         // the close below re-enters JS.

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -124,7 +124,7 @@ impl FakeTimers {
         CURRENT_TIME.set(global, &Timespec::EPOCH, Some(js_now));
     }
 
-    fn deactivate(
+    pub(crate) fn deactivate(
         &mut self,
         global: &JSGlobalObject,
     ) -> Vec<core::ptr::NonNull<TimerObjectInternals>> {

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -6,7 +6,7 @@ use bun_core::Environment;
 use bun_core::Timespec;
 use bun_jsc::{CallFrame, JSFunction, JSGlobalObject, JSHostFn, JSValue, JsResult};
 use crate::timer::{
-    AbortSignalTimeout, ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag, InHeap,
+    ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag, InHeap,
     TimerObjectInternals, TimeoutObject, TimerHeap,
 };
 
@@ -124,7 +124,7 @@ impl FakeTimers {
         CURRENT_TIME.set(global, &Timespec::EPOCH, Some(js_now));
     }
 
-    pub(crate) fn deactivate(
+    fn deactivate(
         &mut self,
         global: &JSGlobalObject,
     ) -> Vec<core::ptr::NonNull<TimerObjectInternals>> {
@@ -132,6 +132,16 @@ impl FakeTimers {
         CURRENT_TIME.clear(global);
         self.active = false;
         pinned
+    }
+
+    /// Restore real timers without draining the fake heap. Used by the
+    /// `--isolate` file boundary so `swap_global_for_test_isolation`'s
+    /// `cancel_all_timeout_objects` (which runs after the outgoing global's
+    /// JS has stopped) can walk the still-populated fake heap and release
+    /// both `TimeoutObject` pins and `AbortSignalTimeout` cycle refs.
+    pub(crate) fn reset_for_isolation(&mut self, global: &JSGlobalObject) {
+        CURRENT_TIME.clear(global);
+        self.active = false;
     }
 
     /// Marking `state = CANCELLED` alone strands the `Box<TimeoutObject>`: its
@@ -142,30 +152,16 @@ impl FakeTimers {
     fn clear(&mut self) -> Vec<core::ptr::NonNull<TimerObjectInternals>> {
         let mut pinned = Vec::new();
         while let Some(timer) = self.timers.delete_min() {
-            // SAFETY: `delete_min` returned a live node; the parent box stays
-            // live until the caller's release pass / the signal unref below.
+            // SAFETY: `delete_min` returned a live node; the `TimeoutObject`
+            // it belongs to stays live until the caller's release pass.
             unsafe {
                 (*timer).in_heap = InHeap::None;
                 (*timer).state = EventLoopTimerState::CANCELLED;
-                match (*timer).tag {
-                    EventLoopTimerTag::TimeoutObject => {
-                        let parent = TimeoutObject::from_timer_ptr(timer);
-                        pinned.push(core::ptr::NonNull::new_unchecked(
-                            core::ptr::addr_of_mut!((*parent).internals),
-                        ));
-                    }
-                    EventLoopTimerTag::AbortSignalTimeout => {
-                        // Break the AbortSignal <-> Timeout refcount cycle the
-                        // same way `All::cancel_all_timeout_objects` does, so
-                        // `~AbortSignal` -> `cancelTimer()` can free the box.
-                        let t = AbortSignalTimeout::from_timer_ptr(timer);
-                        let signal = (*t).signal;
-                        (*t).signal = core::ptr::null_mut();
-                        if !signal.is_null() {
-                            crate::jsc::abort_signal::AbortSignal::opaque_ref(signal).unref();
-                        }
-                    }
-                    _ => {}
+                if (*timer).tag == EventLoopTimerTag::TimeoutObject {
+                    let parent = TimeoutObject::from_timer_ptr(timer);
+                    pinned.push(core::ptr::NonNull::new_unchecked(
+                        core::ptr::addr_of_mut!((*parent).internals),
+                    ));
                 }
             }
         }

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -6,7 +6,7 @@ use bun_core::Environment;
 use bun_core::Timespec;
 use bun_jsc::{CallFrame, JSFunction, JSGlobalObject, JSHostFn, JSValue, JsResult};
 use crate::timer::{
-    ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag, InHeap,
+    AbortSignalTimeout, ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag, InHeap,
     TimerObjectInternals, TimeoutObject, TimerHeap,
 };
 
@@ -142,16 +142,30 @@ impl FakeTimers {
     fn clear(&mut self) -> Vec<core::ptr::NonNull<TimerObjectInternals>> {
         let mut pinned = Vec::new();
         while let Some(timer) = self.timers.delete_min() {
-            // SAFETY: `delete_min` returned a live node; the `TimeoutObject`
-            // it belongs to stays live until the caller's release pass.
+            // SAFETY: `delete_min` returned a live node; the parent box stays
+            // live until the caller's release pass / the signal unref below.
             unsafe {
                 (*timer).in_heap = InHeap::None;
                 (*timer).state = EventLoopTimerState::CANCELLED;
-                if (*timer).tag == EventLoopTimerTag::TimeoutObject {
-                    let parent = TimeoutObject::from_timer_ptr(timer);
-                    pinned.push(core::ptr::NonNull::new_unchecked(
-                        core::ptr::addr_of_mut!((*parent).internals),
-                    ));
+                match (*timer).tag {
+                    EventLoopTimerTag::TimeoutObject => {
+                        let parent = TimeoutObject::from_timer_ptr(timer);
+                        pinned.push(core::ptr::NonNull::new_unchecked(
+                            core::ptr::addr_of_mut!((*parent).internals),
+                        ));
+                    }
+                    EventLoopTimerTag::AbortSignalTimeout => {
+                        // Break the AbortSignal <-> Timeout refcount cycle the
+                        // same way `All::cancel_all_timeout_objects` does, so
+                        // `~AbortSignal` -> `cancelTimer()` can free the box.
+                        let t = AbortSignalTimeout::from_timer_ptr(timer);
+                        let signal = (*t).signal;
+                        (*t).signal = core::ptr::null_mut();
+                        if !signal.is_null() {
+                            crate::jsc::abort_signal::AbortSignal::opaque_ref(signal).unref();
+                        }
+                    }
+                    _ => {}
                 }
             }
         }

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -301,6 +301,63 @@ describe.concurrent("bun test --isolate", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("with --isolate, leaked vi.useFakeTimers() is deactivated before next file", async () => {
+    // Fake-timer state lives in the per-thread timer heap, not the JS global,
+    // so a file that activates vi.useFakeTimers() and never restores real
+    // timers (e.g. an it.failing that throws before useRealTimers()) used to
+    // route the next file's setTimeout into the never-driven fake heap.
+    // net.Server.listen() fires 'listening' via setTimeout, so such a file
+    // would hang until its per-test timeout.
+    const fakeTimerFixtures = {
+      "a-fake.test.ts": `
+        import { test, vi } from "bun:test";
+        test("leak fake timers", () => {
+          vi.useFakeTimers();
+          // intentionally never calling vi.useRealTimers()
+        });
+      `,
+      "b-real.test.ts": `
+        import { test, expect } from "bun:test";
+        import { createServer } from "node:net";
+        test("setTimeout fires and net.Server 'listening' emits", async () => {
+          const fired = await new Promise<boolean>(resolve => {
+            setTimeout(() => resolve(true), 1);
+          });
+          expect(fired).toBe(true);
+
+          const server = createServer();
+          const listened = await new Promise<boolean>(resolve => {
+            server.listen(0, "127.0.0.1", () => resolve(true));
+          });
+          server.close();
+          expect(listened).toBe(true);
+        });
+      `,
+    };
+    const files = ["./a-fake.test.ts", "./b-real.test.ts"];
+
+    using isolated = tempDir("isolate-fake-timers", fakeTimerFixtures);
+    const serial = await runTests(String(isolated), ["--isolate", "--timeout=5000"], files);
+    expect(normalizeBunSnapshot(serial.stderr, isolated)).toContain("2 pass");
+    expect(normalizeBunSnapshot(serial.stderr, isolated)).toContain("0 fail");
+    expect(serial.exitCode).toBe(0);
+
+    // One worker takes both files (scale-up gated) so the same reset runs
+    // between files inside a --parallel worker.
+    using parallel = tempDir("isolate-fake-timers-parallel", fakeTimerFixtures);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--parallel=2", "--timeout=5000", ...files],
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "60000" },
+      cwd: String(parallel),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stderr, parallel)).toContain("2 pass");
+    expect(normalizeBunSnapshot(stderr, parallel)).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
   test("leaked subprocesses are killed for every isolated file, not just the first", async () => {
     using dir = tempDir("isolate-subprocess", {
       "a-spawn.test.ts": `

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -313,6 +313,8 @@ describe.concurrent("bun test --isolate", () => {
         import { test, vi } from "bun:test";
         test("leak fake timers", () => {
           vi.useFakeTimers();
+          setTimeout(() => {}, 1000);
+          AbortSignal.timeout(1000);
           // intentionally never calling vi.useRealTimers()
         });
       `,

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -328,7 +328,8 @@ describe.concurrent("bun test --isolate", () => {
           expect(fired).toBe(true);
 
           const server = createServer();
-          const listened = await new Promise<boolean>(resolve => {
+          const listened = await new Promise<boolean>((resolve, reject) => {
+            server.once("error", reject);
             server.listen(0, "127.0.0.1", () => resolve(true));
           });
           server.close();


### PR DESCRIPTION
## Symptom

`test/regression/issue/29684.test.ts` times out on every test (10 × 90s) in the CI parallel bucket on ~4% of builds, then passes in 66ms on solo retry:

```
test/regression/issue/29684.test.ts:
✗ perMessageDeflate upgrade header > omits Sec-WebSocket-Extensions when perMessageDeflate is false [90000.07ms]
  ^ this test timed out after 90000ms.
✗ perMessageDeflate upgrade header > still sends Sec-WebSocket-Extensions when perMessageDeflate is unset [90002.03ms]
  ^ this test timed out after 90000ms.
...
```

## Repro

```sh
BUN_TEST_PARALLEL_SCALE_MS=999999999 bun test --parallel=2 --timeout=5000 \
  test/js/bun/test/fake-timers/sinonjs/issue-2449.test.ts \
  test/regression/issue/29684.test.ts
```

(Scale-up gated so one worker runs both files sequentially.)

## Cause

`vi.useFakeTimers()` stores its `active` flag in the per-thread `timer::All`, not on the JS global. Under `--isolate` / `--parallel`, `swap_global_for_test_isolation` replaces the global and cancels pending timers but never touches `fake_timers.active`, so a file that activates fake timers and never restores them leaks the flag into every subsequent file in the same worker.

`test/js/bun/test/fake-timers/sinonjs/issue-2449.test.ts` (and `issue-276.test.ts`) have `it.failing` cases that call `FakeTimers.install()` and then throw on an `assert.exception` before reaching `clock.uninstall()`, so `vi.useRealTimers()` never runs.

With `fake_timers.active == true`, `All::insert` routes new `setTimeout` calls into the fake heap, which only advances on `advanceTimersByTime`. `net.Server.listen()` emits `'listening'` via `setTimeout(emitListeningNextTick, 1, this)` (src/js/node/net.ts), so 29684's `server.listen(0, "127.0.0.1", cb)` callback never fires and the WebSocket client is never created.

## Fix

`close_isolation_handles` now deactivates fake timers and releases their heap pins before the global swap, matching how it already closes leaked watchers and servers. Each file starts with real timers regardless of what the previous file left behind.

## Verification

```sh
# fail-before (without src/ change): b-real.test.ts times out
# after: 2 pass, 0 fail
bun bd test test/cli/test/isolation.test.ts -t "leaked vi.useFakeTimers"
```

Also re-ran the exact 71-file CI batch from build 85266 with `--parallel=3` three times; 29684 passes all three.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/isolation.test.ts
bun test v1.4.0 (ed45e778d)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [454.84ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [449.22ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [528.79ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [580.56ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [430.53ms]
(pass) bun test --isolate > with --isolate, leaked outbound socket is closed before next file [2237.93ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [2989.95ms]
(pass) bun test --isolate > with --isolate, leaked fs.watch is closed before next file [2734.81ms]
(pass) bun test --isolate > leaked subprocesses are killed for every isolated file, not just the first [2979.88ms]
(pass) --isolate: SourceProvider cache covers Comm
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (04f35069a)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [146.69ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [164.72ms]
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [168.60ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [167.83ms]
(pass) --isolate: SourceProvider cache covers node_modules .mjs and type:commonjs packages [110.94ms]
(pass) --isolate: collects globals pinned by leaked handles > long setTimeout/setInterval left pending [93.81ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [180.26ms]
(pass) --isolate: cached module_info handles `import * as ns; export { ns }` as a Namespace export [123.67ms]
(pass) --isolate: delete require.cache evicts the SourceProvider cache [162.79ms]
(pass) --isolate: SourceProvider cache covers CommonJS modules [155.08ms]
(pass) --isolate: cached SourceProvider's module_info rebuilds correct exports [140.30ms]
(pass) bun test --isolate > with --isolate, leaked outbound socket 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/isolation.test.ts
bun test v1.4.0 (ed45e778d)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [430.55ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [424.98ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [511.23ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [564.86ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [444.53ms]
(pass) bun test --isolate > with --isolate, leaked outbound socket is closed before next file [2260.41ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [3051.82ms]
(pass) bun test --isolate > with --isolate, leaked fs.watch is closed before next file [2720.75ms]
(pass) bun test --isolate > with --isolate, leaked vi.useFakeTimers() is deactivated before next file [2807.48ms]
(pass) bun test --isolate > leaked subprocesses are
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 720ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] cxx obj/src/jsc/bindings/napi.cpp.o
[2/22] cxx obj/codegen/JSSink.cpp.o
[3/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[4/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[5/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[6/22] cxx obj/unified/UnifiedSource-src_jsc_modules-0.cpp.o
[7/22] cxx obj/src/jsc/bindings/bindings.cpp.o
[8/22] cxx obj/src/jsc/bindings/BunObject.cpp.o
[9/22] cxx obj/codegen/ZigGeneratedClasses.cpp.o
[10/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[11/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[12/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[13/22] gen cpp.rs (cppbind)
[14/22] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[15/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[16/22] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[16/22] cargo bun_bin → libbun_rust.a (--target x
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/jsc_hooks.rs                     | 18 +++++++++
 src/runtime/test_runner/timers/FakeTimers.rs | 10 +++++
 test/cli/test/isolation.test.ts              | 60 ++++++++++++++++++++++++++++
 3 files changed, 88 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/runtime/jsc_hooks.rs                          7      5      0
src/runtime/test_runner/timers/FakeTimers.rs      8      9      0
test/cli/test/isolation.test.ts                   3      3      0
```

</details>

<!-- robobun:evidence:end -->