### PR TITLE
install: fix false "Workspace name already exists" on truncated-hash collisions

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -1,6 +1,6 @@
 use core::sync::atomic::{AtomicU8, Ordering};
 
-use bun_collections::{ArrayHashMap, DynamicBitSet};
+use bun_collections::{DynamicBitSet, StringArrayHashMap};
 use bun_core::Progress::Progress;
 use bun_core::{Global, Output};
 use bun_core::{MutableString, ZStr};
@@ -17,8 +17,8 @@ use bun_threading::{ThreadPool, WaitGroup};
 
 use crate::package_installer::NodeModulesFolder;
 use crate::{
-    BuntagHashBuf, Lockfile, Npm, PackageID, PackageManager, Repository, Resolution,
-    TruncatedPackageNameHash, bun_fs, bun_json, buntaghashbuf_make, initialize_store, resolution,
+    BuntagHashBuf, Lockfile, Npm, PackageID, PackageManager, Repository, Resolution, bun_fs,
+    bun_json, buntaghashbuf_make, initialize_store, resolution,
 };
 
 bun_output::declare_scope!(install, hidden);
@@ -56,10 +56,10 @@ pub struct Summary {
     pub(crate) skipped: u32,
     pub(crate) successfully_installed: Option<DynamicBitSet>,
 
-    /// Package name hash -> number of scripts skipped.
+    /// Package name -> number of scripts skipped.
     /// Multiple versions of the same package might add to the count, and each version
     /// might have a different number of scripts
-    pub(crate) packages_with_blocked_scripts: ArrayHashMap<TruncatedPackageNameHash, usize>,
+    pub(crate) packages_with_blocked_scripts: StringArrayHashMap<usize>,
 }
 
 #[repr(u8)]

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -35,7 +35,7 @@ use crate::postinstall_optimizer::{self, PostinstallOptimizer};
 use crate::resolution::{self, Resolution};
 use crate::{
     DependencyID, DependencyInstallContext, ExtractData, PackageID, PackageNameHash,
-    TaskCallbackContext, TruncatedPackageNameHash, invalid_package_id,
+    TaskCallbackContext, invalid_package_id,
 };
 
 bun_output::declare_scope!(PackageInstaller, hidden);
@@ -1898,8 +1898,6 @@ impl<'a> PackageInstaller<'a> {
                     let dep =
                         &self.lockfile().buffers.dependencies.as_slice()[dependency_id as usize];
                     let dep_behavior = dep.behavior;
-                    let truncated_dep_name_hash: TruncatedPackageNameHash =
-                        dep.name_hash as TruncatedPackageNameHash;
                     let (is_trusted, is_trusted_through_update_request) = 'brk: {
                         if self
                             .trusted_dependencies_from_update_requests
@@ -1967,12 +1965,11 @@ impl<'a> PackageInstaller<'a> {
                                 resolution,
                             ) {
                                 if is_trusted_through_update_request {
-                                    let (trusted_name, trusted_name_hash) =
-                                        if resolution.tag == resolution::Tag::Npm {
-                                            (pkg_name, pkg_name_hash as TruncatedPackageNameHash)
-                                        } else {
-                                            (alias, truncated_dep_name_hash)
-                                        };
+                                    let trusted_name = if resolution.tag == resolution::Tag::Npm {
+                                        pkg_name
+                                    } else {
+                                        alias
+                                    };
                                     self.manager_mut()
                                         .trusted_deps_to_add_to_package_json
                                         .push(Box::<[u8]>::from(trusted_name.slice(string_buf!())));
@@ -1985,10 +1982,7 @@ impl<'a> PackageInstaller<'a> {
                                         .trusted_dependencies
                                         .as_mut()
                                         .unwrap()
-                                        .put(
-                                            trusted_name_hash,
-                                            Box::<[u8]>::from(trusted_name.slice(string_buf!())),
-                                        )
+                                        .insert(trusted_name.slice(string_buf!()))
                                         .unwrap_or_oom();
                                 }
                             }
@@ -2029,7 +2023,7 @@ impl<'a> PackageInstaller<'a> {
                                     let entry = self
                                         .summary
                                         .packages_with_blocked_scripts
-                                        .get_or_put(truncated_dep_name_hash)
+                                        .get_or_put(alias.slice(string_buf!()))
                                         .unwrap_or_oom();
                                     if !entry.found_existing {
                                         *entry.value_ptr = 0;
@@ -2199,8 +2193,6 @@ impl<'a> PackageInstaller<'a> {
 
             let dep = &self.lockfile().buffers.dependencies.as_slice()[dependency_id as usize];
             let dep_behavior = dep.behavior;
-            let truncated_dep_name_hash: TruncatedPackageNameHash =
-                dep.name_hash as TruncatedPackageNameHash;
             let (is_trusted, is_trusted_through_update_request, add_to_lockfile) = 'brk: {
                 // trusted through a --trust dependency. need to enqueue scripts, write to package.json, and add to lockfile
                 if self
@@ -2214,16 +2206,14 @@ impl<'a> PackageInstaller<'a> {
                     .manager()
                     .summary
                     .added_trusted_dependencies
-                    .get(&truncated_dep_name_hash)
+                    .get(alias.slice(string_buf!()))
                 {
                     // is a new trusted dependency. need to enqueue scripts and maybe add to lockfile
-                    if *added.name == *alias.slice(string_buf!())
-                        && self.lockfile().has_trusted_dependency(
-                            alias.slice(string_buf!()),
-                            pkg_name.slice(string_buf!()),
-                            resolution,
-                        )
-                    {
+                    if self.lockfile().has_trusted_dependency(
+                        alias.slice(string_buf!()),
+                        pkg_name.slice(string_buf!()),
+                        resolution,
+                    ) {
                         break 'brk (true, false, added.add_to_lockfile);
                     }
                 }
@@ -2275,12 +2265,11 @@ impl<'a> PackageInstaller<'a> {
                         dep_behavior.contains(crate::dependency::Behavior::OPTIONAL),
                         resolution,
                     ) {
-                        let (trusted_name, trusted_name_hash) =
-                            if resolution.tag == resolution::Tag::Npm {
-                                (pkg_name, pkg_name_hash as TruncatedPackageNameHash)
-                            } else {
-                                (alias, truncated_dep_name_hash)
-                            };
+                        let trusted_name = if resolution.tag == resolution::Tag::Npm {
+                            pkg_name
+                        } else {
+                            alias
+                        };
 
                         if is_trusted_through_update_request {
                             self.manager_mut()
@@ -2296,10 +2285,7 @@ impl<'a> PackageInstaller<'a> {
                                 .trusted_dependencies
                                 .as_mut()
                                 .unwrap()
-                                .put(
-                                    trusted_name_hash,
-                                    Box::<[u8]>::from(trusted_name.slice(string_buf!())),
-                                )
+                                .insert(trusted_name.slice(string_buf!()))
                                 .unwrap_or_oom();
                         }
                     }

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -3,7 +3,7 @@ use std::io::Write as _;
 
 use bun_ast::Log;
 use bun_collections::{ArrayHashMap, DynamicBitSet, StringHashMap};
-use bun_core::{Environment, Global, Output};
+use bun_core::{Environment, Global, Output, UnwrapOrOom};
 use bun_core::{ZStr, strings};
 use bun_paths::{self as paths, AbsPath, AutoAbsPath, AutoRelPath};
 use bun_sys::{self as sys, Fd};
@@ -22,7 +22,7 @@ use crate::postinstall_optimizer::PostinstallOptimizer;
 use crate::resolution;
 use crate::{
     self as install, DependencyID, Lockfile, PackageID, PackageManager, PackageNameHash,
-    Resolution, TaskCallbackContext, TruncatedPackageNameHash, bin, invalid_dependency_id,
+    Resolution, TaskCallbackContext, bin, invalid_dependency_id,
 };
 // Bring `items_<field>()` column accessors into scope for
 // `MultiArrayList<Package>` / `Slice<Package>`.
@@ -1594,8 +1594,6 @@ impl Task {
                     let string_buf = lockfile.buffers.string_bytes.as_slice();
 
                     let dep = &lockfile.buffers.dependencies[dep_id as usize];
-                    let truncated_dep_name_hash: TruncatedPackageNameHash =
-                        dep.name_hash as TruncatedPackageNameHash;
 
                     let (is_trusted, is_trusted_through_update_request) = 'brk: {
                         if installer
@@ -1679,15 +1677,11 @@ impl Task {
                             entry_scripts[self.entry_id.get() as usize].set(Some(clone));
 
                             if is_trusted_through_update_request {
-                                let (trusted_name, trusted_name_hash) =
-                                    if pkg_res.tag == ResolutionTag::Npm {
-                                        (
-                                            pkg_name.slice(string_buf),
-                                            pkg_name_hash as TruncatedPackageNameHash,
-                                        )
-                                    } else {
-                                        (dep.name.slice(string_buf), truncated_dep_name_hash)
-                                    };
+                                let trusted_name = if pkg_res.tag == ResolutionTag::Npm {
+                                    pkg_name.slice(string_buf)
+                                } else {
+                                    dep.name.slice(string_buf)
+                                };
                                 let trusted_dep_to_add: Box<[u8]> = Box::from(trusted_name);
 
                                 let _unlock = installer.trusted_dependencies_mutex.lock_guard();
@@ -1720,7 +1714,8 @@ impl Task {
                                 trusted
                                     .as_mut()
                                     .unwrap()
-                                    .insert(trusted_name_hash, Box::from(trusted_name));
+                                    .insert(trusted_name)
+                                    .unwrap_or_oom();
                             }
 
                             if first_index != 0 {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -113,11 +113,122 @@ pub(crate) type StringBuffer = Vec<u8>;
 pub(crate) type ExternalStringBuffer = Vec<ExternalString>;
 
 pub(crate) type NameHashMap = ArrayHashMap<PackageNameHash, SemverString, ArrayIdentityContextU64>;
-/// Value is the exact byte string the key hash was computed from; lookups must
-/// compare it since truncated hashes can collide. An empty value is the legacy
-/// `bun.lockb` sentinel ("name unknown, hash-only match").
-pub(crate) type TrustedDependenciesSet =
-    ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>, ArrayIdentityContext>;
+
+/// Trusted dependency names. Entries loaded from the legacy binary lockfile
+/// carry only a truncated name hash.
+#[derive(Default)]
+pub struct TrustedDependenciesSet {
+    names: bun_collections::StringArrayHashMap<()>,
+    /// In `bun.lockb` order, which `truncated_hashes` reproduces. The value
+    /// records whether a named entry has since been added for the hash; such
+    /// entries stay here so the hash keeps its position in the file.
+    legacy_hashes: ArrayHashMap<TruncatedPackageNameHash, bool, ArrayIdentityContext>,
+}
+
+impl TrustedDependenciesSet {
+    #[inline]
+    fn truncated_hash(name: &[u8]) -> TruncatedPackageNameHash {
+        SemverStringBuilder::string_hash(name) as TruncatedPackageNameHash
+    }
+
+    pub fn insert(&mut self, name: &[u8]) -> Result<(), AllocError> {
+        self.name_legacy(name);
+        self.names.put(name, ())
+    }
+
+    /// Marks the legacy entry matching `name` as named. Returns whether there
+    /// is one.
+    fn name_legacy(&mut self, name: &[u8]) -> bool {
+        if self.legacy_hashes.is_empty() {
+            return false;
+        }
+        match self.legacy_hashes.get_ptr_mut(&Self::truncated_hash(name)) {
+            Some(named) => {
+                *named = true;
+                true
+            }
+            None => false,
+        }
+    }
+
+    pub(crate) fn insert_legacy_hash(
+        &mut self,
+        hash: TruncatedPackageNameHash,
+    ) -> Result<(), AllocError> {
+        self.legacy_hashes.put(hash, false)
+    }
+
+    /// Name match, or a legacy entry matching the name's truncated hash.
+    pub(crate) fn contains(&self, name: &[u8]) -> bool {
+        self.names.contains(name)
+            || (!self.legacy_hashes.is_empty()
+                && self.legacy_hashes.contains(&Self::truncated_hash(name)))
+    }
+
+    /// Named entries only; legacy entries never match.
+    pub(crate) fn contains_name(&self, name: &[u8]) -> bool {
+        self.names.contains(name)
+    }
+
+    /// If a legacy entry matches `name`, records `name` as its name. Returns
+    /// whether a legacy entry matched.
+    pub(crate) fn promote_legacy(&mut self, name: &[u8]) -> Result<bool, AllocError> {
+        if !self.name_legacy(name) {
+            return Ok(false);
+        }
+        self.names.put(name, ())?;
+        Ok(true)
+    }
+
+    pub(crate) fn names(&self) -> &[Box<[u8]>] {
+        self.names.keys()
+    }
+
+    /// Legacy entries no name has been recorded for.
+    pub(crate) fn unnamed_legacy_hashes(&self) -> impl Iterator<Item = TruncatedPackageNameHash> {
+        self.legacy_hashes
+            .keys()
+            .iter()
+            .zip(self.legacy_hashes.values())
+            .filter_map(|(&hash, &named)| (!named).then_some(hash))
+    }
+
+    pub(crate) fn has_legacy_entries(&self) -> bool {
+        !self.legacy_hashes.is_empty()
+    }
+
+    pub fn count(&self) -> usize {
+        self.names.count() + self.unnamed_legacy_hashes().count()
+    }
+
+    pub(crate) fn ensure_unused_capacity(&mut self, additional: usize) -> Result<(), AllocError> {
+        self.names.ensure_unused_capacity(additional)
+    }
+
+    /// One truncated hash per entry for the binary lockfile: the legacy entries
+    /// in the order they were loaded, then the hashes of names added since.
+    /// Re-saving an unchanged set reproduces the file, and a name added for a
+    /// legacy entry (or a second name sharing a hash) does not add an entry.
+    pub(crate) fn truncated_hashes(&self) -> Vec<TruncatedPackageNameHash> {
+        let mut out: Vec<TruncatedPackageNameHash> =
+            Vec::with_capacity(self.legacy_hashes.count() + self.names.count());
+        out.extend_from_slice(self.legacy_hashes.keys());
+        for name in self.names.keys() {
+            let hash = Self::truncated_hash(name);
+            if !out.contains(&hash) {
+                out.push(hash);
+            }
+        }
+        out
+    }
+
+    pub(crate) fn clone(&self) -> Result<Self, AllocError> {
+        Ok(Self {
+            names: self.names.clone()?,
+            legacy_hashes: self.legacy_hashes.clone()?,
+        })
+    }
+}
 pub(crate) type VersionHashMap =
     ArrayHashMap<PackageNameHash, Semver::Version, ArrayIdentityContextU64>;
 pub(crate) type PatchedDependenciesMap =
@@ -3132,10 +3243,9 @@ pub mod default_trusted_dependencies {
 
 impl Lockfile {
     pub(crate) fn in_trusted_dependencies(&self, name: &[u8]) -> bool {
-        let hash = SemverStringBuilder::string_hash(name) as u32;
         self.trusted_dependencies
             .as_ref()
-            .is_some_and(|trusted| trusted.contains(&hash))
+            .is_some_and(|trusted| trusted.contains(name))
     }
 
     pub fn has_trusted_dependency(
@@ -3150,12 +3260,7 @@ impl Lockfile {
             } else {
                 alias
             };
-            let hash = SemverStringBuilder::string_hash(trusted_name) as u32;
-            let name_is_trusted = match trusted_dependencies.get(&hash) {
-                Some(name) => !name.is_empty() && **name == *trusted_name,
-                None => false,
-            };
-            if !name_is_trusted {
+            if !trusted_dependencies.contains_name(trusted_name) {
                 return false;
             }
             if resolution.tag == ResolutionTag::Npm {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1,7 +1,7 @@
 use bun_collections::VecExt;
 use core::mem;
 
-use bun_collections::{ArrayHashMap, ArrayIdentityContext, MultiArrayList, StringSet, index_sort};
+use bun_collections::{ArrayHashMap, MultiArrayList, StringArrayHashMap, StringSet, index_sort};
 use bun_core::strings;
 use bun_core::{Global, Output};
 use bun_paths::{self as path, AutoAbsPath, MAX_PATH_BYTES, PathBuffer, resolve_path};
@@ -15,9 +15,8 @@ use crate::dependency::{Behavior, DependencyExt as _, TagExt as _};
 use crate::repository::RepositoryExt as _;
 use crate::{
     self as install, Aligner, Bin, Dependency, ExternalStringList, ExternalStringMap, Features,
-    Npm, PackageID, PackageManager, PackageNameHash, Repository, TruncatedPackageNameHash,
-    UpdateRequest, bin, default_trusted_dependencies, dependency, initialize_store,
-    invalid_package_id,
+    Npm, PackageID, PackageManager, PackageNameHash, Repository, UpdateRequest, bin,
+    default_trusted_dependencies, dependency, initialize_store, invalid_package_id,
 };
 // `Package.rs` is mounted as `crate::lockfile_real::package`; the parent module
 // (`super`) is the real `lockfile.rs`, distinct from the `crate::lockfile`
@@ -896,14 +895,12 @@ impl Package<u64> {
 
 pub(crate) struct Diff;
 
-/// A trusted dependency newly added by the current diff. `name` is the exact
-/// byte string the truncated key hash was computed from.
+/// A trusted dependency newly added by the current diff.
 pub struct AddedTrustedDependency {
     /// Whether this dependency should be added to lockfile trusted
     /// dependencies. It is false when the new trusted dependency is coming
     /// from the default list.
     pub(crate) add_to_lockfile: bool,
-    pub(crate) name: Box<[u8]>,
 }
 
 #[derive(Default)]
@@ -915,8 +912,7 @@ pub struct DiffSummary {
     pub(crate) overrides_changed: bool,
     pub(crate) catalogs_changed: bool,
 
-    pub(crate) added_trusted_dependencies:
-        ArrayHashMap<TruncatedPackageNameHash, AddedTrustedDependency, ArrayIdentityContext>,
+    pub(crate) added_trusted_dependencies: StringArrayHashMap<AddedTrustedDependency>,
     pub(crate) removed_trusted_dependencies: TrustedDependenciesSet,
 
     pub(crate) patched_dependencies_changed: bool,
@@ -1201,6 +1197,14 @@ impl Diff {
             //     are dependencies are all from the new lockfile. Removed is empty because the default
             //     list isn't appended to the lockfile.
 
+            debug_assert!(
+                to_lockfile
+                    .trusted_dependencies
+                    .as_ref()
+                    .is_none_or(|trusted| !trusted.has_legacy_entries()),
+                "the new lockfile is built from package.json, so its trusted dependencies are all named",
+            );
+
             // 1
             if from_lockfile.trusted_dependencies.is_none()
                 && to_lockfile.trusted_dependencies.is_none()
@@ -1214,42 +1218,30 @@ impl Diff {
                 to_lockfile.trusted_dependencies.as_ref(),
             ) {
                 // added
-                for (&to_trusted, to_name) in to_trusted_dependencies.iter() {
-                    // Empty name = legacy bun.lockb hash-only sentinel.
-                    let already_trusted = from_trusted_dependencies
-                        .get_mut(&to_trusted)
-                        .is_some_and(|from_name| {
-                            if from_name.is_empty() && !to_name.is_empty() {
-                                from_name.clone_from(to_name);
-                            }
-                            from_name.is_empty() || to_name.is_empty() || **from_name == **to_name
-                        });
-                    if !already_trusted {
+                for to_name in to_trusted_dependencies.names() {
+                    let was_named = from_trusted_dependencies.contains_name(to_name);
+                    let was_legacy = from_trusted_dependencies.promote_legacy(to_name)?;
+                    if !was_named && !was_legacy {
                         summary.added_trusted_dependencies.put(
-                            to_trusted,
+                            to_name,
                             AddedTrustedDependency {
                                 add_to_lockfile: true,
-                                name: to_name.clone(),
                             },
                         )?;
                     }
                 }
 
                 // removed
-                for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
-                    let still_trusted =
-                        to_trusted_dependencies
-                            .get(&from_trusted)
-                            .is_some_and(|to_name| {
-                                from_name.is_empty()
-                                    || to_name.is_empty()
-                                    || **to_name == **from_name
-                            });
-                    if !still_trusted {
-                        summary
-                            .removed_trusted_dependencies
-                            .put(from_trusted, from_name.clone())?;
+                for from_name in from_trusted_dependencies.names() {
+                    if !to_trusted_dependencies.contains_name(from_name) {
+                        summary.removed_trusted_dependencies.insert(from_name)?;
                     }
+                }
+                // `promote_legacy` above named every legacy entry that `to` still lists.
+                for from_hash in from_trusted_dependencies.unnamed_legacy_hashes() {
+                    summary
+                        .removed_trusted_dependencies
+                        .insert_legacy_hash(from_hash)?;
                 }
 
                 break 'trusted_dependencies;
@@ -1262,27 +1254,29 @@ impl Diff {
             ) {
                 // added
                 for entry in default_trusted_dependencies::entries() {
-                    if !from_trusted_dependencies
-                        .contains(&(entry.hash as TruncatedPackageNameHash))
-                    {
+                    if !from_trusted_dependencies.contains(entry.key) {
                         // although this is a new trusted dependency, it is from the default
                         // list so it shouldn't be added to the lockfile
                         summary.added_trusted_dependencies.put(
-                            entry.hash as TruncatedPackageNameHash,
+                            entry.key,
                             AddedTrustedDependency {
                                 add_to_lockfile: false,
-                                name: Box::from(entry.key),
                             },
                         )?;
                     }
                 }
 
                 // removed
-                for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
-                    if !default_trusted_dependencies::has_with_hash(u64::from(from_trusted)) {
+                for from_name in from_trusted_dependencies.names() {
+                    if !default_trusted_dependencies::has(from_name) {
+                        summary.removed_trusted_dependencies.insert(from_name)?;
+                    }
+                }
+                for from_hash in from_trusted_dependencies.unnamed_legacy_hashes() {
+                    if !default_trusted_dependencies::has_with_hash(u64::from(from_hash)) {
                         summary
                             .removed_trusted_dependencies
-                            .put(from_trusted, from_name.clone())?;
+                            .insert_legacy_hash(from_hash)?;
                     }
                 }
 
@@ -1296,12 +1290,11 @@ impl Diff {
             ) {
                 // add all to trusted dependencies, even if they exist in default because they weren't in the
                 // lockfile originally
-                for (&to_trusted, to_name) in to_trusted_dependencies.iter() {
+                for to_name in to_trusted_dependencies.names() {
                     summary.added_trusted_dependencies.put(
-                        to_trusted,
+                        to_name,
                         AddedTrustedDependency {
                             add_to_lockfile: true,
-                            name: to_name.clone(),
                         },
                     )?;
                 }
@@ -2479,10 +2472,7 @@ impl Package<u64> {
                         let Some(name) = item.as_string(&bump) else {
                             return Err(invalid_trusted_dependencies(log, source, q.loc));
                         };
-                        trusted.put_assume_capacity(
-                            semver::string::Builder::string_hash(name) as TruncatedPackageNameHash,
-                            Box::<[u8]>::from(name),
-                        );
+                        trusted.insert(name)?;
                     }
                 }
             }
@@ -2738,20 +2728,15 @@ impl Package<u64> {
 
         for group in &dependency_groups {
             if group.behavior.is_workspace() {
-                let mut seen_workspace_names: ArrayHashMap<
-                    TruncatedPackageNameHash,
-                    (),
-                    ArrayIdentityContext,
-                > = ArrayHashMap::default();
+                let mut seen_workspace_names: StringArrayHashMap<()> =
+                    StringArrayHashMap::default();
                 for (entry, path_) in workspace_names
                     .values()
                     .iter()
                     .zip(workspace_names.keys().iter())
                 {
                     // workspace names from their package jsons. duplicates not allowed
-                    let gop = seen_workspace_names
-                        .get_or_put(semver::string::Builder::string_hash(&entry.name)
-                            as TruncatedPackageNameHash)?;
+                    let gop = seen_workspace_names.get_or_put(&entry.name)?;
                     if gop.found_existing {
                         // this path does alot of extra work to format the error message
                         // but this is ok because the install is going to fail anyways, so this

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -15,7 +15,6 @@ use bun_semver::{self as Semver, ExternalString, String};
 
 use crate::{
     DependencyID, Npm, Origin, PackageID, PackageManager, PackageNameHash, Repository, Resolution,
-    TruncatedPackageNameHash,
     bin::{Bin, Tag as BinTag},
     dependency,
     dependency::{
@@ -518,12 +517,8 @@ impl Stringifier {
 
                     // intentionally not checking default trusted dependencies
                     if let Some(trusted_dependencies) = &lockfile.trusted_dependencies {
-                        if let Some(trusted_name) =
-                            trusted_dependencies.get(&(dep.name_hash as TruncatedPackageNameHash))
-                        {
-                            if **trusted_name == *dep.name.slice(buf) {
-                                found_trusted_dependencies.insert(dep.name_hash, dep.name);
-                            }
+                        if trusted_dependencies.contains_name(dep.name.slice(buf)) {
+                            found_trusted_dependencies.insert(dep.name_hash, dep.name);
                         }
                     }
                 }
@@ -1939,10 +1934,9 @@ pub(crate) fn parse_into_binary_lockfile(
                 );
                 return Err(ParseError::InvalidTrustedDependenciesSet);
             };
-            let name: Box<[u8]> = Box::from(name_str);
-            let name_hash: TruncatedPackageNameHash =
-                StringBuilder::string_hash(&name) as TruncatedPackageNameHash;
-            trusted_dependencies.insert(name_hash, name);
+            trusted_dependencies
+                .insert(name_str)
+                .map_err(|_| ParseError::OutOfMemory)?;
         }
 
         lockfile.trusted_dependencies = Some(trusted_dependencies);

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -259,7 +259,8 @@ pub(crate) fn save(
         if trusted_dependencies.count() > 0 {
             stream.write_all(&HAS_TRUSTED_DEPENDENCIES_TAG.to_ne_bytes())?;
 
-            write_array::<u32>(&mut stream, trusted_dependencies.keys(), PREFIX_U32)?;
+            let hashes = trusted_dependencies.truncated_hashes();
+            write_array::<u32>(&mut stream, &hashes, PREFIX_U32)?;
         } else {
             stream.write_all(&HAS_EMPTY_TRUSTED_DEPENDENCIES_TAG.to_ne_bytes())?;
         }
@@ -565,12 +566,8 @@ pub(crate) fn load(
 
                 lockfile.trusted_dependencies = Some(Default::default());
                 let td = lockfile.trusted_dependencies.as_mut().unwrap();
-                td.ensure_total_capacity(trusted_dependencies_hashes.len())?;
-                // The binary lockfile only stores the truncated hashes, not the
-                // names they were computed from. The empty value is the
-                // "name unknown, hash-only match" sentinel.
                 for &hash in &trusted_dependencies_hashes {
-                    td.put_assume_capacity(hash, Box::<[u8]>::default());
+                    td.insert_legacy_hash(hash)?;
                 }
             } else if next_num == HAS_EMPTY_TRUSTED_DEPENDENCIES_TAG {
                 // trusted dependencies exists in package.json but is an empty array.

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -623,11 +623,7 @@ impl TrustCommand {
                     .trusted_dependencies
                     .as_mut()
                     .unwrap()
-                    .put(
-                        bun_semver::string::Builder::string_hash(name)
-                            as install::TruncatedPackageNameHash,
-                        Box::<[u8]>::from(&**name),
-                    )?;
+                    .insert(name)?;
             }
         }
 

--- a/test/cli/install/bad-workspace.test.ts
+++ b/test/cli/install/bad-workspace.test.ts
@@ -60,6 +60,47 @@ test("non-string workspaces entry prints the error without literal markup", asyn
   expect(exitCode).toBe(1);
 });
 
+// https://github.com/oven-sh/bun/issues/36386
+// Wyhash11 of these two names agrees in the low 32 bits, so they land in the
+// same bucket of any map keyed on the truncated package name hash.
+const collidingA = "@demo/app-03511";
+const collidingB = "@demo/app-13215";
+
+async function installWorkspaceNames(names: string[]) {
+  const files: Record<string, string> = {
+    "package.json": JSON.stringify({ name: "r", private: true, workspaces: ["packages/*"] }),
+  };
+  names.forEach((name, i) => {
+    files[`packages/p${i}/package.json`] = JSON.stringify({ name, version: "0.0.0" });
+  });
+  using dir = tempDir("workspace-name-hash-collision", files);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stderr, exitCode };
+}
+
+test.concurrent("distinct workspace names with colliding truncated name hashes are not duplicates", async () => {
+  const { stderr, exitCode } = await installWorkspaceNames([collidingA, collidingB]);
+  expect(stderr).not.toContain("already exists");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent.each([
+  [collidingA, collidingB],
+  [collidingB, collidingA],
+])("a true duplicate of %s is still reported when %s shares its truncated hash", async (duplicated, other) => {
+  const { stderr, exitCode } = await installWorkspaceNames([collidingA, collidingB, duplicated]);
+  expect(stderr).toContain(`Workspace name "${duplicated}" already exists`);
+  expect(stderr).not.toContain(`Workspace name "${other}" already exists`);
+  expect(exitCode).toBe(1);
+});
+
 test("workspace with ./ should not crash", () => {
   writeFileSync(
     `${cwd}/package.json`,

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -549,6 +549,69 @@ test.concurrent("binary lockfile trusted dependency entries require an exact nam
   expect(await exited).toBe(0);
 });
 
+test.concurrent("bun pm trust on a binary lockfile keeps one entry per dependency, in place", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+
+  await verdaccio.writeBunfig(packageDir, { saveTextLockfile: false, linker: "hoisted" });
+
+  const deps = ["dep-a", "dep-b"];
+  for (const dep of deps) {
+    await mkdir(join(packageDir, dep), { recursive: true });
+    await writeFile(
+      join(packageDir, dep, "package.json"),
+      JSON.stringify({
+        name: dep,
+        version: "1.0.0",
+        scripts: {
+          postinstall: `${bunExe()} -e "require('fs').writeFileSync('postinstall-ran.txt', 'ran')"`,
+        },
+      }),
+    );
+  }
+  await writeFile(
+    packageJson,
+    JSON.stringify({
+      name: "foo",
+      version: "1.0.0",
+      dependencies: Object.fromEntries(deps.map(dep => [dep, `file:./${dep}`])),
+      trustedDependencies: deps,
+    }),
+  );
+
+  let { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  let [, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  expect(err).toContain("Saved lockfile");
+  expect(err).not.toContain("error:");
+  expect(exitCode).toBe(0);
+
+  const lockfileBefore = await file(join(packageDir, "bun.lockb")).bytes();
+
+  // bun.lockb stores the trusted entries as name hashes only, so `bun pm trust`
+  // treats dep-b as untrusted and adds it again. That must neither add a second
+  // entry for it nor move its entry, so the lockfile is written back unchanged.
+  ({ stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "trust", "dep-b"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  }));
+  [, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  expect(err).not.toContain("error:");
+  expect(exitCode).toBe(0);
+
+  expect(await file(join(packageDir, "bun.lockb")).bytes()).toEqual(lockfileBefore);
+});
+
 test.concurrent(
   "lifecycle script trust for file: dependencies is keyed on the dependency alias, not the package's self-declared name",
   async () => {
@@ -2889,6 +2952,92 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(await exited).toBe(0);
 
       expect(await exists(join(packageDir, "node_modules", colliderName, "postinstall-ran.txt"))).toBeTrue();
+    });
+
+    // Same colliding pair as the test above (truncated hash 0x6c4a82d1), this time
+    // with both names present as packages, so anything that keys trusted
+    // dependencies on the truncated hash keeps only one of them.
+    // https://github.com/oven-sh/bun/issues/36386
+    const collidingPair = ["pkg-xjd", "pkg-ztd"] as const;
+
+    async function writeCollidingPair(packageDir: string) {
+      for (const name of collidingPair) {
+        await mkdir(join(packageDir, name), { recursive: true });
+        await writeFile(
+          join(packageDir, name, "package.json"),
+          JSON.stringify({
+            name,
+            version: "1.0.0",
+            scripts: {
+              postinstall: `${bunExe()} -e "require('fs').writeFileSync('postinstall-ran.txt', 'ran')"`,
+            },
+          }),
+        );
+      }
+      return {
+        dependencies: Object.fromEntries(collidingPair.map(name => [name, `file:./${name}`])),
+      };
+    }
+
+    async function postinstallsThatRan(packageDir: string) {
+      const ran = await Promise.all(
+        collidingPair.map(name => exists(join(packageDir, "node_modules", name, "postinstall-ran.txt"))),
+      );
+      return collidingPair.filter((_, i) => ran[i]);
+    }
+
+    async function install(packageDir: string, env: Record<string, string>) {
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env,
+      });
+      const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      return out;
+    }
+
+    test("trustedDependencies keeps both names of a truncated-hash collision", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      const { dependencies } = await writeCollidingPair(packageDir);
+      await writeFile(
+        packageJson,
+        JSON.stringify({ name: "foo", version: "1.0.0", dependencies, trustedDependencies: [...collidingPair] }),
+      );
+
+      const out = await install(packageDir, env);
+      expect(out).not.toContain("Blocked");
+      expect(await postinstallsThatRan(packageDir)).toEqual([...collidingPair]);
+
+      const lockfile = await file(join(packageDir, "bun.lock")).text();
+      const trustedSection = lockfile.match(/"trustedDependencies":\s*\[([^\]]*)\]/)?.[1] ?? "";
+      expect(trustedSection).toContain(`"${collidingPair[0]}"`);
+      expect(trustedSection).toContain(`"${collidingPair[1]}"`);
+    });
+
+    test("adding a truncated-hash-colliding pair to trustedDependencies runs both postinstalls", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      const { dependencies } = await writeCollidingPair(packageDir);
+      await writeFile(packageJson, JSON.stringify({ name: "foo", version: "1.0.0", dependencies }));
+
+      let out = await install(packageDir, env);
+      expect(out).toContain("Blocked 2 postinstalls");
+      expect(await postinstallsThatRan(packageDir)).toEqual([]);
+
+      await writeFile(
+        packageJson,
+        JSON.stringify({ name: "foo", version: "1.0.0", dependencies, trustedDependencies: [...collidingPair] }),
+      );
+
+      out = await install(packageDir, env);
+      expect(out).not.toContain("Blocked");
+      expect(await postinstallsThatRan(packageDir)).toEqual([...collidingPair]);
     });
 
     test("will run default trustedDependencies after install that didn't include them", async () => {


### PR DESCRIPTION
Fixes #36386.

### Problem

- `bun install` rejects a workspace whose package names are all distinct:
  ```
  error: Workspace name "@demo/app-13215" already exists
  ```
- Cause: the duplicate check in `Package::parse_with_json_impl` (`src/install/lockfile/Package.rs`, `seen_workspace_names`) keys a map on `TruncatedPackageNameHash` (the 64-bit Wyhash of the name cut to `u32`) with an identity context, and treats any hit as a duplicate without comparing names. `@demo/app-03511` and `@demo/app-13215` hash to `0x45c21c09_66dff920` and `0x34ddf59e_66dff920`, so they share a bucket. Once a workspace contains such a pair it cannot install until one package is renamed; at 2^32 the birthday bound makes this about 1.2% of 10k-package workspaces.
- The trusted-dependency maps have the same keying, and a map with one slot per truncated hash can only hold one of two colliding names: with `trustedDependencies: ["pkg-xjd", "pkg-ztd"]` (same truncated hash) main trusts only the second entry, blocks the first one's postinstall, and writes one name into `bun.lock`. The earlier per-site mitigation there (name stored as the value, compared on lookup) stops a collider from being trusted by accident but cannot keep both names, and it has to be repeated at every call site; review on the first revision of this PR asked for the check to live in the table instead of adding one more call-site confirm.

### Fix

- Every package-name map that was keyed on `TruncatedPackageNameHash` now uses `bun_collections::StringArrayHashMap`, which hashes the name bytes for the bucket and compares the bytes inside the table's `eql`. A hash collision is then just two entries in one bucket, and there is nothing for a call site to forget:
  - `seen_workspace_names` (the reported bug; the error message and its "also declared here" notes for true duplicates are unchanged).
  - the `trustedDependencies` set parsed from `package.json` and from `bun.lock`, and `DiffSummary.added_trusted_dependencies` (so `AddedTrustedDependency` no longer carries the name).
  - `Summary.packages_with_blocked_scripts`. Only the summed script count is printed, so this one has no observable change; it is converted so the type disappears from install.
  - `Lockfile.trusted_dependencies` becomes a `TrustedDependenciesSet` wrapper: named entries live in the string-keyed table, and the hash-only entries loaded from a legacy `bun.lockb` live in a separate list in file order. `contains` (name, or legacy hash match), `contains_name` (named entries only; used by `has_trusted_dependency` and the `bun.lock` stringifier, preserving their existing semantics), and `promote_legacy` (the diff's upgrade of a hash-only entry to a named one) replace the hand-written value comparisons at each site.
- Saving `bun.lockb` has to stay byte-stable, which the old single map got for free by overwriting the hash's slot in place. The wrapper gets the same result by never removing a legacy entry: recording a name for one (`insert` or `promote_legacy`) only marks it, `truncated_hashes()` writes the legacy list in file order and then the hashes of names not already covered, and `count()` / the diff's removed-entries loop only look at unmarked legacy entries. So `bun pm trust` on a `bun.lockb` project, which `has_trusted_dependency` deliberately treats as untrusted and which therefore re-inserts the name, rewrites the file unchanged; an earlier revision of this branch wrote the hash twice (and, once that was fixed by removing the legacy entry, moved it).
- The new side of the lockfile diff comes from `package.json`, so it only ever holds names; the diff asserts that in debug builds and only handles legacy entries on the old side (promote when the name is still listed, otherwise report it removed). An earlier revision of this branch also carried code for legacy entries on the new side; that was unreachable and is gone.
- `Lockfile::in_trusted_dependencies` now matches by name (or legacy hash) instead of by truncated hash alone.
- Why this is the right shape: a truncated hash is a bucket index, not an identity. Making the key the name puts the equality check in the one place every lookup goes through; the truncated hash survives only inside `TrustedDependenciesSet`, for the legacy entries where the name was never recorded. After this change `TruncatedPackageNameHash` is not used anywhere else in install.
- Main moved under the first version of this branch: #37669 keyed `trusted_dependencies_from_update_requests` on `PackageID` and picks the name written to `trustedDependencies` per resolution kind, so this rebase keeps both of those and only swaps the insertion calls to `TrustedDependenciesSet::insert`.
- Verification (debug build on current main; "fails before" means the test fails on a build without this change):
  - `test/cli/install/bad-workspace.test.ts`: the colliding pair installs (fails before), and the pair plus a true duplicate of either name still fails naming the duplicated package and not the collider. The last two cases are adopted from #36391 by @ejc3 (credited with `Co-authored-by`).
  - `test/cli/install/bun-install-lifecycle-scripts.test.ts`: both names of a colliding pair listed in `trustedDependencies` run their postinstall and both land in `bun.lock` (fails before: "Blocked 1 postinstall"); adding the pair to `trustedDependencies` after a first install runs both postinstalls, which covers `added_trusted_dependencies` (fails before: one runs); and `bun pm trust` of the second of two trusted dependencies on a `bun.lockb` project leaves the lockfile byte-identical, which pins the in-place behaviour above (it passes on main, failed on both earlier revisions of this branch).
  - Also green here: `bun-install.test.ts` workspace cases, every `trust`-related test in the lifecycle file (73), `migrate-bun-lockb-v2` (legacy hash-only entries diffed against a named `trustedDependencies`, snapshot and re-save unchanged), `bun-lockb`, and the `bun.lock` trustedDependencies formatting tests.

### Background

- `TruncatedPackageNameHash` (`src/install_types/resolver_hooks.rs`) is `u32`: the low half of `semver::string::Builder::string_hash`, which is a 64-bit Wyhash. It exists because the binary `bun.lockb` format stores trusted dependencies as these 32-bit values only, with no names.
- `StringArrayHashMap<V>` (`src/collections/array_hash_map.rs`) is the port of Zig's `std.StringArrayHashMap`: insertion-ordered, `&[u8]` keys boxed on insert, bucket hash plus byte equality supplied by its string context.
- Legacy entries: `bun.lockb` stores trusted dependencies as truncated hashes only, so loading one gives us hashes without names. Those entries still have to satisfy "is this name trusted" checks (hence `contains` consults them), the lockfile diff records the name for them when it shows up in `package.json` (`promote_legacy`), which is the behaviour the previous empty-name sentinel implemented, and saving writes the hash array back in the order it was read.
- Lockfile diff: on every install, `Diff::generate` compares the lockfile loaded from disk (old side, the only place legacy entries can come from) with one built from the current `package.json` (new side) to decide which newly trusted packages need their scripts run and whether the lockfile must be saved.

### Related

- #36391 by @ejc3 fixed the workspace check alone with a call-site name comparison, the approach the review on this PR asked to replace; its extra test cases are folded in here.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts, test/cli/install/bad-workspace.test.ts

<!-- robobun:evidence:end -->

