### PR TITLE
node:http2: reset the stream when a response header block cannot be encoded

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4983,8 +4983,22 @@ class ClientHttp2Session extends Http2Session {
     streamError: withStreamFrame((self: ClientHttp2Session, stream: ClientHttp2Stream, error: number) => {
       if (!self || typeof stream !== "object") return;
 
+      // A stream whose own reset was dispatched before any session teardown (e.g. the native
+      // header-encode failure path, which tears the session down on the next dispatch because
+      // the HPACK encoder is desynced) must keep its own code: surface it instead of the
+      // generic ERR_HTTP2_STREAM_CANCEL that destroy() installs for still-open streams.
+      const ownError =
+        typeof error === "number" && error !== 0 && !stream.rstCode && self[kSessionDestroyError] == null;
+      if (ownError) stream.rstCode = error;
       self.#connections--;
-      process.nextTick(emitStreamErrorNT, self, stream, error, true, self.#connections === 0 && self.#closed);
+      process.nextTick(
+        emitStreamErrorNT,
+        self,
+        stream,
+        ownError ? streamErrorFromCode(error) : error,
+        true,
+        self.#connections === 0 && self.#closed,
+      );
     }),
     streamEnd: withStreamFrame((self: ClientHttp2Session, stream: ClientHttp2Stream, state: number) => {
       if (!self || typeof stream !== "object") return;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2494,14 +2494,10 @@ impl H2FrameParser {
         let _ = self.write(&buffer);
     }
 
-    /// A request/response header block hit an entry the HPACK encoder cannot emit (a single field
-    /// exceeding the encoder's per-entry limit). On the server the peer has already opened this
-    /// stream, so silently swallowing the failure leaves it waiting on a HEADERS frame that never
-    /// comes (RFC 9113 section 8.1) while a later end() flushes a stray DATA+END_STREAM with no
-    /// HEADERS in front of it, which a conforming client answers with a connection-level GOAWAY.
-    /// Reset the one stream with RST_STREAM(FRAME_SIZE_ERROR) so the failure stays scoped to it
-    /// (node/nghttp2 behavior). On the client the HEADERS never reached the wire, so RST_STREAM
-    /// would name a stream the peer still considers idle; fail it locally without a wire write.
+    /// A header block hit an entry the HPACK encoder cannot emit (single field over its per-entry
+    /// limit). Surface `frameError` and fail the stream with FRAME_SIZE_ERROR (node/nghttp2
+    /// parity). On the server the stream exists on the wire so RST_STREAM is written; on the
+    /// client the HEADERS never went out so the stream is failed locally only.
     fn reject_unencodable_header_block(
         &self,
         stream_id: u32,
@@ -7488,11 +7484,9 @@ impl H2FrameParser {
         let stream = unsafe { &mut *stream };
 
         stream.wait_for_trailers = false;
-        // The compat response always routes _final through here (kBeginSend sets
-        // waitForTrailers: true); when the response headers could not be encoded the stream has
-        // already been reset to CLOSED, and emitting the empty END_STREAM DATA here would put a
-        // frame on the wire after RST_STREAM (or, before the encode-failure fix, with no HEADERS
-        // in front of it). Same guard write_stream() applies.
+        // Same guard as write_stream(): the compat _final reaches here on every response (kBeginSend
+        // sets waitForTrailers), so a stream already reset by a header-encode failure must not emit
+        // a stray DATA frame.
         if stream.can_send_data() {
             let _ = this.send_data(stream, b"", true, JSValue::UNDEFINED, false, false);
         }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2494,6 +2494,51 @@ impl H2FrameParser {
         let _ = self.write(&buffer);
     }
 
+    /// A request/response header block hit an entry the HPACK encoder cannot emit (a single field
+    /// exceeding the encoder's per-entry limit). On the server the peer has already opened this
+    /// stream, so silently swallowing the failure leaves it waiting on a HEADERS frame that never
+    /// comes (RFC 9113 section 8.1) while a later end() flushes a stray DATA+END_STREAM with no
+    /// HEADERS in front of it, which a conforming client answers with a connection-level GOAWAY.
+    /// Reset the one stream with RST_STREAM(FRAME_SIZE_ERROR) so the failure stays scoped to it
+    /// (node/nghttp2 behavior). On the client the HEADERS never reached the wire, so RST_STREAM
+    /// would name a stream the peer still considers idle; fail it locally without a wire write.
+    fn reject_unencodable_header_block(
+        &self,
+        stream_id: u32,
+        stream_ctx_arg: JSValue,
+        global_object: &JSGlobalObject,
+    ) -> JSValue {
+        let Some(stream_ptr) = self.handle_received_stream_id(stream_id) else {
+            return JSValue::js_number(-1.0);
+        };
+        // SAFETY: stream_ptr is the heap::alloc'd *mut Stream stored in self.streams; valid while
+        // the map entry exists.
+        let stream = unsafe { &mut *stream_ptr };
+        if !stream_ctx_arg.is_empty_or_undefined_or_null() && stream_ctx_arg.is_object() {
+            stream.set_context(stream_ctx_arg, global_object);
+        }
+        let identifier = stream.get_identifier();
+        identifier.ensure_still_alive();
+        self.dispatch_with_2_extra(
+            JSH2FrameParser::Gc::onFrameError,
+            identifier,
+            JSValue::js_number(FrameType::HTTP_FRAME_HEADERS as u8 as f64),
+            JSValue::js_number(ErrorCode::FRAME_SIZE_ERROR.0 as f64),
+        );
+        if self.is_server.get() {
+            self.end_stream(stream, ErrorCode::FRAME_SIZE_ERROR);
+        } else {
+            stream.state = StreamState::CLOSED;
+            stream.rst_code = ErrorCode::FRAME_SIZE_ERROR.0;
+            self.dispatch_with_extra(
+                JSH2FrameParser::Gc::onStreamError,
+                identifier,
+                JSValue::js_number(ErrorCode::FRAME_SIZE_ERROR.0 as f64),
+            );
+        }
+        JSValue::js_number(stream_id as f64)
+    }
+
     pub(crate) fn send_go_away(
         &self,
         triggering_stream_id: u32,
@@ -7443,7 +7488,14 @@ impl H2FrameParser {
         let stream = unsafe { &mut *stream };
 
         stream.wait_for_trailers = false;
-        let _ = this.send_data(stream, b"", true, JSValue::UNDEFINED, false, false);
+        // The compat response always routes _final through here (kBeginSend sets
+        // waitForTrailers: true); when the response headers could not be encoded the stream has
+        // already been reset to CLOSED, and emitting the empty END_STREAM DATA here would put a
+        // frame on the wire after RST_STREAM (or, before the encode-failure fix, with no HEADERS
+        // in front of it). Same guard write_stream() applies.
+        if stream.can_send_data() {
+            let _ = this.send_data(stream, b"", true, JSValue::UNDEFINED, false, false);
+        }
         Ok(JSValue::UNDEFINED)
     }
 
@@ -8603,24 +8655,11 @@ impl H2FrameParser {
                             return Err(global_object
                                 .throw(format_args!("Failed to allocate header buffer")));
                         }
-                        let Some(stream) = this.handle_received_stream_id(stream_id) else {
-                            return Ok(JSValue::js_number(-1.0));
-                        };
-                        // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the map entry exists
-                        let stream = unsafe { &mut *stream };
-                        stream.state = StreamState::CLOSED;
-                        if !stream_ctx_arg.is_empty_or_undefined_or_null()
-                            && stream_ctx_arg.is_object()
-                        {
-                            stream.set_context(stream_ctx_arg, global_object);
-                        }
-                        stream.rst_code = ErrorCode::COMPRESSION_ERROR.0;
-                        this.dispatch_with_extra(
-                            JSH2FrameParser::Gc::onStreamError,
-                            stream.get_identifier(),
-                            JSValue::js_number(stream.rst_code as f64),
-                        );
-                        return Ok(JSValue::js_number(stream_id as f64));
+                        return Ok(this.reject_unencodable_header_block(
+                            stream_id,
+                            stream_ctx_arg,
+                            global_object,
+                        ));
                     }
                 }
             }
@@ -8776,24 +8815,11 @@ impl H2FrameParser {
                                 return Err(global_object
                                     .throw(format_args!("Failed to allocate header buffer")));
                             }
-                            let Some(stream) = this.handle_received_stream_id(stream_id) else {
-                                return Ok(JSValue::js_number(-1.0));
-                            };
-                            // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the map entry exists
-                            let stream = unsafe { &mut *stream };
-                            if !stream_ctx_arg.is_empty_or_undefined_or_null()
-                                && stream_ctx_arg.is_object()
-                            {
-                                stream.set_context(stream_ctx_arg, global_object);
-                            }
-                            stream.state = StreamState::CLOSED;
-                            stream.rst_code = ErrorCode::COMPRESSION_ERROR.0;
-                            this.dispatch_with_extra(
-                                JSH2FrameParser::Gc::onStreamError,
-                                stream.get_identifier(),
-                                JSValue::js_number(stream.rst_code as f64),
-                            );
-                            return Ok(JSValue::UNDEFINED);
+                            return Ok(this.reject_unencodable_header_block(
+                                stream_id,
+                                stream_ctx_arg,
+                                global_object,
+                            ));
                         }
                     }
                 } else if !js_value.is_empty_or_undefined_or_null() {
@@ -8852,24 +8878,11 @@ impl H2FrameParser {
                             return Err(global_object
                                 .throw(format_args!("Failed to allocate header buffer")));
                         }
-                        let Some(stream) = this.handle_received_stream_id(stream_id) else {
-                            return Ok(JSValue::js_number(-1.0));
-                        };
-                        // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the map entry exists
-                        let stream = unsafe { &mut *stream };
-                        stream.state = StreamState::CLOSED;
-                        if !stream_ctx_arg.is_empty_or_undefined_or_null()
-                            && stream_ctx_arg.is_object()
-                        {
-                            stream.set_context(stream_ctx_arg, global_object);
-                        }
-                        stream.rst_code = ErrorCode::COMPRESSION_ERROR.0;
-                        this.dispatch_with_extra(
-                            JSH2FrameParser::Gc::onStreamError,
-                            stream.get_identifier(),
-                            JSValue::js_number(stream.rst_code as f64),
-                        );
-                        return Ok(JSValue::js_number(stream_id as f64));
+                        return Ok(this.reject_unencodable_header_block(
+                            stream_id,
+                            stream_ctx_arg,
+                            global_object,
+                        ));
                     }
                 }
             }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -9089,11 +9089,15 @@ impl H2FrameParser {
         // too much memory being use
         if this.is_over_session_memory_limit() {
             this.rejected_streams.set(this.rejected_streams.get() + 1);
+            // encoder_touched is intentionally false: the memory budget is a transient condition
+            // (a large upload still draining) and tearing the session down here breaks clients
+            // that retry the refused request (grpc-js). max_rejected_streams below is the
+            // session-level escape hatch.
             this.reject_unencodable_header_block(
                 &mut stream,
                 ErrorCode::ENHANCE_YOUR_CALM,
                 None,
-                encoded_size > 0,
+                false,
             );
             if this.rejected_streams.get() >= this.max_rejected_streams.get() {
                 let global = this.handlers.get().global();

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2530,15 +2530,12 @@ impl H2FrameParser {
             );
         }
         if encoder_touched {
-            // On the server the onEnd teardown stops later responds from reusing the desynced
-            // encoder; on the client the stream error above must reach the user first, so only
-            // the wire-level GOAWAY is sent and the local session drains when the peer closes.
             self.send_go_away(
                 triggering_id,
                 ErrorCode::NO_ERROR,
                 b"",
                 self.last_stream_id.get(),
-                self.is_server.get(),
+                true,
             );
         }
     }
@@ -2555,13 +2552,11 @@ impl H2FrameParser {
         let Some(stream_ptr) = self.handle_received_stream_id(stream_id) else {
             return JSValue::js_number(-1.0);
         };
-        // SAFETY: stream_ptr is the heap::alloc'd *mut Stream stored in self.streams; valid while
-        // the map entry exists.
-        let stream = unsafe { &mut *stream_ptr };
+        let mut stream = self.enter_stream_dispatch(stream_ptr);
         if !stream_ctx_arg.is_empty_or_undefined_or_null() && stream_ctx_arg.is_object() {
             stream.set_context(stream_ctx_arg, global_object);
         }
-        self.reject_unencodable_header_block(stream, ErrorCode::FRAME_SIZE_ERROR, encoder_touched);
+        self.reject_unencodable_header_block(&mut stream, ErrorCode::FRAME_SIZE_ERROR, encoder_touched);
         JSValue::js_number(stream_id as f64)
     }
 
@@ -8258,6 +8253,15 @@ impl H2FrameParser {
                     )
                     .is_err()
                 {
+                    if !encoded_headers.is_empty() {
+                        this.send_go_away(
+                            parent_id,
+                            ErrorCode::NO_ERROR,
+                            b"",
+                            this.last_stream_id.get(),
+                            true,
+                        );
+                    }
                     return Err(
                         global_object.throw(format_args!("Failed to encode push promise headers"))
                     );
@@ -8935,12 +8939,10 @@ impl H2FrameParser {
         if callframe.arguments_count() > 4 && !options_arg.is_empty_or_undefined_or_null() {
             let options = options_arg;
             if !options.is_object() {
-                stream.state = StreamState::CLOSED;
-                stream.rst_code = ErrorCode::INTERNAL_ERROR.0;
-                this.dispatch_with_extra(
-                    JSH2FrameParser::Gc::onStreamError,
-                    stream.get_identifier(),
-                    JSValue::js_number(stream.rst_code as f64),
+                this.reject_unencodable_header_block(
+                    &mut stream,
+                    ErrorCode::INTERNAL_ERROR,
+                    encoded_size > 0,
                 );
                 return Ok(JSValue::js_number(stream_id as f64));
             }
@@ -9013,14 +9015,12 @@ impl H2FrameParser {
                     has_priority = true;
                     parent = parent_js.to_int32();
                     if parent <= 0 || parent as u32 > MAX_STREAM_ID {
-                        stream.state = StreamState::CLOSED;
-                        stream.rst_code = ErrorCode::INTERNAL_ERROR.0;
-                        this.dispatch_with_extra(
-                            JSH2FrameParser::Gc::onStreamError,
-                            stream.get_identifier(),
-                            JSValue::js_number(stream.rst_code as f64),
+                        this.reject_unencodable_header_block(
+                            &mut stream,
+                            ErrorCode::INTERNAL_ERROR,
+                            encoded_size > 0,
                         );
-                        return Ok(JSValue::js_number(stream.id as f64));
+                        return Ok(JSValue::js_number(stream_id as f64));
                     }
                     stream.stream_dependency = u32::try_from(parent).expect("int cast");
                 } else {
@@ -9037,12 +9037,10 @@ impl H2FrameParser {
                     has_priority = true;
                     weight = weight_js.to_int32();
                     if weight < 1 || weight > u8::MAX as i32 {
-                        stream.state = StreamState::CLOSED;
-                        stream.rst_code = ErrorCode::INTERNAL_ERROR.0;
-                        this.dispatch_with_extra(
-                            JSH2FrameParser::Gc::onStreamError,
-                            stream.get_identifier(),
-                            JSValue::js_number(stream.rst_code as f64),
+                        this.reject_unencodable_header_block(
+                            &mut stream,
+                            ErrorCode::INTERNAL_ERROR,
+                            encoded_size > 0,
                         );
                         return Ok(JSValue::js_number(stream_id as f64));
                     }
@@ -9054,19 +9052,6 @@ impl H2FrameParser {
                         weight_js,
                     ));
                 }
-
-                if weight < 1 || weight > u8::MAX as i32 {
-                    stream.state = StreamState::CLOSED;
-                    stream.rst_code = ErrorCode::INTERNAL_ERROR.0;
-                    this.dispatch_with_extra(
-                        JSH2FrameParser::Gc::onStreamError,
-                        stream.get_identifier(),
-                        JSValue::js_number(stream.rst_code as f64),
-                    );
-                    return Ok(JSValue::js_number(stream_id as f64));
-                }
-
-                stream.weight = u16::try_from(weight).expect("int cast");
             }
 
             if let Some(signal_arg) = options.get(global_object, "signal")? {

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2495,29 +2495,32 @@ impl H2FrameParser {
     }
 
     /// A header block could not be sent (a single field over the encoder's per-entry limit, the
-    /// encoded block over `maxSendHeaderBlockLength`, or the session over its memory budget).
-    /// Surface `frameError(FRAME_SIZE_ERROR)` and fail the stream with `rst_code`. On the server
-    /// the stream exists on the wire so RST_STREAM is written; on the client the HEADERS never
-    /// went out so the stream is failed locally only. When `encoder_touched` is set, earlier
-    /// entries in the block were already committed to the connection-scoped HPACK encoder's
-    /// dynamic table and the peer will never see them, so the encoder is no longer in step with
-    /// the peer's decoder: gracefully GOAWAY(NO_ERROR) like the trailers encode-failure path so no
-    /// later HEADERS emits a dynamic index the peer lacks.
+    /// encoded block over `maxSendHeaderBlockLength`, bad `respond()` options, or the session over
+    /// its memory budget). Surface `frameError` for the size cases (node parity) and fail the
+    /// stream with `rst_code`. On the server the stream exists on the wire so RST_STREAM is
+    /// written; on the client the HEADERS never went out so the stream is failed locally only.
+    /// When `encoder_touched` is set, earlier entries in the block were already committed to the
+    /// connection-scoped HPACK encoder's dynamic table and the peer will never see them, so the
+    /// encoder is no longer in step with the peer's decoder: gracefully GOAWAY(NO_ERROR) like the
+    /// trailers encode-failure path so no later HEADERS emits a dynamic index the peer lacks.
     fn reject_unencodable_header_block(
         &self,
         stream: &mut Stream,
         rst_code: ErrorCode,
+        frame_error: Option<ErrorCode>,
         encoder_touched: bool,
     ) {
         let identifier = stream.get_identifier();
         identifier.ensure_still_alive();
         let triggering_id = stream.id;
-        self.dispatch_with_2_extra(
-            JSH2FrameParser::Gc::onFrameError,
-            identifier,
-            JSValue::js_number(FrameType::HTTP_FRAME_HEADERS as u8 as f64),
-            JSValue::js_number(ErrorCode::FRAME_SIZE_ERROR.0 as f64),
-        );
+        if let Some(frame_error) = frame_error {
+            self.dispatch_with_2_extra(
+                JSH2FrameParser::Gc::onFrameError,
+                identifier,
+                JSValue::js_number(FrameType::HTTP_FRAME_HEADERS as u8 as f64),
+                JSValue::js_number(frame_error.0 as f64),
+            );
+        }
         if self.is_server.get() {
             self.end_stream(stream, rst_code);
         } else {
@@ -2559,6 +2562,7 @@ impl H2FrameParser {
         self.reject_unencodable_header_block(
             &mut stream,
             ErrorCode::FRAME_SIZE_ERROR,
+            Some(ErrorCode::FRAME_SIZE_ERROR),
             encoder_touched,
         );
         JSValue::js_number(stream_id as f64)
@@ -8946,6 +8950,7 @@ impl H2FrameParser {
                 this.reject_unencodable_header_block(
                     &mut stream,
                     ErrorCode::INTERNAL_ERROR,
+                    None,
                     encoded_size > 0,
                 );
                 return Ok(JSValue::js_number(stream_id as f64));
@@ -9022,6 +9027,7 @@ impl H2FrameParser {
                         this.reject_unencodable_header_block(
                             &mut stream,
                             ErrorCode::INTERNAL_ERROR,
+                            None,
                             encoded_size > 0,
                         );
                         return Ok(JSValue::js_number(stream_id as f64));
@@ -9044,6 +9050,7 @@ impl H2FrameParser {
                         this.reject_unencodable_header_block(
                             &mut stream,
                             ErrorCode::INTERNAL_ERROR,
+                            None,
                             encoded_size > 0,
                         );
                         return Ok(JSValue::js_number(stream_id as f64));
@@ -9085,6 +9092,7 @@ impl H2FrameParser {
             this.reject_unencodable_header_block(
                 &mut stream,
                 ErrorCode::ENHANCE_YOUR_CALM,
+                None,
                 encoded_size > 0,
             );
             if this.rejected_streams.get() >= this.max_rejected_streams.get() {
@@ -9118,6 +9126,7 @@ impl H2FrameParser {
             this.reject_unencodable_header_block(
                 &mut stream,
                 ErrorCode::REFUSED_STREAM,
+                Some(ErrorCode::FRAME_SIZE_ERROR),
                 encoded_size > 0,
             );
             return Ok(JSValue::js_number(stream_id as f64));

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2556,7 +2556,11 @@ impl H2FrameParser {
         if !stream_ctx_arg.is_empty_or_undefined_or_null() && stream_ctx_arg.is_object() {
             stream.set_context(stream_ctx_arg, global_object);
         }
-        self.reject_unencodable_header_block(&mut stream, ErrorCode::FRAME_SIZE_ERROR, encoder_touched);
+        self.reject_unencodable_header_block(
+            &mut stream,
+            ErrorCode::FRAME_SIZE_ERROR,
+            encoder_touched,
+        );
         JSValue::js_number(stream_id as f64)
     }
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8575,6 +8575,42 @@ impl H2FrameParser {
             return Ok(JSValue::js_number(-1.0));
         }
 
+        // Reject on the session memory budget before any header touches the connection-scoped
+        // HPACK encoder, so the encoder's dynamic table is never advanced for a request that is
+        // refused here and the session survives intact. max_rejected_streams is the session-level
+        // escape hatch for a sustained flood.
+        if this.is_over_session_memory_limit() {
+            this.rejected_streams.set(this.rejected_streams.get() + 1);
+            let Some(stream_ptr) = this.handle_received_stream_id(stream_id) else {
+                return Ok(JSValue::js_number(-1.0));
+            };
+            let mut stream = this.enter_stream_dispatch(stream_ptr);
+            if !stream_ctx_arg.is_empty_or_undefined_or_null() && stream_ctx_arg.is_object() {
+                stream.set_context(stream_ctx_arg, global_object);
+            }
+            this.reject_unencodable_header_block(
+                &mut stream,
+                ErrorCode::ENHANCE_YOUR_CALM,
+                None,
+                false,
+            );
+            if this.rejected_streams.get() >= this.max_rejected_streams.get() {
+                let global = this.handlers.get().global();
+                let chunk = this
+                    .handlers
+                    .get()
+                    .binary_type
+                    .to_js(b"ENHANCE_YOUR_CALM", &global)?;
+                this.dispatch_with_2_extra(
+                    JSH2FrameParser::Gc::onError,
+                    JSValue::js_number(ErrorCode::ENHANCE_YOUR_CALM.0 as f64),
+                    JSValue::js_number(this.last_stream_id.get() as f64),
+                    chunk,
+                );
+            }
+            return Ok(JSValue::js_number(stream_id as f64));
+        }
+
         // we iterate twice, because pseudo headers must be sent first, but can appear anywhere in the headers object
         let mut single_value_headers = [false; SINGLE_VALUE_HEADERS_LEN];
 
@@ -9086,35 +9122,6 @@ impl H2FrameParser {
             }
         }
 
-        // too much memory being use
-        if this.is_over_session_memory_limit() {
-            this.rejected_streams.set(this.rejected_streams.get() + 1);
-            // encoder_touched is intentionally false: the memory budget is a transient condition
-            // (a large upload still draining) and tearing the session down here breaks clients
-            // that retry the refused request (grpc-js). max_rejected_streams below is the
-            // session-level escape hatch.
-            this.reject_unencodable_header_block(
-                &mut stream,
-                ErrorCode::ENHANCE_YOUR_CALM,
-                None,
-                false,
-            );
-            if this.rejected_streams.get() >= this.max_rejected_streams.get() {
-                let global = this.handlers.get().global();
-                let chunk = this
-                    .handlers
-                    .get()
-                    .binary_type
-                    .to_js(b"ENHANCE_YOUR_CALM", &global)?;
-                this.dispatch_with_2_extra(
-                    JSH2FrameParser::Gc::onError,
-                    JSValue::js_number(ErrorCode::ENHANCE_YOUR_CALM.0 as f64),
-                    JSValue::js_number(this.last_stream_id.get() as f64),
-                    chunk,
-                );
-            }
-            return Ok(JSValue::js_number(stream_id as f64));
-        }
         let mut length: usize = encoded_size;
         if has_priority {
             length += 5;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2494,15 +2494,58 @@ impl H2FrameParser {
         let _ = self.write(&buffer);
     }
 
-    /// A header block hit an entry the HPACK encoder cannot emit (single field over its per-entry
-    /// limit). Surface `frameError` and fail the stream with FRAME_SIZE_ERROR (node/nghttp2
-    /// parity). On the server the stream exists on the wire so RST_STREAM is written; on the
-    /// client the HEADERS never went out so the stream is failed locally only.
+    /// A header block could not be sent (a single field over the encoder's per-entry limit, or the
+    /// encoded block over `maxSendHeaderBlockLength`). Surface `frameError(FRAME_SIZE_ERROR)` and
+    /// fail the stream with `rst_code`. On the server the stream exists on the wire so RST_STREAM
+    /// is written; on the client the HEADERS never went out so the stream is failed locally only.
+    /// When `encoder_touched` is set, earlier entries in the block were already committed to the
+    /// connection-scoped HPACK encoder's dynamic table and the peer will never see them, so the
+    /// encoder is no longer in step with the peer's decoder: gracefully GOAWAY(NO_ERROR) like the
+    /// trailers encode-failure path so no later response emits a dynamic index the peer lacks.
     fn reject_unencodable_header_block(
+        &self,
+        stream: &mut Stream,
+        rst_code: ErrorCode,
+        encoder_touched: bool,
+    ) {
+        let identifier = stream.get_identifier();
+        identifier.ensure_still_alive();
+        self.dispatch_with_2_extra(
+            JSH2FrameParser::Gc::onFrameError,
+            identifier,
+            JSValue::js_number(FrameType::HTTP_FRAME_HEADERS as u8 as f64),
+            JSValue::js_number(ErrorCode::FRAME_SIZE_ERROR.0 as f64),
+        );
+        if self.is_server.get() {
+            self.end_stream(stream, rst_code);
+            if encoder_touched {
+                self.send_go_away(
+                    stream.id,
+                    ErrorCode::NO_ERROR,
+                    b"",
+                    self.last_stream_id.get(),
+                    true,
+                );
+            }
+        } else {
+            stream.state = StreamState::CLOSED;
+            stream.rst_code = rst_code.0;
+            self.dispatch_with_extra(
+                JSH2FrameParser::Gc::onStreamError,
+                identifier,
+                JSValue::js_number(rst_code.0 as f64),
+            );
+        }
+    }
+
+    /// Lookup-then-reject wrapper for the per-entry encode failure sites in `request()`, where the
+    /// stream may not have been materialized yet.
+    fn reject_unencodable_header_block_for(
         &self,
         stream_id: u32,
         stream_ctx_arg: JSValue,
         global_object: &JSGlobalObject,
+        encoder_touched: bool,
     ) -> JSValue {
         let Some(stream_ptr) = self.handle_received_stream_id(stream_id) else {
             return JSValue::js_number(-1.0);
@@ -2513,25 +2556,7 @@ impl H2FrameParser {
         if !stream_ctx_arg.is_empty_or_undefined_or_null() && stream_ctx_arg.is_object() {
             stream.set_context(stream_ctx_arg, global_object);
         }
-        let identifier = stream.get_identifier();
-        identifier.ensure_still_alive();
-        self.dispatch_with_2_extra(
-            JSH2FrameParser::Gc::onFrameError,
-            identifier,
-            JSValue::js_number(FrameType::HTTP_FRAME_HEADERS as u8 as f64),
-            JSValue::js_number(ErrorCode::FRAME_SIZE_ERROR.0 as f64),
-        );
-        if self.is_server.get() {
-            self.end_stream(stream, ErrorCode::FRAME_SIZE_ERROR);
-        } else {
-            stream.state = StreamState::CLOSED;
-            stream.rst_code = ErrorCode::FRAME_SIZE_ERROR.0;
-            self.dispatch_with_extra(
-                JSH2FrameParser::Gc::onStreamError,
-                identifier,
-                JSValue::js_number(ErrorCode::FRAME_SIZE_ERROR.0 as f64),
-            );
-        }
+        self.reject_unencodable_header_block(stream, ErrorCode::FRAME_SIZE_ERROR, encoder_touched);
         JSValue::js_number(stream_id as f64)
     }
 
@@ -7484,10 +7509,10 @@ impl H2FrameParser {
         let stream = unsafe { &mut *stream };
 
         stream.wait_for_trailers = false;
-        // Same guard as write_stream(): the compat _final reaches here on every response (kBeginSend
-        // sets waitForTrailers), so a stream already reset by a header-encode failure must not emit
-        // a stray DATA frame.
-        if stream.can_send_data() {
+        // A stream already reset (header-encode failure, peer RST) must not emit a stray DATA
+        // frame; HALF_CLOSED_LOCAL still needs the terminating END_STREAM here (client
+        // endStream + waitForTrailers reaches this with no END_STREAM on the wire yet).
+        if stream.state != StreamState::CLOSED {
             let _ = this.send_data(stream, b"", true, JSValue::UNDEFINED, false, false);
         }
         Ok(JSValue::UNDEFINED)
@@ -8649,10 +8674,11 @@ impl H2FrameParser {
                             return Err(global_object
                                 .throw(format_args!("Failed to allocate header buffer")));
                         }
-                        return Ok(this.reject_unencodable_header_block(
+                        return Ok(this.reject_unencodable_header_block_for(
                             stream_id,
                             stream_ctx_arg,
                             global_object,
+                            !encoded_headers.is_empty(),
                         ));
                     }
                 }
@@ -8809,10 +8835,11 @@ impl H2FrameParser {
                                 return Err(global_object
                                     .throw(format_args!("Failed to allocate header buffer")));
                             }
-                            return Ok(this.reject_unencodable_header_block(
+                            return Ok(this.reject_unencodable_header_block_for(
                                 stream_id,
                                 stream_ctx_arg,
                                 global_object,
+                                !encoded_headers.is_empty(),
                             ));
                         }
                     }
@@ -8872,10 +8899,11 @@ impl H2FrameParser {
                             return Err(global_object
                                 .throw(format_args!("Failed to allocate header buffer")));
                         }
-                        return Ok(this.reject_unencodable_header_block(
+                        return Ok(this.reject_unencodable_header_block_for(
                             stream_id,
                             stream_ctx_arg,
                             global_object,
+                            !encoded_headers.is_empty(),
                         ));
                     }
                 }
@@ -9095,20 +9123,10 @@ impl H2FrameParser {
         if this.max_send_header_block_length.get() != 0
             && encoded_size > this.max_send_header_block_length.get() as usize
         {
-            stream.state = StreamState::CLOSED;
-            stream.rst_code = ErrorCode::REFUSED_STREAM.0;
-
-            this.dispatch_with_2_extra(
-                JSH2FrameParser::Gc::onFrameError,
-                stream.get_identifier(),
-                JSValue::js_number(FrameType::HTTP_FRAME_HEADERS as u8 as f64),
-                JSValue::js_number(ErrorCode::FRAME_SIZE_ERROR.0 as f64),
-            );
-
-            this.dispatch_with_extra(
-                JSH2FrameParser::Gc::onStreamError,
-                stream.get_identifier(),
-                JSValue::js_number(stream.rst_code as f64),
+            this.reject_unencodable_header_block(
+                &mut stream,
+                ErrorCode::REFUSED_STREAM,
+                encoded_size > 0,
             );
             return Ok(JSValue::js_number(stream_id as f64));
         }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2494,14 +2494,15 @@ impl H2FrameParser {
         let _ = self.write(&buffer);
     }
 
-    /// A header block could not be sent (a single field over the encoder's per-entry limit, or the
-    /// encoded block over `maxSendHeaderBlockLength`). Surface `frameError(FRAME_SIZE_ERROR)` and
-    /// fail the stream with `rst_code`. On the server the stream exists on the wire so RST_STREAM
-    /// is written; on the client the HEADERS never went out so the stream is failed locally only.
-    /// When `encoder_touched` is set, earlier entries in the block were already committed to the
-    /// connection-scoped HPACK encoder's dynamic table and the peer will never see them, so the
-    /// encoder is no longer in step with the peer's decoder: gracefully GOAWAY(NO_ERROR) like the
-    /// trailers encode-failure path so no later response emits a dynamic index the peer lacks.
+    /// A header block could not be sent (a single field over the encoder's per-entry limit, the
+    /// encoded block over `maxSendHeaderBlockLength`, or the session over its memory budget).
+    /// Surface `frameError(FRAME_SIZE_ERROR)` and fail the stream with `rst_code`. On the server
+    /// the stream exists on the wire so RST_STREAM is written; on the client the HEADERS never
+    /// went out so the stream is failed locally only. When `encoder_touched` is set, earlier
+    /// entries in the block were already committed to the connection-scoped HPACK encoder's
+    /// dynamic table and the peer will never see them, so the encoder is no longer in step with
+    /// the peer's decoder: gracefully GOAWAY(NO_ERROR) like the trailers encode-failure path so no
+    /// later HEADERS emits a dynamic index the peer lacks.
     fn reject_unencodable_header_block(
         &self,
         stream: &mut Stream,
@@ -2510,6 +2511,7 @@ impl H2FrameParser {
     ) {
         let identifier = stream.get_identifier();
         identifier.ensure_still_alive();
+        let triggering_id = stream.id;
         self.dispatch_with_2_extra(
             JSH2FrameParser::Gc::onFrameError,
             identifier,
@@ -2518,15 +2520,6 @@ impl H2FrameParser {
         );
         if self.is_server.get() {
             self.end_stream(stream, rst_code);
-            if encoder_touched {
-                self.send_go_away(
-                    stream.id,
-                    ErrorCode::NO_ERROR,
-                    b"",
-                    self.last_stream_id.get(),
-                    true,
-                );
-            }
         } else {
             stream.state = StreamState::CLOSED;
             stream.rst_code = rst_code.0;
@@ -2534,6 +2527,18 @@ impl H2FrameParser {
                 JSH2FrameParser::Gc::onStreamError,
                 identifier,
                 JSValue::js_number(rst_code.0 as f64),
+            );
+        }
+        if encoder_touched {
+            // On the server the onEnd teardown stops later responds from reusing the desynced
+            // encoder; on the client the stream error above must reach the user first, so only
+            // the wire-level GOAWAY is sent and the local session drains when the peer closes.
+            self.send_go_away(
+                triggering_id,
+                ErrorCode::NO_ERROR,
+                b"",
+                self.last_stream_id.get(),
+                self.is_server.get(),
             );
         }
     }
@@ -9087,13 +9092,11 @@ impl H2FrameParser {
 
         // too much memory being use
         if this.is_over_session_memory_limit() {
-            stream.state = StreamState::CLOSED;
-            stream.rst_code = ErrorCode::ENHANCE_YOUR_CALM.0;
             this.rejected_streams.set(this.rejected_streams.get() + 1);
-            this.dispatch_with_extra(
-                JSH2FrameParser::Gc::onStreamError,
-                stream.get_identifier(),
-                JSValue::js_number(stream.rst_code as f64),
+            this.reject_unencodable_header_block(
+                &mut stream,
+                ErrorCode::ENHANCE_YOUR_CALM,
+                encoded_size > 0,
             );
             if this.rejected_streams.get() >= this.max_rejected_streams.get() {
                 let global = this.handlers.get().global();

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1041,6 +1041,126 @@ describe("request pseudo-header requirements (RFC 9113 §8.3.1)", () => {
   });
 });
 
+describe("response header block encode failures (RFC 9113 section 8.1)", () => {
+  // A single header entry whose encoded size overflows the HPACK encoder's per-entry limit
+  // (name + value > LSHPACK_MAX_HEADER_SIZE) cannot be emitted at all. Before the fix the native
+  // layer marked the stream CLOSED locally and let the JS end path flush a stray DATA+END_STREAM
+  // with no HEADERS in front of it, which a conforming client treats as a connection
+  // PROTOCOL_ERROR and tears down every multiplexed stream. node 26 / nghttp2 instead reset just
+  // that stream with RST_STREAM(FRAME_SIZE_ERROR); the connection stays up.
+  async function serveOversized(
+    handler: (stream: http2.ServerHttp2Stream) => void,
+  ): Promise<{ frames: Frame[]; frameError: [number, number] | null }> {
+    let frameError: [number, number] | null = null;
+    const srv = http2.createServer();
+    srv.on("session", s => s.on("error", () => {}));
+    srv.on("stream", stream => {
+      stream.on("error", () => {});
+      stream.on("frameError", (type, code) => {
+        frameError = [type, code];
+      });
+      handler(stream);
+    });
+    srv.listen(0, "127.0.0.1");
+    await once(srv, "listening");
+    const c = await RawH2.connect((srv.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendSettingsAck();
+      c.sendFrame(FrameType.HEADERS, 0x5 /* END_HEADERS|END_STREAM */, 1, requestHeaderBlock("GET"));
+      await c.waitFor(
+        f => f.streamId === 1 && (f.type === FrameType.RST_STREAM || f.type === FrameType.DATA),
+      );
+      // PING barrier: once the ACK arrives the server has flushed everything queued for stream 1.
+      c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      return { frames: c.frames.slice(), frameError };
+    } finally {
+      c.destroy();
+      srv.close();
+    }
+  }
+
+  function expectStreamReset({ frames, frameError }: { frames: Frame[]; frameError: [number, number] | null }) {
+    const onStream1 = frames.filter(f => f.streamId === 1);
+    const types = onStream1.map(f => f.type);
+    // No response HEADERS or DATA reached the wire for the failed stream.
+    expect(types).not.toContain(FrameType.HEADERS);
+    expect(types).not.toContain(FrameType.DATA);
+    // The peer sees an RST_STREAM(FRAME_SIZE_ERROR) for just that stream.
+    const rst = onStream1.find(f => f.type === FrameType.RST_STREAM);
+    expect(rst?.payload.readUInt32BE(0)).toBe(ErrorCode.FRAME_SIZE_ERROR);
+    // The handler was told via 'frameError' that the HEADERS frame could not be sent.
+    expect(frameError).toEqual([FrameType.HEADERS, ErrorCode.FRAME_SIZE_ERROR]);
+    // The connection survived: PING was answered and no GOAWAY went out.
+    expect(frames.find(f => f.type === FrameType.GOAWAY)).toBeUndefined();
+  }
+
+  const BIG = Buffer.alloc(200000, 0x42).toString("latin1");
+
+  test("stream.respond() with an unencodable header resets the stream, no HEADERS/DATA written", async () => {
+    expectStreamReset(
+      await serveOversized(stream => {
+        stream.respond({ ":status": 200, "x-big": BIG });
+        stream.end("big");
+      }),
+    );
+  });
+
+  test("stream.respond() with the unencodable header as an array value resets the stream", async () => {
+    expectStreamReset(
+      await serveOversized(stream => {
+        stream.respond({ ":status": 200, "x-big": [BIG] });
+        stream.end("big");
+      }),
+    );
+  });
+
+  test("stream.respond() with a raw-array header list resets the stream", async () => {
+    expectStreamReset(
+      await serveOversized(stream => {
+        stream.respond([":status", 200, "x-big", BIG] as any);
+        stream.end("big");
+      }),
+    );
+  });
+
+  test("the compat Http2ServerResponse writes RST_STREAM instead of a headerless DATA frame", async () => {
+    let frameError: [number, number] | null = null;
+    const srv = http2.createServer();
+    srv.on("session", s => s.on("error", () => {}));
+    srv.on("request", (_req, res) => {
+      res.stream.on("error", () => {});
+      res.stream.on("frameError", (type: number, code: number) => {
+        frameError = [type, code];
+      });
+      res.setHeader("x-big", BIG);
+      res.end("big");
+    });
+    srv.listen(0, "127.0.0.1");
+    await once(srv, "listening");
+    const c = await RawH2.connect((srv.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendSettingsAck();
+      c.sendFrame(FrameType.HEADERS, 0x5, 1, requestHeaderBlock("GET"));
+      const first = await c.waitFor(
+        f => f.streamId === 1 && (f.type === FrameType.RST_STREAM || f.type === FrameType.DATA),
+      );
+      // The first stream-1 frame must be the reset, not a stray DATA with no HEADERS.
+      expect(first.type).toBe(FrameType.RST_STREAM);
+      c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      expectStreamReset({ frames: c.frames.slice(), frameError });
+    } finally {
+      c.destroy();
+      srv.close();
+    }
+  });
+});
+
 describe("inbound stream lifecycle", () => {
   test("releases server stream objects once the peer resets their streams", async () => {
     const total = 32;

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1069,9 +1069,7 @@ describe("response header block encode failures (RFC 9113 section 8.1)", () => {
       c.sendEmptySettings();
       c.sendSettingsAck();
       c.sendFrame(FrameType.HEADERS, 0x5 /* END_HEADERS|END_STREAM */, 1, requestHeaderBlock("GET"));
-      await c.waitFor(
-        f => f.streamId === 1 && (f.type === FrameType.RST_STREAM || f.type === FrameType.DATA),
-      );
+      await c.waitFor(f => f.streamId === 1 && (f.type === FrameType.RST_STREAM || f.type === FrameType.DATA));
       // PING barrier: once the ACK arrives the server has flushed everything queued for stream 1.
       c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
       await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1046,13 +1046,17 @@ describe("response header block encode failures (RFC 9113 section 8.1)", () => {
   // (name + value > LSHPACK_MAX_HEADER_SIZE) cannot be emitted at all. Before the fix the native
   // layer marked the stream CLOSED locally and let the JS end path flush a stray DATA+END_STREAM
   // with no HEADERS in front of it, which a conforming client treats as a connection
-  // PROTOCOL_ERROR and tears down every multiplexed stream. node 26 / nghttp2 instead reset just
-  // that stream with RST_STREAM(FRAME_SIZE_ERROR); the connection stays up.
+  // PROTOCOL_ERROR and tears down every multiplexed stream. The stream is now reset with
+  // RST_STREAM(FRAME_SIZE_ERROR); because earlier entries in the failed block may already have
+  // been pushed into the connection-scoped HPACK encoder table (which the peer will never see),
+  // the session also winds down with a graceful GOAWAY(NO_ERROR) when any header was encoded
+  // before the failure.
   async function serveOversized(
     handler: (stream: http2.ServerHttp2Stream) => void,
+    serverOptions?: http2.ServerOptions,
   ): Promise<{ frames: Frame[]; frameError: [number, number] | null }> {
     let frameError: [number, number] | null = null;
-    const srv = http2.createServer();
+    const srv = http2.createServer(serverOptions ?? {});
     srv.on("session", s => s.on("error", () => {}));
     srv.on("stream", stream => {
       stream.on("error", () => {});
@@ -1070,9 +1074,9 @@ describe("response header block encode failures (RFC 9113 section 8.1)", () => {
       c.sendSettingsAck();
       c.sendFrame(FrameType.HEADERS, 0x5 /* END_HEADERS|END_STREAM */, 1, requestHeaderBlock("GET"));
       await c.waitFor(f => f.streamId === 1 && (f.type === FrameType.RST_STREAM || f.type === FrameType.DATA));
-      // PING barrier: once the ACK arrives the server has flushed everything queued for stream 1.
-      c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
-      await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      // The encoder was touched (:status was encoded before the oversized entry failed), so the
+      // server also sends a graceful GOAWAY and closes: wait for either to snapshot the frames.
+      await Promise.race([c.waitForGoaway(2000), c.waitClosed(2000)]).catch(() => {});
       return { frames: c.frames.slice(), frameError };
     } finally {
       c.destroy();
@@ -1091,8 +1095,10 @@ describe("response header block encode failures (RFC 9113 section 8.1)", () => {
     expect(rst?.payload.readUInt32BE(0)).toBe(ErrorCode.FRAME_SIZE_ERROR);
     // The handler was told via 'frameError' that the HEADERS frame could not be sent.
     expect(frameError).toEqual([FrameType.HEADERS, ErrorCode.FRAME_SIZE_ERROR]);
-    // The connection survived: PING was answered and no GOAWAY went out.
-    expect(frames.find(f => f.type === FrameType.GOAWAY)).toBeUndefined();
+    // The session winds down gracefully: earlier encoded entries may have pushed into the HPACK
+    // encoder's dynamic table and the peer never saw them, so the encoder is no longer in step.
+    const goaway = frames.find(f => f.type === FrameType.GOAWAY);
+    expect(goaway && goawayErrorCode(goaway)).toBe(ErrorCode.NO_ERROR);
   }
 
   const BIG = Buffer.alloc(200000, 0x42).toString("latin1");
@@ -1149,12 +1155,104 @@ describe("response header block encode failures (RFC 9113 section 8.1)", () => {
       );
       // The first stream-1 frame must be the reset, not a stray DATA with no HEADERS.
       expect(first.type).toBe(FrameType.RST_STREAM);
-      c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
-      await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      await Promise.race([c.waitForGoaway(2000), c.waitClosed(2000)]).catch(() => {});
       expectStreamReset({ frames: c.frames.slice(), frameError });
     } finally {
       c.destroy();
       srv.close();
+    }
+  });
+
+  test("a later stream on the same session is not sent a HEADERS referencing the desynced encoder", async () => {
+    // Stream 1's content-type is pushed into the encoder's dynamic table before x-big fails;
+    // without the GOAWAY the server would answer stream 3's content-type with an indexed
+    // reference (>= 62) the peer's decoder never saw, and the peer would GOAWAY(COMPRESSION_ERROR).
+    const srv = http2.createServer();
+    srv.on("session", s => s.on("error", () => {}));
+    let hit = 0;
+    srv.on("stream", stream => {
+      stream.on("error", () => {});
+      hit++;
+      if (hit === 1) {
+        stream.respond({ ":status": 200, "content-type": "text/plain", "x-big": BIG });
+      } else {
+        stream.respond({ ":status": 200, "content-type": "text/plain" });
+      }
+      stream.end();
+    });
+    srv.listen(0, "127.0.0.1");
+    await once(srv, "listening");
+    const c = await RawH2.connect((srv.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendSettingsAck();
+      c.sendFrame(FrameType.HEADERS, 0x5, 1, requestHeaderBlock("GET"));
+      c.sendFrame(FrameType.HEADERS, 0x5, 3, requestHeaderBlock("GET"));
+      await Promise.race([c.waitForGoaway(2000), c.waitClosed(2000)]);
+      const rst1 = c.frames.find(f => f.streamId === 1 && f.type === FrameType.RST_STREAM);
+      expect(rst1?.payload.readUInt32BE(0)).toBe(ErrorCode.FRAME_SIZE_ERROR);
+      const goaway = c.frames.find(f => f.type === FrameType.GOAWAY);
+      expect(goaway && goawayErrorCode(goaway)).toBe(ErrorCode.NO_ERROR);
+      // Stream 3 must not have received a HEADERS frame whose payload indexes into the dynamic
+      // table (any byte with the high bit set and value >= 0xBE references index >= 62).
+      const hdr3 = c.frames.find(f => f.streamId === 3 && f.type === FrameType.HEADERS);
+      if (hdr3) {
+        const dynRef = [...hdr3.payload].find(b => b >= 0xbe);
+        expect(dynRef).toBeUndefined();
+      }
+    } finally {
+      c.destroy();
+      srv.close();
+    }
+  });
+
+  test("a response block exceeding maxSendHeaderBlockLength is reset on the wire", async () => {
+    // The whole block exceeds the limit after every field encoded fine; node/nghttp2 close the
+    // stream with REFUSED_STREAM (test-http2-options-max-headers-block-length.js) and emit
+    // frameError(FRAME_SIZE_ERROR).
+    const { frames, frameError } = await serveOversized(
+      stream => {
+        stream.respond({ ":status": 200, "x-a": "aaaa", "x-b": "bbbb", "x-c": "cccc", "x-d": "dddd" });
+        stream.end("x");
+      },
+      { maxSendHeaderBlockLength: 32 },
+    );
+    const onStream1 = frames.filter(f => f.streamId === 1);
+    const types = onStream1.map(f => f.type);
+    expect(types).not.toContain(FrameType.HEADERS);
+    expect(types).not.toContain(FrameType.DATA);
+    const rst = onStream1.find(f => f.type === FrameType.RST_STREAM);
+    expect(rst?.payload.readUInt32BE(0)).toBe(ErrorCode.REFUSED_STREAM);
+    expect(frameError).toEqual([FrameType.HEADERS, ErrorCode.FRAME_SIZE_ERROR]);
+    const goaway = frames.find(f => f.type === FrameType.GOAWAY);
+    expect(goaway && goawayErrorCode(goaway)).toBe(ErrorCode.NO_ERROR);
+  });
+});
+
+describe("client request terminator with waitForTrailers", () => {
+  test("a GET with { waitForTrailers: true } still half-closes its side on the wire", async () => {
+    // Native request() writes HEADERS without END_STREAM here and defers the terminator to
+    // noTrailers(); the state is HALF_CLOSED_LOCAL at that point so a can_send_data()-style
+    // guard would skip the terminating DATA and leave the peer's stream open.
+    const raw = await RawH2Server.listen();
+    try {
+      const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+      client.on("error", () => {});
+      const req = client.request({ ":path": "/" }, { waitForTrailers: true });
+      req.on("error", () => {});
+      req.end();
+      await raw.waitFor(f => f.streamId === 1 && (f.type === FrameType.HEADERS || f.type === FrameType.DATA));
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      // Wait for the client to half-close stream 1 (END_STREAM on HEADERS or DATA).
+      const closer = await raw.waitFor(
+        f => f.streamId === 1 && (f.type === FrameType.HEADERS || f.type === FrameType.DATA) && (f.flags & 0x1) !== 0,
+      );
+      expect(closer.flags & 0x1).toBe(0x1);
+      client.destroy();
+    } finally {
+      raw.close();
     }
   });
 });

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1241,11 +1241,17 @@ describe("client request terminator with waitForTrailers", () => {
       await raw.waitFor(f => f.streamId === 1 && (f.type === FrameType.HEADERS || f.type === FrameType.DATA));
       raw.sendFrame(FrameType.SETTINGS, 0, 0);
       raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
-      // Wait for the client to half-close stream 1 (END_STREAM on HEADERS or DATA).
-      const closer = await raw.waitFor(
-        f => f.streamId === 1 && (f.type === FrameType.HEADERS || f.type === FrameType.DATA) && (f.flags & 0x1) !== 0,
-      );
-      expect(closer.flags & 0x1).toBe(0x1);
+      // Wait for the client to half-close stream 1 (END_STREAM on HEADERS or DATA); if it never
+      // does the waitFor rejects and this assertion surfaces the actual stream-1 frame sequence.
+      const closer = await raw
+        .waitFor(
+          f => f.streamId === 1 && (f.type === FrameType.HEADERS || f.type === FrameType.DATA) && (f.flags & 0x1) !== 0,
+        )
+        .catch(() => null);
+      const stream1 = raw.frames
+        .filter(f => f.streamId === 1)
+        .map(f => ({ type: f.type, endStream: (f.flags & 0x1) !== 0 }));
+      expect({ halfClosed: closer !== null, stream1 }).toMatchObject({ halfClosed: true });
       client.destroy();
     } finally {
       raw.close();

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1232,9 +1232,9 @@ describe("client request terminator with waitForTrailers", () => {
     // noTrailers(); the state is HALF_CLOSED_LOCAL at that point so a can_send_data()-style
     // guard would skip the terminating DATA and leave the peer's stream open.
     const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
     try {
-      const client = http2.connect(`http://127.0.0.1:${raw.port}`);
-      client.on("error", () => {});
       const req = client.request({ ":path": "/" }, { waitForTrailers: true });
       req.on("error", () => {});
       req.end();
@@ -1252,8 +1252,8 @@ describe("client request terminator with waitForTrailers", () => {
         .filter(f => f.streamId === 1)
         .map(f => ({ type: f.type, endStream: (f.flags & 0x1) !== 0 }));
       expect({ halfClosed: closer !== null, stream1 }).toMatchObject({ halfClosed: true });
-      client.destroy();
     } finally {
+      client.destroy();
       raw.close();
     }
   });

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1194,13 +1194,9 @@ describe("response header block encode failures (RFC 9113 section 8.1)", () => {
       expect(rst1?.payload.readUInt32BE(0)).toBe(ErrorCode.FRAME_SIZE_ERROR);
       const goaway = c.frames.find(f => f.type === FrameType.GOAWAY);
       expect(goaway && goawayErrorCode(goaway)).toBe(ErrorCode.NO_ERROR);
-      // Stream 3 must not have received a HEADERS frame whose payload indexes into the dynamic
-      // table (any byte with the high bit set and value >= 0xBE references index >= 62).
-      const hdr3 = c.frames.find(f => f.streamId === 3 && f.type === FrameType.HEADERS);
-      if (hdr3) {
-        const dynRef = [...hdr3.payload].find(b => b >= 0xbe);
-        expect(dynRef).toBeUndefined();
-      }
+      // The session was torn down before stream 3 could be answered, so it receives no HEADERS
+      // at all (and therefore certainly none indexing into the desynced dynamic table).
+      expect(c.frames.find(f => f.streamId === 3 && f.type === FrameType.HEADERS)).toBeUndefined();
     } finally {
       c.destroy();
       srv.close();

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -579,7 +579,7 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             expect("unreachable").toBe(true);
           } catch (err) {
             expect(err.code).toBe("ERR_HTTP2_STREAM_ERROR");
-            expect(err.message).toBe("Stream closed with error code NGHTTP2_COMPRESSION_ERROR");
+            expect(err.message).toBe("Stream closed with error code NGHTTP2_FRAME_SIZE_ERROR");
           }
         });
         it("should be destroyed after close", async () => {


### PR DESCRIPTION
## What

When a `node:http2` server tries to send a response header block that cannot go on the wire (a single field whose name + value exceeds the HPACK encoder's ~64 KiB per-entry limit, or the encoded block exceeding `maxSendHeaderBlockLength`), the native layer marked the stream `CLOSED` locally but wrote nothing. The peer, which had already opened the stream, was left waiting on a `HEADERS` frame that never arrived; the compat `Http2ServerResponse` end path then flushed a stray empty `DATA` frame with `END_STREAM` and no `HEADERS` in front of it. A conforming client (node / nghttp2) answers that RFC 9113 section 8.1 violation with a connection-level `GOAWAY`, tearing down every healthy multiplexed stream on the session. Via `stream.respond()` directly nothing is written at all and the peer's stream hangs.

Node 26 / nghttp2 behavior for the same case: `RST_STREAM(FRAME_SIZE_ERROR)` on just that stream, `frameError` to the handler.

## Repro

```js
import http2 from 'node:http2';
import net from 'node:net';
const srv = http2.createServer();
srv.on('session', s => s.on('error', () => {}));
srv.on('request', (_req, res) => {
  res.stream.on('error', () => {});
  res.setHeader('x-big', 'B'.repeat(200000));
  res.end('big');
});
srv.listen(0, '127.0.0.1', () => {
  // raw h2 client: send a GET on stream 1, print the frame types seen on stream 1
  const fr = (t, f, sid, p = Buffer.alloc(0)) => { const h = Buffer.alloc(9); h.writeUIntBE(p.length, 0, 3); h[3] = t; h[4] = f; h.writeUInt32BE(sid, 5); return Buffer.concat([h, p]); };
  const lit = (n, v) => Buffer.concat([Buffer.from([0, n.length]), Buffer.from(n), Buffer.from([v.length]), Buffer.from(v)]);
  const REQ = Buffer.concat([lit(':method', 'GET'), lit(':scheme', 'http'), lit(':path', '/'), lit(':authority', 'x')]);
  const seen = [];
  const s = net.connect(srv.address().port, '127.0.0.1', () => {
    s.write(Buffer.from('PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n')); s.write(fr(4, 0, 0)); s.write(fr(4, 1, 0));
    s.write(fr(1, 5, 1, REQ));
  });
  let b = Buffer.alloc(0);
  s.on('data', d => { b = Buffer.concat([b, d]); while (b.length >= 9) { const len = b.readUIntBE(0, 3), t = b[3], sid = b.readUInt32BE(5) & 0x7fffffff; if (b.length < 9 + len) break; if (sid === 1) seen.push(t); b = b.subarray(9 + len); } });
  setTimeout(() => { console.log(seen); s.destroy(); srv.close(); process.exit(); }, 1000);
});
```

Before: `[ 0 ]` (a lone `DATA` frame, no `HEADERS`, no `RST_STREAM`).
After: `[ 3 ]` (`RST_STREAM(FRAME_SIZE_ERROR)`).

## Cause

Four sites in `H2FrameParser::request()` share the pattern (three `encode_header_into_list` error branches plus the `maxSendHeaderBlockLength` check): set `state = CLOSED` and `rst_code` locally, dispatch `onStreamError`, return. No `RST_STREAM` went to the wire. The existing trailers encode-failure path already did the right thing (`end_stream(FRAME_SIZE_ERROR)` plus graceful `GOAWAY`).

Separately, `no_trailers()` called `send_data(stream, b"", true, ...)` without checking for `CLOSED`. The compat layer's `[kBeginSend]()` always passes `waitForTrailers: true` to `respond()`, so every compat response's `_final` reaches `noTrailers`, which wrote an empty `DATA` frame on the stream the header path had just closed.

## Fix

- A new `reject_unencodable_header_block` helper, called from all four sites: dispatches `onFrameError(HEADERS, FRAME_SIZE_ERROR)`, then on the server writes `RST_STREAM` (FRAME_SIZE_ERROR for the per-entry case, REFUSED_STREAM for `maxSendHeaderBlockLength`, matching node). On the client the HEADERS never reached the wire so the stream is failed locally only.
- When earlier entries in the failed block were already encoded, the connection-scoped HPACK encoder's dynamic table may have been pushed to and the peer will never see those entries; the server therefore also sends a graceful `GOAWAY(NO_ERROR)` and tears the session down locally (same as the trailers path) so no later response emits a dynamic-table index the peer cannot resolve.
- `no_trailers()` now skips the empty DATA only when `state == CLOSED`; a `HALF_CLOSED_LOCAL` client stream (GET/HEAD with `{ waitForTrailers: true }`) still gets its terminating `DATA+END_STREAM`.
- The client `streamError` handler now records the stream's own `rstCode` synchronously and materializes the `ERR_HTTP2_STREAM_ERROR` before queuing, so a stream reset before any session teardown keeps its own code instead of the generic `ERR_HTTP2_STREAM_CANCEL` that `destroy()` installs. This also brings the no-listener peer-`RST_STREAM` path to Node parity: a client request the peer resets now surfaces the peer's code as `stream.rstCode` and emits `ERR_HTTP2_STREAM_ERROR` (previously `rstCode` stayed `0` and no error was emitted when no `error` listener was attached, which was itself a Bun-vs-Node divergence).
- The existing client-side `headers cannot be bigger than 65536 bytes` test expectation is updated from `NGHTTP2_COMPRESSION_ERROR` to `NGHTTP2_FRAME_SIZE_ERROR` to match node.

## Verification

New wire-level tests in `test/js/node/http2/h2-conformance.test.ts`:
- `stream.respond()` with the oversized value as a single value, an array value, and a raw-array header list, plus the compat `Http2ServerResponse` path: each asserts `RST_STREAM(FRAME_SIZE_ERROR)` on stream 1 with no `HEADERS`/`DATA`, `frameError` emitted, and a graceful `GOAWAY(NO_ERROR)`.
- `a later stream on the same session is not sent a HEADERS referencing the desynced encoder`: `content-type` before the oversized field, two requests on one connection; asserts stream 3 never receives a HEADERS indexing into the dynamic table.
- `a response block exceeding maxSendHeaderBlockLength is reset on the wire`: server with `maxSendHeaderBlockLength: 32` writes `RST_STREAM(REFUSED_STREAM)`.
- `a GET with { waitForTrailers: true } still half-closes its side on the wire`: raw server observes the client's `END_STREAM`.

```
bun bd test test/js/node/http2/h2-conformance.test.ts -t "response header block encode failures|client request terminator"
```

All fail on main, all pass with the fix. Full `test/js/node/http2/` suite: 415 pass (the one failure, `node-http2-streams-rehash.test.ts "does not hold *Stream across user-controlled options getters"`, times out on main with or without this diff).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (62d645051)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [896.50ms]
(pass) node none > Client Basics > should be able to send a POST request [621.76ms]
(pass) node none > Client Basics > constants [18.91ms]
(pass) node none > Client Basics > getDefaultSettings [7.65ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.77ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.96ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.24ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.03ms]
(pass) node none > Client Basics > should be able to send data using end [651.45ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [639.71ms]
(pass) node none > Client Basics > http2 s
... (truncated)

release without fix: 6 skipped
bun test v1.4.0-canary.1 (11bd1dff3)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.82ms]
(pass) node none > Client Basics > getDefaultSettings [0.15ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.36ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.08ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.06ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.06ms]
(pass) node none > Client Basics > is possible to abort request [1.74ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.71ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.62ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.05ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [35.94ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > should fail to con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (62d645051)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [872.05ms]
(pass) node none > Client Basics > should be able to send a POST request [606.78ms]
(pass) node none > Client Basics > constants [18.61ms]
(pass) node none > Client Basics > getDefaultSettings [7.07ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.20ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.32ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.08ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.03ms]
(pass) node none > Client Basics > should be able to send data using end [638.36ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [628.21ms]
(pass) node none > Client Basics > http2 s
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 662ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/122] gen cpp.rs (cppbind)
[2/122] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[3/122] gen JS modules (bundle-modules)
Preprocess modules (8874ms)
Bundle modules (60ms)
Postprocesss modules (318ms)
Bundle Functions (646ms)
Generate Code (26ms)

[9.94s] Bundled "src/js" for production
  2569 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[3/121] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_http v0.0.0 (/workspace/bun/src/http)
^[[1m^[[92m   Compiling^[[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
^[[1m^[[92m   Compiling^[[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
^[[1m^[[92m   Compiling^[[0m bun_install v0.0.0 (/workspace/bun/src/install)
^[[1m^[[92m   Compiling^[[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                      |  16 +-
 src/runtime/api/bun/h2_frame_parser.rs    | 291 +++++++++++++++++-------------
 test/js/node/http2/h2-conformance.test.ts | 218 ++++++++++++++++++++++
 test/js/node/http2/node-http2.test.js     |   2 +-
 4 files changed, 398 insertions(+), 129 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/http2.ts                          18      4      0
src/runtime/api/bun/h2_frame_parser.rs        44     38      0
test/js/node/http2/h2-conformance.test.ts      9      8      0
test/js/node/http2/node-http2.test.js          1      1      0
```

</details>

<!-- robobun:evidence:end -->

## Scope

The post-encode/pre-write sweep covers the branches that fail the header block itself (per-entry encode limit, `maxSendHeaderBlockLength`, session memory budget) and the `respond()` option range checks that route through the same rejection path. The adjacent `throw_invalid_argument_type_value` else-arms for non-numeric `parent`/`weight`/`exclusive`/`signal` and the already-aborted `signal` branch are intentionally left unchanged: they are pre-existing synchronous throws reachable only by passing undocumented client-side priority/signal options to server `respond()`, and the thrown `ERR_INVALID_ARG_TYPE` already signals programmer error. Routing those through a session teardown would widen the behavior change beyond the encode-failure class this PR targets.

