### PR TITLE
install: don't reject distinct workspace names whose truncated name hashes collide

### DIFF
--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -2618,15 +2618,15 @@ impl Package<u64> {
                         .get_or_put(semver::string::Builder::string_hash(&entry.name)
                             as TruncatedPackageNameHash)?;
                     if gop.found_existing {
-                        // this path does alot of extra work to format the error message
-                        // but this is ok because the install is going to fail anyways, so this
-                        // has zero effect on the happy path.
-                        let mut cwd_buf = PathBuffer::uninit();
-                        // `bun_sys::getcwd` returns the byte length — slice
-                        // the buffer ourselves.
-                        let cwd_len = bun_sys::getcwd(&mut cwd_buf.0[..])?;
-                        let cwd: &[u8] = &cwd_buf.0[..cwd_len];
-
+                        // `seen_workspace_names` is keyed by a TRUNCATED (u32)
+                        // name hash, so a bucket hit means either a true
+                        // duplicate workspace name or a u32 collision between
+                        // two distinct names (oven-sh/bun#36386). Confirm with
+                        // a real string comparison before erroring: `entry` is
+                        // itself one of `workspace_names.values()`, so a true
+                        // duplicate exists iff at least two entries (self
+                        // included) carry an equal name. The count doubles as
+                        // `num_notes` for the error below, exactly as before.
                         let num_notes = 'count: {
                             let mut i: usize = 0;
                             for value in workspace_names.values() {
@@ -2636,81 +2636,108 @@ impl Package<u64> {
                             }
                             break 'count i;
                         };
-                        let notes = 'notes: {
-                            let mut notes: Vec<bun_ast::Data> = Vec::with_capacity(num_notes);
-                            let mut i: usize = 0;
-                            for (value, note_path) in workspace_names
-                                .values()
-                                .iter()
-                                .zip(workspace_names.keys().iter())
-                            {
-                                if note_path.as_ptr() == path_.as_ptr() {
-                                    continue;
+                        if num_notes > 1 {
+                            // this path does alot of extra work to format the error message
+                            // but this is ok because the install is going to fail anyways, so this
+                            // has zero effect on the happy path.
+                            let mut cwd_buf = PathBuffer::uninit();
+                            // `bun_sys::getcwd` returns the byte length — slice
+                            // the buffer ourselves.
+                            let cwd_len = bun_sys::getcwd(&mut cwd_buf.0[..])?;
+                            let cwd: &[u8] = &cwd_buf.0[..cwd_len];
+
+                            let notes = 'notes: {
+                                let mut notes: Vec<bun_ast::Data> = Vec::with_capacity(num_notes);
+                                let mut i: usize = 0;
+                                for (value, note_path) in workspace_names
+                                    .values()
+                                    .iter()
+                                    .zip(workspace_names.keys().iter())
+                                {
+                                    if note_path.as_ptr() == path_.as_ptr() {
+                                        continue;
+                                    }
+                                    if strings::eql_long(&value.name, &entry.name, true) {
+                                        let note_abs_path =
+                                            bun_core::ZBox::from_bytes(
+                                                resolve_path::join_abs_string_z::<
+                                                    path::platform::Auto,
+                                                >(
+                                                    cwd, &[note_path, b"package.json"]
+                                                )
+                                                .as_bytes(),
+                                            );
+
+                                        let note_src = match bun_ast::to_source(
+                                            &note_abs_path,
+                                            Default::default(),
+                                        ) {
+                                            Ok(s) => s,
+                                            Err(_) => bun_ast::Source::init_empty_file(
+                                                note_abs_path.as_bytes(),
+                                            ),
+                                        };
+
+                                        // `Location::init_or_null` borrows `file` from
+                                        // `note_src.path.text`, which itself borrows
+                                        // `note_abs_path`; both drop before the log is
+                                        // printed. `Location::clone` deep-copies `file`
+                                        // into a `Cow::Owned`.
+                                        notes.push(bun_ast::Data {
+                                            text: b"Package name is also declared here"
+                                                .to_vec()
+                                                .into(),
+                                            location: bun_ast::Location::init_or_null(
+                                                Some(&note_src),
+                                                note_src.range_of_string(value.name_loc),
+                                            )
+                                            .as_ref()
+                                            .cloned(),
+                                            ..Default::default()
+                                        });
+                                        i += 1;
+                                    }
                                 }
-                                if strings::eql_long(&value.name, &entry.name, true) {
-                                    let note_abs_path = bun_core::ZBox::from_bytes(
-                                        resolve_path::join_abs_string_z::<path::platform::Auto>(
-                                            cwd,
-                                            &[note_path, b"package.json"],
-                                        )
-                                        .as_bytes(),
-                                    );
+                                notes.truncate(i);
+                                break 'notes notes;
+                            };
 
-                                    let note_src = match bun_ast::to_source(
-                                        &note_abs_path,
-                                        Default::default(),
-                                    ) {
-                                        Ok(s) => s,
-                                        Err(_) => bun_ast::Source::init_empty_file(
-                                            note_abs_path.as_bytes(),
-                                        ),
-                                    };
+                            let abs_path = bun_core::ZBox::from_bytes(
+                                resolve_path::join_abs_string_z::<path::platform::Auto>(
+                                    cwd,
+                                    &[path_, b"package.json"],
+                                )
+                                .as_bytes(),
+                            );
 
-                                    // `Location::init_or_null` borrows `file` from
-                                    // `note_src.path.text`, which itself borrows
-                                    // `note_abs_path`; both drop before the log is
-                                    // printed. `Location::clone` deep-copies `file`
-                                    // into a `Cow::Owned`.
-                                    notes.push(bun_ast::Data {
-                                        text: b"Package name is also declared here".to_vec().into(),
-                                        location: bun_ast::Location::init_or_null(
-                                            Some(&note_src),
-                                            note_src.range_of_string(value.name_loc),
-                                        )
-                                        .as_ref()
-                                        .cloned(),
-                                        ..Default::default()
-                                    });
-                                    i += 1;
-                                }
-                            }
-                            notes.truncate(i);
-                            break 'notes notes;
-                        };
+                            let src = match bun_ast::to_source(&abs_path, Default::default()) {
+                                Ok(s) => s,
+                                Err(_) => bun_ast::Source::init_empty_file(abs_path.as_bytes()),
+                            };
 
-                        let abs_path = bun_core::ZBox::from_bytes(
-                            resolve_path::join_abs_string_z::<path::platform::Auto>(
-                                cwd,
-                                &[path_, b"package.json"],
-                            )
-                            .as_bytes(),
-                        );
-
-                        let src = match bun_ast::to_source(&abs_path, Default::default()) {
-                            Ok(s) => s,
-                            Err(_) => bun_ast::Source::init_empty_file(abs_path.as_bytes()),
-                        };
-
-                        let _ = log.add_range_error_fmt_with_notes(
-                            Some(&src),
-                            src.range_of_string(entry.name_loc),
-                            notes.into(),
-                            format_args!(
-                                "Workspace name \"{}\" already exists",
-                                bstr::BStr::new(&entry.name),
-                            ),
-                        );
-                        return Err(crate::Error::InstallFailed);
+                            let _ = log.add_range_error_fmt_with_notes(
+                                Some(&src),
+                                src.range_of_string(entry.name_loc),
+                                notes.into(),
+                                format_args!(
+                                    "Workspace name \"{}\" already exists",
+                                    bstr::BStr::new(&entry.name),
+                                ),
+                            );
+                            return Err(crate::Error::InstallFailed);
+                        }
+                        // Distinct name whose truncated hash collides with an
+                        // earlier name's bucket: not a duplicate — fall
+                        // through and process this workspace normally. The
+                        // bucket stays in the map (`get_or_put` inserted it
+                        // for its first holder), which is sufficient: the map
+                        // value is `()` and cannot say which name owns the
+                        // bucket, so it only ROUTES names into the string
+                        // scan above — every later name with this truncated
+                        // hash (including a true duplicate of this colliding
+                        // name, or of the first holder) takes this
+                        // `found_existing` path and is judged by that scan,
+                        // the source of truth for duplicates.
                     }
 
                     let external_name = string_builder.append::<ExternalString>(&entry.name);

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1211,6 +1211,101 @@ test.concurrent("it should detect duplicate workspace dependencies", async () =>
   expect(await exited).toBe(1);
 });
 
+// The duplicate-workspace-name check keys on a wyhash truncated to u32.
+// "@demo/app-03511" and "@demo/app-13215" are distinct names whose hashes
+// share the low 32 bits (0x66dff920), so before the real-name confirm was
+// added they were falsely rejected as duplicates (#36386).
+const collidingA = "@demo/app-03511";
+const collidingB = "@demo/app-13215";
+
+test.concurrent("workspace names that collide in the truncated name hash are not duplicates", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "foo",
+      workspaces: ["packages/*"],
+    }),
+  );
+
+  await write(join(packageDir, "packages", "a", "package.json"), JSON.stringify({ name: collidingA }));
+  await write(join(packageDir, "packages", "b", "package.json"), JSON.stringify({ name: collidingB }));
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const err = await stderr.text();
+  expect(err).not.toContain("already exists");
+  expect(await exited).toBe(0);
+});
+
+test.concurrent("hash-colliding workspace name plus a true duplicate of the first still errors", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "foo",
+      workspaces: ["packages/*"],
+    }),
+  );
+
+  await write(join(packageDir, "packages", "a", "package.json"), JSON.stringify({ name: collidingA }));
+  await write(join(packageDir, "packages", "b", "package.json"), JSON.stringify({ name: collidingB }));
+  await write(join(packageDir, "packages", "c", "package.json"), JSON.stringify({ name: collidingA }));
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const err = await stderr.text();
+  expect(err).toContain(`Workspace name "${collidingA}" already exists`);
+  expect(err).not.toContain(`Workspace name "${collidingB}" already exists`);
+  expect(await exited).toBe(1);
+});
+
+test.concurrent("hash-colliding workspace name plus a true duplicate of the second still errors", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "foo",
+      workspaces: ["packages/*"],
+    }),
+  );
+
+  await write(join(packageDir, "packages", "a", "package.json"), JSON.stringify({ name: collidingA }));
+  await write(join(packageDir, "packages", "b", "package.json"), JSON.stringify({ name: collidingB }));
+  await write(join(packageDir, "packages", "c", "package.json"), JSON.stringify({ name: collidingB }));
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const err = await stderr.text();
+  expect(err).toContain(`Workspace name "${collidingB}" already exists`);
+  expect(err).not.toContain(`Workspace name "${collidingA}" already exists`);
+  expect(await exited).toBe(1);
+});
+
 const versions = ["workspace:1.0.0", "workspace:*", "workspace:^1.0.0", "1.0.0", "*"];
 
 for (const rootVersion of versions) {


### PR DESCRIPTION
Fixes #36386

`bun install` rejects a workspace tree whose package names are all unique with `error: Workspace name "X" already exists` when two names' wyhash values share the low 32 bits. The duplicate check keys `seen_workspace_names` on `string_hash(name) as TruncatedPackageNameHash` (u64 → u32) with an identity context and treated any bucket hit as a duplicate, with no string comparison before the verdict. `@demo/app-03511` and `@demo/app-13215` collide this way (`0x45c21c09_66dff920` / `0x34ddf59e_66dff920`).

Fix: on `found_existing`, count the entries in `workspace_names` whose name is byte-equal to the current entry — the same scan the error notes already used, hoisted to the front of the branch — and error only when the count is ≥ 2 (a true duplicate; the entry itself accounts for 1). A bare hash collision falls through and the workspace is processed normally. The bucket `get_or_put` inserted stays in the map; equal names always hash equal, so any later true duplicate of either colliding name still lands in `found_existing` and is caught by the same scan.

The non-colliding path executes the same work as before (the confirm runs only inside `found_existing`); the map type, the hash, and `TruncatedPackageNameHash` are unchanged; the error message and notes for true duplicates are unchanged (`bun-install.test.ts` asserts the exact stderr lines and still passes).

Tests: the colliding pair installs; the pair plus a true duplicate of the first (and of the second) still fails, naming the duplicated package, not the collider. Verified with a debug build on linux-aarch64: the repro fails on unpatched `main` (8afcd4b45) and succeeds patched; `bun-workspaces.test.ts` 66/66, the duplicated-workspace test in `bun-install.test.ts` passes.

https://claude.ai/code/session_0115sRahrrJwnY1MUy5m4gYY
