### PR TITLE
bake: strip trailing separator from dev server root after process.chdir()

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -544,7 +544,8 @@ pub fn init(options: Options) -> JsResult<Box<DevServer>> {
         w!(magic, Magic::Valid);
         w!(
             root,
-            paths::string_paths::without_trailing_slash_windows_path(options.root.as_bytes()).into()
+            paths::string_paths::without_trailing_slash_windows_path(options.root.as_bytes())
+                .into()
         );
         w!(vm, bun_ptr::BackRef::new(options.vm));
         w!(server, None);

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -544,7 +544,7 @@ pub fn init(options: Options) -> JsResult<Box<DevServer>> {
         w!(magic, Magic::Valid);
         w!(
             root,
-            strings::without_trailing_slash(options.root.as_bytes()).into()
+            paths::string_paths::without_trailing_slash_windows_path(options.root.as_bytes()).into()
         );
         w!(vm, bun_ptr::BackRef::new(options.vm));
         w!(server, None);

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -542,7 +542,10 @@ pub fn init(options: Options) -> JsResult<Box<DevServer>> {
     // exactly once before `assume_init()` below.
     unsafe {
         w!(magic, Magic::Valid);
-        w!(root, Box::from(options.root.as_bytes()));
+        w!(
+            root,
+            strings::without_trailing_slash(options.root.as_bytes()).into()
+        );
         w!(vm, bun_ptr::BackRef::new(options.vm));
         w!(server, None);
         w!(directory_watchers, DirectoryWatchStore::default());

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1051,16 +1051,9 @@ impl ServerConfig {
                     // `UserOptions` (lives until `args.bake` is dropped).
                     let arena = bun_alloc::Arena::new();
 
-                    // `top_level_dir()` gains a trailing separator after a
-                    // runtime `process.chdir()` (set_process_cwd appends one),
-                    // but the boot-time value has none. DevServer::relative_path
-                    // asserts no trailing '/', so strip it here to match the
-                    // getcwd path in bake_body.rs.
                     let root = bb::arena_dupe_z(
                         &arena,
-                        strings::without_trailing_slash(
-                            bun_paths::fs::FileSystem::instance().top_level_dir(),
-                        ),
+                        bun_paths::fs::FileSystem::instance().top_level_dir(),
                     );
 
                     // Convert `crate::bake::FileSystemRouterType` (Cow-backed)

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1051,9 +1051,16 @@ impl ServerConfig {
                     // `UserOptions` (lives until `args.bake` is dropped).
                     let arena = bun_alloc::Arena::new();
 
+                    // `top_level_dir()` gains a trailing separator after a
+                    // runtime `process.chdir()` (set_process_cwd appends one),
+                    // but the boot-time value has none. DevServer::relative_path
+                    // asserts no trailing '/', so strip it here to match the
+                    // getcwd path in bake_body.rs.
                     let root = bb::arena_dupe_z(
                         &arena,
-                        bun_paths::fs::FileSystem::instance().top_level_dir(),
+                        strings::without_trailing_slash(
+                            bun_paths::fs::FileSystem::instance().top_level_dir(),
+                        ),
                     );
 
                     // Convert `crate::bake::FileSystemRouterType` (Cow-backed)

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1132,4 +1132,4 @@ test("dev server HTML route works after process.chdir() before Bun.serve", async
   expect(json).toBe(JSON.stringify({ status: 200, hasScript: true }));
   expect(stdout).toContain("DONE");
   expect(exitCode).toBe(0);
-}, 30_000);
+});

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1097,3 +1097,39 @@ describe("production headers and import.meta.env", () => {
     expect(a).not.toBe(b);
   });
 });
+
+test("dev server HTML route works after process.chdir() before Bun.serve", async () => {
+  // process.chdir() rewrites the cached top_level_dir with a trailing path
+  // separator; the bake dev server root sourced from it must be normalized
+  // so DevServer::relative_path's no-trailing-'/' invariant holds. Spawn a
+  // subprocess so the chdir is isolated from the test runner.
+  using dir = tempDir("bake-chdir-html", {
+    "index.html": `<!DOCTYPE html><html><body><script type="module" src="./app.ts"></script></body></html>`,
+    "app.ts": `console.log("hi");\n`,
+    "serve.ts": /*js*/ `
+      process.chdir(import.meta.dir);
+      const html = (await import("./index.html")).default;
+      const server = Bun.serve({ port: 0, development: true, routes: { "/": html } });
+      const res = await fetch(server.url);
+      const body = await res.text();
+      console.log(JSON.stringify({ status: res.status, hasScript: body.includes("<script") }));
+      await server.stop(true);
+      console.log("DONE");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "serve.ts"],
+    env: { ...bunEnv, NODE_ENV: undefined },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (exitCode !== 0) console.error({ stdout, stderr });
+  const json = stdout.split("\n").find(l => l.startsWith("{"));
+  expect(json).toBe(JSON.stringify({ status: 200, hasScript: true }));
+  expect(stdout).toContain("DONE");
+  expect(exitCode).toBe(0);
+}, 30_000);


### PR DESCRIPTION
## What

Debug/ASAN builds of bun abort with `panic: assertion failed: self.root[self.root.len() - 1] != b'/'` in `DevServer::relative_path` when a server entry calls `process.chdir()` before `Bun.serve({ development: true, routes: { "/": htmlImport } })` and the first request triggers a bundle.

## Repro

```ts
import { mkdtempSync, writeFileSync } from "fs";
import { tmpdir } from "os";
import { join } from "path";
const D = mkdtempSync(join(tmpdir(), "bake-chdir-"));
writeFileSync(join(D, "index.html"),
  `<!doctype html><html><body><script type="module" src="./app.ts"></script></body></html>`);
writeFileSync(join(D, "app.ts"), `console.log("hi");\n`);
process.chdir(D);
const html = (await import(join(D, "index.html"))).default;
const srv = Bun.serve({ port: 0, development: true, routes: { "/": html } });
await fetch(srv.url);   // panic on assert-enabled builds
await srv.stop(true);
```

```
panic: assertion failed: self.root[self.root.len() - 1] != b'/'
  <bun_runtime::bake::dev_server_body::DevServer>::relative_path  src/runtime/bake/DevServer.rs
  bun_runtime::bake::dev_server_body::finalize_bundle
```

Release builds silently fall through to the slow path in `relative_path` and serve normally; only debug/ASAN aborts.

## Cause

`set_process_cwd` (called by `process.chdir()`) re-appends a trailing `bun_paths::SEP` to `top_level_dir` after the `getcwd` round-trip. The boot-time `FileSystem::init` path stores `getcwd()` verbatim (no trailing separator). `ServerConfig` sources the bake dev-server root from `top_level_dir()` verbatim, so after any runtime chdir the root ends in `/` and the `debug_assert!(self.root[self.root.len() - 1] != b'/')` at the top of `DevServer::relative_path` fires on the first bundle.

## Fix

Strip the trailing separator in `DevServer::init` where `self.root` is assigned, so the no-trailing-`/` invariant holds regardless of which path supplied `options.root` (post-chdir `top_level_dir()`, boot-time cwd, or a user-supplied `root` ending in `/`). This matches the existing `abs_root` normalization a few lines further down.

## Verification

New test in `test/js/bun/http/bun-serve-html.test.ts` spawns a subprocess that `process.chdir()`s then serves an HTML route with `development: true` and self-fetches.

- Before: subprocess aborts with exit 134 and the panic above; test fails.
- After: subprocess serves 200 and exits 0; test passes in ~0.6s.
- `test/bake/dev/html.test.ts` still passes (10/10).

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.0 (276b26030)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_hNazqq {
  "/": "/tmp/html-css-js_hNazqq/index.html",
  "/dashboard": "/tmp/html-css-js_hNazqq/dashboard.html",
}
[0.11ms] bundle index.html 1.09 KB
[0.10ms] bundle dashboard.html 1.27 KB
(pass) serve html [657.05ms]
waitForServer /tmp/bun-serve-html-txt_RIdtHl {
  "/": "/tmp/bun-serve-html-txt_RIdtHl/index.html",
}
[0.15ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [546.95ms]
waitForServer /tmp/html-css-js-failing-plugin_FsCcES {
  "/": "/tmp/html-css-js-failing-plugin_FsCcES/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_FsCcES/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_FsCcES/styles.css:0
(pass) serve plugins > serve html with failing plugin [487.07ms]
waitForServer /tmp/html-css-js-empty-plugins_Dc1e7U {
  "/": "/tmp/html-css-js-empty-plugins_Dc1e7U/index.html",
}
[0.09ms] bu
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3f42be6ec)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_OUudo8 {
  "/": "/tmp/html-css-js_OUudo8/index.html",
  "/dashboard": "/tmp/html-css-js_OUudo8/dashboard.html",
}
[0.00ms] bundle index.html 1.09 KB
[0.00ms] bundle dashboard.html 1.27 KB
(pass) serve html [17.14ms]
waitForServer /tmp/bun-serve-html-txt_mdzVQs {
  "/": "/tmp/bun-serve-html-txt_mdzVQs/index.html",
}
[0.00ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [13.97ms]
waitForServer /tmp/html-css-js-failing-plugin_UHkrvK {
  "/": "/tmp/html-css-js-failing-plugin_UHkrvK/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_UHkrvK/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_UHkrvK/styles.css:0
(pass) serve plugins > serve html with failing plugin [13.21ms]
waitForServer /tmp/html-css-js-empty-plugins_kNMrcK {
  "/": "/tmp/html-css-js-empty-plugins_kNMrcK/index.html",
}
[0.00ms] bundle index.html 0.71 KB
(pass) serve plugins > empty plugin array [11.10ms]
Waiting for server
waitForServer /tmp/html-css-js-concurrent-plugins_SSxrJe {
  "/": "/tmp/
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.0 (276b26030)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_QIO3ZM {
  "/": "/tmp/html-css-js_QIO3ZM/index.html",
  "/dashboard": "/tmp/html-css-js_QIO3ZM/dashboard.html",
}
[0.12ms] bundle index.html 1.09 KB
[0.05ms] bundle dashboard.html 1.27 KB
(pass) serve html [617.24ms]
waitForServer /tmp/bun-serve-html-txt_TiVNgH {
  "/": "/tmp/bun-serve-html-txt_TiVNgH/index.html",
}
[0.16ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [551.43ms]
waitForServer /tmp/html-css-js-failing-plugin_zfH4LY {
  "/": "/tmp/html-css-js-failing-plugin_zfH4LY/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_zfH4LY/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_zfH4LY/styles.css:0
(pass) serve plugins > serve html with failing plugin [484.22ms]
waitForServer /tmp/html-css-js-empty-plugins_ral8Rc {
  "/": "/tmp/html-css-js-empty-plugins_ral8Rc/index.html",
}
[0.12ms] bu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 652ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/120] gen cpp.rs (cppbind)
[2/120] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/120] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/DevServer.rs           |  6 +++++-
 test/js/bun/http/bun-serve-html.test.ts | 36 +++++++++++++++++++++++++++++++++
 2 files changed, 41 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/bake/DevServer.rs                4      3      0
test/js/bun/http/bun-serve-html.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->