### PR TITLE
mock.module: re-throw factory errors on subsequent loads

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -490,9 +490,16 @@ JSObject* JSModuleMock::executeOnce(JSC::JSGlobalObject* lexicalGlobalObject)
 
     JSObject* callback = callbackValue.getObject();
     JSC::JSValue result = JSC::profiledCall(lexicalGlobalObject, ProfilingReason::API, callback, JSC::getCallData(callback), JSC::jsUndefined(), ArgList());
-    RETURN_IF_EXCEPTION(scope, {});
+    if (scope.exception()) [[unlikely]] {
+        // Don't cache a failed invocation: keep the callback so the next
+        // require()/import() re-invokes it and re-throws instead of silently
+        // returning the callback function as the module's exports.
+        hasCalledModuleMock = false;
+        return nullptr;
+    }
 
     if (!result.isObject()) {
+        hasCalledModuleMock = false;
         scope.throwException(lexicalGlobalObject, JSC::createTypeError(lexicalGlobalObject, "mock(module, fn) requires a function that returns an object"_s));
         return nullptr;
     }

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -491,9 +491,6 @@ JSObject* JSModuleMock::executeOnce(JSC::JSGlobalObject* lexicalGlobalObject)
     JSObject* callback = callbackValue.getObject();
     JSC::JSValue result = JSC::profiledCall(lexicalGlobalObject, ProfilingReason::API, callback, JSC::getCallData(callback), JSC::jsUndefined(), ArgList());
     if (scope.exception()) [[unlikely]] {
-        // Don't cache a failed invocation: keep the callback so the next
-        // require()/import() re-invokes it and re-throws instead of silently
-        // returning the callback function as the module's exports.
         hasCalledModuleMock = false;
         return nullptr;
     }

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -175,27 +175,36 @@ test("a factory that throws re-throws on every require()", () => {
   });
 
   expect(() => require("throwing-mock-factory-require")).toThrow("factory-boom");
-  // Previously the second require() returned an empty Module {} instead of throwing.
   expect(() => require("throwing-mock-factory-require")).toThrow("factory-boom");
   expect(() => require("throwing-mock-factory-require")).toThrow("factory-boom");
   expect(calls).toBe(3);
 });
 
 test("a factory that throws re-throws on every import()", async () => {
+  let calls = 0;
   mock.module("throwing-mock-factory-import", () => {
+    calls++;
     throw new Error("factory-boom");
   });
 
   await expect(import("throwing-mock-factory-import")).rejects.toThrow("factory-boom");
   await expect(import("throwing-mock-factory-import")).rejects.toThrow("factory-boom");
   expect(() => require("throwing-mock-factory-import")).toThrow("factory-boom");
+  expect(calls).toBe(3);
 });
 
-test("a factory returning a non-object re-throws on every load", () => {
-  mock.module("non-object-mock-factory", () => null as any);
+test("a factory returning a non-object re-throws on every load", async () => {
+  let calls = 0;
+  mock.module("non-object-mock-factory", () => {
+    calls++;
+    return null as any;
+  });
 
   expect(() => require("non-object-mock-factory")).toThrow("requires a function that returns an object");
   expect(() => require("non-object-mock-factory")).toThrow("requires a function that returns an object");
+  await expect(import("non-object-mock-factory")).rejects.toThrow("requires a function that returns an object");
+  await expect(import("non-object-mock-factory")).rejects.toThrow("requires a function that returns an object");
+  expect(calls).toBe(4);
 });
 
 test("a factory that throws once then succeeds is re-invoked", () => {

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -166,3 +166,49 @@ test("mocking a builtin", async () => {
   const { readFile } = await import("node:fs/promises");
   expect(await readFile("hello.txt", "utf8")).toBe("hello world");
 });
+
+test("a factory that throws re-throws on every require()", () => {
+  let calls = 0;
+  mock.module("throwing-mock-factory-require", () => {
+    calls++;
+    throw new Error("factory-boom");
+  });
+
+  expect(() => require("throwing-mock-factory-require")).toThrow("factory-boom");
+  // Previously the second require() returned an empty Module {} instead of throwing.
+  expect(() => require("throwing-mock-factory-require")).toThrow("factory-boom");
+  expect(() => require("throwing-mock-factory-require")).toThrow("factory-boom");
+  expect(calls).toBe(3);
+});
+
+test("a factory that throws re-throws on every import()", async () => {
+  mock.module("throwing-mock-factory-import", () => {
+    throw new Error("factory-boom");
+  });
+
+  await expect(import("throwing-mock-factory-import")).rejects.toThrow("factory-boom");
+  await expect(import("throwing-mock-factory-import")).rejects.toThrow("factory-boom");
+  expect(() => require("throwing-mock-factory-import")).toThrow("factory-boom");
+});
+
+test("a factory returning a non-object re-throws on every load", () => {
+  mock.module("non-object-mock-factory", () => null as any);
+
+  expect(() => require("non-object-mock-factory")).toThrow("requires a function that returns an object");
+  expect(() => require("non-object-mock-factory")).toThrow("requires a function that returns an object");
+});
+
+test("a factory that throws once then succeeds is re-invoked", () => {
+  let calls = 0;
+  mock.module("throw-once-mock-factory", () => {
+    calls++;
+    if (calls === 1) throw new Error("first-boom");
+    return { value: 42 };
+  });
+
+  expect(() => require("throw-once-mock-factory")).toThrow("first-boom");
+  expect(require("throw-once-mock-factory").value).toBe(42);
+  // Success is cached: no further factory calls.
+  expect(require("throw-once-mock-factory").value).toBe(42);
+  expect(calls).toBe(2);
+});


### PR DESCRIPTION
## Repro

```ts
import { test, mock } from "bun:test";
test("throwing factory", () => {
  mock.module("dep", () => { throw new Error("factory-boom"); });
  try { require("dep"); } catch (e) { console.log("1st:", e.message); } // "factory-boom"
  const m = require("dep");         // no throw
  console.log("2nd:", m);           // Module {}  (every export undefined)
});
```

The first `require()` throws `factory-boom`. Every subsequent `require()`/`import()` silently returns an empty `Module {}` instead of re-throwing, so code under test runs against an all-`undefined` dependency with no diagnostic.

## Cause

`JSModuleMock::executeOnce` sets `hasCalledModuleMock = true` before invoking the factory. When the factory throws (or returns a non-object), the function returns early via `RETURN_IF_EXCEPTION` with the flag already set and `callbackFunctionOrCachedResult` still holding the callback. On the next call the cached-result fast path returns the callback function itself; `generateObjectModuleSourceCode` then synthesizes a module from its own enumerable properties, of which an arrow function has none, yielding an empty `Module {}`.

## Fix

Reset `hasCalledModuleMock` on the throw and non-object return paths so later loads re-invoke the factory and re-throw. The flag is still set before the call, so the existing reentrancy guard for a factory that `require()`s itself is preserved.

## Verification

```
$ bun bd test test/js/bun/test/mock/mock-module.test.ts -t factory
(pass) a factory that throws re-throws on every require()
(pass) a factory that throws re-throws on every import()
(pass) a factory returning a non-object re-throws on every load
(pass) a factory that throws once then succeeds is re-invoked
```

All four fail on main with `Received value: Module {}`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.0 (283925800)

test/js/bun/test/mock/mock-module.test.ts:
(pass) mock.module async [21.28ms]
(pass) mock.restore [5.31ms]
(pass) spyOn [2.19ms]
(pass) mocking a module that points to a file which does not resolve successfully still works [7.19ms]
(pass) mocking a non-existant relative file with a file URL [16.16ms]
(pass) mocking a non-existant relative file [13.47ms]
(pass) mocking a local file [22.81ms]
(todo) adding a default on a module with no default
(pass) mocking a package [12.69ms]
(pass) mocking a builtin [15.21ms]
173 |     calls++;
174 |     throw new Error("factory-boom");
175 |   });
176 | 
177 |   expect(() => require("throwing-mock-factory-require")).toThrow("factory-boom");
178 |   expect(() => require("throwing-mock-factory-require")).toThrow("factory-boom");
                                                               ^
error: expect(received).toThrow(expected)

Expected substring: "factory-boom"

Received function did not throw
Received value: Module {}

    
... (truncated)

release without fix: 4 failed, 1 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/test/mock/mock-module.test.ts:
(pass) mock.module async [0.50ms]
(pass) mock.restore [0.56ms]
(pass) spyOn [0.03ms]
(pass) mocking a module that points to a file which does not resolve successfully still works [0.18ms]
(pass) mocking a non-existant relative file with a file URL [0.33ms]
(pass) mocking a non-existant relative file [0.23ms]
(pass) mocking a local file [0.33ms]
(todo) adding a default on a module with no default
(pass) mocking a package [0.24ms]
(pass) mocking a builtin [0.13ms]
173 |     calls++;
174 |     throw new Error("factory-boom");
175 |   });
176 | 
177 |   expect(() => require("throwing-mock-factory-require")).toThrow("factory-boom");
178 |   expect(() => require("throwing-mock-factory-require")).toThrow("factory-boom");
                                                               ^
error: expect(received).toThrow(expected)

Expected substring: "factory-boom"

Received function did not throw
Received value: Module {}

      at <anonymous> (/workspace/bun/test/js/bun/test/mock/mock-module.test.ts:178:58)
(fail) a factory that throws re-throws on every require() [0.30ms]
186 |     calls++;
187
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.0 (283925800)

test/js/bun/test/mock/mock-module.test.ts:
(pass) mock.module async [20.29ms]
(pass) mock.restore [5.39ms]
(pass) spyOn [2.24ms]
(pass) mocking a module that points to a file which does not resolve successfully still works [7.14ms]
(pass) mocking a non-existant relative file with a file URL [16.39ms]
(pass) mocking a non-existant relative file [13.08ms]
(pass) mocking a local file [22.77ms]
(todo) adding a default on a module with no default
(pass) mocking a package [12.46ms]
(pass) mocking a builtin [14.82ms]
(pass) a factory that throws re-throws on every require() [16.34ms]
(pass) a factory that throws re-throws on every import() [12.06ms]
(pass) a factory returning a non-object re-throws on every load [12.79ms]
(pass) a factory that throws once then succeeds is re-invoked [9.46ms]

 13 pass
 1 todo
 0 fail
 55 expect() calls
Ran 14 tests across 1 file. [2.38s]
__F:0:S:1

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 775ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/458] gen cpp.rs (cppbind)
[2/458] cxx obj/vendor/boringssl/crypto/trust_token/pmbtoken.cc.o
[3/458] cxx obj/vendor/boringssl/crypto/trust_token/voprf.cc.o
[4/458] cxx obj/vendor/boringssl/crypto/x509/a_sign.cc.o
[5/458] cxx obj/vendor/boringssl/crypto/x509/a_digest.cc.o
[6/458] cxx obj/vendor/boringssl/crypto/trust_token/trust_token.cc.o
[7/458] cxx obj/vendor/boringssl/crypto/x509/a_verify.cc.o
[8/458] cxx obj/vendor/boringssl/crypto/x509/algorithm.cc.o
[9/458] cxx obj/vendor/boringssl/crypto/x509/asn1_gen.cc.o
[10/458] cxx obj/vendor/boringssl/crypto/x509/name_print.cc.o
[11/458] cxx obj/vendor/boringssl/crypto/x509/i2d_pr.cc.o
[12/458] cxx obj/vendor/boringssl/crypto/x509/t_crl.cc.o
[13/458] cxx obj/vendor/boringssl/crypto/x509/by_file.cc.o
[14/458] cxx obj/vendor/boringssl/crypto/x509/by_dir.cc.o
[15/458] cxx obj/vendor/boringssl/crypto/x509/rsa_pss.cc.o
[16/458] cxx obj/vendor/boringssl/crypto/x509/t_req.cc.o
[17/458] cxx obj/vendor/boringssl/crypto/x509/t_x509.cc.o
[18/458] cxx obj/vendor/boringss
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunPlugin.cpp            |  6 +++-
 test/js/bun/test/mock/mock-module.test.ts | 55 +++++++++++++++++++++++++++++++
 2 files changed, 60 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/bindings/BunPlugin.cpp                 3      3      0
test/js/bun/test/mock/mock-module.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->