### PR TITLE
bun test: reset fake timers and setSystemTime between test files

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2883,6 +2883,10 @@ impl TestCommand {
             // raw-ptr escape so the closure does not hold a borrowck lock on
             // it for the loop body.
             scopeguard::defer! { unsafe { (*bun_test_root_ptr).exit_file(); } }
+            let global = vm.global();
+            scopeguard::defer! {
+                crate::test_runner::timers::fake_timers::reset_between_files(global);
+            }
 
             // SAFETY: `set()` reads only `reporter.{worker_ipc_file_idx, reporters}`
             // and writes only `current_file` — disjoint fields. Fresh raw-ptr

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -312,6 +312,31 @@ impl FakeTimers {
     }
 }
 
+fn drain_to_real_timers(global: &JSGlobalObject) -> JsResult<()> {
+    // SAFETY: per-thread `timer::All`; the borrow ends before `release`.
+    let cleared = unsafe { (*timer_all()).fake_timers.deactivate(global) };
+    cleared.release(global.bun_vm_ptr());
+    set_fake_timer_marker(global, false)
+}
+
+/// Restore real timers and the real clock at a test-file boundary.
+pub(crate) fn reset_between_files(global: &JSGlobalObject) {
+    let all = timer_all();
+    if all.is_null() {
+        return;
+    }
+    // SAFETY: `timer_all()` is the live per-thread `All`; single JS thread.
+    if unsafe { (*all).fake_timers.is_active() } {
+        // Not a host_fn: nothing above us takes a thrown marker error.
+        if drain_to_real_timers(global).is_err() {
+            let _ = global.clear_exception_except_termination();
+        }
+    } else {
+        // `setSystemTime()` writes `overridenDateNow` without activating fake timers.
+        CURRENT_TIME.clear(global);
+    }
+}
+
 // ===
 // JS Functions
 // ===
@@ -396,13 +421,7 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
 
 #[bun_jsc::host_fn]
 fn use_real_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-    // SAFETY: per-thread `timer::All`; the borrow ends before `release`.
-    let cleared = unsafe { (*timer_all()).fake_timers.deactivate(global) };
-    cleared.release(global.bun_vm_ptr());
-
-    // Remove the setTimeout.clock marker when switching back to real timers.
-    set_fake_timer_marker(global, false)?;
-
+    drain_to_real_timers(global)?;
     Ok(frame.this())
 }
 

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -1,7 +1,7 @@
 import { RedisClient, SQL } from "bun";
 import { heapStats } from "bun:jsc";
 import { setSystemTime } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { spawnSync as childProcessSpawnSync } from "node:child_process";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
@@ -777,5 +777,95 @@ describe("useFakeTimers with options", () => {
     expect(vi.isFakeTimers()).toBe(false);
     expect(performance.timeOrigin).toBe(realTimeOrigin);
     expect(performance.toJSON().timeOrigin).toBe(realTimeOrigin);
+  });
+});
+
+// A file that activates fake timers or setSystemTime and never restores them
+// must not leak that state into the next file: the fake-timer flag and mocked
+// clock live in per-thread runner state, so without an explicit reset the next
+// file's real `await setTimeout` never fires (misattributed timeout) and
+// `Date.now()` stays pinned. Jest gives each file its own fake-timer env.
+// (`--isolate` is covered in test/cli/test/isolation.test.ts.)
+describe.concurrent("fake timers / setSystemTime do not leak across test files", () => {
+  const leakFixtures = {
+    "a_faketimers.test.ts": `
+      import { test, jest, setSystemTime } from "bun:test";
+      test("A leaks fake timers + setSystemTime", () => {
+        jest.useFakeTimers();
+        setSystemTime(new Date("1999-12-31T23:59:59Z"));
+        setTimeout(() => {}, 1000);
+      });
+    `,
+    "b_real.test.ts": `
+      import { test, expect, vi } from "bun:test";
+      test("B expects real timers and real clock", async () => {
+        // Assert the flag first so a leak fails fast instead of waiting on a
+        // real setTimeout that would never fire.
+        expect(vi.isFakeTimers()).toBe(false);
+        expect(typeof (setTimeout as any).clock).toBe("undefined");
+        expect(new Date().getFullYear()).toBeGreaterThan(2000);
+        let fired = false;
+        await new Promise<void>(r => setTimeout(() => { fired = true; r(); }, 1));
+        expect(fired).toBe(true);
+      });
+    `,
+  };
+
+  async function run(dir: string, files: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", ...files],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("useFakeTimers() + setSystemTime() are reset before next file", async () => {
+    using dir = tempDir("fake-timers-cross-file", leakFixtures);
+    const { stderr, exitCode } = await run(String(dir), ["./a_faketimers.test.ts", "./b_real.test.ts"]);
+    const norm = normalizeBunSnapshot(stderr, dir);
+    expect(norm).toContain("2 pass");
+    expect(norm).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("setSystemTime() without useFakeTimers() is reset before next file", async () => {
+    using dir = tempDir("setsystemtime-cross-file", {
+      "a_sys.test.ts": `
+        import { test, setSystemTime } from "bun:test";
+        test("A pins Date", () => { setSystemTime(new Date("1999-12-31T23:59:59Z")); });
+      `,
+      "b_real.test.ts": `
+        import { test, expect } from "bun:test";
+        test("B sees real Date", () => {
+          expect(new Date().getFullYear()).toBeGreaterThan(2000);
+        });
+      `,
+    });
+    const { stderr, exitCode } = await run(String(dir), ["./a_sys.test.ts", "./b_real.test.ts"]);
+    const norm = normalizeBunSnapshot(stderr, dir);
+    expect(norm).toContain("2 pass");
+    expect(norm).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("file that calls useFakeTimers() at module scope and throws does not leak into next file", async () => {
+    using dir = tempDir("fake-timers-module-throw", {
+      "a_throws.test.ts": `
+        import { jest, setSystemTime } from "bun:test";
+        jest.useFakeTimers();
+        setSystemTime(new Date("1999-12-31T23:59:59Z"));
+        throw new Error("module-scope boom");
+      `,
+      "b_real.test.ts": leakFixtures["b_real.test.ts"],
+    });
+    const { stderr, exitCode } = await run(String(dir), ["./a_throws.test.ts", "./b_real.test.ts"]);
+    const norm = normalizeBunSnapshot(stderr, dir);
+    expect(norm).toContain("(pass) B expects real timers and real clock");
+    expect(norm).toContain("module-scope boom");
+    expect(exitCode).not.toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- A test file that calls `jest.useFakeTimers()` or `setSystemTime()` and never restores them leaks that state into every later file in a plain `bun test` run (no `--isolate`). The next file's real `await setTimeout(...)` never fires and the test times out, charged to the wrong file; `Date.now()` stays pinned (`1999`).
- `FakeTimers::active` and the `CURRENT_TIME` clock override live in the per-thread `timer::All` / a static (`src/runtime/test_runner/timers/FakeTimers.rs`), not on the JS global. #36385 resets them at the `--isolate` global swap; the plain sequential path (`TestCommand::run`, `src/runtime/cli/test_command.rs`) had no equivalent.

### Fix
- `reset_between_files()` runs from a `scopeguard::defer!` next to `exit_file()` in `TestCommand::run`, so every exit path from a file (including a module-scope throw that returns early) restores real timers and the real clock before the next file loads.
- If fake timers are active it runs the same drain as `useRealTimers()` (shared `drain_to_real_timers()` helper: deactivate, release heap pins, delete `setTimeout.clock`); otherwise it only clears the clock override so a bare `setSystemTime()` does not bleed through. A non-termination exception from the marker delete is cleared since there is no host call above the defer.
- Correct because Jest gives each file its own fake-timer environment, and the drain is the one `useRealTimers()` already runs from user code. Under `--isolate` the later `reset_for_isolation()` finds fake timers inactive and is a no-op.
- Verified: `test/js/bun/test/fake-timers/fake-timers.test.ts` (three new cases, all fail on 1.4.2). Also `test/cli/test/isolation.test.ts`, `test/js/bun/test/test-timers.test.ts`, and the sinonjs suites under `BUN_JSC_validateExceptionChecks=1`.

### Background
- `timer::All` is the per-thread timer heap. `All::insert` routes a new `setTimeout` into `fake_timers.timers` whenever `fake_timers.active` is set; that heap only advances on `advanceTimersByTime` and friends.
- `CURRENT_TIME` holds the mocked monotonic offset and `Date.now()` offset; `CurrentTime::clear` resets `overridenDateNow` to its NaN "no override" sentinel and `performance.now()`/`timeOrigin` to real.
- `TestCommand::run` is the per-file entry for plain, `--isolate`, and `--parallel` workers, so one defer covers all three.

Fixes #13173

<details><summary>Notes</summary>

- Rebased onto main after #36385 merged. The earlier revision of this PR also reset at the boundary under `--isolate`; that is now #36385's `reset_for_isolation()` in `stop_active_handles`, and this PR only adds the path that plain `bun test` was missing. The `--isolate` row was dropped from the new test matrix since `isolation.test.ts` covers it.
- Not covered here (tracked separately): a `useFakeTimers()` that runs from a continuation of leaked async work after the boundary (`Bun.password.hash(...).then(() => jest.useFakeTimers())`) activates inside the next file. A boundary reset cannot see a future activation; under `--isolate` the activation arrives on the previous file's global and could be refused there, but in plain mode it is indistinguishable from the current file's own call.
- Review history on the pre-rebase revision: moved the reset into a defer so the `Status::Rejected` early return is covered; extracted the shared drain helper; preserve a pending `TerminationException` when swallowing the marker error.

</details>