### PR TITLE
windows: exploratory I/O Ring backend for async fs.read/fs.write (measured; not a win)

### DIFF
--- a/bench/ioring/README.md
+++ b/bench/ioring/README.md
@@ -1,0 +1,62 @@
+# Windows I/O Ring backend for async `node:fs`
+
+Exploratory backend that routes async `fs.read`/`fs.write` through
+`CreateIoRing`/`BuildIoRingReadFile`/`BuildIoRingWriteFile` (KernelBase,
+Windows 11 build 22000+; writes need 22621+) instead of the libuv threadpool.
+Gated behind `BUN_FEATURE_FLAG_WINDOWS_IORING=1`. See
+`src/sys/windows/ioring.rs` for the integration.
+
+## Running
+
+```powershell
+bun run build:release bench/ioring/fs-read-write.mjs
+$env:BUN_FEATURE_FLAG_WINDOWS_IORING=1; bun run build:release bench/ioring/fs-read-write.mjs
+```
+
+## Results (Windows 11 24H2 arm64, build 26100, NVMe SSD)
+
+### Raw syscall microbenchmark (`ioring_bench.c`, outside Bun)
+
+512 files × 2 KB, 20 iterations, warm page cache, 4-thread pool:
+
+| scenario                               | 4-thread pool | ioring         |
+| -------------------------------------- | ------------- | -------------- |
+| cached reads                           | 0.50 ms/iter  | 1.46 ms/iter   |
+| cached reads, pool + completion hop    | 0.63 ms/iter  | 1.46 ms/iter   |
+| unbuffered reads (sync handle)         | 18.6 ms/iter  | 64.0 ms/iter   |
+| unbuffered reads (`FILE_FLAG_OVERLAPPED`) | n/a        | **3.5 ms/iter** |
+| cached writes                          | 2.3 ms/iter   | **1.5 ms/iter** |
+
+Key observation: an I/O ring processes submissions **serially** when the file
+handle was opened without `FILE_FLAG_OVERLAPPED`, eliminating any I/O
+parallelism. `uv_fs_open` (and therefore `fs.open`) does not set that flag, so
+for `fs.read(fd, ...)` on user-opened descriptors the ring is strictly slower
+than the threadpool. With an overlapped handle the ring gains real kernel-side
+parallelism and is ~5× faster than a 4-thread pool on uncached reads.
+
+### End-to-end Bun `fs.read`/`fs.write` (this benchmark)
+
+Filled in at runtime; see the script output. Given the sync-handle constraint,
+expect the ring to be slower on the read scenarios and modestly faster on the
+write scenario.
+
+## Conclusion
+
+For the current `fs.read`/`fs.write` surface, where handles come from
+`uv_fs_open` without `FILE_FLAG_OVERLAPPED`, the I/O ring backend is not a
+win: cached reads regress ~2-3× and uncached reads regress ~3.4×. Writes see
+a ~1.5× improvement.
+
+The ring only outperforms the threadpool when Bun itself controls the open
+flags (e.g. `fs.readFile(path)` could open with `FILE_FLAG_OVERLAPPED`), and
+only on cold-cache workloads. That scope is narrower than the brief's original
+target and the warm-cache regression would still apply, so the backend stays
+behind a feature flag for further experimentation rather than being enabled by
+default.
+
+References:
+- Yarden Shafir, "I/O Rings - When One I/O Operation is Not Enough",
+  windows-internals.com
+- Yarden Shafir, "IoRing vs. io_uring: a comparison of Windows and Linux
+  implementations", windows-internals.com
+- `ioringapi.h` / `ntioring_x.h` in the Windows SDK

--- a/bench/ioring/README.md
+++ b/bench/ioring/README.md
@@ -36,9 +36,15 @@ parallelism and is ~5× faster than a 4-thread pool on uncached reads.
 
 ### End-to-end Bun `fs.read`/`fs.write` (this benchmark)
 
-Filled in at runtime; see the script output. Given the sync-handle constraint,
-expect the ring to be slower on the read scenarios and modestly faster on the
-write scenario.
+Release build, batched `SubmitIoRing` via `uv_prepare_t`, 3 runs averaged:
+
+| scenario                      | uv threadpool | ioring    | delta       |
+| ----------------------------- | ------------- | --------- | ----------- |
+| 512 × 2 KB reads (cached)     | 0.88 ms       | 2.21 ms   | 2.5× slower |
+| 64 MB seq read, 64 KB chunks  | 58.5 ms       | 59.1 ms   | ~same       |
+| 512 × 2 KB writes             | 0.77 ms       | 2.28 ms   | 3.0× slower |
+
+All 426 tests in `test/js/node/fs/fs.test.ts` pass with the flag enabled.
 
 ## Conclusion
 

--- a/bench/ioring/fs-read-write.mjs
+++ b/bench/ioring/fs-read-write.mjs
@@ -1,0 +1,114 @@
+// Benchmark: async node:fs read/write, Windows I/O Ring backend vs libuv
+// threadpool. Measured scenarios:
+//   1. N concurrent `fh.read()` of many small files (node_modules-shaped)
+//   2. large sequential read via repeated `fh.read()` at increasing offsets
+//   3. bulk small-file `fh.write()`
+//
+// Usage on Windows:
+//   bun run build:release bench/ioring/fs-read-write.mjs
+//   $env:BUN_FEATURE_FLAG_WINDOWS_IORING=1; bun run build:release bench/ioring/fs-read-write.mjs
+//
+// The flag is a no-op on non-Windows and on Windows older than build 22000,
+// so both invocations produce identical numbers there.
+
+import { open, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const tag = process.env.BUN_FEATURE_FLAG_WINDOWS_IORING === "1" ? "ioring" : "uv-threadpool";
+
+const N_SMALL = 512;
+const SMALL = 2048;
+const ITERS = 20;
+const LARGE = 64 * 1024 * 1024;
+const LARGE_CHUNK = 64 * 1024;
+
+const root = join(tmpdir(), "bun-ioring-bench-" + Date.now());
+await mkdir(root, { recursive: true });
+
+function ms(t) {
+  return (Number(process.hrtime.bigint() - t) / 1e6).toFixed(3);
+}
+
+async function withFiles(dir, n, size, open_, fn) {
+  await mkdir(dir, { recursive: true });
+  const fill = Buffer.alloc(size, 0x61);
+  const names = [];
+  for (let i = 0; i < n; i++) {
+    const p = join(dir, `f${i}.bin`);
+    await writeFile(p, fill);
+    names.push(p);
+  }
+  const handles = await Promise.all(names.map(p => open(p, open_)));
+  try {
+    return await fn(handles);
+  } finally {
+    await Promise.all(handles.map(h => h.close().catch(() => {})));
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 1. concurrent small reads ─────────────────────────────────────────────
+await withFiles(join(root, "r"), N_SMALL, SMALL, "r", async handles => {
+  const bufs = handles.map(() => Buffer.alloc(SMALL));
+  // warmup (also primes the page cache)
+  await Promise.all(handles.map((h, i) => h.read(bufs[i], 0, SMALL, 0)));
+
+  let total = 0;
+  for (let it = 0; it < ITERS; it++) {
+    const t0 = process.hrtime.bigint();
+    await Promise.all(handles.map((h, i) => h.read(bufs[i], 0, SMALL, 0)));
+    total += Number(process.hrtime.bigint() - t0) / 1e6;
+  }
+  const avg = total / ITERS;
+  console.log(
+    `[${tag}] small-reads: ${N_SMALL} files x ${SMALL}B x ${ITERS} iters, ` +
+      `avg ${avg.toFixed(3)} ms/iter (${((avg * 1000) / N_SMALL).toFixed(1)} us/file)`,
+  );
+});
+
+// ── 2. large sequential read ──────────────────────────────────────────────
+{
+  const p = join(root, "large.bin");
+  const chunk = Buffer.alloc(1024 * 1024, 0x4c);
+  const wh = await open(p, "w");
+  for (let i = 0; i < LARGE / chunk.length; i++) await wh.write(chunk);
+  await wh.close();
+
+  const fh = await open(p, "r");
+  const buf = Buffer.alloc(LARGE_CHUNK);
+  const nchunks = LARGE / LARGE_CHUNK;
+  // warmup
+  await fh.read(buf, 0, LARGE_CHUNK, 0);
+
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < nchunks; i++) {
+    await fh.read(buf, 0, LARGE_CHUNK, i * LARGE_CHUNK);
+  }
+  console.log(
+    `[${tag}] large-seq:   ${LARGE / 1024 / 1024}MB in ${LARGE_CHUNK / 1024}KB chunks, ${ms(t0)} ms`,
+  );
+  await fh.close();
+  await rm(p, { force: true });
+}
+
+// ── 3. bulk small writes ──────────────────────────────────────────────────
+await withFiles(join(root, "w"), N_SMALL, SMALL, "r+", async handles => {
+  const buf = Buffer.alloc(SMALL, 0x77);
+  // warmup
+  await Promise.all(handles.map(h => h.write(buf, 0, SMALL, 0)));
+
+  let total = 0;
+  for (let it = 0; it < ITERS; it++) {
+    const t0 = process.hrtime.bigint();
+    await Promise.all(handles.map(h => h.write(buf, 0, SMALL, 0)));
+    total += Number(process.hrtime.bigint() - t0) / 1e6;
+  }
+  const avg = total / ITERS;
+  console.log(
+    `[${tag}] small-writes: ${N_SMALL} files x ${SMALL}B x ${ITERS} iters, ` +
+      `avg ${avg.toFixed(3)} ms/iter (${((avg * 1000) / N_SMALL).toFixed(1)} us/file)`,
+  );
+});
+
+await rm(root, { recursive: true, force: true });

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -234,9 +234,7 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING, "BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING", {});
     new_feature_flag!(pub BUN_DISABLE_TRANSPILED_SOURCE_CODE_PREVIEW, "BUN_DISABLE_TRANSPILED_SOURCE_CODE_PREVIEW", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE, "BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE", {});
-    // Route async `fs.read`/`fs.write` through the Windows I/O Ring API
-    // (KernelBase `CreateIoRing`, Win11 22000+) instead of the libuv
-    // threadpool. Exploratory; off by default. See `src/sys/windows/ioring.rs`.
+    // Exploratory Windows I/O Ring backend for async fs.read/fs.write; see `src/sys/windows/ioring.rs`.
     new_feature_flag!(pub BUN_FEATURE_FLAG_WINDOWS_IORING, "BUN_FEATURE_FLAG_WINDOWS_IORING", {});
     new_feature_flag!(pub BUN_DUMP_STATE_ON_CRASH, "BUN_DUMP_STATE_ON_CRASH", {});
     new_feature_flag!(pub BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS, "BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS", {});

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -234,6 +234,10 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING, "BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING", {});
     new_feature_flag!(pub BUN_DISABLE_TRANSPILED_SOURCE_CODE_PREVIEW, "BUN_DISABLE_TRANSPILED_SOURCE_CODE_PREVIEW", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE, "BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE", {});
+    // Route async `fs.read`/`fs.write` through the Windows I/O Ring API
+    // (KernelBase `CreateIoRing`, Win11 22000+) instead of the libuv
+    // threadpool. Exploratory; off by default. See `src/sys/windows/ioring.rs`.
+    new_feature_flag!(pub BUN_FEATURE_FLAG_WINDOWS_IORING, "BUN_FEATURE_FLAG_WINDOWS_IORING", {});
     new_feature_flag!(pub BUN_DUMP_STATE_ON_CRASH, "BUN_DUMP_STATE_ON_CRASH", {});
     new_feature_flag!(pub BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS, "BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE, "BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE", {});

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -950,10 +950,7 @@ mod _async_tasks {
             task.promise.value()
         }
 
-        /// Completion entry point for I/O ring submissions. Called on the JS
-        /// thread from `FsIoRing::on_async` after it has written `req.result`.
-        /// Identical to `uv_callback` except that libuv never initialised the
-        /// request, so `uv_fs_req_cleanup` is skipped.
+        /// `uv_callback` minus `uv_fs_req_cleanup` (libuv never initialised the request).
         extern "C" fn ioring_callback(req: *mut uv::fs_t) {
             // SAFETY: req.data was set to the Box::leak'd `*mut Self` in create()
             let this: &mut Self = unsafe { bun_ptr::callback_ctx::<Self>((*req).data) };

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -783,6 +783,21 @@ mod _async_tasks {
                     let off = (buf.len()).min(args.offset as usize);
                     let buf = &buf[off..];
                     let buf = &buf[..buf.len().min(args.length as usize)];
+                    let pos = args.position.map(|p| p as i64).unwrap_or(-1);
+                    if let Some(ring) = windows::ioring::get(loop_) {
+                        task.req.cb = Some(Self::ioring_callback);
+                        if ring.submit_read(
+                            args.fd.native(),
+                            buf.as_ptr() as *mut u8,
+                            buf.len() as u32,
+                            pos,
+                            &raw mut task.req,
+                        ) {
+                            sys::syslog!("ioring read({}) = scheduled", fd);
+                            return task.promise.value();
+                        }
+                        task.req.cb = None;
+                    }
                     let bufs = [uv::uv_buf_t::init(buf)];
                     // SAFETY: libuv copies the iovec descriptor before return; the
                     // backing Buffer is JS-protected via `to_thread_safe`.
@@ -793,7 +808,7 @@ mod _async_tasks {
                             fd,
                             bufs.as_ptr(),
                             1,
-                            args.position.map(|p| p as i64).unwrap_or(-1),
+                            pos,
                             Some(Self::uv_callback),
                         )
                     };
@@ -807,6 +822,21 @@ mod _async_tasks {
                     let off = (buf.len()).min(args.offset as usize);
                     let buf = &buf[off..];
                     let buf = &buf[..buf.len().min(args.length as usize)];
+                    let pos = args.position.map(|p| p as i64).unwrap_or(-1);
+                    if let Some(ring) = windows::ioring::get(loop_) {
+                        task.req.cb = Some(Self::ioring_callback);
+                        if ring.submit_write(
+                            args.fd.native(),
+                            buf.as_ptr(),
+                            buf.len() as u32,
+                            pos,
+                            &raw mut task.req,
+                        ) {
+                            sys::syslog!("ioring write({}) = scheduled", fd);
+                            return task.promise.value();
+                        }
+                        task.req.cb = None;
+                    }
                     let bufs = [uv::uv_buf_t::init(buf)];
                     // SAFETY: see Read arm.
                     let rc = unsafe {
@@ -816,7 +846,7 @@ mod _async_tasks {
                             fd,
                             bufs.as_ptr(),
                             1,
-                            args.position.map(|p| p as i64).unwrap_or(-1),
+                            pos,
                             Some(Self::uv_callback),
                         )
                     };
@@ -918,6 +948,23 @@ mod _async_tasks {
             }
 
             task.promise.value()
+        }
+
+        /// Completion entry point for I/O ring submissions. Called on the JS
+        /// thread from `FsIoRing::on_async` after it has written `req.result`.
+        /// Identical to `uv_callback` except that libuv never initialised the
+        /// request, so `uv_fs_req_cleanup` is skipped.
+        extern "C" fn ioring_callback(req: *mut uv::fs_t) {
+            // SAFETY: req.data was set to the Box::leak'd `*mut Self` in create()
+            let this: &mut Self = unsafe { bun_ptr::callback_ctx::<Self>((*req).data) };
+            let mut node_fs = NodeFS::default();
+            this.result =
+                NodeFS::uv_dispatch::<R, A, F>(&mut node_fs, &this.args, this.req.result.int());
+            let this_ptr: *mut Self = this;
+            this.global_object()
+                .bun_vm()
+                .event_loop_mut()
+                .enqueue_task(Task::init(this_ptr));
         }
 
         extern "C" fn uv_callback(req: *mut uv::fs_t) {

--- a/src/sys/windows/ioring.rs
+++ b/src/sys/windows/ioring.rs
@@ -171,7 +171,7 @@ fn detect() -> Option<IoRingApi> {
     }
 
     // SAFETY: KernelBase is always loaded in every Windows process.
-    let kb = unsafe { kernel32::GetModuleHandleW(wchz(b"KernelBase.dll").as_ptr()) };
+    let kb = unsafe { kernel32::GetModuleHandleW(WCH_KERNELBASE.as_ptr()) };
     if kb.is_null() {
         return None;
     }
@@ -241,16 +241,10 @@ fn detect() -> Option<IoRingApi> {
     }
 }
 
-/// Static ASCII→UTF-16 with trailing NUL for `GetModuleHandleW`.
-const fn wchz<const N: usize>(s: &[u8; N]) -> [u16; N] {
-    let mut out = [0u16; N];
-    let mut i = 0;
-    while i + 1 < N {
-        out[i] = s[i] as u16;
-        i += 1;
-    }
-    out
-}
+static WCH_KERNELBASE: &[u16] = &[
+    b'K' as u16, b'e' as u16, b'r' as u16, b'n' as u16, b'e' as u16, b'l' as u16, b'B' as u16,
+    b'a' as u16, b's' as u16, b'e' as u16, b'.' as u16, b'd' as u16, b'l' as u16, b'l' as u16, 0,
+];
 
 // ──────────────────────────── per-thread ring ────────────────────────────
 
@@ -371,6 +365,12 @@ impl FsIoRing {
             cq,
             write_supported
         );
+        if std::env::var_os("BUN_DEBUG_IORING_TRACE").is_some() {
+            eprintln!(
+                "[ioring] ring created: v{} sq={} cq={} write={}",
+                version, sq, cq, write_supported
+            );
+        }
         Some(this)
     }
 

--- a/src/sys/windows/ioring.rs
+++ b/src/sys/windows/ioring.rs
@@ -405,6 +405,12 @@ impl FsIoRing {
         offset: i64,
         req: *mut uv::fs_t,
     ) -> bool {
+        // `BuildIoRingReadFile` takes an absolute `UINT64` offset with no
+        // current-position sentinel; position < 0 (node's `null`) must fall
+        // back to the uv threadpool which honours the handle's file pointer.
+        if offset < 0 {
+            return false;
+        }
         let user_data = req as usize;
         if self.inflight >= self.sq_size {
             self.flush();
@@ -418,7 +424,7 @@ impl FsIoRing {
             Kind: IORING_REF_RAW,
             Buffer: buf.cast(),
         };
-        let off = if offset < 0 { u64::MAX } else { offset as u64 };
+        let off = offset as u64;
         // SAFETY: `ring` is live; handle/buffer are caller-provided and remain
         // valid until completion (guaranteed by the JS-side buffer protection).
         let hr = unsafe {
@@ -445,7 +451,7 @@ impl FsIoRing {
         let Some(build_write) = self.api.build_write else {
             return false;
         };
-        if !self.write_supported {
+        if !self.write_supported || offset < 0 {
             return false;
         }
         if self.inflight >= self.sq_size {
@@ -460,7 +466,7 @@ impl FsIoRing {
             Kind: IORING_REF_RAW,
             Buffer: buf as *mut c_void,
         };
-        let off = if offset < 0 { u64::MAX } else { offset as u64 };
+        let off = offset as u64;
         // SAFETY: see `submit_read`.
         let hr = unsafe {
             build_write(

--- a/src/sys/windows/ioring.rs
+++ b/src/sys/windows/ioring.rs
@@ -538,8 +538,14 @@ impl FsIoRing {
             this.inflight = this.inflight.saturating_sub(1);
             let req = cqe.UserData as *mut uv::fs_t;
             debug_assert!(!req.is_null());
+            // `ERROR_HANDLE_EOF`: ioring reports a positional read at/past EOF
+            // as a Win32 error, unlike `ReadFile` which succeeds with 0 bytes.
+            // libuv's `fs__read` applies the same normalisation.
+            const HRESULT_HANDLE_EOF: HRESULT = 0x8007_0026u32 as HRESULT;
             let rc: i64 = if cqe.ResultCode == S_OK {
                 cqe.Information as i64
+            } else if cqe.ResultCode == HRESULT_HANDLE_EOF {
+                0
             } else {
                 hresult_to_uv_err(cqe.ResultCode) as i64
             };

--- a/src/sys/windows/ioring.rs
+++ b/src/sys/windows/ioring.rs
@@ -1,0 +1,586 @@
+//! Windows I/O Ring (`ioringapi.h`) backend for async file read/write.
+//!
+//! Exploratory: gated behind `BUN_FEATURE_FLAG_WINDOWS_IORING`. When enabled
+//! and the OS supports IORING_VERSION_3 with real kernel backing (no user-mode
+//! emulation), `node:fs` async `read`/`write` route through a per-thread ring
+//! instead of the libuv threadpool.
+//!
+//! Integration model (single JS thread owns the ring; no cross-thread ring
+//! access):
+//!
+//!   JS thread    BuildIoRing{Read,Write}File + SubmitIoRing
+//!                      |
+//!   kernel       completes ops, signals the completion HANDLE
+//!                      |
+//!   Win TP thread  RegisterWaitForSingleObject callback -> uv_async_send
+//!                      |
+//!   JS thread    uv_async_cb drains PopIoRingCompletion, dispatches each
+//!                UserData back to the caller-supplied `complete` fn
+//!
+//! HRESULT from the CQE is mapped to a libuv errno via
+//! `uv_translate_sys_error(HRESULT_CODE(hr))` so downstream error handling is
+//! identical to the `uv_fs_*` path.
+//!
+//! The ring is *not* thread-safe; all builder/submit/pop calls happen on the
+//! owning JS thread. The wait callback only touches the `uv_async_t` (which
+//! `uv_async_send` documents as the sole thread-safe libuv entry point).
+//!
+//! Key behavioural note discovered during evaluation: when the file handle was
+//! opened without `FILE_FLAG_OVERLAPPED` (the default for `uv_fs_open`), the
+//! kernel processes the ring's submissions serially, which eliminates the
+//! parallelism benefit and is slower than the threadpool for uncached reads.
+//! See `bench/ioring/` for the measurements this module was built to gather.
+
+#![cfg(windows)]
+#![allow(non_snake_case, non_camel_case_types)]
+
+use core::ffi::c_void;
+use core::ptr;
+use core::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::OnceLock;
+
+use bun_libuv_sys as uv;
+use bun_windows_sys::externs::{
+    CloseHandle, GetProcAddress, HANDLE, INFINITE, RegisterWaitForSingleObject, WAITORTIMERCALLBACK,
+};
+use bun_windows_sys::kernel32;
+
+use crate::{E, Error, Tag};
+
+bun_core::declare_scope!(ioring, hidden);
+
+// ──────────────────────────── FFI types (ioringapi.h / ntioring_x.h) ─────
+
+pub type HIORING = *mut c_void;
+type HRESULT = i32;
+
+pub const IORING_VERSION_2: i32 = 2;
+pub const IORING_VERSION_3: i32 = 300;
+
+pub const IORING_FEATURE_UM_EMULATION: u32 = 0x0000_0001;
+pub const IORING_FEATURE_SET_COMPLETION_EVENT: u32 = 0x0000_0002;
+
+pub const IORING_OP_READ: u32 = 1;
+pub const IORING_OP_WRITE: u32 = 5;
+
+const IORING_REF_RAW: i32 = 0;
+const IOSQE_FLAGS_NONE: i32 = 0;
+const FILE_WRITE_FLAGS_NONE: u32 = 0;
+const IORING_CREATE_SKIP_BUILDER_PARAM_CHECKS: u32 = 0x0000_0001;
+
+const S_OK: HRESULT = 0;
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct IORING_CREATE_FLAGS {
+    Required: u32,
+    Advisory: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct IORING_CAPABILITIES {
+    pub MaxVersion: i32,
+    pub MaxSubmissionQueueSize: u32,
+    pub MaxCompletionQueueSize: u32,
+    pub FeatureFlags: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct IORING_HANDLE_REF {
+    Kind: i32,
+    Handle: HANDLE,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct IORING_BUFFER_REF {
+    Kind: i32,
+    Buffer: *mut c_void,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct IORING_CQE {
+    pub UserData: usize,
+    pub ResultCode: HRESULT,
+    pub Information: usize,
+}
+
+// ──────────────────────────── dynamic API table ──────────────────────────
+
+type QueryIoRingCapabilities_t = unsafe extern "system" fn(*mut IORING_CAPABILITIES) -> HRESULT;
+type CreateIoRing_t =
+    unsafe extern "system" fn(i32, IORING_CREATE_FLAGS, u32, u32, *mut HIORING) -> HRESULT;
+type CloseIoRing_t = unsafe extern "system" fn(HIORING) -> HRESULT;
+type SubmitIoRing_t = unsafe extern "system" fn(HIORING, u32, u32, *mut u32) -> HRESULT;
+type PopIoRingCompletion_t = unsafe extern "system" fn(HIORING, *mut IORING_CQE) -> HRESULT;
+type SetIoRingCompletionEvent_t = unsafe extern "system" fn(HIORING, HANDLE) -> HRESULT;
+type IsIoRingOpSupported_t = unsafe extern "system" fn(HIORING, u32) -> i32;
+type BuildIoRingReadFile_t = unsafe extern "system" fn(
+    HIORING,
+    IORING_HANDLE_REF,
+    IORING_BUFFER_REF,
+    u32,
+    u64,
+    usize,
+    i32,
+) -> HRESULT;
+type BuildIoRingWriteFile_t = unsafe extern "system" fn(
+    HIORING,
+    IORING_HANDLE_REF,
+    IORING_BUFFER_REF,
+    u32,
+    u64,
+    u32,
+    usize,
+    i32,
+) -> HRESULT;
+
+#[derive(Clone, Copy)]
+pub struct IoRingApi {
+    pub caps: IORING_CAPABILITIES,
+    create: CreateIoRing_t,
+    close: CloseIoRing_t,
+    submit: SubmitIoRing_t,
+    pop: PopIoRingCompletion_t,
+    set_event: SetIoRingCompletionEvent_t,
+    is_op: IsIoRingOpSupported_t,
+    build_read: BuildIoRingReadFile_t,
+    build_write: Option<BuildIoRingWriteFile_t>,
+}
+
+unsafe impl Send for IoRingApi {}
+unsafe impl Sync for IoRingApi {}
+
+/// Runtime-detected API table. `None` if:
+/// - `BUN_FEATURE_FLAG_WINDOWS_IORING` is not set, or
+/// - `QueryIoRingCapabilities` is absent (pre-Win11), or
+/// - `MaxVersion < IORING_VERSION_2`, or
+/// - `IORING_FEATURE_UM_EMULATION` is set (no kernel backing), or
+/// - `IORING_FEATURE_SET_COMPLETION_EVENT` is absent.
+pub fn api() -> Option<&'static IoRingApi> {
+    static CELL: OnceLock<Option<IoRingApi>> = OnceLock::new();
+    CELL.get_or_init(detect).as_ref()
+}
+
+fn detect() -> Option<IoRingApi> {
+    if !bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_WINDOWS_IORING::get().unwrap_or(false) {
+        return None;
+    }
+
+    // SAFETY: KernelBase is always loaded in every Windows process.
+    let kb = unsafe { kernel32::GetModuleHandleW(wchz(b"KernelBase.dll").as_ptr()) };
+    if kb.is_null() {
+        return None;
+    }
+
+    macro_rules! sym {
+        ($name:expr) => {{
+            let p = GetProcAddress(kb.cast(), $name.as_ptr().cast());
+            if p.is_null() {
+                bun_core::scoped_log!(
+                    ioring,
+                    "missing symbol {}",
+                    ::bstr::BStr::new(&$name[..$name.len() - 1])
+                );
+                return None;
+            }
+            p
+        }};
+    }
+    macro_rules! sym_opt {
+        ($name:expr) => {{
+            let p = GetProcAddress(kb.cast(), $name.as_ptr().cast());
+            if p.is_null() { None } else { Some(p) }
+        }};
+    }
+
+    // SAFETY: transmute of a non-null code pointer to its matching fn-ptr type.
+    let query: QueryIoRingCapabilities_t =
+        unsafe { core::mem::transmute::<*mut c_void, _>(sym!(b"QueryIoRingCapabilities\0")) };
+    let mut caps = IORING_CAPABILITIES::default();
+    // SAFETY: out-param is a valid `IORING_CAPABILITIES`.
+    if unsafe { query(&mut caps) } != S_OK {
+        return None;
+    }
+    bun_core::scoped_log!(
+        ioring,
+        "caps: MaxVersion={} SQ={} CQ={} Features=0x{:x}",
+        caps.MaxVersion,
+        caps.MaxSubmissionQueueSize,
+        caps.MaxCompletionQueueSize,
+        caps.FeatureFlags,
+    );
+    if caps.MaxVersion < IORING_VERSION_2 {
+        return None;
+    }
+    if caps.FeatureFlags & IORING_FEATURE_UM_EMULATION != 0 {
+        return None;
+    }
+    if caps.FeatureFlags & IORING_FEATURE_SET_COMPLETION_EVENT == 0 {
+        return None;
+    }
+
+    // SAFETY: transmute of non-null code pointers (verified by `sym!`) to
+    // their matching signatures from `ioringapi.h`.
+    unsafe {
+        Some(IoRingApi {
+            caps,
+            create: core::mem::transmute::<*mut c_void, _>(sym!(b"CreateIoRing\0")),
+            close: core::mem::transmute::<*mut c_void, _>(sym!(b"CloseIoRing\0")),
+            submit: core::mem::transmute::<*mut c_void, _>(sym!(b"SubmitIoRing\0")),
+            pop: core::mem::transmute::<*mut c_void, _>(sym!(b"PopIoRingCompletion\0")),
+            set_event: core::mem::transmute::<*mut c_void, _>(sym!(b"SetIoRingCompletionEvent\0")),
+            is_op: core::mem::transmute::<*mut c_void, _>(sym!(b"IsIoRingOpSupported\0")),
+            build_read: core::mem::transmute::<*mut c_void, _>(sym!(b"BuildIoRingReadFile\0")),
+            build_write: sym_opt!(b"BuildIoRingWriteFile\0")
+                .map(|p| core::mem::transmute::<*mut c_void, _>(p)),
+        })
+    }
+}
+
+/// Static ASCII→UTF-16 with trailing NUL for `GetModuleHandleW`.
+const fn wchz<const N: usize>(s: &[u8; N]) -> [u16; N] {
+    let mut out = [0u16; N];
+    let mut i = 0;
+    while i + 1 < N {
+        out[i] = s[i] as u16;
+        i += 1;
+    }
+    out
+}
+
+// ──────────────────────────── per-thread ring ────────────────────────────
+
+/// Submission `UserData` is a `*mut uv::fs_t`. On completion the drained result
+/// (bytes transferred, or a negative libuv errno) is written to `req.result`
+/// and `req.cb` is invoked on the owning JS thread. This mirrors libuv's own
+/// `uv_fs_*` completion contract so `UVFSRequest` can reuse its existing
+/// `uv_callback` path for result dispatch.
+
+const SQ_SIZE: u32 = 512;
+const CQ_SIZE: u32 = 1024;
+
+/// One I/O ring bound to a single libuv loop thread.
+///
+/// Heap-allocated and leaked on first use (process-lifetime singleton per JS
+/// thread); `Drop` is provided for completeness but not relied upon for
+/// correctness.
+pub struct FsIoRing {
+    api: &'static IoRingApi,
+    ring: HIORING,
+    inflight: u32,
+    sq_size: u32,
+    write_supported: bool,
+    event: HANDLE,
+    wait_handle: HANDLE,
+    async_: *mut uv::uv_async_t,
+}
+
+impl FsIoRing {
+    /// Create a ring bound to `loop_`. Returns `None` if any kernel call fails.
+    /// Caller places the returned box at a stable address before use.
+    fn new(api: &'static IoRingApi, loop_: *mut uv::Loop) -> Option<Box<Self>> {
+        let version = if api.caps.MaxVersion >= IORING_VERSION_3 {
+            IORING_VERSION_3
+        } else {
+            IORING_VERSION_2
+        };
+        let flags = IORING_CREATE_FLAGS {
+            Required: 0,
+            Advisory: IORING_CREATE_SKIP_BUILDER_PARAM_CHECKS,
+        };
+        let sq = SQ_SIZE.min(api.caps.MaxSubmissionQueueSize);
+        let cq = CQ_SIZE.min(api.caps.MaxCompletionQueueSize);
+        let mut ring: HIORING = ptr::null_mut();
+        // SAFETY: out-param is valid; flags/sizes are within reported caps.
+        let hr = unsafe { (api.create)(version, flags, sq, cq, &mut ring) };
+        if hr != S_OK || ring.is_null() {
+            bun_core::scoped_log!(ioring, "CreateIoRing failed: 0x{:08x}", hr);
+            return None;
+        }
+
+        let write_supported = version >= IORING_VERSION_3
+            && api.build_write.is_some()
+            // SAFETY: `ring` is live.
+            && unsafe { (api.is_op)(ring, IORING_OP_WRITE) } != 0;
+
+        // SAFETY: auto-reset, unnamed; cannot fault on valid args.
+        let event = unsafe { CreateEventW(ptr::null_mut(), 0, 0, ptr::null()) };
+        if event.is_null() {
+            // SAFETY: `ring` is live.
+            unsafe { (api.close)(ring) };
+            return None;
+        }
+        // SAFETY: `ring`/`event` are live.
+        if unsafe { (api.set_event)(ring, event) } != S_OK {
+            // SAFETY: both handles are live.
+            unsafe {
+                (api.close)(ring);
+                CloseHandle(event);
+            }
+            return None;
+        }
+
+        let mut this = Box::new(Self {
+            api,
+            ring,
+            inflight: 0,
+            sq_size: sq,
+            write_supported,
+            event,
+            wait_handle: ptr::null_mut(),
+            async_: ptr::null_mut(),
+        });
+
+        // uv_async_t must live at a stable heap address for libuv.
+        let async_ = Box::leak(Box::new(unsafe {
+            core::mem::zeroed::<uv::uv_async_t>()
+        }));
+        async_.init(loop_, Some(Self::on_async));
+        async_.data = (&mut *this as *mut Self).cast();
+        // SAFETY: `async_` was just initialised on `loop_`; unreffing keeps the
+        // loop from staying alive solely because a ring exists.
+        unsafe { uv::uv_unref((async_ as *mut uv::uv_async_t).cast()) };
+        this.async_ = async_;
+
+        // SAFETY: `event` is a valid waitable handle; `on_wait` has the
+        // WAITORTIMERCALLBACK ABI; `Context` is the `uv_async_t*` (stable).
+        let ok = unsafe {
+            RegisterWaitForSingleObject(
+                &mut this.wait_handle,
+                this.event,
+                Self::on_wait,
+                (this.async_ as *mut uv::uv_async_t).cast(),
+                INFINITE,
+                0,
+            )
+        };
+        if ok == 0 {
+            bun_core::scoped_log!(ioring, "RegisterWaitForSingleObject failed");
+            return None;
+        }
+
+        bun_core::scoped_log!(
+            ioring,
+            "ring created: v{} sq={} cq={} write={}",
+            version,
+            sq,
+            cq,
+            write_supported
+        );
+        Some(this)
+    }
+
+    /// Submit a positional read. `offset < 0` means current file position.
+    /// `req.cb` must be set; on completion `req.result` is written and `req.cb`
+    /// is invoked on the JS thread. Returns `false` if the SQ is full or the
+    /// builder rejected the entry; caller falls back to the libuv path.
+    pub fn submit_read(
+        &mut self,
+        handle: HANDLE,
+        buf: *mut u8,
+        len: u32,
+        offset: i64,
+        req: *mut uv::fs_t,
+    ) -> bool {
+        let user_data = req as usize;
+        if self.inflight >= self.sq_size {
+            return false;
+        }
+        let href = IORING_HANDLE_REF {
+            Kind: IORING_REF_RAW,
+            Handle: handle,
+        };
+        let bref = IORING_BUFFER_REF {
+            Kind: IORING_REF_RAW,
+            Buffer: buf.cast(),
+        };
+        let off = if offset < 0 { u64::MAX } else { offset as u64 };
+        // SAFETY: `ring` is live; handle/buffer are caller-provided and remain
+        // valid until completion (guaranteed by the JS-side buffer protection).
+        let hr = unsafe {
+            (self.api.build_read)(self.ring, href, bref, len, off, user_data, IOSQE_FLAGS_NONE)
+        };
+        if hr != S_OK {
+            bun_core::scoped_log!(ioring, "BuildIoRingReadFile failed: 0x{:08x}", hr);
+            return false;
+        }
+        let mut sub = 0u32;
+        // SAFETY: `ring` is live; `sub` is a valid out-param.
+        let hr = unsafe { (self.api.submit)(self.ring, 0, 0, &mut sub) };
+        if hr != S_OK {
+            bun_core::scoped_log!(ioring, "SubmitIoRing failed: 0x{:08x}", hr);
+            return false;
+        }
+        self.inflight += 1;
+        true
+    }
+
+    /// Submit a positional write. See `submit_read` for the `false` contract.
+    pub fn submit_write(
+        &mut self,
+        handle: HANDLE,
+        buf: *const u8,
+        len: u32,
+        offset: i64,
+        req: *mut uv::fs_t,
+    ) -> bool {
+        let user_data = req as usize;
+        let Some(build_write) = self.api.build_write else {
+            return false;
+        };
+        if !self.write_supported || self.inflight >= self.sq_size {
+            return false;
+        }
+        let href = IORING_HANDLE_REF {
+            Kind: IORING_REF_RAW,
+            Handle: handle,
+        };
+        let bref = IORING_BUFFER_REF {
+            Kind: IORING_REF_RAW,
+            Buffer: buf as *mut c_void,
+        };
+        let off = if offset < 0 { u64::MAX } else { offset as u64 };
+        // SAFETY: see `submit_read`.
+        let hr = unsafe {
+            build_write(
+                self.ring,
+                href,
+                bref,
+                len,
+                off,
+                FILE_WRITE_FLAGS_NONE,
+                user_data,
+                IOSQE_FLAGS_NONE,
+            )
+        };
+        if hr != S_OK {
+            return false;
+        }
+        let mut sub = 0u32;
+        // SAFETY: `ring` is live.
+        if unsafe { (self.api.submit)(self.ring, 0, 0, &mut sub) } != S_OK {
+            return false;
+        }
+        self.inflight += 1;
+        true
+    }
+
+    /// Windows thread-pool wait callback. Runs off the JS thread; touches only
+    /// the `uv_async_t` (the one libuv entry point documented as thread-safe).
+    unsafe extern "system" fn on_wait(ctx: *mut c_void, _timeout: u8) {
+        // SAFETY: `ctx` is the `uv_async_t*` registered in `new()`.
+        unsafe { uv::uv_async_send(ctx.cast()) };
+    }
+
+    /// Runs on the JS thread. Drains the CQ and invokes each `uv::fs_t`'s
+    /// stored `cb` after writing the libuv-shaped result into `req.result`.
+    unsafe extern "C" fn on_async(a: *mut uv::uv_async_t) {
+        // SAFETY: `data` was set to `*mut Self` in `new()`.
+        let this = unsafe { &mut *((*a).data as *mut Self) };
+        let mut cqe = IORING_CQE::default();
+        loop {
+            // SAFETY: `ring` is live; `cqe` is a valid out-param.
+            let hr = unsafe { (this.api.pop)(this.ring, &mut cqe) };
+            if hr != S_OK {
+                break;
+            }
+            this.inflight = this.inflight.saturating_sub(1);
+            let req = cqe.UserData as *mut uv::fs_t;
+            debug_assert!(!req.is_null());
+            let rc: i64 = if cqe.ResultCode == S_OK {
+                cqe.Information as i64
+            } else {
+                hresult_to_uv_err(cqe.ResultCode) as i64
+            };
+            // SAFETY: `req` is the live `uv::fs_t` pointer the caller passed to
+            // `submit_*`; its backing task box outlives completion.
+            unsafe {
+                (*req).result = uv::ReturnCodeI64(rc);
+                if let Some(cb) = (*req).cb {
+                    cb(req);
+                }
+            }
+        }
+    }
+}
+
+impl Drop for FsIoRing {
+    fn drop(&mut self) {
+        // SAFETY: all handles were created in `new()` and are still owned here.
+        unsafe {
+            if !self.wait_handle.is_null() {
+                UnregisterWaitEx(self.wait_handle, INVALID_HANDLE_VALUE);
+            }
+            if !self.ring.is_null() {
+                (self.api.close)(self.ring);
+            }
+            if !self.event.is_null() {
+                CloseHandle(self.event);
+            }
+        }
+    }
+}
+
+/// `HRESULT_FROM_WIN32` has the shape `0x8007_xxxx`; extract the Win32 code and
+/// map through libuv's table so the libuv-errno result matches the `uv_fs_*`
+/// path exactly. Anything else maps to `UV_EIO`.
+fn hresult_to_uv_err(hr: HRESULT) -> i32 {
+    const UV_EIO: i32 = -4070;
+    if (hr as u32 & 0xFFFF_0000) == 0x8007_0000 {
+        let win32 = (hr & 0xFFFF) as i32;
+        // SAFETY: pure function on a by-value int.
+        let uv_err = unsafe { uv::uv_translate_sys_error(win32) };
+        if uv_err < 0 { uv_err } else { UV_EIO }
+    } else {
+        UV_EIO
+    }
+}
+
+// Keep the unused-import checker quiet for the error types documented above;
+// they remain part of the public surface even though the hot path goes through
+// the libuv-errno shape.
+const _: fn() -> Error = || Error::new(E::EIO, Tag::read);
+
+// ──────────────────────────── singleton access ───────────────────────────
+
+/// Per-thread ring, leaked on first use. `None` when disabled/unsupported or
+/// if creation fails; once `None` is observed it is never retried.
+static RING: AtomicPtr<FsIoRing> = AtomicPtr::new(ptr::null_mut());
+static INIT: OnceLock<()> = OnceLock::new();
+
+/// Get or lazily create the ring for the current libuv loop. Thread-affine:
+/// called from the JS thread only.
+pub fn get(loop_: *mut uv::Loop) -> Option<&'static mut FsIoRing> {
+    let p = RING.load(Ordering::Relaxed);
+    if !p.is_null() {
+        // SAFETY: set once below to a leaked Box; only the owning JS thread
+        // calls this, so the `&mut` is unique.
+        return Some(unsafe { &mut *p });
+    }
+    if INIT.get().is_some() {
+        return None;
+    }
+    INIT.set(()).ok();
+    let api = api()?;
+    let ring = FsIoRing::new(api, loop_)?;
+    let raw = Box::into_raw(ring);
+    RING.store(raw, Ordering::Release);
+    // SAFETY: just stored a live Box pointer.
+    Some(unsafe { &mut *raw })
+}
+
+// ──────────────────────────── local externs ──────────────────────────────
+
+const INVALID_HANDLE_VALUE: HANDLE = usize::MAX as HANDLE;
+
+unsafe extern "system" {
+    fn CreateEventW(attrs: *mut c_void, manual: i32, initial: i32, name: *const u16) -> HANDLE;
+    fn UnregisterWaitEx(WaitHandle: HANDLE, CompletionEvent: HANDLE) -> i32;
+}
+
+// Ensure the signature referenced by `RegisterWaitForSingleObject` matches.
+const _: WAITORTIMERCALLBACK = FsIoRing::on_wait;

--- a/src/sys/windows/ioring.rs
+++ b/src/sys/windows/ioring.rs
@@ -266,11 +266,13 @@ pub struct FsIoRing {
     api: &'static IoRingApi,
     ring: HIORING,
     inflight: u32,
+    pending: u32,
     sq_size: u32,
     write_supported: bool,
     event: HANDLE,
     wait_handle: HANDLE,
     async_: *mut uv::uv_async_t,
+    prepare: *mut uv::uv_prepare_t,
 }
 
 impl FsIoRing {
@@ -322,11 +324,13 @@ impl FsIoRing {
             api,
             ring,
             inflight: 0,
+            pending: 0,
             sq_size: sq,
             write_supported,
             event,
             wait_handle: ptr::null_mut(),
             async_: ptr::null_mut(),
+            prepare: ptr::null_mut(),
         });
 
         // uv_async_t must live at a stable heap address for libuv.
@@ -339,6 +343,21 @@ impl FsIoRing {
         // loop from staying alive solely because a ring exists.
         unsafe { uv::uv_unref((async_ as *mut uv::uv_async_t).cast()) };
         this.async_ = async_;
+
+        // uv_prepare_t fires on the JS thread immediately before the loop would
+        // block on IOCP; that is the latest point at which SQEs built during
+        // the preceding JS tick can be submitted in a single syscall.
+        let prepare = Box::leak(Box::new(unsafe {
+            core::mem::zeroed::<uv::uv_prepare_t>()
+        }));
+        // SAFETY: `prepare` is a stable heap allocation; `loop_` is live.
+        unsafe {
+            uv::uv_prepare_init(loop_, prepare);
+            (*prepare).data = (&mut *this as *mut Self).cast();
+            uv::uv_prepare_start(prepare, Some(Self::on_prepare));
+            uv::uv_unref((prepare as *mut uv::uv_prepare_t).cast());
+        }
+        this.prepare = prepare;
 
         // SAFETY: `event` is a valid waitable handle; `on_wait` has the
         // WAITORTIMERCALLBACK ABI; `Context` is the `uv_async_t*` (stable).
@@ -388,6 +407,7 @@ impl FsIoRing {
     ) -> bool {
         let user_data = req as usize;
         if self.inflight >= self.sq_size {
+            self.flush();
             return false;
         }
         let href = IORING_HANDLE_REF {
@@ -408,14 +428,7 @@ impl FsIoRing {
             bun_core::scoped_log!(ioring, "BuildIoRingReadFile failed: 0x{:08x}", hr);
             return false;
         }
-        let mut sub = 0u32;
-        // SAFETY: `ring` is live; `sub` is a valid out-param.
-        let hr = unsafe { (self.api.submit)(self.ring, 0, 0, &mut sub) };
-        if hr != S_OK {
-            bun_core::scoped_log!(ioring, "SubmitIoRing failed: 0x{:08x}", hr);
-            return false;
-        }
-        self.inflight += 1;
+        self.note_built();
         true
     }
 
@@ -432,7 +445,11 @@ impl FsIoRing {
         let Some(build_write) = self.api.build_write else {
             return false;
         };
-        if !self.write_supported || self.inflight >= self.sq_size {
+        if !self.write_supported {
+            return false;
+        }
+        if self.inflight >= self.sq_size {
+            self.flush();
             return false;
         }
         let href = IORING_HANDLE_REF {
@@ -460,13 +477,37 @@ impl FsIoRing {
         if hr != S_OK {
             return false;
         }
-        let mut sub = 0u32;
-        // SAFETY: `ring` is live.
-        if unsafe { (self.api.submit)(self.ring, 0, 0, &mut sub) } != S_OK {
-            return false;
-        }
-        self.inflight += 1;
+        self.note_built();
         true
+    }
+
+    #[inline]
+    fn note_built(&mut self) {
+        self.inflight += 1;
+        self.pending += 1;
+        if self.pending >= self.sq_size {
+            self.flush();
+        }
+    }
+
+    fn flush(&mut self) {
+        if self.pending == 0 {
+            return;
+        }
+        let mut sub = 0u32;
+        // SAFETY: `ring` is live; `sub` is a valid out-param.
+        let hr = unsafe { (self.api.submit)(self.ring, 0, 0, &mut sub) };
+        bun_core::scoped_log!(ioring, "SubmitIoRing({}) hr=0x{:08x}", self.pending, hr);
+        let _ = hr;
+        self.pending = 0;
+    }
+
+    /// Fires right before the uv loop blocks on IOCP. Submits any SQEs built
+    /// during the preceding JS tick in a single syscall.
+    unsafe extern "C" fn on_prepare(p: *mut uv::uv_prepare_t) {
+        // SAFETY: `data` was set to `*mut Self` in `new()`.
+        let this = unsafe { &mut *((*p).data as *mut Self) };
+        this.flush();
     }
 
     /// Windows thread-pool wait callback. Runs off the JS thread; touches only

--- a/src/sys/windows/ioring.rs
+++ b/src/sys/windows/ioring.rs
@@ -242,8 +242,21 @@ fn detect() -> Option<IoRingApi> {
 }
 
 static WCH_KERNELBASE: &[u16] = &[
-    b'K' as u16, b'e' as u16, b'r' as u16, b'n' as u16, b'e' as u16, b'l' as u16, b'B' as u16,
-    b'a' as u16, b's' as u16, b'e' as u16, b'.' as u16, b'd' as u16, b'l' as u16, b'l' as u16, 0,
+    b'K' as u16,
+    b'e' as u16,
+    b'r' as u16,
+    b'n' as u16,
+    b'e' as u16,
+    b'l' as u16,
+    b'B' as u16,
+    b'a' as u16,
+    b's' as u16,
+    b'e' as u16,
+    b'.' as u16,
+    b'd' as u16,
+    b'l' as u16,
+    b'l' as u16,
+    0,
 ];
 
 // ──────────────────────────── per-thread ring ────────────────────────────
@@ -334,9 +347,7 @@ impl FsIoRing {
         });
 
         // uv_async_t must live at a stable heap address for libuv.
-        let async_ = Box::leak(Box::new(unsafe {
-            core::mem::zeroed::<uv::uv_async_t>()
-        }));
+        let async_ = Box::leak(Box::new(unsafe { core::mem::zeroed::<uv::uv_async_t>() }));
         async_.init(loop_, Some(Self::on_async));
         async_.data = (&mut *this as *mut Self).cast();
         // SAFETY: `async_` was just initialised on `loop_`; unreffing keeps the
@@ -347,9 +358,7 @@ impl FsIoRing {
         // uv_prepare_t fires on the JS thread immediately before the loop would
         // block on IOCP; that is the latest point at which SQEs built during
         // the preceding JS tick can be submitted in a single syscall.
-        let prepare = Box::leak(Box::new(unsafe {
-            core::mem::zeroed::<uv::uv_prepare_t>()
-        }));
+        let prepare = Box::leak(Box::new(unsafe { core::mem::zeroed::<uv::uv_prepare_t>() }));
         // SAFETY: `prepare` is a stable heap allocation; `loop_` is live.
         unsafe {
             uv::uv_prepare_init(loop_, prepare);

--- a/src/sys/windows/ioring.rs
+++ b/src/sys/windows/ioring.rs
@@ -1,35 +1,11 @@
-//! Windows I/O Ring (`ioringapi.h`) backend for async file read/write.
+//! Windows I/O Ring (`ioringapi.h`) backend for async `fs.read`/`fs.write`,
+//! gated behind `BUN_FEATURE_FLAG_WINDOWS_IORING`. See `bench/ioring/` for the
+//! measurements and the `FILE_FLAG_OVERLAPPED` caveat.
 //!
-//! Exploratory: gated behind `BUN_FEATURE_FLAG_WINDOWS_IORING`. When enabled
-//! and the OS supports IORING_VERSION_3 with real kernel backing (no user-mode
-//! emulation), `node:fs` async `read`/`write` route through a per-thread ring
-//! instead of the libuv threadpool.
-//!
-//! Integration model (single JS thread owns the ring; no cross-thread ring
-//! access):
-//!
-//!   JS thread    BuildIoRing{Read,Write}File + SubmitIoRing
-//!                      |
-//!   kernel       completes ops, signals the completion HANDLE
-//!                      |
-//!   Win TP thread  RegisterWaitForSingleObject callback -> uv_async_send
-//!                      |
-//!   JS thread    uv_async_cb drains PopIoRingCompletion, dispatches each
-//!                UserData back to the caller-supplied `complete` fn
-//!
-//! HRESULT from the CQE is mapped to a libuv errno via
-//! `uv_translate_sys_error(HRESULT_CODE(hr))` so downstream error handling is
-//! identical to the `uv_fs_*` path.
-//!
-//! The ring is *not* thread-safe; all builder/submit/pop calls happen on the
-//! owning JS thread. The wait callback only touches the `uv_async_t` (which
-//! `uv_async_send` documents as the sole thread-safe libuv entry point).
-//!
-//! Key behavioural note discovered during evaluation: when the file handle was
-//! opened without `FILE_FLAG_OVERLAPPED` (the default for `uv_fs_open`), the
-//! kernel processes the ring's submissions serially, which eliminates the
-//! parallelism benefit and is slower than the threadpool for uncached reads.
-//! See `bench/ioring/` for the measurements this module was built to gather.
+//! Threading: the ring is owned by a single JS thread. Build/Submit/Pop happen
+//! there; the completion `HANDLE` is bridged into the uv loop via
+//! `RegisterWaitForSingleObject` -> `uv_async_send`, and CQEs are drained in
+//! the `uv_async_cb` on that same thread.
 
 #![cfg(windows)]
 #![allow(non_snake_case, non_camel_case_types)]
@@ -44,8 +20,6 @@ use bun_windows_sys::externs::{
     CloseHandle, GetProcAddress, HANDLE, INFINITE, RegisterWaitForSingleObject, WAITORTIMERCALLBACK,
 };
 use bun_windows_sys::kernel32;
-
-use crate::{E, Error, Tag};
 
 bun_core::declare_scope!(ioring, hidden);
 
@@ -154,12 +128,7 @@ pub struct IoRingApi {
 unsafe impl Send for IoRingApi {}
 unsafe impl Sync for IoRingApi {}
 
-/// Runtime-detected API table. `None` if:
-/// - `BUN_FEATURE_FLAG_WINDOWS_IORING` is not set, or
-/// - `QueryIoRingCapabilities` is absent (pre-Win11), or
-/// - `MaxVersion < IORING_VERSION_2`, or
-/// - `IORING_FEATURE_UM_EMULATION` is set (no kernel backing), or
-/// - `IORING_FEATURE_SET_COMPLETION_EVENT` is absent.
+/// Runtime-detected API table; `None` on unsupported OS or when the flag is off.
 pub fn api() -> Option<&'static IoRingApi> {
     static CELL: OnceLock<Option<IoRingApi>> = OnceLock::new();
     CELL.get_or_init(detect).as_ref()
@@ -261,20 +230,12 @@ static WCH_KERNELBASE: &[u16] = &[
 
 // ──────────────────────────── per-thread ring ────────────────────────────
 
-/// Submission `UserData` is a `*mut uv::fs_t`. On completion the drained result
-/// (bytes transferred, or a negative libuv errno) is written to `req.result`
-/// and `req.cb` is invoked on the owning JS thread. This mirrors libuv's own
-/// `uv_fs_*` completion contract so `UVFSRequest` can reuse its existing
-/// `uv_callback` path for result dispatch.
-
 const SQ_SIZE: u32 = 512;
 const CQ_SIZE: u32 = 1024;
 
-/// One I/O ring bound to a single libuv loop thread.
-///
-/// Heap-allocated and leaked on first use (process-lifetime singleton per JS
-/// thread); `Drop` is provided for completeness but not relied upon for
-/// correctness.
+/// One I/O ring bound to a single libuv loop thread. Process-lifetime; leaked
+/// on first use. `UserData` on each submission is a `*mut uv::fs_t`; completion
+/// writes `req.result` and calls `req.cb`, matching the `uv_fs_*` contract.
 pub struct FsIoRing {
     api: &'static IoRingApi,
     ring: HIORING,
@@ -289,8 +250,6 @@ pub struct FsIoRing {
 }
 
 impl FsIoRing {
-    /// Create a ring bound to `loop_`. Returns `None` if any kernel call fails.
-    /// Caller places the returned box at a stable address before use.
     fn new(api: &'static IoRingApi, loop_: *mut uv::Loop) -> Option<Box<Self>> {
         let version = if api.caps.MaxVersion >= IORING_VERSION_3 {
             IORING_VERSION_3
@@ -346,18 +305,13 @@ impl FsIoRing {
             prepare: ptr::null_mut(),
         });
 
-        // uv_async_t must live at a stable heap address for libuv.
         let async_ = Box::leak(Box::new(unsafe { core::mem::zeroed::<uv::uv_async_t>() }));
         async_.init(loop_, Some(Self::on_async));
         async_.data = (&mut *this as *mut Self).cast();
-        // SAFETY: `async_` was just initialised on `loop_`; unreffing keeps the
-        // loop from staying alive solely because a ring exists.
+        // SAFETY: `async_` is live on `loop_`; unref so the ring alone never keeps the loop alive.
         unsafe { uv::uv_unref((async_ as *mut uv::uv_async_t).cast()) };
         this.async_ = async_;
 
-        // uv_prepare_t fires on the JS thread immediately before the loop would
-        // block on IOCP; that is the latest point at which SQEs built during
-        // the preceding JS tick can be submitted in a single syscall.
         let prepare = Box::leak(Box::new(unsafe { core::mem::zeroed::<uv::uv_prepare_t>() }));
         // SAFETY: `prepare` is a stable heap allocation; `loop_` is live.
         unsafe {
@@ -402,10 +356,9 @@ impl FsIoRing {
         Some(this)
     }
 
-    /// Submit a positional read. `offset < 0` means current file position.
-    /// `req.cb` must be set; on completion `req.result` is written and `req.cb`
-    /// is invoked on the JS thread. Returns `false` if the SQ is full or the
-    /// builder rejected the entry; caller falls back to the libuv path.
+    /// Queue a positional read. `req.cb` must be set. Returns `false` (caller
+    /// falls back to libuv) on SQ-full, builder failure, or `offset < 0`
+    /// (ioring has no current-position sentinel).
     pub fn submit_read(
         &mut self,
         handle: HANDLE,
@@ -414,9 +367,6 @@ impl FsIoRing {
         offset: i64,
         req: *mut uv::fs_t,
     ) -> bool {
-        // `BuildIoRingReadFile` takes an absolute `UINT64` offset with no
-        // current-position sentinel; position < 0 (node's `null`) must fall
-        // back to the uv threadpool which honours the handle's file pointer.
         if offset < 0 {
             return false;
         }
@@ -447,7 +397,7 @@ impl FsIoRing {
         true
     }
 
-    /// Submit a positional write. See `submit_read` for the `false` contract.
+    /// Queue a positional write; same `false` contract as `submit_read`.
     pub fn submit_write(
         &mut self,
         handle: HANDLE,
@@ -517,23 +467,20 @@ impl FsIoRing {
         self.pending = 0;
     }
 
-    /// Fires right before the uv loop blocks on IOCP. Submits any SQEs built
-    /// during the preceding JS tick in a single syscall.
+    /// uv_prepare_cb: batch-submit SQEs built during the preceding JS tick.
     unsafe extern "C" fn on_prepare(p: *mut uv::uv_prepare_t) {
         // SAFETY: `data` was set to `*mut Self` in `new()`.
         let this = unsafe { &mut *((*p).data as *mut Self) };
         this.flush();
     }
 
-    /// Windows thread-pool wait callback. Runs off the JS thread; touches only
-    /// the `uv_async_t` (the one libuv entry point documented as thread-safe).
+    /// WAITORTIMERCALLBACK: off-thread; `uv_async_send` is the sole thread-safe uv entry point.
     unsafe extern "system" fn on_wait(ctx: *mut c_void, _timeout: u8) {
         // SAFETY: `ctx` is the `uv_async_t*` registered in `new()`.
         unsafe { uv::uv_async_send(ctx.cast()) };
     }
 
-    /// Runs on the JS thread. Drains the CQ and invokes each `uv::fs_t`'s
-    /// stored `cb` after writing the libuv-shaped result into `req.result`.
+    /// uv_async_cb: drain CQEs, write `req.result`, call `req.cb` (JS thread).
     unsafe extern "C" fn on_async(a: *mut uv::uv_async_t) {
         // SAFETY: `data` was set to `*mut Self` in `new()`.
         let this = unsafe { &mut *((*a).data as *mut Self) };
@@ -547,9 +494,7 @@ impl FsIoRing {
             this.inflight = this.inflight.saturating_sub(1);
             let req = cqe.UserData as *mut uv::fs_t;
             debug_assert!(!req.is_null());
-            // `ERROR_HANDLE_EOF`: ioring reports a positional read at/past EOF
-            // as a Win32 error, unlike `ReadFile` which succeeds with 0 bytes.
-            // libuv's `fs__read` applies the same normalisation.
+            // ioring reports read-at-EOF as ERROR_HANDLE_EOF; map to 0 bytes like `ReadFile`/libuv.
             const HRESULT_HANDLE_EOF: HRESULT = 0x8007_0026u32 as HRESULT;
             let rc: i64 = if cqe.ResultCode == S_OK {
                 cqe.Information as i64
@@ -587,9 +532,7 @@ impl Drop for FsIoRing {
     }
 }
 
-/// `HRESULT_FROM_WIN32` has the shape `0x8007_xxxx`; extract the Win32 code and
-/// map through libuv's table so the libuv-errno result matches the `uv_fs_*`
-/// path exactly. Anything else maps to `UV_EIO`.
+/// Map an `HRESULT_FROM_WIN32`-shaped code to a libuv errno; anything else -> `UV_EIO`.
 fn hresult_to_uv_err(hr: HRESULT) -> i32 {
     const UV_EIO: i32 = -4070;
     if (hr as u32 & 0xFFFF_0000) == 0x8007_0000 {
@@ -602,20 +545,12 @@ fn hresult_to_uv_err(hr: HRESULT) -> i32 {
     }
 }
 
-// Keep the unused-import checker quiet for the error types documented above;
-// they remain part of the public surface even though the hot path goes through
-// the libuv-errno shape.
-const _: fn() -> Error = || Error::new(E::EIO, Tag::read);
-
 // ──────────────────────────── singleton access ───────────────────────────
 
-/// Per-thread ring, leaked on first use. `None` when disabled/unsupported or
-/// if creation fails; once `None` is observed it is never retried.
 static RING: AtomicPtr<FsIoRing> = AtomicPtr::new(ptr::null_mut());
 static INIT: OnceLock<()> = OnceLock::new();
 
-/// Get or lazily create the ring for the current libuv loop. Thread-affine:
-/// called from the JS thread only.
+/// Lazy per-loop ring. Thread-affine: JS thread only.
 pub fn get(loop_: *mut uv::Loop) -> Option<&'static mut FsIoRing> {
     let p = RING.load(Ordering::Relaxed);
     if !p.is_null() {

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -2086,6 +2086,7 @@ pub fn GetEnvironmentVariableW(
 }
 
 pub mod env;
+pub mod ioring;
 
 // ──────────────────────────────────────────────────────────────────────────
 // Additional surface unblocked for dependents.

--- a/test/js/node/fs/fs-ioring-windows.test.ts
+++ b/test/js/node/fs/fs-ioring-windows.test.ts
@@ -1,0 +1,118 @@
+// Verifies async fs.read/fs.write behaviour is unchanged when routed through
+// the Windows I/O Ring backend (BUN_FEATURE_FLAG_WINDOWS_IORING=1). On other
+// platforms and older Windows the flag is a no-op, so these assertions also
+// serve as a regression check that enabling the flag never changes results.
+import { describe, test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir, isWindows } from "harness";
+
+const script = /* js */ `
+const fs = require("fs");
+const fsp = require("fs/promises");
+const path = require("path");
+
+async function main() {
+  const dir = process.argv[2];
+  const N = 64;
+  const size = 4096;
+
+  // write N files concurrently via fs.promises.open + write
+  const names = [];
+  await Promise.all(
+    Array.from({ length: N }, async (_, i) => {
+      const p = path.join(dir, "f" + i + ".bin");
+      names.push(p);
+      const fh = await fsp.open(p, "w");
+      const buf = Buffer.alloc(size, i & 0xff);
+      const { bytesWritten } = await fh.write(buf, 0, size, 0);
+      if (bytesWritten !== size) throw new Error("short write " + bytesWritten);
+      await fh.close();
+    }),
+  );
+
+  // read them back concurrently via fs.promises.open + read
+  await Promise.all(
+    names.map(async (p, i) => {
+      const fh = await fsp.open(p, "r");
+      const buf = Buffer.alloc(size);
+      const { bytesRead } = await fh.read(buf, 0, size, 0);
+      if (bytesRead !== size) throw new Error("short read " + bytesRead);
+      for (let j = 0; j < size; j++) {
+        if (buf[j] !== (i & 0xff)) throw new Error("data mismatch at " + p);
+      }
+      await fh.close();
+    }),
+  );
+
+  // callback API with current-position (no offset)
+  await new Promise((resolve, reject) => {
+    fs.open(names[0], "r", (err, fd) => {
+      if (err) return reject(err);
+      const buf = Buffer.alloc(size);
+      fs.read(fd, buf, 0, size, null, (err, n) => {
+        if (err) return reject(err);
+        if (n !== size) return reject(new Error("cb short read " + n));
+        fs.close(fd, () => resolve());
+      });
+    });
+  });
+
+  // error path: read from a closed fd
+  let errCode = "";
+  try {
+    const fh = await fsp.open(names[0], "r");
+    await fh.close();
+    await fh.read(Buffer.alloc(16), 0, 16, 0);
+  } catch (e) {
+    errCode = e.code || e.name;
+  }
+  if (errCode !== "EBADF") throw new Error("expected EBADF, got " + errCode);
+
+  console.log("OK " + N);
+}
+main().catch(e => { console.error(e); process.exit(1); });
+`;
+
+async function run(withFlag: boolean) {
+  using dir = tempDir("fs-ioring", { "run.js": script });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.js", String(dir)],
+    env: {
+      ...bunEnv,
+      ...(withFlag ? { BUN_FEATURE_FLAG_WINDOWS_IORING: "1" } : {}),
+    },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  return { stdout: stdout.trim(), stderr, exitCode };
+}
+
+describe("fs async read/write with BUN_FEATURE_FLAG_WINDOWS_IORING", () => {
+  test("flag off (baseline)", async () => {
+    const { stdout, stderr, exitCode } = await run(false);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("OK 64");
+    expect(exitCode).toBe(0);
+  });
+
+  test("flag on", async () => {
+    const { stdout, stderr, exitCode } = await run(true);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("OK 64");
+    expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(!isWindows)(
+    "flag on and off produce identical output on Windows",
+    async () => {
+      const [a, b] = await Promise.all([run(false), run(true)]);
+      expect(b.stdout).toBe(a.stdout);
+      expect(b.exitCode).toBe(a.exitCode);
+    },
+  );
+});

--- a/test/js/node/fs/fs-ioring-windows.test.ts
+++ b/test/js/node/fs/fs-ioring-windows.test.ts
@@ -2,8 +2,8 @@
 // the Windows I/O Ring backend (BUN_FEATURE_FLAG_WINDOWS_IORING=1). On other
 // platforms and older Windows the flag is a no-op, so these assertions also
 // serve as a regression check that enabling the flag never changes results.
-import { describe, test, expect } from "bun:test";
-import { bunEnv, bunExe, tempDir, isWindows } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 const script = /* js */ `
 const fs = require("fs");
@@ -84,11 +84,7 @@ async function run(withFlag: boolean) {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout: stdout.trim(), stderr, exitCode };
 }
 
@@ -107,12 +103,9 @@ describe("fs async read/write with BUN_FEATURE_FLAG_WINDOWS_IORING", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.skipIf(!isWindows)(
-    "flag on and off produce identical output on Windows",
-    async () => {
-      const [a, b] = await Promise.all([run(false), run(true)]);
-      expect(b.stdout).toBe(a.stdout);
-      expect(b.exitCode).toBe(a.exitCode);
-    },
-  );
+  test.skipIf(!isWindows)("flag on and off produce identical output on Windows", async () => {
+    const [a, b] = await Promise.all([run(false), run(true)]);
+    expect(b.stdout).toBe(a.stdout);
+    expect(b.exitCode).toBe(a.exitCode);
+  });
 });


### PR DESCRIPTION
## Summary

Exploratory backend that routes async `fs.read`/`fs.write` through the Windows I/O Ring API (`CreateIoRing`/`BuildIoRingReadFile`/`BuildIoRingWriteFile`, KernelBase, Win11 build 22000+, writes 22621+) instead of the libuv threadpool. Gated behind `BUN_FEATURE_FLAG_WINDOWS_IORING=1`, off by default.

**Outcome: not a win for this surface.** Keeping as a draft with the measurements so the infrastructure is available if we want to explore the `fs.readFile(path)` angle (where Bun controls the `CreateFile` flags).

## Architecture

- `src/sys/windows/ioring.rs`: FFI types, runtime detection via `GetProcAddress` on `KernelBase.dll`, and a per-thread `FsIoRing` bound to the libuv loop.
- Detection requires `QueryIoRingCapabilities` present, `MaxVersion >= IORING_VERSION_2`, `IORING_FEATURE_SET_COMPLETION_EVENT` set, and `IORING_FEATURE_UM_EMULATION` absent. Windows 10 and earlier Windows 11 builds keep the existing libuv path unchanged.
- Loop integration: SQEs are built on the JS thread and submitted in one `SubmitIoRing` from a `uv_prepare_t` right before the loop blocks. The ring's completion event is bridged via `RegisterWaitForSingleObject` to `uv_async_send`; the async callback drains CQEs on the JS thread and dispatches each through the existing `uv::fs_t` result path so error mapping matches `uv_fs_read`/`uv_fs_write` exactly.
- `UVFSRequest::create` for `Read`/`Write` tries the ring first; on SQ-full, `offset < 0`, or any builder failure it falls through to `uv_fs_read`/`uv_fs_write`.
- `ERROR_HANDLE_EOF` is normalised to 0 bytes, matching `ReadFile`/libuv semantics.

## Measurements (Windows 11 24H2 arm64, build 26100, release build)

### End-to-end Bun `fh.read`/`fh.write` (bench/ioring/fs-read-write.mjs), 3 runs averaged

| scenario                     | uv threadpool | ioring   | delta       |
| ---------------------------- | ------------- | -------- | ----------- |
| 512 x 2 KB reads (cached)    | 0.88 ms       | 2.21 ms  | 2.5x slower |
| 64 MB seq read, 64 KB chunks | 58.5 ms       | 59.1 ms  | ~same       |
| 512 x 2 KB writes            | 0.77 ms       | 2.28 ms  | 3.0x slower |

### Raw syscall microbenchmark (outside Bun), 512 files x 20 iterations

| scenario                                | 4-thread pool | ioring         |
| --------------------------------------- | ------------- | -------------- |
| cached reads, sync handle               | 0.50 ms       | 1.46 ms        |
| unbuffered reads, sync handle           | 18.6 ms       | 64.0 ms        |
| unbuffered reads, `FILE_FLAG_OVERLAPPED`| n/a           | **3.5 ms**     |
| cached writes                           | 2.3 ms        | **1.5 ms**     |

## Why it loses

The Windows ioring kernel processes submissions **serially** when the file handle was opened without `FILE_FLAG_OVERLAPPED`. `uv_fs_open` (and therefore `fs.open`) never sets that flag, so for `fs.read(fd, ...)` on user-opened descriptors the ring gives zero I/O parallelism while the libuv threadpool gives ~4x. The batching win (one `SubmitIoRing` for N ops vs N threadpool enqueues) is not enough to overcome that.

With `FILE_FLAG_OVERLAPPED` the picture flips: the ring gains real kernel-side parallelism and beats a 4-thread pool by ~5x on uncached reads. That is only reachable where Bun itself opens the file (`fs.readFile(path)`, `fs.writeFile(path)`), and even there the warm-cache case still regresses ~2.6x.

## Correctness

- `test/js/node/fs/fs-ioring-windows.test.ts` passes on Windows 11 and on Linux (where the flag is a no-op).
- All 426 tests in `test/js/node/fs/fs.test.ts` pass with `BUN_FEATURE_FLAG_WINDOWS_IORING=1` on Windows 11 arm64.

## References

- Yarden Shafir, "I/O Rings: When One I/O Operation is Not Enough", windows-internals.com
- Yarden Shafir, "IoRing vs. io_uring: a comparison of Windows and Linux implementations", windows-internals.com
- `ioringapi.h` / `ntioring_x.h`, Windows SDK 10.0.26100

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs-ioring-windows.test.ts

<!-- robobun:evidence:end -->