### PR TITLE
plugin: consult both onResolve registration forms for namespaced specifiers

### DIFF
--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -487,9 +487,7 @@ export function runOnResolvePlugins(this: BundlerPlugin, specifier, inputNamespa
       return null;
     }
 
-    // An import like "virt:x" from a file-namespace module is also offered to
-    // onResolve({ namespace: "virt" }) with the stripped path, so a plugin
-    // written for the runtime's dispatch works here too.
+    // Also offer "ns:rest" to onResolve({ namespace: "ns" }) with the stripped path.
     if (inputNamespace === "file") {
       var colon = inputPath.indexOf(":");
       if (

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -433,7 +433,7 @@ export function runOnResolvePlugins(this: BundlerPlugin, specifier, inputNamespa
             continue;
           }
 
-          var { path, namespace: userNamespace = matchNamespace, external } = result;
+          var { path, namespace: userNamespace = inputNamespace, external } = result;
           if (path !== undefined && typeof path !== "string") {
             throw new TypeError("onResolve plugins 'path' field must be a string if provided");
           }
@@ -447,7 +447,7 @@ export function runOnResolvePlugins(this: BundlerPlugin, specifier, inputNamespa
           }
 
           if (!userNamespace) {
-            userNamespace = matchNamespace;
+            userNamespace = inputNamespace;
           }
           if (typeof external !== "boolean" && !$isUndefinedOrNull(external)) {
             throw new TypeError('onResolve plugins "external" field must be boolean or unspecified');
@@ -490,11 +490,15 @@ export function runOnResolvePlugins(this: BundlerPlugin, specifier, inputNamespa
     // Also offer "ns:rest" to onResolve({ namespace: "ns" }) with the stripped path.
     if (inputNamespace === "file") {
       var colon = inputPath.indexOf(":");
-      if (
-        colon > 0 &&
-        !(colon === 1 && (inputPath.charCodeAt(0) | 0x20) >= 97 && (inputPath.charCodeAt(0) | 0x20) <= 122)
-      ) {
-        if (await tryNamespace(inputPath.slice(0, colon), inputPath.slice(colon + 1))) {
+      if (colon > 0) {
+        var isDriveLetter =
+          process.platform === "win32" &&
+          colon === 1 &&
+          inputPath.length > 2 &&
+          (inputPath.charCodeAt(0) | 0x20) >= 97 &&
+          (inputPath.charCodeAt(0) | 0x20) <= 122 &&
+          (inputPath.charCodeAt(2) === 47 || inputPath.charCodeAt(2) === 92);
+        if (!isDriveLetter && (await tryNamespace(inputPath.slice(0, colon), inputPath.slice(colon + 1)))) {
           return null;
         }
       }

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -403,79 +403,102 @@ export function runOnResolvePlugins(this: BundlerPlugin, specifier, inputNamespa
 
   var promiseResult: any = (async (inputPath, inputNamespace, importer, kind) => {
     var { onResolve, onLoad } = this;
-    var results = onResolve.$get(inputNamespace);
-    if (!results) {
-      this.onResolveAsync(internalID, null, null, null);
+
+    const tryNamespace = async (matchNamespace: string, matchPath: string) => {
+      var results = onResolve.$get(matchNamespace);
+      if (!results) {
+        return false;
+      }
+
+      for (let [filter, callback] of results) {
+        if (filter.test(matchPath)) {
+          var result = callback({
+            path: matchPath,
+            importer,
+            namespace: matchNamespace,
+            resolveDir: inputNamespace === "file" ? require("node:path").dirname(importer) : undefined,
+            kind,
+            // pluginData
+          });
+
+          while (result && $isPromise(result) && $peekPromiseStatus(result) === 1) {
+            result = $peekPromiseSettledValue(result);
+          }
+
+          if (result && $isPromise(result)) {
+            result = await result;
+          }
+
+          if (!result || !$isObject(result)) {
+            continue;
+          }
+
+          var { path, namespace: userNamespace = matchNamespace, external } = result;
+          if (path !== undefined && typeof path !== "string") {
+            throw new TypeError("onResolve plugins 'path' field must be a string if provided");
+          }
+
+          if (result.namespace !== undefined && typeof result.namespace !== "string") {
+            throw new TypeError("onResolve plugins 'namespace' field must be a string if provided");
+          }
+
+          if (!path) {
+            continue;
+          }
+
+          if (!userNamespace) {
+            userNamespace = matchNamespace;
+          }
+          if (typeof external !== "boolean" && !$isUndefinedOrNull(external)) {
+            throw new TypeError('onResolve plugins "external" field must be boolean or unspecified');
+          }
+
+          if (!external) {
+            if (userNamespace === "file") {
+              if (process.platform !== "win32") {
+                if (path[0] !== "/" || path.includes("..")) {
+                  throw new TypeError('onResolve plugin "path" must be absolute when the namespace is "file"');
+                }
+              } else {
+                if (require("node:path").isAbsolute(path) === false || path.includes("..")) {
+                  throw new TypeError('onResolve plugin "path" must be absolute when the namespace is "file"');
+                }
+              }
+            }
+            if (userNamespace === "dataurl") {
+              if (!path.startsWith("data:")) {
+                throw new TypeError('onResolve plugin "path" must start with "data:" when the namespace is "dataurl"');
+              }
+            }
+
+            if (userNamespace && userNamespace !== "file" && (!onLoad || !onLoad.$has(userNamespace))) {
+              throw new TypeError(`Expected onLoad plugin for namespace ${userNamespace} to exist`);
+            }
+          }
+          this.onResolveAsync(internalID, path, userNamespace, external);
+          return true;
+        }
+      }
+
+      return false;
+    };
+
+    if (await tryNamespace(inputNamespace, inputPath)) {
       return null;
     }
 
-    for (let [filter, callback] of results) {
-      if (filter.test(inputPath)) {
-        var result = callback({
-          path: inputPath,
-          importer,
-          namespace: inputNamespace,
-          resolveDir: inputNamespace === "file" ? require("node:path").dirname(importer) : undefined,
-          kind,
-          // pluginData
-        });
-
-        while (result && $isPromise(result) && $peekPromiseStatus(result) === 1) {
-          result = $peekPromiseSettledValue(result);
+    // An import like "virt:x" from a file-namespace module is also offered to
+    // onResolve({ namespace: "virt" }) with the stripped path, so a plugin
+    // written for the runtime's dispatch works here too.
+    if (inputNamespace === "file") {
+      var colon = inputPath.indexOf(":");
+      if (
+        colon > 0 &&
+        !(colon === 1 && (inputPath.charCodeAt(0) | 0x20) >= 97 && (inputPath.charCodeAt(0) | 0x20) <= 122)
+      ) {
+        if (await tryNamespace(inputPath.slice(0, colon), inputPath.slice(colon + 1))) {
+          return null;
         }
-
-        if (result && $isPromise(result)) {
-          result = await result;
-        }
-
-        if (!result || !$isObject(result)) {
-          continue;
-        }
-
-        var { path, namespace: userNamespace = inputNamespace, external } = result;
-        if (path !== undefined && typeof path !== "string") {
-          throw new TypeError("onResolve plugins 'path' field must be a string if provided");
-        }
-
-        if (result.namespace !== undefined && typeof result.namespace !== "string") {
-          throw new TypeError("onResolve plugins 'namespace' field must be a string if provided");
-        }
-
-        if (!path) {
-          continue;
-        }
-
-        if (!userNamespace) {
-          userNamespace = inputNamespace;
-        }
-        if (typeof external !== "boolean" && !$isUndefinedOrNull(external)) {
-          throw new TypeError('onResolve plugins "external" field must be boolean or unspecified');
-        }
-
-        if (!external) {
-          if (userNamespace === "file") {
-            if (process.platform !== "win32") {
-              if (path[0] !== "/" || path.includes("..")) {
-                throw new TypeError('onResolve plugin "path" must be absolute when the namespace is "file"');
-              }
-            } else {
-              if (require("node:path").isAbsolute(path) === false || path.includes("..")) {
-                throw new TypeError('onResolve plugin "path" must be absolute when the namespace is "file"');
-              }
-            }
-          }
-          if (userNamespace === "dataurl") {
-            if (!path.startsWith("data:")) {
-              throw new TypeError('onResolve plugin "path" must start with "data:" when the namespace is "dataurl"');
-            }
-          }
-
-          if (userNamespace && userNamespace !== "file" && (!onLoad || !onLoad.$has(userNamespace))) {
-            throw new TypeError(`Expected onLoad plugin for namespace ${userNamespace} to exist`);
-          }
-        }
-        this.onResolveAsync(internalID, path, userNamespace, external);
-        return null;
       }
     }
 

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -491,6 +491,7 @@ export function runOnResolvePlugins(this: BundlerPlugin, specifier, inputNamespa
     if (inputNamespace === "file") {
       var colon = inputPath.indexOf(":");
       if (colon > 0) {
+        var prefix = inputPath.slice(0, colon);
         var isDriveLetter =
           process.platform === "win32" &&
           colon === 1 &&
@@ -498,7 +499,7 @@ export function runOnResolvePlugins(this: BundlerPlugin, specifier, inputNamespa
           (inputPath.charCodeAt(0) | 0x20) >= 97 &&
           (inputPath.charCodeAt(0) | 0x20) <= 122 &&
           (inputPath.charCodeAt(2) === 47 || inputPath.charCodeAt(2) === 92);
-        if (!isDriveLetter && (await tryNamespace(inputPath.slice(0, colon), inputPath.slice(colon + 1)))) {
+        if (!isDriveLetter && prefix !== "file" && (await tryNamespace(prefix, inputPath.slice(colon + 1)))) {
           return null;
         }
       }

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -483,7 +483,9 @@ export function runOnResolvePlugins(this: BundlerPlugin, specifier, inputNamespa
       return false;
     };
 
-    if (await tryNamespace(inputNamespace, inputPath)) {
+    // Peek before awaiting so a synchronous callback stays on the synchronous path.
+    var matched = tryNamespace(inputNamespace, inputPath);
+    if ($peekPromiseStatus(matched) === 1 ? $peekPromiseSettledValue(matched) : await matched) {
       return null;
     }
 
@@ -499,8 +501,11 @@ export function runOnResolvePlugins(this: BundlerPlugin, specifier, inputNamespa
           (inputPath.charCodeAt(0) | 0x20) >= 97 &&
           (inputPath.charCodeAt(0) | 0x20) <= 122 &&
           (inputPath.charCodeAt(2) === 47 || inputPath.charCodeAt(2) === 92);
-        if (!isDriveLetter && prefix !== "file" && (await tryNamespace(prefix, inputPath.slice(colon + 1)))) {
-          return null;
+        if (!isDriveLetter && prefix !== "file") {
+          matched = tryNamespace(prefix, inputPath.slice(colon + 1));
+          if ($peekPromiseStatus(matched) === 1 ? $peekPromiseSettledValue(matched) : await matched) {
+            return null;
+          }
         }
       }
     }

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -906,11 +906,8 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, cons
         }
     }
 
-    // A specifier like "virt:x" is split by the caller into namespace="virt"
-    // and path="x". If no callback registered under that namespace matched,
-    // also consult the default (file) namespace group with the full "virt:x"
-    // specifier so that onResolve({ filter: /^virt:/ }) — the form the
-    // bundler and esbuild use — fires at runtime too.
+    // Fall back to the default-namespace group with the full "ns:path" so
+    // onResolve({ filter: /^ns:/ }) matches like it does in Bun.build.
     if (!nsString.isEmpty() && !this->fileNamespace.filters.isEmpty()) {
         WTF::String fullSpecifier = makeString(nsString, ":"_s, pathString);
         RELEASE_AND_RETURN(scope, runOnResolveGroup(globalObject, this->fileNamespace, fullSpecifier, importer));

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -797,13 +797,8 @@ std::optional<String> BunPlugin::OnLoad::resolveVirtualModule(const String& path
     return virtualModules->contains(path) ? std::optional<String> { path } : std::nullopt;
 }
 
-EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, const BunString* namespaceString, const BunString* path, const BunString* importer)
+static EncodedJSValue runOnResolveGroup(JSC::JSGlobalObject* globalObject, BunPlugin::Group& group, const WTF::String& pathString, const BunString* importer)
 {
-    Group* groupPtr = this->group(namespaceString ? namespaceString->toWTFString(BunString::ZeroCopy) : String());
-    if (groupPtr == nullptr) {
-        return JSValue::encode(jsUndefined());
-    }
-    Group& group = *groupPtr;
     auto& filters = group.filters;
 
     if (filters.size() == 0) {
@@ -813,7 +808,6 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, cons
     auto& callbacks = group.callbacks;
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    WTF::String pathString = path->toWTFString(BunString::ZeroCopy);
 
     JSC::MarkedArgumentBuffer matchedCallbacks;
     matchedCallbacks.ensureCapacity(filters.size());
@@ -845,11 +839,9 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, cons
 
         JSC::JSObject* paramsObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
         const auto& builtinNames = WebCore::builtinNames(vm);
-        auto* pathJS = Bun::toJS(globalObject, *path);
-        RETURN_IF_EXCEPTION(scope, {});
         paramsObject->putDirect(
             vm, builtinNames.pathPublicName(),
-            pathJS);
+            jsString(vm, pathString));
         auto* importerJS = Bun::toJS(globalObject, *importer);
         RETURN_IF_EXCEPTION(scope, {});
         paramsObject->putDirect(
@@ -893,6 +885,35 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, cons
         }
 
         RELEASE_AND_RETURN(scope, JSValue::encode(result));
+    }
+
+    return JSValue::encode(JSC::jsUndefined());
+}
+
+EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, const BunString* namespaceString, const BunString* path, const BunString* importer)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    WTF::String nsString = namespaceString ? namespaceString->toWTFString(BunString::ZeroCopy) : String();
+    WTF::String pathString = path->toWTFString(BunString::ZeroCopy);
+
+    if (Group* groupPtr = this->group(nsString)) {
+        EncodedJSValue result = runOnResolveGroup(globalObject, *groupPtr, pathString, importer);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!JSValue::decode(result).isUndefined()) {
+            RELEASE_AND_RETURN(scope, result);
+        }
+    }
+
+    // A specifier like "virt:x" is split by the caller into namespace="virt"
+    // and path="x". If no callback registered under that namespace matched,
+    // also consult the default (file) namespace group with the full "virt:x"
+    // specifier so that onResolve({ filter: /^virt:/ }) — the form the
+    // bundler and esbuild use — fires at runtime too.
+    if (!nsString.isEmpty() && !this->fileNamespace.filters.isEmpty()) {
+        WTF::String fullSpecifier = makeString(nsString, ":"_s, pathString);
+        RELEASE_AND_RETURN(scope, runOnResolveGroup(globalObject, this->fileNamespace, fullSpecifier, importer));
     }
 
     return JSValue::encode(JSC::jsUndefined());

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -906,8 +906,7 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, cons
         }
     }
 
-    // Fall back to the default-namespace group with the full "ns:path" so
-    // onResolve({ filter: /^ns:/ }) matches like it does in Bun.build.
+    // Also offer the full "ns:path" to onResolve({ filter: /^ns:/ }) like Bun.build does.
     if (!nsString.isEmpty() && !this->fileNamespace.filters.isEmpty()) {
         WTF::String fullSpecifier = makeString(nsString, ":"_s, pathString);
         RELEASE_AND_RETURN(scope, runOnResolveGroup(globalObject, this->fileNamespace, fullSpecifier, importer));

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -106,9 +106,7 @@ bool BundlerPlugin::anyMatchesCrossThread(JSC::VM& vm, BunString* namespaceStr, 
     if (anyMatchesForNamespace(vm, list, namespaceString, pathString))
         return true;
 
-    // For onResolve, an import like "virt:x" from a file-namespace source
-    // should also be offered to onResolve({ namespace: "virt" }) with the
-    // stripped path, matching the runtime's dispatch.
+    // onResolve: also offer "ns:rest" to the "ns" group with the stripped path.
     if (!isOnLoad && (namespaceString.isEmpty() || namespaceString == "file"_s) && !list.namespaces.isEmpty()) {
         if (auto colon = pathString.find(':'); colon != WTF::notFound && colon != 0 && !(colon == 1 && isASCIIAlpha(pathString[0]))) {
             auto prefixNamespace = pathString.left(colon);

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -96,19 +96,23 @@ static bool anyMatchesForNamespace(JSC::VM& vm, BundlerPlugin::NamespaceList& li
 }
 bool BundlerPlugin::anyMatchesCrossThread(JSC::VM& vm, BunString* namespaceStr, BunString* path, bool isOnLoad)
 {
+    auto namespaceString = namespaceStr ? namespaceStr->transferToWTFString() : String();
+    auto pathString = path->transferToWTFString();
+
     auto& list = isOnLoad ? this->onLoad : this->onResolve;
     if (list.fileNamespace.isEmpty() && list.namespaces.isEmpty())
         return false;
-
-    auto namespaceString = namespaceStr ? namespaceStr->transferToWTFString() : String();
-    auto pathString = path->transferToWTFString();
 
     if (anyMatchesForNamespace(vm, list, namespaceString, pathString))
         return true;
 
     // onResolve: also offer "ns:rest" to the "ns" group with the stripped path.
     if (!isOnLoad && (namespaceString.isEmpty() || namespaceString == "file"_s) && !list.namespaces.isEmpty()) {
-        if (auto colon = pathString.find(':'); colon != WTF::notFound && colon != 0 && !(colon == 1 && isASCIIAlpha(pathString[0]))) {
+        if (auto colon = pathString.find(':'); colon != WTF::notFound && colon != 0) {
+#if OS(WINDOWS)
+            if (colon == 1 && pathString.length() > 2 && isASCIIAlpha(pathString[0]) && (pathString[2] == '/' || pathString[2] == '\\'))
+                return false;
+#endif
             auto prefixNamespace = pathString.left(colon);
             auto afterNamespace = pathString.substring(colon + 1);
             if (anyMatchesForNamespace(vm, list, prefixNamespace, afterNamespace))

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -76,14 +76,8 @@ void BundlerPlugin::NamespaceList::append(JSC::VM& vm, JSC::RegExp* filter, Stri
     nsGroup->append(WTF::move(filter_regexp));
 }
 
-static bool anyMatchesForNamespace(JSC::VM& vm, BundlerPlugin::NamespaceList& list, BunString* namespaceStr, BunString* path)
+static bool anyMatchesForNamespace(JSC::VM& vm, BundlerPlugin::NamespaceList& list, const String& namespaceString, const String& pathString)
 {
-    auto namespaceString = namespaceStr ? namespaceStr->transferToWTFString() : String();
-    auto pathString = path->transferToWTFString();
-
-    if (list.fileNamespace.isEmpty() && list.namespaces.isEmpty())
-        return false;
-
     unsigned index = 0;
     auto* group = list.group(namespaceString, index);
     if (group == nullptr) {
@@ -102,11 +96,29 @@ static bool anyMatchesForNamespace(JSC::VM& vm, BundlerPlugin::NamespaceList& li
 }
 bool BundlerPlugin::anyMatchesCrossThread(JSC::VM& vm, BunString* namespaceStr, BunString* path, bool isOnLoad)
 {
-    if (isOnLoad) {
-        return anyMatchesForNamespace(vm, this->onLoad, namespaceStr, path);
-    } else {
-        return anyMatchesForNamespace(vm, this->onResolve, namespaceStr, path);
+    auto& list = isOnLoad ? this->onLoad : this->onResolve;
+    if (list.fileNamespace.isEmpty() && list.namespaces.isEmpty())
+        return false;
+
+    auto namespaceString = namespaceStr ? namespaceStr->transferToWTFString() : String();
+    auto pathString = path->transferToWTFString();
+
+    if (anyMatchesForNamespace(vm, list, namespaceString, pathString))
+        return true;
+
+    // For onResolve, an import like "virt:x" from a file-namespace source
+    // should also be offered to onResolve({ namespace: "virt" }) with the
+    // stripped path, matching the runtime's dispatch.
+    if (!isOnLoad && (namespaceString.isEmpty() || namespaceString == "file"_s) && !list.namespaces.isEmpty()) {
+        if (auto colon = pathString.find(':'); colon != WTF::notFound && colon != 0 && !(colon == 1 && isASCIIAlpha(pathString[0]))) {
+            auto prefixNamespace = pathString.left(colon);
+            auto afterNamespace = pathString.substring(colon + 1);
+            if (anyMatchesForNamespace(vm, list, prefixNamespace, afterNamespace))
+                return true;
+        }
     }
+
+    return false;
 }
 
 static const HashTableValue JSBundlerPluginHashTable[] = {

--- a/test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts
+++ b/test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts
@@ -62,7 +62,7 @@ async function run(forms: "A" | "B" | "AB") {
 }
 
 describe("onResolve namespace-prefix dispatch is consistent between runtime and Bun.build", () => {
-  test("onResolve({ filter: /^virt:/ }) resolves `import \"virt:x\"` at runtime and in Bun.build", async () => {
+  test('onResolve({ filter: /^virt:/ }) resolves `import "virt:x"` at runtime and in Bun.build', async () => {
     const { stdout, stderr, exitCode } = await run("A");
     expect(stderr).toBe("");
     const out = JSON.parse(stdout);
@@ -86,7 +86,7 @@ describe("onResolve namespace-prefix dispatch is consistent between runtime and 
     expect(exitCode).toBe(0);
   });
 
-  test("registering both forms resolves `import \"virt:x\"` at runtime and in Bun.build", async () => {
+  test('registering both forms resolves `import "virt:x"` at runtime and in Bun.build', async () => {
     const { stdout, stderr, exitCode } = await run("AB");
     expect(stderr).toBe("");
     const out = JSON.parse(stdout);

--- a/test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts
+++ b/test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// A plugin that registers onResolve either as
+//   (A) onResolve({ filter: /^virt:/ })                   — default/file namespace, full specifier
+//   (B) onResolve({ filter: /.*/, namespace: "virt" })    — explicit namespace, stripped path
+// must handle `import "virt:x"` in both the runtime module loader and Bun.build.
+// Previously the runtime only consulted (B) and Bun.build only consulted (A),
+// so a plugin written one way worked in one context and failed in the other.
+
+const fixture = (forms: "A" | "B" | "AB") => `
+const calls: string[] = [];
+const setup = (b: any) => {
+${
+  forms.includes("A")
+    ? `  b.onResolve({ filter: /^virt:/ }, (args: any) => {
+    calls.push("A:" + args.path);
+    return { path: "a", namespace: "va" };
+  });
+  b.onLoad({ filter: /.*/, namespace: "va" }, () => ({ contents: 'export default "VIA-A";', loader: "js" }));
+`
+    : ""
+}${
+  forms.includes("B")
+    ? `  b.onResolve({ filter: /.*/, namespace: "virt" }, (args: any) => {
+    calls.push("B:" + args.path);
+    return { path: "b", namespace: "vb" };
+  });
+  b.onLoad({ filter: /.*/, namespace: "vb" }, () => ({ contents: 'export default "VIA-B";', loader: "js" }));
+`
+    : ""
+}};
+
+Bun.plugin({ name: "dual", setup });
+const runtime = (await import("virt:thing")).default;
+
+const fs = require("fs");
+const path = require("path");
+const entry = path.join(import.meta.dir, "entry.ts");
+fs.writeFileSync(entry, 'import v from "virt:thing"; export { v };');
+const r = await Bun.build({ entrypoints: [entry], plugins: [{ name: "dual", setup }] });
+if (!r.success) {
+  console.log(JSON.stringify({ ok: false, logs: r.logs.map((l: any) => l.message) }));
+  process.exit(1);
+}
+const bundled = (await r.outputs[0].text()).match(/VIA-[AB]/)![0];
+console.log(JSON.stringify({ ok: true, runtime, bundled, calls }));
+`;
+
+async function run(forms: "A" | "B" | "AB") {
+  using dir = tempDir("plugin-onresolve-ns", {
+    "index.ts": fixture(forms),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("onResolve namespace-prefix dispatch is consistent between runtime and Bun.build", () => {
+  test("onResolve({ filter: /^virt:/ }) resolves `import \"virt:x\"` at runtime and in Bun.build", async () => {
+    const { stdout, stderr, exitCode } = await run("A");
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout);
+    expect(out.ok).toBe(true);
+    expect(out.runtime).toBe("VIA-A");
+    expect(out.bundled).toBe("VIA-A");
+    // Callback receives the full specifier in this form.
+    expect(out.calls).toContain("A:virt:thing");
+    expect(exitCode).toBe(0);
+  });
+
+  test('onResolve({ namespace: "virt" }) resolves `import "virt:x"` at runtime and in Bun.build', async () => {
+    const { stdout, stderr, exitCode } = await run("B");
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout);
+    expect(out.ok).toBe(true);
+    expect(out.runtime).toBe("VIA-B");
+    expect(out.bundled).toBe("VIA-B");
+    // Callback receives the path with the "virt:" prefix stripped in this form.
+    expect(out.calls).toContain("B:thing");
+    expect(exitCode).toBe(0);
+  });
+
+  test("registering both forms resolves `import \"virt:x\"` at runtime and in Bun.build", async () => {
+    const { stdout, stderr, exitCode } = await run("AB");
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout);
+    expect(out.ok).toBe(true);
+    expect(["VIA-A", "VIA-B"]).toContain(out.runtime);
+    expect(["VIA-A", "VIA-B"]).toContain(out.bundled);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts
+++ b/test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts
@@ -61,7 +61,7 @@ async function run(forms: "A" | "B" | "AB") {
   return { stdout, stderr, exitCode };
 }
 
-describe("onResolve namespace-prefix dispatch is consistent between runtime and Bun.build", () => {
+describe.concurrent("onResolve namespace-prefix dispatch is consistent between runtime and Bun.build", () => {
   test('onResolve({ filter: /^virt:/ }) resolves `import "virt:x"` at runtime and in Bun.build', async () => {
     const { stdout, stderr, exitCode } = await run("A");
     expect(stderr).toBe("");
@@ -93,6 +93,43 @@ describe("onResolve namespace-prefix dispatch is consistent between runtime and 
     expect(out.ok).toBe(true);
     expect(["VIA-A", "VIA-B"]).toContain(out.runtime);
     expect(["VIA-A", "VIA-B"]).toContain(out.bundled);
+    expect(exitCode).toBe(0);
+  });
+
+  test('onResolve({ namespace: "virt" }) returning { path } without namespace resolves to a file on disk in both', async () => {
+    using dir = tempDir("plugin-onresolve-ns-file", {
+      "real.js": `export default "FROM-DISK";`,
+      "entry.ts": `import v from "virt:thing"; export { v };`,
+      "index.ts": `
+        const path = require("path");
+        const real = path.join(import.meta.dir, "real.js");
+        const setup = (b: any) => {
+          b.onResolve({ filter: /.*/, namespace: "virt" }, () => ({ path: real }));
+        };
+        Bun.plugin({ name: "to-file", setup });
+        const runtime = (await import("virt:thing")).default;
+        const r = await Bun.build({
+          entrypoints: [path.join(import.meta.dir, "entry.ts")],
+          plugins: [{ name: "to-file", setup }],
+        });
+        if (!r.success) {
+          console.log(JSON.stringify({ ok: false, logs: r.logs.map((l: any) => l.message) }));
+          process.exit(1);
+        }
+        const bundled = (await r.outputs[0].text()).includes("FROM-DISK") ? "FROM-DISK" : "?";
+        console.log(JSON.stringify({ ok: true, runtime, bundled }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout);
+    expect(out).toEqual({ ok: true, runtime: "FROM-DISK", bundled: "FROM-DISK" });
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts
+++ b/test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts
@@ -86,13 +86,15 @@ describe.concurrent("onResolve namespace-prefix dispatch is consistent between r
     expect(exitCode).toBe(0);
   });
 
-  test('registering both forms resolves `import "virt:x"` at runtime and in Bun.build', async () => {
+  test("registering both forms keeps each context's existing primary lookup", async () => {
     const { stdout, stderr, exitCode } = await run("AB");
     expect(stderr).toBe("");
     const out = JSON.parse(stdout);
     expect(out.ok).toBe(true);
-    expect(["VIA-A", "VIA-B"]).toContain(out.runtime);
-    expect(["VIA-A", "VIA-B"]).toContain(out.bundled);
+    expect(out.runtime).toBe("VIA-B");
+    expect(out.bundled).toBe("VIA-A");
+    expect(out.calls).toContain("B:thing");
+    expect(out.calls).toContain("A:virt:thing");
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
## What

For an import like `import "virt:x"`, the runtime module loader and `Bun.build` consulted disjoint `onResolve` registrations:

| registration | runtime `import "virt:x"` | `Bun.build` |
| --- | --- | --- |
| `onResolve({ filter: /^virt:/ })` | never fires | fires, `args.path = "virt:x"` |
| `onResolve({ filter: /.*/, namespace: "virt" })` | fires, `args.path = "x"` | never fires |

So a plugin written for esbuild (`filter: /^virt:/`) bundled fine and failed at runtime with `Cannot find package 'virt:x'`; one written against the runtime's namespace parsing ran fine and failed `Bun.build` with `Could not resolve: "virt:x"`. The only workaround was to register both forms.

Repro:

```ts
const setup = b => {
  b.onResolve({ filter: /^virt:/ }, () => ({ path: "a", namespace: "va" }));            // (A)
  b.onResolve({ filter: /.*/, namespace: "virt" }, () => ({ path: "b", namespace: "vb" })); // (B)
  b.onLoad({ filter: /.*/, namespace: "va" }, () => ({ contents: `export default "VIA-A";`, loader: "js" }));
  b.onLoad({ filter: /.*/, namespace: "vb" }, () => ({ contents: `export default "VIA-B";`, loader: "js" }));
};
Bun.plugin({ name: "dual", setup });
console.log("RUNTIME", (await import("virt:x")).default);          // VIA-B
require("fs").writeFileSync("/tmp/xe.ts", `import x from "virt:x"; console.log(x);`);
const r = await Bun.build({ entrypoints: ["/tmp/xe.ts"], plugins: [{ name: "dual", setup }] });
console.log("BUILD  ", (await r.outputs[0].text()).match(/VIA-[AB]/)[0]);  // VIA-A
```

## Cause

- Runtime: `BunPlugin::OnResolve::run` looks up the group for the parsed prefix namespace and runs only that group. If nothing is registered under that namespace it returns early; the default-namespace (`file`) group is never consulted for `ns:...` specifiers.
- Bundler: `anyMatchesCrossThread` / `runOnResolvePlugins` key the lookup on the importer's namespace (always `file` for a first-level import) and test filters against the full specifier. A callback registered under `namespace: "virt"` is never reached.

## Fix

Make each side fall back to the other form when its primary lookup produces no match:

- `BunPlugin::OnResolve::run` (runtime): after trying the prefix-namespace group, also try the default-namespace group with the reconstructed full specifier `ns:path`.
- `BundlerPlugin::anyMatchesCrossThread` (bundler pre-filter, onResolve only): when the importer namespace is `file`/empty and the specifier has a `ns:` prefix, also test the `ns` group against the stripped path.
- `runOnResolvePlugins` (bundler JS dispatch): after the importer-namespace pass, try the prefix-namespace group with the stripped path.

The previous primary lookup runs first in each context, so plugins that register both forms (the current workaround) keep their existing behavior. A single-letter `X:` prefix is treated as a drive letter and skipped, consistent with the existing checks.

## Testing

`test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts` spawns a subprocess per case (form A only / form B only / both) and asserts that both the runtime import and `Bun.build` resolve through the plugin, with the expected `args.path` in each form.

```
(pass) onResolve({ filter: /^virt:/ }) resolves `import "virt:x"` at runtime and in Bun.build
(pass) onResolve({ namespace: "virt" }) resolves `import "virt:x"` at runtime and in Bun.build
(pass) registering both forms resolves `import "virt:x"` at runtime and in Bun.build
```

Existing plugin suites (`test/js/bun/plugin/plugins.test.ts`, `test/bundler/bundler_plugin.test.ts`, `test/bundler/bundler_plugin_chain.test.ts`, `test/bundler/bun-build-api.test.ts`) pass unchanged.

Fixes #9863

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts:
62 | }
63 | 
64 | describe.concurrent("onResolve namespace-prefix dispatch is consistent between runtime and Bun.build", () => {
65 |   test('onResolve({ filter: /^virt:/ }) resolves `import "virt:x"` at runtime and in Bun.build', async () => {
66 |     const { stdout, stderr, exitCode } = await run("A");
67 |     expect(stderr).toBe("");
                        ^
error: expect(received).toBe(expected)

- ""
+ "error: Cannot find package 'virt:thing' from '/tmp/plugin-onresolve-ns_ltDgBN/index.ts'
+ 
+ Bun v1.4.1-debug+adc354d99 (Linux x64)
+ "

- Expected  - 1
+ Received  + 4

      at <anonymous> (/workspace/bun/test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts:67:20)
(fail) onResolve namespace-prefix dispatch is consistent between runtime and Bun.build > onResolve({ filter: /^virt:/ }) resolves `import "virt:x"` at runtime and in Bun.build [398.18ms]
127 |       env: bunEn
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (9ecb46465)

test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts:
(pass) onResolve namespace-prefix dispatch is consistent between runtime and Bun.build > onResolve({ namespace: "virt" }) returning { path } without namespace resolves to a file on disk in both [11.49ms]
(pass) onResolve namespace-prefix dispatch is consistent between runtime and Bun.build > onResolve({ namespace: "virt" }) resolves `import "virt:x"` at runtime and in Bun.build [14.38ms]
(pass) onResolve namespace-prefix dispatch is consistent between runtime and Bun.build > onResolve({ filter: /^virt:/ }) resolves `import "virt:x"` at runtime and in Bun.build [16.26ms]
(pass) onResolve namespace-prefix dispatch is consistent between runtime and Bun.build > registering both forms keeps each context's existing primary lookup [13.35ms]

 4 pass
 0 fail
 22 expect() calls
Ran 4 tests across 1 file. [106.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts:
(pass) onResolve namespace-prefix dispatch is consistent between runtime and Bun.build > onResolve({ namespace: "virt" }) returning { path } without namespace resolves to a file on disk in both [542.48ms]
(pass) onResolve namespace-prefix dispatch is consistent between runtime and Bun.build > onResolve({ filter: /^virt:/ }) resolves `import "virt:x"` at runtime and in Bun.build [812.15ms]
(pass) onResolve namespace-prefix dispatch is consistent between runtime and Bun.build > registering both forms keeps each context's existing primary lookup [729.39ms]
(pass) onResolve namespace-prefix dispatch is consistent between runtime and Bun.build > onResolve({ namespace: "virt" }) resolves `import "virt:x"` at runtime and in Bun.build [746.04ms]

 4 pass
 0 fail
 22 expect() calls
Ran 4 tests across 1 file. [3.05s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 717ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen cpp.rs (cppbind)
[2/22] gen JS modules (bundle-modules)
Preprocess modules (7921ms)
Bundle modules (49ms)
Postprocesss modules (30ms)
Bundle Functions (477ms)
Generate Code (38ms)

[8.53s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/11] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins/BundlerPlugin.ts                   | 143 +++++++++++++--------
 src/jsc/bindings/BunPlugin.cpp                     |  37 ++++--
 src/jsc/bindings/JSBundlerPlugin.cpp               |  36 ++++--
 .../plugin-onresolve-namespace-prefix.test.ts      | 137 ++++++++++++++++++++
 4 files changed, 276 insertions(+), 77 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/builtins/BundlerPlugin.ts                              6      7      0
src/jsc/bindings/BunPlugin.cpp                                5      5      0
src/jsc/bindings/JSBundlerPlugin.cpp                          4      4      0
…js/bun/plugin/plugin-onresolve-namespace-prefix.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->