### PR TITLE
console: format boxed primitives and RegExp from their internal slot

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3848,7 +3848,11 @@ pub mod formatter {
                 let number_value: &[u8] = if inner.is_nan() {
                     b"NaN"
                 } else if inner.is_infinite() {
-                    if inner > 0.0 { b"Infinity" } else { b"-Infinity" }
+                    if inner > 0.0 {
+                        b"Infinity"
+                    } else {
+                        b"-Infinity"
+                    }
                 } else {
                     bun_core::fmt::FormatDouble::dtoa_with_negative_zero(&mut buf, inner)
                 };

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3648,7 +3648,25 @@ pub mod formatter {
         ) -> JsResult<()> {
             // This is called from the '%s' formatter, so it can actually be any value
             use crate::StringJsc as _;
-            let str = OwnedString::new(BunString::from_js(value, self.global_this)?);
+            // For boxed strings and RegExp objects read the internal slot directly;
+            // `BunString::from_js` on the wrapper would dispatch through ToPrimitive
+            // and run user-defined toString / valueOf / Symbol.toPrimitive.
+            let (str, inner) = match js_type {
+                jsc::JSType::StringObject | jsc::JSType::DerivedStringObject => {
+                    let inner = value.wrapper_internal_value();
+                    (
+                        OwnedString::new(BunString::from_js(inner, self.global_this)?),
+                        inner,
+                    )
+                }
+                jsc::JSType::RegExpObject => {
+                    (OwnedString::new(value.regexp_display_string()), value)
+                }
+                _ => (
+                    OwnedString::new(BunString::from_js(value, self.global_this)?),
+                    value,
+                ),
+            };
             let mut writer = WrappedWriter {
                 ctx: writer_,
                 failed: false,
@@ -3673,7 +3691,7 @@ pub mod formatter {
                     if writer.failed {
                         self.failed = true;
                     }
-                    self.print_as::<C>(Tag::JSON, writer_, value, jsc::JSType::StringObject)?;
+                    self.print_as::<C>(Tag::JSON, writer_, inner, jsc::JSType::StringObject)?;
                     if C {
                         let _ = writer_.write_all(pfmt!("<r>", true).as_bytes());
                     }
@@ -3702,7 +3720,7 @@ pub mod formatter {
                     if writer.failed {
                         self.failed = true;
                     }
-                    self.print_as::<C>(Tag::JSON, writer_, value, jsc::JSType::StringObject)?;
+                    self.print_as::<C>(Tag::JSON, writer_, inner, jsc::JSType::StringObject)?;
                     writer = WrappedWriter {
                         ctx: writer_,
                         failed: false,
@@ -3825,12 +3843,20 @@ pub mod formatter {
                 let mut number_name = ZigString::EMPTY;
                 value.get_class_name(self.global_this, &mut number_name)?;
 
-                let mut number_value = ZigString::EMPTY;
-                value.to_zig_string(&mut number_value, self.global_this)?;
+                let inner = value.wrapper_internal_value().as_number();
+                let mut buf = [0u8; 124];
+                let number_value: &[u8] = if inner.is_nan() {
+                    b"NaN"
+                } else if inner.is_infinite() {
+                    if inner > 0.0 { b"Infinity" } else { b"-Infinity" }
+                } else {
+                    bun_core::fmt::FormatDouble::dtoa_with_negative_zero(&mut buf, inner)
+                };
+                let number_value = bstr::BStr::new(number_value);
 
                 if number_name.slice() != b"Number" {
                     writer.add_for_new_line(
-                        number_name.len + number_value.len + "[Number ():]".len(),
+                        number_name.len + number_value.len() + "[Number ():]".len(),
                     );
                     writer.print(format_args!(
                         "{}[Number ({}): {}]{}",
@@ -3845,7 +3871,7 @@ pub mod formatter {
                     return Ok(());
                 }
 
-                writer.add_for_new_line(number_name.len + number_value.len + 4);
+                writer.add_for_new_line(number_name.len + number_value.len() + 4);
                 writer.print(format_args!(
                     "{}[{}: {}]{}",
                     pf!("<r><yellow>"),
@@ -4232,12 +4258,16 @@ pub mod formatter {
             if value.is_cell() {
                 let mut bool_name = ZigString::EMPTY;
                 value.get_class_name(self.global_this, &mut bool_name)?;
-                let mut bool_value = ZigString::EMPTY;
-                value.to_zig_string(&mut bool_value, self.global_this)?;
+                let bool_value: &str = if value.wrapper_internal_value().to_boolean() {
+                    "true"
+                } else {
+                    "false"
+                };
 
                 if bool_name.slice() != b"Boolean" {
-                    writer
-                        .add_for_new_line(bool_value.len + bool_name.len + "[Boolean (): ]".len());
+                    writer.add_for_new_line(
+                        bool_value.len() + bool_name.len + "[Boolean (): ]".len(),
+                    );
                     writer.print(format_args!(
                         "{}[Boolean ({}): {}]{}",
                         pf!("<r><yellow>"),
@@ -4250,7 +4280,7 @@ pub mod formatter {
                     }
                     return Ok(());
                 }
-                writer.add_for_new_line(bool_value.len + "[Boolean: ]".len());
+                writer.add_for_new_line(bool_value.len() + "[Boolean: ]".len());
                 writer.print(format_args!(
                     "{}[Boolean: {}]{}",
                     pf!("<r><yellow>"),

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1520,7 +1520,10 @@ pub fn format2(
             any = true;
 
             tag = formatter::Tag::get(this_value, global)?;
-            if matches!(tag.tag, TagPayload::String) && !fmt.remaining().is_empty() {
+            if matches!(tag.tag, TagPayload::String)
+                && tag.cell == jsc::JSType::String
+                && !fmt.remaining().is_empty()
+            {
                 tag.tag = TagPayload::StringPossiblyFormatted;
             }
 
@@ -1542,7 +1545,10 @@ pub fn format2(
             }
             any = true;
             tag = formatter::Tag::get(this_value, global)?;
-            if matches!(tag.tag, TagPayload::String) && !fmt.remaining().is_empty() {
+            if matches!(tag.tag, TagPayload::String)
+                && tag.cell == jsc::JSType::String
+                && !fmt.remaining().is_empty()
+            {
                 tag.tag = TagPayload::StringPossiblyFormatted;
             }
 

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3648,9 +3648,7 @@ pub mod formatter {
         ) -> JsResult<()> {
             // This is called from the '%s' formatter, so it can actually be any value
             use crate::StringJsc as _;
-            // For boxed strings and RegExp objects read the internal slot directly;
-            // `BunString::from_js` on the wrapper would dispatch through ToPrimitive
-            // and run user-defined toString / valueOf / Symbol.toPrimitive.
+            // Wrapper objects: read the internal slot, not ToString (which runs user hooks).
             let (str, inner) = match js_type {
                 jsc::JSType::StringObject | jsc::JSType::DerivedStringObject => {
                     let inner = value.wrapper_internal_value();

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2287,17 +2287,13 @@ impl JSValue {
     pub fn unwrap_boxed_primitive(self, global: &JSGlobalObject) -> JsResult<JSValue> {
         host_fn::from_js_host_call(global, || JSC__JSValue__unwrapBoxedPrimitive(global, self))
     }
-    /// Reads the internal `[[PrimitiveValue]]` slot of a `Number` / `String` /
-    /// `Boolean` / `Symbol` / `BigInt` wrapper object directly, bypassing
-    /// `ToPrimitive` (and thus any user-defined `toString` / `valueOf` /
-    /// `Symbol.toPrimitive`). Returns `self` unchanged for anything that is
-    /// not a `JSWrapperObject`. Never throws and never runs JS.
+    /// `JSWrapperObject::internalValue()`: the `[[PrimitiveValue]]` slot of a
+    /// boxed primitive, bypassing `ToPrimitive`. Never runs JS.
     pub fn wrapper_internal_value(self) -> JSValue {
         JSC__JSValue__getWrapperInternalValue(self)
     }
-    /// Formats a `RegExp` object as `/source/flags` from its internal record,
-    /// bypassing `RegExp.prototype.toString`. Returns an empty string for
-    /// anything that is not a `RegExpObject`. Never throws and never runs JS.
+    /// `RegExp::toSourceString()`: `/source/flags` from the internal record,
+    /// bypassing `RegExp.prototype.toString`. Never runs JS.
     pub fn regexp_display_string(self) -> bun_core::String {
         let mut out = bun_core::String::default();
         JSC__JSValue__getRegExpDisplayString(self, &mut out);

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2287,6 +2287,22 @@ impl JSValue {
     pub fn unwrap_boxed_primitive(self, global: &JSGlobalObject) -> JsResult<JSValue> {
         host_fn::from_js_host_call(global, || JSC__JSValue__unwrapBoxedPrimitive(global, self))
     }
+    /// Reads the internal `[[PrimitiveValue]]` slot of a `Number` / `String` /
+    /// `Boolean` / `Symbol` / `BigInt` wrapper object directly, bypassing
+    /// `ToPrimitive` (and thus any user-defined `toString` / `valueOf` /
+    /// `Symbol.toPrimitive`). Returns `self` unchanged for anything that is
+    /// not a `JSWrapperObject`. Never throws and never runs JS.
+    pub fn wrapper_internal_value(self) -> JSValue {
+        JSC__JSValue__getWrapperInternalValue(self)
+    }
+    /// Formats a `RegExp` object as `/source/flags` from its internal record,
+    /// bypassing `RegExp.prototype.toString`. Returns an empty string for
+    /// anything that is not a `RegExpObject`. Never throws and never runs JS.
+    pub fn regexp_display_string(self) -> bun_core::String {
+        let mut out = bun_core::String::default();
+        JSC__JSValue__getRegExpDisplayString(self, &mut out);
+        out
+    }
     /// `JSValue.getPrototype`.
     pub fn get_prototype(self, global: &JSGlobalObject) -> JSValue {
         JSC__JSValue__getPrototype(self, global)
@@ -2674,6 +2690,8 @@ unsafe extern "C" {
     safe fn Bun__JSValue__toNumber(this: JSValue, global: &JSGlobalObject) -> f64;
     safe fn JSC__JSValue__toObject(this: JSValue, global: &JSGlobalObject) -> *mut JSObject;
     safe fn JSC__JSValue__unwrapBoxedPrimitive(global: &JSGlobalObject, this: JSValue) -> JSValue;
+    safe fn JSC__JSValue__getWrapperInternalValue(this: JSValue) -> JSValue;
+    safe fn JSC__JSValue__getRegExpDisplayString(this: JSValue, out: &mut bun_core::String);
     safe fn JSC__JSValue__getPrototype(this: JSValue, global: &JSGlobalObject) -> JSValue;
     safe fn JSC__JSValue__getName(
         this: JSValue,

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2287,13 +2287,11 @@ impl JSValue {
     pub fn unwrap_boxed_primitive(self, global: &JSGlobalObject) -> JsResult<JSValue> {
         host_fn::from_js_host_call(global, || JSC__JSValue__unwrapBoxedPrimitive(global, self))
     }
-    /// `JSWrapperObject::internalValue()`: the `[[PrimitiveValue]]` slot of a
-    /// boxed primitive, bypassing `ToPrimitive`. Never runs JS.
+    /// `JSWrapperObject::internalValue()` for a boxed primitive. Never runs JS.
     pub fn wrapper_internal_value(self) -> JSValue {
         JSC__JSValue__getWrapperInternalValue(self)
     }
-    /// `RegExp::toSourceString()`: `/source/flags` from the internal record,
-    /// bypassing `RegExp.prototype.toString`. Never runs JS.
+    /// `RegExp::toSourceString()`: `/source/flags` from the internal record. Never runs JS.
     pub fn regexp_display_string(self) -> bun_core::String {
         let mut out = bun_core::String::default();
         JSC__JSValue__getRegExpDisplayString(self, &mut out);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2284,11 +2284,6 @@ BunString WebCore__DOMURL__fileSystemPath(WebCore::DOMURL* arg0, int* errorCode)
     return BunString { BunStringTag::Dead, nullptr };
 }
 
-// Reads the internal [[PrimitiveValue]] slot of a wrapper object without
-// invoking any user-observable conversion (no ToPrimitive, no getters).
-// Used by the native formatter so that console.log / Bun.inspect cannot be
-// spoofed by overriding toString / valueOf / Symbol.toPrimitive on a boxed
-// primitive, and so that a throwing hook does not abort printing.
 extern "C" JSC::EncodedJSValue JSC__JSValue__getWrapperInternalValue(EncodedJSValue encodedValue)
 {
     JSValue value = JSValue::decode(encodedValue);
@@ -2299,9 +2294,6 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__getWrapperInternalValue(EncodedJSVa
     return encodedValue;
 }
 
-// Formats a RegExp as `/source/flags` from its internal RegExp record, never
-// calling into JS (RegExp.prototype.toString / .source / .flags are all
-// user-overridable).
 extern "C" void JSC__JSValue__getRegExpDisplayString(EncodedJSValue encodedValue, BunString* out)
 {
     JSValue value = JSValue::decode(encodedValue);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2284,6 +2284,34 @@ BunString WebCore__DOMURL__fileSystemPath(WebCore::DOMURL* arg0, int* errorCode)
     return BunString { BunStringTag::Dead, nullptr };
 }
 
+// Reads the internal [[PrimitiveValue]] slot of a wrapper object without
+// invoking any user-observable conversion (no ToPrimitive, no getters).
+// Used by the native formatter so that console.log / Bun.inspect cannot be
+// spoofed by overriding toString / valueOf / Symbol.toPrimitive on a boxed
+// primitive, and so that a throwing hook does not abort printing.
+extern "C" JSC::EncodedJSValue JSC__JSValue__getWrapperInternalValue(EncodedJSValue encodedValue)
+{
+    JSValue value = JSValue::decode(encodedValue);
+    if (!value.isObject())
+        return encodedValue;
+    if (auto* wrapper = dynamicDowncast<JSWrapperObject>(asObject(value)))
+        return JSValue::encode(wrapper->internalValue());
+    return encodedValue;
+}
+
+// Formats a RegExp as `/source/flags` from its internal RegExp record, never
+// calling into JS (RegExp.prototype.toString / .source / .flags are all
+// user-overridable).
+extern "C" void JSC__JSValue__getRegExpDisplayString(EncodedJSValue encodedValue, BunString* out)
+{
+    JSValue value = JSValue::decode(encodedValue);
+    if (auto* object = dynamicDowncast<RegExpObject>(value)) {
+        *out = Bun::toStringRef(object->regExp()->toSourceString());
+        return;
+    }
+    *out = BunString { BunStringTag::Dead, nullptr };
+}
+
 // Taken from unwrapBoxedPrimitive in JSONObject.cpp in WebKit
 extern "C" JSC::EncodedJSValue JSC__JSValue__unwrapBoxedPrimitive(JSGlobalObject* globalObject, EncodedJSValue encodedValue)
 {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -853,6 +853,27 @@ describe("boxed primitives and RegExp with overridden conversion hooks", () => {
     expect(Bun.inspect({ before: 1, boxed: n, after: 2 })).toBe(
       "{\n  before: 1,\n  boxed: [Number: 5],\n  after: 2,\n}",
     );
+
+    const s16 = new String("日本語");
+    s16.toString = throwing;
+    expect(Bun.inspect(s16)).toBe('"日本語"');
+    expect(Bun.inspect({ x: s16 })).toBe('{\n  x: "日本語",\n}');
+
+    class MyNum extends Number {}
+    const mn = new MyNum(3);
+    mn.toString = throwing;
+    expect(Bun.inspect(mn)).toBe("[Number (MyNum): 3]");
+
+    class MyBool extends Boolean {}
+    const mb = new MyBool(false);
+    mb.toString = throwing;
+    expect(Bun.inspect(mb)).toBe("[Boolean (MyBool): false]");
+
+    class MyStr extends String {}
+    const ms = new MyStr("hi");
+    ms.toString = throwing;
+    expect(Bun.inspect(ms)).toBe('"hi"');
+
     expect(calls).toEqual([]);
   });
 
@@ -884,6 +905,15 @@ describe("boxed primitives and RegExp with overridden conversion hooks", () => {
 
       console.log({ before: 1, boxed: t, re: r, after: 2 });
 
+      // As non-last args (must not be promoted to the %-format string path):
+      console.log(r, "x");
+      console.log(s, "x");
+      console.log(new String("%s"), "arg");
+
+      const s16 = new String("😀日本語");
+      s16.toString = throwing;
+      console.log(s16);
+
       console.log("calls:" + calls.length);
     `;
     await using proc = Bun.spawn({
@@ -905,6 +935,10 @@ describe("boxed primitives and RegExp with overridden conversion hooks", () => {
         re: /abc/gi,
         after: 2,
       }
+      /abc/gi x
+      [String: "hi"] x
+      [String: "%s"] arg
+      [String: "😀日本語"]
       calls:0"
     `);
     expect(exitCode).toBe(0);

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -803,3 +803,112 @@ it("CustomEvent", () => {
     }"
   `);
 });
+
+describe("boxed primitives and RegExp with overridden conversion hooks", () => {
+  it("reads the internal slot, does not run user hooks, does not throw", () => {
+    const calls = [];
+    const throwing = () => {
+      calls.push("THROW");
+      throw new Error("should not be called");
+    };
+
+    const n = new Number(5);
+    n[Symbol.toPrimitive] = throwing;
+    n.toString = throwing;
+    n.valueOf = throwing;
+
+    const bFalse = new Boolean(false);
+    bFalse[Symbol.toPrimitive] = throwing;
+    bFalse.toString = throwing;
+    bFalse.valueOf = throwing;
+
+    const bTrue = new Boolean(true);
+    bTrue.toString = throwing;
+
+    const s = new String("hello");
+    s[Symbol.toPrimitive] = throwing;
+    s.toString = throwing;
+    s.valueOf = throwing;
+
+    const r = /a/g;
+    r[Symbol.toPrimitive] = throwing;
+    r.toString = throwing;
+
+    const nan = new Number(NaN);
+    nan.toString = throwing;
+
+    const inf = new Number(Infinity);
+    inf.toString = throwing;
+
+    expect(Bun.inspect(n)).toBe("[Number: 5]");
+    expect(Bun.inspect(nan)).toBe("[Number: NaN]");
+    expect(Bun.inspect(inf)).toBe("[Number: Infinity]");
+    expect(Bun.inspect(bFalse)).toBe("[Boolean: false]");
+    expect(Bun.inspect(bTrue)).toBe("[Boolean: true]");
+    expect(Bun.inspect(s)).toBe('"hello"');
+    expect(Bun.inspect(r)).toBe("/a/g");
+    // nested in an object: must not abort mid-print
+    expect(Bun.inspect({ before: 1, boxed: n, after: 2 })).toBe(
+      "{\n  before: 1,\n  boxed: [Number: 5],\n  after: 2,\n}",
+    );
+    expect(calls).toEqual([]);
+  });
+
+  it("console.log does not run user hooks and does not throw mid-line", async () => {
+    const src = `
+      const calls = [];
+      const hook = tag => () => { calls.push(tag); return "SPOOF"; };
+      const throwing = () => { throw new Error("boom") };
+
+      const n = new Number(5);
+      n[Symbol.toPrimitive] = hook("n");
+      console.log(n);
+
+      const b = new Boolean(false);
+      b.toString = hook("b");
+      console.log(b);
+
+      const s = new String("hi");
+      s.toString = hook("s");
+      console.log(s);
+
+      const t = new Number(7);
+      t.toString = throwing;
+      console.log(t);
+
+      const r = /abc/gi;
+      r.toString = throwing;
+      console.log(r);
+
+      console.log({ before: 1, boxed: t, re: r, after: 2 });
+
+      console.log("calls:" + calls.length);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: { ...bunEnv, NO_COLOR: "1" },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+      "[Number: 5]
+      [Boolean: false]
+      [String: "hi"]
+      [Number: 7]
+      /abc/gi
+      {
+        before: 1,
+        boxed: [Number: 7],
+        re: /abc/gi,
+        after: 2,
+      }
+      calls:0"
+    `);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -889,11 +889,7 @@ describe("boxed primitives and RegExp with overridden conversion hooks", () => {
       env: { ...bunEnv, NO_COLOR: "1" },
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
       "[Number: 5]

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -843,6 +843,8 @@ describe("boxed primitives and RegExp with overridden conversion hooks", () => {
     expect(Bun.inspect(n)).toBe("[Number: 5]");
     expect(Bun.inspect(nan)).toBe("[Number: NaN]");
     expect(Bun.inspect(inf)).toBe("[Number: Infinity]");
+    expect(Bun.inspect(new Number(-Infinity))).toBe("[Number: -Infinity]");
+    expect(Bun.inspect(new Number(-0))).toBe("[Number: -0]");
     expect(Bun.inspect(bFalse)).toBe("[Boolean: false]");
     expect(Bun.inspect(bTrue)).toBe("[Boolean: true]");
     expect(Bun.inspect(s)).toBe('"hello"');


### PR DESCRIPTION
## What

The native `console.log` / `Bun.inspect` formatter rendered boxed primitives (`new Number/String/Boolean`) and `RegExp` objects by running spec `ToString` on the wrapper object, which dispatches through the value's own `[Symbol.toPrimitive]` / `toString` / `valueOf`:

```js
const n = new Number(5);
n[Symbol.toPrimitive] = h => "TP-Number";
console.log(n);          // before: [Number: TP-Number]   after: [Number: 5]

const t = new Number(7);
t.toString = () => { throw new Error("boom") };
console.log(t);          // before: throws "boom" out of console.log
console.log({ a: 1, boxed: t, b: 2 });  // before: "{ a: 1, boxed: " then throws mid-line
```

Node reads the internal `[[NumberData]]` / `[[StringData]]` / `[[BooleanData]]` slot and never invokes the hooks. Bun's own ported `node:util.inspect` was already correct; only the native path had this.

## Fix

- New `JSC__JSValue__getWrapperInternalValue` reads `JSWrapperObject::internalValue()` directly (no `ToPrimitive`, no getters, never throws).
- New `JSC__JSValue__getRegExpDisplayString` formats `/source/flags` from `RegExp::toSourceString()` (the internal `RegExp` record, not `RegExp.prototype.toString`).
- `print_double` / `print_boolean` / `print_string` in `ConsoleObject.rs` now obtain their text from the internal value instead of `to_zig_string` / `BunString::from_js` on the wrapper.

`JSC__JSValue__unwrapBoxedPrimitive` is left alone: it intentionally mirrors WebKit's `JSONObject.cpp` `unwrapBoxedPrimitive` for `JSON.stringify` semantics, which the TOML/YAML/JSON5 stringifiers depend on.

Side effect: `new Number(-0)` now prints `[Number: -0]` (matches Node); it previously printed `[Number: 0]` because spec `ToString(-0)` is `"0"`.

## Verification

```sh
USE_SYSTEM_BUN=1 bun test test/js/bun/util/inspect.test.js -t "boxed primitives"  # 2 fail
bun bd test test/js/bun/util/inspect.test.js -t "boxed primitives"                # 2 pass
bun bd test test/js/bun/util/inspect.test.js                                      # 75 pass
bun bd test test/js/bun/console/ test/js/web/console/                             # pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
bun test v1.4.0 (66730150f)

test/js/bun/util/inspect.test.js:
(pass) prototype [293.97ms]
(pass) getters [5.30ms]
(pass) setters [3.48ms]
(pass) getter/setters [2.10ms]
(pass) Timeout [4.72ms]
(pass) when prototype defines the same property, don't print the same property twice [2.07ms]
(pass) Blob inspect [8.65ms]
(pass) utf16 property name [59.60ms]
(pass) latin1 [4.03ms]
(pass) Request object [2.54ms]
(pass) MessageEvent [1.84ms]
(pass) MessageEvent with no data set [2.14ms]
(pass) MessageEvent with deleted data [2.48ms]
(pass) TypedArray prints [92.01ms]
(pass) BigIntArray [30.25ms]
(pass) Float32Array 42.68000030517578 [3.82ms]
(pass) Float32Array 42.68 [3.85ms]
(pass) Float64Array 42.68000030517578 [1.35ms]
(pass) Float64Array 42.68 [1.60ms]
(pass) jsx with two elements [26.22ms]
(pass) jsx with anon component [2.58ms]
(pass) jsx with fragment [4.28ms]
(pass) inspect [72.42ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [1.64ms]
(pass) latin1 supplemental > latin1 (input) "cbä" 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (96f2fdd40)

test/js/bun/util/inspect.test.js:
(pass) prototype [3.31ms]
(pass) getters [0.11ms]
(pass) setters [0.04ms]
(pass) getter/setters [0.02ms]
(pass) Timeout [0.07ms]
(pass) when prototype defines the same property, don't print the same property twice [0.03ms]
(pass) Blob inspect [0.22ms]
(pass) utf16 property name [1.13ms]
(pass) latin1 [0.05ms]
(pass) Request object [0.04ms]
(pass) MessageEvent [0.03ms]
(pass) MessageEvent with no data set [0.01ms]
(pass) MessageEvent with deleted data [0.03ms]
(pass) TypedArray prints [0.83ms]
(pass) BigIntArray [0.31ms]
(pass) Float32Array 42.68000030517578 [0.07ms]
(pass) Float32Array 42.68 [0.07ms]
(pass) Float64Array 42.68000030517578 [0.01ms]
(pass) Float64Array 42.68
(pass) jsx with two elements [0.54ms]
(pass) jsx with anon component [0.03ms]
(pass) jsx with fragment [0.07ms]
(pass) inspect [0.66ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [0.03ms]
(pass) latin1 supplemental > latin1 (input) "cbä" [ "cbä" ]
(pass) latin1 supplemental > latin1 (input) "cäb" [ "cäb" ]
(pass) latin1 supplemental > latin1 (input) "äbc äbc" [ "äbc äbc" ]
(pass) latin1 supplemental >
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
bun test v1.4.0 (66730150f)

test/js/bun/util/inspect.test.js:
(pass) prototype [341.92ms]
(pass) getters [5.21ms]
(pass) setters [3.72ms]
(pass) getter/setters [3.31ms]
(pass) Timeout [7.29ms]
(pass) when prototype defines the same property, don't print the same property twice [2.72ms]
(pass) Blob inspect [9.26ms]
(pass) utf16 property name [77.17ms]
(pass) latin1 [4.06ms]
(pass) Request object [2.59ms]
(pass) MessageEvent [1.86ms]
(pass) MessageEvent with no data set [1.80ms]
(pass) MessageEvent with deleted data [2.50ms]
(pass) TypedArray prints [129.07ms]
(pass) BigIntArray [35.47ms]
(pass) Float32Array 42.68000030517578 [4.00ms]
(pass) Float32Array 42.68 [4.00ms]
(pass) Float64Array 42.68000030517578 [1.36ms]
(pass) Float64Array 42.68 [1.61ms]
(pass) jsx with two elements [34.10ms]
(pass) jsx with anon component [2.85ms]
(pass) jsx with fragment [6.68ms]
(pass) inspect [103.95ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [4.00ms]
(pass) latin1 supplemental > latin1 (input) "cbä
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 631ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/src/jsc/bindings/bindings.cpp.o
[2/7] gen cpp.rs (cppbind)
[3/7] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Com
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs         |  56 +++++++++++++++-----
 src/jsc/JSValue.rs               |  12 +++++
 src/jsc/bindings/bindings.cpp    |  20 ++++++++
 test/js/bun/util/inspect.test.js | 107 +++++++++++++++++++++++++++++++++++++++
 4 files changed, 183 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/jsc/ConsoleObject.rs              6      9      0
src/jsc/JSValue.rs                    5      5      0
src/jsc/bindings/bindings.cpp         5      3      0
test/js/bun/util/inspect.test.js      3      5      0
```

</details>

<!-- robobun:evidence:end -->