### PR TITLE
glob: cache each brace group's close index so skip_branch is O(1)

### DIFF
--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -565,8 +565,9 @@ fn match_brace_branch(
 /// frames for groups already exited earlier in this attempt (sequential
 /// `{a,b}/{c,d}` keeps A on the stack while matching inside B), and wildcard
 /// backtracks can re-enter a later frame without the count lining up. So scan
-/// the (≤10-entry) stack by range instead. Frames are pushed outer→inner so the
-/// last match when iterating in reverse is the innermost enclosing group.
+/// the (≤10-entry) stack by range instead. Frames are pushed outer→inner, so
+/// iterating in reverse visits inner→outer and the first enclosing frame found
+/// is the innermost.
 fn skip_branch(state: &mut State, glob: &[u8], brace_stack: &BraceStack) -> bool {
     let gi = state.glob_index;
     for frame in brace_stack.as_slice().iter().rev() {

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -34,6 +34,10 @@ use bun_core::strings;
 struct Brace {
     open_brace_idx: u32,
     branch_idx: u32,
+    /// Index of the matching `}` (or `glob.len()` if unterminated). Computed
+    /// once per group so `skip_branch` is an O(1) jump instead of a linear
+    /// scan; without it a wide group costs `BRACE_BRANCH_BUDGET * group_len`.
+    close_brace_idx: u32,
 }
 type BraceStack = BoundedArray<Brace, 10>;
 
@@ -368,16 +372,14 @@ fn glob_match_impl(
                             return match_brace(state, glob, path, brace_stack, brace_budget);
                         }
                         b',' => {
-                            if state.brace_depth > 0 {
-                                skip_branch(state, glob);
+                            if state.brace_depth > 0 && skip_branch(state, glob, brace_stack) {
                                 continue 'main_loop;
                             } else {
                                 break 'to_else;
                             }
                         }
                         b'}' => {
-                            if state.brace_depth > 0 {
-                                skip_branch(state, glob);
+                            if state.brace_depth > 0 && skip_branch(state, glob, brace_stack) {
                                 continue 'main_loop;
                             } else {
                                 break 'to_else;
@@ -442,6 +444,7 @@ fn match_brace(
     let mut in_brackets = false;
 
     let open_brace_index = state.glob_index;
+    let close_brace_index = find_brace_end(glob, open_brace_index);
 
     let mut branch_index: u32 = 0;
 
@@ -465,6 +468,7 @@ fn match_brace(
                             path,
                             open_brace_index,
                             branch_index,
+                            close_brace_index,
                             brace_stack,
                             brace_budget,
                         ) {
@@ -485,6 +489,7 @@ fn match_brace(
                         path,
                         open_brace_index,
                         branch_index,
+                        close_brace_index,
                         brace_stack,
                         brace_budget,
                     ) {
@@ -514,6 +519,7 @@ fn match_brace_branch(
     path: &[u8],
     open_brace_index: u32,
     branch_index: u32,
+    close_brace_index: u32,
     brace_stack: &mut BraceStack,
     brace_budget: &mut u32,
 ) -> bool {
@@ -526,6 +532,7 @@ fn match_brace_branch(
     let Ok(()) = brace_stack.push(Brace {
         open_brace_idx: open_brace_index,
         branch_idx: branch_index,
+        close_brace_idx: close_brace_index,
     }) else {
         return false;
     };
@@ -549,39 +556,60 @@ fn match_brace_branch(
     matched
 }
 
-fn skip_branch(state: &mut State, glob: &[u8]) {
+/// Jumps `state.glob_index` to just past the `}` of the innermost brace group
+/// on `brace_stack` that encloses the current position. Returns `false` when no
+/// stacked group encloses it, i.e. the `,`/`}` is a literal that only looked
+/// like a separator because `brace_depth` over-counts after sequential groups.
+///
+/// `brace_depth` can't index `brace_stack` directly: the stack also holds
+/// frames for groups already exited earlier in this attempt (sequential
+/// `{a,b}/{c,d}` keeps A on the stack while matching inside B), and wildcard
+/// backtracks can re-enter a later frame without the count lining up. So scan
+/// the (≤10-entry) stack by range instead. Frames are pushed outer→inner so the
+/// last match when iterating in reverse is the innermost enclosing group.
+fn skip_branch(state: &mut State, glob: &[u8], brace_stack: &BraceStack) -> bool {
+    let gi = state.glob_index;
+    for frame in brace_stack.as_slice().iter().rev() {
+        if frame.open_brace_idx < gi && gi <= frame.close_brace_idx {
+            let close = frame.close_brace_idx;
+            if (close as usize) < glob.len() {
+                debug_assert_eq!(glob[close as usize], b'}');
+                state.glob_index = close + 1;
+                state.brace_depth -= 1;
+            } else {
+                state.glob_index = close;
+            }
+            return true;
+        }
+    }
+    false
+}
+
+/// Returns the index of the `}` matching the `{` at `open_idx`, or `glob.len()`
+/// if the group is unterminated. Mirrors `match_brace`'s scan (bracket-aware,
+/// escape-aware) so both agree on where a group ends.
+fn find_brace_end(glob: &[u8], open_idx: u32) -> u32 {
+    let mut i = open_idx as usize;
+    debug_assert!(i < glob.len() && glob[i] == b'{');
+    let mut depth: u32 = 0;
     let mut in_brackets = false;
-    // `state.brace_depth` only counts groups entered via `match_brace_branch`,
-    // so nesting merely scanned over while skipping is tracked locally, not in state.
-    let mut nested: u32 = 0;
-    while (state.glob_index as usize) < glob.len() {
-        match glob[state.glob_index as usize] {
-            b'{' => {
-                if !in_brackets {
-                    nested += 1;
+    while i < glob.len() {
+        match glob[i] {
+            b'{' if !in_brackets => depth += 1,
+            b'}' if !in_brackets => {
+                depth -= 1;
+                if depth == 0 {
+                    return i as u32;
                 }
             }
-            b'}' => {
-                if !in_brackets {
-                    if nested == 0 {
-                        state.brace_depth -= 1;
-                        state.glob_index += 1;
-                        return;
-                    }
-                    nested -= 1;
-                }
-            }
-            b'[' => {
-                if !in_brackets {
-                    in_brackets = true;
-                }
-            }
+            b'[' if !in_brackets => in_brackets = true,
             b']' => in_brackets = false,
-            b'\\' => state.glob_index += 1,
+            b'\\' => i += 1,
             _ => {}
         }
-        state.glob_index += 1;
+        i += 1;
     }
+    glob.len() as u32
 }
 
 use bun_paths::is_sep_native as is_separator;

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -34,9 +34,7 @@ use bun_core::strings;
 struct Brace {
     open_brace_idx: u32,
     branch_idx: u32,
-    /// Index of the matching `}` (or `glob.len()` if unterminated). Computed
-    /// once per group so `skip_branch` is an O(1) jump instead of a linear
-    /// scan; without it a wide group costs `BRACE_BRANCH_BUDGET * group_len`.
+    /// Index of the matching `}`, or `glob.len()` if the group is unterminated.
     close_brace_idx: u32,
 }
 type BraceStack = BoundedArray<Brace, 10>;
@@ -556,18 +554,12 @@ fn match_brace_branch(
     matched
 }
 
-/// Jumps `state.glob_index` to just past the `}` of the innermost brace group
-/// on `brace_stack` that encloses the current position. Returns `false` when no
-/// stacked group encloses it, i.e. the `,`/`}` is a literal that only looked
-/// like a separator because `brace_depth` over-counts after sequential groups.
+/// Jumps `glob_index` past the `}` of the innermost stacked group that encloses
+/// it; returns `false` if none does (the `,`/`}` is then a literal).
 ///
-/// `brace_depth` can't index `brace_stack` directly: the stack also holds
-/// frames for groups already exited earlier in this attempt (sequential
-/// `{a,b}/{c,d}` keeps A on the stack while matching inside B), and wildcard
-/// backtracks can re-enter a later frame without the count lining up. So scan
-/// the (≤10-entry) stack by range instead. Frames are pushed outer→inner, so
-/// iterating in reverse visits inner→outer and the first enclosing frame found
-/// is the innermost.
+/// `brace_stack[brace_depth - 1]` is not that group: the stack also holds
+/// already-exited sequential groups, so look up by range. Reverse iteration
+/// visits inner→outer, so the first enclosing frame is the innermost.
 fn skip_branch(state: &mut State, glob: &[u8], brace_stack: &BraceStack) -> bool {
     let gi = state.glob_index;
     for frame in brace_stack.as_slice().iter().rev() {
@@ -586,9 +578,7 @@ fn skip_branch(state: &mut State, glob: &[u8], brace_stack: &BraceStack) -> bool
     false
 }
 
-/// Returns the index of the `}` matching the `{` at `open_idx`, or `glob.len()`
-/// if the group is unterminated. Mirrors `match_brace`'s scan (bracket-aware,
-/// escape-aware) so both agree on where a group ends.
+/// Index of the `}` matching the `{` at `open_idx`, or `glob.len()` if unterminated.
 fn find_brace_end(glob: &[u8], open_idx: u32) -> u32 {
     let mut i = open_idx as usize;
     debug_assert!(i < glob.len() && glob[i] == b'{');

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -369,14 +369,7 @@ fn glob_match_impl(
                             }
                             return match_brace(state, glob, path, brace_stack, brace_budget);
                         }
-                        b',' => {
-                            if state.brace_depth > 0 && skip_branch(state, glob, brace_stack) {
-                                continue 'main_loop;
-                            } else {
-                                break 'to_else;
-                            }
-                        }
-                        b'}' => {
+                        b',' | b'}' => {
                             if state.brace_depth > 0 && skip_branch(state, glob, brace_stack) {
                                 continue 'main_loop;
                             } else {

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -360,6 +360,59 @@ describe("Glob.match", () => {
     expect(glob.match("{")).toBeFalse();
   });
 
+  test("wide brace group with matching alternatives and failing tail is not quadratic", () => {
+    // A group of N alternatives that each match the subject prefix, followed by
+    // a tail that then fails, used to cost O(BRACE_BRANCH_BUDGET * N) because
+    // every budgeted attempt re-scanned the whole group to find the closing `}`.
+    // With the close-brace index cached per group that scan is O(1), so the
+    // whole match() is O(N). Unfixed, each case below takes ~5 s release /
+    // ~30 s ASAN; fixed, low single-digit ms. The 2 s budget is >100x headroom
+    // over the fixed cost and >10x under the unfixed cost even in release.
+    const budgetMs = 2000;
+
+    for (const [label, pattern, path] of [
+      ["150k '*' alternatives", "{" + Buffer.alloc(300_000, "*,").toString() + "*}b", "az"],
+      ["300k literal-prefix alternatives", "{" + Buffer.alloc(600_000, "a,").toString() + "a}b", "az"],
+      ["750k empty alternatives", "{" + Buffer.alloc(750_000, ",").toString() + "a}", "a"],
+    ] as const) {
+      const glob = new Glob(pattern);
+      const t0 = performance.now();
+      glob.match(path);
+      const elapsed = performance.now() - t0;
+      if (elapsed >= budgetMs) {
+        throw new Error(`${label}: match() took ${elapsed.toFixed(0)} ms (budget ${budgetMs} ms)`);
+      }
+    }
+
+    // Correctness is unchanged for the shapes above. Use smaller groups so the
+    // pre-existing branch budget (which makes very wide groups return false
+    // regardless of the fix) isn't hit.
+    expect(new Glob("{" + Buffer.alloc(1000, "*,").toString() + "*}b").match("ab")).toBeTrue();
+    expect(new Glob("{" + Buffer.alloc(1000, "*,").toString() + "*}b").match("az")).toBeFalse();
+    expect(new Glob("{" + Buffer.alloc(1000, "a,").toString() + "a}b").match("ab")).toBeTrue();
+    expect(new Glob("{" + Buffer.alloc(1000, "a,").toString() + "a}b").match("az")).toBeFalse();
+    expect(new Glob("{" + Buffer.alloc(1000, ",").toString() + "a}").match("a")).toBeTrue();
+    expect(new Glob("{" + Buffer.alloc(1000, ",").toString() + "a}").match("")).toBeTrue();
+    expect(new Glob("{" + Buffer.alloc(1000, ",").toString() + "a}").match("b")).toBeFalse();
+  });
+
+  test("literal ',' or '}' after sequential brace groups", () => {
+    // A `,`/`}` past the second group's `}` is a literal. Previously
+    // `brace_depth` was set from the stack length (which still holds the first
+    // group's frame) so the literal was treated as a separator and the whole
+    // tail was skipped.
+    expect(new Glob("{a,b}{c,d},x").match("ac,x")).toBeTrue();
+    expect(new Glob("{a,b}{c,d},x").match("bd,x")).toBeTrue();
+    expect(new Glob("{a,b}{c,d},x").match("ac")).toBeFalse();
+    expect(new Glob("{a,b}{c,d}}x").match("ac}x")).toBeTrue();
+    expect(new Glob("{a,b}/{c,d},x").match("a/c,x")).toBeTrue();
+    expect(new Glob("{a,b}/{c,d},x").match("b/d,x")).toBeTrue();
+    expect(new Glob("{a,b}/{c,d},x").match("a/c")).toBeFalse();
+    // Single group followed by a literal `,` already worked; keep covered.
+    expect(new Glob("{a,b},x").match("a,x")).toBeTrue();
+    expect(new Glob("{a,b},x").match("b,x")).toBeTrue();
+  });
+
   // Most of the potential bugs when dealing with non-ASCII patterns is when the
   // pattern matching algorithm wants to deal with single chars, for example
   // using the `[...]` syntax, it tries to match each char in the brackets. With


### PR DESCRIPTION
## Problem

`Bun.Glob.match()` spends `O(BRACE_BRANCH_BUDGET * group_len)` on a wide brace group whose alternatives match the subject prefix but whose tail then fails. The budget bounds the number of branch attempts (10,000), but every budgeted attempt that matches its alternative then calls `skip_branch`, which linearly scans forward to the matching `}`. A ~300 KB pattern costs ~5 s of CPU per `match()` call:

```js
new Bun.Glob("{" + "*,".repeat(150000) + "*}b").match("az");   // ~5.0 s
new Bun.Glob("{" + "a,".repeat(300000) + "a}b").match("az");   // ~5.1 s
new Bun.Glob("{" + ",".repeat(750000) + "a}").match("a");      // ~4.3 s
new Bun.Glob("x".repeat(800000)).match("az");                  // 0 ms (control)
```

Any surface that accepts a user-supplied glob and calls `match()` (or `scan()`, which pays this per directory entry) can be pinned for seconds per call by a ~300 KB pattern.

## Fix

`match_brace` now computes the matching `}` index once per group via `find_brace_end` (same bracket- and escape-aware scan the old `skip_branch` used) and stores it in the `Brace` frame on the brace stack. `skip_branch` becomes an O(1) lookup: scan the at-most-10-entry stack for the innermost frame whose `[open, close]` range contains the current position, and jump directly past its `}`.

The lookup is by range rather than by `brace_depth` index: the stack also carries frames for groups already exited earlier in the same attempt (sequential `{a,b}/{c,d}` keeps A's frame while matching inside B), and wildcard backtracks can re-enter a later frame without the depth count lining up with the stack position.

That same range lookup also fixes a pre-existing correctness bug: a literal `,` or `}` after two or more sequential groups is now matched as a literal instead of being skipped as a spurious separator.

```js
new Bun.Glob("{a,b}{c,d},x").match("ac,x");   // was false, now true
```

## Verification

```
before (release):    5092 ms / 5136 ms / 4337 ms
after  (release):    1.5 ms / 2.3 ms / 4.2 ms
after  (debug+asan): 15 ms / 17 ms / 27 ms
```

The `50k distinct alternatives` control is unchanged (8.7 ms before, 7.0 ms after). `test/js/bun/glob/match.test.ts` (29 tests) passes; the existing `braces` fixture test (10 real-world patterns against ~10 K file paths each) is slightly faster.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/glob/match.test.ts

<!-- robobun:evidence:end -->