### PR TITLE
shell: initialize env/cwd/throws defaults on new $.Shell() instances

### DIFF
--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -337,6 +337,10 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     Object.setPrototypeOf(Shell, ShellPrototype.prototype);
     Object.defineProperty(Shell, "name", { value: "Shell", configurable: true, enumerable: true });
 
+    Shell[cwdSymbol] = defaultCwd;
+    Shell[envSymbol] = defaultEnv;
+    Shell[throwsSymbol] = true;
+
     return Shell;
   }
 

--- a/test/js/bun/shell/bunshell-instance.test.ts
+++ b/test/js/bun/shell/bunshell-instance.test.ts
@@ -1,6 +1,41 @@
 import { describe, expect, test } from "bun:test";
 
 import { $ } from "bun";
+import { bunEnv, bunExe } from "harness";
+
+test("new $.Shell() inherits process.env and throws on non-zero exit by default", async () => {
+  // Run in a subprocess so other tests mutating $.env / $.throws don't interfere.
+  const src = `
+    import { $ } from "bun";
+    const inst = new $.Shell();
+
+    const fromDefault = (await $\`echo \$BUN_SHELL_INSTANCE_MARKER\`.quiet()).stdout.toString().trim();
+    const fromFresh = (await inst\`echo \$BUN_SHELL_INSTANCE_MARKER\`.quiet()).stdout.toString().trim();
+
+    let threwDefault = false;
+    let threwFresh = false;
+    try { await $\`false\`.quiet(); } catch { threwDefault = true; }
+    try { await inst\`false\`.quiet(); } catch { threwFresh = true; }
+
+    console.log(JSON.stringify({ fromDefault, fromFresh, threwDefault, threwFresh }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: { ...bunEnv, BUN_SHELL_INSTANCE_MARKER: "hello" },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    fromDefault: "hello",
+    fromFresh: "hello",
+    threwDefault: true,
+    threwFresh: true,
+  });
+  expect(exitCode).toBe(0);
+});
 
 test("$$", async () => {
   const $$ = new $.Shell();

--- a/test/js/bun/shell/bunshell-instance.test.ts
+++ b/test/js/bun/shell/bunshell-instance.test.ts
@@ -12,10 +12,9 @@ test("new $.Shell() inherits process.env and throws on non-zero exit by default"
     const fromDefault = (await $\`echo \$BUN_SHELL_INSTANCE_MARKER\`.quiet()).stdout.toString().trim();
     const fromFresh = (await inst\`echo \$BUN_SHELL_INSTANCE_MARKER\`.quiet()).stdout.toString().trim();
 
-    let threwDefault = false;
-    let threwFresh = false;
-    try { await $\`false\`.quiet(); } catch { threwDefault = true; }
-    try { await inst\`false\`.quiet(); } catch { threwFresh = true; }
+    let threwDefault, threwFresh;
+    try { await $\`false\`.quiet(); } catch (e) { threwDefault = { isShellError: e instanceof $.ShellError, exitCode: e.exitCode }; }
+    try { await inst\`false\`.quiet(); } catch (e) { threwFresh = { isShellError: e instanceof $.ShellError, exitCode: e.exitCode }; }
 
     console.log(JSON.stringify({ fromDefault, fromFresh, threwDefault, threwFresh }));
   `;
@@ -31,8 +30,8 @@ test("new $.Shell() inherits process.env and throws on non-zero exit by default"
   expect(JSON.parse(stdout)).toEqual({
     fromDefault: "hello",
     fromFresh: "hello",
-    threwDefault: true,
-    threwFresh: true,
+    threwDefault: { isShellError: true, exitCode: 1 },
+    threwFresh: { isShellError: true, exitCode: 1 },
   });
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Repro

```ts
import { $ } from "bun";
const inst = new $.Shell();
console.log((await inst`echo $PATH`.quiet()).stdout.toString()); // ""
await inst`false`.quiet(); // resolves, does not throw
```

A fresh `new $.Shell()` instance ran commands with an **empty** environment (0 vars, no `PATH`/`HOME`) and resolved silently on non-zero exit, whereas the default `$` inherits `process.env` and throws. The docs state "by default, all commands use `process.env`", and `$.Shell` is typed as `new () => $`.

## Cause

In `src/js/builtins/shell.ts`, the `Shell()` constructor creates the inner tagged-template function and wires up its prototype, but never initializes `Shell[envSymbol]` / `Shell[cwdSymbol]` / `Shell[throwsSymbol]`. The module-level `BunShell` gets these set explicitly right after it is created; the per-instance constructor skipped that step. With `envSymbol` unset the parsed script never gets `setEnv`, so the interpreter falls back to an empty `EnvMap`, and `throws` arrives at `ShellPromise` as `undefined`.

## Fix

Initialize the three symbol slots in the `Shell()` constructor to the same defaults `BunShell` uses (`defaultCwd`, `defaultEnv`, `true`).

## Verification

```
# without fix
(fail) new $.Shell() inherits process.env and throws on non-zero exit by default
  fromFresh: ""        (expected "hello")
  threwFresh: false    (expected true)

# with fix
17 pass / 0 fail in test/js/bun/shell/bunshell-instance.test.ts
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/bunshell-instance.test.ts
bun test v1.4.0 (edee82e1e)

test/js/bun/shell/bunshell-instance.test.ts:
25 |     stderr: "pipe",
26 |   });
27 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
28 | 
29 |   expect(stderr).toBe("");
30 |   expect(JSON.parse(stdout)).toEqual({
                                  ^
error: expect(received).toEqual(expected)

  {
    "fromDefault": "hello",
-   "fromFresh": "hello",
+   "fromFresh": "",
    "threwDefault": {
-     "exitCode": 1,
-     "isShellError": true,
-   },
-   "threwFresh": {
      "exitCode": 1,
      "isShellError": true,
    },
  }

- Expected  - 5
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/shell/bunshell-instance.test.ts:30:30)
(fail) new $.Shell() inherits process.env and throws on non-zero exit by default [459.20ms]
bun

bun
bun2
(pass) $$ [73.34ms]
(pass) $.text [14.33ms]
(pass) $.json [11.25ms]
(pass) $.json [7.06ms]
(pass) $.lines [41.05ms]
(pass) $.arrayBuffer [11.64ms]
(pass) $
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (17f628923)

test/js/bun/shell/bunshell-instance.test.ts:
(pass) new $.Shell() inherits process.env and throws on non-zero exit by default [9.23ms]
bun

bun
bun2
(pass) $$ [1.08ms]
(pass) $.text [0.23ms]
(pass) $.json [0.19ms]
(pass) $.json [0.14ms]
(pass) $.lines [0.64ms]
(pass) $.arrayBuffer [0.22ms]
(pass) $.bytes [0.19ms]
(pass) $.blob [0.19ms]
(pass) hello world!.repeat(9000) > $(cat < Blob).text() [1.77ms]
(pass) hello world!.repeat(9000) > $(cat hello > Blob).text() fails [0.24ms]
(pass) hello world!.repeat(9000) > $(cat < Buffer).text() [1.88ms]
(pass) hello world!.repeat(9000) > $(cat hello > Buffer).text() passes [2.31ms]
(pass) hello world!.repeat(9000) > $(cat < Uint8Array).text() [0.98ms]
(pass) hello world!.repeat(9000) > $(cat hello > Uint8Array).text() passes [1.57ms]
(pass) hello world!.repeat(9000) > $(cat < Response).text() [1.28ms]
(pass) hello world!.repeat(9000) > $(cat hello > Response).text() fails [0.10ms]

 17 pass
 0 fail
 23 expect() calls
Ran 17 tests across 1 file. [169.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/bunshell-instance.test.ts
bun test v1.4.0 (edee82e1e)

test/js/bun/shell/bunshell-instance.test.ts:
(pass) new $.Shell() inherits process.env and throws on non-zero exit by default [424.70ms]
bun

bun
bun2
(pass) $$ [55.62ms]
(pass) $.text [13.44ms]
(pass) $.json [10.89ms]
(pass) $.json [6.56ms]
(pass) $.lines [39.12ms]
(pass) $.arrayBuffer [11.12ms]
(pass) $.bytes [9.08ms]
(pass) $.blob [10.59ms]
(pass) hello world!.repeat(9000) > $(cat < Blob).text() [16.63ms]
(pass) hello world!.repeat(9000) > $(cat hello > Blob).text() fails [10.46ms]
(pass) hello world!.repeat(9000) > $(cat < Buffer).text() [12.33ms]
(pass) hello world!.repeat(9000) > $(cat hello > Buffer).text() passes [20.88ms]
(pass) hello world!.repeat(9000) > $(cat < Uint8Array).text() [4.09ms]
(pass) hello world!.repeat(9000) > $(cat hello > Uint8Array).text() passes [17.37ms]
(pass) hello world!.repeat(9000) > $(cat < Response).text() [14.15ms]
(pass) hello world!.repeat(9000) > $(cat hello > Response).text() fails [4.39ms]

 17 pass
 0 fail
 23 expect() c
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 700ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (8984ms)
Bundle modules (55ms)
Postprocesss modules (27ms)
Bundle Functions (866ms)
Generate Code (19ms)

[9.97s] Bundled "src/js" for production
  2569 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins/shell.ts                    |  4 ++++
 test/js/bun/shell/bunshell-instance.test.ts | 34 +++++++++++++++++++++++++++++
 2 files changed, 38 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/js/builtins/shell.ts                         1      1      0
test/js/bun/shell/bunshell-instance.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->