### PR TITLE
node:http2: cap CONTINUATION frames per header block (CVE-2024-28182)

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2048,6 +2048,7 @@ const kNghttp2ErrorMessages = {
   [-901]: "Out of memory",
   [-903]: "Received bad client magic byte string",
   [-904]: "Flooding was detected in this HTTP/2 session, and it must be closed",
+  [-905]: "Too many CONTINUATION frames following a HEADER frame",
 };
 
 class NghttpError extends Error {

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -108,6 +108,8 @@ struct HeaderBlockInFlight {
     /// The stream id the next frame MUST be a CONTINUATION for (the parent stream id while
     /// assembling a PUSH_PROMISE block).
     continuation_stream: u32,
+    /// CONTINUATION frames received for this block so far (capped at `MAX_CONTINUATIONS`).
+    continuations: u32,
     meta: HeaderBlockMeta,
 }
 
@@ -149,6 +151,10 @@ pub struct Feed {
 /// nghttp2's NGHTTP2_DEFAULT_MAX_OBQ_FLOOD_ITEM: outbound PING/SETTINGS ACKs that may pile up
 /// behind a non-reading peer before the session is treated as flooded (NGHTTP2_ERR_FLOODED).
 const MAX_OUTBOUND_ACK_QUEUE: u32 = 1000;
+
+/// nghttp2's NGHTTP2_DEFAULT_MAX_CONTINUATIONS (CVE-2024-28182): CONTINUATION frames accepted for
+/// one header block. The byte cap in `handle_continuation` cannot bound zero-length frames.
+const MAX_CONTINUATIONS: u32 = 8;
 
 /// What the connection engine calls back into the embedder (the JSC binding) for. Methods take
 /// `&self`: the JSC binding (H2FrameParser) is fully interior-mutable (Cell/JsCell) and its host
@@ -1039,6 +1045,7 @@ impl Connection {
         if !wire::flags::has(hdr.flags, wire::flags::END_HEADERS) {
             self.header_block_in_flight = Some(HeaderBlockInFlight {
                 continuation_stream: hdr.stream_id,
+                continuations: 0,
                 meta,
             });
             return false;
@@ -1048,7 +1055,7 @@ impl Connection {
 
     /// RFC 9113 §6.10 CONTINUATION: append the fragment; complete the block on END_HEADERS.
     fn handle_continuation(&mut self, sink: &impl Sink, hdr: &FrameHeader, payload: &[u8]) -> bool {
-        let Some(inflight) = self.header_block_in_flight.take() else {
+        let Some(mut inflight) = self.header_block_in_flight.take() else {
             // §6.10: a CONTINUATION with no header block in progress is a connection PROTOCOL_ERROR.
             self.send_go_away(
                 sink,
@@ -1058,6 +1065,18 @@ impl Connection {
             return true;
         };
         // dispatch() already enforced that we are assembling this exact stream.
+        inflight.continuations += 1;
+        if inflight.continuations > MAX_CONTINUATIONS {
+            // nghttp2 fails the session with NGHTTP2_ERR_TOO_MANY_CONTINUATIONS, which node
+            // surfaces as errno -905 alongside a GOAWAY(INTERNAL_ERROR).
+            self.local_connection_error(
+                sink,
+                ErrorCode::InternalError,
+                wire::lib_error::TOO_MANY_CONTINUATIONS,
+                b"too many CONTINUATION frames",
+            );
+            return true;
+        }
         // Cap the reassembled block at the header-list limit (floored so tiny custom settings
         // don't reject normal blocks): HPACK output is never smaller than its input, so a
         // compressed block already past max_header_list_size can only decode past it too —
@@ -2326,6 +2345,110 @@ mod tests {
         let fed = c.receive(&sink, &f);
         assert!(fed.fatal);
         assert_eq!(sink.local_error.get(), Some(wire::lib_error::PROTO));
+    }
+
+    /// Error code carried by the last GOAWAY frame the engine wrote, if any.
+    fn last_goaway_error_code(out: &[u8]) -> Option<u32> {
+        let mut off = 0usize;
+        let mut code = None;
+        while out.len() - off >= wire::FRAME_HEADER_SIZE {
+            let hdr = FrameHeader::parse(&out[off..]);
+            let payload = &out[off + wire::FRAME_HEADER_SIZE
+                ..off + wire::FRAME_HEADER_SIZE + hdr.length as usize];
+            if hdr.frame_type == FrameType::GoAway as u8 {
+                code = Some(u32::from_be_bytes([
+                    payload[4], payload[5], payload[6], payload[7],
+                ]));
+            }
+            off += wire::FRAME_HEADER_SIZE + hdr.length as usize;
+        }
+        code
+    }
+
+    fn empty_continuation(stream_id: u32, flags: u8) -> Vec<u8> {
+        frame(FrameType::Continuation, flags, stream_id, &[])
+    }
+
+    fn request_block() -> Vec<u8> {
+        encode_block(&[
+            (b":method", b"GET"),
+            (b":scheme", b"http"),
+            (b":path", b"/"),
+            (b":authority", b"localhost"),
+        ])
+    }
+
+    #[test]
+    fn continuation_budget_is_per_header_block() {
+        let sink = CaptureSink::default();
+        let mut c = Connection::new(true, Settings::default());
+        c.preface_received = wire::CONNECTION_PREFACE.len();
+        // Two request blocks, each split across HEADERS plus exactly MAX_CONTINUATIONS
+        // CONTINUATION frames. A counter that survived from one block to the next would trip on
+        // the second block.
+        let mut bytes = Vec::new();
+        for stream_id in [1u32, 3] {
+            bytes.extend(frame(FrameType::Headers, 0, stream_id, &request_block()));
+            for _ in 1..MAX_CONTINUATIONS {
+                bytes.extend(empty_continuation(stream_id, 0));
+            }
+            bytes.extend(empty_continuation(stream_id, wire::flags::END_HEADERS));
+        }
+        let fed = c.receive(&sink, &bytes);
+        assert!(!fed.fatal);
+        assert_eq!(fed.consumed, bytes.len());
+        assert_eq!(sink.local_error.get(), None);
+        assert_eq!(*sink.headers_done.borrow(), vec![(1, false), (3, false)]);
+
+        // One past the budget on a third block is a connection error even though the frame that
+        // overflows it is the one carrying END_HEADERS.
+        let mut bytes = frame(FrameType::Headers, 0, 5, &request_block());
+        for _ in 0..MAX_CONTINUATIONS {
+            bytes.extend(empty_continuation(5, 0));
+        }
+        bytes.extend(empty_continuation(5, wire::flags::END_HEADERS));
+        let fed = c.receive(&sink, &bytes);
+        assert!(fed.fatal);
+        assert_eq!(
+            sink.local_error.get(),
+            Some(wire::lib_error::TOO_MANY_CONTINUATIONS)
+        );
+        assert_eq!(
+            last_goaway_error_code(&sink.out.borrow()),
+            Some(ErrorCode::InternalError.as_u32())
+        );
+        assert_eq!(sink.headers_done.borrow().len(), 2);
+    }
+
+    #[test]
+    fn push_promise_block_has_the_same_continuation_budget() {
+        let sink = CaptureSink::default();
+        let mut c = Connection::new(false, Settings::default());
+        // PUSH_PROMISE on parent stream 1 promising stream 2, block parked for CONTINUATION.
+        let mut promise = vec![0u8, 0, 0, 2];
+        promise.extend(request_block());
+        let mut bytes = frame(FrameType::PushPromise, 0, 1, &promise);
+        for _ in 0..MAX_CONTINUATIONS {
+            bytes.extend(empty_continuation(1, 0));
+        }
+        let fed = c.receive(&sink, &bytes);
+        assert!(!fed.fatal);
+        assert_eq!(fed.consumed, bytes.len());
+        assert_eq!(sink.local_error.get(), None);
+        assert!(sink.pushes.borrow().is_empty());
+
+        let ninth = empty_continuation(1, 0);
+        let fed = c.receive(&sink, &ninth);
+        assert!(fed.fatal);
+        assert_eq!(
+            sink.local_error.get(),
+            Some(wire::lib_error::TOO_MANY_CONTINUATIONS)
+        );
+        assert_eq!(
+            last_goaway_error_code(&sink.out.borrow()),
+            Some(ErrorCode::InternalError.as_u32())
+        );
+        assert!(sink.pushes.borrow().is_empty());
     }
 
     #[test]

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -152,8 +152,7 @@ pub struct Feed {
 /// behind a non-reading peer before the session is treated as flooded (NGHTTP2_ERR_FLOODED).
 const MAX_OUTBOUND_ACK_QUEUE: u32 = 1000;
 
-/// nghttp2's NGHTTP2_DEFAULT_MAX_CONTINUATIONS (CVE-2024-28182): CONTINUATION frames accepted for
-/// one header block. The byte cap in `handle_continuation` cannot bound zero-length frames.
+/// nghttp2's NGHTTP2_DEFAULT_MAX_CONTINUATIONS (CVE-2024-28182): CONTINUATION frames per header block.
 const MAX_CONTINUATIONS: u32 = 8;
 
 /// What the connection engine calls back into the embedder (the JSC binding) for. Methods take
@@ -1067,8 +1066,7 @@ impl Connection {
         // dispatch() already enforced that we are assembling this exact stream.
         inflight.continuations += 1;
         if inflight.continuations > MAX_CONTINUATIONS {
-            // nghttp2 fails the session with NGHTTP2_ERR_TOO_MANY_CONTINUATIONS, which node
-            // surfaces as errno -905 alongside a GOAWAY(INTERNAL_ERROR).
+            // INTERNAL_ERROR is the GOAWAY code nghttp2 uses for this.
             self.local_connection_error(
                 sink,
                 ErrorCode::InternalError,
@@ -2383,9 +2381,7 @@ mod tests {
         let sink = CaptureSink::default();
         let mut c = Connection::new(true, Settings::default());
         c.preface_received = wire::CONNECTION_PREFACE.len();
-        // Two request blocks, each split across HEADERS plus exactly MAX_CONTINUATIONS
-        // CONTINUATION frames. A counter that survived from one block to the next would trip on
-        // the second block.
+        // Two blocks, each using the whole budget: a session-wide counter would trip on the second.
         let mut bytes = Vec::new();
         for stream_id in [1u32, 3] {
             bytes.extend(frame(FrameType::Headers, 0, stream_id, &request_block()));
@@ -2400,8 +2396,7 @@ mod tests {
         assert_eq!(sink.local_error.get(), None);
         assert_eq!(*sink.headers_done.borrow(), vec![(1, false), (3, false)]);
 
-        // One past the budget on a third block is a connection error even though the frame that
-        // overflows it is the one carrying END_HEADERS.
+        // One past the budget is fatal even when the overflowing frame carries END_HEADERS.
         let mut bytes = frame(FrameType::Headers, 0, 5, &request_block());
         for _ in 0..MAX_CONTINUATIONS {
             bytes.extend(empty_continuation(5, 0));

--- a/src/runtime/api/bun/h2/wire.rs
+++ b/src/runtime/api/bun/h2/wire.rs
@@ -115,6 +115,8 @@ pub mod lib_error {
     pub const BAD_CLIENT_MAGIC: i32 = -903;
     /// NGHTTP2_ERR_FLOODED — "Flooding was detected in this HTTP/2 session, and it must be closed"
     pub const FLOODED: i32 = -904;
+    /// NGHTTP2_ERR_TOO_MANY_CONTINUATIONS — "Too many CONTINUATION frames following a HEADER frame"
+    pub const TOO_MANY_CONTINUATIONS: i32 = -905;
 }
 
 /// RFC 9113 §6.5.2 SETTINGS parameter registry (+ RFC 8441, RFC 9218).

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -406,6 +406,66 @@ describe("CONTINUATION (checklist §3,§7)", () => {
       server.close();
     }
   });
+
+  // nghttp2's NGHTTP2_DEFAULT_MAX_CONTINUATIONS (CVE-2024-28182): a header block may be followed
+  // by at most 8 CONTINUATION frames. The frames here are zero-length because that is the shape
+  // the header-block byte cap cannot bound.
+  const MAX_CONTINUATIONS = 8;
+
+  /** Send a complete GET request block as HEADERS + `continuations` empty CONTINUATIONs (END_HEADERS on the last). */
+  function sendSplitRequest(c: RawH2, continuations: number) {
+    c.sendFrame(FrameType.HEADERS, 0x1 /* END_STREAM */, 1, requestHeaderBlock("GET"));
+    for (let i = 1; i < continuations; i++) c.sendFrame(FrameType.CONTINUATION, 0, 1);
+    c.sendFrame(FrameType.CONTINUATION, 0x4 /* END_HEADERS */, 1);
+  }
+
+  async function withServer(run: (srv: http2.Http2Server, c: RawH2) => Promise<void>) {
+    const srv = http2.createServer();
+    srv.on("stream", (stream: any) => {
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    srv.listen(0, "127.0.0.1");
+    await once(srv, "listening");
+    const c = await RawH2.connect((srv.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      await run(srv, c);
+    } finally {
+      c.destroy();
+      srv.close();
+    }
+  }
+
+  test("server accepts a request block followed by exactly 8 CONTINUATION frames", async () => {
+    await withServer(async (srv, c) => {
+      const dispatched = once(srv, "stream");
+      sendSplitRequest(c, MAX_CONTINUATIONS);
+      await dispatched;
+      await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      expect(c.frames.find(f => f.type === FrameType.GOAWAY)).toBeUndefined();
+    });
+  });
+
+  test("server rejects the 9th CONTINUATION frame with GOAWAY(INTERNAL_ERROR) (CVE-2024-28182)", async () => {
+    await withServer(async (srv, c) => {
+      let dispatched = false;
+      srv.on("stream", () => (dispatched = true));
+      const sessionError = once(srv, "sessionError");
+      sendSplitRequest(c, MAX_CONTINUATIONS + 1);
+      const goaway = await c.waitForGoaway();
+      expect(goawayErrorCode(goaway)).toBe(ErrorCode.INTERNAL_ERROR);
+      // node: nghttp2 fails the session with NGHTTP2_ERR_TOO_MANY_CONTINUATIONS.
+      const [err] = await sessionError;
+      expect(err).toMatchObject({
+        code: "ERR_HTTP2_ERROR",
+        errno: -905,
+        message: "Too many CONTINUATION frames following a HEADER frame",
+      });
+      expect(dispatched).toBe(false);
+    });
+  });
 });
 
 describe("SETTINGS value ranges (checklist §6.5.2)", () => {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1577,6 +1577,159 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           }
         });
 
+        // nghttp2's NGHTTP2_DEFAULT_MAX_CONTINUATIONS (CVE-2024-28182): at most 8 CONTINUATION
+        // frames may follow a HEADERS frame. Zero-length frames are what the byte cap above cannot
+        // bound, so these blocks are split into empty CONTINUATIONs on purpose.
+        const MAX_CONTINUATIONS = 8;
+        const STATUS_200 = Buffer.from([0x88]); // HPACK indexed :status 200
+        // HPACK literal without indexing, new name: x-trailer: 1
+        const TRAILER_BLOCK = Buffer.concat([
+          Buffer.from([0x00, 0x09]),
+          Buffer.from("x-trailer"),
+          Buffer.from([0x01, 0x31]),
+        ]);
+        // PUSH_PROMISE on stream 1 promising stream 2; the promised request is
+        // GET http://localhost/ (HPACK indexed :method/:scheme/:path, literal :authority).
+        const PUSH_PROMISE_NO_END_HEADERS = (() => {
+          const block = Buffer.concat([Buffer.from([0x82, 0x86, 0x84, 0x01, 0x09]), Buffer.from("localhost")]);
+          const payload = Buffer.concat([Buffer.from([0, 0, 0, 2]), block]);
+          return Buffer.concat([new http2utils.Frame(payload.length, 5, 0, 1).data, payload]);
+        })();
+        const emptyContinuation = flags => new http2utils.Frame(0, 9, flags, 1).data;
+        /** `opener` (a HEADERS/PUSH_PROMISE frame without END_HEADERS), then `continuations` empty CONTINUATIONs, the last one with END_HEADERS. */
+        function splitAfter(opener, continuations) {
+          const frames = [opener];
+          for (let i = 1; i < continuations; i++) frames.push(emptyContinuation(0));
+          frames.push(emptyContinuation(0x4));
+          return Buffer.concat(frames);
+        }
+        function splitHeaderBlock(block, continuations, { endStream = false } = {}) {
+          return splitAfter(new http2utils.HeadersFrame(1, block, 0, /* EOH */ false, endStream).data, continuations);
+        }
+        async function rawResponseServer(respond) {
+          const { promise: waitToWrite, resolve: allowWrite } = Promise.withResolvers();
+          const server = net.createServer(async socket => {
+            socket.on("error", () => {});
+            socket.write(new http2utils.SettingsFrame(true).data);
+            await waitToWrite;
+            socket.write(respond());
+          });
+          await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+          return { server, allowWrite, url: `http://127.0.0.1:${server.address().port}` };
+        }
+
+        it("accepts a response and its trailers each split across the full CONTINUATION budget", async () => {
+          // The budget is per header block: two blocks on one stream may use 8 CONTINUATIONs
+          // each (16 on the session), which a counter that was never reset would reject.
+          const { server, allowWrite, url } = await rawResponseServer(() =>
+            Buffer.concat([
+              splitHeaderBlock(STATUS_200, MAX_CONTINUATIONS),
+              splitHeaderBlock(TRAILER_BLOCK, MAX_CONTINUATIONS, { endStream: true }),
+            ]),
+          );
+          const client = http2.connect(url);
+          try {
+            const { promise, resolve } = Promise.withResolvers();
+            const received = { response: undefined, trailers: undefined };
+            client.on("error", err => resolve({ error: err }));
+            client.on("connect", () => {
+              const req = client.request({ ":path": "/" });
+              req.on("error", err => resolve({ error: err }));
+              req.on("response", headers => (received.response = headers[":status"]));
+              req.on("trailers", headers => (received.trailers = headers["x-trailer"]));
+              req.on("end", () => resolve(received));
+              req.resume();
+              req.end();
+              allowWrite();
+            });
+            expect(await promise).toEqual({ response: 200, trailers: "1" });
+          } finally {
+            client.destroy();
+            server.close();
+          }
+        });
+
+        it("rejects the 9th CONTINUATION of a header block (CVE-2024-28182)", async () => {
+          // One past the budget is a connection error even though that frame carries END_HEADERS.
+          const { server, allowWrite, url } = await rawResponseServer(() =>
+            splitHeaderBlock(STATUS_200, MAX_CONTINUATIONS + 1),
+          );
+          const client = http2.connect(url);
+          try {
+            const { promise, resolve } = Promise.withResolvers();
+            client.on("error", resolve);
+            client.on("connect", () => {
+              const req = client.request({ ":path": "/" });
+              req.on("error", () => {});
+              req.on("response", headers => resolve({ response: headers }));
+              req.end();
+              allowWrite();
+            });
+            const err = await promise;
+            // node: NghttpError built from NGHTTP2_ERR_TOO_MANY_CONTINUATIONS.
+            expect(err).toMatchObject({
+              code: "ERR_HTTP2_ERROR",
+              errno: -905,
+              message: "Too many CONTINUATION frames following a HEADER frame",
+            });
+          } finally {
+            client.destroy();
+            server.close();
+          }
+        });
+
+        it("accepts a PUSH_PROMISE block followed by exactly 8 CONTINUATION frames", async () => {
+          const { server, allowWrite, url } = await rawResponseServer(() =>
+            splitAfter(PUSH_PROMISE_NO_END_HEADERS, MAX_CONTINUATIONS),
+          );
+          const client = http2.connect(url);
+          try {
+            const { promise, resolve } = Promise.withResolvers();
+            client.on("error", err => resolve({ error: err }));
+            client.on("stream", (pushed, headers) => {
+              pushed.on("error", () => {});
+              resolve({ pushedPath: headers[":path"] });
+            });
+            client.on("connect", () => {
+              const req = client.request({ ":path": "/" });
+              req.on("error", () => {});
+              allowWrite();
+            });
+            expect(await promise).toEqual({ pushedPath: "/" });
+          } finally {
+            client.destroy();
+            server.close();
+          }
+        });
+
+        it("rejects the 9th CONTINUATION of a PUSH_PROMISE block (CVE-2024-28182)", async () => {
+          const { server, allowWrite, url } = await rawResponseServer(() =>
+            splitAfter(PUSH_PROMISE_NO_END_HEADERS, MAX_CONTINUATIONS + 1),
+          );
+          const client = http2.connect(url);
+          try {
+            const { promise, resolve } = Promise.withResolvers();
+            client.on("error", resolve);
+            client.on("stream", (pushed, headers) => {
+              pushed.on("error", () => {});
+              resolve({ pushedPath: headers[":path"] });
+            });
+            client.on("connect", () => {
+              const req = client.request({ ":path": "/" });
+              req.on("error", () => {});
+              allowWrite();
+            });
+            expect(await promise).toMatchObject({
+              code: "ERR_HTTP2_ERROR",
+              errno: -905,
+              message: "Too many CONTINUATION frames following a HEADER frame",
+            });
+          } finally {
+            client.destroy();
+            server.close();
+          }
+        });
+
         it("rejects a header block whose compressed size exceeds maxHeaderListSize", async () => {
           const { promise: waitToWrite, resolve: allowWrite } = Promise.withResolvers();
           const { promise: serverListening, resolve: serverResolve } = Promise.withResolvers();


### PR DESCRIPTION
### Problem
- `node:http2` (client and server) accepts an unbounded number of CONTINUATION frames for one header block. A peer that sends HEADERS without END_HEADERS and then streams zero-length CONTINUATION frames pins the session in header-block state: no error, the request never completes, and the receiver spends a core parsing 9-byte frames. This is the CVE-2024-28182 CONTINUATION flood; node (nghttp2) fails the session after the 8th frame, main accepts the 9th on both sides.
- Cause: `handle_continuation` in `src/runtime/api/bun/h2/connection.rs` bounds the block only by bytes (`header_block.len() + payload.len() > cap`), which an empty payload never advances. Nothing counts frames.

### Fix
- `HeaderBlockInFlight` gets a `continuations` counter; `handle_continuation` increments it and fails the connection once it exceeds `MAX_CONTINUATIONS` (8, nghttp2's `NGHTTP2_DEFAULT_MAX_CONTINUATIONS`, a private const next to the other nghttp2 policy limit in that file).
- Every HEADERS / PUSH_PROMISE that parks a block builds a fresh `HeaderBlockInFlight`, so the budget is per block by construction; there is no reset to forget.
- Error shape matches node exactly: GOAWAY(INTERNAL_ERROR) on the wire, `NghttpError` with `code: ERR_HTTP2_ERROR`, `errno: -905`, message `Too many CONTINUATION frames following a HEADER frame` (new `lib_error::TOO_MANY_CONTINUATIONS` plus the message-table entry in `http2.ts`). Boundary verified against node v26.3.0: 8 accepted, 9th rejected, including when the 9th carries END_HEADERS.
- Legitimate traffic is unaffected: 8 x 16 KiB frames is more than the existing byte cap admits, and `node-http2-continuation.test.ts` (large headers/trailers in both directions) still passes.
- Tests:
  - `test/js/node/http2/node-http2.test.js` (client): response + trailers on one stream each using exactly 8 CONTINUATIONs are delivered; the 9th on a response block errors with errno -905; PUSH_PROMISE block with 8 is delivered, with 9 errors. All four fail on main (main delivers the 200 / the push).
  - `test/js/node/http2/h2-conformance.test.ts` (server, raw client against `createServer`): 8 CONTINUATIONs dispatch with no GOAWAY; the 9th yields GOAWAY(INTERNAL_ERROR), `sessionError` errno -905, and no `stream` event. Fails on main.
  - Unit tests in the `connection.rs` test mod for the per-block budget (HEADERS) and the PUSH_PROMISE opener, asserting the lib error and the GOAWAY code. These compile (`cargo clippy --all-targets`) but were not executed here: `cargo test -p bun_runtime` does not link in this tree. The JS tests above drive the same engine paths.
  - `bun bd test` on `node-http2.test.js` (381 pass, 6 skip), `h2-conformance.test.ts`, `node-http2-continuation.test.ts`, `h2-push-refusal-staged.test.ts`: all green.
- `fetch()`'s separate HTTP/2 client has the same gap; that is #36411.

### Background
- HTTP/2 sends a header list as one HPACK-compressed block. If it does not fit in a single HEADERS (or PUSH_PROMISE) frame, the rest arrives in CONTINUATION frames; the block ends with the frame that carries the END_HEADERS flag, and until then no other frame may be sent on the connection (RFC 9113 4.3). A receiver therefore has to buffer the block and hold the whole connection in an "assembling" state, which is what makes an endless CONTINUATION stream a denial of service.
- nghttp2 is the HTTP/2 library node uses. Bun implements the protocol itself but reports locally detected connection errors to JS as nghttp2 library error codes (negative integers, `wire::lib_error`) so `node:http2` produces the same `NghttpError` objects node does. `local_connection_error` writes the GOAWAY, marks the session terminated, and hands that code to the embedder.
- `HeaderBlockInFlight` (from #37637) is the record the engine keeps while a block is being assembled: which stream the next CONTINUATION must be on, plus what to do with the block when it completes. It is created when a block is parked and consumed when END_HEADERS arrives.

<details>
<summary>Repro and earlier revision</summary>

Standalone repro (node prints the -905 error immediately, bun on main prints STILL PENDING):

```js
import net from "node:net";
import http2 from "node:http2";
const fr = (t, fl, sid, p = Buffer.alloc(0)) => {
  const h = Buffer.alloc(9);
  h.writeUIntBE(p.length, 0, 3); h[3] = t; h[4] = fl; h.writeUInt32BE(sid, 5);
  return Buffer.concat([h, p]);
};
const srv = net.createServer(sock => {
  let buf = Buffer.alloc(0), pre = false, started = false;
  sock.on("error", () => {});
  sock.on("data", d => {
    buf = Buffer.concat([buf, d]);
    if (!pre && buf.length >= 24) { pre = true; buf = buf.subarray(24); sock.write(fr(4,0,0)); sock.write(fr(4,1,0)); }
    while (pre && buf.length >= 9) {
      const len = buf.readUIntBE(0, 3); if (buf.length < 9 + len) break;
      const type = buf[3], sid = buf.readUInt32BE(5) & 0x7fffffff; buf = buf.subarray(9 + len);
      if (type === 1 && !started) {
        started = true;
        sock.write(fr(1, 0, sid, Buffer.from([0x88])));            // HEADERS :status 200, no END_HEADERS
        sock.write(Buffer.concat(Array(1000).fill(fr(9, 0, sid)))); // empty CONTINUATION flood
      }
    }
  });
});
await new Promise(r => srv.listen(0, "127.0.0.1", r));
const s = http2.connect(`http://127.0.0.1:${srv.address().port}`);
s.on("error", e => { console.log("guarded:", e.code, e.errno, e.message); process.exit(0); });
s.request({ ":path": "/" }).on("error", () => {});
setTimeout(() => { console.log("STILL PENDING (no guard)"); process.exit(1); }, 4000);
```

The first revision of this PR kept the counter as loose `Connection` fields with a `pub max_continuations` knob and only tested 64 frames / 8 frames on the client. It was rebased onto #37637 and reworked per review: counter moved into `HeaderBlockInFlight`, knob replaced by a const, and tests added for the exact 9th-frame boundary, the per-block reset, PUSH_PROMISE, and the server side.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (b40d1e902)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [956.46ms]
(pass) node none > Client Basics > should be able to send a POST request [620.57ms]
(pass) node none > Client Basics > constants [20.31ms]
(pass) node none > Client Basics > getDefaultSettings [8.11ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [24.82ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [6.59ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [5.43ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [6.15ms]
(pass) node none > Client Basics > should be able to send data using end [658.88ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [646.20ms]
(pass) node none > Client Basics > http2 s
... (truncated)

release without fix: 24 failed, 6 skipped
bun test v1.4.0-canary.1 (da3851e57)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.94ms]
(pass) node none > Client Basics > getDefaultSettings [0.16ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.41ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.11ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.03ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.08ms]
(pass) node none > Client Basics > is possible to abort request [2.29ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.89ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.82ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.37ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [46.70ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > should fail to con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (b40d1e902)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [1082.42ms]
(pass) node none > Client Basics > should be able to send a POST request [732.11ms]
(pass) node none > Client Basics > constants [19.99ms]
(pass) node none > Client Basics > getDefaultSettings [8.35ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [25.44ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [6.07ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.61ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.58ms]
(pass) node none > Client Basics > should be able to send data using end [751.74ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [730.94ms]
(pass) node none > Client Basics > http2 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1351ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (14006ms)
Bundle modules (573ms)
Postprocesss modules (1879ms)
Bundle Functions (2505ms)
Generate Code (50ms)

[19.06s] Bundled "src/js" for production
  2626 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_sys v0.0.0 (/workspace/bun/src/sys)
[1m[92m   Compiling[0m bun_url v0.0.0 (/workspace/bun/src/url)
[1m[92m   Compiling[0m bun_http_types v0.0.0 (/workspace/bun/src/http_types)
[1m[92m   Compiling[0m bun_threading v0.0.0 (/workspace/bun/src/threading)
[1m[92m   Compiling[0m bun_perf v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                      |   1 +
 src/runtime/api/bun/h2/connection.rs      | 120 ++++++++++++++++++++++-
 src/runtime/api/bun/h2/wire.rs            |   2 +
 test/js/node/http2/h2-conformance.test.ts |  60 ++++++++++++
 test/js/node/http2/node-http2.test.js     | 153 ++++++++++++++++++++++++++++++
 5 files changed, 335 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/http2.ts                           2      2      0
src/runtime/api/bun/h2/connection.rs          14     17      0
src/runtime/api/bun/h2/wire.rs                 3      3      0
test/js/node/http2/h2-conformance.test.ts      4      2      0
test/js/node/http2/node-http2.test.js          5      4      0
```

</details>

<!-- robobun:evidence:end -->