### PR TITLE
fetch(h2): cap CONTINUATION frames per header block (CVE-2024-28182)

### DIFF
--- a/src/http/H2Client.rs
+++ b/src/http/H2Client.rs
@@ -22,6 +22,10 @@ pub(crate) const LOCAL_INITIAL_WINDOW_SIZE: u32 = 1 << 24;
 /// cap is checked locally regardless of what the server honors.
 pub(crate) const LOCAL_MAX_HEADER_LIST_SIZE: u32 = 256 * 1024;
 
+/// CONTINUATION frames allowed per header block. Matches nghttp2's
+/// `NGHTTP2_DEFAULT_MAX_CONTINUATIONS` (CVE-2024-28182).
+pub(crate) const LOCAL_MAX_CONTINUATIONS: u8 = 8;
+
 /// `write_buffer` high-water mark. `writeDataWindowed` stops queueing once the
 /// userland send buffer crosses this even if flow-control window remains, so a
 /// large grant doesn't duplicate the whole body in memory before the first

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -81,6 +81,8 @@ pub struct ClientSession {
     pub(crate) next_stream_id: u31,
     /// Stream id whose CONTINUATION sequence is in progress; 0 = none.
     pub(crate) expecting_continuation: u31,
+    /// CONTINUATION frames seen so far in the current header block.
+    pub(crate) continuation_count: u8,
 
     /// Cold-start coalesced requests parked until the server's first SETTINGS
     /// frame arrives so the real MAX_CONCURRENT_STREAMS cap can be honoured.
@@ -350,6 +352,7 @@ impl ClientSession {
             by_http_id: ArrayHashMap::default(),
             next_stream_id: 1,
             expecting_continuation: 0,
+            continuation_count: 0,
             pending_attach: Vec::new(),
             preface_sent: false,
             settings_received: false,

--- a/src/http/h2_client/dispatch.rs
+++ b/src/http/h2_client/dispatch.rs
@@ -293,8 +293,6 @@ fn dispatch_frame(
             }
         }
         FT_HEADERS => {
-            // The guard above rejects HEADERS while a block is still open, so
-            // every HEADERS frame starts a fresh CONTINUATION budget.
             session.continuation_count = 0;
             let mut fragment = payload;
             let maybe_stream = session.streams.get(&stream_id).copied();

--- a/src/http/h2_client/dispatch.rs
+++ b/src/http/h2_client/dispatch.rs
@@ -5,7 +5,7 @@
 
 use super::client_session::{ClientSession, stream_mut};
 use super::stream::{State as StreamState, Stream};
-use super::{LOCAL_MAX_HEADER_LIST_SIZE, WRITE_BUFFER_CONTROL_LIMIT};
+use super::{LOCAL_MAX_CONTINUATIONS, LOCAL_MAX_HEADER_LIST_SIZE, WRITE_BUFFER_CONTROL_LIMIT};
 use crate::h2_frame_parser as wire;
 use bun_picohttp as picohttp;
 
@@ -293,6 +293,9 @@ fn dispatch_frame(
             }
         }
         FT_HEADERS => {
+            // The guard above rejects HEADERS while a block is still open, so
+            // every HEADERS frame starts a fresh CONTINUATION budget.
+            session.continuation_count = 0;
             let mut fragment = payload;
             let maybe_stream = session.streams.get(&stream_id).copied();
             if maybe_stream.is_none() {
@@ -378,6 +381,11 @@ fn dispatch_frame(
         FT_CONTINUATION => {
             if session.expecting_continuation == 0 || stream_id != session.expecting_continuation {
                 session.fatal_error = Some(crate::Error::HTTP2ProtocolError);
+                return;
+            }
+            session.continuation_count += 1;
+            if session.continuation_count > LOCAL_MAX_CONTINUATIONS {
+                session.fatal_error = Some(crate::Error::HTTP2EnhanceYourCalm);
                 return;
             }
             if let Some(&stream_ptr) = session.streams.get(&session.expecting_continuation) {

--- a/test/js/web/fetch/fetch-http2-adversarial.test.ts
+++ b/test/js/web/fetch/fetch-http2-adversarial.test.ts
@@ -26,6 +26,8 @@ const setting = (id: number, value: number) => {
   return b;
 };
 const hpackStatus200 = Buffer.from([0x80 | 8]);
+// Literal field, indexed name (:status is static index 8), literal value.
+const hpackStatus = (code: string) => Buffer.concat([Buffer.from([0x08, code.length]), Buffer.from(code)]);
 const hpackLit = (name: string, value: string) =>
   Buffer.concat([Buffer.from([0x10, name.length]), Buffer.from(name), Buffer.from([value.length]), Buffer.from(value)]);
 
@@ -159,9 +161,104 @@ describe.concurrent("fetch() HTTP/2 adversarial", () => {
         // Connection should error well before the ~80 MB of CONTINUATION payload
         // accumulates. Allow generous slack for TLS/allocator overhead.
         // ASAN's quarantine retains freed allocations so widen the threshold there.
-        expect(out.result).toBe("HTTP2HeaderListTooLarge");
+        // The frame-count cap (8 frames x ~16 KB = ~128 KB) fires before the
+        // 256 KiB byte-size cap for this payload shape.
+        expect(out.result).toBe("HTTP2EnhanceYourCalm");
         expect(out.growth).toBeLessThan((isASAN ? 256 : 64) * 1024 * 1024);
         expect(exitCode).toBe(0);
+      },
+    );
+  });
+
+  // 1b. Zero-length CONTINUATION flood (CVE-2024-28182): empty payloads never
+  //     advance the byte-size cap above, so bound the frame count too.
+  test("zero-length CONTINUATION flood is rejected", async () => {
+    await withAdversarialServer(
+      {
+        onStream: (socket, id) => {
+          // HEADERS :status 200, no END_HEADERS, no END_STREAM.
+          socket.write(frame(1, 0, id, hpackStatus200));
+          // 10 000 empty CONTINUATION frames = 90 000 bytes of 9-byte headers
+          // with zero payload; header_block.len() stays at 1 forever.
+          const flood = Buffer.concat(Array.from({ length: 10_000 }, () => frame(9, 0, id)));
+          socket.write(flood);
+        },
+      },
+      async url => {
+        const code = await fetch(url, { ...h2, signal: AbortSignal.timeout(8000) }).then(r => r.status, errcode);
+        expect(code).toBe("HTTP2EnhanceYourCalm");
+      },
+    );
+  });
+
+  // 1c. Boundary: exactly the CONTINUATION budget (8 frames) is accepted.
+  test("header block split across the full CONTINUATION budget is accepted", async () => {
+    await withAdversarialServer(
+      {
+        onStream: (socket, id) => {
+          socket.write(
+            Buffer.concat([
+              frame(1, 0x1, id, hpackStatus200), // HEADERS, END_STREAM, no END_HEADERS
+              ...Array.from({ length: 7 }, () => frame(9, 0, id)),
+              frame(9, 0x4, id), // 8th CONTINUATION, END_HEADERS
+            ]),
+          );
+        },
+      },
+      async url => {
+        const r = await fetch(url, h2);
+        expect(r.status).toBe(200);
+        expect(await r.text()).toBe("");
+      },
+    );
+  });
+
+  // 1d. Boundary: the 9th CONTINUATION is rejected even when it carries
+  //     END_HEADERS and would have completed the block (nghttp2 / node agree).
+  test("9th CONTINUATION is rejected even if it ends the block", async () => {
+    await withAdversarialServer(
+      {
+        onStream: (socket, id) => {
+          socket.write(
+            Buffer.concat([
+              frame(1, 0x1, id, hpackStatus200), // HEADERS, END_STREAM, no END_HEADERS
+              ...Array.from({ length: 8 }, () => frame(9, 0, id)),
+              frame(9, 0x4, id), // 9th CONTINUATION, END_HEADERS
+            ]),
+          );
+        },
+      },
+      async url => {
+        const code = await fetch(url, h2).then(r => r.status, errcode);
+        expect(code).toBe("HTTP2EnhanceYourCalm");
+      },
+    );
+  });
+
+  // 1e. The budget is per header block, not per stream or per connection: a
+  //     103 block and the final 200 block on the same stream may each use all
+  //     8 frames (16 CONTINUATIONs total on one stream).
+  test("CONTINUATION budget resets for each header block on a stream", async () => {
+    await withAdversarialServer(
+      {
+        onStream: (socket, id) => {
+          const splitBlock = (headersFlags: number, block: Buffer) => [
+            frame(1, headersFlags, id, block), // no END_HEADERS
+            ...Array.from({ length: 7 }, () => frame(9, 0, id)),
+            frame(9, 0x4, id), // 8th CONTINUATION, END_HEADERS
+          ];
+          socket.write(
+            Buffer.concat([
+              ...splitBlock(0, hpackStatus("103")), // informational, stream stays open
+              ...splitBlock(0x1, hpackStatus200), // final response, END_STREAM
+            ]),
+          );
+        },
+      },
+      async url => {
+        const r = await fetch(url, h2);
+        expect(r.status).toBe(200);
+        expect(await r.text()).toBe("");
       },
     );
   });


### PR DESCRIPTION
### Problem
- A hostile HTTP/2 origin can pin a `fetch()` forever: it answers with `HEADERS` without `END_HEADERS`, then streams zero-length `CONTINUATION` frames. The promise never settles and the client burns CPU parsing 9-byte frame headers (CVE-2024-28182 class; the `node:http2` side is #36410).
- `src/http/h2_client/dispatch.rs`, `FT_CONTINUATION` arm: the only bound on a header block is `LOCAL_MAX_HEADER_LIST_SIZE` on accumulated bytes. An empty payload never advances that, so nothing ends the sequence.

### Fix
- Add `continuation_count: u8` to `ClientSession`, zeroed at the top of the `FT_HEADERS` arm and incremented in `FT_CONTINUATION`; past `LOCAL_MAX_CONTINUATIONS` (8) the connection fails with `HTTP2EnhanceYourCalm`, which `error_code_for` already maps to `ENHANCE_YOUR_CALM` on the GOAWAY.
- The value and behaviour match nghttp2 (`NGHTTP2_DEFAULT_MAX_CONTINUATIONS`) and node 22: 8 frames accepted, the 9th rejected even when it carries `END_HEADERS`.
- One reset at the top of `FT_HEADERS` is sufficient because `dispatch_frame` already rejects any non-`CONTINUATION` frame while a block is open, so every `HEADERS` that reaches the arm starts a new block; this covers the tracked-stream and orphan (already-RST'd stream) branches alike.
- 8 x 16 KiB (default `MAX_FRAME_SIZE`) is 128 KiB of compressed headers, below the existing 256 KiB byte cap, so the pre-existing `CONTINUATION flood is bounded` test now sees `HTTP2EnhanceYourCalm`; its assertion is updated.
- Verified in `test/js/web/fetch/fetch-http2-adversarial.test.ts` (20/20 with the fix; 3 fail on the released binary):
  - `zero-length CONTINUATION flood is rejected`: the repro, times out without the fix.
  - `header block split across the full CONTINUATION budget is accepted`: 8 frames deliver a 200.
  - `9th CONTINUATION is rejected even if it ends the block`: pins the cap at exactly 8 and the comparison at `>`.
  - `CONTINUATION budget resets for each header block on a stream`: a 103 block and the final 200 block on one stream each use all 8 frames; fails with the reset removed (checked by removing it and rebuilding).
- `fetch-http2-client.test.ts` still 62/62.

### Background
- An HTTP/2 header block starts in a `HEADERS` frame and, when `END_HEADERS` is not set, continues in `CONTINUATION` frames on the same stream; until one arrives with `END_HEADERS`, no other frame is allowed on the connection (RFC 9113 4.3, 6.10). A response may carry several blocks on one stream: 1xx informational blocks, the final response, and trailers.
- HPACK state is connection-wide, so the fetch client also assembles and decodes blocks for streams it has already reset (the "orphan" path in `dispatch.rs`) to keep the decoder in sync; the cap has to apply there too.
- `ENHANCE_YOUR_CALM` is the HTTP/2 error code for "peer is generating excessive load"; `HTTP2EnhanceYourCalm` is the `fetch()` error the client already uses for its other flood limits.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch-http2-adversarial.test.ts

<!-- robobun:evidence:end -->