### PR TITLE
fs.Utf8Stream: don't emit post-reopen 'drain' while a write is in flight

### DIFF
--- a/src/js/internal/streams/fast-utf8-stream.ts
+++ b/src/js/internal/streams/fast-utf8-stream.ts
@@ -454,7 +454,10 @@ class Utf8Stream extends EventEmitter {
       // start
       if ((!this.#writing && this.#len > this.#minLength) || this.#flushPending) {
         this.#actualWrite();
-      } else if (reopening) {
+      } else if (reopening && !this.#writing) {
+        // A 'ready' listener may have called write() synchronously and started
+        // an async fs.write; emitting 'drain' now would signal completion while
+        // that write is still in flight. #release emits 'drain' when it lands.
         process.nextTick(() => this.emit("drain"));
       }
     };

--- a/test/js/node/fs/utf8stream-reopen-drain.test.ts
+++ b/test/js/node/fs/utf8stream-reopen-drain.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Deflake for test/js/node/test/parallel/test-fastutf8stream-reopen.js.
+//
+// After reopen(), fileOpened() emits 'ready' synchronously (async mode). If a
+// 'ready' listener calls write(), #actualWrite starts an async fs.write and
+// sets #writing=true. fileOpened() must then NOT schedule its post-reopen
+// nextTick 'drain': that drain would fire while the write is still in flight,
+// so a listener that reads the file on 'drain' observes an empty file. The
+// real flake surfaces when Bun's fs.write threadpool task completes after
+// nextTick under CI load; here we force it deterministically by deferring the
+// write callback with setImmediate.
+test("fs.Utf8Stream: reopen does not emit 'drain' while a write started from 'ready' is pending", async () => {
+  using dir = tempDir("utf8stream-reopen-drain", {});
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const { Utf8Stream } = require("node:fs");
+const fs = require("node:fs");
+const path = require("node:path");
+const assert = require("node:assert");
+
+const dest = path.join(process.env.DIR, "a.log");
+let afterReopen = false;
+const slowFs = {
+  write(fd, data, enc, cb) {
+    if (afterReopen) {
+      setImmediate(() => fs.write(fd, data, enc, cb));
+    } else {
+      fs.write(fd, data, enc, cb);
+    }
+  },
+};
+
+const stream = new Utf8Stream({ dest, sync: false, fs: slowFs });
+assert.ok(stream.write("hello world\\n"));
+assert.ok(stream.write("something else\\n"));
+const after = dest + "-moved";
+
+stream.once("drain", () => {
+  fs.renameSync(dest, after);
+  stream.reopen();
+  stream.once("ready", () => {
+    afterReopen = true;
+    assert.ok(stream.write("after reopen\\n"));
+    stream.once("drain", () => {
+      assert.strictEqual(stream.writing, false, "'drain' fired while a write is in flight");
+      assert.strictEqual(fs.readFileSync(after, "utf8"), "hello world\\nsomething else\\n");
+      assert.strictEqual(fs.readFileSync(dest, "utf8"), "after reopen\\n");
+      stream.end();
+      stream.on("close", () => console.log("PASS"));
+    });
+  });
+});
+`,
+    ],
+    env: { ...bunEnv, DIR: String(dir) },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("PASS\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
`test/js/node/test/parallel/test-fastutf8stream-reopen.js` has been flaky on roughly 30% of recent CI builds across all platforms (ubuntu, alpine, debian, mac, windows), failing with:

```
AssertionError: Expected values to be strictly equal:
+ ''
- 'after reopen\n'
```

### Repro

Deterministic, by deferring the post-reopen `fs.write` callback past `nextTick`:

```js
const { Utf8Stream } = require("node:fs");
const fs = require("node:fs");

let afterReopen = false;
const slowFs = {
  write(fd, data, enc, cb) {
    if (afterReopen) setImmediate(() => fs.write(fd, data, enc, cb));
    else fs.write(fd, data, enc, cb);
  },
};
const stream = new Utf8Stream({ dest: "/tmp/a.log", sync: false, fs: slowFs });
stream.write("hello\n");
stream.once("drain", () => {
  fs.renameSync("/tmp/a.log", "/tmp/a.log-moved");
  stream.reopen();
  stream.once("ready", () => {
    afterReopen = true;
    stream.write("after reopen\n");
    stream.once("drain", () => {
      console.log("writing:", stream.writing);              // true
      console.log(fs.readFileSync("/tmp/a.log", "utf8"));   // ""
    });
  });
});
```

### Cause

`#openFile`'s `fileOpened` callback, on a successful reopen in async mode, does:

```js
this.#writing = false;
this.emit("ready");           // synchronous
if ((!this.#writing && this.#len > this.#minLength) || this.#flushPending) {
  this.#actualWrite();
} else if (reopening) {
  process.nextTick(() => this.emit("drain"));
}
```

If a `'ready'` listener calls `write()`, `#actualWrite` starts an async `fs.write` and sets `#writing=true`. The first branch's `!this.#writing` is now false, so it falls through to the `reopening` branch and schedules a `nextTick` `'drain'`. That drain fires while the write is still in flight; a `once('drain')` listener that reads the file observes it empty.

The vendored test relies on Node's libuv threadpool completing the physical `write(2)` before `nextTick` fires (even though the callback runs later). Under CI threadpool contention, Bun's `fs.write` hasn't reached disk yet when `nextTick` runs, exposing the race. Node v26.3.0 has the identical logic and fails the same deterministic repro above.

### Fix

Guard the post-reopen drain on `!this.#writing`. When a write is in flight, `#release` emits `'drain'` once it completes.

### Verification

```
$ bun bd test test/js/node/fs/utf8stream-reopen-drain.test.ts
(pass) fs.Utf8Stream: reopen does not emit 'drain' while a write started from 'ready' is pending
```

Fail-before (src/ stashed): `AssertionError: 'drain' fired while a write is in flight`. All 14 `test-fastutf8stream-*.js` vendored tests pass with the fix.