### PR TITLE
test(no-orphans): skip fast-exit perl daemon test on macOS

### DIFF
--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -445,18 +445,23 @@ test.concurrent.skipIf(!isPosix || !hasPerl)(
 // Same daemon shape but the outer and the intermediate exit *immediately* —
 // no spinning on the pidfile (that spin is what made the proc_listallpids
 // scan() pass: it gave the wait loop's NOTE_FORK time to fire and observe
-// each link). With NOTE_TRACK xnu attaches to the intermediate inside fork1()
-// before it's schedulable, recursively, so the daemon is captured even if both
-// ancestors are gone before the wait loop drains a single event. Linux:
-// subreaper is also armed pre-spawn, and `killSubreaperAdoptees()` in the
-// disarm defer kills any ppid==bun adoptee that wasn't a pre-arm sibling
-// before subreaper drops, so the daemon can't escape in the disarm →
-// `onProcessExit` window.
+// each link). Linux: subreaper is armed pre-spawn, and
+// `killSubreaperAdoptees()` in the disarm defer kills any ppid==bun adoptee
+// that wasn't a pre-arm sibling before subreaper drops, so the daemon can't
+// escape in the disarm → `onProcessExit` window.
+//
+// macOS: NOTE_TRACK (which attached atomically inside fork1()) has been
+// ENOTSUP since 10.5; the replacement NOTE_FORK + p_puniqueid scan (#30100)
+// has a documented unfixable-from-userspace race where a fast-exit
+// intermediate dies before the scan records its uniqueid, leaving the
+// daemon's p_puniqueid unlinkable. setsid() also moves it out of the script
+// pgroup, so kill(-pgid) misses it. That race loses under CI load on the x64
+// macs in particular, so this test is Linux-only.
 //
 // `bun run` may finish before the daemon writes its pidfile. Poll for the
 // file from the *test*; if it never appears the daemon was reaped before it
 // could write — also a pass. Only fail if the file appears AND the pid lives.
-test.concurrent.skipIf(!isPosix || !hasPerl)(
+test.concurrent.skipIf(!isLinux || !hasPerl)(
   "bun run --no-orphans (perl): fast-exit intermediate (no pidfile spin) — daemon still reaped",
   async () => {
     using dir = tempDir("no-orphans-fast-daemon", {


### PR DESCRIPTION
`test/cli/run/no-orphans.test.ts`'s fast-exit perl daemon test flaked in 201 of the last 400 CI builds (and hard-failed on 17 distinct branches), almost entirely on macOS:

```
✗ bun run --no-orphans (perl): fast-exit intermediate (no pidfile spin) — daemon still reaped [30002.08ms]
```

### Cause

The test was written for `NOTE_TRACK`, which attached to fork intermediates atomically inside xnu's `fork1()`, so a double-fork + setsid daemon was captured even if both ancestors exited before the wait loop drained a single event. `NOTE_TRACK` has been `ENOTSUP` since macOS 10.5 and was replaced in #30100 by `NOTE_FORK` + `p_puniqueid` scanning. That replacement has a documented unfixable-from-userspace race (`src/spawn/process.rs:3600`, `src/jsc/bindings/NoOrphansTracker.cpp:21`):

> Race: a fast-exit intermediate (fork+setsid+fork+exit) can die before this scan records its uniqueid, leaving its child's `p_puniqueid` unlinkable.

The daemon is also outside the script pgroup (`setsid()`), so `kill(-pgid)` misses it. When the race loses under `test.concurrent` load on the x64 macs, the escaped daemon holds the inherited stderr pipe open and `await proc.stderr.text()` blocks until the 30 s file timeout.

### Fix

Make the test Linux-only (where `PR_SET_CHILD_SUBREAPER` is armed pre-spawn and the guarantee holds) and replace the stale `NOTE_TRACK` comment with the actual macOS story. The adjacent perl daemon test that spins on the pidfile (giving `NOTE_FORK` time to observe each link) remains `!isPosix` and continues to cover macOS.

### Verification

Test still passes on Linux with `bun bd test test/cli/run/no-orphans.test.ts -t "fast-exit intermediate"`. This is a test-only change to stop asserting a guarantee the macOS implementation explicitly documents as best-effort; there is no src/ change and no deterministic fail-before is possible (200-run stress on an idle darwin-arm64 box did not reproduce).

The 20144 deflake originally bundled here is already covered by #34166.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->