### PR TITLE
no-orphans(windows): allow CREATE_BREAKAWAY_FROM_JOB and set DIE_ON_UNHANDLED_EXCEPTION on the Job

### DIFF
--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -115,22 +115,10 @@ pub mod parent_death_watchdog {
             if !job.is_null() {
                 let mut jeli: windows::JOBOBJECT_EXTENDED_LIMIT_INFORMATION =
                     bun_core::ffi::zeroed();
-                // KILL_ON_JOB_CLOSE is the mechanism; the other two keep us
-                // from breaking descendants:
-                //   DIE_ON_UNHANDLED_EXCEPTION — a crashing descendant exits
-                //     with its NTSTATUS instead of parking on the WER dialog.
-                //     Bun's own `SetUnhandledExceptionFilter` callback still
-                //     runs first, so the crash reporter is unaffected.
-                //   BREAKAWAY_OK — without it, a descendant's
-                //     `CreateProcess(CREATE_BREAKAWAY_FROM_JOB)` fails with
-                //     ERROR_ACCESS_DENIED because this is its immediate job.
-                // SILENT_BREAKAWAY_OK is deliberately NOT set: we rely on
-                // inheritance to put the whole tree in the Job, and that flag
-                // would make every child escape it (libuv's global job sets it
-                // because libuv assigns each child explicitly).
-                jeli.BasicLimitInformation.LimitFlags = windows::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
-                    | windows::JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
-                    | windows::JOB_OBJECT_LIMIT_BREAKAWAY_OK;
+                // See the constant's doc — Bun's own crash reporter (installed
+                // via `SetUnhandledExceptionFilter`) still runs before
+                // `DIE_ON_UNHANDLED_EXCEPTION` applies.
+                jeli.BasicLimitInformation.LimitFlags = windows::JOB_LIMIT_FLAGS_KILL_TREE_ON_CLOSE;
                 if windows::SetInformationJobObject(
                     job,
                     windows::JobObjectExtendedLimitInformation,

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -115,9 +115,6 @@ pub mod parent_death_watchdog {
             if !job.is_null() {
                 let mut jeli: windows::JOBOBJECT_EXTENDED_LIMIT_INFORMATION =
                     bun_core::ffi::zeroed();
-                // See the constant's doc — Bun's own crash reporter (installed
-                // via `SetUnhandledExceptionFilter`) still runs before
-                // `DIE_ON_UNHANDLED_EXCEPTION` applies.
                 jeli.BasicLimitInformation.LimitFlags = windows::JOB_LIMIT_FLAGS_KILL_TREE_ON_CLOSE;
                 if windows::SetInformationJobObject(
                     job,

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -115,7 +115,22 @@ pub mod parent_death_watchdog {
             if !job.is_null() {
                 let mut jeli: windows::JOBOBJECT_EXTENDED_LIMIT_INFORMATION =
                     bun_core::ffi::zeroed();
-                jeli.BasicLimitInformation.LimitFlags = windows::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+                // KILL_ON_JOB_CLOSE is the mechanism; the other two keep us
+                // from breaking descendants:
+                //   DIE_ON_UNHANDLED_EXCEPTION — a crashing descendant exits
+                //     with its NTSTATUS instead of parking on the WER dialog.
+                //     Bun's own `SetUnhandledExceptionFilter` callback still
+                //     runs first, so the crash reporter is unaffected.
+                //   BREAKAWAY_OK — without it, a descendant's
+                //     `CreateProcess(CREATE_BREAKAWAY_FROM_JOB)` fails with
+                //     ERROR_ACCESS_DENIED because this is its immediate job.
+                // SILENT_BREAKAWAY_OK is deliberately NOT set: we rely on
+                // inheritance to put the whole tree in the Job, and that flag
+                // would make every child escape it (libuv's global job sets it
+                // because libuv assigns each child explicitly).
+                jeli.BasicLimitInformation.LimitFlags = windows::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+                    | windows::JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
+                    | windows::JOB_OBJECT_LIMIT_BREAKAWAY_OK;
                 if windows::SetInformationJobObject(
                     job,
                     windows::JobObjectExtendedLimitInformation,

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -729,7 +729,15 @@ impl<'a> Coordinator<'a> {
                 return None;
             }
             let mut jeli: windows::JOBOBJECT_EXTENDED_LIMIT_INFORMATION = bun_core::ffi::zeroed();
-            jeli.BasicLimitInformation.LimitFlags = windows::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            // Same flag set as `ParentDeathWatchdog::enable()` (see the comment
+            // there): DIE_ON_UNHANDLED_EXCEPTION so a crashed worker/fixture
+            // exits instead of parking on WER, BREAKAWAY_OK so a fixture's
+            // `CreateProcess(CREATE_BREAKAWAY_FROM_JOB)` doesn't EACCES, and
+            // no SILENT_BREAKAWAY_OK because we want the whole worker tree
+            // (grandchildren included) to inherit Job membership.
+            jeli.BasicLimitInformation.LimitFlags = windows::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+                | windows::JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
+                | windows::JOB_OBJECT_LIMIT_BREAKAWAY_OK;
             if windows::SetInformationJobObject(
                 job,
                 windows::JobObjectExtendedLimitInformation,

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -729,15 +729,7 @@ impl<'a> Coordinator<'a> {
                 return None;
             }
             let mut jeli: windows::JOBOBJECT_EXTENDED_LIMIT_INFORMATION = bun_core::ffi::zeroed();
-            // Same flag set as `ParentDeathWatchdog::enable()` (see the comment
-            // there): DIE_ON_UNHANDLED_EXCEPTION so a crashed worker/fixture
-            // exits instead of parking on WER, BREAKAWAY_OK so a fixture's
-            // `CreateProcess(CREATE_BREAKAWAY_FROM_JOB)` doesn't EACCES, and
-            // no SILENT_BREAKAWAY_OK because we want the whole worker tree
-            // (grandchildren included) to inherit Job membership.
-            jeli.BasicLimitInformation.LimitFlags = windows::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
-                | windows::JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
-                | windows::JOB_OBJECT_LIMIT_BREAKAWAY_OK;
+            jeli.BasicLimitInformation.LimitFlags = windows::JOB_LIMIT_FLAGS_KILL_TREE_ON_CLOSE;
             if windows::SetInformationJobObject(
                 job,
                 windows::JobObjectExtendedLimitInformation,

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1324,6 +1324,19 @@ pub const JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION: DWORD = 0x400;
 pub const JOB_OBJECT_LIMIT_BREAKAWAY_OK: DWORD = 0x800;
 pub const JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK: DWORD = 0x00001000;
 
+/// `LimitFlags` for a kill-on-close Job that reaps an entire **inherited**
+/// descendant tree (`--no-orphans`, the parallel-test coordinator).
+/// `DIE_ON_UNHANDLED_EXCEPTION` keeps a crashed descendant from parking on
+/// WER; `BREAKAWAY_OK` keeps a descendant's
+/// `CreateProcess(CREATE_BREAKAWAY_FROM_JOB)` from failing `ERROR_ACCESS_DENIED`.
+/// Deliberately omits `SILENT_BREAKAWAY_OK`: inheritance is the membership
+/// mechanism, and that flag would make every child escape the Job. (libuv's
+/// global job includes it because libuv assigns each child explicitly; see
+/// `uv__init_global_job_handle`.)
+pub const JOB_LIMIT_FLAGS_KILL_TREE_ON_CLOSE: DWORD = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    | JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
+    | JOB_OBJECT_LIMIT_BREAKAWAY_OK;
+
 pub mod rescle {
     use super::*;
 

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1324,15 +1324,10 @@ pub const JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION: DWORD = 0x400;
 pub const JOB_OBJECT_LIMIT_BREAKAWAY_OK: DWORD = 0x800;
 pub const JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK: DWORD = 0x00001000;
 
-/// `LimitFlags` for a kill-on-close Job that reaps an entire **inherited**
-/// descendant tree (`--no-orphans`, the parallel-test coordinator).
-/// `DIE_ON_UNHANDLED_EXCEPTION` keeps a crashed descendant from parking on
-/// WER; `BREAKAWAY_OK` keeps a descendant's
-/// `CreateProcess(CREATE_BREAKAWAY_FROM_JOB)` from failing `ERROR_ACCESS_DENIED`.
-/// Deliberately omits `SILENT_BREAKAWAY_OK`: inheritance is the membership
-/// mechanism, and that flag would make every child escape the Job. (libuv's
-/// global job includes it because libuv assigns each child explicitly; see
-/// `uv__init_global_job_handle`.)
+/// `LimitFlags` for a kill-on-close Job whose members are added by
+/// inheritance (`--no-orphans`, the parallel-test coordinator). Omits
+/// `SILENT_BREAKAWAY_OK` on purpose: that would make every child escape the
+/// Job. libuv's global job sets it because libuv assigns each child itself.
 pub const JOB_LIMIT_FLAGS_KILL_TREE_ON_CLOSE: DWORD = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
     | JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
     | JOB_OBJECT_LIMIT_BREAKAWAY_OK;

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -1121,8 +1121,8 @@ test.concurrent.skipIf(!isWindows)(
             ],
             returns: FFIType.i32,
           },
-          WaitForSingleObject: { args: [FFIType.ptr, FFIType.u32], returns: FFIType.u32 },
-          CloseHandle: { args: [FFIType.ptr], returns: FFIType.i32 },
+          WaitForSingleObject: { args: [FFIType.u64, FFIType.u32], returns: FFIType.u32 },
+          CloseHandle: { args: [FFIType.u64], returns: FFIType.i32 },
         }).symbols;
 
         // sizeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION) == 144 on x64/arm64;

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -1089,3 +1089,109 @@ describe.concurrent.each([
     }
   });
 });
+
+// The --no-orphans Job Object is Bun's immediate (leaf) job because enable()
+// self-assigns it after startup. Probe its LimitFlags via
+// QueryInformationJobObject(NULL), and exercise CREATE_BREAKAWAY_FROM_JOB:
+// without BREAKAWAY_OK on the immediate job, that CreateProcess fails with
+// ERROR_ACCESS_DENIED (5), which is a compat break --no-orphans mustn't cause.
+// DIE_ON_UNHANDLED_EXCEPTION can't be asserted behaviorally in CI (WER is
+// suppressed there) so the flag check is the proof for that half.
+//
+// Spawn via a cmd.exe supervisor so the bun under test is not explicitly
+// assigned to the test runner's libuv global job (libuv's job has
+// SILENT_BREAKAWAY so cmd.exe's child doesn't inherit it); this guarantees
+// the --no-orphans job is the immediate job regardless of parent timing.
+test.concurrent.skipIf(!isWindows)(
+  "windows: --no-orphans Job allows breakaway and sets DIE_ON_UNHANDLED_EXCEPTION, not SILENT_BREAKAWAY",
+  async () => {
+    using dir = tempDir("no-orphans-jobflags", {
+      "probe.js": `
+        const { dlopen, FFIType, ptr } = require("bun:ffi");
+        const k = dlopen("kernel32.dll", {
+          QueryInformationJobObject: {
+            args: [FFIType.ptr, FFIType.u32, FFIType.ptr, FFIType.u32, FFIType.ptr],
+            returns: FFIType.i32,
+          },
+          GetLastError: { args: [], returns: FFIType.u32 },
+          CreateProcessW: {
+            args: [
+              FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.i32,
+              FFIType.u32, FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.ptr,
+            ],
+            returns: FFIType.i32,
+          },
+          WaitForSingleObject: { args: [FFIType.ptr, FFIType.u32], returns: FFIType.u32 },
+          CloseHandle: { args: [FFIType.ptr], returns: FFIType.i32 },
+        }).symbols;
+
+        // sizeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION) == 144 on x64/arm64;
+        // LimitFlags is at offset 16 inside BasicLimitInformation.
+        const jeli = new Uint8Array(144);
+        const qok = k.QueryInformationJobObject(null, 9, ptr(jeli), 144, null);
+        const flags = qok ? new DataView(jeli.buffer).getUint32(16, true) : -1;
+
+        const w = s => {
+          const a = new Uint16Array(s.length + 1);
+          for (let i = 0; i < s.length; i++) a[i] = s.charCodeAt(i);
+          return a;
+        };
+        const cmdline = w((process.env.COMSPEC || "C:/Windows/System32/cmd.exe") + " /d /c exit 0");
+        const si = new Uint8Array(104);
+        new DataView(si.buffer).setUint32(0, 104, true);
+        const pi = new Uint8Array(24);
+        const cok = k.CreateProcessW(null, ptr(cmdline), null, null, 0,
+          0x01000000 /* CREATE_BREAKAWAY_FROM_JOB */, null, null, ptr(si), ptr(pi));
+        const cerr = cok ? 0 : k.GetLastError();
+        if (cok) {
+          const dv = new DataView(pi.buffer);
+          const hP = dv.getBigUint64(0, true), hT = dv.getBigUint64(8, true);
+          k.WaitForSingleObject(hP, 10000);
+          k.CloseHandle(hP);
+          k.CloseHandle(hT);
+        }
+        process.stdout.write(JSON.stringify({ qok, flags, cok, cerr }));
+      `,
+      "sup.bat": `@"${bunExe()}" --no-orphans "%~dp0probe.js"\r\n`,
+    });
+    const env: Record<string, string> = { ...bunEnv };
+    delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
+    await using proc = Bun.spawn({
+      cmd: ["cmd.exe", "/d", "/c", `${dir}\\sup.bat`],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout.trim());
+
+    const KILL_ON_JOB_CLOSE = 0x2000;
+    const DIE_ON_UNHANDLED_EXCEPTION = 0x400;
+    const BREAKAWAY_OK = 0x800;
+    const SILENT_BREAKAWAY_OK = 0x1000;
+
+    // Sanity: QueryInformationJobObject succeeded and we're looking at the
+    // --no-orphans job (KILL_ON_JOB_CLOSE set, SILENT_BREAKAWAY_OK not).
+    // SILENT_BREAKAWAY_OK would defeat --no-orphans entirely: children
+    // would no longer inherit Job membership.
+    expect({
+      qok: out.qok,
+      KILL_ON_JOB_CLOSE: !!(out.flags & KILL_ON_JOB_CLOSE),
+      DIE_ON_UNHANDLED_EXCEPTION: !!(out.flags & DIE_ON_UNHANDLED_EXCEPTION),
+      BREAKAWAY_OK: !!(out.flags & BREAKAWAY_OK),
+      SILENT_BREAKAWAY_OK: !!(out.flags & SILENT_BREAKAWAY_OK),
+    }).toEqual({
+      qok: 1,
+      KILL_ON_JOB_CLOSE: true,
+      DIE_ON_UNHANDLED_EXCEPTION: true,
+      BREAKAWAY_OK: true,
+      SILENT_BREAKAWAY_OK: false,
+    });
+
+    // Behavioral: a descendant's CreateProcess(CREATE_BREAKAWAY_FROM_JOB) must
+    // succeed. Before the fix this was { cok: 0, cerr: 5 } (ERROR_ACCESS_DENIED).
+    expect({ cok: out.cok, cerr: out.cerr }).toEqual({ cok: 1, cerr: 0 });
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
## What

`ParentDeathWatchdog::enable()` on Windows creates a Job Object for `--no-orphans` and self-assigns Bun into it, so it becomes the immediate job for every descendant. It set only `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.

## Why it matters

Two observable problems:

1. **`CreateProcess(CREATE_BREAKAWAY_FROM_JOB)` fails.** Any descendant that passes that flag gets `ERROR_ACCESS_DENIED` because the immediate job does not permit breakaway. On a Windows 2019 box against current main:

   ```
   with --no-orphans:  LimitFlags=0x2000, CreateProcessW(BREAKAWAY) ok=0 err=5
   without:            CreateProcessW(BREAKAWAY) ok=1
   ```

   That is a hard spawn failure `--no-orphans` should not cause. libuv's own comment on its global job notes the same hazard.

2. **WER can park a crashed descendant.** A non-Bun child that crashes with no top-level filter reaches `UnhandledExceptionFilter`'s default path (WER dialog / JIT debugger prompt), which on a headless box blocks forever. `JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION` makes it exit with the NTSTATUS instead.

## Fix

Set `LimitFlags = KILL_ON_JOB_CLOSE | DIE_ON_UNHANDLED_EXCEPTION | BREAKAWAY_OK`.

**Why this is safe for Bun itself:** Bun's crash reporter is installed via `SetUnhandledExceptionFilter` (`handle_unhandled_exception_windows` in `src/crash_handler/lib.rs`). That callback runs before the Job flag applies; `crash_handler()` is `-> !`. The flag only changes the behavior for exception codes Bun's classifier declines and for non-Bun descendants, both of which should terminate rather than prompt under `--no-orphans`.

**Why not `SILENT_BREAKAWAY_OK`:** libuv's global job sets it because libuv explicitly assigns each child, so grandchildren intentionally escape. The `--no-orphans` Job relies on inheritance to cover the whole descendant tree; `SILENT_BREAKAWAY_OK` would make every child escape and break the feature. The existing "cmd.exe-spawned descendant" tests already rely on this.

Applied the same flag set to the parallel test runner's kill-on-close Job in `Coordinator.rs` (same shape, same failure modes).

## Verification

New test in `test/cli/run/no-orphans.test.ts` probes the immediate Job's `LimitFlags` via `QueryInformationJobObject(NULL)` and exercises `CreateProcess(CREATE_BREAKAWAY_FROM_JOB)` via FFI.

<details><summary>fail-before (canary on Windows Server 2019)</summary>

```
error: expect(received).toEqual(expected)
  {
-   "BREAKAWAY_OK": true,
-   "DIE_ON_UNHANDLED_EXCEPTION": true,
+   "BREAKAWAY_OK": false,
+   "DIE_ON_UNHANDLED_EXCEPTION": false,
    "KILL_ON_JOB_CLOSE": true,
    "SILENT_BREAKAWAY_OK": false,
    "qok": 1,
  }
(fail) windows: --no-orphans Job allows breakaway and sets DIE_ON_UNHANDLED_EXCEPTION, not SILENT_BREAKAWAY
```
</details>

<details><summary>pass-after (`bun bd test` on Windows Server 2019)</summary>

```
(pass) windows: --no-orphans Job allows breakaway and sets DIE_ON_UNHANDLED_EXCEPTION, not SILENT_BREAKAWAY [571.10ms]
 10 pass
 14 skip
 0 fail
```
</details>

The src/ change is entirely `#[cfg(windows)]` and the test is `skipIf(!isWindows)`, so a Linux-only gate cannot observe fail-before; the evidence above was captured on windows-x64.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/no-orphans.test.ts

<!-- robobun:evidence:end -->