### PR TITLE
watcher: report metadata and move_from events, and recover from queue overflow

### DIFF
--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -122,6 +122,12 @@ impl Event {
     pub(crate) fn size(&self) -> u32 {
         u32::try_from(size_of::<Event>()).expect("int cast") + self.name_len
     }
+
+    /// The kernel dropped events because `max_queued_events` was exceeded.
+    /// Delivered with `watch_descriptor == -1`, so it matches no watchlist entry.
+    pub fn is_queue_overflow(&self) -> bool {
+        (self.mask & bun_sys::linux::IN::Q_OVERFLOW) != 0
+    }
 }
 
 impl INotifyWatcher {
@@ -129,8 +135,16 @@ impl INotifyWatcher {
         use bun_sys::linux::IN;
         debug_assert!(self.loaded);
         let old_count = self.watch_count.fetch_add(1, Ordering::Release);
-        let watch_file_mask =
-            IN::EXCL_UNLINK | IN::MOVE_SELF | IN::DELETE_SELF | IN::MOVED_TO | IN::MODIFY;
+        // IN_ATTRIB is a file-watch flag only. On a directory it reports metadata
+        // changes of every entry inside it, named, and consumers treat a named
+        // directory event as "re-resolve this entry" — so a bare `touch` would
+        // reload the module.
+        let watch_file_mask = IN::EXCL_UNLINK
+            | IN::MOVE_SELF
+            | IN::DELETE_SELF
+            | IN::MOVED_TO
+            | IN::MODIFY
+            | IN::ATTRIB;
         // SAFETY: fd is a valid inotify fd (loaded == true), pathname is NUL-terminated.
         let rc = unsafe {
             bun_sys::linux::inotify_add_watch(self.fd.native(), pathname.as_ptr(), watch_file_mask)
@@ -160,6 +174,7 @@ impl INotifyWatcher {
             | IN::CREATE
             | IN::MOVE_SELF
             | IN::ONLYDIR
+            | IN::MOVED_FROM
             | IN::MOVED_TO
             | IN::MODIFY;
         // SAFETY: fd is a valid inotify fd (loaded == true), pathname is NUL-terminated.
@@ -403,6 +418,7 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
 
     let mut event_id: usize = 0;
     let mut events_processed: usize = 0;
+    let mut overflowed = false;
 
     if events_processed < events.len() {
         let mut temp_name_list: [Option<&ZStr>; 128] = [None; 128];
@@ -439,6 +455,14 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
                 }
             }
 
+            // Carries `wd == -1`, so it matches no watchlist entry and would
+            // otherwise be discarded by the lookup below.
+            if event.is_queue_overflow() {
+                overflowed = true;
+                events_processed += 1;
+                continue;
+            }
+
             let idx = match this
                 .eventlist_index_scratch
                 .iter()
@@ -473,7 +497,46 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
         }
     }
 
+    if overflowed {
+        resync_after_overflow(this);
+    }
+
     Ok(())
+}
+
+/// Replay a synthetic `WRITE` for every watched path after the kernel dropped an
+/// unknown set of events (`/proc/sys/fs/inotify/max_queued_events` exceeded).
+/// Which paths changed is unrecoverable, so every one is treated as suspect.
+fn resync_after_overflow(this: &mut Watcher) {
+    // `WatchItemIndex::MAX` is the no-watch-item sentinel, never a real index.
+    let len = {
+        let _guard = this.mutex.lock_guard();
+        this.watchlist.len().min(WatchItemIndex::MAX as usize)
+    };
+    bun_core::warn!(
+        "inotify event queue overflowed; re-checking all {} watched paths. Raise /proc/sys/fs/inotify/max_queued_events to avoid this.\n",
+        len
+    );
+
+    let mut start = 0;
+    while start < len {
+        let count = (len - start).min(max_count);
+        for i in 0..count {
+            // `WRITE` (never `DELETE`) is deliberate: it makes consumers
+            // re-check each path without driving the eviction path, whose
+            // `evict_list` is a fixed 8096-entry buffer.
+            this.watch_events[i] = WatchEvent {
+                op: Op::WRITE,
+                index: (start + i) as WatchItemIndex,
+                ..Default::default()
+            };
+        }
+        // `dispatch_file_updates` re-takes `this.mutex` and re-checks `running`;
+        // entries evicted between batches are filtered by the consumer's own
+        // bounds check against the current watchlist length.
+        this.dispatch_file_updates(count, 0);
+        start += count;
+    }
 }
 
 fn process_inotify_event_batch(
@@ -535,11 +598,17 @@ fn watch_event_from_inotify_event(event: &Event, index: WatchItemIndex) -> Watch
     if (event.mask & IN::MOVED_TO) > 0 {
         op |= Op::MOVE_TO;
     }
+    if (event.mask & IN::MOVED_FROM) > 0 {
+        op |= Op::MOVE_FROM;
+    }
     if (event.mask & IN::MODIFY) > 0 {
         op |= Op::WRITE;
     }
     if (event.mask & IN::CREATE) > 0 {
         op |= Op::CREATE;
+    }
+    if (event.mask & IN::ATTRIB) > 0 {
+        op |= Op::METADATA;
     }
     WatchEvent {
         op,

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -428,7 +428,11 @@ impl Watcher {
                 if (item as usize) < self.watchlist.len() {
                     let moved_fd = self.watchlist.items_fd()[item as usize];
                     if moved_fd.is_valid() {
-                        self.add_file_descriptor_to_kqueue_without_checks(moved_fd, item as usize);
+                        self.add_file_descriptor_to_kqueue_without_checks(
+                            moved_fd,
+                            item as usize,
+                            self.watchlist.items_kind()[item as usize],
+                        );
                     }
                 }
             }
@@ -464,9 +468,10 @@ impl Watcher {
         &mut self,
         fd: Fd,
         watchlist_id: usize,
+        kind: WatchItemKind,
     ) {
         use libc::{EV_ADD, EV_CLEAR, EV_ENABLE, EVFILT_VNODE, kevent as KEvent};
-        use libc::{NOTE_DELETE, NOTE_RENAME, NOTE_WRITE};
+        use libc::{NOTE_ATTRIB, NOTE_DELETE, NOTE_RENAME, NOTE_WRITE};
 
         // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kqueue.2.html
         let mut event: KEvent = bun_core::ffi::zeroed();
@@ -475,7 +480,15 @@ impl Watcher {
         // we want to know about the vnode
         event.filter = EVFILT_VNODE as _;
 
-        event.fflags = (NOTE_WRITE | NOTE_RENAME | NOTE_DELETE) as _;
+        // NOTE_ATTRIB is requested for files only. A directory vnode reports it
+        // solely for changes to the directory's own metadata — entry-level
+        // `chmod`/`touch` raise nothing on the parent — and no consumer acts on
+        // that, so requesting it there only adds wakeups.
+        let mut fflags = NOTE_WRITE | NOTE_RENAME | NOTE_DELETE;
+        if kind == WatchItemKind::File {
+            fflags |= NOTE_ATTRIB;
+        }
+        event.fflags = fflags as _;
 
         // id
         event.ident = usize::try_from(fd.native()).expect("int cast");
@@ -528,7 +541,7 @@ impl Watcher {
         };
 
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-        self.add_file_descriptor_to_kqueue_without_checks(fd, watchlist_id);
+        self.add_file_descriptor_to_kqueue_without_checks(fd, watchlist_id, WatchItemKind::File);
         #[cfg(any(target_os = "linux", target_os = "android"))]
         let eventlist_index = {
             // inotify needs a trailing NUL. When
@@ -607,7 +620,11 @@ impl Watcher {
         let watchlist_id = self.watchlist.len();
 
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-        self.add_file_descriptor_to_kqueue_without_checks(fd, watchlist_id);
+        self.add_file_descriptor_to_kqueue_without_checks(
+            fd,
+            watchlist_id,
+            WatchItemKind::Directory,
+        );
         #[cfg(any(target_os = "linux", target_os = "android"))]
         let eventlist_index = {
             let mut buf = bun_paths::path_buffer_pool::get();
@@ -982,13 +999,16 @@ impl WatchEvent {
 bitflags::bitflags! {
     #[derive(Clone, Copy, Default, PartialEq, Eq)]
     pub struct Op: u8 {
-        const DELETE   = 1 << 0;
-        const METADATA = 1 << 1;
-        const RENAME   = 1 << 2;
-        const WRITE    = 1 << 3;
-        const MOVE_TO  = 1 << 4;
-        const CREATE   = 1 << 5;
-        // bits 6..7 = _padding
+        const DELETE    = 1 << 0;
+        const METADATA  = 1 << 1;
+        const RENAME    = 1 << 2;
+        const WRITE     = 1 << 3;
+        const MOVE_TO   = 1 << 4;
+        const CREATE    = 1 << 5;
+        /// An entry left a watched directory (moved out, or the source half of
+        /// a rename). The mirror of [`Op::MOVE_TO`].
+        const MOVE_FROM = 1 << 6;
+        // bit 7 = _padding
     }
 }
 
@@ -1006,6 +1026,7 @@ pub(crate) const OP_NAMES: &[(Op, &str)] = &[
     (Op::WRITE, "write"),
     (Op::MOVE_TO, "move_to"),
     (Op::CREATE, "create"),
+    (Op::MOVE_FROM, "move_from"),
 ];
 
 impl fmt::Display for Op {

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -541,16 +541,15 @@ fn process_watch_event_batch(this: &mut Watcher, event_count: usize) -> bun_sys:
 }
 
 fn create_watch_event(event: &FileEvent, index: WatchItemIndex) -> WatchEvent {
-    let mut op = Op::empty();
-    if event.action == Action::Removed {
-        op |= Op::DELETE;
-    }
-    if event.action == Action::RenamedOld {
-        op |= Op::RENAME;
-    }
-    if event.action == Action::Modified {
-        op |= Op::WRITE;
-    }
+    // `RenamedOld` carries both `RENAME` and `MOVE_FROM`: consumers key on
+    // `RENAME`, and `MOVE_FROM` names which half of the rename this is.
+    let op = match event.action {
+        Action::Added => Op::CREATE,
+        Action::Removed => Op::DELETE,
+        Action::Modified => Op::WRITE,
+        Action::RenamedOld => Op::RENAME | Op::MOVE_FROM,
+        Action::RenamedNew => Op::MOVE_TO,
+    };
     WatchEvent {
         op,
         index,

--- a/test/cli/watch/watcher-trace.test.ts
+++ b/test/cli/watch/watcher-trace.test.ts
@@ -1,7 +1,69 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
-import { existsSync, readFileSync } from "node:fs";
+import { bunEnv, bunExe, isMacOS, isFreeBSD, isWindows, tempDir } from "harness";
+import { existsSync, readFileSync, renameSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+
+type TraceFileEvent = { events: string[]; changed?: string[] };
+
+/**
+ * Poll the trace file until some recorded event satisfies `pred`.
+ *
+ * Polls rather than sleeping a fixed amount: the watcher coalesces events over
+ * a short window, so the delay before an event lands is variable.
+ */
+async function waitForTraceEvent(
+  traceFile: string,
+  what: string,
+  pred: (path: string, event: TraceFileEvent) => boolean,
+  // Under the per-test default so this throws with the trace dump attached
+  // instead of being cut short by the harness timeout.
+  timeoutMs = 4000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let contents = "";
+  while (Date.now() < deadline) {
+    if (existsSync(traceFile)) {
+      contents = readFileSync(traceFile, "utf-8");
+      for (const line of contents.split("\n")) {
+        if (!line.trim()) continue;
+        let parsed: { files?: Record<string, TraceFileEvent> };
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          continue; // a partially-flushed final line
+        }
+        for (const [path, event] of Object.entries(parsed.files ?? {})) {
+          if (pred(path, event)) return;
+        }
+      }
+    }
+    await Bun.sleep(20);
+  }
+  throw new Error(`timed out waiting for ${what}\ntrace file contents:\n${contents}`);
+}
+
+/** Spawn `bun --watch <entry>` with tracing on and wait for its first run. */
+async function spawnTraced(dir: string, entry: string, traceFile: string, ready: string) {
+  const proc = Bun.spawn({
+    cmd: [bunExe(), "--watch", entry],
+    env: { ...bunEnv, BUN_WATCHER_TRACE: traceFile },
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "inherit",
+    stdin: "ignore",
+  });
+  const decoder = new TextDecoder();
+  let seen = "";
+  for await (const chunk of proc.stdout) {
+    seen += decoder.decode(chunk);
+    if (seen.includes(ready)) return proc;
+  }
+  // stdout ended without the readiness line, so the process died during startup.
+  // Surface that instead of letting the caller time out on a watcher that was
+  // never running.
+  const exitCode = await proc.exited;
+  throw new Error(`bun --watch exited (code ${exitCode}) before printing ${JSON.stringify(ready)}; stdout: ${seen}`);
+}
 
 test("BUN_WATCHER_TRACE creates trace file with watch events", async () => {
   using dir = tempDir("watcher-trace", {
@@ -261,3 +323,71 @@ test("BUN_WATCHER_TRACE appends across reloads", async () => {
     expect(event).toHaveProperty("files");
   }
 }, 10000);
+
+// Bumping mtime without touching contents is a metadata-only change: IN_ATTRIB
+// on Linux, NOTE_ATTRIB on kqueue. Both must surface as the `metadata` op.
+//
+// Skipped on Windows: ReadDirectoryChangesW reports metadata changes as
+// FILE_ACTION_MODIFIED, indistinguishable from a content write, so there is no
+// separate metadata op to assert on.
+test.skipIf(isWindows)("utimes on a watched file records a metadata event", async () => {
+  using dir = tempDir("watcher-trace-metadata", {
+    "script.js": `console.log("ready");`,
+  });
+  // Outside the watched tree: a trace file written *inside* it would record its
+  // own writes and feed itself.
+  using traceDir = tempDir("watcher-trace-metadata-out", {});
+  const traceFile = join(String(traceDir), "metadata-trace.log");
+  const proc = await spawnTraced(String(dir), "script.js", traceFile, "ready");
+
+  const when = new Date();
+  utimesSync(join(String(dir), "script.js"), when, when);
+
+  await waitForTraceEvent(
+    traceFile,
+    "a metadata event on script.js",
+    (path, event) => path.includes("script.js") && event.events.includes("metadata"),
+  );
+
+  proc.kill();
+  await proc.exited;
+});
+
+// A rename inside a watched directory has two halves, and both must be
+// reported: the departure as `move_from` (IN_MOVED_FROM /
+// FILE_ACTION_RENAMED_OLD_NAME) and the arrival as `move_to`. Without the
+// departure the vacated name is never invalidated.
+//
+// Skipped on kqueue: EVFILT_VNODE reports "this directory changed" with no
+// per-entry detail, so there is no departure event to map to move_from.
+test.skipIf(isMacOS || isFreeBSD)("renaming inside a watched directory records move_from", async () => {
+  using dir = tempDir("watcher-trace-movefrom", {
+    "script.js": `console.log("ready");`,
+  });
+  // See the note in the metadata test: keep the trace out of the watched tree.
+  using traceDir = tempDir("watcher-trace-movefrom-out", {});
+  const traceFile = join(String(traceDir), "movefrom-trace.log");
+  const proc = await spawnTraced(String(dir), "script.js", traceFile, "ready");
+
+  // A sibling that is not itself imported, so it has no per-file watch of its
+  // own and can only be observed through the parent directory's watch.
+  writeFileSync(join(String(dir), "sibling.js"), "export const x = 1;\n");
+  await waitForTraceEvent(
+    traceFile,
+    "a create event naming sibling.js",
+    (_path, event) =>
+      event.events.includes("create") && (event.changed ?? []).some(name => name.includes("sibling.js")),
+  );
+
+  renameSync(join(String(dir), "sibling.js"), join(String(dir), "renamed.js"));
+
+  await waitForTraceEvent(
+    traceFile,
+    "a move_from event naming sibling.js",
+    (_path, event) =>
+      event.events.includes("move_from") && (event.changed ?? []).some(name => name.includes("sibling.js")),
+  );
+
+  proc.kill();
+  await proc.exited;
+});


### PR DESCRIPTION
### What does this PR do?

`src/watcher` mapped several `Op` bits it never asked the OS for, so those bits were unreachable and some filesystem changes produced no event at all.

- **`Op::METADATA` was dead on every platform.** kqueue read `NOTE_ATTRIB` in `watch_event_from_kevent`, but `add_file_descriptor_to_kqueue_without_checks` only ever requested `NOTE_WRITE|NOTE_RENAME|NOTE_DELETE`; inotify never had `IN_ATTRIB` in either mask. So `touch` and `chmod` produced **no watcher event at all** on Linux, while ReadDirectoryChangesW reported them as a write. Now requested for **file** watches on both backends.

  Deliberately kept off *directory* watches: on inotify, `IN_ATTRIB` on a directory reports metadata changes of every entry inside it *by name*, and consumers treat a named directory event as "re-resolve this entry" — so a bare `touch` would reload the module. Threading `WatchItemKind` into the kqueue registration is what makes that split expressible.

- **A rename inside a watched directory only reported its arrival half** (`IN_MOVED_TO`). `IN_MOVED_FROM` is now requested and mapped to a new `Op::MOVE_FROM`, so the vacated name is invalidated too.

- **On Windows, `FILE_ACTION_ADDED` and `FILE_ACTION_RENAMED_NEW_NAME` produced a `WatchEvent` with no op bits at all**, making file creation invisible to every consumer matching on `WRITE|DELETE|RENAME`. They now map to `CREATE` and `MOVE_TO`. `RENAMED_OLD_NAME` keeps `RENAME` alongside the new `MOVE_FROM` so existing consumers are unaffected.

Dropped events were also ignored: `IN_Q_OVERFLOW` arrives with `wd == -1`, matches no watchlist entry, and fell through the lookup in `watch_loop_cycle`, so changes the kernel discarded were never noticed. `resync_after_overflow` replays a synthetic `WRITE` per watched path. `WRITE` rather than `DELETE` is deliberate: it makes consumers re-check without driving the eviction path and its fixed 8096-entry `evict_list`.

The fixing lines are the two mask expressions in `watch_path`/`watch_dir`, the `fflags` computation in `add_file_descriptor_to_kqueue_without_checks`, the `create_watch_event` match, and the `is_queue_overflow()` branch in `watch_loop_cycle`. Everything else is the `WatchItemKind` plumbing those need.

### How did you verify your code works?

Two new tests assert the events through `BUN_WATCHER_TRACE`, and **both fail against a build without this change** — `utimes` produces no event at all, and a rename emits only `move_to`:

- `utimes on a watched file records a metadata event`
- `renaming inside a watched directory records move_from`

Platform skips are capability-based, not workarounds: ReadDirectoryChangesW cannot distinguish metadata from a content write, and kqueue has no per-entry departure event to map to `move_from`.

**Linux** (x86_64): `test/cli/watch`, `test/cli/hot` — 24 pass, 0 fail.

**macOS** (arm64, 26.5.2): `utimes on a watched file records a metadata event` passes, which is the end-to-end confirmation that `Op::METADATA` is now reachable on kqueue.

The kqueue semantics were checked against macOS 26.5.2 with a standalone probe rather than assumed — `NOTE_ATTRIB` fires for `utimes`/`chmod` on a file vnode, and a directory vnode reports it only for its *own* metadata, never its entries. That probe also falsified an earlier revision of this change which requested `NOTE_EXTEND`: it never arrives without `NOTE_WRITE`, so it was removed.

**Windows is compile-checked only** (`cargo check --target x86_64-pc-windows-msvc`); I have no Windows host, so CI is the gate for those hunks.

Two pre-existing macOS failures are worth noting since they show up in any local macOS run of these suites, and reproduce identically on `main` built from the same commit — neither is from this change: `test/cli/hot/hot.test.ts` hangs after `should work with sourcemap generation` (indefinitely, because that file sets `longTimeout = isDebug ? Infinity : 30_000`), and `fs.watch(dir) on macOS does not leak the resolved FSEvents path` times out.
