### PR TITLE
watcher: wake the watcher thread on shutdown instead of leaking it

### DIFF
--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -56,6 +56,12 @@ pub mod kernel32 {
             lpOverlapped: *mut *mut OVERLAPPED,
             dwMilliseconds: DWORD,
         ) -> BOOL;
+        pub fn PostQueuedCompletionStatus(
+            CompletionPort: HANDLE,
+            dwNumberOfBytesTransferred: DWORD,
+            dwCompletionKey: ULONG_PTR,
+            lpOverlapped: *mut OVERLAPPED,
+        ) -> BOOL;
         pub fn ReadDirectoryChangesW(
             hDirectory: HANDLE,
             lpBuffer: *mut c_void,

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -40,6 +40,12 @@ pub(crate) type Platform = INotifyWatcher;
 
 pub struct INotifyWatcher {
     pub fd: Fd,
+    /// Signalled by [`INotifyWatcher::wake`]; `read` waits on it alongside `fd`
+    /// so the wait can be ended without a filesystem event.
+    ///
+    /// `Fd::INVALID` when `eventfd(2)` failed. `read` then waits on `fd` alone
+    /// and is uninterruptible, which is degraded but still correct.
+    pub wake_fd: Fd,
     pub loaded: bool,
 
     // Avoid statically allocating because it increases the binary size.
@@ -61,6 +67,7 @@ impl Default for INotifyWatcher {
     fn default() -> Self {
         Self {
             fd: Fd::INVALID,
+            wake_fd: Fd::INVALID,
             loaded: false,
             eventlist_bytes: bun_core::boxed_zeroed(),
             eventlist_ptrs: [core::ptr::null(); max_count],
@@ -193,8 +200,11 @@ impl INotifyWatcher {
         }
         let fd = Fd::from_native(raw);
         bun_core::scoped_log!(watcher, "{} init", fd);
+        let wake_fd =
+            bun_sys::eventfd(0, libc::EFD_CLOEXEC | libc::EFD_NONBLOCK).unwrap_or(Fd::INVALID);
         Ok(Self {
             fd,
+            wake_fd,
             loaded: true,
             coalesce_interval: env_var::BUN_INOTIFY_COALESCE_INTERVAL
                 .get()
@@ -202,6 +212,81 @@ impl INotifyWatcher {
                 .unwrap_or(100_000),
             ..Self::default()
         })
+    }
+
+    /// Interrupt a watcher thread blocked in [`INotifyWatcher::read`].
+    ///
+    /// Safe to call from any thread and more than once; the eventfd counter
+    /// stays signalled until `read` observes it, and `read` never drains it, so
+    /// there is no lost-wakeup window.
+    pub(crate) fn wake(&self) {
+        // Also releases a thread parked in the `watch_count` futex below, which
+        // is where it waits when nothing is being watched yet.
+        Futex::wake(&self.watch_count, 10);
+        if self.wake_fd == Fd::INVALID {
+            return;
+        }
+        let one: u64 = 1;
+        // SAFETY: `wake_fd` is a live eventfd; eventfd writes take exactly 8 bytes.
+        unsafe {
+            libc::write(
+                self.wake_fd.native(),
+                core::ptr::from_ref(&one).cast(),
+                size_of::<u64>(),
+            );
+        }
+    }
+
+    /// Block until the inotify fd has events or [`wake`](Self::wake) fires.
+    /// Returns `false` when woken, meaning the caller should stop reading.
+    fn wait_for_events(&self) -> bun_sys::Result<bool> {
+        use bun_sys::linux as system;
+        if self.wake_fd == Fd::INVALID {
+            return Ok(true);
+        }
+        loop {
+            let mut fds = [
+                system::pollfd {
+                    fd: self.fd.native(),
+                    events: (libc::POLLIN | libc::POLLERR) as _,
+                    revents: 0,
+                },
+                system::pollfd {
+                    fd: self.wake_fd.native(),
+                    events: libc::POLLIN as _,
+                    revents: 0,
+                },
+            ];
+            // SAFETY: both fds are live; null timeout blocks indefinitely, null sigmask.
+            let rc = unsafe {
+                system::ppoll(
+                    fds.as_mut_ptr(),
+                    fds.len(),
+                    core::ptr::null(),
+                    core::ptr::null(),
+                )
+            };
+            if rc < 0 {
+                let errno = bun_sys::E::init(bun_sys::last_errno() as _);
+                if matches!(errno, Some(bun_sys::E::EINTR) | Some(bun_sys::E::EAGAIN)) {
+                    continue;
+                }
+                return Err(bun_sys::Error {
+                    errno: bun_sys::last_errno() as _,
+                    syscall: bun_sys::Tag::watch,
+                    ..Default::default()
+                });
+            }
+            // Check the wake fd first: on a simultaneous wake + event, shutting
+            // down takes priority over draining one more batch.
+            if fds[1].revents != 0 {
+                bun_core::scoped_log!(watcher, "{} woken", self.fd);
+                return Ok(false);
+            }
+            if fds[0].revents != 0 {
+                return Ok(true);
+            }
+        }
     }
 
     pub(crate) fn read(&mut self) -> bun_sys::Result<&[*const Event]> {
@@ -227,6 +312,12 @@ impl INotifyWatcher {
         } else {
             'outer: loop {
                 Futex::wait_forever(&self.watch_count, 0);
+
+                // An empty result is the shutdown signal: `watch_loop` re-checks
+                // `running` and exits.
+                if !self.wait_for_events()? {
+                    return Ok(&[]);
+                }
 
                 // SAFETY: fd is a valid inotify fd; buffer is valid for eventlist_bytes.len() bytes.
                 let rc = unsafe {
@@ -363,6 +454,10 @@ impl INotifyWatcher {
         if self.fd != Fd::INVALID {
             let _ = bun_sys::close(self.fd);
             self.fd = Fd::INVALID;
+        }
+        if self.wake_fd != Fd::INVALID {
+            let _ = bun_sys::close(self.wake_fd);
+            self.wake_fd = Fd::INVALID;
         }
     }
 }

--- a/src/watcher/KEventWatcher.rs
+++ b/src/watcher/KEventWatcher.rs
@@ -26,7 +26,27 @@ impl KEventWatcher {
             self.fd = Fd::INVALID;
         }
     }
+
+    /// Interrupt a watcher thread blocked in `kevent`.
+    ///
+    /// EVFILT_USER is kqueue's self-pipe: registering and triggering the same
+    /// `ident` in one call makes the pending `kevent` wait return immediately.
+    pub(crate) fn wake(&self) {
+        if !self.fd.is_valid() {
+            return;
+        }
+        let mut event: libc::kevent = bun_core::ffi::zeroed();
+        event.ident = WAKE_IDENT;
+        event.filter = libc::EVFILT_USER as _;
+        event.flags = (libc::EV_ADD | libc::EV_ONESHOT) as _;
+        event.fflags = libc::NOTE_TRIGGER as _;
+        let _ = bun_sys::kevent(self.fd, &[event], &mut [], None);
+    }
 }
+
+/// `ident` for the EVFILT_USER wakeup. Cannot collide with a real registration:
+/// those use EVFILT_VNODE and key on file descriptors.
+const WAKE_IDENT: usize = usize::MAX;
 
 pub(crate) fn watch_event_from_kevent(kevent: &libc::kevent) -> WatchEvent {
     let mut op = Op::empty();

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -280,11 +280,16 @@ impl Watcher {
             me.mutex.lock();
             me.close_descriptors.store(close_descriptors);
             me.running.store(false);
+            // Must be inside the lock. `running = false` is published above, so
+            // the watcher thread may now exit and free the `Box<Watcher>`;
+            // `thread_main` takes this same lock before freeing, so holding it
+            // here is what keeps `me` alive across the wake.
+            me.platform.wake();
             me.mutex.unlock();
         } else {
             if close_descriptors && me.running.load() {
                 let fds = me.watchlist.items_fd();
-                for &fd in fds {
+                for &fd in fds.iter().filter(|fd| fd.is_valid()) {
                     let _ = bun_sys::close(fd);
                 }
             }
@@ -335,11 +340,20 @@ impl Watcher {
             // deinit and close descriptors if needed
             if me.close_descriptors.load() {
                 let fds = me.watchlist.items_fd();
-                for &fd in fds {
+                // Platforms that don't need a descriptor per watch (inotify,
+                // ReadDirectoryChangesW) store `Fd::INVALID`, which `close`
+                // asserts against. `flush_evictions` guards the same way.
+                for &fd in fds.iter().filter(|fd| fd.is_valid()) {
                     let _ = bun_sys::close(fd);
                 }
             }
             // watchlist freed by Drop below
+
+            // Rendezvous with `shutdown`, which calls `platform.wake()` under
+            // this lock. Acquiring it here orders that wake before the
+            // deallocation below.
+            me.mutex.lock();
+            me.mutex.unlock();
         }
 
         // Close trace file if open

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -379,6 +379,20 @@ impl WindowsWatcher {
         }
     }
 
+    /// Interrupt a watcher thread blocked in `GetQueuedCompletionStatus` by
+    /// posting a completion packet with a null OVERLAPPED, which the wait loop
+    /// already treats as "stop".
+    pub(crate) fn wake(&self) {
+        if self.iocp == w::INVALID_HANDLE_VALUE {
+            return;
+        }
+        // SAFETY: `iocp` is a live completion port; a null OVERLAPPED is a
+        // documented wakeup packet.
+        unsafe {
+            let _ = w::kernel32::PostQueuedCompletionStatus(self.iocp, 0, 0, ptr::null_mut());
+        }
+    }
+
     pub(crate) fn stop(&mut self) {
         // SAFETY: handles were opened in init() and are valid until stop() is called once.
         unsafe {

--- a/test/bake/fixtures/deinitialization/test.ts
+++ b/test/bake/fixtures/deinitialization/test.ts
@@ -2,6 +2,29 @@ import { getDevServerDeinitCount } from "bun:internal-for-testing";
 import html from "./index.html";
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { fullGC, heapStats } from "bun:jsc";
+import { readdirSync, readFileSync } from "node:fs";
+
+/**
+ * Count live watcher threads by name. Each DevServer starts one; `Drop` calls
+ * `Watcher::shutdown`, which must be able to wake the thread out of its
+ * blocking wait for filesystem events. When it can't, the thread — and the
+ * `Box<Watcher>` it owns — survives until an unrelated change happens to
+ * arrive, which for a stopped server is never.
+ *
+ * Linux-only: reads `/proc/self/task`. Returns -1 elsewhere.
+ */
+function watcherThreadCount(): number {
+  if (process.platform !== "linux") return -1;
+  let count = 0;
+  for (const tid of readdirSync("/proc/self/task")) {
+    try {
+      if (readFileSync(`/proc/self/task/${tid}/comm`, "utf8").trim() === "File Watcher") count++;
+    } catch {
+      // the thread exited between readdir and read
+    }
+  }
+  return count;
+}
 
 expect(process.cwd()).toBe(import.meta.dir);
 
@@ -158,6 +181,17 @@ afterAll(async () => {
   // native NewServer boxes are freed, not just the embedded dev servers.
   await drainServerWrappers(serverWrapperBaseline);
   expect(liveServerWrappers()).toBe(serverWrapperBaseline);
+
+  // Every case above started a dev server and stopped it, so no watcher thread
+  // should still be alive. Poll rather than assert once: the threads wake and
+  // unwind asynchronously.
+  if (process.platform === "linux") {
+    const deadline = Date.now() + 5000;
+    while (watcherThreadCount() > 0 && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, 25));
+    }
+    expect(watcherThreadCount()).toBe(0);
+  }
 });
 
 for (const { closeActiveConnections, sendAnyRequests, websocket } of cases) {


### PR DESCRIPTION
### What does this PR do?

`Watcher::shutdown` published `running = false` and returned, but the watcher thread only re-checks that flag **between** waits and was parked indefinitely waiting for filesystem events. For a stopped `DevServer` none ever arrive, so the thread — and the `Box<Watcher>` it owns and is responsible for freeing — survived for the life of the process.

Creating and dropping six dev servers left six live `File Watcher` threads.

Each backend gets an explicit wakeup:

- **Linux:** an eventfd, waited on alongside the inotify fd via `ppoll`. `read` returns empty when it fires, so `watch_loop` re-checks `running` and exits. The eventfd is never drained, so there is no lost-wakeup window and `wake` is safe to call repeatedly from any thread. If `eventfd(2)` fails the fd is left invalid and `read` waits on the inotify fd alone — uninterruptible but still correct, so watcher startup cannot fail on this. `wake` also releases the `watch_count` futex, which is where the thread parks when nothing is watched yet.
- **kqueue:** `EVFILT_USER` with `NOTE_TRIGGER`, registered and fired in one `kevent` call. The ident cannot collide with a real registration; those use `EVFILT_VNODE` and key on file descriptors.
- **Windows:** `PostQueuedCompletionStatus` with a null `OVERLAPPED`, which the existing wait loop already treats as a stop signal. Adds the missing extern declaration to `bun_sys::windows::kernel32`.

**The load-bearing ordering detail:** `wake` is called *inside* `Watcher.mutex`, and `thread_main` acquires the same lock before deallocating. Waking after unlocking would read `platform.wake_fd` out of freed memory — `running = false` is already published at that point, so the thread is free to exit and drop the box — and write eight bytes into whatever descriptor number that garbage happened to name. I hit exactly that while developing this.

Note this is deliberately **not** an epoll change. For a single inotify fd, epoll measures *slower* than a blocking read (+6.7% draining 8000 events); the reason to wait rather than read is interruptibility, not throughput, so `ppoll` on two fds is the right primitive.

### Why the `Fd::INVALID` guards are in this diff

Making the thread actually exit reached two `close()` loops that were previously unreachable. Both closed every watchlist fd unconditionally, but platforms that do not need a descriptor per watch store `Fd::INVALID`, which `bun_sys::close` asserts against — this surfaced as `panic: assertion failed: fd != Fd::INVALID` in `thread_main`. Both now skip invalid descriptors, matching what `flush_evictions` already did. They are required by this change rather than a drive-by.

### How did you verify your code works?

`test/bake/fixtures/deinitialization` now asserts no `File Watcher` thread outlives its dev server, by counting threads by name in `/proc/self/task` (Linux-only; the check no-ops elsewhere).

**Verified it catches the regression:** with this change stashed and the binary rebuilt, the test fails — six threads leaked. With it, zero.

**Linux** (x86_64): `test/bake/deinitialization`, `test/cli/watch`, `test/cli/hot` — 23 pass, 0 fail.

**macOS** (arm64, 26.5.2): the `EVFILT_USER` mechanism was confirmed with a standalone probe — a thread blocked in `kevent()` with no timeout is woken by `EVFILT_USER` + `NOTE_TRIGGER`. The thread-count assertion itself is Linux-only, so the kqueue wakeup has no end-to-end test here; that is the weakest part of this PR.

**Windows is compile-checked only** (`cargo check --target x86_64-pc-windows-msvc`); I have no Windows host, so CI is the gate for that hunk.
