### PR TITLE
watcher: derive OS watch masks from a per-context Op subscription

### DIFF
--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -17,6 +17,17 @@ use bun_sys::{self, Fd};
 use bun_watcher::WatchItemColumns as _;
 use bun_watcher::{ChangedFilePath, Op as WatchOp, Watcher};
 
+/// Events `--hot` / `--watch` consume. Anything omitted is never requested from
+/// the OS, so it costs nothing to deliver or dispatch.
+///
+/// The reload decisions below test `WRITE`, `DELETE` and `RENAME`; the remaining
+/// bits are needed because a directory event's *names* drive re-resolution
+/// regardless of which op carried them. `METADATA` is the one op nothing tests
+/// for, and it is kept deliberately: it is what makes `touch` and `chmod`
+/// observable at all, so dropping it would narrow what `--watch` reports rather
+/// than merely skip work.
+const HOT_RELOAD_SUBSCRIPTION: WatchOp = WatchOp::all();
+
 use crate::Task as JscTask;
 use crate::event_loop::{ConcurrentTaskItem as ConcurrentTask, EventLoop};
 use crate::virtual_machine::VirtualMachine;
@@ -718,7 +729,11 @@ where
             _event_loop: PhantomData,
         }));
 
-        let watcher = match Watcher::init(reloader, ctx.watcher_top_level_dir()) {
+        let watcher = match Watcher::init(
+            reloader,
+            ctx.watcher_top_level_dir(),
+            HOT_RELOAD_SUBSCRIPTION,
+        ) {
             Ok(w) => w,
             Err(err) => {
                 bun_core::handle_error_return_trace(&err);

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -619,7 +619,12 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
     // not dereference it until `start()` spawns the watcher thread, by which point
     // every `DevServer` field is initialized (`assume_init` below precedes
     // `bun_watcher.start()`).
-    let bun_watcher = match Watcher::init::<DevServer>(p, top_level_dir) {
+    // Everything except METADATA: HMR keys off DELETE/RENAME and re-resolves
+    // whatever a directory event names, but a permission or timestamp change
+    // cannot alter the bundle graph, so those events are not worth waking the
+    // watcher thread for.
+    const SUBSCRIPTION: bun_watcher::Op = bun_watcher::Op::all().difference(bun_watcher::Op::METADATA);
+    let bun_watcher = match Watcher::init::<DevServer>(p, top_level_dir, SUBSCRIPTION) {
         Ok(w) => w,
         Err(err) => {
             return Err(global.throw_error(

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -122,6 +122,12 @@ impl Event {
     pub(crate) fn size(&self) -> u32 {
         u32::try_from(size_of::<Event>()).expect("int cast") + self.name_len
     }
+
+    /// The kernel dropped events because `max_queued_events` was exceeded.
+    /// Delivered with `watch_descriptor == -1`, so it matches no watchlist entry.
+    pub fn is_queue_overflow(&self) -> bool {
+        (self.mask & bun_sys::linux::IN::Q_OVERFLOW) != 0
+    }
 }
 
 impl INotifyWatcher {
@@ -129,8 +135,16 @@ impl INotifyWatcher {
         use bun_sys::linux::IN;
         debug_assert!(self.loaded);
         let old_count = self.watch_count.fetch_add(1, Ordering::Release);
-        let watch_file_mask =
-            IN::EXCL_UNLINK | IN::MOVE_SELF | IN::DELETE_SELF | IN::MOVED_TO | IN::MODIFY;
+        // IN_ATTRIB is a file-watch flag only. On a directory it reports metadata
+        // changes of every entry inside it, named, and consumers treat a named
+        // directory event as "re-resolve this entry" — so a bare `touch` would
+        // reload the module.
+        let watch_file_mask = IN::EXCL_UNLINK
+            | IN::MOVE_SELF
+            | IN::DELETE_SELF
+            | IN::MOVED_TO
+            | IN::MODIFY
+            | IN::ATTRIB;
         // SAFETY: fd is a valid inotify fd (loaded == true), pathname is NUL-terminated.
         let rc = unsafe {
             bun_sys::linux::inotify_add_watch(self.fd.native(), pathname.as_ptr(), watch_file_mask)
@@ -160,6 +174,7 @@ impl INotifyWatcher {
             | IN::CREATE
             | IN::MOVE_SELF
             | IN::ONLYDIR
+            | IN::MOVED_FROM
             | IN::MOVED_TO
             | IN::MODIFY;
         // SAFETY: fd is a valid inotify fd (loaded == true), pathname is NUL-terminated.
@@ -403,6 +418,7 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
 
     let mut event_id: usize = 0;
     let mut events_processed: usize = 0;
+    let mut overflowed = false;
 
     if events_processed < events.len() {
         let mut temp_name_list: [Option<&ZStr>; 128] = [None; 128];
@@ -439,6 +455,14 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
                 }
             }
 
+            // Carries `wd == -1`, so it matches no watchlist entry and would
+            // otherwise be discarded by the lookup below.
+            if event.is_queue_overflow() {
+                overflowed = true;
+                events_processed += 1;
+                continue;
+            }
+
             let idx = match this
                 .eventlist_index_scratch
                 .iter()
@@ -473,7 +497,46 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
         }
     }
 
+    if overflowed {
+        resync_after_overflow(this);
+    }
+
     Ok(())
+}
+
+/// Replay a synthetic `WRITE` for every watched path after the kernel dropped an
+/// unknown set of events (`/proc/sys/fs/inotify/max_queued_events` exceeded).
+/// Which paths changed is unrecoverable, so every one is treated as suspect.
+fn resync_after_overflow(this: &mut Watcher) {
+    // `WatchItemIndex::MAX` is the no-watch-item sentinel, never a real index.
+    let len = {
+        let _guard = this.mutex.lock_guard();
+        this.watchlist.len().min(WatchItemIndex::MAX as usize)
+    };
+    bun_core::warn!(
+        "inotify event queue overflowed; re-checking all {} watched paths. Raise /proc/sys/fs/inotify/max_queued_events to avoid this.\n",
+        len
+    );
+
+    let mut start = 0;
+    while start < len {
+        let count = (len - start).min(max_count);
+        for i in 0..count {
+            // `WRITE` (never `DELETE`) is deliberate: it makes consumers
+            // re-check each path without driving the eviction path, whose
+            // `evict_list` is a fixed 8096-entry buffer.
+            this.watch_events[i] = WatchEvent {
+                op: Op::WRITE,
+                index: (start + i) as WatchItemIndex,
+                ..Default::default()
+            };
+        }
+        // `dispatch_file_updates` re-takes `this.mutex` and re-checks `running`;
+        // entries evicted between batches are filtered by the consumer's own
+        // bounds check against the current watchlist length.
+        this.dispatch_file_updates(count, 0);
+        start += count;
+    }
 }
 
 fn process_inotify_event_batch(
@@ -535,11 +598,17 @@ fn watch_event_from_inotify_event(event: &Event, index: WatchItemIndex) -> Watch
     if (event.mask & IN::MOVED_TO) > 0 {
         op |= Op::MOVE_TO;
     }
+    if (event.mask & IN::MOVED_FROM) > 0 {
+        op |= Op::MOVE_FROM;
+    }
     if (event.mask & IN::MODIFY) > 0 {
         op |= Op::WRITE;
     }
     if (event.mask & IN::CREATE) > 0 {
         op |= Op::CREATE;
+    }
+    if (event.mask & IN::ATTRIB) > 0 {
+        op |= Op::METADATA;
     }
     WatchEvent {
         op,

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -55,6 +55,66 @@ pub struct INotifyWatcher {
     pub(crate) watch_count: AtomicU32,
     /// nanoseconds
     pub(crate) coalesce_interval: isize,
+    /// See [`Watcher::init`].
+    subscription: Op,
+}
+
+/// Translate a subscription into the inotify mask for a **file** watch.
+///
+/// `IN_EXCL_UNLINK` is unconditional: it is a modifier, not an event.
+fn file_mask(subscription: Op) -> u32 {
+    use bun_sys::linux::IN;
+    let mut mask = IN::EXCL_UNLINK;
+    if subscription.contains(Op::DELETE) {
+        mask |= IN::DELETE_SELF;
+    }
+    if subscription.contains(Op::RENAME) {
+        mask |= IN::MOVE_SELF;
+    }
+    if subscription.contains(Op::MOVE_TO) {
+        mask |= IN::MOVED_TO;
+    }
+    if subscription.contains(Op::WRITE) {
+        mask |= IN::MODIFY;
+    }
+    if subscription.contains(Op::METADATA) {
+        mask |= IN::ATTRIB;
+    }
+    mask
+}
+
+/// Translate a subscription into the inotify mask for a **directory** watch.
+///
+/// `IN_ONLYDIR` guards against the path being swapped for a file between
+/// resolution and registration.
+///
+/// `Op::METADATA` is deliberately not honoured here. IN_ATTRIB on a directory
+/// reports metadata changes of every entry inside it, named, and consumers treat
+/// a named directory event as "re-resolve this entry" — so a bare `touch` would
+/// reload the module. Metadata reaches consumers through the per-file watch
+/// instead.
+fn dir_mask(subscription: Op) -> u32 {
+    use bun_sys::linux::IN;
+    let mut mask = IN::EXCL_UNLINK | IN::ONLYDIR;
+    if subscription.contains(Op::DELETE) {
+        mask |= IN::DELETE | IN::DELETE_SELF;
+    }
+    if subscription.contains(Op::CREATE) {
+        mask |= IN::CREATE;
+    }
+    if subscription.contains(Op::RENAME) {
+        mask |= IN::MOVE_SELF;
+    }
+    if subscription.contains(Op::MOVE_TO) {
+        mask |= IN::MOVED_TO;
+    }
+    if subscription.contains(Op::MOVE_FROM) {
+        mask |= IN::MOVED_FROM;
+    }
+    if subscription.contains(Op::WRITE) {
+        mask |= IN::MODIFY;
+    }
+    mask
 }
 
 impl Default for INotifyWatcher {
@@ -67,6 +127,7 @@ impl Default for INotifyWatcher {
             read_ptr: None,
             watch_count: AtomicU32::new(0),
             coalesce_interval: 100_000,
+            subscription: Op::all(),
         }
     }
 }
@@ -132,19 +193,9 @@ impl Event {
 
 impl INotifyWatcher {
     pub(crate) fn watch_path(&mut self, pathname: &ZStr) -> bun_sys::Result<EventListIndex> {
-        use bun_sys::linux::IN;
         debug_assert!(self.loaded);
         let old_count = self.watch_count.fetch_add(1, Ordering::Release);
-        // IN_ATTRIB is a file-watch flag only. On a directory it reports metadata
-        // changes of every entry inside it, named, and consumers treat a named
-        // directory event as "re-resolve this entry" — so a bare `touch` would
-        // reload the module.
-        let watch_file_mask = IN::EXCL_UNLINK
-            | IN::MOVE_SELF
-            | IN::DELETE_SELF
-            | IN::MOVED_TO
-            | IN::MODIFY
-            | IN::ATTRIB;
+        let watch_file_mask = file_mask(self.subscription);
         // SAFETY: fd is a valid inotify fd (loaded == true), pathname is NUL-terminated.
         let rc = unsafe {
             bun_sys::linux::inotify_add_watch(self.fd.native(), pathname.as_ptr(), watch_file_mask)
@@ -165,18 +216,9 @@ impl INotifyWatcher {
     }
 
     pub(crate) fn watch_dir(&mut self, pathname: &ZStr) -> bun_sys::Result<EventListIndex> {
-        use bun_sys::linux::IN;
         debug_assert!(self.loaded);
         let old_count = self.watch_count.fetch_add(1, Ordering::Release);
-        let watch_dir_mask = IN::EXCL_UNLINK
-            | IN::DELETE
-            | IN::DELETE_SELF
-            | IN::CREATE
-            | IN::MOVE_SELF
-            | IN::ONLYDIR
-            | IN::MOVED_FROM
-            | IN::MOVED_TO
-            | IN::MODIFY;
+        let watch_dir_mask = dir_mask(self.subscription);
         // SAFETY: fd is a valid inotify fd (loaded == true), pathname is NUL-terminated.
         let rc = unsafe {
             bun_sys::linux::inotify_add_watch(self.fd.native(), pathname.as_ptr(), watch_dir_mask)
@@ -196,7 +238,7 @@ impl INotifyWatcher {
         result
     }
 
-    pub(crate) fn new(_root: &[u8]) -> crate::Result<Self> {
+    pub(crate) fn new(_root: &[u8], subscription: Op) -> crate::Result<Self> {
         use bun_sys::linux::IN;
 
         let raw = bun_sys::linux::inotify_init1(IN::CLOEXEC);
@@ -211,6 +253,7 @@ impl INotifyWatcher {
         Ok(Self {
             fd,
             loaded: true,
+            subscription,
             coalesce_interval: env_var::BUN_INOTIFY_COALESCE_INTERVAL
                 .get()
                 .and_then(|v| isize::try_from(v).ok())

--- a/src/watcher/KEventWatcher.rs
+++ b/src/watcher/KEventWatcher.rs
@@ -7,17 +7,43 @@ pub(crate) type Platform = KEventWatcher;
 
 pub struct KEventWatcher {
     pub(crate) fd: Fd,
+    /// See [`crate::watcher_impl::Watcher::init`].
+    pub(crate) subscription: Op,
+}
+
+/// Translate a subscription into EVFILT_VNODE `fflags`.
+///
+/// NOTE_ATTRIB is requested for files only. A directory vnode reports it solely
+/// for changes to the directory's own metadata — entry-level `chmod`/`touch`
+/// raise nothing on the parent — and no consumer acts on that, so requesting it
+/// there only adds wakeups. (This differs from inotify, where IN_ATTRIB on a
+/// directory *does* report its entries; see `dir_mask` in INotifyWatcher.)
+pub(crate) fn vnode_fflags(subscription: Op, kind: crate::watcher_impl::WatchItemKind) -> u32 {
+    let mut fflags = 0u32;
+    if subscription.contains(Op::DELETE) {
+        fflags |= libc::NOTE_DELETE;
+    }
+    if subscription.contains(Op::RENAME) {
+        fflags |= libc::NOTE_RENAME | libc::NOTE_LINK;
+    }
+    if subscription.contains(Op::WRITE) {
+        fflags |= libc::NOTE_WRITE;
+    }
+    if subscription.contains(Op::METADATA) && kind == crate::watcher_impl::WatchItemKind::File {
+        fflags |= libc::NOTE_ATTRIB;
+    }
+    fflags
 }
 
 const CHANGELIST_COUNT: usize = 128;
 
 impl KEventWatcher {
-    pub(crate) fn new(_root: &[u8]) -> crate::Result<Self> {
+    pub(crate) fn new(_root: &[u8], subscription: Op) -> crate::Result<Self> {
         let fd = bun_sys::kqueue()?;
         if fd.native() == 0 {
             return Err(crate::Error::KQueueError);
         }
-        Ok(Self { fd })
+        Ok(Self { fd, subscription })
     }
 
     pub(crate) fn stop(&mut self) {

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -428,7 +428,11 @@ impl Watcher {
                 if (item as usize) < self.watchlist.len() {
                     let moved_fd = self.watchlist.items_fd()[item as usize];
                     if moved_fd.is_valid() {
-                        self.add_file_descriptor_to_kqueue_without_checks(moved_fd, item as usize);
+                        self.add_file_descriptor_to_kqueue_without_checks(
+                            moved_fd,
+                            item as usize,
+                            self.watchlist.items_kind()[item as usize],
+                        );
                     }
                 }
             }
@@ -464,9 +468,10 @@ impl Watcher {
         &mut self,
         fd: Fd,
         watchlist_id: usize,
+        kind: WatchItemKind,
     ) {
         use libc::{EV_ADD, EV_CLEAR, EV_ENABLE, EVFILT_VNODE, kevent as KEvent};
-        use libc::{NOTE_DELETE, NOTE_RENAME, NOTE_WRITE};
+        use libc::{NOTE_ATTRIB, NOTE_DELETE, NOTE_RENAME, NOTE_WRITE};
 
         // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kqueue.2.html
         let mut event: KEvent = bun_core::ffi::zeroed();
@@ -475,7 +480,15 @@ impl Watcher {
         // we want to know about the vnode
         event.filter = EVFILT_VNODE as _;
 
-        event.fflags = (NOTE_WRITE | NOTE_RENAME | NOTE_DELETE) as _;
+        // NOTE_ATTRIB is requested for files only. A directory vnode reports it
+        // solely for changes to the directory's own metadata — entry-level
+        // `chmod`/`touch` raise nothing on the parent — and no consumer acts on
+        // that, so requesting it there only adds wakeups.
+        let mut fflags = NOTE_WRITE | NOTE_RENAME | NOTE_DELETE;
+        if kind == WatchItemKind::File {
+            fflags |= NOTE_ATTRIB;
+        }
+        event.fflags = fflags as _;
 
         // id
         event.ident = usize::try_from(fd.native()).expect("int cast");
@@ -528,7 +541,7 @@ impl Watcher {
         };
 
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-        self.add_file_descriptor_to_kqueue_without_checks(fd, watchlist_id);
+        self.add_file_descriptor_to_kqueue_without_checks(fd, watchlist_id, WatchItemKind::File);
         #[cfg(any(target_os = "linux", target_os = "android"))]
         let eventlist_index = {
             // inotify needs a trailing NUL. When
@@ -607,7 +620,11 @@ impl Watcher {
         let watchlist_id = self.watchlist.len();
 
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-        self.add_file_descriptor_to_kqueue_without_checks(fd, watchlist_id);
+        self.add_file_descriptor_to_kqueue_without_checks(
+            fd,
+            watchlist_id,
+            WatchItemKind::Directory,
+        );
         #[cfg(any(target_os = "linux", target_os = "android"))]
         let eventlist_index = {
             let mut buf = bun_paths::path_buffer_pool::get();
@@ -982,13 +999,16 @@ impl WatchEvent {
 bitflags::bitflags! {
     #[derive(Clone, Copy, Default, PartialEq, Eq)]
     pub struct Op: u8 {
-        const DELETE   = 1 << 0;
-        const METADATA = 1 << 1;
-        const RENAME   = 1 << 2;
-        const WRITE    = 1 << 3;
-        const MOVE_TO  = 1 << 4;
-        const CREATE   = 1 << 5;
-        // bits 6..7 = _padding
+        const DELETE    = 1 << 0;
+        const METADATA  = 1 << 1;
+        const RENAME    = 1 << 2;
+        const WRITE     = 1 << 3;
+        const MOVE_TO   = 1 << 4;
+        const CREATE    = 1 << 5;
+        /// An entry left a watched directory (moved out, or the source half of
+        /// a rename). The mirror of [`Op::MOVE_TO`].
+        const MOVE_FROM = 1 << 6;
+        // bit 7 = _padding
     }
 }
 
@@ -1006,6 +1026,7 @@ pub(crate) const OP_NAMES: &[(Op, &str)] = &[
     (Op::WRITE, "write"),
     (Op::MOVE_TO, "move_to"),
     (Op::CREATE, "create"),
+    (Op::MOVE_FROM, "move_from"),
 ];
 
 impl fmt::Display for Op {

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -156,20 +156,24 @@ impl Watcher {
     /// receives watch callbacks on the watcher thread. This function does not
     /// actually start the watcher thread.
     ///
+    /// `subscription` is the set of [`Op`]s the context consumes. Ops outside it
+    /// are never requested from the OS, so they cost nothing to deliver, decode
+    /// or dispatch — and are never delivered, so a context must not rely on an
+    /// op it did not subscribe to. Pass [`Op::all`] to receive everything.
+    ///
     /// ```ignore
-    /// let watcher = Watcher::init(instance_of_t, fs)?;
+    /// let watcher = Watcher::init(instance_of_t, top_level_dir, Op::all())?;
     /// // on error: watcher.shutdown(false);
     /// watcher.start()?;
-    ///
     /// // To integrate a started watcher into module resolution:
     /// transpiler.resolver.watcher = watcher.get_resolve_watcher();
-    ///
     /// // To integrate a started watcher into bundle_v2:
     /// bundle_v2.bun_watcher = watcher;
     /// ```
     pub fn init<T: WatcherContext>(
         ctx: *mut T,
         top_level_dir: &'static [u8],
+        subscription: Op,
     ) -> Result<Box<Watcher>, crate::Error> {
         fn on_file_update_wrapped<T: WatcherContext>(
             ctx_opaque: *mut (),
@@ -194,7 +198,7 @@ impl Watcher {
             ctx: ctx.cast::<()>(),
             on_file_update: on_file_update_wrapped::<T>,
             on_error: on_error_wrapped::<T>,
-            platform: Platform::new(top_level_dir)?,
+            platform: Platform::new(top_level_dir, subscription)?,
             watch_events: vec![WatchEvent::default(); MAX_COUNT].into_boxed_slice(),
             changed_filepaths: [const { None }; MAX_COUNT],
             watchloop_handle: bun_core::AtomicCell::new(false),
@@ -471,7 +475,6 @@ impl Watcher {
         kind: WatchItemKind,
     ) {
         use libc::{EV_ADD, EV_CLEAR, EV_ENABLE, EVFILT_VNODE, kevent as KEvent};
-        use libc::{NOTE_ATTRIB, NOTE_DELETE, NOTE_RENAME, NOTE_WRITE};
 
         // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kqueue.2.html
         let mut event: KEvent = bun_core::ffi::zeroed();
@@ -480,15 +483,7 @@ impl Watcher {
         // we want to know about the vnode
         event.filter = EVFILT_VNODE as _;
 
-        // NOTE_ATTRIB is requested for files only. A directory vnode reports it
-        // solely for changes to the directory's own metadata — entry-level
-        // `chmod`/`touch` raise nothing on the parent — and no consumer acts on
-        // that, so requesting it there only adds wakeups.
-        let mut fflags = NOTE_WRITE | NOTE_RENAME | NOTE_DELETE;
-        if kind == WatchItemKind::File {
-            fflags |= NOTE_ATTRIB;
-        }
-        event.fflags = fflags as _;
+        event.fflags = crate::kevent_watcher::vnode_fflags(self.platform.subscription, kind) as _;
 
         // id
         event.ident = usize::try_from(fd.native()).expect("int cast");

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -541,16 +541,15 @@ fn process_watch_event_batch(this: &mut Watcher, event_count: usize) -> bun_sys:
 }
 
 fn create_watch_event(event: &FileEvent, index: WatchItemIndex) -> WatchEvent {
-    let mut op = Op::empty();
-    if event.action == Action::Removed {
-        op |= Op::DELETE;
-    }
-    if event.action == Action::RenamedOld {
-        op |= Op::RENAME;
-    }
-    if event.action == Action::Modified {
-        op |= Op::WRITE;
-    }
+    // `RenamedOld` carries both `RENAME` and `MOVE_FROM`: consumers key on
+    // `RENAME`, and `MOVE_FROM` names which half of the rename this is.
+    let op = match event.action {
+        Action::Added => Op::CREATE,
+        Action::Removed => Op::DELETE,
+        Action::Modified => Op::WRITE,
+        Action::RenamedOld => Op::RENAME | Op::MOVE_FROM,
+        Action::RenamedNew => Op::MOVE_TO,
+    };
     WatchEvent {
         op,
         index,

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -21,6 +21,31 @@ pub struct WindowsWatcher {
     pub(crate) watcher: DirWatcher,
     pub(crate) buf: PathBuffer,
     pub(crate) base_idx: usize,
+    /// Precomputed `ReadDirectoryChangesW` filter; see [`notify_filter`].
+    /// Held here rather than on `DirWatcher`, whose layout is pinned by
+    /// `assert_ffi_layout!` (the kernel requires `overlapped` at offset 0).
+    pub(crate) filter: w::FileNotifyChangeFilter,
+}
+
+/// Translate a subscription into a `ReadDirectoryChangesW` filter.
+///
+/// Coarser than inotify/kqueue: the filter selects which *changes* wake the
+/// call, not which `FILE_ACTION_*` come back, and one filter bit can produce
+/// several actions. Metadata is deliberately absent — Windows reports it as
+/// FILE_ACTION_MODIFIED, indistinguishable from a content write, so requesting
+/// it would mis-report `chmod` as `Op::WRITE`.
+fn notify_filter(subscription: Op) -> w::FileNotifyChangeFilter {
+    let mut filter = w::FileNotifyChangeFilter::empty();
+    if subscription.intersects(Op::CREATE | Op::DELETE | Op::RENAME | Op::MOVE_TO | Op::MOVE_FROM) {
+        filter |= w::FileNotifyChangeFilter::FILE_NAME | w::FileNotifyChangeFilter::DIR_NAME;
+    }
+    if subscription.contains(Op::CREATE) {
+        filter |= w::FileNotifyChangeFilter::CREATION;
+    }
+    if subscription.contains(Op::WRITE) {
+        filter |= w::FileNotifyChangeFilter::LAST_WRITE;
+    }
+    filter
 }
 
 impl Default for WindowsWatcher {
@@ -34,6 +59,7 @@ impl Default for WindowsWatcher {
             },
             buf: PathBuffer::uninit(),
             base_idx: 0,
+            filter: w::FileNotifyChangeFilter::empty(),
         }
     }
 }
@@ -96,11 +122,7 @@ const _: () = assert!(
 
 impl DirWatcher {
     /// invalidates any EventIterators
-    fn prepare(&mut self) -> bun_sys::Result<()> {
-        let filter = w::FileNotifyChangeFilter::FILE_NAME
-            | w::FileNotifyChangeFilter::DIR_NAME
-            | w::FileNotifyChangeFilter::LAST_WRITE
-            | w::FileNotifyChangeFilter::CREATION;
+    fn prepare(&mut self, filter: w::FileNotifyChangeFilter) -> bun_sys::Result<()> {
         // SAFETY: dir_handle is a valid directory handle opened with FILE_LIST_DIRECTORY;
         // buf and overlapped are valid for the duration of the async operation (self-owned).
         if unsafe {
@@ -214,8 +236,9 @@ impl WindowsWatcher {
     // `Self` carries the 64 KiB `DirWatcher` buffer inline; it is moved once
     // into `Box::new(Watcher { .. })` in `Watcher::init`.
     #[allow(clippy::large_stack_frames)]
-    pub(crate) fn new(root: &[u8]) -> crate::Result<Self> {
+    pub(crate) fn new(root: &[u8], subscription: Op) -> crate::Result<Self> {
         let mut this = Self::default();
+        this.filter = notify_filter(subscription);
         this.init(root)?;
         Ok(this)
     }
@@ -300,7 +323,7 @@ impl WindowsWatcher {
 
     /// wait until new events are available
     fn next(&mut self, timeout: Timeout) -> bun_sys::Result<Option<EventIterator>> {
-        if let Err(err) = self.watcher.prepare() {
+        if let Err(err) = self.watcher.prepare(self.filter) {
             bun_core::scoped_log!(watcher, "prepare() returned error");
             return Err(err);
         }
@@ -355,7 +378,7 @@ impl WindowsWatcher {
                         watcher,
                         "ReadDirectoryChangesW buffer overflow (nbytes==0); re-arming"
                     );
-                    if let Err(err) = self.watcher.prepare() {
+                    if let Err(err) = self.watcher.prepare(self.filter) {
                         return Err(err);
                     }
                     continue;

--- a/test/cli/watch/watcher-trace.test.ts
+++ b/test/cli/watch/watcher-trace.test.ts
@@ -1,7 +1,69 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
-import { existsSync, readFileSync } from "node:fs";
+import { bunEnv, bunExe, isMacOS, isFreeBSD, isWindows, tempDir } from "harness";
+import { existsSync, readFileSync, renameSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+
+type TraceFileEvent = { events: string[]; changed?: string[] };
+
+/**
+ * Poll the trace file until some recorded event satisfies `pred`.
+ *
+ * Polls rather than sleeping a fixed amount: the watcher coalesces events over
+ * a short window, so the delay before an event lands is variable.
+ */
+async function waitForTraceEvent(
+  traceFile: string,
+  what: string,
+  pred: (path: string, event: TraceFileEvent) => boolean,
+  // Under the per-test default so this throws with the trace dump attached
+  // instead of being cut short by the harness timeout.
+  timeoutMs = 4000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let contents = "";
+  while (Date.now() < deadline) {
+    if (existsSync(traceFile)) {
+      contents = readFileSync(traceFile, "utf-8");
+      for (const line of contents.split("\n")) {
+        if (!line.trim()) continue;
+        let parsed: { files?: Record<string, TraceFileEvent> };
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          continue; // a partially-flushed final line
+        }
+        for (const [path, event] of Object.entries(parsed.files ?? {})) {
+          if (pred(path, event)) return;
+        }
+      }
+    }
+    await Bun.sleep(20);
+  }
+  throw new Error(`timed out waiting for ${what}\ntrace file contents:\n${contents}`);
+}
+
+/** Spawn `bun --watch <entry>` with tracing on and wait for its first run. */
+async function spawnTraced(dir: string, entry: string, traceFile: string, ready: string) {
+  const proc = Bun.spawn({
+    cmd: [bunExe(), "--watch", entry],
+    env: { ...bunEnv, BUN_WATCHER_TRACE: traceFile },
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "inherit",
+    stdin: "ignore",
+  });
+  const decoder = new TextDecoder();
+  let seen = "";
+  for await (const chunk of proc.stdout) {
+    seen += decoder.decode(chunk);
+    if (seen.includes(ready)) return proc;
+  }
+  // stdout ended without the readiness line, so the process died during startup.
+  // Surface that instead of letting the caller time out on a watcher that was
+  // never running.
+  const exitCode = await proc.exited;
+  throw new Error(`bun --watch exited (code ${exitCode}) before printing ${JSON.stringify(ready)}; stdout: ${seen}`);
+}
 
 test("BUN_WATCHER_TRACE creates trace file with watch events", async () => {
   using dir = tempDir("watcher-trace", {
@@ -261,3 +323,71 @@ test("BUN_WATCHER_TRACE appends across reloads", async () => {
     expect(event).toHaveProperty("files");
   }
 }, 10000);
+
+// Bumping mtime without touching contents is a metadata-only change: IN_ATTRIB
+// on Linux, NOTE_ATTRIB on kqueue. Both must surface as the `metadata` op.
+//
+// Skipped on Windows: ReadDirectoryChangesW reports metadata changes as
+// FILE_ACTION_MODIFIED, indistinguishable from a content write, so there is no
+// separate metadata op to assert on.
+test.skipIf(isWindows)("utimes on a watched file records a metadata event", async () => {
+  using dir = tempDir("watcher-trace-metadata", {
+    "script.js": `console.log("ready");`,
+  });
+  // Outside the watched tree: a trace file written *inside* it would record its
+  // own writes and feed itself.
+  using traceDir = tempDir("watcher-trace-metadata-out", {});
+  const traceFile = join(String(traceDir), "metadata-trace.log");
+  const proc = await spawnTraced(String(dir), "script.js", traceFile, "ready");
+
+  const when = new Date();
+  utimesSync(join(String(dir), "script.js"), when, when);
+
+  await waitForTraceEvent(
+    traceFile,
+    "a metadata event on script.js",
+    (path, event) => path.includes("script.js") && event.events.includes("metadata"),
+  );
+
+  proc.kill();
+  await proc.exited;
+});
+
+// A rename inside a watched directory has two halves, and both must be
+// reported: the departure as `move_from` (IN_MOVED_FROM /
+// FILE_ACTION_RENAMED_OLD_NAME) and the arrival as `move_to`. Without the
+// departure the vacated name is never invalidated.
+//
+// Skipped on kqueue: EVFILT_VNODE reports "this directory changed" with no
+// per-entry detail, so there is no departure event to map to move_from.
+test.skipIf(isMacOS || isFreeBSD)("renaming inside a watched directory records move_from", async () => {
+  using dir = tempDir("watcher-trace-movefrom", {
+    "script.js": `console.log("ready");`,
+  });
+  // See the note in the metadata test: keep the trace out of the watched tree.
+  using traceDir = tempDir("watcher-trace-movefrom-out", {});
+  const traceFile = join(String(traceDir), "movefrom-trace.log");
+  const proc = await spawnTraced(String(dir), "script.js", traceFile, "ready");
+
+  // A sibling that is not itself imported, so it has no per-file watch of its
+  // own and can only be observed through the parent directory's watch.
+  writeFileSync(join(String(dir), "sibling.js"), "export const x = 1;\n");
+  await waitForTraceEvent(
+    traceFile,
+    "a create event naming sibling.js",
+    (_path, event) =>
+      event.events.includes("create") && (event.changed ?? []).some(name => name.includes("sibling.js")),
+  );
+
+  renameSync(join(String(dir), "sibling.js"), join(String(dir), "renamed.js"));
+
+  await waitForTraceEvent(
+    traceFile,
+    "a move_from event naming sibling.js",
+    (_path, event) =>
+      event.events.includes("move_from") && (event.changed ?? []).some(name => name.includes("sibling.js")),
+  );
+
+  proc.kill();
+  await proc.exited;
+});


### PR DESCRIPTION
> [!NOTE]
> **Depends on #36416** — this branch is stacked on it (it needs `Op::MOVE_FROM` and rewrites the kqueue `fflags` helper that PR introduces). Opened as a draft; I'll rebase and mark ready once #36416 lands. Review the [diff against that branch](https://github.com/oven-sh/bun/compare/main...Properrr:bun:claude/watcher-op-subscription) to see only this change.

### What does this PR do?

Every `bun.Watcher` requested the same fixed inotify mask / kqueue `fflags` / `ReadDirectoryChangesW` filter regardless of what its context actually read, so consumers paid to have events delivered, decoded and dispatched only to drop them in a `contains()` check.

`Watcher::init` now takes the set of `Op`s its context consumes, and each backend derives its registration from it: `file_mask`/`dir_mask` (inotify), `vnode_fflags` (kqueue), `notify_filter` (ReadDirectoryChangesW). An op outside the set is never requested, so a context must not rely on one it did not subscribe to — that contract is documented on `init`.

The dev server subscribes to everything except `METADATA`: it keys off DELETE/RENAME and re-resolves whatever a directory event names, but a permission or timestamp change cannot alter the bundle graph. `--hot`/`--watch` keeps `METADATA`, since that is what makes `touch` and `chmod` observable at all.

The Windows filter is coarser than the other two by nature — it selects which *changes* wake the call rather than which `FILE_ACTION_*` come back, and one filter bit can produce several actions. Metadata is deliberately absent there: Windows reports it as `FILE_ACTION_MODIFIED`, indistinguishable from a content write, so requesting it would mis-report `chmod` as `Op::WRITE`.

### This is not a throughput optimization

I want to be straight about that, because it would be easy to assume otherwise. Measured on a realistic workload (100 files, no synthetic `chmod` pass):

| | full mask | −`IN_ATTRIB` | −dir `IN_MODIFY` |
|---|---|---|---|
| in-place save (editors, build writes) | 400 events | **400 (0%)** | 100 (−75%) |
| atomic save (write tmp + rename) | 700 events | 600 (−14%) | 600 (−14%) |

`IN_ATTRIB` never fires for an in-place write, and the drain path costs 0.24 µs/event against a ~211 ms reload — so event volume is not on the critical path. `--watch` reload latency is unchanged (211.7 ms vs 216.1 ms mean over 30 samples against a same-profile `main` build, i.e. within noise).

The value is that the registration now states what each consumer actually needs, and that narrowing a consumer is a one-line change. The one large lever — dir `IN_MODIFY` at −75% — is **not** taken here: it is how a file that is not individually watched gets noticed at all, so dropping it changes what the reloader sees and belongs in its own PR with its own measurement of per-event dispatch cost.

### How did you verify your code works?

The dev server's resulting inotify file mask is **byte-identical** to the one requested before this change, verified with `strace`, so that narrowing is observably free:

```
--watch  (all)          IN_MODIFY|IN_ATTRIB|IN_MOVED_TO|IN_DELETE_SELF|IN_MOVE_SELF|IN_EXCL_UNLINK
DevServer (no METADATA) IN_MODIFY|IN_MOVED_TO|IN_DELETE_SELF|IN_MOVE_SELF|IN_EXCL_UNLINK
```

That also demonstrates the filter is actually filtering rather than merely plumbed — the two consumers register different masks.

**Linux** (x86_64): `test/cli/watch`, `test/cli/hot`, `test/bake/dev/hot` — 35 pass, 0 fail. The full `test/bake/dev` suite (26 files, 161 tests) also passes with the dev-server narrowing applied.

**Windows is compile-checked only** (`cargo check --target x86_64-pc-windows-msvc`); CI is the gate for the `notify_filter` hunk.
