### PR TITLE
Follow-up dead-code cleanup after visibility narrowing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,17 +289,9 @@ dependencies = [
 name = "bun_brotli"
 version = "0.0.0"
 dependencies = [
- "bitflags",
- "bstr",
  "bun_alloc",
  "bun_brotli_sys",
  "bun_core",
- "const_format",
- "enum-map",
- "enumset",
- "libc",
- "scopeguard",
- "strum",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,6 @@ dependencies = [
  "bun_alloc",
  "bun_brotli_sys",
  "bun_core",
- "bun_io",
  "const_format",
  "enum-map",
  "enumset",
@@ -1721,17 +1720,7 @@ dependencies = [
 name = "bun_safety"
 version = "0.0.0"
 dependencies = [
- "bitflags",
- "bstr",
- "bun_alloc",
  "bun_core",
- "const_format",
- "enum-map",
- "enumset",
- "libc",
- "scopeguard",
- "strum",
- "thiserror",
 ]
 
 [[package]]

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -161,16 +161,15 @@ let url = URL::from_utf8(href)?;                  // Option<NonNull<URL>>
 
 url.protocol()   // bun_core::String
 url.pathname()   // bun_core::String
-url.search()     // bun_core::String
+url.host()       // bun_core::String — the hostname WITHOUT the port (opposite of JS `host`!)
 url.port()       // u32 (u32::MAX = unset; otherwise u16 range)
-
-// NOTE: host()/hostname() are SWAPPED relative to JS:
-url.host()       // hostname WITHOUT port  (opposite of JS!)
-url.hostname()   // hostname WITH port     (opposite of JS!)
 ```
 
-`URL::href_from_string`, `URL::file_url_from_string`, `URL::path_from_file_url`
-do whole-string conversions.
+`URL::href_from_js`, `URL::file_url_from_string`, `URL::path_from_file_url`
+do whole-string conversions. The JSC-free shim `bun_url::whatwg::URL` exposes
+`hostname()`, which returns the host WITH the port (also the opposite of JS
+`hostname`) — so `bun_jsc::URL::host` and `bun_url::whatwg::URL::hostname`
+are effectively swapped relative to their JS namesakes.
 
 ## MIME Types (`bun_http_types::MimeType`)
 

--- a/src/brotli/Cargo.toml
+++ b/src/brotli/Cargo.toml
@@ -11,14 +11,6 @@ workspace = true
 
 [dependencies]
 thiserror.workspace = true
-strum.workspace = true
-bstr.workspace = true
-scopeguard.workspace = true
-const_format.workspace = true
-enum-map.workspace = true
-enumset.workspace = true
-libc.workspace = true
-bitflags.workspace = true
 bun_alloc.workspace = true
 bun_core.workspace = true
 bun_brotli_sys.workspace = true

--- a/src/brotli/Cargo.toml
+++ b/src/brotli/Cargo.toml
@@ -22,4 +22,3 @@ bitflags.workspace = true
 bun_alloc.workspace = true
 bun_core.workspace = true
 bun_brotli_sys.workspace = true
-bun_io.workspace = true

--- a/src/brotli/error.rs
+++ b/src/brotli/error.rs
@@ -8,10 +8,6 @@ pub enum Error {
     BrotliDecompressionError,
     #[error("ShortRead")]
     ShortRead,
-    #[error("BrotliCompressionError")]
-    BrotliCompressionError,
-    #[error(transparent)]
-    Core(#[from] bun_core::Error),
 }
 
 impl Error {
@@ -22,8 +18,6 @@ impl Error {
             Self::BrotliFailedToCreateInstance => "BrotliFailedToCreateInstance",
             Self::BrotliDecompressionError => "BrotliDecompressionError",
             Self::ShortRead => "ShortRead",
-            Self::BrotliCompressionError => "BrotliCompressionError",
-            Self::Core(e) => e.name(),
         }
     }
 }

--- a/src/bun_core/string/wtf.rs
+++ b/src/bun_core/string/wtf.rs
@@ -1,10 +1,9 @@
 use crate::string::ZigStringSlice;
 use crate::strings;
 
-// Canonical layout lives in `bun_alloc` (lowest-tier crate) so the
-// `is_wtf_allocator` vtable-identity check is a local pointer compare with no
-// upward dependency. Re-exported here for back-compat with existing
-// `bun_core::wtf::*` / `bun_core::WTFStringImpl*` import paths.
+// Canonical layout lives in `bun_alloc` (lowest-tier crate); re-exported here
+// for back-compat with existing `bun_core::wtf::*` /
+// `bun_core::WTFStringImpl*` import paths.
 pub use bun_alloc::{WTFStringImpl, WTFStringImplPtr, WTFStringImplStruct};
 
 /// Behaves like `WTF::Ref<WTF::StringImpl>`. The

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -508,8 +508,9 @@ impl<'a> LinkerGraph<'a> {
     #[inline]
     #[allow(clippy::mut_from_ref)]
     pub(crate) unsafe fn symbol_mut(&self, ref_: Ref) -> &mut Symbol {
-        // SAFETY: see `symbol` for liveness/validity; caller guarantees the
-        // mutated slot is disjoint from any other borrow held at the call site.
+        // SAFETY: `ref_` was produced by this symbol table, so `get` is
+        // infallible and points at a live slot; caller guarantees the mutated
+        // slot is disjoint from any other borrow held at the call site.
         unsafe {
             &mut *self
                 .symbols

--- a/src/jsc/URL.rs
+++ b/src/jsc/URL.rs
@@ -75,8 +75,8 @@ impl URL {
 
     /// Returns the host WITHOUT the port.
     ///
-    /// Note that this does NOT match JS behavior, which returns the host with the port. See
-    /// `hostname` for the JS equivalent of `host`.
+    /// Note that this does NOT match JS behavior, which returns the host with the port. The
+    /// with-port form lives on the JSC-free shim as `bun_url::whatwg::URL::hostname`.
     ///
     /// ```text
     /// URL("http://example.com:8080").host() => "example.com"

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -45,11 +45,6 @@
 using namespace JSC;
 extern "C" BunString BunString__fromBytes(const char* bytes, size_t length);
 
-extern "C" [[ZIG_EXPORT(nothrow)]] bool Bun__WTFStringImpl__hasPrefix(const WTF::StringImpl* impl, const char* bytes, size_t length)
-{
-    return impl->startsWith({ bytes, length });
-}
-
 extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__WTFStringImpl__deref(WTF::StringImpl* impl)
 {
     impl->deref();
@@ -680,14 +675,6 @@ extern "C" BunString URL__getHrefJoin(BunString* baseStr, BunString* relativeStr
         return { BunStringTag::Dead };
 
     return Bun::toStringRef(url.string());
-}
-
-extern "C" BunString URL__hash(WTF::URL* url)
-{
-    const auto& fragment = url->fragmentIdentifier().isEmpty()
-        ? emptyString()
-        : url->fragmentIdentifierWithLeadingNumberSign().toStringWithoutCopying();
-    return Bun::toStringRef(fragment);
 }
 
 extern "C" BunString URL__fragmentIdentifier(WTF::URL* url)

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -720,11 +720,6 @@ extern "C" BunString URL__password(WTF::URL* url)
     return Bun::toStringRef(url->password());
 }
 
-extern "C" BunString URL__search(WTF::URL* url)
-{
-    return Bun::toStringRef(url->query().toStringWithoutCopying());
-}
-
 /// Returns the host WITHOUT the port.
 ///
 /// Note that this does NOT match JS behavior, which returns the host with the port.

--- a/src/jsc/bindings/URLSearchParams.cpp
+++ b/src/jsc/bindings/URLSearchParams.cpp
@@ -31,13 +31,6 @@
 
 namespace WebCore {
 
-extern "C" JSC::EncodedJSValue URLSearchParams__create(JSDOMGlobalObject* globalObject, const ZigString* input)
-{
-    String str = Zig::toString(*input);
-    auto result = URLSearchParams::create(str, nullptr);
-    return JSC::JSValue::encode(WebCore::toJSNewlyCreated(globalObject, globalObject, WTF::move(result)));
-}
-
 extern "C" WebCore::URLSearchParams* URLSearchParams__fromJS(JSC::EncodedJSValue value)
 {
     return WebCoreCast<WebCore::JSURLSearchParams, WebCore::URLSearchParams>(value);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1864,13 +1864,6 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createEmpty()
     headers->relaxAdoptionRequirement();
     return headers;
 }
-void WebCore__FetchHeaders__append(WebCore::FetchHeaders* headers, const ZigString* arg1, const ZigString* arg2,
-    JSC::JSGlobalObject* lexicalGlobalObject)
-{
-    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject->vm());
-    WebCore::propagateException(*lexicalGlobalObject, throwScope, headers->append(Zig::toString(*arg1), Zig::toString(*arg2)));
-    RELEASE_AND_RETURN(throwScope, );
-}
 WebCore::FetchHeaders* WebCore__FetchHeaders__cast_(JSC::EncodedJSValue JSValue0, JSC::VM* vm)
 {
     return WebCoreCast<WebCore::JSFetchHeaders, WebCore::FetchHeaders>(JSValue0);
@@ -1945,15 +1938,6 @@ JSC::EncodedJSValue WebCore__FetchHeaders__toJS(WebCore::FetchHeaders* headers, 
     }
 
     return JSC::JSValue::encode(value);
-}
-
-JSC::EncodedJSValue WebCore__FetchHeaders__clone(WebCore::FetchHeaders* headers, JSC::JSGlobalObject* arg1)
-{
-    auto throwScope = DECLARE_THROW_SCOPE(arg1->vm());
-    Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(arg1);
-    auto* clone = new WebCore::FetchHeaders({ WebCore::FetchHeaders::Guard::None, {} });
-    WebCore::propagateException(*arg1, throwScope, clone->fill(*headers));
-    return JSC::JSValue::encode(WebCore::toJSNewlyCreated(arg1, globalObject, WTF::move(clone)));
 }
 
 WebCore::FetchHeaders* WebCore__FetchHeaders__cloneThis(WebCore::FetchHeaders* headers, JSC::JSGlobalObject* lexicalGlobalObject)
@@ -2202,16 +2186,6 @@ void WebCore__FetchHeaders__get_(WebCore::FetchHeaders* headers, const ZigString
     else
         *arg2 = Zig::toZigString(result.releaseReturnValue());
 }
-bool WebCore__FetchHeaders__has(WebCore::FetchHeaders* headers, const ZigString* arg1, JSC::JSGlobalObject* global)
-{
-    auto throwScope = DECLARE_THROW_SCOPE(global->vm());
-    auto result = headers->has(Zig::toString(*arg1));
-    if (result.hasException()) {
-        WebCore::propagateException(*global, throwScope, result.releaseException());
-        return false;
-    } else
-        return result.releaseReturnValue();
-}
 extern "C" void WebCore__FetchHeaders__put(WebCore::FetchHeaders* headers, HTTPHeaderName name, const BunString* arg2, JSC::JSGlobalObject* global)
 {
     auto throwScope = DECLARE_THROW_SCOPE(global->vm());
@@ -2219,13 +2193,6 @@ extern "C" void WebCore__FetchHeaders__put(WebCore::FetchHeaders* headers, HTTPH
     // `toWTFString()` refs a `WTFStringImpl`-tagged value instead of copying it.
     WebCore::propagateException(*global, throwScope, headers->set(name, arg2->toWTFString()));
 }
-void WebCore__FetchHeaders__remove(WebCore::FetchHeaders* headers, const ZigString* arg1, JSC::JSGlobalObject* global)
-{
-    auto throwScope = DECLARE_THROW_SCOPE(global->vm());
-    WebCore::propagateException(*global, throwScope,
-        headers->remove(Zig::toString(*arg1)));
-}
-
 void WebCore__FetchHeaders__fastRemove_(WebCore::FetchHeaders* headers, unsigned char headerName)
 {
     headers->fastRemove(static_cast<WebCore::HTTPHeaderName>(headerName));
@@ -3024,10 +2991,6 @@ void JSC__JSString__toZigString(JSC::JSString* arg0, JSC::JSGlobalObject* arg1, 
     // We don't need to assert here because ->value returns a reference to the same string as the one owned by the JSString.
 }
 
-bool JSC__JSString__eql(const JSC::JSString* arg0, JSC::JSGlobalObject* obj, JSC::JSString* arg2)
-{
-    return arg0->equal(obj, arg2);
-}
 bool JSC__JSString__is8Bit(const JSC::JSString* arg0) { return arg0->is8Bit(); };
 size_t JSC__JSString__length(const JSC::JSString* arg0) { return arg0->length(); }
 
@@ -4896,10 +4859,6 @@ void JSC__VM__deleteAllCode(JSC::VM* arg1, JSC::JSGlobalObject* globalObject)
 void JSC__VM__reportExtraMemory(JSC::VM* arg0, size_t arg1)
 {
     arg0->heap.deprecatedReportExtraMemory(arg1);
-}
-
-void JSC__VM__deinit(JSC::VM* arg1, JSC::JSGlobalObject* globalObject)
-{
 }
 
 void JSC__VM__drainMicrotasks(JSC::VM* arg0)

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -76,9 +76,7 @@ CPP_DECL WebCore::DOMFormData* _fromJS(JSC::EncodedJSValue JSValue0);
 
 #pragma mark - WebCore::FetchHeaders
 
-CPP_DECL void WebCore__FetchHeaders__append(WebCore::FetchHeaders* arg0, const ZigString* arg1, const ZigString* arg2, JSC::JSGlobalObject* arg3);
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__cast_(JSC::EncodedJSValue JSValue0, JSC::VM* arg1);
-CPP_DECL JSC::EncodedJSValue WebCore__FetchHeaders__clone(WebCore::FetchHeaders* arg0, JSC::JSGlobalObject* arg1);
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__cloneThis(WebCore::FetchHeaders* arg0, JSC::JSGlobalObject* arg1);
 CPP_DECL void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* arg0, StringPointer* arg1, StringPointer* arg2, unsigned char* arg3);
 CPP_DECL void WebCore__FetchHeaders__count(WebCore::FetchHeaders* arg0, uint32_t* arg1, uint32_t* arg2);
@@ -93,9 +91,7 @@ CPP_DECL void WebCore__FetchHeaders__fastGet_(WebCore::FetchHeaders* arg0, unsig
 CPP_DECL bool WebCore__FetchHeaders__fastHas_(WebCore::FetchHeaders* arg0, unsigned char arg1);
 CPP_DECL void WebCore__FetchHeaders__fastRemove_(WebCore::FetchHeaders* arg0, unsigned char arg1);
 CPP_DECL void WebCore__FetchHeaders__get_(WebCore::FetchHeaders* arg0, const ZigString* arg1, ZigString* arg2, JSC::JSGlobalObject* arg3);
-CPP_DECL bool WebCore__FetchHeaders__has(WebCore::FetchHeaders* arg0, const ZigString* arg1, JSC::JSGlobalObject* arg2);
 CPP_DECL bool WebCore__FetchHeaders__isEmpty(WebCore::FetchHeaders* arg0);
-CPP_DECL void WebCore__FetchHeaders__remove(WebCore::FetchHeaders* arg0, const ZigString* arg1, JSC::JSGlobalObject* arg2);
 CPP_DECL JSC::EncodedJSValue WebCore__FetchHeaders__toJS(WebCore::FetchHeaders* arg0, JSC::JSGlobalObject* arg1);
 CPP_DECL void WebCore__FetchHeaders__toUWSResponse(WebCore::FetchHeaders* arg0, UWSResponseKind kind, void* arg2);
 CPP_DECL JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* arg1);
@@ -109,7 +105,6 @@ CPP_DECL JSC::JSObject* JSC__JSCell__toObject(JSC::JSCell* cell, JSC::JSGlobalOb
 
 #pragma mark - JSC::JSString
 
-CPP_DECL bool JSC__JSString__eql(const JSC::JSString* arg0, JSC::JSGlobalObject* arg1, JSC::JSString* arg2);
 CPP_DECL bool JSC__JSString__is8Bit(const JSC::JSString* arg0);
 CPP_DECL void JSC__JSString__iterator(JSC::JSString* arg0, JSC::JSGlobalObject* arg1, void* arg2);
 CPP_DECL size_t JSC__JSString__length(const JSC::JSString* arg0);
@@ -304,7 +299,6 @@ CPP_DECL size_t JSC__VM__blockBytesAllocated(JSC::VM* arg0);
 CPP_DECL void JSC__VM__clearExecutionTimeLimit(JSC::VM* arg0);
 CPP_DECL void JSC__VM__collectAsync(JSC::VM* arg0);
 CPP_DECL JSC::VM* JSC__VM__create(unsigned char HeapType0);
-CPP_DECL void JSC__VM__deinit(JSC::VM* arg0, JSC::JSGlobalObject* arg1);
 CPP_DECL void JSC__VM__deleteAllCode(JSC::VM* arg0, JSC::JSGlobalObject* arg1);
 CPP_DECL void JSC__VM__drainMicrotasks(JSC::VM* arg0);
 CPP_DECL bool JSC__VM__executionForbidden(JSC::VM* arg0);

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -310,19 +310,12 @@ impl Default for Entry {
     }
 }
 
-// lifetime-generic, but resolver storage requires `'static`; in practice all
-// three slices borrow process-lifetime interned data (`dir` → DirnameStore,
-// `query` → FilenameStore copy made in `DirEntry::get`, `actual` → EntryStore).
-#[derive(Clone, Copy)]
-pub struct DifferentCase;
-
 // `entry` is a RAW `*mut Entry`. A safe
 // `&self → &mut Entry` accessor would let two `get()` calls produce coexisting
 // aliased `&mut Entry` (PORTING.md §Forbidden). Callers `unsafe { &mut *entry }`
 // at each write site under the per-entry `Entry.mutex`.
 pub struct EntryLookup<'a> {
     pub(crate) entry: *mut Entry,
-    pub(crate) diff_case: Option<DifferentCase>,
     // tie the lookup's nominal lifetime to the DirEntry it came from
     _marker: core::marker::PhantomData<&'a Entry>,
 }
@@ -624,16 +617,10 @@ impl DirEntry {
         Ok(())
     }
 
-    // `query_` borrow detached from the returned Entry lifetime so
-    // callers can pass a slice into the same threadlocal buffer they then
-    // mutate; on a case mismatch the query bytes are interned into the
-    // process-lifetime `FilenameStore` so `DifferentCase<'static>` holds a
-    // genuinely `'static` slice. The store does not dedup, so
-    // repeated lookups of the same case-mismatched specifier (e.g. watch-mode
-    // rebuilds with a busted resolution cache) each intern a fresh copy that
-    // is never freed; accepted because the mismatch arm is a warning/error
-    // path and each copy is small. The intern goes through `handle_oom`
-    // (abort).
+    // `query_` borrow is detached from the returned `Entry` lifetime so callers
+    // can pass a slice into the same threadlocal buffer they then mutate. The
+    // lookup key is the lowercased basename; a case-mismatched query still
+    // returns the stored entry.
     pub fn get<'a>(&'a self, query_: &[u8]) -> Option<EntryLookup<'a>> {
         if query_.is_empty() || query_.len() > MAX_PATH_BYTES {
             return None;
@@ -642,20 +629,8 @@ impl DirEntry {
 
         let query = strings::copy_lowercase_if_needed(query_, &mut scratch_lookup_buffer[..]);
         let &result_ptr = self.data.get(query)?;
-        // SAFETY: EntryStore-owned pointer, valid for lifetime of store; read-only
-        // borrow here only to compare basename — never overlaps a writer.
-        let basename = unsafe { &*result_ptr }.base();
-        if !strings::eql_long(basename, query_, true) {
-            return Some(EntryLookup {
-                entry: result_ptr,
-                diff_case: Some(DifferentCase),
-                _marker: core::marker::PhantomData,
-            });
-        }
-
         Some(EntryLookup {
             entry: result_ptr,
-            diff_case: None,
             _marker: core::marker::PhantomData,
         })
     }
@@ -667,20 +642,8 @@ impl DirEntry {
         query_lower: &'static [u8],
     ) -> Option<EntryLookup<'a>> {
         let &result_ptr = self.data.get(query_lower)?;
-        // SAFETY: EntryStore-owned pointer; read-only basename compare.
-        let basename = unsafe { &*result_ptr }.base();
-
-        if basename != query_lower {
-            return Some(EntryLookup {
-                entry: result_ptr,
-                diff_case: Some(DifferentCase),
-                _marker: core::marker::PhantomData,
-            });
-        }
-
         Some(EntryLookup {
             entry: result_ptr,
-            diff_case: None,
             _marker: core::marker::PhantomData,
         })
     }

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -686,8 +686,8 @@ pub mod fs {
     // Canonical definitions live in `fs.rs` (mounted as `crate::fs_full`).
     // Re-exported here so the public path `bun_resolver::fs::*` is preserved.
     pub use crate::fs_full::{
-        DifferentCase, DirEntry, DirEntryIterator, Entry, EntryCache, EntryKind, EntryKindResolver,
-        EntryLookup, FilenameStoreAppender, dir_entry,
+        DirEntry, DirEntryIterator, Entry, EntryCache, EntryKind, EntryKindResolver, EntryLookup,
+        FilenameStoreAppender, dir_entry,
     };
 
     use bun_core::Generation;
@@ -1765,11 +1765,6 @@ pub mod fs {
 
     pub mod file_system {
         pub use super::{DirEntry, DirnameStore, Entry, EntryKind, FilenameStore, RealFS};
-        pub mod entry {
-            pub mod lookup {
-                pub use crate::fs::DifferentCase;
-            }
-        }
         pub mod real_fs {
             pub use crate::fs::EntriesOption;
         }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1193,7 +1193,6 @@ impl<'a> Resolver<'a> {
                 return ResultUnion::Success(Result {
                     import_kind: kind,
                     path_pair: res.path_pair,
-                    diff_case: res.diff_case,
                     package_json: res.package_json,
                     dirname_fd: res.dirname_fd,
                     file_fd: res.file_fd,
@@ -1842,7 +1841,6 @@ impl<'a> Resolver<'a> {
                             // We don't set the directory fd here because it might remap an entirely different directory
                             return ResultUnion::Success(Result {
                                 path_pair: res.path_pair,
-                                diff_case: res.diff_case,
                                 package_json: res.package_json,
                                 dirname_fd: res.dirname_fd,
                                 file_fd: res.file_fd,
@@ -1892,7 +1890,6 @@ impl<'a> Resolver<'a> {
                 return ResultUnion::Success(Result {
                     dirname_fd: entry.dirname_fd,
                     path_pair: entry.path_pair,
-                    diff_case: entry.diff_case,
                     package_json: entry.package_json,
                     file_fd: entry.file_fd,
                     jsx: self.opts.jsx.clone(),
@@ -2149,7 +2146,6 @@ impl<'a> Resolver<'a> {
                             flags.set_is_external_and_rewrite_import_path(match_result.is_external);
                             return ResultUnion::Success(Result {
                                 path_pair: match_result.path_pair,
-                                diff_case: match_result.diff_case,
                                 dirname_fd: match_result.dirname_fd,
                                 package_json: Some(std::ptr::from_ref(pkg)),
                                 jsx: self.opts.jsx.clone(),
@@ -2175,7 +2171,6 @@ impl<'a> Resolver<'a> {
         {
             ResultUnion::Success(Result {
                 path_pair: res.path_pair,
-                diff_case: res.diff_case,
                 dirname_fd: res.dirname_fd,
                 package_json: res.package_json,
                 jsx: self.opts.jsx.clone(),
@@ -2273,7 +2268,6 @@ impl<'a> Resolver<'a> {
                                 return ResultUnion::Success(Result {
                                     path_pair: pair,
                                     dirname_fd: node_module.dirname_fd,
-                                    diff_case: node_module.diff_case,
                                     package_json: Some(std::ptr::from_ref(package_json)),
                                     jsx: self.opts.jsx.clone(),
                                     ..Default::default()
@@ -2289,7 +2283,6 @@ impl<'a> Resolver<'a> {
                                         primary,
                                         secondary: None,
                                     },
-                                    diff_case: None,
                                     jsx: self.opts.jsx.clone(),
                                     ..Default::default()
                                 });
@@ -2324,7 +2317,6 @@ impl<'a> Resolver<'a> {
                 result.dirname_fd = res.dirname_fd;
                 result.file_fd = res.file_fd;
                 result.package_json = res.package_json;
-                result.diff_case = res.diff_case;
                 result.flags.set_is_from_node_modules(
                     result.flags.is_from_node_modules() || res.is_node_module,
                 );
@@ -2375,7 +2367,6 @@ impl<'a> Resolver<'a> {
                                     result.dirname_fd = remapped.dirname_fd;
                                     result.file_fd = remapped.file_fd;
                                     result.package_json = remapped.package_json;
-                                    result.diff_case = remapped.diff_case;
                                     result.module_type = remapped.module_type;
                                     result.flags.set_is_external(remapped.is_external);
 
@@ -3798,7 +3789,6 @@ impl<'a> Resolver<'a> {
                     dirname_fd: entries.fd,
                     file_fd: entry_query.entry().cache().fd,
                     dir_info: Some(resolved_dir_info),
-                    diff_case: entry_query.diff_case,
                     is_node_module: true,
                     package_json: Some(
                         resolved_dir_info
@@ -5085,7 +5075,6 @@ impl<'a> Resolver<'a> {
                     secondary: None,
                 },
                 dirname_fd: result.dirname_fd,
-                diff_case: result.diff_case,
                 ..Default::default()
             };
             dec_ret!(MatchStatus::Success);
@@ -5207,7 +5196,6 @@ impl<'a> Resolver<'a> {
                                 primary: Path::init(out_buf),
                                 secondary: None,
                             },
-                            diff_case: lookup.diff_case,
                             package_json: Some(std::ptr::from_ref(package_json)),
                             dirname_fd: dir_info.get_file_descriptor(),
                             ..Default::default()
@@ -5220,7 +5208,6 @@ impl<'a> Resolver<'a> {
                             primary: Path::init(out_buf),
                             secondary: None,
                         },
-                        diff_case: lookup.diff_case,
                         dirname_fd: dir_info.get_file_descriptor(),
                         ..Default::default()
                     };
@@ -5303,7 +5290,6 @@ impl<'a> Resolver<'a> {
                                     primary: Path::init(file_result.path),
                                     secondary: None,
                                 },
-                                diff_case: file_result.diff_case,
                                 ..Default::default()
                             };
                             return MatchStatus::Success;
@@ -5355,7 +5341,6 @@ impl<'a> Resolver<'a> {
                                     primary: Path::init(file.path),
                                     secondary: None,
                                 },
-                                diff_case: file.diff_case,
                                 dirname_fd: file.dirname_fd,
                                 package_json: Some(std::ptr::from_ref(package_json)),
                                 file_fd: file.file_fd,
@@ -5374,7 +5359,6 @@ impl<'a> Resolver<'a> {
                     primary: Path::init(file.path),
                     secondary: None,
                 },
-                diff_case: file.diff_case,
                 dirname_fd: file.dirname_fd,
                 file_fd: file.file_fd,
                 ..Default::default()
@@ -5540,7 +5524,6 @@ impl<'a> Resolver<'a> {
                                         primary,
                                         secondary: Some(auto_main_result.path_pair.primary),
                                     },
-                                    diff_case: out.diff_case,
                                     dirname_fd: out.dirname_fd,
                                     package_json,
                                     file_fd: auto_main_result.file_fd,
@@ -5691,7 +5674,6 @@ impl<'a> Resolver<'a> {
 
                 dec_ret!(Some(LoadResult {
                     path: abs_path,
-                    diff_case: query.diff_case,
                     dirname_fd: entries!().fd,
                     file_fd: query.entry().cache().fd,
                 }));
@@ -5811,7 +5793,6 @@ impl<'a> Resolver<'a> {
                                     }
                                     query.entry().abs_path.as_bytes()
                                 },
-                                diff_case: query.diff_case,
                                 dirname_fd: entries!().fd,
                                 file_fd: query.entry().cache().fd,
                             }));
@@ -5901,7 +5882,6 @@ impl<'a> Resolver<'a> {
                         };
                         query.entry().abs_path.as_bytes()
                     },
-                    diff_case: query.diff_case,
                     dirname_fd: entries.fd,
                     file_fd: query.entry().cache().fd,
                 });

--- a/src/resolver/result.rs
+++ b/src/resolver/result.rs
@@ -12,7 +12,6 @@ use bun_core::MutableString;
 use bun_sys::Fd as FD;
 
 use crate::dir_info::DirInfoRef;
-use crate::fs as Fs;
 use crate::options;
 use crate::package_json::PackageJSON;
 use crate::resolver::Dependency;
@@ -93,8 +92,6 @@ pub struct Result {
 
     pub package_json: Option<*const PackageJSON>,
 
-    pub diff_case: Option<Fs::file_system::entry::lookup::DifferentCase>,
-
     // If present, any ES6 imports to this file can be considered to have no side
     // effects. This means they should be removed if unused.
     pub primary_side_effects_data: SideEffects,
@@ -117,7 +114,6 @@ impl Default for Result {
             path_pair: PathPair::default(),
             jsx: options::jsx::Pragma::default(),
             package_json: None,
-            diff_case: None,
             primary_side_effects_data: SideEffects::HasSideEffects,
             module_type: options::ModuleType::Unknown,
             dirname_fd: FD::INVALID,
@@ -363,7 +359,6 @@ pub struct MatchResult {
     pub(crate) file_fd: FD,
     pub(crate) is_node_module: bool,
     pub(crate) package_json: Option<*const PackageJSON>,
-    pub(crate) diff_case: Option<Fs::file_system::entry::lookup::DifferentCase>,
     pub(crate) dir_info: Option<DirInfoRef>,
     pub(crate) module_type: options::ModuleType,
     pub(crate) is_external: bool,
@@ -377,7 +372,6 @@ impl Default for MatchResult {
             file_fd: FD::INVALID,
             is_node_module: false,
             package_json: None,
-            diff_case: None,
             dir_info: None,
             module_type: options::ModuleType::Unknown,
             is_external: false,
@@ -438,7 +432,6 @@ pub struct LoadResult {
     /// Interned in `DirnameStore`/`FilenameStore` (process-lifetime singletons),
     /// so the `'static` borrow is genuine.
     pub(crate) path: &'static [u8],
-    pub(crate) diff_case: Option<Fs::file_system::entry::lookup::DifferentCase>,
     pub(crate) dirname_fd: FD,
     pub(crate) file_fd: FD,
 }

--- a/src/runtime/node/fs_events.rs
+++ b/src/runtime/node/fs_events.rs
@@ -121,8 +121,9 @@ fn dlsym<T>(_handle: *mut c_void, _symbol: &core::ffi::CStr) -> Option<T> {
     None
 }
 
-// Clone/Copy: bitwise OK — `handle` is a leaked dlopen handle held for the
-// process lifetime (never dlclosed); the rest are resolved fn pointers.
+// Clone/Copy: bitwise OK — resolved fn pointers plus a framework-static
+// `*const CFStringRef`; the dlopen handle they came from is leaked (never
+// dlclosed), so copies stay valid for the process lifetime.
 #[derive(Clone, Copy)]
 pub struct CoreFoundation {
     pub(crate) array_create: unsafe extern "C" fn(
@@ -153,13 +154,13 @@ pub struct CoreFoundation {
     pub(crate) run_loop_default_mode: *const CFStringRef,
 }
 
-// SAFETY: `handle` is a leaked dlopen handle (never dlclosed) and `run_loop_default_mode` points at a process-static CFStringRef
-// inside the loaded framework. Everything else is a resolved fn pointer.
-// Sharing/sending bitwise copies across threads is sound.
+// SAFETY: `run_loop_default_mode` points at a process-static CFStringRef
+// inside the loaded (never-dlclosed) framework; every other field is a
+// resolved fn pointer. Sharing/sending bitwise copies across threads is sound.
 unsafe impl Send for CoreFoundation {}
-// SAFETY: all fields are immutable process-lifetime data (leaked dlopen handle,
-// framework-static `*const CFStringRef`, resolved fn pointers); none provide
-// interior mutability, so concurrent `&CoreFoundation` access is sound.
+// SAFETY: all fields are immutable process-lifetime data (framework-static
+// `*const CFStringRef`, resolved fn pointers); none provide interior
+// mutability, so concurrent `&CoreFoundation` access is sound.
 unsafe impl Sync for CoreFoundation {}
 
 impl CoreFoundation {
@@ -168,8 +169,8 @@ impl CoreFoundation {
     }
 }
 
-// Clone/Copy: bitwise OK — `handle` is a leaked dlopen handle held for the
-// process lifetime (never dlclosed); the rest are resolved fn pointers.
+// Clone/Copy: bitwise OK — resolved fn pointers (from a leaked, never-dlclosed
+// dlopen handle) plus a `u64` sentinel.
 #[derive(Clone, Copy)]
 pub struct CoreServices {
     pub(crate) fs_event_stream_create: unsafe extern "C" fn(
@@ -190,15 +191,6 @@ pub struct CoreServices {
     // libuv set it to -1 so the actual value is this
     pub(crate) k_fs_event_stream_event_id_since_now: FSEventStreamEventId,
 }
-
-// SAFETY: `handle` is a leaked dlopen handle (never dlclosed); the rest are
-// resolved fn pointers and a u64 sentinel. Sharing/sending across threads is
-// sound.
-unsafe impl Send for CoreServices {}
-// SAFETY: all fields are immutable process-lifetime data (leaked dlopen handle,
-// resolved fn pointers, a `u64` constant); none provide interior mutability, so
-// concurrent `&CoreServices` access is sound.
-unsafe impl Sync for CoreServices {}
 
 impl CoreServices {
     pub fn get() -> CoreServices {

--- a/src/safety/Cargo.toml
+++ b/src/safety/Cargo.toml
@@ -10,15 +10,4 @@ path = "lib.rs"
 workspace = true
 
 [dependencies]
-strum.workspace = true
-bstr.workspace = true
-scopeguard.workspace = true
-const_format.workspace = true
-enum-map.workspace = true
-enumset.workspace = true
-libc.workspace = true
-bitflags.workspace = true
-bun_alloc.workspace = true
 bun_core.workspace = true
-
-thiserror.workspace = true

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -146,8 +146,6 @@ pub mod postgres {
         pub mod field_type;
         #[path = "PortalOrPreparedStatement.rs"]
         pub mod portal_or_prepared_statement;
-        #[path = "TransactionStatusIndicator.rs"]
-        pub mod transaction_status_indicator;
         #[path = "zHelpers.rs"]
         pub(crate) mod z_helpers;
 

--- a/src/sql/postgres/protocol/BackendKeyData.rs
+++ b/src/sql/postgres/protocol/BackendKeyData.rs
@@ -1,7 +1,6 @@
 use super::new_reader::NewReader;
 use crate::postgres::AnyPostgresError;
 
-#[derive(Default)]
 pub struct BackendKeyData {}
 
 impl BackendKeyData {

--- a/src/sql/postgres/protocol/TransactionStatusIndicator.rs
+++ b/src/sql/postgres/protocol/TransactionStatusIndicator.rs
@@ -1,6 +1,0 @@
-// Any u8 value is valid storage (the wire can carry bytes outside {I, T, E}).
-// A Rust `#[repr(u8)] enum` would be UB for such values, so this is a
-// transparent u8 newtype with associated consts instead.
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-pub struct TransactionStatusIndicator(pub(crate) u8);

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -132,7 +132,6 @@ pub struct PostgresSQLConnection {
     pub(crate) js_value: JsCell<crate::jsc::JsRef>,
 
     pub(crate) backend_parameters: JsCell<StringMap>,
-    pub(crate) backend_key_data: JsCell<protocol::BackendKeyData>,
 
     // Self-referential — `database`/`user`/`password`/`path`/`options` are slices
     // into `options_buf` (built via StringBuilder in `call`). Struct is Box-allocated
@@ -1196,7 +1195,6 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
             pending_activity_count: AtomicU32::new(0),
             js_value: JsCell::new(crate::jsc::JsRef::empty()),
             backend_parameters: JsCell::new(StringMap::init(true)),
-            backend_key_data: JsCell::new(protocol::BackendKeyData::default()),
             database,
             user: username,
             password,
@@ -2965,10 +2963,7 @@ impl PostgresSQLConnection {
                 }
             }
             MessageType::BackendKeyData => {
-                self.backend_key_data
-                    .set(protocol::BackendKeyData::decode_internal(
-                        reader.reborrow(),
-                    )?);
+                let _ = protocol::BackendKeyData::decode_internal(reader.reborrow())?;
             }
             MessageType::ErrorResponse => {
                 let err = protocol::ErrorResponse::decode_internal(reader.reborrow())?;

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -121,7 +121,7 @@ pub mod whatwg {
         pub fn from_utf8(input: &[u8]) -> Option<core::ptr::NonNull<URL>> {
             Self::from_string(&String::borrow_utf8(input))
         }
-        /// Exactly the same as `hash`, excluding the leading '#'.
+        /// The URL fragment (the part after `#`), excluding the leading '#'.
         pub fn fragment_identifier(&self) -> String {
             URL__fragmentIdentifier(self)
         }
@@ -133,8 +133,8 @@ pub mod whatwg {
         }
         /// Returns the host WITH the port.
         ///
-        /// Note that this does NOT match JS behavior which returns the host without the port. See
-        /// `host` for the JS equivalent of `hostname`.
+        /// Note that this does NOT match JS `hostname`, which excludes the port (that
+        /// port-less form is `bun_jsc::URL::host`).
         ///
         /// ```text
         /// URL("http://example.com:8080").hostname() => "example.com:8080"


### PR DESCRIPTION
Follow-up to #36184 — addresses the leftover review comments (second-order dead code, orphaned comments, dead Cargo deps, dead C++ FFI exports).

1. `css_parser.rs` `ToCssResult` / `ToCssResultInternal` — already reconciled in the merged squash (the internal husk type and the `'static` placeholder fields are gone; `ToCssResult` carries only `code`); nothing further to do.
2. `resolver/fs.rs` — `DifferentCase` and the write-only `diff_case` threaded through `EntryLookup` / `Result` / `MatchResult` / `LoadResult` (zero readers) deleted, along with ~20 assignment-only sites in `resolver.rs`; the orphaned comment and the stale `DirEntry::get` doc rewritten to stand alone.
3. `src/url/lib.rs` + `src/CLAUDE.md` — `fragment_identifier()` / `hostname()` docs no longer reference deleted `hash` / `host`; the `bun_jsc::URL` docs list only methods that exist and state the `host`/`hostname` swap truthfully.
4. `src/safety/Cargo.toml` — the re-export shim now depends only on `bun_core` (10 dead deps dropped; lockfile updated).
5. `sql` — deleted the dead `TransactionStatusIndicator` type + its `pub mod`; `PostgresSQLConnection.backend_key_data` (write-only) removed — the wire read is kept as `let _ = protocol::BackendKeyData::decode_internal(reader.reborrow())?;`, matching the sibling `CopyData` arm.
6. `LinkerGraph::symbol_mut` — SAFETY comment inlines the one-line contract instead of pointing at the debug-only `symbol()`.
7. `fs_events.rs` — comments no longer mention the deleted `handle` field; the now-vacuous `unsafe impl Send/Sync for CoreServices` are gone (only fn pointers + a `u64` remain, so both auto-derive). `CoreFoundation` keeps its impls because it still holds a `*const CFStringRef`.
8. C++ — deleted definitions and the hand-maintained `headers.h` `CPP_DECL`s for `Bun__WTFStringImpl__hasPrefix`, `URL__hash`, `URLSearchParams__create`, `WebCore__FetchHeaders__{append,clone,has,remove}`, `JSC__JSString__eql`, `JSC__VM__deinit`. Each was verified by `rg` to have zero Rust references and no C++ callers before deletion (`Bun__WTFStringImpl__hasPrefix` was the only `ZIG_EXPORT` one; its generated wrapper drops out with the definition). These deletions are grep-verified only — this relies on CI's C++ build for confirmation.
9. `bun_core/string/wtf.rs` — dropped the rationale for the deleted `is_wtf_allocator` / `StringImplAllocator`.
10. `brotli` — dropped the dead `bun_io` dep; deleted the never-constructed `Error::BrotliCompressionError` and `Error::Core(bun_core::Error)` variants and their `name()` arms.

## Verification

- `cargo check --workspace --all-targets --keep-going` (debug rustflags, host) — 0 errors
- `cargo check --workspace --release --keep-going` on host, `--target aarch64-apple-darwin`, and `--target x86_64-pc-windows-msvc` — 0 errors
- `cargo clippy --workspace --no-deps --keep-going` — exit 0
- `cargo test --doc --workspace` — pass
- rustfmt clean on the touched Rust files
- C++ deletions: symbol-grep verified only (see item 8); CI's C++ build is the gate for those.