### PR TITLE
node:zlib: accept explicit undefined/null options in zstdCompress

### DIFF
--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -688,7 +688,7 @@ function createConvenienceMethod(ctor, sync, methodName, isZstd) {
           bufferSize = 0;
         }
         // Set pledgedSrcSize if not already set
-        if (!opts.pledgedSrcSize && bufferSize > 0) {
+        if (!opts?.pledgedSrcSize && bufferSize > 0) {
           opts = { ...opts, pledgedSrcSize: bufferSize };
         }
       }

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -556,6 +556,13 @@ describe("zlib.zstd", () => {
     expect(roundtrip.toString()).toEqual(inputString);
   });
 
+  it.each([undefined, null])("zstdCompress accepts explicit %p options", async opts => {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    zlib.zstdCompress(inputString, opts, (err, out) => (err ? reject(err) : resolve(out)));
+    const compressed = await promise;
+    expect(compressed.toString("base64")).toEqual(compressedString);
+  });
+
   it("zstdCompressSync", () => {
     const compressed = zlib.zstdCompressSync(inputString);
     expect(compressed.toString("base64")).toEqual(compressedString);


### PR DESCRIPTION
### What does this PR do?

`zlib.zstdCompress(buf, undefined, cb)` and `zlib.zstdCompress(buf, null, cb)` threw a synchronous `TypeError: undefined is not an object (evaluating 'opts')` instead of compressing. Node.js accepts both, as do every sibling convenience method in Bun (`zstdDecompress`, `gzip`, `brotliCompress`, all `*Sync` forms).

```js
import zlib from "node:zlib";
zlib.zstdCompress(Buffer.from("hello"), undefined, (err, out) => console.log(out.length));
// bun:  TypeError: undefined is not an object (evaluating 'opts')
// node: 14
```

The async `zstdCompress` path in `createConvenienceMethod` reads `opts.pledgedSrcSize` to auto-fill the content size header. It only normalized `opts` when `typeof opts === "function"`, so an explicit nullish value reached the property access unguarded. Switched to `opts?.pledgedSrcSize`; the subsequent `{ ...opts }` already handles nullish spread.

### How did you verify your code works?

New `it.each([undefined, null])` case in `test/js/node/zlib/zlib.test.js` fails on main with the TypeError above and passes with this change.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/zlib/zlib.test.js
bun test v1.4.0 (156aa7b01)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [2.08ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [1.12ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [1.45ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [1.82ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.47ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.28ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip [0.29ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib [0.30ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__prot
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (b5d28fe54)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [0.03ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [0.01ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [0.02ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto__
(pass) prototype and name and constructor > Deflate > Deflate.prototype.constructor should be Deflate
(pass) prototype and name and constructor > Deflate > Deflate.name should be Deflate
(pass) pr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/zlib/zlib.test.js
bun test v1.4.0 (156aa7b01)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [2.27ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [1.14ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [1.42ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [1.52ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.47ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.29ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip [0.29ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib [0.30ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__prot
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 671ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen cpp.rs (cppbind)
[2/23] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[3/23] gen JS modules (bundle-modules)
Preprocess modules (8965ms)
Bundle modules (44ms)
Postprocesss modules (26ms)
Bundle Functions (749ms)
Generate Code (17ms)

[9.82s] Bundled "src/js" for production
  2569 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/zlib.ts            | 2 +-
 test/js/node/zlib/zlib.test.js | 7 +++++++
 2 files changed, 8 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/js/node/zlib.ts                 1      1      0
test/js/node/zlib/zlib.test.js      2      1      0
```

</details>

<!-- robobun:evidence:end -->