### PR TITLE
test(parallel): do not upload the deliberate segfault to CI's crash remap server

### DIFF
--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -214,12 +214,9 @@ test.skipIf(isWindows)(
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--parallel=2", "--bail=1"],
-      // BUN_CRASH_REPORT_URL="": this segfault is deliberate. On CI the runner
-      // sets BUN_CRASH_REPORT_URL to its remap server and only drains /traces
-      // when a later test exits non-zero, so an upload from here gets pinned on
-      // the next unrelated failing test as "crash reported" and blocks its
-      // retries (observed as a spurious 0xDEADBEEF crash on
-      // proxy-stress-concurrent.test.ts in build 85618).
+      // BUN_CRASH_REPORT_URL="": this segfault is deliberate; uploading it to
+      // CI's remap server pins a spurious "crash reported" error on the next
+      // unrelated failing test (runner only drains /traces on non-zero exit).
       env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0", BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPORTING: "0" },
       cwd: String(dir),
       stderr: "pipe",

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -214,7 +214,13 @@ test.skipIf(isWindows)(
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--parallel=2", "--bail=1"],
-      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+      // BUN_CRASH_REPORT_URL="": this segfault is deliberate. On CI the runner
+      // sets BUN_CRASH_REPORT_URL to its remap server and only drains /traces
+      // when a later test exits non-zero, so an upload from here gets pinned on
+      // the next unrelated failing test as "crash reported" and blocks its
+      // retries (observed as a spurious 0xDEADBEEF crash on
+      // proxy-stress-concurrent.test.ts in build 85618).
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0", BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPORTING: "0" },
       cwd: String(dir),
       stderr: "pipe",
       stdout: "pipe",


### PR DESCRIPTION
## Symptom

[Build 85618, macOS 14 x64](https://buildkite.com/bun/bun/builds/85618#019fb13a-b6e5-4858-a22b-e6bd16a0fea9): `test/js/bun/http/proxy-stress-concurrent.test.ts` annotated as "crash reported" with a segfault at `0xDEADBEEF`:

```
Segmentation fault at address 0xDEADBEEF
- bun_runtime::api::crash_handler_jsc::js_bindings::__jsc_host_js_segfault
- ...
- bun_runtime::cli::test::parallel::runner::run_as_worker
```

The proxy test never calls `crash_handler.segfault()`. Its actual failure was a single `ConnectionRefused` on the first fetch of one sub-test, which would normally be retried.

## Cause

`test/cli/test/parallel.test.ts`'s "worker panic still prints the panic banner" test spawns `bun test --parallel=2 --bail=1` over a fixture that calls `crash_handler.segfault()`. It passes `bunEnv`, which spreads `process.env`; on CI that includes `BUN_CRASH_REPORT_URL` (set by `scripts/runner.node.mjs` to its local remap server), so the deliberate segfault uploads its trace there.

`runner.node.mjs` only drains `/traces` when a test exits non-zero, and `parallel.test.ts` itself passes (exit 0). The trace sat in the remap server across 16 subsequent passing tests until `proxy-stress-concurrent.test.ts` exited 1, at which point the runner fetched `/traces`, found the lingering `0xDEADBEEF` entry, and marked the proxy test as "crash reported". `isAlwaysFailure` treats "crash reported" as a hard failure, so the proxy test's one-off `ConnectionRefused` was never retried.

From the job log: `parallel.test.ts` ran at position 57/980, `proxy-stress-concurrent.test.ts` at 74/980, with only passing tests in between.

## Fix

Clear `BUN_CRASH_REPORT_URL` and `BUN_ENABLE_CRASH_REPORTING` in the subprocess env so the deliberate segfault never uploads. This matches the existing guard in `run-crash-handler.test.ts`, `tls-syscall-fault.test.ts`, and `native-plugin.test.ts`.

## Verification

Simulated CI by setting `BUN_CRASH_REPORT_URL` to a local `Bun.serve` before running the test.

Before: the server receives one `/ack` upload with the encoded trace.
After: zero uploads; the test still passes.

```
# before
UNEXPECTED UPLOAD: http://localhost:39319/1.4.0/lt2070b0c9Agggg.../ack
crash-report uploads seen: 1

# after
crash-report uploads seen: 0
```

The `ConnectionRefused` in the proxy test itself did not reproduce in 18 recent builds scanned and is not addressed here; with this fix it becomes retry-eligible again.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->