### PR TITLE
Update mimalloc to the upstream dev3 (v3.4.3) sync

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "aba864aa275982ec4171711dd566c12ada8cca99";
+const MIMALLOC_COMMIT = "d078ad066752ea7fd06acb2323b7a90c49d7d8e4";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "0e6e51895669632b0610effafa96a85a283c6933";
+const MIMALLOC_COMMIT = "52800a87d7df8bdb9363adf9e389bebfaeccd854";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "acd9924a0af3ba7c341910b48815106f2944ffa0";
+const MIMALLOC_COMMIT = "0e6e51895669632b0610effafa96a85a283c6933";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "52800a87d7df8bdb9363adf9e389bebfaeccd854";
+const MIMALLOC_COMMIT = "aba864aa275982ec4171711dd566c12ada8cca99";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/test/js/bun/jsc/heapStats-mimalloc.test.ts
+++ b/test/js/bun/jsc/heapStats-mimalloc.test.ts
@@ -1,5 +1,6 @@
 import { heapStats } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isMacOS } from "harness";
 
 describe("heapStats() mimalloc integration", () => {
   test("mimalloc aggregate stats are present", () => {
@@ -61,5 +62,32 @@ describe("heapStats() mimalloc integration", () => {
       expect(Array.isArray(h.pages)).toBe(true);
     }
     void before;
+  });
+
+  // mimalloc tags its arena mmaps with an app-reserved VM tag (240-255). The old default,
+  // 100, is VM_MEMORY_IOACCELERATOR, so profilers reported Bun's heap as GPU memory.
+  test.skipIf(!isMacOS)("arena memory is tagged as application memory, not IOAccelerator", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const keep = [];
+         for (let i = 0; i < 96; i++) keep.push(Buffer.alloc(1 << 20, i).toString("latin1"));
+         const summary = Bun.spawnSync({ cmd: ["vmmap", "--summary", String(process.pid)] }).stdout.toString();
+         const mb = name => summary.split("\\n").filter(l => l.startsWith(name)).reduce((n, l) => {
+           const m = l.slice(name.length).match(/([\\d.]+)([KMG])/);
+           return m ? n + parseFloat(m[1]) * { K: 1 / 1024, M: 1, G: 1024 }[m[2]] : n;
+         }, 0);
+         console.log(JSON.stringify({ ioaccelerator: mb("IOAccelerator"), appTag: mb("Memory Tag 24") + mb("Memory Tag 25"), kept: keep.length }));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const { ioaccelerator, appTag } = JSON.parse(stdout.trim().split("\n").at(-1)!);
+    expect(ioaccelerator).toBe(0);
+    expect(appTag).toBeGreaterThan(64);
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -333,7 +333,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "1a41b9025c2c0a37edd07ff10f6944f03e028522",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "acd9924a0af3ba7c341910b48815106f2944ffa0",
+    mimalloc: "0e6e51895669632b0610effafa96a85a283c6933",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "05f0fafaa3be31e31d7b4b5c17dc60f62c991171",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -333,7 +333,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "1a41b9025c2c0a37edd07ff10f6944f03e028522",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "aba864aa275982ec4171711dd566c12ada8cca99",
+    mimalloc: "d078ad066752ea7fd06acb2323b7a90c49d7d8e4",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "05f0fafaa3be31e31d7b4b5c17dc60f62c991171",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -333,7 +333,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "1a41b9025c2c0a37edd07ff10f6944f03e028522",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "0e6e51895669632b0610effafa96a85a283c6933",
+    mimalloc: "52800a87d7df8bdb9363adf9e389bebfaeccd854",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "05f0fafaa3be31e31d7b4b5c17dc60f62c991171",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -333,7 +333,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "1a41b9025c2c0a37edd07ff10f6944f03e028522",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "52800a87d7df8bdb9363adf9e389bebfaeccd854",
+    mimalloc: "aba864aa275982ec4171711dd566c12ada8cca99",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "05f0fafaa3be31e31d7b4b5c17dc60f62c991171",


### PR DESCRIPTION
Pins mimalloc at oven-sh/mimalloc#11 — a merge of upstream `microsoft/mimalloc` dev3 (v3.4.3+) into our fork. Fork intents (macOS fixed TLS slots 96/97, scavenger + idle-sweep handoff, hole purging, Darwin `MADV_FREE_REUSE` skip) are preserved; see #11 for the conflict-resolution table.

| upstream change picked up | why we care |
|---|---|
| usable size on aligned blocks over-reported (@zoxc audit) | `mi_usable_size` on over-aligned blocks |
| `realloc_aligned` alignment check / power-of-two guard | we bind `mi_realloc_aligned` |
| thread-init / TLS rework (`prim-tls.h`) | supersedes our theap-init placeholder fix |
| arm64 `mi_free` codegen, faster ptr→page check, `-mno-outline` on apple | perf |
| v3.4.2 / v3.4.3 | current with upstream |

Also updates `process.versions.mimalloc` in `process.test.js` to the new commit.

| check | result |
|---|---|
| oven-sh/mimalloc ctest, macOS arm64, debug (`MI_DEBUG_FULL`) / release | 20/20, 19/19 (incl. `theap-sentinel`, `park-handoff` ×3, `purge-holes`, `heap-churn`) |
| purge/scavenger A/B vs previous pin (256 MB freed, default `purge_delay`) | footprint 252.5 → 2.5 MB after the scavenger cycle in both |
| `bun bd` on the new pin | builds; `serve-body-leak.test.ts` 8/8, `heap-snapshot.test.ts` 9/9, serve/worker/spawn/install/bundler smoke clean |
