### PR TITLE
webstreams: copy the single-chunk arm of bytes()/arrayBuffer() consumers

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -467,8 +467,6 @@ static JSValue convertChunksToArrayBuffer(JSGlobalObject* globalObject, JSValue 
     if (length == 1) {
         JSValue chunk = chunks->getIndex(globalObject, 0);
         RETURN_IF_EXCEPTION(scope, {});
-        // Fetch's body-read builds arrayBuffer() as a fresh buffer over the concatenated
-        // bytes; never hand back the producer's own backing store.
         std::span<const uint8_t> span;
         bool isBinary = false;
         if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
@@ -511,8 +509,6 @@ static JSValue convertChunksToBytes(JSGlobalObject* globalObject, JSValue chunks
     if (length == 1) {
         JSValue chunk = chunks->getIndex(globalObject, 0);
         RETURN_IF_EXCEPTION(scope, {});
-        // Fetch's body-read builds bytes() as "create a Uint8Array from bytes" over a
-        // fresh buffer; never hand back or wrap the producer's own backing store.
         std::span<const uint8_t> span;
         bool isBinary = false;
         if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -467,16 +467,21 @@ static JSValue convertChunksToArrayBuffer(JSGlobalObject* globalObject, JSValue 
     if (length == 1) {
         JSValue chunk = chunks->getIndex(globalObject, 0);
         RETURN_IF_EXCEPTION(scope, {});
-        if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk))
-            return jsBuffer;
-        if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
-            RefPtr<JSC::ArrayBuffer> impl = view->possiblySharedBuffer();
-            if (impl && !view->byteOffset() && view->byteLength() == impl->byteLength()) {
-                auto* jsBuffer = view->possiblySharedJSBuffer(globalObject);
-                RETURN_IF_EXCEPTION(scope, {});
-                return jsBuffer;
-            }
-            auto copied = JSC::ArrayBuffer::tryCreate(view->span());
+        // Fetch's body-read builds arrayBuffer() as a fresh buffer over the concatenated
+        // bytes; never hand back the producer's own backing store.
+        std::span<const uint8_t> span;
+        bool isBinary = false;
+        if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
+            isBinary = true;
+            if (auto* impl = jsBuffer->impl(); impl && !impl->isDetached())
+                span = impl->span();
+        } else if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
+            isBinary = true;
+            if (!view->isDetached())
+                span = view->span();
+        }
+        if (isBinary) {
+            auto copied = JSC::ArrayBuffer::tryCreate(span);
             if (!copied) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 return {};
@@ -506,18 +511,26 @@ static JSValue convertChunksToBytes(JSGlobalObject* globalObject, JSValue chunks
     if (length == 1) {
         JSValue chunk = chunks->getIndex(globalObject, 0);
         RETURN_IF_EXCEPTION(scope, {});
-        if (auto* uint8 = dynamicDowncast<JSC::JSUint8Array>(chunk))
-            return uint8;
+        // Fetch's body-read builds bytes() as "create a Uint8Array from bytes" over a
+        // fresh buffer; never hand back or wrap the producer's own backing store.
+        std::span<const uint8_t> span;
+        bool isBinary = false;
         if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
-            size_t byteOffset = view->byteOffset();
-            size_t byteLength = view->byteLength();
-            RefPtr<JSC::ArrayBuffer> impl = view->possiblySharedBuffer();
-            RELEASE_AND_RETURN(scope, JSC::JSUint8Array::create(globalObject, structure, WTF::move(impl), byteOffset, byteLength));
+            isBinary = true;
+            if (!view->isDetached())
+                span = view->span();
+        } else if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
+            isBinary = true;
+            if (auto* impl = jsBuffer->impl(); impl && !impl->isDetached())
+                span = impl->span();
         }
-        if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
-            RefPtr<JSC::ArrayBuffer> impl = jsBuffer->impl();
-            size_t byteLength = impl ? impl->byteLength() : 0;
-            RELEASE_AND_RETURN(scope, JSC::JSUint8Array::create(globalObject, structure, WTF::move(impl), 0, byteLength));
+        if (isBinary) {
+            auto copied = JSC::ArrayBuffer::tryCreate(span);
+            if (!copied) [[unlikely]] {
+                throwOutOfMemoryError(globalObject, scope);
+                return {};
+            }
+            RELEASE_AND_RETURN(scope, JSC::JSUint8Array::create(globalObject, structure, WTF::move(copied), 0, span.size()));
         }
         if (chunk.isString())
             RELEASE_AND_RETURN(scope, encodeStringToUint8Array(vm, globalObject, chunk));

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -445,6 +445,21 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
     return JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(JSC::ArrayBufferSharingMode::Default), WTF::move(buffer));
 }
 
+static bool binaryChunkSpan(JSValue chunk, std::span<const uint8_t>& out)
+{
+    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
+        if (!view->isDetached())
+            out = view->span();
+        return true;
+    }
+    if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
+        if (auto* impl = jsBuffer->impl(); impl && !impl->isDetached())
+            out = impl->span();
+        return true;
+    }
+    return false;
+}
+
 // The toArrayBuffer chunk-array converter (RS:157-206).
 static JSValue convertChunksToArrayBuffer(JSGlobalObject* globalObject, JSValue chunksValue)
 {
@@ -468,17 +483,7 @@ static JSValue convertChunksToArrayBuffer(JSGlobalObject* globalObject, JSValue 
         JSValue chunk = chunks->getIndex(globalObject, 0);
         RETURN_IF_EXCEPTION(scope, {});
         std::span<const uint8_t> span;
-        bool isBinary = false;
-        if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
-            isBinary = true;
-            if (auto* impl = jsBuffer->impl(); impl && !impl->isDetached())
-                span = impl->span();
-        } else if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
-            isBinary = true;
-            if (!view->isDetached())
-                span = view->span();
-        }
-        if (isBinary) {
+        if (binaryChunkSpan(chunk, span)) {
             auto copied = JSC::ArrayBuffer::tryCreate(span);
             if (!copied) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
@@ -510,17 +515,7 @@ static JSValue convertChunksToBytes(JSGlobalObject* globalObject, JSValue chunks
         JSValue chunk = chunks->getIndex(globalObject, 0);
         RETURN_IF_EXCEPTION(scope, {});
         std::span<const uint8_t> span;
-        bool isBinary = false;
-        if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
-            isBinary = true;
-            if (!view->isDetached())
-                span = view->span();
-        } else if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
-            isBinary = true;
-            if (auto* impl = jsBuffer->impl(); impl && !impl->isDetached())
-                span = impl->span();
-        }
-        if (isBinary) {
+        if (binaryChunkSpan(chunk, span)) {
             auto copied = JSC::ArrayBuffer::tryCreate(span);
             if (!copied) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
@@ -563,17 +558,8 @@ static JSValue convertChunksToText(JSGlobalObject* globalObject, JSValue chunksV
                 return chunk;
             RELEASE_AND_RETURN(scope, jsString(vm, stripped));
         }
-        bool isBinary = false;
         std::span<const uint8_t> span;
-        if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
-            isBinary = true;
-            span = view->isDetached() ? std::span<const uint8_t> {} : view->span();
-        } else if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
-            isBinary = true;
-            if (auto* impl = jsBuffer->impl(); impl && !impl->isDetached())
-                span = impl->span();
-        }
-        if (isBinary) {
+        if (binaryChunkSpan(chunk, span)) {
             if (exceedsStringLimit(span.size())) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 return {};

--- a/test/js/web/fetch/stream-fast-path.test.ts
+++ b/test/js/web/fetch/stream-fast-path.test.ts
@@ -64,6 +64,18 @@ describe("single-chunk stream consumers return a fresh buffer", () => {
       expect(out).toEqual(new Uint8Array(new Float32Array([1.5]).buffer));
     });
 
+    test("subarray over a larger backing store copies only the view", async () => {
+      const backing = new Uint8Array(300).fill(0xee);
+      const view = backing.subarray(100, 200).fill(0x11);
+      const out = await consume(one(view));
+      expect(out.byteLength).toBe(100);
+      expect(out.buffer.byteLength).toBe(100);
+      expect(out.buffer).not.toBe(backing.buffer);
+      expect(out.every(x => x === 0x11)).toBe(true);
+      out[0] = 0;
+      expect(backing[100]).toBe(0x11);
+    });
+
     test("detached chunk yields a fresh empty result", async () => {
       const src = detached();
       const out = await consume(one(src));
@@ -122,6 +134,18 @@ describe("single-chunk stream consumers return a fresh buffer", () => {
       expect(out).toBeInstanceOf(ArrayBuffer);
       expect(out).not.toBe(src.buffer);
       expect(new Uint8Array(out)).toEqual(new Uint8Array(new Float32Array([1.5]).buffer));
+    });
+
+    test("subarray over a larger backing store copies only the view", async () => {
+      const backing = new Uint8Array(300).fill(0xee);
+      const view = backing.subarray(100, 200).fill(0x11);
+      const out = await consume(one(view));
+      expect(out).toBeInstanceOf(ArrayBuffer);
+      expect(out.byteLength).toBe(100);
+      expect(out).not.toBe(backing.buffer);
+      expect(new Uint8Array(out).every(x => x === 0x11)).toBe(true);
+      new Uint8Array(out)[0] = 0;
+      expect(backing[100]).toBe(0x11);
     });
 
     test("detached chunk yields a fresh empty result", async () => {

--- a/test/js/web/fetch/stream-fast-path.test.ts
+++ b/test/js/web/fetch/stream-fast-path.test.ts
@@ -1,5 +1,6 @@
 import { readableStreamToArrayBuffer, readableStreamToBlob, readableStreamToBytes, readableStreamToText } from "bun";
 import { describe, expect, test } from "bun:test";
+import { arrayBuffer as consumersArrayBuffer, bytes as consumersBytes } from "node:stream/consumers";
 
 // Fetch's body-read algorithms ("get a byte sequence … create a Uint8Array from
 // bytes" / "an ArrayBuffer whose contents are bytes") return fresh buffers. The
@@ -15,10 +16,17 @@ describe("single-chunk stream consumers return a fresh buffer", () => {
       },
     });
 
+  const detached = () => {
+    const buf = new Uint8Array([1, 2, 3]).buffer;
+    structuredClone(buf, { transfer: [buf] });
+    return buf;
+  };
+
   describe.each([
     ["Response.bytes()", (s: ReadableStream) => new Response(s).bytes()],
     ["Request.bytes()", (s: ReadableStream) => new Request("http://x", { method: "POST", body: s }).bytes()],
     ["Bun.readableStreamToBytes", (s: ReadableStream) => readableStreamToBytes(s)],
+    ["stream/consumers.bytes", (s: ReadableStream) => consumersBytes(s)],
   ] as const)("%s", (_, consume) => {
     test("Uint8Array chunk", async () => {
       const src = new Uint8Array([1, 2, 3]);
@@ -56,6 +64,14 @@ describe("single-chunk stream consumers return a fresh buffer", () => {
       expect(out).toEqual(new Uint8Array(new Float32Array([1.5]).buffer));
     });
 
+    test("detached chunk yields a fresh empty result", async () => {
+      const src = detached();
+      const out = await consume(one(src));
+      expect(out.buffer).not.toBe(src);
+      expect(out.byteLength).toBe(0);
+      expect(out.buffer.detached).toBe(false);
+    });
+
     test("transferring the result does not detach the producer", async () => {
       const src = new Uint8Array([1, 2, 3]);
       const out = await consume(one(src));
@@ -72,6 +88,7 @@ describe("single-chunk stream consumers return a fresh buffer", () => {
       (s: ReadableStream) => new Request("http://x", { method: "POST", body: s }).arrayBuffer(),
     ],
     ["Bun.readableStreamToArrayBuffer", (s: ReadableStream) => readableStreamToArrayBuffer(s)],
+    ["stream/consumers.arrayBuffer", (s: ReadableStream) => consumersArrayBuffer(s)],
   ] as const)("%s", (_, consume) => {
     test("Uint8Array chunk", async () => {
       const src = new Uint8Array([1, 2, 3]);
@@ -83,12 +100,37 @@ describe("single-chunk stream consumers return a fresh buffer", () => {
       expect(src[0]).toBe(1);
     });
 
+    test("Buffer chunk", async () => {
+      const src = Buffer.from([9, 8, 7]);
+      const out = await consume(one(src));
+      expect(out).toBeInstanceOf(ArrayBuffer);
+      expect(out).not.toBe(src.buffer);
+      expect([...new Uint8Array(out)]).toEqual([9, 8, 7]);
+    });
+
     test("ArrayBuffer chunk", async () => {
       const src = new Uint8Array([7, 7, 7]).buffer;
       const out = await consume(one(src));
       expect(out).toBeInstanceOf(ArrayBuffer);
       expect(out).not.toBe(src);
       expect([...new Uint8Array(out)]).toEqual([7, 7, 7]);
+    });
+
+    test("non-Uint8 view chunk", async () => {
+      const src = new Float32Array([1.5]);
+      const out = await consume(one(src));
+      expect(out).toBeInstanceOf(ArrayBuffer);
+      expect(out).not.toBe(src.buffer);
+      expect(new Uint8Array(out)).toEqual(new Uint8Array(new Float32Array([1.5]).buffer));
+    });
+
+    test("detached chunk yields a fresh empty result", async () => {
+      const src = detached();
+      const out = await consume(one(src));
+      expect(out).toBeInstanceOf(ArrayBuffer);
+      expect(out).not.toBe(src);
+      expect(out.byteLength).toBe(0);
+      expect((out as ArrayBuffer).detached).toBe(false);
     });
 
     test("transferring the result does not detach the producer", async () => {

--- a/test/js/web/fetch/stream-fast-path.test.ts
+++ b/test/js/web/fetch/stream-fast-path.test.ts
@@ -67,7 +67,10 @@ describe("single-chunk stream consumers return a fresh buffer", () => {
 
   describe.each([
     ["Response.arrayBuffer()", (s: ReadableStream) => new Response(s).arrayBuffer()],
-    ["Request.arrayBuffer()", (s: ReadableStream) => new Request("http://x", { method: "POST", body: s }).arrayBuffer()],
+    [
+      "Request.arrayBuffer()",
+      (s: ReadableStream) => new Request("http://x", { method: "POST", body: s }).arrayBuffer(),
+    ],
     ["Bun.readableStreamToArrayBuffer", (s: ReadableStream) => readableStreamToArrayBuffer(s)],
   ] as const)("%s", (_, consume) => {
     test("Uint8Array chunk", async () => {
@@ -113,7 +116,6 @@ describe("single-chunk stream consumers return a fresh buffer", () => {
     expect(src[0]).toBe(5);
   });
 });
-
 
 describe("ByteBlobLoader", () => {
   const blobs = [

--- a/test/js/web/fetch/stream-fast-path.test.ts
+++ b/test/js/web/fetch/stream-fast-path.test.ts
@@ -1,6 +1,120 @@
 import { readableStreamToArrayBuffer, readableStreamToBlob, readableStreamToBytes, readableStreamToText } from "bun";
 import { describe, expect, test } from "bun:test";
 
+// Fetch's body-read algorithms ("get a byte sequence … create a Uint8Array from
+// bytes" / "an ArrayBuffer whose contents are bytes") return fresh buffers. The
+// single-chunk fast path used to hand back the producer's own backing store, so
+// mutating/transferring the result aliased the producer. Multi-chunk paths have
+// always copied; every single-chunk binary shape must too.
+describe("single-chunk stream consumers return a fresh buffer", () => {
+  const one = <T>(chunk: T) =>
+    new ReadableStream<T>({
+      start(c) {
+        c.enqueue(chunk);
+        c.close();
+      },
+    });
+
+  describe.each([
+    ["Response.bytes()", (s: ReadableStream) => new Response(s).bytes()],
+    ["Request.bytes()", (s: ReadableStream) => new Request("http://x", { method: "POST", body: s }).bytes()],
+    ["Bun.readableStreamToBytes", (s: ReadableStream) => readableStreamToBytes(s)],
+  ] as const)("%s", (_, consume) => {
+    test("Uint8Array chunk", async () => {
+      const src = new Uint8Array([1, 2, 3]);
+      const out = await consume(one(src));
+      expect(out).not.toBe(src);
+      expect(out.buffer).not.toBe(src.buffer);
+      expect(Object.getPrototypeOf(out)).toBe(Uint8Array.prototype);
+      expect([...out]).toEqual([1, 2, 3]);
+      out[0] = 42;
+      expect(src[0]).toBe(1);
+    });
+
+    test("Buffer chunk yields a plain Uint8Array copy", async () => {
+      const src = Buffer.from([9, 8, 7]);
+      const out = await consume(one(src));
+      expect(out).not.toBe(src);
+      expect(out.buffer).not.toBe(src.buffer);
+      expect(Object.getPrototypeOf(out)).toBe(Uint8Array.prototype);
+      expect([...out]).toEqual([9, 8, 7]);
+    });
+
+    test("ArrayBuffer chunk", async () => {
+      const src = new Uint8Array([4, 5, 6]).buffer;
+      const out = await consume(one(src));
+      expect(out.buffer).not.toBe(src);
+      expect([...out]).toEqual([4, 5, 6]);
+      out[0] = 0;
+      expect(new Uint8Array(src)[0]).toBe(4);
+    });
+
+    test("non-Uint8 view chunk", async () => {
+      const src = new Float32Array([1.5]);
+      const out = await consume(one(src));
+      expect(out.buffer).not.toBe(src.buffer);
+      expect(out).toEqual(new Uint8Array(new Float32Array([1.5]).buffer));
+    });
+
+    test("transferring the result does not detach the producer", async () => {
+      const src = new Uint8Array([1, 2, 3]);
+      const out = await consume(one(src));
+      structuredClone(out.buffer, { transfer: [out.buffer] });
+      expect(src.byteLength).toBe(3);
+      expect([...src]).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe.each([
+    ["Response.arrayBuffer()", (s: ReadableStream) => new Response(s).arrayBuffer()],
+    ["Request.arrayBuffer()", (s: ReadableStream) => new Request("http://x", { method: "POST", body: s }).arrayBuffer()],
+    ["Bun.readableStreamToArrayBuffer", (s: ReadableStream) => readableStreamToArrayBuffer(s)],
+  ] as const)("%s", (_, consume) => {
+    test("Uint8Array chunk", async () => {
+      const src = new Uint8Array([1, 2, 3]);
+      const out = await consume(one(src));
+      expect(out).toBeInstanceOf(ArrayBuffer);
+      expect(out).not.toBe(src.buffer);
+      expect([...new Uint8Array(out)]).toEqual([1, 2, 3]);
+      new Uint8Array(out)[0] = 42;
+      expect(src[0]).toBe(1);
+    });
+
+    test("ArrayBuffer chunk", async () => {
+      const src = new Uint8Array([7, 7, 7]).buffer;
+      const out = await consume(one(src));
+      expect(out).toBeInstanceOf(ArrayBuffer);
+      expect(out).not.toBe(src);
+      expect([...new Uint8Array(out)]).toEqual([7, 7, 7]);
+    });
+
+    test("transferring the result does not detach the producer", async () => {
+      const src = new Uint8Array([1, 2, 3]);
+      const out = await consume(one(src));
+      structuredClone(out, { transfer: [out] });
+      expect(src.byteLength).toBe(3);
+      expect(src.buffer.byteLength).toBe(3);
+    });
+  });
+
+  test("async single-chunk stream copies too", async () => {
+    const src = new Uint8Array([5, 6, 7]);
+    const stream = new ReadableStream({
+      async start(c) {
+        await Promise.resolve();
+        c.enqueue(src);
+        c.close();
+      },
+    });
+    const out = await new Response(stream).bytes();
+    expect(out).not.toBe(src);
+    expect(out.buffer).not.toBe(src.buffer);
+    out[0] = 0;
+    expect(src[0]).toBe(5);
+  });
+});
+
+
 describe("ByteBlobLoader", () => {
   const blobs = [
     ["Empty", new Blob()],


### PR DESCRIPTION
## What

`convertChunksToBytes` / `convertChunksToArrayBuffer` had a `length == 1` fast path that returned the producer's own `Uint8Array` (or its backing `ArrayBuffer`) by identity. Mutating or transferring the result aliased the producer's live buffer, and whether that happened depended on how many chunks the stream emitted: the multi-chunk path (via `concatenateChunks` / `flattenArrayOfBuffersIntoArrayBufferOrUint8Array`) already copies.

```js
const u = new Uint8Array([1, 2, 3]);
const b = await new Response(new ReadableStream({ start(c) { c.enqueue(u); c.close(); } })).bytes();
b === u                 // true  -> now false
b[0] = 42; u[0]         // 42    -> now 1

const ab = await new Response(new ReadableStream({ start(c) { c.enqueue(u); c.close(); } })).arrayBuffer();
structuredClone(ab, { transfer: [ab] });
u.byteLength            // 0 (producer's buffer detached) -> now 3
```

Reaches `Response#bytes`/`arrayBuffer`, `Request#bytes`/`arrayBuffer`, `Bun.readableStreamToBytes`/`ToArrayBuffer`, and `node:stream/consumers` (which delegates to the Bun helpers).

## Fix

Keep the single-chunk fast path for the single allocation it saves over the general concatenator, but allocate a fresh `ArrayBuffer` over the chunk's span in both arms. A detached chunk contributes an empty span, matching `concatenateChunks`' sizing.

This also makes `bytes()` on a single `Buffer` or `Float32Array` chunk return a plain `Uint8Array` instead of the enqueued subclass/view wrapped over the producer's store.

## Spec / other runtimes

Fetch builds `bytes()` as "create a `Uint8Array` from *bytes*" and `arrayBuffer()` as "a new `ArrayBuffer` whose contents are *bytes*", i.e. fresh buffers.

Checked node v26.3.0 and deno 2.9.4 across `Response`/`Request` `.bytes()`/`.arrayBuffer()` with a single `Uint8Array`/`ArrayBuffer`/`Float32Array`/`Buffer` chunk, `node:stream/consumers.{arrayBuffer,buffer,bytes}`, and `Blob` round-trips: every path copies. Undici's `readAllBytes` does `Buffer.concat(chunks, total)` which always allocates even for one element; node's `stream/consumers.arrayBuffer` routes through `new Blob(chunks).arrayBuffer()`. Both node and deno reject non-`Uint8Array` chunks in the body-read path with a `TypeError`; Bun keeps accepting them (unchanged here).

`reader.read()` and `Bun.readableStreamToArray` still return the enqueued value as-is, per spec.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/web/fetch/stream-fast-path.test.ts   # 25 of the new tests fail
bun bd test test/js/web/fetch/stream-fast-path.test.ts                 # 43 pass
```

Also ran `body.test.ts`, `body-clone.test.ts`, `body-stream.test.ts`, `body-mixin-errors.test.ts`, `readablestreamtoarraybuffer.test.ts`, `direct-readable-stream.test.tsx`, and node's `parallel/test-stream-consumers.js`: all green.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 53 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/stream-fast-path.test.ts
bun test v1.4.0 (75a8df052)

test/js/web/fetch/stream-fast-path.test.ts:
29 |     ["stream/consumers.bytes", (s: ReadableStream) => consumersBytes(s)],
30 |   ] as const)("%s", (_, consume) => {
31 |     test("Uint8Array chunk", async () => {
32 |       const src = new Uint8Array([1, 2, 3]);
33 |       const out = await consume(one(src));
34 |       expect(out).not.toBe(src);
                           ^
error: expect(received).not.toBe(expected)

Expected: not Uint8Array(3) [ 1, 2, 3 ]

      at <anonymous> (/workspace/bun/test/js/web/fetch/stream-fast-path.test.ts:34:23)
(fail) single-chunk stream consumers return a fresh buffer > Response.bytes() > Uint8Array chunk [20.86ms]
40 |     });
41 | 
42 |     test("Buffer chunk yields a plain Uint8Array copy", async () => {
43 |       const src = Buffer.from([9, 8, 7]);
44 |       const out = await consume(one(src));
45 |       expect(out).not.toBe(src);
                           ^
error: expect(received).not.toBe(expected)

Expected: not <Buffer
... (truncated)

release without fix: 53 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/fetch/stream-fast-path.test.ts:
29 |     ["stream/consumers.bytes", (s: ReadableStream) => consumersBytes(s)],
30 |   ] as const)("%s", (_, consume) => {
31 |     test("Uint8Array chunk", async () => {
32 |       const src = new Uint8Array([1, 2, 3]);
33 |       const out = await consume(one(src));
34 |       expect(out).not.toBe(src);
                           ^
error: expect(received).not.toBe(expected)

Expected: not Uint8Array(3) [ 1, 2, 3 ]

      at <anonymous> (/workspace/bun/test/js/web/fetch/stream-fast-path.test.ts:34:23)
(fail) single-chunk stream consumers return a fresh buffer > Response.bytes() > Uint8Array chunk [1.93ms]
40 |     });
41 | 
42 |     test("Buffer chunk yields a plain Uint8Array copy", async () => {
43 |       const src = Buffer.from([9, 8, 7]);
44 |       const out = await consume(one(src));
45 |       expect(out).not.toBe(src);
                           ^
error: expect(received).not.toBe(expected)

Expected: not 

      at <anonymous> (/workspace/bun/test/js/web/fetch/stream-fast-path.test.ts:45:23)
(fail) single-chunk stream consumers return a fresh buffer > Response.bytes() > Buffer
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/stream-fast-path.test.ts
bun test v1.4.0 (75a8df052)

test/js/web/fetch/stream-fast-path.test.ts:
(pass) single-chunk stream consumers return a fresh buffer > Response.bytes() > Uint8Array chunk [24.82ms]
(pass) single-chunk stream consumers return a fresh buffer > Response.bytes() > Buffer chunk yields a plain Uint8Array copy [7.24ms]
(pass) single-chunk stream consumers return a fresh buffer > Response.bytes() > ArrayBuffer chunk [6.00ms]
(pass) single-chunk stream consumers return a fresh buffer > Response.bytes() > non-Uint8 view chunk [5.60ms]
(pass) single-chunk stream consumers return a fresh buffer > Response.bytes() > subarray over a larger backing store copies only the view [9.56ms]
(pass) single-chunk stream consumers return a fresh buffer > Response.bytes() > detached chunk yields a fresh empty result [7.28ms]
(pass) single-chunk stream consumers return a fresh buffer > Response.bytes() > transferring the result does not detach the producer [5.79ms]
(pass) single-chunk stream consumers return a fresh buffe
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     75a8df052f
  features     baseline

22 deps, 108 codegen, 1171 objects in 680ms

ninja: Entering directory `/workspace/bun/build/release'
[1/146] gen ErrorCode+*.h
[2/146] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[3/146] fetch mimalloc
[mimalloc] up to date
[4/146] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindings/webcore/JSEvent.cpp
[5/146] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[6/146] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[7/146] gen cpp.rs (cppbind)
[8/146] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 6 sinks, 72 exported symbols
Generating /workspace/bun/build/release/codegen/JSSink.lut.h from /workspace/bun/build/release/codegen/JSSink.lut.txt
[9/146] cc obj/vendor/mimalloc/src/stati
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../webcore/streams/BunStreamConsumers.cpp         |  59 +++----
 test/js/web/fetch/stream-fast-path.test.ts         | 182 +++++++++++++++++++++
 2 files changed, 209 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp      7      9      0
test/js/web/fetch/stream-fast-path.test.ts                   3      6      0
```

</details>

<!-- robobun:evidence:end -->