### PR TITLE
MessagePort: pin the entangled peer while a side holds a loop ref

### DIFF
--- a/src/jsc/bindings/webcore/JSMessagePort.cpp
+++ b/src/jsc/bindings/webcore/JSMessagePort.cpp
@@ -198,9 +198,8 @@ static inline bool setJSMessagePort_onmessageSetter(JSGlobalObject& lexicalGloba
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     UNUSED_PARAM(vm);
-    // The listener-count loop-ref (onDidChangeListener → updateListenerEventLoopRef)
-    // tracks this handler via setEventHandlerAttribute's add/remove, so no separate
-    // jsRef() here: a second unbalanced keepalive made `onmessage = null` stick.
+    // No jsRef(): onDidChangeListener already tracks this handler's loop ref, and the
+    // second unbalanced keepalive made `onmessage = null` stick.
     setEventHandlerAttribute<JSEventListener>(thisObject.wrapped(), eventNames().messageEvent, value, thisObject);
     vm.writeBarrier(&thisObject, value);
     ensureStillAliveHere(value);
@@ -228,8 +227,7 @@ static inline bool setJSMessagePort_onmessageerrorSetter(JSGlobalObject& lexical
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     UNUSED_PARAM(vm);
-    // Node only refs the event loop for 'message' listeners; a messageerror
-    // handler alone must not keep the process alive.
+    // No jsRef(): node never refs the loop for a messageerror handler.
     setEventHandlerAttribute<JSEventListener>(thisObject.wrapped(), eventNames().messageerrorEvent, value, thisObject);
     vm.writeBarrier(&thisObject, value);
     ensureStillAliveHere(value);

--- a/src/jsc/bindings/webcore/JSMessagePort.cpp
+++ b/src/jsc/bindings/webcore/JSMessagePort.cpp
@@ -198,11 +198,12 @@ static inline bool setJSMessagePort_onmessageSetter(JSGlobalObject& lexicalGloba
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     UNUSED_PARAM(vm);
+    // The listener-count loop-ref (onDidChangeListener → updateListenerEventLoopRef)
+    // tracks this handler via setEventHandlerAttribute's add/remove, so no separate
+    // jsRef() here: a second unbalanced keepalive made `onmessage = null` stick.
     setEventHandlerAttribute<JSEventListener>(thisObject.wrapped(), eventNames().messageEvent, value, thisObject);
     vm.writeBarrier(&thisObject, value);
     ensureStillAliveHere(value);
-
-    thisObject.wrapped().jsRef(&lexicalGlobalObject);
 
     return true;
 }
@@ -227,11 +228,11 @@ static inline bool setJSMessagePort_onmessageerrorSetter(JSGlobalObject& lexical
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     UNUSED_PARAM(vm);
+    // Node only refs the event loop for 'message' listeners; a messageerror
+    // handler alone must not keep the process alive.
     setEventHandlerAttribute<JSEventListener>(thisObject.wrapped(), eventNames().messageerrorEvent, value, thisObject);
     vm.writeBarrier(&thisObject, value);
     ensureStillAliveHere(value);
-
-    thisObject.wrapped().jsRef(&lexicalGlobalObject);
 
     return true;
 }

--- a/src/jsc/bindings/webcore/JSMessagePort.cpp
+++ b/src/jsc/bindings/webcore/JSMessagePort.cpp
@@ -198,9 +198,11 @@ static inline bool setJSMessagePort_onmessageSetter(JSGlobalObject& lexicalGloba
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     UNUSED_PARAM(vm);
-    // No jsRef(): onDidChangeListener already tracks this handler's loop ref, and the
-    // second unbalanced keepalive made `onmessage = null` stick.
     setEventHandlerAttribute<JSEventListener>(thisObject.wrapped(), eventNames().messageEvent, value, thisObject);
+    // setEventHandlerAttribute's in-place replace path never fires onDidChangeListener,
+    // so re-ref here too (node's defineEventHandler fires [kNewListener] on replace).
+    if (value.isObject())
+        thisObject.wrapped().refFromMessageListener();
     vm.writeBarrier(&thisObject, value);
     ensureStillAliveHere(value);
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -67,8 +67,26 @@ MessagePort::MessagePort(ScriptExecutionContext& context, Ref<MessagePortPipe>&&
 
 MessagePort::~MessagePort()
 {
-    if (!m_isDetached)
-        m_pipe->close(m_side, MessagePortPipe::CloseKind::Collected);
+    if (m_isDetached)
+        return;
+    // A peer holding its event loop open is waiting on this side. Node would never
+    // destroy an entangled port, so a Collected close delivering peerClosed() here is
+    // the GC making a keep-alive decision. Leave this side's pipe state untouched so
+    // the peer stays pinned via isOtherSideOpen() until it unrefs/closes.
+    //
+    // During VM teardown (markTerminating() precedes the lastChanceToFinalize sweep
+    // that reaches this destructor) the context is going away and nothing else will
+    // ever notify the peer, so close explicitly as contextDestroyed() would have.
+    // A wrapper pinned by hasPendingActivity() is only swept at teardown, so "not
+    // terminating && peer waiting" is exactly the no-wrapper/normal-GC case.
+    if (m_pipe->otherSideHoldsLoopRef(m_side)) {
+        auto* context = scriptExecutionContext();
+        if (!context || !context->isTerminating())
+            return;
+        m_pipe->close(m_side, MessagePortPipe::CloseKind::Explicit);
+        return;
+    }
+    m_pipe->close(m_side, MessagePortPipe::CloseKind::Collected);
 }
 
 ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
@@ -422,6 +440,14 @@ bool MessagePort::hasPendingActivity() const
     // the context dies; node retains more — it never collects an entangled port at all.
     if (m_hasCloseEventListener.load(std::memory_order_acquire) && !m_closeEventDispatched)
         return true;
+    // The peer is holding its event loop open waiting on this port (message listener
+    // while ref'd, or an explicit .ref()). Collecting this wrapper would fire a
+    // GC-timed 'close' on that peer and release its loop ref via peerClosed(), so a
+    // thread kept alive only by that port exits. Node never collects an entangled
+    // port; pin this side only while the peer actually holds a ref, so a channel
+    // with neither side listening is still collectible.
+    if (m_pipe->otherSideHoldsLoopRef(m_side))
+        return true;
     if (!m_hasMessageEventListener)
         return false;
 
@@ -479,16 +505,20 @@ Vector<RefPtr<MessagePort>> MessagePort::entanglePorts(ScriptExecutionContext& c
 void MessagePort::updateListenerEventLoopRef()
 {
     bool shouldHold = m_isRefd && m_messageEventCount > 0;
-    if (shouldHold == m_listenerLoopRefActive)
-        return;
-    auto* context = scriptExecutionContext();
-    if (!context)
-        return;
-    if (shouldHold)
-        context->refEventLoop();
-    else
-        context->unrefEventLoop();
-    m_listenerLoopRefActive = shouldHold;
+    if (shouldHold != m_listenerLoopRefActive) {
+        auto* context = scriptExecutionContext();
+        if (!context)
+            return;
+        if (shouldHold)
+            context->refEventLoop();
+        else
+            context->unrefEventLoop();
+        m_listenerLoopRefActive = shouldHold;
+    }
+    // Publish the combined loop-ref state to the pipe so the entangled wrapper's
+    // hasPendingActivity() can pin itself while this side is waiting on it.
+    if (!m_isDetached)
+        m_pipe->setHoldsLoopRef(m_side, m_listenerLoopRefActive || m_hasRef);
 }
 
 void MessagePort::onDidChangeListenerImpl(EventTarget& self, const AtomString& eventType, OnDidChangeListenerKind kind)
@@ -564,31 +594,30 @@ void MessagePort::jsRef(JSGlobalObject* lexicalGlobalObject)
         return;
 
     // Re-acquire the message-listener loop-ref (if a listener is present) that .unref() released.
-    if (!m_isRefd) {
+    if (!m_isRefd)
         m_isRefd = true;
-        updateListenerEventLoopRef();
-    }
 
     if (!m_hasRef) {
         m_hasRef = true;
         ref();
         Bun__eventLoop__incrementRefConcurrently(WebCore::clientData(lexicalGlobalObject->vm())->bunVM, 1);
     }
+    // After both flags are settled so the pipe's HoldsLoopRef reflects the union.
+    updateListenerEventLoopRef();
 }
 
 void MessagePort::jsUnref(JSGlobalObject* lexicalGlobalObject)
 {
     // Also release the listener loop-ref; otherwise an always-listening transferred
     // port (a postMessageToThread control port) would pin the event loop forever.
-    if (m_isRefd) {
+    if (m_isRefd)
         m_isRefd = false;
-        updateListenerEventLoopRef();
-    }
     if (m_hasRef) {
         m_hasRef = false;
         deref();
         Bun__eventLoop__incrementRefConcurrently(WebCore::clientData(lexicalGlobalObject->vm())->bunVM, -1);
     }
+    updateListenerEventLoopRef();
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -69,16 +69,10 @@ MessagePort::~MessagePort()
 {
     if (m_isDetached)
         return;
-    // A peer holding its event loop open is waiting on this side. Node would never
-    // destroy an entangled port, so a Collected close delivering peerClosed() here is
-    // the GC making a keep-alive decision. Leave this side's pipe state untouched so
-    // the peer stays pinned via isOtherSideOpen() until it unrefs/closes.
-    //
-    // During VM teardown (markTerminating() precedes the lastChanceToFinalize sweep
-    // that reaches this destructor) the context is going away and nothing else will
-    // ever notify the peer, so close explicitly as contextDestroyed() would have.
-    // A wrapper pinned by hasPendingActivity() is only swept at teardown, so "not
-    // terminating && peer waiting" is exactly the no-wrapper/normal-GC case.
+    // A waiting peer (HoldsLoopRef) must not be closed at GC timing — node never
+    // destroys an entangled port — except during VM teardown, where nothing else
+    // will ever notify it (markTerminating() precedes the sweep that reaches here,
+    // and hasPendingActivity() pins the wrapper otherwise).
     if (m_pipe->otherSideHoldsLoopRef(m_side)) {
         auto* context = scriptExecutionContext();
         if (!context || !context->isTerminating())
@@ -440,12 +434,8 @@ bool MessagePort::hasPendingActivity() const
     // the context dies; node retains more — it never collects an entangled port at all.
     if (m_hasCloseEventListener.load(std::memory_order_acquire) && !m_closeEventDispatched)
         return true;
-    // The peer is holding its event loop open waiting on this port (message listener
-    // while ref'd, or an explicit .ref()). Collecting this wrapper would fire a
-    // GC-timed 'close' on that peer and release its loop ref via peerClosed(), so a
-    // thread kept alive only by that port exits. Node never collects an entangled
-    // port; pin this side only while the peer actually holds a ref, so a channel
-    // with neither side listening is still collectible.
+    // The peer is waiting on this side (see MessagePortPipe::HoldsLoopRef); collecting
+    // here would peerClosed() it and release that loop ref at GC timing.
     if (m_pipe->otherSideHoldsLoopRef(m_side))
         return true;
     if (!m_hasMessageEventListener)
@@ -515,8 +505,7 @@ void MessagePort::updateListenerEventLoopRef()
             context->unrefEventLoop();
         m_listenerLoopRefActive = shouldHold;
     }
-    // Publish the combined loop-ref state to the pipe so the entangled wrapper's
-    // hasPendingActivity() can pin itself while this side is waiting on it.
+    // Publish jsHasRef() to the pipe so the peer's hasPendingActivity() can pin itself.
     if (!m_isDetached)
         m_pipe->setHoldsLoopRef(m_side, m_listenerLoopRefActive || m_hasRef);
 }
@@ -593,16 +582,13 @@ void MessagePort::jsRef(JSGlobalObject* lexicalGlobalObject)
     if (!isEntangled() || m_pipe->isOtherSideClosedByRequest(m_side))
         return;
 
-    // Re-acquire the message-listener loop-ref (if a listener is present) that .unref() released.
-    if (!m_isRefd)
-        m_isRefd = true;
-
+    m_isRefd = true;
     if (!m_hasRef) {
         m_hasRef = true;
         ref();
         Bun__eventLoop__incrementRefConcurrently(WebCore::clientData(lexicalGlobalObject->vm())->bunVM, 1);
     }
-    // After both flags are settled so the pipe's HoldsLoopRef reflects the union.
+    // After both flags settle so the listener ref and the pipe's HoldsLoopRef agree.
     updateListenerEventLoopRef();
 }
 
@@ -610,8 +596,7 @@ void MessagePort::jsUnref(JSGlobalObject* lexicalGlobalObject)
 {
     // Also release the listener loop-ref; otherwise an always-listening transferred
     // port (a postMessageToThread control port) would pin the event loop forever.
-    if (m_isRefd)
-        m_isRefd = false;
+    m_isRefd = false;
     if (m_hasRef) {
         m_hasRef = false;
         deref();

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -69,6 +69,13 @@ MessagePort::~MessagePort()
 {
     if (m_isDetached)
         return;
+    // The wrapper was swept before any pending peerClosed() could jsUnref(): balance
+    // the refEventLoop() taken by the listener so it isn't leaked.
+    if (m_listenerLoopRefActive) {
+        m_listenerLoopRefActive = false;
+        if (auto* context = scriptExecutionContext())
+            context->unrefEventLoop();
+    }
     // A waiting peer (HoldsLoopRef) must not be closed at GC timing — node never
     // destroys an entangled port — except during VM teardown, where nothing else
     // will ever notify it (markTerminating() precedes the sweep that reaches here,

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -593,6 +593,8 @@ void MessagePort::jsRef(JSGlobalObject* lexicalGlobalObject)
 
 void MessagePort::jsUnref(JSGlobalObject* lexicalGlobalObject)
 {
+    // deref() below releases the self-ref taken by jsRef(); keep `this` alive past it.
+    Ref protectedThis { *this };
     // Also release the listener loop-ref; otherwise an always-listening transferred
     // port (a postMessageToThread control port) would pin the event loop forever.
     m_isRefd = false;

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -496,14 +496,13 @@ void MessagePort::updateListenerEventLoopRef()
 {
     bool shouldHold = m_isRefd && m_messageEventCount > 0;
     if (shouldHold != m_listenerLoopRefActive) {
-        auto* context = scriptExecutionContext();
-        if (!context)
-            return;
-        if (shouldHold)
-            context->refEventLoop();
-        else
-            context->unrefEventLoop();
-        m_listenerLoopRefActive = shouldHold;
+        if (auto* context = scriptExecutionContext()) {
+            if (shouldHold)
+                context->refEventLoop();
+            else
+                context->unrefEventLoop();
+            m_listenerLoopRefActive = shouldHold;
+        }
     }
     // Publish jsHasRef() to the pipe so the peer's hasPendingActivity() can pin itself.
     if (!m_isDetached)

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -230,13 +230,12 @@ void MessagePort::close()
     // it in hasPendingActivity()); marking our side Closed is sufficient.
     m_pipe->close(m_side, MessagePortPipe::CloseKind::Explicit);
 
-    // Release the self-reference taken by jsRef() (set when .onmessage is
-    // assigned or .ref() is called from JS). The JS .close() binding calls
-    // jsUnref() first, so m_hasRef is already false on that path; we only
-    // reach this branch when close() runs without a preceding jsUnref() —
-    // most importantly from contextDestroyed() during Worker teardown.
-    // Without this, the self-ref pins the MessagePort past the JS wrapper
-    // sweep and it leaks forever.
+    // Release the self-reference taken by jsRef() (set when .ref() is called
+    // from JS). The JS .close() binding calls jsUnref() first, so m_hasRef is
+    // already false on that path; we only reach this branch when close() runs
+    // without a preceding jsUnref() — most importantly from contextDestroyed()
+    // during Worker teardown. Without this, the self-ref pins the MessagePort
+    // past the JS wrapper sweep and it leaks forever.
     if (m_hasRef) {
         m_hasRef = false;
         if (auto* context = scriptExecutionContext())
@@ -303,8 +302,8 @@ void MessagePort::peerClosed()
     // Fire 'close' (guarded against a double dispatch) and release this side's loop refs
     // so the loop can idle, matching node.
     dispatchCloseEvent();
-    // jsUnref() clears both the listener loop-ref (m_isRefd) and the onmessage/ref()
-    // keepalive (m_hasRef), so a listening transferred port stops pinning the loop.
+    // jsUnref() clears both the listener loop-ref (m_isRefd) and the explicit
+    // .ref() keepalive (m_hasRef), so a listening transferred port stops pinning the loop.
     auto* globalObject = defaultGlobalObject(context->globalObject());
     jsUnref(globalObject);
 }
@@ -525,6 +524,12 @@ void MessagePort::onDidChangeListenerImpl(EventTarget& self, const AtomString& e
     switch (kind) {
     case Add:
         port.m_messageEventCount++;
+        // Node's [kNewListener] hook calls this.ref() on every 'message' listener
+        // add, so a listener installed after .unref() re-refs on every path.
+        // Gated like jsRef(): once the peer has explicitly closed, node's ref()
+        // is a no-op on the already-closed handle.
+        if (!port.m_isDetached && !port.m_pipe->isOtherSideClosedByRequest(port.m_side))
+            port.m_isRefd = true;
         break;
     case Remove:
         if (port.m_messageEventCount > 0)
@@ -582,9 +587,9 @@ void MessagePort::jsRef(JSGlobalObject* lexicalGlobalObject)
     // close()/disentangle() have already run and nothing will ever release a
     // ref taken afterwards. Same once the peer has closed: peerClosed() already
     // ran jsUnref(), and nothing releases a ref re-taken after it, so `.ref()`
-    // or a late `onmessage =` would pin the loop forever. Node no-ops both.
-    // Only an explicit peer close counts: node never closes a channel because a
-    // port was collected, so keying on Closed alone made this GC-dependent.
+    // would pin the loop forever. Node no-ops it. Only an explicit peer close
+    // counts: node never closes a channel because a port was collected, so
+    // keying on Closed alone made this GC-dependent.
     if (!isEntangled() || m_pipe->isOtherSideClosedByRequest(m_side))
         return;
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -515,12 +515,12 @@ void MessagePort::updateListenerEventLoopRef()
         m_pipe->setHoldsLoopRef(m_side, m_listenerLoopRefActive || m_hasRef);
 }
 
-// Node's [kNewListener] hook calls this.ref() on every 'message' listener install
-// (including an onmessage replace), so .unref() before a listener is undone. Gated
-// like jsRef(): on an already-closed handle node's ref() is a no-op.
+// Node's [kNewListener] hook calls newListener(size-1), which refs only on the
+// 0→1 transition (size==1 here). Gated like jsRef(): on an already-closed handle
+// node's ref() is a no-op.
 void MessagePort::refFromMessageListener()
 {
-    if (m_isDetached || m_pipe->isOtherSideClosedByRequest(m_side))
+    if (m_messageEventCount != 1 || m_isDetached || m_pipe->isOtherSideClosedByRequest(m_side))
         return;
     m_isRefd = true;
     updateListenerEventLoopRef();

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -515,6 +515,17 @@ void MessagePort::updateListenerEventLoopRef()
         m_pipe->setHoldsLoopRef(m_side, m_listenerLoopRefActive || m_hasRef);
 }
 
+// Node's [kNewListener] hook calls this.ref() on every 'message' listener install
+// (including an onmessage replace), so .unref() before a listener is undone. Gated
+// like jsRef(): on an already-closed handle node's ref() is a no-op.
+void MessagePort::refFromMessageListener()
+{
+    if (m_isDetached || m_pipe->isOtherSideClosedByRequest(m_side))
+        return;
+    m_isRefd = true;
+    updateListenerEventLoopRef();
+}
+
 void MessagePort::onDidChangeListenerImpl(EventTarget& self, const AtomString& eventType, OnDidChangeListenerKind kind)
 {
     if (eventType != eventNames().messageEvent)
@@ -524,12 +535,7 @@ void MessagePort::onDidChangeListenerImpl(EventTarget& self, const AtomString& e
     switch (kind) {
     case Add:
         port.m_messageEventCount++;
-        // Node's [kNewListener] hook calls this.ref() on every 'message' listener
-        // add, so a listener installed after .unref() re-refs on every path.
-        // Gated like jsRef(): once the peer has explicitly closed, node's ref()
-        // is a no-op on the already-closed handle.
-        if (!port.m_isDetached && !port.m_pipe->isOtherSideClosedByRequest(port.m_side))
-            port.m_isRefd = true;
+        port.refFromMessageListener();
         break;
     case Remove:
         if (port.m_messageEventCount > 0)

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -112,6 +112,9 @@ public:
 
     void jsRef(JSGlobalObject*);
     void jsUnref(JSGlobalObject*);
+    // Node's [kNewListener] re-ref on every 'message' listener install, including
+    // the onmessage-replace path which never reaches onDidChangeListener.
+    void refFromMessageListener();
     // Report the actual loop-ref state (matches Node's uv_has_ref), not the intent flag.
     bool jsHasRef() { return m_hasRef || m_listenerLoopRefActive; }
 

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -112,8 +112,8 @@ public:
 
     void jsRef(JSGlobalObject*);
     void jsUnref(JSGlobalObject*);
-    // Node's [kNewListener] re-ref on every 'message' listener install, including
-    // the onmessage-replace path which never reaches onDidChangeListener.
+    // Node's [kNewListener] re-ref on the 0→1 'message' listener transition,
+    // including the onmessage-replace path which never reaches onDidChangeListener.
     void refFromMessageListener();
     // Report the actual loop-ref state (matches Node's uv_has_ref), not the intent flag.
     bool jsHasRef() { return m_hasRef || m_listenerLoopRefActive; }

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -158,7 +158,7 @@ private:
     bool m_hasRef { false };
 
     // Whether .ref()/.unref() want this port to keep the loop alive (default refd);
-    // independent of m_hasRef (the .onmessage=/.ref() keepalive).
+    // independent of m_hasRef (the explicit .ref() keepalive).
     bool m_isRefd { true };
     // Whether the message-listener mechanism currently holds an event-loop ref
     // (held iff m_isRefd && m_messageEventCount > 0).

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -252,7 +252,26 @@ void MessagePortPipe::detach(uint8_t side)
     // drainAndDispatch()'s s.ctxId != expectedCtx check makes it a no-op —
     // even if a new owner attach()es to a different context before it runs.
     // Messages remain queued for the next owner.
-    s.state.fetch_and(~uint64_t(Attached | ContextKnown | DrainScheduled), std::memory_order_acq_rel);
+    s.state.fetch_and(~uint64_t(Attached | ContextKnown | DrainScheduled | HoldsLoopRef), std::memory_order_acq_rel);
+}
+
+void MessagePortPipe::setHoldsLoopRef(uint8_t side, bool value)
+{
+    ASSERT(side < 2);
+    auto& s = m_sides[side];
+    // Cheap unlocked probe: only the owning port's thread flips this bit, so a
+    // matching read means no transition is needed and we skip the lock.
+    uint64_t st = s.state.load(std::memory_order_acquire);
+    if ((st & Closed) || !!(st & HoldsLoopRef) == value)
+        return;
+    Locker locker { s.lock };
+    st = s.state.load(std::memory_order_relaxed);
+    if (st & Closed)
+        return;
+    if (value)
+        s.state.store(st | HoldsLoopRef, std::memory_order_release);
+    else
+        s.state.store(st & ~uint64_t(HoldsLoopRef), std::memory_order_release);
 }
 
 void MessagePortPipe::close(uint8_t side, CloseKind kind)

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -259,8 +259,7 @@ void MessagePortPipe::setHoldsLoopRef(uint8_t side, bool value)
 {
     ASSERT(side < 2);
     auto& s = m_sides[side];
-    // Cheap unlocked probe: only the owning port's thread flips this bit, so a
-    // matching read means no transition is needed and we skip the lock.
+    // Only the owning thread flips this bit, so a matching unlocked read skips the lock.
     uint64_t st = s.state.load(std::memory_order_acquire);
     if ((st & Closed) || !!(st & HoldsLoopRef) == value)
         return;

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -46,11 +46,9 @@ public:
         Attached = 1ull << 2, // ctxId/port are valid; ok to schedule drains.
         ContextKnown = 1ull << 3, // ctxId/port are valid for close-notification only (no drains).
         ClosedByRequest = 1ull << 4, // the Closed above came from close(), not from the port being collected.
-        // This side's MessagePort holds an event-loop ref (message listener while
-        // ref'd, or explicit .ref()). The entangled wrapper reads this from the GC
-        // thread: a side whose peer is holding the loop must not be collected, or
-        // peerClosed() would release that ref at GC timing. Node never collects an
-        // entangled port; this narrows retention to "peer is actively waiting".
+        // This side's MessagePort is holding an event-loop ref (jsHasRef()). Read from
+        // the GC thread by the peer's hasPendingActivity(): a side whose peer is waiting
+        // must not be collected or peerClosed() releases that ref at GC timing.
         HoldsLoopRef = 1ull << 5,
 
         QueuedShift = 8,
@@ -89,8 +87,7 @@ public:
     bool isOtherSideClosedByRequest(uint8_t side) const { return state(1 - side) & ClosedByRequest; }
     bool otherSideHoldsLoopRef(uint8_t side) const { return state(1 - side) & HoldsLoopRef; }
 
-    // Called from the owning port's thread when its jsHasRef() transitions. Takes
-    // the side lock: send() rewrites the same word from the peer thread.
+    // Owning-thread only. Takes the side lock: send() rewrites the same word from the peer.
     void setHoldsLoopRef(uint8_t side, bool value);
 
     // Equality is by identity; used to reject "port posted through itself".

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -46,6 +46,12 @@ public:
         Attached = 1ull << 2, // ctxId/port are valid; ok to schedule drains.
         ContextKnown = 1ull << 3, // ctxId/port are valid for close-notification only (no drains).
         ClosedByRequest = 1ull << 4, // the Closed above came from close(), not from the port being collected.
+        // This side's MessagePort holds an event-loop ref (message listener while
+        // ref'd, or explicit .ref()). The entangled wrapper reads this from the GC
+        // thread: a side whose peer is holding the loop must not be collected, or
+        // peerClosed() would release that ref at GC timing. Node never collects an
+        // entangled port; this narrows retention to "peer is actively waiting".
+        HoldsLoopRef = 1ull << 5,
 
         QueuedShift = 8,
         QueuedOne = 1ull << QueuedShift,
@@ -81,6 +87,11 @@ public:
     uint64_t state(uint8_t side) const { return m_sides[side].state.load(std::memory_order_acquire); }
     bool isOtherSideOpen(uint8_t side) const { return !(state(1 - side) & Closed); }
     bool isOtherSideClosedByRequest(uint8_t side) const { return state(1 - side) & ClosedByRequest; }
+    bool otherSideHoldsLoopRef(uint8_t side) const { return state(1 - side) & HoldsLoopRef; }
+
+    // Called from the owning port's thread when its jsHasRef() transitions. Takes
+    // the side lock: send() rewrites the same word from the peer thread.
+    void setHoldsLoopRef(uint8_t side, bool value);
 
     // Equality is by identity; used to reject "port posted through itself".
     bool operator==(const MessagePortPipe& other) const { return this == &other; }

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -658,7 +658,10 @@ describe("a message listener keeps the event loop alive", () => {
   for (const [label, body] of [
     [".unref()", `port2.onmessage = () => {}; port2.unref();`],
     [".close()", `port2.onmessage = () => {}; port2.close();`],
-    ["removing the last listener", `const f = () => {}; port2.addEventListener('message', f); port2.removeEventListener('message', f);`],
+    [
+      "removing the last listener",
+      `const f = () => {}; port2.addEventListener('message', f); port2.removeEventListener('message', f);`,
+    ],
     ["onmessage = null", `port2.onmessage = () => {}; port2.onmessage = null;`],
     ["onmessageerror alone", `port2.onmessageerror = () => {};`],
     ["peer .close()", `port2.onmessage = () => {}; port1.close();`],

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -1,3 +1,5 @@
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+
 test("simple usage", done => {
   const channel = new MessageChannel();
   const port1 = channel.port1;
@@ -456,4 +458,238 @@ test("transferring a port from inside peerClosed()'s flush preserves the remaini
   await done.promise;
   // m1 delivered to the old owner; m2/m3 buffered for the new owner.
   expect(seen).toEqual(["old:m1", "new:m2", "new:m3"]);
+});
+
+// A listening port must keep the event loop alive like Node even after the
+// unreferenced entangled peer is garbage-collected. Before this fix, collecting
+// the peer delivered peerClosed() to the listener and released its loop ref, so
+// hasRef() reported true while the process exited. The peer's wrapper is now
+// pinned by hasPendingActivity() while this side holds a loop ref.
+describe("a message listener keeps the event loop alive", () => {
+  async function readUntil(stream: ReadableStream<Uint8Array>, marker: string) {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    try {
+      while (!buf.includes(marker)) {
+        const { done, value } = await reader.read();
+        if (done) return { found: false, buf };
+        buf += decoder.decode(value, { stream: true });
+      }
+      return { found: true, buf };
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  async function runKeepalive(code: string) {
+    // Each child prints READY once its listener is installed, so we synchronize
+    // on that marker rather than time. A listening port holds the loop open, so
+    // on a fixed build the child hangs; on the broken build it prints READY and
+    // exits shortly after (the peer is collected and peerClosed() releases the
+    // ref). A short race window after READY cleanly separates the two.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stderrDrained = proc.stderr.text();
+    const { found } = await readUntil(proc.stdout, "READY");
+    const outcome = await Promise.race([
+      proc.exited.then(() => "exited" as const),
+      Bun.sleep(isDebug || isASAN ? 1500 : 500).then(() => "alive" as const),
+    ]);
+    proc.kill();
+    await Promise.all([stderrDrained, proc.exited]);
+    return { ready: found, outcome };
+  }
+
+  const releaseWindowMs = isDebug || isASAN ? 4000 : 2000;
+  async function runRelease(code: string) {
+    // These children must exit on their own; the wait only elapses on a hang.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const outcome = await Promise.race([
+      proc.exited.then(code => ({ kind: "exited" as const, exitCode: code })),
+      Bun.sleep(releaseWindowMs).then(() => ({ kind: "hung" as const, exitCode: -1 })),
+    ]);
+    if (outcome.kind === "hung") proc.kill();
+    const [stdout] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { ...outcome, stdout: stdout.trim() };
+  }
+
+  // Same-context: the listener is on one port of a local MessageChannel and the
+  // other port is dropped. All three listener-install paths must hold.
+  for (const [label, attach] of [
+    [".onmessage", `port2.onmessage = () => {};`],
+    [".addEventListener('message')", `port2.addEventListener('message', () => {});`],
+    [".on('message')", `port2.on('message', () => {});`],
+  ] as const) {
+    test.concurrent(`${label} holds the loop while the unreferenced peer is GC'd`, async () => {
+      expect(
+        await runKeepalive(`
+          require('node:worker_threads');
+          let port2;
+          (() => {
+            const ch = new MessageChannel();
+            port2 = ch.port2;
+            ${attach}
+          })(); // port1 is now unreachable
+          for (let i = 0; i < 10; i++) Bun.gc(true);
+          if (!port2.hasRef()) throw new Error('hasRef() must be true');
+          console.log('READY');
+        `),
+      ).toEqual({ ready: true, outcome: "alive" });
+    });
+  }
+
+  test.concurrent("explicit .ref() after a listener is not defeated by peer GC", async () => {
+    expect(
+      await runKeepalive(`
+        require('node:worker_threads');
+        let port2;
+        (() => {
+          const ch = new MessageChannel();
+          port2 = ch.port2;
+          port2.onmessage = () => {};
+          port2.ref();
+        })();
+        for (let i = 0; i < 10; i++) Bun.gc(true);
+        if (!port2.hasRef()) throw new Error('hasRef() must be true');
+        console.log('READY');
+      `),
+    ).toEqual({ ready: true, outcome: "alive" });
+  });
+
+  // Cross-context: a worker is kept alive only by a transferred port's listener,
+  // and the main thread drops its side. On the broken build the worker receives a
+  // GC-timed 'close' and exits; Node keeps the worker (and its port) alive.
+  test.concurrent(
+    "a worker held only by a transferred port survives GC of the main-side peer",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const { Worker, MessageChannel } = require('node:worker_threads');
+          let weak, held;
+          const worker = (() => {
+            const { port1, port2 } = new MessageChannel();
+            weak = new WeakRef(port1);
+            held = port1;
+            return new Worker([
+              "const { workerData, parentPort } = require('node:worker_threads');",
+              "workerData.port.onmessage = () => {};",
+              "workerData.port.on('close', () => require('node:fs').writeSync(2, 'CLOSE'));",
+              "parentPort.postMessage('listening');",
+            ].join(String.fromCharCode(10)), { eval: true, workerData: { port: port2 }, transferList: [port2] });
+          })();
+          worker.on('exit', () => { console.log('WORKER_EXITED'); });
+          worker.once('message', () => {
+            // The worker's listener is installed; drop main's port and force GC.
+            // The worker stays ref'd so main is held open exactly as long as the
+            // worker is: on a broken build the worker exits and WORKER_EXITED
+            // prints; on a fixed build both stay alive.
+            held = null;
+            for (let i = 0; i < 10; i++) Bun.gc(true);
+            console.log('PORT1_ALIVE=' + (weak.deref() !== undefined));
+            console.log('READY');
+          });
+        `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      // Synchronize on READY (condition, not time): debug worker startup is slow.
+      const stderrDrained = proc.stderr.text();
+      const reader = proc.stdout.getReader();
+      const decoder = new TextDecoder();
+      let stdout = "";
+      while (!stdout.includes("READY")) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        stdout += decoder.decode(value, { stream: true });
+      }
+      const ready = stdout.includes("READY");
+      // After READY the child's main thread is idle (worker unref'd). On a broken
+      // build the worker's peerClosed() task releases its only loop ref and it
+      // exits, so main's 'exit' listener prints WORKER_EXITED and the process
+      // ends. On a fixed build the worker holds and the process stays alive.
+      const outcome = await Promise.race([
+        proc.exited.then(() => "exited" as const),
+        Bun.sleep(isDebug || isASAN ? 1500 : 500).then(() => "alive" as const),
+      ]);
+      proc.kill();
+      // Drain the rest of stdout so WORKER_EXITED (if any) is captured.
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        stdout += decoder.decode(value, { stream: true });
+      }
+      reader.releaseLock();
+      const stderr = await stderrDrained;
+      await proc.exited;
+      expect({
+        ready,
+        port1Alive: stdout.includes("PORT1_ALIVE=true"),
+        workerExited: stdout.includes("WORKER_EXITED"),
+        closeFired: stderr.includes("CLOSE"),
+        outcome,
+      }).toEqual({
+        ready: true,
+        port1Alive: true,
+        workerExited: false,
+        closeFired: false,
+        outcome: "alive",
+      });
+    },
+    20000,
+  );
+
+  // Release paths: these must still let the process exit on its own. The peer is
+  // held live so peer collection cannot mask a stuck ref.
+  for (const [label, body] of [
+    [".unref()", `port2.onmessage = () => {}; port2.unref();`],
+    [".close()", `port2.onmessage = () => {}; port2.close();`],
+    ["removing the last listener", `const f = () => {}; port2.addEventListener('message', f); port2.removeEventListener('message', f);`],
+    ["onmessage = null", `port2.onmessage = () => {}; port2.onmessage = null;`],
+    ["onmessageerror alone", `port2.onmessageerror = () => {};`],
+    ["peer .close()", `port2.onmessage = () => {}; port1.close();`],
+  ] as const) {
+    test.concurrent(
+      `${label} releases the hold`,
+      async () => {
+        expect(
+          await runRelease(`
+          require('node:worker_threads');
+          const { port1, port2 } = new MessageChannel();
+          globalThis.__keep = { port1, port2 };
+          ${body}
+        `),
+        ).toEqual({ kind: "exited", exitCode: 0, stdout: "" });
+      },
+      releaseWindowMs + 2000,
+    );
+  }
+
+  // An idle channel with no listener on either side must stay collectible: the
+  // new HoldsLoopRef pin is per-side and only set while a side holds a loop ref.
+  test.concurrent("idle channels with no listener remain collectible", async () => {
+    expect(
+      await runRelease(`
+        const { heapStats } = require('bun:jsc');
+        for (let i = 0; i < 200; i++) new MessageChannel();
+        for (let i = 0; i < 10; i++) Bun.gc(true);
+        const n = heapStats().objectTypeCounts.MessagePort ?? 0;
+        if (n > 20) throw new Error('MessagePort wrappers retained: ' + n);
+      `),
+    ).toEqual({ kind: "exited", exitCode: 0, stdout: "" });
+  });
 });

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -682,6 +682,32 @@ describe("a message listener keeps the event loop alive", () => {
     );
   }
 
+  // The wrapper of a listening port whose peer was explicitly closed can be
+  // swept before the posted peerClosed() task runs; ~MessagePort must balance
+  // the listener's refEventLoop() itself or the loop ref leaks and the process
+  // hangs. Not covered by the pinned "peer .close()" case above.
+  for (const [label, attach] of [
+    [".onmessage", `port2.onmessage = () => {};`],
+    [".addEventListener('message')", `port2.addEventListener('message', () => {});`],
+  ] as const) {
+    test.concurrent(
+      `a listening port swept after its peer closed does not leak a loop ref (${label})`,
+      async () => {
+        expect(
+          await runRelease(`
+            (() => {
+              const { port1, port2 } = new MessageChannel();
+              ${attach}
+              port1.close();
+            })();
+            for (let i = 0; i < 10; i++) Bun.gc(true);
+          `),
+        ).toEqual({ kind: "exited", exitCode: 0, stdout: "", stderr: "" });
+      },
+      releaseWindowMs + 2000,
+    );
+  }
+
   // An idle channel with no listener on either side must stay collectible: the
   // new HoldsLoopRef pin is per-side and only set while a side holds a loop ref.
   test.concurrent("idle channels with no listener remain collectible", async () => {

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -519,8 +519,8 @@ describe("a message listener keeps the event loop alive", () => {
       Bun.sleep(releaseWindowMs).then(() => ({ kind: "hung" as const, exitCode: -1 })),
     ]);
     if (outcome.kind === "hung") proc.kill();
-    const [stdout] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { ...outcome, stdout: stdout.trim() };
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { ...outcome, stdout: stdout.trim(), stderr: stderr.trim() };
   }
 
   // Same-context: the listener is on one port of a local MessageChannel and the
@@ -676,7 +676,7 @@ describe("a message listener keeps the event loop alive", () => {
           globalThis.__keep = { port1, port2 };
           ${body}
         `),
-        ).toEqual({ kind: "exited", exitCode: 0, stdout: "" });
+        ).toEqual({ kind: "exited", exitCode: 0, stdout: "", stderr: "" });
       },
       releaseWindowMs + 2000,
     );
@@ -693,6 +693,6 @@ describe("a message listener keeps the event loop alive", () => {
         const n = heapStats().objectTypeCounts.MessagePort ?? 0;
         if (n > 20) throw new Error('MessagePort wrappers retained: ' + n);
       `),
-    ).toEqual({ kind: "exited", exitCode: 0, stdout: "" });
+    ).toEqual({ kind: "exited", exitCode: 0, stdout: "", stderr: "" });
   });
 });

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -692,6 +692,16 @@ describe("a message listener keeps the event loop alive", () => {
     ["onmessage = null", `port2.onmessage = () => {}; port2.onmessage = null;`],
     ["onmessageerror alone", `port2.onmessageerror = () => {};`],
     ["peer .close()", `port2.onmessage = () => {}; port1.close();`],
+    // Node's [kNewListener] only refs on the 0→1 transition, so a 1→2 add or a
+    // replace while count>1 must not undo an earlier .unref().
+    [
+      "a second listener after .unref() does not re-ref",
+      `port2.addEventListener('message', () => {}); port2.unref(); port2.addEventListener('message', () => {});`,
+    ],
+    [
+      "replacing onmessage while other listeners exist does not re-ref",
+      `port2.onmessage = () => {}; port2.addEventListener('message', () => {}); port2.unref(); port2.onmessage = () => {};`,
+    ],
   ] as const) {
     test.concurrent(
       `${label} releases the hold`,

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -574,7 +574,10 @@ describe("a message listener keeps the event loop alive", () => {
     [".onmessage", `port2.unref(); port2.onmessage = () => {};`],
     [".addEventListener('message')", `port2.unref(); port2.addEventListener('message', () => {});`],
     [".on('message')", `port2.unref(); port2.on('message', () => {});`],
-    [".onmessage replacing an existing handler", `port2.onmessage = () => {}; port2.unref(); port2.onmessage = () => {};`],
+    [
+      ".onmessage replacing an existing handler",
+      `port2.onmessage = () => {}; port2.unref(); port2.onmessage = () => {};`,
+    ],
   ] as const) {
     test.concurrent(`${label} after .unref() re-refs the port`, async () => {
       expect(

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -566,6 +566,28 @@ describe("a message listener keeps the event loop alive", () => {
     ).toEqual({ ready: true, outcome: "alive", stderr: "" });
   });
 
+  // Node's [kNewListener] hook calls this.ref() on every 'message' listener add,
+  // so installing a listener after .unref() re-refs the port on every path.
+  for (const [label, attach] of [
+    [".onmessage", `port2.onmessage = () => {};`],
+    [".addEventListener('message')", `port2.addEventListener('message', () => {});`],
+    [".on('message')", `port2.on('message', () => {});`],
+  ] as const) {
+    test.concurrent(`${label} after .unref() re-refs the port`, async () => {
+      expect(
+        await runKeepalive(`
+          require('node:worker_threads');
+          const { port1, port2 } = new MessageChannel();
+          globalThis.__keep = { port1, port2 };
+          port2.unref();
+          ${attach}
+          if (!port2.hasRef()) throw new Error('hasRef() must be true after listener add');
+          console.log('READY');
+        `),
+      ).toEqual({ ready: true, outcome: "alive", stderr: "" });
+    });
+  }
+
   // Cross-context: a worker is kept alive only by a transferred port's listener,
   // and the main thread drops its side. On the broken build the worker receives a
   // GC-timed 'close' and exits; Node keeps the worker (and its port) alive.

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -501,8 +501,8 @@ describe("a message listener keeps the event loop alive", () => {
       Bun.sleep(isDebug || isASAN ? 1500 : 500).then(() => "alive" as const),
     ]);
     proc.kill();
-    await Promise.all([stderrDrained, proc.exited]);
-    return { ready: found, outcome };
+    const [stderr] = await Promise.all([stderrDrained, proc.exited]);
+    return { ready: found, outcome, stderr: stderr.trim() };
   }
 
   const releaseWindowMs = isDebug || isASAN ? 4000 : 2000;
@@ -544,7 +544,7 @@ describe("a message listener keeps the event loop alive", () => {
           if (!port2.hasRef()) throw new Error('hasRef() must be true');
           console.log('READY');
         `),
-      ).toEqual({ ready: true, outcome: "alive" });
+      ).toEqual({ ready: true, outcome: "alive", stderr: "" });
     });
   }
 
@@ -563,7 +563,7 @@ describe("a message listener keeps the event loop alive", () => {
         if (!port2.hasRef()) throw new Error('hasRef() must be true');
         console.log('READY');
       `),
-    ).toEqual({ ready: true, outcome: "alive" });
+    ).toEqual({ ready: true, outcome: "alive", stderr: "" });
   });
 
   // Cross-context: a worker is kept alive only by a transferred port's listener,
@@ -618,7 +618,7 @@ describe("a message listener keeps the event loop alive", () => {
         stdout += decoder.decode(value, { stream: true });
       }
       const ready = stdout.includes("READY");
-      // After READY the child's main thread is idle (worker unref'd). On a broken
+      // After READY main is held open only by the ref'd worker. On a broken
       // build the worker's peerClosed() task releases its only loop ref and it
       // exits, so main's 'exit' listener prints WORKER_EXITED and the process
       // ends. On a fixed build the worker holds and the process stays alive.
@@ -710,11 +710,12 @@ describe("a message listener keeps the event loop alive", () => {
 
   // An idle channel with no listener on either side must stay collectible: the
   // new HoldsLoopRef pin is per-side and only set while a side holds a loop ref.
+  // Destructure both ports so the JSMessagePort wrappers are materialized.
   test.concurrent("idle channels with no listener remain collectible", async () => {
     expect(
       await runRelease(`
         const { heapStats } = require('bun:jsc');
-        for (let i = 0; i < 200; i++) new MessageChannel();
+        for (let i = 0; i < 200; i++) { const { port1, port2 } = new MessageChannel(); }
         for (let i = 0; i < 10; i++) Bun.gc(true);
         const n = heapStats().objectTypeCounts.MessagePort ?? 0;
         if (n > 20) throw new Error('MessagePort wrappers retained: ' + n);

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -566,10 +566,9 @@ describe("a message listener keeps the event loop alive", () => {
     ).toEqual({ ready: true, outcome: "alive", stderr: "" });
   });
 
-  // Node's [kNewListener] hook calls this.ref() on every 'message' listener add,
-  // so installing a listener after .unref() re-refs the port on every path,
-  // including setEventHandlerAttribute's in-place replace (node's defineEventHandler
-  // fires [kNewListener] there too).
+  // Node's [kNewListener] refs the port on the 0→1 'message' listener transition,
+  // so installing a listener after .unref() re-refs on every install path; the
+  // onmessage replace at count==1 fires [kNewListener] too (defineEventHandler).
   for (const [label, body] of [
     [".onmessage", `port2.unref(); port2.onmessage = () => {};`],
     [".addEventListener('message')", `port2.unref(); port2.addEventListener('message', () => {});`],

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -567,11 +567,14 @@ describe("a message listener keeps the event loop alive", () => {
   });
 
   // Node's [kNewListener] hook calls this.ref() on every 'message' listener add,
-  // so installing a listener after .unref() re-refs the port on every path.
-  for (const [label, attach] of [
-    [".onmessage", `port2.onmessage = () => {};`],
-    [".addEventListener('message')", `port2.addEventListener('message', () => {});`],
-    [".on('message')", `port2.on('message', () => {});`],
+  // so installing a listener after .unref() re-refs the port on every path,
+  // including setEventHandlerAttribute's in-place replace (node's defineEventHandler
+  // fires [kNewListener] there too).
+  for (const [label, body] of [
+    [".onmessage", `port2.unref(); port2.onmessage = () => {};`],
+    [".addEventListener('message')", `port2.unref(); port2.addEventListener('message', () => {});`],
+    [".on('message')", `port2.unref(); port2.on('message', () => {});`],
+    [".onmessage replacing an existing handler", `port2.onmessage = () => {}; port2.unref(); port2.onmessage = () => {};`],
   ] as const) {
     test.concurrent(`${label} after .unref() re-refs the port`, async () => {
       expect(
@@ -579,8 +582,7 @@ describe("a message listener keeps the event loop alive", () => {
           require('node:worker_threads');
           const { port1, port2 } = new MessageChannel();
           globalThis.__keep = { port1, port2 };
-          port2.unref();
-          ${attach}
+          ${body}
           if (!port2.hasRef()) throw new Error('hasRef() must be true after listener add');
           console.log('READY');
         `),


### PR DESCRIPTION
Fixes #32562

### Repro

```js
require('node:worker_threads');
let port2;
(() => {
  const ch = new MessageChannel();
  port2 = ch.port2;
  port2.onmessage = () => {};
})();
for (let i = 0; i < 10; i++) Bun.gc(true);
console.log('hasRef=' + port2.hasRef());
// Node: hangs (port2 keeps the loop alive). Bun main: prints hasRef=true and exits.
```

Same for `.on('message', ...)` and `.addEventListener('message', ...)`, and for a worker kept alive only by a transferred port whose main-thread peer is dropped: the worker receives a GC-timed `close` and exits.

### Cause

`MessagePort::hasPendingActivity()` only considers this side's own listener state, so a port with no listener is collectible even while its entangled peer is holding the event loop open waiting on it. `~MessagePort` on the collected side calls `MessagePortPipe::close(Collected)` which delivers `peerClosed()` to the listening peer, and `peerClosed()` calls `jsUnref()`, releasing both the listener loop ref and `m_hasRef`. Node never collects an entangled port, so it never faces this path.

### Fix

Publish each side's combined loop-ref state (`m_listenerLoopRefActive || m_hasRef`) as a new `HoldsLoopRef` bit in the pipe's per-side atomic state word, updated from `updateListenerEventLoopRef()` / `jsRef()` / `jsUnref()` and cleared by `close()` / `detach()`. `hasPendingActivity()` returns true when the peer's bit is set, so a wrapper whose peer is waiting survives GC, same- or cross-context. A channel with neither side listening remains collectible (unlike Node, which retains every entangled port).

`~MessagePort` skips the `Collected` close while the peer is waiting during normal GC (covers the case where the sender-side wrapper was never materialized, i.e. only `ch.port2` was touched). During VM teardown (`isTerminating()`) it closes explicitly instead, since nothing else will notify the surviving peer once this context is gone. This preserves the existing "a port collected in a worker does not strand its peer" contract.

The `onmessage` / `onmessageerror` setters no longer take an extra `jsRef()`. `setEventHandlerAttribute` already drives the listener-count loop ref via `onDidChangeListener`, and the unbalanced `m_hasRef` it left behind made `onmessage = null` hang once the peer was no longer being collected out from under it. In Node a `messageerror` handler alone never refs the loop.

### Verification

New tests in `test/js/web/workers/message-channel.test.ts` cover all three listener-install paths plus explicit `.ref()` surviving forced GC of the unreferenced peer, the cross-context worker case, and the release paths (`unref`, `close`, listener removal, `onmessage = null`, `onmessageerror` alone, peer `close()`), plus an idle-channel collectibility guard. 7 of the 12 fail on origin/main and all pass with the fix (debug+ASAN).

All existing `message-channel` / `message-port-pipe` / `message-port-*-leak` tests, the `worker_threads.test.ts` stranded-peer test, and the 22 `test-worker-message-port*` / `test-worker-message-channel*` / `test-messagechannel` / `test-worker-workerdata-messageport` Node parallel tests pass unchanged.

### Related

#32564 addresses the same-context face by suppressing the `Collected` notification for a same-context peer; that leaves the cross-context face (a worker's listening port released when main collects its side) by design. This PR pins the sender wrapper instead, which covers both, and subsumes #32821's `onmessage = null` release.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/message-channel.test.ts
bun test v1.4.0 (8b0088f0f)

test/js/web/workers/message-channel.test.ts:
(pass) simple usage [6.98ms]
(pass) transfer message port [10.98ms]
(pass) transfer array buffer [4.94ms]
Warning: The target port was posted to itself, and the communication channel was lost
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:59:19)
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:60:10)

(pass) non-transferable [34.83ms]
(pass) transfer message ports and post messages [16.68ms]
(pass) message channel created on main thread [153.36ms]
(pass) message channel created on other thread [176.83ms]
Warning: The target port was posted to itself, and the communication channel was lost
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:151:25)
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:152:12)

(pass) many message channels [61.53ms]
(pass) gc [99.93ms]
(pass) cloneable and transferable
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (2493e8ca0)

test/js/web/workers/message-channel.test.ts:
(pass) simple usage [0.14ms]
(pass) transfer message port [0.18ms]
(pass) transfer array buffer [0.08ms]
Warning: The target port was posted to itself, and the communication channel was lost
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:59:19)
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:60:10)

(pass) non-transferable [0.52ms]
(pass) transfer message ports and post messages [0.19ms]
(pass) message channel created on main thread [4.05ms]
(pass) message channel created on other thread [3.62ms]
Warning: The target port was posted to itself, and the communication channel was lost
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:151:25)
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:152:12)

(pass) many message channels [0.83ms]
(pass) gc [0.87ms]
(pass) cloneable and transferable equals [6.26ms]
(pass) cloneable and non-transferable equals (BunFile) [0.25ms]
(pass) cloneable and non-transferable equals (net.BlockList) [2.58ms]
(pass) a pending close eve
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/message-channel.test.ts
bun test v1.4.0 (8b0088f0f)

test/js/web/workers/message-channel.test.ts:
(pass) simple usage [7.00ms]
(pass) transfer message port [11.72ms]
(pass) transfer array buffer [4.99ms]
Warning: The target port was posted to itself, and the communication channel was lost
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:59:19)
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:60:10)

(pass) non-transferable [34.22ms]
(pass) transfer message ports and post messages [16.38ms]
(pass) message channel created on main thread [149.07ms]
(pass) message channel created on other thread [151.43ms]
Warning: The target port was posted to itself, and the communication channel was lost
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:151:25)
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:152:12)

(pass) many message channels [59.89ms]
(pass) gc [87.26ms]
(pass) cloneable and transferable
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1075ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/17] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[2/17] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[3/17] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[4/17] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[5/17] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[6/17] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[7/17] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[8/17] gen cpp.rs (cppbind)
[8/17] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSMessagePort.cpp   |   9 +-
 src/jsc/bindings/webcore/MessagePort.cpp     |  99 ++++++---
 src/jsc/bindings/webcore/MessagePort.h       |   5 +-
 src/jsc/bindings/webcore/MessagePortPipe.cpp |  20 +-
 src/jsc/bindings/webcore/MessagePortPipe.h   |   8 +
 test/js/web/workers/message-channel.test.ts  | 302 +++++++++++++++++++++++++++
 6 files changed, 404 insertions(+), 39 deletions(-)
```

</details>

**gate history** · 8 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/bindings/webcore/JSMessagePort.cpp        3      5      0
src/jsc/bindings/webcore/MessagePort.cpp         15     26      0
src/jsc/bindings/webcore/MessagePort.h            4      5      0
src/jsc/bindings/webcore/MessagePortPipe.cpp      2      3      0
src/jsc/bindings/webcore/MessagePortPipe.h        2      4      0
test/js/web/workers/message-channel.test.ts      10     21      0
```

</details>

<!-- robobun:evidence:end -->