### PR TITLE
FormData: preserve filename when parsing a zero-byte multipart file part

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4340,6 +4340,18 @@ pub(crate) extern "C" fn Blob__setAsFile(this: &mut Blob, path_str: &mut BunStri
                 bytes.stored_name = path_str.to_owned_slice().into_boxed_slice();
             }
         }
+    } else if !path_str.is_empty() {
+        // A zero-byte `Blob` has no store; create an empty `Bytes` store to carry
+        // the name so `get_file_name()` (and thus `File.prototype.name`) works.
+        // Same shape as the `new File([], name)` path in `jsdom_file_construct`.
+        this.store.set(Some(StoreRef::from(Store::new(Store {
+            data: store::Data::Bytes(store::Bytes::init_empty_with_name(
+                path_str.to_owned_slice().into_boxed_slice(),
+            )),
+            ref_count: bun_ptr::ThreadSafeRefCount::init(),
+            mime_type: bun_http_types::MimeType::NONE,
+            is_all_ascii: None,
+        }))));
     }
 }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4341,9 +4341,7 @@ pub(crate) extern "C" fn Blob__setAsFile(this: &mut Blob, path_str: &mut BunStri
             }
         }
     } else if !path_str.is_empty() {
-        // A zero-byte `Blob` has no store; create an empty `Bytes` store to carry
-        // the name so `get_file_name()` (and thus `File.prototype.name`) works.
-        // Same shape as the `new File([], name)` path in `jsdom_file_construct`.
+        // Zero-byte Blob has no store; create one to carry the name.
         this.store.set(Some(StoreRef::from(Store::new(Store {
             data: store::Data::Bytes(store::Bytes::init_empty_with_name(
                 path_str.to_owned_slice().into_boxed_slice(),

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -71,7 +71,9 @@ describe("FormData", () => {
     for (const C of [Response, Request] as const) {
       it(`preserves filename with ${C.name}`, async () => {
         const make = (body: string) =>
-          C === Response ? new Response(body, { headers }) : new Request("http://x/", { method: "POST", headers, body });
+          C === Response
+            ? new Response(body, { headers })
+            : new Request("http://x/", { method: "POST", headers, body });
 
         const empty = (await make(part("")).formData()).get("f") as File;
         expect(empty).toBeInstanceOf(File);

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -63,6 +63,43 @@ describe("FormData", () => {
     expect(b1.name).toBe("foo.txt");
   });
 
+  describe("multipart parse of a zero-byte file part", () => {
+    const headers = { "content-type": "multipart/form-data; boundary=B" };
+    const part = (body: string) =>
+      `--B\r\nContent-Disposition: form-data; name="f"; filename="empty.txt"\r\nContent-Type: text/plain\r\n\r\n${body}\r\n--B--\r\n`;
+
+    for (const C of [Response, Request] as const) {
+      it(`preserves filename with ${C.name}`, async () => {
+        const make = (body: string) =>
+          C === Response ? new Response(body, { headers }) : new Request("http://x/", { method: "POST", headers, body });
+
+        const empty = (await make(part("")).formData()).get("f") as File;
+        expect(empty).toBeInstanceOf(File);
+        expect(empty.size).toBe(0);
+        expect(empty.name).toBe("empty.txt");
+        expect(await empty.text()).toBe("");
+
+        // control: a 1-byte body already worked
+        const nonEmpty = (await make(part("a")).formData()).get("f") as File;
+        expect(nonEmpty.name).toBe("empty.txt");
+      });
+    }
+
+    it("round-trips an empty File through Response.formData()", async () => {
+      const fd = new FormData();
+      fd.append("e", new File([], "empty.log", { type: "text/plain" }));
+
+      const serialized = await new Response(fd).text();
+      expect(serialized).toContain('filename="empty.log"');
+
+      const parsed = await new Response(fd).formData();
+      const e = parsed.get("e") as File;
+      expect(e).toBeInstanceOf(File);
+      expect(e.size).toBe(0);
+      expect(e.name).toBe("empty.log");
+    });
+  });
+
   const multipartFormDataFixturesRawBody = [
     {
       name: "simple",

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -100,6 +100,15 @@ describe("FormData", () => {
       expect(e.size).toBe(0);
       expect(e.name).toBe("empty.log");
     });
+
+    it("preserves the filename argument on an empty Blob entry", () => {
+      const fd = new FormData();
+      fd.append("f", new Blob([]), "empty.bin");
+      const f = fd.get("f") as File;
+      expect(f).toBeInstanceOf(File);
+      expect(f.size).toBe(0);
+      expect(f.name).toBe("empty.bin");
+    });
   });
 
   const multipartFormDataFixturesRawBody = [


### PR DESCRIPTION
## Problem

Parsing a `multipart/form-data` body where a file part has a non-empty `filename` but an empty body produces a `File` whose `.name` is `undefined`. Bun cannot round-trip its own serialization of an empty `File`:

```js
const ct = { headers: { "content-type": "multipart/form-data; boundary=B" } };
const part = body => `--B\r\nContent-Disposition: form-data; name="z"; filename="z.txt"\r\nContent-Type: text/plain\r\n\r\n${body}\r\n--B--\r\n`;

(await new Response(part(""),  ct).formData()).get("z").name;  // undefined (should be "z.txt")
(await new Response(part("a"), ct).formData()).get("z").name;  // "z.txt"

const fd = new FormData();
fd.append("e", new File([], "empty.log", { type: "text/plain" }));
(await new Response(fd).text()).includes('filename="empty.log"');  // true, serializer emits it
(await new Response(fd).formData()).get("e").name;                 // undefined (should be "empty.log")
```

Node returns the filename in all of these cases.

## Cause

The multipart parser builds a `Blob` from the part body and passes it to `DOMFormData` along with the filename. When JS reads the entry, `toJS()` calls `Blob__setAsFile()` to attach the filename to the Rust-side `Blob`. `Blob__setAsFile` wrote the name onto the blob's byte store via `bytes.stored_name`, but a zero-byte `Blob` has no store (`Blob::create_with_bytes_and_allocator` only allocates one when `len > 0`), so the name was dropped.

## Fix

When `Blob__setAsFile` is given a non-empty name and the blob has no store, create an empty `Bytes` store to carry the name. This is the same thing the `File` constructor (`jsdom_file_construct`) already does for `new File([], name)`.

## Verification

```
FormData > multipart parse of a zero-byte file part > preserves filename with Response
FormData > multipart parse of a zero-byte file part > preserves filename with Request
FormData > multipart parse of a zero-byte file part > round-trips an empty File through Response.formData()
```

All three fail on `main` with `Received: undefined` and pass with this change. Full `FormData.test.ts` (152 tests) passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.0 (026a33b90)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.46ms]
(pass) FormData > should be able to append a Blob [7.81ms]
(pass) FormData > should be able to set a Blob [6.98ms]
(pass) FormData > should be able to set a string [2.32ms]
(pass) FormData > should get filename from file [3.78ms]
(pass) FormData > should use the correct filenames [4.89ms]
76 |             : new Request("http://x/", { method: "POST", headers, body });
77 | 
78 |         const empty = (await make(part("")).formData()).get("f") as File;
79 |         expect(empty).toBeInstanceOf(File);
80 |         expect(empty.size).toBe(0);
81 |         expect(empty.name).toBe("empty.txt");
                                ^
error: expect(received).toBe(expected)

Expected: "empty.txt"
Received: undefined

      at <anonymous> (/workspace/bun/test/js/web/html/FormData.test.ts:81:28)
(fail) FormData > multipart parse of a zero-byte file part > preserves filename with Response [13.29m
... (truncated)

release without fix: 21 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.06ms]
(pass) FormData > should be able to append a Blob [0.15ms]
(pass) FormData > should be able to set a Blob [0.08ms]
(pass) FormData > should be able to set a string [0.04ms]
(pass) FormData > should get filename from file [0.05ms]
(pass) FormData > should use the correct filenames [0.05ms]
76 |             : new Request("http://x/", { method: "POST", headers, body });
77 | 
78 |         const empty = (await make(part("")).formData()).get("f") as File;
79 |         expect(empty).toBeInstanceOf(File);
80 |         expect(empty.size).toBe(0);
81 |         expect(empty.name).toBe("empty.txt");
                                ^
error: expect(received).toBe(expected)

Expected: "empty.txt"
Received: undefined

      at <anonymous> (/workspace/bun/test/js/web/html/FormData.test.ts:81:28)
(fail) FormData > multipart parse of a zero-byte file part > preserves filename with Response [0.43ms]
76 |             : new Request("http://x/", { method: "POST", headers, body });
77 | 
78 |         const empty = (await make(part("")).formData()).get("f") 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.0 (026a33b90)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.32ms]
(pass) FormData > should be able to append a Blob [7.96ms]
(pass) FormData > should be able to set a Blob [6.73ms]
(pass) FormData > should be able to set a string [2.60ms]
(pass) FormData > should get filename from file [4.14ms]
(pass) FormData > should use the correct filenames [5.79ms]
(pass) FormData > multipart parse of a zero-byte file part > preserves filename with Response [13.87ms]
(pass) FormData > multipart parse of a zero-byte file part > preserves filename with Request [4.44ms]
(pass) FormData > multipart parse of a zero-byte file part > round-trips an empty File through Response.formData() [15.13ms]
(pass) FormData > multipart parse of a zero-byte file part > preserves the filename argument on an empty Blob entry [2.82ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [13.81ms]
(pass) FormData > should roundtrip multipart/form-data (simple
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 941ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/115] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[1/115] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m gimli v0.34.0
[1m[92m   Compiling[0m object v0.39.1
[1m[92m   Compiling[0m addr2line v0.27.0
[1m[92m   Compiling[0m std v0.0.0 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std)
[1m[92m   Compiling[0m proc_macro v0.0.0 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/proc_macro)
[1m[92m   Compiling[0m bitflags v2.11.1
[1m[92m   Compiling[0m memchr v2.8.0
[1m[92m   Compiling[0m libc v0.2.186
[1m[92m   Compiling[0m konst_macro_rules v0.2.19
[1m[92m   Compiling[0m stru
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Blob.rs       | 10 ++++++++
 test/js/web/html/FormData.test.ts | 48 +++++++++++++++++++++++++++++++++++++++
 2 files changed, 58 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/webcore/Blob.rs            8      3      0
test/js/web/html/FormData.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->