### PR TITLE
webcore: preserve FormData entry value identity across get/getAll/iteration

### DIFF
--- a/src/jsc/bindings/DOMFormData.cpp
+++ b/src/jsc/bindings/DOMFormData.cpp
@@ -102,16 +102,19 @@ static auto createStringEntry(const String& name, const String& value) -> DOMFor
 
 void DOMFormData::append(const String& name, const String& value)
 {
+    Locker locker { m_itemsLock };
     m_items.append(createStringEntry(name, value));
 }
 
 void DOMFormData::append(const String& name, RefPtr<Blob> blob, const String& filename)
 {
     blob->setFileName(replaceUnpairedSurrogatesWithReplacementCharacter(String(filename)));
+    Locker locker { m_itemsLock };
     m_items.append({ replaceUnpairedSurrogatesWithReplacementCharacter(String(name)), blob });
 }
 void DOMFormData::remove(const StringView name)
 {
+    Locker locker { m_itemsLock };
     m_items.removeAllMatching([name](const auto& item) {
         return item.name == name;
     });
@@ -162,6 +165,7 @@ void DOMFormData::set(const String& name, RefPtr<Blob> blob, const String& filen
 
 void DOMFormData::set(const String& name, Item&& item)
 {
+    Locker locker { m_itemsLock };
     std::optional<size_t> initialMatchLocation;
 
     // Find location of the first item with a matching name.

--- a/src/jsc/bindings/DOMFormData.h
+++ b/src/jsc/bindings/DOMFormData.h
@@ -32,6 +32,7 @@
 
 #include "ContextDestructionObserver.h"
 #include <variant>
+#include <wtf/Lock.h>
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
 #include "blob.h"
@@ -76,6 +77,15 @@ public:
     size_t count() const { return m_items.size(); }
     size_t memoryCost() const;
 
+    template<typename Visitor> void visitWrappers(Visitor& visitor)
+    {
+        Locker locker { m_itemsLock };
+        for (auto& item : m_items) {
+            if (auto* blob = std::get_if<RefPtr<Blob>>(&item.data))
+                (*blob)->visitWrapper(visitor);
+        }
+    }
+
     String toURLEncodedString();
 
     class Iterator {
@@ -98,6 +108,8 @@ private:
 
     // PAL::TextEncoding m_encoding;
     Vector<Item> m_items;
+    // Guards m_items against concurrent iteration from visitWrappers (GC thread).
+    Lock m_itemsLock;
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/blob.cpp
+++ b/src/jsc/bindings/blob.cpp
@@ -1,5 +1,6 @@
 #include "blob.h"
 #include "ZigGeneratedClasses.h"
+#include <JavaScriptCore/StrongInlines.h>
 
 extern "C" JSC::EncodedJSValue SYSV_ABI Blob__create(JSC::JSGlobalObject* globalObject, void* impl);
 extern "C" void Blob__setAsFile(void* impl, BunString* filename);
@@ -8,10 +9,16 @@ namespace WebCore {
 
 JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, WebCore::Blob& impl)
 {
+    if (auto* wrapper = impl.wrapper())
+        return wrapper;
+
     BunString filename = Bun::toString(impl.fileName());
     Blob__setAsFile(impl.impl(), &filename);
 
-    return JSC::JSValue::decode(Blob__create(lexicalGlobalObject, Blob__dupe(impl.impl())));
+    JSC::JSValue value = JSC::JSValue::decode(Blob__create(lexicalGlobalObject, Blob__dupe(impl.impl())));
+    if (auto* object = value.getObject())
+        impl.setWrapper(lexicalGlobalObject->vm(), object);
+    return value;
 }
 
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<WebCore::Blob>&& impl)

--- a/src/jsc/bindings/blob.cpp
+++ b/src/jsc/bindings/blob.cpp
@@ -1,11 +1,19 @@
 #include "blob.h"
 #include "ZigGeneratedClasses.h"
-#include <JavaScriptCore/StrongInlines.h>
 
 extern "C" JSC::EncodedJSValue SYSV_ABI Blob__create(JSC::JSGlobalObject* globalObject, void* impl);
 extern "C" void Blob__setAsFile(void* impl, BunString* filename);
 
 namespace WebCore {
+
+void Blob::setWrapper(JSC::VM& vm, const JSC::JSCell* owner, JSC::JSObject* wrapper)
+{
+    JSC::Weak<JSC::JSObject> weak { wrapper };
+    WTF::storeStoreFence();
+    m_wrapper = WTF::move(weak);
+    if (owner)
+        vm.writeBarrier(owner, wrapper);
+}
 
 JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, WebCore::Blob& impl)
 {
@@ -17,7 +25,7 @@ JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* g
 
     JSC::JSValue value = JSC::JSValue::decode(Blob__create(lexicalGlobalObject, Blob__dupe(impl.impl())));
     if (auto* object = value.getObject())
-        impl.setWrapper(lexicalGlobalObject->vm(), object);
+        impl.setWrapper(lexicalGlobalObject->vm(), nullptr, object);
     return value;
 }
 

--- a/src/jsc/bindings/blob.h
+++ b/src/jsc/bindings/blob.h
@@ -104,10 +104,7 @@ private:
 
     BlobRefPtr m_impl;
     String m_fileName;
-    // Caches the JS wrapper returned by toJS so that FormData get/getAll/iteration
-    // return the same JS object each time. For a File appended without a filename
-    // override this is the user's original File; otherwise it is created lazily on
-    // first access.
+    // Cached JS wrapper so FormData accessors return the same object each time.
     JSC::Strong<JSC::JSObject> m_wrapper;
 };
 

--- a/src/jsc/bindings/blob.h
+++ b/src/jsc/bindings/blob.h
@@ -3,6 +3,7 @@
 #include "root.h"
 #include "JSDOMGlobalObject.h"
 #include "BunClientData.h"
+#include <JavaScriptCore/Strong.h>
 
 namespace WebCore {
 
@@ -74,6 +75,16 @@ public:
         m_fileName = fileName;
     }
 
+    JSC::JSObject* wrapper() const
+    {
+        return m_wrapper.get();
+    }
+
+    void setWrapper(JSC::VM& vm, JSC::JSObject* wrapper)
+    {
+        m_wrapper.set(vm, wrapper);
+    }
+
     size_t memoryCost() const;
 
 private:
@@ -93,6 +104,11 @@ private:
 
     BlobRefPtr m_impl;
     String m_fileName;
+    // Caches the JS wrapper returned by toJS so that FormData get/getAll/iteration
+    // return the same JS object each time. For a File appended without a filename
+    // override this is the user's original File; otherwise it is created lazily on
+    // first access.
+    JSC::Strong<JSC::JSObject> m_wrapper;
 };
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, Blob&);

--- a/src/jsc/bindings/blob.h
+++ b/src/jsc/bindings/blob.h
@@ -3,7 +3,8 @@
 #include "root.h"
 #include "JSDOMGlobalObject.h"
 #include "BunClientData.h"
-#include <JavaScriptCore/Strong.h>
+#include <JavaScriptCore/Weak.h>
+#include <JavaScriptCore/WeakInlines.h>
 
 namespace WebCore {
 
@@ -80,9 +81,11 @@ public:
         return m_wrapper.get();
     }
 
-    void setWrapper(JSC::VM& vm, JSC::JSObject* wrapper)
+    void setWrapper(JSC::VM&, const JSC::JSCell* owner, JSC::JSObject*);
+
+    template<typename Visitor> void visitWrapper(Visitor& visitor) const
     {
-        m_wrapper.set(vm, wrapper);
+        visitor.append(m_wrapper);
     }
 
     size_t memoryCost() const;
@@ -105,7 +108,7 @@ private:
     BlobRefPtr m_impl;
     String m_fileName;
     // Cached JS wrapper so FormData accessors return the same object each time.
-    JSC::Strong<JSC::JSObject> m_wrapper;
+    JSC::Weak<JSC::JSObject> m_wrapper;
 };
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, Blob&);

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -289,6 +289,7 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_append1Body(JSC
 }
 
 extern "C" BunString Blob__getFileNameString(void* impl);
+extern "C" bool Blob__isJSDOMFile(void* impl);
 
 static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_append2Body(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSDOMFormData>::ClassParameter castedThis)
 {
@@ -315,6 +316,11 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_append2Body(JSC
     EnsureStillAliveScope argument2 = callFrame->argument(2);
     auto filename = argument2.value().isUndefined() ? Blob__getFileNameString(blobValue->impl()).toWTFString(BunString::ZeroCopy) : convert<IDLUSVString>(*lexicalGlobalObject, argument2.value());
     RETURN_IF_EXCEPTION(throwScope, {});
+
+    // https://xhr.spec.whatwg.org/#create-an-entry
+    // If value is a File and filename was not given, the entry's value is the File itself.
+    if (argument2.value().isUndefined() && Blob__isJSDOMFile(blobValue->impl()))
+        blobValue->setWrapper(vm, asObject(argument1.value()));
 
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.append(WTF::move(name), WTF::move(blobValue), WTF::move(filename)); })));
 }
@@ -478,6 +484,11 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_set2Body(JSC::J
 
     auto filename = argument2.value().isUndefined() ? Blob__getFileNameString(blobValue->impl()).toWTFString(BunString::ZeroCopy) : convert<IDLUSVString>(*lexicalGlobalObject, argument2.value());
     RETURN_IF_EXCEPTION(throwScope, {});
+
+    // https://xhr.spec.whatwg.org/#create-an-entry
+    // If value is a File and filename was not given, the entry's value is the File itself.
+    if (argument2.value().isUndefined() && Blob__isJSDOMFile(blobValue->impl()))
+        blobValue->setWrapper(vm, asObject(argument1.value()));
 
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.set(WTF::move(name), WTF::move(blobValue), WTF::move(filename)); })));
 }

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -318,7 +318,6 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_append2Body(JSC
     RETURN_IF_EXCEPTION(throwScope, {});
 
     // https://xhr.spec.whatwg.org/#create-an-entry
-    // If value is a File and filename was not given, the entry's value is the File itself.
     if (argument2.value().isUndefined() && Blob__isJSDOMFile(blobValue->impl()))
         blobValue->setWrapper(vm, asObject(argument1.value()));
 
@@ -486,7 +485,6 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_set2Body(JSC::J
     RETURN_IF_EXCEPTION(throwScope, {});
 
     // https://xhr.spec.whatwg.org/#create-an-entry
-    // If value is a File and filename was not given, the entry's value is the File itself.
     if (argument2.value().isUndefined() && Blob__isJSDOMFile(blobValue->impl()))
         blobValue->setWrapper(vm, asObject(argument1.value()));
 

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -319,7 +319,7 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_append2Body(JSC
 
     // https://xhr.spec.whatwg.org/#create-an-entry
     if (argument2.value().isUndefined() && Blob__isJSDOMFile(blobValue->impl()))
-        blobValue->setWrapper(vm, asObject(argument1.value()));
+        blobValue->setWrapper(vm, castedThis, asObject(argument1.value()));
 
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.append(WTF::move(name), WTF::move(blobValue), WTF::move(filename)); })));
 }
@@ -486,7 +486,7 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_set2Body(JSC::J
 
     // https://xhr.spec.whatwg.org/#create-an-entry
     if (argument2.value().isUndefined() && Blob__isJSDOMFile(blobValue->impl()))
-        blobValue->setWrapper(vm, asObject(argument1.value()));
+        blobValue->setWrapper(vm, castedThis, asObject(argument1.value()));
 
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.set(WTF::move(name), WTF::move(blobValue), WTF::move(filename)); })));
 }
@@ -713,6 +713,35 @@ JSC::GCClient::IsoSubspace* JSDOMFormData::subspaceForImpl(JSC::VM& vm)
         [](auto& spaces) { return spaces.m_subspaceForDOMFormData.get(); },
         [](auto& spaces, auto&& space) { spaces.m_subspaceForDOMFormData = std::forward<decltype(space)>(space); });
 }
+
+template<typename Visitor>
+void JSDOMFormData::visitAdditionalChildrenInGCThread(Visitor& visitor)
+{
+    wrapped().visitWrappers(visitor);
+}
+
+template<typename Visitor>
+void JSDOMFormData::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = uncheckedDowncast<JSDOMFormData>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+    thisObject->visitAdditionalChildrenInGCThread(visitor);
+}
+
+DEFINE_VISIT_CHILDREN(JSDOMFormData);
+
+template<typename Visitor>
+void JSDOMFormData::visitOutputConstraints(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = uncheckedDowncast<JSDOMFormData>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitOutputConstraints(thisObject, visitor);
+    thisObject->visitAdditionalChildrenInGCThread(visitor);
+}
+
+template void JSDOMFormData::visitOutputConstraints(JSCell*, AbstractSlotVisitor&);
+template void JSDOMFormData::visitOutputConstraints(JSCell*, SlotVisitor&);
 
 void JSDOMFormData::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {

--- a/src/jsc/bindings/webcore/JSDOMFormData.h
+++ b/src/jsc/bindings/webcore/JSDOMFormData.h
@@ -56,6 +56,9 @@ public:
         return subspaceForImpl(vm);
     }
     static JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM& vm);
+    DECLARE_VISIT_CHILDREN;
+    template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
+    template<typename Visitor> static void visitOutputConstraints(JSCell*, Visitor&);
     static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
     static size_t estimatedSize(JSCell* cell, JSC::VM& vm);
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4349,6 +4349,11 @@ pub(crate) extern "C" fn Blob__dupe(this: &Blob) -> *mut Blob {
 }
 
 #[unsafe(no_mangle)]
+pub(crate) extern "C" fn Blob__isJSDOMFile(this: &Blob) -> bool {
+    this.is_jsdom_file.get()
+}
+
+#[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
     if let Some(filename) = this.get_file_name() {
         return BunString::from_bytes(filename);

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -958,6 +958,119 @@ test("FormData.toJSON merges duplicate numeric field names into an array", async
   expect(exitCode).toBe(0);
 });
 
+describe("FormData entry value identity", () => {
+  it("get() returns the same File object that was appended", () => {
+    const file = new File(["abc"], "f.txt", { type: "text/plain" });
+    const fd = new FormData();
+    fd.append("f", file);
+    expect(fd.get("f")).toBe(file);
+    expect(fd.get("f") === fd.get("f")).toBe(true);
+  });
+
+  it("get() returns the same File object that was set", () => {
+    const file = new File(["abc"], "f.txt");
+    const fd = new FormData();
+    fd.set("f", file);
+    expect(fd.get("f")).toBe(file);
+  });
+
+  it("getAll() returns the same File object that was appended", () => {
+    const a = new File(["a"], "a.txt");
+    const b = new File(["b"], "b.txt");
+    const fd = new FormData();
+    fd.append("f", a);
+    fd.append("f", b);
+    const all = fd.getAll("f");
+    expect(all[0]).toBe(a);
+    expect(all[1]).toBe(b);
+    expect(fd.getAll("f")[0]).toBe(a);
+  });
+
+  it("values()/entries()/forEach return the same File object that was appended", () => {
+    const file = new File(["abc"], "f.txt");
+    const fd = new FormData();
+    fd.append("f", file);
+
+    expect([...fd.values()][0]).toBe(file);
+    expect([...fd.entries()][0][1]).toBe(file);
+
+    let seen: unknown;
+    fd.forEach(v => {
+      seen = v;
+    });
+    expect(seen).toBe(file);
+  });
+
+  it("preserves expando properties on the stored File", () => {
+    const file = new File(["abc"], "f.txt");
+    const fd = new FormData();
+    fd.append("f", file);
+    (fd.get("f") as any).expando = 123;
+    expect((fd.get("f") as any).expando).toBe(123);
+    expect((file as any).expando).toBe(123);
+  });
+
+  it("returns a stable object across repeated get() for a non-File Blob entry", async () => {
+    const blob = new Blob(["abc"], { type: "text/plain" });
+    const fd = new FormData();
+    fd.append("b", blob);
+    const first = fd.get("b");
+    // A plain Blob is wrapped in a new File per spec, so it is not the same object...
+    expect(first === blob).toBe(false);
+    // ...but the entry's value is stable across accesses.
+    expect(fd.get("b")).toBe(first);
+    expect(fd.getAll("b")[0]).toBe(first);
+    expect([...fd.values()][0]).toBe(first);
+    expect(await (first as Blob).text()).toBe("abc");
+  });
+
+  it("returns a stable object across repeated get() when a filename override is given", () => {
+    const file = new File(["abc"], "orig.txt");
+    const fd = new FormData();
+    fd.append("f", file, "other.txt");
+    const first = fd.get("f") as File;
+    // A filename override creates a new File per spec.
+    expect(first === file).toBe(false);
+    // The entry's value is stable across accesses.
+    expect(fd.get("f")).toBe(first);
+    expect(fd.getAll("f")[0]).toBe(first);
+  });
+
+  it("returns a stable object across repeated get() for multipart-parsed file parts", async () => {
+    const body =
+      '--x\r\nContent-Disposition: form-data; name="f"; filename="a.txt"\r\nContent-Type: text/plain\r\n\r\nhello\r\n--x--\r\n';
+    const fd = await new Response(body, {
+      headers: { "Content-Type": "multipart/form-data; boundary=x" },
+    }).formData();
+    const first = fd.get("f");
+    expect(first).toBeInstanceOf(Blob);
+    expect(fd.get("f")).toBe(first);
+    expect(fd.getAll("f")[0]).toBe(first);
+  });
+
+  it("keeps the entry value alive while the FormData is alive", () => {
+    const fd = new FormData();
+    {
+      const file = new File(["abc"], "f.txt");
+      fd.append("f", file);
+    }
+    Bun.gc(true);
+    const got = fd.get("f") as File;
+    expect(got.name).toBe("f.txt");
+    Bun.gc(true);
+    expect(fd.get("f")).toBe(got);
+  });
+
+  it("can be used as a WeakMap key", () => {
+    const file = new File(["abc"], "f.txt");
+    const fd = new FormData();
+    fd.append("f", file);
+    const wm = new WeakMap();
+    wm.set(file, "hello");
+    expect(wm.get(fd.get("f") as object)).toBe("hello");
+  });
+});
+
 describe("USVString conversion of lone surrogates", () => {
   const loneHigh = "a\uD800b";
   const loneLow = "a\uDC00b";

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -963,8 +963,9 @@ describe("FormData entry value identity", () => {
     const file = new File(["abc"], "f.txt", { type: "text/plain" });
     const fd = new FormData();
     fd.append("f", file);
-    expect(fd.get("f")).toBe(file);
-    expect(fd.get("f") === fd.get("f")).toBe(true);
+    const first = fd.get("f");
+    expect(first).toBe(file);
+    expect(fd.get("f")).toBe(first);
   });
 
   it("get() returns the same File object that was set", () => {
@@ -1016,7 +1017,8 @@ describe("FormData entry value identity", () => {
     fd.append("b", blob);
     const first = fd.get("b");
     // A plain Blob is wrapped in a new File per spec, so it is not the same object...
-    expect(first === blob).toBe(false);
+    expect(first).toBeInstanceOf(Blob);
+    expect(first).not.toBe(blob);
     // ...but the entry's value is stable across accesses.
     expect(fd.get("b")).toBe(first);
     expect(fd.getAll("b")[0]).toBe(first);
@@ -1030,10 +1032,21 @@ describe("FormData entry value identity", () => {
     fd.append("f", file, "other.txt");
     const first = fd.get("f") as File;
     // A filename override creates a new File per spec.
-    expect(first === file).toBe(false);
+    expect(first).toBeInstanceOf(Blob);
+    expect(first).not.toBe(file);
     // The entry's value is stable across accesses.
     expect(fd.get("f")).toBe(first);
     expect(fd.getAll("f")[0]).toBe(first);
+  });
+
+  it("returns a stable object across repeated get() when set() is given a filename override", () => {
+    const file = new File(["abc"], "orig.txt");
+    const fd = new FormData();
+    fd.set("f", file, "other.txt");
+    const first = fd.get("f") as File;
+    expect(first).toBeInstanceOf(Blob);
+    expect(first).not.toBe(file);
+    expect(fd.get("f")).toBe(first);
   });
 
   it("returns a stable object across repeated get() for multipart-parsed file parts", async () => {

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1062,16 +1062,43 @@ describe("FormData entry value identity", () => {
   });
 
   it("keeps the entry value alive while the FormData is alive", () => {
-    const fd = new FormData();
-    {
-      const file = new File(["abc"], "f.txt");
-      fd.append("f", file);
+    const iterations = isASAN || isDebug ? 50 : 500;
+    let mismatches = 0;
+    for (let i = 0; i < iterations; i++) {
+      const fd = new FormData();
+      (function () {
+        fd.append("f", new File(["abc"], "f.txt"));
+        fd.append("b", new Blob(["xyz"]));
+      })();
+      Bun.gc(true);
+      const f = fd.get("f") as File;
+      const b = fd.get("b");
+      if (f?.name !== "f.txt") mismatches++;
+      Bun.gc(true);
+      if (fd.get("f") !== f) mismatches++;
+      if (fd.get("b") !== b) mismatches++;
+      if (fd.getAll("f")[0] !== f) mismatches++;
     }
+    expect(mismatches).toBe(0);
+  });
+
+  it("does not leak when an entry's value has an expando referencing the FormData", () => {
+    const refs: WeakRef<FormData>[] = [];
+    (function () {
+      for (let i = 0; i < 256; i++) {
+        const file = new File(["abc"], "f.txt");
+        const fd = new FormData();
+        fd.append("f", file);
+        (file as any).owner = fd;
+        refs.push(new WeakRef(fd));
+      }
+    })();
     Bun.gc(true);
-    const got = fd.get("f") as File;
-    expect(got.name).toBe("f.txt");
     Bun.gc(true);
-    expect(fd.get("f")).toBe(got);
+    Bun.gc(true);
+    const alive = refs.filter(r => r.deref() !== undefined).length;
+    // Conservative stack scanning may pin a handful; a Strong-rooted cycle would keep all 256.
+    expect(alive).toBeLessThanOrEqual(8);
   });
 
   it("can be used as a WeakMap key", () => {

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1063,7 +1063,6 @@ describe("FormData entry value identity", () => {
 
   it("keeps the entry value alive while the FormData is alive", () => {
     const iterations = isASAN || isDebug ? 50 : 500;
-    let mismatches = 0;
     for (let i = 0; i < iterations; i++) {
       const fd = new FormData();
       (function () {
@@ -1073,13 +1072,12 @@ describe("FormData entry value identity", () => {
       Bun.gc(true);
       const f = fd.get("f") as File;
       const b = fd.get("b");
-      if (f?.name !== "f.txt") mismatches++;
+      expect(f?.name).toBe("f.txt");
       Bun.gc(true);
-      if (fd.get("f") !== f) mismatches++;
-      if (fd.get("b") !== b) mismatches++;
-      if (fd.getAll("f")[0] !== f) mismatches++;
+      expect(fd.get("f")).toBe(f);
+      expect(fd.get("b")).toBe(b);
+      expect(fd.getAll("f")[0]).toBe(f);
     }
-    expect(mismatches).toBe(0);
   });
 
   it("does not leak when an entry's value has an expando referencing the FormData", () => {


### PR DESCRIPTION
## Problem

`FormData` mints a fresh JS `Blob` wrapper on every `get()` / `getAll()` / iteration access, so `fd.get("f") === fd.get("f")` is always `false` and expando properties set on a retrieved value are lost. Per [XHR §create an entry](https://xhr.spec.whatwg.org/#create-an-entry) the entry list holds the value itself; Node and browsers return the same object on every access.

```js
const f = new File(["abc"], "f.txt");
const fd = new FormData();
fd.append("f", f);
fd.get("f") === f;            // node: true   bun: false
fd.get("f") === fd.get("f");  // node: true   bun: false
const v = fd.get("f"); v.x = 1;
fd.get("f").x;                // node: 1      bun: undefined
```

This breaks identity-based code paths (WeakMap/Set keyed by the File, `===` dedupe, expando/subclass state) and allocates a new wrapper + Rust `Blob` per access.

## Cause

`DOMFormData` stores a `RefPtr<WebCore::Blob>` holding a duped Rust `Blob` and never the JS object. `toJS(WebCore::Blob&)` (`src/jsc/bindings/blob.cpp`) calls `Blob__create(Blob__dupe(...))` every time, producing a fresh `JSBlob` on each conversion.

## Fix

Cache the JS wrapper on `WebCore::Blob` in a `JSC::Weak<JSObject>` and have `toJS()` return it when set. `JSDOMFormData` overrides `visitChildren` / `visitOutputConstraints` to trace each entry's wrapper (under a new `m_itemsLock`, same shape as `AbortSignal::m_abortAlgorithms`), so the wrapper stays alive exactly as long as the `FormData` is reachable and the GC can still collect a `file.owner = fd` cycle when both become unreachable.

In `FormData.append` / `FormData.set`, when the value is a `File` and no filename override is given, the caller's `File` object is stored directly so `fd.get("f") === file`. For plain `Blob` values, filename-overridden entries, and multipart-parsed file parts, the wrapper is created and cached on first access so subsequent reads are stable.

## Verification

New tests in `test/js/web/html/FormData.test.ts` cover `get`/`getAll`/`values`/`entries`/`forEach` identity for appended `File`, `set`, plain `Blob`, filename override, multipart parse, expando persistence, WeakMap keying, a GC liveness stress loop, and a cycle-collection check for `file.owner = fd` back-references.

```
fail-before: stock bun test FormData.test.ts -t "entry value identity"  → 1 pass, 11 fail
pass-after:  bun bd test FormData.test.ts -t "entry value identity"     → 12 pass, 0 fail
full file:   bun bd test FormData.test.ts                               → 161 pass, 0 fail
```

Out of scope (unchanged, tracked separately): `constructor.name === "File"` for synthesized entries (#32430) and the `name === "blob"` default for wrapped plain Blobs.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.0 (1dbc106ed)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.20ms]
(pass) FormData > should be able to append a Blob [8.03ms]
(pass) FormData > should be able to set a Blob [5.89ms]
(pass) FormData > should be able to set a string [2.62ms]
(pass) FormData > should get filename from file [4.13ms]
(pass) FormData > should use the correct filenames [5.97ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [13.53ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [36.05ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [2.63ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [5.36ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [1.77ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [3.96ms]
(pass) FormData > should parse multipart/form-data (si
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (6628ccf51)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.05ms]
(pass) FormData > should be able to append a Blob [0.13ms]
(pass) FormData > should be able to set a Blob [0.07ms]
(pass) FormData > should be able to set a string [0.03ms]
(pass) FormData > should get filename from file [0.05ms]
(pass) FormData > should use the correct filenames [0.05ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [0.29ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [0.83ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [0.04ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [0.05ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Request [0.01ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Request [0.02ms]
(pass) F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.0 (1dbc106ed)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.31ms]
(pass) FormData > should be able to append a Blob [7.66ms]
(pass) FormData > should be able to set a Blob [5.48ms]
(pass) FormData > should be able to set a string [2.56ms]
(pass) FormData > should get filename from file [3.90ms]
(pass) FormData > should use the correct filenames [6.34ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [13.96ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [36.30ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [2.63ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [5.34ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [1.72ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [3.84ms]
(pass) FormData > should parse multipart/form-data (si
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 844ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] cxx obj/src/jsc/bindings/webcore/JSMessageEventCustom.cpp.o
[2/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[3/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[4/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[5/22] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[6/22] cxx obj/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp.o
[7/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-1.cpp.o
[8/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[9/22] cxx obj/codegen/GeneratedSSLConfig.cpp.o
[10/22] cxx obj/codegen/GeneratedSocketConfig.cpp.o
[11/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[12/22] cxx obj/src/jsc/bindings/bindings.cpp.o
[13/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[14/22] cxx obj/src/jsc/bindings/webcore/SerializedScriptValue.cpp.o
[15/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[16/22] gen cpp.rs (cppbind)
[17/22] gen generated_host_exports.rs
generated_host_expor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/DOMFormData.cpp           |   4 +
 src/jsc/bindings/DOMFormData.h             |  12 +++
 src/jsc/bindings/blob.cpp                  |  17 +++-
 src/jsc/bindings/blob.h                    |  16 +++
 src/jsc/bindings/webcore/JSDOMFormData.cpp |  38 ++++++++
 src/jsc/bindings/webcore/JSDOMFormData.h   |   3 +
 src/runtime/webcore/Blob.rs                |   5 +
 test/js/web/html/FormData.test.ts          | 151 +++++++++++++++++++++++++++++
 8 files changed, 245 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/jsc/bindings/DOMFormData.cpp                1      2      0
src/jsc/bindings/DOMFormData.h                  1      3      0
src/jsc/bindings/blob.cpp                       2      3      0
src/jsc/bindings/blob.h                         3      9      0
src/jsc/bindings/webcore/JSDOMFormData.cpp      3      6      0
src/jsc/bindings/webcore/JSDOMFormData.h        1      1      0
src/runtime/webcore/Blob.rs                     1      1      0
test/js/web/html/FormData.test.ts               6      8      0
```

</details>

<!-- robobun:evidence:end -->