### PR TITLE
error: print the Error's own stack, not the rethrow site, for uncaught errors

### DIFF
--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -504,7 +504,6 @@ __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     // Node prints `err.stack`: the Error's own state wins over the wrapper's throw-site stack.
-    // ZigException__collectSourceLines repeats this selection, so the predicate must match.
     bool getFromSourceURL = false;
     if (hasVisibleFrames(err->stackTrace())) {
         populateStackTrace(vm, *err->stackTrace(), except.stack, global, flags, FinalizerSafety::MustNotTriggerGC);
@@ -903,7 +902,6 @@ extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException
         JSValue unwrapped = jscException->value();
 
         // Same selection as fromErrorInstance: OnlySourceLines indexes the chosen vector via jsc_stack_frame_index.
-        // Frames parsed from a `.stack` string carry index -1 and are skipped whichever vector is passed.
         auto* error = dynamicDowncast<JSC::ErrorInstance>(unwrapped);
         if (error && hasVisibleFrames(error->stackTrace())) {
             populateStackTrace(global->vm(), *error->stackTrace(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines, FinalizerSafety::MustNotTriggerGC);

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -421,6 +421,23 @@ public:
     }
 };
 
+// A frame populateStackTrace(OnlyPosition) emits; native frames are skipped.
+static bool isVisibleFrame(const JSC::StackFrame& frame)
+{
+    return frame.hasLineAndColumnInfo() || frame.isWasmFrame();
+}
+
+static bool hasVisibleFrames(const WTF::Vector<JSC::StackFrame>* frames)
+{
+    if (!frames)
+        return false;
+    for (const auto& frame : *frames) {
+        if (isVisibleFrame(frame))
+            return true;
+    }
+    return false;
+}
+
 static void populateStackTrace(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& frames, ZigStackTrace& trace, JSC::JSGlobalObject* globalObject, PopulateStackTraceFlags flags, FinalizerSafety finalizerSafety = FinalizerSafety::NotInFinalizer)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
@@ -432,7 +449,7 @@ static void populateStackTrace(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& 
 
         while (frame_i < frame_count && stack_frame_i < total_frame_count) {
             // Skip native frames
-            while (stack_frame_i < total_frame_count && !(frames.at(stack_frame_i).hasLineAndColumnInfo()) && !(frames.at(stack_frame_i).isWasmFrame())) {
+            while (stack_frame_i < total_frame_count && !isVisibleFrame(frames.at(stack_frame_i))) {
                 stack_frame_i++;
             }
             if (stack_frame_i >= total_frame_count)
@@ -487,8 +504,9 @@ __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     // Node prints `err.stack`: the Error's own state wins over the wrapper's throw-site stack.
+    // ZigException__collectSourceLines repeats this selection, so the predicate must match.
     bool getFromSourceURL = false;
-    if (err->stackTrace() != nullptr && err->stackTrace()->size() > 0) {
+    if (hasVisibleFrames(err->stackTrace())) {
         populateStackTrace(vm, *err->stackTrace(), except.stack, global, flags, FinalizerSafety::MustNotTriggerGC);
         RETURN_IF_EXCEPTION(scope, );
 
@@ -640,11 +658,10 @@ __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC
         }
     }
 
-    if (except.stack.frames_len == 0 && stackTrace != nullptr && stackTrace->size() > 0) {
+    if (except.stack.frames_len == 0 && hasVisibleFrames(stackTrace)) {
         // Last resort: the wrapper's throw-site stack.
         populateStackTrace(vm, *stackTrace, except.stack, global, flags);
         RETURN_IF_EXCEPTION(scope, );
-        getFromSourceURL = false;
     }
 
     if (except.stack.frames_len == 0 && getFromSourceURL) {
@@ -885,11 +902,12 @@ extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException
         auto* jscException = uncheckedDowncast<JSC::Exception>(value);
         JSValue unwrapped = jscException->value();
 
-        // Must match fromErrorInstance's selection: OnlySourceLines indexes the same vector via jsc_stack_frame_index.
-        if (auto* error = dynamicDowncast<JSC::ErrorInstance>(unwrapped);
-            error && error->stackTrace() != nullptr && error->stackTrace()->size() > 0) {
+        // Same selection as fromErrorInstance: OnlySourceLines indexes the chosen vector via jsc_stack_frame_index.
+        // Frames parsed from a `.stack` string carry index -1 and are skipped whichever vector is passed.
+        auto* error = dynamicDowncast<JSC::ErrorInstance>(unwrapped);
+        if (error && hasVisibleFrames(error->stackTrace())) {
             populateStackTrace(global->vm(), *error->stackTrace(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines, FinalizerSafety::MustNotTriggerGC);
-        } else if (jscException->stack().size() > 0) {
+        } else if (hasVisibleFrames(&jscException->stack())) {
             populateStackTrace(global->vm(), jscException->stack(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines);
         }
 

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -486,12 +486,9 @@ __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC
     auto& vm = JSC::getVM(global);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
+    // Node prints `err.stack`: the Error's own state wins over the wrapper's throw-site stack.
     bool getFromSourceURL = false;
-    if (stackTrace != nullptr && stackTrace->size() > 0) {
-        populateStackTrace(vm, *stackTrace, except.stack, global, flags);
-        RETURN_IF_EXCEPTION(scope, );
-
-    } else if (err->stackTrace() != nullptr && err->stackTrace()->size() > 0) {
+    if (err->stackTrace() != nullptr && err->stackTrace()->size() > 0) {
         populateStackTrace(vm, *err->stackTrace(), except.stack, global, flags, FinalizerSafety::MustNotTriggerGC);
         RETURN_IF_EXCEPTION(scope, );
 
@@ -594,11 +591,8 @@ __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC
         JSC::JSValue stackValue = obj->getIfPropertyExists(global, vm.propertyNames->stack);
         if (!scope.clearExceptionExceptTermination()) [[unlikely]]
             return;
-        if (stackValue) {
-            // Prevent infinite recursion if stack property is the error object itself
-            if (stackValue == val) {
-                return;
-            }
+        // Skip self-referential `.stack` (fall through to the wrapper-stack fallback below).
+        if (stackValue && stackValue != val) {
             if (stackValue.isString()) {
                 WTF::String stack = stackValue.toWTFString(global);
                 if (!scope.clearExceptionExceptTermination()) [[unlikely]] {
@@ -644,6 +638,13 @@ __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC
                 }
             }
         }
+    }
+
+    if (except.stack.frames_len == 0 && stackTrace != nullptr && stackTrace->size() > 0) {
+        // Last resort: the wrapper's throw-site stack.
+        populateStackTrace(vm, *stackTrace, except.stack, global, flags);
+        RETURN_IF_EXCEPTION(scope, );
+        getFromSourceURL = false;
     }
 
     if (except.stack.frames_len == 0 && getFromSourceURL) {
@@ -884,7 +885,11 @@ extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException
         auto* jscException = uncheckedDowncast<JSC::Exception>(value);
         JSValue unwrapped = jscException->value();
 
-        if (jscException->stack().size() > 0) {
+        // Must match fromErrorInstance's selection: OnlySourceLines indexes the same vector via jsc_stack_frame_index.
+        if (auto* error = dynamicDowncast<JSC::ErrorInstance>(unwrapped);
+            error && error->stackTrace() != nullptr && error->stackTrace()->size() > 0) {
+            populateStackTrace(global->vm(), *error->stackTrace(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines, FinalizerSafety::MustNotTriggerGC);
+        } else if (jscException->stack().size() > 0) {
             populateStackTrace(global->vm(), jscException->stack(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines);
         }
 

--- a/test/js/bun/test/dots.test.ts
+++ b/test/js/bun/test/dots.test.ts
@@ -87,7 +87,7 @@ test("dots 2", async () => {
     6 |   setTimeout(() => {
     7 |     resolve();
     8 |     throw new Error("unhandled error");
-                                             ^
+                      ^
     error: unhandled error
         at <anonymous> (file:NN:NN)
     (fail) failure

--- a/test/js/bun/test/only-failures.test.ts
+++ b/test/js/bun/test/only-failures.test.ts
@@ -39,7 +39,7 @@ test.concurrent("only-failures flag should show only failures", async () => {
     24 | 
     25 | test("another failing test", () => {
     26 |   throw new Error("This test fails");
-                                            ^
+                     ^
     error: This test fails
         at <anonymous> (file:NN:NN)
     (fail) another failing test

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1647,6 +1647,37 @@ describe.concurrent(() => {
     expect(await proc.stderr.text()).toContain("bar");
   });
 
+  // https://github.com/oven-sh/bun/issues/30504
+  it.each([
+    ["rethrows", "throw err;"],
+    ["reads err.stack and then rethrows", "void err.stack; throw err;"],
+  ])("prints the Error's own stack when the uncaughtException handler %s", async (_, handlerBody) => {
+    using dir = tempDir("rethrow-uncaught", {
+      "index.cjs": `
+        'use strict';
+        function rethrowHandler(err) {
+          ${handlerBody}
+        }
+        process.on('uncaughtException', rethrowHandler);
+        function throwUncaughtError() {
+          throw new Error('Boom');
+        }
+        throwUncaughtError();
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(String(dir), "index.cjs")],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Boom");
+    expect(stderr).toContain("at throwUncaughtError (");
+    expect(stderr).not.toContain("at rethrowHandler (");
+    expect(exitCode).toBe(7);
+  });
+
   it("aborts when the uncaughtExceptionCaptureCallback throws", async () => {
     const proc = Bun.spawn([bunExe(), join(import.meta.dir, "process-uncaughtExceptionCaptureCallbackAbort.js")], {
       stderr: "pipe",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1671,7 +1671,8 @@ describe.concurrent(() => {
       stderr: "pipe",
       stdout: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
     expect(stderr).toContain("Boom");
     expect(stderr).toContain("at throwUncaughtError (");
     expect(stderr).not.toContain("at rethrowHandler (");

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1647,36 +1647,37 @@ describe.concurrent(() => {
     expect(await proc.stderr.text()).toContain("bar");
   });
 
-  // https://github.com/oven-sh/bun/issues/30504
-  it.each([
+  describe.each([
     ["rethrows", "throw err;"],
     ["reads err.stack and then rethrows", "void err.stack; throw err;"],
-  ])("prints the Error's own stack when the uncaughtException handler %s", async (_, handlerBody) => {
-    using dir = tempDir("rethrow-uncaught", {
-      "index.cjs": `
-        'use strict';
-        function rethrowHandler(err) {
-          ${handlerBody}
-        }
-        process.on('uncaughtException', rethrowHandler);
-        function throwUncaughtError() {
-          throw new Error('Boom');
-        }
-        throwUncaughtError();
-      `,
+  ])("when the uncaughtException handler %s", (_, handlerBody) => {
+    it("prints the Error's own stack", async () => {
+      using dir = tempDir("rethrow-uncaught", {
+        "index.cjs": `
+          'use strict';
+          function rethrowHandler(err) {
+            ${handlerBody}
+          }
+          process.on('uncaughtException', rethrowHandler);
+          function throwUncaughtError() {
+            throw new Error('Boom');
+          }
+          throwUncaughtError();
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(String(dir), "index.cjs")],
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("");
+      expect(stderr).toContain("Boom");
+      expect(stderr).toContain("at throwUncaughtError (");
+      expect(stderr).not.toContain("at rethrowHandler (");
+      expect(exitCode).toBe(7);
     });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(String(dir), "index.cjs")],
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout).toBe("");
-    expect(stderr).toContain("Boom");
-    expect(stderr).toContain("at throwUncaughtError (");
-    expect(stderr).not.toContain("at rethrowHandler (");
-    expect(exitCode).toBe(7);
   });
 
   it("aborts when the uncaughtExceptionCaptureCallback throws", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -715,6 +715,67 @@ describe("error event", () => {
     expect(err).toBeInstanceOf(Error);
     expect(err.message).toMatch(/MessagePort \[EventTarget\] \{.*\}/s);
   });
+
+  test("uncaught output shows the worker stack when there is no 'error' listener", async () => {
+    // The error is structuredClone'd across the thread boundary and then
+    // rethrown by the EventEmitter 'error' path. The crash report must point
+    // at the worker's frame (from the cloned `.stack` string), not at the
+    // internal `throw er` site in node:events.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        /* js */ `
+          const { Worker } = require("node:worker_threads");
+          new Worker(\`
+            function crashInWorkerFn() { throw new TypeError("WORKER-ORIGIN-9201"); }
+            crashInWorkerFn();
+          \`, { eval: true });
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("WORKER-ORIGIN-9201");
+    expect(stderr).toContain("crashInWorkerFn");
+    expect(stderr).not.toContain("node:events");
+    expect(stderr).not.toContain("node:worker_threads");
+    expect(exitCode).toBe(1);
+  });
+
+  test("uncaught output uses the error's own stack, not the rethrow site", async () => {
+    // A structuredClone'd error has no captured JSC frames, only a `.stack`
+    // string. When it escapes a microtask, the printer must prefer that
+    // string over the JSC::Exception wrapper stack captured at the `throw`.
+    // This is the same mechanism as the worker case above, exercised
+    // directly without the cross-thread hop.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        /* js */ `
+          const cloned = structuredClone(new TypeError("CLONED"));
+          cloned.stack = "TypeError: CLONED\\n    at workerSideFrame (fake.js:1:1)";
+          queueMicrotask(() => {
+            function rethrowIt(e) { throw e; }
+            rethrowIt(cloned);
+          });
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("CLONED");
+    expect(stderr).toContain("at workerSideFrame (fake.js");
+    expect(stderr).not.toContain("rethrowIt");
+    expect(exitCode).toBe(1);
+  });
 });
 
 describe("getHeapSnapshot", () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -717,10 +717,6 @@ describe("error event", () => {
   });
 
   test("uncaught output shows the worker stack when there is no 'error' listener", async () => {
-    // The error is structuredClone'd across the thread boundary and then
-    // rethrown by the EventEmitter 'error' path. The crash report must point
-    // at the worker's frame (from the cloned `.stack` string), not at the
-    // internal `throw er` site in node:events.
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -746,12 +742,7 @@ describe("error event", () => {
     expect(exitCode).toBe(1);
   });
 
-  test("uncaught output uses the error's own stack, not the rethrow site", async () => {
-    // A structuredClone'd error has no captured JSC frames, only a `.stack`
-    // string. When it escapes a microtask, the printer must prefer that
-    // string over the JSC::Exception wrapper stack captured at the `throw`.
-    // This is the same mechanism as the worker case above, exercised
-    // directly without the cross-thread hop.
+  test("uncaught output uses a structuredClone'd error's own stack, not the rethrow site", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),

--- a/test/regression/issue/12782.test.ts
+++ b/test/regression/issue/12782.test.ts
@@ -28,7 +28,7 @@ test("12782", async () => {
     4 | 
     5 | beforeAll(() => {
     6 |   if (!FOO) throw new Error("Environment variable FOO is not set");
-                                                                         ^
+                              ^
     error: Environment variable FOO is not set
         at <anonymous> (file:NN:NN)
     (fail) (unnamed)

--- a/test/regression/issue/19850/19850.test.ts
+++ b/test/regression/issue/19850/19850.test.ts
@@ -25,17 +25,17 @@ err-in-hook-and-multiple-tests.ts:
 2 | 
 3 | beforeEach(() => {
 4 |   throw new Error("beforeEach");
-                                  ^
+                ^
 error: beforeEach
-      at <anonymous> (/err-in-hook-and-multiple-tests.ts:4:31)
+      at <anonymous> (/err-in-hook-and-multiple-tests.ts:4:13)
 (fail) test 0
 1 | import { beforeEach, test } from "bun:test";
 2 | 
 3 | beforeEach(() => {
 4 |   throw new Error("beforeEach");
-                                  ^
+                ^
 error: beforeEach
-      at <anonymous> (/err-in-hook-and-multiple-tests.ts:4:31)
+      at <anonymous> (/err-in-hook-and-multiple-tests.ts:4:13)
 (fail) test 1
 
  0 pass


### PR DESCRIPTION
Fixes #30504

### Problem
- A rethrown Error's uncaught-exception report blames the rethrow site. `process.on('uncaughtException', err => { throw err })` prints `at <anonymous> (rethrow.cjs:4:9)`; node prints `at throwUncaughtError (rethrow.cjs:8:9)`. A worker that dies with no `'error'` listener prints `at emitError (node:events:51:13)` and no worker frame.
- Cause: `fromErrorInstance` (`src/jsc/bindings/ZigException.cpp`) reads the `JSC::Exception` wrapper's stack first. Every `throw` creates a fresh wrapper captured at the throw site, so the Error's own record is never consulted.

### Fix
- `fromErrorInstance` picks, in order: the Error's native trace, the frames parsed from its `.stack` string, and the wrapper stack only when neither yields a frame. A self-referential `.stack` falls through instead of returning empty.
- `ZigException__collectSourceLines` shares the `hasVisibleFrames` predicate, so the source excerpt indexes the same frame vector the printer used.
- Node always prints `err.stack`. The wrapper stays as the last resort, so Errors with no usable stack print as before.
- Verified: `test/js/node/process/process.test.js` (handler rethrows, handler reads `err.stack` then rethrows) and `test/js/node/worker_threads/worker_threads.test.ts` (`error event`). Both fail on main. Also the snapshots in Notes, `reportError`, `circular-error-stack*`, `stack.test.ts`.

### Background
- `JSC::Exception` wraps a thrown value and records the stack at the `throw`. It belongs to the throw, not the Error.
- `ErrorInstance` keeps a native trace from construction. The first `.stack` read or write turns it into the string property and frees the vector. A `structuredClone`d or worker `'error'` Error is built from the string and never has one.
- `populateStackTrace` runs twice: `OnlyPosition` picks frames with line info, `OnlySourceLines` re-indexes the same vector through `jsc_stack_frame_index`.

<details><summary>Notes</summary>

- Supersedes #30508 (closed), which swapped the native trace ahead of the wrapper but left a handler that logs `err.stack`, and every worker error, on the rethrow site. Its process test is carried here.
- The reported column for `throw new Error("x")` moves from the end of the throw statement to the `Error` call, matching `err.stack`. Four bun:test output snapshots change only in that column: `test/js/bun/test/dots.test.ts`, `only-failures.test.ts`, `test/regression/issue/12782.test.ts`, `19850/19850.test.ts`.
- `hasVisibleFrames` exists because an earlier revision gated `fromErrorInstance` on the outcome (`frames_len == 0`) but `collectSourceLines` on the predicate (`size() > 0`). An Error whose native trace is all host frames would have had its indices resolved against the wrong vector. The bounds check made that a missing excerpt, not a crash.
- Exit code 7 in the process test is node's code for an `uncaughtException` handler that throws.
- Probes under `BUN_JSC_validateExceptionChecks=1`: worker with no listener, cloned Error rethrown from a microtask, `e.stack = e`, and a throwing `.stack` getter. No validator trips.
- Rebased onto main after #40410 (jsc-exception-lint). The `RETURN_IF_EXCEPTION` checks main added after each `populateStackTrace` call are kept, including on the new fallback call.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->