### PR TITLE
os: freeze os.constants.signals to match Node.js

### DIFF
--- a/src/js/node/os.ts
+++ b/src/js/node/os.ts
@@ -88,6 +88,8 @@ function lazyCpus({ cpus, hostCpuCount }) {
 
 // all logic based on `process.platform` and `process.arch` is inlined at bundle time
 function bound(binding) {
+  const constants = $processBindingConstants.os;
+  Object.freeze(constants.signals);
   return {
     availableParallelism: function () {
       return navigator.hardwareConcurrency;
@@ -148,7 +150,7 @@ function bound(binding) {
     get EOL() {
       return process.platform === "win32" ? "\r\n" : "\n";
     },
-    constants: $processBindingConstants.os,
+    constants,
   };
 }
 

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -300,7 +300,7 @@ it.skipIf(isWindows)(
       out += d;
       if (!sent && out.includes("READY")) { sent = true; kid.kill("SIGTERM"); }
     });
-    kid.on("exit", (code, sig) => {
+    kid.on("close", (code, sig) => {
       console.log(JSON.stringify({ out: out.trim().split("\\n"), code, sig }));
     });
   `;

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -286,8 +286,10 @@ it("os.constants.signals is frozen", () => {
   expect(os.constants.signals.SIGTERM).toBe(15);
 });
 
-it.skipIf(isWindows)("child_process signal name resolution is not affected by mutating os.constants.signals", async () => {
-  const script = `
+it.skipIf(isWindows)(
+  "child_process signal name resolution is not affected by mutating os.constants.signals",
+  async () => {
+    const script = `
     const os = require("node:os");
     const { spawn } = require("node:child_process");
     try { os.constants.signals.SIGTERM = 9; } catch {}
@@ -302,21 +304,22 @@ it.skipIf(isWindows)("child_process signal name resolution is not affected by mu
       console.log(JSON.stringify({ out: out.trim().split("\\n"), code, sig }));
     });
   `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(JSON.parse(stdout.trim())).toEqual({
-    out: ["READY", "CAUGHT-SIGTERM"],
-    code: 42,
-    sig: null,
-  });
-  expect(exitCode).toBe(0);
-});
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      out: ["READY", "CAUGHT-SIGTERM"],
+      code: 42,
+      sig: null,
+    });
+    expect(exitCode).toBe(0);
+  },
+);
 
 it("getPriority system error object", () => {
   try {

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { realpathSync } from "fs";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { isIPv4, isIPv6 } from "node:net";
 import * as os from "node:os";
 
@@ -276,6 +276,46 @@ describe("toString works like node", () => {
       }
     });
   }
+});
+
+it("os.constants.signals is frozen", () => {
+  expect(Object.isFrozen(os.constants.signals)).toBe(true);
+  expect(() => {
+    os.constants.signals.SIGTERM = 9;
+  }).toThrow(TypeError);
+  expect(os.constants.signals.SIGTERM).toBe(15);
+});
+
+it.skipIf(isWindows)("child_process signal name resolution is not affected by mutating os.constants.signals", async () => {
+  const script = `
+    const os = require("node:os");
+    const { spawn } = require("node:child_process");
+    try { os.constants.signals.SIGTERM = 9; } catch {}
+    const kid = spawn(process.execPath, ["-e", 'process.on("SIGTERM",()=>{console.log("CAUGHT-SIGTERM");process.exit(42)});setInterval(()=>{},1000);console.log("READY")']);
+    let out = "", sent = false;
+    kid.stdout.setEncoding("utf8");
+    kid.stdout.on("data", d => {
+      out += d;
+      if (!sent && out.includes("READY")) { sent = true; kid.kill("SIGTERM"); }
+    });
+    kid.on("exit", (code, sig) => {
+      console.log(JSON.stringify({ out: out.trim().split("\\n"), code, sig }));
+    });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({
+    out: ["READY", "CAUGHT-SIGTERM"],
+    code: 42,
+    sig: null,
+  });
+  expect(exitCode).toBe(0);
 });
 
 it("getPriority system error object", () => {


### PR DESCRIPTION
## What

`os.constants.signals` is now frozen when `node:os` is loaded, matching Node.js v26+.

## Why

Bun left `os.constants.signals` mutable. `node:child_process` resolves signal names through this exact object, so user code could poison signal resolution:

```js
import os from "node:os";
import { spawn } from "node:child_process";
os.constants.signals.SIGTERM = 9;          // node: TypeError (frozen). bun: silently succeeds.
const kid = spawn(process.execPath, ["-e", 'process.on("SIGTERM",()=>process.exit(42));setInterval(()=>{},1e3);console.log("READY")']);
kid.stdout.once("data", () => kid.kill("SIGTERM"));
kid.on("exit", (code, sig) => console.log({ code, sig }));
// bun before: { code: null, sig: "SIGKILL" }  (handler never runs)
// node:       throws on the assignment; Object.isFrozen(os.constants.signals) === true
```

Node added `ObjectFreeze(constants.signals)` to `lib/os.js` in [nodejs/node#61038](https://github.com/nodejs/node/pull/61038) (v26.0.0) with the same rationale: "Remove the ability to mutate signals constant as doing so can lead to unexpected behavior, notably when spawning child process." Bun reports `process.versions.node` as `26.3.0`.

Bun's `child_process.ts` already does `require("node:os")`, so freezing in `os.ts` also protects `child.kill(name)` and `spawnSync({ killSignal: name })`.

## Verification

```
# before (USE_SYSTEM_BUN=1): isFrozen=false, child dies SIGKILL
# after  (bun bd):           isFrozen=true,  child catches SIGTERM and exits 42
bun bd test test/js/node/os/os.test.js -t signals
```

`os.constants.errno` / `priority` / `dlopen` remain unfrozen, matching Node v26.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/os/os.test.js

<!-- robobun:evidence:end -->