### PR TITLE
Implement navigator.language, navigator.languages, and globalThis.Navigator

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1434,9 +1434,15 @@ interface Navigator {
   readonly userAgent: string;
   readonly platform: "MacIntel" | "Win32" | "Linux x86_64";
   readonly hardwareConcurrency: number;
+  readonly language: string;
+  readonly languages: readonly string[];
 }
 
 declare var navigator: Navigator;
+declare var Navigator: {
+  prototype: Navigator;
+  new (): Navigator;
+};
 
 interface BlobPropertyBag {
   /** Set a default "type". Not yet implemented. */

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -52,6 +52,7 @@
 #include "JavaScriptCore/LazyClassStructure.h"
 #include "JavaScriptCore/LazyClassStructureInlines.h"
 #include "JavaScriptCore/ObjectConstructor.h"
+#include "JavaScriptCore/IntlObject.h"
 #include "JavaScriptCore/JSBasePrivate.h"
 #include "JavaScriptCore/ScriptExecutable.h"
 #include "JavaScriptCore/ScriptFetchParameters.h"
@@ -1732,6 +1733,24 @@ JSC_DEFINE_HOST_FUNCTION(functionNavigatorGetHardwareConcurrency, (JSC::JSGlobal
     return JSValue::encode(JSC::jsNumber(WTF::numberOfProcessorCores()));
 }
 
+JSC_DEFINE_HOST_FUNCTION(functionNavigatorGetLanguage, (JSC::JSGlobalObject * globalObject, JSC::CallFrame*))
+{
+    auto& vm = JSC::getVM(globalObject);
+    return JSValue::encode(JSC::jsString(vm, JSC::defaultLocale(globalObject)));
+}
+
+JSC_DEFINE_HOST_FUNCTION(functionNavigatorGetLanguages, (JSC::JSGlobalObject * globalObject, JSC::CallFrame*))
+{
+    return JSValue::encode(uncheckedDowncast<Zig::GlobalObject>(globalObject)->navigatorLanguages());
+}
+
+JSC_DEFINE_HOST_FUNCTION(functionNavigatorConstructor, (JSC::JSGlobalObject * globalObject, JSC::CallFrame*))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    return Bun::throwError(globalObject, scope, Bun::ErrorCode::ERR_ILLEGAL_CONSTRUCTOR, "Illegal constructor"_s);
+}
+
 JSC_DECLARE_HOST_FUNCTION(makeGetterTypeErrorForBuiltins);
 JSC_DECLARE_HOST_FUNCTION(makeDOMExceptionForBuiltins);
 JSC_DECLARE_HOST_FUNCTION(isAbortSignal);
@@ -2349,16 +2368,32 @@ void GlobalObject::finishCreation(VM& vm)
             JSC::JSGlobalObject* globalObject = init.owner;
             unsigned accessorAttributes = PropertyAttribute::Accessor | 0;
 
-            JSC::JSObject* obj = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 4);
+            JSC::JSObject* prototype = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 7);
+            prototype->structure()->setMayBePrototype(true);
 
-            obj->putDirectNativeIntrinsicGetter(init.vm, globalObject, JSC::Identifier::fromString(init.vm, "userAgent"_s), functionNavigatorGetUserAgent, JSC::NoIntrinsic, accessorAttributes);
-            obj->putDirectNativeIntrinsicGetter(init.vm, globalObject, JSC::Identifier::fromString(init.vm, "platform"_s), functionNavigatorGetPlatform, JSC::NoIntrinsic, accessorAttributes);
-            obj->putDirectNativeIntrinsicGetter(init.vm, globalObject, JSC::Identifier::fromString(init.vm, "hardwareConcurrency"_s), functionNavigatorGetHardwareConcurrency, JSC::NoIntrinsic, accessorAttributes);
+            prototype->putDirectNativeIntrinsicGetter(init.vm, globalObject, JSC::Identifier::fromString(init.vm, "hardwareConcurrency"_s), functionNavigatorGetHardwareConcurrency, JSC::NoIntrinsic, accessorAttributes);
+            prototype->putDirectNativeIntrinsicGetter(init.vm, globalObject, JSC::Identifier::fromString(init.vm, "language"_s), functionNavigatorGetLanguage, JSC::NoIntrinsic, accessorAttributes);
+            prototype->putDirectNativeIntrinsicGetter(init.vm, globalObject, JSC::Identifier::fromString(init.vm, "languages"_s), functionNavigatorGetLanguages, JSC::NoIntrinsic, accessorAttributes);
+            prototype->putDirectNativeIntrinsicGetter(init.vm, globalObject, JSC::Identifier::fromString(init.vm, "userAgent"_s), functionNavigatorGetUserAgent, JSC::NoIntrinsic, accessorAttributes);
+            prototype->putDirectNativeIntrinsicGetter(init.vm, globalObject, JSC::Identifier::fromString(init.vm, "platform"_s), functionNavigatorGetPlatform, JSC::NoIntrinsic, accessorAttributes);
 
-            obj->putDirect(init.vm, init.vm.propertyNames->toStringTagSymbol,
+            prototype->putDirect(init.vm, init.vm.propertyNames->toStringTagSymbol,
                 jsNontrivialString(init.vm, "Navigator"_s), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
 
-            init.set(obj);
+            JSC::JSFunction* constructor = JSC::JSFunction::create(init.vm, globalObject, 0, "Navigator"_s, functionNavigatorConstructor, ImplementationVisibility::Public, NoIntrinsic, functionNavigatorConstructor);
+            constructor->putDirect(init.vm, init.vm.propertyNames->prototype, prototype, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+            prototype->putDirect(init.vm, init.vm.propertyNames->constructor, constructor, static_cast<unsigned>(PropertyAttribute::DontEnum));
+
+            init.set(JSC::constructEmptyObject(globalObject, prototype, 0));
+        });
+
+    m_navigatorLanguages.initLater(
+        [](const Initializer<JSC::JSArray>& init) {
+            JSC::JSGlobalObject* globalObject = init.owner;
+            JSC::JSArray* array = JSC::constructEmptyArray(globalObject, nullptr, 1);
+            array->putDirectIndex(globalObject, 0, JSC::jsString(init.vm, JSC::defaultLocale(globalObject)));
+            JSC::objectConstructorFreeze(globalObject, array);
+            init.set(array);
         });
 
     this->m_jsonlParseResultStructure.initLater(
@@ -3059,6 +3094,13 @@ JSValue GlobalObject_getPerformanceObject(VM& vm, JSObject* globalObject)
 JSValue GlobalObject_getGlobalThis(VM& vm, JSObject* globalObject)
 {
     return uncheckedDowncast<Zig::GlobalObject>(globalObject)->globalThis();
+}
+
+JSValue NavigatorConstructorCallback(VM& vm, JSObject* globalObject)
+{
+    JSObject* instance = uncheckedDowncast<Zig::GlobalObject>(globalObject)->navigatorObject();
+    JSObject* prototype = instance->getPrototypeDirect().getObject();
+    return prototype->getDirect(vm, vm.propertyNames->constructor);
 }
 
 // This is like `putDirectBuiltinFunction` but for the global static list.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2363,7 +2363,7 @@ void GlobalObject::finishCreation(VM& vm)
             init.set(JSFunction::create(init.vm, init.owner, 2, ""_s, functionNativeMicrotaskTrampoline, ImplementationVisibility::Private));
         });
 
-    m_navigatorObject.initLater(
+    m_navigatorConstructor.initLater(
         [](const Initializer<JSObject>& init) {
             JSC::JSGlobalObject* globalObject = init.owner;
             unsigned accessorAttributes = PropertyAttribute::Accessor | 0;
@@ -2384,7 +2384,14 @@ void GlobalObject::finishCreation(VM& vm)
             constructor->putDirect(init.vm, init.vm.propertyNames->prototype, prototype, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
             prototype->putDirect(init.vm, init.vm.propertyNames->constructor, constructor, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
-            init.set(JSC::constructEmptyObject(globalObject, prototype, 0));
+            init.set(constructor);
+        });
+
+    m_navigatorObject.initLater(
+        [](const Initializer<JSObject>& init) {
+            JSObject* constructor = uncheckedDowncast<Zig::GlobalObject>(init.owner)->m_navigatorConstructor.get(init.owner);
+            JSObject* prototype = constructor->getDirect(init.vm, init.vm.propertyNames->prototype).getObject();
+            init.set(JSC::constructEmptyObject(init.owner, prototype, 0));
         });
 
     m_navigatorLanguages.initLater(
@@ -3098,9 +3105,8 @@ JSValue GlobalObject_getGlobalThis(VM& vm, JSObject* globalObject)
 
 JSValue NavigatorConstructorCallback(VM& vm, JSObject* globalObject)
 {
-    JSObject* instance = uncheckedDowncast<Zig::GlobalObject>(globalObject)->navigatorObject();
-    JSObject* prototype = instance->getPrototypeDirect().getObject();
-    return prototype->getDirect(vm, vm.propertyNames->constructor);
+    auto* zigGlobalObject = uncheckedDowncast<Zig::GlobalObject>(globalObject);
+    return zigGlobalObject->m_navigatorConstructor.get(zigGlobalObject);
 }
 
 // This is like `putDirectBuiltinFunction` but for the global static list.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2397,9 +2397,13 @@ void GlobalObject::finishCreation(VM& vm)
     m_navigatorLanguages.initLater(
         [](const Initializer<JSC::JSArray>& init) {
             JSC::JSGlobalObject* globalObject = init.owner;
+            auto scope = DECLARE_THROW_SCOPE(init.vm);
             JSC::JSArray* array = JSC::constructEmptyArray(globalObject, nullptr, 1);
+            scope.assertNoException();
             array->putDirectIndex(globalObject, 0, JSC::jsString(init.vm, JSC::defaultLocale(globalObject)));
+            scope.assertNoException();
             JSC::objectConstructorFreeze(globalObject, array);
+            scope.assertNoException();
             init.set(array);
         });
 

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -659,6 +659,7 @@ public:
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_bunObject)                                             \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_cryptoObject)                                          \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_navigatorObject)                                       \
+    V(private, LazyPropertyOfGlobalObject<JSC::JSArray>, m_navigatorLanguages)                               \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_performanceObject)                                     \
     V(public, LazyPropertyOfGlobalObject<Bun::Process>, m_processObject)                                     \
     V(public, LazyPropertyOfGlobalObject<CustomGetterSetter>, m_lazyStackCustomGetterSetter)                 \
@@ -719,6 +720,7 @@ public:
     }
 
     JSObject* navigatorObject();
+    JSC::JSArray* navigatorLanguages() { return m_navigatorLanguages.getInitializedOnMainThread(this); }
     JSFunction* nativeMicrotaskTrampoline() const { return m_nativeMicrotaskTrampoline.getInitializedOnMainThread(this); }
 
     String agentClusterID() const;

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -659,6 +659,7 @@ public:
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_bunObject)                                             \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_cryptoObject)                                          \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_navigatorObject)                                       \
+    V(public, LazyPropertyOfGlobalObject<JSObject>, m_navigatorConstructor)                                  \
     V(private, LazyPropertyOfGlobalObject<JSC::JSArray>, m_navigatorLanguages)                               \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_performanceObject)                                     \
     V(public, LazyPropertyOfGlobalObject<Bun::Process>, m_processObject)                                     \

--- a/src/jsc/bindings/ZigGlobalObject.lut.txt
+++ b/src/jsc/bindings/ZigGlobalObject.lut.txt
@@ -60,9 +60,9 @@
   FormData                        DOMFormDataConstructorCallback                       PropertyCallback
   Headers                         FetchHeadersConstructorCallback                      PropertyCallback
   MessageChannel                  MessageChannelConstructorCallback                    PropertyCallback
-  Navigator                       NavigatorConstructorCallback                         PropertyCallback
   MessageEvent                    MessageEventConstructorCallback                      PropertyCallback
   MessagePort                     MessagePortConstructorCallback                       PropertyCallback
+  Navigator                       NavigatorConstructorCallback                         PropertyCallback
   Performance                     PerformanceConstructorCallback                       PropertyCallback
   PerformanceEntry                PerformanceEntryConstructorCallback                  PropertyCallback
   PerformanceMark                 PerformanceMarkConstructorCallback                   PropertyCallback

--- a/src/jsc/bindings/ZigGlobalObject.lut.txt
+++ b/src/jsc/bindings/ZigGlobalObject.lut.txt
@@ -60,6 +60,7 @@
   FormData                        DOMFormDataConstructorCallback                       PropertyCallback
   Headers                         FetchHeadersConstructorCallback                      PropertyCallback
   MessageChannel                  MessageChannelConstructorCallback                    PropertyCallback
+  Navigator                       NavigatorConstructorCallback                         PropertyCallback
   MessageEvent                    MessageEventConstructorCallback                      PropertyCallback
   MessagePort                     MessagePortConstructorCallback                       PropertyCallback
   Performance                     PerformanceConstructorCallback                       PropertyCallback

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -244,8 +244,44 @@ test("navigator", () => {
   }
 });
 
+// https://github.com/oven-sh/bun/issues/3168
+test("navigator.language / navigator.languages", () => {
+  const locale = Intl.DateTimeFormat().resolvedOptions().locale;
+  expect(typeof navigator.language).toBe("string");
+  expect(navigator.language).toBe(locale);
+  expect(navigator.language.split("-")[0].length).toBeGreaterThanOrEqual(2);
+
+  expect(Array.isArray(navigator.languages)).toBe(true);
+  expect(navigator.languages).toEqual([locale]);
+  expect(Object.isFrozen(navigator.languages)).toBe(true);
+  expect(navigator.languages).toBe(navigator.languages);
+});
+
+test("globalThis.Navigator", () => {
+  expect(typeof Navigator).toBe("function");
+  expect(Navigator.name).toBe("Navigator");
+  expect(Navigator.length).toBe(0);
+  expect(navigator instanceof Navigator).toBe(true);
+  expect(Object.getPrototypeOf(navigator)).toBe(Navigator.prototype);
+  expect(Navigator.prototype.constructor).toBe(Navigator);
+
+  expect(() => new Navigator()).toThrow(expect.objectContaining({ code: "ERR_ILLEGAL_CONSTRUCTOR" }));
+
+  expect(Object.getOwnPropertyNames(navigator)).toEqual([]);
+  expect(Object.getOwnPropertyNames(Navigator.prototype).sort()).toEqual(
+    expect.arrayContaining(["constructor", "hardwareConcurrency", "language", "languages", "platform", "userAgent"]),
+  );
+
+  expect(Object.getOwnPropertyDescriptor(Navigator, "prototype")).toEqual({
+    value: Navigator.prototype,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+});
+
 // https://github.com/oven-sh/bun/issues/21585
-test.concurrent.each(["userAgent", "platform", "hardwareConcurrency"])(
+test.concurrent.each(["userAgent", "platform", "hardwareConcurrency", "language", "languages"])(
   "navigator.%s is a getter-only accessor",
   async key => {
     // Spawn a fresh process so we don't mutate the test runner's own navigator object.
@@ -253,7 +289,7 @@ test.concurrent.each(["userAgent", "platform", "hardwareConcurrency"])(
     const src = `
     const nav = globalThis.navigator;
     const before = nav[${k}];
-    const desc = Object.getOwnPropertyDescriptor(nav, ${k});
+    const desc = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(nav), ${k});
     let strictErr = null;
     try {
       (function () { "use strict"; nav[${k}] = "overwritten"; })();
@@ -265,6 +301,7 @@ test.concurrent.each(["userAgent", "platform", "hardwareConcurrency"])(
     console.log(JSON.stringify({
       before,
       after: nav[${k}],
+      hasOwn: Object.hasOwn(nav, ${k}),
       desc: { get: typeof desc.get, set: typeof desc.set, enumerable: desc.enumerable, configurable: desc.configurable, hasWritable: "writable" in desc },
       strictErr,
     }));
@@ -279,6 +316,7 @@ test.concurrent.each(["userAgent", "platform", "hardwareConcurrency"])(
     expect({ ...result, stderr, exitCode }).toEqual({
       before: result.before,
       after: result.before,
+      hasOwn: false,
       desc: { get: "function", set: "undefined", enumerable: true, configurable: true, hasWritable: false },
       strictErr: "TypeError",
       stderr: expect.any(String),

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -281,6 +281,9 @@ test("globalThis.Navigator", () => {
 });
 
 test.concurrent("globalThis.Navigator is not derived through mutable navigator state", async () => {
+  // Runs a script file rather than -e: the -e code path reifies the global lut entry for
+  // Navigator before user code runs, so the lazy PropertyCallback this test targets is
+  // only reached from the module-loading path.
   using dir = tempDir("navigator-tamper", {
     "index.js": `
       const nav = globalThis.navigator;
@@ -299,9 +302,11 @@ test.concurrent("globalThis.Navigator is not derived through mutable navigator s
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual({ Navigator: "function", name: "Navigator", hasProto: "object" });
-  expect(exitCode).toBe(0);
+  expect({ result: stdout.trim() && JSON.parse(stdout), stderr, exitCode }).toEqual({
+    result: { Navigator: "function", name: "Navigator", hasProto: "object" },
+    stderr: expect.any(String),
+    exitCode: 0,
+  });
 });
 
 // https://github.com/oven-sh/bun/issues/21585

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isMacOS, isWindows, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS, isWindows, tempDir, withoutAggressiveGC } from "harness";
 
 test("exists", () => {
   expect(typeof URL !== "undefined").toBe(true);
@@ -278,6 +278,30 @@ test("globalThis.Navigator", () => {
     enumerable: false,
     configurable: false,
   });
+});
+
+test.concurrent("globalThis.Navigator is not derived through mutable navigator state", async () => {
+  using dir = tempDir("navigator-tamper", {
+    "index.js": `
+      const nav = globalThis.navigator;
+      Object.setPrototypeOf(nav, null);
+      console.log(JSON.stringify({
+        Navigator: typeof globalThis.Navigator,
+        name: globalThis.Navigator.name,
+        hasProto: typeof globalThis.Navigator.prototype,
+      }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ Navigator: "function", name: "Navigator", hasProto: "object" });
+  expect(exitCode).toBe(0);
 });
 
 // https://github.com/oven-sh/bun/issues/21585


### PR DESCRIPTION
Closes #3168

## What

`navigator` now exposes `language`, `languages`, and a global `Navigator` class, matching Node.js 21+ and browsers.

## Why

The guarded i18n idiom that works everywhere else throws only in Bun:

```js
if (typeof navigator !== 'undefined') {
  const lang = navigator.language.split('-')[0];
  // TypeError: undefined is not an object (evaluating 'navigator.language.split')
}
```

Bun shipped `navigator` with `userAgent`/`platform`/`hardwareConcurrency`, so the `typeof` guard passes, but `language`/`languages` were `undefined` and there was no `Navigator` class.

## How

- `navigator.language` returns `JSC::defaultLocale()` (the same ICU-derived value as `Intl.DateTimeFormat().resolvedOptions().locale`).
- `navigator.languages` returns a frozen `[language]` array, cached per global so repeated reads return the same reference (matches Node).
- `globalThis.Navigator` is a constructor that throws `ERR_ILLEGAL_CONSTRUCTOR` on `new`; `navigator instanceof Navigator` is `true`.
- All accessors (including the existing three) now live on `Navigator.prototype`; `navigator` itself has no own properties. This matches Node and browsers and fixes the shape oddity where `delete navigator.userAgent` used to remove the getter.

`navigator.locks` is intentionally left out; it requires a Web Locks / `worker_threads.locks` implementation that Bun does not have yet.

## Verification

Before:
```
{"hasNavigator":true,"language":"undefined","languages":false,"NavigatorClass":"undefined"}
THROW TypeError: undefined is not an object (evaluating 'navigator.language.split')
```

After:
```
{"hasNavigator":true,"language":"string","languages":true,"NavigatorClass":"function"}
ok:en
```

New tests in `test/js/web/web-globals.test.js` cover `language`/`languages`, the `Navigator` class shape, and the prototype accessor descriptors.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/web-globals.test.js

<!-- robobun:evidence:end -->