### PR TITLE
worker_threads: run worker uncaughtException/unhandledRejection listeners under bun test

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1353,7 +1353,12 @@ impl VirtualMachine {
             return true;
         }
 
-        if isBunTest.load(core::sync::atomic::Ordering::Relaxed) {
+        // The test-runner short-circuit routes errors to jest's reporter and
+        // skips process.on('uncaughtException'). It is a main-thread concept: a
+        // worker VM's `on_unhandled_rejection` is the worker error dispatcher,
+        // not jest's, and the worker's own uncaughtException listeners / exit
+        // code must behave as they do outside `bun test`.
+        if isBunTest.load(core::sync::atomic::Ordering::Relaxed) && self.is_main_thread() {
             self.unhandled_error_counter += 1;
             (self.on_unhandled_rejection)(self, global_object, err);
             return true;
@@ -3301,7 +3306,10 @@ impl VirtualMachine {
             return;
         }
 
-        if isBunTest.load(core::sync::atomic::Ordering::Relaxed) {
+        // See `uncaught_exception`: the test-runner short-circuit is main-thread
+        // only. A worker's unhandledRejection listeners and exit code must match
+        // standalone behaviour.
+        if isBunTest.load(core::sync::atomic::Ordering::Relaxed) && self.is_main_thread() {
             self.unhandled_error_counter += 1;
             (self.on_unhandled_rejection)(self, global_object, reason);
             return;

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -604,6 +604,58 @@ describe("error event", () => {
     expect(err).toBeInstanceOf(Error);
     expect(err.message).toMatch(/MessagePort \[EventTarget\] \{.*\}/s);
   });
+
+  // These run the Worker directly inside the test process (not spawned) because the
+  // bug they cover only reproduces under `bun test`: the process-global isBunTest
+  // flag used to short-circuit the worker VM's uncaught-exception path too.
+  test("synchronous top-level throw exits with code 1", async () => {
+    const worker = new Worker('throw new Error("boom")', { eval: true });
+    let errMessage: unknown;
+    worker.on("error", e => (errMessage = (e as Error)?.message));
+    const { promise, resolve } = Promise.withResolvers<number>();
+    worker.on("exit", resolve);
+    const code = await promise;
+    expect({ errMessage, code }).toEqual({ errMessage: "boom", code: 1 });
+  });
+
+  test("worker's own process.on('uncaughtException') handles the error", async () => {
+    const worker = new Worker(
+      /* js */ `
+      const { parentPort } = require("node:worker_threads");
+      process.on("uncaughtException", e => parentPort.postMessage("caught:" + e.message));
+      setImmediate(() => { throw new Error("late") });`,
+      { eval: true },
+    );
+    const events: unknown[] = [];
+    worker.on("message", m => events.push({ message: m }));
+    worker.on("error", e => events.push({ error: (e as Error)?.message }));
+    const { promise, resolve } = Promise.withResolvers<number>();
+    worker.on("exit", resolve);
+    const code = await promise;
+    expect({ events, code }).toEqual({ events: [{ message: "caught:late" }], code: 0 });
+  });
+
+  test("worker's own process.on('unhandledRejection') handles the rejection", async () => {
+    const worker = new Worker(
+      /* js */ `
+      const { parentPort } = require("node:worker_threads");
+      process.on("unhandledRejection", e => {
+        parentPort.postMessage("rejected:" + e.message);
+        parentPort.close();
+      });
+      parentPort.once("message", () => { Promise.reject(new Error("nope")); });`,
+      { eval: true },
+    );
+    const events: unknown[] = [];
+    worker.on("message", m => events.push({ message: m }));
+    worker.on("error", e => events.push({ error: (e as Error)?.message }));
+    await once(worker, "online");
+    worker.postMessage("go");
+    const { promise, resolve } = Promise.withResolvers<number>();
+    worker.on("exit", resolve);
+    const code = await promise;
+    expect({ events, code }).toEqual({ events: [{ message: "rejected:nope" }], code: 0 });
+  });
 });
 
 describe("getHeapSnapshot", () => {
@@ -626,14 +678,9 @@ describe("getHeapSnapshot", () => {
     });
   });
 
-  // "entry throws" is omitted: under `bun test`, isBunTest makes a worker's
-  // uncaught_exception return handled=true so spin() continues to
-  // fireEarlyMessages (the call resolves with real data). Under `bun -e`
-  // it rejects — see the test-worker-heapdump-failure.js vendored test for
-  // subprocess coverage. The two cases below take the shutdown() path
-  // directly so they exercise the m_pendingTasks abandon drain regardless.
   test.each([
     ["entry not found", undefined],
+    ["entry throws", "throw new Error('x')"],
     ["unsettled top-level await", "await new Promise(() => {})"],
   ])("rejects ERR_WORKER_NOT_RUNNING when called before a worker that fails to start (%s)", async (_, src) => {
     const worker =


### PR DESCRIPTION
## Repro

A `node:worker_threads` Worker that throws synchronously emits `'exit'` with code 1 when run standalone, but code 0 when run inside `bun test`. Node gives 1 in both contexts. Separately, a worker's own `process.on('uncaughtException')` / `process.on('unhandledRejection')` listeners are never called under `bun test`.

```js
// under bun -e: exit code 1.  under bun test: exit code 0.
import { Worker } from 'node:worker_threads';
const w = new Worker('throw new Error("X")', { eval: true });
w.on('error', () => {});
w.on('exit', c => console.log('exit code:', c));
```

```js
// under bun -e / node: prints HANDLER CALLED, exit 0.
// under bun test: handler never runs, parent 'error' fires, exit 0.
const w = new Worker(`
  process.on('uncaughtException', e => console.error('HANDLER CALLED:', e.message));
  setImmediate(() => { throw new Error('X') });
`, { eval: true });
```

## Cause

`isBunTest` is a process-global atomic, so it is true inside a worker VM spawned by a test. Both `VirtualMachine::uncaught_exception` and `VirtualMachine::unhandled_rejection` have a short-circuit when `isBunTest` is set: increment `unhandled_error_counter`, call `(self.on_unhandled_rejection)(...)`, return. That short-circuit skips `Bun__handleUncaughtException` / `Bun__handleUnhandledRejection` (so the worker's own `process.on(...)` listeners never run) and skips the `exit_handler.exit_code = 1` write. The short-circuit exists so jest's main-thread reporter captures errors instead of the user's `process` listeners swallowing them, but in a worker VM `on_unhandled_rejection` is the worker error dispatcher in `web_worker.rs`, not jest's, and the test runner has no visibility into the worker's error counter.

For the sync-throw case the entry promise is a `JSInternalPromise`, so the rejection is not tracked via `promiseRejectionTracker`; `spin()` sees `Rejected`, calls `uncaught_exception`, gets `handled == true` back, and continues with `exit_code` still 0. (An async `Promise.reject` at top level accidentally gave 1 because the rejection trips `handle_rejected_promises` inside `wait_for_promise_with_termination`, which makes `load_entry_point_for_web_worker` return `Err(WorkerTerminated)` and hit `spin()`'s Err arm.)

## Fix

Gate both `isBunTest` short-circuits on `self.is_main_thread()`. Worker VMs under `bun test` now take the normal path: the worker's own `uncaughtException`/`unhandledRejection` listeners run, and an unhandled error sets `exit_code = 1` before dispatching to the parent, same as standalone.

## Verification

Three new tests in the `error event` describe of `worker_threads.test.ts` run the Worker directly inside the test process (the bug only reproduces under `bun test`): sync-throw exit code 1, worker's `uncaughtException` listener is called, worker's `unhandledRejection` listener is called. All three fail on main and pass with the fix; all three match Node's output.

Also re-enabled the `entry throws` case in the `getHeapSnapshot` rejects-ERR_WORKER_NOT_RUNNING table, which had been omitted with a comment explaining that `isBunTest` made it resolve instead of reject under `bun test`.

Full `worker_threads.test.ts` (95 tests), `test/js/web/workers/worker.test.ts`, and the vendored `test-worker-*uncaught*`/`test-worker-*exit*` Node tests pass.

## Related

#34193 sets `exit_code = 1` in the worker's last-resort `on_unhandled_rejection` for the standalone unhandled-rejection path; this PR fixes the `bun test`-specific divergence. They compose without conflict.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (54d3761fa)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1905.66ms]
(pass) all worker_threads module properties are present [25.09ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [27.32ms]
(pass) all worker_threads worker instance properties are present [166.23ms]
(pass) threadId module and worker property is consistent [208.09ms]
(pass) receiveMessageOnPort works across threads [1723.32ms]
(pass) receiveMessageOnPort works as FIFO [14.76ms]
(pass) you can override globalThis.postMessage [1689.70ms]
(pass) support require in eval [1679.69ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1701.24ms]
(pass) support require in eval for a file that doesnt exist [1677.94ms]
(pass) support worker eval that throws [1669.97ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [6811.29ms]
(
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/worker_threads/worker_threads.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'markAsUncloneable' not found in module 'node:worker_threads'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [166.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (54d3761fa)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1766.45ms]
(pass) all worker_threads module properties are present [23.31ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [23.73ms]
(pass) all worker_threads worker instance properties are present [167.57ms]
(pass) threadId module and worker property is consistent [195.10ms]
(pass) receiveMessageOnPort works across threads [1706.00ms]
(pass) receiveMessageOnPort works as FIFO [12.75ms]
(pass) you can override globalThis.postMessage [1678.83ms]
(pass) support require in eval [1658.70ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1686.67ms]
(pass) support require in eval for a file that doesnt exist [1680.47ms]
(pass) support worker eval that throws [1667.32ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [6734.60ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     54d3761faf
  features     baseline

22 deps, 108 codegen, 1171 objects in 783ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [13.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[4/1234] gen .bind.ts → GeneratedBindings.cpp
[5/1234] fetch zlib
[zlib] up to date
[6/1234] fetch tinycc
[tinycc] up to date
[7/1234] gen ErrorCode+*.h
[8/1234] gen bindgenv2
[9/1234] fetch picohttpparser
[picohttpparser] up to date
[10/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs                          | 12 ++++-
 test/js/node/worker_threads/worker_threads.test.ts | 59 +++++++++++++++++++---
 2 files changed, 63 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/VirtualMachine.rs                               6      2      0
test/js/node/worker_threads/worker_threads.test.ts      2      4      0
```

</details>

**self-review** · no surviving concerns

30 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->