### PR TITLE
perf_hooks: expose eventLoopUtilization/timerify/nodeTiming on the global without an import

### DIFF
--- a/src/jsc/bindings/webcore/JSPerformance.cpp
+++ b/src/jsc/bindings/webcore/JSPerformance.cpp
@@ -55,6 +55,8 @@
 
 #include "ScriptExecutionContext.h"
 #include "WebCoreJSClientData.h"
+#include "ZigGlobalObject.h"
+#include "InternalModuleRegistry.h"
 // #include "WebCoreOpaqueRootInlines.h"
 #include <JavaScriptCore/HeapAnalyzer.h>
 #include <JavaScriptCore/JSArray.h>
@@ -146,6 +148,54 @@ JSC_DEFINE_HOST_FUNCTION(jsPerformancePrototypeFunction_markResourceTiming, (JSG
     return JSValue::encode(jsUndefined());
 }
 
+// Node.js defines eventLoopUtilization/timerify/nodeTiming on Performance.prototype
+// from process start. Bun's implementations live in src/js/node/perf_hooks.ts, so the
+// first touch of one of these on the global lazily evaluates that module, whose body
+// replaces this accessor with the real data property on the prototype.
+static JSC::EncodedJSValue jsPerformancePrototypeLoadNodePerfHooks(JSGlobalObject* lexicalGlobalObject, PropertyName propertyName)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+
+    globalObject->internalModuleRegistry()->requireId(globalObject, vm, Bun::InternalModuleRegistry::NodePerfHooks);
+    RETURN_IF_EXCEPTION(throwScope, {});
+
+    JSObject* prototype = JSPerformance::prototype(vm, *globalObject);
+    JSValue value = prototype->getDirect(vm, propertyName);
+    if (!value || value.isCustomGetterSetter()) [[unlikely]]
+        return JSValue::encode(jsUndefined());
+    return JSValue::encode(value);
+}
+
+static JSC_DEFINE_CUSTOM_GETTER(jsPerformance_eventLoopUtilization, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue, PropertyName propertyName))
+{
+    return jsPerformancePrototypeLoadNodePerfHooks(lexicalGlobalObject, propertyName);
+}
+
+static JSC_DEFINE_CUSTOM_GETTER(jsPerformance_timerify, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue, PropertyName propertyName))
+{
+    return jsPerformancePrototypeLoadNodePerfHooks(lexicalGlobalObject, propertyName);
+}
+
+static JSC_DEFINE_CUSTOM_GETTER(jsPerformance_nodeTiming, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue, PropertyName propertyName))
+{
+    return jsPerformancePrototypeLoadNodePerfHooks(lexicalGlobalObject, propertyName);
+}
+
+// Node's properties are writable data properties; an accessor with a null setter would
+// swallow `performance.eventLoopUtilization = x`. Shadow on the receiver instead so
+// assignment before the lazy load behaves like assignment through a writable prototype slot.
+static JSC_DEFINE_CUSTOM_SETTER(setJSPerformance_nodePerfHooksLazy, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName propertyName))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    JSObject* thisObject = JSValue::decode(thisValue).getObject();
+    if (!thisObject) [[unlikely]]
+        return false;
+    thisObject->putDirect(vm, propertyName, JSValue::decode(encodedValue), 0);
+    return true;
+}
+
 // -- end copied --
 
 class JSPerformancePrototype final : public JSC::JSNonFinalObject {
@@ -230,6 +280,14 @@ void JSPerformancePrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSPerformance::info(), JSPerformancePrototypeTableValues, *this);
+
+    auto nodePerfHooksAttrs = PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum | 0;
+    putDirectCustomAccessor(vm, Identifier::fromString(vm, "eventLoopUtilization"_s),
+        CustomGetterSetter::create(vm, jsPerformance_eventLoopUtilization, setJSPerformance_nodePerfHooksLazy), nodePerfHooksAttrs);
+    putDirectCustomAccessor(vm, Identifier::fromString(vm, "timerify"_s),
+        CustomGetterSetter::create(vm, jsPerformance_timerify, setJSPerformance_nodePerfHooksLazy), nodePerfHooksAttrs);
+    putDirectCustomAccessor(vm, Identifier::fromString(vm, "nodeTiming"_s),
+        CustomGetterSetter::create(vm, jsPerformance_nodeTiming, setJSPerformance_nodePerfHooksLazy), nodePerfHooksAttrs);
     // bool hasDisabledRuntimeProperties = false;
     // if (!(globalObject())->inherits<JSDOMWindowBase>()) {
     //     hasDisabledRuntimeProperties = true;

--- a/src/jsc/bindings/webcore/JSPerformance.cpp
+++ b/src/jsc/bindings/webcore/JSPerformance.cpp
@@ -148,10 +148,7 @@ JSC_DEFINE_HOST_FUNCTION(jsPerformancePrototypeFunction_markResourceTiming, (JSG
     return JSValue::encode(jsUndefined());
 }
 
-// Node.js defines eventLoopUtilization/timerify/nodeTiming on Performance.prototype
-// from process start. Bun's implementations live in src/js/node/perf_hooks.ts, so the
-// first touch of one of these on the global lazily evaluates that module, whose body
-// replaces this accessor with the real data property on the prototype.
+// node:perf_hooks' module body overwrites this accessor with the real data property.
 static JSC::EncodedJSValue jsPerformancePrototypeLoadNodePerfHooks(JSGlobalObject* lexicalGlobalObject, PropertyName propertyName)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
@@ -183,9 +180,7 @@ static JSC_DEFINE_CUSTOM_GETTER(jsPerformance_nodeTiming, (JSGlobalObject * lexi
     return jsPerformancePrototypeLoadNodePerfHooks(lexicalGlobalObject, propertyName);
 }
 
-// Node's properties are writable data properties; an accessor with a null setter would
-// swallow `performance.eventLoopUtilization = x`. Shadow on the receiver instead so
-// assignment before the lazy load behaves like assignment through a writable prototype slot.
+// Shadow on the receiver so assignment matches Node's writable data slot.
 static JSC_DEFINE_CUSTOM_SETTER(setJSPerformance_nodePerfHooksLazy, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName propertyName))
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -169,6 +169,45 @@ test("timerify and AsyncResource.bind survive Object.prototype.get pollution", a
   expect(exitCode).toBe(0);
 });
 
+// Node defines these on Performance.prototype from process start. Bun used to
+// install them as a side-effect of the first `require("node:perf_hooks")`, so
+// `performance.eventLoopUtilization()` on a pristine global threw.
+test("eventLoopUtilization/timerify/nodeTiming exist on globalThis.performance without importing perf_hooks", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const p = globalThis.performance;
+       const before = {
+         elu: typeof p.eventLoopUtilization,
+         timerify: typeof p.timerify,
+         nodeTiming: typeof p.nodeTiming,
+       };
+       const desc = Object.getOwnPropertyDescriptor(Performance.prototype, "eventLoopUtilization");
+       const elu = p.eventLoopUtilization();
+       const ph = require("node:perf_hooks");
+       console.log(JSON.stringify({
+         before,
+         desc: { writable: desc.writable, enumerable: desc.enumerable, configurable: desc.configurable, hasValue: typeof desc.value },
+         eluKeys: Object.keys(elu).sort(),
+         same: ph.performance === p,
+       }));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    before: { elu: "function", timerify: "function", nodeTiming: "object" },
+    desc: { writable: true, enumerable: false, configurable: true, hasValue: "function" },
+    eluKeys: ["active", "idle", "utilization"],
+    same: true,
+  });
+  expect(exitCode).toBe(0);
+});
+
 test("net entries are instanceof PerformanceEntry", async () => {
   const { promise, resolve } = Promise.withResolvers();
   const observer = new PerformanceObserver(list => resolve(list.getEntries()[0]));

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -178,6 +178,10 @@ test("eventLoopUtilization/timerify/nodeTiming exist on globalThis.performance w
       bunExe(),
       "-e",
       `const p = globalThis.performance;
+       // Assignment before any lazy read must shadow on the instance (Node's slot is a writable data property).
+       p.timerify = 1;
+       const ownTimerify = Object.getOwnPropertyDescriptor(p, "timerify")?.value;
+       delete p.timerify;
        const before = {
          elu: typeof p.eventLoopUtilization,
          timerify: typeof p.timerify,
@@ -187,6 +191,7 @@ test("eventLoopUtilization/timerify/nodeTiming exist on globalThis.performance w
        const elu = p.eventLoopUtilization();
        const ph = require("node:perf_hooks");
        console.log(JSON.stringify({
+         ownTimerify,
          before,
          desc: { writable: desc.writable, enumerable: desc.enumerable, configurable: desc.configurable, hasValue: typeof desc.value },
          eluKeys: Object.keys(elu).sort(),
@@ -200,6 +205,7 @@ test("eventLoopUtilization/timerify/nodeTiming exist on globalThis.performance w
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   expect(JSON.parse(stdout)).toEqual({
+    ownTimerify: 1,
     before: { elu: "function", timerify: "function", nodeTiming: "object" },
     desc: { writable: true, enumerable: false, configurable: true, hasValue: "function" },
     eluKeys: ["active", "idle", "utilization"],


### PR DESCRIPTION
## What

`performance.eventLoopUtilization`, `performance.timerify`, and `performance.nodeTiming` are now present on `globalThis.performance` from process start, matching Node.

## Repro

```js
// bun -e
console.log(typeof performance.eventLoopUtilization);
```

Node prints `function`. Bun printed `undefined` until `node:perf_hooks` was loaded, so the Node-docs call shape `performance.eventLoopUtilization()` threw `TypeError: performance.eventLoopUtilization is not a function` on a pristine global.

## Cause

The three Node-only members are implemented in `src/js/node/perf_hooks.ts` and installed onto `Performance.prototype` as a side effect of that module's first evaluation. The global/module unification landed earlier makes `require("perf_hooks").performance === globalThis.performance`, but the members themselves still only appeared after the first import.

## Fix

`JSPerformancePrototype::finishCreation` now installs configurable `CustomAccessor` slots for the three names. The getter evaluates `node:perf_hooks` via the internal module registry; that module's existing `Object.defineProperties(Performance.prototype, ...)` replaces the accessor with the real `{ value, writable: true, enumerable: false, configurable: true }` data property, so subsequent reads are direct. A write-through setter keeps `performance.eventLoopUtilization = x` shadowing on the receiver exactly as it does against Node's writable prototype slot.

## Verification

```
$ bun -e 'console.log(typeof performance.eventLoopUtilization, typeof performance.timerify, typeof performance.nodeTiming)'
function function object

$ bun /tmp/repro.mjs   # the ledger repro
before: {"elu":"function","timerify":"function","nodeTiming":"object"} after: {"elu":"function","same":true}
PASS (node shape)
```

New test spawns a fresh process (the test file itself imports `perf_hooks`, which would mask the bug) and asserts presence, call result, descriptor shape, and identity with `require("perf_hooks").performance`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
bun test v1.4.0 (21214814b)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [15.96ms]
(pass) doesn't throw [14.79ms]
(pass) Symbol name argument throws V8 wording [6.80ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [4.93ms]
(pass) timerify entry shape [50.36ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [1.69ms]
(pass) export surface matches Node v26.3.0 [6.99ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [432.04ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [480.82ms]
201 |     env: bunEnv,
202 |     stdout: "pipe",
203 |     stderr: "pipe",
204 |   });
205 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
206 |   expect(stderr).toBe("");
                       ^
error: expect(received).toBe(expected)

- ""
+ " 7 |          elu: typeof p.eventLoopUtilization,
+  8 |  
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (386b0ebe8)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [0.07ms]
(pass) doesn't throw [0.12ms]
(pass) Symbol name argument throws V8 wording [0.07ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [0.07ms]
(pass) timerify entry shape [0.81ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [0.02ms]
(pass) export surface matches Node v26.3.0 [0.07ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [9.23ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [8.29ms]
(pass) eventLoopUtilization/timerify/nodeTiming exist on globalThis.performance without importing perf_hooks [8.18ms]
(pass) net entries are instanceof PerformanceEntry [7.80ms]

 11 pass
 0 fail
 59 expect() calls
Ran 11 tests across 1 file. [190.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
bun test v1.4.0 (21214814b)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [17.21ms]
(pass) doesn't throw [15.18ms]
(pass) Symbol name argument throws V8 wording [6.65ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [4.97ms]
(pass) timerify entry shape [51.67ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [1.79ms]
(pass) export surface matches Node v26.3.0 [7.11ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [429.35ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [483.72ms]
(pass) eventLoopUtilization/timerify/nodeTiming exist on globalThis.performance without importing perf_hooks [425.59ms]
(pass) net entries are instanceof PerformanceEntry [412.49ms]

 11 pass
 0 fail
 59 expect() calls
Ran 11 tests across 1 file. [4.04s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 654ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m  
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSPerformance.cpp | 53 ++++++++++++++++++++++++++++++
 test/js/node/perf_hooks/perf_hooks.test.ts | 45 +++++++++++++++++++++++++
 2 files changed, 98 insertions(+)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/jsc/bindings/webcore/JSPerformance.cpp      2      8      0
test/js/node/perf_hooks/perf_hooks.test.ts      4      3      0
```

</details>

<!-- robobun:evidence:end -->