### PR TITLE
cli: don't print a rejected promise's reason twice in `bun -p`

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1603,10 +1603,7 @@ impl Run {
                                 break 'brk Some(promise.result(vm.jsc_vm()));
                             }
                             PromiseStatus::Rejected => {
-                                // The unhandled-rejection reporter prints the
-                                // reason (either in the drain loop above or in
-                                // `handle_rejected_promises` below); printing
-                                // it again here would duplicate the output.
+                                // Reported by the unhandled-rejection path; don't print twice.
                                 break 'brk None;
                             }
                         }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1572,7 +1572,7 @@ impl Run {
             }
 
             if ctx.runtime_options.eval.eval_and_print {
-                let to_print: Option<JSValue> = 'brk: {
+                let to_print: JSValue = 'brk: {
                     let result = vm
                         .entry_point_result
                         .value
@@ -1597,32 +1597,27 @@ impl Run {
                                     vm.tick();
                                     vm.auto_tick_active();
                                 }
-                                break 'brk Some(result);
+                                break 'brk result;
                             }
-                            PromiseStatus::Fulfilled => {
-                                break 'brk Some(promise.result(vm.jsc_vm()));
-                            }
-                            PromiseStatus::Rejected => {
-                                // Reported by the unhandled-rejection path; don't print twice.
-                                break 'brk None;
-                            }
+                            PromiseStatus::Fulfilled => break 'brk promise.result(vm.jsc_vm()),
+                            // Print the promise itself (like Node); unwrapping
+                            // the reason re-emits the unhandled-rejection block.
+                            PromiseStatus::Rejected => break 'brk result,
                         }
                     }
-                    Some(result)
+                    result
                 };
-                if let Some(to_print) = to_print {
-                    // SAFETY: `vals[..1]` is the single stack `to_print`; null
-                    // `ctype` routes to the VM's stdout/stderr default.
-                    unsafe {
-                        bun_jsc::ConsoleObject::message_with_type_and_level(
-                            ::core::ptr::null_mut(),
-                            bun_jsc::ConsoleObject::MessageType::Log,
-                            bun_jsc::ConsoleObject::MessageLevel::Log,
-                            vm.global(),
-                            &raw const to_print,
-                            1,
-                        );
-                    }
+                // SAFETY: `vals[..1]` is the single stack `to_print`; null
+                // `ctype` routes to the VM's stdout/stderr default.
+                unsafe {
+                    bun_jsc::ConsoleObject::message_with_type_and_level(
+                        ::core::ptr::null_mut(),
+                        bun_jsc::ConsoleObject::MessageType::Log,
+                        bun_jsc::ConsoleObject::MessageLevel::Log,
+                        vm.global(),
+                        &raw const to_print,
+                        1,
+                    );
                 }
             }
 

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1572,7 +1572,7 @@ impl Run {
             }
 
             if ctx.runtime_options.eval.eval_and_print {
-                let to_print: JSValue = 'brk: {
+                let to_print: Option<JSValue> = 'brk: {
                     let result = vm
                         .entry_point_result
                         .value
@@ -1597,24 +1597,35 @@ impl Run {
                                     vm.tick();
                                     vm.auto_tick_active();
                                 }
-                                break 'brk result;
+                                break 'brk Some(result);
                             }
-                            _ => break 'brk promise.result(vm.jsc_vm()),
+                            PromiseStatus::Fulfilled => {
+                                break 'brk Some(promise.result(vm.jsc_vm()));
+                            }
+                            PromiseStatus::Rejected => {
+                                // The unhandled-rejection reporter prints the
+                                // reason (either in the drain loop above or in
+                                // `handle_rejected_promises` below); printing
+                                // it again here would duplicate the output.
+                                break 'brk None;
+                            }
                         }
                     }
-                    result
+                    Some(result)
                 };
-                // SAFETY: `vals[..1]` is the single stack `to_print`; null
-                // `ctype` routes to the VM's stdout/stderr default.
-                unsafe {
-                    bun_jsc::ConsoleObject::message_with_type_and_level(
-                        ::core::ptr::null_mut(),
-                        bun_jsc::ConsoleObject::MessageType::Log,
-                        bun_jsc::ConsoleObject::MessageLevel::Log,
-                        vm.global(),
-                        &raw const to_print,
-                        1,
-                    );
+                if let Some(to_print) = to_print {
+                    // SAFETY: `vals[..1]` is the single stack `to_print`; null
+                    // `ctype` routes to the VM's stdout/stderr default.
+                    unsafe {
+                        bun_jsc::ConsoleObject::message_with_type_and_level(
+                            ::core::ptr::null_mut(),
+                            bun_jsc::ConsoleObject::MessageType::Log,
+                            bun_jsc::ConsoleObject::MessageLevel::Log,
+                            vm.global(),
+                            &raw const to_print,
+                            1,
+                        );
+                    }
                 }
             }
 

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -184,9 +184,30 @@ describe("--print for cjs/esm", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const count = (stderr.toString("utf8").match(/^error: rej$/gm) ?? []).length;
-    expect({ count, stdout: stdout.toString("utf8") }).toEqual({ count: 1, stdout: "" });
+    const err = stderr.toString("utf8");
+    const out = stdout.toString("utf8");
+    expect({
+      stderrErrors: (err.match(/^error: rej$/gm) ?? []).length,
+      stdoutErrors: (out.match(/^error: rej$/gm) ?? []).length,
+      stdout: out,
+    }).toEqual({ stderrErrors: 1, stdoutErrors: 0, stdout: "Promise { <rejected> }\n" });
     expect(exitCode).toBe(1);
+  });
+
+  test.each([
+    'const p = Promise.reject(new Error("rej")); p.catch(() => {}); p',
+    'process.on("unhandledRejection", () => {}); Promise.reject(new Error("rej"))',
+  ])("-p prints a handled rejected promise: %s", async expr => {
+    const { stdout, stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), "-p", expr],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    expect({
+      stderr: stderr.toString("utf8"),
+      stdout: stdout.toString("utf8"),
+    }).toEqual({ stderr: "", stdout: "Promise { <rejected> }\n" });
+    expect(exitCode).toBe(0);
   });
 
   test.each(["Promise.resolve(41)", "new Promise(res => setTimeout(() => res(41), 1))"])(

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -173,6 +173,32 @@ describe("--print for cjs/esm", () => {
     expect(stdout.toString()).toBe("true\n");
     expect(exitCode).toBe(0);
   });
+
+  test.each([
+    'Promise.reject(new Error("rej"))',
+    'new Promise((_, rej) => setTimeout(() => rej(new Error("rej")), 1))',
+    'Promise.resolve().then(() => { throw new Error("rej") })',
+  ])("-p reports a rejected promise once: %s", async expr => {
+    const { stdout, stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), "-p", expr],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const count = (stderr.toString("utf8").match(/^error: rej$/gm) ?? []).length;
+    expect({ count, stdout: stdout.toString("utf8") }).toEqual({ count: 1, stdout: "" });
+    expect(exitCode).toBe(1);
+  });
+
+  test("-p on a fulfilled promise still prints the value", async () => {
+    const { stdout, stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), "-p", "Promise.resolve(41)"],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    expect(stderr.toString("utf8")).toBe("");
+    expect(stdout.toString("utf8")).toBe("41\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 function group(run: (code: string) => SyncSubprocess<"pipe", "inherit">) {

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -189,16 +189,19 @@ describe("--print for cjs/esm", () => {
     expect(exitCode).toBe(1);
   });
 
-  test("-p on a fulfilled promise still prints the value", async () => {
-    const { stdout, stderr, exitCode } = Bun.spawnSync({
-      cmd: [bunExe(), "-p", "Promise.resolve(41)"],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    expect(stderr.toString("utf8")).toBe("");
-    expect(stdout.toString("utf8")).toBe("41\n");
-    expect(exitCode).toBe(0);
-  });
+  test.each(["Promise.resolve(41)", "new Promise(res => setTimeout(() => res(41), 1))"])(
+    "-p on a fulfilled promise still prints the value: %s",
+    async expr => {
+      const { stdout, stderr, exitCode } = Bun.spawnSync({
+        cmd: [bunExe(), "-p", expr],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      expect(stderr.toString("utf8")).toBe("");
+      expect(stdout.toString("utf8")).toBe("41\n");
+      expect(exitCode).toBe(0);
+    },
+  );
 });
 
 function group(run: (code: string) => SyncSubprocess<"pipe", "inherit">) {


### PR DESCRIPTION
## Repro

```sh
$ bun -p 'Promise.reject(new Error("rej"))'
1 | Promise.reject(new Error("rej"))
                       ^
error: rej
      at [eval]:1:20
1 | Promise.reject(new Error("rej"))
                       ^
error: rej
      at [eval]:1:20

Bun v1.4.0 (Linux x64)
```

The same error block is printed twice (once to stderr from the unhandled-rejection reporter, once to stdout from the `-p` printer). `bun -e` with the same expression prints once, as does `bun -p` with a synchronous `throw`.

## Cause

The `--print` result printer in `run_command.rs` unwraps a settled promise with a match arm that treated `Fulfilled` and `Rejected` identically: both extracted `promise.result()` and console.log'd it. For a rejected promise that means console.log'ing the Error, which Bun renders in the same `error: ...` format as the unhandled-rejection reporter, so the block appears twice.

## Fix

Split the arm: `Fulfilled` still unwraps and prints the value; `Rejected` prints the promise object itself (`Promise { <rejected> }`) rather than the reason. This matches Node's `-p` output for a rejected promise, keeps `-p`'s contract of always printing something (including when the rejection is handled via `.catch` or a `process.on("unhandledRejection", ...)` listener), and avoids re-emitting the error block.

## Verification

```sh
$ bun -p 'Promise.reject(new Error("rej"))' 2>&1 | grep -c '^error: rej'
1
```

New tests in `test/cli/run/run-eval.test.ts` cover: `Promise.reject`, `setTimeout`-deferred rejection, `.then(() => { throw })`, handled rejection via `.catch`, suppression via an `unhandledRejection` listener, and fulfilled promises (sync and async) as regression guards.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-eval.test.ts

<!-- robobun:evidence:end -->