### PR TITLE
node:test: enforce run({ timeout }) as the inherited per-test timeout

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -49,6 +49,9 @@ const kJoinSeparator = " > ";
 // spawned child, so use node's variable and value rather than a bun-specific one.
 const kRunChildEnv = "NODE_TEST_CONTEXT";
 const kRunChildEnvValue = "child-v8";
+// node passes `--test-timeout` to the child process; bun's `bun test --timeout`
+// is the bun:test watchdog, so carry the node:test default via env instead.
+const kRunChildTimeoutEnv = "BUN_NODE_TEST_RUN_TIMEOUT";
 const kRunEventPrefix = "\0bun:test:run\0";
 
 // Created lazily on the first run() call so the common test()/describe()
@@ -313,9 +316,8 @@ function run(options: Record<string, unknown> = kEmptyObject) {
   }
 
   // Options whose semantics we cannot honor yet must fail loudly rather than be
-  // silently ignored. testTagFilters and timeout are the deliberate exceptions:
-  // validated for node's error contract but not yet forwarded (node's own
-  // test-runner-filetest-location.js passes timeout).
+  // silently ignored. testTagFilters is the deliberate exception: validated for
+  // node's error contract but not yet forwarded.
   if (opts.watch) throwNotImplemented("run({ watch: true })", 5090, "Use `bun:test --watch` in the interim.");
   if (opts.coverage) throwNotImplemented("run({ coverage: true })", 5090, "Use `bun:test --coverage` in the interim.");
   if (opts.shard) throwNotImplemented("run({ shard })", 5090);
@@ -473,10 +475,13 @@ async function runOneFile(
   reporter.enqueue({ __proto__: null, ...fileNode });
   reporter.dequeue({ __proto__: null, ...fileNode });
 
+  const childEnv = { ...(opts.env ?? process.env), BUN_TEST_DRAIN_EVENT_LOOP: "1", [kRunChildEnv]: kRunChildEnvValue };
+  const { timeout } = opts;
+  if (typeof timeout === "number" && Number.isFinite(timeout)) childEnv[kRunChildTimeoutEnv] = String(timeout);
   const proc = Bun.spawn({
     cmd: args,
     cwd: opts.cwd as string,
-    env: { ...(opts.env ?? process.env), BUN_TEST_DRAIN_EVENT_LOOP: "1", [kRunChildEnv]: kRunChildEnvValue },
+    env: childEnv,
     stdout: "pipe",
     stderr: "pipe",
     signal: opts.signal,
@@ -666,6 +671,15 @@ function republishChildEvent(
 // Child side: with kRunChildEnv set, stream one JSON event per line so the
 // spawning parent can rebuild node's event stream.
 const runChildReporterEnabled = process.env[kRunChildEnv] !== undefined;
+// Node's root-test timeout, set from run({ timeout }) in the parent. Tests
+// that don't specify their own timeout inherit this (node Test constructor:
+// this.timeout = parent.timeout).
+let runChildTimeout: number | undefined;
+{
+  const raw = process.env[kRunChildTimeoutEnv];
+  const parsed = raw !== undefined ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed >= 0) runChildTimeout = parsed;
+}
 
 function emitRunChildEvent(type: string, data: unknown) {
   try {
@@ -1529,6 +1543,7 @@ class TestNode {
   isExecutionPhase: boolean;
   filePath: string | undefined;
   options: TestOptions;
+  timeout: number | undefined;
   ownTags: string[] | undefined;
   hooks: HookSets = { before: [], after: [], beforeEach: [], afterEach: [] };
   plan: TestPlan | null = null;
@@ -1568,9 +1583,17 @@ class TestNode {
     // (under `bun test` with multiple files, Bun.main is the file currently
     // being collected); nested tests inherit their parent's file.
     this.filePath = parent !== undefined && parent.parent !== undefined ? parent.filePath : Bun.main;
-    const { skip, todo } = options;
+    const { skip, todo, timeout } = options;
     this.skipped = !!skip;
     this.todoFlag = !!todo || (parent?.todoFlag ?? false);
+    // node Test constructor: only a finite number overrides; Infinity / null /
+    // undefined all inherit the parent's timeout (ultimately run({ timeout })).
+    this.timeout =
+      typeof timeout === "number" && Number.isFinite(timeout)
+        ? timeout
+        : parent !== undefined
+          ? parent.timeout
+          : runChildTimeout;
     if (typeof skip === "string") this.message = skip;
     else if (typeof todo === "string") this.message = todo;
     this.expectFailure = parseExpectFailure(options.expectFailure) || parent?.expectFailure || false;
@@ -2144,7 +2167,10 @@ function createStopController(timeout: number | undefined) {
   const promise = new Promise<never>((_, reject) => {
     // Not unref'd: dispose() always clears it, and on Windows an unref'd timer
     // alone under bun:test leaves the uws loop inactive so auto_tick busy-spins.
-    timer = realSetTimeout(() => reject(makeTestFailure(`test timed out after ${timeout}ms`)), timeout);
+    timer = realSetTimeout(
+      () => reject(makeTestFailure(`test timed out after ${timeout}ms`, "testTimeoutFailure")),
+      timeout,
+    );
   });
   // Swallow the rejection when nothing is racing it anymore.
   promise.catch(() => {});
@@ -2174,7 +2200,10 @@ async function raceWithTimeoutAndSignal(
     if (typeof timeout === "number" && Number.isFinite(timeout)) {
       racers.push(
         new Promise<never>((_, reject) => {
-          timer = realSetTimeout(() => reject(makeTestFailure(`test timed out after ${timeout}ms`)), timeout);
+          timer = realSetTimeout(
+            () => reject(makeTestFailure(`test timed out after ${timeout}ms`, "testTimeoutFailure")),
+            timeout,
+          );
         }),
       );
     }
@@ -2285,7 +2314,7 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
     // Node arms one stopPromise (timeout + signal) and races both the body
     // AND the plan wait against it. Arm timeout once here so plan({wait:true})
     // is bounded by the same test timeout, not left unbounded.
-    const stop = createStopController(node.options.timeout);
+    const stop = createStopController(node.timeout);
     try {
       const runBody = async () => {
         await runWithNode(node, () => invokeTestFn(fn, ctx));
@@ -2499,20 +2528,21 @@ function bunTest() {
   return jest(Bun.main);
 }
 
-function bunTestOptions(options: TestOptions) {
+function bunTestOptions(node: TestNode) {
   // The node-style timeout is enforced by executeTestNode itself so that a
   // tiny timeout (e.g. 1ms) with a synchronous body still passes like in Node.
   // bun:test's own watchdog measures the whole wrapper, so it is only told
   // about timeouts that extend past its 5s default.
-  const { timeout } = options;
-  if (timeout === Infinity) {
-    // Node's "no timeout" must override bun:test's default (bun saturates it).
-    return { timeout };
-  }
+  const timeout = node.timeout;
   if (typeof timeout === "number" && Number.isFinite(timeout)) {
     // Keep bun:test's watchdog at or above both the node-style timeout and
     // bun's default so a lower `--timeout` cannot cut a node timeout short.
     return { timeout: Math.max(timeout, kBunTestDefaultTimeoutMs) };
+  }
+  if (node.options.timeout === Infinity) {
+    // No inherited node-style timeout and the user asked for none: let Infinity
+    // override bun:test's default (bun saturates it).
+    return { timeout: Infinity };
   }
   return undefined;
 }
@@ -2594,7 +2624,7 @@ function addTest(
   node.ownTags = ownTags;
 
   const { test } = bunTest();
-  const passOptions = bunTestOptions(options);
+  const passOptions = bunTestOptions(node);
 
   // Node merges .todo()/.skip() into the options and checks skip first, so
   // test.todo(name, { skip: true }, fn) is a skip.
@@ -2727,7 +2757,7 @@ function addSuite(
           return runWithNode(suiteNode, () => fn(suiteNode.getSuiteCtx()));
         };
 
-  const passOptions = bunTestOptions(options);
+  const passOptions = bunTestOptions(suiteNode);
 
   let register: Function = describe;
   if (effectiveMode === "skip") register = describe.skip;

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
 describe("node:test", () => {
@@ -323,6 +323,81 @@ describe("node:test", () => {
       stderr: expect.stringContaining("0 fail"),
     });
   });
+});
+
+describe("node:test run()", () => {
+  // run({ timeout }) is node's root-test timeout, inherited by every test that
+  // does not specify its own. An explicit finite timeout overrides it; Infinity
+  // and null inherit (node Test constructor semantics).
+  test.concurrent(
+    "should enforce run({ timeout }) as the inherited per-test timeout",
+    async () => {
+      using dir = tempDir("node-test-run-timeout", {
+        "inner.mjs":
+          "import t from 'node:test';\n" +
+          "t('slow 1500ms', async () => { await new Promise(r => setTimeout(r, 1500)); });\n" +
+          "t('own 3000', { timeout: 3000 }, async () => { await new Promise(r => setTimeout(r, 1500)); });\n" +
+          "t('quick', () => {});\n",
+        "driver.mjs":
+          "import { run } from 'node:test';\n" +
+          "const s = run({ files: ['inner.mjs'], timeout: 500 });\n" +
+          "const pass = [], fail = [];\n" +
+          "s.on('data', () => {});\n" +
+          "s.on('test:pass', d => pass.push(d.name));\n" +
+          "s.on('test:fail', d => fail.push({ name: d.name, failureType: d.details?.error?.failureType }));\n" +
+          "await new Promise(r => s.on('close', r));\n" +
+          "console.log(JSON.stringify({ pass, fail }));\n",
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "driver.mjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderr, out: JSON.parse(stdout.trim() || "null") }).toEqual({
+        stderr: "",
+        out: {
+          pass: ["own 3000", "quick"],
+          fail: [{ name: "slow 1500ms", failureType: "testTimeoutFailure" }],
+        },
+      });
+      expect(exitCode).toBe(0);
+    },
+    30_000,
+  );
+
+  test.concurrent(
+    "should tag an explicit per-test timeout failure with testTimeoutFailure",
+    async () => {
+      using dir = tempDir("node-test-run-timeout-own", {
+        "inner.mjs":
+          "import t from 'node:test';\n" +
+          "t('times out', { timeout: 100 }, async () => { await new Promise(r => setTimeout(r, 1500)); });\n",
+        "driver.mjs":
+          "import { run } from 'node:test';\n" +
+          "const s = run({ files: ['inner.mjs'] });\n" +
+          "const fail = [];\n" +
+          "s.on('data', () => {});\n" +
+          "s.on('test:fail', d => fail.push({ name: d.name, failureType: d.details?.error?.failureType, code: d.details?.error?.code }));\n" +
+          "await new Promise(r => s.on('close', r));\n" +
+          "console.log(JSON.stringify(fail));\n",
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "driver.mjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderr, out: JSON.parse(stdout.trim() || "null") }).toEqual({
+        stderr: "",
+        out: [{ name: "times out", failureType: "testTimeoutFailure", code: "ERR_TEST_FAILURE" }],
+      });
+      expect(exitCode).toBe(0);
+    },
+    30_000,
+  );
 });
 
 async function runTests(filenames: string[], env: Record<string, string> = {}, args: string[] = []) {


### PR DESCRIPTION
## Problem

`run({ timeout })` is range-checked (a negative value throws the Node-identical `ERR_OUT_OF_RANGE`) but then never applied. Every other unimplemented `run()` option throws a loud `ERR_NOT_IMPLEMENTED`; `timeout` is the only one accepted silently, so a programmatic run goes green where Node is red:

```js
// slow.mjs
import t from 'node:test';
t('slow 200ms', async () => { await new Promise(r => setTimeout(r, 200)); });
t('quick', () => {});
```
```js
import { run } from 'node:test';
const s = run({ files: ['slow.mjs'], timeout: 50 });
s.on('test:pass', d => pass.push(d.name));
s.on('test:fail', d => fail.push(d.name + ' failureType=' + d.details?.error?.failureType));
```
```
node v26.3.0:  pass=["quick"] fail=["slow 200ms failureType=testTimeoutFailure"]
bun main:      pass=["slow 200ms","quick"] fail=[]
```

A never-settling test is bounded only by bun:test's 5s watchdog, and when that fires the `test:fail` event carries the file path with `failureType: 'testCodeFailure'` rather than the test name with `testTimeoutFailure`.

## Cause

- `validateRunOptions` validated `timeout` and returned it, but `runOneFile` never forwarded it to the spawned `bun test` child.
- `TestNode` stored only the test's own `options.timeout`; there was no parent-to-child inheritance, so even if the root had a timeout the children would not see it.
- `createStopController` / `raceWithTimeoutAndSignal` built the timeout error without `failureType`, so even an explicit per-test `{ timeout }` failure surfaced without `testTimeoutFailure`.

## Fix

Route the option end to end the way Node does:

- `run()` forwards `timeout` to each file's child via `BUN_NODE_TEST_RUN_TIMEOUT` (Node passes `--test-timeout` on argv; `bun test --timeout` is the bun:test watchdog, so env is the right carrier here).
- `TestNode` gains a `timeout` field with Node's inheritance rule: only a finite number overrides; `Infinity` / `null` / `undefined` inherit the parent's value. The root seeds from the env var, so `describe({ timeout })` also propagates to its children.
- `executeTestNode` and `bunTestOptions` consult `node.timeout` (inherited) instead of `node.options.timeout` (own only).
- Timeout errors now carry `failureType: 'testTimeoutFailure'` (Node's `kTestTimeoutFailure`), so `test:fail` attributes the failure to the test by name.

## Verification

Two new tests in `test/js/node/test_runner/node-test.test.ts`:

- "should enforce run({ timeout }) as the inherited per-test timeout": with `run({ timeout: 500 })`, a 1500ms test fails with `testTimeoutFailure`, a `{ timeout: 3000 }` sibling passes, and a quick sibling passes.
- "should tag an explicit per-test timeout failure with testTimeoutFailure": with no run-level timeout, a per-test `{ timeout: 100 }` failure carries `{ failureType: 'testTimeoutFailure', code: 'ERR_TEST_FAILURE' }`.

Fail-before (src/ stashed): `slow 1500ms` passes and `failureType` is absent. Fail-after: both tests pass. All 47 tests in the file pass; `test-runner-filetest-location.js` (upstream, passes `timeout`) still passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test_runner/node-test.test.ts
bun test v1.4.0 (ed6e687e3)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [3053.15ms]
(pass) node:test > should run hooks in the right order [3050.94ms]
(pass) node:test > should run tests with different variations [2622.36ms]
(pass) node:test > should run async tests [2634.71ms]
(pass) node:test > should run all tests from multiple files [3755.58ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [2727.00ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [2681.42ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [2837.47ms]
(pass) node:test > should support done callbacks in tests and hooks [2613.82ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [2984.34ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurre
... (truncated)

release without fix: 26 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [47.75ms]
(pass) node:test > should run hooks in the right order [64.46ms]
(pass) node:test > should run tests with different variations [45.77ms]
(pass) node:test > should run async tests [46.81ms]
(pass) node:test > should run all tests from multiple files [69.43ms]
60 |     30_000,
61 |   );
62 | 
63 |   test("should run test() and describe() called inside another test() as subtests", async () => {
64 |     const { exitCode, stderr } = await runTests(["05-test-in-test.js"]);
65 |     expect({ exitCode, stderr }).toMatchObject({
                                      ^
error: expect(received).toMatchObject(expected)

  {
-   "exitCode": 0,
-   "stderr": StringContaining "0 fail",
+   "exitCode": 1,
+   "stderr": 
+ "
+ test/js/node/test_runner/fixtures/05-test-in-test.js:
+ 1 | const { describe, test } = require("node:test");
+ 2 | const assert = require("node:assert");
+ 3 | 
+ 4 | test("t.test() runs subtests inline and returns a promise", async t = {
+ 5 |   const order = [];
+ 6 |   const result = await t.test("awaited subtest", subtest =>
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test_runner/node-test.test.ts
bun test v1.4.0 (ed6e687e3)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [2973.95ms]
(pass) node:test > should run hooks in the right order [2999.09ms]
(pass) node:test > should run tests with different variations [2553.27ms]
(pass) node:test > should run async tests [2529.40ms]
(pass) node:test > should run all tests from multiple files [3672.46ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [2626.48ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [2608.73ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [2755.85ms]
(pass) node:test > should support done callbacks in tests and hooks [2511.35ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [2797.05ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurre
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 671ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (9155ms)
Bundle modules (62ms)
Postprocesss modules (161ms)
Bundle Functions (758ms)
Generate Code (32ms)

[10.18s] Bundled "src/js" for production
  2569 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 03s
[2/6] cxx obj/codegen/ZigGeneratedClasses.cpp.o
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.0-canary.1+ed6e687e3
[build] done
bun test v1.4.0-canary.1 (ed6e687e3)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [45.11ms]
(pass) node:test > shoul
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/test.ts                        | 62 +++++++++++++++++-------
 test/js/node/test_runner/node-test.test.ts | 77 +++++++++++++++++++++++++++++-
 2 files changed, 122 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js/node/test.ts                            11     14      0
test/js/node/test_runner/node-test.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->