### PR TITLE
sql: add support for column name transforms (snake_case to camelCase)

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1180,12 +1180,49 @@ console.log(typeof x, x); // "bigint" 9223372036854777n
 
 ---
 
+## Column Name Transforms
+
+You can automatically transform column names (for example, `snake_case` from your database to `camelCase` in JavaScript) by passing the `transform` option to the SQL client:
+
+```ts
+import { SQL, postgres } from "bun";
+
+const sql = new SQL({
+  transform: postgres.camel, // convert snake_case column names to camelCase
+});
+
+const [user] = await sql`SELECT first_name, last_name FROM users WHERE id = 1`;
+console.log(user.firstName, user.lastName); // "Alice" "Smith"
+
+// When using query helpers, Object property keys are automatically converted back to snake_case column names in SQL:
+await sql`INSERT INTO users ${sql({ firstName: "Bob", lastName: "Jones" })}`;
+// SQL generated: INSERT INTO users ("first_name", "last_name") VALUES ($1, $2)
+```
+
+Bun supports built-in Unicode-aware transformers:
+
+- `postgres.camel` / `SQL.camel` (`snake_case` <-> `camelCase`)
+- `postgres.pascal` / `SQL.pascal` (`snake_case` <-> `PascalCase`)
+- `postgres.kebab` / `SQL.kebab` (`snake_case` <-> `kebab-case`)
+- `postgres.snake` / `SQL.snake` (`camelCase` <-> `snake_case`)
+
+Or pass a custom transform function:
+
+```ts
+const sql = new SQL({
+  transform: {
+    column: (name) => name.toUpperCase(),
+  },
+});
+```
+
+---
+
 ## Roadmap
 
 Things we haven't finished yet:
 
 - Connection preloading with the `--db-preconnect` Bun CLI flag
-- Column name transforms (for example, `snake_case` to `camelCase`). This is mostly blocked on a unicode-aware implementation of changing the case in C++ using WebKit's `WTF::String`.
 - Column type transforms
 
 ---

--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -159,12 +159,43 @@ declare module "bun" {
       constructor(message: string, options: { code: string; errno: number; byteOffset?: number | undefined });
     }
 
+    const camel: ColumnTransform;
+    const pascal: ColumnTransform;
+    const kebab: ColumnTransform;
+    const snake: ColumnTransform;
+    function toCamel(str: string): string;
+    function toPascal(str: string): string;
+    function toKebab(str: string): string;
+    function toSnake(str: string): string;
+    function fromCamel(str: string): string;
+    function fromPascal(str: string): string;
+    function fromKebab(str: string): string;
+    function fromSnake(str: string): string;
+
     type AwaitPromisesArray<T extends Array<PromiseLike<any>>> = {
       [K in keyof T]: Awaited<T[K]>;
     };
 
     type ContextCallbackResult<T> = T extends Array<PromiseLike<any>> ? AwaitPromisesArray<T> : Awaited<T>;
     type ContextCallback<T, SQL> = (sql: SQL) => Bun.MaybePromise<T>;
+
+    interface ColumnTransform {
+      (column: string): string;
+      to?: (column: string) => string;
+      from?: (column: string) => string;
+    }
+
+    interface TransformOptions {
+      column?: ColumnTransform | {
+        to?: (column: string) => string;
+        from?: (column: string) => string;
+      } | undefined;
+      value?: ((value: any) => any) | {
+        to?: (value: any) => any;
+        from?: (value: any) => any;
+      } | undefined;
+      row?: ((row: any) => any) | undefined;
+    }
 
     interface SQLiteOptions extends BunSQLite.DatabaseOptions {
       adapter?: "sqlite";
@@ -195,6 +226,11 @@ declare module "bun" {
        * Receives the closing `Error`, or `null`.
        */
       onclose?: ((err: Error | null) => void) | undefined;
+
+      /**
+       * Column name and value transforms (e.g. `postgres.camel` for snake_case -> camelCase).
+       */
+      transform?: TransformOptions | ColumnTransform | ((column: string) => string) | undefined;
     }
 
     interface PostgresOrMySQLOptions {
@@ -389,6 +425,11 @@ declare module "bun" {
        * @default false
        */
       allowPublicKeyRetrieval?: boolean | undefined;
+
+      /**
+       * Column name and value transforms (e.g. `postgres.camel` for snake_case -> camelCase).
+       */
+      transform?: TransformOptions | ColumnTransform | ((column: string) => string) | undefined;
     }
 
     /**

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -7,7 +7,26 @@ const { Query, SQLQueryFlags } = require("internal/sql/query");
 const { PostgresAdapter } = require("internal/sql/postgres");
 const { MySQLAdapter } = require("internal/sql/mysql");
 const { SQLiteAdapter } = require("internal/sql/sqlite");
-const { SQLHelper, parseOptions } = require("internal/sql/shared");
+const {
+  SQLHelper,
+  parseOptions,
+  camel,
+  pascal,
+  kebab,
+  snake,
+  toCamel,
+  toPascal,
+  toKebab,
+  toSnake,
+  toCamelTransform,
+  fromCamelTransform,
+  toPascalTransform,
+  fromPascalTransform,
+  toKebabTransform,
+  fromKebabTransform,
+  toSnakeTransform,
+  fromSnakeTransform,
+} = require("internal/sql/shared");
 
 const { SQLError, PostgresError, SQLiteError, MySQLError } = require("internal/sql/errors");
 
@@ -1037,6 +1056,31 @@ SQL.SQLError = SQLError;
 SQL.PostgresError = PostgresError;
 SQL.SQLiteError = SQLiteError;
 SQL.MySQLError = MySQLError;
+SQL.camel = camel;
+SQL.pascal = pascal;
+SQL.kebab = kebab;
+SQL.snake = snake;
+SQL.toCamel = toCamel;
+SQL.toPascal = toPascal;
+SQL.toKebab = toKebab;
+SQL.toSnake = toSnake;
+SQL.fromCamel = fromCamelTransform;
+SQL.fromPascal = fromPascalTransform;
+SQL.fromKebab = fromKebabTransform;
+SQL.fromSnake = fromSnakeTransform;
+
+defaultSQLObject.camel = camel;
+defaultSQLObject.pascal = pascal;
+defaultSQLObject.kebab = kebab;
+defaultSQLObject.snake = snake;
+defaultSQLObject.toCamel = toCamel;
+defaultSQLObject.toPascal = toPascal;
+defaultSQLObject.toKebab = toKebab;
+defaultSQLObject.toSnake = toSnake;
+defaultSQLObject.fromCamel = fromCamelTransform;
+defaultSQLObject.fromPascal = fromPascalTransform;
+defaultSQLObject.fromKebab = fromKebabTransform;
+defaultSQLObject.fromSnake = fromSnakeTransform;
 
 // // Helper functions for native code to create error instances
 // // These are internal functions used by native code
@@ -1076,4 +1120,16 @@ export default {
   PostgresError,
   MySQLError,
   SQLiteError,
+  camel,
+  pascal,
+  kebab,
+  snake,
+  toCamel,
+  toPascal,
+  toKebab,
+  toSnake,
+  fromCamel: fromCamelTransform,
+  fromPascal: fromPascalTransform,
+  fromKebab: fromKebabTransform,
+  fromSnake: fromSnakeTransform,
 };

--- a/src/js/internal/sql/query.ts
+++ b/src/js/internal/sql/query.ts
@@ -190,6 +190,17 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
 
     handle.done?.();
 
+    const transform = (this[_adapter] as any)?.connectionInfo?.transform;
+    if (transform) {
+      try {
+        const { applyResultTransform } = require("./shared");
+        applyResultTransform(x, transform);
+      } catch (err) {
+        this[_queryStatus] |= SQLQueryStatus.error;
+        return this.reject(err as Error);
+      }
+    }
+
     return this[_resolve](x);
   }
 

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1,11 +1,21 @@
-import type { Query as QueryType } from "./query";
+if (typeof (globalThis as any).$isArray === "undefined") {
+  (globalThis as any).$isArray = Array.isArray;
+}
 
 const PublicArray = globalThis.Array;
-const {
-  Query,
-  SQLQueryFlags,
-  symbols: { _strings, _values },
-} = require("internal/sql/query");
+function getQueryMod() {
+  try {
+    return require("internal/sql/query");
+  } catch {
+    return require("./query");
+  }
+}
+const queryMod = getQueryMod();
+const queryModExp = queryMod?.default || queryMod || {};
+const Query = queryModExp.Query;
+const SQLQueryFlags = queryModExp.SQLQueryFlags;
+const _strings = queryModExp.symbols?._strings;
+const _values = queryModExp.symbols?._values;
 
 declare global {
   interface NumberConstructor {
@@ -193,6 +203,7 @@ function buildDefinedColumnsAndQuery<T>(
   columns: (keyof T)[],
   items: T | T[],
   escapeIdentifier: (name: string) => string,
+  fromTransform?: (name: string) => string,
 ): { definedColumns: (keyof T)[]; columnsSql: string } {
   const definedColumns: (keyof T)[] = [];
   let columnsSql = "(";
@@ -224,7 +235,8 @@ function buildDefinedColumnsAndQuery<T>(
 
     if (hasDefinedValue) {
       if (definedColumns.length > 0) columnsSql += ", ";
-      columnsSql += escapeIdentifier(column as string);
+      const dbColumnName = fromTransform ? fromTransform(column as string) : (column as string);
+      columnsSql += escapeIdentifier(dbColumnName);
       definedColumns.push(column);
     }
   }
@@ -427,6 +439,9 @@ function normalizeQuery(
             throw new SyntaxError(`Cannot ${commandToString(command)} with no columns`);
           }
           const lastColumnIndex = columns.length - 1;
+          const transform = (adapter as any)?.connectionInfo?.transform;
+          const fromTransform = transform?.column?.from;
+          const valFromTransform = transform?.value?.from;
 
           if (command === SQLCommand.insert) {
             //
@@ -438,6 +453,7 @@ function normalizeQuery(
               columns,
               items,
               adapter.escapeIdentifier.bind(adapter),
+              fromTransform,
             );
 
             const definedColumnCount = definedColumns.length;
@@ -458,7 +474,11 @@ function normalizeQuery(
                   const columnValue = item[column];
                   query += `${adapter.placeholder(binding_idx++)}${k < lastDefinedColumnIndex ? ", " : ""}`;
                   // If this item has undefined for a column that other items defined, use null
-                  binding_values.push(typeof columnValue === "undefined" ? null : columnValue);
+                  let boundVal = typeof columnValue === "undefined" ? null : columnValue;
+                  if (valFromTransform && boundVal !== null) {
+                    boundVal = valFromTransform(boundVal);
+                  }
+                  binding_values.push(boundVal);
                 }
                 if (j < lastItemIndex) {
                   query += "),";
@@ -473,7 +493,11 @@ function normalizeQuery(
                 const column = definedColumns[j];
                 const columnValue = item[column];
                 query += `${adapter.placeholder(binding_idx++)}${j < lastDefinedColumnIndex ? ", " : ""}`;
-                binding_values.push(columnValue);
+                let boundVal = columnValue;
+                if (valFromTransform && typeof boundVal !== "undefined" && boundVal !== null) {
+                  boundVal = valFromTransform(boundVal);
+                }
+                binding_values.push(boundVal);
               }
               query += ") "; // the user can add RETURNING * or RETURNING id
             }
@@ -505,7 +529,11 @@ function normalizeQuery(
                   if (typeof value_from_key === "undefined") {
                     binding_values.push(null);
                   } else {
-                    binding_values.push(value_from_key);
+                    let boundVal = value_from_key;
+                    if (valFromTransform && boundVal !== null) {
+                      boundVal = valFromTransform(boundVal);
+                    }
+                    binding_values.push(boundVal);
                   }
                 }
               } else {
@@ -513,7 +541,11 @@ function normalizeQuery(
                 if (typeof value === "undefined") {
                   binding_values.push(null);
                 } else {
-                  binding_values.push(value);
+                  let boundVal = value;
+                  if (valFromTransform && boundVal !== null) {
+                    boundVal = valFromTransform(boundVal);
+                  }
+                  binding_values.push(boundVal);
                 }
               }
             }
@@ -545,8 +577,13 @@ function normalizeQuery(
                 continue;
               }
               hasValues = true;
-              query += `${adapter.escapeIdentifier(column as string)} = ${adapter.placeholder(binding_idx++)}${i < lastColumnIndex ? ", " : ""}`;
-              binding_values.push(columnValue);
+              const dbColumnName = fromTransform ? fromTransform(column as string) : (column as string);
+              query += `${adapter.escapeIdentifier(dbColumnName)} = ${adapter.placeholder(binding_idx++)}${i < lastColumnIndex ? ", " : ""}`;
+              let boundVal = columnValue;
+              if (valFromTransform && boundVal !== null) {
+                boundVal = valFromTransform(boundVal);
+              }
+              binding_values.push(boundVal);
             }
             if (query.endsWith(", ")) {
               // we got an undefined value at the end, lets remove the last comma
@@ -1440,6 +1477,10 @@ function parseSQLiteOptions(
     adapter: "sqlite" as const,
     filename: ":memory:",
   };
+  const transform = parseTransform(options.transform);
+  if (transform) {
+    sqliteOptions.transform = transform;
+  }
 
   let filename = filenameOrUrl || ":memory:";
   let originalUrl = filename; // Keep the original URL for query parsing
@@ -2093,6 +2134,11 @@ function parseOptions(
     }
   }
 
+  const transform = parseTransform(options.transform);
+  if (transform) {
+    ret.transform = transform;
+  }
+
   return ret;
 }
 
@@ -2142,6 +2188,195 @@ export interface DatabaseAdapter<Connection, ConnectionHandle, QueryHandle> {
   invalidTransactionStateError(message: string): Error;
 }
 
+const WORD_REGEX = /(\p{Lu}\p{Ll}+|\p{Lu}+(?!\p{Ll})|\p{Ll}+|\p{N}+)/gu;
+
+function getWords(str: string): string[] {
+  if (typeof str !== "string" || !str) return [];
+  const matches = str.match(WORD_REGEX);
+  return matches || [];
+}
+
+function toCamel(str: string): string {
+  const words = getWords(str);
+  if (words.length === 0) return str;
+  const first = words[0].toLowerCase();
+  const rest = words.slice(1).map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
+  return first + rest.join("");
+}
+
+function toPascal(str: string): string {
+  const words = getWords(str);
+  if (words.length === 0) return str;
+  return words.map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join("");
+}
+
+function toKebab(str: string): string {
+  const words = getWords(str);
+  if (words.length === 0) return str;
+  return words.map(w => w.toLowerCase()).join("-");
+}
+
+function toSnake(str: string): string {
+  const words = getWords(str);
+  if (words.length === 0) return str;
+  return words.map(w => w.toLowerCase()).join("_");
+}
+
+export interface TransformFunction {
+  (str: string): string;
+  to?: (str: string) => string;
+  from?: (str: string) => string;
+}
+
+function createTransform(toFn: (str: string) => string, fromFn: (str: string) => string): TransformFunction {
+  const fn: TransformFunction = (str: string) => toFn(str);
+  fn.to = toFn;
+  fn.from = fromFn;
+  return fn;
+}
+
+const camel = createTransform(toCamel, toSnake);
+const pascal = createTransform(toPascal, toSnake);
+const kebab = createTransform(toKebab, toSnake);
+const snake = createTransform(toSnake, toCamel);
+
+const toCamelTransform = toCamel;
+const fromCamelTransform = toSnake;
+const toPascalTransform = toPascal;
+const fromPascalTransform = toSnake;
+const toKebabTransform = toKebab;
+const fromKebabTransform = toSnake;
+const toSnakeTransform = toSnake;
+const fromSnakeTransform = toCamel;
+
+export interface ParsedTransform {
+  column?: {
+    to?: (str: string) => string;
+    from?: (str: string) => string;
+  };
+  value?: {
+    to?: (val: any) => any;
+    from?: (val: any) => any;
+  };
+  row?: (row: any) => any;
+}
+
+function parseTransform(transform: any): ParsedTransform | undefined {
+  if (!transform) return undefined;
+  if (typeof transform !== "function" && typeof transform !== "object") {
+    throw $ERR_INVALID_ARG_TYPE("options.transform", "function or object", transform);
+  }
+
+  let colTo: ((str: string) => string) | undefined;
+  let colFrom: ((str: string) => string) | undefined;
+  let valTo: ((val: any) => any) | undefined;
+  let valFrom: ((val: any) => any) | undefined;
+  let rowFn: ((row: any) => any) | undefined;
+
+  if (typeof transform === "function") {
+    colTo = transform;
+    if (transform.from) colFrom = transform.from;
+    if (transform.to) colTo = transform.to;
+  } else if (typeof transform === "object") {
+    if (transform.column) {
+      if (typeof transform.column === "function") {
+        colTo = transform.column;
+        if (transform.column.from) colFrom = transform.column.from;
+        if (transform.column.to) colTo = transform.column.to;
+      } else if (typeof transform.column === "object") {
+        colTo = transform.column.to;
+        colFrom = transform.column.from;
+      }
+    }
+    if (transform.value) {
+      if (typeof transform.value === "function") {
+        valTo = transform.value;
+        if (transform.value.from) valFrom = transform.value.from;
+        if (transform.value.to) valTo = transform.value.to;
+      } else if (typeof transform.value === "object") {
+        valTo = transform.value.to;
+        valFrom = transform.value.from;
+      }
+    }
+    if (typeof transform.row === "function") {
+      rowFn = transform.row;
+    }
+    if (!transform.column && (transform.to || transform.from)) {
+      colTo = transform.to;
+      colFrom = transform.from;
+    }
+  }
+
+  if (!colTo && !colFrom && !valTo && !valFrom && !rowFn) {
+    return undefined;
+  }
+
+  if (colTo) {
+    const rawColTo = colTo;
+    const cache = new Map<string, string>();
+    colTo = (key: string) => {
+      let cached = cache.get(key);
+      if (cached === undefined) {
+        cached = rawColTo(key);
+        cache.set(key, cached);
+      }
+      return cached;
+    };
+  }
+
+  return {
+    column: colTo || colFrom ? { to: colTo, from: colFrom } : undefined,
+    value: valTo || valFrom ? { to: valTo, from: valFrom } : undefined,
+    row: rowFn,
+  };
+}
+
+function applyResultTransform(result: any, transform: ParsedTransform | undefined): any {
+  if (!result || !transform) return result;
+
+  const colTo = transform.column?.to;
+  const valTo = transform.value?.to;
+  const rowFn = transform.row;
+
+  if (!colTo && !valTo && !rowFn) return result;
+
+  const transformRowObj = (row: any) => {
+    if (!row || typeof row !== "object" || Array.isArray(row) || row instanceof Date || Buffer.isBuffer(row)) {
+      return row;
+    }
+    let out: any = row;
+    if (colTo || valTo) {
+      out = {};
+      const keys = Object.keys(row);
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        const newKey = colTo ? colTo(key) : key;
+        let val = row[key];
+        if (valTo) {
+          val = valTo(val);
+        }
+        out[newKey] = val;
+      }
+    }
+    if (rowFn) {
+      out = rowFn(out);
+    }
+    return out;
+  };
+
+  if (Array.isArray(result)) {
+    for (let i = 0; i < result.length; i++) {
+      const item = result[i];
+      if (Array.isArray(item) && (item as any).command !== undefined) {
+        applyResultTransform(item, transform);
+      } else {
+        result[i] = transformRowObj(item);
+      }
+    }
+  }
+  return result;
+}
+
 export default {
   parseDefinitelySqliteUrl,
   isOptionsOfAdapter,
@@ -2161,4 +2396,22 @@ export default {
   // @ts-expect-error we're exporting a const enum which works in our builtins
   // generator but not in typescript officially
   SSLMode,
+  camel,
+  pascal,
+  kebab,
+  snake,
+  toCamel,
+  toPascal,
+  toKebab,
+  toSnake,
+  toCamelTransform,
+  fromCamelTransform,
+  toPascalTransform,
+  fromPascalTransform,
+  toKebabTransform,
+  fromKebabTransform,
+  toSnakeTransform,
+  fromSnakeTransform,
+  parseTransform,
+  applyResultTransform,
 };

--- a/test/js/sql/sql-transform.test.ts
+++ b/test/js/sql/sql-transform.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+import { SQL, postgres } from "bun";
+
+describe("SQL Column Name Transforms", () => {
+  describe("String case functions (Unicode-aware)", () => {
+    test("toCamel", () => {
+      expect(postgres.toCamel("user_id")).toBe("userId");
+      expect(postgres.toCamel("USER_ID")).toBe("userId");
+      expect(postgres.toCamel("first_name")).toBe("firstName");
+      expect(postgres.toCamel("user_id_2024")).toBe("userId2024");
+      expect(postgres.toCamel("créée_à")).toBe("crééeÀ");
+      expect(postgres.toCamel("über_größe")).toBe("überGröße");
+      expect(postgres.toCamel("имя_пользователя")).toBe("имяПользователя");
+      expect(postgres.toCamel("FooBar")).toBe("fooBar");
+      expect(postgres.toCamel("foo-bar")).toBe("fooBar");
+    });
+
+    test("toPascal", () => {
+      expect(postgres.toPascal("user_id")).toBe("UserId");
+      expect(postgres.toPascal("USER_ID")).toBe("UserId");
+      expect(postgres.toPascal("first_name")).toBe("FirstName");
+      expect(postgres.toPascal("créée_à")).toBe("CrééeÀ");
+      expect(postgres.toPascal("foo-bar")).toBe("FooBar");
+    });
+
+    test("toKebab", () => {
+      expect(postgres.toKebab("user_id")).toBe("user-id");
+      expect(postgres.toKebab("userId")).toBe("user-id");
+      expect(postgres.toKebab("First_Name")).toBe("first-name");
+    });
+
+    test("toSnake", () => {
+      expect(postgres.toSnake("userId")).toBe("user_id");
+      expect(postgres.toSnake("UserId")).toBe("user_id");
+      expect(postgres.toSnake("first-name")).toBe("first_name");
+      expect(postgres.toSnake("FOO_BAR")).toBe("foo_bar");
+      expect(postgres.toSnake("crééeÀ")).toBe("créée_à");
+    });
+  });
+
+  describe("SQL Client transform options", () => {
+    test("snake_case to camelCase with postgres.camel", async () => {
+      await using sql = new SQL({
+        adapter: "sqlite",
+        filename: ":memory:",
+        transform: postgres.camel,
+      });
+
+      const [row] = await sql`SELECT 1 as user_id, 'Alice' as first_name, '2024-01-01' as created_at`;
+      expect(row).toEqual({
+        userId: 1,
+        firstName: "Alice",
+        createdAt: "2024-01-01",
+      });
+    });
+
+    test("snake_case to camelCase with Unicode column names", async () => {
+      await using sql = new SQL({
+        adapter: "sqlite",
+        filename: ":memory:",
+        transform: { column: postgres.camel },
+      });
+
+      const [row] = await sql`SELECT 'oui' as créée_à, 'groß' as über_größe`;
+      expect(row).toEqual({
+        crééeÀ: "oui",
+        überGröße: "groß",
+      });
+    });
+
+    test("snake_case to PascalCase with postgres.pascal", async () => {
+      await using sql = new SQL({
+        adapter: "sqlite",
+        filename: ":memory:",
+        transform: postgres.pascal,
+      });
+
+      const [row] = await sql`SELECT 1 as user_id, 'Bob' as first_name`;
+      expect(row).toEqual({
+        UserId: 1,
+        FirstName: "Bob",
+      });
+    });
+
+    test("camelCase to snake_case with postgres.snake", async () => {
+      await using sql = new SQL({
+        adapter: "sqlite",
+        filename: ":memory:",
+        transform: postgres.snake,
+      });
+
+      const [row] = await sql`SELECT 1 as userId, 'Charlie' as firstName`;
+      expect(row).toEqual({
+        user_id: 1,
+        first_name: "Charlie",
+      });
+    });
+
+    test("Custom column transform function", async () => {
+      await using sql = new SQL({
+        adapter: "sqlite",
+        filename: ":memory:",
+        transform: {
+          column: (col: string) => col.toUpperCase(),
+        },
+      });
+
+      const [row] = await sql`SELECT 1 as user_id, 'Dave' as first_name`;
+      expect(row).toEqual({
+        USER_ID: 1,
+        FIRST_NAME: "Dave",
+      });
+    });
+
+    test("SQLHelper INSERT with column transform (from camelCase to snake_case)", async () => {
+      await using sql = new SQL({
+        adapter: "sqlite",
+        filename: ":memory:",
+        transform: postgres.camel,
+      });
+
+      await sql`CREATE TABLE users (id INTEGER PRIMARY KEY, first_name TEXT, last_name TEXT)`;
+
+      const newUser = { firstName: "Eve", lastName: "Adams" };
+      await sql`INSERT INTO users ${sql(newUser)}`;
+
+      const [retrieved] = await sql`SELECT first_name, last_name FROM users WHERE id = 1`;
+      expect(retrieved).toEqual({
+        firstName: "Eve",
+        lastName: "Adams",
+      });
+    });
+
+    test("SQLHelper UPDATE with column transform", async () => {
+      await using sql = new SQL({
+        adapter: "sqlite",
+        filename: ":memory:",
+        transform: postgres.camel,
+      });
+
+      await sql`CREATE TABLE users (id INTEGER PRIMARY KEY, first_name TEXT, last_name TEXT)`;
+      await sql`INSERT INTO users (id, first_name, last_name) VALUES (1, 'Frank', 'Smith')`;
+
+      const updateData = { firstName: "Franklin", lastName: "Smith-Doe" };
+      await sql`UPDATE users SET ${sql(updateData)} WHERE id = 1`;
+
+      const [retrieved] = await sql`SELECT first_name, last_name FROM users WHERE id = 1`;
+      expect(retrieved).toEqual({
+        firstName: "Franklin",
+        lastName: "Smith-Doe",
+      });
+    });
+
+    test("Row transform function", async () => {
+      await using sql = new SQL({
+        adapter: "sqlite",
+        filename: ":memory:",
+        transform: {
+          column: postgres.camel,
+          row: (row: any) => ({ ...row, extraProp: true }),
+        },
+      });
+
+      const [row] = await sql`SELECT 'Grace' as first_name`;
+      expect(row).toEqual({
+        firstName: "Grace",
+        extraProp: true,
+      });
+    });
+
+    test("Bidirectional value transform function (value.to and value.from)", async () => {
+      await using sql = new SQL({
+        adapter: "sqlite",
+        filename: ":memory:",
+        transform: {
+          column: postgres.camel,
+          value: {
+            to: (val: any) => (typeof val === "string" ? val.toUpperCase() : val),
+            from: (val: any) => (typeof val === "string" ? val.toLowerCase() : val),
+          },
+        },
+      });
+
+      await sql`CREATE TABLE notes (id INTEGER PRIMARY KEY, text_content TEXT)`;
+
+      // Write path applies value.from (toLowerCase)
+      await sql`INSERT INTO notes ${sql({ textContent: "HELLO WORLD" })}`;
+
+      // Read path applies value.to (toUpperCase)
+      const [row] = await sql`SELECT text_content FROM notes WHERE id = 1`;
+      expect(row).toEqual({
+        textContent: "HELLO WORLD",
+      });
+    });
+
+    test("Throws error for invalid transform options type", () => {
+      expect(() => {
+        new SQL({
+          adapter: "sqlite",
+          filename: ":memory:",
+          transform: "invalid" as any,
+        });
+      }).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Implements Unicode-aware column name transforms for Bun SQL (`new SQL()` / `postgres()`), resolving the Roadmap item in `docs/runtime/sql.mdx`.

### Details:
- Adds Unicode-aware casing helpers: `toCamel`, `toPascal`, `toKebab`, `toSnake` supporting multi-language characters (accents, Cyrillic, German Eszett, etc.).
- Exposes transform presets `postgres.camel`, `postgres.pascal`, `postgres.kebab`, `postgres.snake` on `SQL`, `postgres`, and `bun` module exports.
- Applies bidirectional column transforms:
  - **Results**: transforms DB column names (e.g. `user_id` -> `userId`) when reading query results.
  - **Helpers**: transforms JS object keys back to DB column names when constructing `sql({ firstName: "Alice" })` INSERT / UPDATE queries.
- Includes $O(1)$ per-column memoization cache to optimize multi-row result sets.
- Adds comprehensive unit tests in `test/js/sql/sql-transform.test.ts`.

### Related Docs:
- Updates `docs/runtime/sql.mdx` documentation and removes column transforms from the Roadmap list.