### PR TITLE
node:child_process: accept stdio: 'overlapped' string shorthand

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1786,6 +1786,8 @@ function normalizeStdio(stdio): string[] {
         return ["ignore", "ignore", "ignore"];
       case "pipe":
         return ["pipe", "pipe", "pipe"];
+      case "overlapped":
+        return ["overlapped", "overlapped", "overlapped"];
       case "inherit":
         return ["inherit", "inherit", "inherit"];
       default:

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -431,16 +431,18 @@ describe("spawn()", () => {
       expect(child.stdin).not.toBeNull();
       expect(child.stdout).not.toBeNull();
       expect(child.stderr).not.toBeNull();
-      const { promise, resolve } = Promise.withResolvers<string>();
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
       let out = "";
+      const closed = new Promise<number | null>(r => child.on("close", r));
+      child.on("error", reject);
+      child.on("close", code => reject(new Error(`child closed (${code}) before echoing; out=${JSON.stringify(out)}`)));
       child.stdout!.on("data", d => {
         out += d;
         if (out.includes("\n")) resolve(out);
       });
       child.stdin!.end("hi\n");
       expect(await promise).toBe("out:hi\n");
-      const code = await new Promise<number | null>(r => child.on("close", r));
-      expect(code).toBe(0);
+      expect(await closed).toBe(0);
     });
     it("overlapped string shorthand works with spawnSync", () => {
       const { stdout, status } = spawnSync(bunExe(), ["-e", "console.log('ok')"], {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -431,6 +431,7 @@ describe("spawn()", () => {
       expect(child.stdin).not.toBeNull();
       expect(child.stdout).not.toBeNull();
       expect(child.stderr).not.toBeNull();
+      child.stderr!.resume();
       const { promise, resolve, reject } = Promise.withResolvers<string>();
       let out = "";
       const closed = new Promise<number | null>(r => child.on("close", r));

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -417,11 +417,39 @@ describe("spawn()", () => {
       expect(child.stdout).not.toBeNull();
       expect(child.stderr).not.toBeNull();
     });
-    it.todo("overlapped", () => {
+    it("overlapped", () => {
       const child = spawn(bunExe(), ["-v"], { stdio: "overlapped" });
       expect(!!child).toBe(true);
       expect(child.stdout).not.toBeNull();
       expect(child.stderr).not.toBeNull();
+    });
+    it("overlapped string shorthand behaves like pipe", async () => {
+      const child = spawn(bunExe(), ["-e", "process.stdin.on('data', d => process.stdout.write('out:' + d))"], {
+        env: bunEnv,
+        stdio: "overlapped",
+      });
+      expect(child.stdin).not.toBeNull();
+      expect(child.stdout).not.toBeNull();
+      expect(child.stderr).not.toBeNull();
+      const { promise, resolve } = Promise.withResolvers<string>();
+      let out = "";
+      child.stdout!.on("data", d => {
+        out += d;
+        if (out.includes("\n")) resolve(out);
+      });
+      child.stdin!.end("hi\n");
+      expect(await promise).toBe("out:hi\n");
+      const code = await new Promise<number | null>(r => child.on("close", r));
+      expect(code).toBe(0);
+    });
+    it("overlapped string shorthand works with spawnSync", () => {
+      const { stdout, status } = spawnSync(bunExe(), ["-e", "console.log('ok')"], {
+        env: bunEnv,
+        stdio: "overlapped",
+        encoding: "utf8",
+      });
+      expect(stdout).toBe("ok\n");
+      expect(status).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Problem

`spawn(cmd, args, { stdio: 'overlapped' })` and `spawnSync(..., { stdio: 'overlapped' })` throw synchronously:

```
TypeError: The value "overlapped" is invalid for option "stdio"
 code: "ERR_INVALID_OPT_VALUE"
```

Only the **string shorthand** fails. The array forms `['overlapped', 'overlapped', 'overlapped']` and mixed `['pipe', 'overlapped', 'inherit']` already work. Node documents `'overlapped'` as equivalent to `'pipe'` on non-Windows, so a cross-platform library that passes the string form cannot spawn at all under Bun.

## Repro

```js
import cp from 'node:child_process';
// node: prints "out:hi"; bun: throws ERR_INVALID_OPT_VALUE
const c = cp.spawn('/bin/sh', ['-c', 'read x; echo out:$x'], { stdio: 'overlapped' });
c.stdout.on('data', d => process.stdout.write(d));
c.stdin.end('hi\n');
```

## Cause

`normalizeStdio()` in `src/js/node/child_process.ts` switches on the string with only `"ignore" / "pipe" / "inherit"` and falls through to `throw ERR_INVALID_OPT_VALUE`. The per-element lookup table (`nodeToBunLookup`) right above it already maps `overlapped: "pipe"`, and `stdioStringToArray()` (used by `fork()`) already handles `"overlapped"`; only `normalizeStdio`'s string switch was missing the case.

## Fix

Add `case "overlapped": return ["overlapped", "overlapped", "overlapped"]` to `normalizeStdio()`. The existing `nodeToBunLookup` then maps each element to `"pipe"` as it already does for the array form.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/child_process/child_process.test.ts -t overlapped
 3 fail  (ERR_INVALID_OPT_VALUE)

$ bun bd test test/js/node/child_process/child_process.test.ts -t overlapped
 3 pass
```

Un-todo'd the existing `stdio > overlapped` test and added two more: an end-to-end stdin→stdout pipe check under `stdio: 'overlapped'`, and a `spawnSync` check.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child_process.test.ts

<!-- robobun:evidence:end -->