### PR TITLE
Bun.serve: pass a handler's Content-Length through on 304 instead of writing 0

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3384,16 +3384,10 @@ where
         }
     }
 
-    /// Render a response whose status forbids a body (RFC 9112 §6.3).
-    ///
-    /// `render_bytes()` → `try_end` emits `Content-Length: <blob size>` on the
-    /// wire. uWS suppresses that for 1xx/204 via `HTTP_NO_BODY_STATUS`, but a
-    /// 304 falls through and gets `Content-Length: 0`, which RFC 9110 §8.6
-    /// forbids unless it equals what the 200 would have carried. A downstream
-    /// cache updates its stored headers from a 304 (RFC 9111 §4.3.4), so the
-    /// fabricated zero overwrites the cached body's real length. Pass the
-    /// handler's Content-Length through (only it knows the 200 length) and
-    /// otherwise emit none.
+    /// Render a response whose status forbids a body (RFC 9112 §6.3). `try_end`
+    /// would put `Content-Length: 0` on a 304 (uWS only suppresses it for
+    /// 1xx/204); RFC 9110 §8.6 only allows the 200's length, so forward the
+    /// handler's value or emit none.
     ///
     /// # Safety
     /// `this` must point to a live `RequestContext` threaded through cork user-data.
@@ -3404,11 +3398,9 @@ where
         let (status, app_content_length) = {
             let response: &mut Response = this.response_weakref.get().unwrap();
             let status = response.status_code();
+            // Parsed before render_metadata() fast_remove()s it and derefs the headers.
             let app_cl = (status == 304)
                 .then(|| {
-                    // Parse before render_metadata(): do_write_headers()
-                    // fast_remove()s ContentLength and derefs the FetchHeaders.
-                    // A non-1*DIGIT value is dropped rather than coerced to 0.
                     let s = response
                         .get_init_headers_mut()?
                         .fast_get(jsc::HTTPHeaderName::ContentLength)?
@@ -3426,17 +3418,13 @@ where
                 if let Some(len) = app_content_length {
                     resp.write_header_int(b"content-length", len);
                 }
-                // uws_res_end_without_body bypasses internalEnd's writeMark();
-                // emit Date here so 304 keeps it (try_end did, and RFC 9110
-                // §6.6.1 MUSTs it for origin servers with a clock).
+                // end_without_body skips writeMark(); keep Date as try_end did.
                 resp.write_mark();
                 this.end_without_body(this.should_close_connection());
                 return;
             }
         }
-        // Non-304, and the 304 resp-gone edge: render_bytes unconditionally
-        // runs detach_response/end_request_streaming_and_drain/deref, matching
-        // the base-ref release do_render_blob_corked always provided.
+        // render_bytes releases the base ref on every path (resp gone included).
         this.render_bytes();
     }
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3400,42 +3400,44 @@ where
     fn do_render_null_body_status_corked(this: *mut Self) {
         // SAFETY: caller upholds the fn-level contract.
         let this = unsafe { &mut *this };
-        let Some(resp) = this.resp else { return };
 
         let (status, app_content_length) = {
             let response: &mut Response = this.response_weakref.get().unwrap();
             let status = response.status_code();
             let app_cl = (status == 304)
                 .then(|| {
-                    response
+                    // Parse before render_metadata(): do_write_headers()
+                    // fast_remove()s ContentLength and derefs the FetchHeaders.
+                    // A non-1*DIGIT value is dropped rather than coerced to 0.
+                    let s = response
                         .get_init_headers_mut()?
-                        .fast_get(jsc::HTTPHeaderName::ContentLength)
-                        .map(|cl| {
-                            // Parse before render_metadata(): do_write_headers()
-                            // fast_remove()s ContentLength and derefs the FetchHeaders.
-                            let s = cl.to_slice();
-                            HTTP::parse_content_length(s.slice()) as u64
-                        })
+                        .fast_get(jsc::HTTPHeaderName::ContentLength)?
+                        .to_slice();
+                    bun_core::parse_int::<u64>(s.slice(), 10).ok()
                 })
                 .flatten();
             (status, app_cl)
         };
 
-        if status != 304 {
-            this.render_metadata();
-            this.render_bytes();
-            return;
-        }
-
         this.render_metadata();
-        if let Some(len) = app_content_length {
-            resp.write_header_int(b"content-length", len);
+
+        if status == 304 {
+            if let Some(resp) = this.resp {
+                if let Some(len) = app_content_length {
+                    resp.write_header_int(b"content-length", len);
+                }
+                // uws_res_end_without_body bypasses internalEnd's writeMark();
+                // emit Date here so 304 keeps it (try_end did, and RFC 9110
+                // §6.6.1 MUSTs it for origin servers with a clock).
+                resp.write_mark();
+                this.end_without_body(this.should_close_connection());
+                return;
+            }
         }
-        // uws_res_end_without_body bypasses internalEnd's writeMark(); emit
-        // Date here so 304 keeps it (try_end did, and RFC 9110 §6.6.1 MUSTs
-        // it for origin servers with a clock).
-        resp.write_mark();
-        this.end_without_body(this.should_close_connection());
+        // Non-304, and the 304 resp-gone edge: render_bytes unconditionally
+        // runs detach_response/end_request_streaming_and_drain/deref, matching
+        // the base-ref release do_render_blob_corked always provided.
+        this.render_bytes();
     }
 
     /// `render_metadata` adapter for `run_corked_with_type` (takes `fn(*mut U)`).

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2502,7 +2502,7 @@ where
         // not derive framing from that body (or the user headers) either
         // (RFC 9110 §9.3.2): render the exact metadata+framing GET would.
         if HTTPStatusText::is_null_body(response.status_code()) {
-            Self::do_render_blob_corked(std::ptr::from_mut::<Self>(this));
+            Self::do_render_null_body_status_corked(std::ptr::from_mut::<Self>(this));
             return;
         }
 
@@ -3374,6 +3374,70 @@ where
         this.render_bytes();
     }
 
+    pub(crate) fn do_render_null_body_status(&mut self) {
+        if self.flags.has_abort_handler() {
+            if let Some(resp) = self.resp {
+                resp.run_corked_with_type(Self::do_render_null_body_status_corked, self);
+            }
+        } else {
+            Self::do_render_null_body_status_corked(std::ptr::from_mut::<Self>(self));
+        }
+    }
+
+    /// Render a response whose status forbids a body (RFC 9112 §6.3).
+    ///
+    /// `render_bytes()` → `try_end` emits `Content-Length: <blob size>` on the
+    /// wire. uWS suppresses that for 1xx/204 via `HTTP_NO_BODY_STATUS`, but a
+    /// 304 falls through and gets `Content-Length: 0`, which RFC 9110 §8.6
+    /// forbids unless it equals what the 200 would have carried. A downstream
+    /// cache updates its stored headers from a 304 (RFC 9111 §4.3.4), so the
+    /// fabricated zero overwrites the cached body's real length. Pass the
+    /// handler's Content-Length through (only it knows the 200 length) and
+    /// otherwise emit none.
+    ///
+    /// # Safety
+    /// `this` must point to a live `RequestContext` threaded through cork user-data.
+    fn do_render_null_body_status_corked(this: *mut Self) {
+        // SAFETY: caller upholds the fn-level contract.
+        let this = unsafe { &mut *this };
+        let Some(resp) = this.resp else { return };
+
+        let (status, app_content_length) = {
+            let response: &mut Response = this.response_weakref.get().unwrap();
+            let status = response.status_code();
+            let app_cl = (status == 304)
+                .then(|| {
+                    response
+                        .get_init_headers_mut()?
+                        .fast_get(jsc::HTTPHeaderName::ContentLength)
+                        .map(|cl| {
+                            // Parse before render_metadata(): do_write_headers()
+                            // fast_remove()s ContentLength and derefs the FetchHeaders.
+                            let s = cl.to_slice();
+                            HTTP::parse_content_length(s.slice()) as u64
+                        })
+                })
+                .flatten();
+            (status, app_cl)
+        };
+
+        if status != 304 {
+            this.render_metadata();
+            this.render_bytes();
+            return;
+        }
+
+        this.render_metadata();
+        if let Some(len) = app_content_length {
+            resp.write_header_int(b"content-length", len);
+        }
+        // uws_res_end_without_body bypasses internalEnd's writeMark(); emit
+        // Date here so 304 keeps it (try_end did, and RFC 9110 §6.6.1 MUSTs
+        // it for origin servers with a clock).
+        resp.write_mark();
+        this.end_without_body(this.should_close_connection());
+    }
+
     /// `render_metadata` adapter for `run_corked_with_type` (takes `fn(*mut U)`).
     fn render_metadata_corked(this: *mut Self) {
         // SAFETY: this is the live RequestContext threaded through cork user-data.
@@ -3904,7 +3968,7 @@ where
 
         // SAFETY: caller contract — `response` is live.
         if HTTPStatusText::is_null_body(unsafe { (*response).status_code() }) {
-            self.do_render_blob();
+            self.do_render_null_body_status();
             return;
         }
 

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -303,12 +303,17 @@ impl StaticRoute {
         // `do_render_blob_corked` drops the body for a null-body status, so
         // HEAD reports the zero bytes GET actually sends (RFC 9110 §9.3.2).
         // (For 1xx/204 uWS suppresses the Content-Length header entirely.)
-        let size = if HTTPStatusText::is_null_body(self.status_code) {
-            0
-        } else {
-            self.cached_blob_size
-        };
-        resp.write_header_int(b"Content-Length", size);
+        // 304 carries no synthesized Content-Length at all: RFC 9110 §8.6
+        // only allows the value a 200 would carry, and `from_js` already
+        // stripped any handler-supplied one, so there is nothing to forward.
+        if self.status_code != 304 {
+            let size = if HTTPStatusText::is_null_body(self.status_code) {
+                0
+            } else {
+                self.cached_blob_size
+            };
+            resp.write_header_int(b"Content-Length", size);
+        }
         resp.end_without_body(resp.should_close_connection());
     }
 
@@ -436,7 +441,17 @@ impl StaticRoute {
         // `render` and `FileRoute` already do. Writing them here with no
         // Content-Length (uWS suppresses it for 1xx/204) desyncs keep-alive.
         if HTTPStatusText::is_null_body(self.status_code) {
-            *did_finish = resp.try_end(b"", 0, resp.should_close_connection());
+            // try_end fabricates `Content-Length: 0` on a 304 (uWS only sets
+            // HTTP_NO_BODY_STATUS for 1xx/204). RFC 9110 §8.6 forbids any 304
+            // Content-Length that is not the 200's, and `from_js` stripped the
+            // handler's, so emit none. write_mark keeps the Date try_end wrote.
+            if self.status_code == 304 {
+                resp.write_mark();
+                resp.end_without_body(resp.should_close_connection());
+                *did_finish = true;
+            } else {
+                *did_finish = resp.try_end(b"", 0, resp.should_close_connection());
+            }
             return;
         }
         self.render_bytes(resp, did_finish);

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -302,10 +302,8 @@ impl StaticRoute {
         self.render_metadata(resp);
         // `do_render_blob_corked` drops the body for a null-body status, so
         // HEAD reports the zero bytes GET actually sends (RFC 9110 §9.3.2).
-        // (For 1xx/204 uWS suppresses the Content-Length header entirely.)
-        // 304 carries no synthesized Content-Length at all: RFC 9110 §8.6
-        // only allows the value a 200 would carry, and `from_js` already
-        // stripped any handler-supplied one, so there is nothing to forward.
+        // 304: no synthesized Content-Length (RFC 9110 §8.6 only allows the
+        // 200's length; `from_js` already stripped the handler's).
         if self.status_code != 304 {
             let size = if HTTPStatusText::is_null_body(self.status_code) {
                 0
@@ -441,10 +439,8 @@ impl StaticRoute {
         // `render` and `FileRoute` already do. Writing them here with no
         // Content-Length (uWS suppresses it for 1xx/204) desyncs keep-alive.
         if HTTPStatusText::is_null_body(self.status_code) {
-            // try_end fabricates `Content-Length: 0` on a 304 (uWS only sets
-            // HTTP_NO_BODY_STATUS for 1xx/204). RFC 9110 §8.6 forbids any 304
-            // Content-Length that is not the 200's, and `from_js` stripped the
-            // handler's, so emit none. write_mark keeps the Date try_end wrote.
+            // 304: try_end would write Content-Length: 0 (RFC 9110 §8.6 forbids
+            // any but the 200's length); write_mark keeps Date.
             if self.status_code == 304 {
                 resp.write_mark();
                 resp.end_without_body(resp.should_close_connection());

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1582,9 +1582,9 @@ describe("response framing", () => {
         hostname: "127.0.0.1",
         fetch: () => new Response(null, { status: 205 }),
       });
-      const { statusLine, headerNames } = await rawRequest(server.port, method);
+      const { statusLine, headers } = await rawRequest(server.port, method);
       expect(statusLine).toStartWith(`HTTP/1.1 205 `);
-      expect(headerNames).toContain("content-length");
+      expect(headers["content-length"]).toBe("0");
     });
 
     // RFC 9110 8.6: a 304 MAY carry Content-Length but MUST NOT unless it
@@ -1595,6 +1595,7 @@ describe("response framing", () => {
       [undefined, null],
       ["1234", "1234"],
       ["0", "0"],
+      ["abc", null],
     ])("a 304 response passes the handler's Content-Length through (%p -> %p)", async (appCL, expected) => {
       using server = Bun.serve({
         port: 0,

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1574,18 +1574,82 @@ describe("response framing", () => {
       expect(headerNames).not.toContain("transfer-encoding");
     });
 
-    // 205 MUST indicate a zero-length body (RFC 9110 15.3.6) and 304 MAY carry
-    // a Content-Length (RFC 9110 15.4.5) -- both keep the explicit 0.
-    it.each([205, 304])("a %i response keeps Content-Length: 0", async status => {
+    // RFC 9110 15.3.6: a 205 MUST NOT generate content; the explicit 0 it
+    // already emitted stays (still conformant, and matches prior releases).
+    it("a 205 response keeps Content-Length: 0", async () => {
       using server = Bun.serve({
         port: 0,
         hostname: "127.0.0.1",
-        fetch: () => new Response(null, { status }),
+        fetch: () => new Response(null, { status: 205 }),
       });
       const { statusLine, headerNames } = await rawRequest(server.port, method);
-      expect(statusLine).toStartWith(`HTTP/1.1 ${status} `);
+      expect(statusLine).toStartWith(`HTTP/1.1 205 `);
       expect(headerNames).toContain("content-length");
     });
+
+    // RFC 9110 8.6: a 304 MAY carry Content-Length but MUST NOT unless it
+    // equals what the 200 would have sent. Only the handler knows that value,
+    // so pass its header through; when it sets none, emit none (a fabricated 0
+    // poisons caches that update stored headers from a 304, RFC 9111 4.3.4).
+    it.each([
+      [undefined, null],
+      ["1234", "1234"],
+      ["0", "0"],
+    ])("a 304 response passes the handler's Content-Length through (%p -> %p)", async (appCL, expected) => {
+      using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch: () =>
+          new Response(null, {
+            status: 304,
+            headers: appCL === undefined ? { etag: '"x"' } : { etag: '"x"', "content-length": appCL },
+          }),
+      });
+      const { statusLine, headers, body } = await rawRequest(server.port, method);
+      expect({ statusLine: statusLine.slice(0, 12), contentLength: headers["content-length"] ?? null, body }).toEqual({
+        statusLine: "HTTP/1.1 304",
+        contentLength: expected,
+        body: "",
+      });
+      expect(headers["date"]).toBeDefined();
+    });
+  });
+
+  // RFC 9112 6.3: a 304 is terminated at the blank line regardless of
+  // Content-Length, so a non-zero handler value must not desync keep-alive.
+  it("a 304 with a handler Content-Length does not desync keep-alive", async () => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const p = new URL(req.url).pathname;
+        if (p === "/a") return new Response(null, { status: 304, headers: { "content-length": "1234", etag: '"a"' } });
+        return new Response("ok-b");
+      },
+    });
+    const received: Buffer[] = [];
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+    await using c = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      socket: {
+        data: (_, d) => received.push(d),
+        close: () => resolve(),
+        end: () => resolve(),
+        error: (_, e) => reject(e),
+      },
+    });
+    c.write(
+      "GET /a HTTP/1.1\r\nHost: x\r\n\r\n" + //
+        "GET /b HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n",
+    );
+    c.flush();
+    await promise;
+    const raw = Buffer.concat(received).toString();
+    const [first, ...rest] = raw.split("HTTP/1.1 ").filter(Boolean);
+    expect(first).toMatch(/^304 Not Modified\r\n/);
+    expect(first).toMatch(/\r\ncontent-length: 1234\r\n/i);
+    expect(rest.join("HTTP/1.1 ")).toMatch(/^200 OK\r\n[\s\S]*\r\n\r\nok-b$/);
   });
 
   // RFC 9112 6.3 terminates a 1xx/204/304 at the blank line after the header
@@ -1599,8 +1663,8 @@ describe("response framing", () => {
       [204, "HEAD", null],
       [205, "GET", "0"],
       [205, "HEAD", "0"],
-      [304, "GET", "0"],
-      [304, "HEAD", "0"],
+      [304, "GET", null],
+      [304, "HEAD", null],
     ];
     it.each(cases)("%i %s", async (status, method, contentLength) => {
       const makeResponse = () => new Response("data", { status });


### PR DESCRIPTION
## Repro

```ts
import net from "node:net";
const server = Bun.serve({
  port: 0,
  hostname: "127.0.0.1",
  fetch: () => new Response(null, { status: 304, headers: { "content-length": "1234", etag: '"abc"' } }),
});
const sock = net.connect(server.port, "127.0.0.1", () =>
  sock.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"),
);
let raw = "";
sock.on("data", d => (raw += d));
sock.on("close", () => {
  console.log(JSON.stringify(raw.split("\r\n\r\n")[0]));
  server.stop(true);
});
```

Before:
```
"HTTP/1.1 304 Not Modified\r\nETag: \"abc\"\r\nDate: ...\r\nContent-Length: 0"
```
After:
```
"HTTP/1.1 304 Not Modified\r\nETag: \"abc\"\r\n...\r\ncontent-length: 1234\r\nDate: ..."
```

A 304 with no handler-supplied `Content-Length` now emits none (was `Content-Length: 0`). `node:http` `writeHead(304, {"content-length": "1234"})` already preserved the value; this brings `Bun.serve` in line.

## Cause

The null-body-status branch of `render()` went through `do_render_blob()` -> `render_bytes()` -> `resp.try_end(b"", 0, ..)`. uWS's `internalEnd` writes `Content-Length: <totalSize>` unless `HTTP_NO_BODY_STATUS` is set, and `writeStatus` only sets that bit for 1xx and 204 (304 MAY carry the header, so it is intentionally excluded). Meanwhile `do_write_headers()` had already `fast_remove`d the handler's `Content-Length`, so every 304 reached the wire with `Content-Length: 0`.

RFC 9110 8.6: a server MUST NOT send `Content-Length` in a 304 unless its value equals what the 200 would have sent. RFC 9111 4.3.4 has caches update their stored headers from a 304, so a downstream cache can record `Content-Length: 0` for the cached body.

## Fix

Route null-body statuses through a dedicated `do_render_null_body_status`. For 304 it reads the handler's `Content-Length` before `render_metadata()` strips it (same pattern `do_render_head_response` already uses), re-emits that value after `render_metadata()`, then terminates with `end_without_body()` so `try_end`'s fabricated zero is never written. `write_mark()` keeps the `Date` header `try_end` previously wrote. 101/103/204/205 keep their existing framing unchanged.

`StaticRoute` had the same shape (`do_render_blob_corked` called `try_end(b"", 0, ..)` for null-body; HEAD wrote `Content-Length: 0` explicitly). `StaticRoute::from_js` already strips any handler `Content-Length`, so there is nothing to forward: 304 now emits no `Content-Length` there either.

## Verification

New raw-socket tests in `test/js/bun/http/serve.test.ts` (`response framing` block) cover GET and HEAD, handler-set / absent / zero `Content-Length`, the static-route path, and a pipelined keep-alive request after a 304 carrying `Content-Length: 1234`.

```
git stash push -- src/ && bun bd test test/js/bun/http/serve.test.ts -t 304  # 9 fail (Content-Length: 0)
git stash pop && bun bd test test/js/bun/http/serve.test.ts -t 304           # all pass
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->