### PR TITLE
inspector: collapse JSC async wrapper frames in CDP Debugger.paused

### DIFF
--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -54,56 +54,8 @@ function breakpointUrlRegex(url: string): string {
   return Array.from(candidates, candidate => `^${escapeRegex(candidate)}$`).join("|");
 }
 
-function scopeKey(scope: AnyObject): string {
-  const location = scope.location;
-  return `${scope.type}|${scope.name ?? ""}|${location?.scriptId ?? ""}|${location?.lineNumber ?? ""}|${location?.columnNumber ?? ""}`;
-}
-
-// JSC splits an `async function` that uses `await` into a wrapper and a body
-// (Parser.cpp parseAsyncFunctionSourceElements); before the first suspend both
-// are on the VM stack, so the backend lists the function twice in callFrames.
-// V8 lists it once. The body closes over the wrapper's activation, so the
-// wrapper's scope chain is a proper suffix of the body's; drop that caller.
-function dropAsyncWrapperFrames(frames: AnyObject[]): AnyObject[] {
-  if (frames.length < 2) return frames;
-  const result: AnyObject[] = [frames[0]];
-  let previousDropped = false;
-  for (let i = 1; i < frames.length; i++) {
-    const frame = frames[i];
-    // A wrapper always immediately follows its body: once a frame is dropped,
-    // its caller is a distinct body and must be kept.
-    if (!previousDropped) {
-      const body = frames[i - 1];
-      const bodyScopes = body.scopeChain;
-      const wrapperScopes = frame.scopeChain;
-      if (
-        body.functionName === frame.functionName &&
-        body.location?.scriptId === frame.location?.scriptId &&
-        $isArray(bodyScopes) &&
-        $isArray(wrapperScopes)
-      ) {
-        const bodyScopeCount = bodyScopes.length;
-        const wrapperScopeCount = wrapperScopes.length;
-        if (wrapperScopeCount > 0 && bodyScopeCount > wrapperScopeCount) {
-          const offset = bodyScopeCount - wrapperScopeCount;
-          let isSuffix = true;
-          for (let k = 0; k < wrapperScopeCount; k++) {
-            if (scopeKey(bodyScopes[offset + k]) !== scopeKey(wrapperScopes[k])) {
-              isSuffix = false;
-              break;
-            }
-          }
-          if (isSuffix) {
-            previousDropped = true;
-            continue;
-          }
-        }
-      }
-    }
-    result.push(frame);
-    previousDropped = false;
-  }
-  return result;
+function locationKey(location: AnyObject | undefined): string {
+  return location ? `${location.scriptId}:${location.lineNumber}:${location.columnNumber}` : "";
 }
 
 const SCOPE_TYPE_MAP: Record<string, string> = {
@@ -153,6 +105,7 @@ class InspectorCDPAdapter {
     { clientId: number | string | null; method: string; onResult?: (result: AnyObject, error?: AnyObject) => void }
   >();
   #scripts = new Map<string, { cdpUrl: string; endLine: number; endColumn: number }>();
+  #asyncWrapperLocations: Set<string> | undefined;
 
   constructor(writeToBackend: (message: string) => void, writeToClient: (message: string) => void) {
     this.#writeToBackend = writeToBackend;
@@ -640,20 +593,32 @@ class InspectorCDPAdapter {
         return;
       }
 
+      // Bun emits this from the inspected thread immediately before
+      // Debugger.paused with the pause locations of JSC's generator/async
+      // wrapper frames (see BunInspectorConnection::sendMessageToFrontend), so
+      // the translation below can drop them to match V8's one-frame view.
+      case "Bun.asyncWrapperFrames":
+        this.#asyncWrapperLocations = new Set((params.locations ?? []).map(locationKey));
+        return;
+
       case "Debugger.paused": {
-        const callFrames = dropAsyncWrapperFrames(params.callFrames ?? []).map((frame: AnyObject) => ({
-          callFrameId: frame.callFrameId,
-          functionName: frame.functionName ?? "",
-          location: frame.location,
-          url: this.#scripts.$get(frame.location?.scriptId)?.cdpUrl ?? "",
-          scopeChain: (frame.scopeChain ?? []).map((scope: AnyObject) => ({
-            type: SCOPE_TYPE_MAP[scope.type] ?? "closure",
-            object: scope.object,
-            name: scope.name,
-          })),
-          this: frame.this,
-          canBeRestarted: false,
-        }));
+        const wrapperLocations = this.#asyncWrapperLocations;
+        this.#asyncWrapperLocations = undefined;
+        const callFrames = (params.callFrames ?? [])
+          .filter((frame: AnyObject) => !wrapperLocations?.has(locationKey(frame.location)))
+          .map((frame: AnyObject) => ({
+            callFrameId: frame.callFrameId,
+            functionName: frame.functionName ?? "",
+            location: frame.location,
+            url: this.#scripts.$get(frame.location?.scriptId)?.cdpUrl ?? "",
+            scopeChain: (frame.scopeChain ?? []).map((scope: AnyObject) => ({
+              type: SCOPE_TYPE_MAP[scope.type] ?? "closure",
+              object: scope.object,
+              name: scope.name,
+            })),
+            this: frame.this,
+            canBeRestarted: false,
+          }));
         const { data, asyncStackTrace } = params;
         const cdpParams: AnyObject = { callFrames, reason: "other", data };
         switch (params.reason) {

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -54,6 +54,63 @@ function breakpointUrlRegex(url: string): string {
   return Array.from(candidates, candidate => `^${escapeRegex(candidate)}$`).join("|");
 }
 
+function scopeKey(scope: AnyObject): string {
+  const location = scope.location;
+  return `${scope.type}|${scope.name ?? ""}|${location?.scriptId ?? ""}|${location?.lineNumber ?? ""}|${location?.columnNumber ?? ""}`;
+}
+
+// JSC compiles an `async function` (or generator) that uses `await` into a
+// wrapper function and a separate body function. Before the first `await`
+// suspends, both sit on the VM stack, so the backend reports the function
+// twice in Debugger.paused callFrames: the body at its current statement and
+// the wrapper paused at the function header. `new Error().stack` already hides
+// the wrapper via ImplementationVisibility::Private (Parser.cpp), but the
+// debugger's ShadowChicken stack walk does not consult that bit. V8 reports
+// one frame, so collapse the pair in the CDP translation.
+//
+// The wrapper is the body's immediate caller and the body closes over the
+// wrapper's activation, so the wrapper's scope chain is a proper suffix of the
+// body's. A frame is dropped only when its immediate predecessor was kept, so
+// an anonymous async closure further up the stack whose scope chain happens to
+// be a suffix of a kept descendant's is not mistaken for a wrapper.
+function dropAsyncWrapperFrames(frames: AnyObject[]): AnyObject[] {
+  if (frames.length < 2) return frames;
+  const result: AnyObject[] = [frames[0]];
+  let previousDropped = false;
+  for (let i = 1; i < frames.length; i++) {
+    const frame = frames[i];
+    if (!previousDropped) {
+      const body = frames[i - 1];
+      const bodyScopes = body.scopeChain;
+      const wrapperScopes = frame.scopeChain;
+      if (
+        body.functionName === frame.functionName &&
+        body.location?.scriptId === frame.location?.scriptId &&
+        $isArray(bodyScopes) &&
+        $isArray(wrapperScopes) &&
+        wrapperScopes.length > 0 &&
+        bodyScopes.length > wrapperScopes.length
+      ) {
+        const offset = bodyScopes.length - wrapperScopes.length;
+        let isSuffix = true;
+        for (let k = 0; k < wrapperScopes.length; k++) {
+          if (scopeKey(bodyScopes[offset + k]) !== scopeKey(wrapperScopes[k])) {
+            isSuffix = false;
+            break;
+          }
+        }
+        if (isSuffix) {
+          previousDropped = true;
+          continue;
+        }
+      }
+    }
+    result.push(frame);
+    previousDropped = false;
+  }
+  return result;
+}
+
 const SCOPE_TYPE_MAP: Record<string, string> = {
   global: "global",
   with: "with",
@@ -589,7 +646,7 @@ class InspectorCDPAdapter {
       }
 
       case "Debugger.paused": {
-        const callFrames = (params.callFrames ?? []).map((frame: AnyObject) => ({
+        const callFrames = dropAsyncWrapperFrames(params.callFrames ?? []).map((frame: AnyObject) => ({
           callFrameId: frame.callFrameId,
           functionName: frame.functionName ?? "",
           location: frame.location,

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -59,26 +59,19 @@ function scopeKey(scope: AnyObject): string {
   return `${scope.type}|${scope.name ?? ""}|${location?.scriptId ?? ""}|${location?.lineNumber ?? ""}|${location?.columnNumber ?? ""}`;
 }
 
-// JSC compiles an `async function` (or generator) that uses `await` into a
-// wrapper function and a separate body function. Before the first `await`
-// suspends, both sit on the VM stack, so the backend reports the function
-// twice in Debugger.paused callFrames: the body at its current statement and
-// the wrapper paused at the function header. `new Error().stack` already hides
-// the wrapper via ImplementationVisibility::Private (Parser.cpp), but the
-// debugger's ShadowChicken stack walk does not consult that bit. V8 reports
-// one frame, so collapse the pair in the CDP translation.
-//
-// The wrapper is the body's immediate caller and the body closes over the
-// wrapper's activation, so the wrapper's scope chain is a proper suffix of the
-// body's. A frame is dropped only when its immediate predecessor was kept, so
-// an anonymous async closure further up the stack whose scope chain happens to
-// be a suffix of a kept descendant's is not mistaken for a wrapper.
+// JSC splits an `async function` that uses `await` into a wrapper and a body
+// (Parser.cpp parseAsyncFunctionSourceElements); before the first suspend both
+// are on the VM stack, so the backend lists the function twice in callFrames.
+// V8 lists it once. The body closes over the wrapper's activation, so the
+// wrapper's scope chain is a proper suffix of the body's; drop that caller.
 function dropAsyncWrapperFrames(frames: AnyObject[]): AnyObject[] {
   if (frames.length < 2) return frames;
   const result: AnyObject[] = [frames[0]];
   let previousDropped = false;
   for (let i = 1; i < frames.length; i++) {
     const frame = frames[i];
+    // A wrapper always immediately follows its body: once a frame is dropped,
+    // its caller is a distinct body and must be kept.
     if (!previousDropped) {
       const body = frames[i - 1];
       const bodyScopes = body.scopeChain;

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -87,21 +87,23 @@ function dropAsyncWrapperFrames(frames: AnyObject[]): AnyObject[] {
         body.functionName === frame.functionName &&
         body.location?.scriptId === frame.location?.scriptId &&
         $isArray(bodyScopes) &&
-        $isArray(wrapperScopes) &&
-        wrapperScopes.length > 0 &&
-        bodyScopes.length > wrapperScopes.length
+        $isArray(wrapperScopes)
       ) {
-        const offset = bodyScopes.length - wrapperScopes.length;
-        let isSuffix = true;
-        for (let k = 0; k < wrapperScopes.length; k++) {
-          if (scopeKey(bodyScopes[offset + k]) !== scopeKey(wrapperScopes[k])) {
-            isSuffix = false;
-            break;
+        const bodyScopeCount = bodyScopes.length;
+        const wrapperScopeCount = wrapperScopes.length;
+        if (wrapperScopeCount > 0 && bodyScopeCount > wrapperScopeCount) {
+          const offset = bodyScopeCount - wrapperScopeCount;
+          let isSuffix = true;
+          for (let k = 0; k < wrapperScopeCount; k++) {
+            if (scopeKey(bodyScopes[offset + k]) !== scopeKey(wrapperScopes[k])) {
+              isSuffix = false;
+              break;
+            }
           }
-        }
-        if (isSuffix) {
-          previousDropped = true;
-          continue;
+          if (isSuffix) {
+            previousDropped = true;
+            continue;
+          }
         }
       }
     }

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -605,7 +605,7 @@ class InspectorCDPAdapter {
         const wrapperLocations = this.#asyncWrapperLocations;
         this.#asyncWrapperLocations = undefined;
         const callFrames = (params.callFrames ?? [])
-          .filter((frame: AnyObject) => !wrapperLocations?.has(locationKey(frame.location)))
+          .filter((frame: AnyObject) => !wrapperLocations?.$has(locationKey(frame.location)))
           .map((frame: AnyObject) => ({
             callFrameId: frame.callFrameId,
             functionName: frame.functionName ?? "",

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -16,6 +16,10 @@
 #include "BunInjectedScriptHost.h"
 #include <JavaScriptCore/JSGlobalObjectInspectorController.h>
 #include <wtf/JSONValues.h>
+#include <wtf/text/StringBuilder.h>
+#include <JavaScriptCore/StackVisitor.h>
+#include <JavaScriptCore/CodeBlock.h>
+#include <JavaScriptCore/UnlinkedCodeBlock.h>
 
 #include "InspectorLifecycleAgent.h"
 #include "InspectorTestReporterAgent.h"
@@ -233,10 +237,53 @@ public:
         return globalObject->inspectorDebuggable();
     }
 
+    // JSC splits an `async function` that uses `await` into a wrapper and a
+    // body function (Parser.cpp parseAsyncFunctionSourceElements). Before the
+    // first suspend both sit on the VM stack, so Debugger.paused lists the
+    // function twice. The parse mode is not exposed in the inspector protocol,
+    // so walk the paused stack here and report each wrapper frame's location as
+    // a Bun-specific event the debugger-thread CDP adapter consumes to present
+    // V8's one-frame-per-async-function view.
+    String asyncWrapperFrameLocationsEvent()
+    {
+        JSC::VM& vm = this->globalObject->vm();
+        JSC::CallFrame* topFrame = vm.topCallFrame;
+        if (!topFrame)
+            return String();
+        StringBuilder locations;
+        StackVisitor::visit(topFrame, vm, [&](StackVisitor& visitor) -> IterationStatus {
+            JSC::CodeBlock* codeBlock = visitor->codeBlock();
+            if (!codeBlock)
+                return IterationStatus::Continue;
+            if (!isGeneratorOrAsyncFunctionWrapperParseMode(codeBlock->unlinkedCodeBlock()->parseMode()))
+                return IterationStatus::Continue;
+            JSC::LineColumn lineColumn = visitor->computeLineAndColumn();
+            if (!locations.isEmpty())
+                locations.append(',');
+            locations.append("{\"scriptId\":\""_s);
+            locations.append(String::number(codeBlock->ownerExecutable()->sourceID()));
+            locations.append("\",\"lineNumber\":"_s);
+            locations.append(String::number(lineColumn.line ? lineColumn.line - 1 : 0));
+            locations.append(",\"columnNumber\":"_s);
+            locations.append(String::number(lineColumn.column ? lineColumn.column - 1 : 0));
+            locations.append('}');
+            return IterationStatus::Continue;
+        });
+        if (locations.isEmpty())
+            return String();
+        return makeString("{\"method\":\"Bun.asyncWrapperFrames\",\"params\":{\"locations\":["_s, locations.toString(), "]}}"_s);
+    }
+
     void sendMessageToFrontend(const String& message) override
     {
         if (message.length() == 0)
             return;
+
+        if (message.contains("\"method\":\"Debugger.paused\""_s)) {
+            String hint = asyncWrapperFrameLocationsEvent();
+            if (!hint.isEmpty())
+                this->sendMessageToDebuggerThread(WTF::move(hint));
+        }
 
         this->sendMessageToDebuggerThread(message.isolatedCopy());
     }

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -251,22 +251,31 @@ public:
         if (!topFrame)
             return String();
         StringBuilder locations;
+        bool calleeIsBody = false;
         StackVisitor::visit(topFrame, vm, [&](StackVisitor& visitor) -> IterationStatus {
             JSC::CodeBlock* codeBlock = visitor->codeBlock();
-            if (!codeBlock)
+            if (!codeBlock) {
+                calleeIsBody = false;
                 return IterationStatus::Continue;
-            if (!isGeneratorOrAsyncFunctionWrapperParseMode(codeBlock->unlinkedCodeBlock()->parseMode()))
-                return IterationStatus::Continue;
-            JSC::LineColumn lineColumn = visitor->computeLineAndColumn();
-            if (!locations.isEmpty())
-                locations.append(',');
-            locations.append("{\"scriptId\":\""_s);
-            locations.append(String::number(codeBlock->ownerExecutable()->sourceID()));
-            locations.append("\",\"lineNumber\":"_s);
-            locations.append(String::number(lineColumn.line ? lineColumn.line - 1 : 0));
-            locations.append(",\"columnNumber\":"_s);
-            locations.append(String::number(lineColumn.column ? lineColumn.column - 1 : 0));
-            locations.append('}');
+            }
+            JSC::SourceParseMode parseMode = codeBlock->unlinkedCodeBlock()->parseMode();
+            // A no-await async function has its body inlined into the wrapper,
+            // so a lone wrapper-mode frame is the user's frame; only the
+            // wrapper half of a body/wrapper pair (callee is the body) is
+            // redundant.
+            if (calleeIsBody && isGeneratorOrAsyncFunctionWrapperParseMode(parseMode)) {
+                JSC::LineColumn lineColumn = visitor->computeLineAndColumn();
+                if (!locations.isEmpty())
+                    locations.append(',');
+                locations.append("{\"scriptId\":\""_s);
+                locations.append(String::number(codeBlock->ownerExecutable()->sourceID()));
+                locations.append("\",\"lineNumber\":"_s);
+                locations.append(String::number(lineColumn.line ? lineColumn.line - 1 : 0));
+                locations.append(",\"columnNumber\":"_s);
+                locations.append(String::number(lineColumn.column ? lineColumn.column - 1 : 0));
+                locations.append('}');
+            }
+            calleeIsBody = isGeneratorOrAsyncFunctionBodyParseMode(parseMode);
             return IterationStatus::Continue;
         });
         if (locations.isEmpty())
@@ -279,7 +288,7 @@ public:
         if (message.length() == 0)
             return;
 
-        if (message.contains("\"method\":\"Debugger.paused\""_s)) {
+        if (message.startsWith("{\"method\":\"Debugger.paused\""_s)) {
             String hint = asyncWrapperFrameLocationsEvent();
             if (!hint.isEmpty())
                 this->sendMessageToDebuggerThread(WTF::move(hint));

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1043,6 +1043,13 @@ function f(n) {
   f(n - 1);
 }
 f(2);
+function syncLeaf() {
+  globalThis.hit = 2;
+}
+async function noAwaitOuter() {
+  syncLeaf();
+}
+noAwaitOuter();
 inspector.close();
 process.exit(0);
 `,
@@ -1129,6 +1136,7 @@ process.exit(0);
     // two nested anonymous async arrows, all before any of their awaits suspend.
     await send("Debugger.setBreakpointByUrl", { url: entryScript!.url, lineNumber: 4, columnNumber: 2 });
     await send("Debugger.setBreakpointByUrl", { url: entryScript!.url, lineNumber: 19, columnNumber: 4 });
+    await send("Debugger.setBreakpointByUrl", { url: entryScript!.url, lineNumber: 26, columnNumber: 2 });
     await send("Runtime.runIfWaitingForDebugger");
 
     awaiting = "Debugger.paused";
@@ -1165,6 +1173,15 @@ process.exit(0);
     awaiting = "Debugger.paused";
     await paused.promise;
     expect(names(callFrames!, entryScript!.scriptId)).toEqual(["f", "f", "f", "module code"]);
+
+    // Third pause: a no-await async caller. JSC inlines its body into the
+    // wrapper (parseAsyncFunctionSourceElements's !bodyUsesAwait path), so the
+    // lone wrapper-mode frame is the user's frame and must survive.
+    paused = Promise.withResolvers<void>();
+    await send("Debugger.resume");
+    awaiting = "Debugger.paused";
+    await paused.promise;
+    expect(names(callFrames!, entryScript!.scriptId)).toEqual(["syncLeaf", "noAwaitOuter", "module code"]);
 
     ws.send(JSON.stringify({ id: nextId++, method: "Debugger.resume" }));
     expect(await proc.exited).toBe(0);

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1025,13 +1025,24 @@ async function inner() {
   await 0;
 }
 async function outer() {
+  let outerLocal = 42;
   await inner();
+  return outerLocal;
 }
 await (async () => {
   await (async () => {
     await outer();
   })();
 })();
+function f(n) {
+  if (n === 0) {
+    let blockLocal = 1;
+    globalThis.hit = blockLocal;
+    return;
+  }
+  f(n - 1);
+}
+f(2);
 inspector.close();
 process.exit(0);
 `,
@@ -1064,81 +1075,102 @@ process.exit(0);
   })();
 
   const ws = new WebSocket(wsUrl);
-  await new Promise<void>((resolve, reject) => {
-    ws.onopen = () => resolve();
-    ws.onerror = err => reject(err);
-  });
-  let nextId = 1;
-  let awaiting = "";
-  const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
-  const scripts: { scriptId: string; url: string }[] = [];
-  let callFrames: { functionName: string; location: { scriptId: string }; callFrameId: string }[] | undefined;
-  const paused = Promise.withResolvers<void>();
-  ws.onmessage = event => {
-    const msg = JSON.parse(String(event.data));
-    if (msg.id != null && pending.has(msg.id)) {
-      const p = pending.get(msg.id)!;
-      pending.delete(msg.id);
-      msg.error ? p.reject(new Error(JSON.stringify(msg.error))) : p.resolve(msg.result);
-    } else if (msg.method === "Debugger.scriptParsed") {
-      scripts.push(msg.params);
-    } else if (msg.method === "Debugger.paused") {
-      callFrames = msg.params?.callFrames;
-      paused.resolve();
-    }
-  };
-  const abandon = (why: string) => {
-    const err = new Error(`${why} while awaiting ${awaiting}; stderr: ${stderrText}`);
-    paused.reject(err);
-    for (const p of pending.values()) p.reject(err);
-    pending.clear();
-  };
-  ws.onerror = () => abandon("inspector websocket errored");
-  ws.onclose = () => abandon("inspector websocket closed");
-  proc.exited.then(code => abandon(`child exited (code ${code})`));
-  function send(method: string, params?: unknown) {
-    return new Promise((resolve, reject) => {
-      const id = nextId++;
-      awaiting = method;
-      pending.set(id, { resolve, reject });
-      ws.send(JSON.stringify({ id, method, params }));
+  try {
+    await new Promise<void>((resolve, reject) => {
+      ws.onopen = () => resolve();
+      ws.onerror = event => reject(new Error(`inspector websocket failed to open: ${event}`));
+      ws.onclose = () => reject(new Error("inspector websocket closed before open"));
     });
+    let nextId = 1;
+    let awaiting = "";
+    const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+    const scripts: { scriptId: string; url: string }[] = [];
+    type CallFrame = { functionName: string; location: { scriptId: string }; callFrameId: string };
+    let callFrames: CallFrame[] | undefined;
+    let paused = Promise.withResolvers<void>();
+    ws.onmessage = event => {
+      const msg = JSON.parse(String(event.data));
+      if (msg.id != null && pending.has(msg.id)) {
+        const p = pending.get(msg.id)!;
+        pending.delete(msg.id);
+        msg.error ? p.reject(new Error(JSON.stringify(msg.error))) : p.resolve(msg.result);
+      } else if (msg.method === "Debugger.scriptParsed") {
+        scripts.push(msg.params);
+      } else if (msg.method === "Debugger.paused") {
+        callFrames = msg.params?.callFrames;
+        paused.resolve();
+      }
+    };
+    const abandon = (why: string) => {
+      const err = new Error(`${why} while awaiting ${awaiting}; stderr: ${stderrText}`);
+      paused.reject(err);
+      for (const p of pending.values()) p.reject(err);
+      pending.clear();
+    };
+    ws.onerror = () => abandon("inspector websocket errored");
+    ws.onclose = () => abandon("inspector websocket closed");
+    proc.exited.then(code => abandon(`child exited (code ${code})`));
+    function send(method: string, params?: unknown) {
+      return new Promise((resolve, reject) => {
+        const id = nextId++;
+        awaiting = method;
+        pending.set(id, { resolve, reject });
+        ws.send(JSON.stringify({ id, method, params }));
+      });
+    }
+    const names = (frames: CallFrame[], scriptId: string) =>
+      frames.filter(f => f.location.scriptId === scriptId).map(f => f.functionName || "<anonymous>");
+
+    await send("Runtime.enable");
+    await send("Debugger.enable");
+    const entryScript = scripts.find(s => s.url.endsWith("entry.mjs"));
+    expect(entryScript).toBeDefined();
+    // Pause inside inner(), which is reached synchronously from outer() through
+    // two nested anonymous async arrows, all before any of their awaits suspend.
+    await send("Debugger.setBreakpointByUrl", { url: entryScript!.url, lineNumber: 4, columnNumber: 2 });
+    await send("Debugger.setBreakpointByUrl", { url: entryScript!.url, lineNumber: 19, columnNumber: 4 });
+    await send("Runtime.runIfWaitingForDebugger");
+
+    awaiting = "Debugger.paused";
+    await paused.promise;
+    expect(callFrames).toBeDefined();
+    // One frame per function: inner, outer, the two anonymous async arrows, and
+    // the module body. Without the adapter's wrapper collapse this reports each
+    // async function twice (the body and the JSC async wrapper), so 9 frames.
+    expect(names(callFrames!, entryScript!.scriptId)).toEqual([
+      "inner",
+      "outer",
+      "<anonymous>",
+      "<anonymous>",
+      "module code",
+    ]);
+
+    // The kept frames carry JSC's original callFrameIds, so evaluateOnCallFrame
+    // on a frame past a dropped wrapper still addresses the body (where
+    // outerLocal is in scope) rather than the wrapper or another frame.
+    const outerFrame = callFrames!.find(f => f.functionName === "outer");
+    expect(outerFrame).toBeDefined();
+    const evaluated = (await send("Debugger.evaluateOnCallFrame", {
+      callFrameId: outerFrame!.callFrameId,
+      expression: "outerLocal",
+      returnByValue: true,
+    })) as { result: { value: unknown } };
+    expect(evaluated.result.value).toBe(42);
+
+    // Second pause: a plain sync recursive function with an extra block scope at
+    // the leaf. Every recursive frame must survive; only async wrappers are
+    // collapsed.
+    paused = Promise.withResolvers<void>();
+    await send("Debugger.resume");
+    awaiting = "Debugger.paused";
+    await paused.promise;
+    expect(names(callFrames!, entryScript!.scriptId)).toEqual(["f", "f", "f", "module code"]);
+
+    ws.send(JSON.stringify({ id: nextId++, method: "Debugger.resume" }));
+    expect(await proc.exited).toBe(0);
+  } finally {
+    ws.close();
   }
-  await send("Runtime.enable");
-  await send("Debugger.enable");
-  const entryScript = scripts.find(s => s.url.endsWith("entry.mjs"));
-  expect(entryScript).toBeDefined();
-  // Pause inside inner(), which is reached synchronously from outer() through
-  // two nested anonymous async arrows, all before any of their awaits suspend.
-  await send("Debugger.setBreakpointByUrl", { url: entryScript!.url, lineNumber: 4, columnNumber: 2 });
-  await send("Runtime.runIfWaitingForDebugger");
-
-  awaiting = "Debugger.paused";
-  await paused.promise;
-
-  expect(callFrames).toBeDefined();
-  const names = callFrames!
-    .filter(f => f.location.scriptId === entryScript!.scriptId)
-    .map(f => f.functionName || "<anonymous>");
-  // One frame per function: inner, outer, the two anonymous async arrows, and
-  // the module body. Without the adapter's wrapper collapse this reports each
-  // async function twice (the body and the JSC async wrapper), giving 9 frames.
-  expect(names).toEqual(["inner", "outer", "<anonymous>", "<anonymous>", "module code"]);
-
-  // The kept frames carry JSC's original callFrameIds, so evaluateOnCallFrame
-  // on a frame past a dropped wrapper still addresses the right ordinal.
-  const outerFrame = callFrames!.find(f => f.functionName === "outer");
-  expect(outerFrame).toBeDefined();
-  const evaluated = (await send("Debugger.evaluateOnCallFrame", {
-    callFrameId: outerFrame!.callFrameId,
-    expression: "typeof inner",
-    returnByValue: true,
-  })) as { result: { value: unknown } };
-  expect(evaluated.result.value).toBe("function");
-
-  ws.send(JSON.stringify({ id: nextId++, method: "Debugger.resume" }));
-  expect(await proc.exited).toBe(0);
-  ws.close();
   await stderrDrained;
 });
 

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1011,6 +1011,137 @@ export { after };
   expect(await proc.exited).toBe(0);
 });
 
+// JSC compiles an async function that uses `await` into a wrapper and a body;
+// before the first `await` suspends both sit on the VM stack, so without the
+// adapter's collapse step Debugger.paused would list the async caller twice.
+// Node/V8 reports one frame, so assert the CDP output matches.
+test("Debugger.paused reports one frame per async caller before its first await", async () => {
+  using dir = tempDir("inspector-async-callframes", {
+    "entry.mjs": `
+import inspector from "node:inspector";
+inspector.open(0, "127.0.0.1", true);
+async function inner() {
+  globalThis.hit = 1;
+  await 0;
+}
+async function outer() {
+  await inner();
+}
+await (async () => {
+  await (async () => {
+    await outer();
+  })();
+})();
+inspector.close();
+process.exit(0);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    env: injectedScriptChildEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const decoder = new TextDecoder();
+  const stderrReader = proc.stderr.getReader();
+  let stderrText = "";
+  let wsUrl: string | undefined;
+  while (!wsUrl) {
+    const { value, done } = await stderrReader.read();
+    if (done) throw new Error(`stderr closed before listening line: ${stderrText}`);
+    stderrText += decoder.decode(value);
+    wsUrl = stderrText.match(/Debugger listening on (ws:\S+)/)?.[1];
+  }
+  const stderrDrained = (async () => {
+    for (;;) {
+      const { value, done } = await stderrReader.read();
+      if (done) break;
+      stderrText += decoder.decode(value);
+    }
+  })();
+
+  const ws = new WebSocket(wsUrl);
+  await new Promise<void>((resolve, reject) => {
+    ws.onopen = () => resolve();
+    ws.onerror = err => reject(err);
+  });
+  let nextId = 1;
+  let awaiting = "";
+  const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  const scripts: { scriptId: string; url: string }[] = [];
+  let callFrames: { functionName: string; location: { scriptId: string }; callFrameId: string }[] | undefined;
+  const paused = Promise.withResolvers<void>();
+  ws.onmessage = event => {
+    const msg = JSON.parse(String(event.data));
+    if (msg.id != null && pending.has(msg.id)) {
+      const p = pending.get(msg.id)!;
+      pending.delete(msg.id);
+      msg.error ? p.reject(new Error(JSON.stringify(msg.error))) : p.resolve(msg.result);
+    } else if (msg.method === "Debugger.scriptParsed") {
+      scripts.push(msg.params);
+    } else if (msg.method === "Debugger.paused") {
+      callFrames = msg.params?.callFrames;
+      paused.resolve();
+    }
+  };
+  const abandon = (why: string) => {
+    const err = new Error(`${why} while awaiting ${awaiting}; stderr: ${stderrText}`);
+    paused.reject(err);
+    for (const p of pending.values()) p.reject(err);
+    pending.clear();
+  };
+  ws.onerror = () => abandon("inspector websocket errored");
+  ws.onclose = () => abandon("inspector websocket closed");
+  proc.exited.then(code => abandon(`child exited (code ${code})`));
+  function send(method: string, params?: unknown) {
+    return new Promise((resolve, reject) => {
+      const id = nextId++;
+      awaiting = method;
+      pending.set(id, { resolve, reject });
+      ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+  await send("Runtime.enable");
+  await send("Debugger.enable");
+  const entryScript = scripts.find(s => s.url.endsWith("entry.mjs"));
+  expect(entryScript).toBeDefined();
+  // Pause inside inner(), which is reached synchronously from outer() through
+  // two nested anonymous async arrows, all before any of their awaits suspend.
+  await send("Debugger.setBreakpointByUrl", { url: entryScript!.url, lineNumber: 4, columnNumber: 2 });
+  await send("Runtime.runIfWaitingForDebugger");
+
+  awaiting = "Debugger.paused";
+  await paused.promise;
+
+  expect(callFrames).toBeDefined();
+  const names = callFrames!
+    .filter(f => f.location.scriptId === entryScript!.scriptId)
+    .map(f => f.functionName || "<anonymous>");
+  // One frame per function: inner, outer, the two anonymous async arrows, and
+  // the module body. Without the adapter's wrapper collapse this reports each
+  // async function twice (the body and the JSC async wrapper), giving 9 frames.
+  expect(names).toEqual(["inner", "outer", "<anonymous>", "<anonymous>", "module code"]);
+
+  // The kept frames carry JSC's original callFrameIds, so evaluateOnCallFrame
+  // on a frame past a dropped wrapper still addresses the right ordinal.
+  const outerFrame = callFrames!.find(f => f.functionName === "outer");
+  expect(outerFrame).toBeDefined();
+  const evaluated = (await send("Debugger.evaluateOnCallFrame", {
+    callFrameId: outerFrame!.callFrameId,
+    expression: "typeof inner",
+    returnByValue: true,
+  })) as { result: { value: unknown } };
+  expect(evaluated.result.value).toBe("function");
+
+  ws.send(JSON.stringify({ id: nextId++, method: "Debugger.resume" }));
+  expect(await proc.exited).toBe(0);
+  ws.close();
+  await stderrDrained;
+});
+
 test("disconnect does not clobber a console method reassigned by user code", () => {
   const session = new inspector.Session();
   session.connect();


### PR DESCRIPTION
### Problem

A `Debugger.paused` event inside an async function's pre-first-`await` segment lists the async caller twice in `callFrames`: once for the resumable body at its current line and once for the JSC-generated wrapper paused at the function header. Node reports one frame, so an IDE call-stack panel showed the async function twice.

```js
async function inner() { debugger; await 0; }
async function outer() { await inner(); }
outer();
```

Paused at `debugger`, `callFrames` was `["inner", "inner", "outer", "outer", ...]`.

### Cause

JSC compiles an `async function` that uses `await` into a wrapper (`SourceParseMode::AsyncFunctionMode`) and a body (`AsyncFunctionBodyMode`) in `Parser.cpp parseAsyncFunctionSourceElements`. Before the first `await` suspends, both are on the VM stack. `new Error().stack` hides the wrapper via `ImplementationVisibility::Private`, but the debugger path (`DebuggerCallFrame::create` / `ShadowChicken::iterate`) does not consult that bit, and the inspector protocol does not expose the parse mode.

### Fix

`BunInspectorConnection::sendMessageToFrontend` detects the outgoing `Debugger.paused` notification and, while still on the inspected thread with the paused stack intact, walks `vm.topCallFrame` via `StackVisitor`. For every frame whose `codeBlock->unlinkedCodeBlock()->parseMode()` satisfies `isGeneratorOrAsyncFunctionWrapperParseMode`, it records the pause location (computed the same way `DebuggerCallFrame` does) and emits a `Bun.asyncWrapperFrames` event ahead of the pause. The CDP adapter drops exactly those `callFrames` entries whose `location` matches.

Dropped frames keep JSC's original `callFrameId` on the surviving frames, so `Debugger.evaluateOnCallFrame` on a frame past a dropped wrapper still addresses the body. The test evaluates a body-only local (`outerLocal`) on the kept `outer` frame to prove this.

The filter applies to `inspector.open()` / `node:inspector` CDP connections. The `--inspect` CLI server still speaks raw JSC protocol; it now also receives the `Bun.asyncWrapperFrames` hint so a JSC-aware frontend can apply the same collapse, but its `Debugger.paused` payload is unchanged.

### Verification

```
# without fix: 9 frames (inner x2, outer x2, two anonymous x2 each, module)
# with fix:    5 frames
bun bd test test/js/node/inspector/inspector.test.ts -t "one frame per async caller"
```

The test additionally pauses inside a plain sync recursive function with a `let` block at the leaf and asserts all three recursive frames survive; an earlier scope-chain-suffix approach dropped one.

<details>
<summary>Shapes checked against the parseMode filter (dropped = exact wrapper frames only)</summary>

```
tp_basic             dropped=["inner","outer"]        kept=["inner","outer","<anon>"]
fp_syncRecurseBlock  dropped=[]                       kept=["f","f","f","<anon>"]
fp_syncInAsync       dropped=["<anon>"]               kept=["<anon>","<anon>"]
fp_shadowName        dropped=["work"]                 kept=["work","work","<anon>"]
fp_nestedNamedExpr   dropped=[]                       kept=["g","g","<anon>"]
```
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector.test.ts
bun test v1.4.0 (44ff384f5)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [11.37ms]
(pass) inspector.console [2.21ms]
(pass) inspector.close() is a no-op when the inspector is not open [3.57ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [5.19ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [3962.15ms]
(pass) inspector.close() followed by inspector.open() starts a new server [1733.62ms]
(pass) inspector.open() can be retried after a failed start [1720.82ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [1640.74ms]
(pass) inspector.waitForDebugger() blocks until a client resumes the process [2014.57ms]
(pass) inspector.waitForDebugger() blocks again on the second call after a frontend disconnects [2003.99ms]
hello 42
after disable
(pass) Runtime.consoleAPICalled is emitted while the Runtime domain is enabled [64.44ms]
-0 NaN Infinity -Infinity 1
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (eae30b520)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [0.03ms]
(pass) inspector.console [0.01ms]
(pass) inspector.close() is a no-op when the inspector is not open [0.04ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [0.07ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [68.12ms]
(pass) inspector.close() followed by inspector.open() starts a new server [30.22ms]
(pass) inspector.open() can be retried after a failed start [30.06ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [27.37ms]
(pass) inspector.waitForDebugger() blocks until a client resumes the process [32.99ms]
(pass) inspector.waitForDebugger() blocks again on the second call after a frontend disconnects [33.41ms]
hello 42
after disable
(pass) Runtime.consoleAPICalled is emitted while the Runtime domain is enabled [1.13ms]
-0 NaN Infinity -Infinity 1n
(pass) Runtime.consoleAPICalled encodes -0/NaN/Infinity/bigint as unserializableValue like Node [0.11ms]
(pass) Session errors carry Node's ERR_INSPECTOR_* codes and post() vali
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector.test.ts
bun test v1.4.0 (44ff384f5)

test/js/node/inspector/inspector.test.ts:
(pass) inspector.url() [7.66ms]
(pass) inspector.console [10.15ms]
(pass) inspector.close() is a no-op when the inspector is not open [4.77ms]
(pass) inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspector is not active [5.63ms]
(pass) inspector.open() serves the DevTools protocol and /json discovery endpoints [3988.63ms]
(pass) inspector.close() followed by inspector.open() starts a new server [1705.62ms]
(pass) inspector.open() can be retried after a failed start [1713.22ms]
(pass) inspector.open() with wait=true does not hang the process after a bind failure [1642.88ms]
(pass) inspector.waitForDebugger() blocks until a client resumes the process [2017.97ms]
(pass) inspector.waitForDebugger() blocks again on the second call after a frontend disconnects [2083.29ms]
hello 42
after disable
(pass) Runtime.consoleAPICalled is emitted while the Runtime domain is enabled [66.17ms]
-0 NaN Infinity -Infinity 1
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 690ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen cpp.rs (cppbind)
[2/22] gen JS modules (bundle-modules)
Preprocess modules (8784ms)
Bundle modules (41ms)
Postprocesss modules (233ms)
Bundle Functions (781ms)
Generate Code (34ms)

[9.89s] Bundled "src/js" for production
  2569 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/10] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/inspector/cdp.ts         |  43 +++++---
 src/jsc/bindings/BunDebugger.cpp         |  56 ++++++++++
 test/js/node/inspector/inspector.test.ts | 180 +++++++++++++++++++++++++++++++
 3 files changed, 266 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/js/internal/inspector/cdp.ts              8      9      0
src/jsc/bindings/BunDebugger.cpp              4      3      0
test/js/node/inspector/inspector.test.ts      4      7      0
```

</details>

<!-- robobun:evidence:end -->