### PR TITLE
install: refuse to overwrite a bun.lock with a newer lockfileVersion

### DIFF
--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1370,11 +1370,7 @@ fn report_lockfile_load_error(
     cause: &lockfile::LoadResultErr,
     log_level: Options::LogLevel,
 ) -> crate::Result<()> {
-    // A lockfile whose format version is newer than this build understands was
-    // written by a newer Bun. Falling through to the ignore-and-regenerate path
-    // would silently re-resolve from package.json and overwrite (downgrade) the
-    // committed lockfile with exit 0, so treat it as fatal regardless of
-    // `fail_early`.
+    // Never regenerate over a lockfile written by a newer Bun.
     let fatal = manager.options.enable.fail_early()
         || matches!(cause.value, crate::Error::UnexpectedLockfileVersion);
 

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1370,6 +1370,14 @@ fn report_lockfile_load_error(
     cause: &lockfile::LoadResultErr,
     log_level: Options::LogLevel,
 ) -> crate::Result<()> {
+    // A lockfile whose format version is newer than this build understands was
+    // written by a newer Bun. Falling through to the ignore-and-regenerate path
+    // would silently re-resolve from package.json and overwrite (downgrade) the
+    // committed lockfile with exit 0, so treat it as fatal regardless of
+    // `fail_early`.
+    let fatal = manager.options.enable.fail_early()
+        || matches!(cause.value, crate::Error::UnexpectedLockfileVersion);
+
     if log_level != Options::LogLevel::Silent {
         match cause.step {
             lockfile::LoadStep::OpenFile => Output::err(
@@ -1394,7 +1402,7 @@ fn report_lockfile_load_error(
             ),
         }
 
-        if !manager.options.enable.fail_early() {
+        if !fatal {
             Output::print_errorln("");
             bun_core::warn!("Ignoring lockfile");
         }
@@ -1408,7 +1416,7 @@ fn report_lockfile_load_error(
         Output::flush();
     }
 
-    if manager.options.enable.fail_early() {
+    if fatal {
         Global::crash();
     }
     Ok(())

--- a/src/install/error.rs
+++ b/src/install/error.rs
@@ -468,10 +468,10 @@ impl From<crate::lockfile_real::tree::SubtreeError> for Error {
 
 impl From<crate::lockfile_real::bun_lock::ParseError> for Error {
     fn from(e: crate::lockfile_real::bun_lock::ParseError) -> Self {
+        use crate::lockfile_real::bun_lock::ParseError as E;
         match e {
-            crate::lockfile_real::bun_lock::ParseError::OutOfMemory => {
-                Self::Alloc(bun_alloc::AllocError)
-            }
+            E::OutOfMemory => Self::Alloc(bun_alloc::AllocError),
+            E::UnknownLockfileVersion => Self::UnexpectedLockfileVersion,
             _ => Self::InvalidLockfile,
         }
     }

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -826,7 +826,7 @@ it("escapes quotes and newlines in requested version literals when writing yarn.
   expect(lines.filter(line => line.trimStart().startsWith('resolved "http://injected.example'))).toEqual([]);
 });
 
-it("prints an actionable error for a lockfile version newer than this build supports", async () => {
+it("refuses to overwrite a lockfile whose version is newer than this build supports", async () => {
   const { packageDir, packageJson } = await registry.createTestDir();
 
   await write(
@@ -837,18 +837,16 @@ it("prints an actionable error for a lockfile version newer than this build supp
     }),
   );
 
-  await write(
-    join(packageDir, "bun.lock"),
-    JSON.stringify({
-      lockfileVersion: 99,
-      workspaces: {
-        "": {
-          name: "future-lockfile",
-        },
+  const futureLockfile = JSON.stringify({
+    lockfileVersion: 99,
+    workspaces: {
+      "": {
+        name: "future-lockfile",
       },
-      packages: {},
-    }),
-  );
+    },
+    packages: {},
+  });
+  await write(join(packageDir, "bun.lock"), futureLockfile);
 
   const { exited, stdout, stderr } = spawn({
     cmd: [bunExe(), "install"],
@@ -867,5 +865,13 @@ it("prints an actionable error for a lockfile version newer than this build supp
   expect(err).toContain("Run 'bun upgrade'");
   // the old message gave no hint at all
   expect(err).not.toContain("Unknown lockfile version");
-  expect(await exited).toBe(0);
+
+  // Previously this fell through to the generic "warn: Ignoring lockfile" path,
+  // re-resolved from package.json, rewrote/deleted the newer lockfile and
+  // exited 0. An older client must not silently downgrade a lockfile written
+  // by a newer Bun.
+  expect(err).not.toContain("Ignoring lockfile");
+  expect(err).not.toContain("Saved lockfile");
+  expect(await file(join(packageDir, "bun.lock")).text()).toBe(futureLockfile);
+  expect(await exited).toBe(1);
 });

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -829,11 +829,12 @@ it("escapes quotes and newlines in requested version literals when writing yarn.
 it("refuses to overwrite a lockfile whose version is newer than this build supports", async () => {
   const { packageDir, packageJson } = await registry.createTestDir();
 
+  await write(join(packageDir, "vendor", "leaf", "package.json"), JSON.stringify({ name: "leaf", version: "1.2.3" }));
   await write(
     packageJson,
     JSON.stringify({
       name: "future-lockfile",
-      dependencies: {},
+      dependencies: { leaf: "file:./vendor/leaf" },
     }),
   );
 
@@ -866,10 +867,7 @@ it("refuses to overwrite a lockfile whose version is newer than this build suppo
   // the old message gave no hint at all
   expect(err).not.toContain("Unknown lockfile version");
 
-  // Previously this fell through to the generic "warn: Ignoring lockfile" path,
-  // re-resolved from package.json, rewrote/deleted the newer lockfile and
-  // exited 0. An older client must not silently downgrade a lockfile written
-  // by a newer Bun.
+  // An older client must not silently downgrade a lockfile written by a newer Bun.
   expect(err).not.toContain("Ignoring lockfile");
   expect(err).not.toContain("Saved lockfile");
   expect(await file(join(packageDir, "bun.lock")).text()).toBe(futureLockfile);


### PR DESCRIPTION
### What

A `bun.lock` declaring `"lockfileVersion": N` where `N` is higher than the running build supports was correctly diagnosed but then **overwritten**: a plain `bun install` (including under `CI=true`) warned `Ignoring lockfile`, re-resolved everything from `package.json`, rewrote the file at the current format version, and exited 0. Only `--frozen-lockfile` refused.

### Repro

```sh
BUN=${BUN:-bun}; W=$(mktemp -d); export HOME=$W/h BUN_INSTALL_CACHE_DIR=$W/c
cd $W && mkdir -p vendor/leaf
echo '{"name":"fx","version":"1.0.0","dependencies":{"leaf":"file:./vendor/leaf"}}' > package.json
echo '{"name":"leaf","version":"1.2.3"}' > vendor/leaf/package.json
$BUN install >/dev/null 2>&1
sed -i 's/"lockfileVersion": [0-9]*/"lockfileVersion": 999/' bun.lock
$BUN install; echo "rc=$?"
grep lockfileVersion bun.lock
```

Before:
```
error: Unsupported lockfile version 999. This lockfile was likely created by a newer version of Bun. ...
note: Run 'bun upgrade' to update to the latest version of Bun
...
warn: Ignoring lockfile
Saved lockfile
+ leaf@vendor/leaf
rc=0
  "lockfileVersion": 2,
```

After:
```
error: Unsupported lockfile version 999. This lockfile was likely created by a newer version of Bun. ...
note: Run 'bun upgrade' to update to the latest version of Bun
Unexpected lockfile version: failed to parse lockfile: 'bun.lock'
rc=1
  "lockfileVersion": 999,
```

### Cause

`From<bun_lock::ParseError> for install::Error` squashed every non-OOM parse error to `InvalidLockfile`, and `report_lockfile_load_error` only crashes when `fail_early()` is set (i.e. `--production`). Every other parse failure falls through to "warn: Ignoring lockfile" and the install proceeds with `needs_new_lockfile = true`, which rewrites the file.

### Fix

* Map `ParseError::UnknownLockfileVersion` to `Error::UnexpectedLockfileVersion` (the same variant the binary lockfile loader already uses for a future format version), so the cause is distinguishable.
* In `report_lockfile_load_error`, treat `UnexpectedLockfileVersion` as fatal regardless of `fail_early`: print the diagnostic and exit 1 without touching the file.

The binary `bun.lockb` path gets the same protection for free since it already returns `UnexpectedLockfileVersion`.

### Why it matters

Latent while Bun only ships `lockfileVersion: 2`, but the first release that bumps the format turns every older client's non-frozen install into a silent re-resolve and downgrade of the committed lockfile with a green exit. pnpm errors hard on an unsupported version; npm reads best-effort; neither rewrites the newer file.

### Tests

Extended the existing future-version test in `test/cli/install/bun-lock.test.ts` to assert exit 1, no `Ignoring lockfile` / `Saved lockfile`, and that the on-disk `bun.lock` is byte-identical after the failed install.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-lock.test.ts

<!-- robobun:evidence:end -->