### PR TITLE
Bun.udpSocket: reload() preserves binaryType/hostname instead of resetting to defaults

### DIFF
--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -742,8 +742,7 @@ impl BinaryType {
         Ok(None)
     }
 
-    /// The value accepted by [`from_js_value`](Self::from_js_value) that
-    /// round-trips to this variant; used for `binaryType` getters.
+    /// Lowercase variant name, as returned by `binaryType` getters.
     pub const fn as_lowercase_str(self) -> &'static str {
         match self {
             BinaryType::Buffer => "buffer",

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -742,6 +742,27 @@ impl BinaryType {
         Ok(None)
     }
 
+    /// The value accepted by [`from_js_value`](Self::from_js_value) that
+    /// round-trips to this variant; used for `binaryType` getters.
+    pub const fn as_lowercase_str(self) -> &'static str {
+        match self {
+            BinaryType::Buffer => "buffer",
+            BinaryType::ArrayBuffer => "arraybuffer",
+            BinaryType::Uint8Array => "uint8array",
+            BinaryType::Uint8ClampedArray => "uint8clampedarray",
+            BinaryType::Uint16Array => "uint16array",
+            BinaryType::Uint32Array => "uint32array",
+            BinaryType::Int8Array => "int8array",
+            BinaryType::Int16Array => "int16array",
+            BinaryType::Int32Array => "int32array",
+            BinaryType::Float16Array => "float16array",
+            BinaryType::Float32Array => "float32array",
+            BinaryType::Float64Array => "float64array",
+            BinaryType::BigInt64Array => "bigint64array",
+            BinaryType::BigUint64Array => "biguint64array",
+        }
+    }
+
     /// This clones bytes
     pub fn to_js(self, bytes: &[u8], global: &JSGlobalObject) -> JsResult<JSValue> {
         match self {

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -506,7 +506,7 @@ pub mod js {
     bun_jsc::codegen_cached_accessors!(
         "UDPSocket";
         on_data, on_drain, on_error,
-        address, remoteAddress
+        address, remoteAddress, binaryType
     );
 }
 
@@ -1744,9 +1744,61 @@ impl UDPSocket {
         let Some(this_value) = this.this_value.get().try_get() else {
             return Ok(JSValue::UNDEFINED);
         };
-        let config = UDPSocketConfig::from_js(global_this, options, this_value)?;
 
-        let _ = this.config.replace(config);
+        if options.is_empty_or_undefined_or_null() || !options.is_object() {
+            return Err(global_this.throw_invalid_arguments(format_args!("Expected an object")));
+        }
+
+        // reload() is a handler hot-swap, not a rebind: parse only the handler
+        // set and (optionally) binaryType, and merge into the live config.
+        // hostname/port/flags/fd/connect are bind-time options and are ignored
+        // here so unspecified options keep their creation values.
+        let mut new_binary_type: Option<BinaryType> = None;
+
+        if let Some(socket) = options.get_truthy(global_this, "socket")? {
+            if !socket.is_object() {
+                return Err(global_this
+                    .throw_invalid_arguments(format_args!("Expected \"socket\" to be an object")));
+            }
+
+            if let Some(value) = options.get_truthy(global_this, "binaryType")? {
+                if !value.is_string() {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "Expected \"socket.binaryType\" to be a string"
+                    )));
+                }
+                new_binary_type = Some(match BinaryType::from_js_value(global_this, value)? {
+                    Some(bt) => bt,
+                    None => {
+                        return Err(global_this.throw_invalid_arguments(format_args!(
+                            "Expected \"socket.binaryType\" to be 'arraybuffer', 'uint8array', or 'buffer'"
+                        )));
+                    }
+                });
+            }
+
+            macro_rules! handler {
+                ($name:literal, $set:path) => {
+                    if let Some(value) = socket.get_truthy(global_this, $name)? {
+                        if !value.is_cell() || !value.is_callable() {
+                            return Err(global_this.throw_invalid_arguments(format_args!(
+                                concat!("Expected \"socket.", $name, "\" to be a function")
+                            )));
+                        }
+                        let callback = value.with_async_context_if_needed(global_this);
+                        $set(this_value, global_this, callback);
+                    }
+                };
+            }
+            handler!("data", js::on_data_set_cached);
+            handler!("drain", js::on_drain_set_cached);
+            handler!("error", js::on_error_set_cached);
+        }
+
+        if let Some(bt) = new_binary_type {
+            this.config.with_mut(|c| c.binary_type = bt);
+            js::binary_type_set_cached(this_value, global_this, JSValue::ZERO);
+        }
 
         Ok(JSValue::UNDEFINED)
     }

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -1871,7 +1871,7 @@ impl UDPSocket {
             BinaryType::Buffer => global_this.common_strings().buffer(),
             BinaryType::Uint8Array => global_this.common_strings().uint8array(),
             BinaryType::ArrayBuffer => global_this.common_strings().arraybuffer(),
-            _ => panic!("Invalid binary type"),
+            other => BunString::static_(other.as_lowercase_str()).to_js(global_this)?,
         })
     }
 

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -335,6 +335,75 @@ impl Default for UDPSocketConfig {
     }
 }
 
+/// Parsed `binaryType` + `socket.{data,drain,error}` from an options object.
+/// Validation only; callers apply the handlers so a thrown error leaves a
+/// live socket unchanged.
+#[derive(Default)]
+struct ReloadOptions {
+    binary_type: Option<BinaryType>,
+    on_data: Option<JSValue>,
+    on_drain: Option<JSValue>,
+    on_error: Option<JSValue>,
+}
+
+impl ReloadOptions {
+    fn from_js(global_this: &JSGlobalObject, options: JSValue) -> JsResult<Self> {
+        let mut out = Self::default();
+
+        if let Some(value) = options.get_truthy(global_this, "binaryType")? {
+            if !value.is_string() {
+                return Err(global_this.throw_invalid_arguments(format_args!(
+                    "Expected \"binaryType\" to be a string"
+                )));
+            }
+            out.binary_type = Some(match BinaryType::from_js_value(global_this, value)? {
+                Some(bt) => bt,
+                None => {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "Expected \"binaryType\" to be 'arraybuffer', 'uint8array', or 'buffer'"
+                    )));
+                }
+            });
+        }
+
+        if let Some(socket) = options.get_truthy(global_this, "socket")? {
+            if !socket.is_object() {
+                return Err(global_this
+                    .throw_invalid_arguments(format_args!("Expected \"socket\" to be an object")));
+            }
+            macro_rules! handler {
+                ($name:literal, $slot:ident) => {
+                    if let Some(value) = socket.get_truthy(global_this, $name)? {
+                        if !value.is_cell() || !value.is_callable() {
+                            return Err(global_this.throw_invalid_arguments(format_args!(
+                                concat!("Expected \"socket.", $name, "\" to be a function")
+                            )));
+                        }
+                        out.$slot = Some(value.with_async_context_if_needed(global_this));
+                    }
+                };
+            }
+            handler!("data", on_data);
+            handler!("drain", on_drain);
+            handler!("error", on_error);
+        }
+
+        Ok(out)
+    }
+
+    fn apply_handlers(&self, global_this: &JSGlobalObject, this_value: JSValue) {
+        if let Some(cb) = self.on_data {
+            js::on_data_set_cached(this_value, global_this, cb);
+        }
+        if let Some(cb) = self.on_drain {
+            js::on_drain_set_cached(this_value, global_this, cb);
+        }
+        if let Some(cb) = self.on_error {
+            js::on_error_set_cached(this_value, global_this, cb);
+        }
+    }
+}
+
 impl UDPSocketConfig {
     fn from_js(
         global_this: &JSGlobalObject,
@@ -403,46 +472,11 @@ impl UDPSocketConfig {
 
         // `config` cleanup: Drop handles this on `?` paths.
 
-        if let Some(socket) = options.get_truthy(global_this, "socket")? {
-            if !socket.is_object() {
-                return Err(global_this
-                    .throw_invalid_arguments(format_args!("Expected \"socket\" to be an object")));
-            }
-
-            if let Some(value) = options.get_truthy(global_this, "binaryType")? {
-                if !value.is_string() {
-                    return Err(global_this.throw_invalid_arguments(format_args!(
-                        "Expected \"socket.binaryType\" to be a string"
-                    )));
-                }
-
-                config.binary_type = match BinaryType::from_js_value(global_this, value)? {
-                    Some(bt) => bt,
-                    None => {
-                        return Err(global_this.throw_invalid_arguments(format_args!(
-                            "Expected \"socket.binaryType\" to be 'arraybuffer', 'uint8array', or 'buffer'"
-                        )));
-                    }
-                };
-            }
-
-            macro_rules! handler {
-                ($name:literal, $set:path) => {
-                    if let Some(value) = socket.get_truthy(global_this, $name)? {
-                        if !value.is_cell() || !value.is_callable() {
-                            return Err(global_this.throw_invalid_arguments(format_args!(
-                                concat!("Expected \"socket.", $name, "\" to be a function")
-                            )));
-                        }
-                        let callback = value.with_async_context_if_needed(global_this);
-                        $set(this_value, global_this, callback);
-                    }
-                };
-            }
-            handler!("data", js::on_data_set_cached);
-            handler!("drain", js::on_drain_set_cached);
-            handler!("error", js::on_error_set_cached);
+        let reload = ReloadOptions::from_js(global_this, options)?;
+        if let Some(bt) = reload.binary_type {
+            config.binary_type = bt;
         }
+        reload.apply_handlers(global_this, this_value);
 
         if let Some(connect) = options.get_truthy(global_this, "connect")? {
             if !connect.is_object() {
@@ -498,9 +532,9 @@ struct ConnectInfo {
 /// `.classes.ts` codegen cached accessors.
 ///
 /// `values: ["on_data", "on_drain", "on_error"]` (GC-tracked WriteBarrier slots)
-/// plus the `cache: true` getters
-/// `address` / `remoteAddress` (cleared on connect to invalidate the JS-side
-/// memo). All resolve to the C++ `UDPSocketPrototype__${prop}{Get,Set}CachedValue`
+/// plus the `cache: true` getters `address` / `remoteAddress` (cleared on
+/// connect) and `binaryType` (cleared on reload) to invalidate the JS-side
+/// memo. All resolve to the C++ `UDPSocketPrototype__${prop}{Get,Set}CachedValue`
 /// shims via [`bun_jsc::codegen_cached_accessors!`].
 pub mod js {
     bun_jsc::codegen_cached_accessors!(
@@ -1749,66 +1783,10 @@ impl UDPSocket {
             return Err(global_this.throw_invalid_arguments(format_args!("Expected an object")));
         }
 
-        // reload() is a handler hot-swap, not a rebind: parse only the handler
-        // set and (optionally) binaryType, and merge into the live config.
-        // hostname/port/flags/fd/connect are bind-time options and are ignored
-        // here so unspecified options keep their creation values. Validate
-        // everything before applying anything so a thrown error leaves the
-        // live socket unchanged.
-        let mut new_binary_type: Option<BinaryType> = None;
-        let mut new_data: Option<JSValue> = None;
-        let mut new_drain: Option<JSValue> = None;
-        let mut new_error: Option<JSValue> = None;
-
-        if let Some(value) = options.get_truthy(global_this, "binaryType")? {
-            if !value.is_string() {
-                return Err(global_this.throw_invalid_arguments(format_args!(
-                    "Expected \"binaryType\" to be a string"
-                )));
-            }
-            new_binary_type = Some(match BinaryType::from_js_value(global_this, value)? {
-                Some(bt) => bt,
-                None => {
-                    return Err(global_this.throw_invalid_arguments(format_args!(
-                        "Expected \"binaryType\" to be 'arraybuffer', 'uint8array', or 'buffer'"
-                    )));
-                }
-            });
-        }
-
-        if let Some(socket) = options.get_truthy(global_this, "socket")? {
-            if !socket.is_object() {
-                return Err(global_this
-                    .throw_invalid_arguments(format_args!("Expected \"socket\" to be an object")));
-            }
-
-            macro_rules! handler {
-                ($name:literal, $slot:ident) => {
-                    if let Some(value) = socket.get_truthy(global_this, $name)? {
-                        if !value.is_cell() || !value.is_callable() {
-                            return Err(global_this.throw_invalid_arguments(format_args!(
-                                concat!("Expected \"socket.", $name, "\" to be a function")
-                            )));
-                        }
-                        $slot = Some(value.with_async_context_if_needed(global_this));
-                    }
-                };
-            }
-            handler!("data", new_data);
-            handler!("drain", new_drain);
-            handler!("error", new_error);
-        }
-
-        if let Some(cb) = new_data {
-            js::on_data_set_cached(this_value, global_this, cb);
-        }
-        if let Some(cb) = new_drain {
-            js::on_drain_set_cached(this_value, global_this, cb);
-        }
-        if let Some(cb) = new_error {
-            js::on_error_set_cached(this_value, global_this, cb);
-        }
-        if let Some(bt) = new_binary_type {
+        // Hot-swap handlers + binaryType only; bind-time options stay as-is.
+        let reload = ReloadOptions::from_js(global_this, options)?;
+        reload.apply_handlers(global_this, this_value);
+        if let Some(bt) = reload.binary_type {
             this.config.with_mut(|c| c.binary_type = bt);
             js::binary_type_set_cached(this_value, global_this, JSValue::ZERO);
         }

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -1752,8 +1752,29 @@ impl UDPSocket {
         // reload() is a handler hot-swap, not a rebind: parse only the handler
         // set and (optionally) binaryType, and merge into the live config.
         // hostname/port/flags/fd/connect are bind-time options and are ignored
-        // here so unspecified options keep their creation values.
+        // here so unspecified options keep their creation values. Validate
+        // everything before applying anything so a thrown error leaves the
+        // live socket unchanged.
         let mut new_binary_type: Option<BinaryType> = None;
+        let mut new_data: Option<JSValue> = None;
+        let mut new_drain: Option<JSValue> = None;
+        let mut new_error: Option<JSValue> = None;
+
+        if let Some(value) = options.get_truthy(global_this, "binaryType")? {
+            if !value.is_string() {
+                return Err(global_this.throw_invalid_arguments(format_args!(
+                    "Expected \"binaryType\" to be a string"
+                )));
+            }
+            new_binary_type = Some(match BinaryType::from_js_value(global_this, value)? {
+                Some(bt) => bt,
+                None => {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "Expected \"binaryType\" to be 'arraybuffer', 'uint8array', or 'buffer'"
+                    )));
+                }
+            });
+        }
 
         if let Some(socket) = options.get_truthy(global_this, "socket")? {
             if !socket.is_object() {
@@ -1761,40 +1782,32 @@ impl UDPSocket {
                     .throw_invalid_arguments(format_args!("Expected \"socket\" to be an object")));
             }
 
-            if let Some(value) = options.get_truthy(global_this, "binaryType")? {
-                if !value.is_string() {
-                    return Err(global_this.throw_invalid_arguments(format_args!(
-                        "Expected \"socket.binaryType\" to be a string"
-                    )));
-                }
-                new_binary_type = Some(match BinaryType::from_js_value(global_this, value)? {
-                    Some(bt) => bt,
-                    None => {
-                        return Err(global_this.throw_invalid_arguments(format_args!(
-                            "Expected \"socket.binaryType\" to be 'arraybuffer', 'uint8array', or 'buffer'"
-                        )));
-                    }
-                });
-            }
-
             macro_rules! handler {
-                ($name:literal, $set:path) => {
+                ($name:literal, $slot:ident) => {
                     if let Some(value) = socket.get_truthy(global_this, $name)? {
                         if !value.is_cell() || !value.is_callable() {
                             return Err(global_this.throw_invalid_arguments(format_args!(
                                 concat!("Expected \"socket.", $name, "\" to be a function")
                             )));
                         }
-                        let callback = value.with_async_context_if_needed(global_this);
-                        $set(this_value, global_this, callback);
+                        $slot = Some(value.with_async_context_if_needed(global_this));
                     }
                 };
             }
-            handler!("data", js::on_data_set_cached);
-            handler!("drain", js::on_drain_set_cached);
-            handler!("error", js::on_error_set_cached);
+            handler!("data", new_data);
+            handler!("drain", new_drain);
+            handler!("error", new_error);
         }
 
+        if let Some(cb) = new_data {
+            js::on_data_set_cached(this_value, global_this, cb);
+        }
+        if let Some(cb) = new_drain {
+            js::on_drain_set_cached(this_value, global_this, cb);
+        }
+        if let Some(cb) = new_error {
+            js::on_error_set_cached(this_value, global_this, cb);
+        }
         if let Some(bt) = new_binary_type {
             this.config.with_mut(|c| c.binary_type = bt);
             js::binary_type_set_cached(this_value, global_this, JSValue::ZERO);

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -335,9 +335,7 @@ impl Default for UDPSocketConfig {
     }
 }
 
-/// Parsed `binaryType` + `socket.{data,drain,error}` from an options object.
-/// Validation only; callers apply the handlers so a thrown error leaves a
-/// live socket unchanged.
+/// Validation-only parse of `binaryType` + `socket.{data,drain,error}`; callers apply.
 #[derive(Default)]
 struct ReloadOptions {
     binary_type: Option<BinaryType>,

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -583,6 +583,88 @@ describe("udpSocket()", () => {
       30_000,
     );
   });
+
+  // reload() is a handler hot-swap: options not explicitly passed must keep
+  // their creation values. Previously reload() built a fresh config over
+  // defaults and replaced the live one wholesale, so a handler-only reload
+  // reset binaryType to 'buffer' and hostname to '0.0.0.0'.
+  describe("reload()", () => {
+    test("preserves binaryType and hostname when only handlers are reloaded", async () => {
+      let pre = Promise.withResolvers<string>();
+      let post = Promise.withResolvers<string>();
+      await using server = await udpSocket({
+        hostname: "127.0.0.1",
+        port: 0,
+        binaryType: "arraybuffer",
+        socket: { data: (_sk, b) => pre.resolve(b.constructor.name) },
+      });
+      // Read once before reload so the cached-getter path is exercised too.
+      const binaryTypeBefore = server.binaryType;
+      const hostnameBefore = server.hostname;
+
+      await using client = await udpSocket({ hostname: "127.0.0.1", port: 0 });
+      client.send("1", server.port, "127.0.0.1");
+      const preName = await pre.promise;
+
+      server.reload({ socket: { data: (_sk, b) => post.resolve(b.constructor.name) } });
+      client.send("2", server.port, "127.0.0.1");
+      const postName = await post.promise;
+
+      // A second socket whose getters are first read AFTER reload: previously
+      // these reported the reset defaults ('buffer', '0.0.0.0').
+      await using fresh = await udpSocket({
+        hostname: "127.0.0.1",
+        port: 0,
+        binaryType: "arraybuffer",
+        socket: { data() {} },
+      });
+      fresh.reload({ socket: { data() {} } });
+
+      expect({
+        preName,
+        postName,
+        binaryTypeBefore,
+        hostnameBefore,
+        binaryTypeAfter: server.binaryType,
+        hostnameAfter: server.hostname,
+        freshBinaryType: fresh.binaryType,
+        freshHostname: fresh.hostname,
+        freshBound: fresh.address.address,
+      }).toEqual({
+        preName: "ArrayBuffer",
+        postName: "ArrayBuffer",
+        binaryTypeBefore: "arraybuffer",
+        hostnameBefore: "127.0.0.1",
+        binaryTypeAfter: "arraybuffer",
+        hostnameAfter: "127.0.0.1",
+        freshBinaryType: "arraybuffer",
+        freshHostname: "127.0.0.1",
+        freshBound: "127.0.0.1",
+      });
+    });
+
+    test("updates binaryType when explicitly passed and invalidates the cached getter", async () => {
+      let got = Promise.withResolvers<string>();
+      await using server = await udpSocket({
+        hostname: "127.0.0.1",
+        port: 0,
+        binaryType: "arraybuffer",
+        socket: { data() {} },
+      });
+      expect(server.binaryType).toBe("arraybuffer");
+
+      server.reload({
+        binaryType: "uint8array",
+        socket: { data: (_sk, b) => got.resolve(b.constructor.name) },
+      });
+      // The getter is `cache: true`; reload must invalidate it when the value changes.
+      expect(server.binaryType).toBe("uint8array");
+
+      await using client = await udpSocket({ hostname: "127.0.0.1", port: 0 });
+      client.send("x", server.port, "127.0.0.1");
+      expect(await got.promise).toBe("Uint8Array");
+    });
+  });
 });
 
 // us_udp_socket_send batches at most ~204 messages per sendmmsg; a >batch-size

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -589,9 +589,20 @@ describe("udpSocket()", () => {
   // defaults and replaced the live one wholesale, so a handler-only reload
   // reset binaryType to 'buffer' and hostname to '0.0.0.0'.
   describe("reload()", () => {
+    // handle unreliable transmission in UDP
+    async function sendUntil<T>(client: any, port: number, received: Promise<T>): Promise<T> {
+      const retry = setInterval(() => client.send("x", port, "127.0.0.1"), 20);
+      client.send("x", port, "127.0.0.1");
+      try {
+        return await received;
+      } finally {
+        clearInterval(retry);
+      }
+    }
+
     test("preserves binaryType and hostname when only handlers are reloaded", async () => {
-      let pre = Promise.withResolvers<string>();
-      let post = Promise.withResolvers<string>();
+      const pre = Promise.withResolvers<string>();
+      const post = Promise.withResolvers<string>();
       await using server = await udpSocket({
         hostname: "127.0.0.1",
         port: 0,
@@ -603,12 +614,10 @@ describe("udpSocket()", () => {
       const hostnameBefore = server.hostname;
 
       await using client = await udpSocket({ hostname: "127.0.0.1", port: 0 });
-      client.send("1", server.port, "127.0.0.1");
-      const preName = await pre.promise;
+      const preName = await sendUntil(client, server.port, pre.promise);
 
       server.reload({ socket: { data: (_sk, b) => post.resolve(b.constructor.name) } });
-      client.send("2", server.port, "127.0.0.1");
-      const postName = await post.promise;
+      const postName = await sendUntil(client, server.port, post.promise);
 
       // A second socket whose getters are first read AFTER reload: previously
       // these reported the reset defaults ('buffer', '0.0.0.0').
@@ -661,8 +670,7 @@ describe("udpSocket()", () => {
       expect(server.binaryType).toBe("uint8array");
 
       await using client = await udpSocket({ hostname: "127.0.0.1", port: 0 });
-      client.send("x", server.port, "127.0.0.1");
-      expect(await got.promise).toBe("Uint8Array");
+      expect(await sendUntil(client, server.port, got.promise)).toBe("Uint8Array");
 
       // binaryType can be reloaded without a `socket` key; the existing
       // handler keeps dispatching with the new payload type.
@@ -670,12 +678,11 @@ describe("udpSocket()", () => {
       server.reload({ socket: { data: (_sk, b) => got.resolve(b.constructor.name) } });
       server.reload({ binaryType: "buffer" });
       expect(server.binaryType).toBe("buffer");
-      client.send("y", server.port, "127.0.0.1");
-      expect(await got.promise).toBe("Buffer");
+      expect(await sendUntil(client, server.port, got.promise)).toBe("Buffer");
     });
 
     test("does not partially apply when a later handler is invalid", async () => {
-      let got = Promise.withResolvers<string>();
+      const got = Promise.withResolvers<string>();
       await using server = await udpSocket({
         hostname: "127.0.0.1",
         port: 0,
@@ -697,8 +704,7 @@ describe("udpSocket()", () => {
       expect(server.binaryType).toBe("arraybuffer");
 
       await using client = await udpSocket({ hostname: "127.0.0.1", port: 0 });
-      client.send("x", server.port, "127.0.0.1");
-      expect(await got.promise).toBe("original:ArrayBuffer");
+      expect(await sendUntil(client, server.port, got.promise)).toBe("original:ArrayBuffer");
     });
   });
 });

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -541,6 +541,7 @@ describe("udpSocket()", () => {
                 socket: {
                   data(socket, data) {
                     resolve({
+                      binaryType: server.binaryType,
                       ctor: data?.constructor?.name ?? String(data),
                       byteLength: data?.byteLength,
                       length: data?.length,
@@ -571,6 +572,7 @@ describe("udpSocket()", () => {
           .join("\n");
         expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
           stdout: JSON.stringify({
+            binaryType,
             ctor: ctorName,
             byteLength: 8,
             length: expectedLen,
@@ -700,7 +702,7 @@ describe("udpSocket()", () => {
             error: "not a function" as any,
           },
         }),
-      ).toThrow();
+      ).toThrow('Expected "socket.error" to be a function');
       expect(server.binaryType).toBe("arraybuffer");
 
       await using client = await udpSocket({ hostname: "127.0.0.1", port: 0 });

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -663,6 +663,42 @@ describe("udpSocket()", () => {
       await using client = await udpSocket({ hostname: "127.0.0.1", port: 0 });
       client.send("x", server.port, "127.0.0.1");
       expect(await got.promise).toBe("Uint8Array");
+
+      // binaryType can be reloaded without a `socket` key; the existing
+      // handler keeps dispatching with the new payload type.
+      got = Promise.withResolvers<string>();
+      server.reload({ socket: { data: (_sk, b) => got.resolve(b.constructor.name) } });
+      server.reload({ binaryType: "buffer" });
+      expect(server.binaryType).toBe("buffer");
+      client.send("y", server.port, "127.0.0.1");
+      expect(await got.promise).toBe("Buffer");
+    });
+
+    test("does not partially apply when a later handler is invalid", async () => {
+      let got = Promise.withResolvers<string>();
+      await using server = await udpSocket({
+        hostname: "127.0.0.1",
+        port: 0,
+        binaryType: "arraybuffer",
+        socket: { data: (_sk, b) => got.resolve("original:" + b.constructor.name) },
+      });
+
+      // `data` is valid but `error` is not: the whole reload must be rejected
+      // and the original `data` handler and binaryType must stay in place.
+      expect(() =>
+        server.reload({
+          binaryType: "buffer",
+          socket: {
+            data: (_sk, b) => got.resolve("replaced:" + b.constructor.name),
+            error: "not a function" as any,
+          },
+        }),
+      ).toThrow();
+      expect(server.binaryType).toBe("arraybuffer");
+
+      await using client = await udpSocket({ hostname: "127.0.0.1", port: 0 });
+      client.send("x", server.port, "127.0.0.1");
+      expect(await got.promise).toBe("original:ArrayBuffer");
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

`Bun.udpSocket`'s `reload()` is a handler hot-swap, but it was building a fresh `UDPSocketConfig::from_js()` over defaults and replacing the live config wholesale. A handler-only `reload({socket:{data}})` therefore silently reset `binaryType` back to `'buffer'` and `hostname` back to `'0.0.0.0'`. Because those getters are `cache: true`, they would report either the stale creation value or the reset default depending only on whether they had been read before the reload.

```js
const s = await Bun.udpSocket({
  hostname: '127.0.0.1', port: 0, binaryType: 'arraybuffer',
  socket: { data(_sk, b) { console.log(b.constructor.name); } },
});
s.reload({ socket: { data(_sk, b) { console.log(b.constructor.name); } } });
// next data() receives Buffer, not ArrayBuffer
// s.binaryType: 'arraybuffer' if read before reload, 'buffer' if first read after
// s.hostname:   '127.0.0.1' if read before reload, '0.0.0.0' if first read after
```

### How did you verify your code works?

Two new tests in `test/js/bun/udp/udp_socket.test.ts`:
- handler-only `reload()` keeps `binaryType`/`hostname` and the `data` handler keeps receiving `ArrayBuffer`
- `reload({binaryType: 'uint8array', socket})` updates `binary_type` and invalidates the cached `binaryType` getter

Both fail on main, pass with the fix. Full `test/js/bun/udp/` suite (261 tests) and `dgram.test.ts` (61 tests) pass.

### Fix

`reload()` no longer routes through `UDPSocketConfig::from_js`. It parses only the `socket` handler set and (optionally) `binaryType`, merging into the live config. Bind-time options (`hostname`/`port`/`flags`/`fd`/`connect`) are ignored so unspecified options keep their creation values. When `binaryType` is explicitly passed, the `cache: true` getter slot is cleared so the next read reflects the new value.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/udp/udp_socket.test.ts

<!-- robobun:evidence:end -->