### PR TITLE
docs(cron): note UTC->local time-zone change in v1.4

### DIFF
--- a/docs/runtime/cron.mdx
+++ b/docs/runtime/cron.mdx
@@ -121,6 +121,11 @@ console.log(next); // => next local midnight
 
 Schedules are interpreted in the system's **local time zone** — the same way crontab, launchd, and Windows Task Scheduler read them. The OS-level form and the in-process callback form fire at the same wall-clock time.
 
+<Note>
+  Prior to Bun v1.4, `Bun.cron.parse()` and the in-process `Bun.cron(schedule, handler)` interpreted schedules in
+  **UTC**. If you're upgrading and relied on that, pass `{ tz: "UTC" }` to keep the previous behavior.
+</Note>
+
 To override, pass an IANA time-zone name as `{ tz }` to `Bun.cron.parse()` or the in-process `Bun.cron(schedule, handler, options)`:
 
 ```ts

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7625,6 +7625,8 @@ declare module "bun" {
     /**
      * IANA time-zone name to interpret the schedule in (e.g. `"UTC"`,
      * `"America/New_York"`). Defaults to the system's local time zone.
+     *
+     * Prior to Bun v1.4 the default was UTC; pass `"UTC"` to keep that behavior.
      */
     tz?: string;
   }

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7689,6 +7689,12 @@ declare module "bun" {
      *   fires when **either** matches — [POSIX cron](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html) OR semantics.
      * - All expressions work on all platforms — there is no Windows trigger limit here.
      *
+     * ### Time zone
+     *
+     * Schedules run in the system's local time zone — the same way crontab, launchd, and
+     * Windows Task Scheduler read them. Pass `{ tz: "UTC" }` (or any IANA time-zone name)
+     * to override. Prior to Bun v1.4 the default was UTC.
+     *
      * ### Lifecycle & `--hot`
      *
      * Under `bun --hot`, all in-process cron jobs are stopped immediately before the module
@@ -7702,10 +7708,12 @@ declare module "bun" {
      * @param schedule Cron expression or nickname (e.g. `"*\/5 * * * *"`, `"@hourly"`).
      * @param handler Function to call on each fire. May return a Promise — the next fire
      *   is not scheduled until it settles.
+     * @param options `{ tz?: string }` — IANA time-zone name to interpret the schedule in
+     *   (defaults to the system's local zone).
      * @returns A {@link CronJob} handle. Chainable: `.stop()`, `.ref()`, `.unref()` all
      *   return the job itself.
-     * @throws Synchronously if `schedule` is invalid, or the expression has no future
-     *   occurrences (e.g. `"0 0 30 2 *"` — February 30th).
+     * @throws Synchronously if `schedule` is invalid, `options.tz` is not a valid IANA
+     *   name, or the expression has no future occurrences (e.g. `"0 0 30 2 *"` — February 30th).
      *
      * @example
      * ```ts


### PR DESCRIPTION
Part of #28792. Follow-up to #35122.

## What

`Bun.cron.parse()` and the in-process `Bun.cron(schedule, handler)` switched from UTC to local time in #35122. The [Time zone section](https://bun.sh/docs/runtime/cron#time-zone) now describes the new behavior but never mentions that it changed, so a 1.3.x user reading it would assume local time was always the default and miss that their schedules will shift on upgrade.

This adds:

- A `<Note>` callout under **Time zone** in `docs/runtime/cron.mdx`:

  > Prior to Bun v1.4, `Bun.cron.parse()` and the in-process `Bun.cron(schedule, handler)` interpreted schedules in **UTC**. If you're upgrading and relied on that, pass `{ tz: "UTC" }` to keep the previous behavior.

- A **Time zone** subsection and `@param options` on the in-process `Bun.cron(schedule, handler, options?)` overload JSDoc in `bun.d.ts`. #35122 added the `options` parameter to the signature without documenting it, so hovering an existing `Bun.cron(expr, fn)` call in an editor showed neither the local-time default nor the escape hatch. This closes the asymmetry with `parse()`, which already documented both.
- A one-line "prior to v1.4 the default was UTC" on `CronOptions.tz`.

The v1.3.14 docs stated the UTC behavior explicitly (`git show bun-v1.3.14:docs/runtime/cron.mdx` line 35: "return the next matching `Date` in UTC"), so there are shipped releases whose documented semantics differ.

## Why docs, not a runtime warning

A one-time stderr warning (first call per process when `{ tz }` is omitted and the process TZ isn't UTC) was considered and rejected:

- None of the other ~40 breaking changes tracked in #28792 emit a runtime warning; the 1.4 migration story is changelog + docs + escape hatch, and this change already has all three.
- Local time is the default for crontab, launchd, Windows Task Scheduler, and the popular npm schedulers (`node-cron`, `croner`). A user writing `Bun.cron("0 9 * * *", handler)` for the first time almost certainly means 9 AM local, so the warning's heuristic can't distinguish "wanted the old UTC behavior" from "wants what every other cron does".
- The heuristic would fire for essentially every developer outside UTC on every process start, permanently, with no way to silence it other than passing `{ tz }` everywhere.

## Verification

- `bunx prettier --check docs/runtime/cron.mdx packages/bun-types/bun.d.ts` passes.
- `bun test test/integration/bun-types/bun-types.test.ts` passes (14/14).
- Backtick-wrapped `{ ... }` inside `<Note>` matches existing usage in `docs/runtime/sql.mdx` and `docs/bundler/hot-reloading.mdx`.

Docs-only; no runtime change.
