### PR TITLE
install: add [install.lockfile] lockfileVersion to cap bun.lock lockfileVersion

### DIFF
--- a/docs/pm/lockfile.mdx
+++ b/docs/pm/lockfile.mdx
@@ -54,16 +54,16 @@ For more on the format, see [the blog post](https://bun.com/blog/bun-lock-text-l
 
 #### Lockfile format versions
 
-`bun.lock` carries a `"lockfileVersion"` field. Bun 1.4 writes version 2 by default for a fresh install or migration. Re-saving an existing version 0 or 1 lockfile preserves its version, so a project that already has a `bun.lock` is unaffected.
+`bun.lock` carries a `"lockfileVersion"` field. Bun 1.4 writes version 2 by default for a fresh install or migration. Re-saving an existing version 1 lockfile preserves its version (version 0 is upgraded to version 1), so a project that already has a `bun.lock` is unaffected.
 
-Bun releases before 1.4 cannot read version 2 lockfiles. If your project is installed by a mix of Bun versions, set `formatVersion` in `bunfig.toml` to cap the written version:
+Bun releases before 1.4 cannot read version 2 lockfiles. If your project is installed by a mix of Bun versions, set `lockfileVersion` in `bunfig.toml` to cap the written version:
 
 ```toml bunfig.toml icon="settings"
 [install.lockfile]
-formatVersion = 1
+lockfileVersion = 1
 ```
 
-This also downgrades an existing version 2 lockfile to version 1 the next time it is re-saved.
+With this set, `bun install` writes a version 1 lockfile and downgrades an existing version 2 lockfile on the next install.
 
 #### Automatic lockfile migration
 

--- a/docs/pm/lockfile.mdx
+++ b/docs/pm/lockfile.mdx
@@ -52,6 +52,19 @@ Bun v1.2 changed the default lockfile format to the text-based `bun.lock`. To mi
 
 For more on the format, see [the blog post](https://bun.com/blog/bun-lock-text-lockfile).
 
+#### Lockfile format versions
+
+`bun.lock` carries a `"lockfileVersion"` field. Bun 1.4 writes version 2 by default for a fresh install or migration. Re-saving an existing version 0 or 1 lockfile preserves its version, so a project that already has a `bun.lock` is unaffected.
+
+Bun releases before 1.4 cannot read version 2 lockfiles. If your project is installed by a mix of Bun versions, set `formatVersion` in `bunfig.toml` to cap the written version:
+
+```toml bunfig.toml icon="settings"
+[install.lockfile]
+formatVersion = 1
+```
+
+This also downgrades an existing version 2 lockfile to version 1 the next time it is re-saved.
+
 #### Automatic lockfile migration
 
 When running `bun install` in a project without a `bun.lock`, Bun automatically migrates existing lockfiles:

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -643,6 +643,13 @@ Whether to generate a non-Bun lockfile alongside `bun.lock`. (A `bun.lock` is al
 print = "yarn"
 ```
 
+Cap the `"lockfileVersion"` written to `bun.lock`. Set this to `1` in a project that is also installed by Bun `< 1.4`, which cannot read lockfile version 2.
+
+```toml title="bunfig.toml" icon="settings"
+[install.lockfile]
+formatVersion = 1
+```
+
 ### `install.linker`
 
 Configure the linker strategy: how `bun install` lays out dependencies in `node_modules`. Defaults to `"isolated"` for new workspaces, `"hoisted"` for new single-package projects and existing projects (made pre-v1.3.2).

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -647,7 +647,7 @@ Cap the `"lockfileVersion"` written to `bun.lock`. Set this to `1` in a project 
 
 ```toml title="bunfig.toml" icon="settings"
 [install.lockfile]
-formatVersion = 1
+lockfileVersion = 1
 ```
 
 ### `install.linker`

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1402,6 +1402,11 @@ impl<'a> Parser<'a> {
             {
                 install.save_lockfile_path = Some(v.into());
             }
+            if let Some(v) = lockfile_expr.get(b"formatVersion") {
+                if let Some(n) = v.as_number() {
+                    install.lockfile_format_version = Some(num_to_u32(n));
+                }
+            }
         }
 
         if let Some(v) = install_obj.get(b"optional").and_then(|e| e.as_bool()) {

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1402,7 +1402,7 @@ impl<'a> Parser<'a> {
             {
                 install.save_lockfile_path = Some(v.into());
             }
-            if let Some(v) = lockfile_expr.get(b"formatVersion") {
+            if let Some(v) = lockfile_expr.get(b"lockfileVersion") {
                 if let Some(n) = v.as_number() {
                     install.lockfile_format_version = Some(num_to_u32(n));
                 }

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -90,6 +90,11 @@ pub struct Options {
     pub(crate) os: Npm::OperatingSystem,
 
     pub(crate) config_version: Option<ConfigVersion>,
+
+    /// `[install.lockfile] formatVersion` from bunfig — caps the
+    /// `lockfileVersion` stamped into a written `bun.lock`, so a project
+    /// shared with older Bun versions can keep producing a lockfile they read.
+    pub(crate) lockfile_format_version: Option<crate::lockfile::bun_lock::Version>,
 }
 
 impl Default for Options {
@@ -153,6 +158,7 @@ impl Default for Options {
             cpu: Npm::Architecture::CURRENT,
             os: Npm::OperatingSystem::CURRENT,
             config_version: None,
+            lockfile_format_version: None,
         }
     }
 }
@@ -524,6 +530,12 @@ impl Options {
 
             if let Some(save_text_lockfile) = config.save_text_lockfile {
                 self.save_text_lockfile = Some(save_text_lockfile);
+            }
+
+            if let Some(n) = config.lockfile_format_version {
+                // Unknown (future) versions cap above CURRENT and are a no-op.
+                self.lockfile_format_version =
+                    crate::lockfile::bun_lock::Version::from_int(n);
             }
 
             if let Some(jobs) = config.concurrent_scripts {

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -534,8 +534,7 @@ impl Options {
 
             if let Some(n) = config.lockfile_format_version {
                 // Unknown (future) versions cap above CURRENT and are a no-op.
-                self.lockfile_format_version =
-                    crate::lockfile::bun_lock::Version::from_int(n);
+                self.lockfile_format_version = crate::lockfile::bun_lock::Version::from_int(n);
             }
 
             if let Some(jobs) = config.concurrent_scripts {

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -91,9 +91,7 @@ pub struct Options {
 
     pub(crate) config_version: Option<ConfigVersion>,
 
-    /// `[install.lockfile] formatVersion` from bunfig — caps the
-    /// `lockfileVersion` stamped into a written `bun.lock`, so a project
-    /// shared with older Bun versions can keep producing a lockfile they read.
+    /// `[install.lockfile] lockfileVersion` — caps the written `lockfileVersion`.
     pub(crate) lockfile_format_version: Option<crate::lockfile::bun_lock::Version>,
 }
 
@@ -533,7 +531,6 @@ impl Options {
             }
 
             if let Some(n) = config.lockfile_format_version {
-                // Unknown (future) versions cap above CURRENT and are a no-op.
                 self.lockfile_format_version = crate::lockfile::bun_lock::Version::from_int(n);
             }
 

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -531,7 +531,9 @@ impl Options {
             }
 
             if let Some(n) = config.lockfile_format_version {
-                self.lockfile_format_version = crate::lockfile::bun_lock::Version::from_int(n);
+                use crate::lockfile::bun_lock::Version;
+                // Floor to V1 (the writer never emits v0 content).
+                self.lockfile_format_version = Version::from_int(n.max(Version::V1 as u32));
             }
 
             if let Some(jobs) = config.concurrent_scripts {

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -106,7 +106,13 @@ pub fn install_with_manager(
                 && (load_result.ok().migrated != lockfile::Migrated::None
                     // if loaded from binary and save-text-lockfile is passed
                     || (load_result.ok().format == lockfile::Format::Binary
-                        && manager.options.save_text_lockfile.unwrap_or(false)))),
+                        && manager.options.save_text_lockfile.unwrap_or(false))
+                    // if `[install.lockfile] lockfileVersion` caps below the
+                    // loaded text-lockfile version, re-save to apply it
+                    || (load_result.ok().format == lockfile::Format::Text
+                        && manager.options.lockfile_format_version.is_some_and(|cap| {
+                            !cap.at_least(load_result.ok().lockfile.text_lockfile_version)
+                        })))),
     );
 
     // this defaults to false

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -107,8 +107,7 @@ pub fn install_with_manager(
                     // if loaded from binary and save-text-lockfile is passed
                     || (load_result.ok().format == lockfile::Format::Binary
                         && manager.options.save_text_lockfile.unwrap_or(false))
-                    // if `[install.lockfile] lockfileVersion` caps below the
-                    // loaded text-lockfile version, re-save to apply it
+                    // if bunfig lockfileVersion caps below the loaded version
                     || (load_result.ok().format == lockfile::Format::Text
                         && manager.options.lockfile_format_version.is_some_and(|cap| {
                             !cap.at_least(load_result.ok().lockfile.text_lockfile_version)

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -212,8 +212,6 @@ impl Stringifier {
     /// are actually serialized are considered, not every entry in the in-memory
     /// `pkg_resolutions` buffer (migration can leave pruned/unreferenced entries
     /// there that never reach the written `packages` object).
-    ///
-    /// `cap` is `[install.lockfile] lockfileVersion` from bunfig.
     fn version_to_write(lockfile: &BinaryLockfile, cap: Option<Version>) -> Version {
         // An older on-disk lockfile keeps its version; only a no-prior-version
         // lockfile (the `Version::CURRENT` default) is a candidate for v2. v0 is

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -213,9 +213,7 @@ impl Stringifier {
     /// `pkg_resolutions` buffer (migration can leave pruned/unreferenced entries
     /// there that never reach the written `packages` object).
     ///
-    /// `cap` is `[install.lockfile] formatVersion` from bunfig: when set, the
-    /// result never exceeds it, so a project shared with older Bun versions can
-    /// keep producing a lockfile they read. The v0→v1 floor still applies.
+    /// `cap` is `[install.lockfile] lockfileVersion` from bunfig.
     fn version_to_write(lockfile: &BinaryLockfile, cap: Option<Version>) -> Version {
         // An older on-disk lockfile keeps its version; only a no-prior-version
         // lockfile (the `Version::CURRENT` default) is a candidate for v2. v0 is

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -212,15 +212,24 @@ impl Stringifier {
     /// are actually serialized are considered, not every entry in the in-memory
     /// `pkg_resolutions` buffer (migration can leave pruned/unreferenced entries
     /// there that never reach the written `packages` object).
-    fn version_to_write(lockfile: &BinaryLockfile) -> Version {
+    ///
+    /// `cap` is `[install.lockfile] formatVersion` from bunfig: when set, the
+    /// result never exceeds it, so a project shared with older Bun versions can
+    /// keep producing a lockfile they read. The v0→v1 floor still applies.
+    fn version_to_write(lockfile: &BinaryLockfile, cap: Option<Version>) -> Version {
         // An older on-disk lockfile keeps its version; only a no-prior-version
         // lockfile (the `Version::CURRENT` default) is a candidate for v2. v0 is
         // the exception: the writer can't emit v0-format workspace entries, so a
         // v0 lockfile is upgraded to v1 rather than preserved verbatim.
         let loaded = lockfile.text_lockfile_version;
-        if !loaded.at_least(Version::CURRENT) {
-            return if loaded.at_least(Version::V1) {
-                loaded
+        let target = match cap {
+            Some(c) if !loaded.at_least(c) => loaded,
+            Some(c) => c,
+            None => loaded,
+        };
+        if !target.at_least(Version::CURRENT) {
+            return if target.at_least(Version::V1) {
+                target
             } else {
                 Version::V1
             };
@@ -365,7 +374,8 @@ impl Stringifier {
         writer.write_all(b"{\n")?;
         Self::inc_indent(writer, indent)?;
         {
-            let lockfile_version = Self::version_to_write(lockfile);
+            let lockfile_version =
+                Self::version_to_write(lockfile, options.lockfile_format_version);
             writeln!(writer, "\"lockfileVersion\": {},", lockfile_version as u32)?;
             Self::write_indent(writer, *indent)?;
 

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -321,8 +321,7 @@ pub mod api {
         pub minimum_release_age_excludes: Option<Vec<Box<[u8]>>>,
         pub public_hoist_pattern: Option<PnpmMatcher>,
         pub hoist_pattern: Option<PnpmMatcher>,
-        /// `[install.lockfile] formatVersion` — caps the `lockfileVersion`
-        /// stamped into a written `bun.lock`.
+        /// `[install.lockfile] lockfileVersion`
         pub lockfile_format_version: Option<u32>,
     }
 

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -321,6 +321,9 @@ pub mod api {
         pub minimum_release_age_excludes: Option<Vec<Box<[u8]>>>,
         pub public_hoist_pattern: Option<PnpmMatcher>,
         pub hoist_pattern: Option<PnpmMatcher>,
+        /// `[install.lockfile] formatVersion` — caps the `lockfileVersion`
+        /// stamped into a written `bun.lock`.
+        pub lockfile_format_version: Option<u32>,
     }
 
     /// Open `enum(u8)` in the wire schema. Generated body emits `_` open

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -134,6 +134,41 @@ it("bunfig [install.lockfile] lockfileVersion = 2 does not bump a loaded v1 lock
   expect(exitCode).toBe(0);
 });
 
+// cap = 0 is floored to 1 at config-load time, so a v1 lockfile with no other
+// change is not spuriously re-saved on every install.
+it("bunfig [install.lockfile] lockfileVersion = 0 does not re-save an unchanged v1 lockfile", async () => {
+  using dir = tempDir("lockfile-bunfig-cap0-noop", {
+    "package.json": JSON.stringify({ name: "root", dependencies: { a: "file:./a" } }),
+    "a/package.json": JSON.stringify({ name: "a", version: "1.0.0" }),
+    "bunfig.toml": `[install.lockfile]\nlockfileVersion = 0\n`,
+  });
+
+  await using first = spawn({
+    cmd: [bunExe(), "install", "--save-text-lockfile"],
+    cwd: String(dir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await Promise.all([first.stdout.text(), first.stderr.text(), first.exited]);
+  const before = await file(join(String(dir), "bun.lock")).text();
+  expect(before).toContain(`"lockfileVersion": 1,`);
+
+  await using second = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, exitCode] = await Promise.all([second.stdout.text(), second.stderr.text(), second.exited]);
+
+  expect(err).not.toContain("error:");
+  expect(out).not.toContain("Saved lockfile");
+  expect(await file(join(String(dir), "bun.lock")).text()).toBe(before);
+  expect(exitCode).toBe(0);
+});
+
 // 0 is floored to 1 (the writer cannot emit v0 content). Equal to or above the
 // current version is a no-op cap.
 it.each([

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -30,6 +30,97 @@ it("a freshly written text lockfile defaults to version 2", async () => {
   expect(exitCode).toBe(0);
 });
 
+// `[install.lockfile] formatVersion = 1` caps the written lockfileVersion, so a
+// fresh install on a newer Bun still produces a lockfile an older Bun can read.
+it("bunfig [install.lockfile] formatVersion = 1 writes a v1 lockfile for a fresh install", async () => {
+  using dir = tempDir("lockfile-bunfig-format-v1", {
+    "package.json": JSON.stringify({ name: "root", dependencies: { dep: "file:./dep" } }),
+    "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+    "bunfig.toml": `[install.lockfile]\nformatVersion = 1\n`,
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install", "--save-text-lockfile"],
+    cwd: String(dir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lockfile = await file(join(String(dir), "bun.lock")).text();
+  expect(err).not.toContain("error:");
+  expect(lockfile).toContain(`"lockfileVersion": 1,`);
+  expect(lockfile).not.toContain(`"lockfileVersion": 2,`);
+  expect(exitCode).toBe(0);
+});
+
+it("bunfig [install.lockfile] formatVersion = 1 downgrades an existing v2 lockfile on re-save", async () => {
+  // Fresh install first (writes v2), then add bunfig + a new dep to force a re-save.
+  using dir = tempDir("lockfile-bunfig-downgrade", {
+    "package.json": JSON.stringify({ name: "root", dependencies: { a: "file:./a" } }),
+    "a/package.json": JSON.stringify({ name: "a", version: "1.0.0" }),
+    "b/package.json": JSON.stringify({ name: "b", version: "1.0.0" }),
+  });
+
+  await using first = spawn({
+    cmd: [bunExe(), "install", "--save-text-lockfile"],
+    cwd: String(dir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await Promise.all([first.stdout.text(), first.stderr.text(), first.exited]);
+  const before = await file(join(String(dir), "bun.lock")).text();
+  expect(before).toContain(`"lockfileVersion": 2,`);
+
+  await Bun.write(join(String(dir), "bunfig.toml"), `[install.lockfile]\nformatVersion = 1\n`);
+  await Bun.write(
+    join(String(dir), "package.json"),
+    JSON.stringify({ name: "root", dependencies: { a: "file:./a", b: "file:./b" } }),
+  );
+
+  await using second = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, err, exitCode] = await Promise.all([second.stdout.text(), second.stderr.text(), second.exited]);
+
+  const after = await file(join(String(dir), "bun.lock")).text();
+  expect(err).not.toContain("error:");
+  expect(after).toContain(`"b": ["b@file:b"`);
+  expect(after).toContain(`"lockfileVersion": 1,`);
+  expect(after).not.toContain(`"lockfileVersion": 2,`);
+  expect(exitCode).toBe(0);
+});
+
+// formatVersion equal to the current version is a no-op; values above it are
+// ignored (a cap above current has no effect).
+it.each([2, 99])("bunfig [install.lockfile] formatVersion = %d writes the current version", async n => {
+  using dir = tempDir("lockfile-bunfig-format-noop", {
+    "package.json": JSON.stringify({ name: "root", dependencies: { dep: "file:./dep" } }),
+    "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+    "bunfig.toml": `[install.lockfile]\nformatVersion = ${n}\n`,
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install", "--save-text-lockfile"],
+    cwd: String(dir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lockfile = await file(join(String(dir), "bun.lock")).text();
+  expect(err).not.toContain("error:");
+  expect(lockfile).toContain(`"lockfileVersion": 2,`);
+  expect(exitCode).toBe(0);
+});
+
 // Re-saving an existing lockfile must never bump its version. A v1 `bun.lock`
 // that is rewritten — here because a new dependency is added — keeps
 // `lockfileVersion: 1`, even though every entry would satisfy the v2 invariants.

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -161,10 +161,10 @@ it("bunfig [install.lockfile] lockfileVersion = 0 does not re-save an unchanged 
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [out, err, exitCode] = await Promise.all([second.stdout.text(), second.stderr.text(), second.exited]);
+  const [, err, exitCode] = await Promise.all([second.stdout.text(), second.stderr.text(), second.exited]);
 
   expect(err).not.toContain("error:");
-  expect(out).not.toContain("Saved lockfile");
+  expect(err).not.toContain("Saved lockfile");
   expect(await file(join(String(dir), "bun.lock")).text()).toBe(before);
   expect(exitCode).toBe(0);
 });

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -30,13 +30,13 @@ it("a freshly written text lockfile defaults to version 2", async () => {
   expect(exitCode).toBe(0);
 });
 
-// `[install.lockfile] formatVersion = 1` caps the written lockfileVersion, so a
-// fresh install on a newer Bun still produces a lockfile an older Bun can read.
-it("bunfig [install.lockfile] formatVersion = 1 writes a v1 lockfile for a fresh install", async () => {
-  using dir = tempDir("lockfile-bunfig-format-v1", {
+// `[install.lockfile] lockfileVersion = 1` caps the written lockfileVersion, so
+// a fresh install on a newer Bun still produces a lockfile an older Bun can read.
+it("bunfig [install.lockfile] lockfileVersion = 1 writes a v1 lockfile for a fresh install", async () => {
+  using dir = tempDir("lockfile-bunfig-cap-v1", {
     "package.json": JSON.stringify({ name: "root", dependencies: { dep: "file:./dep" } }),
     "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
-    "bunfig.toml": `[install.lockfile]\nformatVersion = 1\n`,
+    "bunfig.toml": `[install.lockfile]\nlockfileVersion = 1\n`,
   });
 
   await using proc = spawn({
@@ -55,12 +55,12 @@ it("bunfig [install.lockfile] formatVersion = 1 writes a v1 lockfile for a fresh
   expect(exitCode).toBe(0);
 });
 
-it("bunfig [install.lockfile] formatVersion = 1 downgrades an existing v2 lockfile on re-save", async () => {
-  // Fresh install first (writes v2), then add bunfig + a new dep to force a re-save.
+// The cap alone is enough to trigger a re-save: a v2 lockfile + bunfig cap 1,
+// with no package.json change, is rewritten as v1 on the next install.
+it("bunfig [install.lockfile] lockfileVersion = 1 downgrades an existing v2 lockfile on install", async () => {
   using dir = tempDir("lockfile-bunfig-downgrade", {
     "package.json": JSON.stringify({ name: "root", dependencies: { a: "file:./a" } }),
     "a/package.json": JSON.stringify({ name: "a", version: "1.0.0" }),
-    "b/package.json": JSON.stringify({ name: "b", version: "1.0.0" }),
   });
 
   await using first = spawn({
@@ -70,15 +70,13 @@ it("bunfig [install.lockfile] formatVersion = 1 downgrades an existing v2 lockfi
     stdout: "pipe",
     stderr: "pipe",
   });
-  await Promise.all([first.stdout.text(), first.stderr.text(), first.exited]);
+  const [, firstErr, firstExit] = await Promise.all([first.stdout.text(), first.stderr.text(), first.exited]);
+  expect(firstErr).not.toContain("error:");
+  expect(firstExit).toBe(0);
   const before = await file(join(String(dir), "bun.lock")).text();
   expect(before).toContain(`"lockfileVersion": 2,`);
 
-  await Bun.write(join(String(dir), "bunfig.toml"), `[install.lockfile]\nformatVersion = 1\n`);
-  await Bun.write(
-    join(String(dir), "package.json"),
-    JSON.stringify({ name: "root", dependencies: { a: "file:./a", b: "file:./b" } }),
-  );
+  await Bun.write(join(String(dir), "bunfig.toml"), `[install.lockfile]\nlockfileVersion = 1\n`);
 
   await using second = spawn({
     cmd: [bunExe(), "install"],
@@ -91,23 +89,36 @@ it("bunfig [install.lockfile] formatVersion = 1 downgrades an existing v2 lockfi
 
   const after = await file(join(String(dir), "bun.lock")).text();
   expect(err).not.toContain("error:");
-  expect(after).toContain(`"b": ["b@file:b"`);
   expect(after).toContain(`"lockfileVersion": 1,`);
   expect(after).not.toContain(`"lockfileVersion": 2,`);
   expect(exitCode).toBe(0);
 });
 
-// formatVersion equal to the current version is a no-op; values above it are
-// ignored (a cap above current has no effect).
-it.each([2, 99])("bunfig [install.lockfile] formatVersion = %d writes the current version", async n => {
-  using dir = tempDir("lockfile-bunfig-format-noop", {
-    "package.json": JSON.stringify({ name: "root", dependencies: { dep: "file:./dep" } }),
-    "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
-    "bunfig.toml": `[install.lockfile]\nformatVersion = ${n}\n`,
+// The cap is a ceiling, not a floor: `lockfileVersion = 2` on a loaded v1
+// lockfile keeps it at v1 (preserve-loaded-version still wins).
+it("bunfig [install.lockfile] lockfileVersion = 2 does not bump a loaded v1 lockfile", async () => {
+  const v1Lockfile =
+    JSON.stringify(
+      {
+        lockfileVersion: 1,
+        configVersion: 1,
+        workspaces: { "": { name: "root", dependencies: { a: "file:./a" } } },
+        packages: { a: ["a@file:a", {}] },
+      },
+      null,
+      2,
+    ) + "\n";
+
+  using dir = tempDir("lockfile-bunfig-cap-no-bump", {
+    "package.json": JSON.stringify({ name: "root", dependencies: { a: "file:./a", b: "file:./b" } }),
+    "a/package.json": JSON.stringify({ name: "a", version: "1.0.0" }),
+    "b/package.json": JSON.stringify({ name: "b", version: "1.0.0" }),
+    "bun.lock": v1Lockfile,
+    "bunfig.toml": `[install.lockfile]\nlockfileVersion = 2\n`,
   });
 
   await using proc = spawn({
-    cmd: [bunExe(), "install", "--save-text-lockfile"],
+    cmd: [bunExe(), "install"],
     cwd: String(dir),
     env,
     stdout: "pipe",
@@ -115,11 +126,44 @@ it.each([2, 99])("bunfig [install.lockfile] formatVersion = %d writes the curren
   });
   const [, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const lockfile = await file(join(String(dir), "bun.lock")).text();
+  const after = await file(join(String(dir), "bun.lock")).text();
   expect(err).not.toContain("error:");
-  expect(lockfile).toContain(`"lockfileVersion": 2,`);
+  expect(after).toContain(`"b": ["b@file:b"`);
+  expect(after).toContain(`"lockfileVersion": 1,`);
+  expect(after).not.toContain(`"lockfileVersion": 2,`);
   expect(exitCode).toBe(0);
 });
+
+// 0 is floored to 1 (the writer cannot emit v0 content). Equal to or above the
+// current version is a no-op cap.
+it.each([
+  [0, 1],
+  [2, 2],
+  [99, 2],
+])(
+  "bunfig [install.lockfile] lockfileVersion = %d writes lockfileVersion %d for a fresh install",
+  async (n, expected) => {
+    using dir = tempDir("lockfile-bunfig-cap-edge", {
+      "package.json": JSON.stringify({ name: "root", dependencies: { dep: "file:./dep" } }),
+      "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+      "bunfig.toml": `[install.lockfile]\nlockfileVersion = ${n}\n`,
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--save-text-lockfile"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const lockfile = await file(join(String(dir), "bun.lock")).text();
+    expect(err).not.toContain("error:");
+    expect(lockfile).toContain(`"lockfileVersion": ${expected},`);
+    expect(exitCode).toBe(0);
+  },
+);
 
 // Re-saving an existing lockfile must never bump its version. A v1 `bun.lock`
 // that is rewritten — here because a new dependency is added — keeps


### PR DESCRIPTION
### What

Adds a `bunfig.toml` option to cap the `lockfileVersion` written to `bun.lock`:

```toml
[install.lockfile]
lockfileVersion = 1
```

### Why

#31539 bumped the default text lockfile to `lockfileVersion: 2` for fresh installs and migrations. Bun releases before 1.4 reject version 2 with `Unknown lockfile version`. #31602 already ensures an existing v1 lockfile is preserved on re-save, and #32465 makes the error actionable going forward, but there is no way to make a *fresh* install (or a migration from package-lock/yarn/pnpm) produce a lockfile that a teammate on 1.3.x can read.

With `lockfileVersion = 1` committed alongside the project:
- a fresh `bun install` writes `"lockfileVersion": 1`
- an existing v2 lockfile is re-saved as v1 on the next install (the cap below the loaded version is a `FORCE_SAVE_LOCKFILE` trigger, same as `changed_config_version`)
- a loaded v1 lockfile stays at v1 even with `lockfileVersion = 2` set (the cap is a ceiling, not a floor)

The v1 format is a strict subset of what the v2 writer emits (v1 to v2 only added parse-time checks on identical content), so capping at v1 never loses information. The existing v0 to v1 floor still applies since the writer cannot emit v0-format workspace entries. Values at or above the current version are a no-op. `--frozen-lockfile` is unaffected (`force_save_lockfile` is gated behind `do_.save_lockfile()`, which frozen-lockfile clears).

The key name matches the bun.lock field and npm's `--lockfile-version` flag.

### Tests

New tests in `test/cli/install/lockfile-version-2.test.ts`:

```
bunfig [install.lockfile] lockfileVersion = 1 writes a v1 lockfile for a fresh install
bunfig [install.lockfile] lockfileVersion = 1 downgrades an existing v2 lockfile on install
bunfig [install.lockfile] lockfileVersion = 2 does not bump a loaded v1 lockfile
bunfig [install.lockfile] lockfileVersion = 0 writes lockfileVersion 1 for a fresh install
bunfig [install.lockfile] lockfileVersion = 2 writes lockfileVersion 2 for a fresh install
bunfig [install.lockfile] lockfileVersion = 99 writes lockfileVersion 2 for a fresh install
```

Fail-before on the first two and the `= 0` case; the rest are no-op controls. Full file: 15 pass, 0 fail.

Also adds a `Lockfile format versions` section to `docs/pm/lockfile.mdx` and documents the key in `docs/runtime/bunfig.mdx`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/cli/install/lockfile-version-2.test.ts"
bun test v1.4.0 (c49791713)

test/cli/install/lockfile-version-2.test.ts:
(pass) a freshly written text lockfile defaults to version 2 [180.28ms]
48 |   });
49 |   const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
50 | 
51 |   const lockfile = await file(join(String(dir), "bun.lock")).text();
52 |   expect(err).not.toContain("error:");
53 |   expect(lockfile).toContain(`"lockfileVersion": 1,`);
                        ^
error: expect(received).toContain(expected)

Expected to contain: "\"lockfileVersion\": 1,"
Received: "{\n  \"lockfileVersion\": 2,\n  \"configVersion\": 1,\n  \"workspaces\": {\n    \"\": {\n      \"name\": \"root\",\n      \"dependencies\": {\n        \"dep\": \"file:./dep\",\n      },\n    },\n  },\n  \"packages\": {\n    \"dep\": [\"dep@file:dep\", {}],\n  }\n}\n"

      at <anonymous> (/workspace/bun/test/cli/install/lockfile-version-2.test.ts:53:20)
(fail) bunfig [install.lockfile] lockfileVersion = 1 writes a v1 loc
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (b8ba35af1)

test/cli/install/lockfile-version-2.test.ts:
(pass) a freshly written text lockfile defaults to version 2 [4.37ms]
(pass) bunfig [install.lockfile] lockfileVersion = 1 writes a v1 lockfile for a fresh install [3.28ms]
(pass) bunfig [install.lockfile] lockfileVersion = 1 downgrades an existing v2 lockfile on install [5.87ms]
(pass) bunfig [install.lockfile] lockfileVersion = 2 does not bump a loaded v1 lockfile [3.09ms]
(pass) bunfig [install.lockfile] lockfileVersion = 0 does not re-save an unchanged v1 lockfile [6.21ms]
(pass) bunfig [install.lockfile] lockfileVersion = 0 writes lockfileVersion 1 for a fresh install [3.22ms]
(pass) bunfig [install.lockfile] lockfileVersion = 2 writes lockfileVersion 2 for a fresh install [2.74ms]
(pass) bunfig [install.lockfile] lockfileVersion = 99 writes lockfileVersion 2 for a fresh install [2.93ms]
(pass) re-saving a v1 lockfile keeps it at version 1 even after adding a dependency [3.69ms]
(pass) re-saving a v0 lockfile floors it to version 1 so it stays parseable [5.91ms]
(pass) an existing v1 lockfile still loads (backward compatible) [2.73ms]
(pass) off-registry npm tarball integrity is 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/cli/install/lockfile-version-2.test.ts"
bun test v1.4.0 (c49791713)

test/cli/install/lockfile-version-2.test.ts:
(pass) a freshly written text lockfile defaults to version 2 [185.33ms]
(pass) bunfig [install.lockfile] lockfileVersion = 1 writes a v1 lockfile for a fresh install [155.74ms]
(pass) bunfig [install.lockfile] lockfileVersion = 1 downgrades an existing v2 lockfile on install [294.55ms]
(pass) bunfig [install.lockfile] lockfileVersion = 2 does not bump a loaded v1 lockfile [163.30ms]
(pass) bunfig [install.lockfile] lockfileVersion = 0 does not re-save an unchanged v1 lockfile [288.56ms]
(pass) bunfig [install.lockfile] lockfileVersion = 0 writes lockfileVersion 1 for a fresh install [160.62ms]
(pass) bunfig [install.lockfile] lockfileVersion = 2 writes lockfileVersion 2 for a fresh install [139.30ms]
(pass) bunfig [install.lockfile] lockfileVersion = 99 writes lockfileVersion 2 for a fresh install [146.33ms]
(pass) re-saving a v1 lockfile keeps it at version 1 even after adding a dependency [160.06ms]
(pass) re-saving
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 897ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/pm/lockfile.mdx                               |  13 ++
 docs/runtime/bunfig.mdx                            |   7 +
 src/bunfig/bunfig.rs                               |   5 +
 .../PackageManager/PackageManagerOptions.rs        |  10 ++
 src/install/PackageManager/install_with_manager.rs |   7 +-
 src/install/lockfile/bun.lock.rs                   |  16 +-
 src/options_types/schema.rs                        |   2 +
 test/cli/install/lockfile-version-2.test.ts        | 170 +++++++++++++++++++++
 8 files changed, 224 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
docs/pm/lockfile.mdx                                     1      3      0
docs/runtime/bunfig.mdx                                  1      2      0
src/bunfig/bunfig.rs                                     4      2      0
src/install/PackageManager/PackageManagerOptions.rs      6      6      0
src/install/PackageManager/install_with_manager.rs       5      3      0
src/install/lockfile/bun.lock.rs                         4      5      0
src/options_types/schema.rs                              1      3      0
test/cli/install/lockfile-version-2.test.ts              3      5      0
```

</details>

<!-- robobun:evidence:end -->