### PR TITLE
toml: actionable diagnostics for unquoted values and Windows-path backslashes

### DIFF
--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -286,7 +286,12 @@ impl<'a, 'log> Scanner<'a, 'log> {
             key_start += 1;
         }
         let prefix = &self.src[key_start..pos];
-        if bun_core::strings::contains(prefix, b"=") {
+        // A stop byte inside a quoted key (`"a,b" = v`) truncates the scan
+        // mid-key; an unbalanced quote in the prefix is the tell, so drop the
+        // prefix rather than print a garbled one.
+        let balanced = prefix.iter().filter(|&&c| c == b'"').count() % 2 == 0
+            && prefix.iter().filter(|&&c| c == b'\'').count() % 2 == 0;
+        if balanced && bun_core::strings::contains(prefix, b"=") {
             self.err_fmt(
                 pos,
                 format_args!(

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -258,20 +258,71 @@ impl<'a, 'log> Scanner<'a, 'log> {
     }
 
     /// A bare word in value position is almost always an unquoted string,
-    /// which the old parser silently accepted; name the fix directly.
+    /// which the old parser silently accepted; name the fix directly. Scans
+    /// back to the start of the `key = ` expression so the suggestion is a
+    /// drop-in replacement for the whole line.
     fn err_unquoted_string(&mut self, pos: usize) -> PErr {
         let mut end = pos;
         while end < self.src.len() && is_bare_key_char(self.peek_at(end)) && end - pos < 64 {
             end += 1;
         }
         if self.redact || end == pos {
-            return self.err(pos, b"Strings must be quoted");
+            return self.err(
+                pos,
+                b"String values must be quoted; wrap the value in double quotes",
+            );
+        }
+        // Back up to the start of the enclosing `key = ` (stopping at a line
+        // break or an array/inline-table opener) so the fix reads as the
+        // whole expression, not just the word.
+        let mut key_start = pos;
+        while key_start > 0
+            && pos - key_start < 64
+            && !matches!(self.src[key_start - 1], b'\n' | b'\r' | b'[' | b'{' | b',')
+        {
+            key_start -= 1;
+        }
+        while key_start < pos && matches!(self.src[key_start], b' ' | b'\t') {
+            key_start += 1;
+        }
+        let prefix = &self.src[key_start..pos];
+        if bun_core::strings::contains(prefix, b"=") {
+            self.err_fmt(
+                pos,
+                format_args!(
+                    "String values must be quoted; write: {}\"{}\"",
+                    bstr::BStr::new(prefix),
+                    bstr::BStr::new(&self.src[pos..end]),
+                ),
+            )
+        } else {
+            self.err_fmt(
+                pos,
+                format_args!(
+                    "String values must be quoted; write: \"{}\"",
+                    bstr::BStr::new(&self.src[pos..end]),
+                ),
+            )
+        }
+    }
+
+    /// A backslash inside a basic string that begins with a drive letter
+    /// (`C:`) almost certainly meant a Windows path separator, not an
+    /// escape; say so instead of naming the escape rule that was violated.
+    fn err_windows_path_escape(&mut self, escape_pos: usize, drive: u8) -> PErr {
+        if self.redact {
+            return self.err(
+                escape_pos,
+                b"Backslash begins an escape sequence; for a Windows path, \
+                  use a single-quoted string or double each backslash",
+            );
         }
         self.err_fmt(
-            pos,
+            escape_pos,
             format_args!(
-                "Strings must be quoted: \"{}\"",
-                bstr::BStr::new(&self.src[pos..end])
+                "Backslash begins an escape sequence; for a Windows path, \
+                 use a single-quoted string ('{}:\\...') or double each backslash (\"{}:\\\\...\")",
+                drive as char, drive as char,
             ),
         )
     }
@@ -1119,6 +1170,16 @@ impl<'a, 'log> Scanner<'a, 'log> {
         }
 
         let start = self.pos;
+        // A single-line basic string that opens with `<letter>:` is almost
+        // certainly a Windows path; escape errors then name that fix.
+        let path_drive = if !multiline
+            && self.peek_at(start).is_ascii_alphabetic()
+            && self.peek_at(start + 1) == b':'
+        {
+            self.peek_at(start)
+        } else {
+            0
+        };
         let mut buf: Option<ArenaVec<'a, u8>> = None;
         let mut is_ascii = true;
         loop {
@@ -1185,7 +1246,7 @@ impl<'a, 'log> Scanner<'a, 'log> {
                         }
                     }
                     let b = Self::materialize(self.bump, self.src, start, self.pos, &mut buf);
-                    self.scan_escape(b, &mut is_ascii)?;
+                    self.scan_escape(b, &mut is_ascii, path_drive)?;
                 }
                 b'\n' => {
                     if !multiline {
@@ -1239,7 +1300,12 @@ impl<'a, 'log> Scanner<'a, 'log> {
         }
     }
 
-    fn scan_escape(&mut self, buf: &mut ArenaVec<'a, u8>, is_ascii: &mut bool) -> PResult<()> {
+    fn scan_escape(
+        &mut self,
+        buf: &mut ArenaVec<'a, u8>,
+        is_ascii: &mut bool,
+        path_drive: u8,
+    ) -> PResult<()> {
         debug_assert_eq!(self.peek(), b'\\');
         let escape_pos = self.pos;
         self.pos += 1;
@@ -1256,15 +1322,15 @@ impl<'a, 'log> Scanner<'a, 'log> {
             // TOML 1.1
             b'e' => buf.push(0x1B),
             b'x' => {
-                let cp = self.read_hex_codepoint("hex escape", 2, escape_pos)?;
+                let cp = self.read_hex_codepoint("hex escape", 2, escape_pos, path_drive)?;
                 self.append_scalar(buf, cp, escape_pos, is_ascii)?;
             }
             b'u' => {
-                let cp = self.read_hex_codepoint("Unicode escape", 4, escape_pos)?;
+                let cp = self.read_hex_codepoint("Unicode escape", 4, escape_pos, path_drive)?;
                 self.append_scalar(buf, cp, escape_pos, is_ascii)?;
             }
             b'U' => {
-                let cp = self.read_hex_codepoint("Unicode escape", 8, escape_pos)?;
+                let cp = self.read_hex_codepoint("Unicode escape", 8, escape_pos, path_drive)?;
                 self.append_scalar(buf, cp, escape_pos, is_ascii)?;
             }
             0 if self.at_eof() => {
@@ -1272,6 +1338,9 @@ impl<'a, 'log> Scanner<'a, 'log> {
             }
             _ => {
                 self.pos -= 1;
+                if path_drive != 0 {
+                    return Err(self.err_windows_path_escape(escape_pos, path_drive));
+                }
                 return Err(self.err_char(self.pos, "Invalid escape sequence:"));
             }
         }
@@ -1283,10 +1352,14 @@ impl<'a, 'log> Scanner<'a, 'log> {
         what: &'static str,
         digits: usize,
         escape_pos: usize,
+        path_drive: u8,
     ) -> PResult<u32> {
         let mut value: u32 = 0;
         for _ in 0..digits {
             let Some(d) = bun_core::fmt::hex_digit_value_u32(u32::from(self.peek())) else {
+                if path_drive != 0 {
+                    return Err(self.err_windows_path_escape(escape_pos, path_drive));
+                }
                 return Err(self.err_fmt(
                     escape_pos,
                     format_args!(

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -272,9 +272,6 @@ impl<'a, 'log> Scanner<'a, 'log> {
                 b"String values must be quoted; wrap the value in double quotes",
             );
         }
-        // Back up to the start of the enclosing `key = ` (stopping at a line
-        // break or an array/inline-table opener) so the fix reads as the
-        // whole expression, not just the word.
         let mut key_start = pos;
         while key_start > 0
             && pos - key_start < 64
@@ -286,9 +283,8 @@ impl<'a, 'log> Scanner<'a, 'log> {
             key_start += 1;
         }
         let prefix = &self.src[key_start..pos];
-        // A stop byte inside a quoted key (`"a,b" = v`) truncates the scan
-        // mid-key; an unbalanced quote in the prefix is the tell, so drop the
-        // prefix rather than print a garbled one.
+        // Unbalanced quotes mean a stop byte sat inside a quoted key; drop
+        // the prefix rather than print half a key.
         let balanced = prefix.iter().filter(|&&c| c == b'"').count() % 2 == 0
             && prefix.iter().filter(|&&c| c == b'\'').count() % 2 == 0;
         if balanced && bun_core::strings::contains(prefix, b"=") {
@@ -1175,8 +1171,7 @@ impl<'a, 'log> Scanner<'a, 'log> {
         }
 
         let start = self.pos;
-        // A single-line basic string that opens with `<letter>:` is almost
-        // certainly a Windows path; escape errors then name that fix.
+        // `"<letter>:...` is treated as a Windows path for escape errors.
         let path_drive = if !multiline
             && self.peek_at(start).is_ascii_alphabetic()
             && self.peek_at(start + 1) == b':'

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -271,9 +271,10 @@ impl<'a, 'log> Scanner<'a, 'log> {
         let mut end = pos;
         loop {
             match self.peek_at(end) {
-                0 | b'\n' | b'\r' | b'#' | b',' | b']' | b'}' => break,
+                0 if end >= self.src.len() => break,
+                b'\n' | b'\r' | b'#' | b',' | b']' | b'}' => break,
                 b'"' | b'\'' | b'\\' => return self.err(pos, GENERIC),
-                c if c < 0x20 || c == 0x7F => return self.err(pos, GENERIC),
+                c if (c < 0x20 && c != b'\t') || c == 0x7F => return self.err(pos, GENERIC),
                 _ => end += 1,
             }
             if end - pos == 64 {

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -273,21 +273,29 @@ impl<'a, 'log> Scanner<'a, 'log> {
             );
         }
         let mut key_start = pos;
+        let mut capped = false;
         while key_start > 0
-            && pos - key_start < 64
             && !matches!(self.src[key_start - 1], b'\n' | b'\r' | b'[' | b'{' | b',')
         {
+            if pos - key_start == 64 {
+                capped = true;
+                break;
+            }
             key_start -= 1;
         }
         while key_start < pos && matches!(self.src[key_start], b' ' | b'\t') {
             key_start += 1;
         }
         let prefix = &self.src[key_start..pos];
-        // Unbalanced quotes mean a stop byte sat inside a quoted key; drop
-        // the prefix rather than print half a key.
-        let balanced = prefix.iter().filter(|&&c| c == b'"').count() % 2 == 0
+        // A prefix the scan did not reach the start of (length cap, or a
+        // stop byte inside a quoted key) is dropped rather than printed
+        // half-formed; `\` in the prefix means a basic-key escape makes the
+        // quote-parity check untrustworthy.
+        let whole = !capped
+            && !bun_core::strings::contains(prefix, b"\\")
+            && prefix.iter().filter(|&&c| c == b'"').count() % 2 == 0
             && prefix.iter().filter(|&&c| c == b'\'').count() % 2 == 0;
-        if balanced && bun_core::strings::contains(prefix, b"=") {
+        if whole && bun_core::strings::contains(prefix, b"=") {
             self.err_fmt(
                 pos,
                 format_args!(

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -263,14 +263,27 @@ impl<'a, 'log> Scanner<'a, 'log> {
     /// drop-in replacement for the whole line.
     fn err_unquoted_string(&mut self, pos: usize) -> PErr {
         const GENERIC: &[u8] = b"String values must be quoted; wrap the value in double quotes";
+        if self.redact {
+            return self.err(pos, GENERIC);
+        }
+        // Capture everything up to the end of the value expression, then trim
+        // trailing whitespace, so URLs and file names are quoted whole.
         let mut end = pos;
-        while is_bare_key_char(self.peek_at(end)) {
-            end += 1;
+        loop {
+            match self.peek_at(end) {
+                0 | b'\n' | b'\r' | b'#' | b',' | b']' | b'}' => break,
+                b'"' | b'\'' | b'\\' => return self.err(pos, GENERIC),
+                c if c < 0x20 => return self.err(pos, GENERIC),
+                _ => end += 1,
+            }
             if end - pos == 64 {
                 return self.err(pos, GENERIC);
             }
         }
-        if self.redact || end == pos {
+        while end > pos && matches!(self.src[end - 1], b' ' | b'\t') {
+            end -= 1;
+        }
+        if end == pos {
             return self.err(pos, GENERIC);
         }
         let mut key_start = pos;

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -273,7 +273,7 @@ impl<'a, 'log> Scanner<'a, 'log> {
             match self.peek_at(end) {
                 0 | b'\n' | b'\r' | b'#' | b',' | b']' | b'}' => break,
                 b'"' | b'\'' | b'\\' => return self.err(pos, GENERIC),
-                c if c < 0x20 => return self.err(pos, GENERIC),
+                c if c < 0x20 || c == 0x7F => return self.err(pos, GENERIC),
                 _ => end += 1,
             }
             if end - pos == 64 {

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -262,15 +262,16 @@ impl<'a, 'log> Scanner<'a, 'log> {
     /// back to the start of the `key = ` expression so the suggestion is a
     /// drop-in replacement for the whole line.
     fn err_unquoted_string(&mut self, pos: usize) -> PErr {
+        const GENERIC: &[u8] = b"String values must be quoted; wrap the value in double quotes";
         let mut end = pos;
-        while end < self.src.len() && is_bare_key_char(self.peek_at(end)) && end - pos < 64 {
+        while is_bare_key_char(self.peek_at(end)) {
             end += 1;
+            if end - pos == 64 {
+                return self.err(pos, GENERIC);
+            }
         }
         if self.redact || end == pos {
-            return self.err(
-                pos,
-                b"String values must be quoted; wrap the value in double quotes",
-            );
+            return self.err(pos, GENERIC);
         }
         let mut key_start = pos;
         let mut capped = false;
@@ -287,10 +288,8 @@ impl<'a, 'log> Scanner<'a, 'log> {
             key_start += 1;
         }
         let prefix = &self.src[key_start..pos];
-        // A prefix the scan did not reach the start of (length cap, or a
-        // stop byte inside a quoted key) is dropped rather than printed
-        // half-formed; `\` in the prefix means a basic-key escape makes the
-        // quote-parity check untrustworthy.
+        // An unbalanced quote or a `\` in the prefix means a stop byte sat
+        // inside a quoted key, so the prefix is a fragment; drop it.
         let whole = !capped
             && !bun_core::strings::contains(prefix, b"\\")
             && prefix.iter().filter(|&&c| c == b'"').count() % 2 == 0

--- a/test/js/bun/toml/toml-test-suite.test.ts
+++ b/test/js/bun/toml/toml-test-suite.test.ts
@@ -2697,7 +2697,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "No"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: "No"');
   });
 
   test("invalid/array/text-before-array-separator", () => {
@@ -2721,7 +2721,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "I"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: "I"');
   });
 
   test("invalid/bool/almost-false-with-extra", () => {
@@ -2733,7 +2733,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "falsify"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: almost-false-with-extra = "falsify"',
+    );
   });
 
   test("invalid/bool/almost-false", () => {
@@ -2745,7 +2747,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "fals"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: almost-false            = "fals"',
+    );
   });
 
   test("invalid/bool/almost-true-with-extra", () => {
@@ -2757,7 +2761,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "truthy"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: almost-true-with-extra  = "truthy"',
+    );
   });
 
   test("invalid/bool/almost-true", () => {
@@ -2769,7 +2775,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "tru"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: almost-true             = "tru"',
+    );
   });
 
   test("invalid/bool/capitalized-false", () => {
@@ -2781,7 +2789,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "False"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: capitalized-false        = "False"',
+    );
   });
 
   test("invalid/bool/capitalized-true", () => {
@@ -2793,7 +2803,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "True"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: capitalized-true         = "True"',
+    );
   });
 
   test("invalid/bool/just-f", () => {
@@ -2805,7 +2817,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "f"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: just-f                  = "f"',
+    );
   });
 
   test("invalid/bool/just-t", () => {
@@ -2817,7 +2831,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "t"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: just-t                  = "t"',
+    );
   });
 
   test("invalid/bool/mixed-case-false", () => {
@@ -2829,7 +2845,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "falsE"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: mixed-case-false        = "falsE"',
+    );
   });
 
   test("invalid/bool/mixed-case-true", () => {
@@ -2841,7 +2859,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "trUe"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: mixed-case-true         = "trUe"',
+    );
   });
 
   test("invalid/bool/mixed-case", () => {
@@ -2853,7 +2873,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "valid"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: mixed-case              = "valid"',
+    );
   });
 
   test("invalid/bool/starting-same-false", () => {
@@ -2865,7 +2887,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "falsey"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: starting-same-false     = "falsey"',
+    );
   });
 
   test("invalid/bool/starting-same-true", () => {
@@ -2877,7 +2901,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "truer"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: starting-same-true      = "truer"',
+    );
   });
 
   test("invalid/bool/wrong-case-false", () => {
@@ -2889,7 +2915,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "FALSE"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: wrong-case-false        = "FALSE"',
+    );
   });
 
   test("invalid/bool/wrong-case-true", () => {
@@ -2901,7 +2929,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "TRUE"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: wrong-case-true         = "TRUE"',
+    );
   });
 
   test("invalid/control/bare-cr", () => {
@@ -3768,7 +3798,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "T"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: foo = "T"');
   });
 
   test("invalid/datetime/only-TZ", () => {
@@ -3780,7 +3810,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "TZ"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: foo = "TZ"');
   });
 
   test("invalid/datetime/only-Tdot", () => {
@@ -3792,7 +3822,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "T"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: foo = "T"');
   });
 
   test("invalid/datetime/second-over", () => {
@@ -4166,7 +4196,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "Inf"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: v = "Inf"');
   });
 
   test("invalid/float/inf-incomplete-01", () => {
@@ -4178,7 +4208,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "in"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: inf-incomplete-01 = "in"',
+    );
   });
 
   test("invalid/float/inf-incomplete-02", () => {
@@ -4214,7 +4246,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "in_f"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: inf_underscore = "in_f"',
+    );
   });
 
   test("invalid/float/leading-dot-neg", () => {
@@ -4310,7 +4344,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "NaN"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: v = "NaN"');
   });
 
   test("invalid/float/nan-incomplete-01", () => {
@@ -4322,7 +4356,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "na"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: nan-incomplete-01 = "na"',
+    );
   });
 
   test("invalid/float/nan-incomplete-02", () => {
@@ -4358,7 +4394,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "na_n"');
+    expect((err as SyntaxError).message).toBe(
+      'TOML Parse error: String values must be quoted; write: nan_underscore = "na_n"',
+    );
   });
 
   test("invalid/float/trailing-dot-01", () => {
@@ -6046,7 +6084,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "b"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: a="b"');
   });
 
   test("invalid/key/without-value-01", () => {
@@ -7146,7 +7184,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "value"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: "value"');
   });
 
   test("invalid/string/missing-quotes-inline-table", () => {
@@ -7158,7 +7196,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "value"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: key = "value"');
   });
 
   test("invalid/string/missing-quotes", () => {
@@ -7170,7 +7208,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "value"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: name = "value"');
   });
 
   test("invalid/string/multiline-bad-escape-01", () => {
@@ -7506,7 +7544,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "a"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: s = "a"');
   });
 
   test("invalid/string/no-open-02", () => {
@@ -7518,7 +7556,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "a"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: "a"');
   });
 
   test("invalid/string/no-open-03", () => {
@@ -7530,7 +7568,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "a"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: s = "a"');
   });
 
   test("invalid/string/no-open-04", () => {
@@ -7542,7 +7580,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "a"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: "a"');
   });
 
   test("invalid/string/no-open-05", () => {
@@ -7554,7 +7592,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "a"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: a = "a"');
   });
 
   test("invalid/string/no-open-06", () => {
@@ -7566,7 +7604,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "a"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: "a"');
   });
 
   test("invalid/string/no-open-07", () => {
@@ -7578,7 +7616,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "a"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: a = "a"');
   });
 
   test("invalid/string/no-open-08", () => {
@@ -7590,7 +7628,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: Strings must be quoted: "a"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: "a"');
   });
 
   test("invalid/string/text-after-string", () => {

--- a/test/js/bun/toml/toml-test-suite.test.ts
+++ b/test/js/bun/toml/toml-test-suite.test.ts
@@ -2721,7 +2721,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: "I"');
+    expect((err as SyntaxError).message).toBe(
+      "TOML Parse error: String values must be quoted; wrap the value in double quotes",
+    );
   });
 
   test("invalid/bool/almost-false-with-extra", () => {
@@ -2874,7 +2876,7 @@ describe("toml-test/invalid", () => {
     }
     expect(err).toBeInstanceOf(SyntaxError);
     expect((err as SyntaxError).message).toBe(
-      'TOML Parse error: String values must be quoted; write: mixed-case              = "valid"',
+      'TOML Parse error: String values must be quoted; write: mixed-case              = "valid   = False"',
     );
   });
 
@@ -3822,7 +3824,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: foo = "T"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: foo = "T."');
   });
 
   test("invalid/datetime/second-over", () => {
@@ -6084,7 +6086,7 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: a="b"');
+    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: a="b=1"');
   });
 
   test("invalid/key/without-value-01", () => {
@@ -7544,7 +7546,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: s = "a"');
+    expect((err as SyntaxError).message).toBe(
+      "TOML Parse error: String values must be quoted; wrap the value in double quotes",
+    );
   });
 
   test("invalid/string/no-open-02", () => {
@@ -7556,7 +7560,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: "a"');
+    expect((err as SyntaxError).message).toBe(
+      "TOML Parse error: String values must be quoted; wrap the value in double quotes",
+    );
   });
 
   test("invalid/string/no-open-03", () => {
@@ -7568,7 +7574,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: s = "a"');
+    expect((err as SyntaxError).message).toBe(
+      "TOML Parse error: String values must be quoted; wrap the value in double quotes",
+    );
   });
 
   test("invalid/string/no-open-04", () => {
@@ -7580,7 +7588,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: "a"');
+    expect((err as SyntaxError).message).toBe(
+      "TOML Parse error: String values must be quoted; wrap the value in double quotes",
+    );
   });
 
   test("invalid/string/no-open-05", () => {
@@ -7592,7 +7602,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: a = "a"');
+    expect((err as SyntaxError).message).toBe(
+      "TOML Parse error: String values must be quoted; wrap the value in double quotes",
+    );
   });
 
   test("invalid/string/no-open-06", () => {
@@ -7604,7 +7616,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: "a"');
+    expect((err as SyntaxError).message).toBe(
+      "TOML Parse error: String values must be quoted; wrap the value in double quotes",
+    );
   });
 
   test("invalid/string/no-open-07", () => {
@@ -7616,7 +7630,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: a = "a"');
+    expect((err as SyntaxError).message).toBe(
+      "TOML Parse error: String values must be quoted; wrap the value in double quotes",
+    );
   });
 
   test("invalid/string/no-open-08", () => {
@@ -7628,7 +7644,9 @@ describe("toml-test/invalid", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(SyntaxError);
-    expect((err as SyntaxError).message).toBe('TOML Parse error: String values must be quoted; write: "a"');
+    expect((err as SyntaxError).message).toBe(
+      "TOML Parse error: String values must be quoted; wrap the value in double quotes",
+    );
   });
 
   test("invalid/string/text-after-string", () => {

--- a/test/js/bun/toml/toml.test.ts
+++ b/test/js/bun/toml/toml.test.ts
@@ -551,6 +551,11 @@ describe("error contract", () => {
     expect(syntaxError(Buffer.alloc(70, "a").toString() + " = isolated").message).toBe(
       'TOML Parse error: String values must be quoted; write: "isolated"',
     );
+    // When the value itself exceeds the scan cap the suggestion is generic
+    // rather than a truncated quote.
+    expect(syntaxError("a = " + Buffer.alloc(70, "x").toString()).message).toBe(
+      "TOML Parse error: String values must be quoted; wrap the value in double quotes",
+    );
   });
 
   test("escape errors inside a drive-letter string name the Windows-path fix", () => {

--- a/test/js/bun/toml/toml.test.ts
+++ b/test/js/bun/toml/toml.test.ts
@@ -446,7 +446,7 @@ describe("robustness", () => {
     const path = Buffer.alloc(depth * 2 - 1, "a.").toString();
     expect(() => TOML.parse(path + " = 1")).toThrow(RangeError);
     expect(() => TOML.parse(`[${path}]`)).toThrow(RangeError);
-  });
+  }, 20_000);
 
   test("a very long string value round-trips", () => {
     const long = Buffer.alloc(1 << 20, "x").toString();

--- a/test/js/bun/toml/toml.test.ts
+++ b/test/js/bun/toml/toml.test.ts
@@ -503,13 +503,66 @@ describe("error contract", () => {
 
   test("unquoted string values name the fix", () => {
     // The old parser silently accepted bare words as strings; this is the
-    // most common spec violation in real-world bunfig.toml files.
-    expect(syntaxError("linker = isolated").message).toBe('TOML Parse error: Strings must be quoted: "isolated"');
-    expect(syntaxError("a = tru").message).toBe('TOML Parse error: Strings must be quoted: "tru"');
-    expect(syntaxError("a = nope").message).toBe('TOML Parse error: Strings must be quoted: "nope"');
+    // most common spec violation in real-world bunfig.toml files. The fix-it
+    // includes the `key = ` portion so it can be pasted verbatim.
+    expect(syntaxError("linker = isolated").message).toBe(
+      'TOML Parse error: String values must be quoted; write: linker = "isolated"',
+    );
+    expect(syntaxError("[install]\nlinker = isolated").message).toBe(
+      'TOML Parse error: String values must be quoted; write: linker = "isolated"',
+    );
+    expect(syntaxError("install.linker = isolated").message).toBe(
+      'TOML Parse error: String values must be quoted; write: install.linker = "isolated"',
+    );
+    expect(syntaxError('"my key" = isolated').message).toBe(
+      'TOML Parse error: String values must be quoted; write: "my key" = "isolated"',
+    );
+    expect(syntaxError("a = tru").message).toBe('TOML Parse error: String values must be quoted; write: a = "tru"');
+    expect(syntaxError("a = nope").message).toBe('TOML Parse error: String values must be quoted; write: a = "nope"');
     // Bare words that merely start with inf/nan are unquoted strings too.
-    expect(syntaxError("timeout = infinity").message).toBe('TOML Parse error: Strings must be quoted: "infinity"');
-    expect(syntaxError("unit = nanoseconds").message).toBe('TOML Parse error: Strings must be quoted: "nanoseconds"');
+    expect(syntaxError("timeout = infinity").message).toBe(
+      'TOML Parse error: String values must be quoted; write: timeout = "infinity"',
+    );
+    expect(syntaxError("unit = nanoseconds").message).toBe(
+      'TOML Parse error: String values must be quoted; write: unit = "nanoseconds"',
+    );
+    // Inside an array or inline table the `key = ` part is omitted.
+    expect(syntaxError("a = [isolated]").message).toBe(
+      'TOML Parse error: String values must be quoted; write: "isolated"',
+    );
+    expect(syntaxError("a = [1, isolated]").message).toBe(
+      'TOML Parse error: String values must be quoted; write: "isolated"',
+    );
+    expect(syntaxError("a = { b = isolated }").message).toBe(
+      'TOML Parse error: String values must be quoted; write: b = "isolated"',
+    );
+  });
+
+  test("escape errors inside a drive-letter string name the Windows-path fix", () => {
+    // `"C:\Users"` is an easy mistake to carry over from .npmrc; the
+    // spec-accurate "must be followed by 8 hex digits" message does not
+    // help a user who meant a path separator.
+    const hint =
+      "TOML Parse error: Backslash begins an escape sequence; for a Windows path, " +
+      "use a single-quoted string ('C:\\...') or double each backslash (\"C:\\\\...\")";
+    expect(syntaxError('cache = "C:\\Users\\bob"').message).toBe(hint);
+    expect(syntaxError('cache = "C:\\Program Files"').message).toBe(hint);
+    expect(syntaxError('cache = "C:\\xyz"').message).toBe(hint);
+    expect(syntaxError('cache = "C:\\users"').message).toBe(hint);
+    // The drive letter is echoed back so the example matches the input.
+    expect(syntaxError('cache = "d:\\my"').message).toBe(
+      "TOML Parse error: Backslash begins an escape sequence; for a Windows path, " +
+        "use a single-quoted string ('d:\\...') or double each backslash (\"d:\\\\...\")",
+    );
+    // A string that is not drive-letter-prefixed keeps the precise escape error.
+    expect(syntaxError('a = "foo\\zbar"').message).toBe("TOML Parse error: Invalid escape sequence: 'z'");
+    expect(syntaxError('a = "\\U12345"').message).toBe(
+      "TOML Parse error: A Unicode escape must be followed by exactly 8 hex digits",
+    );
+    // Multi-line strings are not path-shaped, so they keep the precise error too.
+    expect(syntaxError('a = """C:\\my"""').message).toBe("TOML Parse error: Invalid escape sequence: 'm'");
+    // The single-quoted form the hint recommends actually parses.
+    expect(TOML.parse("cache = 'C:\\Users\\bob'")).toEqual({ cache: "C:\\Users\\bob" });
   });
 
   test("common mistakes produce specific messages", () => {

--- a/test/js/bun/toml/toml.test.ts
+++ b/test/js/bun/toml/toml.test.ts
@@ -526,6 +526,17 @@ describe("error contract", () => {
     expect(syntaxError("unit = nanoseconds").message).toBe(
       'TOML Parse error: String values must be quoted; write: unit = "nanoseconds"',
     );
+    // The captured value runs to the end of the value expression (not just
+    // bare-key characters) so URLs and file names are quoted whole.
+    expect(syntaxError("registry = https://registry.npmjs.org/").message).toBe(
+      'TOML Parse error: String values must be quoted; write: registry = "https://registry.npmjs.org/"',
+    );
+    expect(syntaxError("preload = setup.ts").message).toBe(
+      'TOML Parse error: String values must be quoted; write: preload = "setup.ts"',
+    );
+    expect(syntaxError("a = foo bar  # c").message).toBe(
+      'TOML Parse error: String values must be quoted; write: a = "foo bar"',
+    );
     // Inside an array or inline table the `key = ` part is omitted.
     expect(syntaxError("a = [isolated]").message).toBe(
       'TOML Parse error: String values must be quoted; write: "isolated"',
@@ -551,11 +562,12 @@ describe("error contract", () => {
     expect(syntaxError(Buffer.alloc(70, "a").toString() + " = isolated").message).toBe(
       'TOML Parse error: String values must be quoted; write: "isolated"',
     );
-    // When the value itself exceeds the scan cap the suggestion is generic
-    // rather than a truncated quote.
-    expect(syntaxError("a = " + Buffer.alloc(70, "x").toString()).message).toBe(
-      "TOML Parse error: String values must be quoted; wrap the value in double quotes",
-    );
+    // Values that would need escaping to quote, or that exceed the scan cap,
+    // fall back to the generic instruction rather than a broken suggestion.
+    const generic = "TOML Parse error: String values must be quoted; wrap the value in double quotes";
+    expect(syntaxError("a = " + Buffer.alloc(70, "x").toString()).message).toBe(generic);
+    expect(syntaxError("a = it's").message).toBe(generic);
+    expect(syntaxError("a = has\\back").message).toBe(generic);
   });
 
   test("escape errors inside a drive-letter string name the Windows-path fix", () => {

--- a/test/js/bun/toml/toml.test.ts
+++ b/test/js/bun/toml/toml.test.ts
@@ -536,12 +536,19 @@ describe("error contract", () => {
     expect(syntaxError("a = { b = isolated }").message).toBe(
       'TOML Parse error: String values must be quoted; write: b = "isolated"',
     );
-    // A quoted key containing a stop byte would otherwise truncate mid-key;
-    // the prefix is dropped so the suggestion is never garbled.
+    // The prefix is dropped (never printed half-formed) when the backward
+    // scan did not provably reach its start: a stop byte inside a quoted
+    // key, an escape that defeats quote-parity, or the length cap.
     expect(syntaxError('"a,b" = isolated').message).toBe(
       'TOML Parse error: String values must be quoted; write: "isolated"',
     );
     expect(syntaxError("'a[b' = isolated").message).toBe(
+      'TOML Parse error: String values must be quoted; write: "isolated"',
+    );
+    expect(syntaxError('"a,\\"b" = isolated').message).toBe(
+      'TOML Parse error: String values must be quoted; write: "isolated"',
+    );
+    expect(syntaxError(Buffer.alloc(70, "a").toString() + " = isolated").message).toBe(
       'TOML Parse error: String values must be quoted; write: "isolated"',
     );
   });

--- a/test/js/bun/toml/toml.test.ts
+++ b/test/js/bun/toml/toml.test.ts
@@ -437,16 +437,18 @@ describe("robustness", () => {
     expect(cur).toEqual({ a: 1 });
   });
 
-  test("extremely deep dotted keys and headers throw instead of crashing", () => {
-    // Parsing these is iterative (every segment is processed before the limit
-    // can trip), so unlike OVERFLOW_DEPTH this depth is paid in full: it must
-    // stay small enough to be fast in debug builds while still overflowing
-    // the JS-conversion recursion at release frame sizes.
-    const depth = 250_000;
-    const path = Buffer.alloc(depth * 2 - 1, "a.").toString();
-    expect(() => TOML.parse(path + " = 1")).toThrow(RangeError);
-    expect(() => TOML.parse(`[${path}]`)).toThrow(RangeError);
-  }, 20_000);
+  // Parsing these is iterative (every segment is processed before the limit
+  // can trip), so unlike OVERFLOW_DEPTH this depth is paid in full: it must
+  // stay small enough to be fast in debug builds while still overflowing the
+  // JS-conversion recursion at release frame sizes. One parse per test so
+  // each stays under the default timeout.
+  const DEEP_DOTTED = Buffer.alloc(250_000 * 2 - 1, "a.").toString();
+  test("an extremely deep dotted key throws instead of crashing", () => {
+    expect(() => TOML.parse(DEEP_DOTTED + " = 1")).toThrow(RangeError);
+  });
+  test("an extremely deep dotted header throws instead of crashing", () => {
+    expect(() => TOML.parse(`[${DEEP_DOTTED}]`)).toThrow(RangeError);
+  });
 
   test("a very long string value round-trips", () => {
     const long = Buffer.alloc(1 << 20, "x").toString();
@@ -568,6 +570,7 @@ describe("error contract", () => {
     expect(syntaxError("a = " + Buffer.alloc(70, "x").toString()).message).toBe(generic);
     expect(syntaxError("a = it's").message).toBe(generic);
     expect(syntaxError("a = has\\back").message).toBe(generic);
+    expect(syntaxError("a = foo\x7Fbar").message).toBe(generic);
   });
 
   test("escape errors inside a drive-letter string name the Windows-path fix", () => {

--- a/test/js/bun/toml/toml.test.ts
+++ b/test/js/bun/toml/toml.test.ts
@@ -539,6 +539,9 @@ describe("error contract", () => {
     expect(syntaxError("a = foo bar  # c").message).toBe(
       'TOML Parse error: String values must be quoted; write: a = "foo bar"',
     );
+    expect(syntaxError("a = foo\t# c").message).toBe(
+      'TOML Parse error: String values must be quoted; write: a = "foo"',
+    );
     // Inside an array or inline table the `key = ` part is omitted.
     expect(syntaxError("a = [isolated]").message).toBe(
       'TOML Parse error: String values must be quoted; write: "isolated"',
@@ -571,6 +574,7 @@ describe("error contract", () => {
     expect(syntaxError("a = it's").message).toBe(generic);
     expect(syntaxError("a = has\\back").message).toBe(generic);
     expect(syntaxError("a = foo\x7Fbar").message).toBe(generic);
+    expect(syntaxError(Buffer.from("a = foo\x00bar")).message).toBe(generic);
   });
 
   test("escape errors inside a drive-letter string name the Windows-path fix", () => {

--- a/test/js/bun/toml/toml.test.ts
+++ b/test/js/bun/toml/toml.test.ts
@@ -536,6 +536,14 @@ describe("error contract", () => {
     expect(syntaxError("a = { b = isolated }").message).toBe(
       'TOML Parse error: String values must be quoted; write: b = "isolated"',
     );
+    // A quoted key containing a stop byte would otherwise truncate mid-key;
+    // the prefix is dropped so the suggestion is never garbled.
+    expect(syntaxError('"a,b" = isolated').message).toBe(
+      'TOML Parse error: String values must be quoted; write: "isolated"',
+    );
+    expect(syntaxError("'a[b' = isolated").message).toBe(
+      'TOML Parse error: String values must be quoted; write: "isolated"',
+    );
   });
 
   test("escape errors inside a drive-letter string name the Windows-path fix", () => {


### PR DESCRIPTION
## What this changes

Two diagnostic-only improvements to the TOML parser (`src/parsers/toml.rs`). Parsing behavior is unchanged; only the error message text is more specific in two cases that real-world `bunfig.toml` files hit.

### Unquoted string values

The #32953 rewrite correctly rejects bare-word values (`linker = isolated`), which the previous parser silently accepted. That error now captures the whole value expression (up to the end of the line / comment / `]` / `}` / `,`) and scans back to the start of `key = ` so the suggestion is a drop-in replacement:

```
- error: Strings must be quoted: "isolated"
+ error: String values must be quoted; write: linker = "isolated"
+ error: String values must be quoted; write: registry = "https://registry.npmjs.org/"
+ error: String values must be quoted; write: preload = "setup.ts"
```

The `write:` form is what `Bun.TOML.parse` and `.toml` imports see. `bunfig.toml` parsing runs with redaction on and gets the generic `String values must be quoted; wrap the value in double quotes` instead (no user content in the message text), which is still clearer than the old `Strings must be quoted`; the source line and caret in the bunfig error output already point at the value:

```
2 | linker = isolated
             ^
error: String values must be quoted; wrap the value in double quotes
```

The suggestion also falls back to that generic form when it cannot be a clean paste: value >64 bytes, value containing `"` / `'` / `\` / a control character, a stop byte inside a quoted key, or a key path longer than 64 bytes. Inside an array (no `key = ` immediately before) the `key = ` part is omitted.

### Windows paths in basic strings

A basic string that starts with a drive letter (`"C:…"`) and hits a bad escape now names the Windows-path fix instead of the escape rule that was violated:

```
cache = "C:\Users\bob"
- error: A Unicode escape must be followed by exactly 8 hex digits
+ error: Backslash begins an escape sequence; for a Windows path, use a
+        single-quoted string ('C:\...') or double each backslash ("C:\\...")
```

The hint covers unknown escapes (`\P`) and short `\x`/`\u`/`\U` escapes (`\Users`, `\xyz`). Under redaction (bunfig) the hint omits the drive-letter example but still names the fix. Multi-line basic strings and strings without a drive-letter prefix keep the precise escape error. The single-quoted form the hint recommends parses today and is asserted in the new test.

## Why

These are the two most likely ways a previously-accepted `bunfig.toml` becomes a startup error after #32953 (the unquoted-value pattern showed up in about 1% of real-world bunfigs sampled for that PR). Naming the fix directly turns a confusing spec citation into a one-edit repair.

## Tests

- `test/js/bun/toml/toml.test.ts`: the unquoted-value coverage now includes key-after-header / dotted key / quoted key / inline table / array element, the URL and file-name shapes, and every fallback case (long key, long value, stop byte in quoted key, escape in quoted key, quote / backslash / control character / DEL / NUL in value, tab before a comment). A new test covers the Windows-path hint and its negative cases. The deep-dotted-keys stress test is split into two tests (keyval / header) so each stays under the default timeout under debug+ASAN.
- `test/js/bun/toml/toml-test-suite.test.ts`: regenerated (`bun bd test/js/bun/toml/generate_toml_test_suite.ts`); only the exact-message assertions for the affected rejection cases changed.
