### PR TITLE
Fix use-after-free in us_socket_group_close_all_ex when a close handler closes a sibling

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -139,16 +139,25 @@ void us_socket_group_close_all_ex(struct us_socket_group_t *group, int also_list
     if (group->low_prio_count) {
         /* Don't pre-unlink — leave low_prio_state==1 so us_socket_close takes
          * its low-prio branch (which knows the socket is NOT in head_sockets
-         * and decrements low_prio_count itself). The cached `next` survives
-         * the close because that branch rewires the list before dispatch. */
+         * and decrements low_prio_count itself). That branch unlinks q before
+         * dispatching the JS close/handshake handler, but the handler may
+         * close any OTHER parked socket (whose close_raw then repoints its
+         * `next` at the closed-socket list), so no pointer into the queue
+         * survives a dispatch: re-scan from the head after every close. The
+         * group->iterator trick from the walk above doesn't apply here — the
+         * low-prio close branch never touches it. `budget` keeps a deferred
+         * TLS close (never observed for parked mid-handshake sockets; the
+         * assert below encodes that) from turning the re-scan into a spin. */
         struct us_internal_loop_data_t *ld = &group->loop->data;
-        struct us_socket_t *q = ld->low_prio_head;
-        while (q) {
-            struct us_socket_t *next = q->next;
-            if (q->group == group) {
-                us_socket_close(q, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, 0);
+        for (uint16_t budget = group->low_prio_count; budget && group->low_prio_count; budget--) {
+            struct us_socket_t *q = ld->low_prio_head;
+            while (q && q->group != group) {
+                q = q->next;
             }
-            q = next;
+            if (!q) {
+                break;
+            }
+            us_socket_close(q, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, 0);
         }
         US_ASSERT(group->low_prio_count == 0);
     }

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -94,9 +94,17 @@ void us_socket_group_close_all_ex(struct us_socket_group_t *group, int also_list
         c = nextC;
     }
 
-    struct us_socket_t *s = group->head_sockets;
-    while (s) {
-        struct us_socket_t *nextS = s->next;
+    /* Drive the walk off group->iterator rather than a cached s->next: each
+     * us_socket_close dispatches a JS close/handshake handler that may close a
+     * *sibling*, and the sibling is what a plain cached `next` would point at.
+     * us_internal_socket_group_unlink_socket advances group->iterator past any
+     * socket it unlinks, so parking the next pointer there lets a handler free
+     * it without leaving us a dangling step (same pattern as the timeout sweep
+     * in loop.c). */
+    group->iterator = group->head_sockets;
+    while (group->iterator) {
+        struct us_socket_t *s = group->iterator;
+        group->iterator = s->next;
         if (us_internal_poll_type(&s->p) & POLL_TYPE_SEMI_SOCKET) {
             /* In-flight connect — close_raw skips dispatch for SEMI_SOCKET
              * (on_close without on_open is wrong), so the Zig wrapper's
@@ -112,8 +120,8 @@ void us_socket_group_close_all_ex(struct us_socket_group_t *group, int also_list
         } else {
             us_socket_close(s, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, 0);
         }
-        s = nextS;
     }
+    group->iterator = 0;
 
     /* TLS sockets may have *deferred* the close above: us_internal_ssl_close
      * with code==0 sends close_notify and, on WANT_READ, leaves the socket

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -145,7 +145,7 @@ test.skipIf(skip)(
 // The explicit timeout matches the low-prio fixture above: this spawns child
 // Bun processes and drives hundreds of concurrent TLS handshakes across
 // several rounds, which runs long on a debug+ASAN build.
-test.skipIf(isWindows)(
+test(
   "TLS server.stop(true): a close handler that closes a sibling does not crash the teardown walk",
   async () => {
     await using proc = Bun.spawn({

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -145,25 +145,21 @@ test.skipIf(skip)(
 // The explicit timeout matches the low-prio fixture above: this spawns child
 // Bun processes and drives hundreds of concurrent TLS handshakes across
 // several rounds, which runs long on a debug+ASAN build.
-test(
-  "TLS server.stop(true): a close handler that closes a sibling does not crash the teardown walk",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "tls-close-all-sibling-fixture.ts")],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({
-      stdout: stdout.trim(),
-      signalCode: proc.signalCode,
-      exitCode,
-      stderrTail: exitCode === 0 ? "" : stderr.slice(-2000),
-    }).toEqual({ stdout: "OK", signalCode: null, exitCode: 0, stderrTail: "" });
-  },
-  180_000,
-);
+test("TLS server.stop(true): a close handler that closes a sibling does not crash the teardown walk", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "tls-close-all-sibling-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({
+    stdout: stdout.trim(),
+    signalCode: proc.signalCode,
+    exitCode,
+    stderrTail: exitCode === 0 ? "" : stderr.slice(-2000),
+  }).toEqual({ stdout: "OK", signalCode: null, exitCode: 0, stderrTail: "" });
+}, 180_000);
 
 // An injected send() errno that is neither would-block/transient
 // (EAGAIN/ENOBUFS/ENOMEM) nor a known peer-gone error (EPIPE/ECONNRESET/...)

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -134,6 +134,37 @@ test.skipIf(skip)(
   180_000,
 );
 
+// us_socket_group_close_all_ex walks group->head_sockets during
+// server.stop(true), closing each connection. Closing a socket dispatches its
+// JS close/handshake handler; if that handler closes a *sibling* connection,
+// the walk used to advance onto the freed sibling it had cached as `next` and
+// dereference its vtable (`panic: us_socket_t with kind=invalid`, a
+// use-after-free). The fixture reproduces it with a burst of TLS connections
+// torn down mid-handshake while the handlers close siblings.
+//
+// The explicit timeout matches the low-prio fixture above: this spawns child
+// Bun processes and drives hundreds of concurrent TLS handshakes across
+// several rounds, which runs long on a debug+ASAN build.
+test.skipIf(isWindows)(
+  "TLS server.stop(true): a close handler that closes a sibling does not crash the teardown walk",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "tls-close-all-sibling-fixture.ts")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({
+      stdout: stdout.trim(),
+      signalCode: proc.signalCode,
+      exitCode,
+      stderrTail: exitCode === 0 ? "" : stderr.slice(-2000),
+    }).toEqual({ stdout: "OK", signalCode: null, exitCode: 0, stderrTail: "" });
+  },
+  180_000,
+);
+
 // An injected send() errno that is neither would-block/transient
 // (EAGAIN/ENOBUFS/ENOMEM) nor a known peer-gone error (EPIPE/ECONNRESET/...)
 // exercises the bounded unclassified-errno retry in

--- a/test/js/bun/net/tls-close-all-sibling-fixture.ts
+++ b/test/js/bun/net/tls-close-all-sibling-fixture.ts
@@ -117,29 +117,41 @@ async function round() {
     },
   });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", clientSrc],
-    env: { ...bunEnv, REPRO_PORT: String(server.port), REPRO_N: String(N), REPRO_HELLO: clientHello.toString("hex") },
-    stdout: "pipe",
-    stderr: "ignore",
-  });
+  // The finally keeps a failed round (child crashed before BURST, spawn threw)
+  // from leaking the listener and hanging the fixture until the test timeout;
+  // stop(true) on an already-stopped listener is a no-op.
+  try {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", clientSrc],
+      env: { ...bunEnv, REPRO_PORT: String(server.port), REPRO_N: String(N), REPRO_HELLO: clientHello.toString("hex") },
+      stdout: "pipe",
+      stderr: "ignore",
+    });
 
-  const reader = proc.stdout.getReader();
-  const dec = new TextDecoder();
-  let buf = "";
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buf += dec.decode(value);
-    if (buf.includes("BURST")) {
-      tearing = true;
-      server.stop(true);
-      break;
+    const reader = proc.stdout.getReader();
+    const dec = new TextDecoder();
+    let buf = "";
+    let sawBurst = false;
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += dec.decode(value);
+      if (buf.includes("BURST")) {
+        // The stop must land HERE, while the burst holds connections
+        // mid-handshake, or the round doesn't exercise the teardown walk.
+        sawBurst = true;
+        tearing = true;
+        server.stop(true);
+        break;
+      }
     }
+    reader.cancel().catch(() => {});
+    proc.kill();
+    await proc.exited;
+    if (!sawBurst) throw new Error("flood child exited before printing BURST");
+  } finally {
+    server.stop(true);
   }
-  reader.cancel().catch(() => {});
-  proc.kill();
-  await proc.exited;
 }
 
 for (let i = 0; i < ROUNDS; i++) {

--- a/test/js/bun/net/tls-close-all-sibling-fixture.ts
+++ b/test/js/bun/net/tls-close-all-sibling-fixture.ts
@@ -1,0 +1,149 @@
+// Regression fixture for the TLS `server.stop(true)` sibling-close
+// use-after-free (issue #36459).
+//
+// us_socket_group_close_all_ex walks group->head_sockets to close every
+// connection during teardown. It used to cache `next = s->next` and then call
+// us_socket_close(s), which dispatches the JS close/handshake handler. If that
+// handler closes a *sibling* connection (the one cached as `next`), the walk
+// then advanced onto freed memory. With a burst of a few hundred TLS
+// connections mid-handshake (overflowing the 5-per-tick handshake budget) the
+// crash is reliable: the event loop dispatches through a freed socket's vtable
+// and aborts with `panic: us_socket_t with kind=invalid`.
+//
+// This fixture is the server: it closes a sibling from both the handshake and
+// close handlers, then floods itself from a CHILD process and tears down with
+// server.stop(true) while connections are still mid-handshake.
+import net from "node:net";
+import tls from "node:tls";
+import { tls as certs, bunEnv, bunExe } from "harness";
+
+// Capture one real TLS 1.2 ClientHello record so raw net clients can replay it
+// without doing a full handshake. TLS 1.2 keeps the server waiting for the
+// client's second flight, so the accepted socket stays mid-handshake.
+async function captureClientHello(): Promise<Buffer> {
+  const { promise, resolve, reject } = Promise.withResolvers<Buffer>();
+  const srv = net.createServer(sock => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    sock.on("error", reject);
+    sock.on("close", () => reject(new Error("socket closed before a full ClientHello record arrived")));
+    sock.on("data", d => {
+      chunks.push(d);
+      total += d.length;
+      const buf = Buffer.concat(chunks, total);
+      if (buf.length < 5) return;
+      const recordLength = 5 + buf.readUInt16BE(3);
+      if (buf.length < recordLength) return;
+      sock.removeAllListeners("close");
+      sock.destroy();
+      resolve(buf.subarray(0, recordLength));
+    });
+  });
+  srv.on("error", reject);
+  await new Promise<void>((r, rej) => {
+    srv.once("error", rej);
+    srv.listen(0, "127.0.0.1", r);
+  });
+  const port = (srv.address() as net.AddressInfo).port;
+  let c: tls.TLSSocket | undefined;
+  try {
+    c = tls.connect({ port, host: "127.0.0.1", maxVersion: "TLSv1.2", minVersion: "TLSv1.2", rejectUnauthorized: false });
+    c.on("error", reject);
+    c.on("close", () => reject(new Error("tls.connect closed before the ClientHello was captured")));
+    return await promise;
+  } finally {
+    c?.destroy();
+    await new Promise<void>(r => srv.close(() => r()));
+  }
+}
+
+const clientHello = await captureClientHello();
+const N = Number(process.env.REPRO_N || 240);
+const ROUNDS = Number(process.env.REPRO_ROUNDS || 3);
+
+// Child floods `N` raw TLS ClientHellos, staggered so they sit mid-handshake,
+// then fires a one-byte burst at all of them in a single tick and prints BURST.
+const clientSrc = `
+const net = require("node:net");
+const port = Number(process.env.REPRO_PORT);
+const N = Number(process.env.REPRO_N);
+const hello = Buffer.from(process.env.REPRO_HELLO, "hex");
+const socks = [];
+for (let i = 0; i < N; i++) {
+  const c = net.connect(port, "127.0.0.1");
+  c.setNoDelay(true);
+  c.on("error", () => {});
+  socks.push(c);
+  c.on("connect", () => setTimeout(() => { try { c.write(hello); } catch {} }, 30 + Math.floor(i / 4) * 40));
+}
+setTimeout(() => {
+  for (const c of socks) if (!c.destroyed) { try { c.write(Buffer.from([0])); } catch {} }
+  process.stdout.write("BURST\\n");
+}, 30 + Math.ceil(N / 4) * 40 + 300);
+setTimeout(() => process.exit(0), 60000);
+`;
+
+async function round() {
+  const socks: any[] = [];
+  let tearing = false;
+  function closeSibling(self: any) {
+    if (!tearing) return;
+    const i = socks.indexOf(self);
+    if (i < 0) return;
+    const other = socks[(i + (socks.length >> 1)) % socks.length];
+    if (other && other !== self) {
+      try {
+        other.end();
+      } catch {}
+    }
+  }
+
+  const server = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    tls: { key: certs.key, cert: certs.cert },
+    socket: {
+      open(s) {
+        socks.push(s);
+      },
+      handshake(s) {
+        closeSibling(s);
+      },
+      data() {},
+      close(s) {
+        closeSibling(s);
+      },
+      error() {},
+    },
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", clientSrc],
+    env: { ...bunEnv, REPRO_PORT: String(server.port), REPRO_N: String(N), REPRO_HELLO: clientHello.toString("hex") },
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+
+  const reader = proc.stdout.getReader();
+  const dec = new TextDecoder();
+  let buf = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += dec.decode(value);
+    if (buf.includes("BURST")) {
+      tearing = true;
+      server.stop(true);
+      break;
+    }
+  }
+  reader.cancel().catch(() => {});
+  proc.kill();
+  await proc.exited;
+}
+
+for (let i = 0; i < ROUNDS; i++) {
+  await round();
+  Bun.gc(true);
+}
+console.log("OK");


### PR DESCRIPTION
Fixes #36459.

### Repro

A TLS `Bun.listen`/`Bun.serve` whose `close`/`handshake` handler closes another connection, torn down with `server.stop(true)` while a burst of connections is still mid-handshake, aborts with:

```
panic: us_socket_t with kind=invalid
  us_dispatch_connect_error     src/runtime/socket/uws_dispatch.rs
  us_socket_group_close_all_ex  packages/bun-usockets/src/context.c
```

### Cause

`us_socket_group_close_all_ex` walks `group->head_sockets` during teardown:

```c
struct us_socket_t *s = group->head_sockets;
while (s) {
    struct us_socket_t *nextS = s->next;            // cached
    ...
    us_socket_close(s, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, 0); // dispatches JS
    s = nextS;                                      // may be freed
}
```

`us_socket_close(s)` dispatches the JS `close`/`handshake` handler. When that handler closes a *sibling* connection, the sibling is the socket cached in `nextS`; the loop then advances onto freed memory and dispatches through a freed vtable, which the `kind` guard turns into the panic. A burst of a few hundred mid-handshake TLS connections (overflowing the 5-per-tick handshake budget) plus a sibling-closing handler are both required.

### Fix

Drive the walk off `group->iterator` instead of a cached `next`. `us_internal_socket_group_unlink_socket` already advances `group->iterator` past any socket it unlinks, so a handler that frees the next socket leaves the iterator pointing at a live entry. This is the same pattern the timeout sweep in `loop.c` uses for list mutation during dispatch.

### Verification

`test/js/bun/net/tls-close-all-sibling-fixture.ts` floods a TLS server with connections torn down mid-handshake while its handlers close siblings, then `server.stop(true)`. Added to `socket-syscall-fault.test.ts`.

- Without the fix (rebuilt with `packages/` reverted): aborts during `Listener.do_stop` teardown.
- With the fix: exits clean (`OK`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket-syscall-fault.test.ts

<!-- robobun:evidence:end -->