### PR TITLE
docs(jsx): note that tsconfig "react-jsx" now selects the production automatic runtime

### DIFF
--- a/docs/runtime/jsx.mdx
+++ b/docs/runtime/jsx.mdx
@@ -38,6 +38,16 @@ How JSX constructs are transformed into vanilla JavaScript internally. The follo
 | `json<br/>{<br/>  "jsx": "react-jsxdev"<br/>}<br/>` | `tsx<br/>import { jsxDEV } from "react/jsx-dev-runtime";<br/>jsxDEV(<br/>  "Box",<br/>  { width: 5, children: "Hello" },<br/>  undefined,<br/>  false,<br/>  undefined,<br/>  this,<br/>);<br/>`<br/><br/>The `jsxDEV` variable name is a React convention. The `DEV` suffix marks code intended for development. The development version of React is slower and includes additional validity checks & debugging tools. |
 | `json<br/>{<br/>  "jsx": "preserve"<br/>}<br/>`     | `tsx<br/>// JSX is not transpiled<br/>// "preserve" is not supported by Bun currently<br/><Box width={5}>Hello</Box><br/>`                                                                                                                                                                                                                                                                                              |
 
+<Note>
+  `"react-jsx"` selects the production automatic runtime (`jsx`/`jsxs` from `<source>/jsx-runtime`) and `"react-jsxdev"`
+  selects the development runtime (`jsxDEV` from `<source>/jsx-dev-runtime`), matching TypeScript and esbuild. If you
+  rely on the extra debug information `jsxDEV` provides (component source locations for React DevTools, key warnings),
+  use `"react-jsxdev"` during development.
+
+Prior to Bun 1.4, `"react-jsx"` behaved like `"react-jsxdev"` and emitted the development runtime.
+
+</Note>
+
 ### [`jsxFactory`](https://www.typescriptlang.org/tsconfig#jsxFactory)
 
 <Note>Only applicable when `jsx` is `react`.</Note>

--- a/docs/runtime/jsx.mdx
+++ b/docs/runtime/jsx.mdx
@@ -41,8 +41,8 @@ How JSX constructs are transformed into vanilla JavaScript internally. The follo
 <Note>
   `"react-jsx"` selects the production automatic runtime (`jsx`/`jsxs` from `<source>/jsx-runtime`) and `"react-jsxdev"`
   selects the development runtime (`jsxDEV` from `<source>/jsx-dev-runtime`), matching TypeScript and esbuild. If you
-  rely on the extra debug information `jsxDEV` provides (component source locations for React DevTools, key warnings),
-  use `"react-jsxdev"` during development.
+  rely on React's development-mode checks that `jsxDEV` enables (for example, missing `key` warnings), use
+  `"react-jsxdev"` during development.
 
 Prior to Bun 1.4, `"react-jsx"` behaved like `"react-jsxdev"` and emitted the development runtime.
 

--- a/docs/runtime/jsx.mdx
+++ b/docs/runtime/jsx.mdx
@@ -40,9 +40,8 @@ How JSX constructs are transformed into vanilla JavaScript internally. The follo
 
 <Note>
   `"react-jsx"` selects the production automatic runtime (`jsx`/`jsxs` from `<source>/jsx-runtime`) and `"react-jsxdev"`
-  selects the development runtime (`jsxDEV` from `<source>/jsx-dev-runtime`), matching TypeScript and esbuild. If you
-  rely on React's development-mode checks that `jsxDEV` enables (for example, missing `key` warnings), use
-  `"react-jsxdev"` during development.
+  selects the development runtime (`jsxDEV` from `<source>/jsx-dev-runtime`), matching TypeScript and esbuild. Use
+  `"react-jsxdev"` during development if you want the `jsxDEV` entry point.
 
 Prior to Bun 1.4, `"react-jsx"` behaved like `"react-jsxdev"` and emitted the development runtime.
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2392,7 +2392,7 @@ declare module "bun" {
        *
        * - `"react"`: classic runtime. Emits `React.createElement(...)` (or the configured {@link jsxFactory}).
        * - `"react-jsx"`: automatic runtime, production. Emits `jsx`/`jsxs` imported from `<jsxImportSource>/jsx-runtime`.
-       * - `"react-jsxdev"`: automatic runtime, development. Emits `jsxDEV` imported from `<jsxImportSource>/jsx-dev-runtime`, including source location and `__self` for React DevTools.
+       * - `"react-jsxdev"`: automatic runtime, development. Emits `jsxDEV` imported from `<jsxImportSource>/jsx-dev-runtime` with the extra arguments React uses for development-mode checks.
        * - `"preserve"`: not supported yet; currently falls back to the automatic runtime.
        *
        * Prior to Bun 1.4, `"react-jsx"` emitted the development runtime. It now matches TypeScript and esbuild.
@@ -2941,8 +2941,8 @@ declare module "bun" {
        */
       sideEffects?: boolean;
       /**
-       * Use the development automatic runtime: import `jsxDEV` from `<importSource>/jsx-dev-runtime` and
-       * pass source location / `__self` for React DevTools. When `false`, import `jsx`/`jsxs` from
+       * Use the development automatic runtime: import `jsxDEV` from `<importSource>/jsx-dev-runtime` with the
+       * extra arguments React uses for development-mode checks. When `false`, import `jsx`/`jsxs` from
        * `<importSource>/jsx-runtime`. Only used when `runtime` is `"automatic"`.
        *
        * When not set, derived from `NODE_ENV` and tsconfig `compilerOptions.jsx`.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2909,7 +2909,8 @@ declare module "bun" {
      */
     jsx?: {
       /**
-       * - `"automatic"`: auto-import `jsx`/`jsxs` (or `jsxDEV`) from `<importSource>/jsx-runtime`.
+       * - `"automatic"`: auto-import `jsx`/`jsxs` from `<importSource>/jsx-runtime`, or `jsxDEV` from
+       *   `<importSource>/jsx-dev-runtime` when {@link development} is `true`.
        * - `"classic"`: emit `factory(type, props, ...children)` with no auto-import.
        *
        * @default "automatic"
@@ -2935,7 +2936,8 @@ declare module "bun" {
        */
       fragment?: string;
       /**
-       * Treat the auto-imported JSX runtime module as having side effects, disabling tree-shaking of the import.
+       * Treat JSX elements as having side effects. Disables the pure annotation on each emitted
+       * `jsx(...)` / `createElement(...)` call so unused JSX elements are not removed.
        *
        * @default false
        */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2392,7 +2392,7 @@ declare module "bun" {
        *
        * - `"react"`: classic runtime. Emits `React.createElement(...)` (or the configured {@link jsxFactory}).
        * - `"react-jsx"`: automatic runtime, production. Emits `jsx`/`jsxs` imported from `<jsxImportSource>/jsx-runtime`.
-       * - `"react-jsxdev"`: automatic runtime, development. Emits `jsxDEV` imported from `<jsxImportSource>/jsx-dev-runtime` with the extra arguments React uses for development-mode checks.
+       * - `"react-jsxdev"`: automatic runtime, development. Emits `jsxDEV` imported from `<jsxImportSource>/jsx-dev-runtime`.
        * - `"preserve"`: not supported yet; currently falls back to the automatic runtime.
        *
        * Prior to Bun 1.4, `"react-jsx"` emitted the development runtime. It now matches TypeScript and esbuild.
@@ -2943,11 +2943,8 @@ declare module "bun" {
        */
       sideEffects?: boolean;
       /**
-       * Use the development automatic runtime: import `jsxDEV` from `<importSource>/jsx-dev-runtime` with the
-       * extra arguments React uses for development-mode checks. When `false`, import `jsx`/`jsxs` from
-       * `<importSource>/jsx-runtime`. Only used when `runtime` is `"automatic"`.
-       *
-       * When not set, derived from `NODE_ENV` and tsconfig `compilerOptions.jsx`.
+       * Use the development automatic runtime: import `jsxDEV` from `<importSource>/jsx-dev-runtime`. When `false`,
+       * import `jsx`/`jsxs` from `<importSource>/jsx-runtime`. Only used when `runtime` is `"automatic"`.
        */
       development?: boolean;
     };

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2387,7 +2387,16 @@ declare module "bun" {
     compilerOptions?: {
       paths?: Record<string, string[]>;
       baseUrl?: string;
-      /** "preserve" is not supported yet */
+      /**
+       * How JSX is transformed.
+       *
+       * - `"react"`: classic runtime. Emits `React.createElement(...)` (or the configured {@link jsxFactory}).
+       * - `"react-jsx"`: automatic runtime, production. Emits `jsx`/`jsxs` imported from `<jsxImportSource>/jsx-runtime`.
+       * - `"react-jsxdev"`: automatic runtime, development. Emits `jsxDEV` imported from `<jsxImportSource>/jsx-dev-runtime`, including source location and `__self` for React DevTools.
+       * - `"preserve"`: not supported yet; currently falls back to the automatic runtime.
+       *
+       * Prior to Bun 1.4, `"react-jsx"` emitted the development runtime. It now matches TypeScript and esbuild.
+       */
       jsx?: "preserve" | "react" | "react-jsx" | "react-jsxdev";
       jsxFactory?: string;
       jsxFragmentFactory?: string;
@@ -2899,11 +2908,45 @@ declare module "bun" {
      * JSX configuration options
      */
     jsx?: {
+      /**
+       * - `"automatic"`: auto-import `jsx`/`jsxs` (or `jsxDEV`) from `<importSource>/jsx-runtime`.
+       * - `"classic"`: emit `factory(type, props, ...children)` with no auto-import.
+       *
+       * @default "automatic"
+       */
       runtime?: "automatic" | "classic";
+      /**
+       * Package the automatic runtime imports from. Bun appends `/jsx-runtime` or `/jsx-dev-runtime`.
+       * Only used when `runtime` is `"automatic"`.
+       *
+       * @default "react"
+       */
       importSource?: string;
+      /**
+       * Function called for each JSX element when `runtime` is `"classic"`.
+       *
+       * @default "React.createElement"
+       */
       factory?: string;
+      /**
+       * Value used for JSX fragments (`<>...</>`) when `runtime` is `"classic"`.
+       *
+       * @default "React.Fragment"
+       */
       fragment?: string;
+      /**
+       * Treat the auto-imported JSX runtime module as having side effects, disabling tree-shaking of the import.
+       *
+       * @default false
+       */
       sideEffects?: boolean;
+      /**
+       * Use the development automatic runtime: import `jsxDEV` from `<importSource>/jsx-dev-runtime` and
+       * pass source location / `__self` for React DevTools. When `false`, import `jsx`/`jsxs` from
+       * `<importSource>/jsx-runtime`. Only used when `runtime` is `"automatic"`.
+       *
+       * When not set, derived from `NODE_ENV` and tsconfig `compilerOptions.jsx`.
+       */
       development?: boolean;
     };
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2387,16 +2387,7 @@ declare module "bun" {
     compilerOptions?: {
       paths?: Record<string, string[]>;
       baseUrl?: string;
-      /**
-       * How JSX is transformed.
-       *
-       * - `"react"`: classic runtime. Emits `React.createElement(...)` (or the configured {@link jsxFactory}).
-       * - `"react-jsx"`: automatic runtime, production. Emits `jsx`/`jsxs` imported from `<jsxImportSource>/jsx-runtime`.
-       * - `"react-jsxdev"`: automatic runtime, development. Emits `jsxDEV` imported from `<jsxImportSource>/jsx-dev-runtime`.
-       * - `"preserve"`: not supported yet; currently falls back to the automatic runtime.
-       *
-       * Prior to Bun 1.4, `"react-jsx"` emitted the development runtime. It now matches TypeScript and esbuild.
-       */
+      /** "preserve" is not supported yet */
       jsx?: "preserve" | "react" | "react-jsx" | "react-jsxdev";
       jsxFactory?: string;
       jsxFragmentFactory?: string;
@@ -2908,44 +2899,11 @@ declare module "bun" {
      * JSX configuration options
      */
     jsx?: {
-      /**
-       * - `"automatic"`: auto-import `jsx`/`jsxs` from `<importSource>/jsx-runtime`, or `jsxDEV` from
-       *   `<importSource>/jsx-dev-runtime` when {@link development} is `true`.
-       * - `"classic"`: emit `factory(type, props, ...children)` with no auto-import.
-       *
-       * @default "automatic"
-       */
       runtime?: "automatic" | "classic";
-      /**
-       * Package the automatic runtime imports from. Bun appends `/jsx-runtime` or `/jsx-dev-runtime`.
-       * Only used when `runtime` is `"automatic"`.
-       *
-       * @default "react"
-       */
       importSource?: string;
-      /**
-       * Function called for each JSX element when `runtime` is `"classic"`.
-       *
-       * @default "React.createElement"
-       */
       factory?: string;
-      /**
-       * Value used for JSX fragments (`<>...</>`) when `runtime` is `"classic"`.
-       *
-       * @default "React.Fragment"
-       */
       fragment?: string;
-      /**
-       * Treat JSX elements as having side effects. Disables the pure annotation on each emitted
-       * `jsx(...)` / `createElement(...)` call so unused JSX elements are not removed.
-       *
-       * @default false
-       */
       sideEffects?: boolean;
-      /**
-       * Use the development automatic runtime: import `jsxDEV` from `<importSource>/jsx-dev-runtime`. When `false`,
-       * import `jsx`/`jsxs` from `<importSource>/jsx-runtime`. Only used when `runtime` is `"automatic"`.
-       */
       development?: boolean;
     };
 


### PR DESCRIPTION
#34422 made tsconfig `"jsx": "react-jsx"` select the production automatic runtime (`jsx`/`jsxs` from `<source>/jsx-runtime`) instead of the development one (`jsxDEV` from `<source>/jsx-dev-runtime`), matching TypeScript and esbuild. The JSX docs page already showed `react-jsx` -> `jsx-runtime` in its table, so the table itself is correct, but nothing on the page said that this is what distinguishes the two values or that it changed.

### Why

The output for the most common React tsconfig value changed. Projects upgrading from a Bun that always emitted `jsxDEV` will see the import target switch from `jsx-dev-runtime` to `jsx-runtime`, and the reason is not discoverable from the docs. A short note makes it discoverable without changing any runtime behavior.

### Change

`docs/runtime/jsx.mdx`: add a `<Note>` under the `jsx` table that spells out `"react-jsx"` = production / `"react-jsxdev"` = development (matching tsc/esbuild), points at `"react-jsxdev"` for the `jsxDEV` entry point, and records the pre-1.4 behavior.

A build-time warning was considered and rejected: tsc, esbuild and Babel do not warn, `"react-jsx"` is the value `tsc --init` writes, and the new output is what every other tool already produces.

### Verification

Docs only; no `src/` or `packages/` change. The claims were verified against a debug build at c08f665:

```
bun-debug run m.jsx, tsconfig "react-jsx",    NODE_ENV unset  -> prod jsx
bun-debug run m.jsx, tsconfig "react-jsxdev", NODE_ENV unset  -> dev jsxDEV
bun-debug build m.jsx, tsconfig "react-jsx",  NODE_ENV unset  -> shim/jsx-runtime
```

### Related

- #33709 adds a note to the same page describing the pre-#34422 behavior; left a comment there.
- #36269 is fixing the `NODE_ENV` / `--jsx-*` precedence in `bun build`; this PR deliberately does not document the override precedence while that is in flight.
- Per-field JSDoc for `TSConfig.compilerOptions.jsx` and `BuildConfig.jsx` was drafted and reviewed on this branch (bf5c795) but dropped: JSDoc comments have no fail-before-observable effect. Happy to restore in a follow-up if wanted.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->