### PR TITLE
bun run: let env NODE_ENV=development override tsconfig jsx dev/prod

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -542,6 +542,10 @@ impl<'a> Transpiler<'a> {
 
         let env_loader = self.env_mut();
         let mut is_production = env_loader.is_production();
+        // `bun run` uses `LoadAllWithoutInlining`, which skips injecting env
+        // `NODE_ENV` into `define.dots` — so the define-map check below never
+        // sees it. Sample development here too so it is symmetric with production.
+        let mut is_development = env_loader.get_node_env() == Some(b"development");
 
         // `load_defines` injects a default `process.env.NODE_ENV`; sample the
         // explicit sources first so that default isn't mistaken for user intent
@@ -572,15 +576,16 @@ impl<'a> Transpiler<'a> {
         // inside the `&mut self` scope without `unsafe`.
         self.options.load_defines(self.arena, Some(env_loader))?;
 
-        let mut is_development = false;
         if had_explicit_node_env {
             if let Some(node_env) = self.options.define.dots.get(b"NODE_ENV".as_slice()) {
                 if !node_env.is_empty() {
                     if let Some(s) = node_env[0].data.value.e_string() {
                         if s.eql_comptime(b"production") {
                             is_production = true;
+                            is_development = false;
                         } else if s.eql_comptime(b"development") {
                             is_development = true;
+                            is_production = false;
                         }
                     }
                 }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -542,9 +542,6 @@ impl<'a> Transpiler<'a> {
 
         let env_loader = self.env_mut();
         let mut is_production = env_loader.is_production();
-        // `bun run` uses `LoadAllWithoutInlining`, which skips injecting env
-        // `NODE_ENV` into `define.dots` — so the define-map check below never
-        // sees it. Sample development here too so it is symmetric with production.
         let mut is_development = env_loader.get_node_env() == Some(b"development");
 
         // `load_defines` injects a default `process.env.NODE_ENV`; sample the

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -28,6 +28,57 @@ const shimFiles = {
   "m.jsx": `const a = <div p="1">x</div>;\nglobalThis.s = a;\n`,
 };
 
+// `NODE_ENV` in the environment overrides tsconfig dev/prod for `bun run` in
+// both directions; `--define process.env.NODE_ENV` overrides both.
+describe.each(["NODE_ENV", "BUN_ENV"])("bun run: env %s overrides tsconfig jsx dev/prod", envVar => {
+  test.concurrent.each([
+    // [tsconfig jsx,   env value,      expected runtime]
+    ["react-jsx", "development", "dev jsxDEV"], // env wins (was: tsconfig won -> prod)
+    ["react-jsx", "production", "prod jsx"], // both agree
+    ["react-jsxdev", "development", "dev jsxDEV"], // both agree
+    ["react-jsxdev", "production", "prod jsx"], // env wins
+  ] as const)(`tsconfig "%s" + ${envVar}=%s -> %s`, async (jsx, envValue, expected) => {
+    using dir = tempDir("jsx-tsconfig-env", {
+      ...shimFiles,
+      "tsconfig.json": JSON.stringify({ compilerOptions: { jsx, jsxImportSource: "shim" } }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "m.jsx"],
+      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined, [envVar]: envValue },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, stdout: stdout.trim(), exitCode }).toEqual({ stderr: "", stdout: expected, exitCode: 0 });
+  });
+});
+
+describe("bun run: --define process.env.NODE_ENV overrides env NODE_ENV for jsx dev/prod", () => {
+  test.concurrent.each([
+    // [env NODE_ENV,   --define value,   tsconfig jsx,     expected]
+    ["development", '"production"', "react-jsxdev", "prod jsx"], // --define > env > tsconfig
+    ["production", '"development"', "react-jsx", "dev jsxDEV"], // --define > env > tsconfig
+  ] as const)(
+    "env NODE_ENV=%s + --define process.env.NODE_ENV=%s -> %s",
+    async (envValue, defineValue, jsx, expected) => {
+      using dir = tempDir("jsx-tsconfig-define", {
+        ...shimFiles,
+        "tsconfig.json": JSON.stringify({ compilerOptions: { jsx, jsxImportSource: "shim" } }),
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "--define", `process.env.NODE_ENV=${defineValue}`, "m.jsx"],
+        env: { ...bunEnv, NODE_ENV: envValue, BUN_ENV: undefined },
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderr, stdout: stdout.trim(), exitCode }).toEqual({ stderr: "", stdout: expected, exitCode: 0 });
+    },
+  );
+});
+
 describe("tsconfig compilerOptions.jsx", () => {
   test.each([
     ["react-jsx", "prod jsx", "shim/jsx-runtime"],

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -60,7 +60,7 @@ describe("bun run: --define process.env.NODE_ENV overrides env NODE_ENV for jsx 
     ["development", '"production"', "react-jsxdev", "prod jsx"], // --define > env > tsconfig
     ["production", '"development"', "react-jsx", "dev jsxDEV"], // --define > env > tsconfig
   ] as const)(
-    "env NODE_ENV=%s + --define process.env.NODE_ENV=%s -> %s",
+    "env NODE_ENV=%s + --define process.env.NODE_ENV=%s (tsconfig %s) -> %s",
     async (envValue, defineValue, jsx, expected) => {
       using dir = tempDir("jsx-tsconfig-define", {
         ...shimFiles,

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -33,7 +33,7 @@ const shimFiles = {
 describe.each(["NODE_ENV", "BUN_ENV"])("bun run: env %s overrides tsconfig jsx dev/prod", envVar => {
   test.concurrent.each([
     // [tsconfig jsx,   env value,      expected runtime]
-    ["react-jsx", "development", "dev jsxDEV"], // env wins (was: tsconfig won -> prod)
+    ["react-jsx", "development", "dev jsxDEV"], // env wins
     ["react-jsx", "production", "prod jsx"], // both agree
     ["react-jsxdev", "development", "dev jsxDEV"], // both agree
     ["react-jsxdev", "production", "prod jsx"], // env wins


### PR DESCRIPTION
## What

Since #34422 made tsconfig `"jsx": "react-jsx"` select the production automatic runtime, `bun run` applies env `NODE_ENV` to that selection asymmetrically:

```
tsconfig "react-jsxdev" + NODE_ENV=production   -> jsx-runtime       NODE_ENV wins
tsconfig "react-jsx"    + NODE_ENV=development  -> jsx-runtime       tsconfig wins (bug)
```

`--define process.env.NODE_ENV='"development"'` did force dev; only the env-var path was one-directional.

## Repro

```sh
mkdir /tmp/j && cd /tmp/j
mkdir -p node_modules/shim
printf '{"name":"shim","type":"module","exports":{"./jsx-runtime":"./rt.js","./jsx-dev-runtime":"./dev.js"}}' > node_modules/shim/package.json
echo 'export const jsx=()=>console.log("prod");export const jsxs=jsx;export const Fragment=0;' > node_modules/shim/rt.js
echo 'export const jsxDEV=()=>console.log("dev");export const Fragment=0;' > node_modules/shim/dev.js
printf 'globalThis.a=<div/>;\n' > m.jsx
printf '{"compilerOptions":{"jsx":"react-jsx","jsxImportSource":"shim"}}' > tsconfig.json

NODE_ENV=development bun run m.jsx   # prints "prod", expected "dev"
```

## Cause

`configure_defines()` samples `is_production` from the env loader directly (`env_loader.is_production()`) but derives `is_development` only from `options.define.dots["NODE_ENV"]`. `bun run` sets `env.behavior = LoadAllWithoutInlining`, which makes `load_defines` skip injecting env `NODE_ENV` into the define map, so `is_development` can never become `true` from the environment. `--define` goes into the define map regardless of behavior, which is why that path worked.

## Fix

Sample `is_development` from the env loader alongside `is_production`. When the define map does carry a `NODE_ENV` value (via `--define`, or on the `bun build` path which does inject it), that value still takes precedence and now clears the opposite flag, so `--define process.env.NODE_ENV='"production"'` continues to beat env `NODE_ENV=development`.

This gives the precedence documented on `Pragma::development` (`--define` > `NODE_ENV` > tsconfig) for `bun run` in both directions.

## Verification

Added a 2x4 matrix (`NODE_ENV` / `BUN_ENV` x both tsconfig values x both env values) plus two `--define`-over-env cases to `test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts`. 2 of the 10 new cases fail on main (`"react-jsx"` + `{NODE_ENV,BUN_ENV}=development`), all pass with the fix.

Existing suites green: `bundler_jsx`, `jsx-production`, `esbuild/tsconfig`, `bundler_env`, `bundler_cjs2esm -t NodeEnv`, `bundler_bun`.

## Related

#36269 fixes the `bun build` (bundled) half of the dev/prod precedence and touches the same `configure_defines` block with a `force_node_env == Unspecified` guard and `force_node_env = Production` assignment; both read the same `is_production`/`is_development` locals so whichever lands second is a trivial rebase. #36209 and #36261 change the `Arguments.rs` `--jsx-*` default and are independent of this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
bun test v1.4.0 (ad86bb4a2)

test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:
48 |       cwd: String(dir),
49 |       stdout: "pipe",
50 |       stderr: "pipe",
51 |     });
52 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
53 |     expect({ stderr, stdout: stdout.trim(), exitCode }).toEqual({ stderr: "", stdout: expected, exitCode: 0 });
                                                             ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
-   "stdout": "dev jsxDEV",
+   "stdout": "prod jsx",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:53:57)
(fail) bun run: env NODE_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsx" + NODE_ENV=development -> dev jsxDEV [348.87ms]
48 |       cwd: String(dir),
49 |       stdout: "pipe",
50 |       stderr: "pipe",
51 |     });
52 |     const
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:
(pass) bun run: env NODE_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsx" + NODE_ENV=development -> dev jsxDEV [18.86ms]
(pass) bun run: env NODE_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsx" + NODE_ENV=production -> prod jsx [17.24ms]
(pass) bun run: env NODE_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsxdev" + NODE_ENV=development -> dev jsxDEV [17.57ms]
(pass) bun run: env NODE_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsxdev" + NODE_ENV=production -> prod jsx [16.63ms]
(pass) bun run: env BUN_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsx" + BUN_ENV=production -> prod jsx [14.98ms]
(pass) bun run: env BUN_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsx" + BUN_ENV=development -> dev jsxDEV [16.15ms]
(pass) bun run: env BUN_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsxdev" + BUN_ENV=development -> dev jsxDEV [14.76ms]
(pass) bun run: env BUN_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsxdev" + BUN_ENV=production -> prod jsx [16.31ms]
(pass) bun run: --define process.env.NODE_ENV over
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
bun test v1.4.0 (ad86bb4a2)

test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:
(pass) bun run: env NODE_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsx" + NODE_ENV=development -> dev jsxDEV [313.06ms]
(pass) bun run: env NODE_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsx" + NODE_ENV=production -> prod jsx [284.68ms]
(pass) bun run: env NODE_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsxdev" + NODE_ENV=production -> prod jsx [281.06ms]
(pass) bun run: env NODE_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsxdev" + NODE_ENV=development -> dev jsxDEV [296.63ms]
(pass) bun run: env BUN_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsx" + BUN_ENV=development -> dev jsxDEV [304.59ms]
(pass) bun run: env BUN_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsx" + BUN_ENV=production -> prod jsx [301.25ms]
(pass) bun run: env BUN_ENV overrides tsconfig jsx dev/prod > tsconfig "react-jsxdev" + BUN_ENV=development -> dev jsxDEV [281
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ad86bb4a2e
  features     baseline

22 deps, 108 codegen, 1171 objects in 818ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [14.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [4.00ms]
[4/1234] gen ErrorCode+*.h
[5/1234] fetch picohttpparser
[picohttpparser] up to date
[6/1234] gen bindgenv2
[7/1234] fetch zlib
[zlib] up to date
[8/1234] gen .bind.ts → GeneratedBindings.cpp
[9/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1234] fetch tinycc
[tinycc] up to date
[11/1234] subst deps/zlib/zlib.h
[12/1234] subst deps/zlib/zconf.h
[13/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[14/123
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/transpiler.rs                          |  4 +-
 .../transpiler/jsx-tsconfig-react-jsx.test.ts      | 51 ++++++++++++++++++++++
 2 files changed, 54 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/bundler/transpiler.rs                                   5      5      0
test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->