### PR TITLE
console: apply group indent to count/time/assert and no-args log paths

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2800,7 +2800,7 @@ pub mod formatter {
     /// conflict with the `&self` borrow `Formatter::write_indent` takes.
     /// `self.indent` is a disjoint field read, so passing it by value here
     /// keeps the borrow checker happy.
-    fn write_indent_n(indent: u32, writer: &mut dyn bun_io::Write) -> bun_io::Result<()> {
+    pub(super) fn write_indent_n(indent: u32, writer: &mut dyn bun_io::Write) -> bun_io::Result<()> {
         let mut total_remain: u32 = indent;
         while total_remain > 0 {
             let written: u8 = total_remain.min(32) as u8;
@@ -5785,7 +5785,9 @@ pub(crate) extern "C" fn Bun__ConsoleObject__count(
     } + 1;
     *counter.value_ptr = current;
 
+    let default_indent = this.default_indent;
     let writer = this.writer();
+    let _ = formatter::write_indent_n(u32::from(default_indent), writer);
     if Output::enable_ansi_colors_stdout() {
         let _ = writeln!(
             writer,
@@ -5856,7 +5858,7 @@ pub(crate) extern "C" fn Bun__ConsoleObject__time(
 #[crate::host_call]
 pub(crate) extern "C" fn Bun__ConsoleObject__timeEnd(
     _console: *mut ConsoleObject,
-    _global: &JSGlobalObject,
+    global_this: &JSGlobalObject,
     chars: *const u8,
     len: usize,
 ) {
@@ -5873,6 +5875,10 @@ pub(crate) extern "C" fn Bun__ConsoleObject__timeEnd(
         return;
     };
     let Some(value) = prev else { return };
+    // SAFETY: top-level JS-thread host call ⇒ exclusive access to the
+    // set-once `VirtualMachine.console` box.
+    let default_indent = unsafe { vm_console_mut(global_this) }.default_indent;
+    let _ = formatter::write_indent_n(u32::from(default_indent), Output::error_writer());
     // get the duration in microseconds, then display it in milliseconds
     Output::print_elapsed(
         (value.read() / bun_core::time::NS_PER_US) as f64 / bun_core::time::US_PER_MS as f64,
@@ -5905,6 +5911,10 @@ pub(crate) extern "C" fn Bun__ConsoleObject__timeLog(
     let Some(Some(value)) = PENDING_TIME_LOGS.with_borrow(|m| m.get(&id).copied()) else {
         return;
     };
+    // SAFETY: top-level JS-thread host call ⇒ exclusive access to the
+    // set-once `VirtualMachine.console` box.
+    let default_indent = unsafe { vm_console_mut(global) }.default_indent;
+    let _ = formatter::write_indent_n(u32::from(default_indent), Output::error_writer());
     // get the duration in microseconds, then display it in milliseconds
     Output::print_elapsed(
         (value.read() / bun_core::time::NS_PER_US) as f64 / bun_core::time::US_PER_MS as f64,

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2800,7 +2800,10 @@ pub mod formatter {
     /// conflict with the `&self` borrow `Formatter::write_indent` takes.
     /// `self.indent` is a disjoint field read, so passing it by value here
     /// keeps the borrow checker happy.
-    pub(super) fn write_indent_n(indent: u32, writer: &mut dyn bun_io::Write) -> bun_io::Result<()> {
+    pub(super) fn write_indent_n(
+        indent: u32,
+        writer: &mut dyn bun_io::Write,
+    ) -> bun_io::Result<()> {
         let mut total_remain: u32 = indent;
         while total_remain > 0 {
             let written: u8 = total_remain.min(32) as u8;

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -425,7 +425,10 @@ fn message_with_type_and_level_(
         // SAFETY: no other borrow of the console is live in this
         // early-return arm (the deferred `_indent_guard` only holds the raw
         // pointer, not a reference).
-        let ew = unsafe { vm_console_mut(global) }.error_writer();
+        let this = unsafe { vm_console_mut(global) };
+        let default_indent = this.default_indent;
+        let ew = this.error_writer();
+        let _ = formatter::write_indent_n(u32::from(default_indent), ew);
         let _ = ew.write_all(text.as_bytes());
         let _ = ew.flush();
         return Ok(());
@@ -545,9 +548,11 @@ fn message_with_type_and_level_(
         // the only later uses are in the mutually-exclusive `Trace` block, and
         // `message_type == Log` here.
         let w = unsafe { (*console).writer() };
+        let _ = formatter::write_indent_n(u32::from(default_indent), w);
         let _ = w.write_all(b"\n");
         let _ = w.flush();
     } else if message_type != MessageType::Trace {
+        let _ = formatter::write_indent_n(u32::from(default_indent), writer);
         let _ = writer.write_all(b"undefined\n");
     }
 

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -448,10 +448,7 @@ fn message_with_type_and_level_(
     let default_indent = unsafe { vm_console_mut(global) }.default_indent;
 
     // SAFETY: see [`vm_console`] — `console` points at the live boxed
-    // `ConsoleObject` for this VM; JS-thread-only. Kept as a raw deref (not
-    // `vm_console_mut`) so the resulting `writer` borrow does not pin a
-    // long-lived `&mut ConsoleObject` across the re-derive in the empty-`Log`
-    // arm below.
+    // `ConsoleObject` for this VM; JS-thread-only.
     let raw_writer: &mut bun_core::io::Writer = unsafe {
         if matches!(level, MessageLevel::Warning | MessageLevel::Error) {
             (*console).error_writer()
@@ -544,13 +541,9 @@ fn message_with_type_and_level_(
             print_options,
         )?;
     } else if message_type == MessageType::Log {
-        // SAFETY: see [`vm_console`]. `writer` (above) is dead in this arm —
-        // the only later uses are in the mutually-exclusive `Trace` block, and
-        // `message_type == Log` here.
-        let w = unsafe { (*console).writer() };
-        let _ = formatter::write_indent_n(u32::from(default_indent), w);
-        let _ = w.write_all(b"\n");
-        let _ = w.flush();
+        let _ = formatter::write_indent_n(u32::from(default_indent), writer);
+        let _ = writer.write_all(b"\n");
+        let _ = writer.flush();
     } else if message_type != MessageType::Trace {
         let _ = formatter::write_indent_n(u32::from(default_indent), writer);
         let _ = writer.write_all(b"undefined\n");

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -143,6 +143,49 @@ NamedError: console.error a named error
 `);
 });
 
+it.concurrent("console.group indents console.count and console.time/timeLog/timeEnd", async () => {
+  const src = `
+    console.group("G1");
+    console.count("cnt");
+    console.count("cnt");
+    console.group("G2");
+    console.count("cnt");
+    console.time("t");
+    console.timeLog("t");
+    console.timeEnd("t");
+    console.groupEnd();
+    console.count("cnt");
+    console.groupEnd();
+    console.count("cnt");
+    console.time("u");
+    console.timeEnd("u");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.replaceAll("\r\n", "\n")).toBe(
+    "G1\n" + //
+      "  cnt: 1\n" +
+      "  cnt: 2\n" +
+      "  G2\n" +
+      "    cnt: 3\n" +
+      "  cnt: 4\n" +
+      "cnt: 5\n",
+  );
+
+  const stderrLines = stderr.replaceAll("\r\n", "\n").replace(/\n$/, "").split("\n");
+  expect(stderrLines.length).toBe(3);
+  expect(stderrLines[0]).toMatch(/^    \[[\d.]+[mnµ]?s\] t$/);
+  expect(stderrLines[1]).toMatch(/^    \[[\d.]+[mnµ]?s\] t$/);
+  expect(stderrLines[2]).toMatch(/^\[[\d.]+[mnµ]?s\] u$/);
+  expect(exitCode).toBe(0);
+});
+
 it("console.log with SharedArrayBuffer", () => {
   // console.log(x) === Bun.inspect(x) + "\n" written to stdout.
   expect(Bun.inspect(new ArrayBuffer(0))).toBe("ArrayBuffer(0) []");

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -149,6 +149,9 @@ it.concurrent("console.group indents count/time/assert and the no-args log paths
     console.count("cnt");
     console.count("cnt");
     console.log();
+    console.info();
+    console.warn();
+    console.error();
     console.group("G2");
     console.count("cnt");
     console.assert(false);
@@ -177,6 +180,7 @@ it.concurrent("console.group indents count/time/assert and the no-args log paths
       "  cnt: 1\n" +
       "  cnt: 2\n" +
       "  \n" +
+      "  \n" +
       "  G2\n" +
       "    cnt: 3\n" +
       "  cnt: 4\n" +
@@ -185,12 +189,14 @@ it.concurrent("console.group indents count/time/assert and the no-args log paths
   );
 
   const stderrLines = stderr.replaceAll("\r\n", "\n").replace(/\n$/, "").split("\n");
-  expect(stderrLines.length).toBe(5);
-  expect(stderrLines[0]).toBe("    Assertion failed");
-  expect(stderrLines[1]).toMatch(/^    \[[\d.]+[mnµ]?s\] t$/);
-  expect(stderrLines[2]).toMatch(/^    \[[\d.]+[mnµ]?s\] t$/);
-  expect(stderrLines[3]).toBe("Assertion failed");
-  expect(stderrLines[4]).toMatch(/^\[[\d.]+[mnµ]?s\] u$/);
+  expect(stderrLines.length).toBe(7);
+  expect(stderrLines[0]).toBe("  ");
+  expect(stderrLines[1]).toBe("  ");
+  expect(stderrLines[2]).toBe("    Assertion failed");
+  expect(stderrLines[3]).toMatch(/^    \[[\d.]+[mnµ]?s\] t$/);
+  expect(stderrLines[4]).toMatch(/^    \[[\d.]+[mnµ]?s\] t$/);
+  expect(stderrLines[5]).toBe("Assertion failed");
+  expect(stderrLines[6]).toMatch(/^\[[\d.]+[mnµ]?s\] u$/);
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -143,13 +143,15 @@ NamedError: console.error a named error
 `);
 });
 
-it.concurrent("console.group indents console.count and console.time/timeLog/timeEnd", async () => {
+it.concurrent("console.group indents count/time/assert and the no-args log paths", async () => {
   const src = `
     console.group("G1");
     console.count("cnt");
     console.count("cnt");
+    console.log();
     console.group("G2");
     console.count("cnt");
+    console.assert(false);
     console.time("t");
     console.timeLog("t");
     console.timeEnd("t");
@@ -157,6 +159,8 @@ it.concurrent("console.group indents console.count and console.time/timeLog/time
     console.count("cnt");
     console.groupEnd();
     console.count("cnt");
+    console.log();
+    console.assert(false);
     console.time("u");
     console.timeEnd("u");
   `;
@@ -172,17 +176,21 @@ it.concurrent("console.group indents console.count and console.time/timeLog/time
     "G1\n" + //
       "  cnt: 1\n" +
       "  cnt: 2\n" +
+      "  \n" +
       "  G2\n" +
       "    cnt: 3\n" +
       "  cnt: 4\n" +
-      "cnt: 5\n",
+      "cnt: 5\n" +
+      "\n",
   );
 
   const stderrLines = stderr.replaceAll("\r\n", "\n").replace(/\n$/, "").split("\n");
-  expect(stderrLines.length).toBe(3);
-  expect(stderrLines[0]).toMatch(/^    \[[\d.]+[mnµ]?s\] t$/);
+  expect(stderrLines.length).toBe(5);
+  expect(stderrLines[0]).toBe("    Assertion failed");
   expect(stderrLines[1]).toMatch(/^    \[[\d.]+[mnµ]?s\] t$/);
-  expect(stderrLines[2]).toMatch(/^\[[\d.]+[mnµ]?s\] u$/);
+  expect(stderrLines[2]).toMatch(/^    \[[\d.]+[mnµ]?s\] t$/);
+  expect(stderrLines[3]).toBe("Assertion failed");
+  expect(stderrLines[4]).toMatch(/^\[[\d.]+[mnµ]?s\] u$/);
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
## Repro

```js
console.group('G');
console.log('log-line');
console.count('cnt');
console.assert(false);
console.log();
console.warn();
console.time('t'); console.timeLog('t'); console.timeEnd('t');
console.groupEnd();
```

Node v26:
```
G
  log-line
  cnt: 1
                        (stdout: indented blank from log())
  t: 0.011ms
  t: 0.965ms
```
stderr: `  Assertion failed`, `  ` (indented blank from warn()).

Bun (before): `cnt: 1`, `Assertion failed`, `[0.00ms] t` all at column 0; bare `console.warn()`/`console.error()` wrote their newline to stdout instead of stderr.

## Cause

Several console output paths in `src/jsc/ConsoleObject.rs` write directly to a writer, bypassing the `default_indent` prefix and the level-based stdout/stderr selection that the log-family path applies via `Formatter::write_indent`:

- `Bun__ConsoleObject__count`
- `Bun__ConsoleObject__timeLog` / `Bun__ConsoleObject__timeEnd`
- the `MessageType::Assert && len == 0` early return (`Assertion failed\n`)
- the `print_length == 0` fallthroughs: bare `console.log()` / `info()` / `warn()` / `error()` wrote `\n` and also re-derived `(*console).writer()` (always stdout) instead of reusing the level-selected writer, so no-args `warn()`/`error()` landed on stdout

The `time*` output landing on stderr in bracket format is a separate pre-existing divergence and not changed here; `console.table` indentation is tracked separately in #34236.

## Fix

Expose `formatter::write_indent_n` as `pub(super)` and call it with the current `ConsoleObject.default_indent` before each of these writes. The `print_length == 0 && Log` arm now reuses the already level-selected `writer` so bare `warn()`/`error()` route to stderr.

## Verification

New test in `test/js/web/console/console-log.test.ts` exercises nested groups with `count`, `assert(false)`, bare `log`/`info`/`warn`/`error`, and the `time` family at two indent levels plus back at level 0, asserting both stream and indentation.

- `USE_SYSTEM_BUN=1 bun test test/js/web/console/console-log.test.ts -t 'console.group indents count'` fails
- `bun bd test test/js/web/console/console-log.test.ts` passes (5 tests)
- `bun bd test test/js/web/console/console-timeLog.test.ts` passes (3 tests)
- `bun bd test test/js/node/console/console.test.ts` passes (7 tests)

Fixes #30017

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-log.test.ts
bun test v1.4.0 (0ecfecacc)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [786.87ms]
(pass) long arrays get cutoff [3.31ms]
(pass) console.group [303.50ms]
173 |     stdout: "pipe",
174 |     stderr: "pipe",
175 |   });
176 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
177 | 
178 |   expect(stdout.replaceAll("\r\n", "\n")).toBe(
                                                ^
error: expect(received).toBe(expected)

  "G1
-   cnt: 1
-   cnt: 2
-   
-   
+ cnt: 1
+ cnt: 2
+ 
+ 
+ 
+ 
    G2
-     cnt: 3
-   cnt: 4
+ cnt: 3
+ cnt: 4
  cnt: 5
  
  "

- Expected  - 6
+ Received  + 8

      at <anonymous> (/workspace/bun/test/js/web/console/console-log.test.ts:178:43)
(fail) console.group indents count/time/assert and the no-args log paths [292.14ms]
(pass) console.log with SharedArrayBuffer [4.41ms]

 4 pass
 1 fail
 2 snapshots, 10 expect() calls
Ran 5 tests across 1 file. [3.41s]
error: script "bd
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (c68b37c0a)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [17.82ms]
(pass) long arrays get cutoff [0.10ms]
(pass) console.group [7.35ms]
173 |     stdout: "pipe",
174 |     stderr: "pipe",
175 |   });
176 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
177 | 
178 |   expect(stdout.replaceAll("\r\n", "\n")).toBe(
                                                ^
error: expect(received).toBe(expected)

  "G1
    cnt: 1
    cnt: 2
    
    
+   
+   
    G2
      cnt: 3
    cnt: 4
  cnt: 5
  
  "

- Expected  - 0
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/web/console/console-log.test.ts:178:43)
(fail) console.group indents count/time/assert and the no-args log paths [6.38ms]
(pass) console.log with SharedArrayBuffer [0.07ms]

 4 pass
 1 fail
 2 snapshots, 10 expect() calls
Ran 5 tests across 1 file. [177.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-log.test.ts
bun test v1.4.0 (0ecfecacc)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [808.34ms]
(pass) long arrays get cutoff [3.43ms]
(pass) console.group [391.59ms]
(pass) console.group indents count/time/assert and the no-args log paths [298.99ms]
(pass) console.log with SharedArrayBuffer [4.67ms]

 5 pass
 0 fail
 2 snapshots, 19 expect() calls
Ran 5 tests across 1 file. [3.50s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 678ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_collecti
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                | 37 +++++++++++++--------
 test/js/web/console/console-log.test.ts | 57 +++++++++++++++++++++++++++++++++
 2 files changed, 81 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/ConsoleObject.rs                     7      8      0
test/js/web/console/console-log.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->