### PR TITLE
toml: cap dotted-key/header path length at 4096 segments

### DIFF
--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -181,6 +181,14 @@ impl TOML {
 
 const MAX_SAFE_INTEGER: i64 = (1 << 53) - 1;
 
+/// Dotted keys and table headers are parsed iteratively, so without this cap a
+/// single `a.a.a…` path builds an unbounded chain of nested tables before the
+/// (recursive) JS conversion trips its own stack guard. Every consumer of the
+/// result recurses over it with a stack guard, so a path much deeper than this
+/// throws at conversion time anyway; capping here just refuses to build the
+/// tree it would throw on. Well above the old parser's 512 and any real use.
+const MAX_DOTTED_PATH_SEGMENTS: usize = 4096;
+
 const BARE_CR: &[u8] = b"Bare carriage return is not allowed; use \\r\\n or \\n";
 const UNDERSCORE_IN_NUMBER: &[u8] = b"Underscores in numbers must be surrounded by digits";
 
@@ -1497,7 +1505,12 @@ impl<'a, 'log> Parser<'a, 'log> {
         path.push(self.scanner.scan_key_after_sep()?);
         loop {
             match self.scanner.scan_header_sep(aot)? {
-                HeaderSep::Dot => path.push(self.scanner.scan_key_after_sep()?),
+                HeaderSep::Dot => {
+                    if path.len() >= MAX_DOTTED_PATH_SEGMENTS {
+                        return Err(PErr::StackOverflow);
+                    }
+                    path.push(self.scanner.scan_key_after_sep()?);
+                }
                 HeaderSep::Close => break,
             }
         }
@@ -1648,7 +1661,12 @@ impl<'a, 'log> Parser<'a, 'log> {
         path.push(first);
         loop {
             match self.scanner.scan_keyval_sep()? {
-                KeyvalSep::Dot => path.push(self.scanner.scan_key_after_sep()?),
+                KeyvalSep::Dot => {
+                    if path.len() >= MAX_DOTTED_PATH_SEGMENTS {
+                        return Err(PErr::StackOverflow);
+                    }
+                    path.push(self.scanner.scan_key_after_sep()?);
+                }
                 KeyvalSep::Equals => break,
             }
         }

--- a/test/js/bun/toml/toml.test.ts
+++ b/test/js/bun/toml/toml.test.ts
@@ -438,14 +438,17 @@ describe("robustness", () => {
   });
 
   test("extremely deep dotted keys and headers throw instead of crashing", () => {
-    // Parsing these is iterative (every segment is processed before the limit
-    // can trip), so unlike OVERFLOW_DEPTH this depth is paid in full: it must
-    // stay small enough to be fast in debug builds while still overflowing
-    // the JS-conversion recursion at release frame sizes.
-    const depth = 250_000;
+    // The parser caps a single dotted path at 4096 segments and reports it as
+    // a stack overflow; before the cap, parsing was iterative and had to build
+    // the full chain of nested tables before the (recursive) JS conversion
+    // could trip its own stack guard, which took seconds under ASAN. The cap
+    // is well above the old parser's 512 and far beyond any real document.
+    const depth = 5000;
     const path = Buffer.alloc(depth * 2 - 1, "a.").toString();
     expect(() => TOML.parse(path + " = 1")).toThrow(RangeError);
     expect(() => TOML.parse(`[${path}]`)).toThrow(RangeError);
+    expect(() => TOML.parse(`[[${path}]]`)).toThrow(RangeError);
+    expect(() => TOML.parse(`a = { ${path} = 1 }`)).toThrow(RangeError);
   });
 
   test("a very long string value round-trips", () => {


### PR DESCRIPTION
## Problem

`test/js/bun/toml/toml.test.ts` → `robustness > extremely deep dotted keys and headers throw instead of crashing` times out under the 5s default on debug+ASAN builds (measured ~5.1s at c08f665367). The test parses two 250,000-segment `a.a.a...` paths to assert that pathologically deep dotted keys throw `RangeError` instead of crashing.

## Cause

Dotted keys and table headers are scanned iteratively (`parse_keyval` / `parse_table_header` in `src/parsers/toml.rs`), so a single `a.a.a…` path builds an unbounded chain of nested `E::Object` tables (one `Expr::init` + one `meta` HashMap insert per segment) before the recursive JS conversion (`expr_to_js_with_check` in `src/runtime/api.rs`) can trip its stack guard. Under ASAN each segment costs ~10µs, so 250,000 × 2 parses is ~5s of work to build a tree that is guaranteed to throw at conversion.

Every consumer of the parsed tree recurses over it with a stack guard: `Bun.TOML.parse` via `expr_to_js_with_check`, and the `.toml` loader / bundler via `js_printer::print_expr`. On this machine the debug+ASAN conversion handles ~6000 levels before throwing.

## Fix

Cap the scan loop at 4096 segments per dotted path and return `PErr::StackOverflow` (surfaces as the same `RangeError`). The pre-#32953 parser capped at 512 segments with a `SyntaxError`; #32953 removed that cap because the scan became iterative, but the consumers of the result are still recursive. 4096 is 8× the old cap and 4× the existing "parses beyond the old 512 cap" test at depth 1000.

This is a per-path syntactic limit, not a total-tree-depth bound: a header plus a keyval (`[a…(4000)]` then `b…(4000) = 1`), or inline tables nesting dotted keys, can still compose past 4096 levels. Those fall through to the conversion stack guard as before, which still throws `RangeError`; they just no longer include the single-huge-path shape that a short input could trigger.

The test drops to depth 5000 (just above the cap) and adds `[[…]]` array-of-tables and inline-table coverage for the same scan loop.

## Verification

```
bun bd test test/js/bun/toml/            # 791 pass
bun bd test test/js/bun/resolve/toml/    # 19 pass
```

The "extremely deep" test now runs in ~16ms (was ~5.1s timeout). Without the `src/` change the test fails with "Received function did not throw" because 5000 segments parse to a real nested object under the old unbounded scan.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/toml/toml.test.ts
bun test v1.4.0 (0c5215e9c)

test/js/bun/toml/toml.test.ts:
(pass) input types > string [2.55ms]
(pass) input types > Buffer [2.03ms]
(pass) input types > Uint8Array subarray respects byteOffset and length [2.60ms]
(pass) input types > DataView [3.48ms]
(pass) input types > ArrayBuffer [1.96ms]
(pass) input types > SharedArrayBuffer [2.86ms]
(pass) input types > Blob parses synchronously [3.08ms]
(pass) input types > DataView over a SharedArrayBuffer [2.90ms]
(pass) input types > non-string values are coerced via toString [6.60ms]
(pass) input types > null and undefined throw [5.86ms]
(pass) input types > invalid UTF-8 bytes throw SyntaxError [5.56ms]
(pass) input types > lone surrogates: replaced in string input (USVString), rejected in byte input [3.44ms]
(pass) input types > UTF-8 BOM is skipped in both string and byte input [2.51ms]
(pass) JS value mapping > returns a plain object with Object.prototype [2.15ms]
(pass) JS value mapping > __proto__ key becomes an own property, not the prototype [4.63ms]

... (truncated)

release without fix: 60 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/toml/toml.test.ts:
(pass) input types > string [0.11ms]
(pass) input types > Buffer [0.05ms]
(pass) input types > Uint8Array subarray respects byteOffset and length [0.04ms]
33 |     expect(TOML.parse(padded.subarray(3, 3 + doc.length))).toEqual(expected);
34 |   });
35 | 
36 |   test("DataView", () => {
37 |     const bytes = new TextEncoder().encode(doc);
38 |     expect(TOML.parse(new DataView(bytes.buffer))).toEqual(expected);
                     ^
AggregateError: Failed to parse toml
      at <anonymous> (/workspace/bun/test/js/bun/toml/toml.test.ts:38:17)
(fail) input types > DataView [0.32ms]
37 |     const bytes = new TextEncoder().encode(doc);
38 |     expect(TOML.parse(new DataView(bytes.buffer))).toEqual(expected);
39 |   });
40 | 
41 |   test("ArrayBuffer", () => {
42 |     expect(TOML.parse(new TextEncoder().encode(doc).buffer)).toEqual(expected);
                     ^
AggregateError: Failed to parse toml
      at <anonymous> (/workspace/bun/test/js/bun/toml/toml.test.ts:42:17)
(fail) input types > ArrayBuffer [0.12ms]
44 | 
45 |   test("SharedArrayBuffer", () => {
46 |     const bytes = new TextEncode
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/toml/toml.test.ts
bun test v1.4.0 (0c5215e9c)

test/js/bun/toml/toml.test.ts:
(pass) input types > string [2.46ms]
(pass) input types > Buffer [2.20ms]
(pass) input types > Uint8Array subarray respects byteOffset and length [2.05ms]
(pass) input types > DataView [3.38ms]
(pass) input types > ArrayBuffer [2.09ms]
(pass) input types > SharedArrayBuffer [2.73ms]
(pass) input types > Blob parses synchronously [3.02ms]
(pass) input types > DataView over a SharedArrayBuffer [2.85ms]
(pass) input types > non-string values are coerced via toString [6.19ms]
(pass) input types > null and undefined throw [5.72ms]
(pass) input types > invalid UTF-8 bytes throw SyntaxError [4.56ms]
(pass) input types > lone surrogates: replaced in string input (USVString), rejected in byte input [3.43ms]
(pass) input types > UTF-8 BOM is skipped in both string and byte input [2.45ms]
(pass) JS value mapping > returns a plain object with Object.prototype [2.12ms]
(pass) JS value mapping > __proto__ key becomes an own property, not the prototype [4.56ms]

... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0c5215e9c3
  features     baseline

22 deps, 108 codegen, 1171 objects in 790ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [37.00ms]
[2/1234] gen ErrorCode+*.h
[3/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1234] fetch zlib
[zlib] up to date
[5/1234] gen bindgenv2
[6/1234] gen .bind.ts → GeneratedBindings.cpp
[7/1234] fetch tinycc
[tinycc] up to date
[8/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1234] fetch picohttpparser
[picohttpparser] up to date
[10/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [22.00m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/parsers/toml.rs           | 22 ++++++++++++++++++++--
 test/js/bun/toml/toml.test.ts | 13 ++++++++-----
 2 files changed, 28 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/parsers/toml.rs                4      3      0
test/js/bun/toml/toml.test.ts      2      2      0
```

</details>

**self-review** · 1 surviving concern

- consider: The cap bounds per-call path-vector length, not the tree depth the recursive consumers actually choke on - header+keyval and inline-table nesting compose past 4096 without tripping it.

21 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->