### PR TITLE
node:tls: return the ticket-bearing session from getSession()/getTLSTicket() on TLS 1.3

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -186,6 +186,11 @@ extern const unsigned char BUN_SOCKET_KIND_UWS_HTTP_TLS;
  * SSL stack unwinds; freed with the SSL if never delivered. */
 static int us_ssl_pending_session_idx = -1;
 static int us_ssl_pending_keylog_idx = -1;
+/* The SSL_SESSION* most recently delivered to the new-session callback. Under
+ * TLS 1.3 BoringSSL never updates the SSL's own established_session with a
+ * received NewSessionTicket, so SSL_get_session() alone gives an unresumable
+ * snapshot; node:tls's getSession()/getTLSTicket() read from here instead. */
+static int us_ssl_new_session_ref_idx = -1;
 #ifdef _WIN32
 static INIT_ONCE us_ex_idx_once = INIT_ONCE_STATIC_INIT;
 #else
@@ -272,6 +277,11 @@ static void us_ssl_pending_session_free(void *parent, void *ptr, CRYPTO_EX_DATA 
     pending = next;
   }
 }
+static void us_ssl_new_session_ref_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
+                                        int index, long argl, void *argp) {
+  (void)parent; (void)ad; (void)index; (void)argl; (void)argp;
+  if (ptr) SSL_SESSION_free((SSL_SESSION *)ptr);
+}
 /* NSS key-log lines are produced from inside SSL_do_handshake/SSL_read, so
  * they are parked on the SSL the same way new sessions are and delivered once
  * the read unwinds. The stored bytes already carry the trailing newline Node
@@ -333,6 +343,14 @@ static int us_ssl_new_session_cb(SSL *ssl, SSL_SESSION *session) {
   if (!SSL_get_ex_data(ssl, us_ssl_is_socket_ex_idx)) {
     return 0;
   }
+  /* Stash the latest session for getSession()/getTLSTicket(): BoringSSL only
+   * hands a TLS 1.3 NewSessionTicket to this callback, never to the SSL's
+   * established_session. Do this before the serialize/park step so a session
+   * too large to queue is still reachable. */
+  SSL_SESSION_up_ref(session);
+  SSL_SESSION *prev = SSL_get_ex_data(ssl, us_ssl_new_session_ref_idx);
+  SSL_set_ex_data(ssl, us_ssl_new_session_ref_idx, session);
+  if (prev) SSL_SESSION_free(prev);
   int length = i2d_SSL_SESSION(session, NULL);
   if (length <= 0 || length > US_SSL_PENDING_SESSION_MAX) {
     return 0;
@@ -402,6 +420,7 @@ static void us_ex_idx_init(void) {
   us_ssl_inline_reject_err_ex_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
   us_ssl_pending_session_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_pending_session_free);
   us_ssl_pending_keylog_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_pending_session_free);
+  us_ssl_new_session_ref_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_new_session_ref_free);
 }
 
 #ifdef _WIN32
@@ -462,6 +481,14 @@ int us_ssl_pop_pending_session(SSL *ssl, unsigned char *out, int out_cap) {
 
 int us_ssl_pop_pending_keylog(SSL *ssl, unsigned char *out, int out_cap) {
   return us_ssl_pop_pending(ssl, us_ssl_pending_keylog_idx, out, out_cap);
+}
+
+/* The resumable session most recently delivered via the new-session callback,
+ * or NULL if none has arrived. The returned pointer is borrowed from the SSL's
+ * ex_data and valid until the next NewSessionTicket or SSL_free. */
+SSL_SESSION *us_ssl_get_new_session(SSL *ssl) {
+  if (us_ssl_new_session_ref_idx < 0) return NULL;
+  return SSL_get_ex_data(ssl, us_ssl_new_session_ref_idx);
 }
 
 int us_ssl_ctx_cache_ex_idx(void) {

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -551,6 +551,9 @@ int us_ssl_ctx_add_ca_cert(struct ssl_ctx_st *ctx, const char *content);
 void us_ssl_enable_pending_events(struct ssl_st *ssl);
 int us_ssl_pop_pending_session(struct ssl_st *ssl, unsigned char *out, int out_cap);
 int us_ssl_pop_pending_keylog(struct ssl_st *ssl, unsigned char *out, int out_cap);
+/* The resumable session most recently delivered via the new-session callback,
+ * or NULL if none. Borrowed; valid until the next NewSessionTicket or SSL_free. */
+struct ssl_session_st *us_ssl_get_new_session(struct ssl_st *ssl);
 
 /* Public interfaces for loops */
 

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -104,6 +104,8 @@ pub(super) mod ffi {
 
         // ── SSL_SESSION ───────────────────────────────────────────────────
         pub(crate) safe fn SSL_get_session(ssl: &SSL) -> *mut SSL_SESSION;
+        // Borrowed from the SSL's ex_data; no caller-side precondition.
+        pub(crate) safe fn us_ssl_get_new_session(ssl: &SSL) -> *mut SSL_SESSION;
         // Both handles are opaque-ZST refs (`UnsafeCell` body); BoringSSL bumps
         // `session`'s refcount internally — no caller-side precondition.
         pub(crate) safe fn SSL_set_session(ssl: &SSL, session: &SSL_SESSION) -> c_int;
@@ -1104,6 +1106,17 @@ pub(super) fn get_alpn_protocol(this: &This, global: &JSGlobalObject) -> JsResul
     Ok(ZigString::from_utf8(slice).to_js(global))
 }
 
+/// The session Node's `getSession()`/`getTLSTicket()` read: the one most
+/// recently delivered to the new-session callback (the only place BoringSSL
+/// surfaces a TLS 1.3 NewSessionTicket), falling back to the SSL's own.
+fn current_session(ssl: &boringssl::SSL) -> *mut ffi::SSL_SESSION {
+    let new = ffi::us_ssl_get_new_session(ssl);
+    if !new.is_null() {
+        return new;
+    }
+    ffi::SSL_get_session(ssl)
+}
+
 pub(super) fn get_session(
     this: &This,
     global: &JSGlobalObject,
@@ -1112,7 +1125,7 @@ pub(super) fn get_session(
     let Some(ssl_ptr) = this.socket.get().ssl() else {
         return Ok(JSValue::UNDEFINED);
     };
-    let session = ffi::SSL_get_session(boringssl::SSL::opaque_ref(ssl_ptr));
+    let session = current_session(boringssl::SSL::opaque_ref(ssl_ptr));
     if session.is_null() {
         return Ok(JSValue::UNDEFINED);
     }
@@ -1193,7 +1206,7 @@ pub(super) fn get_tls_ticket(
     let Some(ssl_ptr) = this.socket.get().ssl() else {
         return Ok(JSValue::UNDEFINED);
     };
-    let session = ffi::SSL_get_session(boringssl::SSL::opaque_ref(ssl_ptr));
+    let session = current_session(boringssl::SSL::opaque_ref(ssl_ptr));
     if session.is_null() {
         return Ok(JSValue::UNDEFINED);
     }

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -739,6 +739,102 @@ it("delivers 'session' even when the data handler destroys the socket immediatel
   await once(server, "close");
 });
 
+describe.each(["TLSv1.2", "TLSv1.3"] as const)("%s: getSession() / getTLSTicket()", version => {
+  // BoringSSL never folds a TLS 1.3 NewSessionTicket into the SSL's own
+  // established_session; it only hands the ticket-bearing session to the
+  // new-session callback. getSession()/getTLSTicket() must read from that
+  // session once it arrives, or the blob they return cannot resume.
+  type Snapshot = {
+    protocol: string | null;
+    viaGetSession: Buffer | undefined;
+    ticket: Buffer | undefined;
+  };
+
+  function onFirstSession(client: TLSSocket) {
+    const { promise, resolve, reject } = Promise.withResolvers<Snapshot>();
+    client.on("error", reject);
+    client.on("data", () => {});
+    client.once("session", () =>
+      resolve({
+        protocol: client.getProtocol(),
+        viaGetSession: client.getSession(),
+        ticket: client.getTLSTicket(),
+      }),
+    );
+    return promise;
+  }
+
+  it("returns a resumable session once the NewSessionTicket arrives", async () => {
+    const serverReused: boolean[] = [];
+    const twoConnections = Promise.withResolvers<void>();
+    await using server = tls.createServer({ ...COMMON_CERT_, minVersion: version, maxVersion: version }, socket => {
+      serverReused.push(socket.isSessionReused());
+      if (serverReused.length === 2) twoConnections.resolve();
+      socket.write("x");
+      socket.on("data", () => {});
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const port = (server.address() as AddressInfo).port;
+    const opts = {
+      port,
+      host: "127.0.0.1",
+      servername: "localhost",
+      ca: COMMON_CERT_.cert,
+      minVersion: version,
+      maxVersion: version,
+    } as const;
+
+    const first = tlsConnect(opts);
+    const { protocol, viaGetSession, ticket } = await onFirstSession(first);
+    first.destroy();
+    await once(first, "close");
+
+    expect(protocol).toBe(version);
+    expect(Buffer.isBuffer(viaGetSession)).toBe(true);
+
+    // Second connection: the getSession() blob resumes on both ends.
+    const second = tlsConnect({ ...opts, session: viaGetSession });
+    second.on("data", () => {});
+    await once(second, "secureConnect");
+    const clientReused = second.isSessionReused();
+    await twoConnections.promise;
+    second.destroy();
+    await once(second, "close");
+
+    expect({ clientReused, serverReused }).toEqual({ clientReused: true, serverReused: [false, true] });
+    expect(Buffer.isBuffer(ticket)).toBe(true);
+    expect(ticket!.length).toBeGreaterThan(0);
+  });
+
+  it("over a duplex-wrapped TLSSocket", async () => {
+    await using server = tls.createServer({ ...COMMON_CERT_, minVersion: version, maxVersion: version }, socket => {
+      socket.on("data", () => socket.end());
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const port = (server.address() as AddressInfo).port;
+
+    const raw = net.connect(port, "127.0.0.1");
+    await once(raw, "connect");
+    const client = tls.connect({
+      socket: new SocketProxy(raw),
+      servername: "localhost",
+      ca: COMMON_CERT_.cert,
+      minVersion: version,
+      maxVersion: version,
+    });
+    const snapshot = onFirstSession(client);
+    await once(client, "secureConnect");
+    client.write("x");
+    const { viaGetSession, ticket } = await snapshot;
+    client.destroy();
+    await once(client, "close");
+
+    expect(Buffer.isBuffer(viaGetSession)).toBe(true);
+    expect(Buffer.isBuffer(ticket)).toBe(true);
+    expect(ticket!.length).toBeGreaterThan(0);
+  });
+});
+
 it("a write before 'secureConnect' still reports the handshake's own failure", async () => {
   // An early write drives the handshake from inside SSL_write. The fatal
   // reason that write hit used to be dropped, so the handshake dispatch had


### PR DESCRIPTION
On a TLS 1.3 client, `socket.getSession()` called after the `'session'` events have fired returns a session that cannot resume: passing it to `tls.connect({ session })` results in a full handshake (`isSessionReused() === false` on both ends). The Buffer the `'session'` event carries does resume. `getTLSTicket()` returns `undefined` on the same connection. Node returns the latest ticket-bearing session from both accessors and it resumes. TLS 1.2 already matched Node.

### Repro

```js
import tls from 'node:tls';
import { once } from 'node:events';

const srv = tls.createServer({ key, cert }, s => {
  s.write(`reused=${s.isSessionReused()}`);
}).listen(0, '127.0.0.1');
await once(srv, 'listening');
const port = srv.address().port;

const first = tls.connect({ port, ca: cert, servername: 'localhost' });
await once(first, 'session');          // NewSessionTicket processed
const viaGet = first.getSession();     // bun: 1095 bytes, no ticket
console.log(first.getTLSTicket());     // bun: undefined   node: <Buffer ...>
first.destroy();

const second = tls.connect({ port, ca: cert, servername: 'localhost', session: viaGet });
await once(second, 'secureConnect');
console.log(second.isSessionReused()); // bun: false   node: true
```

### Cause

BoringSSL's `SSL_get_session()` returns `ssl->s3->established_session`, set once at handshake completion. When a TLS 1.3 NewSessionTicket arrives post-handshake, BoringSSL builds a new `SSL_SESSION` (`tls13_create_session_with_ticket`) and hands it only to the new-session callback; `established_session` is never updated. This is documented in [`ssl.h`](https://github.com/oven-sh/bun/blob/main/vendor/boringssl/include/openssl/ssl.h):

> using the callback is required as of TLS 1.3. For compatibility, this function will return an unresumable session which may be cached, but will never be resumed.

Node uses OpenSSL, which replaces the connection's session with the ticket-bearing one, so `SSL_get_session()` reflects it there.

Bun already receives these sessions in `us_ssl_new_session_cb` (where the `'session'` event's payload comes from) but only serialized them for the event queue.

### Fix

Keep a reference to the most recent `SSL_SESSION*` the new-session callback saw in an ex_data slot on the SSL, and have `getSession()` / `getTLSTicket()` read from it (falling back to `SSL_get_session()` before any ticket arrives or on sockets that never opted into session events). The reference is released on `SSL_free` via the ex_data free hook, and replaced on each subsequent ticket.

TLS 1.2 is unchanged: `new_session_cb` there receives `established_session` itself (`ssl_update_cache`), so reading from the ex_data slot yields the same session.

### Verification

Against node v26.3.0 on loopback, after the first `'session'` event:

| | node | bun before | bun after |
| --- | --- | --- | --- |
| TLS 1.3 `getSession()` resumes | true | **false** | true |
| TLS 1.3 `getTLSTicket()` | Buffer | **undefined** | Buffer |
| TLS 1.2 `getSession()` resumes | true | true | true |
| TLS 1.2 `getTLSTicket()` | Buffer | Buffer | Buffer |

New tests in `test/js/node/tls/node-tls-connect.test.ts` cover both protocol versions on the direct-TCP and duplex-wrapped paths; the TLS 1.3 cases fail on `main` (`clientReused: false`, `serverReused: [false, false]`) and pass here.

Related: #33514 fixes `getTLSTicket()` by tracking ticket bytes in Rust per-socket state; this change addresses both accessors at the usockets layer with no per-socket state.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.0 (e09ce2add)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.38ms]
(pass) should thow ECONNRESET if FIN is received before handshake [349.95ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [7.51ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [109.31ms]
(pass) should be able to grab the JSStreamSocket constructor [13.74ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [78.05ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [76.77ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port a
... (truncated)

release without fix: 16 failed, 18 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.05ms]
(pass) should thow ECONNRESET if FIN is received before handshake [14.75ms]
161 | it("initializes authorizationError to null in the TLSSocket constructor", () => {
162 |   // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L556
163 |   // Node's onServerSocketSecure/onConnectSecure only assign on failure; a
164 |   // clean handshake leaves the constructor's null untouched.
165 |   const socket = new tls.TLSSocket();
166 |   expect({ value: socket.authorizationError, hasOwn: "authorizationError" in socket }).toEqual({
                                                                                             ^
error: expect(received).toEqual(expected)

  {
-   "hasOwn": true,
-   "value": null,
+   "hasOwn": false,
+   "value": undefined,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/node/tls/node-tls-connect.test.ts:166:88)
(fail) initializes authorizationError to null in the TLSSocket constructor [0.44ms]
182 |     connected.resolve,
183 |   );
184 |   client.on("error", connecte
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.0 (e09ce2add)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.14ms]
(pass) should thow ECONNRESET if FIN is received before handshake [345.13ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [7.26ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [109.22ms]
(pass) should be able to grab the JSStreamSocket constructor [14.00ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [75.89ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [78.84ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port a
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 655ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/45] cxx obj/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_KW.cpp.o
[2/45] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[3/45] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[4/45] cxx obj/src/jsc/bindings/bindings.cpp.o
[5/45] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[6/45] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[7/45] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[8/45] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[9/45] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[10/45] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[11/45] cxx obj/src/simdutf_sys/bun-simdutf.cpp.o
[12/45] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[12/45] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Com
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/crypto/openssl.c | 27 +++++++++
 packages/bun-usockets/src/libusockets.h    |  3 +
 src/runtime/socket/tls_socket_functions.rs | 17 +++++-
 test/js/node/tls/node-tls-connect.test.ts  | 96 ++++++++++++++++++++++++++++++
 4 files changed, 141 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-usockets/src/crypto/openssl.c      2      5      0
packages/bun-usockets/src/libusockets.h         1      2      0
src/runtime/socket/tls_socket_functions.rs      2      3      0
test/js/node/tls/node-tls-connect.test.ts       1      4      0
```

</details>

<!-- robobun:evidence:end -->