### PR TITLE
event_loop: yield mid-tick thread-pool re-drain to due timers and pending setImmediate

### DIFF
--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -191,6 +191,10 @@ unsafe extern "Rust" {
     /// `WTFTimer::run` — `timer` is an erased `*mut bun_runtime::timer::WTFTimer`.
     /// Defined in `bun_runtime::dispatch`. Link-time resolved.
     fn __bun_run_wtf_timer(timer: *mut (), vm: *mut VirtualMachine);
+    /// `timer::All::has_due_regular_timer` — peek the JS timer heap and
+    /// report whether its soonest entry is already due. Defined in
+    /// `bun_runtime::dispatch`. Link-time resolved.
+    safe fn __bun_has_due_timer() -> bool;
     /// Tag-specific shutdown release for a queued-but-never-run task. Called
     /// from `release_queued_tasks_for_shutdown` (after `shutdown_for_exit`,
     /// before `destructOnExit`) for every entry left in `self.tasks`.
@@ -455,6 +459,20 @@ impl EventLoop {
         let _ = self.tick_concurrent_with_count();
     }
 
+    /// Re-drain the concurrent queue mid-tick only when nothing is waiting on
+    /// `tick()` to return. libuv delivers thread-pool completions once per
+    /// poll and runs the timers/check phases between polls, so Node interleaves
+    /// due `setInterval`/`setTimeout` (and `setImmediate`) with a chain of
+    /// `fs.read` callbacks that each submit the next read. The unconditional
+    /// `tick_concurrent()` at the start of `tick()` is that once-per-iteration
+    /// batch boundary; re-draining here is a throughput nicety that must yield
+    /// when a timer is due or an immediate is pending.
+    fn tick_concurrent_unless_due(&mut self) {
+        if self.immediate_tasks.is_empty() && !__bun_has_due_timer() {
+            self.tick_concurrent();
+        }
+    }
+
     /// Check whether refConcurrently has been called but the change has not yet been applied to the
     /// underlying event loop's `active` counter
     pub fn has_pending_refs(&self) -> bool {
@@ -620,7 +638,7 @@ impl EventLoop {
 
         loop {
             while self.tick_with_count(ctx) > 0 {
-                self.tick_concurrent();
+                self.tick_concurrent_unless_due();
                 self.global_ref().handle_rejected_promises();
             }
             if self
@@ -631,7 +649,7 @@ impl EventLoop {
                 self.entered_event_loop_count -= 1;
                 return;
             }
-            self.tick_concurrent();
+            self.tick_concurrent_unless_due();
             if self.tasks.readable_length() > 0 {
                 continue;
             }
@@ -639,7 +657,7 @@ impl EventLoop {
         }
 
         while self.tick_with_count(ctx) > 0 {
-            self.tick_concurrent();
+            self.tick_concurrent_unless_due();
         }
 
         self.global_ref().handle_rejected_promises();

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -467,10 +467,19 @@ impl EventLoop {
     /// `tick_concurrent()` at the start of `tick()` is that once-per-iteration
     /// batch boundary; re-draining here is a throughput nicety that must yield
     /// when a timer is due or an immediate is pending.
+    ///
+    /// The yield probe is guarded on `concurrent_tasks` being non-empty so the
+    /// clock read in `__bun_has_due_timer` is only paid when there is actually
+    /// something to re-drain (an HTTP server always has `DateHeaderTimer`
+    /// armed, so an unguarded probe would add a `clock_gettime` to every
+    /// inner-loop iteration of `tick()`).
     fn tick_concurrent_unless_due(&mut self) {
-        if self.immediate_tasks.is_empty() && !__bun_has_due_timer() {
-            self.tick_concurrent();
+        if !self.concurrent_tasks.is_empty()
+            && (!self.immediate_tasks.is_empty() || __bun_has_due_timer())
+        {
+            return;
         }
+        self.tick_concurrent();
     }
 
     /// Check whether refConcurrently has been called but the change has not yet been applied to the

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -191,9 +191,7 @@ unsafe extern "Rust" {
     /// `WTFTimer::run` — `timer` is an erased `*mut bun_runtime::timer::WTFTimer`.
     /// Defined in `bun_runtime::dispatch`. Link-time resolved.
     fn __bun_run_wtf_timer(timer: *mut (), vm: *mut VirtualMachine);
-    /// `timer::All::has_due_regular_timer` — peek the JS timer heap and
-    /// report whether its soonest entry is already due. Defined in
-    /// `bun_runtime::dispatch`. Link-time resolved.
+    /// `timer::All::has_due_regular_timer`. Defined in `bun_runtime::dispatch`.
     safe fn __bun_has_due_timer() -> bool;
     /// Tag-specific shutdown release for a queued-but-never-run task. Called
     /// from `release_queued_tasks_for_shutdown` (after `shutdown_for_exit`,
@@ -459,20 +457,11 @@ impl EventLoop {
         let _ = self.tick_concurrent_with_count();
     }
 
-    /// Re-drain the concurrent queue mid-tick only when nothing is waiting on
-    /// `tick()` to return. libuv delivers thread-pool completions once per
-    /// poll and runs the timers/check phases between polls, so Node interleaves
-    /// due `setInterval`/`setTimeout` (and `setImmediate`) with a chain of
-    /// `fs.read` callbacks that each submit the next read. The unconditional
-    /// `tick_concurrent()` at the start of `tick()` is that once-per-iteration
-    /// batch boundary; re-draining here is a throughput nicety that must yield
-    /// when a timer is due or an immediate is pending.
-    ///
-    /// The yield probe is guarded on `concurrent_tasks` being non-empty so the
-    /// clock read in `__bun_has_due_timer` is only paid when there is actually
-    /// something to re-drain (an HTTP server always has `DateHeaderTimer`
-    /// armed, so an unguarded probe would add a `clock_gettime` to every
-    /// inner-loop iteration of `tick()`).
+    /// Mid-tick re-drain, skipped when a `setImmediate` is pending or a JS
+    /// timer is due so `tick()` returns and `auto_tick*` can run them (Node
+    /// interleaves timers/check between thread-pool completion batches). The
+    /// `concurrent_tasks` guard keeps the clock-read probe off the path when
+    /// nothing arrived.
     fn tick_concurrent_unless_due(&mut self) {
         if !self.concurrent_tasks.is_empty()
             && (!self.immediate_tasks.is_empty() || __bun_has_due_timer())

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -461,11 +461,13 @@ impl EventLoop {
     /// timer is due so `tick()` returns and `auto_tick*` can run them (Node
     /// interleaves timers/check between thread-pool completion batches). The
     /// `concurrent_tasks` guard keeps the clock-read probe off the path when
-    /// nothing arrived.
+    /// nothing arrived; `immediate_tasks` is same-thread so it is checked
+    /// unconditionally (no TOCTOU against a late cross-thread push).
     fn tick_concurrent_unless_due(&mut self) {
-        if !self.concurrent_tasks.is_empty()
-            && (!self.immediate_tasks.is_empty() || __bun_has_due_timer())
-        {
+        if !self.immediate_tasks.is_empty() {
+            return;
+        }
+        if !self.concurrent_tasks.is_empty() && __bun_has_due_timer() {
             return;
         }
         self.tick_concurrent();

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -457,20 +457,22 @@ impl EventLoop {
         let _ = self.tick_concurrent_with_count();
     }
 
-    /// Mid-tick re-drain, skipped when a `setImmediate` is pending or a JS
-    /// timer is due so `tick()` returns and `auto_tick*` can run them (Node
-    /// interleaves timers/check between thread-pool completion batches). The
-    /// `concurrent_tasks` guard keeps the clock-read probe off the path when
-    /// nothing arrived; `immediate_tasks` is same-thread so it is checked
-    /// unconditionally (no TOCTOU against a late cross-thread push).
+    /// Mid-tick re-drain: the ref-count/signal/GC maintenance always runs;
+    /// only the `concurrent_tasks` pop is skipped when a `setImmediate` is
+    /// pending or a JS timer is due, so `tick()` returns and `auto_tick*`
+    /// can run them (Node interleaves timers/check between thread-pool
+    /// completion batches). `immediate_tasks` is same-thread and checked
+    /// first so a late cross-thread push cannot slip ahead of it; the
+    /// `concurrent_tasks` guard keeps the clock read off the path when
+    /// nothing arrived.
     fn tick_concurrent_unless_due(&mut self) {
-        if !self.immediate_tasks.is_empty() {
+        self.tick_concurrent_maintenance();
+        if !self.immediate_tasks.is_empty()
+            || (!self.concurrent_tasks.is_empty() && __bun_has_due_timer())
+        {
             return;
         }
-        if !self.concurrent_tasks.is_empty() && __bun_has_due_timer() {
-            return;
-        }
-        self.tick_concurrent();
+        let _ = self.tick_concurrent_pop_batch();
     }
 
     /// Check whether refConcurrently has been called but the change has not yet been applied to the
@@ -492,7 +494,7 @@ impl EventLoop {
         }
     }
 
-    pub fn tick_concurrent_with_count(&mut self) -> usize {
+    fn tick_concurrent_maintenance(&mut self) {
         self.update_counts();
 
         #[cfg(unix)]
@@ -507,7 +509,14 @@ impl EventLoop {
         }
 
         self.run_imminent_gc_timer();
+    }
 
+    pub fn tick_concurrent_with_count(&mut self) -> usize {
+        self.tick_concurrent_maintenance();
+        self.tick_concurrent_pop_batch()
+    }
+
+    fn tick_concurrent_pop_batch(&mut self) -> usize {
         let concurrent = self.concurrent_tasks.pop_batch();
         let count = concurrent.count;
         if count == 0 {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -878,12 +878,8 @@ unsafe fn __bun_cancel_pending_immediate(
     }
 }
 
-/// `__bun_has_due_timer` body — declared `extern "Rust"` in
-/// `bun_jsc::event_loop`. `EventLoop::tick()` polls this to decide whether to
-/// keep re-draining `concurrent_tasks` mid-tick or yield so `auto_tick*` can
-/// run the timers phase (Node interleaves due timers between thread-pool
-/// completion batches; without this a self-feeding `fs.read` chain starves
-/// `setInterval`).
+/// Declared `extern "Rust"` in `bun_jsc::event_loop`; `tick()`'s mid-tick
+/// yield check.
 #[unsafe(no_mangle)]
 fn __bun_has_due_timer() -> bool {
     let all = crate::jsc_hooks::timer_all();

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -878,6 +878,23 @@ unsafe fn __bun_cancel_pending_immediate(
     }
 }
 
+/// `__bun_has_due_timer` body — declared `extern "Rust"` in
+/// `bun_jsc::event_loop`. `EventLoop::tick()` polls this to decide whether to
+/// keep re-draining `concurrent_tasks` mid-tick or yield so `auto_tick*` can
+/// run the timers phase (Node interleaves due timers between thread-pool
+/// completion batches; without this a self-feeding `fs.read` chain starves
+/// `setInterval`).
+#[unsafe(no_mangle)]
+fn __bun_has_due_timer() -> bool {
+    let all = crate::jsc_hooks::timer_all();
+    if all.is_null() {
+        return false;
+    }
+    // SAFETY: `all` is the live per-thread `All`; single JS thread, and
+    // `has_due_regular_timer` only peeks (no heap mutation, no JS re-entry).
+    unsafe { (*all).has_due_regular_timer() }
+}
+
 /// `__bun_run_wtf_timer` body — cast the low-tier erased `*mut ()` to the real
 /// `crate::timer::WTFTimer` and fire it.
 ///

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -1013,13 +1013,8 @@ impl All {
         }
     }
 
-    /// Cheap "is the soonest JS timer already due" probe for
-    /// `EventLoop::tick()`'s mid-tick yield check. Reads the clock only when
-    /// the regular heap is non-empty. WTF timers are ignored: taking the
-    /// `wtf_timers` lock on every inner-loop iteration of `tick()` is not
-    /// worth it, and the `drain_due_wtf_timers` call at the next
-    /// `get_timeout`/`drain_timers` is never more than one loop iteration
-    /// away once `tick()` returns.
+    /// `EventLoop::tick()`'s mid-tick yield probe. WTF timers are skipped to
+    /// avoid the `wtf_timers` lock; they drain at the next `get_timeout`.
     pub(crate) fn has_due_regular_timer(&self) -> bool {
         let Some(timer) = self.timers.peek() else {
             return false;

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -1013,6 +1013,26 @@ impl All {
         }
     }
 
+    /// Cheap "is the soonest JS timer already due" probe for
+    /// `EventLoop::tick()`'s mid-tick yield check. Reads the clock only when
+    /// the regular heap is non-empty. WTF timers are ignored: taking the
+    /// `wtf_timers` lock on every inner-loop iteration of `tick()` is not
+    /// worth it, and the `drain_due_wtf_timers` call at the next
+    /// `get_timeout`/`drain_timers` is never more than one loop iteration
+    /// away once `tick()` returns.
+    pub(crate) fn has_due_regular_timer(&self) -> bool {
+        let Some(timer) = self.timers.peek() else {
+            return false;
+        };
+        // SAFETY: `peek` returns a live heap node.
+        let next = unsafe { &(*timer).next };
+        let next = Timespec {
+            sec: next.sec,
+            nsec: next.nsec,
+        };
+        !next.greater(&Timespec::now(TimespecMockMode::ForceRealTime))
+    }
+
     /// Pop the next due timer. `now` is filled lazily on first call so we
     /// don't pay for `clock_gettime` when the heap is empty.
     fn next(&mut self, has_set_now: &mut bool, now: &mut Timespec) -> Option<*mut EventLoopTimer> {

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -247,15 +247,9 @@ it("should defer microtasks when an exception is thrown in an immediate", async 
 });
 
 test("chained thread-pool callbacks yield to due timers", async () => {
-  // Node/libuv delivers thread-pool completions once per poll and runs the
-  // timers phase between polls, so a chain of callbacks that each submit the
-  // next job interleaves with an overdue setInterval. Bun used to keep
-  // re-draining thread-pool completions inside one EventLoop::tick(), so the
-  // chain ran to completion before any due timer fired.
-  //
-  // crypto.pbkdf2 is used (not fs.read) because its completion goes through
-  // enqueue_task_concurrent on every platform; fs.read on Windows goes through
-  // libuv's own callback and never reaches the re-drain this test covers.
+  // crypto.pbkdf2 completes via enqueue_task_concurrent on every platform
+  // (fs.read on Windows goes through libuv's callback and would not exercise
+  // the mid-tick re-drain path).
   const script = `
     const crypto = require('crypto');
     let order = '';
@@ -273,9 +267,7 @@ test("chained thread-pool callbacks yield to due timers", async () => {
           go(i + 1);
         });
         // Spin so the 1ms interval is overdue and the thread-pool job has
-        // landed before the event loop decides whether to re-drain mid-tick.
-        // Wall-clock, not wait-for-condition: it constructs the state the
-        // yield check must observe.
+        // landed before the mid-tick re-drain decision.
         const s = Date.now(); while (Date.now() - s < 3);
       })(0);
     }, 5);
@@ -288,17 +280,12 @@ test("chained thread-pool callbacks yield to due timers", async () => {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   const out = JSON.parse(stdout.trim());
-  // Node and fixed Bun yield between every job (max consecutive R's = 1).
-  // Unfixed Bun runs the whole chain in one tick (max = 20); under CPU load
-  // the chain breaks up but the longest burst stays well above 3.
+  // Due timers must break the chain every iteration; allow small jitter.
   expect({ maxRunAtMost3: out.maxRun <= 3, order: out.order }).toEqual({ maxRunAtMost3: true, order: out.order });
   expect(exitCode).toBe(0);
 });
 
 test("chained thread-pool callbacks yield to pending setImmediate", async () => {
-  // Same mid-tick re-drain: a setImmediate queued from the first callback
-  // must run before the rest of the chain, matching Node's poll/check
-  // alternation.
   const script = `
     const crypto = require('crypto');
     let order = '';
@@ -322,8 +309,6 @@ test("chained thread-pool callbacks yield to pending setImmediate", async () => 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   const out = JSON.parse(stdout.trim());
-  // Node: "RIRRRR...". Bun before the fix: "RRRR...R" (immediate dropped by
-  // process.exit) or "RRRR...RI".
   expect(out.order.slice(0, 2)).toBe("RI");
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -245,3 +245,83 @@ describe.each(["with", "without"])("setImmediate %s timers running", mode => {
 it("should defer microtasks when an exception is thrown in an immediate", async () => {
   expect(await bunRun(["run", path.join(import.meta.dir, "timers-immediate-exception-fixture.js")])).toSpawn();
 });
+
+test("chained fs.read callbacks yield to due timers", async () => {
+  // Node/libuv delivers thread-pool completions once per poll and runs the
+  // timers phase between polls, so a chain of fs.read callbacks that each
+  // submit the next read interleaves with an overdue setInterval. Bun used to
+  // keep re-draining thread-pool completions inside one EventLoop::tick(),
+  // which meant the chain ran to completion before any due timer fired.
+  const script = `
+    const fs = require('fs');
+    const fd = fs.openSync(process.execPath, 'r');
+    let order = '';
+    setInterval(() => { order += 'T'; }, 1).unref();
+    setTimeout(() => {
+      (function go(i) {
+        if (i >= 20) {
+          const first = order.indexOf('R');
+          const last = order.lastIndexOf('R');
+          const between = order.slice(first, last + 1).split('T').length - 1;
+          console.log(JSON.stringify({ order, between }));
+          process.exit(0);
+        }
+        fs.read(fd, Buffer.alloc(1), 0, 1, 0, () => {
+          order += 'R';
+          go(i + 1);
+        });
+        // Spin so the 1ms interval is overdue and the thread-pool read has
+        // landed before the event loop decides whether to re-drain mid-tick.
+        // The spin is wall-clock, not a wait-for-condition: it constructs the
+        // state the yield check must observe.
+        const s = Date.now(); while (Date.now() - s < 2);
+      })(0);
+    }, 5);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const out = JSON.parse(stdout.trim());
+  // Node fires ~N-1 intervals between N reads with this shape; the fix only
+  // needs to guarantee the chain yields at all, so assert at least one.
+  expect({ between: out.between > 0, order: out.order }).toEqual({ between: true, order: out.order });
+  expect(exitCode).toBe(0);
+});
+
+test("chained fs.read callbacks yield to pending setImmediate", async () => {
+  // Same mid-tick re-drain: a setImmediate queued from the first read
+  // callback must run before the rest of the chain, matching Node's
+  // poll/check alternation.
+  const script = `
+    const fs = require('fs');
+    const fd = fs.openSync(process.execPath, 'r');
+    let order = '';
+    setTimeout(() => {
+      (function go(i) {
+        if (i >= 20) { console.log(JSON.stringify({ order })); process.exit(0); }
+        fs.read(fd, Buffer.alloc(1), 0, 1, 0, () => {
+          order += 'R';
+          if (i === 0) setImmediate(() => { order += 'I'; });
+          go(i + 1);
+        });
+        const s = Date.now(); while (Date.now() - s < 2);
+      })(0);
+    }, 1);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const out = JSON.parse(stdout.trim());
+  // Node: "RIRRRR...". Bun before the fix: "RRRR...RI" (or "RRRR...R" with
+  // the immediate dropped by process.exit).
+  expect(out.order.slice(0, 2)).toBe("RI");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -246,35 +246,37 @@ it("should defer microtasks when an exception is thrown in an immediate", async 
   expect(await bunRun(["run", path.join(import.meta.dir, "timers-immediate-exception-fixture.js")])).toSpawn();
 });
 
-test("chained fs.read callbacks yield to due timers", async () => {
+test("chained thread-pool callbacks yield to due timers", async () => {
   // Node/libuv delivers thread-pool completions once per poll and runs the
-  // timers phase between polls, so a chain of fs.read callbacks that each
-  // submit the next read interleaves with an overdue setInterval. Bun used to
-  // keep re-draining thread-pool completions inside one EventLoop::tick(),
-  // which meant the chain ran to completion before any due timer fired.
+  // timers phase between polls, so a chain of callbacks that each submit the
+  // next job interleaves with an overdue setInterval. Bun used to keep
+  // re-draining thread-pool completions inside one EventLoop::tick(), so the
+  // chain ran to completion before any due timer fired.
+  //
+  // crypto.pbkdf2 is used (not fs.read) because its completion goes through
+  // enqueue_task_concurrent on every platform; fs.read on Windows goes through
+  // libuv's own callback and never reaches the re-drain this test covers.
   const script = `
-    const fs = require('fs');
-    const fd = fs.openSync(process.execPath, 'r');
+    const crypto = require('crypto');
     let order = '';
     setInterval(() => { order += 'T'; }, 1).unref();
     setTimeout(() => {
       (function go(i) {
         if (i >= 20) {
-          const first = order.indexOf('R');
-          const last = order.lastIndexOf('R');
-          const between = order.slice(first, last + 1).split('T').length - 1;
-          console.log(JSON.stringify({ order, between }));
+          const runs = order.match(/R+/g) || [];
+          const maxRun = Math.max(0, ...runs.map(r => r.length));
+          console.log(JSON.stringify({ order, maxRun }));
           process.exit(0);
         }
-        fs.read(fd, Buffer.alloc(1), 0, 1, 0, () => {
+        crypto.pbkdf2('a', 'b', 1, 8, 'sha256', () => {
           order += 'R';
           go(i + 1);
         });
-        // Spin so the 1ms interval is overdue and the thread-pool read has
+        // Spin so the 1ms interval is overdue and the thread-pool job has
         // landed before the event loop decides whether to re-drain mid-tick.
-        // The spin is wall-clock, not a wait-for-condition: it constructs the
-        // state the yield check must observe.
-        const s = Date.now(); while (Date.now() - s < 2);
+        // Wall-clock, not wait-for-condition: it constructs the state the
+        // yield check must observe.
+        const s = Date.now(); while (Date.now() - s < 3);
       })(0);
     }, 5);
   `;
@@ -286,29 +288,29 @@ test("chained fs.read callbacks yield to due timers", async () => {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   const out = JSON.parse(stdout.trim());
-  // Node fires ~N-1 intervals between N reads with this shape; the fix only
-  // needs to guarantee the chain yields at all, so assert at least one.
-  expect({ between: out.between > 0, order: out.order }).toEqual({ between: true, order: out.order });
+  // Node and fixed Bun yield between every job (max consecutive R's = 1).
+  // Unfixed Bun runs the whole chain in one tick (max = 20); under CPU load
+  // the chain breaks up but the longest burst stays well above 3.
+  expect({ maxRunAtMost3: out.maxRun <= 3, order: out.order }).toEqual({ maxRunAtMost3: true, order: out.order });
   expect(exitCode).toBe(0);
 });
 
-test("chained fs.read callbacks yield to pending setImmediate", async () => {
-  // Same mid-tick re-drain: a setImmediate queued from the first read
-  // callback must run before the rest of the chain, matching Node's
-  // poll/check alternation.
+test("chained thread-pool callbacks yield to pending setImmediate", async () => {
+  // Same mid-tick re-drain: a setImmediate queued from the first callback
+  // must run before the rest of the chain, matching Node's poll/check
+  // alternation.
   const script = `
-    const fs = require('fs');
-    const fd = fs.openSync(process.execPath, 'r');
+    const crypto = require('crypto');
     let order = '';
     setTimeout(() => {
       (function go(i) {
         if (i >= 20) { console.log(JSON.stringify({ order })); process.exit(0); }
-        fs.read(fd, Buffer.alloc(1), 0, 1, 0, () => {
+        crypto.pbkdf2('a', 'b', 1, 8, 'sha256', () => {
           order += 'R';
           if (i === 0) setImmediate(() => { order += 'I'; });
           go(i + 1);
         });
-        const s = Date.now(); while (Date.now() - s < 2);
+        const s = Date.now(); while (Date.now() - s < 3);
       })(0);
     }, 1);
   `;
@@ -320,8 +322,8 @@ test("chained fs.read callbacks yield to pending setImmediate", async () => {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   const out = JSON.parse(stdout.trim());
-  // Node: "RIRRRR...". Bun before the fix: "RRRR...RI" (or "RRRR...R" with
-  // the immediate dropped by process.exit).
+  // Node: "RIRRRR...". Bun before the fix: "RRRR...R" (immediate dropped by
+  // process.exit) or "RRRR...RI".
   expect(out.order.slice(0, 2)).toBe("RI");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Repro

```js
const crypto = require('crypto');
let order = '';
setInterval(() => { order += 'T'; }, 1).unref();
setTimeout(() => {
  (function go(i) {
    if (i >= 20) { console.log(order); process.exit(0); }
    crypto.pbkdf2('a', 'b', 1, 8, 'sha256', () => { order += 'R'; go(i + 1); });
    const s = Date.now(); while (Date.now() - s < 3);
  })(0);
}, 5);
```

```
node (linux+windows): TTRTRTRTRTRTRTRTRTRTRTRTRTRTRTRTRTRTRTRTR
bun  (linux+windows): TTTTRRRRRRRRRRRRRRRRRRRR
```

No interval fires between the 20 thread-pool callbacks even though every one of them is overdue. Same shape with `setImmediate` queued from the first callback: Node runs it before the second callback, Bun runs the whole chain first. The same starvation shows with `fs.read` on POSIX (on Windows `fs.read` completes via libuv's own callback and is unaffected).

### Cause

`EventLoop::tick()` re-drains `concurrent_tasks` (thread-pool completions) inside its `while tick_with_count() > 0` loop (`src/jsc/event_loop.rs`). When a callback submits the next job and the worker thread finishes before the loop cycles, `tick_concurrent()` promotes the completion and `tick_with_count` runs it in the same `tick()`. The chain runs to completion before `tick()` returns, and `auto_tick*` (which runs immediates, polls, and drains timers) is never reached.

libuv delivers thread-pool completions once per poll (`uv_async_t`) and every poll is followed by check and then the timers phase, so Node interleaves. The inner-loop `tickConcurrent()` dates to `0ce709d96a` ("Make new HTTP client more stable", 2022) with no documented invariant; before that it was once per outer iteration.

This is the same mechanism #36314 addresses for `MessagePort` reschedules and #32807 addresses for `setImmediate`, but for due JS timers, and applied at the re-drain site rather than per producer.

### Fix

Gate the three mid-tick `tick_concurrent()` calls via `tick_concurrent_unless_due()`:

- return early when `immediate_tasks` is non-empty (same-thread `Vec`, checked unconditionally so a cross-thread push landing between the `concurrent_tasks` peek and `pop_batch()` cannot slip ahead of a pending `setImmediate`);
- return early when `concurrent_tasks` is non-empty and a JS timer is already due. The `concurrent_tasks` guard keeps the clock read off the path when nothing arrived (an HTTP server always has `DateHeaderTimer` armed).

The unconditional `tick_concurrent()` at the start of `tick()` stays as the once-per-iteration batch boundary (one poll's worth of completions, as in libuv).

The due-timer probe (`timer::All::has_due_regular_timer`, reached via a link-time `extern "Rust"` because the heap lives in `bun_runtime`) peeks the regular heap and reads the clock only when it is non-empty. `tick_with_count` drains the whole `tasks` FIFO in one call, so the probe runs once per thread-pool completion batch, not per task. WTF timers are not checked (would need the `wtf_timers` lock every iteration; they are at most one loop iteration away once `tick()` returns).

Applies on both platforms: on Windows `on_uv_timer` fires inside `uv_run` in `auto_tick*`, which is only reached when `tick()` returns. `tick_tasks_only` (spawnSync's isolated loop) is unchanged since that context does not run timers.

### Verification

Two new tests in `test/js/node/timers/node-timers.test.ts` use `crypto.pbkdf2` (its completion goes through `enqueue_task_concurrent` on every platform; `fs.read` on Windows does not):

- `chained thread-pool callbacks yield to due timers`: asserts the longest run of consecutive callbacks between interval firings is at most 3. Fails on main with `maxRun:20`, passes with the fix (`maxRun:1`, same as Node). The longest-run metric stays robust under CPU contention, where the unfixed build's bursts stay at 9+ while the fixed build stays at 1.
- `chained thread-pool callbacks yield to pending setImmediate`: asserts `order` starts `RI`. Fails on main with `RR`, passes with the fix.

Both tests fail on the Windows canary build (`maxRun:20`, `RR`) and match Node there once the fix applies.

Regression sweep on the debug build: `node-timers.test.ts` 22/22, `worker_threads.test.ts` 91/91, node parallel `test-timers-*` / `test-fs-read-stream-pos.js` all pass. The `setInterval`/`setTimeout` leak tests in `test/js/web/timers` and the `fetch.test.ts` connect failures also fail on main in this container.

Surfaced by `test-fs-read-stream-pos.js` (#36478): after #34834 raised Windows timer resolution to ~1ms, each `ReadStream` instance's pread chain ran ahead of the 1ms appender and the test's exit-path race rarely hit.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/timers/node-timers.test.ts

<!-- robobun:evidence:end -->