### PR TITLE
shell: reject `>>` to a Buffer/ArrayBuffer instead of silently overwriting from offset 0

### DIFF
--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -158,7 +158,7 @@ You can redirect output to these JavaScript objects:
 - `Buffer`, `Uint8Array`, `Uint16Array`, `Uint32Array`, `Int8Array`, `Int16Array`, `Int32Array`, `Float32Array`, `Float64Array`, `ArrayBuffer`, `SharedArrayBuffer` (writes to the underlying buffer)
 - `Bun.file(path)`, `Bun.file(fd)` (writes to the file)
 
-The append operators (`>>`, `2>>`, `&>>`) are only supported for file destinations. Appending to any of the fixed-size buffer targets above (`Buffer`, typed arrays, `ArrayBuffer`, `SharedArrayBuffer`) fails with an error because a fixed-size buffer has no write cursor to append after; use `>` to write from the start of the buffer instead.
+The append operators (`>>`, `2>>`, `&>>`) are only supported for file destinations (a path string or `Bun.file(path)`). Appending to any of the fixed-size buffer targets above (`Buffer`, typed arrays, `ArrayBuffer`, `SharedArrayBuffer`) fails with an error because a fixed-size buffer has no write cursor to append after; use `>` to write from the start of the buffer instead.
 
 ### Example: Redirect input from JavaScript objects (`<`)
 

--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -158,7 +158,7 @@ You can redirect output to these JavaScript objects:
 - `Buffer`, `Uint8Array`, `Uint16Array`, `Uint32Array`, `Int8Array`, `Int16Array`, `Int32Array`, `Float32Array`, `Float64Array`, `ArrayBuffer`, `SharedArrayBuffer` (writes to the underlying buffer)
 - `Bun.file(path)`, `Bun.file(fd)` (writes to the file)
 
-The append operators (`>>`, `2>>`, `&>>`) are only supported for file destinations. Appending to a `Buffer` or `ArrayBuffer` fails with an error because a fixed-size buffer has no write cursor to append after; use `>` to write from the start of the buffer instead.
+The append operators (`>>`, `2>>`, `&>>`) are only supported for file destinations. Appending to any of the fixed-size buffer targets above (`Buffer`, typed arrays, `ArrayBuffer`, `SharedArrayBuffer`) fails with an error because a fixed-size buffer has no write cursor to append after; use `>` to write from the start of the buffer instead.
 
 ### Example: Redirect input from JavaScript objects (`<`)
 

--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -158,6 +158,8 @@ You can redirect output to these JavaScript objects:
 - `Buffer`, `Uint8Array`, `Uint16Array`, `Uint32Array`, `Int8Array`, `Int16Array`, `Int32Array`, `Float32Array`, `Float64Array`, `ArrayBuffer`, `SharedArrayBuffer` (writes to the underlying buffer)
 - `Bun.file(path)`, `Bun.file(fd)` (writes to the file)
 
+The append operators (`>>`, `2>>`, `&>>`) are only supported for file destinations. Appending to a `Buffer` or `ArrayBuffer` fails with an error because a fixed-size buffer has no write cursor to append after; use `>` to write from the start of the buffer instead.
+
 ### Example: Redirect input from JavaScript objects (`<`)
 
 To use a JavaScript object as stdin, use the `<` operator:

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -704,6 +704,16 @@ impl Builtin {
                 let jsval = interp.jsobjs[idx];
 
                 if let Some(buf) = jsval.as_array_buffer(global) {
+                    if redirect.append() && !redirect.stdin() {
+                        return Some(Self::cmd_write_failing_error(
+                            interp,
+                            cmd,
+                            format_args!(
+                                "bun: can't append (>>) output to a Buffer or ArrayBuffer; \
+                                 use > to overwrite, or redirect to a file\n"
+                            ),
+                        ));
+                    }
                     // Each slot gets its own Strong (sharing one would
                     // double-free on Drop).
                     let mk = || {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -709,6 +709,16 @@ impl Cmd {
                 let jsval = interp.jsobjs[idx];
 
                 if let Some(buf) = jsval.as_array_buffer(global) {
+                    if flags.append() && !flags.stdin() {
+                        return Ok(Some(Builtin::cmd_write_failing_error(
+                            interp,
+                            this,
+                            format_args!(
+                                "bun: can't append (>>) output to a Buffer or ArrayBuffer; \
+                                 use > to overwrite, or redirect to a file\n"
+                            ),
+                        )));
+                    }
                     let mk_out = || {
                         let pinned = jsval.as_pinned_arraybuffer(global);
                         Stdio::ArrayBuffer(crate::jsc::array_buffer::ArrayBufferStrong {

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -477,7 +477,7 @@ pub mod ast {
             self.contains(Self::STDERR)
         }
         #[inline]
-        pub(crate) fn append(self) -> bool {
+        pub fn append(self) -> bool {
             self.contains(Self::APPEND)
         }
         #[inline]

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1617,6 +1617,17 @@ describe("deno_task", () => {
           exitCode: 0,
         });
       });
+
+      test(">> Bun.file(path) still appends", async () => {
+        using dir = tempDir("shell-append-bunfile", { "out.txt": "AAAA\n" });
+        const p = join(String(dir), "out.txt");
+        const { stderr, exitCode } = await $`echo BB >> ${Bun.file(p)}`.quiet();
+        expect({ stderr: stderr.toString(), text: await Bun.file(p).text(), exitCode }).toEqual({
+          stderr: "",
+          text: "AAAA\nBB\n",
+          exitCode: 0,
+        });
+      });
     });
 
     // &> and &>> redirect

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1552,43 +1552,58 @@ describe("deno_task", () => {
       // this was rejected, `>>` silently overwrote from offset 0 (identical to
       // `>`), losing data without warning.
       const msg = "bun: can't append (>>) output to a Buffer or ArrayBuffer";
+      const targets: Array<[string, () => ArrayBufferLike | ArrayBufferView]> = [
+        ["Buffer", () => Buffer.alloc(16, ".")],
+        ["ArrayBuffer", () => new ArrayBuffer(16)],
+        ["Uint8Array", () => new Uint8Array(16)],
+      ];
+      const bytes = (b: ArrayBufferLike | ArrayBufferView) =>
+        b instanceof ArrayBuffer || b instanceof SharedArrayBuffer ? new Uint8Array(b) : new Uint8Array(b.buffer);
 
-      test(">> Buffer (builtin)", async () => {
-        const buf = Buffer.alloc(16, ".");
-        const { stderr, exitCode } = await $`echo AAAA >> ${buf}`.quiet();
-        expect(stderr.toString()).toContain(msg);
-        expect(buf.toString()).toBe(Buffer.alloc(16, ".").toString());
-        expect(exitCode).toBe(1);
+      describe.each(targets)("builtin -> %s", (_name, make) => {
+        test(">>", async () => {
+          const buf = make();
+          const before = bytes(buf).slice();
+          const { stderr, exitCode } = await $`echo AAAA >> ${buf}`.quiet();
+          expect(stderr.toString()).toContain(msg);
+          expect(bytes(buf)).toEqual(before);
+          expect(exitCode).toBe(1);
+        });
+        test("2>>", async () => {
+          const buf = make();
+          const { stderr, exitCode } = await $`echo AAAA 2>> ${buf}`.quiet();
+          expect(stderr.toString()).toContain(msg);
+          expect(exitCode).toBe(1);
+        });
+        test("&>>", async () => {
+          const buf = make();
+          const { stderr, exitCode } = await $`echo AAAA &>> ${buf}`.quiet();
+          expect(stderr.toString()).toContain(msg);
+          expect(exitCode).toBe(1);
+        });
       });
 
-      test(">> ArrayBuffer (builtin)", async () => {
-        const ab = new ArrayBuffer(16);
-        const { stderr, exitCode } = await $`echo AAAA >> ${ab}`.quiet();
-        expect(stderr.toString()).toContain(msg);
-        expect(new Uint8Array(ab).every(b => b === 0)).toBe(true);
-        expect(exitCode).toBe(1);
-      });
-
-      test("2>> Buffer (builtin)", async () => {
-        const buf = Buffer.alloc(16, ".");
-        const { stderr, exitCode } = await $`echo AAAA 2>> ${buf}`.quiet();
-        expect(stderr.toString()).toContain(msg);
-        expect(exitCode).toBe(1);
-      });
-
-      test("&>> Buffer (builtin)", async () => {
-        const buf = Buffer.alloc(16, ".");
-        const { stderr, exitCode } = await $`echo AAAA &>> ${buf}`.quiet();
-        expect(stderr.toString()).toContain(msg);
-        expect(exitCode).toBe(1);
-      });
-
-      test(">> Buffer (external command)", async () => {
-        const buf = Buffer.alloc(16, ".");
-        const { stderr, exitCode } = await $`${BUN} -e 'console.log("AAAA")' >> ${buf}`.env(bunEnv).quiet();
-        expect(stderr.toString()).toContain(msg);
-        expect(buf.toString()).toBe(Buffer.alloc(16, ".").toString());
-        expect(exitCode).toBe(1);
+      describe.each(targets)("external -> %s", (_name, make) => {
+        test.concurrent(">>", async () => {
+          const buf = make();
+          const before = bytes(buf).slice();
+          const { stderr, exitCode } = await $`${BUN} -e 'console.log("AAAA")' >> ${buf}`.env(bunEnv).quiet();
+          expect(stderr.toString()).toContain(msg);
+          expect(bytes(buf)).toEqual(before);
+          expect(exitCode).toBe(1);
+        });
+        test.concurrent("2>>", async () => {
+          const buf = make();
+          const { stderr, exitCode } = await $`${BUN} -e 'console.error("AAAA")' 2>> ${buf}`.env(bunEnv).quiet();
+          expect(stderr.toString()).toContain(msg);
+          expect(exitCode).toBe(1);
+        });
+        test.concurrent("&>>", async () => {
+          const buf = make();
+          const { stderr, exitCode } = await $`${BUN} -e 'console.log("AAAA")' &>> ${buf}`.env(bunEnv).quiet();
+          expect(stderr.toString()).toContain(msg);
+          expect(exitCode).toBe(1);
+        });
       });
 
       test("> Buffer still overwrites from offset 0", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1560,7 +1560,11 @@ describe("deno_task", () => {
       ];
       const bytes = (b: ArrayBufferLike | ArrayBufferView) =>
         b instanceof ArrayBuffer || b instanceof SharedArrayBuffer ? new Uint8Array(b) : new Uint8Array(b.buffer);
-      const expectRejected = (buf: ArrayBufferLike | ArrayBufferView, before: Uint8Array, result: Bun.$.ShellOutput) => {
+      const expectRejected = (
+        buf: ArrayBufferLike | ArrayBufferView,
+        before: Uint8Array,
+        result: Bun.$.ShellOutput,
+      ) => {
         expect({ stderr: result.stderr.toString(), bytes: bytes(buf), exitCode: result.exitCode }).toEqual({
           stderr: msg,
           bytes: before,

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1547,6 +1547,59 @@ describe("deno_task", () => {
       .fileEquals("test.txt", "1\n2\n")
       .runAsTest("appending");
 
+    describe(">> to a Buffer/ArrayBuffer is rejected (no silent overwrite)", () => {
+      // A fixed-size buffer has no write cursor, so `>>` cannot append. Before
+      // this was rejected, `>>` silently overwrote from offset 0 (identical to
+      // `>`), losing data without warning.
+      const msg = "bun: can't append (>>) output to a Buffer or ArrayBuffer";
+
+      test(">> Buffer (builtin)", async () => {
+        const buf = Buffer.alloc(16, ".");
+        const { stderr, exitCode } = await $`echo AAAA >> ${buf}`.quiet();
+        expect(stderr.toString()).toContain(msg);
+        expect(buf.toString()).toBe(Buffer.alloc(16, ".").toString());
+        expect(exitCode).toBe(1);
+      });
+
+      test(">> ArrayBuffer (builtin)", async () => {
+        const ab = new ArrayBuffer(16);
+        const { stderr, exitCode } = await $`echo AAAA >> ${ab}`.quiet();
+        expect(stderr.toString()).toContain(msg);
+        expect(new Uint8Array(ab).every(b => b === 0)).toBe(true);
+        expect(exitCode).toBe(1);
+      });
+
+      test("2>> Buffer (builtin)", async () => {
+        const buf = Buffer.alloc(16, ".");
+        const { stderr, exitCode } = await $`echo AAAA 2>> ${buf}`.quiet();
+        expect(stderr.toString()).toContain(msg);
+        expect(exitCode).toBe(1);
+      });
+
+      test("&>> Buffer (builtin)", async () => {
+        const buf = Buffer.alloc(16, ".");
+        const { stderr, exitCode } = await $`echo AAAA &>> ${buf}`.quiet();
+        expect(stderr.toString()).toContain(msg);
+        expect(exitCode).toBe(1);
+      });
+
+      test(">> Buffer (external command)", async () => {
+        const buf = Buffer.alloc(16, ".");
+        const { stderr, exitCode } = await $`${BUN} -e 'console.log("AAAA")' >> ${buf}`.env(bunEnv).quiet();
+        expect(stderr.toString()).toContain(msg);
+        expect(buf.toString()).toBe(Buffer.alloc(16, ".").toString());
+        expect(exitCode).toBe(1);
+      });
+
+      test("> Buffer still overwrites from offset 0", async () => {
+        const buf = Buffer.alloc(16, ".");
+        const { stderr, exitCode } = await $`echo AAAA > ${buf}`.quiet();
+        expect(stderr.toString()).toBe("");
+        expect(buf.subarray(0, 5).toString()).toBe("AAAA\n");
+        expect(exitCode).toBe(0);
+      });
+    });
+
     // &> and &>> redirect
     await TestBuilder.command`BUN_TEST_VAR=1 ${BUN} -e 'console.log(1); setTimeout(() => console.error(23), 10)' &> file.txt && BUN_TEST_VAR=1 ${BUN} -e 'console.log(456); setTimeout(() => console.error(789), 10)' &>> file.txt`
       .fileEquals("file.txt", "1\n23\n456\n789\n")

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1551,7 +1551,8 @@ describe("deno_task", () => {
       // A fixed-size buffer has no write cursor, so `>>` cannot append. Before
       // this was rejected, `>>` silently overwrote from offset 0 (identical to
       // `>`), losing data without warning.
-      const msg = "bun: can't append (>>) output to a Buffer or ArrayBuffer";
+      const msg =
+        "bun: can't append (>>) output to a Buffer or ArrayBuffer; use > to overwrite, or redirect to a file\n";
       const targets: Array<[string, () => ArrayBufferLike | ArrayBufferView]> = [
         ["Buffer", () => Buffer.alloc(16, ".")],
         ["ArrayBuffer", () => new ArrayBuffer(16)],
@@ -1559,27 +1560,29 @@ describe("deno_task", () => {
       ];
       const bytes = (b: ArrayBufferLike | ArrayBufferView) =>
         b instanceof ArrayBuffer || b instanceof SharedArrayBuffer ? new Uint8Array(b) : new Uint8Array(b.buffer);
+      const expectRejected = (buf: ArrayBufferLike | ArrayBufferView, before: Uint8Array, result: Bun.$.ShellOutput) => {
+        expect({ stderr: result.stderr.toString(), bytes: bytes(buf), exitCode: result.exitCode }).toEqual({
+          stderr: msg,
+          bytes: before,
+          exitCode: 1,
+        });
+      };
 
       describe.each(targets)("builtin -> %s", (_name, make) => {
         test(">>", async () => {
           const buf = make();
           const before = bytes(buf).slice();
-          const { stderr, exitCode } = await $`echo AAAA >> ${buf}`.quiet();
-          expect(stderr.toString()).toContain(msg);
-          expect(bytes(buf)).toEqual(before);
-          expect(exitCode).toBe(1);
+          expectRejected(buf, before, await $`echo AAAA >> ${buf}`.quiet());
         });
         test("2>>", async () => {
           const buf = make();
-          const { stderr, exitCode } = await $`echo AAAA 2>> ${buf}`.quiet();
-          expect(stderr.toString()).toContain(msg);
-          expect(exitCode).toBe(1);
+          const before = bytes(buf).slice();
+          expectRejected(buf, before, await $`echo AAAA 2>> ${buf}`.quiet());
         });
         test("&>>", async () => {
           const buf = make();
-          const { stderr, exitCode } = await $`echo AAAA &>> ${buf}`.quiet();
-          expect(stderr.toString()).toContain(msg);
-          expect(exitCode).toBe(1);
+          const before = bytes(buf).slice();
+          expectRejected(buf, before, await $`echo AAAA &>> ${buf}`.quiet());
         });
       });
 
@@ -1587,31 +1590,28 @@ describe("deno_task", () => {
         test.concurrent(">>", async () => {
           const buf = make();
           const before = bytes(buf).slice();
-          const { stderr, exitCode } = await $`${BUN} -e 'console.log("AAAA")' >> ${buf}`.env(bunEnv).quiet();
-          expect(stderr.toString()).toContain(msg);
-          expect(bytes(buf)).toEqual(before);
-          expect(exitCode).toBe(1);
+          expectRejected(buf, before, await $`${BUN} -e 'console.log("AAAA")' >> ${buf}`.env(bunEnv).quiet());
         });
         test.concurrent("2>>", async () => {
           const buf = make();
-          const { stderr, exitCode } = await $`${BUN} -e 'console.error("AAAA")' 2>> ${buf}`.env(bunEnv).quiet();
-          expect(stderr.toString()).toContain(msg);
-          expect(exitCode).toBe(1);
+          const before = bytes(buf).slice();
+          expectRejected(buf, before, await $`${BUN} -e 'console.error("AAAA")' 2>> ${buf}`.env(bunEnv).quiet());
         });
         test.concurrent("&>>", async () => {
           const buf = make();
-          const { stderr, exitCode } = await $`${BUN} -e 'console.log("AAAA")' &>> ${buf}`.env(bunEnv).quiet();
-          expect(stderr.toString()).toContain(msg);
-          expect(exitCode).toBe(1);
+          const before = bytes(buf).slice();
+          expectRejected(buf, before, await $`${BUN} -e 'console.log("AAAA")' &>> ${buf}`.env(bunEnv).quiet());
         });
       });
 
       test("> Buffer still overwrites from offset 0", async () => {
         const buf = Buffer.alloc(16, ".");
         const { stderr, exitCode } = await $`echo AAAA > ${buf}`.quiet();
-        expect(stderr.toString()).toBe("");
-        expect(buf.subarray(0, 5).toString()).toBe("AAAA\n");
-        expect(exitCode).toBe(0);
+        expect({ stderr: stderr.toString(), head: buf.subarray(0, 5).toString(), exitCode }).toEqual({
+          stderr: "",
+          head: "AAAA\n",
+          exitCode: 0,
+        });
       });
     });
 


### PR DESCRIPTION
## Repro

```js
import { $ } from "bun";
const buf = Buffer.alloc(40, ".");
await $`echo AAAA >> ${buf}`;
await $`echo BB >> ${buf}`;
console.log(JSON.stringify(buf.toString()));
// before: "BB\nA\n..."   (second >> wrote at offset 0, clobbered AAAA)
// file control: `echo AAAA >> f; echo BB >> f` correctly gives "AAAA\nBB\n"
```

The same overwrite happened for raw `ArrayBuffer`, `2>>`, `&>>`, and for external (non-builtin) commands.

## Cause

The JS-object redirect branch builds the array-buffer sink without consulting `RedirectFlags::append()`, so `>>` and `>` were identical for buffer targets:

- `src/runtime/shell/Builtin.rs` (`init_redirections`, builtin path): `BuiltinIO::ArrayBuf { buf, i: 0 }`
- `src/runtime/shell/states/Cmd.rs` (`init_subproc_redirections`, subprocess path): `Stdio::ArrayBuffer(...)` → `BufferedOutput::ArrayBuffer { buf, i: 0 }`

Both always write from offset 0. The file path honours `O_APPEND` via `RedirectFlags::to_flags()`.

## Fix

A fixed-size `Buffer`/`ArrayBuffer` has no write cursor, so there is no sound way to "append" to one across (or even within) separate `$` invocations. Rather than inventing an arbitrary heuristic, the append redirect now fails the command with exit code 1 and a stderr message:

```
bun: can't append (>>) output to a Buffer or ArrayBuffer; use > to overwrite, or redirect to a file
```

The error is reported via `Builtin::cmd_write_failing_error` so it flows through the normal `child_done` → `finish()` teardown (stderr + exit 1), the same path the existing "ambiguous redirect" errors take. `>` to a buffer is unchanged.

`RedirectFlags::append()` is made `pub` so the runtime crate can read it (the other flag accessors were already public).

## Verification

```
$ bun bd test test/js/bun/shell/bunshell.test.ts -t ">> to a Buffer"
 6 pass
 0 fail
```

Full `bunshell.test.ts`: 420 pass, 0 fail. The new tests fail on stock bun 1.4.0 (5 fail, control passes).

Docs updated to note that append operators are file-only for JS redirect targets.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->