### PR TITLE
bundler: scope thread-pool join barriers to the batch, not the whole pool

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -145,7 +145,7 @@ unsafe impl Sync for Chunk {}
 /// Allocated single-threaded in `generate_chunks_in_parallel` *before* the
 /// `generate_compile_result_for_*_chunk` fan-out, written concurrently by
 /// worker threads at **disjoint** indices (one slot per `PendingPartRange.i`),
-/// then read single-threaded after `worker_pool.wait_for_all()`. Wrapping each
+/// then read single-threaded after the batch `WaitGroup` is joined. Wrapping each
 /// slot in `UnsafeCell` makes the per-task write sound through a shared view —
 /// worker callbacks never need to materialize an aliased `&mut Chunk` or
 /// `&mut [CompileResult]` to publish their result.
@@ -154,7 +154,7 @@ unsafe impl Sync for Chunk {}
 pub struct CompileResultSlots(Box<[UnsafeCell<CompileResult>]>);
 
 // SAFETY: writes target disjoint slots (unique `i` per task); reads happen
-// only after the pool join (happens-before via `wait_for_all`).
+// only after the pool join (happens-before via the batch `WaitGroup`).
 // `CompileResult` itself is `Send`.
 unsafe impl Sync for CompileResultSlots {}
 
@@ -170,7 +170,7 @@ impl CompileResultSlots {
         self.0.len()
     }
 
-    /// Post-join read view. Single-threaded callers only (after `wait_for_all`).
+    /// Post-join read view. Single-threaded callers only (after the batch join).
     #[inline]
     pub fn iter(&self) -> impl ExactSizeIterator<Item = &CompileResult> + '_ {
         // SAFETY: reads happen only after the pool join; no concurrent writer.

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1566,7 +1566,7 @@ pub struct GenerateChunkCtx<'a> {
     pub(crate) c: bun_ptr::ParentRef<LinkerContext<'a>>,
     /// Backref to the full `chunks: &mut [Chunk]` slice owned by
     /// `generate_chunks_in_parallel`. The slice outlives every
-    /// `GenerateChunkCtx` (joined via `wait_for_all`), so [`bun_ptr::BackRef`]'s
+    /// `GenerateChunkCtx` (joined via the batch `WaitGroup`), so [`bun_ptr::BackRef`]'s
     /// owner-outlives-holder invariant holds and per-task reads go through
     /// safe `Deref`. Tasks that need write provenance (HTML loader) recover
     /// the raw `*mut [Chunk]` via [`bun_ptr::BackRef::as_ptr`].
@@ -1619,6 +1619,27 @@ pub struct PendingPartRange<'a> {
     pub(crate) task: ThreadPoolLib::Task,
     pub(crate) ctx: &'a GenerateChunkCtx<'a>,
     pub(crate) i: u32,
+    /// Owned by the scheduling stack frame, which blocks in `wait()` until every
+    /// task in the batch has finished. Counted down via [`BatchDone`].
+    pub(crate) wait_group: *const WaitGroup,
+}
+
+/// Counts one task down on a batch-scoped [`WaitGroup`] when dropped.
+///
+/// [`pending_part_range_prologue`] returns this as the **first** tuple element so
+/// that callbacks bind it first and it therefore drops *last* — after the
+/// per-thread `Worker` is ungot and after any crash-trace guard. Releasing the
+/// barrier earlier would let the scheduling frame (which owns the tasks and the
+/// `WaitGroup`) be destroyed while this callback is still running.
+pub(crate) struct BatchDone(*const WaitGroup);
+
+impl Drop for BatchDone {
+    fn drop(&mut self) {
+        // SAFETY: the scheduling frame blocks in `WaitGroup::wait()` until every
+        // task in the batch has finished, so the pointee outlives this call.
+        // `finish()` does not touch `self` after publishing zero (WaitGroup.rs).
+        unsafe { (*self.0).finish() };
+    }
 }
 
 /// Shared prologue for `generate_compile_result_for_{js,css}_chunk` thread-pool
@@ -1648,6 +1669,7 @@ pub struct PendingPartRange<'a> {
 pub(crate) unsafe fn pending_part_range_prologue<'a>(
     task: *mut ThreadPoolLib::Task,
 ) -> (
+    BatchDone,
     &'a PendingPartRange<'a>,
     *mut LinkerContext<'a>,
     *mut Chunk,
@@ -1664,7 +1686,13 @@ pub(crate) unsafe fn pending_part_range_prologue<'a>(
     let chunk_ptr: *mut Chunk = ctx.chunk.as_ptr();
     let worker = crate::thread_pool::Worker::get(ctx.bundle());
     let worker = scopeguard::guard(worker, |w| w.unget());
-    (part_range, c_ptr, chunk_ptr, worker)
+    (
+        BatchDone(part_range.wait_group),
+        part_range,
+        c_ptr,
+        chunk_ptr,
+        worker,
+    )
 }
 
 impl<'a> LinkerContext<'a> {

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -83,7 +83,7 @@ pub(crate) fn generate_chunk_json(
         let file_source_index = *file_source_index;
         // Counters are `AtomicUsize` because they're populated by the parallel
         // codegen workers; metafile emission runs strictly after the
-        // `wait_for_all` join in `generate_chunks_in_parallel`, so a relaxed
+        // batch-`WaitGroup` join in `generate_chunks_in_parallel`, so a relaxed
         // load observes the final value.
         let bytes_in_output = bytes_in_output.load(core::sync::atomic::Ordering::Relaxed);
         if file_source_index as usize >= sources.len() {

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -8,7 +8,7 @@ use bun_collections::StringHashMap;
 use bun_core::String as BunString;
 use bun_core::strings;
 use bun_paths as path;
-use bun_threading::thread_pool as ThreadPoolLib;
+use bun_threading::{WaitGroup, thread_pool as ThreadPoolLib};
 
 use crate::BundleV2;
 use crate::Chunk;
@@ -100,6 +100,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
 
             let mut batch = ThreadPoolLib::Batch::default();
             let mut tasks: Vec<PrepareCssAstTask> = Vec::with_capacity(total_count);
+            let wait_group = WaitGroup::init_with_count(total_count);
             for chunk in chunks.iter_mut() {
                 if chunk.content.is_css() {
                     tasks.push(PrepareCssAstTask {
@@ -111,6 +112,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         // `PrepareCssAstTask.linker` is `*mut LinkerContext<'static>`
                         // (raw ptr is invariant); `.cast()` erases the inner `'a` to satisfy it.
                         linker: std::ptr::from_mut::<LinkerContext>(c).cast(),
+                        wait_group: &raw const wait_group,
                     });
                     // Capacity pre-reserved → push never reallocates → ptr stays stable.
                     let task = tasks.last_mut().unwrap();
@@ -122,7 +124,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             // the link step); `pool` is the arena-allocated bundler ThreadPool.
             let worker_pool = c.worker_pool();
             worker_pool.schedule(batch);
-            worker_pool.wait_for_all();
+            wait_group.wait();
 
             debug!("  DONE {} prepare CSS ast (total count)", total_count);
         } else if cfg!(debug_assertions) {
@@ -180,6 +182,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             // batch holds raw pointers into this buffer.
             let mut combined_part_ranges: Vec<PendingPartRange> = Vec::with_capacity(total_count);
             let mut batch = ThreadPoolLib::Batch::default();
+            let wait_group = WaitGroup::init_with_count(total_count);
             for (chunk, chunk_ctx) in chunks.iter_mut().zip(chunk_contexts.iter_mut()) {
                 match &chunk.content {
                     crate::chunk::Content::Javascript(js) => {
@@ -195,10 +198,11 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                                 // conflating the borrow with
                                 // LinkerContext's `'a`. Launder via raw ptr so borrowck
                                 // doesn't pin `chunk_contexts` for `'a`; tasks complete
-                                // before `chunk_contexts` drops (we `wait_for_all` below).
+                                // before `chunk_contexts` drops (we wait on `wait_group` below).
                                 ctx: unsafe {
                                     bun_ptr::detach_lifetime_ref::<GenerateChunkCtx>(chunk_ctx)
                                 },
+                                wait_group: &raw const wait_group,
                             });
                             batch.push(ThreadPoolLib::Batch::from(
                                 &raw mut combined_part_ranges.last_mut().unwrap().task,
@@ -218,10 +222,11 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                                 // conflating the borrow with
                                 // LinkerContext's `'a`. Launder via raw ptr so borrowck
                                 // doesn't pin `chunk_contexts` for `'a`; tasks complete
-                                // before `chunk_contexts` drops (we `wait_for_all` below).
+                                // before `chunk_contexts` drops (we wait on `wait_group` below).
                                 ctx: unsafe {
                                     bun_ptr::detach_lifetime_ref::<GenerateChunkCtx>(chunk_ctx)
                                 },
+                                wait_group: &raw const wait_group,
                             });
                             batch.push(ThreadPoolLib::Batch::from(
                                 &raw mut combined_part_ranges.last_mut().unwrap().task,
@@ -240,10 +245,11 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                             // conflating the borrow with
                             // LinkerContext's `'a`. Launder via raw ptr so borrowck
                             // doesn't pin `chunk_contexts` for `'a`; tasks complete
-                            // before `chunk_contexts` drops (we `wait_for_all` below).
+                            // before `chunk_contexts` drops (we wait on `wait_group` below).
                             ctx: unsafe {
                                 bun_ptr::detach_lifetime_ref::<GenerateChunkCtx>(chunk_ctx)
                             },
+                            wait_group: &raw const wait_group,
                         });
                         batch.push(ThreadPoolLib::Batch::from(
                             &raw mut combined_part_ranges.last_mut().unwrap().task,
@@ -256,7 +262,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             // the link step); `pool` is the arena-allocated bundler ThreadPool.
             let worker_pool = c.worker_pool();
             worker_pool.schedule(batch);
-            worker_pool.wait_for_all();
+            wait_group.wait();
             debug!("  DONE {} compiling part ranges", total_count);
         }
 

--- a/src/bundler/linker_context/generateCompileResultForCssChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForCssChunk.rs
@@ -29,7 +29,8 @@ use crate::{Chunk, CompileResult, Index};
 pub(crate) unsafe fn generate_compile_result_for_css_chunk(task: *mut ThreadPoolLib::Task) {
     // SAFETY: `task` is the intrusive `task` field of a `PendingPartRange`
     // scheduled by `generate_chunks_in_parallel`; see the helper's contract.
-    let (part_range, c_ptr, chunk_ptr, mut worker) =
+    // `_batch_done` must stay first: binding order is drop order (see `BatchDone`).
+    let (_batch_done, part_range, c_ptr, chunk_ptr, mut worker) =
         unsafe { crate::linker_context_mod::pending_part_range_prologue(task) };
 
     // CONCURRENCY: the CSS impl is read-only over `c`/`chunk` (the

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -51,7 +51,8 @@ use crate::{Chunk, CompileResult};
 pub(crate) unsafe fn generate_compile_result_for_html_chunk(task: *mut ThreadPoolLibTask) {
     // SAFETY: `task` is the intrusive `task` field of a `PendingPartRange`
     // scheduled by `generate_chunks_in_parallel`; see the helper's contract.
-    let (part_range, _c_ptr, chunk_ptr, _worker) =
+    // `_batch_done` must stay first: binding order is drop order (see `BatchDone`).
+    let (_batch_done, part_range, _c_ptr, chunk_ptr, _worker) =
         unsafe { crate::linker_context_mod::pending_part_range_prologue(task) };
     let i = part_range.i as usize;
     let ctx: &GenerateChunkCtx = part_range.ctx;

--- a/src/bundler/linker_context/generateCompileResultForJSChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForJSChunk.rs
@@ -29,7 +29,8 @@ use super::generate_code_for_file_in_chunk_js::generate_code_for_file_in_chunk_j
 pub(crate) unsafe fn generate_compile_result_for_js_chunk(task: *mut ThreadPoolLib::Task) {
     // SAFETY: `task` is the intrusive `task` field of a `PendingPartRange`
     // scheduled by `generate_chunks_in_parallel`; see the helper's contract.
-    let (part_range, c_ptr, chunk_ptr, mut worker) =
+    // `_batch_done` must stay first: binding order is drop order (see `BatchDone`).
+    let (_batch_done, part_range, c_ptr, chunk_ptr, mut worker) =
         unsafe { crate::linker_context_mod::pending_part_range_prologue(task) };
 
     let result = {

--- a/src/bundler/linker_context/prepareCssAstsForChunk.rs
+++ b/src/bundler/linker_context/prepareCssAstsForChunk.rs
@@ -1,7 +1,7 @@
 use crate::mal_prelude::*;
 
 use bun_alloc::{Arena as Bump, ArenaVec, ArenaVecExt};
-use bun_threading::thread_pool as ThreadPoolLib;
+use bun_threading::{WaitGroup, thread_pool as ThreadPoolLib};
 
 use crate::{BundleV2, Chunk, LinkerContext};
 
@@ -29,6 +29,9 @@ pub(crate) struct PrepareCssAstTask {
     pub(crate) task: ThreadPoolLib::Task,
     pub(crate) chunk: *mut Chunk,
     pub(crate) linker: *mut LinkerContext<'static>,
+    /// Owned by the scheduling stack frame, which blocks in `wait()` until every
+    /// task in the batch has finished.
+    pub(crate) wait_group: *const WaitGroup,
 }
 
 // SAFETY: scheduled on the worker pool via raw `*mut Task` (bypassing the
@@ -60,6 +63,9 @@ pub(crate) unsafe fn prepare_css_asts_for_chunk(task: *mut ThreadPoolLib::Task) 
         unsafe { &*bun_core::from_field_ptr!(PrepareCssAstTask, task, task) };
     let linker: *mut LinkerContext = prepare_css_asts.linker;
     let chunk: *mut Chunk = prepare_css_asts.chunk;
+    // Copied out before the body runs: releasing the barrier may free the frame
+    // that owns `prepare_css_asts`.
+    let wait_group: *const WaitGroup = prepare_css_asts.wait_group;
     let worker = {
         // SAFETY: `linker` is a raw `*mut` to `BundleV2.linker` (embedded by value),
         // carrying provenance over the full `BundleV2` allocation. Recover the
@@ -77,6 +83,14 @@ pub(crate) unsafe fn prepare_css_asts_for_chunk(task: *mut ThreadPoolLib::Task) 
     // was initialized in `Worker::create()` and points at the worker's heap
     // arena.
     prepare_css_asts_for_chunk_impl(unsafe { &*linker }, unsafe { &mut *chunk }, worker.arena());
+
+    // Ordering: return the `Worker` before releasing the barrier, since doing so
+    // lets the scheduling frame (owner of this task) be destroyed.
+    drop(worker);
+    // SAFETY: the caller's `WaitGroup` outlives every task in its batch by
+    // construction (it blocks on `wait()`), and `finish()` does not touch
+    // `self` after publishing zero (see WaitGroup.rs).
+    unsafe { (*wait_group).finish() };
 }
 
 fn prepare_css_asts_for_chunk_impl(c: &LinkerContext, chunk: &mut Chunk, bump: &Bump) {

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -199,7 +199,6 @@ pub struct ThreadPool {
     join_event: Event,
     run_queue: node::Queue,
     threads: AtomicPtr<Thread>,
-    wait_group: WaitGroup,
     /// Used by `schedule` to optimize for the case where the thread pool isn't running yet.
     is_running: AtomicBool,
     stats: PoolStats,
@@ -234,7 +233,6 @@ impl ThreadPool {
             join_event: Event::default(),
             run_queue: node::Queue::default(),
             threads: AtomicPtr::new(ptr::null_mut()),
-            wait_group: WaitGroup::init(),
             is_running: AtomicBool::new(false),
             stats: PoolStats {
                 // Seed wall-clock origin so the first `dump_stats` window is
@@ -506,14 +504,17 @@ impl ThreadPool {
             ctx: Ctx,
             values: *mut [V],
             run_fn: F,
+            /// Scoped to this call, so unrelated tasks sharing the pool cannot
+            /// delay it.
+            wait_group: WaitGroup,
         }
 
         #[repr(C)]
         struct RunnerTask<Ctx, V, F> {
             task: Task,
             // LIFETIMES.tsv row 2144: BORROW_PARAM. The stack-local `WaitContext`
-            // strictly outlives every `RunnerTask` (wait_for_all() blocks until all
-            // tasks finish), so this is the canonical `BackRef` invariant.
+            // strictly outlives every `RunnerTask` (`wait_group.wait()` blocks until
+            // all tasks finish), so this is the canonical `BackRef` invariant.
             ctx: bun_ptr::BackRef<WaitContext<Ctx, V, F>>,
             i: usize,
         }
@@ -526,24 +527,31 @@ impl ThreadPool {
                 unsafe { &mut *bun_core::from_field_ptr!(RunnerTask<Ctx, V, F>, task, task) };
             let i = runner_task.i;
             let wctx = runner_task.ctx.get();
-            // SAFETY: `values` slice outlives all RunnerTasks (wait_for_all() blocks until
-            // every task finishes); each task owns a distinct index `i`.
+            // SAFETY: `values` slice outlives all RunnerTasks (`wait_group.wait()` blocks
+            // until every task finishes); each task owns a distinct index `i`.
             let value: *mut V = unsafe { &raw mut (*wctx.values)[i] };
             // SAFETY: `value` is live and exclusively owned by this task per the index.
             unsafe { wctx.run_fn.call(&wctx.ctx, value, i) };
+            // Must stay last: publishing count==0 releases `each_impl`, which drops
+            // the frame owning `wctx`. Touching `wctx`/`runner_task` below this line
+            // is a use-after-free. `finish()` itself does not touch `self` after
+            // publishing zero (WaitGroup.rs).
+            wctx.wait_group.finish();
         }
 
+        let len = values.len();
         let wait_context = WaitContext {
             ctx,
             values: std::ptr::from_mut::<[V]>(values),
             run_fn,
+            wait_group: WaitGroup::init_with_count(len),
         };
 
-        let mut tasks: Vec<RunnerTask<Ctx, V, F>> = Vec::with_capacity(values.len());
+        let mut tasks: Vec<RunnerTask<Ctx, V, F>> = Vec::with_capacity(len);
         let mut batch = Batch::default();
-        let mut offset = values.len();
+        let mut offset = len;
 
-        for _ in 0..values.len() {
+        for _ in 0..len {
             offset -= 1;
             tasks.push(RunnerTask {
                 i: offset,
@@ -560,7 +568,7 @@ impl ThreadPool {
             batch.push(Batch::from(ptr::addr_of_mut!(runner_task.task)));
         }
         self.schedule(batch);
-        self.wait_for_all();
+        wait_context.wait_group.wait();
         // `tasks` drops here after all worker threads have finished touching it.
     }
 
@@ -577,23 +585,6 @@ impl ThreadPool {
             head: Task::node_of(head.unwrap()),
             tail: Task::node_of(tail.unwrap()),
         };
-
-        // .monotonic access is okay because:
-        //
-        // * If the thread pool hasn't started yet, no thread could concurrently set
-        //   `is_running` to true, because thread pool initialization should only
-        //   happen on one thread.
-        //
-        // * If the thread pool is running, the current thread could be one of the threads
-        //   in the thread pool, but `is_running` was necessarily set to true before the
-        //   thread was created.
-        if self.is_running.load(Ordering::Relaxed) {
-            self.wait_group.add(len);
-        } else {
-            // `&self` precludes `&mut WaitGroup` here, so use the relaxed
-            // atomic add even though the pool isn't running yet.
-            self.wait_group.add(len);
-        }
 
         let current: *mut Thread = 'blk: {
             if !try_current {
@@ -638,11 +629,6 @@ impl ThreadPool {
     /// This function should only be called from threads that are part of the thread pool.
     pub fn schedule_inside_thread_pool(&self, batch: Batch) {
         self.schedule_impl(&batch, true);
-    }
-
-    /// Wait for all tasks to complete. This does not shut down or deinit the thread pool.
-    pub fn wait_for_all(&self) {
-        self.wait_group.wait();
     }
 
     fn force_spawn(&self) {
@@ -1239,7 +1225,6 @@ impl Thread {
                         .fetch_add(now_ns().wrapping_sub(task_start), Ordering::Relaxed);
                     pool.stats.tasks.fetch_add(1, Ordering::Relaxed);
                 }
-                pool.wait_group.finish();
             }
 
             Output::flush();

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -41,17 +41,23 @@ describe("Bun.build", () => {
     const release = async () => {
       if (released) return;
       released = true;
-      const w = await fsPromises.open(fifo, "w");
-      await w.write("x");
-      await w.close();
+      try {
+        const w = await fsPromises.open(fifo, "w");
+        await w.write("x");
+        await w.close();
+      } catch (e) {
+        // Let the `finally` retry and surface the failure instead of it
+        // becoming an unhandled rejection from the timer.
+        released = false;
+        throw e;
+      }
     };
 
-    // No wait is needed before building: the pool counts a task at schedule
-    // time, synchronously inside readFile(), not when the worker parks. The
-    // safety release bounds a regression -- without it a pool-wide barrier would
-    // deadlock here. It must stay under the 5s default test timeout so a
-    // regression reports the assertion below rather than a timeout.
-    const safety = setTimeout(release, isDebug || isASAN ? 3000 : 1500);
+    // The pool counts a task at schedule time, synchronously inside readFile(),
+    // so no wait is needed before building. The safety release keeps a
+    // regression from deadlocking here, and must fire before the 5s default
+    // timeout so the assertion below reports instead.
+    const safety = setTimeout(() => void release().catch(() => {}), isDebug || isASAN ? 3000 : 1500);
 
     let settledAtBuildEnd: boolean;
     try {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -17,6 +17,58 @@ import { SourceMapConsumer } from "source-map";
 import { buildNoThrow } from "./buildNoThrow";
 
 describe("Bun.build", () => {
+  // A blocked task on the shared WorkPool must not delay Bun.build(). Asserts
+  // ordering, not timing: the build must finish while the blocker is still
+  // pending. Before the batch-scoped WaitGroup, Bun.build() waited for the whole
+  // pool to drain, so it finished only after the blocker did.
+  test.skipIf(isWindows)("is not blocked by unrelated WorkPool tasks", async () => {
+    const { promises: fs } = await import("fs");
+    const { execFileSync } = await import("child_process");
+
+    using dir = tempDir("bun-build-pool-independence", {
+      "entry.js": "export const x = 1;\n",
+    });
+    const fifo = join(String(dir), "blocker.fifo");
+    execFileSync("mkfifo", [fifo]);
+
+    // Occupies one WorkPool worker: node:fs readFile is an AsyncFSTask, and
+    // opening a FIFO with no writer parks the worker until a writer appears.
+    let blockerSettled = false;
+    const blocker = fs.readFile(fifo).then(
+      () => void (blockerSettled = true),
+      () => void (blockerSettled = true),
+    );
+
+    let released = false;
+    const release = async () => {
+      if (released) return;
+      released = true;
+      const w = await fs.open(fifo, "w");
+      await w.write("x");
+      await w.close();
+    };
+
+    // There is no observable signal for "a pool worker is parked", so wait for
+    // the worker to reach open(2) before building. The safety release bounds a
+    // regression: without it a pool-wide barrier would deadlock this test rather
+    // than fail it.
+    await Bun.sleep(50);
+    const safety = setTimeout(release, isDebug || isASAN ? 8000 : 2000);
+
+    let settledAtBuildEnd: boolean;
+    try {
+      const build = await Bun.build({ entrypoints: [join(String(dir), "entry.js")] });
+      settledAtBuildEnd = blockerSettled;
+      expect(build.success).toBe(true);
+    } finally {
+      clearTimeout(safety);
+      await release();
+      await blocker;
+    }
+
+    expect(settledAtBuildEnd).toBe(false);
+  });
+
   test("css works", async () => {
     const dir = tempDirWithFiles("bun-build-api-css", {
       "a.css": `

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -43,8 +43,11 @@ describe("Bun.build", () => {
       released = true;
       try {
         const w = await fsPromises.open(fifo, "w");
-        await w.write("x");
-        await w.close();
+        try {
+          await w.write("x");
+        } finally {
+          await w.close();
+        }
       } catch (e) {
         // Let the `finally` retry and surface the failure instead of it
         // becoming an unhandled rejection from the timer.

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from "fs";
+import { execFileSync } from "child_process";
+import { mkdirSync, promises as fsPromises, readFileSync, symlinkSync, writeFileSync } from "fs";
 import {
   bunEnv,
   bunExe,
@@ -22,9 +23,6 @@ describe("Bun.build", () => {
   // pending. Before the batch-scoped WaitGroup, Bun.build() waited for the whole
   // pool to drain, so it finished only after the blocker did.
   test.skipIf(isWindows)("is not blocked by unrelated WorkPool tasks", async () => {
-    const { promises: fs } = await import("fs");
-    const { execFileSync } = await import("child_process");
-
     using dir = tempDir("bun-build-pool-independence", {
       "entry.js": "export const x = 1;\n",
     });
@@ -34,7 +32,7 @@ describe("Bun.build", () => {
     // Occupies one WorkPool worker: node:fs readFile is an AsyncFSTask, and
     // opening a FIFO with no writer parks the worker until a writer appears.
     let blockerSettled = false;
-    const blocker = fs.readFile(fifo).then(
+    const blocker = fsPromises.readFile(fifo).then(
       () => void (blockerSettled = true),
       () => void (blockerSettled = true),
     );
@@ -43,17 +41,17 @@ describe("Bun.build", () => {
     const release = async () => {
       if (released) return;
       released = true;
-      const w = await fs.open(fifo, "w");
+      const w = await fsPromises.open(fifo, "w");
       await w.write("x");
       await w.close();
     };
 
-    // There is no observable signal for "a pool worker is parked", so wait for
-    // the worker to reach open(2) before building. The safety release bounds a
-    // regression: without it a pool-wide barrier would deadlock this test rather
-    // than fail it.
-    await Bun.sleep(50);
-    const safety = setTimeout(release, isDebug || isASAN ? 8000 : 2000);
+    // No wait is needed before building: the pool counts a task at schedule
+    // time, synchronously inside readFile(), not when the worker parks. The
+    // safety release bounds a regression -- without it a pool-wide barrier would
+    // deadlock here. It must stay under the 5s default test timeout so a
+    // regression reports the assertion below rather than a timeout.
+    const safety = setTimeout(release, isDebug || isASAN ? 3000 : 1500);
 
     let settledAtBuildEnd: boolean;
     try {


### PR DESCRIPTION
## Problem

`ThreadPool::wait_for_all()` waits on a **pool-global** `WaitGroup`: `schedule_impl` increments it for every task, `Thread::run` decrements after every task. `Bun.build()` and the bake DevServer run on the process-global `WorkPool`, so the linker's two joins in `generateChunksInParallel` block until the pool is *completely* drained — including tasks belonging to unrelated subsystems.

Build latency therefore has a floor set by whatever else happens to be on the pool.

## Honest scoping of the impact

**Under typical concurrent load this costs approximately nothing.** Measured on release+LTO, 2000-module build, median of 9:

| concurrent load | with bug | fixed |
|---|---|---|
| idle | 57.6 ms | 59.0 ms |
| continuous `fs.readFile` (32 files in flight) | 63.6 ms | 60.9 ms |
| one `scrypt` (N=16384) | 54.7 ms | 55.4 ms |

Ordinary pool tasks finish in microseconds, so the barrier waits ~one task and the difference is inside the noise.

**The problem is the unbounded tail, not the median.** The wait is bounded only by the *slowest in-flight pool task*, and several of those have no useful bound:

- `getaddrinfo` on the libc DNS backend — up to the resolver timeout (seconds), uncancellable
- `napi_queue_async_work` — arbitrary user native code
- large `Bun.file().copyTo()` / `fs.cp` — seconds on big files

With a worker held for 3 s, a 1-module rebuild goes from **1 ms to 3002 ms**; a 400-module build from 11 ms to 3007 ms. Because the barrier is a *floor* rather than a proportional cost, the smallest builds are hurt most — i.e. incremental DevServer rebuilds, where a single slow DNS lookup during SSR stalls the rebuild for its whole duration.

So: this is a tail-latency and predictability fix, not a throughput win. If you only care about median build time under normal load, this PR does nothing for you.

Controls confirming the mechanism is the barrier and not contention: CPU stays flat (~3.8 s) across arms differing 260× in wall time; pending **non-pool** work causes zero inflation; and absolute blocked time is independent of pool width (`UV_THREADPOOL_SIZE` 4/8/32 → 3242/3201/3178 ms) while the unblocked baseline moves 779→473 ms.

## Fix

Batch-scoped `WaitGroup`s, extending the pattern the bundler already uses for sourcemap tasks (`line_offset_wait_group` / `quoted_contents_wait_group`):

- `each_impl` owns a `WaitGroup` in its `WaitContext`; the runner callback finishes it **last**, after which touching the context is a use-after-free.
- `PrepareCssAstTask` and `PendingPartRange` carry a pointer to the scheduling frame's `WaitGroup`. For the latter, `pending_part_range_prologue` returns a `BatchDone` drop guard as its **first** tuple element — binding order is drop order, so it drops after the per-thread `Worker` is ungot and after the crash-trace guard, and the decrement can't be omitted by a future callback.
- Delete the pool-global `WaitGroup`, `wait_for_all()`, and the add/finish pair, removing two atomic RMWs from the per-task hot path.

## Safety note

The SAFETY comments at `ThreadPool.rs:515`/`:529` justify the stack-local `RunnerTask`/`values` lifetimes *on the grounds that the barrier over-waits*. Making it per-batch had to preserve that or this becomes a UAF rather than a perf fix — hence `finish()` being strictly last in `each_impl`, and the drop-guard ordering for `PendingPartRange`. `panic = "abort"` in every profile, so a panicking task cannot skip the decrement and strand a waiter.

## Relation to existing work

#35060 also touches `src/threading/WaitGroup.rs`, but for a different purpose: it makes *multiple waiters* on the shared barrier correct (broadcast vs signal) while preserving the coupling. This PR removes the shared barrier instead and does not touch `WaitGroup.rs`. Complementary, though they would conflict textually near `WaitGroup::finish`.

## Testing

The regression test asserts **ordering, not timing** — the build must finish while the blocker is still pending — so it cannot flake on a loaded machine. It carries a safety release, firing under the 5 s default timeout, so a regression fails with an assertion rather than deadlocking the suite.

- Passes on this commit; **fails on the parent** with `Expected: false / Received: true` at ~3.2 s
- `test/bundler/`: **5849 pass / 3 fail / 6371 tests** vs **5848 / 3 / 6370** on the parent — the 3 failures reproduce on a clean tree
- `test/bake/dev/{css,html}` (DevServer path, shares the global pool): 24 pass / 0 fail
- Debug + ASAN clean

## Performance

No measurable throughput change. hyperfine, 12 runs, release+LTO, 16C/32T: 400 modules 17.8→17.7 ms, 2000 modules 87.2→86.4 ms, 5000 modules 218.1→217.3 ms — all within 1σ. Module loading and WorkPool task-rate micros flat. **Binary size delta: 0 bytes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHCbmUpR4JGrHHhiC6Vd2i
