### PR TITLE
node:http: drop the unbalanced socket.cork() in the request dispatcher

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1066,8 +1066,6 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           }
         }
 
-        socket.cork();
-
         if (isPipelined) {
           // Completion of a queued response is tracked through the pipeline
           // (advanceResponsePipeline) and its native handle, not this dispatch.

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -826,13 +826,23 @@ test("CONNECT: process exits after the tunnel socket is re-emitted as a connecti
 // invisible until the socket was handed to 'upgrade'/'connect' on a reused
 // connection: user writes then hit the corked Duplex and buffered forever.
 describe("server socket handed to 'upgrade'/'connect' after a prior keep-alive request", () => {
-  async function readUntil(sock: import("node:net").Socket, needle: string): Promise<string> {
-    let raw = "";
-    while (!raw.includes(needle)) {
-      const [chunk] = (await once(sock, "data")) as [Buffer];
-      raw += chunk.toString("latin1");
-    }
-    return raw;
+  function readUntil(sock: import("node:net").Socket, needle: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      let raw = "";
+      const onData = (chunk: Buffer) => {
+        raw += chunk.toString("latin1");
+        if (raw.includes(needle)) {
+          cleanup();
+          resolve(raw);
+        }
+      };
+      const onClose = () =>
+        reject(new Error(`socket closed before ${JSON.stringify(needle)}; got ${JSON.stringify(raw)}`));
+      const cleanup = () => {
+        sock.off("data", onData).off("close", onClose).off("error", reject);
+      };
+      sock.on("data", onData).once("close", onClose).once("error", reject);
+    });
   }
 
   test.concurrent("'upgrade' socket writes reach the client", async () => {

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -820,3 +820,121 @@ test("CONNECT: process exits after the tunnel socket is re-emitted as a connecti
     signalCode: null,
   });
 });
+
+// The dispatcher used to cork() the socket's Duplex after every request and never
+// uncork it. ServerResponse writes go through the native handle so this was
+// invisible until the socket was handed to 'upgrade'/'connect' on a reused
+// connection: user writes then hit the corked Duplex and buffered forever.
+describe("server socket handed to 'upgrade'/'connect' after a prior keep-alive request", () => {
+  async function readUntil(sock: import("node:net").Socket, needle: string): Promise<string> {
+    let raw = "";
+    while (!raw.includes(needle)) {
+      const [chunk] = (await once(sock, "data")) as [Buffer];
+      raw += chunk.toString("latin1");
+    }
+    return raw;
+  }
+
+  test.concurrent("'upgrade' socket writes reach the client", async () => {
+    const got = { head: "", data: "", wlAfterWrite: -1 };
+    const sockReady = Promise.withResolvers<import("node:net").Socket>();
+    await using server = http.createServer((req, res) => res.end("ok"));
+    server.on("upgrade", (req, sock, head) => {
+      got.head = head.toString();
+      sock.on("data", d => {
+        got.data += d.toString();
+        sock.write("ECHO:" + d);
+      });
+      sock.write("HTTP/1.1 101 Switching Protocols\r\n\r\nSRV0");
+      got.wlAfterWrite = sock.writableLength;
+      sockReady.resolve(sock);
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const addr = server.address() as AddressInfo;
+
+    const client = net.connect(addr.port, addr.address);
+    try {
+      await once(client, "connect");
+      // First: an ordinary request on the connection.
+      client.write("GET /a HTTP/1.1\r\nHost: h\r\n\r\n");
+      await readUntil(client, "\r\n\r\nok");
+      // Second: the upgrade, on the same (kept-alive) connection.
+      client.write("GET /up HTTP/1.1\r\nHost: h\r\nConnection: Upgrade\r\nUpgrade: p\r\n\r\nT");
+      const serverSock = await sockReady.promise;
+      const firstReply = await readUntil(client, "SRV0");
+      client.write("MORE");
+      const echoReply = await readUntil(client, "ECHO:MORE");
+
+      expect({ ...got, firstReply, echoReply, serverCorked: serverSock.writableCorked }).toEqual({
+        head: "T",
+        data: "MORE",
+        wlAfterWrite: 0,
+        firstReply: "HTTP/1.1 101 Switching Protocols\r\n\r\nSRV0",
+        echoReply: "ECHO:MORE",
+        serverCorked: 0,
+      });
+    } finally {
+      client.destroy();
+    }
+  });
+
+  test.concurrent("'connect' socket writes reach the client", async () => {
+    const sockReady = Promise.withResolvers<import("node:net").Socket>();
+    await using server = http.createServer((req, res) => res.end("ok"));
+    server.on("connect", (req, sock, head) => {
+      sock.on("data", d => sock.write("ECHO:" + d));
+      sock.write("HTTP/1.1 200 Connection Established\r\n\r\nSRV0");
+      sockReady.resolve(sock);
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const addr = server.address() as AddressInfo;
+
+    const client = net.connect(addr.port, addr.address);
+    try {
+      await once(client, "connect");
+      client.write("GET /a HTTP/1.1\r\nHost: h\r\n\r\n");
+      await readUntil(client, "\r\n\r\nok");
+      client.write("CONNECT target:1 HTTP/1.1\r\nHost: target:1\r\n\r\n");
+      const serverSock = await sockReady.promise;
+      const firstReply = await readUntil(client, "SRV0");
+      client.write("MORE");
+      const echoReply = await readUntil(client, "ECHO:MORE");
+
+      expect({
+        firstReply,
+        echoReply,
+        serverCorked: serverSock.writableCorked,
+        serverWritableLength: serverSock.writableLength,
+      }).toEqual({
+        firstReply: "HTTP/1.1 200 Connection Established\r\n\r\nSRV0",
+        echoReply: "ECHO:MORE",
+        serverCorked: 0,
+        serverWritableLength: 0,
+      });
+    } finally {
+      client.destroy();
+    }
+  });
+
+  test.concurrent("socket.writableCorked stays 0 across keep-alive requests", async () => {
+    const corked: number[] = [];
+    await using server = http.createServer((req, res) => {
+      corked.push(req.socket.writableCorked);
+      res.end("ok");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const addr = server.address() as AddressInfo;
+
+    const client = net.connect(addr.port, addr.address);
+    try {
+      await once(client, "connect");
+      for (let i = 0; i < 3; i++) {
+        client.write("GET / HTTP/1.1\r\nHost: h\r\n\r\n");
+        await readUntil(client, "\r\n\r\nok");
+      }
+      expect(corked).toEqual([0, 0, 0]);
+    } finally {
+      client.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## What

The server request dispatcher called `socket.cork()` after every `'request'` emit and nothing ever uncorked it, so the server socket's Duplex `corked` counter grew by one per request on a keep-alive connection (0, 1, 2, ...). `ServerResponse` writes go through the native response handle (`handle.write` / `handle.writeHeadAndEnd`), not the socket Duplex, so normal response bytes were never affected and the leak was invisible.

It surfaced when the connection was handed to an `'upgrade'` or `'connect'` listener after a prior request on the same connection: user `sock.write()` calls on the handed-off socket went into the corked Duplex's buffer and were never flushed. `writableLength` only grew, no `'drain'`, write callbacks never ran, and zero bytes reached the client until `sock.end()` flushed at teardown. The same switch as the first request on a fresh connection worked because `corked` was still 0.

## Repro

```js
import http from "node:http"; import net from "node:net";
const srv = http.createServer((req, res) => res.end("ok"));
srv.on("upgrade", (req, sock, head) => {
  sock.on("data", d => sock.write("ECHO:" + d));
  sock.write("HTTP/1.1 101 X\r\n\r\nSRV0");   // never reaches the client
});
srv.listen(0, "127.0.0.1", () => {
  const c = net.connect(srv.address().port, "127.0.0.1"); let raw = "";
  c.on("data", d => raw += d);
  c.on("connect", () => {
    c.write("GET /a HTTP/1.1\r\nHost: h\r\n\r\n");          // ordinary request first
    setTimeout(() => c.write("GET /up HTTP/1.1\r\nHost: h\r\nConnection: Upgrade\r\nUpgrade: p\r\n\r\nT"), 100);
    setTimeout(() => { console.log(JSON.stringify({ raw })); process.exit(0); }, 1000);
  });
});
// node: {"raw":"HTTP/1.1 101 X\r\n\r\nSRV0..."}
// bun:  {"raw":""}
```

Inside the `'upgrade'` listener, `sock._writableState.corked === 1`.

## Fix

Remove the `socket.cork()` at `_http_server.ts:1069`. It was added in #17093 and is vestigial: every `ServerResponse` write path that the in-server dispatcher reaches writes through the native handle, so corking the Duplex never batched anything and only leaked the counter. This also fixes `res.writableCorked` / `req.socket.writableCorked` reporting nonzero on the Nth keep-alive request where Node reports 0.

## Verification

```
# before (USE_SYSTEM_BUN=1 bun test -t "handed to 'upgrade'/'connect'")
(fail) 'upgrade' socket writes reach the client  [timed out]
(fail) 'connect' socket writes reach the client  [timed out]
(fail) socket.writableCorked stays 0 across keep-alive requests  [0,1,2] != [0,0,0]

# after (bun bd test -t "handed to 'upgrade'/'connect'")
(pass) 'upgrade' socket writes reach the client
(pass) 'connect' socket writes reach the client
(pass) socket.writableCorked stays 0 across keep-alive requests
```

Also passes `test-http-upgrade-server*.js`, `test-http-connect*.js`, `node-http-nested-cork.test.ts`, `node-http-pinned-write.test.ts`, `node-http-backpressure.test.ts`, `node-http-with-ws.test.ts` and the main `node-http.test.ts` suite.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/http/node-http-connect.test.ts

<!-- robobun:evidence:end -->