### PR TITLE
image: decode base64 data: URLs with the SIMD decoder

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -3588,9 +3588,9 @@ pub mod hash {
 }
 
 // ── base64 ────────────────────────────────────────────────────────────────
-// Thin simdutf-backed encoders + scalar decoder — the subset
-// tier-0/1 callers need (npm auth, sourcemaps,
-// ansi_renderer). Full URL-safe / streaming variants stay in bun_base64.
+// Thin simdutf-backed encoders — the subset tier-0/1 callers need (npm auth,
+// ansi_renderer). Decoding and the URL-safe / streaming variants live in
+// bun_base64.
 pub mod base64 {
     use bun_simdutf_sys::simdutf;
 
@@ -3620,71 +3620,6 @@ pub mod base64 {
         &dest[..n]
     }
 
-    /// Result of a decode-into-buffer call.
-    #[derive(Clone, Copy, Debug)]
-    pub struct DecodeResult {
-        pub written: usize,
-        pub fail: bool,
-    }
-
-    /// Scalar fallback base64 decode (the SIMD path lives in
-    /// bun_base64). Tolerates missing padding; stops at first invalid char.
-    pub fn decode(dest: &mut [u8], source: &[u8]) -> DecodeResult {
-        const INV: u8 = 0xFF;
-        static LUT: [u8; 256] = {
-            let mut t = [INV; 256];
-            let mut i = 0u8;
-            while i < 26 {
-                t[(b'A' + i) as usize] = i;
-                i += 1;
-            }
-            let mut i = 0u8;
-            while i < 26 {
-                t[(b'a' + i) as usize] = 26 + i;
-                i += 1;
-            }
-            let mut i = 0u8;
-            while i < 10 {
-                t[(b'0' + i) as usize] = 52 + i;
-                i += 1;
-            }
-            t[b'+' as usize] = 62;
-            t[b'/' as usize] = 63;
-            t
-        };
-        let mut w = 0usize;
-        let mut acc: u32 = 0;
-        let mut bits: u32 = 0;
-        for &c in source {
-            if c == b'=' || c == b'\n' || c == b'\r' {
-                continue;
-            }
-            let v = LUT[c as usize];
-            if v == INV {
-                return DecodeResult {
-                    written: w,
-                    fail: true,
-                };
-            }
-            acc = (acc << 6) | v as u32;
-            bits += 6;
-            if bits >= 8 {
-                bits -= 8;
-                if w >= dest.len() {
-                    return DecodeResult {
-                        written: w,
-                        fail: true,
-                    };
-                }
-                dest[w] = (acc >> bits) as u8;
-                w += 1;
-            }
-        }
-        DecodeResult {
-            written: w,
-            fail: false,
-        }
-    }
 }
 
 // ── dupe_z / free_sensitive ───────────────────────────────────────────────

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -385,13 +385,13 @@ fn source_from_js(
                 )));
             }
             let mut out = vec![0u8; bun_base64::decode_len(payload)];
-            let r = base64::decode(&mut out, payload);
-            if r.fail {
+            let r = bun_base64::decode(&mut out, payload);
+            if !r.is_successful() {
                 return Err(global.throw_invalid_arguments(format_args!(
                     "Image(): invalid base64 in data: URL"
                 )));
             }
-            out.truncate(r.written);
+            out.truncate(r.count);
             return Ok(Source::Owned(out));
         }
         return Ok(Source::Path(ZBox::from_bytes(s)));


### PR DESCRIPTION
## Problem

`Bun.Image` decodes `data:image/*;base64,` payloads with `bun_core::base64::decode` — a scalar, byte-at-a-time LUT loop whose own doc comment says *"Scalar fallback base64 decode (the SIMD path lives in bun_base64)"*. Image data URLs are typically 10 KB to several MB, so this was the slowest available decoder on the largest inputs.

The line directly above already calls `bun_base64::decode_len`, so the SIMD decoder was already in scope — this reads as an oversight rather than a deliberate choice.

## Fix

Use `bun_base64::decode` (simdutf).

Release+LTO (`build:btg`), Ryzen 9 5950X, payload decoded from a `data:` URL:

| decoded bytes | before | after | speedup |
|---|---|---|---|
| 4 KB | 5938 ns | **543 ns** | 10.9× |
| 64 KB | 94198 ns | **6239 ns** | **15.1×** |
| 256 KB | 352567 ns | **24704 ns** | 14.3× |
| 1 MB | 1.46 ms | **100.2 µs** | 14.6× |

`Bun.Image` now sits within **1.0–1.26×** of `Buffer.from(s, "base64")` on the same payload, where it was 19–20× off before — i.e. it reaches the simdutf floor.

### What share of a real operation this is

Measured on real fixtures (`person-large.jpg` 137 KB, `fixture.png` 80 KB, `lenna.png` 463 KB), base64 decode as a fraction of the whole call:

| operation | base64 share before |
|---|---|
| `metadata()` from a data URL | **97–100%** |
| full `resize(128,128).png().bytes()` | **2–12%** |

So this is a large win for metadata/probe reads of data URLs, and a 2–12% win on pipelines that actually decode and re-encode the image. It is not a 15× end-to-end speedup for image processing, and shouldn't be read as one.

Method note: the ratio *stabilises* at ~19–20× from 64 KB up (vs 9.9× at 4 KB), which is what identifies the decode as the cost rather than the surrounding allocation and error path — a fixed overhead would shrink in relative terms as the payload grows, and it does.

## Behaviour

Unchanged. Verified empirically across payload lengths and padding counts:

| input | before | after |
|---|---|---|
| `\n`, `\r`, CRLF in payload | accepted | accepted |
| space, tab, VT, FF in payload | rejected | rejected |
| base64url (`-_`) | rejected | rejected |
| invalid characters | throws | throws |

An earlier revision of this PR claimed the change relaxed whitespace handling. That was wrong — the apparent tolerance was payload-length dependent, and a test asserting it passed only by luck of one fixture. Corrected, and the test removed.

## Dead code

This leaves `bun_core::base64::decode` with **zero callers**, so it is removed along with its private 256-byte LUT and `DecodeResult` — one of three duplicate scalar decode tables in the tree. The module doc is corrected too: it claimed a decoder and named sourcemaps as a caller, but sourcemaps use `bun_base64::decode`.

Net diff is **+6 / −71**.

## Testing

No new test: this is a decoder swap with no observable behaviour delta, and the existing `data: URL input (base64)` and `data: URL with bad base64 throws` tests already exercise the changed line.

- `test/js/bun/image/`: **220 pass, 0 fail**
- `atob` / `base64-url-safe-encode` / `sourcemap-simd`: 32 pass, 0 fail

## Unrelated, noted for a follow-up

`src/base64/neonbase64` is 17 KB of git-tracked, entirely unreferenced LLVM bitcode (a 2022 macOS/clang-13 ARM NEON decoder). Left out to keep this diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHCbmUpR4JGrHHhiC6Vd2i

