### PR TITLE
fs: honor { flush: true } in appendFile / appendFileSync

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4793,16 +4793,29 @@ impl NodeFS {
             data = &data[written..];
         }
         if args.flush {
-            #[cfg(windows)]
-            {
-                let _ = unsafe { windows::kernel32::FlushFileBuffers(fd.native()) };
-            }
-            #[cfg(not(windows))]
-            {
-                let _ = Syscall::fsync(fd);
-            }
+            Self::flush_file_buffers(fd)?;
         }
         Ok(())
+    }
+
+    /// The `{ flush: true }` fsync for `writeFile` / `appendFile`. Node surfaces
+    /// this error (it calls `fsyncSync(fd)` / passes the fsync error to the
+    /// callback), so an EIO/ENOSPC here must reach the caller.
+    #[inline]
+    fn flush_file_buffers(fd: FD) -> Maybe<()> {
+        #[cfg(windows)]
+        {
+            if unsafe { windows::kernel32::FlushFileBuffers(fd.native()) } == 0 {
+                return Err(
+                    sys::Error::from_code(windows::get_last_errno(), sys::Tag::fsync).with_fd(fd),
+                );
+            }
+            Ok(())
+        }
+        #[cfg(not(windows))]
+        {
+            Syscall::fsync(fd)
+        }
     }
 
     pub fn close(&mut self, args: &args::Close, _: Flavor) -> Maybe<ret::Close> {
@@ -7631,14 +7644,7 @@ impl NodeFS {
         }
 
         if args.flush {
-            #[cfg(windows)]
-            {
-                let _ = unsafe { windows::kernel32::FlushFileBuffers(fd.native()) };
-            }
-            #[cfg(not(windows))]
-            {
-                let _ = Syscall::fsync(fd);
-            }
+            Self::flush_file_buffers(fd)?;
         }
 
         Ok(())

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4787,6 +4787,9 @@ impl NodeFS {
         let _close = close_guard;
         while !data.is_empty() {
             let written = Syscall::write(fd, data)?;
+            if written == 0 {
+                break;
+            }
             data = &data[written..];
         }
         if args.flush {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4798,9 +4798,6 @@ impl NodeFS {
         Ok(())
     }
 
-    /// The `{ flush: true }` fsync for `writeFile` / `appendFile`. Node surfaces
-    /// this error (it calls `fsyncSync(fd)` / passes the fsync error to the
-    /// callback), so an EIO/ENOSPC here must reach the caller.
     #[inline]
     fn flush_file_buffers(fd: FD) -> Maybe<()> {
         #[cfg(windows)]

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4776,25 +4776,30 @@ impl NodeFS {
         _: Flavor,
     ) -> Maybe<ret::AppendFile> {
         let mut data = args.data.slice();
-        match &args.file {
-            PathOrFileDescriptor::Fd(fd) => {
-                while !data.is_empty() {
-                    let written = Syscall::write(*fd, data)?;
-                    data = &data[written..];
-                }
-                Ok(())
-            }
+        let (fd, close_guard) = match &args.file {
+            PathOrFileDescriptor::Fd(fd) => (*fd, None),
             PathOrFileDescriptor::Path(path_) => {
                 let path = path_.slice_z(&mut self.sync_error_buf);
                 let fd = Syscall::open(path, FileSystemFlags::A.as_int(), args.mode)?;
-                let _close = scopeguard::guard(fd, |fd| fd.close());
-                while !data.is_empty() {
-                    let written = Syscall::write(fd, data)?;
-                    data = &data[written..];
-                }
-                Ok(())
+                (fd, Some(scopeguard::guard(fd, |fd| fd.close())))
+            }
+        };
+        let _close = close_guard;
+        while !data.is_empty() {
+            let written = Syscall::write(fd, data)?;
+            data = &data[written..];
+        }
+        if args.flush {
+            #[cfg(windows)]
+            {
+                let _ = unsafe { windows::kernel32::FlushFileBuffers(fd.native()) };
+            }
+            #[cfg(not(windows))]
+            {
+                let _ = Syscall::fsync(fd);
             }
         }
+        Ok(())
     }
 
     pub fn close(&mut self, args: &args::Close, _: Flavor) -> Maybe<ret::Close> {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5859,3 +5859,102 @@ describe("fs.close on stdio descriptors", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// Node >=21 `{ flush: true }` on fs.appendFile* must fsync the data before
+// returning. Bun's fsync happens in native code, so the Node test suite's
+// jest.spyOn approach can't see it; interpose fsync() via LD_PRELOAD instead.
+describe.skipIf(!isLinux || !(Bun.which("cc") || Bun.which("gcc") || Bun.which("clang")))(
+  "fs.appendFile { flush: true } fsyncs",
+  () => {
+    const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+    it.concurrent("appendFileSync / appendFile / promises.appendFile, path and fd", async () => {
+      using dir = tempDir("appendfile-flush", {
+        "shim.c": `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+static int (*real)(int);
+int fsync(int fd) {
+  if (!real) real = dlsym(RTLD_NEXT, "fsync");
+  fprintf(stderr, "[fsync] fd=%d\\n", fd);
+  return real(fd);
+}
+`,
+        "fixture.mjs": `
+import fs from "node:fs";
+const file = process.argv[2];
+const mark = s => process.stderr.write("-- " + s + " --\\n");
+
+mark("appendFileSync flush:true");
+fs.appendFileSync(file, "a", { flush: true });
+
+mark("promises.appendFile flush:true");
+await fs.promises.appendFile(file, "b", { flush: true });
+
+mark("callback appendFile flush:true");
+await new Promise((res, rej) => fs.appendFile(file, "c", { flush: true }, e => e ? rej(e) : res()));
+
+mark("appendFileSync fd flush:true");
+const fd = fs.openSync(file, "a");
+fs.appendFileSync(fd, "d", { flush: true });
+fs.closeSync(fd);
+
+mark("appendFileSync no-flush");
+fs.appendFileSync(file, "e");
+fs.appendFileSync(file, "f", { flush: false });
+
+mark("writeFileSync flush:true");
+fs.writeFileSync(file + ".w", "g", { flush: true });
+
+mark("end");
+process.stdout.write(fs.readFileSync(file, "utf8"));
+`,
+      });
+      const shim = join(String(dir), "shim.so");
+      await using ccProc = Bun.spawn({
+        cmd: [cc!, "-shared", "-fPIC", "-o", shim, join(String(dir), "shim.c"), "-ldl"],
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+      if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr}`);
+
+      const existing = bunEnv.LD_PRELOAD;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(String(dir), "fixture.mjs"), join(String(dir), "out.log")],
+        env: { ...bunEnv, LD_PRELOAD: existing ? `${shim}:${existing}` : shim },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // Count fsyncs between each pair of markers.
+      const sections: Record<string, number> = {};
+      let current = "";
+      for (const line of stderr.split("\n")) {
+        const m = line.match(/^-- (.+) --$/);
+        if (m) {
+          current = m[1];
+          sections[current] ??= 0;
+        } else if (line.startsWith("[fsync] ")) {
+          sections[current] = (sections[current] ?? 0) + 1;
+        }
+      }
+
+      expect({ stdout, sections }).toEqual({
+        stdout: "abcdef",
+        sections: {
+          "appendFileSync flush:true": 1,
+          "promises.appendFile flush:true": 1,
+          "callback appendFile flush:true": 1,
+          "appendFileSync fd flush:true": 1,
+          "appendFileSync no-flush": 0,
+          "writeFileSync flush:true": 1,
+          "end": 0,
+        },
+      });
+      expect(exitCode).toBe(0);
+    });
+  },
+);

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5864,22 +5864,44 @@ describe("fs.close on stdio descriptors", () => {
 // returning. Bun's fsync happens in native code, so the Node test suite's
 // jest.spyOn approach can't see it; interpose fsync() via LD_PRELOAD instead.
 describe.skipIf(!isLinux || !(Bun.which("cc") || Bun.which("gcc") || Bun.which("clang")))(
-  "fs.appendFile { flush: true } fsyncs",
+  "fs.appendFile / fs.writeFile { flush: true } fsyncs",
   () => {
     const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
-    it.concurrent("appendFileSync / appendFile / promises.appendFile, path and fd", async () => {
-      using dir = tempDir("appendfile-flush", {
-        "shim.c": `
+    const SHIM_C = `
 #define _GNU_SOURCE
 #include <dlfcn.h>
+#include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 static int (*real)(int);
+static int fail = -1;
 int fsync(int fd) {
-  if (!real) real = dlsym(RTLD_NEXT, "fsync");
+  if (!real) {
+    real = dlsym(RTLD_NEXT, "fsync");
+    fail = getenv("FAIL_FSYNC") != NULL;
+  }
   fprintf(stderr, "[fsync] fd=%d\\n", fd);
+  if (fail) { errno = EIO; return -1; }
   return real(fd);
 }
-`,
+`;
+    async function compileShim(dir: string) {
+      const shim = join(dir, "shim.so");
+      await using ccProc = Bun.spawn({
+        cmd: [cc!, "-shared", "-fPIC", "-o", shim, join(dir, "shim.c"), "-ldl"],
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+      if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr}`);
+      const existing = bunEnv.LD_PRELOAD;
+      return existing ? `${shim}:${existing}` : shim;
+    }
+
+    it.concurrent("appendFileSync / appendFile / promises.appendFile, path and fd", async () => {
+      using dir = tempDir("appendfile-flush", {
+        "shim.c": SHIM_C,
         "fixture.mjs": `
 import fs from "node:fs";
 const file = process.argv[2];
@@ -5910,20 +5932,10 @@ mark("end");
 process.stdout.write(fs.readFileSync(file, "utf8"));
 `,
       });
-      const shim = join(String(dir), "shim.so");
-      await using ccProc = Bun.spawn({
-        cmd: [cc!, "-shared", "-fPIC", "-o", shim, join(String(dir), "shim.c"), "-ldl"],
-        env: bunEnv,
-        stderr: "pipe",
-        stdout: "pipe",
-      });
-      const [, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
-      if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr}`);
-
-      const existing = bunEnv.LD_PRELOAD;
+      const preload = await compileShim(String(dir));
       await using proc = Bun.spawn({
         cmd: [bunExe(), join(String(dir), "fixture.mjs"), join(String(dir), "out.log")],
-        env: { ...bunEnv, LD_PRELOAD: existing ? `${shim}:${existing}` : shim },
+        env: { ...bunEnv, LD_PRELOAD: preload },
         stderr: "pipe",
         stdout: "pipe",
       });
@@ -5953,6 +5965,42 @@ process.stdout.write(fs.readFileSync(file, "utf8"));
           "writeFileSync flush:true": 1,
           "end": 0,
         },
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    // Node surfaces the fsync error (it calls fsyncSync / passes it to the
+    // callback). With FAIL_FSYNC=1 the shim returns EIO for every fsync.
+    it.concurrent("propagates fsync errors from { flush: true }", async () => {
+      using dir = tempDir("appendfile-flush-err", {
+        "shim.c": SHIM_C,
+        "fixture.mjs": `
+import fs from "node:fs";
+const file = process.argv[2];
+const out = [];
+for (const [name, run] of [
+  ["appendFileSync", () => fs.appendFileSync(file, "a", { flush: true })],
+  ["writeFileSync", () => fs.writeFileSync(file, "b", { flush: true })],
+  ["promises.appendFile", () => fs.promises.appendFile(file, "c", { flush: true })],
+]) {
+  try { await run(); out.push(name + ":ok"); }
+  catch (e) { out.push(name + ":" + e.code + ":" + e.syscall); }
+}
+process.stdout.write(JSON.stringify(out));
+`,
+      });
+      const preload = await compileShim(String(dir));
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(String(dir), "fixture.mjs"), join(String(dir), "out.log")],
+        env: { ...bunEnv, LD_PRELOAD: preload, FAIL_FSYNC: "1" },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ out: JSON.parse(stdout || "null"), stderr: stderr.match(/\[fsync\]/g)?.length }).toEqual({
+        out: ["appendFileSync:EIO:fsync", "writeFileSync:EIO:fsync", "promises.appendFile:EIO:fsync"],
+        stderr: 3,
       });
       expect(exitCode).toBe(0);
     });


### PR DESCRIPTION
## Repro

```js
const fs = require("fs");
fs.appendFileSync("/tmp/a.log", "a1\n", { flush: true });         // bun: no fsync
await fs.promises.appendFile("/tmp/a.log", "a2\n", { flush: true }); // bun: no fsync
await new Promise(r => fs.appendFile("/tmp/a.log", "a3\n", { flush: true }, r)); // bun: no fsync
fs.writeFileSync("/tmp/w.txt", "w", { flush: true });             // bun: fsync (control)
```

Under `strace -f -e trace=fsync` (or an `LD_PRELOAD` interposer), Node v21+ issues one `fsync` per append; Bun issues zero. An application appending journal/WAL records with `{ flush: true }` gets none of the durability it asked for.

## Cause

`args::AppendFile` is a type alias for `args::WriteFile`, so the `flush` option is already parsed, and `write_file()` honors it. `append_file()` in `src/runtime/node/node_fs.rs` never read `args.flush`: both the fd and path arms wrote the data and returned (closing the fd it opened) with no fsync.

Separately, both `append_file` and `write_file_with_path_buffer` bound the fsync/`FlushFileBuffers` result to `let _`, so an `EIO`/`ENOSPC` at flush time returned success. Node surfaces that error (`writeFileSync` calls `fsyncSync(fd)`, the async paths pass it to the callback).

## Fix

Unify the two match arms in `append_file` so the write loop and the flush run on a single `fd`, with the close guard held until after the flush. Factor the flush into `NodeFS::flush_file_buffers` (propagates `Syscall::fsync` on POSIX, checks `FlushFileBuffers` + `get_last_errno` on Windows) and call it with `?` from both `append_file` and `write_file_with_path_buffer`.

## Verification

New tests in `test/js/node/fs/fs.test.ts` compile a tiny `LD_PRELOAD` shim that logs every `fsync()` to stderr (the native call is invisible to `jest.spyOn`, which is why the upstream Node test is commented out in Bun). The first case runs all four append forms (`appendFileSync`, `fs.promises.appendFile`, callback `appendFile`, `appendFileSync` on an fd) with `{ flush: true }`, two no-flush controls, and a `writeFileSync` control, asserting exactly one fsync per flushed section and zero otherwise. The second case runs the shim with `FAIL_FSYNC=1` (every fsync returns `EIO`) and asserts `appendFileSync` / `writeFileSync` / `fs.promises.appendFile` all surface `{ code: 'EIO', syscall: 'fsync' }`.

```
USE_SYSTEM_BUN=1 bun test test/js/node/fs/fs.test.ts -t "{ flush: true }"
# 2 fail: 0 fsyncs on all append forms; error-propagation test sees "ok" for all three
bun bd test test/js/node/fs/fs.test.ts -t "{ flush: true }"
# 2 pass
```

The full `fs.test.ts` suite (433 pass / 6 skip), `test-fs-append-file.js`, `test-fs-append-file-sync.js`, `test-fs-append-file-flush.js`, and `test-fs-write-file-flush.js` remain green. `rust:check-all` passes on all targets.

Related: #33559 routes `append_file` through the write path to fix the sibling `flag` option and would also cover the missing fsync, but it has merge conflicts; this change is the minimal fix for `flush`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->