### PR TITLE
bunfig: fall back to $HOME/.bunfig.toml when $XDG_CONFIG_HOME has none

### DIFF
--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -17,42 +17,23 @@ use crate::bunfig::Bunfig;
 
 // ─── bunfig loading ──────────────────────────────────────────────────────────
 
-/// Resolve a user-level config file (`.bunfig.toml`, `.npmrc`) to
-/// `$XDG_CONFIG_HOME/<name>` when it exists there, otherwise `$HOME/<name>`.
-///
-/// The existence probe is what makes this a fallback rather than an override:
-/// many Linux setups export `XDG_CONFIG_HOME` by default, so preferring it
-/// unconditionally hides a pre-existing `$HOME/.npmrc` from users who never
-/// opted into XDG.
-pub fn user_config_path<'a>(buf: &'a mut PathBuffer, name: &[u8]) -> Option<&'a ZStr> {
-    let paths: [&[u8]; 1] = [name];
+/// `$XDG_CONFIG_HOME/.bunfig.toml` when that file exists, otherwise
+/// `$HOME/.bunfig.toml` (same rule as the user-level `.npmrc` in
+/// `PackageManager::init`). Many desktops and CI runners export
+/// `XDG_CONFIG_HOME` without ever putting a bunfig there.
+fn get_home_config_path(buf: &mut PathBuffer) -> Option<&ZStr> {
+    let paths: [&[u8]; 1] = [b".bunfig.toml"];
 
-    let dir = match (env_var::XDG_CONFIG_HOME.get(), env_var::HOME.get()) {
-        (Some(xdg_dir), Some(home_dir)) => {
-            let mut probe = bun_paths::path_buffer_pool::get();
-            let candidate = resolve_path::join_abs_string_buf_z::<platform::Auto>(
-                xdg_dir,
-                &mut probe[..],
-                &paths,
-            );
-            if bun_sys::exists_z(candidate) {
-                xdg_dir
-            } else {
-                home_dir
-            }
-        }
-        (Some(xdg_dir), None) => xdg_dir,
-        (None, Some(home_dir)) => home_dir,
-        (None, None) => return None,
-    };
+    let xdg_dir = env_var::XDG_CONFIG_HOME.get_not_empty().filter(|xdg_dir| {
+        bun_sys::exists_z(resolve_path::join_abs_string_buf_z::<platform::Auto>(
+            xdg_dir, &mut **buf, &paths,
+        ))
+    });
+    let dir = xdg_dir.or_else(|| env_var::HOME.get_not_empty())?;
 
     Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
         dir, &mut **buf, &paths,
     ))
-}
-
-fn get_home_config_path(buf: &mut PathBuffer) -> Option<&ZStr> {
-    user_config_path(buf, b".bunfig.toml")
 }
 
 fn load_bunfig(

--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -17,22 +17,42 @@ use crate::bunfig::Bunfig;
 
 // ─── bunfig loading ──────────────────────────────────────────────────────────
 
+/// Resolve a user-level config file (`.bunfig.toml`, `.npmrc`) to
+/// `$XDG_CONFIG_HOME/<name>` when it exists there, otherwise `$HOME/<name>`.
+///
+/// The existence probe is what makes this a fallback rather than an override:
+/// many Linux setups export `XDG_CONFIG_HOME` by default, so preferring it
+/// unconditionally hides a pre-existing `$HOME/.npmrc` from users who never
+/// opted into XDG.
+pub fn user_config_path<'a>(buf: &'a mut PathBuffer, name: &[u8]) -> Option<&'a ZStr> {
+    let paths: [&[u8]; 1] = [name];
+
+    let dir = match (env_var::XDG_CONFIG_HOME.get(), env_var::HOME.get()) {
+        (Some(xdg_dir), Some(home_dir)) => {
+            let mut probe = bun_paths::path_buffer_pool::get();
+            let candidate = resolve_path::join_abs_string_buf_z::<platform::Auto>(
+                xdg_dir,
+                &mut probe[..],
+                &paths,
+            );
+            if bun_sys::exists_z(candidate) {
+                xdg_dir
+            } else {
+                home_dir
+            }
+        }
+        (Some(xdg_dir), None) => xdg_dir,
+        (None, Some(home_dir)) => home_dir,
+        (None, None) => return None,
+    };
+
+    Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
+        dir, &mut **buf, &paths,
+    ))
+}
+
 fn get_home_config_path(buf: &mut PathBuffer) -> Option<&ZStr> {
-    let paths: [&[u8]; 1] = [b".bunfig.toml"];
-
-    if let Some(data_dir) = env_var::XDG_CONFIG_HOME.get() {
-        return Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
-            data_dir, &mut **buf, &paths,
-        ));
-    }
-
-    if let Some(home_dir) = env_var::HOME.get() {
-        return Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
-            home_dir, &mut **buf, &paths,
-        ));
-    }
-
-    None
+    user_config_path(buf, b".bunfig.toml")
 }
 
 fn load_bunfig(

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -2,7 +2,7 @@ import { write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { rm } from "fs/promises";
 import { VerdaccioRegistry, bunExe, bunEnv as env, tempDir } from "harness";
-import { join } from "path";
+import { basename, join } from "path";
 const { iniInternals } = require("bun:internal-for-testing");
 const { loadNpmrc } = iniInternals;
 
@@ -221,6 +221,67 @@ registry = http://localhost:${registry.port}/
       using dir = tempDir("npmrc-xdg-empty", { ...pkg, "home/.npmrc": npmrc(1) });
       const result = await publishDryRun(String(dir), { XDG_CONFIG_HOME: "" });
       expect(result).toEqual(usesRegistry(1));
+    });
+  });
+
+  // The global .bunfig.toml is looked up with the same rule as the user .npmrc above.
+  describe("global .bunfig.toml lookup", () => {
+    const bunfig = (cacheDir: string) => `[install]\ncache = "${cacheDir}"\n`;
+    const pkg = { "pkg/package.json": JSON.stringify({ name: "bunfig-lookup", version: "0.0.1" }) };
+
+    // `bun pm cache` prints the install cache directory, which each candidate
+    // .bunfig.toml points at a differently named directory, so its output shows
+    // which file was read. BUN_INSTALL_CACHE_DIR would take precedence over
+    // bunfig, and CI runners set it as well as XDG_CONFIG_HOME, so both are removed.
+    async function pmCache(dir: string, envOverride: Record<string, string>) {
+      const spawnEnv = { ...env, HOME: join(dir, "home"), USERPROFILE: join(dir, "home") };
+      delete spawnEnv.XDG_CONFIG_HOME;
+      delete spawnEnv.BUN_INSTALL_CACHE_DIR;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "pm", "cache"],
+        cwd: join(dir, "pkg"),
+        env: { ...spawnEnv, ...envOverride },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { cacheDir: basename(stdout.trim()), stderr, exitCode };
+    }
+
+    const usesCacheDir = (cacheDir: string) => ({ cacheDir, stderr: "", exitCode: 0 });
+
+    it.concurrent("uses $XDG_CONFIG_HOME/.bunfig.toml when it exists", async () => {
+      using dir = tempDir("bunfig-xdg", {
+        ...pkg,
+        "home/.bunfig.toml": bunfig("home-cache"),
+        "xdg/.bunfig.toml": bunfig("xdg-cache"),
+      });
+      const result = await pmCache(String(dir), { XDG_CONFIG_HOME: join(String(dir), "xdg") });
+      expect(result).toEqual(usesCacheDir("xdg-cache"));
+    });
+
+    // https://github.com/oven-sh/bun/issues/23128
+    it.concurrent("falls back to $HOME/.bunfig.toml when $XDG_CONFIG_HOME has no .bunfig.toml", async () => {
+      using dir = tempDir("bunfig-xdg-without-bunfig", {
+        ...pkg,
+        "home/.bunfig.toml": bunfig("home-cache"),
+        "xdg/.keep": "",
+      });
+      const result = await pmCache(String(dir), { XDG_CONFIG_HOME: join(String(dir), "xdg") });
+      expect(result).toEqual(usesCacheDir("home-cache"));
+    });
+
+    it.concurrent("uses $HOME/.bunfig.toml when $XDG_CONFIG_HOME is unset", async () => {
+      using dir = tempDir("bunfig-xdg-unset", { ...pkg, "home/.bunfig.toml": bunfig("home-cache") });
+      const result = await pmCache(String(dir), {});
+      expect(result).toEqual(usesCacheDir("home-cache"));
+    });
+
+    it.concurrent("uses $HOME/.bunfig.toml when $XDG_CONFIG_HOME is empty", async () => {
+      using dir = tempDir("bunfig-xdg-empty", { ...pkg, "home/.bunfig.toml": bunfig("home-cache") });
+      const result = await pmCache(String(dir), { XDG_CONFIG_HOME: "" });
+      expect(result).toEqual(usesCacheDir("home-cache"));
     });
   });
 


### PR DESCRIPTION
Fixes #23128 (the `.bunfig.toml` half; the `.npmrc` half landed in #36289).

Rebased onto main by @robobun at a maintainer's request: #36289 already changed the `PackageManager.rs` hunk this PR used to touch, so this PR now only carries the `.bunfig.toml` side and uses the same rule as #36289. The original description is kept at the bottom.

### Problem
- With `XDG_CONFIG_HOME` exported (GitHub Actions ubuntu runners and most Linux desktops export it), `~/.bunfig.toml` is never read by `bun install`, `bun add`, `bun pm ...` and the other commands that load the global bunfig, whether or not `$XDG_CONFIG_HOME/.bunfig.toml` exists.
- Cause: `get_home_config_path` in `src/bunfig/arguments.rs` returned `$XDG_CONFIG_HOME/.bunfig.toml` as soon as the variable was set, without checking that the file exists. `XDG_CONFIG_HOME=""` had the same effect, since the empty value still counted as set.
- docs/runtime/bunfig.mdx and docs/pm/cli/install.mdx describe the global file as `$XDG_CONFIG_HOME/.bunfig.toml` or `$HOME/.bunfig.toml`, and `.npmrc` has used that rule since #36289.

### Fix
- `get_home_config_path` uses `$XDG_CONFIG_HOME/.bunfig.toml` only when that file exists (`bun_sys::exists_z`), otherwise `$HOME/.bunfig.toml`. Both variables are read with `get_not_empty()`, so an empty string counts as unset. Still at most one global file is loaded, and a bunfig that was deliberately placed under `XDG_CONFIG_HOME` keeps winning.
- `PackageManager.rs` is untouched; the user-level `.npmrc` lookup there already works this way after #36289.
- Tests: `test/cli/install/npmrc.test.ts`, `describe("global .bunfig.toml lookup")`, next to the `user .npmrc lookup` cases from #36289. Each case points the candidate files at differently named cache directories and reads back which one `bun pm cache` prints (offline, no registry involved):
  - `$XDG_CONFIG_HOME/.bunfig.toml` present: it wins
  - `XDG_CONFIG_HOME` set, no file there: `$HOME/.bunfig.toml` is used (fails on main)
  - `XDG_CONFIG_HOME` unset: `$HOME/.bunfig.toml` is used
  - `XDG_CONFIG_HOME=""`: `$HOME/.bunfig.toml` is used (fails on main)
- `USE_SYSTEM_BUN=1 bun test test/cli/install/npmrc.test.ts -t "bunfig.toml lookup"` (bun 1.4.0): 2 pass, 2 fail, both failures printing the default cache directory instead of the one from `$HOME/.bunfig.toml`
- `bun bd test test/cli/install/npmrc.test.ts`: 35 pass (whole file)
- `bun bd test test/cli/install/minimum-release-age.test.ts -t "global bunfig"`: 2 pass (existing tests that set `XDG_CONFIG_HOME` to a directory containing a `.bunfig.toml`)

### Background
- The global bunfig is the per-user `.bunfig.toml` that install-family commands (and `bunx`) load before the project's `./bunfig.toml`; the local file's settings override it. Runtime commands such as `bun run` do not load it; that is unchanged here (#34987 proposed changing it and is closed in favour of this PR).
- `XDG_CONFIG_HOME` is the freedesktop variable for a user's config directory, usually `~/.config`. Bun also looks for `.bunfig.toml` directly inside it, so on a machine that merely exports the variable the lookup used to stop at a path where nothing exists.
- `bun pm cache` prints the install cache directory, which `[install] cache = "..."` in any loaded bunfig overrides, which is why the tests use it to see which file was read. `BUN_INSTALL_CACHE_DIR` would take precedence over bunfig and CI exports it, so the tests drop it from the environment.

<details>
<summary>Original description (before the rebase)</summary>

### What does this PR do?

Fixes #23128.

`bun install` resolved its user-level `.npmrc` with:

```rust
XDG_CONFIG_HOME.get().or_else(|| HOME.get())
```

That picks one directory *or* the other. Because many Linux distros and shells export `XDG_CONFIG_HOME` by default, users who never opted into XDG would have `$HOME/.npmrc` silently ignored — scoped registries and auth tokens dropped with no diagnostic. `$HOME/.bunfig.toml` had the identical bug in `get_home_config_path`.

This probes `$XDG_CONFIG_HOME/<name>` and only uses it when the file is actually there, otherwise falling back to `$HOME/<name>`.

Two notes on the approach:

- **Fallback, not merge.** Only one user-level file is ever loaded, which keeps npm's `userconfig` model and avoids introducing a new config layer with new precedence rules to reason about.
- **XDG still wins when populated**, so anyone who deliberately moved their config there is unaffected. There's a test pinning that direction so it can't silently regress.

The resolution is shared between `.npmrc` and `.bunfig.toml` via `bun_bunfig::arguments::user_config_path`, since both sites had the same bug. `bun_install` already depends on `bun_bunfig`, so no new edges. Cost is one extra `stat` at startup, and only when both env vars are set.

### How did you verify your code works?

Two tests added to `test/cli/install/npmrc.test.ts`. Both assert offline via `bun pm cache` reading `cache=` out of the resolved `.npmrc`, so there's no registry or network dependency:

- `falls back to $HOME/.npmrc when $XDG_CONFIG_HOME has none`
- `prefers $XDG_CONFIG_HOME/.npmrc over $HOME/.npmrc`

`USE_SYSTEM_BUN=1` can't validate this file — it fails at import on `bun:internal-for-testing`, which release builds don't ship. So I verified the tests are real by reverting the source change, rebuilding, and re-running:

```
(fail) npmrc > falls back to $HOME/.npmrc when $XDG_CONFIG_HOME has none
 1 pass  1 fail
```

The fallback test fails without the fix; the precedence test passes without it, confirming it guards existing behavior rather than the new path. With the fix restored:

```
bun bd test test/cli/install/npmrc.test.ts \
            test/config/bunfig/bunfig-errors.test.ts \
            test/cli/bunfig-test-options.test.ts \
            test/cli/install/bun-run-bunfig.test.ts
 65 pass  0 fail
```

The bunfig suites are included because the shared helper also governs `.bunfig.toml` resolution. `cargo clippy -p bun_bunfig -p bun_install --no-deps` is clean.

Not covered: I only exercised this on Linux. The code path is platform-independent, and the tests now set `USERPROFILE` alongside `HOME` since `env_var::HOME` reads `USERPROFILE` on Windows — but I have not run them on macOS or Windows.

**Correction to an earlier version of this description:** I originally wrote that `HOME` is unset on Windows so the `(None, ...)` arms preserve existing behavior there. That was wrong — `env_var::HOME` is defined as `posix = "HOME", windows = "USERPROFILE"` (`src/bun_core/env_var.rs:146`), so it is populated on Windows too. The practical impact is small because `XDG_CONFIG_HOME` is rarely set on Windows, but when it is, resolution changes there the same way it does on Linux. Thanks to @coderabbitai for the nudge that surfaced this.


</details>
