### PR TITLE
fetch: set the "immutable" headers guard on Response.redirect/error and fetch() responses

### DIFF
--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -11,8 +11,7 @@ bun_opaque::opaque_ffi! {
     pub struct FetchHeaders;
 }
 
-/// Mirrors `WebCore::FetchHeaders::Guard` (FetchHeaders.h). Discriminants must
-/// stay in sync with the C++ enum order.
+/// Mirrors `WebCore::FetchHeaders::Guard` (FetchHeaders.h); discriminant order is ABI.
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum HeadersGuard {

--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -11,6 +11,18 @@ bun_opaque::opaque_ffi! {
     pub struct FetchHeaders;
 }
 
+/// Mirrors `WebCore::FetchHeaders::Guard` (FetchHeaders.h). Discriminants must
+/// stay in sync with the C++ enum order.
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum HeadersGuard {
+    None = 0,
+    Immutable = 1,
+    Request = 2,
+    RequestNoCors = 3,
+    Response = 4,
+}
+
 // `FetchHeaders`/`JSGlobalObject`/`VM` are opaque `UnsafeCell`-backed ZST
 // handles, so `&T` is ABI-identical to a non-null `*const T` and C++ mutating
 // header storage / VM state through them is interior mutation invisible to
@@ -89,6 +101,7 @@ unsafe extern "C" {
         value: &BunString,
         global: &JSGlobalObject,
     );
+    safe fn WebCore__FetchHeaders__setGuard(this: &FetchHeaders, guard: u8);
 }
 
 #[repr(C)]
@@ -180,6 +193,10 @@ impl FetchHeaders {
     pub fn create_empty() -> NonNull<FetchHeaders> {
         NonNull::new(WebCore__FetchHeaders__createEmpty())
             .expect("WebCore__FetchHeaders__createEmpty returned null")
+    }
+
+    pub fn set_guard(&mut self, guard: HeadersGuard) {
+        WebCore__FetchHeaders__setGuard(self, guard as u8)
     }
 
     pub fn create_from_pico_headers<T>(pico_headers_list: &[T]) -> NonNull<FetchHeaders> {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1864,6 +1864,10 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createEmpty()
     headers->relaxAdoptionRequirement();
     return headers;
 }
+extern "C" void WebCore__FetchHeaders__setGuard(WebCore::FetchHeaders* headers, uint8_t guard)
+{
+    headers->setGuard(static_cast<WebCore::FetchHeaders::Guard>(guard));
+}
 void WebCore__FetchHeaders__append(WebCore::FetchHeaders* headers, const ZigString* arg1, const ZigString* arg2,
     JSC::JSGlobalObject* lexicalGlobalObject)
 {
@@ -1962,6 +1966,9 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__cloneThis(WebCore::FetchHeaders* h
     auto* clone = new WebCore::FetchHeaders({ WebCore::FetchHeaders::Guard::None, {} });
     clone->relaxAdoptionRequirement();
     WebCore::propagateException(*lexicalGlobalObject, throwScope, clone->fill(*headers));
+    // Preserve the guard so Response.clone() keeps immutable headers immutable.
+    // fill() runs with Guard::None so copying from an immutable source succeeds.
+    clone->setGuard(headers->guard());
     return clone;
 }
 
@@ -2049,7 +2056,10 @@ typedef struct PicoHTTPHeaders {
 WebCore::FetchHeaders* WebCore__FetchHeaders__createFromPicoHeaders_(const void* arg1)
 {
     PicoHTTPHeaders pico_headers = *reinterpret_cast<const PicoHTTPHeaders*>(arg1);
-    auto* headers = new WebCore::FetchHeaders({ WebCore::FetchHeaders::Guard::None, {} });
+    // https://fetch.spec.whatwg.org/#ref-for-concept-headers-guard%E2%91%A0%E2%91%A1
+    // A Response created by fetch() has its headers guard set to "immutable".
+    // This function's only caller is FetchTasklet::to_response.
+    auto* headers = new WebCore::FetchHeaders({ WebCore::FetchHeaders::Guard::Immutable, {} });
     headers->relaxAdoptionRequirement(); // This prevents an assertion later, but may not be the proper approach.
 
     if (pico_headers.len > 0) {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1966,8 +1966,7 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__cloneThis(WebCore::FetchHeaders* h
     auto* clone = new WebCore::FetchHeaders({ WebCore::FetchHeaders::Guard::None, {} });
     clone->relaxAdoptionRequirement();
     WebCore::propagateException(*lexicalGlobalObject, throwScope, clone->fill(*headers));
-    // Preserve the guard so Response.clone() keeps immutable headers immutable.
-    // fill() runs with Guard::None so copying from an immutable source succeeds.
+    // Preserve the guard after fill() (which needs Guard::None to copy from an immutable source).
     clone->setGuard(headers->guard());
     return clone;
 }
@@ -2056,9 +2055,7 @@ typedef struct PicoHTTPHeaders {
 WebCore::FetchHeaders* WebCore__FetchHeaders__createFromPicoHeaders_(const void* arg1)
 {
     PicoHTTPHeaders pico_headers = *reinterpret_cast<const PicoHTTPHeaders*>(arg1);
-    // https://fetch.spec.whatwg.org/#ref-for-concept-headers-guard%E2%91%A0%E2%91%A1
-    // A Response created by fetch() has its headers guard set to "immutable".
-    // This function's only caller is FetchTasklet::to_response.
+    // Only caller is FetchTasklet::to_response; a fetch() Response's headers guard is "immutable".
     auto* headers = new WebCore::FetchHeaders({ WebCore::FetchHeaders::Guard::Immutable, {} });
     headers->relaxAdoptionRequirement(); // This prevents an assertion later, but may not be the proper approach.
 

--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -240,10 +240,10 @@ ExceptionOr<void> FetchHeaders::append(const String& name, const String& value)
 // https://fetch.spec.whatwg.org/#dom-headers-delete
 ExceptionOr<void> FetchHeaders::remove(const StringView name)
 {
-    ASSERT_WITH_MESSAGE(m_guard == FetchHeaders::Guard::None, "We don't use guards in Bun");
-
     HTTPHeaderName headerName;
     if (findHTTPHeaderName(name, headerName)) {
+        if (m_guard == FetchHeaders::Guard::Immutable)
+            return Exception { TypeError, "Headers object's guard is 'immutable'"_s };
         ++m_updateCounter;
         m_headers.remove(headerName);
         return {};
@@ -251,6 +251,8 @@ ExceptionOr<void> FetchHeaders::remove(const StringView name)
 
     if (!isValidHTTPToken(name))
         return Exception { TypeError, makeString("Invalid header name: '"_s, name, "'"_s) };
+    if (m_guard == FetchHeaders::Guard::Immutable)
+        return Exception { TypeError, "Headers object's guard is 'immutable'"_s };
 
     ++m_updateCounter;
     m_headers.removeUncommonHeader(name);

--- a/src/jsc/bindings/webcore/FetchHeaders.h
+++ b/src/jsc/bindings/webcore/FetchHeaders.h
@@ -143,7 +143,6 @@ inline FetchHeaders::FetchHeaders(const FetchHeaders& other)
 
 inline void FetchHeaders::setGuard(Guard guard)
 {
-    ASSERT(!m_headers.size());
     m_guard = guard;
 }
 

--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -136,9 +136,7 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSFetchHeadersDOMConstru
     if (argument0.value() && !argument0.value().isUndefined()) {
         if (auto* existingJsFetchHeaders = dynamicDowncast<JSFetchHeaders>(argument0.value())) {
             auto newHeaders = FetchHeaders::create(existingJsFetchHeaders->wrapped());
-            // https://fetch.spec.whatwg.org/#dom-headers: a Headers object created
-            // by the JS constructor always has guard "none", regardless of the
-            // source's guard. The copy constructor above copies m_guard.
+            // The copy constructor copies m_guard; `new Headers(init)` has guard "none".
             newHeaders->setGuard(FetchHeaders::Guard::None);
             auto jsValue = toJSNewlyCreated<IDLInterface<FetchHeaders>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, WTF::move(newHeaders));
             if constexpr (IsExceptionOr<decltype(jsValue)>)

--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -136,6 +136,10 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSFetchHeadersDOMConstru
     if (argument0.value() && !argument0.value().isUndefined()) {
         if (auto* existingJsFetchHeaders = dynamicDowncast<JSFetchHeaders>(argument0.value())) {
             auto newHeaders = FetchHeaders::create(existingJsFetchHeaders->wrapped());
+            // https://fetch.spec.whatwg.org/#dom-headers: a Headers object created
+            // by the JS constructor always has guard "none", regardless of the
+            // source's guard. The copy constructor above copies m_guard.
+            newHeaders->setGuard(FetchHeaders::Guard::None);
             auto jsValue = toJSNewlyCreated<IDLInterface<FetchHeaders>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, WTF::move(newHeaders));
             if constexpr (IsExceptionOr<decltype(jsValue)>)
                 RETURN_IF_EXCEPTION(throwScope, {});

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -967,7 +967,7 @@ pub use self::resolved_source_tag::ResolvedSourceTag;
 // ──────────────────────────────────────────────────────────────────────────
 #[path = "FetchHeaders.rs"]
 pub mod fetch_headers;
-pub use self::fetch_headers::{FetchHeaders, HTTPHeaderName};
+pub use self::fetch_headers::{FetchHeaders, HTTPHeaderName, HeadersGuard};
 
 /// `BuiltinName` — fast-path property keys preallocated as `JSC::Identifier`s
 /// in C++ (`BunBuiltinNames.h`). Passed to `JSValue::fast_get` as a `u8` index

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -706,7 +706,12 @@ impl BufferOutputSink {
             // `self` (FFI mutates a freshly-allocated clone, not the receiver).
             if let Some(headers) = (*original).get_init_headers_mut() {
                 let cloned = headers.clone_this(global)?;
-                (*result).set_init_headers(cloned.map(|p| HeadersRef::adopt(p)));
+                (*result).set_init_headers(cloned.map(|p| {
+                    let mut h = HeadersRef::adopt(p);
+                    // transform() returns a new Response, not a spec clone().
+                    h.set_guard(jsc::HeadersGuard::None);
+                    h
+                }));
             }
         }
 

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1214,8 +1214,7 @@ impl Request {
                                     req.headers.set(h.map(|p| {
                                         // SAFETY: clone_this returns a +1 ref FetchHeaders.
                                         let mut h = unsafe { HeadersRef::adopt(p) };
-                                        // Request headers are never immutable;
-                                        // drop any guard copied from the Response.
+                                        // clone_this preserves guard; Request headers are never immutable.
                                         h.set_guard(jsc::HeadersGuard::None);
                                         h
                                     }));

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1211,8 +1211,8 @@ impl Request {
                             // repopulate headers from a different source.
                             match headers.clone_this(global_this) {
                                 Ok(h) => {
-                                    // SAFETY: clone_this returns a +1 ref FetchHeaders.
                                     req.headers.set(h.map(|p| {
+                                        // SAFETY: clone_this returns a +1 ref FetchHeaders.
                                         let mut h = unsafe { HeadersRef::adopt(p) };
                                         // Request headers are never immutable;
                                         // drop any guard copied from the Response.

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1212,7 +1212,13 @@ impl Request {
                             match headers.clone_this(global_this) {
                                 Ok(h) => {
                                     // SAFETY: clone_this returns a +1 ref FetchHeaders.
-                                    req.headers.set(h.map(|p| unsafe { HeadersRef::adopt(p) }));
+                                    req.headers.set(h.map(|p| {
+                                        let mut h = unsafe { HeadersRef::adopt(p) };
+                                        // Request headers are never immutable;
+                                        // drop any guard copied from the Response.
+                                        h.set_guard(jsc::HeadersGuard::None);
+                                        h
+                                    }));
                                     fields.insert(Fields::Headers);
                                 }
                                 Err(e) => bail!(Err(e)),

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -8,8 +8,8 @@ use bun_jsc::{AbortSignal, AbortSignalRef, GlobalRef};
 
 use crate::webcore::BlobExt as _;
 use crate::webcore::jsc::{
-    BuiltinName, CallFrame, HTTPHeaderName, JSGlobalObject, JSType, JSValue, JsError, JsRef,
-    JsResult, StringJsc as _,
+    BuiltinName, CallFrame, HTTPHeaderName, HeadersGuard, JSGlobalObject, JSType, JSValue, JsError,
+    JsRef, JsResult, StringJsc as _,
 };
 use bun_core::Output;
 use bun_core::{OwnedString, String as BunString, WTFStringImplExt as _, ZigStringSlice};
@@ -1170,6 +1170,9 @@ impl Response {
 
         // `get_or_create_headers` already populated init.headers.
         let headers = response.get_or_create_headers(global_this)?;
+        // `Init::init` may have cloned headers from an immutable source; clear
+        // the guard so `put(Location)` below does not throw.
+        headers.set_guard(HeadersGuard::None);
         // https://fetch.spec.whatwg.org/#dom-response-redirect steps 1 & 6: `Location`
         // gets the serialization of the parsed url, not the raw input. Non-absolute
         // input keeps the raw string: relative redirects are documented Bun behavior.
@@ -1177,6 +1180,9 @@ impl Response {
         // The JS string's own WTF string (no re-encode), same as `Headers.prototype.set`.
         let location = if href.is_empty() { &url_string } else { &href };
         headers.put(HTTPHeaderName::Location, location, global_this)?;
+        // https://fetch.spec.whatwg.org/#dom-response-redirect step 4: the Response
+        // object is created with guard "immutable".
+        headers.set_guard(HeadersGuard::Immutable);
         Ok(response)
     }
 
@@ -1184,10 +1190,15 @@ impl Response {
         global_this: &JSGlobalObject,
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
+        // https://fetch.spec.whatwg.org/#dom-response-error: the Response object
+        // is created with guard "immutable".
+        let mut headers = HeadersRef::create_empty();
+        headers.set_guard(HeadersGuard::Immutable);
         // Ownership transfers to the JSC wrapper (freed via `finalize`).
         let response = bun_core::heap::into_raw(Box::new(Response {
             init: JsCell::new(Init {
                 status_code: 0,
+                headers: Some(headers),
                 ..Default::default()
             }),
             body: JsCell::new(Body::new(BodyValue::Empty)),
@@ -1431,7 +1442,14 @@ impl Init {
                 // SAFETY: `as_direct` returned a live `*mut Response` owned by the
                 // JS wrapper cell; rooted by `response_init` for this call.
                 let resp = unsafe { &*resp };
-                return Ok(Some(resp.init.get().clone(global_this)?));
+                let mut init = resp.init.get().clone(global_this)?;
+                // A Response built by a constructor has guard "response" (treated
+                // as "none" here); drop any "immutable" guard carried over from
+                // the source so the new object's headers remain writable.
+                if let Some(h) = init.headers.as_mut() {
+                    h.set_guard(HeadersGuard::None);
+                }
+                return Ok(Some(init));
             }
         }
 
@@ -1451,7 +1469,12 @@ impl Init {
                     result.headers = orig.clone_this(global_this)?.map(|p| {
                         // SAFETY: `clone_this` returns a fresh +1-ref'd `FetchHeaders*`;
                         // ownership of that ref is transferred into the `HeadersRef`.
-                        unsafe { HeadersRef::adopt(p) }
+                        let mut h = unsafe { HeadersRef::adopt(p) };
+                        // `clone_this` preserves the source guard; a Response
+                        // built from ResponseInit has guard "response" (treated
+                        // as "none" here), so drop any "immutable" copied over.
+                        h.set_guard(HeadersGuard::None);
+                        h
                     });
                 }
             } else {

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1170,8 +1170,7 @@ impl Response {
 
         // `get_or_create_headers` already populated init.headers.
         let headers = response.get_or_create_headers(global_this)?;
-        // `Init::init` may have cloned headers from an immutable source; clear
-        // the guard so `put(Location)` below does not throw.
+        // Clear any guard cloned from an immutable init so `put(Location)` does not throw.
         headers.set_guard(HeadersGuard::None);
         // https://fetch.spec.whatwg.org/#dom-response-redirect steps 1 & 6: `Location`
         // gets the serialization of the parsed url, not the raw input. Non-absolute
@@ -1180,8 +1179,7 @@ impl Response {
         // The JS string's own WTF string (no re-encode), same as `Headers.prototype.set`.
         let location = if href.is_empty() { &url_string } else { &href };
         headers.put(HTTPHeaderName::Location, location, global_this)?;
-        // https://fetch.spec.whatwg.org/#dom-response-redirect step 4: the Response
-        // object is created with guard "immutable".
+        // https://fetch.spec.whatwg.org/#dom-response-redirect step 4: guard is "immutable".
         headers.set_guard(HeadersGuard::Immutable);
         Ok(response)
     }
@@ -1190,8 +1188,7 @@ impl Response {
         global_this: &JSGlobalObject,
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        // https://fetch.spec.whatwg.org/#dom-response-error: the Response object
-        // is created with guard "immutable".
+        // https://fetch.spec.whatwg.org/#dom-response-error: guard is "immutable".
         let mut headers = HeadersRef::create_empty();
         headers.set_guard(HeadersGuard::Immutable);
         // Ownership transfers to the JSC wrapper (freed via `finalize`).
@@ -1443,9 +1440,7 @@ impl Init {
                 // JS wrapper cell; rooted by `response_init` for this call.
                 let resp = unsafe { &*resp };
                 let mut init = resp.init.get().clone(global_this)?;
-                // A Response built by a constructor has guard "response" (treated
-                // as "none" here); drop any "immutable" guard carried over from
-                // the source so the new object's headers remain writable.
+                // A Response built from ResponseInit is never immutable.
                 if let Some(h) = init.headers.as_mut() {
                     h.set_guard(HeadersGuard::None);
                 }
@@ -1470,9 +1465,7 @@ impl Init {
                         // SAFETY: `clone_this` returns a fresh +1-ref'd `FetchHeaders*`;
                         // ownership of that ref is transferred into the `HeadersRef`.
                         let mut h = unsafe { HeadersRef::adopt(p) };
-                        // `clone_this` preserves the source guard; a Response
-                        // built from ResponseInit has guard "response" (treated
-                        // as "none" here), so drop any "immutable" copied over.
+                        // A Response built from ResponseInit is never immutable.
                         h.set_guard(HeadersGuard::None);
                         h
                     });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1831,9 +1831,13 @@ it("should support multiple Set-Cookie headers", async () => {
       const cloned = response.clone().headers;
       expect(response.headers.getAll("Set-Cookie")).toEqual(["foo=bar", "baz=qux"]);
 
-      response.headers.delete("Set-Cookie");
-      expect(response.headers.getAll("Set-Cookie")).toEqual([]);
-      response.headers.delete("Set-Cookie");
+      // fetch() response headers are immutable; exercise Set-Cookie deletion on
+      // a mutable copy and verify the original and clone are untouched.
+      const copy = new Headers(response.headers);
+      copy.delete("Set-Cookie");
+      expect(copy.getAll("Set-Cookie")).toEqual([]);
+      copy.delete("Set-Cookie");
+      expect(response.headers.getAll("Set-Cookie")).toEqual(["foo=bar", "baz=qux"]);
       expect(cloned.getAll("Set-Cookie")).toEqual(["foo=bar", "baz=qux"]);
       expect(new Headers(cloned).getAll("Set-Cookie")).toEqual(["foo=bar", "baz=qux"]);
     },

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -852,6 +852,17 @@ describe("Headers", () => {
         expect(() => r.headers.set("x-foo", "1")).not.toThrow();
         expect(() => r.headers.delete("x-foo")).not.toThrow();
       });
+
+      test("HTMLRewriter.transform(fetchResponse) output is mutable", async () => {
+        await using server = Bun.serve({
+          port: 0,
+          fetch: () => new Response("<p>x</p>", { headers: { "content-type": "text/html" } }),
+        });
+        const res = await fetch(server.url);
+        const out = new HTMLRewriter().on("p", { element() {} }).transform(res);
+        expect(() => out.headers.set("content-type", "text/html; charset=utf-8")).not.toThrow();
+        expect(out.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      });
     });
   });
 });

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -735,4 +735,123 @@ describe("Headers", () => {
       expect(lowercaseHeaderNameSIMD(s)).toBe("x-ab\u0100cd\u0101ef\uffffgz");
     });
   });
+
+  // https://fetch.spec.whatwg.org/#concept-headers-guard
+  describe("immutable guard", () => {
+    const immutableMsg = /guard is 'immutable'/;
+
+    function expectImmutable(h: Headers) {
+      expect(() => h.set("x-foo", "1")).toThrow(TypeError);
+      expect(() => h.set("x-foo", "1")).toThrow(immutableMsg);
+      expect(() => h.append("x-foo", "1")).toThrow(TypeError);
+      expect(() => h.delete("x-foo")).toThrow(TypeError);
+      expect(() => h.delete("location")).toThrow(TypeError);
+      expect(h.get("x-foo")).toBeNull();
+    }
+
+    test("Response.redirect() headers reject set/append/delete", () => {
+      const r = Response.redirect("http://example.com/good");
+      expect(r.headers.get("location")).toBe("http://example.com/good");
+      expectImmutable(r.headers);
+      expect(() => r.headers.set("location", "http://example.com/evil")).toThrow(TypeError);
+      expect(r.headers.get("location")).toBe("http://example.com/good");
+    });
+
+    test("Response.redirect() with headers init rejects set/append/delete", () => {
+      // Bun extension: second arg may be a ResponseInit.
+      const r = Response.redirect("http://example.com/good", {
+        status: 301,
+        headers: { "x-extra": "a" },
+      });
+      expect(r.headers.get("location")).toBe("http://example.com/good");
+      expect(r.headers.get("x-extra")).toBe("a");
+      expectImmutable(r.headers);
+    });
+
+    test("Response.error() headers reject set/append/delete", () => {
+      const r = Response.error();
+      expectImmutable(r.headers);
+    });
+
+    test("fetch() response headers reject set/append/delete", async () => {
+      await using server = Bun.serve({
+        port: 0,
+        fetch: () => new Response("ok", { headers: { "x-orig": "1" } }),
+      });
+      const res = await fetch(server.url);
+      expect(res.headers.get("x-orig")).toBe("1");
+      expectImmutable(res.headers);
+      expect(() => res.headers.delete("x-orig")).toThrow(TypeError);
+      expect(res.headers.get("x-orig")).toBe("1");
+    });
+
+    test("Response.prototype.clone() preserves the immutable guard", () => {
+      const r = Response.redirect("http://example.com/good");
+      const c = r.clone();
+      expect(c.headers.get("location")).toBe("http://example.com/good");
+      expectImmutable(c.headers);
+    });
+
+    test("Bun.serve sends Location as set by Response.redirect()", async () => {
+      await using server = Bun.serve({
+        port: 0,
+        fetch: () => {
+          const r = Response.redirect("http://example.com/good");
+          // The handler can still observe the Location it set but cannot
+          // rewrite it; a sanitizer relying on spec immutability is sound.
+          try {
+            r.headers.set("location", "http://example.com/evil");
+          } catch {}
+          return r;
+        },
+      });
+      const res = await fetch(server.url, { redirect: "manual" });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("http://example.com/good");
+    });
+
+    test("delete() still validates the header name first", () => {
+      const r = Response.error();
+      expect(() => r.headers.delete("bad header\n")).toThrow(/Invalid header name/);
+    });
+
+    describe("sources that must stay mutable", () => {
+      test("new Headers(immutable) is mutable", () => {
+        const src = Response.redirect("http://example.com/good").headers;
+        const h = new Headers(src);
+        expect(h.get("location")).toBe("http://example.com/good");
+        expect(() => h.set("location", "http://example.com/other")).not.toThrow();
+        expect(h.get("location")).toBe("http://example.com/other");
+        expect(() => h.delete("location")).not.toThrow();
+      });
+
+      test("new Response(body, { headers: immutable }) is mutable", () => {
+        const src = Response.redirect("http://example.com/good").headers;
+        const r = new Response("", { headers: src });
+        expect(r.headers.get("location")).toBe("http://example.com/good");
+        expect(() => r.headers.set("x-foo", "1")).not.toThrow();
+        expect(r.headers.get("x-foo")).toBe("1");
+      });
+
+      test("Response.json(data, { headers: immutable }) is mutable", () => {
+        const src = Response.redirect("http://example.com/good").headers;
+        const r = Response.json({}, { headers: src });
+        expect(r.headers.get("content-type")).toContain("application/json");
+        expect(() => r.headers.set("x-foo", "1")).not.toThrow();
+      });
+
+      test("new Response(body, immutableResponse) is mutable", () => {
+        // Bun fast-path: ResponseInit may be a Response instance.
+        const src = Response.redirect("http://example.com/good");
+        const r = new Response("", src);
+        expect(() => r.headers.set("x-foo", "1")).not.toThrow();
+      });
+
+      test("new Response() with no init is mutable", () => {
+        const r = new Response("ok");
+        expect(() => r.headers.set("x-foo", "1")).not.toThrow();
+        expect(() => r.headers.delete("x-foo")).not.toThrow();
+      });
+    });
+  });
 });


### PR DESCRIPTION
## What

Make `Response.redirect()`, `Response.error()`, and the `Response` returned by `fetch()` carry a Headers object whose guard is `"immutable"`, so `set`/`append`/`delete` throw `TypeError` as the Fetch spec requires.

## Why

Bun already kept WebKit's `FetchHeaders::Guard` enum and `canWriteHeader()` already rejected `Guard::Immutable`, but nothing ever called `setGuard()`: every `FetchHeaders` was created with `Guard::None`, and `FetchHeaders::remove()` opened with `ASSERT_WITH_MESSAGE(m_guard == Guard::None, "We don't use guards in Bun")`.

Repro (fails on current Bun, throws on Node/undici and Deno):

```js
const r = Response.redirect("http://example.com/good");
r.headers.set("location", "http://example.com/evil"); // should throw TypeError
r.headers.get("location"); // => "http://example.com/evil"
```

Wire consequence: a `Bun.serve` handler that mutates a `Response.redirect()` after the fact sends the rewritten `Location`.

## How

- `FetchHeaders::remove()` now returns the `"Headers object's guard is 'immutable'"` `TypeError` instead of asserting guards are unused. Invalid-name validation still runs first for uncommon header names.
- `FetchHeaders::setGuard()` drops its `ASSERT(!m_headers.size())` so the guard can be applied after `Location` has been written.
- `WebCore__FetchHeaders__createFromPicoHeaders_` (the only caller is `FetchTasklet::to_response`) constructs with `Guard::Immutable`; the headers are populated via `setInternalHeaders()`, which bypasses the guard.
- `WebCore__FetchHeaders__cloneThis` preserves the source guard so `Response.clone()` of an immutable response stays immutable.
- `new Headers(h)` resets its guard to `"none"` after copy-constructing (the copy constructor copies `m_guard`, which was latent while guards were never set).
- A new `WebCore__FetchHeaders__setGuard` FFI shim lets the Rust side set the guard; `Response::construct_redirect_impl` and `Response::construct_error` use it to mark their headers immutable.
- `Init::init` (the ResponseInit parser used by `new Response`/`Response.json`/`Response.redirect`'s init-object extension) and the Request-from-Response fast path clear the guard on headers cloned from an immutable source, so `new Response(body, { headers: fetchRes.headers })` stays writable per spec.

## Tests

`test/js/web/fetch/headers.test.ts` gains an `immutable guard` describe covering all seven spec-immutable cells (`Response.redirect().headers.{set,append,delete}`, `Response.error().headers.set`, `(await fetch()).headers.{set,delete}`), plus `Response.clone()` preservation, the wire assertion that `Bun.serve` still sends the original `Location` after an attempted rewrite, and the negative cells that must remain mutable (`new Headers(immutable)`, `new Response(body, { headers: immutable })`, `Response.json(data, { headers: immutable })`, `new Response(body, immutableResponse)`, plain `new Response()`).

`test/js/bun/http/serve.test.ts`'s "should support multiple Set-Cookie headers" test is adjusted to exercise `delete()` on a `new Headers()` copy instead of the now-immutable fetch response.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->