### PR TITLE
socket: support listening on an inherited fd (socket activation)

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -424,6 +424,55 @@ struct us_listen_socket_t *us_socket_group_listen_unix(struct us_socket_group_t 
     return ls;
 }
 
+struct us_listen_socket_t *us_socket_group_listen_from_fd(struct us_socket_group_t *group,
+        unsigned char kind, struct ssl_ctx_st *ssl_ctx,
+        LIBUS_SOCKET_DESCRIPTOR fd, int options, int socket_ext_size, int *error) {
+    /* Adopting a connected or merely-bound fd would leave us polling something
+     * that never becomes acceptable, so the caller would hang instead of
+     * getting an error. SO_ACCEPTCONN is the only portable way to tell. */
+    int is_listening = 0;
+    socklen_t is_listening_len = sizeof(is_listening);
+    if (getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, (char *) &is_listening, &is_listening_len) != 0) {
+        int saved_errno = errno ? errno : ENOTSOCK;
+        *error = saved_errno;
+        errno = saved_errno;
+        return 0;
+    }
+    if (!is_listening) {
+        *error = EINVAL;
+        errno = EINVAL;
+        return 0;
+    }
+
+    if (bsd_set_nonblocking(fd) == LIBUS_SOCKET_ERROR) {
+        int saved_errno = errno;
+        *error = saved_errno;
+        errno = saved_errno;
+        return 0;
+    }
+
+    struct us_poll_t *p = us_create_poll(group->loop, 0, sizeof(struct us_listen_socket_t));
+    us_poll_init(p, fd, POLL_TYPE_SEMI_SOCKET);
+    if (us_poll_start_rc(p, group->loop, LIBUS_SOCKET_READABLE) != 0) {
+        /* The fd stays the caller's on failure — we only take ownership once
+         * the listener is live, unlike the paths that create their own fd. */
+        int saved_errno = errno;
+        us_poll_free(p, group->loop);
+        *error = saved_errno;
+        errno = saved_errno;
+        return 0;
+    }
+
+    struct us_listen_socket_t *ls = (struct us_listen_socket_t *) p;
+    us_internal_init_listen_socket(ls, group, kind, ssl_ctx, options, socket_ext_size);
+
+    if (options & LIBUS_LISTEN_DEFER_ACCEPT) {
+        ls->deferred_accept = bsd_set_defer_accept(fd);
+    }
+
+    return ls;
+}
+
 void us_listen_socket_close(struct us_listen_socket_t *ls) {
     struct us_socket_t *s = &ls->s;
     if (!us_socket_is_closed(s)) {

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -395,6 +395,14 @@ struct us_listen_socket_t *us_socket_group_listen_unix(us_socket_group_r group,
     unsigned char kind, struct ssl_ctx_st *ssl_ctx,
     const char *path, size_t pathlen, int options, int socket_ext_size, int *error)
     __attribute__((nonnull(1, 4, 8)));  /* ssl_ctx nullable */
+/* Adopt an fd that is already bound and listening (systemd LISTEN_FDS, inetd,
+ * a privilege-dropping supervisor) instead of creating one. Takes ownership on
+ * success: the fd is closed by us_listen_socket_close like any other listener.
+ * Fails with ENOTSOCK/EINVAL if the fd is not a listening socket. */
+struct us_listen_socket_t *us_socket_group_listen_from_fd(us_socket_group_r group,
+    unsigned char kind, struct ssl_ctx_st *ssl_ctx,
+    LIBUS_SOCKET_DESCRIPTOR fd, int options, int socket_ext_size, int *error)
+    __attribute__((nonnull(1, 7)));  /* ssl_ctx nullable */
 void us_listen_socket_close(struct us_listen_socket_t *ls) nonnull_fn_decl;
 
 /* SNI: tree hangs off the listen socket. ssl_ctx is up_ref'd; user is opaque

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -742,6 +742,12 @@ public:
         return std::move(*this);
     }
 
+    /* callback, fd that is already bound and listening (socket activation) */
+    TemplatedApp &&listen_from_fd(MoveOnlyFunction<void(us_listen_socket_t *)> &&handler, LIBUS_SOCKET_DESCRIPTOR fd, int options) {
+        handler(httpContext ? trackListenSocket(httpContext->listen_from_fd(sslCtxOrNull(), fd, options)) : nullptr);
+        return std::move(*this);
+    }
+
     void setOnSocketClosed(HttpContextData<SSL>::OnSocketClosedCallback onClose) {
         httpContext->getSocketContextData()->onSocketClosed = onClose;
     }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -1027,6 +1027,18 @@ public:
 
         return socket;
     }
+
+    /* Serve on an fd that is already bound and listening (socket activation) */
+    us_listen_socket_t *listen_from_fd(struct ssl_ctx_st *sslCtx, LIBUS_SOCKET_DESCRIPTOR fd, int options) {
+        int error = 0;
+        auto* socket = us_socket_group_listen_from_fd(&group, socketKind(), sslCtx, fd, options | LIBUS_LISTEN_DEFER_ACCEPT, socketExtSize(), &error);
+        // we dont depend on libuv ref for keeping it alive
+        if (socket) {
+            us_socket_unref(&socket->s);
+        }
+
+        return socket;
+    }
 };
 
 }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -561,6 +561,7 @@ Server.prototype.listen = function () {
   const server = this;
   let port, host, onListen;
   let socketPath;
+  let fd;
   let tls = this[tlsSymbol];
 
   // This logic must align with:
@@ -573,6 +574,15 @@ Server.prototype.listen = function () {
       port = arg0.port;
       host = arg0.host;
       socketPath = arg0.path;
+
+      // Socket activation: the fd is already bound and listening, so it
+      // supersedes port/path rather than being one more thing to bind.
+      const arg0Fd = arg0.fd;
+      if (typeof arg0Fd === "number" && arg0Fd >= 0) {
+        fd = arg0Fd;
+        port = undefined;
+        socketPath = undefined;
+      }
 
       const otherTLS = arg0.tls;
       if (otherTLS && $isObject(otherTLS)) {
@@ -592,7 +602,7 @@ Server.prototype.listen = function () {
 
   // Bun defaults to port 3000.
   // Node defaults to port 0.
-  if (port === undefined && !socketPath) {
+  if (port === undefined && !socketPath && fd === undefined) {
     port = 0;
   }
 
@@ -612,7 +622,7 @@ Server.prototype.listen = function () {
     // listenInCluster
 
     if (isPrimary) {
-      server[kRealListen](tls, port, host, socketPath, false, onListen);
+      server[kRealListen](tls, port, host, socketPath, false, onListen, fd);
       return this;
     }
 
@@ -652,7 +662,7 @@ Server.prototype.listen = function () {
       sendHelper(message, null);
     });
 
-    server[kRealListen](tls, port, host, socketPath, true, onListen);
+    server[kRealListen](tls, port, host, socketPath, true, onListen, fd);
   } catch (err) {
     setTimeout(() => server.emit("error", err), 1);
   }
@@ -660,7 +670,7 @@ Server.prototype.listen = function () {
   return this;
 };
 
-Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort, onListen) {
+Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort, onListen, fd) {
   {
     const ResponseClass = this[optionsSymbol].ServerResponse || ServerResponse;
     const RequestClass = this[optionsSymbol].IncomingMessage || IncomingMessage;
@@ -677,6 +687,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
       port,
       hostname: host,
       unix: socketPath,
+      fd,
       reusePort,
       // Bindings to be used for WS Server
       websocket: {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -109,6 +109,8 @@ pub enum Address {
     },
     /// Leading NUL is valid (Linux abstract sockets).
     Unix(ZBox),
+    /// An fd inherited already bound and listening (systemd `LISTEN_FDS`, inetd).
+    Fd(i32),
 }
 
 impl Default for Address {
@@ -595,6 +597,9 @@ impl ServerConfig {
                 } else {
                     let _ = write!(&mut arraylist, "tcp:localhost:{}", port);
                 }
+            }
+            Address::Fd(fd) => {
+                let _ = write!(&mut arraylist, "fd:{}", fd);
             }
             Address::Unix(addr) => {
                 let _ = write!(&mut arraylist, "unix:{}", bstr::BStr::new(addr.as_bytes()));
@@ -1249,6 +1254,21 @@ impl ServerConfig {
                 }
 
                 args.address = Address::Unix(bun_core::ZBox::from_bytes(unix_str.slice()));
+            }
+        }
+        if global.has_exception() {
+            return Err(JsError::Thrown);
+        }
+
+        if let Some(fd_js) = arg.get_truthy(global, "fd")? {
+            if fd_js.is_number() {
+                let fd = fd_js.to_int32();
+                if fd < 0 {
+                    return Err(
+                        global.throw_invalid_arguments(format_args!("Expected \"fd\" to be >= 0"))
+                    );
+                }
+                args.address = Address::Fd(fd);
             }
         }
         if global.has_exception() {

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -513,8 +513,13 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     }
                 }
             }
-            server_config::Address::Tcp { port, hostname } => {
-                let mut port = *port;
+            server_config::Address::Tcp { .. } | server_config::Address::Fd(_) => {
+                // An adopted fd contributes no configured port/hostname; both
+                // come from the live listener below.
+                let (mut port, hostname) = match &self.config.address {
+                    server_config::Address::Tcp { port, hostname } => (*port, hostname),
+                    _ => (0u16, &None),
+                };
                 if let Some(listener) = self.listener {
                     // S012: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
                     port = bun_opaque::opaque_deref_mut(listener)
@@ -1848,6 +1853,20 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         let global = self.global_this();
 
         let error_instance = match &self.config.address {
+            server_config::Address::Fd(fd) => {
+                let err = jsc::SystemError {
+                    errno: bun_sys::SystemErrno::EINVAL as i32,
+                    code: bun_core::String::static_("EINVAL").into(),
+                    message: bun_core::String::create_format(format_args!(
+                        "Failed to listen on file descriptor {fd}: not a bound, listening socket"
+                    ))
+                    .into(),
+                    syscall: bun_core::String::static_("listen").into(),
+                    fd: *fd,
+                    ..Default::default()
+                };
+                err.to_error_instance(global)
+            }
             server_config::Address::Tcp {
                 port,
                 hostname: _hostname,
@@ -2844,6 +2863,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         enum Addr {
             Tcp { port: u16, host: *const c_char },
             Unix { ptr: *const u8, len: usize },
+            Fd(i32),
         }
         let (addr, http1, options) = {
             let cfg = &this_ref.get().config;
@@ -2868,6 +2888,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     ptr: unix.as_ptr().cast(),
                     len: unix.as_bytes().len(),
                 },
+                server_config::Address::Fd(fd) => Addr::Fd(*fd),
             };
             (addr, cfg.http1, cfg.get_usockets_options())
         };
@@ -2984,6 +3005,28 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         trampoline::on_listen_unix::<SSL, DEBUG>,
                         this.cast::<c_void>(),
                         z,
+                        options,
+                    );
+                }
+            }
+            Addr::Fd(fd) => {
+                if Self::HAS_H3 {
+                    // SAFETY: `this` is the live boxed server; no other borrow is live across this take.
+                    if let Some(h3a) = unsafe { (*this).h3_app.take() } {
+                        // The inherited fd is a stream socket; H3 needs its own
+                        // UDP socket, which the supervisor did not hand us.
+                        bun_core::warn!("http3: true with fd — HTTP/3 listener skipped");
+                        // SAFETY: h3a is a live H3::App handle just taken from self.h3_app.
+                        unsafe { uws_sys::h3::App::destroy(h3a) };
+                    }
+                }
+                // SAFETY: app is a live uws handle owned by this server. No
+                // `&*this` is live across this call.
+                unsafe {
+                    (*app).listen_from_fd(
+                        trampoline::on_listen::<SSL, DEBUG>,
+                        this.cast::<c_void>(),
+                        fd,
                         options,
                     );
                 }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2644,6 +2644,9 @@ where
         let config_port = match &self.config.address {
             server_config::Address::Unix(_) => return JSValue::UNDEFINED,
             server_config::Address::Tcp { port, .. } => *port,
+            // The bound port belongs to whoever created the fd; the live
+            // listener below is the only source for it.
+            server_config::Address::Fd(_) => 0,
         };
 
         if let Some(listener) = self.listener {
@@ -2688,8 +2691,13 @@ where
                 let value = scopeguard::guard(value, |v| v.deref());
                 value.to_js(global)
             }
-            server_config::Address::Tcp { port: tcp_port, .. } => {
-                let mut port: u16 = *tcp_port;
+            server_config::Address::Tcp { .. } | server_config::Address::Fd(_) => {
+                // An adopted fd carries no configured port; the listener below
+                // reports the one it was already bound to.
+                let mut port: u16 = match &self.config.address {
+                    server_config::Address::Tcp { port, .. } => *port,
+                    _ => 0,
+                };
 
                 if let Some(listener) = self.listener {
                     // S008: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
@@ -2750,7 +2758,7 @@ where
     pub(crate) fn get_hostname(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
         match &self.config.address {
             server_config::Address::Unix(_) => return Ok(JSValue::UNDEFINED),
-            server_config::Address::Tcp { .. } => {}
+            server_config::Address::Tcp { .. } | server_config::Address::Fd(_) => {}
         }
         {
             if let Some(listener) = self.listener {
@@ -2776,6 +2784,11 @@ where
                         } else {
                             return BunString::static_(b"localhost").to_js(global);
                         }
+                    }
+                    // An adopted fd has no configured hostname; the listener
+                    // lookup above is what resolves it.
+                    server_config::Address::Fd(_) => {
+                        return BunString::static_(b"localhost").to_js(global);
                     }
                     server_config::Address::Unix(_) => unreachable!(),
                 }

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -462,20 +462,16 @@ impl Listener {
                     &mut errno,
                 )
             }),
-            UnixOrHost::Fd(fd) => {
-                let err = jsc::SystemError {
-                    errno: bun_sys::SystemErrno::EINVAL as c_int,
-                    code: bun_core::String::static_("EINVAL").into(),
-                    message: bun_core::String::static_(
-                        "Bun does not support listening on a file descriptor.",
-                    )
-                    .into(),
-                    syscall: bun_core::String::static_("listen").into(),
-                    fd: fd.uv(),
-                    ..Default::default()
-                };
-                return Err(global.throw_value(err.to_error_instance(global)));
-            }
+            UnixOrHost::Fd(fd) => this_ref.group.with_mut(|g| {
+                g.listen_from_fd(
+                    kind,
+                    secure_ctx_ptr,
+                    fd.native(),
+                    socket_flags,
+                    size_of::<*mut c_void>() as c_int,
+                    &mut errno,
+                )
+            }),
         };
         if listen_socket.is_null() {
             // Note: reshaped for borrowck — extract hostname bytes for error formatting

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -304,6 +304,29 @@ impl<const SSL: bool> App<SSL> {
         }
     }
 
+    /// Serve on an fd that is already bound and listening (socket activation).
+    pub fn listen_from_fd(
+        &mut self,
+        handler: extern "C" fn(*mut UwsListenSocket, *mut c_void),
+        user_data: *mut c_void,
+        fd: crate::LIBUS_SOCKET_DESCRIPTOR,
+        flags: i32,
+    ) {
+        // Callers supply the C-ABI shim directly.
+        // SAFETY: self is a valid app; `fd` is validated as a listening socket by
+        // us_socket_group_listen_from_fd before adoption.
+        unsafe {
+            c::uws_app_listen_from_fd(
+                Self::SSL_FLAG,
+                std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
+                fd,
+                flags,
+                handler,
+                user_data,
+            )
+        }
+    }
+
     pub fn num_subscribers(&mut self, topic: &[u8]) -> u32 {
         // SAFETY: self is a valid app; topic valid for the call.
         unsafe {
@@ -626,6 +649,15 @@ pub mod c {
             pathlen: usize,
             flags: i32,
             handler: extern "C" fn(*mut UwsListenSocket, *const c_char, i32, *mut c_void),
+            user_data: *mut c_void,
+        );
+
+        pub(crate) fn uws_app_listen_from_fd(
+            ssl_flag: c_int,
+            app: *mut uws_app_t,
+            fd: crate::LIBUS_SOCKET_DESCRIPTOR,
+            options: i32,
+            handler: extern "C" fn(*mut UwsListenSocket, *mut c_void),
             user_data: *mut c_void,
         );
 

--- a/src/uws_sys/SocketGroup.rs
+++ b/src/uws_sys/SocketGroup.rs
@@ -285,6 +285,31 @@ impl SocketGroup {
         }
     }
 
+    /// Adopt an already-bound-and-listening fd (systemd `LISTEN_FDS`, inetd, a
+    /// privilege-dropping supervisor). Takes ownership only on success.
+    pub fn listen_from_fd(
+        &mut self,
+        kind: SocketKind,
+        ssl_ctx: Option<*mut SslCtx>,
+        fd: LIBUS_SOCKET_DESCRIPTOR,
+        options: c_int,
+        socket_ext_size: c_int,
+        error: &mut c_int,
+    ) -> *mut ListenSocket {
+        // SAFETY: forwarding to C; `error` is a valid out-param.
+        unsafe {
+            us_socket_group_listen_from_fd(
+                self,
+                kind as u8,
+                ssl_ctx.unwrap_or(ptr::null_mut()),
+                fd,
+                options,
+                socket_ext_size,
+                error,
+            )
+        }
+    }
+
     pub fn pair(
         &mut self,
         kind: SocketKind,
@@ -325,6 +350,15 @@ unsafe extern "C" {
         ssl_ctx: *mut SslCtx,
         path: *const u8,
         pathlen: usize,
+        options: c_int,
+        socket_ext_size: c_int,
+        err: *mut c_int,
+    ) -> *mut ListenSocket;
+    fn us_socket_group_listen_from_fd(
+        group: *mut SocketGroup,
+        kind: u8,
+        ssl_ctx: *mut SslCtx,
+        fd: LIBUS_SOCKET_DESCRIPTOR,
         options: c_int,
         socket_ext_size: c_int,
         err: *mut c_int,

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -519,6 +519,26 @@ extern "C"
     }
   }
 
+  void uws_app_listen_from_fd(int ssl, uws_app_t *app, LIBUS_SOCKET_DESCRIPTOR fd, int options, uws_listen_handler handler, void *user_data)
+  {
+    if (ssl)
+    {
+      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+      uwsApp->listen_from_fd(
+          [handler, user_data](struct us_listen_socket_t *listen_socket)
+          { handler((struct us_listen_socket_t *)listen_socket, user_data); },
+          fd, options);
+    }
+    else
+    {
+      uWS::App *uwsApp = (uWS::App *)app;
+      uwsApp->listen_from_fd(
+          [handler, user_data](struct us_listen_socket_t *listen_socket)
+          { handler((struct us_listen_socket_t *)listen_socket, user_data); },
+          fd, options);
+    }
+  }
+
   void uws_app_domain(int ssl, uws_app_t *app, const char *server_name)
   {
     if (ssl)

--- a/test/js/node/http/node-http-listen-fd.test.ts
+++ b/test/js/node/http/node-http-listen-fd.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+
+// Socket activation: a supervisor (systemd LISTEN_FDS, inetd, a
+// privilege-dropping parent) binds and listens, then hands the descriptor to
+// the process that serves it. The donor server below stands in for the
+// supervisor; the child inherits its own copy of the fd as fd 3.
+async function serveOnInheritedFd(fixture: string) {
+  const donor = net.createServer(() => {});
+  await new Promise<void>(resolve => donor.listen(0, "127.0.0.1", () => resolve()));
+  const fd = (donor as any)._handle.fd;
+  const port = (donor.address() as net.AddressInfo).port;
+
+  using dir = tempDir("listen-fd", { "fixture.js": fixture });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(String(dir), "fixture.js")],
+    env: bunEnv,
+    stdio: ["ignore", "pipe", "pipe", fd],
+  });
+
+  try {
+    // Await the child's own "listening" callback rather than a fixed delay.
+    const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    let banner = "";
+    while (!banner.includes("\n")) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      banner += decoder.decode(value, { stream: true });
+    }
+
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    return { banner: banner.trim(), body: await res.text() };
+  } finally {
+    proc.kill();
+    donor.close();
+  }
+}
+
+test.skipIf(!isPosix)("http.Server.listen({ fd }) serves on an inherited listening socket", async () => {
+  const { banner, body } = await serveOnInheritedFd(`
+    const http = require("http");
+    const server = http.createServer((req, res) => res.end("served-on-inherited-fd"));
+    server.on("error", e => { console.log("ERROR " + e.code); process.exit(1); });
+    server.listen({ fd: 3 }, () => console.log("LISTENING " + server.address().address));
+  `);
+
+  expect(banner).toBe("LISTENING 127.0.0.1");
+  expect(body).toBe("served-on-inherited-fd");
+});
+
+test.skipIf(!isPosix)("net.Server.listen({ fd }) serves on an inherited listening socket", async () => {
+  const { banner, body } = await serveOnInheritedFd(`
+    const net = require("net");
+    const server = net.createServer(sock => {
+      sock.end("HTTP/1.1 200 OK\\r\\ncontent-length: 3\\r\\nconnection: close\\r\\n\\r\\nnet");
+    });
+    server.on("error", e => { console.log("ERROR " + e.code); process.exit(1); });
+    server.listen({ fd: 3 }, () => console.log("LISTENING " + server.address().address));
+  `);
+
+  expect(banner).toBe("LISTENING 127.0.0.1");
+  expect(body).toBe("net");
+});
+
+// The adopted fd must actually be a listening socket. Polling a regular file
+// or a connected socket would never become acceptable, so the caller would
+// hang instead of being told the descriptor is unusable.
+test.skipIf(!isPosix)("listen({ fd }) rejects a descriptor that is not a listening socket", async () => {
+  using dir = tempDir("listen-fd-bad", { "not-a-socket.txt": "hello" });
+  const fd = fs.openSync(path.join(String(dir), "not-a-socket.txt"), "r");
+
+  try {
+    const server = net.createServer(() => {});
+    const result = await new Promise<any>(resolve => {
+      server.once("error", (e: any) => resolve({ event: "error", code: e.code }));
+      server.once("listening", () => resolve({ event: "listening", address: server.address() }));
+      server.listen({ fd });
+    });
+    server.close();
+
+    expect(result).toEqual({ event: "error", code: "ENOTSOCK" });
+  } finally {
+    fs.closeSync(fd);
+  }
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #22559 — makes systemd socket activation actually work, rather than fail more loudly.

```console
$ systemd-socket-activate --listen=127.0.0.1:3000 node ./build   # serves
$ systemd-socket-activate --listen=127.0.0.1:3000 bun  ./build   # hangs
```

Two different failures were behind this:

- **`net.Server.listen({ fd })`** returned a blanket `EINVAL — Bun does not support listening on a file descriptor`.
- **`http.Server.listen({ fd })`** never read `fd` at all. It bound a fresh ephemeral port on `::` and emitted `listening`, so the process reported healthy and passed liveness checks while the socket the supervisor was holding never got accepted on — no error anywhere. This is the one the reporter hit, via the SvelteKit node adapter.

#### Relationship to #33578

@robobun's #33578 fixes the second half by making `http` report `EINVAL` like `net` does, noting *"uSockets exposes no listen-from-fd entry point"*. That's accurate for the tree as it stands — so this PR adds that entry point and adopts the descriptor instead. It supersedes #33578 and touches the same test path; happy to rebase onto it or close this if you'd rather land the error-surfacing fix first.

#### Cause

uSockets could *create* listeners (`us_socket_group_listen`, `us_socket_group_listen_unix`) but not *adopt* one. There was precedent for connected sockets (`us_socket_from_fd`) and UDP (`us_create_udp_socket_from_fd`), just nothing for a TCP listener.

#### Fix

Adds `us_socket_group_listen_from_fd` alongside the existing two and plumbs it through the layers: uws `HttpContext`/`App` → C ABI (`uws_app_listen_from_fd`) → `Bun.listen` (`UnixOrHost::Fd`) → `Bun.serve` (`Address::Fd`) → `node:http`.

Three things worth reviewer attention:

- **Validation.** The fd is checked with `SO_ACCEPTCONN` before adoption. Polling a regular file or a connected socket would never become acceptable, so without this an unusable descriptor hangs instead of reporting — the exact failure mode being fixed. `ENOTSOCK` (not a socket) and `EINVAL` (a socket, but not listening) are now distinguished.
- **Ownership.** Transfers only once the listener is live. The paths that create their own fd close it on failure; this one leaves it with the caller, since the supervisor may still want it.
- **Address reporting.** `server.address()` returns the descriptor's real bound address (`{"address":"127.0.0.1","family":"IPv4","port":18760}`), matching Node, because port/hostname are read back from the live listener rather than from config. `Address::Fd` contributes neither.

`http3: true` with an inherited fd skips the H3 listener with a warning — the inherited descriptor is a stream socket and QUIC needs its own UDP socket, which the supervisor did not hand us. Same shape as the existing unix-socket behaviour.

### How did you verify your code works?

Real systemd, end to end, with the debug build:

```console
$ systemd-socket-activate --listen=127.0.0.1:18760 bun-debug net-only.js
Listening on 127.0.0.1:18760 as 3.
Communication attempt on fd 3.
listening, address={"address":"127.0.0.1","family":"IPv4","port":18760}

$ curl http://127.0.0.1:18760/
served-on-inherited-fd
```

Before this change the same command reported `address={"address":"::","port":40069}` and curl hung.

Three tests in `test/js/node/http/node-http-listen-fd.test.ts`, covering `http`, `net`, and the rejection path. They don't require systemd: a donor server binds `127.0.0.1:0`, and the child inherits its own copy of the descriptor as fd 3 via `stdio` — the same handoff systemd performs, so the child gets a distinct fd and there's no shared-ownership close. The child's `listening` callback is awaited rather than slept on.

Verified the tests are real by reverting the source changes and rebuilding — all 3 fail:

```
 0 pass  3 fail
```

The rejection test fails differently pre-fix (`EINVAL` from the old blanket error vs `ENOTSOCK` now), which is the added diagnostic precision.

With the fix: `3 pass`. Regression run over `node-http.test.ts` + `serve.test.ts`: **413 pass, 2 skip, 1 fail**. The one failure is `server.requestIP > v6`, which I confirmed fails identically on a clean tree (it binds `::1` but fetches `localhost`, which resolves to `127.0.0.1` first on this box) — pre-existing and unrelated. `cargo clippy -p bun_runtime -p bun_uws_sys --no-deps` is clean.

Not covered: executed on Linux x64 only. The C path is POSIX-shaped and `SO_ACCEPTCONN` exists on macOS and Winsock, but I have not run it on either, and the tests are `skipIf(!isPosix)`.

**Update on the Windows typing question I raised earlier:** I flagged uncertainty about the `getsockopt` optlen type on Windows. Resolved by inspection — `packages/bun-usockets/src/internal/networking/bsd.h` includes `ws2tcpip.h` on Windows, which typedefs `socklen_t` as `int`, matching Winsock's `getsockopt(SOCKET, int, int, char *, int *)`. The `(char *)` cast and `socklen_t` out-param are correct on both platforms, and `struct bsd_addr_t` in that same header already uses `socklen_t` unguarded. So this should compile and behave on Windows; it still has not been *run* there.
