### PR TITLE
install: stop resolving global install dirs from $XDG_CACHE_HOME

### DIFF
--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -283,6 +283,27 @@ pub struct Update {
     pub(crate) peer: bool,
 }
 
+/// Base directory that `.bun/<sub>` hangs off for globally installed packages
+/// and their bins.
+///
+/// `XDG_CACHE_HOME` used to select this outright, which put global installs
+/// under a cache directory: not the `~/.bun/bin` the installer puts on `PATH`,
+/// and fair game for any tool that clears caches. It is honored now only when
+/// that legacy location already exists, so existing installs keep resolving.
+fn global_install_base(sub: &[&[u8]]) -> Option<&'static [u8]> {
+    use bun_paths::{platform, resolve_path::join_abs_string_buf};
+
+    if let Some(cache_dir) = env_var::XDG_CACHE_HOME.get() {
+        let mut probe = bun_paths::path_buffer_pool::get();
+        let legacy = join_abs_string_buf::<platform::Auto>(cache_dir, &mut probe[..], sub);
+        if bun_sys::exists(legacy) {
+            return Some(cache_dir);
+        }
+    }
+
+    env_var::HOME.get()
+}
+
 // mkdir -p + open the dir. Callers store the raw `Fd` (`options.global_bin_dir: Fd`).
 pub fn open_global_dir(explicit_global_dir: &[u8]) -> crate::Result<bun_sys::Fd> {
     use bun_paths::{platform, resolve_path::join_abs_string_buf};
@@ -312,12 +333,9 @@ pub fn open_global_dir(explicit_global_dir: &[u8]) -> crate::Result<bun_sys::Fd>
             .map_err(Into::into);
     }
 
-    if let Some(home_dir) = env_var::XDG_CACHE_HOME
-        .get()
-        .or_else(|| env_var::HOME.get())
-    {
+    let parts: [&[u8]; 3] = [b".bun", b"install", b"global"];
+    if let Some(home_dir) = global_install_base(&parts) {
         let mut buf = PathBuffer::uninit();
-        let parts: [&[u8]; 3] = [b".bun", b"install", b"global"];
         let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
         return Dir::cwd()
             .make_open_path(path, OpenDirOptions::default())
@@ -360,12 +378,9 @@ pub(crate) fn open_global_bin_dir(opts_: Option<&Api::BunInstall>) -> crate::Res
             .map_err(Into::into);
     }
 
-    if let Some(home_dir) = env_var::XDG_CACHE_HOME
-        .get()
-        .or_else(|| env_var::HOME.get())
-    {
+    let parts: [&[u8]; 2] = [b".bun", b"bin"];
+    if let Some(home_dir) = global_install_base(&parts) {
         let mut buf = PathBuffer::uninit();
-        let parts: [&[u8]; 2] = [b".bun", b"bin"];
         let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
         return Dir::cwd()
             .make_open_path(path, OpenDirOptions::default())

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -906,3 +906,57 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
 });
+
+// Globally installed packages and their bins are data, not cache. Selecting
+// their location from XDG_CACHE_HOME put them outside the ~/.bun/bin the
+// installer adds to PATH, and inside a directory cache-cleaning tools own.
+it("global bin dir ignores XDG_CACHE_HOME", async () => {
+  using dir = tempDir("global-xdg", {
+    ".bun/install/global/package.json": JSON.stringify({ name: "globals" }),
+    "xdg-cache/.keep": "",
+  });
+  const dirStr = String(dir);
+
+  const spawnEnv = { ...bunEnv, HOME: dirStr, XDG_CACHE_HOME: join(dirStr, "xdg-cache") };
+  delete spawnEnv.BUN_INSTALL;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "bin", "-g"],
+    cwd: dirStr,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: spawnEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe(join(dirStr, ".bun", "bin"));
+  expect(stderr).not.toContain("error");
+  expect(exitCode).toBe(0);
+});
+
+// An install that already lives in the old XDG_CACHE_HOME location keeps
+// resolving there, so upgrading doesn't strand anyone's global binaries.
+it("global bin dir keeps using an existing XDG_CACHE_HOME location", async () => {
+  using dir = tempDir("global-xdg-legacy", {
+    "xdg-cache/.bun/install/global/package.json": JSON.stringify({ name: "globals" }),
+    "xdg-cache/.bun/bin/.keep": "",
+  });
+  const dirStr = String(dir);
+  const cacheHome = join(dirStr, "xdg-cache");
+
+  const spawnEnv = { ...bunEnv, HOME: dirStr, XDG_CACHE_HOME: cacheHome };
+  delete spawnEnv.BUN_INSTALL;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "bin", "-g"],
+    cwd: dirStr,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: spawnEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe(join(cacheHome, ".bun", "bin"));
+  expect(stderr).not.toContain("error");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

Refs #1678. This is a scoped correctness fix in that issue's area, not the full XDG migration — see the note at the bottom.

`bun install -g` resolved both its install directory and its bin directory with:

```rust
env_var::XDG_CACHE_HOME.get().or_else(|| env_var::HOME.get())
```

Most Linux desktops export `XDG_CACHE_HOME`, so on those systems globally installed packages landed in `$XDG_CACHE_HOME/.bun/bin` rather than `~/.bun/bin`. Two consequences:

- **The binary isn't runnable.** `~/.bun/bin` is what `curl -fsSL https://bun.com/install | bash` adds to `PATH`. `bun install -g some-cli` reported success and `some-cli` was not found.
- **It's in a directory that exists to be deleted.** `XDG_CACHE_HOME` means "safe to remove at any time" — that's the contract cache-cleaning tools rely on. Globally installed programs are data, not cache.

The cache directory itself (`install/cache`) correctly uses `XDG_CACHE_HOME` and is untouched here.

#### Fix

Resolve global install dirs from `HOME`, and honor an existing `$XDG_CACHE_HOME/.bun` location only when it's already on disk — so anyone whose global binaries currently live there keeps working, and nothing needs migrating.

Deliberately **not** moved to `$XDG_DATA_HOME`. That's the more XDG-correct destination, but the install script's `PATH` handling would have to move with it or the fix reintroduces the same not-on-PATH failure under a new name. That's the coupled decision in #1678 that wants a maintainer call; this PR just stops the current behavior from being actively wrong.

### How did you verify your code works?

Two tests added to `test/cli/install/bun-pm.test.ts`, which already had `XDG_CACHE_HOME`/`HOME` fixtures. Both use `bun pm bin -g` to print the resolved directory, so they're offline and exact:

- `global bin dir ignores XDG_CACHE_HOME` — the fix
- `global bin dir keeps using an existing XDG_CACHE_HOME location` — the compatibility guarantee

Verified against the debug build by hand first:

```console
# fresh XDG_CACHE_HOME
$ HOME=$T/home XDG_CACHE_HOME=$T/cache bun-debug pm bin -g
$T/home/.bun/bin                      # was $T/cache/.bun/bin

# legacy location already present
$ mkdir -p $T/cache/.bun/install/global
$ HOME=$T/home XDG_CACHE_HOME=$T/cache bun-debug pm bin -g
$T/cache/.bun/bin                     # preserved
```

Confirmed the tests are real by reverting the source change and rebuilding — the first fails (`Expected: ".../.bun/bin"`, `Received: ""`, since it resolved into the cache dir and errored). The second passes both before and after, which is what makes it a compatibility guard rather than a restatement of the fix.

With the fix, the full file passes: **20 pass, 0 fail**. `cargo clippy -p bun_install --no-deps` is clean.

Not covered: executed on Linux only — I have not run this on Windows or macOS.

**Correction to an earlier version of this description:** I originally wrote that `HOME` is unset on Windows, so the `None` path preserves today's behavior there. That is wrong. `env_var::HOME` is declared `posix = "HOME", windows = "USERPROFILE"` (`src/bun_core/env_var.rs:146`), so it is populated on Windows. The fix is still correct there — with `XDG_CACHE_HOME` unset (the norm on Windows) both old and new code resolve to `HOME`, so nothing changes — but when `XDG_CACHE_HOME` *is* set on Windows, resolution changes exactly as it does on Linux. Reviewers should not have been told otherwise.
