### PR TITLE
websocket client: use 16 random bytes for Sec-WebSocket-Key, not a v4 UUID

### DIFF
--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -2011,31 +2011,20 @@ fn build_request_body(
     let mut encoded_buf = [0u8; 24];
     let key: &[u8] = 'blk: {
         if let Some(k_slice) = user_key {
-            // Validate that it's a valid base64-encoded 16-byte value
-            let mut decoded_buf = [0u8; 24]; // Max possible decoded size
-            let Ok(decoded_len) = B64_STD.decoder.calc_size_for_slice(k_slice) else {
-                // Invalid base64, fall through to generate
-                break 'blk B64_STD
-                    .encoder
-                    .encode(&mut encoded_buf, &vm.rare_data().next_uuid().bytes);
-            };
-
-            if decoded_len == 16 {
-                // Try to decode to verify it's valid base64
-                if B64_STD.decoder.decode(&mut decoded_buf, k_slice).is_err() {
-                    // Invalid base64, fall through to generate
-                    break 'blk B64_STD
-                        .encoder
-                        .encode(&mut encoded_buf, &vm.rare_data().next_uuid().bytes);
-                }
-                // Valid 16-byte key, use it as-is
+            // Accept only a valid base64 encoding of exactly 16 bytes.
+            let mut decoded_buf = [0u8; 24];
+            if B64_STD.decoder.calc_size_for_slice(k_slice) == Ok(16)
+                && B64_STD.decoder.decode(&mut decoded_buf, k_slice).is_ok()
+            {
                 break 'blk k_slice;
             }
         }
-        // Generate a new key if user key is invalid or not provided
+        // RFC 6455 §4.1: "a nonce consisting of a randomly selected 16-byte
+        // value that has been base64-encoded". Use raw CSPRNG output rather
+        // than a v4 UUID, whose version/variant bits are constant.
         B64_STD
             .encoder
-            .encode(&mut encoded_buf, &vm.rare_data().next_uuid().bytes)
+            .encode(&mut encoded_buf, vm.rare_data().entropy_slice(16))
     };
 
     // Compute the expected Sec-WebSocket-Accept value per RFC 6455 §4.2.2:

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -2011,7 +2011,6 @@ fn build_request_body(
     let mut encoded_buf = [0u8; 24];
     let key: &[u8] = 'blk: {
         if let Some(k_slice) = user_key {
-            // Accept only a valid base64 encoding of exactly 16 bytes.
             let mut decoded_buf = [0u8; 24];
             if B64_STD.decoder.calc_size_for_slice(k_slice) == Ok(16)
                 && B64_STD.decoder.decode(&mut decoded_buf, k_slice).is_ok()
@@ -2019,9 +2018,7 @@ fn build_request_body(
                 break 'blk k_slice;
             }
         }
-        // RFC 6455 §4.1: "a nonce consisting of a randomly selected 16-byte
-        // value that has been base64-encoded". Use raw CSPRNG output rather
-        // than a v4 UUID, whose version/variant bits are constant.
+        // RFC 6455 §4.1: base64 of a randomly selected 16-byte value.
         B64_STD
             .encoder
             .encode(&mut encoded_buf, vm.rare_data().entropy_slice(16))

--- a/test/js/web/websocket/websocket-upgrade.test.ts
+++ b/test/js/web/websocket/websocket-upgrade.test.ts
@@ -111,14 +111,19 @@ describe("WebSocket upgrade", () => {
       },
     });
 
-    for (let i = 0; i < N; i++) {
-      const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
-      const { promise, resolve } = Promise.withResolvers<void>();
-      ws.onclose = () => resolve();
-      ws.onerror = () => {};
-      await promise;
-    }
+    let opened = 0;
+    await Promise.all(
+      Array.from({ length: N }, () => {
+        const { promise, resolve } = Promise.withResolvers<void>();
+        const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
+        ws.onopen = () => opened++;
+        ws.onerror = () => {};
+        ws.onclose = () => resolve();
+        return promise;
+      }),
+    );
 
+    expect(opened).toBe(N);
     expect(keys).toHaveLength(N);
     const decoded = keys.map(k => Buffer.from(k, "base64"));
     for (const d of decoded) expect(d.length).toBe(16);

--- a/test/js/web/websocket/websocket-upgrade.test.ts
+++ b/test/js/web/websocket/websocket-upgrade.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import { createHash } from "node:crypto";
 
 describe("WebSocket upgrade", () => {
   // https://github.com/oven-sh/bun/issues/2896
@@ -73,5 +74,64 @@ describe("WebSocket upgrade", () => {
     });
 
     ws.close();
+  });
+
+  // RFC 6455 §4.1: Sec-WebSocket-Key "MUST be a nonce consisting of a randomly
+  // selected 16-byte value". Sourcing it from a v4 UUID stamps 6 constant bits
+  // (byte[6] high nibble = 4, byte[8] top two bits = 10) into every handshake,
+  // which lets any peer fingerprint a Bun client.
+  test.concurrent("Sec-WebSocket-Key is 16 uniformly random bytes, not a UUIDv4", async () => {
+    const N = 64;
+    const keys: string[] = [];
+    using server = Bun.listen<{ buf: string }>({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(socket) {
+          socket.data = { buf: "" };
+        },
+        data(socket, chunk) {
+          socket.data.buf += chunk.toString("latin1");
+          if (!socket.data.buf.includes("\r\n\r\n")) return;
+          const m = socket.data.buf.match(/^Sec-WebSocket-Key:\s*(\S+)\s*$/im);
+          const key = m?.[1] ?? "";
+          keys.push(key);
+          const accept = createHash("sha1")
+            .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+            .digest("base64");
+          socket.write(
+            "HTTP/1.1 101 Switching Protocols\r\n" +
+              "Upgrade: websocket\r\n" +
+              "Connection: Upgrade\r\n" +
+              `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+          );
+          socket.flush();
+          socket.end();
+        },
+      },
+    });
+
+    for (let i = 0; i < N; i++) {
+      const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
+      const { promise, resolve } = Promise.withResolvers<void>();
+      ws.onclose = () => resolve();
+      ws.onerror = () => {};
+      await promise;
+    }
+
+    expect(keys).toHaveLength(N);
+    const decoded = keys.map(k => Buffer.from(k, "base64"));
+    for (const d of decoded) expect(d.length).toBe(16);
+
+    const b6 = new Set(decoded.map(d => d[6] >> 4));
+    const b8 = new Set(decoded.map(d => d[8] >> 6));
+    const uuidShaped = decoded.filter(d => (d[6] & 0xf0) === 0x40 && (d[8] & 0xc0) === 0x80).length;
+
+    // Uniform bytes: P(single-value set) is 16·16⁻ᴺ and 4·4⁻ᴺ respectively;
+    // a UUIDv4 source yields {4} and {2} with certainty.
+    expect(b6.size).toBeGreaterThan(1);
+    expect(b8.size).toBeGreaterThan(1);
+    // E[uuidShaped] = N/64 = 1 for uniform bytes; equals N under the bug.
+    expect(uuidShaped).toBeLessThan(N);
   });
 });


### PR DESCRIPTION
## What

The WebSocket client built `Sec-WebSocket-Key` from `vm.rare_data().next_uuid().bytes`. `UUID::init_with` stamps the v4 version nibble and RFC 4122 variant bits onto 16 otherwise-random bytes, so every Bun handshake had `byte[6] & 0xF0 == 0x40` and `byte[8] & 0xC0 == 0x80`. RFC 6455 section 4.1 requires the key to be "a nonce consisting of a randomly selected 16-byte value".

The 122 remaining bits are CSPRNG output, so the `Sec-WebSocket-Accept` check is not weakened; the practical effect is that any server or middlebox can fingerprint a Bun WebSocket client from the handshake alone. Node/undici keys are uniform.

## Repro

Capture 64 client handshakes with a raw TCP responder and census the decoded key bytes:

```
byte[6] high-nibble census: { 4: 64 }
byte[8] top-2-bit census:   { 2: 64 }
```

On `main` every key is UUIDv4-shaped; with this change the censuses are spread across all buckets.

## Fix

Source the nonce from `rare_data().entropy_slice(16)` (the same BoringSSL-backed entropy cache the frame mask already uses) instead of `next_uuid()`. The user-supplied-key validation block is flattened to a single fall-through so the generation path is no longer duplicated three times.

## Verification

New test in `test/js/web/websocket/websocket-upgrade.test.ts` collects 64 handshake keys over loopback, asserts each decodes to 16 bytes, and checks that `byte[6] >> 4` and `byte[8] >> 6` are not constant across the sample (P(false-fail) for uniform bytes is below `16 * 16^-64`).

```
fail-before (src/ stashed): b6.size == 1  -> fails
fix-after:                  3 pass, 0 fail
websocket-custom-headers.test.ts: 10 pass (user-key path unchanged)
websocket-client.test.ts:         34 pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-upgrade.test.ts
bun test v1.4.0 (836e3d66f)

test/js/web/websocket/websocket-upgrade.test.ts:
(pass) WebSocket upgrade > sends the expected upgrade request headers [193.75ms]
132 |     const b8 = new Set(decoded.map(d => d[8] >> 6));
133 |     const uuidShaped = decoded.filter(d => (d[6] & 0xf0) === 0x40 && (d[8] & 0xc0) === 0x80).length;
134 | 
135 |     // Uniform bytes: P(single-value set) is 16·16⁻ᴺ and 4·4⁻ᴺ respectively;
136 |     // a UUIDv4 source yields {4} and {2} with certainty.
137 |     expect(b6.size).toBeGreaterThan(1);
                          ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 1
Received: 1

      at <anonymous> (/workspace/bun/test/js/web/websocket/websocket-upgrade.test.ts:137:21)
(fail) WebSocket upgrade > Sec-WebSocket-Key is 16 uniformly random bytes, not a UUIDv4 [214.69ms]
(pass) WebSocket upgrade > fails the handshake when the server never responds [4298.52ms]

 2 pass
 1 fail
 72 expect() calls
Ran 3 tests across 1 file. [6.38s]
error: sc
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (9c13e98a3)

test/js/web/websocket/websocket-upgrade.test.ts:
(pass) WebSocket upgrade > sends the expected upgrade request headers [8.92ms]
(pass) WebSocket upgrade > Sec-WebSocket-Key is 16 uniformly random bytes, not a UUIDv4 [8.47ms]
(pass) WebSocket upgrade > fails the handshake when the server never responds [4008.76ms]

 3 pass
 0 fail
 74 expect() calls
Ran 3 tests across 1 file. [4.16s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-upgrade.test.ts
bun test v1.4.0 (836e3d66f)

test/js/web/websocket/websocket-upgrade.test.ts:
(pass) WebSocket upgrade > sends the expected upgrade request headers [258.61ms]
(pass) WebSocket upgrade > Sec-WebSocket-Key is 16 uniformly random bytes, not a UUIDv4 [260.52ms]
(pass) WebSocket upgrade > fails the handshake when the server never responds [4307.78ms]

 3 pass
 0 fail
 74 expect() calls
Ran 3 tests across 1 file. [6.83s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 641ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../websocket_client/WebSocketUpgradeClient.rs     | 26 ++-------
 test/js/web/websocket/websocket-upgrade.test.ts    | 65 ++++++++++++++++++++++
 2 files changed, 71 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/http_jsc/websocket_client/WebSocketUpgradeClient.rs      2      2      0
test/js/web/websocket/websocket-upgrade.test.ts              2      3      0
```

</details>

<!-- robobun:evidence:end -->