### PR TITLE
perf_hooks: keep insertion order for equal-startTime entries in getEntries()

### DIFF
--- a/src/jsc/bindings/webcore/Performance.cpp
+++ b/src/jsc/bindings/webcore/Performance.cpp
@@ -289,6 +289,7 @@ void Performance::addResourceTiming(ResourceTiming&& resourceTiming)
     ASSERT(scriptExecutionContext());
 
     auto entry = PerformanceResourceTiming::create(m_timeOrigin, WTF::move(resourceTiming));
+    entry->setBufferIndex(nextEntrySequence());
 
     if (m_waitingForBackupBufferToBeProcessed) {
         m_backupResourceTimingBuffer.append(WTF::move(entry));

--- a/src/jsc/bindings/webcore/Performance.cpp
+++ b/src/jsc/bindings/webcore/Performance.cpp
@@ -161,7 +161,7 @@ Vector<RefPtr<PerformanceEntry>> Performance::getEntries() const
     // if (m_firstContentfulPaint)
     //     entries.append(m_firstContentfulPaint);
 
-    std::sort(entries.begin(), entries.end(), PerformanceEntry::startTimeCompareLessThan);
+    std::stable_sort(entries.begin(), entries.end(), PerformanceEntry::startTimeCompareLessThan);
     return entries;
 }
 
@@ -185,7 +185,7 @@ Vector<RefPtr<PerformanceEntry>> Performance::getEntriesByType(const String& ent
             entries.appendVector(m_userTiming->getMeasures());
     }
 
-    std::sort(entries.begin(), entries.end(), PerformanceEntry::startTimeCompareLessThan);
+    std::stable_sort(entries.begin(), entries.end(), PerformanceEntry::startTimeCompareLessThan);
     return entries;
 }
 
@@ -223,7 +223,7 @@ Vector<RefPtr<PerformanceEntry>> Performance::getEntriesByName(const String& nam
             entries.appendVector(m_userTiming->getMeasures(name));
     }
 
-    std::sort(entries.begin(), entries.end(), PerformanceEntry::startTimeCompareLessThan);
+    std::stable_sort(entries.begin(), entries.end(), PerformanceEntry::startTimeCompareLessThan);
     return entries;
 }
 

--- a/src/jsc/bindings/webcore/Performance.h
+++ b/src/jsc/bindings/webcore/Performance.h
@@ -117,6 +117,8 @@ public:
     void registerPerformanceObserver(PerformanceObserver&);
     void unregisterPerformanceObserver(PerformanceObserver&);
 
+    uint64_t nextEntrySequence() { return ++m_nextEntrySequence; }
+
     static void allowHighPrecisionTime();
     static Seconds timeResolution();
     static Seconds reduceTimeResolution(Seconds);
@@ -169,6 +171,7 @@ private:
     bool m_hasScheduledTimingBufferDeliveryTask { false };
 
     MonotonicTime m_timeOrigin;
+    uint64_t m_nextEntrySequence { 0 };
 
     // RefPtr<PerformanceNavigationTiming> m_navigationTiming;
     // RefPtr<PerformancePaintTiming> m_firstContentfulPaint;

--- a/src/jsc/bindings/webcore/PerformanceEntry.h
+++ b/src/jsc/bindings/webcore/PerformanceEntry.h
@@ -48,6 +48,9 @@ public:
     const double startTime() const { return m_startTime; }
     const double duration() const { return m_duration; }
 
+    uint64_t bufferIndex() const { return m_bufferIndex; }
+    void setBufferIndex(uint64_t bufferIndex) { m_bufferIndex = bufferIndex; }
+
     enum class Type : uint8_t {
         Navigation = 1 << 0,
         Mark = 1 << 1,
@@ -65,7 +68,9 @@ public:
 
     static bool startTimeCompareLessThan(const RefPtr<PerformanceEntry>& a, const RefPtr<PerformanceEntry>& b)
     {
-        return a->startTime() < b->startTime();
+        if (a->startTime() != b->startTime())
+            return a->startTime() < b->startTime();
+        return a->bufferIndex() < b->bufferIndex();
     }
 
 protected:
@@ -75,6 +80,7 @@ private:
     const String m_name;
     const double m_startTime;
     const double m_duration;
+    uint64_t m_bufferIndex { 0 };
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/PerformanceEntry.h
+++ b/src/jsc/bindings/webcore/PerformanceEntry.h
@@ -68,8 +68,11 @@ public:
 
     static bool startTimeCompareLessThan(const RefPtr<PerformanceEntry>& a, const RefPtr<PerformanceEntry>& b)
     {
-        if (a->startTime() != b->startTime())
-            return a->startTime() < b->startTime();
+        return a->startTime() < b->startTime();
+    }
+
+    static bool bufferIndexCompareLessThan(const RefPtr<PerformanceEntry>& a, const RefPtr<PerformanceEntry>& b)
+    {
         return a->bufferIndex() < b->bufferIndex();
     }
 

--- a/src/jsc/bindings/webcore/PerformanceUserTiming.cpp
+++ b/src/jsc/bindings/webcore/PerformanceUserTiming.cpp
@@ -108,8 +108,9 @@ static void clearPerformanceEntries(PerformanceEntryMap& map, const String& name
         map.remove(name);
 }
 
-static void addPerformanceEntry(PerformanceEntryMap& map, const String& name, PerformanceEntry& entry)
+static void addPerformanceEntry(Performance& performance, PerformanceEntryMap& map, const String& name, PerformanceEntry& entry)
 {
+    entry.setBufferIndex(performance.nextEntrySequence());
     auto& performanceEntryList = map.ensure(name, [] { return Vector<RefPtr<PerformanceEntry>>(); }).iterator->value;
     performanceEntryList.append(&entry);
 }
@@ -128,7 +129,7 @@ ExceptionOr<Ref<PerformanceMark>> PerformanceUserTiming::mark(JSC::JSGlobalObjec
     if (mark.hasException())
         return mark.releaseException();
 
-    addPerformanceEntry(m_marksMap, markName, mark.returnValue().get());
+    addPerformanceEntry(m_performance, m_marksMap, markName, mark.returnValue().get());
     m_markCounter += 1;
     return mark.releaseReturnValue();
 }
@@ -206,7 +207,7 @@ ExceptionOr<Ref<PerformanceMeasure>> PerformanceUserTiming::measure(const String
     if (measure.hasException())
         return measure.releaseException();
 
-    addPerformanceEntry(m_measuresMap, measureName, measure.returnValue().get());
+    addPerformanceEntry(m_performance, m_measuresMap, measureName, measure.returnValue().get());
     m_measureCounter += 1;
     return measure.releaseReturnValue();
 }
@@ -261,7 +262,7 @@ ExceptionOr<Ref<PerformanceMeasure>> PerformanceUserTiming::measure(JSC::JSGloba
         if (measure.hasException())
             return measure.releaseException();
 
-        addPerformanceEntry(m_measuresMap, measureName, measure.returnValue().get());
+        addPerformanceEntry(m_performance, m_measuresMap, measureName, measure.returnValue().get());
         m_measureCounter += 1;
         return measure.releaseReturnValue();
     } else {
@@ -269,7 +270,7 @@ ExceptionOr<Ref<PerformanceMeasure>> PerformanceUserTiming::measure(JSC::JSGloba
         if (measure.hasException())
             return measure.releaseException();
 
-        addPerformanceEntry(m_measuresMap, measureName, measure.returnValue().get());
+        addPerformanceEntry(m_performance, m_measuresMap, measureName, measure.returnValue().get());
         m_measureCounter += 1;
         return measure.releaseReturnValue();
     }

--- a/src/jsc/bindings/webcore/PerformanceUserTiming.cpp
+++ b/src/jsc/bindings/webcore/PerformanceUserTiming.cpp
@@ -335,6 +335,7 @@ static Vector<RefPtr<PerformanceEntry>> convertToEntrySequence(const Performance
         entries.appendVector(entry);
 
     ASSERT(entries.size() <= safeInitialCapacity);
+    std::sort(entries.begin(), entries.end(), PerformanceEntry::bufferIndexCompareLessThan);
     return entries;
 }
 

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -209,14 +209,25 @@ test("getEntries()/getEntriesByType()/getEntriesByName() keep insertion order fo
        // getEntriesByName(): same name, same startTime, distinguished by detail.
        for (let i = 0; i < 8; i++) performance.mark("dup", { startTime: 100, detail: i });
        const byName = performance.getEntriesByName("dup", "mark").map(e => e.detail).join(",");
+       // Cross-type tie: Node concats per-type buffers (marks then measures) before
+       // the stable startTime sort, so interleaved inserts still group by type.
+       performance.clearMarks();
+       performance.clearMeasures();
+       performance.mark("m0", { startTime: 100 });
+       performance.measure("s0", { start: 100, end: 100 });
+       performance.mark("m1", { startTime: 100 });
+       performance.measure("s1", { start: 100, end: 100 });
+       performance.mark("m2", { startTime: 100 });
+       const crossType = performance.getEntries().map(e => e.name).join(",");
        // Entries with distinct startTimes are still ordered by startTime, and
        // interleaving with the tied group keeps the tied group's insertion order.
        performance.clearMarks();
+       performance.clearMeasures();
        performance.mark("lo", { startTime: 10 });
        for (const n of names) performance.mark(n, { startTime: 100 });
        performance.mark("hi", { startTime: 200 });
        const mixed = performance.getEntriesByType("mark").map(e => e.name).join(",");
-       console.log(JSON.stringify({ marks, measures, all, byName, mixed }));`,
+       console.log(JSON.stringify({ marks, measures, all, byName, crossType, mixed }));`,
     ],
     env: bunEnv,
     stdout: "pipe",
@@ -230,6 +241,7 @@ test("getEntries()/getEntriesByType()/getEntriesByName() keep insertion order fo
       measures: "a,b,c,d,e,f,g,h",
       all: "ea,eb,ec,ed,ee,ef,eg,eh,aa,ab,ac,ad,ae,af,ag,ah",
       byName: "0,1,2,3,4,5,6,7",
+      crossType: "m0,m1,m2,s0,s1",
       mixed: "lo,a,b,c,d,e,f,g,h,hi",
     }),
     exitCode: 0,

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -192,7 +192,7 @@ test("net entries are instanceof PerformanceEntry", async () => {
 
 // The Performance Timeline startTime sort is spec'd as a stable Infra list-sort,
 // so entries with equal startTime keep insertion order. Verified against Node v26.3.0.
-test("getEntries()/getEntriesByType() keep insertion order for equal startTime", async () => {
+test("getEntries()/getEntriesByType()/getEntriesByName() keep insertion order for equal startTime", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -206,6 +206,9 @@ test("getEntries()/getEntriesByType() keep insertion order for equal startTime",
        // getEntries() mixes types: all measures (startTime 50) sort before all marks (100),
        // and within each tied group insertion order is preserved.
        const all = performance.getEntries().map(e => e.entryType[1] + e.name).join(",");
+       // getEntriesByName(): same name, same startTime, distinguished by detail.
+       for (let i = 0; i < 8; i++) performance.mark("dup", { startTime: 100, detail: i });
+       const byName = performance.getEntriesByName("dup", "mark").map(e => e.detail).join(",");
        // Entries with distinct startTimes are still ordered by startTime, and
        // interleaving with the tied group keeps the tied group's insertion order.
        performance.clearMarks();
@@ -213,19 +216,22 @@ test("getEntries()/getEntriesByType() keep insertion order for equal startTime",
        for (const n of names) performance.mark(n, { startTime: 100 });
        performance.mark("hi", { startTime: 200 });
        const mixed = performance.getEntriesByType("mark").map(e => e.name).join(",");
-       console.log(JSON.stringify({ marks, measures, all, mixed }));`,
+       console.log(JSON.stringify({ marks, measures, all, byName, mixed }));`,
     ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual({
-    marks: "a,b,c,d,e,f,g,h",
-    measures: "a,b,c,d,e,f,g,h",
-    all: "ea,eb,ec,ed,ee,ef,eg,eh,aa,ab,ac,ad,ae,af,ag,ah",
-    mixed: "lo,a,b,c,d,e,f,g,h,hi",
+  expect({ stderr, stdout: stdout.trim(), exitCode }).toEqual({
+    stderr: "",
+    stdout: JSON.stringify({
+      marks: "a,b,c,d,e,f,g,h",
+      measures: "a,b,c,d,e,f,g,h",
+      all: "ea,eb,ec,ed,ee,ef,eg,eh,aa,ab,ac,ad,ae,af,ag,ah",
+      byName: "0,1,2,3,4,5,6,7",
+      mixed: "lo,a,b,c,d,e,f,g,h,hi",
+    }),
+    exitCode: 0,
   });
-  expect(exitCode).toBe(0);
 });

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -189,3 +189,43 @@ test("net entries are instanceof PerformanceEntry", async () => {
   expect(entry.constructor.name).toBe("PerformanceNodeEntry");
   expect(entry.entryType).toBe("net");
 });
+
+// The Performance Timeline startTime sort is spec'd as a stable Infra list-sort,
+// so entries with equal startTime keep insertion order. Verified against Node v26.3.0.
+test("getEntries()/getEntriesByType() keep insertion order for equal startTime", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { performance } = require("node:perf_hooks");
+       const names = ["a","b","c","d","e","f","g","h"];
+       for (const n of names) performance.mark(n, { startTime: 100 });
+       for (const n of names) performance.measure(n, { start: 50, end: 50 });
+       const marks = performance.getEntriesByType("mark").map(e => e.name).join(",");
+       const measures = performance.getEntriesByType("measure").map(e => e.name).join(",");
+       // getEntries() mixes types: all measures (startTime 50) sort before all marks (100),
+       // and within each tied group insertion order is preserved.
+       const all = performance.getEntries().map(e => e.entryType[1] + e.name).join(",");
+       // Entries with distinct startTimes are still ordered by startTime, and
+       // interleaving with the tied group keeps the tied group's insertion order.
+       performance.clearMarks();
+       performance.mark("lo", { startTime: 10 });
+       for (const n of names) performance.mark(n, { startTime: 100 });
+       performance.mark("hi", { startTime: 200 });
+       const mixed = performance.getEntriesByType("mark").map(e => e.name).join(",");
+       console.log(JSON.stringify({ marks, measures, all, mixed }));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    marks: "a,b,c,d,e,f,g,h",
+    measures: "a,b,c,d,e,f,g,h",
+    all: "ea,eb,ec,ed,ee,ef,eg,eh,aa,ab,ac,ad,ae,af,ag,ah",
+    mixed: "lo,a,b,c,d,e,f,g,h,hi",
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What does this PR do?

`performance.getEntries()` / `getEntriesByType()` / `getEntriesByName()` returned User Timing entries that share an equal `startTime` in a scrambled, non-insertion order.

```js
const { performance } = require("node:perf_hooks");
for (const n of ["a","b","c","d","e","f","g","h"]) performance.mark(n, { startTime: 100 });
console.log(performance.getEntriesByType("mark").map(e => e.name).join(","));
// node v26.3.0:  a,b,c,d,e,f,g,h
// bun (before):  f,g,b,h,a,e,d,c
```

The [Performance Timeline spec](https://w3c.github.io/performance-timeline/#dfn-filter-buffer-map-by-name-and-type) concatenates per-type buffers and sorts by `startTime` using an [Infra list sort](https://infra.spec.whatwg.org/#list-sort-in-ascending-order), which is defined to be stable. So ties keep per-type insertion order, with cross-type ties grouped by type (marks before measures). Node matches that.

### Cause

Two stacked sources of nondeterminism:

1. `PerformanceUserTiming` stores marks/measures in a name-keyed `WTF::HashMap<String, Vector<...>>` and `convertToEntrySequence` iterates `map.values()`, which yields hash-table order.
2. `Performance::getEntries*()` then calls `std::sort` with a `startTime`-only comparator; `std::sort` is not stable, so ties can be reordered even for sorted input.

### Fix

- Stamp each buffered entry with a monotone sequence number from `Performance` when it is added (`addPerformanceEntry` for marks/measures, `addResourceTiming` for resource entries).
- `convertToEntrySequence` sorts the `HashMap`-flattened vector by that sequence, so `getMarks()` / `getMeasures()` return entries in insertion order.
- `Performance::getEntries*()` use `std::stable_sort` over the unchanged `startTime`-only comparator, so per-type insertion order and node's type grouping for cross-type ties are both preserved.

## How did you verify your code works?

New test in `test/js/node/perf_hooks/perf_hooks.test.ts` covers marks, measures, mixed `getEntries()`, `getEntriesByName()`, a cross-type tie, and a tied group embedded between distinct `startTime`s; all expectations were captured from node v26.3.0. Fails on canary (`f,g,b,h,a,e,d,c`), passes with this change. Existing `perf_hooks.test.ts`, `performance-entries.test.ts`, `deno/performance/performance.test.ts`, `performance-observer-leak.test.ts`, and the node `test-performance-*` parallel tests all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
bun test v1.4.0 (f2705a158)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [16.20ms]
(pass) doesn't throw [14.96ms]
(pass) Symbol name argument throws V8 wording [7.15ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [5.04ms]
(pass) timerify entry shape [51.99ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [1.74ms]
(pass) export surface matches Node v26.3.0 [7.26ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [442.97ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [476.69ms]
(pass) net entries are instanceof PerformanceEntry [419.71ms]
232 |     env: bunEnv,
233 |     stdout: "pipe",
234 |     stderr: "pipe",
235 |   });
236 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
237 |   expect({ stderr, stdout: stdout.trim(), exitCode }).toEqual({
                                
... (truncated)

release without fix: 9 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [0.07ms]
(pass) doesn't throw [0.14ms]
26 | 
27 | // Node coerces the name via `${name}` for mark/clearMarks/clearMeasures, so a
28 | // Symbol hits V8's ToString message. Verified against Node v26.3.0.
29 | test("Symbol name argument throws V8 wording", () => {
30 |   const msg = "Cannot convert a Symbol value to a string";
31 |   expect(() => performance.mark(Symbol())).toThrow(new TypeError(msg));
                                                ^
error: expect(received).toThrow(expected)

Expected message: "Cannot convert a Symbol value to a string"
Received message: "Cannot convert a symbol to a string"

      at <anonymous> (/workspace/bun/test/js/node/perf_hooks/perf_hooks.test.ts:31:44)
(fail) Symbol name argument throws V8 wording [0.17ms]
36 | // Node only looks at start/end to decide whether the options dict supplies
37 | // timing; a {detail}/{duration}-only dict falls through and the trailing
38 | // endMark is honoured. Verified against Node v26.3.0.
39 | test("measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark", () => {
40 |   perfo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
bun test v1.4.0 (f2705a158)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [15.61ms]
(pass) doesn't throw [15.85ms]
(pass) Symbol name argument throws V8 wording [7.47ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [5.12ms]
(pass) timerify entry shape [52.25ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [1.44ms]
(pass) export surface matches Node v26.3.0 [7.41ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [444.16ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [485.51ms]
(pass) net entries are instanceof PerformanceEntry [419.09ms]
(pass) getEntries()/getEntriesByType()/getEntriesByName() keep insertion order for equal startTime [446.01ms]

 11 pass
 0 fail
 57 expect() calls
Ran 11 tests across 1 file. [4.14s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 670ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] gen cpp.rs (cppbind)
[1/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/Performance.cpp           |  7 +--
 src/jsc/bindings/webcore/Performance.h             |  3 ++
 src/jsc/bindings/webcore/PerformanceEntry.h        |  9 ++++
 src/jsc/bindings/webcore/PerformanceUserTiming.cpp | 12 +++--
 test/js/node/perf_hooks/perf_hooks.test.ts         | 58 ++++++++++++++++++++++
 5 files changed, 81 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcore/Performance.cpp                2      4      0
src/jsc/bindings/webcore/Performance.h                  1      2      0
src/jsc/bindings/webcore/PerformanceEntry.h             2      5      0
src/jsc/bindings/webcore/PerformanceUserTiming.cpp      2      5      0
test/js/node/perf_hooks/perf_hooks.test.ts              2      4      0
```

</details>

<!-- robobun:evidence:end -->