### PR TITLE
fetch: reject already-used Request stream bodies before connecting

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1237,6 +1237,14 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
             if matches!(*body_value, BodyValue::Locked(_)) {
                 if let Some(readable) = req.get_body_readable_stream(global_this) {
+                    if readable.is_disturbed(global_this) || readable.is_locked(global_this) {
+                        return Err(global_this
+                            .err(
+                                jsc::ErrorCode::BODY_ALREADY_USED,
+                                format_args!("Request body already used"),
+                            )
+                            .throw());
+                    }
                     break 'extract_body Some(HTTPRequestBody::ReadableStream(
                         readable_stream::Strong::init(readable, global_this),
                     ));

--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -130,4 +130,109 @@ describe("body-mixin-errors", () => {
       });
     },
   );
+
+  it.concurrent(
+    "fetch: re-fetching a Request whose stream body was consumed rejects before any network I/O",
+    async () => {
+      let connections = 0;
+      const sockets: net.Socket[] = [];
+      const server = net.createServer(socket => {
+        connections++;
+        sockets.push(socket);
+        let buf = Buffer.alloc(0);
+        socket.on("data", d => {
+          buf = Buffer.concat([buf, d]);
+          if (buf.toString("latin1").endsWith("\r\n0\r\n\r\n")) {
+            socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+          }
+        });
+        socket.on("error", () => {});
+      });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const { port } = server.address() as net.AddressInfo;
+      const url = `http://127.0.0.1:${port}/up`;
+
+      try {
+        const makeBody = () =>
+          new ReadableStream({
+            start(c) {
+              c.enqueue(new TextEncoder().encode("hello"));
+              c.close();
+            },
+          });
+        const req = new Request(url, { method: "POST", body: makeBody(), duplex: "half" } as RequestInit);
+
+        const first = await fetch(req);
+        expect(first.status).toBe(200);
+        expect(req.bodyUsed).toBe(true);
+
+        const errors: unknown[] = [];
+        for (let i = 0; i < 3; i++) {
+          await fetch(req).then(
+            () => errors.push(null),
+            e => errors.push(e),
+          );
+        }
+
+        // Probe with a fresh body so every accept queued before this one has
+        // been delivered by the time the response arrives.
+        const probe = await fetch(url, { method: "POST", body: makeBody(), duplex: "half" } as RequestInit);
+        expect(probe.status).toBe(200);
+
+        // First fetch + probe only. The three re-fetches must not have opened
+        // connections or written request heads to the origin.
+        expect(connections).toBe(2);
+
+        expect(errors).toHaveLength(3);
+        for (const e of errors) {
+          expect(e).toBeInstanceOf(TypeError);
+          expect((e as any).code).toBe("ERR_BODY_ALREADY_USED");
+        }
+      } finally {
+        for (const s of sockets) s.destroy();
+        server.close();
+      }
+    },
+  );
+
+  it.concurrent("fetch: Request with a locked stream body rejects before any network I/O", async () => {
+    let connections = 0;
+    const sockets: net.Socket[] = [];
+    const server = net.createServer(socket => {
+      connections++;
+      sockets.push(socket);
+      socket.resume();
+      socket.on("error", () => {});
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as net.AddressInfo;
+    const url = `http://127.0.0.1:${port}/up`;
+
+    try {
+      const rs = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("hello"));
+          c.close();
+        },
+      });
+      const req = new Request(url, { method: "POST", body: rs, duplex: "half" } as RequestInit);
+      // Lock the stream without disturbing it.
+      req.body!.getReader();
+      expect(req.bodyUsed).toBe(false);
+
+      let err: unknown;
+      await fetch(req).then(
+        () => expect.unreachable("fetch should reject for a locked body"),
+        e => (err = e),
+      );
+      expect(err).toBeInstanceOf(TypeError);
+      expect((err as any).code).toBe("ERR_BODY_ALREADY_USED");
+      expect(connections).toBe(0);
+    } finally {
+      for (const s of sockets) s.destroy();
+      server.close();
+    }
+  });
 });

--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -202,7 +202,13 @@ describe("body-mixin-errors", () => {
     const server = net.createServer(socket => {
       connections++;
       sockets.push(socket);
-      socket.resume();
+      let buf = Buffer.alloc(0);
+      socket.on("data", d => {
+        buf = Buffer.concat([buf, d]);
+        if (buf.toString("latin1").endsWith("\r\n0\r\n\r\n")) {
+          socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+        }
+      });
       socket.on("error", () => {});
     });
     server.listen(0, "127.0.0.1");
@@ -211,13 +217,14 @@ describe("body-mixin-errors", () => {
     const url = `http://127.0.0.1:${port}/up`;
 
     try {
-      const rs = new ReadableStream({
-        start(c) {
-          c.enqueue(new TextEncoder().encode("hello"));
-          c.close();
-        },
-      });
-      const req = new Request(url, { method: "POST", body: rs, duplex: "half" } as RequestInit);
+      const makeBody = () =>
+        new ReadableStream({
+          start(c) {
+            c.enqueue(new TextEncoder().encode("hello"));
+            c.close();
+          },
+        });
+      const req = new Request(url, { method: "POST", body: makeBody(), duplex: "half" } as RequestInit);
       // Lock the stream without disturbing it.
       req.body!.getReader();
       expect(req.bodyUsed).toBe(false);
@@ -227,9 +234,17 @@ describe("body-mixin-errors", () => {
         () => expect.unreachable("fetch should reject for a locked body"),
         e => (err = e),
       );
+
+      // Probe with a fresh body so every accept queued before this one has
+      // been delivered by the time the response arrives.
+      const probe = await fetch(url, { method: "POST", body: makeBody(), duplex: "half" } as RequestInit);
+      expect(probe.status).toBe(200);
+
+      // Probe only. The rejected fetch must not have opened a connection.
+      expect(connections).toBe(1);
+
       expect(err).toBeInstanceOf(TypeError);
       expect((err as any).code).toBe("ERR_BODY_ALREADY_USED");
-      expect(connections).toBe(0);
     } finally {
       for (const s of sockets) s.destroy();
       server.close();

--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -131,72 +131,17 @@ describe("body-mixin-errors", () => {
     },
   );
 
-  it.concurrent(
-    "fetch: re-fetching a Request whose stream body was consumed rejects before any network I/O",
-    async () => {
-      let connections = 0;
-      const sockets: net.Socket[] = [];
-      const server = net.createServer(socket => {
-        connections++;
-        sockets.push(socket);
-        let buf = Buffer.alloc(0);
-        socket.on("data", d => {
-          buf = Buffer.concat([buf, d]);
-          if (buf.toString("latin1").endsWith("\r\n0\r\n\r\n")) {
-            socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
-          }
-        });
-        socket.on("error", () => {});
-      });
-      server.listen(0, "127.0.0.1");
-      await once(server, "listening");
-      const { port } = server.address() as net.AddressInfo;
-      const url = `http://127.0.0.1:${port}/up`;
-
-      try {
-        const makeBody = () =>
-          new ReadableStream({
-            start(c) {
-              c.enqueue(new TextEncoder().encode("hello"));
-              c.close();
-            },
-          });
-        const req = new Request(url, { method: "POST", body: makeBody(), duplex: "half" } as RequestInit);
-
-        const first = await fetch(req);
-        expect(first.status).toBe(200);
-        expect(req.bodyUsed).toBe(true);
-
-        const errors: unknown[] = [];
-        for (let i = 0; i < 3; i++) {
-          await fetch(req).then(
-            () => errors.push(null),
-            e => errors.push(e),
-          );
-        }
-
-        // Probe with a fresh body so every accept queued before this one has
-        // been delivered by the time the response arrives.
-        const probe = await fetch(url, { method: "POST", body: makeBody(), duplex: "half" } as RequestInit);
-        expect(probe.status).toBe(200);
-
-        // First fetch + probe only. The three re-fetches must not have opened
-        // connections or written request heads to the origin.
-        expect(connections).toBe(2);
-
-        expect(errors).toHaveLength(3);
-        for (const e of errors) {
-          expect(e).toBeInstanceOf(TypeError);
-          expect((e as any).code).toBe("ERR_BODY_ALREADY_USED");
-        }
-      } finally {
-        for (const s of sockets) s.destroy();
-        server.close();
-      }
-    },
-  );
-
-  it.concurrent("fetch: Request with a locked stream body rejects before any network I/O", async () => {
+  // Counts inbound TCP connections on a server that answers a chunked POST
+  // once it sees the 0\r\n\r\n terminator. `expectConnections(n)` first sends
+  // a probe request so every accept queued before it has been delivered by the
+  // time the response arrives, then asserts the total (including the probe).
+  async function withConnectionCountingServer(
+    fn: (ctx: {
+      url: string;
+      makeBody: () => ReadableStream;
+      expectConnections: (n: number) => Promise<void>;
+    }) => Promise<void>,
+  ): Promise<void> {
     let connections = 0;
     const sockets: net.Socket[] = [];
     const server = net.createServer(socket => {
@@ -215,15 +160,62 @@ describe("body-mixin-errors", () => {
     await once(server, "listening");
     const { port } = server.address() as net.AddressInfo;
     const url = `http://127.0.0.1:${port}/up`;
-
+    const makeBody = () =>
+      new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("hello"));
+          c.close();
+        },
+      });
     try {
-      const makeBody = () =>
-        new ReadableStream({
-          start(c) {
-            c.enqueue(new TextEncoder().encode("hello"));
-            c.close();
-          },
-        });
+      await fn({
+        url,
+        makeBody,
+        expectConnections: async n => {
+          const probe = await fetch(url, { method: "POST", body: makeBody(), duplex: "half" } as RequestInit);
+          expect(probe.status).toBe(200);
+          expect(connections).toBe(n);
+        },
+      });
+    } finally {
+      for (const s of sockets) s.destroy();
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  }
+
+  it.concurrent(
+    "fetch: re-fetching a Request whose stream body was consumed rejects before any network I/O",
+    async () => {
+      await withConnectionCountingServer(async ({ url, makeBody, expectConnections }) => {
+        const req = new Request(url, { method: "POST", body: makeBody(), duplex: "half" } as RequestInit);
+
+        const first = await fetch(req);
+        expect(first.status).toBe(200);
+        expect(req.bodyUsed).toBe(true);
+
+        const errors: unknown[] = [];
+        for (let i = 0; i < 3; i++) {
+          await fetch(req).then(
+            () => errors.push(null),
+            e => errors.push(e),
+          );
+        }
+
+        // First fetch + probe only. The three re-fetches must not have opened
+        // connections or written request heads to the origin.
+        await expectConnections(2);
+
+        expect(errors).toHaveLength(3);
+        for (const e of errors) {
+          expect(e).toBeInstanceOf(TypeError);
+          expect((e as any).code).toBe("ERR_BODY_ALREADY_USED");
+        }
+      });
+    },
+  );
+
+  it.concurrent("fetch: Request with a locked stream body rejects before any network I/O", async () => {
+    await withConnectionCountingServer(async ({ url, makeBody, expectConnections }) => {
       const req = new Request(url, { method: "POST", body: makeBody(), duplex: "half" } as RequestInit);
       // Lock the stream without disturbing it.
       req.body!.getReader();
@@ -235,19 +227,11 @@ describe("body-mixin-errors", () => {
         e => (err = e),
       );
 
-      // Probe with a fresh body so every accept queued before this one has
-      // been delivered by the time the response arrives.
-      const probe = await fetch(url, { method: "POST", body: makeBody(), duplex: "half" } as RequestInit);
-      expect(probe.status).toBe(200);
-
       // Probe only. The rejected fetch must not have opened a connection.
-      expect(connections).toBe(1);
+      await expectConnections(1);
 
       expect(err).toBeInstanceOf(TypeError);
       expect((err as any).code).toBe("ERR_BODY_ALREADY_USED");
-    } finally {
-      for (const s of sockets) s.destroy();
-      server.close();
-    }
+    });
   });
 });


### PR DESCRIPTION
## Problem

`fetch(request)` where `request` has a `ReadableStream` body that was already consumed opens a TCP connection and writes the full request head (`POST /path HTTP/1.1` + `Transfer-Encoding: chunked`) before rejecting with `ERR_STREAM_CANNOT_PIPE`. Each retry leaves a half-open, unterminated chunked request at the origin (0 body bytes, no `0\r\n\r\n`).

```js
const rs = new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode("x")); c.close(); } });
const req = new Request(url, { method: "POST", body: rs, duplex: "half" });
await fetch(req);              // 200, bodyUsed: true
await fetch(req);              // rejects ERR_STREAM_CANNOT_PIPE, but origin saw a POST head
await fetch(req);              // same
// origin saw 3 connections (1 real + 2 phantom POST heads); node/undici: 1
```

Node/undici throws `TypeError` before any network activity. String/Blob-body used Requests already reject pre-flight in Bun; only the stream-body path has this bug.

## Cause

The pre-flight `already_used` check in `fetch_impl` consults `PendingValue::is_disturbed::<Request>`, which looks at `body_get_cached` (only populated once `.body` is accessed) and `Locked.readable`. But `check_body_stream_ref` (run from `Request::to_js`) migrates the stream out of `Locked.readable` into the JS `stream` cache slot, so neither lookup finds it. The disturbed stream isn't checked until `ResumableSink::init_exact_refs` runs, which is after the HTTP thread has connected and written the request head.

## Fix

Check `is_disturbed || is_locked` on the actual `ReadableStream` returned by `get_body_readable_stream` (which consults the `stream` cache slot) before wrapping it as the request body. This is the same spec unusable check that `Request.prototype.clone` applies via `throw_if_body_unusable`, and throws `TypeError` with `ERR_BODY_ALREADY_USED` before any I/O.

## Verification

```
# before (system bun)
connections seen by origin: 4   refetch -> Error ERR_STREAM_CANNOT_PIPE

# after
connections seen by origin: 1   refetch -> TypeError ERR_BODY_ALREADY_USED
```

New tests in `test/js/web/fetch/body-mixin-errors.test.ts` assert the origin sees exactly the expected connection count (2: first fetch + probe) and that re-fetches reject with `TypeError`/`ERR_BODY_ALREADY_USED`. A second test covers the locked-but-not-disturbed case.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/body-mixin-errors.test.ts
bun test v1.4.0 (5739a2efa)

test/js/web/fetch/body-mixin-errors.test.ts:
(pass) body-mixin-errors > should throw TypeError when body already used on Response [14.02ms]
(pass) body-mixin-errors > should throw TypeError when body already used on Request [8.76ms]
(pass) body-mixin-errors > fetch: truncated body read rejects with TypeError and marks body used [506.07ms]
(pass) body-mixin-errors > fetch: body that failed before any reader call is still consumed by the first read [392.05ms]
(pass) body-mixin-errors > fetch: reading .body directly marks body used when the stream errors [388.69ms]
(pass) body-mixin-errors > fetch: truncated body arrayBuffer() marks body used [403.82ms]
(pass) body-mixin-errors > fetch: truncated body bytes() marks body used [452.99ms]
(pass) body-mixin-errors > fetch: truncated body blob() marks body used [170.51ms]
(pass) body-mixin-errors > fetch: truncated body json() marks body used [167.50ms]
172 |         url,
173 |         makeBody,
174 |         expectConnec
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (c4d619167)

test/js/web/fetch/body-mixin-errors.test.ts:
(pass) body-mixin-errors > should throw TypeError when body already used on Response [0.25ms]
(pass) body-mixin-errors > should throw TypeError when body already used on Request [0.28ms]
(pass) body-mixin-errors > fetch: truncated body read rejects with TypeError and marks body used [11.01ms]
(pass) body-mixin-errors > fetch: body that failed before any reader call is still consumed by the first read [9.00ms]
(pass) body-mixin-errors > fetch: reading .body directly marks body used when the stream errors [8.86ms]
(pass) body-mixin-errors > fetch: truncated body arrayBuffer() marks body used [8.77ms]
(pass) body-mixin-errors > fetch: truncated body bytes() marks body used [8.68ms]
(pass) body-mixin-errors > fetch: truncated body blob() marks body used [8.63ms]
(pass) body-mixin-errors > fetch: truncated body json() marks body used [8.59ms]
(pass) body-mixin-errors > fetch: Request with a locked stream body rejects before any network I/O [8.79ms]
(pass) body-mixin-errors > fetch: re-fetching a Request whose stream body was consumed rejects before any network I/O [9.37ms]

 11 pass
 0 fai
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/body-mixin-errors.test.ts
bun test v1.4.0 (5739a2efa)

test/js/web/fetch/body-mixin-errors.test.ts:
(pass) body-mixin-errors > should throw TypeError when body already used on Response [18.13ms]
(pass) body-mixin-errors > should throw TypeError when body already used on Request [15.51ms]
(pass) body-mixin-errors > fetch: truncated body read rejects with TypeError and marks body used [617.46ms]
(pass) body-mixin-errors > fetch: body that failed before any reader call is still consumed by the first read [490.63ms]
(pass) body-mixin-errors > fetch: reading .body directly marks body used when the stream errors [485.67ms]
(pass) body-mixin-errors > fetch: truncated body arrayBuffer() marks body used [498.10ms]
(pass) body-mixin-errors > fetch: truncated body bytes() marks body used [495.77ms]
(pass) body-mixin-errors > fetch: truncated body blob() marks body used [135.92ms]
(pass) body-mixin-errors > fetch: truncated body json() marks body used [131.40ms]
(pass) body-mixin-errors > fetch: Request with a locked stream body 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1521ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/fetch.rs                |   8 +++
 test/js/web/fetch/body-mixin-errors.test.ts | 104 ++++++++++++++++++++++++++++
 2 files changed, 112 insertions(+)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/runtime/webcore/fetch.rs                     1      1      0
test/js/web/fetch/body-mixin-errors.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->