### PR TITLE
fix(node:util): correct numericSeparator for negative fractions and exponent-form numbers

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -2205,28 +2205,33 @@ function addNumericSeparatorEnd(integerString) {
 const remainingText = remaining => `... ${remaining} more item${remaining > 1 ? "s" : ""}`;
 
 function formatNumber(fn, number, numericSeparator) {
+  // Format -0 as '-0'. Checking `number === -0` won't distinguish 0 from -0.
+  // String(-0) === '0', so this must be checked before any String() conversion.
+  if (ObjectIs(number, -0)) {
+    return fn("-0", "number");
+  }
   if (!numericSeparator) {
-    // Format -0 as '-0'. Checking `number === -0` won't distinguish 0 from -0.
-    if (ObjectIs(number, -0)) {
-      return fn("-0", "number");
-    }
     return fn(`${number}`, "number");
   }
+
+  const numberString = String(number);
   const integer = MathTrunc(number);
-  const string = String(integer);
+
   if (integer === number) {
-    if (!NumberIsFinite(number) || StringPrototypeIncludes(string, "e")) {
-      return fn(string, "number");
+    if (!NumberIsFinite(number) || StringPrototypeIncludes(numberString, "e")) {
+      return fn(numberString, "number");
     }
-    return fn(`${addNumericSeparator(string)}`, "number");
+    return fn(addNumericSeparator(numberString), "number");
   }
-  if (NumberIsNaN(number)) {
-    return fn(string, "number");
+  if (NumberIsNaN(number) || StringPrototypeIncludes(numberString, "e")) {
+    return fn(numberString, "number");
   }
-  return fn(
-    `${addNumericSeparator(string)}.${addNumericSeparatorEnd(StringPrototypeSlice(String(number), string.length + 1))}`,
-    "number",
-  );
+
+  const decimalIndex = StringPrototypeIndexOf(numberString, ".");
+  const integerPart = StringPrototypeSlice(numberString, 0, decimalIndex);
+  const fractionalPart = StringPrototypeSlice(numberString, decimalIndex + 1);
+
+  return fn(`${addNumericSeparator(integerPart)}.${addNumericSeparatorEnd(fractionalPart)}`, "number");
 }
 
 function formatBigInt(fn, bigint, numericSeparator) {

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -466,7 +466,6 @@ describe("util", () => {
     const sep = v => util.inspect(v, { numericSeparator: true });
 
     it("formats negative fractional numbers (#23098)", () => {
-      // Previously produced "0..12" and dropped the sign.
       expect(sep([0.1234, -0.12, -0.123, -0.1234, -1.234])).toBe("[ 0.123_4, -0.12, -0.123, -0.123_4, -1.234 ]");
     });
 
@@ -491,14 +490,11 @@ describe("util", () => {
     });
 
     it("leaves exponent-form numbers intact", () => {
-      // The old integer-length split corrupted these: 1e-7 became "0.-7",
-      // -1e-7 lost its sign as "0.e-7", and 1.23456e-7 became "0.234_56e_-7".
       expect(sep(1e-7)).toBe("1e-7");
       expect(sep(-1e-7)).toBe("-1e-7");
       expect(sep(2e-7)).toBe("2e-7");
       expect(sep(1.23456e-7)).toBe("1.23456e-7");
       expect(sep(-0.5)).toBe("-0.5");
-      // Integers large enough to stringify in exponent form take the same path.
       expect(sep(1234567891234567891234)).toBe("1.234567891234568e+21");
     });
 

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -462,6 +462,53 @@ describe("util", () => {
     });
   });
 
+  describe("inspect numericSeparator", () => {
+    const sep = v => util.inspect(v, { numericSeparator: true });
+
+    it("formats negative fractional numbers (#23098)", () => {
+      // Previously produced "0..12" and dropped the sign.
+      expect(sep([0.1234, -0.12, -0.123, -0.1234, -1.234])).toBe("[ 0.123_4, -0.12, -0.123, -0.123_4, -1.234 ]");
+    });
+
+    it("matches Node for each negative fraction", () => {
+      expect(sep(-0.12)).toBe("-0.12");
+      expect(sep(-0.123)).toBe("-0.123");
+      expect(sep(-0.1234)).toBe("-0.123_4");
+      expect(sep(-1.234)).toBe("-1.234");
+      expect(sep(-12345.6789)).toBe("-12_345.678_9");
+    });
+
+    it("keeps the sign on -0", () => {
+      expect(sep(-0)).toBe("-0");
+      expect(sep(0)).toBe("0");
+    });
+
+    it("groups large integers and fractions", () => {
+      expect(sep(1234567)).toBe("1_234_567");
+      expect(sep(-1234567)).toBe("-1_234_567");
+      expect(sep(123456.789)).toBe("123_456.789");
+      expect(sep(0.1234)).toBe("0.123_4");
+    });
+
+    it("leaves exponent-form numbers intact", () => {
+      // The old integer-length split corrupted these: 1e-7 became "0.-7",
+      // -1e-7 lost its sign as "0.e-7", and 1.23456e-7 became "0.234_56e_-7".
+      expect(sep(1e-7)).toBe("1e-7");
+      expect(sep(-1e-7)).toBe("-1e-7");
+      expect(sep(2e-7)).toBe("2e-7");
+      expect(sep(1.23456e-7)).toBe("1.23456e-7");
+      expect(sep(-0.5)).toBe("-0.5");
+      // Integers large enough to stringify in exponent form take the same path.
+      expect(sep(1234567891234567891234)).toBe("1.234567891234568e+21");
+    });
+
+    it("handles non-finite values", () => {
+      expect(sep(NaN)).toBe("NaN");
+      expect(sep(Infinity)).toBe("Infinity");
+      expect(sep(-Infinity)).toBe("-Infinity");
+    });
+  });
+
   describe("getSystemErrorName", () => {
     for (const item of ["test", {}, []]) {
       it(`throws when passing: ${item}`, () => {


### PR DESCRIPTION
### What does this PR do?

`util.inspect(n, { numericSeparator: true })` mangled negative fractional numbers and numbers that stringify in exponent form. Fixes #23098. Adopted from #32460 by @0xfandom.

| Input | Bun before | Bun after | Node main |
| --- | --- | --- | --- |
| `-0.12` | `0..12` | `-0.12` | `-0.12` |
| `-0.1234` | `0..12_34` | `-0.123_4` | `-0.123_4` |
| `1e-7` | `0.-7` | `1e-7` | `1e-7` |
| `-1e-7` | `0.e-7` | `-1e-7` | `-1e-7` |
| `1.23456e-7` | `0.234_56e_-7` | `1.23456e-7` | `1.23456e-7` |
| `-0` | `0` | `-0` | `-0` |

`formatNumber` derived the fractional slice from `String(Math.trunc(n)).length + 1`. For `-0.12`, `Math.trunc` is `-0` and `String(-0)` is `"0"`, so the sign was lost and the slice offset into `"-0.12"` was off by one. For `1e-7`, trunc is `0` so `"0"` bears no relation to the `.` position in `"1e-7"` and `addNumericSeparatorEnd` treated `"-7"` as a digit run.

The fix ports Node's current `formatNumber` verbatim:
- hoist the `-0` check above the `numericSeparator` branch (since `String(-0) === "0"`)
- split the number's own string representation on `indexOf(".")` rather than on `String(Math.trunc(n)).length`
- pass exponent-form strings (containing `e`) through unchanged

Node v26.3.0 only had the `indexOf` change; the `-0` hoist and exponent-form guard landed upstream after that, so the "Node main" column above is what Node nightly produces.

### How did you verify your code works?

New `describe("inspect numericSeparator")` block in `test/js/node/util/util.test.js` covers the #23098 repro array, each negative fraction individually (including grouped `-12_345.678_9`), `-0`/`0`, large integer and fraction grouping, exponent-form inputs (`1e-7`, `-1e-7`, `2e-7`, `1.23456e-7`, `1.2345...e+21`), and `NaN`/`Infinity`/`-Infinity`.

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/util/util.test.js -t numericSeparator
 2 pass, 4 fail   # the 4 failing cases are the bugs above

$ bun bd test test/js/node/util/util.test.js -t numericSeparator
 6 pass, 0 fail
```

Also green: full `util.test.js` (214), `node-inspect-tests/parallel/util-format.test.js`, `node-inspect-tests/internal-inspect.test.js`, `test/js/bun/util/inspect.test.js`. The `util-inspect.test.js` "no assertion failures 2" debug-build timeout reproduces identically on unmodified main (see #36147).

Co-authored-by: 0xfandom <kashyapshivank01@gmail.com>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/util.test.js
bun test v1.4.0 (9952f31d0)

test/js/node/util/util.test.js:
(pass) util > toUSVString [5.25ms]
(pass) util > inherits [5.75ms]
(pass) util > isArray > all cases [7.74ms]
(pass) util > isRegExp > all cases [4.50ms]
(pass) util > isDate > all cases [165.84ms]
(pass) util > isError > all cases [17.10ms]
(pass) util > isObject > all cases [3.69ms]
(pass) util > isPrimitive > all cases [9.23ms]
(pass) util > isBuffer > all cases [3.72ms]
(pass) util > _extend > all cases [8.11ms]
(pass) util > isBoolean > all cases [3.04ms]
(pass) util > isNull > all cases [2.97ms]
(pass) util > isUndefined > all cases [2.95ms]
(pass) util > isNullOrUndefined > all cases [2.94ms]
(pass) util > isNumber > all cases [2.65ms]
(pass) util > isString > all cases [2.96ms]
(pass) util > isSymbol > all cases [2.80ms]
(pass) util > isFunction > all cases [3.40ms]
(pass) util > types.isNativeError > all cases [4.52ms]
(pass) util > TextEncoder > is same as global TextEncoder [1.28ms]
(pass) util > TextDecoder > is same as global TextDe
... (truncated)

release without fix: 13 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/util/util.test.js:
(pass) util > toUSVString [0.13ms]
(pass) util > inherits [0.13ms]
(pass) util > isArray > all cases [0.14ms]
(pass) util > isRegExp > all cases [0.06ms]
(pass) util > isDate > all cases [0.15ms]
(pass) util > isError > all cases [0.27ms]
(pass) util > isObject > all cases [0.10ms]
(pass) util > isPrimitive > all cases [0.13ms]
(pass) util > isBuffer > all cases [0.06ms]
(pass) util > _extend > all cases [0.12ms]
(pass) util > isBoolean > all cases [0.03ms]
(pass) util > isNull > all cases [0.03ms]
(pass) util > isUndefined > all cases [0.03ms]
(pass) util > isNullOrUndefined > all cases [0.03ms]
(pass) util > isNumber > all cases [0.02ms]
(pass) util > isString > all cases [0.02ms]
(pass) util > isSymbol > all cases [0.02ms]
(pass) util > isFunction > all cases [0.03ms]
(pass) util > types.isNativeError > all cases [0.05ms]
(pass) util > TextEncoder > is same as global TextEncoder [0.02ms]
(pass) util > TextDecoder > is same as global TextDecoder [0.01ms]
(pass) util > format [0.26ms]
(pass) util > formatWithOptions [1.66ms]
345 |   // node v26.3.0 binary.
346 |   describe("styleText hex colors",
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/util.test.js
bun test v1.4.0 (9952f31d0)

test/js/node/util/util.test.js:
(pass) util > toUSVString [5.38ms]
(pass) util > inherits [6.27ms]
(pass) util > isArray > all cases [8.14ms]
(pass) util > isRegExp > all cases [4.72ms]
(pass) util > isDate > all cases [167.64ms]
(pass) util > isError > all cases [18.67ms]
(pass) util > isObject > all cases [3.93ms]
(pass) util > isPrimitive > all cases [9.59ms]
(pass) util > isBuffer > all cases [4.32ms]
(pass) util > _extend > all cases [8.31ms]
(pass) util > isBoolean > all cases [3.37ms]
(pass) util > isNull > all cases [3.50ms]
(pass) util > isUndefined > all cases [3.44ms]
(pass) util > isNullOrUndefined > all cases [3.08ms]
(pass) util > isNumber > all cases [3.20ms]
(pass) util > isString > all cases [2.79ms]
(pass) util > isSymbol > all cases [2.92ms]
(pass) util > isFunction > all cases [3.33ms]
(pass) util > types.isNativeError > all cases [4.66ms]
(pass) util > TextEncoder > is same as global TextEncoder [1.51ms]
(pass) util > TextDecoder > is same as global TextDe
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     9952f31d04
  features     baseline

22 deps, 108 codegen, 1171 objects in 1018ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [30.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [3.00ms]
[3/1234] gen ErrorCode+*.h
[4/1234] gen bindgenv2
[5/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [16.00ms]
[6/1234] fetch picohttpparser
[picohttpparser] up to date
[7/1234] fetch tinycc
[tinycc] up to date
[8/1234] gen .bind.ts → GeneratedBindings.cpp
[9/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1234] fetch zlib
[zlib] up to date
[11/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/util/inspect.js | 33 +++++++++++++++++------------
 test/js/node/util/util.test.js  | 47 +++++++++++++++++++++++++++++++++++++++++
 2 files changed, 66 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/js/internal/util/inspect.js      1      1      0
test/js/node/util/util.test.js       2      3      0
```

</details>

<!-- robobun:evidence:end -->