### PR TITLE
node:fs: avoid i32 truncation in non-bigint statfs

### DIFF
--- a/src/runtime/node/StatFS.rs
+++ b/src/runtime/node/StatFS.rs
@@ -4,29 +4,28 @@ use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 // On POSIX this is `libc::statfs`; on Windows it's `uv_statfs_t` (the value
 // `sys_uv::statfs` returns / `uv_fs_statfs` writes into `req.ptr`). Field
 // names match (`f_type`/`f_bsize`/…); widths differ (u64 vs platform-specific)
-// but `init` does an explicit `as i64`/`as $Int` truncate so either shape works.
+// but `init` widens each field with `as i64` so either shape works.
 #[cfg(unix)]
 pub(crate) type RawStatFS = libc::statfs;
 #[cfg(not(unix))]
 pub(crate) type RawStatFS = bun_sys::StatFS;
 
 // Both variants store fields as `i64`; they differ only in the JS conversion
-// (Number vs BigInt). The default JS API returns Number, so there is no reason
-// to narrow. The macro just stamps out the two aliases; the exported
+// (Number vs BigInt). The macro just stamps out the two aliases; the exported
 // `StatFSSmall`/`StatFSBig` are the only call sites.
 macro_rules! define_statfs_type {
-    ($name:ident, $Int:ty, big = $big:expr) => {
+    ($name:ident, big = $big:expr) => {
         #[allow(non_snake_case)]
         pub struct $name {
             // Common fields between Linux and macOS
-            pub _fstype: $Int,
-            pub _bsize: $Int,
-            pub _frsize: $Int,
-            pub _blocks: $Int,
-            pub _bfree: $Int,
-            pub _bavail: $Int,
-            pub _files: $Int,
-            pub _ffree: $Int,
+            pub _fstype: i64,
+            pub _bsize: i64,
+            pub _frsize: i64,
+            pub _blocks: i64,
+            pub _bfree: i64,
+            pub _bavail: i64,
+            pub _files: i64,
+            pub _ffree: i64,
         }
 
         impl $name {
@@ -39,28 +38,28 @@ macro_rules! define_statfs_type {
                     return bun_jsc::from_js_host_call(global, || {
                         Bun__createJSBigIntStatFSObject(
                             global,
-                            self._fstype as i64,
-                            self._bsize as i64,
-                            self._frsize as i64,
-                            self._blocks as i64,
-                            self._bfree as i64,
-                            self._bavail as i64,
-                            self._files as i64,
-                            self._ffree as i64,
+                            self._fstype,
+                            self._bsize,
+                            self._frsize,
+                            self._blocks,
+                            self._bfree,
+                            self._bavail,
+                            self._files,
+                            self._ffree,
                         )
                     });
                 }
 
                 Ok(Bun__createJSStatFSObject(
                     global,
-                    self._fstype as i64,
-                    self._bsize as i64,
-                    self._frsize as i64,
-                    self._blocks as i64,
-                    self._bfree as i64,
-                    self._bavail as i64,
-                    self._files as i64,
-                    self._ffree as i64,
+                    self._fstype,
+                    self._bsize,
+                    self._frsize,
+                    self._blocks,
+                    self._bfree,
+                    self._bavail,
+                    self._files,
+                    self._ffree,
                 ))
             }
 
@@ -91,17 +90,16 @@ macro_rules! define_statfs_type {
                 compile_error!("Unsupported OS");
 
                 // Platform field types vary (u32/i64/u64); `as i64` is lossless
-                // for the in-range values statfs reports. `$Int` is `i64` for
-                // both variants, so this no longer narrows.
+                // for the in-range values statfs reports.
                 Self {
-                    _fstype: (fstype_ as i64) as $Int,
-                    _bsize: (bsize_ as i64) as $Int,
-                    _frsize: (frsize_ as i64) as $Int,
-                    _blocks: (blocks_ as i64) as $Int,
-                    _bfree: (bfree_ as i64) as $Int,
-                    _bavail: (bavail_ as i64) as $Int,
-                    _files: (files_ as i64) as $Int,
-                    _ffree: (ffree_ as i64) as $Int,
+                    _fstype: fstype_ as i64,
+                    _bsize: bsize_ as i64,
+                    _frsize: frsize_ as i64,
+                    _blocks: blocks_ as i64,
+                    _bfree: bfree_ as i64,
+                    _bavail: bavail_ as i64,
+                    _files: files_ as i64,
+                    _ffree: ffree_ as i64,
                 }
             }
         }
@@ -134,8 +132,8 @@ unsafe extern "C" {
     ) -> JSValue;
 }
 
-define_statfs_type!(StatFSSmall, i64, big = false);
-define_statfs_type!(StatFSBig, i64, big = true);
+define_statfs_type!(StatFSSmall, big = false);
+define_statfs_type!(StatFSBig, big = true);
 
 /// Union between `Stats` and `BigIntStats` where the type can be decided at runtime
 pub enum StatFS {

--- a/src/runtime/node/StatFS.rs
+++ b/src/runtime/node/StatFS.rs
@@ -10,9 +10,12 @@ pub(crate) type RawStatFS = libc::statfs;
 #[cfg(not(unix))]
 pub(crate) type RawStatFS = bun_sys::StatFS;
 
-// The field integer type is i64 ("big") or i32 ("small"). Stable Rust const
+// Both variants store fields as `i64` and differ only in the JS conversion
+// (Number vs BigInt). Earlier the non-bigint fields were `i32`, truncating
+// block counts above `i32::MAX` (oven-sh/bun#31510); the default JS API returns
+// Number, not `i32`, so there is no reason to narrow here. Stable Rust const
 // generics cannot select a field type from a `const BIG: bool`, so we generate
-// the two concrete instantiations with a small macro. The two exported aliases
+// the two concrete instantiations with a small macro. The exported aliases
 // (`StatFSSmall`, `StatFSBig`) are the only call sites.
 macro_rules! define_statfs_type {
     ($name:ident, $Int:ty, big = $big:expr) => {
@@ -90,9 +93,9 @@ macro_rules! define_statfs_type {
                 #[cfg(target_arch = "wasm32")]
                 compile_error!("Unsupported OS");
 
-                // Platform field types vary (u32/i64/u64); widen with `as i64`
-                // (lossless for the in-range values statfs reports), then `as $Int`
-                // truncates (intentional wrap).
+                // Platform field types vary (u32/i64/u64); `as i64` is lossless
+                // for the in-range values statfs reports. `$Int` is `i64` for
+                // both variants, so this no longer narrows.
                 Self {
                     _fstype: (fstype_ as i64) as $Int,
                     _bsize: (bsize_ as i64) as $Int,
@@ -134,7 +137,7 @@ unsafe extern "C" {
     ) -> JSValue;
 }
 
-define_statfs_type!(StatFSSmall, i32, big = false);
+define_statfs_type!(StatFSSmall, i64, big = false);
 define_statfs_type!(StatFSBig, i64, big = true);
 
 /// Union between `Stats` and `BigIntStats` where the type can be decided at runtime

--- a/src/runtime/node/StatFS.rs
+++ b/src/runtime/node/StatFS.rs
@@ -10,13 +10,10 @@ pub(crate) type RawStatFS = libc::statfs;
 #[cfg(not(unix))]
 pub(crate) type RawStatFS = bun_sys::StatFS;
 
-// Both variants store fields as `i64` and differ only in the JS conversion
-// (Number vs BigInt). Earlier the non-bigint fields were `i32`, truncating
-// block counts above `i32::MAX` (oven-sh/bun#31510); the default JS API returns
-// Number, not `i32`, so there is no reason to narrow here. Stable Rust const
-// generics cannot select a field type from a `const BIG: bool`, so we generate
-// the two concrete instantiations with a small macro. The exported aliases
-// (`StatFSSmall`, `StatFSBig`) are the only call sites.
+// Both variants store fields as `i64`; they differ only in the JS conversion
+// (Number vs BigInt). The default JS API returns Number, so there is no reason
+// to narrow. The macro just stamps out the two aliases; the exported
+// `StatFSSmall`/`StatFSBig` are the only call sites.
 macro_rules! define_statfs_type {
     ($name:ident, $Int:ty, big = $big:expr) => {
         #[allow(non_snake_case)]

--- a/src/runtime/node/StatFS.rs
+++ b/src/runtime/node/StatFS.rs
@@ -10,9 +10,6 @@ pub(crate) type RawStatFS = libc::statfs;
 #[cfg(not(unix))]
 pub(crate) type RawStatFS = bun_sys::StatFS;
 
-// Both variants store fields as `i64`; they differ only in the JS conversion
-// (Number vs BigInt). The macro just stamps out the two aliases; the exported
-// `StatFSSmall`/`StatFSBig` are the only call sites.
 macro_rules! define_statfs_type {
     ($name:ident, big = $big:expr) => {
         #[allow(non_snake_case)]

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5258,7 +5258,8 @@ it("fs.statfs (callback) should work with bigint", async () => {
 // sentinel `bsize` (proving the shim actually interposed). glibc-only: the
 // shim relies on ELF symbol interposition and a libc `struct statfs` layout.
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
-it.skipIf(!isGlibc || !cc)("fs.statfsSync preserves block counts above i32::MAX (#31510)", () => {
+it.skipIf(!isGlibc || !cc)("fs.statfsSync preserves values above i32::MAX (#31510)", () => {
+  const TYPE = 0x9123683e; // BTRFS_SUPER_MAGIC, > i32::MAX: .type also wrapped negative
   const BSIZE = 12288; // sentinel (3 * 4096): proves the shim ran
   const BLOCKS = 3747442852; // > i32::MAX
   const BFREE = 3248532185; // > i32::MAX
@@ -5275,6 +5276,7 @@ it.skipIf(!isGlibc || !cc)("fs.statfsSync preserves block counts above i32::MAX 
 // keep each prototype type-correct.
 #define FILL(buf) do { \\
   memset((buf), 0, sizeof(*(buf))); \\
+  (buf)->f_type = ${TYPE}ULL; \\
   (buf)->f_bsize = ${BSIZE}ULL; \\
   (buf)->f_blocks = ${BLOCKS}ULL; \\
   (buf)->f_bfree = ${BFREE}ULL; \\
@@ -5297,7 +5299,7 @@ int statfs64(const char *path, struct statfs64 *buf) { (void)path; FILL(buf); re
 
   const script = `console.log(JSON.stringify((() => {
     const s = require("fs").statfsSync(process.cwd());
-    return { bsize: s.bsize, blocks: s.blocks, bfree: s.bfree, bavail: s.bavail };
+    return { type: s.type, bsize: s.bsize, blocks: s.blocks, bfree: s.bfree, bavail: s.bavail };
   })()));`;
 
   const existing = bunEnv.LD_PRELOAD;
@@ -5312,7 +5314,7 @@ int statfs64(const char *path, struct statfs64 *buf) { (void)path; FILL(buf); re
 
   const result = JSON.parse(stdout);
   // If bsize isn't the sentinel, the shim didn't interpose: fail loudly, don't skip.
-  expect(result).toEqual({ bsize: BSIZE, blocks: BLOCKS, bfree: BFREE, bavail: BAVAIL });
+  expect(result).toEqual({ type: TYPE, bsize: BSIZE, blocks: BLOCKS, bfree: BFREE, bavail: BAVAIL });
   expect(proc.exitCode).toBe(0);
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5257,12 +5257,8 @@ it("fs.statfs (callback) should work with bigint", async () => {
 // LD_PRELOAD a shim that makes `statfs(2)` report large block counts and a
 // sentinel `bsize` (proving the shim actually interposed). glibc-only: the
 // shim relies on ELF symbol interposition and a libc `struct statfs` layout.
-it.skipIf(!isGlibc)("fs.statfsSync preserves block counts above i32::MAX (#31510)", () => {
-  const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
-  if (!cc) {
-    throw new Error("No C compiler found for statfs LD_PRELOAD regression");
-  }
-
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+it.skipIf(!isGlibc || !cc)("fs.statfsSync preserves block counts above i32::MAX (#31510)", () => {
   const BSIZE = 12288; // sentinel (3 * 4096): proves the shim ran
   const BLOCKS = 3747442852; // > i32::MAX
   const BFREE = 3248532185; // > i32::MAX
@@ -5292,7 +5288,7 @@ int statfs64(const char *path, struct statfs64 *buf) { (void)path; FILL(buf); re
 
   const soPath = path.join(String(dir), "shim.so");
   const compile = Bun.spawnSync({
-    cmd: [cc, "-shared", "-fPIC", "-o", soPath, path.join(String(dir), "shim.c")],
+    cmd: [cc!, "-shared", "-fPIC", "-o", soPath, path.join(String(dir), "shim.c")],
     env: bunEnv,
   });
   if (compile.exitCode !== 0) {
@@ -5304,9 +5300,10 @@ int statfs64(const char *path, struct statfs64 *buf) { (void)path; FILL(buf); re
     return { bsize: s.bsize, blocks: s.blocks, bfree: s.bfree, bavail: s.bavail };
   })()));`;
 
+  const existing = bunEnv.LD_PRELOAD;
   const proc = Bun.spawnSync({
     cmd: [bunExe(), "-e", script],
-    env: { ...bunEnv, LD_PRELOAD: soPath },
+    env: { ...bunEnv, LD_PRELOAD: existing ? `${soPath}:${existing}` : soPath },
     cwd: String(dir),
   });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6,6 +6,7 @@ import {
   getMaxFD,
   isBroken,
   isDebug,
+  isGlibc,
   isIntelMacOS,
   isLinux,
   isPosix,
@@ -5248,6 +5249,74 @@ it("fs.statfs (callback) should work with bigint", async () => {
     expect(stats.bsize > 0n).toBe(true);
     expect(stats.blocks > 0n).toBe(true);
   }
+});
+
+// Regression for oven-sh/bun#31510: the non-bigint statfs path stored block
+// counts as i32, so values above i32::MAX (e.g. `bavail` on a filesystem past
+// ~8 TiB) wrapped negative. We can't mount a multi-TiB filesystem in CI, so we
+// LD_PRELOAD a shim that makes `statfs(2)` report large block counts and a
+// sentinel `bsize` (proving the shim actually interposed). glibc-only: the
+// shim relies on ELF symbol interposition and a libc `struct statfs` layout.
+it.skipIf(!isGlibc)("fs.statfsSync preserves block counts above i32::MAX (#31510)", () => {
+  const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+  if (!cc) {
+    throw new Error("No C compiler found for statfs LD_PRELOAD regression");
+  }
+
+  const BSIZE = 12288; // sentinel (3 * 4096): proves the shim ran
+  const BLOCKS = 3747442852; // > i32::MAX
+  const BFREE = 3248532185; // > i32::MAX
+  const BAVAIL = 3248532185; // > i32::MAX
+
+  using dir = tempDir("statfs-i32", {
+    "shim.c": `
+#define _GNU_SOURCE
+#include <sys/statfs.h>
+#include <string.h>
+
+// glibc declares statfs() with \`struct statfs *\` and statfs64() with
+// \`struct statfs64 *\`; both share these field names, so fill via a macro to
+// keep each prototype type-correct.
+#define FILL(buf) do { \\
+  memset((buf), 0, sizeof(*(buf))); \\
+  (buf)->f_bsize = ${BSIZE}ULL; \\
+  (buf)->f_blocks = ${BLOCKS}ULL; \\
+  (buf)->f_bfree = ${BFREE}ULL; \\
+  (buf)->f_bavail = ${BAVAIL}ULL; \\
+} while (0)
+
+int statfs(const char *path, struct statfs *buf) { (void)path; FILL(buf); return 0; }
+int statfs64(const char *path, struct statfs64 *buf) { (void)path; FILL(buf); return 0; }
+`,
+  });
+
+  const soPath = path.join(String(dir), "shim.so");
+  const compile = Bun.spawnSync({
+    cmd: [cc, "-shared", "-fPIC", "-o", soPath, path.join(String(dir), "shim.c")],
+    env: bunEnv,
+  });
+  if (compile.exitCode !== 0) {
+    throw new Error(`Failed to build statfs shim:\n${compile.stderr.toString()}`);
+  }
+
+  const script = `console.log(JSON.stringify((() => {
+    const s = require("fs").statfsSync(process.cwd());
+    return { bsize: s.bsize, blocks: s.blocks, bfree: s.bfree, bavail: s.bavail };
+  })()));`;
+
+  const proc = Bun.spawnSync({
+    cmd: [bunExe(), "-e", script],
+    env: { ...bunEnv, LD_PRELOAD: soPath },
+    cwd: String(dir),
+  });
+
+  const stdout = proc.stdout.toString().trim();
+  expect(proc.stderr.toString()).toBe("");
+
+  const result = JSON.parse(stdout);
+  // If bsize isn't the sentinel, the shim didn't interpose: fail loudly, don't skip.
+  expect(result).toEqual({ bsize: BSIZE, blocks: BLOCKS, bfree: BFREE, bavail: BAVAIL });
+  expect(proc.exitCode).toBe(0);
 });
 
 it("fs.Stat constructor", () => {


### PR DESCRIPTION
Closes #31616 by @EffortlessSteven (which had developed merge conflicts after `frsize` was added to `StatFS.rs`). Fixes #31510.

## Problem

The non-bigint `fs.statfs` / `fs.statfsSync` path stored every field as `i32`. On any filesystem with more than 2^31 blocks (roughly 8 TiB at 4 KiB block size), `bavail` / `bfree` / `blocks` wrap negative. Reported on a 13.3 TiB btrfs volume:

```
bun:  { bavail: -1046435111, bfree: -1046435111, blocks: -547524444 }
node: { bavail:  3248532185, bfree:  3248532185, blocks: 3747442852 }
```

The same narrowing also hit `.type`: filesystem magics above `i32::MAX` (btrfs `0x9123683E`, f2fs `0xF2F52010`, CIFS `0xFF534D42`, hugetlbfs, hpfs) were reported as negative where Node returns the positive value.

## Cause

`src/runtime/node/StatFS.rs` instantiated the non-bigint variant as `define_statfs_type!(StatFSSmall, i32, ...)`, so `init()`'s `(field as i64) as $Int` narrowed the values from `libc::statfs` to `i32`. The C++ binding `Bun__createJSStatFSObject` already takes every field as `i64` and returns a JS Number (53-bit mantissa), so there was never a reason to store as 32 bits; Node passes the full `uint64_t` through to Number.

## Fix

Store all fields as `i64`. With both variants now using the same storage width, the `$Int` macro parameter is dead and is dropped; the two variants differ only in the JS conversion (Number vs BigInt). The `{ bigint: true }` path was already correct and is unchanged.

## Test

We can't mount a multi-TiB filesystem in CI, so the test LD_PRELOADs a `statfs`/`statfs64` shim that reports `f_type = BTRFS_SUPER_MAGIC` and block counts above `i32::MAX`, plus a sentinel `bsize` (12288) that proves the shim actually interposed. glibc-only: relies on ELF symbol interposition and the libc `struct statfs` layout.

<details>
<summary>Before/after</summary>

```
# before (USE_SYSTEM_BUN=1)
error: expect(received).toEqual(expected)
  {
-   "bavail": 3248532185,
+   "bavail": -1046435111,
-   "bfree": 3248532185,
+   "bfree": -1046435111,
-   "blocks": 3747442852,
+   "blocks": -547524444,
    "bsize": 12288,
-   "type": 2435016766,
+   "type": -1859950530,
  }

# after (bun bd)
(pass) fs.statfsSync preserves values above i32::MAX (#31510)
```
</details>

Closes #31616. Also related: #31790 (closed as duplicate of #31616).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->