### PR TITLE
bun-types: SharedArrayBuffer.prototype.grow returns void

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1080,7 +1080,7 @@ interface SharedArrayBuffer {
   /**
    * Grow the SharedArrayBuffer in-place.
    */
-  grow(size: number): SharedArrayBuffer;
+  grow(size: number): void;
 }
 
 interface ArrayConstructor {

--- a/test/integration/bun-types/fixture/array-buffer.ts
+++ b/test/integration/bun-types/fixture/array-buffer.ts
@@ -11,5 +11,6 @@ TextDecoder;
 
 const buf = new SharedArrayBuffer(1024);
 buf.grow(2048);
+expectType(buf.grow(1024)).is<void>();
 
 expectType(buffer[Symbol.toStringTag]).extends<string>();


### PR DESCRIPTION
### Problem
- `packages/bun-types/globals.d.ts` declares `SharedArrayBuffer.prototype.grow()` as returning the `SharedArrayBuffer` (`globals.d.ts:1083`). Per the spec it returns `undefined` ([sec-sharedarraybuffer.prototype.grow](https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.grow), last step), and `bun -e 'const b = new SharedArrayBuffer(1, { maxByteLength: 8 }); console.log(b.grow(4))'` prints `undefined`.
- bun-types merges its own `interface SharedArrayBuffer` into the lib one, and the merged-in signature is the one a `grow(n)` call resolves to, so code that chains off the result (`sab.grow(n).byteLength`) type-checks and then throws at runtime.

### Fix
- `grow(size: number): SharedArrayBuffer` becomes `grow(size: number): void`, matching the spec, the runtime, and TypeScript's own `lib.es2024.sharedmemory.d.ts`.
- This is the same correction #32484 makes for `ArrayBuffer.prototype.resize()`; that PR stays as is, and the two merge independently in either order (checked locally).
- Verified with `bun test test/integration/bun-types/bun-types.test.ts` (types-only change, so it runs with the released bun): with only the fixture line, every lib configuration fails with `array-buffer.ts(14,31): error TS2344: Type 'void' does not satisfy the constraint 'SharedArrayBuffer'.`; with the declaration change, 14 pass.

### Background
- bun-types declares some globals that also exist in TypeScript's lib files. TypeScript merges same-named interfaces, and when both declare a method the signatures become overloads, with the later-merged declaration (bun-types) tried first. A wrong return type in bun-types therefore wins over the correct one in lib, which is why this shows up even with `lib.dom`/`es2024` enabled.

<details>
<summary>History: this PR used to be a batch of seven type fixes</summary>

The earlier revision of this PR bundled `YAML.stringify`, `ArrayBuffer.resize`, the `FormData` iterator types, `jest.now()`, `jest.setSystemTime()` chaining, `toHaveBeenCalledOnce()` and the return-matcher aliases. Each of those already has a focused PR from its original author, and all seven still merge cleanly on current main with the types test passing, so this PR was cut down to the one line that none of them covers. The focused PRs are the ones to merge:

| Fix | PR |
|---|---|
| `Bun.YAML.stringify()` returns `string \| undefined` | #34162 |
| `ArrayBuffer.prototype.resize()` returns `void` | #32484 |
| `FormData` `values()` / `entries()` / `[Symbol.iterator]()` yield `FormDataEntryValue` (#27194) | #34264 |
| `toHaveBeenCalledOnce()` declaration (#32332) | #32333 |
| `toReturn()` / `lastReturnedWith()` / `nthReturnedWith()` declarations (#32334) | #32335 |
| `jest.now()` declaration | #32455 |
| `jest.setSystemTime()` returns `typeof jest` | #33923 |

Note for whoever merges the four `bun:test` ones (#32333, #32335, #32455, #33923): they all append to `test/integration/bun-types/fixture/mocks.ts`, so after the first one lands the other three need a trivial rebase (keep both sides). #32455 and #33923 additionally touch adjacent lines of the `jest` namespace in `test.d.ts`. The combined result of all seven plus this PR was checked locally and passes the types test.
</details>
