### PR TITLE
console: route console.trace() output to stderr

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -408,7 +408,8 @@ fn message_with_type_and_level_(
     // Lock/unlock a mutex incase two JS threads are console.log'ing at the same
     // time. We do this the slightly annoying way to avoid assigning a pointer.
     let use_stderr = matches!(level, MessageLevel::Warning | MessageLevel::Error)
-        || message_type == MessageType::Assert;
+        || message_type == MessageType::Assert
+        || message_type == MessageType::Trace;
     let _stream_lock = ConsoleStreamLock::acquire(use_stderr);
 
     if message_type == MessageType::Clear {
@@ -431,7 +432,7 @@ fn message_with_type_and_level_(
         return Ok(());
     }
 
-    let enable_colors = if matches!(level, MessageLevel::Warning | MessageLevel::Error) {
+    let enable_colors = if use_stderr {
         Output::enable_ansi_colors_stderr()
     } else {
         Output::enable_ansi_colors_stdout()
@@ -450,7 +451,7 @@ fn message_with_type_and_level_(
     // long-lived `&mut ConsoleObject` across the re-derive in the empty-`Log`
     // arm below.
     let raw_writer: &mut bun_core::io::Writer = unsafe {
-        if matches!(level, MessageLevel::Warning | MessageLevel::Error) {
+        if use_stderr {
             (*console).error_writer()
         } else {
             (*console).writer()

--- a/test/js/web/console/console-trace.test.ts
+++ b/test/js/web/console/console-trace.test.ts
@@ -1,0 +1,43 @@
+import { expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/19952
+it.concurrent("console.trace() writes to stderr, not stdout", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `console.trace("marker");`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("");
+  expect(stderr).toContain("marker");
+  expect(stderr).toContain("at ");
+  expect(exitCode).toBe(0);
+});
+
+it.concurrent("console.trace() with no arguments writes the stack to stderr", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `console.trace();`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("");
+  expect(stderr).toContain("at ");
+  expect(exitCode).toBe(0);
+});
+
+it.concurrent("console.trace() does not interleave with console.log() on stdout", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `console.log("before"); console.trace("traced"); console.log("after");`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("before\nafter\n");
+  expect(stderr).toContain("traced");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

`console.trace()` writes to stdout. Node.js writes it to stderr.

```sh
$ bun -e 'console.trace("hello")' >/dev/null
$ # no output

$ node -e 'console.trace("hello")' >/dev/null
Trace: hello
    at [eval]:1:9
    ...
```

## Cause

`message_with_type_and_level` in `src/jsc/ConsoleObject.rs` selects the output stream based on `MessageLevel::Warning | MessageLevel::Error`. JSC dispatches `console.trace()` with `MessageType::Trace` and `MessageLevel::Log`, so it fell through to stdout. The stream lock, color selection, and writer selection each repeated the same incomplete condition.

## Fix

Add `MessageType::Trace` to the `use_stderr` computation and reuse that flag for the color and writer selection so all three stay consistent. This is the fix from #35058 by @hanu-14 with the three duplicated conditions folded into the existing `use_stderr` variable.

This PR is scoped to the stderr routing only. #32638 and #20020 also add a Node-style `Trace:` header before the message; that is a separate formatting change not included here (#36471 covers it via the JS wrapper path).

Fixes #19952
Closes #35058
Closes #35040

## Verification

New `test/js/web/console/console-trace.test.ts` asserts that `console.trace()` (with and without arguments) writes nothing to stdout and writes both the message and the stack to stderr. All three cases fail on main and pass with this change.

```
bun bd test test/js/web/console/ test/js/bun/console/ test/js/node/console/
# 107 pass, 1 skip, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-trace.test.ts
bun test v1.4.0 (abc5a163f)

test/js/web/console/console-trace.test.ts:
22 |     env: bunEnv,
23 |     stdout: "pipe",
24 |     stderr: "pipe",
25 |   });
26 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
27 |   expect(stdout).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "      at /workspace/bun/[eval]:1:9
+ "

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/web/console/console-trace.test.ts:27:18)
(fail) console.trace() with no arguments writes the stack to stderr [413.95ms]
 8 |     env: bunEnv,
 9 |     stdout: "pipe",
10 |     stderr: "pipe",
11 |   });
12 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
13 |   expect(stdout).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "marker
+       at /workspace/bun/[eval]:1:9
+ "

- Expected  - 1
+ Received  + 3

      at <a
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/console/console-trace.test.ts:
 8 |     env: bunEnv,
 9 |     stdout: "pipe",
10 |     stderr: "pipe",
11 |   });
12 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
13 |   expect(stdout).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "marker
+       at /workspace/bun/[eval]:1:9
+ "

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/web/console/console-trace.test.ts:13:18)
(fail) console.trace() writes to stderr, not stdout [27.80ms]
35 |     env: bunEnv,
36 |     stdout: "pipe",
37 |     stderr: "pipe",
38 |   });
39 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
40 |   expect(stdout).toBe("before\nafter\n");
                      ^
error: expect(received).toBe(expected)

  "before
+ traced
+       at /workspace/bun/[eval]:1:32
  after
  "

- Expected  - 0
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/web/console/console-trace.test.ts:40:18)
(fail) console.trace() does not interleave with console.log() on stdout
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-trace.test.ts
bun test v1.4.0 (abc5a163f)

test/js/web/console/console-trace.test.ts:
(pass) console.trace() does not interleave with console.log() on stdout [420.90ms]
(pass) console.trace() with no arguments writes the stack to stderr [932.18ms]
(pass) console.trace() writes to stderr, not stdout [985.33ms]

 3 pass
 0 fail
 10 expect() calls
Ran 3 tests across 1 file. [4.02s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     abc5a163f2
  features     baseline

22 deps, 108 codegen, 1171 objects in 2519ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] fetch tinycc
[tinycc] up to date
[2/1234] gen ErrorCode+*.h
[3/1234] gen bindgenv2
[4/1234] gen .bind.ts → GeneratedBindings.cpp
[5/1234] fetch zlib
[zlib] up to date
[6/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1234] fetch picohttpparser
[picohttpparser] up to date
[8/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [119.00ms]
[9/1234] subst deps/zlib/zconf.h
[10/1234] fetch brotli
[brotli] up to date
[11/1234] subst deps/zlib/zlib.h
[12/1234] host-cc deps/tinycc/codegen-tool
[13/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[14/1234] fetch libdeflate
[libdeflate] up to date
[15/1234] fetch zstd
[zstd] up to date
[16/1234] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                  |  7 ++---
 test/js/web/console/console-trace.test.ts | 43 +++++++++++++++++++++++++++++++
 2 files changed, 47 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/ConsoleObject.rs                       2      3      0
test/js/web/console/console-trace.test.ts      0      1      0
```

</details>

**self-review** · 1 surviving concern

- consider: PR body says "Closes #32638" and "Closes #20020" but both of those PRs bundle a second change (the Node-style "Trace:" prefix) that this PR does not implement, so closing them drops that half of the contribution with no tracking.

24 concerns were raised and did not survive verification.

**root cause** · written by the author bot

The stderr routing logic in ConsoleObject.rs decided the output stream solely from the message level, checking only for Warning or Error, so console.trace() was written to stdout instead of stderr as Node.js does. The fix extends the use_stderr computation to also account for MessageType::Trace and reuses that flag at the color and writer selection sites rather than repeating the level check. This routes trace output to stderr without altering behavior for any other console method.

<!-- robobun:evidence:end -->