### PR TITLE
bun:test: accept legacy string argument in jest.useFakeTimers()

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -94,7 +94,7 @@ declare module "bun:test" {
     function fn<T extends (...args: any[]) => any>(func?: T): Mock<T>;
     function setSystemTime(now?: number | Date): void;
     function setTimeout(milliseconds: number): void;
-    function useFakeTimers(options?: { now?: number | Date }): typeof vi;
+    function useFakeTimers(options?: { now?: number | Date } | "modern" | "legacy"): typeof vi;
     function useRealTimers(): typeof vi;
     function advanceTimersByTime(milliseconds: number): typeof vi;
     function advanceTimersToNextTimer(): typeof vi;

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -284,9 +284,7 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
     if args.len() > 0 && !args[0].is_undefined() {
         let options_value = args[0];
         if options_value.is_string() {
-            // Jest 26 accepted jest.useFakeTimers("modern" | "legacy") to select the
-            // implementation. Accept a string argument as a no-op so suites migrating
-            // from older Jest versions don't need to rewrite these calls.
+            // Jest 26 compat: useFakeTimers("modern" | "legacy") is a no-op.
         } else if !options_value.is_object() {
             return Err(global.throw_invalid_arguments(format_args!(
                 "useFakeTimers() expects an options object"

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -283,12 +283,15 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
     let args = frame.arguments_as_array::<1>();
     if args.len() > 0 && !args[0].is_undefined() {
         let options_value = args[0];
-        if !options_value.is_object() {
+        if options_value.is_string() {
+            // Jest 26 accepted jest.useFakeTimers("modern" | "legacy") to select the
+            // implementation. Accept a string argument as a no-op so suites migrating
+            // from older Jest versions don't need to rewrite these calls.
+        } else if !options_value.is_object() {
             return Err(global.throw_invalid_arguments(format_args!(
                 "useFakeTimers() expects an options object"
             )));
-        }
-        if let Some(now) = options_value.get(global, "now")? {
+        } else if let Some(now) = options_value.get(global, "now")? {
             if now.is_number() {
                 js_now = now.as_number();
             } else if now.is_date() {

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -447,15 +447,12 @@ describe("useFakeTimers with options", () => {
     expect(Date.now()).toBe(targetTime + 500);
   });
 
-  test.each(["modern", "legacy"] as const)(
-    "useFakeTimers(%j) accepts legacy Jest string argument",
-    implementation => {
-      expect(() => vi.useFakeTimers(implementation)).not.toThrow();
-      expect(vi.isFakeTimers()).toBe(true);
-      vi.useRealTimers();
-      expect(vi.isFakeTimers()).toBe(false);
-    },
-  );
+  test.each(["modern", "legacy"] as const)("useFakeTimers(%j) accepts legacy Jest string argument", implementation => {
+    expect(() => vi.useFakeTimers(implementation)).not.toThrow();
+    expect(vi.isFakeTimers()).toBe(true);
+    vi.useRealTimers();
+    expect(vi.isFakeTimers()).toBe(false);
+  });
 
   test("useFakeTimers still rejects non-string non-object arguments", () => {
     expect(() => vi.useFakeTimers(123 as any)).toThrow("useFakeTimers() expects an options object");

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -446,4 +446,19 @@ describe("useFakeTimers with options", () => {
     expect(performance.now()).toBe(500);
     expect(Date.now()).toBe(targetTime + 500);
   });
+
+  test.each(["modern", "legacy"] as const)(
+    "useFakeTimers(%j) accepts legacy Jest string argument",
+    implementation => {
+      expect(() => vi.useFakeTimers(implementation)).not.toThrow();
+      expect(vi.isFakeTimers()).toBe(true);
+      vi.useRealTimers();
+      expect(vi.isFakeTimers()).toBe(false);
+    },
+  );
+
+  test("useFakeTimers still rejects non-string non-object arguments", () => {
+    expect(() => vi.useFakeTimers(123 as any)).toThrow("useFakeTimers() expects an options object");
+    expect(vi.isFakeTimers()).toBe(false);
+  });
 });


### PR DESCRIPTION
Adopts #30400 by @mchv.

## Repro

```ts
import { jest } from "bun:test";
jest.useFakeTimers("modern");
// TypeError: useFakeTimers() expects an options object
```

Jest 26 accepted `jest.useFakeTimers("modern" | "legacy")` to select the timer implementation. Since Jest 27 only the modern implementation exists, but many test suites migrating to Bun still have these calls and currently crash on the argument check. Vitest ignores a string argument at runtime.

## Fix

`use_fake_timers` in `src/runtime/test_runner/timers/FakeTimers.rs` now treats a string argument as a no-op and falls through to the default activation path (same as calling with no argument). Non-string non-object arguments still throw. The `useFakeTimers` type in `packages/bun-types/test.d.ts` gains a `"modern" | "legacy"` overload.

## Verification

```
$ bun bd test test/js/bun/test/fake-timers/fake-timers.test.ts
 33 pass
 0 fail
```

New tests assert that `useFakeTimers("modern")` and `useFakeTimers("legacy")` activate fake timers (`isFakeTimers()` returns `true`) without throwing, and that a numeric argument is still rejected. The string-argument tests fail on main with `TypeError: useFakeTimers() expects an options object`.

Closes #30400.