### PR TITLE
node:crypto: throw (not return) validation errors from createDiffieHellman

### DIFF
--- a/src/jsc/bindings/node/crypto/JSDiffieHellmanConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSDiffieHellmanConstructor.cpp
@@ -95,7 +95,8 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalOb
         }
 
         if (!generatorValue.isNumber()) {
-            return JSValue::encode(createError(globalObject, ErrorCode::ERR_INVALID_ARG_TYPE, "Second argument must be an int32"_s));
+            throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE, "Second argument must be an int32"_s);
+            return {};
         }
 
         int32_t generator = 0;
@@ -110,7 +111,8 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalOb
 
         dh = ncrypto::DHPointer::New(bits, generator);
         if (!dh) {
-            return JSValue::encode(createError(globalObject, ErrorCode::ERR_INVALID_ARG_VALUE, "Invalid DH parameters"_s));
+            throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_VALUE, "Invalid DH parameters"_s);
+            return {};
         }
     } else {
 
@@ -121,12 +123,14 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalOb
         RETURN_IF_EXCEPTION(scope, {});
 
         if (keyView->byteLength() > INT32_MAX) {
-            return JSValue::encode(createError(globalObject, ErrorCode::ERR_OUT_OF_RANGE, "prime is too big"_s));
+            throwError(globalObject, scope, ErrorCode::ERR_OUT_OF_RANGE, "prime is too big"_s);
+            return {};
         }
 
         ncrypto::BignumPointer bn_p(reinterpret_cast<uint8_t*>(keyView->vector()), keyView->byteLength());
         if (!bn_p) {
-            return JSValue::encode(createError(globalObject, ErrorCode::ERR_INVALID_ARG_VALUE, "Invalid prime"_s));
+            throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_VALUE, "Invalid prime"_s);
+            return {};
         }
         ncrypto::BignumPointer bn_g;
 
@@ -141,18 +145,21 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalOb
             if (!bn_g.setWord(generator)) {
                 ERR_put_error(ERR_LIB_DH, 0, DH_R_BAD_GENERATOR, __FILE__, __LINE__);
                 throwCryptoError(globalObject, scope, ERR_get_error(), "Invalid generator"_s);
+                return {};
             }
         } else {
             auto* generatorView = getArrayBufferOrView(globalObject, scope, generatorValue, "generator"_s, genEncodingValue);
             RETURN_IF_EXCEPTION(scope, {});
 
             if (generatorView->byteLength() > INT32_MAX) {
-                return JSValue::encode(createError(globalObject, ErrorCode::ERR_OUT_OF_RANGE, "generator is too big"_s));
+                throwError(globalObject, scope, ErrorCode::ERR_OUT_OF_RANGE, "generator is too big"_s);
+                return {};
             }
 
             bn_g = ncrypto::BignumPointer(reinterpret_cast<uint8_t*>(generatorView->vector()), generatorView->byteLength());
             if (!bn_g) {
-                return JSValue::encode(createError(globalObject, ErrorCode::ERR_INVALID_ARG_VALUE, "Invalid generator"_s));
+                throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_VALUE, "Invalid generator"_s);
+                return {};
             }
 
             // A generator too wide for BN_get_word is necessarily >= 2, so only
@@ -167,7 +174,8 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalOb
 
         dh = ncrypto::DHPointer::New(WTF::move(bn_p), WTF::move(bn_g));
         if (!dh) {
-            return JSValue::encode(createError(globalObject, ErrorCode::ERR_INVALID_ARG_VALUE, "Invalid DH parameters"_s));
+            throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_VALUE, "Invalid DH parameters"_s);
+            return {};
         }
     }
 

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -661,6 +661,34 @@ describe("DiffieHellman", () => {
     expect(() => crypto.createDiffieHellman(p, Buffer.from([0x01]))).toThrow(/bad.generator/i);
     expect(() => crypto.createDiffieHellman(p, Buffer.from([0x02]))).not.toThrow();
   });
+
+  it("throws (not returns) validation errors from the constructor", () => {
+    // toThrow() accepts a *returned* Error instance as a throw, so it cannot
+    // distinguish the two here; capture the control-flow outcome explicitly.
+    function outcome(fn) {
+      try {
+        return { threw: false, value: fn() };
+      } catch (e) {
+        return { threw: true, value: e };
+      }
+    }
+
+    // DHPointer::New rejects a 2-bit modulus; that must surface as a thrown error.
+    expect(outcome(() => crypto.createDiffieHellman(2))).toEqual({
+      threw: true,
+      value: expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE", message: "Invalid DH parameters" }),
+    });
+    // Numeric sizeOrKey with a non-numeric generator reaches the int32-only guard.
+    expect(outcome(() => crypto.createDiffieHellman(1024, "abc"))).toEqual({
+      threw: true,
+      value: expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", message: "Second argument must be an int32" }),
+    });
+    // `new DiffieHellman(...)` must behave identically to the factory.
+    expect(outcome(() => new crypto.DiffieHellman(2))).toEqual({
+      threw: true,
+      value: expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+    });
+  });
 });
 
 describe("ECDH", () => {


### PR DESCRIPTION
Closes #31708 by @saklani.

## Repro

```js
const crypto = require("crypto");
try {
  const r = crypto.createDiffieHellman(2);
  console.log("returned:", r instanceof Error, r.code);  // returned: true ERR_INVALID_ARG_VALUE
} catch (e) {
  console.log("threw:", e.code);
}
```

Bun prints `returned: true ERR_INVALID_ARG_VALUE`; Node throws `ERR_INVALID_ARG_VALUE`.

## Cause

Seven error paths in `constructDiffieHellman()` did `return JSValue::encode(createError(...))`, which returns an `Error` instance from the constructor rather than throwing it. A `[[Construct]]` that returns an object makes that object the result of the `new`-expression, so `createDiffieHellman(2)` evaluated to a `TypeError` instead of raising one.

The `bn_g.setWord()` failure path also called `throwCryptoError()` without returning, falling through into `DHPointer::New()` with a pending exception.

## Fix

Mechanical swap to `throwError(globalObject, scope, ...); return {};` at each site, matching the pattern used in the neighbouring ECDH bindings.

## Verification

```
DiffieHellman > throws (not returns) validation errors from the constructor  (pass)
```

New test fails on the released binary (`threw: false`), passes on this branch. `test/js/node/crypto/node-crypto.test.js` is 203/203, and the vendored `test-crypto-dh-constructor.js` / `test-crypto-dh-errors.js` still pass.

The test captures control flow explicitly rather than using `toThrow()`, because `toThrow()` accepts a *returned* `Error` instance as a throw and cannot distinguish the two cases here.

## Related

Overlaps with #33522, which fixes the same constructor paths as part of a larger `DH_check()` / `verifyError` change. Whichever lands first, the other rebases trivially.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.0 (f250508a3)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.90ms]
(pass) crypto.randomInt should return a number [2.39ms]
(pass) crypto.randomInt with no arguments [4.24ms]
(pass) crypto.randomInt with one argument [2.61ms]
(pass) crypto.randomInt with a callback [40.92ms]
(pass) createHash > rsa-md5 - "Hello World" [8.82ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.94ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [1.07ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [1.05ms]
(pass) createHash > rsa-sha1 - "Hello World" [9.46ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.89ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.84ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.95ms]
(pass) createHash > rsa-sha224 - "Hello World" [3.12ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.89ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.95ms]
(pass) create
... (truncated)

release without fix: 13 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [0.14ms]
(pass) crypto.randomInt should return a number [0.04ms]
(pass) crypto.randomInt with no arguments [0.13ms]
(pass) crypto.randomInt with one argument [0.07ms]
(pass) crypto.randomInt with a callback [0.75ms]
(pass) createHash > rsa-md5 - "Hello World" [0.20ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [0.11ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.02ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.03ms]
(pass) createHash > rsa-sha1 - "Hello World" [0.16ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [0.08ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.01ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.01ms]
(pass) createHash > rsa-sha224 - "Hello World" [0.05ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.01ms]
(pass) createHash > rsa-sha256 - "Hello World" [0.02ms]
(pass) createHash > rsa-sha256 - "Hello World" -> binary [0.01ms]
(pass) createHash > rsa-sha3-224 - "Hello World"
(pass) createHash > rsa-sha3-224 - "Hello World" -> binary
(pas
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.0 (f250508a3)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [5.50ms]
(pass) crypto.randomInt should return a number [2.71ms]
(pass) crypto.randomInt with no arguments [4.92ms]
(pass) crypto.randomInt with one argument [2.47ms]
(pass) crypto.randomInt with a callback [42.07ms]
(pass) createHash > rsa-md5 - "Hello World" [8.87ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [5.58ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [1.13ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [1.49ms]
(pass) createHash > rsa-sha1 - "Hello World" [9.81ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.84ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.91ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.92ms]
(pass) createHash > rsa-sha224 - "Hello World" [3.03ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.99ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.97ms]
(pass) create
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 824ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cc obj/packages/bun-usockets/src/context.c.o
[2/8] gen cpp.rs (cppbind)
[3/8] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 5m 08s
[4/8] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-0.cpp.o
[5/8] link bun-profile
[7/8] strip bun
[7/8] bun-profile --revision
1.4.0-canary.1+f250508a3
[build] done
bun test v1.4.0-canary.1 (f250508a3)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [0.10ms]

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../node/crypto/JSDiffieHellmanConstructor.cpp     | 22 +++++++++++------
 test/js/node/crypto/node-crypto.test.js            | 28 ++++++++++++++++++++++
 2 files changed, 43 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…jsc/bindings/node/crypto/JSDiffieHellmanConstructor.cpp      1      2      0
test/js/node/crypto/node-crypto.test.js                       2      2      0
```

</details>

<!-- robobun:evidence:end -->