### PR TITLE
repl: strip trailing CR when loading history (Windows CRLF)

### DIFF
--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -204,6 +204,7 @@ impl History {
         };
 
         for line in strings::split(&content, b"\n") {
+            let line = line.strip_suffix(b"\r").unwrap_or(line);
             if !line.is_empty() {
                 self.entries.push(Box::<[u8]>::from(line));
             }

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1296,6 +1296,7 @@ describe("REPL history file", () => {
     const historyLines = stripAnsi(stdout)
       .split("\n")
       .filter(l => l.includes("old_one") || l.includes("old_two"));
+    expect(historyLines).toHaveLength(2);
     for (const line of historyLines) {
       expect(line).not.toContain("\r");
     }

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1266,6 +1266,49 @@ describe.skipIf(isWindows)("REPL history file permissions", () => {
   });
 });
 
+describe("REPL history file", () => {
+  // A history file written on Windows (or edited in a CRLF editor) has CRLF
+  // line endings. Loading it must strip the trailing '\r' so entries don't
+  // carry a stray CR into recall, .history output, or the next save.
+  test("strips CRLF when loading existing history", async () => {
+    using dir = tempDir("repl-history-crlf", {
+      ".bun_repl_history": "old_one\r\nold_two\r\n",
+    });
+    const home = String(dir);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "repl"],
+      stdin: Buffer.from(".history\nnew_three\n.exit\n"),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...bunEnv,
+        TERM: "dumb",
+        NO_COLOR: "1",
+        HOME: home,
+        USERPROFILE: home,
+      },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // .history prints the loaded entries verbatim; a kept '\r' would appear
+    // between the entry text and the line's trailing '\n'.
+    const historyLines = stripAnsi(stdout)
+      .split("\n")
+      .filter(l => l.includes("old_one") || l.includes("old_two"));
+    for (const line of historyLines) {
+      expect(line).not.toContain("\r");
+    }
+
+    const saved = await Bun.file(path.join(home, ".bun_repl_history")).text();
+    expect(saved).not.toContain("\r");
+    expect(saved.split("\n").filter(Boolean)).toEqual(["old_one", "old_two", "new_three"]);
+
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});
+
 // `bun --interactive` boots the full node:repl + readline + acorn stack; on a
 // debug+asan build that is ~4–5s per spawn, so the 5s default is too tight.
 const interactiveTimeout = 20_000;


### PR DESCRIPTION
Adopts #30293 by @samuelpatro onto current main. That PR also patches `src/runtime/cli/repl.zig`, which no longer exists; this applies the fix to `repl.rs` only.

## Repro

```sh
printf 'old_one\r\nold_two\r\n' > ~/.bun_repl_history
bun repl
> .history
     1  old_one\r
     2  old_two\r
```

Arrow-up recall lands the cursor at column 0 after the recalled text, and the next save writes `old_one\r\nold_two\r\n…` back, so the stray CR survives every session.

## Cause

`History::load` in [`src/runtime/cli/repl.rs`](https://github.com/oven-sh/bun/blob/f426a8e173fa348c37248d5ce078f549099545d5/src/runtime/cli/repl.rs#L206) splits the history file on `'\n'` only:

```rust
for line in strings::split(&content, b"\n") {
    if !line.is_empty() {
        self.entries.push(Box::<[u8]>::from(line));
    }
}
```

A history file with CRLF line endings (written on Windows, or edited in a CRLF-defaulting editor) therefore leaves a trailing `'\r'` on every loaded entry. That CR leaks into arrow-key recall, `.history` output, and the next `save()` (which writes `entry + '\n'`), so the corruption compounds.

## Fix

Strip a trailing `'\r'` from each split line before storing it:

```rust
let line = line.strip_suffix(b"\r").unwrap_or(line);
```

`save()` already writes LF-only, so the file normalizes after one load/save cycle.

Why this is the right behavior:
- Matches node: its REPL history loader splits the file on `/\r?\n+/` (see the vendored `src/js/internal/repl/history.js` used by `node:repl`), so a CRLF history file loads cleanly there too.
- Nothing legitimate is lost: `save()` emits `entry + '\n'`, so an entry whose text ended in `'\r'` would be written as CRLF and be indistinguishable from a CRLF file anyway. The native format has no meaning for a trailing CR.
- A blank CRLF line (`"\r"`) becomes empty and is skipped, the same as a blank LF line already is.

## Verification

New test in `test/js/bun/repl/repl.test.ts` (`REPL history file > strips CRLF when loading existing history`) seeds `.bun_repl_history` with `"old_one\r\nold_two\r\n"`, runs `.history` + a new entry + `.exit`, then asserts:
- `.history` output lines contain no `\r`
- the saved file contains no `\r` and splits to exactly `["old_one","old_two","new_three"]`

```
# without fix (canary da3851e57)
(fail) REPL history file > strips CRLF when loading existing history
  Expected to not contain: "\r"
  Received: "     1  old_one\r"

# with fix (debug build of this branch, rebased on f426a8e173)
(pass) REPL history file > strips CRLF when loading existing history

# full suite
149 pass / 0 fail
```

Closes #30293.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts

<!-- robobun:evidence:end -->
