### PR TITLE
HTMLRewriter: stop protecting handler exceptions stored in the rejection-capture slot

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1261,11 +1261,13 @@ where
                 let exc_value = JSValue::from_cell(exc.as_ptr());
                 // Store the exception in the VM's unhandled rejection capture
                 // mechanism if it's available (this is the same mechanism used
-                // by BufferOutputSink)
+                // by BufferOutputSink). The slot is `sink_error` on
+                // `BufferOutputSink::init`'s stack; the conservative scanner
+                // roots it, so no `.protect()` is needed (matching
+                // `on_quiet_unhandled_rejection_handler_capture_value`).
                 if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
                     // SAFETY: VM-owned pointer set by BufferOutputSink::init.
                     unsafe { *err_ptr = exc_value };
-                    exc_value.protect();
                 }
             }
             // Clear the exception from the scope to prevent assertion failures
@@ -1283,7 +1285,6 @@ where
         if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
             // SAFETY: VM-owned pointer set by BufferOutputSink::init.
             unsafe { *err_ptr = exc_value };
-            exc_value.protect();
         }
         // Clear the exception to prevent assertion failures
         scope.clear_exception();
@@ -1423,14 +1424,10 @@ fn create_lolhtml_error(global: &JSGlobalObject, message: &dyn core::fmt::Displa
         // SAFETY: VM-owned pointer; valid while VM lives.
         let slot = unsafe { &mut *err_ptr };
         if !slot.is_empty() {
-            // Either a protected callback exception captured by
-            // `handler_callback`, or an unprotected promise rejection reason
-            // captured by the VM rejection handler.
+            // Either a callback exception captured by `handler_callback`, or a
+            // promise-rejection reason captured by the VM rejection handler.
             let result = *slot;
             *slot = JSValue::ZERO;
-            if result.is_exception(core::ptr::from_ref(global.vm()).cast_mut()) {
-                result.unprotect();
-            }
             return result;
         }
     }

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1261,8 +1261,7 @@ where
                 let exc_value = JSValue::from_cell(exc.as_ptr());
                 // Store the exception in the VM's unhandled rejection capture
                 // mechanism if it's available (this is the same mechanism used
-                // by BufferOutputSink). The slot is stack-rooted in
-                // `BufferOutputSink::init`; no `.protect()` needed.
+                // by BufferOutputSink)
                 if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
                     // SAFETY: VM-owned pointer set by BufferOutputSink::init.
                     unsafe { *err_ptr = exc_value };

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1261,10 +1261,8 @@ where
                 let exc_value = JSValue::from_cell(exc.as_ptr());
                 // Store the exception in the VM's unhandled rejection capture
                 // mechanism if it's available (this is the same mechanism used
-                // by BufferOutputSink). The slot is `sink_error` on
-                // `BufferOutputSink::init`'s stack; the conservative scanner
-                // roots it, so no `.protect()` is needed (matching
-                // `on_quiet_unhandled_rejection_handler_capture_value`).
+                // by BufferOutputSink). The slot is stack-rooted in
+                // `BufferOutputSink::init`; no `.protect()` needed.
                 if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
                     // SAFETY: VM-owned pointer set by BufferOutputSink::init.
                     unsafe { *err_ptr = exc_value };
@@ -1424,8 +1422,6 @@ fn create_lolhtml_error(global: &JSGlobalObject, message: &dyn core::fmt::Displa
         // SAFETY: VM-owned pointer; valid while VM lives.
         let slot = unsafe { &mut *err_ptr };
         if !slot.is_empty() {
-            // Either a callback exception captured by `handler_callback`, or a
-            // promise-rejection reason captured by the VM rejection handler.
             let result = *slot;
             *slot = JSValue::ZERO;
             return result;

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1423,9 +1423,14 @@ fn create_lolhtml_error(global: &JSGlobalObject, message: &dyn core::fmt::Displa
         // SAFETY: VM-owned pointer; valid while VM lives.
         let slot = unsafe { &mut *err_ptr };
         if !slot.is_empty() {
-            // it's a promise rejection
+            // Either a protected callback exception captured by
+            // `handler_callback`, or an unprotected promise rejection reason
+            // captured by the VM rejection handler.
             let result = *slot;
             *slot = JSValue::ZERO;
+            if result.is_exception(core::ptr::from_ref(global.vm()).cast_mut()) {
+                result.unprotect();
+            }
             return result;
         }
     }

--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -2,13 +2,13 @@ import { heapStats } from "bun:jsc";
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug } from "harness";
 
-// When a handler throws, handler_callback() .protect()s the JSC Exception cell
-// and parks it in the VM's rejection-capture slot so create_lolhtml_error()
-// can hand it to the caller. create_lolhtml_error() must drop that protection
-// when it takes the value; the caller re-protects before storing it in
-// tmp_sync_error, and BufferOutputSink::init() unprotects once when it throws.
-// Without the drop, every caught handler exception leaked one protected
-// Exception (and the Error it wraps) for the life of the process.
+// When a handler throws, handler_callback() parks the JSC Exception cell in the
+// VM's rejection-capture slot (a stack local in BufferOutputSink::init(),
+// conservatively scanned) so create_lolhtml_error() can hand it to the caller.
+// handler_callback() used to .protect() the stored cell, but nothing on the
+// consuming path dropped that protection, so every caught handler exception
+// leaked one protected Exception (and the Error it wraps) for the life of the
+// process.
 //
 // https://github.com/oven-sh/bun/issues/31804
 test("exceptions thrown from handlers do not leak protected Exception roots", async () => {

--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -2,6 +2,77 @@ import { heapStats } from "bun:jsc";
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug } from "harness";
 
+// When a handler throws, handler_callback() .protect()s the JSC Exception cell
+// and parks it in the VM's rejection-capture slot so create_lolhtml_error()
+// can hand it to the caller. create_lolhtml_error() must drop that protection
+// when it takes the value; the caller re-protects before storing it in
+// tmp_sync_error, and BufferOutputSink::init() unprotects once when it throws.
+// Without the drop, every caught handler exception leaked one protected
+// Exception (and the Error it wraps) for the life of the process.
+//
+// https://github.com/oven-sh/bun/issues/31804
+test("exceptions thrown from handlers do not leak protected Exception roots", async () => {
+  const code = /* js */ `
+    const { heapStats } = require("bun:jsc");
+
+    async function settle() {
+      for (let i = 0; i < 8; i++) {
+        Bun.gc(true);
+        await Bun.sleep(0);
+      }
+    }
+
+    function counts() {
+      const stats = heapStats();
+      return {
+        Exception: stats.objectTypeCounts.Exception ?? 0,
+        protectedException: stats.protectedObjectTypeCounts.Exception ?? 0,
+      };
+    }
+
+    await settle();
+    const before = counts();
+
+    let caught = 0;
+    for (let i = 0; i < 100; i++) {
+      const rewriter = new HTMLRewriter().on("div", {
+        element() {
+          throw new Error("handler failed");
+        },
+      });
+      try {
+        rewriter.transform("<div>hello</div>");
+      } catch (error) {
+        if (error?.message !== "handler failed") throw error;
+        caught++;
+      }
+    }
+
+    await settle();
+    const after = counts();
+
+    console.log(JSON.stringify({ caught, before, after }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+
+  const { caught, before, after } = JSON.parse(stdout.trim());
+  expect(caught).toBe(100);
+  // Unfixed: after.protectedException == before.protectedException + 100.
+  expect(after.protectedException).toBeLessThanOrEqual(before.protectedException);
+  expect(after.Exception).toBeLessThanOrEqual(before.Exception + 1);
+  expect(exitCode).toBe(0);
+});
+
 // Every `element.onEndTag(fn)` call JSValue::protect()s its callback. The old
 // lol-html C-API binding parked that protection in a per-call heap handler it
 // handed to lol-html as raw userdata and never freed on the success path, so


### PR DESCRIPTION
## What

When an `HTMLRewriter` handler throws and the caller catches the failed `transform()`, Bun leaks one protected JSC `Exception` root per failure. The protected exception keeps the user's `Error` alive, and both survive explicit GC, growing linearly with the number of caught handler exceptions.

```js
const { heapStats } = require("bun:jsc");
for (let i = 0; i < 100; i++) {
  try {
    new HTMLRewriter()
      .on("div", { element() { throw new Error("x"); } })
      .transform("<div>hi</div>");
  } catch {}
}
Bun.gc(true);
console.log(heapStats().protectedObjectTypeCounts.Exception); // 100
```

## Why

`handler_callback()` `.protect()`s the exception cell it stores in the VM's rejection-capture slot. Nothing on the consuming path (`create_lolhtml_error` reads the slot, `on_finished_buffering` re-protects the returned value, `BufferOutputSink::init` unprotects once) drops that first protection, so every caught throw leaves one extra root.

## Fix

Delete the two `.protect()` calls in `handler_callback`. The slot they write to is `sink_error: Cell<JSValue>` on `BufferOutputSink::init`'s stack; its address is exported into the VM struct and a heap field, so it stays in init()'s live frame and the conservative scanner roots it for the whole synchronous rewrite. The slot's other writer, `on_quiet_unhandled_rejection_handler_capture_value`, already writes unprotected; this makes both paths consistent and the existing `on_finished_buffering` protect / `init()` unprotect pair is the single balanced root.

Also drops a stale `// it's a promise rejection` comment in `create_lolhtml_error` (the slot also holds sync exceptions).

## Verification

- `USE_SYSTEM_BUN=1 bun test test/js/workerd/html-rewriter-leak.test.ts -t "exceptions thrown"` fails with `Received: 100`
- `bun bd test test/js/workerd/html-rewriter-leak.test.ts` passes
- `bun bd test test/js/workerd/html-rewriter.test.js test/js/workerd/html-rewriter-end-error.test.ts test/regression/issue/19219.test.ts test/regression/issue/21680.test.ts` passes
- `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1` clean
- `BUN_GARBAGE_COLLECTOR_LEVEL=2` delivers the thrown `Error` to the catch block intact (20/20 messages correct)

Closes #31805 by @Gusarich (rebased; the fix landed one layer up from that PR's hunk after review).

Closes #31804
Closes #31805
