### PR TITLE
bun:test: normalise test.each tables like Jest so a [] row does not wait on done()

### DIFF
--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -323,10 +323,12 @@ describe.each([
 
 ### Argument Passing
 
-How arguments are passed to your test function depends on the structure of your test cases:
+How arguments are passed to your test function depends on the shape of the table as a whole:
 
-- If a table row is an array (like `[1, 2, 3]`), each element is passed as an individual argument
-- If a row is not an array (like an object), it's passed as a single argument
+- If every row is an array (like `[[1, 2, 3], [4, 5, 9]]`), each row is spread and its elements are passed as individual arguments
+- Otherwise, each row is passed as a single argument, even if that row happens to be an array
+
+This matches Jest. If you need each row passed through unchanged regardless of its type, wrap every row in a one-element array (`[[a], [b], [c]]`).
 
 ```ts title="example.test.ts" icon="/icons/typescript.svg"
 // Array items passed as individual arguments

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -200,9 +200,7 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
             return Err(global.throw(format_args!("Expected array, got {}", this.each.to_fmt(&mut formatter))));
         }
 
-        // Match Jest's `jest-each`: rows are spread only when *every* row is an
-        // array (`table.every(Array.isArray)`); a mixed table passes each row as
-        // a single argument.
+        // Jest spreads rows only when every row is an array (`table.every(Array.isArray)`).
         let spread_rows = {
             let mut scan = this.each.array_iterator(global)?;
             let mut all_arrays = true;

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -200,11 +200,9 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
             return Err(global.throw(format_args!("Expected array, got {}", this.each.to_fmt(&mut formatter))));
         }
 
-        // Jest's `jest-each` normalises the table once up front: rows are spread
-        // only when *every* row is already an array (`table.every(Array.isArray)`);
-        // otherwise each row is passed through as a single argument. Deciding per
-        // row meant a mixed table containing `[]` spread to zero bound args, and
-        // the callback's one declared parameter was then miscounted as `done`.
+        // Match Jest's `jest-each`: rows are spread only when *every* row is an
+        // array (`table.every(Array.isArray)`); a mixed table passes each row as
+        // a single argument.
         let spread_rows = {
             let mut scan = this.each.array_iterator(global)?;
             let mut all_arrays = true;

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -199,6 +199,27 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
             let mut formatter = bun_jsc::ConsoleObject::Formatter::new(global);
             return Err(global.throw(format_args!("Expected array, got {}", this.each.to_fmt(&mut formatter))));
         }
+
+        // Jest's `jest-each` normalises the table once up front: rows are spread
+        // only when *every* row is already an array (`table.every(Array.isArray)`);
+        // otherwise each row is passed through as a single argument. Deciding per
+        // row meant a mixed table containing `[]` spread to zero bound args, and
+        // the callback's one declared parameter was then miscounted as `done`.
+        let spread_rows = {
+            let mut scan = this.each.array_iterator(global)?;
+            let mut all_arrays = true;
+            while let Some(item) = scan.next()? {
+                if item.is_empty() {
+                    break;
+                }
+                if !item.is_array() {
+                    all_arrays = false;
+                    break;
+                }
+            }
+            all_arrays
+        };
+
         let mut iter = this.each.array_iterator(global)?;
         let mut test_idx: usize = 0;
         while let Some(item) = iter.next()? {
@@ -215,7 +236,7 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
                 rooted.append(item);
                 let mut args_list: Vec<JSValue> = Vec::new();
 
-                if item.is_array() {
+                if spread_rows && item.is_array() {
                     // Spread array as args_list (matching Jest & Vitest)
                     let mut item_iter = item.array_iterator(global)?;
                     while let Some(array_item) = item_iter.next()? {

--- a/test/js/bun/test/jest-each.test.ts
+++ b/test/js/bun/test/jest-each.test.ts
@@ -60,9 +60,7 @@ describe("does not return zero", () => {
 
 describe("mixed table containing an empty array row", () => {
   // In Jest, a table whose rows are not all arrays is normalised so that each
-  // row is passed as a single argument. Bun previously decided per row, so the
-  // `[]` row spread to zero arguments and the callback's sole parameter was
-  // misread as a `done` callback, leaving the test waiting on a timeout.
+  // row is passed as a single argument.
   it.each([undefined, null, "", [], {}])("does not wait on done() for %p", v => {
     expect(typeof v).not.toBe("function");
   });

--- a/test/js/bun/test/jest-each.test.ts
+++ b/test/js/bun/test/jest-each.test.ts
@@ -57,3 +57,26 @@ describe.each(["some", "cool", "strings"])("works with describe: %s", s => {
 describe("does not return zero", () => {
   expect(it.each([1, 2])("wat", () => {})).toBeUndefined();
 });
+
+describe("mixed table containing an empty array row", () => {
+  // In Jest, a table whose rows are not all arrays is normalised so that each
+  // row is passed as a single argument. Bun previously decided per row, so the
+  // `[]` row spread to zero arguments and the callback's sole parameter was
+  // misread as a `done` callback, leaving the test waiting on a timeout.
+  const seen: unknown[] = [];
+  it.each([undefined, null, "", [], {}])("does not wait on done() for %p", v => {
+    expect(typeof v).not.toBe("function");
+    seen.push(v);
+  });
+  it("passes each row value through unchanged", () => {
+    expect(seen).toEqual([undefined, null, "", [], {}]);
+  });
+
+  const mixedSeen: unknown[][] = [];
+  it.each([["a", "b"], "c"])("wraps array rows in a mixed table: row %#", (...row) => {
+    mixedSeen.push(row);
+  });
+  it("did not spread array rows in a mixed table", () => {
+    expect(mixedSeen).toEqual([[["a", "b"]], ["c"]]);
+  });
+});

--- a/test/js/bun/test/jest-each.test.ts
+++ b/test/js/bun/test/jest-each.test.ts
@@ -63,20 +63,17 @@ describe("mixed table containing an empty array row", () => {
   // row is passed as a single argument. Bun previously decided per row, so the
   // `[]` row spread to zero arguments and the callback's sole parameter was
   // misread as a `done` callback, leaving the test waiting on a timeout.
-  const seen: unknown[] = [];
   it.each([undefined, null, "", [], {}])("does not wait on done() for %p", v => {
     expect(typeof v).not.toBe("function");
-    seen.push(v);
-  });
-  it("passes each row value through unchanged", () => {
-    expect(seen).toEqual([undefined, null, "", [], {}]);
   });
 
-  const mixedSeen: unknown[][] = [];
-  it.each([["a", "b"], "c"])("wraps array rows in a mixed table: row %#", (...row) => {
-    mixedSeen.push(row);
+  const emptyArr: never[] = [];
+  it.each([0, emptyArr])("passes %p through as the row value", v => {
+    expect(v === 0 || v === emptyArr).toBe(true);
   });
-  it("did not spread array rows in a mixed table", () => {
-    expect(mixedSeen).toEqual([[["a", "b"]], ["c"]]);
+
+  const rowA = ["a", "b"];
+  it.each([rowA, "c"])("wraps array rows in a mixed table: %p", v => {
+    expect(v === rowA || v === "c").toBe(true);
   });
 });


### PR DESCRIPTION
## Repro

```js
it.each([undefined, null, "", [], {}])("handles %p", v => {
  expect(true).toBe(true);
});
```

On `main`, the `[]` case hangs until the per-test timeout:

```
(fail) handles %p [5000.00ms]
  ^ this test timed out after 5000ms, before its done callback was called
```

## Cause

`ScopeFunctions.rs` decided per row whether to spread: `if item.is_array() { /* spread */ } else { /* single arg */ }`. For a mixed table the `[]` row spread to zero arguments, so `callback_length.saturating_sub(args_list.len())` stayed at 1 and the runner attached a `done` callback that the test body never called.

Jest's [`jest-each`](https://github.com/jestjs/jest/blob/main/packages/jest-each/src/table/array.ts) decides once for the whole table:

```js
const normaliseTable = table => isTable(table) ? table : table.map(colToRow);
const isTable = table => table.every(Array.isArray);
```

so rows in a mixed table are each passed as a single argument and the `[]` value reaches the callback intact.

## Fix

Pre-scan the table with the same `every(Array.isArray)` rule and only spread when it holds. A mixed table now passes each row value straight through; a table that is entirely arrays keeps spreading exactly as before (the all-arrays `test.each([[]])` case and the `11793` regression snapshot are unchanged).

This supersedes #30512, whose `.max(1)` adjustment stopped the hang but left the `[]` row receiving `undefined` rather than `[]` and changed the all-arrays `test.each([[]])` behaviour away from Jest.

## Verification

```
bun bd test test/js/bun/test/jest-each.test.ts          # 34 pass
bun bd test test/regression/issue/11793.test.ts         # 1 pass (snapshot unchanged)
bun bd test test/js/bun/test/jest-each-gc-root.test.ts  # 1 pass
bun bd test test/js/bun/test/bun_test.test.ts           # 5 pass
```

The new `jest-each.test.ts` cases fail on `main` (the `[]` row receives the `done` function; the mixed `["a","b"]` row is spread) and pass with this change. Cross-checked against Jest 30 and Vitest 4, which both pass `[]` through unchanged for the mixed-table case.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/jest-each.test.ts
bun test v1.4.0 (7199a7093)

test/js/bun/test/jest-each.test.ts:
(pass) jest-each > check types [2.16ms]
(pass) jest-each > 1 + 1 = 2 [1.16ms]
(pass) jest-each > 1 + 2 = 3 [0.37ms]
(pass) jest-each > 2 + 1 = 3 [0.22ms]
(pass) jest-each > with callback: 1 + 1 = 2 [2.07ms]
(pass) jest-each > with callback: 1 + 2 = 3 [0.78ms]
(pass) jest-each > with callback: 2 + 1 = 3 [0.50ms]
(pass) jest-each > a + b = ab [2.57ms]
(pass) jest-each > c + d = cd [1.04ms]
(pass) jest-each > e + f = ef [0.68ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":1,"e":2} [1.67ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":2,"e":3} [0.79ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15} [0.37ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15} [0.32ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":123,"e":125} [0.31ms]
(pass) jest-each > add two numbers with object: {"a":15,"b":13,"e":28} [0.42ms]
(pass) jest-each > stringify 0:  [0.84ms]
(pass)
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (180b72919)

test/js/bun/test/jest-each.test.ts:
(pass) jest-each > check types [0.02ms]
(pass) jest-each > 1 + 1 = 2 [0.01ms]
(pass) jest-each > 1 + 2 = 3
(pass) jest-each > 2 + 1 = 3
(pass) jest-each > with callback: 1 + 1 = 2 [0.63ms]
(pass) jest-each > with callback: 1 + 2 = 3
(pass) jest-each > with callback: 2 + 1 = 3
(pass) jest-each > a + b = ab [0.03ms]
(pass) jest-each > c + d = cd
(pass) jest-each > e + f = ef
(pass) jest-each > add two numbers with object: {"a":1,"b":1,"e":2} [0.02ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":2,"e":3}
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15}
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15}
(pass) jest-each > add two numbers with object: {"a":2,"b":123,"e":125}
(pass) jest-each > add two numbers with object: {"a":15,"b":13,"e":28}
(pass) jest-each > stringify 0:  [0.01ms]
(pass) jest-each > stringify 1: null
(pass) jest-each > stringify 2: null
(pass) jest-each > stringify 3: null
(pass) works with describe: some > has access to params : some [0.01ms]
(pass) works with describe: cool > has access to params : cool
(pass) works with 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/jest-each.test.ts
bun test v1.4.0 (7199a7093)

test/js/bun/test/jest-each.test.ts:
(pass) jest-each > check types [2.15ms]
(pass) jest-each > 1 + 1 = 2 [1.12ms]
(pass) jest-each > 1 + 2 = 3 [0.32ms]
(pass) jest-each > 2 + 1 = 3 [0.19ms]
(pass) jest-each > with callback: 1 + 1 = 2 [2.03ms]
(pass) jest-each > with callback: 1 + 2 = 3 [0.70ms]
(pass) jest-each > with callback: 2 + 1 = 3 [0.42ms]
(pass) jest-each > a + b = ab [2.32ms]
(pass) jest-each > c + d = cd [0.97ms]
(pass) jest-each > e + f = ef [0.57ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":1,"e":2} [1.80ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":2,"e":3} [0.39ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15} [0.31ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15} [0.27ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":123,"e":125} [0.27ms]
(pass) jest-each > add two numbers with object: {"a":15,"b":13,"e":28} [0.37ms]
(pass) jest-each > stringify 0:  [0.79ms]
(pass)
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 723ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/138] gen ErrorCode+*.h
[2/138] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[3/138] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindings/webcore/JSEvent.cpp
[4/138] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[5/138] gen cpp.rs (cppbind)
[6/138] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 6 sinks, 72 exported symbols
Generating /workspace/bun/build/release/codegen/JSSink.lut.h from /workspace/bun/build/release/codegen/JSSink.lut.txt
[7/138] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[8/138] gen JS modules (bundle-modules)
Preprocess modules (8810ms)
Bundle modules (51ms)
Postprocesss modules (205ms)
Bundle Functions (752ms)
Generate Code (39ms)

[9.88s] Bundled "src/js" for production
  2569 kb
  193 internal modules
  13
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/test/writing-tests.mdx               |  8 +++++---
 src/runtime/test_runner/ScopeFunctions.rs | 19 ++++++++++++++++++-
 test/js/bun/test/jest-each.test.ts        | 18 ++++++++++++++++++
 3 files changed, 41 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
docs/test/writing-tests.mdx                    1      1      0
src/runtime/test_runner/ScopeFunctions.rs      3      3      0
test/js/bun/test/jest-each.test.ts             1      4      0
```

</details>

<!-- robobun:evidence:end -->