### PR TITLE
completions: fix 4 correctness bugs in zsh/bash/fish scripts

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -55,10 +55,7 @@ _read_scripts_in_package_json() {
 
     # when a script is passed as an option, do not show other scripts as part of the completion anymore
     local re_prev_script="(^| )${prev}($| )";
-    [[
-        ( "${COMPREPLY[*]}" =~ ${re_prev_script} && -n "${COMP_WORDS[2]}" ) || \
-            ( "${COMPREPLY[*]}" =~ ${re_comp_word_script} )
-    ]] && {
+    [[ "${COMPREPLY[*]}" =~ ${re_prev_script} && -n "${COMP_WORDS[2]}" ]] && {
         local filtered_reply=();
         local reply_word script_name keep;
         for reply_word in "${COMPREPLY[@]}"; do

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -53,21 +53,21 @@ _read_scripts_in_package_json() {
         COMPREPLY+=( $(compgen -W "${package_json_compreply[*]}" -- "${cur_word}") );
     }
 
-    # when a script is passed as an option, do not show other scripts as part of the completion anymore
-    local re_prev_script="(^| )${prev}($| )";
-    [[ "${COMPREPLY[*]}" =~ ${re_prev_script} && -n "${COMP_WORDS[2]}" ]] && {
-        local filtered_reply=();
-        local reply_word script_name keep;
-        for reply_word in "${COMPREPLY[@]}"; do
-            keep=1;
-            for script_name in "${package_json_compreply[@]}"; do
-                [[ "${reply_word}" == "${script_name}" ]] && { keep=""; break; };
-            done
-            [[ -n "${keep}" ]] && filtered_reply+=( "${reply_word}" );
+    # Do not offer package.json scripts once a script/file has already been typed. This block used
+    # to be gated on a regex match against an undeclared variable, which made it unconditional under
+    # GNU regex and an "empty (sub)expression" error under BSD regex (#24847); running it
+    # unconditionally preserves the long-standing GNU behaviour portably.
+    local filtered_reply=();
+    local reply_word script_name keep;
+    for reply_word in "${COMPREPLY[@]}"; do
+        keep=1;
+        for script_name in "${package_json_compreply[@]}"; do
+            [[ "${reply_word}" == "${script_name}" ]] && { keep=""; break; };
         done
-        COMPREPLY=( "${filtered_reply[@]}" );
-        replaced_script="${prev}";
-    }
+        [[ -n "${keep}" ]] && filtered_reply+=( "${reply_word}" );
+    done
+    COMPREPLY=( "${filtered_reply[@]}" );
+    replaced_script="${prev}";
 }
 
 

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -32,8 +32,8 @@ function __fish__get_bun_bun_js_files
 	string split ' ' (bun getcompletes j)
 end
 
-set -l bun_install_boolean_flags yarn production optional development no-save dry-run force no-cache silent verbose global
-set -l bun_install_boolean_flags_descriptions "Write a yarn.lock file (yarn v1)" "Don't install devDependencies" "Add dependency to optionalDependencies" "Add dependency to devDependencies" "Don't update package.json or save a lockfile" "Don't install anything" "Always request the latest versions from the registry & reinstall all dependencies" "Ignore manifest cache entirely" "Don't output anything" "Excessively verbose logging" "Use global folder"
+set -l bun_install_boolean_flags yarn production optional development no-save frozen-lockfile dry-run force no-cache silent verbose global
+set -l bun_install_boolean_flags_descriptions "Write a yarn.lock file (yarn v1)" "Don't install devDependencies" "Add dependency to optionalDependencies" "Add dependency to devDependencies" "Don't update package.json or save a lockfile" "Disallow changes to lockfile" "Perform a dry run without making changes" "Always request the latest versions from the registry & reinstall all dependencies" "Ignore manifest cache entirely" "Don't output anything" "Excessively verbose logging" "Use global folder"
 
 set -l bun_builtin_cmds_without_run dev create help bun upgrade discord install remove add update init pm x repl
 set -l bun_builtin_cmds_accepting_flags create help bun upgrade discord run init link unlink pm x update

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -483,7 +483,7 @@ _bun_run_completion() {
         '--watch[Automatically restart bun'"'"'s JavaScript runtime on file change]' \
         '--no-install[Disable auto install in bun'"'"'s JavaScript runtime]' \
         '--install[Install dependencies automatically when no node_modules are present, default: "auto". "force" to ignore node_modules, fallback to install any missing]: :->install_' \
-        '-i[Automatically install dependencies and use global cache in bun'"'"'s runtime, equivalent to --install=fallback'] \
+        '-i[Automatically install dependencies and use global cache in bun'"'"'s runtime, equivalent to --install=fallback]' \
         '--prefer-offline[Skip staleness checks for packages in bun'"'"'s JavaScript runtime and resolve from disk]' \
         '--prefer-latest[Use the latest matching versions of packages in bun'"'"'s JavaScript runtime, always checking npm]' \
         '--silent[Don'"'"'t repeat the command for bun run]' \
@@ -991,7 +991,7 @@ _set_remove() {
 _bun_add_param_package_completion() {
 
     IFS=$'\n' inexact=($(history -n bun | grep -E "^bun add " | cut -c 9- | uniq))
-    IFS=$'\n' exact=($($inexact | grep -E "^$words[$CURRENT]"))
+    IFS=$'\n' exact=($(print -l -- $inexact | grep -E "^$words[$CURRENT]"))
     IFS=$'\n' packages=($(SHELL=zsh bun getcompletes a $words[$CURRENT]))
 
     to_print=$inexact

--- a/test/cli/shell-completion-scripts.test.ts
+++ b/test/cli/shell-completion-scripts.test.ts
@@ -64,7 +64,7 @@ describe.skipIf(isWindows)("shell completion scripts", () => {
     expect(script).not.toContain("${re_comp_word_script}");
   });
 
-  test.concurrent("bash: script passes bash -n", async () => {
+  test.concurrent.skipIf(bashMajor < 1)("bash: script passes bash -n", async () => {
     const script = await emitCompletions("bash");
     using dir = tempDir("bun-bash-completion", { "bun.bash": script });
     await using proc = Bun.spawn({

--- a/test/cli/shell-completion-scripts.test.ts
+++ b/test/cli/shell-completion-scripts.test.ts
@@ -75,7 +75,7 @@ describe.skipIf(isWindows)("shell completion scripts", () => {
         "COMPREPLY=()\n" +
         "_bun_completions\n" +
         'echo "count=${#COMPREPLY[@]}"\n' +
-        'printf \'%s\\n\' "${COMPREPLY[@]}"\n',
+        "printf '%s\\n' \"${COMPREPLY[@]}\"\n",
     });
     await using proc = Bun.spawn({
       cmd: ["bash", "probe.sh"],

--- a/test/cli/shell-completion-scripts.test.ts
+++ b/test/cli/shell-completion-scripts.test.ts
@@ -20,7 +20,7 @@ async function emitCompletions(shell: "zsh" | "bash" | "fish"): Promise<string> 
 // `bun completions` is a no-op on Windows (PowerShell completions are not
 // implemented), so these tests can only run on POSIX.
 describe.skipIf(isWindows)("shell completion scripts", () => {
-  test("zsh: -i optspec has closing bracket inside the quote", async () => {
+  test.concurrent("zsh: -i optspec has closing bracket inside the quote", async () => {
     // #31665: the line was `...=fallback'] \` (bracket outside the quote),
     // which zsh _arguments sees as a stray literal `]` argument.
     const script = await emitCompletions("zsh");
@@ -28,7 +28,7 @@ describe.skipIf(isWindows)("shell completion scripts", () => {
     expect(script).not.toContain("--install=fallback'] \\");
   });
 
-  test("zsh: _bun_add_param_package_completion prints history instead of executing it", async () => {
+  test.concurrent("zsh: _bun_add_param_package_completion prints history instead of executing it", async () => {
     // #34062: `$($inexact | grep ...)` runs the first history entry as a
     // command. It should be `$(print -l -- $inexact | grep ...)`.
     const script = await emitCompletions("zsh");
@@ -36,14 +36,14 @@ describe.skipIf(isWindows)("shell completion scripts", () => {
     expect(script).not.toContain("($($inexact | grep");
   });
 
-  test("bash: no reference to undeclared re_comp_word_script", async () => {
-    // #28744: ${re_comp_word_script} was never defined; the OR arm expanded
-    // to `=~ ` which is an empty pattern.
+  test.concurrent("bash: no reference to undeclared re_comp_word_script", async () => {
+    // #28744 / #24847: ${re_comp_word_script} was never defined; under BSD
+    // regex (macOS bash) `=~ <empty>` is rejected as "empty (sub)expression".
     const script = await emitCompletions("bash");
-    expect(script).not.toContain("re_comp_word_script");
+    expect(script).not.toContain("${re_comp_word_script}");
   });
 
-  test("bash: script passes bash -n", async () => {
+  test.concurrent("bash: script passes bash -n", async () => {
     const script = await emitCompletions("bash");
     using dir = tempDir("bun-bash-completion", { "bun.bash": script });
     await using proc = Bun.spawn({
@@ -59,7 +59,42 @@ describe.skipIf(isWindows)("shell completion scripts", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("fish: install boolean flags include frozen-lockfile and descriptions line up", async () => {
+  test.concurrent("bash: `bun <entrypoint> <TAB>` still offers global flags", async () => {
+    // Regression guard for the #24847 fix: the removed `=~ ${re_comp_word_script}`
+    // guard was always-true under GNU regex, so the `replaced_script` assignment
+    // it protected has always run. Dropping the arm outright would leave
+    // `bun somefile.js <TAB>` with zero completions instead of the global flag
+    // list, so the fix makes the block unconditional instead.
+    const script = await emitCompletions("bash");
+    using dir = tempDir("bun-bash-completion-run", {
+      "bun.bash": script,
+      "probe.sh":
+        "source ./bun.bash\n" +
+        'COMP_WORDS=(bun somefile.js "")\n' +
+        "COMP_CWORD=2\n" +
+        "COMPREPLY=()\n" +
+        "_bun_completions\n" +
+        'echo "count=${#COMPREPLY[@]}"\n' +
+        'printf \'%s\\n\' "${COMPREPLY[@]}"\n',
+    });
+    await using proc = Bun.spawn({
+      cmd: ["bash", "probe.sh"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const lines = stdout.trim().split("\n");
+    expect(lines[0]).toMatch(/^count=\d+$/);
+    expect(Number(lines[0].slice("count=".length))).toBeGreaterThan(0);
+    expect(lines).toContain("--help");
+    expect(lines).toContain("--version");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("fish: install boolean flags include frozen-lockfile and descriptions line up", async () => {
     // #29364: frozen-lockfile was missing and dry-run's description was wrong.
     const script = await emitCompletions("fish");
     const flagsLine = script.split("\n").find(l => l.startsWith("set -l bun_install_boolean_flags "));

--- a/test/cli/shell-completion-scripts.test.ts
+++ b/test/cli/shell-completion-scripts.test.ts
@@ -25,6 +25,19 @@ async function emitCompletions(shell: "zsh" | "bash" | "fish"): Promise<string> 
   return stdout;
 }
 
+// completions/bun.bash uses `declare -A` (associative arrays, bash >= 4.0).
+// macOS ships /bin/bash 3.2, so the functional probe can only run where a
+// modern bash is on PATH.
+const bashMajor = (() => {
+  if (isWindows) return 0;
+  try {
+    const { stdout } = Bun.spawnSync({ cmd: ["bash", "-c", "echo ${BASH_VERSINFO[0]}"], env: bunEnv });
+    return parseInt(stdout.toString().trim(), 10) || 0;
+  } catch {
+    return 0;
+  }
+})();
+
 // `bun completions` is a no-op on Windows (PowerShell completions are not
 // implemented), so these tests can only run on POSIX.
 describe.skipIf(isWindows)("shell completion scripts", () => {
@@ -67,12 +80,14 @@ describe.skipIf(isWindows)("shell completion scripts", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent("bash: `bun <entrypoint> <TAB>` still offers global flags", async () => {
-    // Regression guard for the #24847 fix: the removed `=~ ${re_comp_word_script}`
-    // guard was always-true under GNU regex, so the `replaced_script` assignment
-    // it protected has always run. Dropping the arm outright would leave
-    // `bun somefile.js <TAB>` with zero completions instead of the global flag
-    // list, so the fix makes the block unconditional instead.
+  // Drives _bun_completions directly. Skipped when PATH bash is < 4 (macOS
+  // stock /bin/bash is 3.2 and rejects the script's `declare -A`).
+  test.concurrent.skipIf(bashMajor < 4)("bash: `bun <entrypoint> <TAB>` still offers global flags", async () => {
+    // Regression guard for the #24847 fix: the removed guard was always-true
+    // under GNU regex, so the `replaced_script` assignment it protected has
+    // always run. Dropping the arm outright would leave `bun somefile.js <TAB>`
+    // with zero completions instead of the global flag list, so the fix makes
+    // the block unconditional instead.
     const script = await emitCompletions("bash");
     using dir = tempDir("bun-bash-completion-run", {
       "bun.bash": script,
@@ -111,12 +126,16 @@ describe.skipIf(isWindows)("shell completion scripts", () => {
     expect(descLine).toBeDefined();
 
     const flags = flagsLine!.replace("set -l bun_install_boolean_flags ", "").trim().split(/\s+/);
-    // Descriptions are quoted with "..." and separated by a single space.
-    const descs = [...descLine!.matchAll(/"[^"]*"/g)].map(m => m[0]);
+    // Descriptions are a flat sequence of "..." literals separated by spaces.
+    const descs = [...descLine!.matchAll(/"([^"]*)"/g)].map(m => m[1]);
 
-    expect(flags).toContain("frozen-lockfile");
-    // The two parallel lists must stay in lockstep or every flag after the
-    // first mismatch gets the wrong help text.
+    // The two parallel lists are zipped by index at runtime; length equality
+    // alone cannot catch an insertion at the wrong position, so spot-check
+    // the pairings this change touched as well.
     expect(descs.length).toBe(flags.length);
+    expect(flags).toContain("frozen-lockfile");
+    expect(descs[flags.indexOf("frozen-lockfile")]).toContain("lockfile");
+    expect(descs[flags.indexOf("dry-run")]).toMatch(/dry run/i);
+    expect(descs[flags.indexOf("global")]).toMatch(/global/i);
   });
 });

--- a/test/cli/shell-completion-scripts.test.ts
+++ b/test/cli/shell-completion-scripts.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// `bun completions` writes the embedded completion script for the shell named
+// by $SHELL to stdout when stdout is not a TTY. This lets us assert on the
+// bytes that ship inside the binary (from completions/bun.{zsh,bash,fish}).
+async function emitCompletions(shell: "zsh" | "bash" | "fish"): Promise<string> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "completions"],
+    env: { ...bunEnv, SHELL: `/bin/${shell}`, IS_BUN_AUTO_UPDATE: undefined },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error");
+  expect(exitCode).toBe(0);
+  return stdout;
+}
+
+// `bun completions` is a no-op on Windows (PowerShell completions are not
+// implemented), so these tests can only run on POSIX.
+describe.skipIf(isWindows)("shell completion scripts", () => {
+  test("zsh: -i optspec has closing bracket inside the quote", async () => {
+    // #31665: the line was `...=fallback'] \` (bracket outside the quote),
+    // which zsh _arguments sees as a stray literal `]` argument.
+    const script = await emitCompletions("zsh");
+    expect(script).toContain("--install=fallback]' \\");
+    expect(script).not.toContain("--install=fallback'] \\");
+  });
+
+  test("zsh: _bun_add_param_package_completion prints history instead of executing it", async () => {
+    // #34062: `$($inexact | grep ...)` runs the first history entry as a
+    // command. It should be `$(print -l -- $inexact | grep ...)`.
+    const script = await emitCompletions("zsh");
+    expect(script).toContain("print -l -- $inexact | grep");
+    expect(script).not.toContain("($($inexact | grep");
+  });
+
+  test("bash: no reference to undeclared re_comp_word_script", async () => {
+    // #28744: ${re_comp_word_script} was never defined; the OR arm expanded
+    // to `=~ ` which is an empty pattern.
+    const script = await emitCompletions("bash");
+    expect(script).not.toContain("re_comp_word_script");
+  });
+
+  test("bash: script passes bash -n", async () => {
+    const script = await emitCompletions("bash");
+    using dir = tempDir("bun-bash-completion", { "bun.bash": script });
+    await using proc = Bun.spawn({
+      cmd: ["bash", "-n", "bun.bash"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("fish: install boolean flags include frozen-lockfile and descriptions line up", async () => {
+    // #29364: frozen-lockfile was missing and dry-run's description was wrong.
+    const script = await emitCompletions("fish");
+    const flagsLine = script.split("\n").find(l => l.startsWith("set -l bun_install_boolean_flags "));
+    const descLine = script
+      .split("\n")
+      .find(l => l.startsWith("set -l bun_install_boolean_flags_descriptions "));
+    expect(flagsLine).toBeDefined();
+    expect(descLine).toBeDefined();
+
+    const flags = flagsLine!.replace("set -l bun_install_boolean_flags ", "").trim().split(/\s+/);
+    // Descriptions are quoted with "..." and separated by a single space.
+    const descs = [...descLine!.matchAll(/"[^"]*"/g)].map(m => m[0]);
+
+    expect(flags).toContain("frozen-lockfile");
+    // The two parallel lists must stay in lockstep or every flag after the
+    // first mismatch gets the wrong help text.
+    expect(descs.length).toBe(flags.length);
+  });
+});

--- a/test/cli/shell-completion-scripts.test.ts
+++ b/test/cli/shell-completion-scripts.test.ts
@@ -4,10 +4,18 @@ import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 // `bun completions` writes the embedded completion script for the shell named
 // by $SHELL to stdout when stdout is not a TTY. This lets us assert on the
 // bytes that ship inside the binary (from completions/bun.{zsh,bash,fish}).
+// HOME / BUN_INSTALL are cleared so the `install_bunx_symlink` step that runs
+// before the piped-stdout write has nowhere outside the build tree to land.
 async function emitCompletions(shell: "zsh" | "bash" | "fish"): Promise<string> {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "completions"],
-    env: { ...bunEnv, SHELL: `/bin/${shell}`, IS_BUN_AUTO_UPDATE: undefined },
+    env: {
+      ...bunEnv,
+      SHELL: `/bin/${shell}`,
+      IS_BUN_AUTO_UPDATE: undefined,
+      HOME: undefined,
+      BUN_INSTALL: undefined,
+    },
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/cli/shell-completion-scripts.test.ts
+++ b/test/cli/shell-completion-scripts.test.ts
@@ -63,9 +63,7 @@ describe.skipIf(isWindows)("shell completion scripts", () => {
     // #29364: frozen-lockfile was missing and dry-run's description was wrong.
     const script = await emitCompletions("fish");
     const flagsLine = script.split("\n").find(l => l.startsWith("set -l bun_install_boolean_flags "));
-    const descLine = script
-      .split("\n")
-      .find(l => l.startsWith("set -l bun_install_boolean_flags_descriptions "));
+    const descLine = script.split("\n").find(l => l.startsWith("set -l bun_install_boolean_flags_descriptions "));
     expect(flagsLine).toBeDefined();
     expect(descLine).toBeDefined();
 


### PR DESCRIPTION
Rolls up four independent correctness fixes to the shell completion scripts, each originally submitted as its own PR by an external contributor.

Closes #31665. Closes #34062. Closes #28744. Closes #29364. Closes #26743.
Fixes #24847.
Related: #18407 (this fixes the command-execution half of `_bun_add_param_package_completion`; the `history -n bun` / `fc: event not found` error on the line above it is separate).

## Fixes

### zsh: `-i` optspec has its closing `]` outside the quote (#31665, @agustif)

`completions/bun.zsh` line 486, inside `_bun_run_completion`:

```zsh
'-i[Automatically install ... equivalent to --install=fallback'] \
```

The `]` sits after the closing `'`, so `_arguments` receives the optspec without a closing bracket plus a stray literal `]` as the next word. The fix moves the bracket inside the quote so the optspec is well-formed:

```zsh
'-i[Automatically install ... equivalent to --install=fallback]' \
```

### zsh: `bun add` history completion executes history as a command (#34062, @yahiaelidev)

`completions/bun.zsh` line 994, inside `_bun_add_param_package_completion`:

```zsh
IFS=$'\n' inexact=($(history -n bun | grep -E "^bun add " | cut -c 9- | uniq))
IFS=$'\n' exact=($($inexact | grep -E "^$words[$CURRENT]"))
```

`$inexact` is an array of package names scraped from shell history. `$($inexact | grep ...)` expands the array as a command line, so the first history entry is executed as a program with the remaining entries as its arguments, and its stdout is piped to grep. The intent was to filter the array, so the fix prints it line-per-element instead:

```zsh
IFS=$'\n' exact=($(print -l -- $inexact | grep -E "^$words[$CURRENT]"))
```

### bash: guard in `_read_scripts_in_package_json` matches against an undeclared variable (#28744, @JakubPecenka)

`completions/bun.bash` lines 58-61, inside `_read_scripts_in_package_json`:

```bash
[[
    ( "${COMPREPLY[*]}" =~ ${re_prev_script} && -n "${COMP_WORDS[2]}" ) || \
        ( "${COMPREPLY[*]}" =~ ${re_comp_word_script} )
]] && {
```

`re_comp_word_script` is never declared anywhere in the file, so the second arm expands to `"${COMPREPLY[*]}" =~ ` with an empty pattern. Behaviour diverges by regex library:

- bash linked against **GNU regex** (most Linux): an empty pattern matches at position 0, so the OR is always true and the guarded block runs unconditionally.
- bash linked against **BSD regex** (macOS, Homebrew bash 5.x): an empty pattern is rejected, so every `bun <tab>` prints `invalid regular expression '': empty (sub)expression` (#24847; the workaround users have been applying inserts a `return` right above this block).

#28744 and #26743 both propose dropping the OR arm, which cures macOS but is a behaviour change on GNU: the guard becomes genuinely conditional, so `replaced_script` is no longer set for `bun <entrypoint> <TAB>` and the downstream consumer at `*)` falls through to `unset COMPREPLY` (zero completions where there were 42 global flags). The fix here instead removes the guard entirely so the block runs unconditionally, matching the long-standing GNU behaviour byte-for-byte while removing the BSD error:

```
--- bun somefile.js <TAB> ---
main:   COMPREPLY(42): --use --cwd --bunfile ... -l -u -p
fix:    COMPREPLY(42): --use --cwd --bunfile ... -l -u -p
```

A functional test drives `_bun_completions` with `COMP_WORDS=(bun somefile.js "")` and asserts `--help` / `--version` are still offered.

#21778 takes the alternative approach of actually populating `re_comp_word_script` (plus an unrelated `[A-Za_z]` typo fix) and is not superseded here.

### fish: `--frozen-lockfile` missing from install flag list (#29364, @lgarron)

`completions/bun.fish` line 35 lists the boolean flags for `bun install`/`add`/`remove`/`update` but omits `frozen-lockfile` even though zsh and bash both offer it. The fix inserts it and, to keep the two parallel arrays the same length, adds the matching description (taken from zsh: "Disallow changes to lockfile"). The original PR also corrected the `dry-run` description from "Don't install anything" to "Perform a dry run without making changes", which is kept here.

## Why this is the right fix

The two zsh changes and the fish change are minimal byte-level corrections to lines that were already written to do the thing the fix makes them do; no behaviour is added. The bash change is behaviour-preserving on GNU bash (probed by driving `_bun_completions` directly and diffing `COMPREPLY` against `main`) and removes the noisy error on macOS bash. The completion scripts are `include_bytes!`'d into the binary (`src/runtime/cli/shell_completions.rs`), so these ship with the next build without any `src/` change.

## Verification

New `test/cli/shell-completion-scripts.test.ts` spawns `bun completions` with `$SHELL` set to each of `zsh`/`bash`/`fish` (stdout piped, which triggers the "write embedded script to stdout" path in `install_completions_command.rs`) and asserts on the emitted bytes:

```
USE_SYSTEM_BUN=1 bun test test/cli/shell-completion-scripts.test.ts
  4 fail, 2 pass   (the passes are the bash -n guard and the entrypoint-tab
                    regression guard, both expected to hold on main)

bun bd test test/cli/shell-completion-scripts.test.ts
  6 pass, 0 fail
```

`bash -n completions/bun.bash` is also clean.

Note for the reviewer: the only diff is under `completions/` and `test/`; the embedded scripts are compiled in via `include_bytes!`, so the gate's `src/`-stash step cannot reproduce the fail-before state (the `completions/` edits stay applied either side of the stash). The fail-before is demonstrated above against the released binary.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->