### PR TITLE
fix(node:perf_hooks): report nodeTiming milestones as offsets from timeOrigin

### DIFF
--- a/src/js/node/perf_hooks.ts
+++ b/src/js/node/perf_hooks.ts
@@ -79,7 +79,8 @@ class PerformanceNodeTiming {
   }
 
   get startTime() {
-    return this.nodeStart;
+    // A "node" entry is the timeOrigin reference, so its startTime is always 0.
+    return 0;
   }
 
   get duration() {
@@ -107,11 +108,26 @@ if (PerformanceEntry) {
   Object.setPrototypeOf(PerformanceNodeTiming, PerformanceEntry);
 }
 
+// Node exposes the entry accessors as own enumerable properties of the
+// nodeTiming object, not only on the prototype. Null-prototype descriptors so
+// prototype pollution before this module loads cannot inject extra keys.
+const performanceNodeTimingEntryDescriptors = {
+  __proto__: null,
+  name: { __proto__: null, get: () => "node", configurable: true, enumerable: true },
+  entryType: { __proto__: null, get: () => "node", configurable: true, enumerable: true },
+  startTime: { __proto__: null, get: () => 0, configurable: true, enumerable: true },
+  duration: { __proto__: null, get: () => performance.now(), configurable: true, enumerable: true },
+};
+
 function createPerformanceNodeTiming() {
   const object = Object.create(PerformanceNodeTiming.prototype);
+  Object.defineProperties(object, performanceNodeTimingEntryDescriptors);
 
-  object.bootstrapComplete = object.environment = object.nodeStart = object.v8Start = performance.timeOrigin;
-  object.loopStart = object.idleTime = 1;
+  // Milestones are offsets in milliseconds from performance.timeOrigin, not
+  // absolute epoch timestamps. Bun does not record the individual startup
+  // milestones, so report them relative to the process start (0).
+  object.nodeStart = object.v8Start = object.environment = object.bootstrapComplete = 0;
+  object.loopStart = object.idleTime = 0;
   object.loopExit = -1;
   return object;
 }

--- a/src/js/node/perf_hooks.ts
+++ b/src/js/node/perf_hooks.ts
@@ -108,10 +108,7 @@ if (PerformanceEntry) {
   Object.setPrototypeOf(PerformanceNodeTiming, PerformanceEntry);
 }
 
-// Node exposes name/entryType/startTime as own enumerable data properties of
-// the nodeTiming object (writable:false), and duration as an own enumerable
-// getter. Null-prototype descriptors so prototype pollution before this module
-// loads cannot inject extra keys.
+// Own-property shape taken from Node's lib/internal/perf/nodetiming.js.
 const performanceNodeTimingEntryDescriptors = {
   __proto__: null,
   name: { __proto__: null, value: "node", enumerable: true, configurable: true },
@@ -124,9 +121,7 @@ function createPerformanceNodeTiming() {
   const object = Object.create(PerformanceNodeTiming.prototype);
   Object.defineProperties(object, performanceNodeTimingEntryDescriptors);
 
-  // Milestones are offsets in milliseconds from performance.timeOrigin, not
-  // absolute epoch timestamps. Bun does not record the individual startup
-  // milestones, so report them relative to the process start (0).
+  // Milestones are ms offsets from timeOrigin; Bun doesn't record them yet.
   object.nodeStart = object.v8Start = object.environment = object.bootstrapComplete = 0;
   object.loopStart = object.idleTime = 0;
   object.loopExit = -1;

--- a/src/js/node/perf_hooks.ts
+++ b/src/js/node/perf_hooks.ts
@@ -108,15 +108,16 @@ if (PerformanceEntry) {
   Object.setPrototypeOf(PerformanceNodeTiming, PerformanceEntry);
 }
 
-// Node exposes the entry accessors as own enumerable properties of the
-// nodeTiming object, not only on the prototype. Null-prototype descriptors so
-// prototype pollution before this module loads cannot inject extra keys.
+// Node exposes name/entryType/startTime as own enumerable data properties of
+// the nodeTiming object (writable:false), and duration as an own enumerable
+// getter. Null-prototype descriptors so prototype pollution before this module
+// loads cannot inject extra keys.
 const performanceNodeTimingEntryDescriptors = {
   __proto__: null,
-  name: { __proto__: null, get: () => "node", configurable: true, enumerable: true },
-  entryType: { __proto__: null, get: () => "node", configurable: true, enumerable: true },
-  startTime: { __proto__: null, get: () => 0, configurable: true, enumerable: true },
-  duration: { __proto__: null, get: () => performance.now(), configurable: true, enumerable: true },
+  name: { __proto__: null, value: "node", enumerable: true, configurable: true },
+  entryType: { __proto__: null, value: "node", enumerable: true, configurable: true },
+  startTime: { __proto__: null, value: 0, enumerable: true, configurable: true },
+  duration: { __proto__: null, get: () => performance.now(), enumerable: true, configurable: true },
 };
 
 function createPerformanceNodeTiming() {

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -11,6 +11,46 @@ test("stubs", () => {
   expect(perf.performance.eventLoopUtilization()).toBeObject();
 });
 
+// https://github.com/oven-sh/bun/issues/23041
+test("nodeTiming reports offsets from timeOrigin, not epoch timestamps", () => {
+  const nt = perf.performance.nodeTiming;
+
+  expect(nt.name).toBe("node");
+  expect(nt.entryType).toBe("node");
+  // A "node" entry is the timeOrigin reference, so startTime is 0 in Node.
+  expect(nt.startTime).toBe(0);
+  expect(nt.duration).toBeNumber();
+
+  // timeOrigin is epoch-scale; the milestones are offsets from it, so they must
+  // not themselves be epoch timestamps.
+  expect(perf.performance.timeOrigin).toBeGreaterThan(1e12);
+  for (const key of ["nodeStart", "v8Start", "environment", "bootstrapComplete", "loopStart", "idleTime"] as const) {
+    expect(nt[key]).toBeNumber();
+    expect(nt[key]).toBeLessThan(1e12);
+  }
+  expect(nt.loopExit).toBe(-1);
+
+  // Node exposes the entry accessors as own enumerable properties.
+  expect(Object.keys(nt)).toEqual(expect.arrayContaining(["name", "entryType", "startTime", "duration"]));
+
+  const json = nt.toJSON();
+  // duration is a live reading, so assert its type and drop it before comparing.
+  expect(json.duration).toBeNumber();
+  delete json.duration;
+  expect(json).toEqual({
+    name: "node",
+    entryType: "node",
+    startTime: 0,
+    nodeStart: nt.nodeStart,
+    v8Start: nt.v8Start,
+    bootstrapComplete: nt.bootstrapComplete,
+    environment: nt.environment,
+    loopStart: nt.loopStart,
+    loopExit: nt.loopExit,
+    idleTime: nt.idleTime,
+  });
+});
+
 test("doesn't throw", () => {
   expect(() => performance.mark("test")).not.toThrow();
   expect(() => performance.measure("test", "test")).not.toThrow();

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -32,7 +32,11 @@ test("nodeTiming reports offsets from timeOrigin, not epoch timestamps", () => {
 
   // Node defines name/entryType/startTime as own data properties
   // (writable:false) and duration as an own getter.
-  for (const [key, value] of [["name", "node"], ["entryType", "node"], ["startTime", 0]] as const) {
+  for (const [key, value] of [
+    ["name", "node"],
+    ["entryType", "node"],
+    ["startTime", 0],
+  ] as const) {
     expect({ key, ...Object.getOwnPropertyDescriptor(nt, key) }).toEqual({
       key,
       value,

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -19,7 +19,7 @@ test("nodeTiming reports offsets from timeOrigin, not epoch timestamps", () => {
   expect(nt.entryType).toBe("node");
   // A "node" entry is the timeOrigin reference, so startTime is 0 in Node.
   expect(nt.startTime).toBe(0);
-  expect(nt.duration).toBeNumber();
+  expect(nt.duration).toBeGreaterThan(0);
 
   // timeOrigin is epoch-scale; the milestones are offsets from it, so they must
   // not themselves be epoch timestamps.
@@ -30,12 +30,27 @@ test("nodeTiming reports offsets from timeOrigin, not epoch timestamps", () => {
   }
   expect(nt.loopExit).toBe(-1);
 
-  // Node exposes the entry accessors as own enumerable properties.
-  expect(Object.keys(nt)).toEqual(expect.arrayContaining(["name", "entryType", "startTime", "duration"]));
+  // Node defines name/entryType/startTime as own data properties
+  // (writable:false) and duration as an own getter.
+  for (const [key, value] of [["name", "node"], ["entryType", "node"], ["startTime", 0]] as const) {
+    expect({ key, ...Object.getOwnPropertyDescriptor(nt, key) }).toEqual({
+      key,
+      value,
+      writable: false,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+  const durationDesc = Object.getOwnPropertyDescriptor(nt, "duration");
+  expect({
+    enumerable: durationDesc?.enumerable,
+    configurable: durationDesc?.configurable,
+    get: typeof durationDesc?.get,
+  }).toEqual({ enumerable: true, configurable: true, get: "function" });
 
   const json = nt.toJSON();
-  // duration is a live reading, so assert its type and drop it before comparing.
-  expect(json.duration).toBeNumber();
+  // duration is a live reading, so assert it's positive and drop it before comparing.
+  expect(json.duration).toBeGreaterThan(0);
   delete json.duration;
   expect(json).toEqual({
     name: "node",
@@ -182,6 +197,28 @@ test("timerify and createHistogram survive Object.prototype option pollution", a
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout, exitCode }).toEqual({ stdout: "timerify=function\nhistogram=function\n", exitCode: 0 });
   expect(stderr).not.toContain("ERR_INVALID_ARG_TYPE");
+});
+
+test("nodeTiming initialization survives Object.prototype.value pollution", async () => {
+  // The own-property descriptor for `duration` is an accessor descriptor; an
+  // inherited `value` key would make it invalid ("Invalid property descriptor")
+  // without the null-prototype guard.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `Object.prototype.value = 1;
+       const nt = require("node:perf_hooks").performance.nodeTiming;
+       console.log(JSON.stringify({ name: nt.name, entryType: nt.entryType, startTime: nt.startTime }));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("Invalid property descriptor");
+  expect(JSON.parse(stdout)).toEqual({ name: "node", entryType: "node", startTime: 0 });
+  expect(exitCode).toBe(0);
 });
 
 test("timerify and AsyncResource.bind survive Object.prototype.get pollution", async () => {


### PR DESCRIPTION
Adopts #32481 by @0xfandom.

### Repro

```js
const nt = require("node:perf_hooks").performance.nodeTiming;
nt.nodeStart;   // before: 1.785e12 (epoch ms)   node: ~0
nt.startTime;   // before: 1.785e12 (epoch ms)   node: 0
```

### Cause

`createPerformanceNodeTiming()` in `src/js/node/perf_hooks.ts` set `bootstrapComplete`/`environment`/`nodeStart`/`v8Start` to `performance.timeOrigin` (an absolute epoch timestamp), and `get startTime()` returned `this.nodeStart`. Node measures every startup milestone in milliseconds from `timeOrigin`, and a `"node"` entry *is* the timeOrigin reference, so its `startTime` is `0`.

### Fix

- Milestones are now offsets from `timeOrigin` (`0`; Bun does not record the individual startup milestones, so they are reported relative to process start). `loopExit` stays `-1`.
- `startTime` returns `0`.
- `name`/`entryType`/`startTime` are defined as own enumerable data properties (`writable:false`) and `duration` as an own enumerable getter, matching Node's `lib/internal/perf/nodetiming.js`, so `Object.keys(performance.nodeTiming)` matches Node. Null-prototype descriptors so prototype pollution before the module loads cannot inject extra descriptor keys.

### Why this is correct

Node's `lib/internal/perf/nodetiming.js` defines `name`/`entryType`/`startTime` as own data properties with `value:` and `duration`/milestones as own getters, with `startTime: 0` hardcoded and each milestone computed as `(ns - timeOrigin) / 1e6`. Verified against Node v26.3.0: `Object.getOwnPropertyDescriptor(nt, 'startTime')` is `{value: 0, writable: false, enumerable: true, configurable: true}`. The OpenTelemetry bootstrap-span use case in #23041 depends on these being offsets, not epoch values.

### Verification

```
$ bun bd test test/js/node/perf_hooks/perf_hooks.test.ts
 12 pass, 0 fail
```

Without the `src/` change, the new tests fail:
```
error: expect(received).toBe(expected)
Expected: 0
Received: 1785472769724.3042
```

Fixes #23041. Supersedes #32481 (same patch, brought into a repo branch so CI can run, plus the descriptor-kind correction).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
bun test v1.4.0 (d074a22ce)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [19.71ms]
16 |   const nt = perf.performance.nodeTiming;
17 | 
18 |   expect(nt.name).toBe("node");
19 |   expect(nt.entryType).toBe("node");
20 |   // A "node" entry is the timeOrigin reference, so startTime is 0 in Node.
21 |   expect(nt.startTime).toBe(0);
                            ^
error: expect(received).toBe(expected)

Expected: 0
Received: 1785475972805.419

      at <anonymous> (/workspace/bun/test/js/node/perf_hooks/perf_hooks.test.ts:21:24)
(fail) nodeTiming reports offsets from timeOrigin, not epoch timestamps [11.84ms]
(pass) doesn't throw [15.73ms]
(pass) Symbol name argument throws V8 wording [6.67ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [5.25ms]
(pass) timerify entry shape [54.82ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [2.10ms]
(pass) export surface matches Node v26.3.0 [8.53ms]
(pass) timerify 
... (truncated)

release without fix: 10 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [0.11ms]
13 | 
14 | // https://github.com/oven-sh/bun/issues/23041
15 | test("nodeTiming reports offsets from timeOrigin, not epoch timestamps", () => {
16 |   const nt = perf.performance.nodeTiming;
17 | 
18 |   expect(nt.name).toBe("node");
              ^
TypeError: The PerformanceEntry.name getter can only be used on instances of PerformanceEntry
      at <anonymous> (/workspace/bun/test/js/node/perf_hooks/perf_hooks.test.ts:18:10)
(fail) nodeTiming reports offsets from timeOrigin, not epoch timestamps [0.40ms]
(pass) doesn't throw [0.98ms]
85 | 
86 | // Node coerces the name via `${name}` for mark/clearMarks/clearMeasures, so a
87 | // Symbol hits V8's ToString message. Verified against Node v26.3.0.
88 | test("Symbol name argument throws V8 wording", () => {
89 |   const msg = "Cannot convert a Symbol value to a string";
90 |   expect(() => performance.mark(Symbol())).toThrow(new TypeError(msg));
                                                ^
error: expect(received).toThrow(expected)

Expected message: "Cannot convert a Symbol value to a string"
Received message: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
bun test v1.4.0 (d074a22ce)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [15.16ms]
(pass) nodeTiming reports offsets from timeOrigin, not epoch timestamps [14.61ms]
(pass) doesn't throw [14.95ms]
(pass) Symbol name argument throws V8 wording [7.59ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [4.96ms]
(pass) timerify entry shape [51.08ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [1.77ms]
(pass) export surface matches Node v26.3.0 [7.35ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [447.17ms]
(pass) nodeTiming initialization survives Object.prototype.value pollution [477.15ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [575.09ms]
(pass) net entries are instanceof PerformanceEntry [441.04ms]

 12 pass
 0 fail
 83 expect() calls
Ran 12 tests across 1 file. [4.41s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     d074a22ce9
  features     baseline

22 deps, 108 codegen, 1171 objects in 914ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [25.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1234] gen ErrorCode+*.h
[4/1234] gen bindgenv2
[5/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [21.00ms]
[7/1234] fetch tinycc
[tinycc] up to date
[8/1234] fetch picohttpparser
[picohttpparser] up to date
[9/1234] gen .bind.ts → GeneratedBindings.cpp
[10/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1234] fetch zlib
[zl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/perf_hooks.ts                  | 18 +++++--
 test/js/node/perf_hooks/perf_hooks.test.ts | 81 ++++++++++++++++++++++++++++++
 2 files changed, 96 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js/node/perf_hooks.ts                       4      7      0
test/js/node/perf_hooks/perf_hooks.test.ts      1      5      0
```

</details>

<!-- robobun:evidence:end -->