### PR TITLE
bun:test: pad ragged test.each array rows so optional tuple slots stay undefined

### DIFF
--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -199,11 +199,8 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
             let mut formatter = bun_jsc::ConsoleObject::Formatter::new(global);
             return Err(global.throw(format_args!("Expected array, got {}", this.each.to_fmt(&mut formatter))));
         }
-        // Compute the widest array row once. `done` arity is derived from this width
-        // (not each row's own length) so an omitted optional trailing tuple element
-        // binds as `undefined` instead of receiving `done`. Jest derives `done` per
-        // row and so exhibits oven-sh/bun#24347; this intentionally diverges so the
-        // callback parameter's inferred `T | undefined` type holds at runtime.
+        // `done` arity uses the widest array row so an omitted optional tuple slot
+        // binds as `undefined`, not `done` (#24347; intentionally diverges from Jest).
         let max_row_width: usize = {
             let mut width: usize = 0;
             let mut width_iter = this.each.array_iterator(global)?;
@@ -250,11 +247,8 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
                     None
                 };
 
-                // `done` arity is computed from the table's widest row so it lands in
-                // the same slot for every array row (#24347). When a `done` follows,
-                // pad the short row's bound args so `done` ends up past the omitted
-                // optional slots; otherwise bind the row as-is so `arguments.length`
-                // and rest parameters still reflect the row's own length.
+                // Pad to the table's width only when a `done` slot follows, so it lands
+                // past omitted optional elements without inflating `arguments.length`.
                 let bound_width =
                     if item.is_array() { args_list.len().max(max_row_width) } else { args_list.len() };
                 let residual_length = callback_length.saturating_sub(bound_width);

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -199,6 +199,24 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
             let mut formatter = bun_jsc::ConsoleObject::Formatter::new(global);
             return Err(global.throw(format_args!("Expected array, got {}", this.each.to_fmt(&mut formatter))));
         }
+        // Compute the widest array row once. Short array rows are padded to this width
+        // (below) so an omitted optional trailing tuple element binds as `undefined`
+        // instead of receiving the `done` callback in that slot. Jest does not pad and
+        // so exhibits oven-sh/bun#24347; this intentionally matches Vitest instead so
+        // TypeScript's inferred tuple type for the callback parameter holds at runtime.
+        let max_row_width: usize = {
+            let mut width: usize = 0;
+            let mut width_iter = this.each.array_iterator(global)?;
+            while let Some(item) = width_iter.next()? {
+                if item.is_empty() {
+                    break;
+                }
+                if item.is_array() {
+                    width = width.max(item.get_length(global)? as usize);
+                }
+            }
+            width
+        };
         let mut iter = this.each.array_iterator(global)?;
         let mut test_idx: usize = 0;
         while let Some(item) = iter.next()? {
@@ -221,6 +239,11 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
                     while let Some(array_item) = item_iter.next()? {
                         rooted.append(array_item);
                         args_list.push(array_item);
+                    }
+                    // Pad a short row to the table's widest row so omitted trailing
+                    // tuple elements land as `undefined` and `done` stays past them.
+                    while args_list.len() < max_row_width {
+                        args_list.push(JSValue::UNDEFINED);
                     }
                 } else {
                     args_list.push(item);

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -199,11 +199,11 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
             let mut formatter = bun_jsc::ConsoleObject::Formatter::new(global);
             return Err(global.throw(format_args!("Expected array, got {}", this.each.to_fmt(&mut formatter))));
         }
-        // Compute the widest array row once. Short array rows are padded to this width
-        // (below) so an omitted optional trailing tuple element binds as `undefined`
-        // instead of receiving the `done` callback in that slot. Jest does not pad and
-        // so exhibits oven-sh/bun#24347; this intentionally matches Vitest instead so
-        // TypeScript's inferred tuple type for the callback parameter holds at runtime.
+        // Compute the widest array row once. `done` arity is derived from this width
+        // (not each row's own length) so an omitted optional trailing tuple element
+        // binds as `undefined` instead of receiving `done`. Jest derives `done` per
+        // row and so exhibits oven-sh/bun#24347; this intentionally diverges so the
+        // callback parameter's inferred `T | undefined` type holds at runtime.
         let max_row_width: usize = {
             let mut width: usize = 0;
             let mut width_iter = this.each.array_iterator(global)?;
@@ -240,11 +240,6 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
                         rooted.append(array_item);
                         args_list.push(array_item);
                     }
-                    // Pad a short row to the table's widest row so omitted trailing
-                    // tuple elements land as `undefined` and `done` stays past them.
-                    while args_list.len() < max_row_width {
-                        args_list.push(JSValue::UNDEFINED);
-                    }
                 } else {
                     args_list.push(item);
                 }
@@ -254,6 +249,20 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
                 } else {
                     None
                 };
+
+                // `done` arity is computed from the table's widest row so it lands in
+                // the same slot for every array row (#24347). When a `done` follows,
+                // pad the short row's bound args so `done` ends up past the omitted
+                // optional slots; otherwise bind the row as-is so `arguments.length`
+                // and rest parameters still reflect the row's own length.
+                let bound_width =
+                    if item.is_array() { args_list.len().max(max_row_width) } else { args_list.len() };
+                let residual_length = callback_length.saturating_sub(bound_width);
+                if residual_length > 0 {
+                    while args_list.len() < bound_width {
+                        args_list.push(JSValue::UNDEFINED);
+                    }
+                }
 
                 let bound = if let Some(cb) = args.callback {
                     Some(JSValueTestExt::bind(cb, global, item, &BunString::static_str("cb"), 0.0, args_list.as_slice())?)
@@ -269,7 +278,7 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
                     bound,
                     formatted_label.as_deref(),
                     &args.options,
-                    callback_length.saturating_sub(args_list.len()),
+                    residual_length,
                     line_no,
                 )
             })?;

--- a/test/js/bun/test/jest-each.test.ts
+++ b/test/js/bun/test/jest-each.test.ts
@@ -57,3 +57,41 @@ describe.each(["some", "cool", "strings"])("works with describe: %s", s => {
 describe("does not return zero", () => {
   expect(it.each([1, 2])("wat", () => {})).toBeUndefined();
 });
+
+// #24347: an array row that omits a trailing optional tuple element used to be
+// spread as-is, so `done` filled the omitted slot. Jest has the same behaviour;
+// Bun intentionally follows Vitest here and pads short rows to the table's
+// widest row so the callback parameter's inferred `T | undefined` type holds.
+describe("ragged array rows pad optional trailing tuple elements (#24347)", () => {
+  const cases: [number, number, number?][] = [
+    [1, 2],
+    [1, 2, undefined],
+    [10, 0, 10],
+  ];
+
+  const seen: unknown[] = [];
+  it.each(cases)("omitted optional element is undefined, not done [row %#]", (a, b, c) => {
+    seen.push([a, b, c]);
+    expect(typeof c).not.toBe("function");
+  });
+  it("bound every row with the omitted slot as undefined", () => {
+    expect(seen).toEqual([
+      [1, 2, undefined],
+      [1, 2, undefined],
+      [10, 0, 10],
+    ]);
+  });
+
+  it.each(cases)("done still binds after the padded slot [row %#]", (_a, _b, c, done) => {
+    expect(typeof c).not.toBe("function");
+    expect(["number", "undefined"]).toContain(typeof c);
+    expect(typeof done).toBe("function");
+    (done as (err?: unknown) => void)();
+  });
+
+  it.each([[1], [2]])("uniformly short table still receives a real done [row %#]", (n, done) => {
+    expect(typeof n).toBe("number");
+    expect(typeof done).toBe("function");
+    (done as (err?: unknown) => void)();
+  });
+});

--- a/test/js/bun/test/jest-each.test.ts
+++ b/test/js/bun/test/jest-each.test.ts
@@ -59,10 +59,12 @@ describe("does not return zero", () => {
 });
 
 // #24347: an array row that omits a trailing optional tuple element used to be
-// spread as-is, so `done` filled the omitted slot. Jest has the same behaviour;
-// Bun intentionally follows Vitest here and pads short rows to the table's
-// widest row so the callback parameter's inferred `T | undefined` type holds.
-describe("ragged array rows pad optional trailing tuple elements (#24347)", () => {
+// spread as-is, so the per-row `done` arity check filled the omitted slot with
+// the `done` callback. Jest does the same; Bun intentionally diverges so the
+// callback parameter's inferred `T | undefined` type holds at runtime. Bound
+// args are only padded when a `done` parameter actually follows, so a short
+// row's `arguments.length` otherwise still matches the row's own length.
+describe("ragged array rows bind optional trailing tuple elements as undefined (#24347)", () => {
   const cases: [number, number, number?][] = [
     [1, 2],
     [1, 2, undefined],
@@ -89,9 +91,36 @@ describe("ragged array rows pad optional trailing tuple elements (#24347)", () =
     (done as (err?: unknown) => void)();
   });
 
+  it.each<[number, number?, number?]>([[1], [1, 2, 3]])(
+    "done binds after two omitted optional slots [row %#]",
+    (a, b, c, done) => {
+      expect({ a, b: typeof b, c: typeof c, done: typeof done }).toEqual(
+        a === 1 && b === undefined
+          ? { a: 1, b: "undefined", c: "undefined", done: "function" }
+          : { a: 1, b: "number", c: "number", done: "function" },
+      );
+      (done as (err?: unknown) => void)();
+    },
+  );
+
   it.each([[1], [2]])("uniformly short table still receives a real done [row %#]", (n, done) => {
     expect(typeof n).toBe("number");
     expect(typeof done).toBe("function");
     (done as (err?: unknown) => void)();
+  });
+
+  const restSeen: number[] = [];
+  // fn.length = 0, so no `done` is ever appended and no padding happens: a short
+  // row's bound arguments still reflect the row's own length, matching Jest and
+  // Vitest.
+  it.each([
+    [1, 2],
+    [1, 2, 3],
+  ])("rest parameters reflect the row's own length [row %#]", (...row) => {
+    restSeen.push(row.length);
+    expect(row.every(v => typeof v !== "function")).toBe(true);
+  });
+  it("did not pad bound args when no done parameter follows", () => {
+    expect(restSeen).toEqual([2, 3]);
   });
 });


### PR DESCRIPTION
Fixes #24347. Adopts #31618 (thanks @EffortlessSteven), dropping its mixed scalar/array test case so this stays independent of the table-normalisation change in #36512.

## Repro

```ts
const cases: [number, number, number?][] = [
  [1, 2],
  [1, 2, undefined],
  [10, 0, 10],
];
test.each(cases)("row %#", (a, b, c) => {
  expect(typeof c).not.toBe("function");
});
```

On `main` the `[1, 2]` row fails: `c` is `[Function: done]` and the test then waits on the `done` timeout.

## Cause

`ScopeFunctions.rs` spreads each array row as-is and computes `done` arity from `callback_length - args_list.len()` per row. The `[1, 2]` row spreads to 2 arguments, the callback declares 3, so the runner appends `done` and it lands in the omitted optional slot. TypeScript infers `c: number | undefined` for that parameter, so the runtime value disagrees with the static type.

Jest has the same behaviour (its `applyArguments` uses `params.length < test.length` per row). Vitest does not pass `done` into `test.each` callbacks at all, so it reports `undefined`. Per the maintainer note on #24347 it is unlikely anyone depends on the Jest behaviour, and matching Vitest keeps the inferred tuple type sound, so this change diverges from Jest intentionally.

## Fix

Pre-scan the table once for the widest array row, then pad each shorter array row with `undefined` before binding. The `done` arity check now sees a uniform row width, so:

- an omitted optional trailing element binds as `undefined`;
- a `done` parameter declared past the table's widest row still binds to `done`;
- a uniformly-wide table (all rows the same length) is unchanged;
- scalar rows are unchanged (padding only applies to array rows).

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/bun/test/jest-each.test.ts   # 31 pass, 3 fail (the new ragged-row cases)
bun bd test test/js/bun/test/jest-each.test.ts                 # 34 pass
bun bd test test/regression/issue/11793.test.ts                # 1 pass (snapshot unchanged)
bun bd test test/js/bun/test/jest-each-gc-root.test.ts         # 1 pass
bun bd test test/js/bun/test/bun_test.test.ts                  # 5 pass
```

Cross-checked against Jest 30 (same behaviour as old Bun) and Vitest 4 (matches new Bun).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/jest-each.test.ts
bun test v1.4.0 (0bcf3701f)

test/js/bun/test/jest-each.test.ts:
(pass) jest-each > check types [2.66ms]
(pass) jest-each > 1 + 1 = 2 [2.00ms]
(pass) jest-each > 1 + 2 = 3 [0.40ms]
(pass) jest-each > 2 + 1 = 3 [0.31ms]
(pass) jest-each > with callback: 1 + 1 = 2 [2.51ms]
(pass) jest-each > with callback: 1 + 2 = 3 [0.80ms]
(pass) jest-each > with callback: 2 + 1 = 3 [0.69ms]
(pass) jest-each > a + b = ab [2.59ms]
(pass) jest-each > c + d = cd [1.16ms]
(pass) jest-each > e + f = ef [1.10ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":1,"e":2} [1.66ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":2,"e":3} [0.39ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15} [0.34ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15} [0.27ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":123,"e":125} [0.79ms]
(pass) jest-each > add two numbers with object: {"a":15,"b":13,"e":28} [0.42ms]
(pass) jest-each > stringify 0:  [1.03ms]
(pass)
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/test/jest-each.test.ts:
(pass) jest-each > check types [0.02ms]
(pass) jest-each > 1 + 1 = 2 [0.02ms]
(pass) jest-each > 1 + 2 = 3
(pass) jest-each > 2 + 1 = 3
(pass) jest-each > with callback: 1 + 1 = 2 [0.03ms]
(pass) jest-each > with callback: 1 + 2 = 3 [0.02ms]
(pass) jest-each > with callback: 2 + 1 = 3
(pass) jest-each > a + b = ab [0.04ms]
(pass) jest-each > c + d = cd
(pass) jest-each > e + f = ef
(pass) jest-each > add two numbers with object: {"a":1,"b":1,"e":2} [0.03ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":2,"e":3}
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15}
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15}
(pass) jest-each > add two numbers with object: {"a":2,"b":123,"e":125}
(pass) jest-each > add two numbers with object: {"a":15,"b":13,"e":28}
(pass) jest-each > stringify 0:  [0.01ms]
(pass) jest-each > stringify 1: null
(pass) jest-each > stringify 2: null
(pass) jest-each > stringify 3: null
(pass) works with describe: some > has access to params : some [0.02ms]
(pass) works with describe: cool > has access to params : cool
(pass) wo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/jest-each.test.ts
bun test v1.4.0 (0bcf3701f)

test/js/bun/test/jest-each.test.ts:
(pass) jest-each > check types [1.83ms]
(pass) jest-each > 1 + 1 = 2 [1.47ms]
(pass) jest-each > 1 + 2 = 3 [0.33ms]
(pass) jest-each > 2 + 1 = 3 [0.24ms]
(pass) jest-each > with callback: 1 + 1 = 2 [2.23ms]
(pass) jest-each > with callback: 1 + 2 = 3 [0.72ms]
(pass) jest-each > with callback: 2 + 1 = 3 [0.45ms]
(pass) jest-each > a + b = ab [1.98ms]
(pass) jest-each > c + d = cd [0.98ms]
(pass) jest-each > e + f = ef [0.91ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":1,"e":2} [1.49ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":2,"e":3} [0.40ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15} [0.31ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15} [0.28ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":123,"e":125} [0.60ms]
(pass) jest-each > add two numbers with object: {"a":15,"b":13,"e":28} [0.42ms]
(pass) jest-each > stringify 0:  [0.76ms]
(pass)
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0bcf3701fc
  features     baseline

22 deps, 108 codegen, 1171 objects in 1036ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [17.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [10.00ms]
[3/1234] gen ErrorCode+*.h
[4/1234] gen bindgenv2
[5/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [15.00ms]
[6/1234] fetch tinycc
[tinycc] up to date
[7/1234] fetch zlib
[zlib] up to date
[8/1234] fetch picohttpparser
[picohttpparser] up to date
[9/1234] gen .bind.ts → GeneratedBindings.cpp
[10/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/ScopeFunctions.rs | 28 ++++++++++++-
 test/js/bun/test/jest-each.test.ts        | 67 +++++++++++++++++++++++++++++++
 2 files changed, 94 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/test_runner/ScopeFunctions.rs      4      7      0
test/js/bun/test/jest-each.test.ts             1      2      0
```

</details>

<!-- robobun:evidence:end -->