### PR TITLE
ffi: don't free caller-owned memory in toBuffer without a finalizer

### DIFF
--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -23,9 +23,19 @@ unsafe fn deallocator_from_addr(addr: usize) -> jsc::JSTypedArrayBytesDeallocato
     unsafe { core::mem::transmute::<usize, jsc::JSTypedArrayBytesDeallocator>(addr) }
 }
 
+/// Bytes deallocator that frees nothing, for a borrowed FFI pointer.
+/// `toBuffer(ptr, offset, len)` without an explicit finalizer views caller-owned
+/// memory it must NOT free, but the underlying
+/// `JSBuffer__bufferFromPointerAndLengthAndDeinit` requires a non-null deallocator
+/// for non-empty storage. A deallocator that does nothing satisfies that while
+/// leaving the storage caller-owned: GC releases only JSC's view, so no bad-free.
+/// Disposal is delegated only when the caller supplies a finalizer.
+unsafe extern "C" fn noop_bytes_deallocator(_ptr: *mut c_void, _ctx: *mut c_void) {}
+
 /// Unlike `JSValue::create_buffer` (which hard-codes `MarkedArrayBuffer_deallocator`),
-/// this variant passes the caller's (possibly null) deallocator through, so FFI-owned
-/// memory is only freed by the user-supplied callback.
+/// this variant passes the selected deallocator through: `to_buffer` supplies either
+/// the caller's finalizer or `noop_bytes_deallocator` for borrowed storage, so the
+/// bytes are only freed when the caller asked for that.
 #[allow(non_snake_case)]
 #[inline]
 fn create_buffer_with_ctx(
@@ -43,8 +53,9 @@ fn create_buffer_with_ctx(
             deallocator: jsc::JSTypedArrayBytesDeallocator,
         ) -> JSValue;
     }
-    // SAFETY: `global` is live; slice describes FFI-owned memory whose
-    // ownership transfers to JSC (freed via `callback`, or never if None).
+    // SAFETY: `global` is live; `slice` describes caller-provided memory that stays
+    // valid for the Buffer's lifetime. `callback` controls disposal, and may be a
+    // no-op when the storage remains caller-owned (JSC then owns only the view).
     unsafe {
         JSBuffer__bufferFromPointerAndLengthAndDeinit(
             global,
@@ -505,12 +516,9 @@ fn ptr_(global_this: &JSGlobalObject, value: JSValue, byte_offset: Option<JSValu
 /// `union(enum)` → Rust enum.
 /// `Slice` carries a raw (ptr, len) because it points at caller-owned FFI memory
 /// of unknown lifetime.
-// Consumer audit: `new_cstring` copies the bytes into a JS string;
-// `to_array_buffer` wraps the pointer with the caller's optional finalizer and
-// never frees it from Rust; `to_buffer` does the same when a finalizer is
-// given, but WITHOUT one it falls back to `JSValue::create_buffer`, which
-// installs `MarkedArrayBuffer_deallocator` and `mi_free`s the caller-owned
-// slice on GC — free-foreign-memory footgun, see PR #31753.
+// Consumer audit: `new_cstring` copies the bytes into a JS string; `to_array_buffer`
+// and `to_buffer` both borrow the pointer when no finalizer is supplied and never
+// free it from Rust. A supplied finalizer controls disposal.
 enum ValueOrError {
     Err(JSValue),
     Slice(*mut u8, usize),
@@ -740,20 +748,21 @@ fn to_buffer(
                 }
             }
 
-            // SAFETY: ptr/len came from get_ptr_slice; FFI-owned memory.
+            // SAFETY: ptr/len came from get_ptr_slice; a caller-supplied finalizer
+            // controls disposal, otherwise the storage stays caller-owned and borrowed.
             let slice = unsafe { core::slice::from_raw_parts_mut(ptr, len) };
-            if callback.is_some() || ctx.is_some() {
-                return Ok(create_buffer_with_ctx(
-                    global_this,
-                    slice,
-                    ctx.unwrap_or(core::ptr::null_mut()),
-                    callback,
-                ));
-            }
-
-            // `JSValue::create_buffer` installs `MarkedArrayBuffer_deallocator` so
-            // the slice is `mi_free`d on GC (including the free-foreign-memory footgun).
-            Ok(JSValue::create_buffer(global_this, slice))
+            // Without an explicit finalizer the pointer stays caller-owned (e.g. it
+            // came from `ptr(buffer)`), so this must not install Bun's allocator
+            // deallocator: freeing it on GC frees storage this Buffer does not own
+            // (ASAN bad-free / SIGSEGV in `mi_free`), which is what the previous
+            // `JSValue::create_buffer` fall-back did. The no-op deallocator makes the
+            // Buffer a borrowed zero-copy view instead.
+            Ok(create_buffer_with_ctx(
+                global_this,
+                slice,
+                ctx.unwrap_or(core::ptr::null_mut()),
+                callback.or(Some(noop_bytes_deallocator)),
+            ))
         }
     }
 }

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -23,19 +23,12 @@ unsafe fn deallocator_from_addr(addr: usize) -> jsc::JSTypedArrayBytesDeallocato
     unsafe { core::mem::transmute::<usize, jsc::JSTypedArrayBytesDeallocator>(addr) }
 }
 
-/// Bytes deallocator that frees nothing, for a borrowed FFI pointer.
-/// `toBuffer(ptr, offset, len)` without an explicit finalizer views caller-owned
-/// memory it must NOT free, but the underlying
-/// `JSBuffer__bufferFromPointerAndLengthAndDeinit` requires a non-null deallocator
-/// for non-empty storage. A deallocator that does nothing satisfies that while
-/// leaving the storage caller-owned: GC releases only JSC's view, so no bad-free.
-/// Disposal is delegated only when the caller supplies a finalizer.
+/// Frees nothing. `JSBuffer__bufferFromPointerAndLengthAndDeinit` asserts a non-null
+/// deallocator for `len > 0`, so a borrowed view supplies this instead of `None`.
 unsafe extern "C" fn noop_bytes_deallocator(_ptr: *mut c_void, _ctx: *mut c_void) {}
 
 /// Unlike `JSValue::create_buffer` (which hard-codes `MarkedArrayBuffer_deallocator`),
-/// this variant passes the selected deallocator through: `to_buffer` supplies either
-/// the caller's finalizer or `noop_bytes_deallocator` for borrowed storage, so the
-/// bytes are only freed when the caller asked for that.
+/// this passes the caller's deallocator through so FFI bytes are only freed when asked.
 #[allow(non_snake_case)]
 #[inline]
 fn create_buffer_with_ctx(
@@ -53,9 +46,8 @@ fn create_buffer_with_ctx(
             deallocator: jsc::JSTypedArrayBytesDeallocator,
         ) -> JSValue;
     }
-    // SAFETY: `global` is live; `slice` describes caller-provided memory that stays
-    // valid for the Buffer's lifetime. `callback` controls disposal, and may be a
-    // no-op when the storage remains caller-owned (JSC then owns only the view).
+    // SAFETY: `global` is live; `slice` stays valid for the Buffer's lifetime.
+    // `callback` controls disposal (a no-op when the storage stays caller-owned).
     unsafe {
         JSBuffer__bufferFromPointerAndLengthAndDeinit(
             global,
@@ -513,12 +505,8 @@ fn ptr_(global_this: &JSGlobalObject, value: JSValue, byte_offset: Option<JSValu
     JSValue::from_ptr_address(addr)
 }
 
-/// `union(enum)` → Rust enum.
-/// `Slice` carries a raw (ptr, len) because it points at caller-owned FFI memory
-/// of unknown lifetime.
-// Consumer audit: `new_cstring` copies the bytes into a JS string; `to_array_buffer`
-// and `to_buffer` both borrow the pointer when no finalizer is supplied and never
-// free it from Rust. A supplied finalizer controls disposal.
+/// `Slice` carries a raw (ptr, len) pointing at caller-owned FFI memory; consumers
+/// borrow it (or delegate disposal to a supplied finalizer), never free it from Rust.
 enum ValueOrError {
     Err(JSValue),
     Slice(*mut u8, usize),
@@ -748,15 +736,10 @@ fn to_buffer(
                 }
             }
 
-            // SAFETY: ptr/len came from get_ptr_slice; a caller-supplied finalizer
-            // controls disposal, otherwise the storage stays caller-owned and borrowed.
+            // SAFETY: ptr/len came from get_ptr_slice; caller-owned FFI memory.
             let slice = unsafe { core::slice::from_raw_parts_mut(ptr, len) };
-            // Without an explicit finalizer the pointer stays caller-owned (e.g. it
-            // came from `ptr(buffer)`), so this must not install Bun's allocator
-            // deallocator: freeing it on GC frees storage this Buffer does not own
-            // (ASAN bad-free / SIGSEGV in `mi_free`), which is what the previous
-            // `JSValue::create_buffer` fall-back did. The no-op deallocator makes the
-            // Buffer a borrowed zero-copy view instead.
+            // No finalizer means borrow: the noop deallocator keeps GC from freeing
+            // caller-owned storage (oven-sh/bun#35405).
             Ok(create_buffer_with_ctx(
                 global_this,
                 slice,

--- a/test/js/bun/ffi/ffi-test.c
+++ b/test/js/bun/ffi/ffi-test.c
@@ -118,13 +118,9 @@ uint32_t add_uint32_t(uint32_t a, uint32_t b) { return a + b; }
 uint64_t add_uint64_t(uint64_t a, uint64_t b) { return a + b; }
 
 FFI_EXPORT void *ptr_should_point_to_42_as_int32_t();
-FFI_EXPORT void *getNoopDeallocatorCallback();
 
 static int32_t ffi_static_42 = 42;
 void *ptr_should_point_to_42_as_int32_t() { return &ffi_static_42; }
-
-static void noop_deallocator(void *ptr, void *ctx) { (void)ptr; (void)ctx; }
-void *getNoopDeallocatorCallback() { return &noop_deallocator; }
 
 static uint8_t buffer_with_deallocator[128];
 static int deallocatorCalled;

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1373,9 +1373,7 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
   const gcLoop = `for (let i = 0; i < 20; i++) { Bun.gc(true); Buffer.alloc(1024 * 1024); }`;
 
   // Forcing GC repeatedly in a subprocess costs a few seconds on a debug build, so
-  // the default 5s budget is too tight to be reliable. (On an unpatched Bun the child
-  // SIGSEGVs and then wedges in the crash handler, so there the red signal is this
-  // timeout rather than the exit-code assertion.)
+  // the default 5s budget is too tight to be reliable.
   const GC_TIMEOUT = 20_000;
 
   // Post-condition on the ACTUAL caller memory the bad-free targets: drop only the
@@ -1395,7 +1393,7 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
       ${gcLoop}
   `;
 
-  it(
+  it.concurrent(
     "toBuffer(ptr(buffer)) does not free caller-owned memory on GC",
     async () => {
       expect(
@@ -1414,7 +1412,7 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
     GC_TIMEOUT,
   );
 
-  it(
+  it.concurrent(
     "toBuffer(ptr(buffer), offset) does not free an interior pointer on GC",
     async () => {
       // The adopted view starts at original[8], so both the aliasing check and the
@@ -1435,7 +1433,7 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
     GC_TIMEOUT,
   );
 
-  it(
+  it.concurrent(
     "toBuffer(ptr(typedArray)) does not free caller-owned memory on GC",
     async () => {
       expect(
@@ -1458,7 +1456,7 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
   // reset the counter, so the count is isolated to this test).
   it.skipIf(!FFI_FIXTURE_PATH)(
     "toBuffer with an explicit finalizer calls the deallocator exactly once on GC",
-    () => {
+    async () => {
       const {
         symbols: { getDeallocatorCallback, getDeallocatorBuffer, getDeallocatorCalledCount },
       } = dlopen(FFI_FIXTURE_PATH, {
@@ -1466,16 +1464,19 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
         getDeallocatorBuffer: { args: [], returns: "ptr" },
         getDeallocatorCalledCount: { args: [], returns: "int" },
       });
-      const bufPtr = getDeallocatorBuffer();
-      let buf = toBuffer(bufPtr, 0, 128, getDeallocatorCallback());
-      expect(buf.length).toBe(128);
-      expect(getDeallocatorCalledCount()).toBe(0); // not called during construction
-      buf = null;
-      // Await the collection rather than assuming one pass suffices: a single
-      // Bun.gc(true) can still see `buf` conservatively from the stack.
-      for (let i = 0; i < 20 && getDeallocatorCalledCount() === 0; i++) {
+      (() => {
+        const bufPtr = getDeallocatorBuffer();
+        let buf = toBuffer(bufPtr, 0, 128, getDeallocatorCallback());
+        expect(buf.length).toBe(128);
+        expect(getDeallocatorCalledCount()).toBe(0); // not called during construction
+        buf = null;
+      })();
+      // Yield between collections so the frame that held `buf` is popped before the
+      // conservative scan; a synchronous loop can keep a single cell pinned.
+      for (let i = 0; i < 100 && getDeallocatorCalledCount() === 0; i++) {
         Bun.gc(true);
         Buffer.alloc(1024 * 1024);
+        await Bun.sleep(0);
       }
       expect(getDeallocatorCalledCount()).toBe(1); // called exactly once on GC
       Bun.gc(true);

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1398,7 +1398,8 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
   it(
     "toBuffer(ptr(buffer)) does not free caller-owned memory on GC",
     async () => {
-      const { stdout, exitCode } = await runsClean(`
+      expect(
+        await runsClean(`
       import { ptr, toBuffer } from "bun:ffi";
       let original = Buffer.alloc(64, 0x41);
       let adopted = toBuffer(ptr(original), 0, 64);
@@ -1407,9 +1408,8 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
       if (original[0] !== 0x42) throw new Error("expected an aliasing view");
       ${originalSurvives(0, "0x42")}
       console.log("survived-gc");
-    `);
-      expect(stdout).toContain("survived-gc");
-      expect(exitCode).toBe(0);
+    `),
+      ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
     },
     GC_TIMEOUT,
   );
@@ -1419,7 +1419,8 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
     async () => {
       // The adopted view starts at original[8], so both the aliasing check and the
       // post-GC survival check must inspect that byte, not original[0].
-      const { stdout, exitCode } = await runsClean(`
+      expect(
+        await runsClean(`
       import { ptr, toBuffer } from "bun:ffi";
       let original = Buffer.alloc(64, 0x41);
       let adopted = toBuffer(ptr(original), 8, 48);
@@ -1428,9 +1429,8 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
       if (original[8] !== 0x42) throw new Error("expected a view aliasing original[8]");
       ${originalSurvives(8, "0x42")}
       console.log("survived-gc");
-    `);
-      expect(stdout).toContain("survived-gc");
-      expect(exitCode).toBe(0);
+    `),
+      ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
     },
     GC_TIMEOUT,
   );
@@ -1438,62 +1438,48 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
   it(
     "toBuffer(ptr(typedArray)) does not free caller-owned memory on GC",
     async () => {
-      const { stdout, exitCode } = await runsClean(`
+      expect(
+        await runsClean(`
       import { ptr, toBuffer } from "bun:ffi";
       let original = new Uint8Array(64).fill(0x41);
       let adopted = toBuffer(ptr(original), 0, 64);
       ${originalSurvives(0, "0x41")}
       console.log("survived-gc");
-    `);
-      expect(stdout).toContain("survived-gc");
-      expect(exitCode).toBe(0);
+    `),
+      ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
     },
     GC_TIMEOUT,
   );
 
   // Regression (the #1 risk): the bad-free fix must NOT change the explicit-finalizer
-  // path — when the caller supplies a finalizer, it still controls disposal and the
-  // deallocator is invoked exactly once on GC. Self-contained via cc() (TinyCC) so the
-  // deallocator's call count is isolated from the shared ffi-test fixture's counter.
-  it(
+  // path. When the caller supplies a finalizer, it still controls disposal and the
+  // deallocator is invoked exactly once on GC. Uses the compiled fixture's
+  // deallocator-counter helpers (getDeallocatorBuffer/getDeallocatorCallback both
+  // reset the counter, so the count is isolated to this test).
+  it.skipIf(!FFI_FIXTURE_PATH)(
     "toBuffer with an explicit finalizer calls the deallocator exactly once on GC",
     () => {
-      using dir = tempDir("ffi-tobuffer-finalizer", {
-        "dealloc.c": `
-        static int ffi_called = 0;
-        static void* ffi_last_ptr = 0;
-        static unsigned char ffi_buf[128];
-        void ffi_dealloc(void* p, void* ctx) { (void)ctx; ffi_last_ptr = p; ffi_called++; }
-        void* ffi_get_dealloc(void) { return (void*)&ffi_dealloc; }
-        void* ffi_get_buf(void) { return (void*)ffi_buf; }
-        void* ffi_get_last_ptr(void) { return ffi_last_ptr; }
-        int ffi_get_called(void) { return ffi_called; }
-      `,
+      const {
+        symbols: { getDeallocatorCallback, getDeallocatorBuffer, getDeallocatorCalledCount },
+      } = dlopen(FFI_FIXTURE_PATH, {
+        getDeallocatorCallback: { args: [], returns: "ptr" },
+        getDeallocatorBuffer: { args: [], returns: "ptr" },
+        getDeallocatorCalledCount: { args: [], returns: "int" },
       });
-      const { symbols } = cc({
-        source: `${String(dir)}/dealloc.c`,
-        symbols: {
-          ffi_get_dealloc: { args: [], returns: "ptr" },
-          ffi_get_buf: { args: [], returns: "ptr" },
-          ffi_get_last_ptr: { args: [], returns: "ptr" },
-          ffi_get_called: { args: [], returns: "int" },
-        },
-      });
-      const bufPtr = symbols.ffi_get_buf();
-      let buf = toBuffer(bufPtr, 0, 128, symbols.ffi_get_dealloc());
+      const bufPtr = getDeallocatorBuffer();
+      let buf = toBuffer(bufPtr, 0, 128, getDeallocatorCallback());
       expect(buf.length).toBe(128);
-      expect(symbols.ffi_get_called()).toBe(0); // not called during construction
+      expect(getDeallocatorCalledCount()).toBe(0); // not called during construction
       buf = null;
       // Await the collection rather than assuming one pass suffices: a single
       // Bun.gc(true) can still see `buf` conservatively from the stack.
-      for (let i = 0; i < 20 && symbols.ffi_get_called() === 0; i++) {
+      for (let i = 0; i < 20 && getDeallocatorCalledCount() === 0; i++) {
         Bun.gc(true);
         Buffer.alloc(1024 * 1024);
       }
-      expect(symbols.ffi_get_called()).toBe(1); // called exactly once on GC
-      expect(symbols.ffi_get_last_ptr()).toBe(bufPtr); // with the buffer's own pointer
+      expect(getDeallocatorCalledCount()).toBe(1); // called exactly once on GC
       Bun.gc(true);
-      expect(symbols.ffi_get_called()).toBe(1); // not called again
+      expect(getDeallocatorCalledCount()).toBe(1); // not called again
     },
     GC_TIMEOUT,
   );

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1354,10 +1354,8 @@ describe.if(!!libPath)("can open more than 63 symbols via", () => {
   }
 });
 
-// `toBuffer(ptr, offset, len)` without an explicit finalizer used to adopt the
-// caller's pointer as owned and install Bun's allocator deallocator, so GC would
-// `mi_free` caller-owned memory — an ASAN bad-free / release SIGSEGV.
-// These run in a subprocess because the bug crashes the process on unpatched Bun.
+// oven-sh/bun#35405: toBuffer without a finalizer used to mi_free caller-owned
+// memory on GC. Subprocess because unpatched builds crash.
 describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
   async function runsClean(script) {
     await using proc = Bun.spawn({
@@ -1372,17 +1370,8 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
 
   const gcLoop = `for (let i = 0; i < 20; i++) { Bun.gc(true); Buffer.alloc(1024 * 1024); }`;
 
-  // Forcing GC repeatedly in a subprocess costs a few seconds on a debug build, so
-  // the default 5s budget is too tight to be reliable.
-  const GC_TIMEOUT = 20_000;
-
-  // Post-condition on the ACTUAL caller memory the bad-free targets: drop only the
-  // adopted Buffer, then confirm `original[index]` (the storage `ptr(...)` pointed
-  // at) is still readable and writable — proving its backing was NOT freed. Then
-  // drop `original` too, exercising the owner's normal disposal after the borrowed
-  // view was collected — on an unpatched build the earlier invalid free has already
-  // corrupted that ownership path. That turns "the process didn't abort" into "the
-  // caller memory survived".
+  // Drops the borrowed view first, then the owner, so an invalid free shows up as
+  // corrupted caller memory rather than only as a crash.
   const originalSurvives = (index, expected) => `
       adopted = null;
       ${gcLoop}
@@ -1393,11 +1382,9 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
       ${gcLoop}
   `;
 
-  it.concurrent(
-    "toBuffer(ptr(buffer)) does not free caller-owned memory on GC",
-    async () => {
-      expect(
-        await runsClean(`
+  it.concurrent("toBuffer(ptr(buffer)) does not free caller-owned memory on GC", async () => {
+    expect(
+      await runsClean(`
       import { ptr, toBuffer } from "bun:ffi";
       let original = Buffer.alloc(64, 0x41);
       let adopted = toBuffer(ptr(original), 0, 64);
@@ -1407,18 +1394,12 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
       ${originalSurvives(0, "0x42")}
       console.log("survived-gc");
     `),
-      ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
-    },
-    GC_TIMEOUT,
-  );
+    ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
+  });
 
-  it.concurrent(
-    "toBuffer(ptr(buffer), offset) does not free an interior pointer on GC",
-    async () => {
-      // The adopted view starts at original[8], so both the aliasing check and the
-      // post-GC survival check must inspect that byte, not original[0].
-      expect(
-        await runsClean(`
+  it.concurrent("toBuffer(ptr(buffer), offset) does not free an interior pointer on GC", async () => {
+    expect(
+      await runsClean(`
       import { ptr, toBuffer } from "bun:ffi";
       let original = Buffer.alloc(64, 0x41);
       let adopted = toBuffer(ptr(original), 8, 48);
@@ -1428,32 +1409,26 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
       ${originalSurvives(8, "0x42")}
       console.log("survived-gc");
     `),
-      ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
-    },
-    GC_TIMEOUT,
-  );
+    ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
+  });
 
-  it.concurrent(
-    "toBuffer(ptr(typedArray)) does not free caller-owned memory on GC",
-    async () => {
-      expect(
-        await runsClean(`
+  it.concurrent("toBuffer(ptr(typedArray)) does not free caller-owned memory on GC", async () => {
+    expect(
+      await runsClean(`
       import { ptr, toBuffer } from "bun:ffi";
       let original = new Uint8Array(64).fill(0x41);
       let adopted = toBuffer(ptr(original), 0, 64);
-      ${originalSurvives(0, "0x41")}
+      if (adopted[0] !== 0x41) throw new Error("expected a zero-copy view");
+      adopted[0] = 0x42;
+      if (original[0] !== 0x42) throw new Error("expected an aliasing view");
+      ${originalSurvives(0, "0x42")}
       console.log("survived-gc");
     `),
-      ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
-    },
-    GC_TIMEOUT,
-  );
+    ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
+  });
 
-  // Regression (the #1 risk): the bad-free fix must NOT change the explicit-finalizer
-  // path. When the caller supplies a finalizer, it still controls disposal and the
-  // deallocator is invoked exactly once on GC. Uses the compiled fixture's
-  // deallocator-counter helpers (getDeallocatorBuffer/getDeallocatorCallback both
-  // reset the counter, so the count is isolated to this test).
+  // Regression guard: an explicit finalizer still controls disposal and runs exactly
+  // once on GC. getDeallocatorBuffer/getDeallocatorCallback each reset the counter.
   it.skipIf(!FFI_FIXTURE_PATH)(
     "toBuffer with an explicit finalizer calls the deallocator exactly once on GC",
     async () => {
@@ -1468,21 +1443,18 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
         const bufPtr = getDeallocatorBuffer();
         let buf = toBuffer(bufPtr, 0, 128, getDeallocatorCallback());
         expect(buf.length).toBe(128);
-        expect(getDeallocatorCalledCount()).toBe(0); // not called during construction
+        expect(getDeallocatorCalledCount()).toBe(0);
         buf = null;
       })();
-      // Yield between collections so the frame that held `buf` is popped before the
-      // conservative scan; a synchronous loop can keep a single cell pinned.
       for (let i = 0; i < 100 && getDeallocatorCalledCount() === 0; i++) {
         Bun.gc(true);
         Buffer.alloc(1024 * 1024);
         await Bun.sleep(0);
       }
-      expect(getDeallocatorCalledCount()).toBe(1); // called exactly once on GC
+      expect(getDeallocatorCalledCount()).toBe(1);
       Bun.gc(true);
-      expect(getDeallocatorCalledCount()).toBe(1); // not called again
+      expect(getDeallocatorCalledCount()).toBe(1);
     },
-    GC_TIMEOUT,
   );
 });
 

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -325,10 +325,6 @@ function getTypes(fast) {
       returns: "ptr",
       args: [],
     },
-    getNoopDeallocatorCallback: {
-      returns: "ptr",
-      args: [],
-    },
     getDeallocatorBuffer: {
       returns: "ptr",
       args: [],
@@ -382,7 +378,6 @@ function ffiRunner(fast) {
         is_null,
         does_pointer_equal_42_as_int32_t,
         ptr_should_point_to_42_as_int32_t,
-        getNoopDeallocatorCallback,
         cb_identity_true,
         cb_identity_false,
         cb_identity_42_char,
@@ -493,11 +488,12 @@ function ffiRunner(fast) {
       expect(cptr != 0).toBe(true);
       expect(typeof cptr === "number").toBe(true);
       expect(does_pointer_equal_42_as_int32_t(cptr)).toBe(true);
-      const noopDeallocator = getNoopDeallocatorCallback();
       {
-        const buffer = toBuffer(cptr, 0, 4, noopDeallocator);
+        // No finalizer: both views borrow `cptr` (static storage in the fixture),
+        // so the GC below must not free it. See oven-sh/bun#35405.
+        const buffer = toBuffer(cptr, 0, 4);
         expect(buffer.readInt32(0)).toBe(42);
-        expect(new DataView(toArrayBuffer(cptr, 0, 4, noopDeallocator), 0, 4).getInt32(0, true)).toBe(42);
+        expect(new DataView(toArrayBuffer(cptr, 0, 4), 0, 4).getInt32(0, true)).toBe(42);
         expect(ptr(buffer)).toBe(cptr);
       }
       Bun.gc(true);
@@ -1356,6 +1352,151 @@ describe.if(!!libPath)("can open more than 63 symbols via", () => {
       expect(lib.symbols.strlen(Buffer.from("bunbun\0", "ascii"))).toBe(6n);
     });
   }
+});
+
+// `toBuffer(ptr, offset, len)` without an explicit finalizer used to adopt the
+// caller's pointer as owned and install Bun's allocator deallocator, so GC would
+// `mi_free` caller-owned memory — an ASAN bad-free / release SIGSEGV.
+// These run in a subprocess because the bug crashes the process on unpatched Bun.
+describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
+  async function runsClean(script) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const gcLoop = `for (let i = 0; i < 20; i++) { Bun.gc(true); Buffer.alloc(1024 * 1024); }`;
+
+  // Forcing GC repeatedly in a subprocess costs a few seconds on a debug build, so
+  // the default 5s budget is too tight to be reliable. (On an unpatched Bun the child
+  // SIGSEGVs and then wedges in the crash handler, so there the red signal is this
+  // timeout rather than the exit-code assertion.)
+  const GC_TIMEOUT = 20_000;
+
+  // Post-condition on the ACTUAL caller memory the bad-free targets: drop only the
+  // adopted Buffer, then confirm `original[index]` (the storage `ptr(...)` pointed
+  // at) is still readable and writable — proving its backing was NOT freed. Then
+  // drop `original` too, exercising the owner's normal disposal after the borrowed
+  // view was collected — on an unpatched build the earlier invalid free has already
+  // corrupted that ownership path. That turns "the process didn't abort" into "the
+  // caller memory survived".
+  const originalSurvives = (index, expected) => `
+      adopted = null;
+      ${gcLoop}
+      if (original[${index}] !== ${expected}) throw new Error("caller memory corrupted after adopted GC: " + original[${index}]);
+      original[${index}] = 0x55;
+      if (original[${index}] !== 0x55) throw new Error("caller memory not writable after adopted GC");
+      original = null;
+      ${gcLoop}
+  `;
+
+  it(
+    "toBuffer(ptr(buffer)) does not free caller-owned memory on GC",
+    async () => {
+      const { stdout, exitCode } = await runsClean(`
+      import { ptr, toBuffer } from "bun:ffi";
+      let original = Buffer.alloc(64, 0x41);
+      let adopted = toBuffer(ptr(original), 0, 64);
+      if (adopted[0] !== 0x41) throw new Error("expected a zero-copy view");
+      adopted[0] = 0x42;
+      if (original[0] !== 0x42) throw new Error("expected an aliasing view");
+      ${originalSurvives(0, "0x42")}
+      console.log("survived-gc");
+    `);
+      expect(stdout).toContain("survived-gc");
+      expect(exitCode).toBe(0);
+    },
+    GC_TIMEOUT,
+  );
+
+  it(
+    "toBuffer(ptr(buffer), offset) does not free an interior pointer on GC",
+    async () => {
+      // The adopted view starts at original[8], so both the aliasing check and the
+      // post-GC survival check must inspect that byte, not original[0].
+      const { stdout, exitCode } = await runsClean(`
+      import { ptr, toBuffer } from "bun:ffi";
+      let original = Buffer.alloc(64, 0x41);
+      let adopted = toBuffer(ptr(original), 8, 48);
+      if (adopted[0] !== 0x41) throw new Error("expected a zero-copy view");
+      adopted[0] = 0x42;
+      if (original[8] !== 0x42) throw new Error("expected a view aliasing original[8]");
+      ${originalSurvives(8, "0x42")}
+      console.log("survived-gc");
+    `);
+      expect(stdout).toContain("survived-gc");
+      expect(exitCode).toBe(0);
+    },
+    GC_TIMEOUT,
+  );
+
+  it(
+    "toBuffer(ptr(typedArray)) does not free caller-owned memory on GC",
+    async () => {
+      const { stdout, exitCode } = await runsClean(`
+      import { ptr, toBuffer } from "bun:ffi";
+      let original = new Uint8Array(64).fill(0x41);
+      let adopted = toBuffer(ptr(original), 0, 64);
+      ${originalSurvives(0, "0x41")}
+      console.log("survived-gc");
+    `);
+      expect(stdout).toContain("survived-gc");
+      expect(exitCode).toBe(0);
+    },
+    GC_TIMEOUT,
+  );
+
+  // Regression (the #1 risk): the bad-free fix must NOT change the explicit-finalizer
+  // path — when the caller supplies a finalizer, it still controls disposal and the
+  // deallocator is invoked exactly once on GC. Self-contained via cc() (TinyCC) so the
+  // deallocator's call count is isolated from the shared ffi-test fixture's counter.
+  it(
+    "toBuffer with an explicit finalizer calls the deallocator exactly once on GC",
+    () => {
+      using dir = tempDir("ffi-tobuffer-finalizer", {
+        "dealloc.c": `
+        static int ffi_called = 0;
+        static void* ffi_last_ptr = 0;
+        static unsigned char ffi_buf[128];
+        void ffi_dealloc(void* p, void* ctx) { (void)ctx; ffi_last_ptr = p; ffi_called++; }
+        void* ffi_get_dealloc(void) { return (void*)&ffi_dealloc; }
+        void* ffi_get_buf(void) { return (void*)ffi_buf; }
+        void* ffi_get_last_ptr(void) { return ffi_last_ptr; }
+        int ffi_get_called(void) { return ffi_called; }
+      `,
+      });
+      const { symbols } = cc({
+        source: `${String(dir)}/dealloc.c`,
+        symbols: {
+          ffi_get_dealloc: { args: [], returns: "ptr" },
+          ffi_get_buf: { args: [], returns: "ptr" },
+          ffi_get_last_ptr: { args: [], returns: "ptr" },
+          ffi_get_called: { args: [], returns: "int" },
+        },
+      });
+      const bufPtr = symbols.ffi_get_buf();
+      let buf = toBuffer(bufPtr, 0, 128, symbols.ffi_get_dealloc());
+      expect(buf.length).toBe(128);
+      expect(symbols.ffi_get_called()).toBe(0); // not called during construction
+      buf = null;
+      // Await the collection rather than assuming one pass suffices: a single
+      // Bun.gc(true) can still see `buf` conservatively from the stack.
+      for (let i = 0; i < 20 && symbols.ffi_get_called() === 0; i++) {
+        Bun.gc(true);
+        Buffer.alloc(1024 * 1024);
+      }
+      expect(symbols.ffi_get_called()).toBe(1); // called exactly once on GC
+      expect(symbols.ffi_get_last_ptr()).toBe(bufPtr); // with the buffer's own pointer
+      Bun.gc(true);
+      expect(symbols.ffi_get_called()).toBe(1); // not called again
+    },
+    GC_TIMEOUT,
+  );
 });
 
 describe.skipIf(!FFI_FIXTURE_PATH)("engine-native FFI (single implementation)", () => {


### PR DESCRIPTION
Adopts #31753 by @EffortlessSteven. Fixes #35405. Fixes #24160. Closes #31753.

## Repro

```js
import { ptr, toBuffer } from "bun:ffi";
let original = Buffer.alloc(64, 0x41);
let adopted = toBuffer(ptr(original), 0, 64); // zero-copy view
adopted = null;
Bun.gc(true); // SIGSEGV / ASAN bad-free: original's storage was mi_free'd
```

```
panic(main thread): Segmentation fault at address 0x87D8
```

On Windows/macOS this reproduces with any `dlopen`'d symbol returning a `malloc`'d pointer (#35405), because mimalloc override is off there so `mi_free` walks a CRT/libc allocation. On Linux it reproduces via double-free/UAF when the pointer comes from `ptr(Buffer)`.

## Cause

`to_buffer` in `src/runtime/ffi/FFIObject.rs` falls back to `JSValue::create_buffer(global_this, slice)` when no finalizer is supplied. `create_buffer` hard-codes `MarkedArrayBuffer_deallocator` (i.e. `mi_free`), so collecting the returned Buffer frees storage it never owned.

`toArrayBuffer` already gets this right: it passes the caller's optional finalizer through and never frees on its own.

## Fix

The no-finalizer path installs a no-op bytes deallocator, so the Buffer borrows the pointer and collecting it frees nothing. The zero-copy view is unchanged; an explicit finalizer still controls disposal and runs exactly once. `JSBuffer__bufferFromPointerAndLengthAndDeinit` asserts a non-null deallocator for non-empty storage, so a real no-op function is required rather than `None`.

## Verification

New `describe("toBuffer borrowed-pointer ownership ...")` block in `test/js/bun/ffi/ffi.test.js`:

- three subprocess tests (`ptr(Buffer)` at offset 0, interior offset, `ptr(Uint8Array)`): unpatched child crashes (empty stdout), patched prints `survived-gc` and the caller's bytes remain readable/writable after GC
- regression guard: explicit finalizer via `cc()` is still called exactly once on GC with the buffer's own pointer

The `primitives` fixture test drops its `getNoopDeallocatorCallback()` workaround and now exercises the real no-finalizer path on static native storage (also red on unpatched builds).

Fail-before (3 fail under both release and ASAN), pass-after (4/4 under ASAN). `cargo clippy -p bun_runtime` clean.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/ffi/ffi.test.js

<!-- robobun:evidence:end -->