### PR TITLE
inspector: share TestReporter test ID counter between live and retroactive paths

### DIFF
--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -126,6 +126,12 @@ pub struct Debugger {
     pub protocol: Protocol,
 
     pub test_reporter_agent: TestReporterAgent,
+    /// Next `describe`/`test` ID to hand out to the TestReporter frontend.
+    /// Shared between the live-collection path (`ScopeFunctions::call`) and
+    /// the retroactive path (`retroactively_report_discovered_tests`) so the
+    /// two cannot assign colliding IDs when `TestReporter.enable` arrives
+    /// mid-collection. JS-thread only.
+    pub next_test_id_for_debugger: i32,
     pub lifecycle_reporter_agent: LifecycleAgent,
     /// Reached through a shared `&Debugger` borrow; the slot's `Cell` fields
     /// provide the interior mutability. JS-thread only.
@@ -147,6 +153,7 @@ impl Default for Debugger {
             mode: Mode::Listen,
             protocol: Protocol::Jsc,
             test_reporter_agent: TestReporterAgent::default(),
+            next_test_id_for_debugger: 0,
             lifecycle_reporter_agent: LifecycleAgent::default(),
             extension_agent: ErasedAgentSlot::default(),
             http_server_agent: HTTPServerAgent::default(),
@@ -921,8 +928,13 @@ pub fn test_reporter_agent_enable(agent: *mut TestReporterHandle) {
         // — a forward-dep cycle. Dispatched through [`RuntimeHooks`].
         if let Some(hooks) = runtime_hooks() {
             // SAFETY: `handle` is the live C++ agent just stored above.
-            unsafe {
-                (hooks.retroactively_report_discovered_tests)(dbg.test_reporter_agent.handle)
+            // The counter is threaded through by value so the retroactive
+            // walk resumes from wherever live collection left off.
+            dbg.next_test_id_for_debugger = unsafe {
+                (hooks.retroactively_report_discovered_tests)(
+                    dbg.test_reporter_agent.handle,
+                    dbg.next_test_id_for_debugger,
+                )
             };
         }
     }

--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -126,12 +126,6 @@ pub struct Debugger {
     pub protocol: Protocol,
 
     pub test_reporter_agent: TestReporterAgent,
-    /// Next `describe`/`test` ID to hand out to the TestReporter frontend.
-    /// Shared between the live-collection path (`ScopeFunctions::call`) and
-    /// the retroactive path (`retroactively_report_discovered_tests`) so the
-    /// two cannot assign colliding IDs when `TestReporter.enable` arrives
-    /// mid-collection. JS-thread only.
-    pub next_test_id_for_debugger: i32,
     pub lifecycle_reporter_agent: LifecycleAgent,
     /// Reached through a shared `&Debugger` borrow; the slot's `Cell` fields
     /// provide the interior mutability. JS-thread only.
@@ -153,7 +147,6 @@ impl Default for Debugger {
             mode: Mode::Listen,
             protocol: Protocol::Jsc,
             test_reporter_agent: TestReporterAgent::default(),
-            next_test_id_for_debugger: 0,
             lifecycle_reporter_agent: LifecycleAgent::default(),
             extension_agent: ErasedAgentSlot::default(),
             http_server_agent: HTTPServerAgent::default(),
@@ -816,6 +809,9 @@ pub fn will_dispatch_async_call(global_object: &JSGlobalObject, call: AsyncCallT
 #[derive(Default)]
 pub struct TestReporterAgent {
     pub(crate) handle: *mut TestReporterHandle,
+    /// Shared `describe`/`test` ID counter for both the live
+    /// (`ScopeFunctions::call`) and retroactive reporting paths.
+    pub next_test_id: i32,
 }
 
 /// this enum is kept in sync with c++ InspectorTestReporterAgent.cpp `enum class BunTestStatus`
@@ -928,12 +924,10 @@ pub fn test_reporter_agent_enable(agent: *mut TestReporterHandle) {
         // — a forward-dep cycle. Dispatched through [`RuntimeHooks`].
         if let Some(hooks) = runtime_hooks() {
             // SAFETY: `handle` is the live C++ agent just stored above.
-            // The counter is threaded through by value so the retroactive
-            // walk resumes from wherever live collection left off.
-            dbg.next_test_id_for_debugger = unsafe {
+            dbg.test_reporter_agent.next_test_id = unsafe {
                 (hooks.retroactively_report_discovered_tests)(
                     dbg.test_reporter_agent.handle,
-                    dbg.next_test_id_for_debugger,
+                    dbg.test_reporter_agent.next_test_id,
                 )
             };
         }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1809,14 +1809,9 @@ pub struct RuntimeHooks {
     /// discovered before the inspector connected. `Jest` / `DescribeScope`
     /// live in `bun_runtime::test_runner` (forward-dep cycle), so the body is
     /// hoisted to the high tier; low-tier `Bun__TestReporterAgentEnable`
-    /// dispatches here. No-op (returns `next_test_id` unchanged) when
-    /// `bun test` isn't running.
-    ///
-    /// `next_test_id` is `Debugger::next_test_id_for_debugger` passed by
-    /// value; the return is the advanced counter, which the caller writes
-    /// back. Sharing this counter with the live-collection path in
-    /// `ScopeFunctions::call` prevents ID collisions when `TestReporter.enable`
-    /// lands mid-collection.
+    /// dispatches here. `next_test_id` / the return value thread
+    /// `TestReporterAgent::next_test_id` through by value; no-op returns it
+    /// unchanged.
     pub retroactively_report_discovered_tests:
         unsafe fn(agent: *mut crate::debugger::TestReporterHandle, next_test_id: i32) -> i32,
     /// Cancel every `TimeoutObject` / `ImmediateObject` still in the calling

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1803,15 +1803,22 @@ pub struct RuntimeHooks {
     /// path. The caller gates the call on `vm.standalone_module_graph`.
     pub load_standalone_sourcemap:
         fn(path: &[u8]) -> Option<std::sync::Arc<bun_sourcemap::ParsedSourceMap>>,
-    /// `TestReporterAgent.retroactivelyReportDiscoveredTests(agent)`.
+    /// `TestReporterAgent.retroactivelyReportDiscoveredTests(agent, next_test_id)`.
     /// Walks the active test file's
     /// scope tree and emits `reportTestFoundWithLocation` for every test
     /// discovered before the inspector connected. `Jest` / `DescribeScope`
     /// live in `bun_runtime::test_runner` (forward-dep cycle), so the body is
     /// hoisted to the high tier; low-tier `Bun__TestReporterAgentEnable`
-    /// dispatches here. No-op when `bun test` isn't running.
+    /// dispatches here. No-op (returns `next_test_id` unchanged) when
+    /// `bun test` isn't running.
+    ///
+    /// `next_test_id` is `Debugger::next_test_id_for_debugger` passed by
+    /// value; the return is the advanced counter, which the caller writes
+    /// back. Sharing this counter with the live-collection path in
+    /// `ScopeFunctions::call` prevents ID collisions when `TestReporter.enable`
+    /// lands mid-collection.
     pub retroactively_report_discovered_tests:
-        unsafe fn(agent: *mut crate::debugger::TestReporterHandle),
+        unsafe fn(agent: *mut crate::debugger::TestReporterHandle, next_test_id: i32) -> i32,
     /// Cancel every `TimeoutObject` / `ImmediateObject` still in the calling
     /// thread's `timer::All` heap so their JS pins and in-heap `+1` refs drop
     /// before the GC sweep. `timer::All` lives in `bun_runtime` (forward-dep);

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1698,7 +1698,9 @@ unsafe fn retroactively_report_discovered_tests(
     use crate::test_runner::jest::Jest;
     use bun_jsc::debugger::{TestReporterHandle, TestType};
 
-    let Some(runner) = Jest::runner() else { return next_test_id };
+    let Some(runner) = Jest::runner() else {
+        return next_test_id;
+    };
     let Some(active_file) = runner.bun_test_root.active_file.as_ref() else {
         return next_test_id;
     };

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1679,12 +1679,8 @@ pub(crate) fn close_isolation_handles(vm: &mut VirtualMachine) {
 /// When `TestReporter.enable` arrives after test
 /// collection has started, walk the already-discovered scope tree, assign
 /// debugger test IDs, and emit `reportTestFoundWithLocation` for each.
-///
-/// `next_test_id` is the caller's `Debugger::next_test_id_for_debugger`
-/// passed by value; the return is that counter advanced past every ID this
-/// call assigned. The caller writes the return back so the live-collection
-/// path in `ScopeFunctions::call` (which increments the same field) continues
-/// from where this left off.
+/// Returns `next_test_id` advanced past every ID assigned (the caller writes
+/// it back into `TestReporterAgent::next_test_id`).
 ///
 /// # Safety
 /// `agent` is a live C++ `Inspector::TestReporterAgent::Handle*` (just stored
@@ -1721,8 +1717,6 @@ unsafe fn retroactively_report_discovered_tests(
         .text();
     let mut source_url = bun_core::String::init(file_path);
 
-    // Seed from the shared counter so IDs here never collide with IDs the
-    // live path already handed out (or will hand out after we return).
     let mut max_id: i32 = next_test_id;
 
     // Recursively report all discovered tests starting from root scope.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1675,23 +1675,32 @@ pub(crate) fn close_isolation_handles(vm: &mut VirtualMachine) {
     }
 }
 
-/// `TestReporterAgent.retroactivelyReportDiscoveredTests(agent)`.
+/// `TestReporterAgent.retroactivelyReportDiscoveredTests(agent, next_test_id)`.
 /// When `TestReporter.enable` arrives after test
 /// collection has started, walk the already-discovered scope tree, assign
 /// debugger test IDs, and emit `reportTestFoundWithLocation` for each.
+///
+/// `next_test_id` is the caller's `Debugger::next_test_id_for_debugger`
+/// passed by value; the return is that counter advanced past every ID this
+/// call assigned. The caller writes the return back so the live-collection
+/// path in `ScopeFunctions::call` (which increments the same field) continues
+/// from where this left off.
 ///
 /// # Safety
 /// `agent` is a live C++ `Inspector::TestReporterAgent::Handle*` (just stored
 /// into `debugger.test_reporter_agent.handle` by the caller). Called on the JS
 /// thread.
-unsafe fn retroactively_report_discovered_tests(agent: *mut bun_jsc::debugger::TestReporterHandle) {
+unsafe fn retroactively_report_discovered_tests(
+    agent: *mut bun_jsc::debugger::TestReporterHandle,
+    next_test_id: i32,
+) -> i32 {
     use crate::test_runner::bun_test::{DescribeScope, Phase, TestScheduleEntry};
     use crate::test_runner::jest::Jest;
     use bun_jsc::debugger::{TestReporterHandle, TestType};
 
-    let Some(runner) = Jest::runner() else { return };
+    let Some(runner) = Jest::runner() else { return next_test_id };
     let Some(active_file) = runner.bun_test_root.active_file.as_ref() else {
-        return;
+        return next_test_id;
     };
     // SAFETY: single-threaded; `active_file` keeps the cell alive for this call.
     let active_file = unsafe { &mut *active_file.as_ptr() };
@@ -1700,7 +1709,7 @@ unsafe fn retroactively_report_discovered_tests(agent: *mut bun_jsc::debugger::T
     // discovered).
     match active_file.phase {
         Phase::Collection | Phase::Execution => {}
-        Phase::Done => return,
+        Phase::Done => return next_test_id,
     }
 
     // Get the file path for source location info.
@@ -1710,8 +1719,9 @@ unsafe fn retroactively_report_discovered_tests(agent: *mut bun_jsc::debugger::T
         .text();
     let mut source_url = bun_core::String::init(file_path);
 
-    // Track the maximum ID we assign.
-    let mut max_id: i32 = 0;
+    // Seed from the shared counter so IDs here never collide with IDs the
+    // live path already handed out (or will hand out after we return).
+    let mut max_id: i32 = next_test_id;
 
     // Recursively report all discovered tests starting from root scope.
     retroactively_report_scope(
@@ -1722,9 +1732,7 @@ unsafe fn retroactively_report_discovered_tests(agent: *mut bun_jsc::debugger::T
         &mut source_url,
     );
 
-    // A debug-only log of `max_id` was dropped here: `scoped_log!` only accepts
-    // an ident, so it can't name the scoped-logger static in `bun_jsc::debugger`.
-    let _ = max_id;
+    return max_id;
 
     fn retroactively_report_scope(
         agent: *mut TestReporterHandle,

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -351,11 +351,8 @@ impl ScopeFunctions {
         let mut test_id_for_debugger: i32 = 0;
         if let Some(debugger) = (*vm).debugger.as_mut() {
             if debugger.test_reporter_agent.is_enabled() {
-                // Shared with `retroactively_report_discovered_tests` via
-                // `Debugger::next_test_id_for_debugger` so IDs never collide
-                // when `TestReporter.enable` lands mid-collection.
-                debugger.next_test_id_for_debugger += 1;
-                let id = debugger.next_test_id_for_debugger;
+                debugger.test_reporter_agent.next_test_id += 1;
+                let id = debugger.test_reporter_agent.next_test_id;
                 let mut name = BunString::init(description.unwrap_or(b"(unnamed)"));
                 let parent: &DescribeScope = bun_test.collection.active_scope();
                 let parent_id = if parent.base.test_id_for_debugger != 0 {

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -1,6 +1,5 @@
 use core::fmt;
 use crate::test_runner::expect::JSValueTestExt;
-use core::sync::atomic::{AtomicI32, Ordering};
 
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass, JsResult};
 use bun_core::String as BunString;
@@ -352,8 +351,11 @@ impl ScopeFunctions {
         let mut test_id_for_debugger: i32 = 0;
         if let Some(debugger) = (*vm).debugger.as_mut() {
             if debugger.test_reporter_agent.is_enabled() {
-                static MAX_TEST_ID_FOR_DEBUGGER: AtomicI32 = AtomicI32::new(0);
-                let id = MAX_TEST_ID_FOR_DEBUGGER.fetch_add(1, Ordering::Relaxed) + 1;
+                // Shared with `retroactively_report_discovered_tests` via
+                // `Debugger::next_test_id_for_debugger` so IDs never collide
+                // when `TestReporter.enable` lands mid-collection.
+                debugger.next_test_id_for_debugger += 1;
+                let id = debugger.next_test_id_for_debugger;
                 let mut name = BunString::init(description.unwrap_or(b"(unnamed)"));
                 let parent: &DescribeScope = bun_test.collection.active_scope();
                 let parent_id = if parent.base.test_id_for_debugger != 0 {

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -430,7 +430,8 @@ afterAll(async () => {
     // can exit.
     await write(doneGatePath, "go");
 
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    void stdout;
 
     // Core assertion: every `found` id across both paths is unique.
     expect(rawFoundIds.length).toBe(5);

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -310,4 +310,148 @@ afterAll(async () => {
     const exitCode = await proc.exited;
     expect(exitCode).toBe(0);
   });
+
+  test("assigns unique test IDs when TestReporter.enable lands mid-collection", async () => {
+    // Regression: the live-registration path (ScopeFunctions::call) and the
+    // retroactive path (retroactively_report_discovered_tests) used to draw
+    // IDs from two independent counters. The existing test above enables
+    // TestReporter only after collection finishes, so the two paths never
+    // interleave there.
+    //
+    // Here we pause inside suite B's *async describe callback*. By that point
+    // collection has already run suite A's (sync) callback to completion
+    // (registering test A1/A2), while suite B's own test() has not yet been
+    // called. Enabling TestReporter in that window sends suite A + suite B's
+    // describe through the retroactive walk; test B1 is registered live once
+    // we release the gate.
+
+    using dir = tempDir("test-reporter-mid-collection", {
+      "mid-collection.test.ts": `
+import { afterAll, describe, test, expect } from "bun:test";
+import { existsSync } from "node:fs";
+
+describe("suite A", () => {
+  test("test A1", () => {
+    expect(1).toBe(1);
+  });
+  test("test A2", () => {
+    expect(2).toBe(2);
+  });
+});
+
+describe("suite B", async () => {
+  console.log("__COLLECTION_CHECKPOINT__");
+  while (!existsSync("collect-gate")) {
+    await Bun.sleep(5);
+  }
+  test("test B1", () => {
+    expect(3).toBe(3);
+  });
+});
+
+afterAll(async () => {
+  while (!existsSync("done-gate")) await Bun.sleep(10);
+});
+`,
+    });
+
+    const socketPath = join(String(dir), `inspector-${Math.random().toString(36).substring(2)}.sock`);
+    const collectGatePath = join(String(dir), "collect-gate");
+    const doneGatePath = join(String(dir), "done-gate");
+
+    const session = new TestReporterSession();
+    const framer = new SocketFramer((message: string) => {
+      session.onMessage(message);
+    });
+
+    // Track every raw `found` id in arrival order (no dedupe) so a collision
+    // shows up as a literal duplicate independent of the Map-keyed bookkeeping
+    // in TestReporterSession (which would silently coalesce same-id events).
+    const rawFoundIds: number[] = [];
+    session.addEventListener("TestReporter.found", (params: any) => {
+      rawFoundIds.push(params.id);
+    });
+
+    const socketPromise = connect(`unix://${socketPath}`).then(s => {
+      socket = s;
+      session.socket = s;
+      session.framer = framer;
+      s.data = {
+        onData: framer.onData.bind(framer),
+      };
+      return s;
+    });
+
+    proc = spawn({
+      cmd: [bunExe(), `--inspect-wait=unix:${socketPath}`, "test", "--timeout", "30000", "mid-collection.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    await socketPromise;
+
+    // Enable Inspector and Console (NOT TestReporter). Console lets us observe
+    // the collection checkpoint without disturbing collection itself.
+    session.enableInspector();
+    session.send("Console.enable");
+
+    const checkpointSeen = session.waitForConsoleMessage("__COLLECTION_CHECKPOINT__", 15000);
+
+    // Signal ready - this allows test collection to proceed.
+    session.initialize();
+
+    // Wait until suite A has fully registered and collection is paused inside
+    // suite B's async describe callback (test B1 not yet registered).
+    await checkpointSeen;
+
+    // Enable TestReporter now, genuinely mid-collection.
+    session.enableTestReporter();
+
+    // suite A's describe + 2 tests, plus suite B's (empty) describe: 4 events
+    // via the retroactive walk.
+    await session.waitForFoundTests(4, 15000);
+
+    // Release the gate so suite B's callback registers test B1 via the live
+    // path while the agent is enabled.
+    await write(collectGatePath, "go");
+
+    // test B1 brings the total to 5. Pre-fix its id collides with one the
+    // retroactive walk already used, so the Map stays at 4 keys and this
+    // wait times out.
+    const foundTests = await session.waitForFoundTests(5, 15000);
+    expect(foundTests.size).toBe(5);
+
+    const endedTests = await session.waitForEndedTests(3, 15000);
+    expect(endedTests.size).toBe(3);
+
+    // All `end` events received; release the afterAll hold so the subprocess
+    // can exit.
+    await write(doneGatePath, "go");
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    // Core assertion: every `found` id across both paths is unique.
+    expect(rawFoundIds.length).toBe(5);
+    expect(new Set(rawFoundIds).size).toBe(5);
+
+    // Every `end` event's id must correspond to an actual `test`.
+    for (const id of endedTests.keys()) {
+      const found = foundTests.get(id);
+      expect(found).toBeDefined();
+      expect(found.type).toBe("test");
+    }
+
+    const testNames = [...foundTests.values()]
+      .filter(t => t.type === "test")
+      .map(t => t.name)
+      .sort();
+    expect(testNames).toEqual(["test A1", "test A2", "test B1"]);
+
+    if (exitCode !== 0) {
+      expect(stderr).toBe("");
+    }
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
Adopts the fix from #34221 by @hughescr.

### Problem

`TestReporter` test/describe IDs came from two independent counters:

- the live-registration path (`ScopeFunctions::call`, which assigns an ID as each `describe()`/`test()` is collected) used a function-local `static AtomicI32` that only advances while the agent is enabled
- the retroactive path (`retroactively_report_discovered_tests`, which walks the already-discovered scope tree when `TestReporter.enable` arrives after collection has started) seeded a fresh local `max_id` at `0` on every call

When `enable` lands mid-collection (some scopes already discovered, others still being registered live) both paths run in the same process and each hands out its own `1..N` range, so two unrelated tests can be reported under the same ID. Inspector clients keying state by ID (correlating `found`/`start`/`end` events) silently conflate them.

### Fix

Move the counter to a `next_test_id: i32` field on `TestReporterAgent` (matching `HTTPServerAgent::next_server_id` / `ErasedAgentSlot::sequence`):

- `ScopeFunctions::call` increments it directly through its `&mut Debugger` borrow
- `retroactively_report_discovered_tests` takes the counter by value and returns the advanced value through the `RuntimeHooks` hook; `test_reporter_agent_enable` writes the return back into the field

Both paths now draw from the same monotone counter. Single JS thread, so no synchronization needed.

### Verification

New test in `test/cli/inspect/test-reporter.test.ts` creates a genuine mid-collection window by pausing inside an async `describe()` callback (suite A's sync callback has already registered 2 tests; suite B's `test()` call has not yet run). `TestReporter.enable` is sent in that window so suite A + suite B's describe go through the retroactive walk and `test B1` goes through the live path in the same run. The test asserts every `found` ID across both paths is unique via a raw non-deduped list (the `Map`-keyed session bookkeeping would coalesce a collision).

```
USE_SYSTEM_BUN=1 bun test test/cli/inspect/test-reporter.test.ts -t "mid-collection"
# (fail) ... timed out after 5000ms  (Map never reaches 5 distinct keys)

bun bd test test/cli/inspect/test-reporter.test.ts
#  2 pass, 0 fail
```

Supersedes #34221 (same fix, adopted with co-author credit).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/test-reporter.test.ts
bun test v1.4.0 (532af4234)

test/cli/inspect/test-reporter.test.ts:
(pass) TestReporter inspector protocol > retroactively reports tests when TestReporter.enable is called after tests are discovered [1618.23ms]
killed 1 dangling process
(fail) TestReporter inspector protocol > assigns unique test IDs when TestReporter.enable lands mid-collection [5001.59ms]
  ^ this test timed out after 5000ms.

 1 pass
 1 fail
 7 expect() calls
Ran 2 tests across 1 file. [8.88s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/inspect/test-reporter.test.ts:
(pass) TestReporter inspector protocol > retroactively reports tests when TestReporter.enable is called after tests are discovered [58.29ms]
killed 1 dangling process
(fail) TestReporter inspector protocol > assigns unique test IDs when TestReporter.enable lands mid-collection [5000.27ms]
  ^ this test timed out after 5000ms.

 1 pass
 1 fail
 7 expect() calls
Ran 2 tests across 1 file. [5.26s]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/test-reporter.test.ts
bun test v1.4.0 (532af4234)

test/cli/inspect/test-reporter.test.ts:
(pass) TestReporter inspector protocol > retroactively reports tests when TestReporter.enable is called after tests are discovered [1671.03ms]
(pass) TestReporter inspector protocol > assigns unique test IDs when TestReporter.enable lands mid-collection [1602.82ms]

 2 pass
 0 fail
 19 expect() calls
Ran 2 tests across 1 file. [5.40s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 692ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cc obj/packages/bun-usockets/src/context.c.o
[2/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_css_jsc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/Debugger.rs                       |  10 ++-
 src/jsc/VirtualMachine.rs                 |   8 +-
 src/runtime/jsc_hooks.rs                  |  24 ++---
 src/runtime/test_runner/ScopeFunctions.rs |   5 +-
 test/cli/inspect/test-reporter.test.ts    | 145 ++++++++++++++++++++++++++++++
 5 files changed, 174 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/Debugger.rs                            4      4      0
src/jsc/VirtualMachine.rs                      2      4      0
src/runtime/jsc_hooks.rs                       4      5      0
src/runtime/test_runner/ScopeFunctions.rs      4      4      0
test/cli/inspect/test-reporter.test.ts         3      3      0
```

</details>

<!-- robobun:evidence:end -->