### PR TITLE
cli: fail when an explicit --env-file cannot be loaded

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -752,37 +752,30 @@ impl<'a> Transpiler<'a> {
                     self.resolver.opts.set_production(true);
                 }
 
-                // Load the project root for .env file discovery. If the cwd
-                // (or a parent) is unreadable, readDirInfo may return null;
-                // bail out of .env file loading in that case, but process
-                // env vars were already loaded above.
+                // The cwd listing only drives default `.env*` discovery; an
+                // unreadable cwd leaves it empty so nothing is probed, while
+                // explicit `--env-file` paths below are still opened directly.
                 let top_level_dir = self.fs().top_level_dir;
-                let dir_info = match self.resolver.read_dir_info(top_level_dir) {
-                    Ok(Some(d)) => d,
-                    _ => return Ok(()),
-                };
+                let mut dir = dot_env::DirEntryKeys(Vec::new());
+                if let Ok(Some(dir_info)) = self.resolver.read_dir_info(top_level_dir) {
+                    if let Some(tsconfig) = dir_info.tsconfig_json() {
+                        merge_tsconfig_jsx_into(tsconfig, &mut self.options.jsx);
+                    }
 
-                if let Some(tsconfig) = dir_info.tsconfig_json() {
-                    merge_tsconfig_jsx_into(tsconfig, &mut self.options.jsx);
-                }
-
-                // Copy the listing's basenames out under `entries_mutex`,
-                // refreshing it at our generation in the same critical
-                // section: concurrent resolvers rewrite the `DirEntry` map in
-                // place under that lock, and `dot_env::Loader::load` does
-                // file I/O between probes.
-                let dir = {
+                    // Copy the listing's basenames out under `entries_mutex`,
+                    // refreshing it at our generation in the same critical
+                    // section: concurrent resolvers rewrite the `DirEntry` map in
+                    // place under that lock, and `dot_env::Loader::load` does
+                    // file I/O between probes.
                     let _entries_lock = bun_resolver::fs::FileSystem::instance()
                         .fs
                         .entries_mutex
                         .lock_guard();
-                    match dir_info.get_entries_ref_locked(self.resolver.generation) {
-                        Some(entries) => dot_env::DirEntryKeys(
-                            entries.data.iter().map(|(k, _)| Box::from(&**k)).collect(),
-                        ),
-                        None => return Ok(()),
+                    if let Some(entries) = dir_info.get_entries_ref_locked(self.resolver.generation)
+                    {
+                        dir.0 = entries.data.iter().map(|(k, _)| Box::from(&**k)).collect();
                     }
-                };
+                }
 
                 // `Env.files: Box<[Box<[u8]>]>` but `Loader::load`
                 // wants `&[&[u8]]`. Re-borrow into a small Vec; the explicit

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -752,30 +752,32 @@ impl<'a> Transpiler<'a> {
                     self.resolver.opts.set_production(true);
                 }
 
-                // The cwd listing only drives default `.env*` discovery; an
-                // unreadable cwd leaves it empty so nothing is probed, while
-                // explicit `--env-file` paths below are still opened directly.
+                // The listing only feeds default `.env*` discovery; `--env-file` opens by path.
                 let top_level_dir = self.fs().top_level_dir;
-                let mut dir = dot_env::DirEntryKeys(Vec::new());
-                if let Ok(Some(dir_info)) = self.resolver.read_dir_info(top_level_dir) {
-                    if let Some(tsconfig) = dir_info.tsconfig_json() {
-                        merge_tsconfig_jsx_into(tsconfig, &mut self.options.jsx);
-                    }
+                let dir_info = self.resolver.read_dir_info(top_level_dir).ok().flatten();
 
-                    // Copy the listing's basenames out under `entries_mutex`,
-                    // refreshing it at our generation in the same critical
-                    // section: concurrent resolvers rewrite the `DirEntry` map in
-                    // place under that lock, and `dot_env::Loader::load` does
-                    // file I/O between probes.
+                if let Some(tsconfig) = dir_info.and_then(|d| d.tsconfig_json()) {
+                    merge_tsconfig_jsx_into(tsconfig, &mut self.options.jsx);
+                }
+
+                // Copy the listing's basenames out under `entries_mutex`,
+                // refreshing it at our generation in the same critical
+                // section: concurrent resolvers rewrite the `DirEntry` map in
+                // place under that lock, and `dot_env::Loader::load` does
+                // file I/O between probes.
+                let dir = {
                     let _entries_lock = bun_resolver::fs::FileSystem::instance()
                         .fs
                         .entries_mutex
                         .lock_guard();
-                    if let Some(entries) = dir_info.get_entries_ref_locked(self.resolver.generation)
-                    {
-                        dir.0 = entries.data.iter().map(|(k, _)| Box::from(&**k)).collect();
-                    }
-                }
+                    dot_env::DirEntryKeys(
+                        dir_info
+                            .and_then(|d| d.get_entries_ref_locked(self.resolver.generation))
+                            .map_or_else(Vec::new, |entries| {
+                                entries.data.iter().map(|(k, _)| Box::from(&**k)).collect()
+                            }),
+                    )
+                };
 
                 // `Env.files: Box<[Box<[u8]>]>` but `Loader::load`
                 // wants `&[&[u8]]`. Re-borrow into a small Vec; the explicit

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1275,7 +1275,7 @@ mod draft {
             super::out_of_memory();
         } else if matches!(
             name,
-            b"InvalidArgument" | b"Invalid Bunfig" | b"InstallFailed"
+            b"InvalidArgument" | b"Invalid Bunfig" | b"InstallFailed" | b"EnvFileNotFound"
         ) {
             if !show_trace {
                 Global::exit(1);

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1275,7 +1275,7 @@ mod draft {
             super::out_of_memory();
         } else if matches!(
             name,
-            b"InvalidArgument" | b"Invalid Bunfig" | b"InstallFailed" | b"EnvFileNotFound"
+            b"InvalidArgument" | b"Invalid Bunfig" | b"InstallFailed" | b"EnvFileLoadFailed"
         ) {
             if !show_trace {
                 Global::exit(1);

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -857,10 +857,20 @@ impl Loader {
 
         let file = match bun_sys::open_file(file_path, bun_sys::OpenFlags::READ_ONLY) {
             Ok(f) => f,
-            Err(_) => {
-                // prevent retrying
-                self.custom_files_loaded.insert(file_path)?;
-                return Ok(());
+            Err(err) => {
+                // Only explicitly requested files reach here (default `.env`
+                // discovery goes through `load_default_files`), so a failed open
+                // is a user error: Node exits non-zero for
+                // `--env-file=<missing>`. Print the detailed line here while we
+                // have both the path and the errno, and return a sentinel the
+                // CLI sinks recognize as already reported.
+                bun_core::err_generic!(
+                    "{} reading env file {}",
+                    bstr::BStr::new(err.name()),
+                    bun_core::fmt::QuotedFormatter { text: file_path },
+                );
+                Output::flush();
+                return Err(crate::Error::EnvFileNotFound);
             }
         };
 

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -855,35 +855,17 @@ impl Loader {
             return Ok(());
         }
 
+        // Unlike the default `.env` discovery above, these files were asked for
+        // by name (`--env-file`), so failing to load one is fatal, as in Node.
         let file = match bun_sys::open_file(file_path, bun_sys::OpenFlags::READ_ONLY) {
             Ok(f) => f,
-            Err(err) => {
-                // Only explicitly requested files reach here (default `.env`
-                // discovery goes through `load_default_files`), so a failed open
-                // is a user error: Node exits non-zero for
-                // `--env-file=<missing>`. Print the detailed line here while we
-                // have both the path and the errno, and return a sentinel the
-                // CLI sinks recognize as already reported.
-                bun_core::err_generic!(
-                    "{} reading env file {}",
-                    bstr::BStr::new(err.name()),
-                    bun_core::fmt::QuotedFormatter { text: file_path },
-                );
-                Output::flush();
-                return Err(crate::Error::EnvFileNotFound);
-            }
+            Err(err) => return Err(explicit_env_file_failed(file_path, err.name())),
         };
 
         match read_env_file_contents(&file)? {
             ReadEnvFile::Empty => {}
             ReadEnvFile::ReadErr(err) => {
-                if !self.quiet {
-                    bun_core::pretty_errorln!(
-                        "<r><red>{}<r> error loading {} file",
-                        bstr::BStr::new(err.name()),
-                        bstr::BStr::new(file_path)
-                    );
-                }
+                return Err(explicit_env_file_failed(file_path, err.name()));
             }
             ReadEnvFile::Bytes(buf) => {
                 Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?;
@@ -895,6 +877,16 @@ impl Loader {
     }
 }
 
+fn explicit_env_file_failed(file_path: &[u8], errno_name: &[u8]) -> crate::Error {
+    bun_core::err_generic!(
+        "{} loading env file {}",
+        bstr::BStr::new(errno_name),
+        bun_core::fmt::QuotedFormatter { text: file_path },
+    );
+    Output::flush();
+    crate::Error::EnvFileLoadFailed
+}
+
 /// Shared post-open tail of `load_env_file` / `load_env_file_dynamic`:
 /// `File::read_to_end` (fstat-presized) with the recoverable-errno filter.
 /// The two callers differ in their open path, open-error handling, and the
@@ -903,8 +895,8 @@ impl Loader {
 enum ReadEnvFile {
     /// Zero-length — caller marks the slot and returns.
     Empty,
-    /// Recoverable read errno (ENOMEM/EPIPE/EACCES/EISDIR) — caller prints
-    /// (unless `quiet`), marks the slot, and returns.
+    /// Recoverable read errno (ENOMEM/EPIPE/EACCES/EISDIR) — a default file
+    /// warns (unless `quiet`) and is skipped; an explicit `--env-file` fails.
     ReadErr(bun_sys::Error),
     /// File contents; `buf.len()` is the amount read.
     Bytes(Vec<u8>),

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -861,15 +861,11 @@ impl Loader {
             Err(err) => return Err(explicit_env_file_failed(file_path, err.name())),
         };
 
-        match read_env_file_contents(&file)? {
-            ReadEnvFile::Empty => {}
-            ReadEnvFile::ReadErr(err) => {
-                return Err(explicit_env_file_failed(file_path, err.name()));
-            }
-            ReadEnvFile::Bytes(buf) => {
-                Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?;
-            }
-        }
+        let buf = match file.read_to_end() {
+            Ok(buf) => buf,
+            Err(err) => return Err(explicit_env_file_failed(file_path, err.name())),
+        };
+        Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?;
 
         self.custom_files_loaded.insert(file_path)?;
         Ok(())
@@ -886,15 +882,12 @@ fn explicit_env_file_failed(file_path: &[u8], errno_name: &[u8]) -> crate::Error
     crate::Error::EnvFileLoadFailed
 }
 
-/// Shared post-open tail of `load_env_file` / `load_env_file_dynamic`:
-/// `File::read_to_end` (fstat-presized) with the recoverable-errno filter.
-/// The two callers differ in their open path, open-error handling, and the
-/// memo slot they write — those stay in the callers. Only the shared read
-/// tail is factored here.
+/// Read tail of `load_env_file`: `read_to_end` plus the errnos that merely skip a default file.
 enum ReadEnvFile {
     /// Zero-length — caller marks the slot and returns.
     Empty,
-    /// Recoverable read errno (ENOMEM/EPIPE/EACCES/EISDIR); defaults skip it, explicit files fail.
+    /// Recoverable read errno (ENOMEM/EPIPE/EACCES/EISDIR) — caller prints
+    /// (unless `quiet`), marks the slot, and returns.
     ReadErr(bun_sys::Error),
     /// File contents; `buf.len()` is the amount read.
     Bytes(Vec<u8>),

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -855,8 +855,7 @@ impl Loader {
             return Ok(());
         }
 
-        // Unlike the default `.env` discovery above, these files were asked for
-        // by name (`--env-file`), so failing to load one is fatal, as in Node.
+        // Asked for by name (`--env-file`), so failing to load it is fatal, as in Node.
         let file = match bun_sys::open_file(file_path, bun_sys::OpenFlags::READ_ONLY) {
             Ok(f) => f,
             Err(err) => return Err(explicit_env_file_failed(file_path, err.name())),
@@ -895,8 +894,7 @@ fn explicit_env_file_failed(file_path: &[u8], errno_name: &[u8]) -> crate::Error
 enum ReadEnvFile {
     /// Zero-length — caller marks the slot and returns.
     Empty,
-    /// Recoverable read errno (ENOMEM/EPIPE/EACCES/EISDIR) — a default file
-    /// warns (unless `quiet`) and is skipped; an explicit `--env-file` fails.
+    /// Recoverable read errno (ENOMEM/EPIPE/EACCES/EISDIR); defaults skip it, explicit files fail.
     ReadErr(bun_sys::Error),
     /// File contents; `buf.len()` is the amount read.
     Bytes(Vec<u8>),

--- a/src/dotenv/error.rs
+++ b/src/dotenv/error.rs
@@ -1,10 +1,8 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
-    /// An explicit `--env-file` could not be opened. The loader has already
-    /// printed the detailed message; callers should exit non-zero without
-    /// adding a second generic line.
-    #[error("EnvFileNotFound")]
-    EnvFileNotFound,
+    /// An explicit `--env-file` failed to load; the loader already printed the error.
+    #[error("EnvFileLoadFailed")]
+    EnvFileLoadFailed,
     #[error(transparent)]
     Sys(#[from] bun_errno::SystemErrno),
     #[error(transparent)]
@@ -21,7 +19,7 @@ impl Error {
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn name(&self) -> &'static str {
         match self {
-            Self::EnvFileNotFound => "EnvFileNotFound",
+            Self::EnvFileLoadFailed => "EnvFileLoadFailed",
             Self::Sys(e) => <&'static str>::from(e),
             Self::Alloc(_) => "OutOfMemory",
         }

--- a/src/dotenv/error.rs
+++ b/src/dotenv/error.rs
@@ -1,5 +1,10 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
+    /// An explicit `--env-file` could not be opened. The loader has already
+    /// printed the detailed message; callers should exit non-zero without
+    /// adding a second generic line.
+    #[error("EnvFileNotFound")]
+    EnvFileNotFound,
     #[error(transparent)]
     Sys(#[from] bun_errno::SystemErrno),
     #[error(transparent)]
@@ -16,6 +21,7 @@ impl Error {
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn name(&self) -> &'static str {
         match self {
+            Self::EnvFileNotFound => "EnvFileNotFound",
             Self::Sys(e) => <&'static str>::from(e),
             Self::Alloc(_) => "OutOfMemory",
         }

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -605,8 +605,8 @@ impl WebWorker {
         // proxy_env_storage / env.map, copy of standalone_module_graph),
         // so a shared reference is sufficient.
         let parent = self.parent.get();
-        // Deref-clone out of the `Arc` — worker mutates `allow_addons` and the
-        // env-file fields below and passes the owned struct as `args` to the new VM.
+        // Deref-clone out of the `Arc` — worker mutates `allow_addons` below
+        // and passes the owned struct as `args` to the new VM.
         let mut transform_options = (*parent.transpiler.options.transform_options).clone();
 
         if let Some(exec_argv) = self.exec_argv() {
@@ -628,12 +628,10 @@ impl WebWorker {
             }
         }
 
-        // The parent's `--env-file` values arrive through the env map cloned
-        // below; re-reading the files here would fail the worker if one was
-        // removed after startup. Explicit files also disabled default `.env`
-        // discovery in the parent, so keep it disabled here.
+        // `--env-file` values are in the env map cloned below; re-reading fails if a file is gone.
         if !transform_options.env_files.is_empty() {
             transform_options.env_files.clear();
+            // Explicit files disabled default `.env` discovery in the parent; keep it that way.
             transform_options.disable_default_env_files = true;
         }
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -605,8 +605,8 @@ impl WebWorker {
         // proxy_env_storage / env.map, copy of standalone_module_graph),
         // so a shared reference is sufficient.
         let parent = self.parent.get();
-        // Deref-clone out of the `Arc` — worker mutates `allow_addons` below
-        // and passes the owned struct as `args` to the new VM.
+        // Deref-clone out of the `Arc` — worker mutates `allow_addons` and the
+        // env-file fields below and passes the owned struct as `args` to the new VM.
         let mut transform_options = (*parent.transpiler.options.transform_options).clone();
 
         if let Some(exec_argv) = self.exec_argv() {
@@ -626,6 +626,15 @@ impl WebWorker {
                 let parent_allows = transform_options.allow_addons.unwrap_or(true);
                 transform_options.allow_addons = Some(parent_allows && allow_addons);
             }
+        }
+
+        // The parent's `--env-file` values arrive through the env map cloned
+        // below; re-reading the files here would fail the worker if one was
+        // removed after startup. Explicit files also disabled default `.env`
+        // discovery in the parent, so keep it disabled here.
+        if !transform_options.env_files.is_empty() {
+            transform_options.env_files.clear();
+            transform_options.disable_default_env_files = true;
         }
 
         // worker-thread only field; no other thread reads `arena`.

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1418,6 +1418,14 @@ pub mod command {
         Ok(())
     }
 
+    #[cold]
+    fn run_scripts_failed_exit(err: &crate::Error) -> ! {
+        if !err.is_env_file_load_failed() {
+            pretty_errorln!("<r><red>error<r>: {}", err.name());
+        }
+        Global::exit(1);
+    }
+
     /// `bun [run] <script>` / `bun --version` / bare `bun`. The dominant tag
     /// pair — kept out-of-line so `start` is a jump table, but *not* `#[cold]`.
     #[inline(never)]
@@ -1440,15 +1448,13 @@ pub mod command {
         if ctx.parallel || ctx.sequential {
             // Result<Infallible, _>: if this returns at all, it's Err.
             let Err(err) = super::multi_run::run(ctx);
-            pretty_errorln!("<r><red>error<r>: {}", err.name());
-            Global::exit(1);
+            run_scripts_failed_exit(&err);
         }
 
         if !ctx.filters.is_empty() || ctx.workspaces {
             // Result<Infallible, _>: if this returns at all, it's Err.
             let Err(err) = super::filter_run::run_scripts_with_filter(ctx);
-            pretty_errorln!("<r><red>error<r>: {}", err.name());
-            Global::exit(1);
+            run_scripts_failed_exit(&err);
         }
 
         // Node: `-i foo.js` runs the script; `-i -e code` evals then enters the

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -672,8 +672,9 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             }
 
             // Always skip default .env files for package.json script runner
-            // (the script's own bun instance loads .env)
-            let _ = this_transpiler.run_env_loader(true);
+            // (the script's own bun instance loads .env). Propagate so a
+            // missing explicit `--env-file` surfaces as a non-zero exit.
+            this_transpiler.run_env_loader(true)?;
         }
 
         // Re-derive after `run_env_loader` — that call creates its own
@@ -1726,6 +1727,12 @@ impl RunCommand {
         let _ = unsafe { ctx.log() }.print(std::ptr::from_mut::<bun_core::io::Writer>(
             Output::error_writer(),
         ));
+
+        // The env loader prints the detailed line itself for a missing
+        // `--env-file`; don't add a second generic one.
+        if err.name() == "EnvFileNotFound" {
+            Global::exit(1);
+        }
 
         pretty_errorln!(
             "<r><red>error<r>: Failed to run <b>{}<r> due to error <b>{}<r>",

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -599,9 +599,32 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         // Out-param constructor — `configure_env_for_run` writes the whole struct.
         // `Transpiler` holds `&Arena`/`Box`/enum fields (non-null invariants),
         // so callers MUST pass a `MaybeUninit` slot.
-        this_transpiler.write(Transpiler::init(arena, ctx.log, args, env)?);
-        // SAFETY: fully written on the line above.
-        let this_transpiler = unsafe { this_transpiler.assume_init_mut() };
+        let this_transpiler = this_transpiler.write(Transpiler::init(arena, ctx.log, args, env)?);
+        let result = Self::configure_run_transpiler(
+            ctx,
+            this_transpiler,
+            env_is_none,
+            log_errors,
+            store_root_fd,
+            with_linker,
+        );
+        if result.is_err() {
+            // SAFETY: written above and handed out to nobody else; callers
+            // treat the slot as uninitialized on `Err`, so this is its only
+            // release.
+            unsafe { this_transpiler.deinit() };
+        }
+        result
+    }
+
+    fn configure_run_transpiler(
+        ctx: &mut ContextData,
+        this_transpiler: &mut Transpiler<'static>,
+        env_is_none: bool,
+        log_errors: bool,
+        store_root_fd: bool,
+        with_linker: bool,
+    ) -> crate::Result<bun_resolver::DirInfoRef> {
         this_transpiler.options.env.behavior = api::DotEnvBehavior::LoadAll;
         let env_loader = this_transpiler.env_mut();
         env_loader.quiet = true;
@@ -3022,6 +3045,10 @@ impl RunCommand {
         let _ = unsafe { ctx.log() }.print(std::ptr::from_mut::<bun_core::io::Writer>(
             Output::error_writer(),
         ));
+
+        if err.is_env_file_load_failed() {
+            Global::exit(1);
+        }
 
         Output::err(
             err,

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -672,8 +672,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             }
 
             // Always skip default .env files for package.json script runner
-            // (the script's own bun instance loads .env). Propagate so a
-            // missing explicit `--env-file` surfaces as a non-zero exit.
+            // (the script's own bun instance loads .env)
             this_transpiler.run_env_loader(true)?;
         }
 
@@ -1728,9 +1727,7 @@ impl RunCommand {
             Output::error_writer(),
         ));
 
-        // The env loader prints the detailed line itself for a missing
-        // `--env-file`; don't add a second generic one.
-        if err.name() == "EnvFileNotFound" {
+        if err.is_env_file_load_failed() {
             Global::exit(1);
         }
 

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -817,8 +817,7 @@ impl Error {
         }
     }
 
-    /// The env loader already printed the error for the `--env-file` that
-    /// failed to load, so CLI error sinks exit without printing a second line.
+    /// The env loader already printed this one; error sinks exit without adding a second line.
     pub(crate) fn is_env_file_load_failed(&self) -> bool {
         matches!(
             self,

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -816,6 +816,17 @@ impl Error {
             Self::Js(_) => "JSError",
         }
     }
+
+    /// The env loader already printed the error for the `--env-file` that
+    /// failed to load, so CLI error sinks exit without printing a second line.
+    pub(crate) fn is_env_file_load_failed(&self) -> bool {
+        matches!(
+            self,
+            Self::Bundler(bun_bundler::Error::Dotenv(
+                bun_dotenv::Error::EnvFileLoadFailed
+            ))
+        )
+    }
 }
 
 impl From<std::io::Error> for Error {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -673,6 +673,19 @@ describe.concurrent("--env-file", () => {
     };
   }
 
+  async function spawnEnvFile(cmd: string[], cwd = dir) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...cmd],
+      cwd,
+      env: { ...bunEnv, NODE_ENV: undefined },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
   test("single arg", async () => {
     expect((await runEnvFile(["--env-file", ".env.a"])).stdout).toBe("BUNTEST_A=1");
     expect((await runEnvFile(["--env-file=.env.a"])).stdout).toBe("BUNTEST_A=1");
@@ -726,7 +739,7 @@ describe.concurrent("--env-file", () => {
   });
 
   test("empty string disables default dotenv behavior", async () => {
-    expect((await runEnvFile(["--env-file=''"])).stdout).toBe("");
+    expect((await runEnvFile(["--env-file="])).stdout).toBe("");
   });
 
   test("should correctly ignore invalid values and parse the rest", async () => {
@@ -734,9 +747,58 @@ describe.concurrent("--env-file", () => {
     expect(res.stdout).toBe("BUNTEST_A=1,BUNTEST_B=1,BUNTEST_C=1,BUNTEST_D=,BUNTEST_E=1");
   });
 
-  test("should ignore a file that doesn't exist", async () => {
-    const res = await runEnvFile(["--env-file=.env.nonexisting"]);
-    expect(res.stdout).toBe("");
+  // #21105: an explicitly requested --env-file that can't be opened must fail
+  // (like Node), not silently run without the variables. Default .env
+  // discovery (which stays silent when the file is missing) goes through a
+  // separate path and is covered by "when arg missing, fallback to default
+  // dotenv behavior" above.
+  describe("errors when an explicit env file does not exist", () => {
+    function check({ stdout, stderr, exitCode }: { stdout: string; stderr: string; exitCode: number | null }) {
+      expect(stdout).toBe("");
+      expect(stderr).toContain(".env.nonexisting");
+      expect(stderr).not.toContain("EnvFileNotFound");
+      expect(stderr).not.toContain("Failed to run");
+      expect(stderr).not.toContain("internal error");
+      expect(exitCode).not.toBe(0);
+    }
+
+    test("bun <file>", async () => {
+      check(await spawnEnvFile(["--env-file=.env.nonexisting", `${dir}/index.ts`]));
+    });
+
+    test("bun -e", async () => {
+      check(await spawnEnvFile(["--env-file=.env.nonexisting", "-e", "0"]));
+    });
+
+    test("bun run <script>", async () => {
+      using scriptDir = tempDir("dotenv-missing-script", {
+        "package.json": JSON.stringify({ scripts: { go: "echo hi" } }),
+      });
+      check(await spawnEnvFile(["--env-file=.env.nonexisting", "run", "go"], String(scriptDir)));
+    });
+
+    test("bun <file.sh>", async () => {
+      using shDir = tempDir("dotenv-missing-sh", { "script.sh": "echo hi\n" });
+      check(await spawnEnvFile(["--env-file=.env.nonexisting", `${shDir}/script.sh`], String(shDir)));
+    });
+
+    test("bun test", async () => {
+      using testDir = tempDir("dotenv-missing-test", {
+        "a.test.ts": "import {test,expect} from 'bun:test'; test('x',()=>expect(1).toBe(1));",
+      });
+      const { stderr, exitCode } = await spawnEnvFile(
+        ["--env-file=.env.nonexisting", "test", "a.test.ts"],
+        String(testDir),
+      );
+      expect(stderr).toContain(".env.nonexisting");
+      expect(stderr).not.toContain("EnvFileNotFound");
+      expect(stderr).not.toContain("internal error");
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("one missing in a comma list of several", async () => {
+      check(await spawnEnvFile(["--env-file=.env.a,.env.nonexisting,.env.b", `${dir}/index.ts`]));
+    });
   });
 });
 

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -777,13 +777,30 @@ describe.concurrent("--env-file", () => {
       });
     });
 
-    test("bun <file.sh>", async () => {
+    // `./` makes bun open the file directly and boot the shell runner; a bare
+    // name goes through the package.json script lookup instead (covered below).
+    test("bun ./file.sh", async () => {
       using shDir = tempDir("dotenv-missing-sh", { "script.sh": "echo ran\n" });
-      expect(await spawnEnvFile(["--env-file=.env.nonexisting", "script.sh"], String(shDir))).toEqual({
+      expect(await spawnEnvFile(["--env-file=.env.nonexisting", "./script.sh"], String(shDir))).toEqual({
         stdout: "",
         stderr: missing,
         exitCode: 1,
       });
+    });
+
+    test("node ./file.sh (argv0=node)", async () => {
+      using shDir = tempDir("dotenv-missing-sh-node", { "script.sh": "echo ran\n" });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--env-file=.env.nonexisting", "./script.sh"],
+        argv0: "node",
+        cwd: String(shDir),
+        env: { ...bunEnv, NODE_ENV: undefined },
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: missing, exitCode: 1 });
     });
 
     test("bun test", async () => {
@@ -804,11 +821,13 @@ describe.concurrent("--env-file", () => {
     // point, and each has its own error sink that must not add a second line.
     test.each([
       ["bun run <script>", ["run", "go"]],
+      ["bun <file.sh> (bare name, resolved like a script)", ["script.sh"]],
       ["bun run --parallel <script>", ["run", "--parallel", "go"]],
       ["bun run --filter <script>", ["run", "--filter", "*", "go"]],
     ])("%s", async (_, args) => {
       using scriptDir = tempDir("dotenv-missing-script", {
         "package.json": JSON.stringify({ name: "pkg", scripts: { go: "echo ran" } }),
+        "script.sh": "echo ran\n",
       });
       expect(await spawnEnvFile(["--env-file=.env.nonexisting", ...args], String(scriptDir))).toEqual({
         stdout: "",

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -852,9 +852,31 @@ describe.concurrent("--env-file", () => {
       expect(exitCode).toBe(1);
     });
 
+    // A pipe opens fine but cannot be read the way a file is (pread), so this is
+    // a read failure outside the set a default .env file tolerates. It used to
+    // exit 1 without printing anything. A shell pipeline is used because
+    // Bun.spawn's stdin: "pipe" hands the child a socket, which fails at open.
+    test.skipIf(isWindows)("a pipe (opens, then fails to read with an errno defaults never see)", async () => {
+      await using proc = Bun.spawn({
+        cmd: ["sh", "-c", 'echo BUNTEST_P=1 | exec "$0" --env-file=/dev/stdin "$1"', bunExe(), `${dir}/index.ts`],
+        cwd: dir,
+        env: { ...bunEnv, NODE_ENV: undefined },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "",
+        stderr: 'error: ESPIPE loading env file "/dev/stdin"\n',
+        exitCode: 1,
+      });
+    });
+
     test("a worker inherits the values instead of re-reading the file", async () => {
       using workerDir = tempDir("dotenv-worker", {
         ".env.w": "BUNTEST_W=1",
+        // --env-file turned default discovery off in the parent; the worker must not turn it back on.
+        ".env": "BUNTEST_DOTENV=1",
         "index.ts": `
           import { unlinkSync } from "fs";
           unlinkSync(".env.w");
@@ -864,10 +886,10 @@ describe.concurrent("--env-file", () => {
             worker.terminate();
           };
         `,
-        "worker.ts": `postMessage(process.env.BUNTEST_W);`,
+        "worker.ts": `postMessage(JSON.stringify({ w: process.env.BUNTEST_W, dotenv: process.env.BUNTEST_DOTENV }));`,
       });
       expect(await spawnEnvFile(["--env-file=.env.w", "index.ts"], String(workerDir))).toEqual({
-        stdout: "1\n",
+        stdout: '{"w":"1"}\n',
         stderr: "",
         exitCode: 0,
       });

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1268,6 +1268,55 @@ test.skipIf(!canUseRunuser)("process.env is preserved when cwd lacks read permis
   }
 });
 
+// Explicit files are opened by path, so they must not depend on the cwd
+// listing that default .env discovery needs. Same execute-only cwd setup as above.
+describe.skipIf(!canUseRunuser)("--env-file when cwd lacks read permission", () => {
+  function runAsNobodyIn(files: Record<string, string>, envFileArg: string) {
+    using dir = tempDir("env-file-eacces", { ...files, "noread/.keep": "" });
+    const noreadDir = path.join(dir, "noread");
+    fs.chmodSync(dir, 0o755);
+    for (const name of Object.keys(files)) fs.chmodSync(path.join(dir, name), 0o644);
+    fs.chmodSync(noreadDir, 0o111);
+    try {
+      const result = Bun.spawnSync({
+        cmd: [
+          "runuser",
+          "-m",
+          "-u",
+          "nobody",
+          "--",
+          "/bin/sh",
+          "-c",
+          `cd '${noreadDir}' && exec '${bunExe()}' --env-file='${path.join(dir, envFileArg)}' '${path.join(dir, "script.ts")}'`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      return { stdout: result.stdout.toString(), stderr: result.stderr.toString(), exitCode: result.exitCode };
+    } finally {
+      fs.chmodSync(noreadDir, 0o755);
+    }
+  }
+
+  const script = { "script.ts": 'console.log(process.env.MY_VAR ?? "unset");' };
+
+  test("an existing file is still loaded", () => {
+    expect(runAsNobodyIn({ ...script, "vars.env": "MY_VAR=from-file\n" }, "vars.env")).toEqual({
+      stdout: "from-file\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("a missing file still fails", () => {
+    const { stdout, stderr, exitCode } = runAsNobodyIn(script, "missing.env");
+    expect(stdout).toBe("");
+    expect(stderr).toMatch(/^error: ENOENT loading env file ".*\/missing\.env"\n$/);
+    expect(exitCode).toBe(1);
+  });
+});
+
 // `st_size` is only a hint (sparse file, writer racing the loader): the env
 // loader's whole-file read used to `reserve_exact` it and abort the process in
 // `handle_alloc_error` before any user code ran. It must surface as a

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -747,57 +747,111 @@ describe.concurrent("--env-file", () => {
     expect(res.stdout).toBe("BUNTEST_A=1,BUNTEST_B=1,BUNTEST_C=1,BUNTEST_D=,BUNTEST_E=1");
   });
 
-  // #21105: an explicitly requested --env-file that can't be opened must fail
-  // (like Node), not silently run without the variables. Default .env
-  // discovery (which stays silent when the file is missing) goes through a
-  // separate path and is covered by "when arg missing, fallback to default
-  // dotenv behavior" above.
-  describe("errors when an explicit env file does not exist", () => {
-    function check({ stdout, stderr, exitCode }: { stdout: string; stderr: string; exitCode: number | null }) {
-      expect(stdout).toBe("");
-      expect(stderr).toContain(".env.nonexisting");
-      expect(stderr).not.toContain("EnvFileNotFound");
-      expect(stderr).not.toContain("Failed to run");
-      expect(stderr).not.toContain("internal error");
-      expect(exitCode).not.toBe(0);
-    }
+  // https://github.com/oven-sh/bun/issues/21105
+  // Default .env discovery stays silent when nothing is there (covered by
+  // "when arg missing, fallback to default dotenv behavior" above).
+  describe("errors when an explicit env file cannot be loaded", () => {
+    const missing = 'error: ENOENT loading env file ".env.nonexisting"\n';
 
     test("bun <file>", async () => {
-      check(await spawnEnvFile(["--env-file=.env.nonexisting", `${dir}/index.ts`]));
+      expect(await spawnEnvFile(["--env-file=.env.nonexisting", `${dir}/index.ts`])).toEqual({
+        stdout: "",
+        stderr: missing,
+        exitCode: 1,
+      });
+    });
+
+    test("bun run <file>", async () => {
+      expect(await spawnEnvFile(["--env-file=.env.nonexisting", "run", `${dir}/index.ts`])).toEqual({
+        stdout: "",
+        stderr: missing,
+        exitCode: 1,
+      });
     });
 
     test("bun -e", async () => {
-      check(await spawnEnvFile(["--env-file=.env.nonexisting", "-e", "0"]));
-    });
-
-    test("bun run <script>", async () => {
-      using scriptDir = tempDir("dotenv-missing-script", {
-        "package.json": JSON.stringify({ scripts: { go: "echo hi" } }),
+      expect(await spawnEnvFile(["--env-file=.env.nonexisting", "-e", "console.log('ran')"])).toEqual({
+        stdout: "",
+        stderr: missing,
+        exitCode: 1,
       });
-      check(await spawnEnvFile(["--env-file=.env.nonexisting", "run", "go"], String(scriptDir)));
     });
 
     test("bun <file.sh>", async () => {
-      using shDir = tempDir("dotenv-missing-sh", { "script.sh": "echo hi\n" });
-      check(await spawnEnvFile(["--env-file=.env.nonexisting", `${shDir}/script.sh`], String(shDir)));
+      using shDir = tempDir("dotenv-missing-sh", { "script.sh": "echo ran\n" });
+      expect(await spawnEnvFile(["--env-file=.env.nonexisting", "script.sh"], String(shDir))).toEqual({
+        stdout: "",
+        stderr: missing,
+        exitCode: 1,
+      });
     });
 
     test("bun test", async () => {
       using testDir = tempDir("dotenv-missing-test", {
-        "a.test.ts": "import {test,expect} from 'bun:test'; test('x',()=>expect(1).toBe(1));",
+        "a.test.ts": "import { test } from 'bun:test'; test('ran', () => {});",
       });
-      const { stderr, exitCode } = await spawnEnvFile(
+      const { stdout, stderr, exitCode } = await spawnEnvFile(
         ["--env-file=.env.nonexisting", "test", "a.test.ts"],
         String(testDir),
       );
-      expect(stderr).toContain(".env.nonexisting");
-      expect(stderr).not.toContain("EnvFileNotFound");
-      expect(stderr).not.toContain("internal error");
-      expect(exitCode).not.toBe(0);
+      // Only the version banner, which is printed before env files load; no test ran.
+      expect(stdout).toMatch(/^bun test v[^\n]*\n$/);
+      expect(stderr).toBe(missing);
+      expect(exitCode).toBe(1);
+    });
+
+    // Each of these runs package.json scripts through a different CLI entry
+    // point, and each has its own error sink that must not add a second line.
+    test.each([
+      ["bun run <script>", ["run", "go"]],
+      ["bun run --parallel <script>", ["run", "--parallel", "go"]],
+      ["bun run --filter <script>", ["run", "--filter", "*", "go"]],
+    ])("%s", async (_, args) => {
+      using scriptDir = tempDir("dotenv-missing-script", {
+        "package.json": JSON.stringify({ name: "pkg", scripts: { go: "echo ran" } }),
+      });
+      expect(await spawnEnvFile(["--env-file=.env.nonexisting", ...args], String(scriptDir))).toEqual({
+        stdout: "",
+        stderr: missing,
+        exitCode: 1,
+      });
     });
 
     test("one missing in a comma list of several", async () => {
-      check(await spawnEnvFile(["--env-file=.env.a,.env.nonexisting,.env.b", `${dir}/index.ts`]));
+      expect(await spawnEnvFile(["--env-file=.env.a,.env.nonexisting,.env.b", `${dir}/index.ts`])).toEqual({
+        stdout: "",
+        stderr: missing,
+        exitCode: 1,
+      });
+    });
+
+    test("a directory (opens, then fails to read)", async () => {
+      const { stdout, stderr, exitCode } = await spawnEnvFile(["--env-file=subdir", `${dir}/index.ts`]);
+      expect(stdout).toBe("");
+      // The errno differs by platform (EISDIR on POSIX).
+      expect(stderr).toMatch(/^error: \w+ loading env file "subdir"\n$/);
+      expect(exitCode).toBe(1);
+    });
+
+    test("a worker inherits the values instead of re-reading the file", async () => {
+      using workerDir = tempDir("dotenv-worker", {
+        ".env.w": "BUNTEST_W=1",
+        "index.ts": `
+          import { unlinkSync } from "fs";
+          unlinkSync(".env.w");
+          const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
+          worker.onmessage = ({ data }) => {
+            console.log(data);
+            worker.terminate();
+          };
+        `,
+        "worker.ts": `postMessage(process.env.BUNTEST_W);`,
+      });
+      expect(await spawnEnvFile(["--env-file=.env.w", "index.ts"], String(workerDir))).toEqual({
+        stdout: "1\n",
+        stderr: "",
+        exitCode: 0,
+      });
     });
   });
 });

--- a/test/js/node/util/parse_args/default-args.test.mjs
+++ b/test/js/node/util/parse_args/default-args.test.mjs
@@ -61,7 +61,7 @@ describe("parseArgs default args", () => {
     ["--bun file-test.js --foo asdf", ["foo"], ["asdf"], ["--bun"]], // implicit run, with bun "--bun" arg (should not appear in argv)
     ["run --bun file-test.js --foo asdf", ["foo"], ["asdf"], ["--bun"]], // explicit run, with bun "--bun" arg (after the run)
     ["--bun run file-test.js --foo asdf", ["foo"], ["asdf"], ["--bun"]], // explicit run, with bun "--bun" arg (before the run)
-    ["--bun run --env-file='' file-test.js --foo asdf", ["foo"], ["asdf"], ["--bun", "--env-file=''"]], // explicit run, multiple bun args
+    ["--bun run --env-file= file-test.js --foo asdf", ["foo"], ["asdf"], ["--bun", "--env-file="]], // explicit run, multiple bun args
     ["run file-test.js --bun", ["bun"], [], []], // passing --bun only to the program
     ["--bun run file-test.js --foo asdf -- --foo2 -- --foo3", ["foo"], ["asdf", "--foo2", "--", "--foo3"], ["--bun"]],
     //[`--bun -e ${evalSrc} --foo asdf`, ["foo"], ["asdf"]], // eval seems to crash when triggered from tests


### PR DESCRIPTION
Fixes #21105. Supersedes #31625 (same fix, adopted with credit in the commit; that branch no longer applies to main).

### Problem
- `bun --env-file=missing.env index.ts` runs the script without the requested variables and exits 0. Node refuses to start (`node: missing.env: not found`, exit 9); for a directory it prints `invalid format` and also refuses.
- `Loader::load_env_file_dynamic` (`src/dotenv/env_loader.rs`), which every `--env-file` entry goes through, swallowed the open error and returned `Ok(())`. A file that opens but fails to read (a directory, EISDIR) was only warned about, and not at all on the `bun run <script>` path, which runs the loader quiet.
- `configure_env_for_run_impl` (`src/runtime/cli/run_command.rs`) also discarded the loader result with `let _ =`, so `bun run <script>` could not fail even when the loader did.
- `Transpiler::run_env_loader` (`src/bundler/transpiler.rs`) returned early when the cwd could not be listed, before it got to the explicit list, so from an execute-only cwd even an absolute `--env-file` was ignored (present or missing). Node loads it.
- Explicit files also went through the default files' read-errno filter (`read_env_file_contents`), so a read error outside that set escaped as a bare errno: with a pipe as the env file (`--env-file=<(...)`, ESPIPE) `bun <file>` and `bun -e` exited 1 with nothing on stderr.

### Fix
- An explicit file that fails to open, or fails to read with any errno, prints `error: ENOENT loading env file ".env.nonexisting"` (errno and quoted path) and returns the new `bun_dotenv::Error::EnvFileLoadFailed`; every entry point then exits 1 (Bun's usual CLI failure code). The explicit path now reads the file directly instead of through the default files' errno filter, which stays in place for default discovery (`load_env_file`, unchanged: a missing `.env` is still silent, an unreadable one still only warns).
- The variant lets the error sinks tell "already printed" from everything else. `bun_runtime::Error::is_env_file_load_failed()` matches it structurally (`Bundler(Dotenv(EnvFileLoadFailed))`); `boot_failed_exit`, the argv0=node boot sink, and the `--parallel`/`--filter` dispatch use it to exit without a second line. Matching the variant instead of `err.name()` follows the review comment; the `--parallel`/`--filter` and argv0=node sinks would otherwise print a second line naming the variant.
- `handle_root_error` (crash handler) gets the variant name added to its sentinel list; that function is generic over `ErrName` and already dispatches `InvalidArgument`/`InstallFailed` by name.
- `bun <file>` and `bun -e` need no sink change: a `configure_defines` failure there goes to `fail_with_build_error`, which prints the (empty) build log and exits 1.
- `configure_env_for_run` now releases the `Transpiler` it wrote into the caller's slot when the rest of the setup fails (`Transpiler::deinit`, the existing teardown for slot-owned transpilers). The slot lives in a mimalloc arena that LSAN does not scan, so the first push of this PR failed the asan lane with the transpiler's allocations reported as leaked on the new error path; the same applied latently to the pre-existing `read_dir_info` early returns.
- `run_env_loader` no longer returns early on an unlistable cwd. The listing is only consulted by default `.env*` discovery, so it is left empty (nothing is probed, same as the old early return) and the explicit list is loaded as usual; the tsconfig JSX merge that shared the block still happens whenever the directory is readable.
- Workers stop re-reading the parent's `--env-file` list (`src/jsc/web_worker.rs`). The values are already in the env map cloned from the parent; with loading now fatal, the re-read would make `new Worker()` fail if the file was removed after startup. Explicit files disable default `.env` discovery in the parent, so the worker keeps it disabled too.
- Why this is correct: the file was requested by name, so silently running without it means running with the wrong configuration (typo in the path, secrets not loaded), which is what #21105 reports and what Node rejects. Every way an explicit file can fail to load (open error, any read error, unlistable cwd) now ends in the same line naming the path and a non-zero exit; the default discovery path is not touched. Whether a pipe should be readable as an env file is a separate question (it was never supported); this PR only makes that failure say so.
- Tests (`test/cli/run/env.test.ts`, "errors when an explicit env file cannot be loaded") assert stdout, the exact stderr line, and exit code 1 for `bun <file>`, `bun run <file>` (the issue's repro), `bun -e`, `bun ./file.sh`, `node ./file.sh` (argv0=node), `bun test`, `bun run <script>`, a bare `file.sh` (resolved like a script), `run --parallel`, `run --filter`, a comma list with one missing entry, a directory, and (POSIX) a pipe via `/dev/stdin` in a shell pipeline, which pins the direct read (`Bun.spawn`'s `stdin: "pipe"` is a socket and already fails at open), plus a worker test that removes the env file after startup and checks the worker still sees the value while a `.env` in the same directory stays unloaded (pins the `disable_default_env_files` half of the worker change), and two tests ("--env-file when cwd lacks read permission", gated like the existing runuser test next to them) that run from an execute-only cwd and check an absolute `--env-file` is loaded when present and fails when missing. Each sink is pinned by the exact-stderr assertion of the test that goes through it (table below); the `bun run <script>` and bare `file.sh` rows are the ones that caught the transpiler release on the asan lane.
- `test/js/node/util/parse_args/default-args.test.mjs` passed `--env-file=''` as a literal two-quote filename (spawn args are not shell-parsed) and relied on it being ignored; it now passes an empty value, the documented way to disable `.env` loading.
- Verified with `bun bd test` (debug, asan): `env.test.ts` (the 14 tests of the new describe plus the runuser pair pass; the rest of the file passes apart from one pre-existing default-`.env` priority test that hit its 5s timeout under the concurrent run and passes alone), `default-args.test.mjs` (8). The previously failing scenarios were also run directly with CI's `detect_leaks=1` options and print only the one line. With the unfixed binary the new error-path tests fail (the pipe case exits 1 with empty stderr) and the worker test passes.

### Background
- `bun_dotenv::Loader::load` either loads the explicit `--env-file` list (`load_env_file_dynamic`) or probes the default `.env*` names (`load_env_file`). `Transpiler::run_env_loader` calls it and `configure_defines` calls that, which is how every entry point (file boot, `-e`, `bun test`, `bun run`, `.sh` entry, workers) loads env files. `run_env_loader` passes `load` a copy of the cwd's directory listing (`DirEntryKeys`) that the default path consults before opening each `.env*` name; the explicit path opens its arguments directly and never reads it.
- Error sinks are the places that turn a returned error into a message plus `exit(1)`: `boot_failed_exit` and `exec_as_if_node_boot_failed` for boots that fail before the VM runs, `run_scripts_failed_exit` in `cli/mod.rs` for `--parallel`/`--filter`, and `crash_handler::handle_root_error` for anything that propagates out of `main`. A sentinel error here is a variant meaning "the message was already printed, just exit non-zero"; `InvalidArgument` and `InstallFailed` already work this way.
- Each crate has its own `Error` enum and lower-tier errors nest in higher-tier ones through `#[from]` variants, so a dotenv error reaches `bun_runtime` as `Error::Bundler(bun_bundler::Error::Dotenv(..))` and can be matched without comparing names.
- `configure_env_for_run` is an out-param constructor: callers hand it a `MaybeUninit<Transpiler>` (stack or arena) and may only use the slot after `Ok`. `Transpiler` has no `Drop` of its own for these slot-owned instances; `deinit` is the explicit release.
- `bun <name>` with a bare name is resolved as a package.json script or bin (through `configure_env_for_run`); `bun ./name` or an absolute path opens the file directly and boots it, which for `.sh` means the shell runner. That is why the two spellings reach different sinks.
- A worker builds a fresh `Loader` from a clone of the parent's env map and then runs `configure_defines` with a copy of the parent's transform options, which is why it used to re-open the `--env-file` paths on every `new Worker()`.

<details>
<summary>Per entry point: output and the sink it goes through</summary>

All of these print exactly `error: ENOENT loading env file ".env.nonexisting"` on stderr and exit 1 (`bun test` also prints its version banner on stdout first):

| command | sink |
| --- | --- |
| `bun --env-file=.env.nonexisting index.ts` | `fail_with_build_error` |
| `bun --env-file=.env.nonexisting -e 0` | `fail_with_build_error` |
| `bun --env-file=.env.nonexisting ./script.sh` | `boot_failed_exit` (typed check) |
| `node --env-file=.env.nonexisting ./script.sh` (bun as argv0=node) | `exec_as_if_node_boot_failed` (typed check) |
| `bun --env-file=.env.nonexisting run index.ts` | `handle_root_error` (name list) |
| `bun --env-file=.env.nonexisting run go` | `handle_root_error` (name list), after `configure_env_for_run` releases the transpiler |
| `bun --env-file=.env.nonexisting script.sh` (bare name) | same as `run go` |
| `bun --env-file=.env.nonexisting test` | `handle_root_error` (name list) |
| `bun --env-file=.env.nonexisting run --parallel go` | `run_scripts_failed_exit` (typed check) |
| `bun --env-file=.env.nonexisting run --filter '*' go` | `run_scripts_failed_exit` (typed check) |

`bun --env-file=subdir index.ts` prints `error: EISDIR loading env file "subdir"` (the test accepts any errno name there since it can differ by platform). `echo X=1 | bun --env-file=/dev/stdin index.ts` prints `error: ESPIPE loading env file "/dev/stdin"`; before this revision it exited 1 silently, and `bun run go` with the same pipe printed `An internal error occurred (ESPIPE)` without the path.

Without the typed checks the `--parallel`/`--filter` runs print a second line `error: EnvFileLoadFailed`, the `./script.sh` run prints `Failed to run script.sh due to error EnvFileLoadFailed`, and the argv0=node run prints `EnvFileLoadFailed: Failed to run script "script.sh"`; without the crash handler entry the `handle_root_error` runs print `'main' returned error.EnvFileLoadFailed` (debug) or `An internal error occurred` (release); without the transpiler release the `run go` and bare `script.sh` runs append an LSAN report on the asan lane.
</details>

<details>
<summary>Earlier revisions of this PR</summary>

The first revision returned an `EnvFileNotFound` sentinel from the open failure only, compared `err.name()` against it in `boot_failed_exit`, and left the read-failure arm and the `--parallel`/`--filter` sinks alone. The second renamed the variant, matched it structurally, covered the read-failure arm, fixed those two sinks, added the worker change, and tightened the tests to the exact line and exit code; its `.sh` test used a bare name, so it exercised the script-resolution path rather than the shell runner. The third added the transpiler release (asan lane), the argv0=node sink, and the `./script.sh` spelling, keeping the bare name as a row of its own. The fourth removed the unlistable-cwd early return in `run_env_loader`, which review pointed out was one more way for an explicit file to be skipped silently. The current revision reads explicit files directly so every read errno gets the same message (review found the pipe case exiting silently), and adds a `.env` to the worker fixture so the worker's default-discovery setting is pinned too.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/env.test.ts

<!-- robobun:evidence:end -->


