### PR TITLE
fix(process): NUL-terminate PSI trigger write so memoryPressure arms on Linux

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -421,6 +421,18 @@ export const isMemoryPressureWatcherInstalled: () => boolean = $newCppFunction(
   0,
 );
 
+export const memoryPressureWatcherHasOsBackend: () => boolean = $newCppFunction(
+  "InternalForTesting.cpp",
+  "jsFunction_memoryPressureWatcherHasOsBackend",
+  0,
+);
+
+export const memoryPressurePsiTrigger: () => Buffer | null = $newCppFunction(
+  "InternalForTesting.cpp",
+  "jsFunction_memoryPressurePsiTrigger",
+  0,
+);
+
 export const getEventLoopStats: () => { activeTasks: number; concurrentRef: number; numPolls: number } =
   $newRustFunction("event_loop.rs", "getActiveTasks", 0);
 

--- a/src/jsc/bindings/InternalForTesting.cpp
+++ b/src/jsc/bindings/InternalForTesting.cpp
@@ -5,6 +5,7 @@
 #include "JavaScriptCore/JSCast.h"
 #include "JavaScriptCore/JSArrayBufferView.h"
 #include "headers-handwritten.h"
+#include "JSBuffer.h"
 #include "webcore/HTTPHeaderMap.h"
 #include <wtf/text/StringImpl.h>
 #include <wtf/text/WTFString.h>
@@ -103,6 +104,8 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_BunString_toThreadSafeRefCountDelta, (JSC::J
 
 extern "C" void Bun__MemoryPressure__emit(JSC::JSGlobalObject* global, int level);
 extern "C" bool Bun__MemoryPressure__isInstalled(JSC::JSGlobalObject* global);
+extern "C" bool Bun__MemoryPressure__hasOsBackend(JSC::JSGlobalObject* global);
+extern "C" const uint8_t* Bun__MemoryPressure__psiTrigger(size_t* len);
 
 // Synthetically fire process.on("memoryPressure") so tests can exercise the
 // emit path without depending on real OS memory pressure.
@@ -122,6 +125,25 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_emitMemoryPressure, (JSC::JSGlobalObject * g
 JSC_DEFINE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     return JSValue::encode(jsBoolean(Bun__MemoryPressure__isInstalled(defaultGlobalObject(globalObject))));
+}
+
+// Whether the installed watcher registered a real OS signal source (PSI
+// trigger, kqueue filter, notification thread) rather than the silent
+// no-backend fallback.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_memoryPressureWatcherHasOsBackend, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    return JSValue::encode(jsBoolean(Bun__MemoryPressure__hasOsBackend(defaultGlobalObject(globalObject))));
+}
+
+// The exact bytes open_psi_fd() writes to arm the Linux PSI trigger. Returned
+// as a Buffer so the test can verify the trailing NUL. Null on non-Linux.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_memoryPressurePsiTrigger, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    size_t len = 0;
+    const uint8_t* ptr = Bun__MemoryPressure__psiTrigger(&len);
+    if (!ptr || !len)
+        return JSValue::encode(jsNull());
+    return JSValue::encode(createBuffer(globalObject, ptr, len));
 }
 
 }

--- a/src/jsc/bindings/InternalForTesting.cpp
+++ b/src/jsc/bindings/InternalForTesting.cpp
@@ -127,16 +127,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled, (JSC::JSGl
     return JSValue::encode(jsBoolean(Bun__MemoryPressure__isInstalled(defaultGlobalObject(globalObject))));
 }
 
-// Whether the installed watcher registered a real OS signal source (PSI
-// trigger, kqueue filter, notification thread) rather than the silent
-// no-backend fallback.
 JSC_DEFINE_HOST_FUNCTION(jsFunction_memoryPressureWatcherHasOsBackend, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     return JSValue::encode(jsBoolean(Bun__MemoryPressure__hasOsBackend(defaultGlobalObject(globalObject))));
 }
 
-// The exact bytes open_psi_fd() writes to arm the Linux PSI trigger. Returned
-// as a Buffer so the test can verify the trailing NUL. Null on non-Linux.
 JSC_DEFINE_HOST_FUNCTION(jsFunction_memoryPressurePsiTrigger, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     size_t len = 0;

--- a/src/jsc/bindings/InternalForTesting.h
+++ b/src/jsc/bindings/InternalForTesting.h
@@ -13,5 +13,7 @@ JSC_DECLARE_HOST_FUNCTION(jsFunction_BunString_toThreadSafeRefCountDelta);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_lowercaseHeaderNameSIMD);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_emitMemoryPressure);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_memoryPressureWatcherHasOsBackend);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_memoryPressurePsiTrigger);
 
 }

--- a/src/runtime/node/memory_pressure.rs
+++ b/src/runtime/node/memory_pressure.rs
@@ -138,13 +138,17 @@ mod posix {
     /// in place over the last byte written, so the NUL must be included.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub(super) const PSI_TRIGGER: &[u8] = b"some 150000 2000000\0";
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    const _: () = assert!(
+        PSI_TRIGGER[PSI_TRIGGER.len() - 1] == 0,
+        "psi_write() overwrites the last byte with NUL; trigger must include it"
+    );
 
     /// Open a PSI memory file and write a trigger. Tries the system-wide
     /// `/proc/pressure/memory` first, then the current cgroup's file.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn open_psi_fd() -> Option<Fd> {
         use bun_sys::O;
-
         let mut cgroup_buf = [0u8; 320];
         let paths = [
             Some(bun_core::zstr!("/proc/pressure/memory")),
@@ -416,9 +420,7 @@ pub(crate) extern "C" fn Bun__MemoryPressure__emit(global: &JSGlobalObject, lvl:
     emit(global, lvl);
 }
 
-/// Whether the installed watcher actually registered an OS-level signal
-/// source (PSI trigger / kqueue filter / notification thread), as opposed to
-/// the silent no-backend fallback. Windows installs are all-or-nothing.
+/// Test hook: watcher registered a real OS source (vs. silent fallback).
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Bun__MemoryPressure__hasOsBackend(global: &JSGlobalObject) -> bool {
     #[cfg(not(windows))]
@@ -431,9 +433,7 @@ pub(crate) extern "C" fn Bun__MemoryPressure__hasOsBackend(global: &JSGlobalObje
     }
 }
 
-/// The exact bytes `open_psi_fd()` writes to arm the Linux PSI trigger, for
-/// test environments that can't open `/proc/pressure/memory` (containers
-/// without `CAP_SYS_RESOURCE`, AppArmor `docker-default`). Null on non-Linux.
+/// Test hook: exact bytes `open_psi_fd()` writes (null on non-Linux).
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Bun__MemoryPressure__psiTrigger(len: &mut usize) -> *const u8 {
     #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/runtime/node/memory_pressure.rs
+++ b/src/runtime/node/memory_pressure.rs
@@ -133,15 +133,17 @@ mod posix {
         None
     }
 
+    /// 150 ms of "some"-stall in any 2 s window (the minimum for
+    /// unprivileged PSI triggers, kernel 6.6+). `psi_write()` NUL-terminates
+    /// in place over the last byte written, so the NUL must be included.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub(super) const PSI_TRIGGER: &[u8] = b"some 150000 2000000\0";
+
     /// Open a PSI memory file and write a trigger. Tries the system-wide
     /// `/proc/pressure/memory` first, then the current cgroup's file.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn open_psi_fd() -> Option<Fd> {
         use bun_sys::O;
-
-        /// 150 ms of "some"-stall in any 2 s window. 2 s is the minimum
-        /// window for unprivileged PSI triggers (kernel 6.6+).
-        const TRIGGER: &[u8] = b"some 150000 2000000";
 
         let mut cgroup_buf = [0u8; 320];
         let paths = [
@@ -152,7 +154,7 @@ mod posix {
             let Ok(fd) = bun_sys::open(path, O::RDWR | O::NONBLOCK | O::CLOEXEC, 0) else {
                 continue;
             };
-            if bun_sys::write(fd, TRIGGER).is_ok() {
+            if bun_sys::write(fd, PSI_TRIGGER).is_ok() {
                 return Some(fd);
             }
             let _ = bun_sys::close(fd);
@@ -204,6 +206,16 @@ mod posix {
             poll: register_os_watch(global),
         });
         *slot(global.bun_vm().as_mut()) = NonNull::new(bun_core::heap::into_raw(watcher).cast());
+    }
+
+    pub(super) fn has_os_backend(global: &JSGlobalObject) -> bool {
+        match slot(global.bun_vm().as_mut()) {
+            // SAFETY: slot is populated only by `install` with a `Box<MemoryPressureWatcher>`.
+            Some(raw) => unsafe { raw.cast::<MemoryPressureWatcher>().as_ref() }
+                .poll
+                .is_some(),
+            None => false,
+        }
     }
 
     pub(super) fn uninstall(global: &JSGlobalObject) {
@@ -402,6 +414,38 @@ pub(crate) extern "C" fn Bun__MemoryPressure__uninstall(global: &JSGlobalObject)
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Bun__MemoryPressure__emit(global: &JSGlobalObject, lvl: i32) {
     emit(global, lvl);
+}
+
+/// Whether the installed watcher actually registered an OS-level signal
+/// source (PSI trigger / kqueue filter / notification thread), as opposed to
+/// the silent no-backend fallback. Windows installs are all-or-nothing.
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn Bun__MemoryPressure__hasOsBackend(global: &JSGlobalObject) -> bool {
+    #[cfg(not(windows))]
+    {
+        posix::has_os_backend(global)
+    }
+    #[cfg(windows)]
+    {
+        Bun__MemoryPressure__isInstalled(global)
+    }
+}
+
+/// The exact bytes `open_psi_fd()` writes to arm the Linux PSI trigger, for
+/// test environments that can't open `/proc/pressure/memory` (containers
+/// without `CAP_SYS_RESOURCE`, AppArmor `docker-default`). Null on non-Linux.
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn Bun__MemoryPressure__psiTrigger(len: &mut usize) -> *const u8 {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        *len = posix::PSI_TRIGGER.len();
+        posix::PSI_TRIGGER.as_ptr()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    {
+        *len = 0;
+        core::ptr::null()
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/test/js/node/process/process-memory-pressure.test.ts
+++ b/test/js/node/process/process-memory-pressure.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { closeSync, constants, openSync, readFileSync, writeSync } from "node:fs";
 import { bunEnv, bunExe } from "harness";
 
 // process.on("memoryPressure") is a Bun extension. These tests drive the
@@ -91,6 +92,68 @@ describe.concurrent("process.on('memoryPressure')", () => {
       process.stdout.write("done");
     `);
     expect(stdout).toBe("done");
+    expect(exitCode).toBe(0);
+  });
+
+  // The kernel's psi_write() NUL-terminates the incoming buffer in place by
+  // overwriting the last byte of the write before parsing, so the NUL must be
+  // part of the payload or the window argument is truncated. Environments
+  // without PSI write access (AppArmor docker-default, CONFIG_PSI=n, kernels
+  // before 6.6 without CAP_SYS_RESOURCE) can't observe the write() result
+  // directly, so this asserts the exact bytes open_psi_fd() sends.
+  test.skipIf(process.platform !== "linux")("PSI trigger write is NUL-terminated", async () => {
+    const { stdout, stderr, exitCode } = await run(/* js */ `
+      const { memoryPressurePsiTrigger } = require("bun:internal-for-testing");
+      process.stdout.write(JSON.stringify([...memoryPressurePsiTrigger()]));
+    `);
+    expect({ stderr: stderr.trim(), trigger: Buffer.from(JSON.parse(stdout || "[]")) }).toEqual({
+      stderr: "",
+      trigger: Buffer.from("some 150000 2000000\0"),
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  function canCreatePsiTriggerAt(path: string) {
+    try {
+      const fd = openSync(path, constants.O_RDWR | constants.O_NONBLOCK);
+      try {
+        writeSync(fd, Buffer.from("some 150000 2000000\0"));
+        return true;
+      } finally {
+        closeSync(fd);
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  // Probe the same fallback order as open_psi_fd(): the system-wide file,
+  // then the current cgroup's memory.pressure.
+  const canCreatePsiTrigger = (() => {
+    if (process.platform !== "linux") return false;
+    if (canCreatePsiTriggerAt("/proc/pressure/memory")) return true;
+    let cgroup: string | undefined;
+    try {
+      cgroup = readFileSync("/proc/self/cgroup", "utf8")
+        .split("\n")
+        .find(line => line.startsWith("0::"));
+    } catch {
+      return false;
+    }
+    if (!cgroup) return false;
+    const rest = cgroup.slice("0::".length).replace(/^\/+/, "");
+    return canCreatePsiTriggerAt(`/sys/fs/cgroup/${rest}${rest ? "/" : ""}memory.pressure`);
+  })();
+
+  // Skipped where PSI trigger creation is unavailable: non-Linux, CONFIG_PSI=n,
+  // AppArmor docker-default, or unprivileged on kernels before 6.6.
+  test.skipIf(!canCreatePsiTrigger)("arms a PSI trigger on Linux", async () => {
+    const { stdout, stderr, exitCode } = await run(/* js */ `
+      const { memoryPressureWatcherHasOsBackend } = require("bun:internal-for-testing");
+      process.on("memoryPressure", () => {});
+      process.stdout.write(JSON.stringify(memoryPressureWatcherHasOsBackend()));
+    `);
+    expect({ stdout, stderr: stderr.trim() }).toEqual({ stdout: "true", stderr: "" });
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/node/process/process-memory-pressure.test.ts
+++ b/test/js/node/process/process-memory-pressure.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { closeSync, constants, openSync, readFileSync, writeSync } from "node:fs";
 import { bunEnv, bunExe } from "harness";
+import { closeSync, constants, openSync, readFileSync, writeSync } from "node:fs";
 
 // process.on("memoryPressure") is a Bun extension. These tests drive the
 // emit path synthetically via bun:internal-for-testing since real OS memory


### PR DESCRIPTION
Adopts #34018 by @catpranks (external fork PR, CI does not run).

### What does this PR do?

On Linux, `process.on("memoryPressure")` never arms its OS backend: the PSI trigger write in `open_psi_fd()` sends `some 150000 2000000` without a trailing NUL, and the kernel's `psi_write()` NUL-terminates the buffer in place by overwriting the last byte of the write before parsing ([kernel/sched/psi.c](https://github.com/torvalds/linux/blob/master/kernel/sched/psi.c)):

```c
buf_size = min(nbytes, sizeof(buf));
if (copy_from_user(buf, user_buf, buf_size))
    return -EFAULT;
buf[buf_size - 1] = '\\0';
```

So the kernel parses `some 150000 200000`, a 200 ms window, which fails trigger validation (unprivileged triggers must use a multiple of 2 s). The write fails with `EINVAL` on both `/proc/pressure/memory` and the cgroup fallback, and the watcher silently installs with no backend. No `memoryPressure` event is ever delivered on Linux.

With `CAP_SYS_RESOURCE` (root in many containers), current kernels accept the truncated string instead: the trigger arms with a 200 ms window, requiring 75% stall instead of the intended 7.5%, and takes the privileged RT-polling aggregator path. Same one-byte cause.

Repro (unprivileged, kernel 6.6+):

```python
>>> fd = os.open("/proc/pressure/memory", os.O_RDWR | os.O_NONBLOCK)
>>> os.write(fd, b"some 150000 2000000")    # OSError: EINVAL  (what Bun writes today)
>>> os.write(fd, b"some 150000 2000000\\0")  # 20, trigger armed
```

The fix is one byte: include the NUL in `PSI_TRIGGER`, matching the kernel's own sample code which writes `strlen(trig) + 1` bytes ([Documentation/accounting/psi.rst](https://www.kernel.org/doc/html/latest/accounting/psi.html)).

### Testing

The no-backend fallback is deliberately silent, so `bun:internal-for-testing` gains two hooks:

- `memoryPressurePsiTrigger()` returns the exact bytes `open_psi_fd()` writes. The new `PSI trigger write is NUL-terminated` test asserts they equal `"some 150000 2000000\\0"`. Runs on every Linux build regardless of PSI availability (AppArmor `docker-default` denies RDWR on `/proc/pressure/memory`, so many CI containers cannot exercise the real write).
- `memoryPressureWatcherHasOsBackend()` reports whether the installed watcher registered a real OS signal source. The `arms a PSI trigger on Linux` test (from #34018) first proves the environment can create PSI triggers with a direct write, then requires Bun to have done the same; skipped where PSI trigger creation is unavailable.

### How did you verify your code works?

- `bun bd test test/js/node/process/process-memory-pressure.test.ts`: 6 pass, 1 skip (the end-to-end PSI test, since this container's AppArmor profile blocks RDWR on `/proc/pressure/memory`).
- Reverting only the `\\0` in `PSI_TRIGGER` makes `PSI trigger write is NUL-terminated` fail with a one-byte diff showing the missing trailing `0`.
- `bun run rust:check-all`: 10/10 targets clean.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process-memory-pressure.test.ts

<!-- robobun:evidence:end -->