### PR TITLE
parser: tree-shake classes with private elements, keep side-effectful computed keys

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5414,21 +5414,28 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 continue;
             }
 
-            if !self.expr_can_be_removed_if_unused_without_dce_check(
-                property.key.as_ref().expect("unreachable"),
-            ) {
+            // ToPropertyKey on a computed key can run user code unless it's a primitive literal.
+            if property.flags.contains(Flags::Property::IsComputed)
+                && !property
+                    .key
+                    .map(|key| key.unwrap_inlined().is_primitive_literal())
+                    .unwrap_or(false)
+            {
                 return false;
             }
 
-            if let Some(val) = &property.value {
-                if !self.expr_can_be_removed_if_unused_without_dce_check(val) {
-                    return false;
+            // Non-static values/initializers only run on construction or access, never for an unused class.
+            if property.flags.contains(Flags::Property::IsStatic) {
+                if let Some(val) = &property.value {
+                    if !self.expr_can_be_removed_if_unused_without_dce_check(val) {
+                        return false;
+                    }
                 }
-            }
 
-            if let Some(val) = &property.initializer {
-                if !self.expr_can_be_removed_if_unused_without_dce_check(val) {
-                    return false;
+                if let Some(val) = &property.initializer {
+                    if !self.expr_can_be_removed_if_unused_without_dce_check(val) {
+                        return false;
+                    }
                 }
             }
         }

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -1509,7 +1509,6 @@ describe("bundler", () => {
     dce: true,
   });
   itBundled("dce/TreeShakingClassProperty", {
-    todo: true,
     files: {
       "/entry.js": /* js */ `
         let remove1 = class { x }
@@ -1536,16 +1535,13 @@ describe("bundler", () => {
         let keep4 = class { set [x](_) {} }
         let keep5 = class { async [x]() {} }
         let keep6 = class { [{ toString() { console.log(1); } }] = 'x' }
-
-        let POSSIBLE_REMOVAL_1 = class { [{ toString() {} }] = 'x' }
+        let keep7 = class { [{ toString() {} }] = 'x' }
       `,
     },
-    bundling: false,
     treeShaking: true,
     dce: true,
   });
   itBundled("dce/TreeShakingClassStaticProperty", {
-    todo: true,
     files: {
       "/entry.js": /* js */ `
         let remove1 = class { static x }
@@ -1572,12 +1568,49 @@ describe("bundler", () => {
         let keep6 = class { static set [x](_) {} }
         let keep7 = class { static async [x]() {} }
         let keep8 = class { static [{ toString() { console.log(1); } }] = 'x' }
-
-        let POSSIBLE_REMOVAL_1 = class { static [{ toString() {} }] = 'x' }
+        let keep9 = class { static [{ toString() {} }] = 'x' }
       `,
     },
-    bundling: false,
     treeShaking: true,
+    dce: true,
+  });
+  // https://github.com/oven-sh/bun/issues/20866
+  itBundled("dce/TreeShakingClassPrivateProperty", {
+    files: {
+      "/entry.js": /* js */ `
+        let remove1 = class { #x }
+        let remove2 = class { #x = x }
+        let remove3 = class { #x() {} }
+        let remove4 = class { get #x() {} }
+        let remove5 = class { set #x(_) {} }
+        let remove6 = class { async #x() {} }
+        let remove7 = class { static #x }
+        let remove8 = class { static #x = 1 }
+        let remove9 = class { static #x() {} }
+        let remove10 = class { static get #x() {} }
+        let remove11 = class { static set #x(_) {} }
+
+        let keep1 = class { static #x = x }
+        let keep2 = class { #x; static { x() } }
+      `,
+    },
+    treeShaking: true,
+    dce: true,
+  });
+  // https://github.com/oven-sh/bun/issues/20866
+  itBundled("dce/TreeShakingClassPrivatePropertyDeclaration", {
+    files: {
+      "/entry.js": /* js */ `
+        class REMOVE1 { #x }
+        class REMOVE2 { #x = x }
+        class REMOVE3 { #x() {} }
+        class REMOVE4 { static #x }
+        class REMOVE5 { static #x = 1 }
+        class REMOVE6 { static #x() {} }
+
+        class KEEP1 { static #x = x }
+      `,
+    },
     dce: true,
   });
   itBundled("dce/TreeShakingUnaryOperators", {

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -1613,6 +1613,26 @@ describe("bundler", () => {
     },
     dce: true,
   });
+  // Sibling of edgecase/TsEnumKeyedLiteralObjectTreeShaking#31755 for classes:
+  // the computed-key check must unwrap EInlinedEnum before is_primitive_literal.
+  itBundled("dce/TreeShakingClassEnumKey", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { A } from './lib';
+        console.log(JSON.stringify(A));
+      `,
+      "/lib.ts": /* ts */ `
+        export enum A { FOO, BAR }
+        export const unusedInstanceREMOVE = class { [A.FOO]() {} };
+        export const unusedStaticREMOVE = class { static [A.BAR] = 1 };
+      `,
+    },
+    dce: true,
+    dceKeepMarkerCount: false,
+    run: {
+      stdout: `{"0":"FOO","1":"BAR","FOO":0,"BAR":1}`,
+    },
+  });
   itBundled("dce/TreeShakingUnaryOperators", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
Adopts #33917 by @Nic-Polumeyv, rebased onto current main so CI can run. Fixes #20866.

### Repro

```js
// entry.mjs
class A { #x }
```
```
$ bun build --minify entry.mjs
class s{#s}
```
The class is unused and side-effect free but is never removed. esbuild emits nothing for the same input.

### Cause

`class_can_be_removed_if_unused` in `src/js_parser/p.rs` ran `expr_can_be_removed_if_unused` on every `property.key`. `EPrivateIdentifier` is not in that function's allowlist, so any private member made the whole class "side-effectful". It also checked `property.value` / `property.initializer` for instance members, which never execute for an unreferenced class.

Because the old check accepted any key that was itself a removable expression, it also let through computed keys whose `ToPropertyKey` has side effects: `class { [{ toString() { console.log(1) } }] = 'x' }` was tree-shaken on main, dropping the `console.log`.

### Fix

Match esbuild's `ClassCanBeRemovedIfUnused`:
- Only check the key when `IsComputed` and it is not a primitive literal (same idiom as the existing `EObject` arm in the same function).
- Only check `value` / `initializer` when `IsStatic`.

Not ported from esbuild: decorator guards (decorators are lowered to sibling statements before this check runs) and the `!UseDefineForClassFields` static-field bailout (Bun always uses define semantics; the option is parsed but never acted on).

### Tests

Enabled the two `todo` esbuild-ported cases `dce/TreeShakingClassProperty` and `dce/TreeShakingClassStaticProperty` (dropped `bundling: false` so statement-level DCE runs, and renamed the `POSSIBLE_REMOVAL_1` cases to `keep7`/`keep9` since computed object keys are now correctly kept). Added `dce/TreeShakingClassPrivateProperty` and `dce/TreeShakingClassPrivatePropertyDeclaration` covering the issue repros.

```
$ USE_SYSTEM_BUN=1 bun test test/bundler/esbuild/dce.test.ts -t TreeShakingClass
 0 pass  4 fail
$ bun bd test test/bundler/esbuild/dce.test.ts -t TreeShakingClass
 4 pass  0 fail
$ bun bd test test/bundler/esbuild/dce.test.ts
 77 pass  17 todo  0 fail
```

`bundler_edgecase`, `esbuild/default`, `esbuild/ts`, `esbuild/lower`, and `transpiler/transpiler` all pass with 0 fail.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/esbuild/dce.test.ts

<!-- robobun:evidence:end -->