### PR TITLE
URLPattern: strip trailing C0 control/space when canonicalizing pathname

### DIFF
--- a/src/jsc/bindings/webcore/URLPatternCanonical.cpp
+++ b/src/jsc/bindings/webcore/URLPatternCanonical.cpp
@@ -191,6 +191,19 @@ ExceptionOr<String> canonicalizePathname(StringView pathnameValue)
     if (pathnameValue.isEmpty())
         return pathnameValue.toString();
 
+    // Node and Chromium implement this step by parsing a full URL string that ends in
+    // pathnameValue, so the basic URL parser's "remove any leading and trailing C0 control
+    // or space" preprocessing strips trailing C0/space from the value. URL::setPath below
+    // goes through parseAllowingC0AtEnd and keeps them as %NN, which makes a pattern with
+    // stray trailing whitespace match neither the clean URL nor the whitespace one. Strip
+    // them here for parity. Leading C0/space is shielded by the "/-" prefix in both
+    // implementations and stays percent-encoded.
+    while (!pathnameValue.isEmpty() && pathnameValue[pathnameValue.length() - 1] <= 0x20)
+        pathnameValue = pathnameValue.left(pathnameValue.length() - 1);
+
+    if (pathnameValue.isEmpty())
+        return String { emptyString() };
+
     bool hasLeadingSlash = pathnameValue[0] == '/';
     String maybeAddSlashPrefix = hasLeadingSlash ? pathnameValue.toString() : makeString("/-"_s, pathnameValue);
 

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -206,4 +206,52 @@ describe("URLPattern", () => {
       expect(new URLPattern({ pathname: "/a/:foo/:baz([a-z]+)?/b/*" }).hasRegExpGroups).toBe(true);
     });
   });
+
+  describe("pathname canonicalization strips trailing C0 control or space", () => {
+    test("trailing space and NUL are stripped", () => {
+      expect(new URLPattern({ pathname: "/p/ " }).pathname).toBe("/p/");
+      expect(new URLPattern({ pathname: "/p/\0" }).pathname).toBe("/p/");
+      expect(new URLPattern({ pathname: "/p  " }).pathname).toBe("/p");
+      expect(new URLPattern({ pathname: "/p\0 " }).pathname).toBe("/p");
+      expect(new URLPattern({ pathname: "\x01/p/\x1f" }).pathname).toBe("%01/p/");
+      expect(new URLPattern({ pathname: "   " }).pathname).toBe("");
+      expect(new URLPattern({ pathname: "\0" }).pathname).toBe("");
+    });
+
+    test("pattern with trailing space matches the clean URL", () => {
+      const p = new URLPattern({ pathname: "/admin " });
+      expect(p.pathname).toBe("/admin");
+      // The URL parser strips the trailing space from "http://x/admin ", so both forms
+      // should match once the pattern itself is canonicalized the same way.
+      expect(p.test("http://x/admin ")).toBe(true);
+      expect(p.test("http://x/admin")).toBe(true);
+      expect(p.test({ pathname: "/admin " })).toBe(true);
+      expect(p.test({ pathname: "/admin" })).toBe(true);
+    });
+
+    test("pattern with trailing NUL matches the clean URL", () => {
+      const n = new URLPattern({ pathname: "/p/\0" });
+      expect(n.pathname).toBe("/p/");
+      expect(n.test("http://x/p/")).toBe(true);
+      expect(n.test("http://x/p/%00")).toBe(false);
+    });
+
+    test("leading and mid-string C0/space are still percent-encoded", () => {
+      expect(new URLPattern({ pathname: " /p/" }).pathname).toBe("%20/p/");
+      expect(new URLPattern({ pathname: "\0/p/" }).pathname).toBe("%00/p/");
+      expect(new URLPattern({ pathname: "/a b/" }).pathname).toBe("/a%20b/");
+      expect(new URLPattern({ pathname: "/a\0b/" }).pathname).toBe("/a%00b/");
+    });
+
+    test("tabs and newlines are still stripped everywhere", () => {
+      expect(new URLPattern({ pathname: "/a\tb" }).pathname).toBe("/ab");
+      expect(new URLPattern({ pathname: "/a\nb\r" }).pathname).toBe("/ab");
+    });
+
+    test("other components keep trailing space percent-encoded", () => {
+      expect(new URLPattern({ search: "q=1 " }).search).toBe("q=1%20");
+      expect(new URLPattern({ hash: "foo " }).hash).toBe("foo%20");
+      expect(new URLPattern({ username: "u " }).username).toBe("u%20");
+    });
+  });
 });


### PR DESCRIPTION
## Problem

`URLPattern` pathname canonicalization keeps a trailing C0 control or space as `%00`/`%20`, while the URL parser (Bun's own included) strips it. A pattern authored with trailing whitespace or NUL (config/copy-paste artifact) becomes a silently dead route: it matches neither the whitespace URL nor the clean one.

```js
const p = new URLPattern({ pathname: '/p/ ' });   // trailing space
const n = new URLPattern({ pathname: '/p/\0' });  // trailing NUL
p.pathname                         // bun: "/p/%20"   node: "/p/"
n.pathname                         // bun: "/p/%00"   node: "/p/"
new URL('http://x/p/ ').pathname   // "/p/"  (URL parser strips it)
p.test('http://x/p/ ')             // bun: false   node: true
p.test('http://x/p/')              // bun: false   node: true
n.test('http://x/p/')              // bun: false   node: true
```

Tabs/LF/CR are already removed identically; mid-string and leading NUL/space encode identically. Only the trailing case differs.

## Cause

`canonicalizePathname` uses `URL::setPath`, which calls `parseAllowingC0AtEnd` and therefore keeps trailing C0/space as `%NN`. Node (via ada) parses a full `"fake://fake-url" + value` URL string, so the basic URL parser's "remove any leading and trailing C0 control or space" preprocessing strips trailing bytes from the value. Leading bytes are shielded by the `"/-"` prefix in both implementations and stay percent-encoded.

Note on spec alignment: the URLPattern spec's [canonicalize a pathname](https://urlpattern.spec.whatwg.org/#canonicalize-a-pathname) runs the basic URL parser with a dummy URL and path-start state override, and the URL parser's leading/trailing C0-or-space strip is scoped to the no-url-given case (tab/newline removal is unconditional). So the previous `%20` output was the spec-literal reading; this change is Node/ada parity and removes a route that can never be reached, rather than fixing a spec violation.

## Fix

Strip trailing C0-control-or-space (`<= 0x20`) from the input before handing it to `setPath`. Leading and mid-string bytes are unchanged. `search`/`hash`/`username` are left alone: they also percent-encode trailing space, but Node does the same, so changing them would break parity.

## Verification

```
=== before (USE_SYSTEM_BUN=1) ===
3 fail  (trailing space/NUL kept as %20/%00)

=== after (bun bd) ===
414 pass, 0 fail  (all WPT URLPattern tests + 6 new)
```

All assertions in the new tests were cross-checked against Node v26.3.0.
