### PR TITLE
Decode UTF-16BE (BOM) source files and Blob bytes

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1693,6 +1693,31 @@ pub(crate) mod strings_impl {
         to_utf8_alloc(&aligned)
     }
 
+    /// Transcode raw UTF-16-BE *bytes* (no alignment requirement) to a fresh
+    /// UTF-8 `Vec`. See `to_utf8_alloc_from_le_bytes` for the alignment rationale;
+    /// this variant additionally byte-swaps each `u16` after the aligned copy so
+    /// the existing host-endian (`LE`) transcode path can be reused.
+    pub fn to_utf8_alloc_from_be_bytes(be_bytes: &[u8]) -> Vec<u8> {
+        let n_u16 = be_bytes.len() / 2;
+        if n_u16 == 0 {
+            return Vec::new();
+        }
+        let mut aligned: Vec<u16> = Vec::with_capacity(n_u16);
+        // SAFETY: identical to `to_utf8_alloc_from_le_bytes` above.
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                be_bytes.as_ptr(),
+                aligned.as_mut_ptr().cast::<u8>(),
+                n_u16 * 2,
+            );
+            aligned.set_len(n_u16);
+        }
+        for unit in aligned.iter_mut() {
+            *unit = unit.swap_bytes();
+        }
+        to_utf8_alloc(&aligned)
+    }
+
     pub fn to_utf8_append_to_list(list: &mut Vec<u8>, utf16: &[u16]) {
         let need = simdutf::length::utf8::from::utf16::le(utf16);
         list.reserve(need + 16);

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1655,65 +1655,41 @@ pub(crate) mod strings_impl {
         convert_utf16_to_utf8(Vec::new(), utf16)
     }
 
-    /// Transcode raw UTF-16-LE *bytes* (no alignment requirement) to a fresh
-    /// UTF-8 `Vec`.
-    ///
-    /// `to_utf8_alloc` takes `&[u16]`, but constructing a `&[u16]` from a
-    /// `&[u8]` whose pointer is not 2-byte-aligned is immediate language-level
-    /// UB (`core::slice::from_raw_parts` requires `data` be aligned for `T`),
-    /// regardless of how the consumer reads the memory. Callers that hold a
-    /// `Vec<u8>` / `&[u8]` of LE bytes (e.g. BOM-stripping a file buffer) MUST
-    /// route through this helper instead of casting.
-    ///
-    /// The bytes are first copied into a freshly-allocated, properly-aligned
-    /// `Vec<u16>` via a raw byte `memcpy` (no per-element decode — simdutf
-    /// interprets the buffer as little-endian and Bun targets only LE hosts),
-    /// then handed to `to_utf8_alloc`. An odd trailing byte is dropped, which
-    /// matches the prior `len() / 2` truncation.
-    pub fn to_utf8_alloc_from_le_bytes(le_bytes: &[u8]) -> Vec<u8> {
-        let n_u16 = le_bytes.len() / 2;
-        if n_u16 == 0 {
-            return Vec::new();
-        }
+    /// Copy possibly-unaligned UTF-16 bytes into a fresh, aligned `Vec<u16>`,
+    /// dropping an odd trailing byte. Forming a `&[u16]` directly over a
+    /// `&[u8]` is UB unless the pointer is 2-byte-aligned, so byte-slice
+    /// callers must copy first.
+    fn utf16_units_from_bytes(bytes: &[u8]) -> Vec<u16> {
+        let n_u16 = bytes.len() / 2;
         let mut aligned: Vec<u16> = Vec::with_capacity(n_u16);
-        // SAFETY: `aligned.as_mut_ptr()` is a fresh `Vec<u16>` allocation, so it
-        // is 2-byte-aligned and has `n_u16 * 2` writable bytes of capacity. We
-        // copy exactly that many bytes from `le_bytes` (which has at least
-        // `n_u16 * 2` readable bytes) into it as raw `u8`, then expose them as
-        // initialized `u16` via `set_len`. No `&[u16]` is ever formed over the
-        // possibly-misaligned source.
+        // SAFETY: the fresh `Vec<u16>` allocation is 2-byte-aligned with
+        // `n_u16 * 2` writable bytes of capacity; we copy exactly that many
+        // bytes from `bytes` before exposing them as initialized via `set_len`.
         unsafe {
             core::ptr::copy_nonoverlapping(
-                le_bytes.as_ptr(),
+                bytes.as_ptr(),
                 aligned.as_mut_ptr().cast::<u8>(),
                 n_u16 * 2,
             );
             aligned.set_len(n_u16);
         }
-        to_utf8_alloc(&aligned)
+        aligned
     }
 
-    /// Big-endian twin of [`to_utf8_alloc_from_le_bytes`]: byte-swaps each
-    /// aligned `u16` so the host-endian transcode path can be reused.
+    /// Transcode raw UTF-16-LE bytes (no alignment requirement) to a fresh
+    /// UTF-8 `Vec`.
+    pub fn to_utf8_alloc_from_le_bytes(le_bytes: &[u8]) -> Vec<u8> {
+        to_utf8_alloc(&utf16_units_from_bytes(le_bytes))
+    }
+
+    /// Transcode raw UTF-16-BE bytes (no alignment requirement) to a fresh
+    /// UTF-8 `Vec`.
     pub fn to_utf8_alloc_from_be_bytes(be_bytes: &[u8]) -> Vec<u8> {
-        let n_u16 = be_bytes.len() / 2;
-        if n_u16 == 0 {
-            return Vec::new();
-        }
-        let mut aligned: Vec<u16> = Vec::with_capacity(n_u16);
-        // SAFETY: identical to `to_utf8_alloc_from_le_bytes` above.
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                be_bytes.as_ptr(),
-                aligned.as_mut_ptr().cast::<u8>(),
-                n_u16 * 2,
-            );
-            aligned.set_len(n_u16);
-        }
-        for unit in aligned.iter_mut() {
+        let mut units = utf16_units_from_bytes(be_bytes);
+        for unit in units.iter_mut() {
             *unit = unit.swap_bytes();
         }
-        to_utf8_alloc(&aligned)
+        to_utf8_alloc(&units)
     }
 
     pub fn to_utf8_append_to_list(list: &mut Vec<u8>, utf16: &[u16]) {

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1693,10 +1693,8 @@ pub(crate) mod strings_impl {
         to_utf8_alloc(&aligned)
     }
 
-    /// Transcode raw UTF-16-BE *bytes* (no alignment requirement) to a fresh
-    /// UTF-8 `Vec`. See `to_utf8_alloc_from_le_bytes` for the alignment rationale;
-    /// this variant additionally byte-swaps each `u16` after the aligned copy so
-    /// the existing host-endian (`LE`) transcode path can be reused.
+    /// Big-endian twin of [`to_utf8_alloc_from_le_bytes`]: byte-swaps each
+    /// aligned `u16` so the host-endian transcode path can be reused.
     pub fn to_utf8_alloc_from_be_bytes(be_bytes: &[u8]) -> Vec<u8> {
         let n_u16 = be_bytes.len() / 2;
         if n_u16 == 0 {

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -2220,7 +2220,8 @@ unsafe extern "C" {
 pub use crate::strings_impl::{
     allocate_latin1_into_utf8_with_list, convert_utf16_to_utf8, convert_utf16_to_utf8_append,
     encode_wtf8_rune, is_all_ascii, latin1_to_codepoint_bytes_assume_not_ascii, narrow_ascii_u16,
-    to_utf8_alloc, to_utf8_alloc_from_le_bytes, to_utf8_append_to_list, to_utf8_from_latin1,
+    to_utf8_alloc, to_utf8_alloc_from_be_bytes, to_utf8_alloc_from_le_bytes,
+    to_utf8_append_to_list, to_utf8_from_latin1,
 };
 
 #[inline]

--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -571,7 +571,9 @@ impl BOM {
             //   return .utf32_le;
             return Some(BOM::Utf16Le);
         }
-        // if (eqlComptimeIgnoreLen(bytes, utf16_be_bytes)) return .utf16_be;
+        if eql_ignore_len(bytes, &Self::UTF16_BE_BYTES) {
+            return Some(BOM::Utf16Be);
+        }
         // if (bytes.len > 4 and eqlComptimeIgnoreLen(bytes, utf32_le_bytes)) return .utf32_le;
         None
     }
@@ -625,6 +627,12 @@ impl BOM {
                 drop(bytes);
                 out
             }
+            BOM::Utf16Be => {
+                let trimmed_bytes = &bytes[Self::UTF16_BE_BYTES.len()..];
+                let out = crate::strings_impl::to_utf8_alloc_from_be_bytes(trimmed_bytes);
+                drop(bytes);
+                out
+            }
             _ => {
                 // TODO: this needs to re-encode, for now we just remove the BOM
                 crate::vec::drain_front(&mut bytes, self.get_header().len());
@@ -655,6 +663,14 @@ impl BOM {
                 list.extend_from_slice(&out);
                 // Return the list slice (not `out`, the new alloc) to honor the
                 // "always points to the base of the input" doc comment.
+                &list[..]
+            }
+            BOM::Utf16Be => {
+                let out = crate::strings_impl::to_utf8_alloc_from_be_bytes(
+                    &list[Self::UTF16_BE_BYTES.len()..],
+                );
+                list.clear();
+                list.extend_from_slice(&out);
                 &list[..]
             }
             _ => {

--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -560,11 +560,13 @@ impl BOM {
     pub(crate) const UTF32_BE_BYTES: [u8; 4] = [0x00, 0x00, 0xfe, 0xff];
 
     pub fn detect(bytes: &[u8]) -> Option<BOM> {
-        if bytes.len() < 3 {
-            return None;
-        }
-        if eql_ignore_len(bytes, &Self::UTF8_BYTES) {
+        // `eql_ignore_len` reads `needle.len()` bytes unchecked, so each
+        // comparison needs a length guard; a BOM-only UTF-16 input is 2 bytes.
+        if bytes.len() >= Self::UTF8_BYTES.len() && eql_ignore_len(bytes, &Self::UTF8_BYTES) {
             return Some(BOM::Utf8);
+        }
+        if bytes.len() < Self::UTF16_LE_BYTES.len() {
+            return None;
         }
         if eql_ignore_len(bytes, &Self::UTF16_LE_BYTES) {
             // if (bytes.len > 4 and eqlComptimeIgnoreLen(bytes[2..], utf32_le_bytes[2..]))

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6241,9 +6241,7 @@ impl Drop for TemporaryBytes {
     }
 }
 
-/// Decode BOM-stripped UTF-16 payload bytes to an `OwnedString`. `buf` has no
-/// alignment guarantee (it is `raw[2..]`); take the `bytemuck` fast path only
-/// for little-endian when it happens to be 2-byte aligned.
+/// Decode BOM-stripped UTF-16 payload bytes (possibly odd-aligned) to an `OwnedString`.
 fn utf16_bom_payload_to_owned_string(bom: strings::BOM, buf: &[u8]) -> OwnedString {
     debug_assert!(matches!(bom, strings::BOM::Utf16Le | strings::BOM::Utf16Be));
     let buf = &buf[..buf.len() & !1];

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2624,30 +2624,11 @@ impl BlobExt for Blob {
 
         if let Some(bom @ (strings::BOM::Utf16Le | strings::BOM::Utf16Be)) = bom {
             let _free = (LIFETIME == Lifetime::Temporary).then(|| TemporaryBytes(raw_bytes));
-            // Reinterpret as u16: drop a trailing odd byte.
             // +1 WTF ref; `OwnedString` releases it on scope exit.
             //
             // This branch intentionally does NOT `self.detach()` for
             // `Lifetime::Transfer`, unlike the toJSON path.
-            let buf = &buf[..buf.len() & !1];
-            let out = match (bom, bytemuck::try_cast_slice::<u8, u16>(buf)) {
-                (strings::BOM::Utf16Le, Ok(units)) => {
-                    OwnedString::new(BunString::clone_utf16(units))
-                }
-                _ => {
-                    let units: Vec<u16> = buf
-                        .as_chunks::<2>()
-                        .0
-                        .iter()
-                        .map(|pair| match bom {
-                            strings::BOM::Utf16Be => u16::from_be_bytes(*pair),
-                            _ => u16::from_le_bytes(*pair),
-                        })
-                        .collect();
-                    OwnedString::new(BunString::clone_utf16(&units))
-                }
-            };
-            return out.to_js(global);
+            return utf16_bom_payload_to_owned_string(bom, buf).to_js(global);
         }
 
         // null == unknown
@@ -2866,26 +2847,8 @@ impl BlobExt for Blob {
         }
 
         if let Some(bom @ (strings::BOM::Utf16Le | strings::BOM::Utf16Be)) = bom {
-            // Reinterpret as u16: drop a trailing odd byte.
             // +1 WTF ref; `OwnedString` releases it on scope exit.
-            let buf = &buf[..buf.len() & !1];
-            let mut out = match (bom, bytemuck::try_cast_slice::<u8, u16>(buf)) {
-                (strings::BOM::Utf16Le, Ok(units)) => {
-                    OwnedString::new(BunString::clone_utf16(units))
-                }
-                _ => {
-                    let units: Vec<u16> = buf
-                        .as_chunks::<2>()
-                        .0
-                        .iter()
-                        .map(|pair| match bom {
-                            strings::BOM::Utf16Be => u16::from_be_bytes(*pair),
-                            _ => u16::from_le_bytes(*pair),
-                        })
-                        .collect();
-                    OwnedString::new(BunString::clone_utf16(&units))
-                }
-            };
+            let mut out = utf16_bom_payload_to_owned_string(bom, buf);
             // Compute the
             // result first, then perform the deferred work explicitly — capturing
             // `&mut self` in a scopeguard closure conflicts with later uses below.
@@ -6276,6 +6239,29 @@ impl Drop for TemporaryBytes {
         // caller passed ownership of a leaked default-allocator `Box<[u8]>`.
         unsafe { drop(bun_core::heap::take(self.0)) };
     }
+}
+
+/// Decode BOM-stripped UTF-16 payload bytes to an `OwnedString`. `buf` has no
+/// alignment guarantee (it is `raw[2..]`); take the `bytemuck` fast path only
+/// for little-endian when it happens to be 2-byte aligned.
+fn utf16_bom_payload_to_owned_string(bom: strings::BOM, buf: &[u8]) -> OwnedString {
+    debug_assert!(matches!(bom, strings::BOM::Utf16Le | strings::BOM::Utf16Be));
+    let buf = &buf[..buf.len() & !1];
+    if bom == strings::BOM::Utf16Le {
+        if let Ok(units) = bytemuck::try_cast_slice::<u8, u16>(buf) {
+            return OwnedString::new(BunString::clone_utf16(units));
+        }
+    }
+    let units: Vec<u16> = buf
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|pair| match bom {
+            strings::BOM::Utf16Be => u16::from_be_bytes(*pair),
+            _ => u16::from_le_bytes(*pair),
+        })
+        .collect();
+    OwnedString::new(BunString::clone_utf16(&units))
 }
 
 // Marker types for static fn dispatch through do_read_file/do_read_from_s3.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2622,7 +2622,7 @@ impl BlobExt for Blob {
             return Ok(ZigString::EMPTY.to_js(global));
         }
 
-        if bom == Some(strings::BOM::Utf16Le) {
+        if let Some(bom @ (strings::BOM::Utf16Le | strings::BOM::Utf16Be)) = bom {
             let _free = (LIFETIME == Lifetime::Temporary).then(|| TemporaryBytes(raw_bytes));
             // Reinterpret as u16: drop a trailing odd byte.
             // +1 WTF ref; `OwnedString` releases it on scope exit.
@@ -2630,14 +2630,19 @@ impl BlobExt for Blob {
             // This branch intentionally does NOT `self.detach()` for
             // `Lifetime::Transfer`, unlike the toJSON path.
             let buf = &buf[..buf.len() & !1];
-            let out = match bytemuck::try_cast_slice::<u8, u16>(buf) {
-                Ok(units) => OwnedString::new(BunString::clone_utf16(units)),
-                Err(_) => {
+            let out = match (bom, bytemuck::try_cast_slice::<u8, u16>(buf)) {
+                (strings::BOM::Utf16Le, Ok(units)) => {
+                    OwnedString::new(BunString::clone_utf16(units))
+                }
+                _ => {
                     let units: Vec<u16> = buf
                         .as_chunks::<2>()
                         .0
                         .iter()
-                        .map(|pair| u16::from_le_bytes(*pair))
+                        .map(|pair| match bom {
+                            strings::BOM::Utf16Be => u16::from_be_bytes(*pair),
+                            _ => u16::from_le_bytes(*pair),
+                        })
                         .collect();
                     OwnedString::new(BunString::clone_utf16(&units))
                 }
@@ -2860,18 +2865,23 @@ impl BlobExt for Blob {
             );
         }
 
-        if bom == Some(strings::BOM::Utf16Le) {
+        if let Some(bom @ (strings::BOM::Utf16Le | strings::BOM::Utf16Be)) = bom {
             // Reinterpret as u16: drop a trailing odd byte.
             // +1 WTF ref; `OwnedString` releases it on scope exit.
             let buf = &buf[..buf.len() & !1];
-            let mut out = match bytemuck::try_cast_slice::<u8, u16>(buf) {
-                Ok(units) => OwnedString::new(BunString::clone_utf16(units)),
-                Err(_) => {
+            let mut out = match (bom, bytemuck::try_cast_slice::<u8, u16>(buf)) {
+                (strings::BOM::Utf16Le, Ok(units)) => {
+                    OwnedString::new(BunString::clone_utf16(units))
+                }
+                _ => {
                     let units: Vec<u16> = buf
                         .as_chunks::<2>()
                         .0
                         .iter()
-                        .map(|pair| u16::from_le_bytes(*pair))
+                        .map(|pair| match bom {
+                            strings::BOM::Utf16Be => u16::from_be_bytes(*pair),
+                            _ => u16::from_le_bytes(*pair),
+                        })
                         .collect();
                     OwnedString::new(BunString::clone_utf16(&units))
                 }

--- a/test/cli/run/run-unicode.test.ts
+++ b/test/cli/run/run-unicode.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { mkdirSync, realpathSync } from "fs";
-import { bunEnv, bunExe, bunRun } from "harness";
+import { bunEnv, bunExe, bunRun, tempDir } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -39,5 +39,28 @@ describe.concurrent("run-unicode", () => {
   "Fran\u00E7ais": 123,
   bbb: 123,
 }`);
+  });
+
+  describe.each([
+    ["UTF-16LE", (s: string) => Buffer.from("\uFEFF" + s, "utf16le")],
+    ["UTF-16BE", (s: string) => Buffer.from("\uFEFF" + s, "utf16le").swap16()],
+  ])("runs %s source with a BOM", (_, encode) => {
+    test.each([
+      ["ascii", `console.log("hello")`, "hello\n"],
+      ["non-ascii", `console.log("é汉字🎉".length, "é汉字🎉")`, "5 é汉字🎉\n"],
+    ])("%s", async (_, source, expected) => {
+      using dir = tempDir("run-utf16-bom", { "index.js": encode(source) });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "index.js"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(expected);
+      expect(exitCode).toBe(0);
+    });
   });
 });

--- a/test/cli/run/run-unicode.test.ts
+++ b/test/cli/run/run-unicode.test.ts
@@ -48,6 +48,7 @@ describe.concurrent("run-unicode", () => {
     test.each([
       ["ascii", `console.log("hello")`, "hello\n"],
       ["non-ascii", `console.log("é汉字🎉".length, "é汉字🎉")`, "5 é汉字🎉\n"],
+      ["bom only", ``, ""],
     ])("%s", async (_, source, expected) => {
       using dir = tempDir("run-utf16-bom", { "index.js": encode(source) });
       await using proc = Bun.spawn({

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -560,22 +560,29 @@ test("Blob.slice at an odd byte offset decodes UTF-16LE (BOM) content with text(
   expect(exitCode).toBe(0);
 });
 
-test("Blob text()/json() decode UTF-16BE (BOM) content", async () => {
+test("Bun.file() text()/json() decode UTF-16BE (BOM) content", async () => {
+  using dir = tempDir("bun-file-utf16be", {
+    // UTF-16BE BOM (FE FF) followed by "hi" / "42" / "é汉字🎉".
+    "a.txt": new Uint8Array([0xfe, 0xff, 0x00, 0x68, 0x00, 0x69]),
+    "b.json": new Uint8Array([0xfe, 0xff, 0x00, 0x34, 0x00, 0x32]),
+    "c.txt": Buffer.from("\uFEFFé汉字🎉", "utf16le").swap16(),
+    // slice(1) starts the FE FF at an odd offset into the backing store.
+    "d.txt": new Uint8Array([0x41, 0xfe, 0xff, 0x00, 0x68, 0x00, 0x69]),
+  });
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
-        // UTF-16BE BOM (FE FF) followed by "hi" / "42" / "é汉字🎉".
-        const text = await new Blob([new Uint8Array([0xfe, 0xff, 0x00, 0x68, 0x00, 0x69])]).text();
-        const json = await new Blob([new Uint8Array([0xfe, 0xff, 0x00, 0x34, 0x00, 0x32])]).json();
-        const wide = await new Blob([Buffer.from("\\uFEFFé汉字🎉", "utf16le").swap16()]).text();
-        // slice(1) starts the FE FF at an odd offset into the backing store.
-        const odd = await new Blob([new Uint8Array([0x41, 0xfe, 0xff, 0x00, 0x68, 0x00, 0x69])]).slice(1).text();
+        const text = await Bun.file("a.txt").text();
+        const json = await Bun.file("b.json").json();
+        const wide = await Bun.file("c.txt").text();
+        const odd  = await Bun.file("d.txt").slice(1).text();
         console.log(JSON.stringify({ text, json, wide, odd }));
       `,
     ],
     env: bunEnv,
+    cwd: String(dir),
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -568,6 +568,9 @@ test("Bun.file() text()/json() decode UTF-16BE (BOM) content", async () => {
     "c.txt": Buffer.from("\uFEFFé汉字🎉", "utf16le").swap16(),
     // slice(1) starts the FE FF at an odd offset into the backing store.
     "d.txt": new Uint8Array([0x41, 0xfe, 0xff, 0x00, 0x68, 0x00, 0x69]),
+    // BOM with no payload decodes to the empty string.
+    "e.txt": new Uint8Array([0xfe, 0xff]),
+    "f.txt": new Uint8Array([0xff, 0xfe]),
   });
   await using proc = Bun.spawn({
     cmd: [
@@ -578,7 +581,9 @@ test("Bun.file() text()/json() decode UTF-16BE (BOM) content", async () => {
         const json = await Bun.file("b.json").json();
         const wide = await Bun.file("c.txt").text();
         const odd  = await Bun.file("d.txt").slice(1).text();
-        console.log(JSON.stringify({ text, json, wide, odd }));
+        const beEmpty = await Bun.file("e.txt").text();
+        const leEmpty = await Bun.file("f.txt").text();
+        console.log(JSON.stringify({ text, json, wide, odd, beEmpty, leEmpty }));
       `,
     ],
     env: bunEnv,
@@ -588,7 +593,9 @@ test("Bun.file() text()/json() decode UTF-16BE (BOM) content", async () => {
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(stdout.trim()).toBe(JSON.stringify({ text: "hi", json: 42, wide: "é汉字🎉", odd: "hi" }));
+  expect(stdout.trim()).toBe(
+    JSON.stringify({ text: "hi", json: 42, wide: "é汉字🎉", odd: "hi", beEmpty: "", leEmpty: "" }),
+  );
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -560,6 +560,31 @@ test("Blob.slice at an odd byte offset decodes UTF-16LE (BOM) content with text(
   expect(exitCode).toBe(0);
 });
 
+test("Blob text()/json() decode UTF-16BE (BOM) content", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        // UTF-16BE BOM (FE FF) followed by "hi" / "42" / "é汉字🎉".
+        const text = await new Blob([new Uint8Array([0xfe, 0xff, 0x00, 0x68, 0x00, 0x69])]).text();
+        const json = await new Blob([new Uint8Array([0xfe, 0xff, 0x00, 0x34, 0x00, 0x32])]).json();
+        const wide = await new Blob([Buffer.from("\\uFEFFé汉字🎉", "utf16le").swap16()]).text();
+        // slice(1) starts the FE FF at an odd offset into the backing store.
+        const odd = await new Blob([new Uint8Array([0x41, 0xfe, 0xff, 0x00, 0x68, 0x00, 0x69])]).slice(1).text();
+        console.log(JSON.stringify({ text, json, wide, odd }));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe(JSON.stringify({ text: "hi", json: 42, wide: "é汉字🎉", odd: "hi" }));
+  expect(exitCode).toBe(0);
+});
+
 // structuredClone/postMessage of sliced Blobs and Files is covered by
 // test/js/web/structured-clone-blob-file.test.ts. These tests focus on the
 // consumer paths that go through resolve_size()/resolved_size() rather than


### PR DESCRIPTION
### What does this PR do?

Bun already transcodes UTF-16LE source files (FF FE BOM) to UTF-8 before parsing. The UTF-16BE case (FE FF BOM) was left as a commented-out detection line plus a fallthrough `_ =>` arm that just strips the BOM header, so a `.js`/`.ts` file saved as UTF-16BE produces a cascade of parse errors on the raw bytes:

```
$ node -e 'require("fs").writeFileSync("be.js", Buffer.from("\uFEFFconsole.log(1)", "utf16le").swap16())'
$ bun be.js
1 | ��console.log(1)
      ^
error: Expected ";" but found ""
...
```

Adopts and extends #34712:

- `BOM::detect` now returns `Utf16Be` for an `FE FF` prefix, and detects 2-byte BOM-only input: the old `len < 3` guard (which protects the unchecked 3-byte UTF-8 compare) is now per-comparison, so a file that is just a UTF-16 BOM runs as an empty program instead of raw bytes.
- The unaligned-bytes-to-`Vec<u16>` copy is shared between the LE and BE transcode helpers (`utf16_units_from_bytes`); the BE variant byte-swaps each unit, then both reuse the existing host-endian UTF-16 to UTF-8 transcoder.
- Both `BOM::remove_and_convert_to_utf8_*` helpers get a `Utf16Be` arm mirroring the `Utf16Le` one.
- `Blob::to_string_with_bytes` / `to_json_with_bytes` also match `Utf16Be`: now that `BOM::detect` reports it, falling through would strip the FE FF but UTF-8-decode the payload, which is worse than before. The previously duplicated decode body is extracted into `utf16_bom_payload_to_owned_string` and reused at both sites.

This is a Bun convenience feature (Node and esbuild decode neither byte order); supporting BE is the symmetric completion of the LE support that already shipped.

**Interaction with #35190:** that PR narrows the `Blob.text()`/`.json()` UTF-16 sniff to `Bun.file()`/S3 only, leaving in-memory `Blob`s on the spec UTF-8 decode. The new Blob test here is scoped to `Bun.file()` so it asserts only the path both PRs agree keeps the sniff; the in-memory `new Blob([FE FF ...])` case is left to #35190's control test. `to_string_with_bytes`/`to_json_with_bytes` touch overlapping lines, so whichever lands second will need a small textual merge (after #35190 the helper call sits behind its `is_bun_file()` gate).


### How did you verify your code works?

New tests cover both the source-file path and the `Bun.file()` path for LE and BE, including non-ASCII content (Latin-1, CJK, astral), an odd-offset slice, and BOM-only 2-byte files.

```
bun bd test test/cli/run/run-unicode.test.ts test/js/web/fetch/blob.test.ts
 55 pass, 0 fail
```

With `src/` reverted the new UTF-16BE and BOM-only tests fail (parse errors / `SyntaxError: Failed to parse JSON`); the UTF-16LE content tests keep passing.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-unicode.test.ts test/js/web/fetch/blob.test.ts

<!-- robobun:evidence:end -->