### PR TITLE
TextEncoder.encodeInto: return {read:0, written:0} for detached destination

### DIFF
--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -267,6 +267,11 @@ unsafe extern "C" fn TextEncoder__encodeInto16(
     buf_ptr: *mut u8,
     buf_len: usize,
 ) -> u64 {
+    // A detached destination has `buf_len == 0` and `buf_ptr == null`; `from_raw_parts_mut`
+    // requires a non-null pointer even for zero-length slices, so return { read: 0, written: 0 }.
+    if buf_len == 0 {
+        return 0;
+    }
     // SAFETY: caller guarantees buf_ptr[0..buf_len] is a valid mutable buffer
     let output = unsafe { core::slice::from_raw_parts_mut(buf_ptr, buf_len) };
     // SAFETY: caller guarantees input_ptr[0..input_len] is valid UTF-16 data
@@ -289,6 +294,11 @@ unsafe extern "C" fn TextEncoder__encodeInto8(
     buf_ptr: *mut u8,
     buf_len: usize,
 ) -> u64 {
+    // A detached destination has `buf_len == 0` and `buf_ptr == null`; `from_raw_parts_mut`
+    // requires a non-null pointer even for zero-length slices, so return { read: 0, written: 0 }.
+    if buf_len == 0 {
+        return 0;
+    }
     // SAFETY: caller guarantees buf_ptr[0..buf_len] is a valid mutable buffer
     let output = unsafe { core::slice::from_raw_parts_mut(buf_ptr, buf_len) };
     // SAFETY: caller guarantees input_ptr[0..input_len] is valid Latin-1 data

--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -267,15 +267,11 @@ unsafe extern "C" fn TextEncoder__encodeInto16(
     buf_ptr: *mut u8,
     buf_len: usize,
 ) -> u64 {
-    // A detached destination has `buf_len == 0` and `buf_ptr == null`; `from_raw_parts_mut`
-    // requires a non-null pointer even for zero-length slices, so return { read: 0, written: 0 }.
-    if buf_len == 0 {
-        return 0;
-    }
-    // SAFETY: caller guarantees buf_ptr[0..buf_len] is a valid mutable buffer
-    let output = unsafe { core::slice::from_raw_parts_mut(buf_ptr, buf_len) };
+    // SAFETY: caller guarantees buf_ptr[0..buf_len] is a valid mutable buffer. `ffi::slice_mut`
+    // tolerates the C convention of `(null, 0)` from a detached ArrayBufferView.
+    let output = unsafe { bun_core::ffi::slice_mut(buf_ptr, buf_len) };
     // SAFETY: caller guarantees input_ptr[0..input_len] is valid UTF-16 data
-    let input = unsafe { core::slice::from_raw_parts(input_ptr, input_len) };
+    let input = unsafe { bun_core::ffi::slice(input_ptr, input_len) };
     let result: strings::EncodeIntoResult = strings::copy_utf16_into_utf8(output, input);
     // Pack `read` at byte offset 0 and `written` at offset 4 via native-endian bytes — no `unsafe`.
     let mut b = [0u8; 8];
@@ -294,15 +290,11 @@ unsafe extern "C" fn TextEncoder__encodeInto8(
     buf_ptr: *mut u8,
     buf_len: usize,
 ) -> u64 {
-    // A detached destination has `buf_len == 0` and `buf_ptr == null`; `from_raw_parts_mut`
-    // requires a non-null pointer even for zero-length slices, so return { read: 0, written: 0 }.
-    if buf_len == 0 {
-        return 0;
-    }
-    // SAFETY: caller guarantees buf_ptr[0..buf_len] is a valid mutable buffer
-    let output = unsafe { core::slice::from_raw_parts_mut(buf_ptr, buf_len) };
+    // SAFETY: caller guarantees buf_ptr[0..buf_len] is a valid mutable buffer. `ffi::slice_mut`
+    // tolerates the C convention of `(null, 0)` from a detached ArrayBufferView.
+    let output = unsafe { bun_core::ffi::slice_mut(buf_ptr, buf_len) };
     // SAFETY: caller guarantees input_ptr[0..input_len] is valid Latin-1 data
-    let input = unsafe { core::slice::from_raw_parts(input_ptr, input_len) };
+    let input = unsafe { bun_core::ffi::slice(input_ptr, input_len) };
     let result: strings::EncodeIntoResult = strings::copy_latin1_into_utf8(output, input);
     // Pack `read` at byte offset 0 and `written` at offset 4 via native-endian bytes — no `unsafe`.
     let mut b = [0u8; 8];

--- a/test/js/web/encoding/text-encoder.test.js
+++ b/test/js/web/encoding/text-encoder.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { gc as gcTrace, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, gc as gcTrace, withoutAggressiveGC } from "harness";
 
 const getByteLength = str => {
   // returns the byte length of an utf8 string
@@ -684,35 +684,66 @@ describe("TextEncoder UTF-16 exact-size path", () => {
   });
 });
 
-describe("TextEncoder encodeInto with zero-length destination", () => {
-  const encoder = new TextEncoder();
-
+describe.concurrent("TextEncoder encodeInto with zero-length destination", () => {
   // Detaching drives the view's byteLength to 0 and its backing pointer to null.
+  // Before this fix a debug build aborted on the `from_raw_parts_mut` precondition
+  // (null pointer at len 0); run in a subprocess so a reintroduction surfaces as
+  // a non-null signalCode instead of aborting the whole test file.
   // "x" exercises the Latin-1 path; "Ā" and "💕" exercise the UTF-16 path.
-  it.each([["x"], ["Ā"], ["💕"]])("returns { read: 0, written: 0 } for a detached Uint8Array with input %j", input => {
-    const ab = new ArrayBuffer(8);
-    const dest = new Uint8Array(ab);
-    structuredClone(ab, { transfer: [ab] });
+  it.each([["x"], ["Ā"], ["💕"]])(
+    "returns { read: 0, written: 0 } for a detached Uint8Array with input %j",
+    async input => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const ab = new ArrayBuffer(8);
+         const dest = new Uint8Array(ab);
+         structuredClone(ab, { transfer: [ab] });
+         if (dest.byteLength !== 0) throw new Error("not detached");
+         process.stdout.write(JSON.stringify(new TextEncoder().encodeInto(${JSON.stringify(input)}, dest)));`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, signalCode: proc.signalCode, exitCode }).toEqual({
+        stdout: '{"read":0,"written":0}',
+        stderr: "",
+        signalCode: null,
+        exitCode: 0,
+      });
+    },
+  );
 
-    expect(dest.byteLength).toBe(0);
-    expect(encoder.encodeInto(input, dest)).toEqual({ read: 0, written: 0 });
+  it("returns { read: 0, written: 0 } when source toString() detaches the destination mid-call", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const ab = new ArrayBuffer(16);
+         const dest = new Uint8Array(ab);
+         const src = { toString() { structuredClone(ab, { transfer: [ab] }); return "hello"; } };
+         const r = new TextEncoder().encodeInto(src, dest);
+         process.stdout.write(JSON.stringify({ ...r, byteLength: dest.byteLength }));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, signalCode: proc.signalCode, exitCode }).toEqual({
+      stdout: '{"read":0,"written":0,"byteLength":0}',
+      stderr: "",
+      signalCode: null,
+      exitCode: 0,
+    });
   });
 
   it("returns { read: 0, written: 0 } for a non-detached zero-length destination", () => {
+    const encoder = new TextEncoder();
     expect(encoder.encodeInto("x", new Uint8Array(0))).toEqual({ read: 0, written: 0 });
     expect(encoder.encodeInto("Ā", new Uint8Array(0))).toEqual({ read: 0, written: 0 });
-  });
-
-  it("returns { read: 0, written: 0 } when source toString() detaches the destination mid-call", () => {
-    const ab = new ArrayBuffer(16);
-    const dest = new Uint8Array(ab);
-    const src = {
-      toString() {
-        structuredClone(ab, { transfer: [ab] });
-        return "hello";
-      },
-    };
-    expect(encoder.encodeInto(src, dest)).toEqual({ read: 0, written: 0 });
-    expect(dest.byteLength).toBe(0);
   });
 });

--- a/test/js/web/encoding/text-encoder.test.js
+++ b/test/js/web/encoding/text-encoder.test.js
@@ -683,3 +683,36 @@ describe("TextEncoder UTF-16 exact-size path", () => {
     }
   });
 });
+
+describe("TextEncoder encodeInto with zero-length destination", () => {
+  const encoder = new TextEncoder();
+
+  // Detaching drives the view's byteLength to 0 and its backing pointer to null.
+  // "x" exercises the Latin-1 path; "Ā" and "💕" exercise the UTF-16 path.
+  it.each([["x"], ["Ā"], ["💕"]])("returns { read: 0, written: 0 } for a detached Uint8Array with input %j", input => {
+    const ab = new ArrayBuffer(8);
+    const dest = new Uint8Array(ab);
+    structuredClone(ab, { transfer: [ab] });
+
+    expect(dest.byteLength).toBe(0);
+    expect(encoder.encodeInto(input, dest)).toEqual({ read: 0, written: 0 });
+  });
+
+  it("returns { read: 0, written: 0 } for a non-detached zero-length destination", () => {
+    expect(encoder.encodeInto("x", new Uint8Array(0))).toEqual({ read: 0, written: 0 });
+    expect(encoder.encodeInto("Ā", new Uint8Array(0))).toEqual({ read: 0, written: 0 });
+  });
+
+  it("returns { read: 0, written: 0 } when source toString() detaches the destination mid-call", () => {
+    const ab = new ArrayBuffer(16);
+    const dest = new Uint8Array(ab);
+    const src = {
+      toString() {
+        structuredClone(ab, { transfer: [ab] });
+        return "hello";
+      },
+    };
+    expect(encoder.encodeInto(src, dest)).toEqual({ read: 0, written: 0 });
+    expect(dest.byteLength).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

`TextEncoder.prototype.encodeInto()` with a detached `Uint8Array` destination hits undefined behavior. A detached view reports `byteLength == 0` and a null backing pointer; `TextEncoder__encodeInto8/16` passed that null pointer straight into `core::slice::from_raw_parts_mut`, which requires a non-null pointer even for a zero-length slice. Debug builds abort on the precondition check:

```
panic: unsafe precondition(s) violated: slice::from_raw_parts_mut requires
the pointer to be aligned and non-null
  at TextEncoder__encodeInto8 (src/runtime/webcore/TextEncoder.rs:293)
SIGABRT
```

Release builds execute the UB silently (in practice returning `{ read: 0, written: 0 }` because nothing dereferences the empty slice, but this is not guaranteed).

Repro:

```js
const ab = new ArrayBuffer(8);
const dest = new Uint8Array(ab);
structuredClone(ab, { transfer: [ab] }); // detach
new TextEncoder().encodeInto("x", dest); // SIGABRT in debug
```

## Fix

Switch both FFI entry points from bare `core::slice::from_raw_parts{,_mut}` to `bun_core::ffi::{slice, slice_mut}`, the repo's audited helper for `(ptr, len)` pairs crossing the C++ boundary that tolerates the `(null, 0)` convention. With an empty output slice the downstream `copy_{latin1,utf16}_into_utf8` encoders return `{ read: 0, written: 0 }`, matching Node.js:

```
$ node -e 'const ab=new ArrayBuffer(1);const d=new Uint8Array(ab);structuredClone(ab,{transfer:[ab]});console.log(new TextEncoder().encodeInto("x",d))'
{ read: 0, written: 0 }
```

This brings `TextEncoder.rs` in line with the sibling `encoding.rs` and `array_buffer.rs`, which already use these helpers for the same pointer shape.

Adopts the fix from #31630 by @EffortlessSteven. That PR is from a fork and has been stuck on CI approval; this applies the same fix from a repo branch so CI can run.

## Tests

- Detached destination via `structuredClone(ab, { transfer: [ab] })` for Latin-1 (`"x"`), UTF-16 BMP (`"Ā"`), and astral (`"💕"`) source paths
- Source `toString()` that detaches the destination mid-call (the C++ side coerces the source before reading `destination->vector()/byteLength()`, so the guard covers this too)
- Non-detached zero-length destination (`new Uint8Array(0)`) as a control

The detached cases spawn a subprocess so a reintroduced debug-build abort shows up as a failed test rather than tearing down the whole file.

Verification: `bun bd test test/js/web/encoding/text-encoder.test.js` passes 47/47 with the fix; with `src/` at `origin/main` the four detached subprocess tests fail.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/encoding/text-encoder.test.js
bun test v1.4.0 (f40102655)

test/js/web/encoding/text-encoder.test.js:
(pass) not enough space for replacement character [12.78ms]
(pass) encodeInto astral characters and buffer sizing > "😀" into 3-byte buffer [2.99ms]
(pass) encodeInto astral characters and buffer sizing > "😀" into 4-byte buffer [1.24ms]
(pass) encodeInto astral characters and buffer sizing > "😀" into 2-byte buffer [0.85ms]
(pass) encodeInto astral characters and buffer sizing > "\ud800" into 3-byte buffer [0.89ms]
(pass) encodeInto astral characters and buffer sizing > "\udc00" into 3-byte buffer [0.73ms]
(pass) encodeInto astral characters and buffer sizing > "\ud800" into 2-byte buffer [0.68ms]
(pass) encodeInto astral characters and buffer sizing > "a😀" into 3-byte buffer [0.85ms]
(pass) encodeInto astral characters and buffer sizing > "a😀" into 4-byte buffer [1.40ms]
(pass) encodeInto astral characters and buffer sizing > "a😀" into 5-byte buffer [0.95ms]
(pass) TextEncoder > should handle undefined [2.6
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/encoding/text-encoder.test.js:
(pass) not enough space for replacement character [0.32ms]
(pass) encodeInto astral characters and buffer sizing > "😀" into 3-byte buffer [0.06ms]
(pass) encodeInto astral characters and buffer sizing > "😀" into 4-byte buffer [0.02ms]
(pass) encodeInto astral characters and buffer sizing > "😀" into 2-byte buffer
(pass) encodeInto astral characters and buffer sizing > "\ud800" into 3-byte buffer
(pass) encodeInto astral characters and buffer sizing > "\udc00" into 3-byte buffer
(pass) encodeInto astral characters and buffer sizing > "\ud800" into 2-byte buffer
(pass) encodeInto astral characters and buffer sizing > "a😀" into 3-byte buffer
(pass) encodeInto astral characters and buffer sizing > "a😀" into 4-byte buffer [0.27ms]
(pass) encodeInto astral characters and buffer sizing > "a😀" into 5-byte buffer
(pass) TextEncoder > should handle undefined [0.04ms]
(pass) TextEncoder > should encode latin1 text with non-ascii latin1 characters [3.45ms]
(pass) TextEncoder > should encode latin1 text [526.02ms]
(pass) TextEncoder > should encode long latin1 text [14.06ms]
(pass) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/encoding/text-encoder.test.js
bun test v1.4.0 (f40102655)

test/js/web/encoding/text-encoder.test.js:
(pass) not enough space for replacement character [13.26ms]
(pass) encodeInto astral characters and buffer sizing > "😀" into 3-byte buffer [2.97ms]
(pass) encodeInto astral characters and buffer sizing > "😀" into 4-byte buffer [1.19ms]
(pass) encodeInto astral characters and buffer sizing > "😀" into 2-byte buffer [0.90ms]
(pass) encodeInto astral characters and buffer sizing > "\ud800" into 3-byte buffer [0.88ms]
(pass) encodeInto astral characters and buffer sizing > "\udc00" into 3-byte buffer [0.73ms]
(pass) encodeInto astral characters and buffer sizing > "\ud800" into 2-byte buffer [0.67ms]
(pass) encodeInto astral characters and buffer sizing > "a😀" into 3-byte buffer [0.82ms]
(pass) encodeInto astral characters and buffer sizing > "a😀" into 4-byte buffer [1.16ms]
(pass) encodeInto astral characters and buffer sizing > "a😀" into 5-byte buffer [0.94ms]
(pass) TextEncoder > should handle undefined [2.7
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f40102655b
  features     baseline

22 deps, 108 codegen, 1171 objects in 790ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [14.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [14.00ms]
[4/1234] gen bindgenv2
[5/1234] gen ErrorCode+*.h
[6/1234] fetch zlib
[zlib] up to date
[7/1234] fetch tinycc
[tinycc] up to date
[8/1234] fetch picohttpparser
[picohttpparser] up to date
[9/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1234] fetch libjpeg-turbo
[libjpeg-turbo] 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/TextEncoder.rs        | 14 ++++---
 test/js/web/encoding/text-encoder.test.js | 66 ++++++++++++++++++++++++++++++-
 2 files changed, 73 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/webcore/TextEncoder.rs             0      0      0
test/js/web/encoding/text-encoder.test.js      0      0      0
```

</details>

**root cause** · written by the author bot

When the destination ArrayBuffer passed to `TextEncoder.encodeInto` is detached, JSC reports a null backing pointer with a byte length of zero, and the Rust entry points fed that pair directly into `core::slice::from_raw_parts{,_mut}`, which requires a non-null pointer even for empty slices, producing a debug abort and undefined behavior in release builds. The fix routes the `(ptr, len)` pairs through the audited `bun_core::ffi::{slice, slice_mut}` helpers, which return an empty slice for `(null, 0)` while still asserting on a null pointer with a nonzero length. This converts the detached-b…

<!-- robobun:evidence:end -->