### PR TITLE
fix(windows): normalize backslashes in html dev server routes

### DIFF
--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -140,7 +140,7 @@ yourself with Bun.serve().
     return acc.slice(0, i);
   });
 
-  if (path.platform === "win32") {
+  if (process.platform === "win32") {
     longestCommonPath = longestCommonPath.replaceAll("\\", "/");
   }
 
@@ -165,7 +165,10 @@ yourself with Bun.serve().
     if (servePath.startsWith(longestCommonPath)) {
       servePath = servePath.slice(longestCommonPath.length);
     } else {
-      const relative = path.relative(longestCommonPath, servePath);
+      let relative = path.relative(longestCommonPath, servePath);
+      if (process.platform === "win32") {
+        relative = relative.replaceAll("\\", "/");
+      }
       if (!relative.startsWith("..")) {
         servePath = relative;
       }

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -678,17 +678,15 @@ test("importing bun:main from HTML entry preload does not crash", async () => {
 // https://github.com/oven-sh/bun/issues/24031
 test.concurrent("subdirectory routes use forward slashes on Windows", async () => {
   await using dir = tempDir("html-subdir-routes", {
-    "index.html": `<!DOCTYPE html><html><head><title>Home</title></head><body>Home</body></html>`,
-    "demos/bubbles.html": `<!DOCTYPE html><html><head><title>Bubbles</title></head><body>Bubbles</body></html>`,
-    "demos/nested/page.html": `<!DOCTYPE html><html><head><title>Nested</title></head><body>Nested</body></html>`,
+    "dist/index.html": `<!DOCTYPE html><html><head><title>Home</title></head><body>Home</body></html>`,
+    "dist/components/buttons.html": `<!DOCTYPE html><html><head><title>Buttons</title></head><body>Buttons</body></html>`,
   });
 
   await using process = Bun.spawn({
     cmd: [
       bunExe(),
-      join(String(dir), "index.html"),
-      join(String(dir), "demos", "bubbles.html"),
-      join(String(dir), "demos", "nested", "page.html"),
+      "./dist/**/*.html",
+      join(String(dir), "dist", "components", "buttons.html"),
       "--port=0",
       "--hostname=127.0.0.1",
     ],
@@ -707,71 +705,14 @@ test.concurrent("subdirectory routes use forward slashes on Windows", async () =
       const match = text.match(/http:\/\/\S+/);
       if (match && URL.canParse(match[0])) serverUrl = match[0];
     }
-    if (serverUrl && text.includes("Routes:") && text.includes("page")) break;
-  }
-
-  expect(serverUrl).toBeTruthy();
-  expect(text).toContain("/demos/bubbles");
-  expect(text).toContain("/demos/nested/page");
-  expect(text).not.toContain("/demos\\bubbles");
-  expect(text).not.toContain("/demos\\nested");
-
-  const bubbles = await fetch(new URL("/demos/bubbles", serverUrl));
-  expect(bubbles.status).toBe(200);
-  expect(await bubbles.text()).toContain("<title>Bubbles</title>");
-
-  const nested = await fetch(new URL("/demos/nested/page", serverUrl));
-  expect(nested.status).toBe(200);
-  expect(await nested.text()).toContain("<title>Nested</title>");
-
-  const home = await fetch(new URL("/", serverUrl));
-  expect(home.status).toBe(200);
-  expect(await home.text()).toContain("<title>Home</title>");
-});
-
-// https://github.com/oven-sh/bun/issues/24031
-test.concurrent("glob pattern subdirectory routes use forward slashes on Windows", async () => {
-  await using dir = tempDir("html-glob-subdir-routes", {
-    "dist/index.html": `<!DOCTYPE html><html><head><title>Home</title></head><body>Home</body></html>`,
-    "dist/components/buttons.html": `<!DOCTYPE html><html><head><title>Buttons</title></head><body>Buttons</body></html>`,
-    "dist/components/forms.html": `<!DOCTYPE html><html><head><title>Forms</title></head><body>Forms</body></html>`,
-  });
-
-  await using process = Bun.spawn({
-    cmd: [bunExe(), "./dist/**/*.html", "--port=0", "--hostname=127.0.0.1"],
-    env: { ...bunEnv, NODE_ENV: "production", NO_COLOR: "1" },
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const decoder = new TextDecoder();
-  let text = "";
-  let serverUrl = "";
-  for await (const chunk of process.stdout as ReadableStream<Uint8Array>) {
-    text += decoder.decode(chunk, { stream: true });
-    if (!serverUrl) {
-      const match = text.match(/http:\/\/\S+/);
-      if (match && URL.canParse(match[0])) serverUrl = match[0];
-    }
-    if (serverUrl && text.includes("Routes:") && text.includes("forms")) break;
+    if (serverUrl && text.includes("Routes:") && text.includes("buttons")) break;
   }
 
   expect(serverUrl).toBeTruthy();
   expect(text).toContain("/components/buttons");
-  expect(text).toContain("/components/forms");
-  expect(text).not.toContain("/components\\buttons");
-  expect(text).not.toContain("/components\\forms");
+  expect(text).not.toContain("/components\\");
 
   const buttons = await fetch(new URL("/components/buttons", serverUrl));
   expect(buttons.status).toBe(200);
   expect(await buttons.text()).toContain("<title>Buttons</title>");
-
-  const forms = await fetch(new URL("/components/forms", serverUrl));
-  expect(forms.status).toBe(200);
-  expect(await forms.text()).toContain("<title>Forms</title>");
-
-  const home = await fetch(new URL("/", serverUrl));
-  expect(home.status).toBe(200);
-  expect(await home.text()).toContain("<title>Home</title>");
 });

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -1,6 +1,7 @@
 import type { Subprocess } from "bun";
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 
 async function getServerUrl(process: Subprocess) {
   // Read the port number from stdout
@@ -672,4 +673,105 @@ test("importing bun:main from HTML entry preload does not crash", async () => {
 
   proc.kill();
   await proc.exited;
+});
+
+// https://github.com/oven-sh/bun/issues/24031
+test.concurrent("subdirectory routes use forward slashes on Windows", async () => {
+  await using dir = tempDir("html-subdir-routes", {
+    "index.html": `<!DOCTYPE html><html><head><title>Home</title></head><body>Home</body></html>`,
+    "demos/bubbles.html": `<!DOCTYPE html><html><head><title>Bubbles</title></head><body>Bubbles</body></html>`,
+    "demos/nested/page.html": `<!DOCTYPE html><html><head><title>Nested</title></head><body>Nested</body></html>`,
+  });
+
+  await using process = Bun.spawn({
+    cmd: [
+      bunExe(),
+      join(String(dir), "index.html"),
+      join(String(dir), "demos", "bubbles.html"),
+      join(String(dir), "demos", "nested", "page.html"),
+      "--port=0",
+      "--hostname=127.0.0.1",
+    ],
+    env: { ...bunEnv, NODE_ENV: "production", NO_COLOR: "1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const decoder = new TextDecoder();
+  let text = "";
+  let serverUrl = "";
+  for await (const chunk of process.stdout as ReadableStream<Uint8Array>) {
+    text += decoder.decode(chunk, { stream: true });
+    if (!serverUrl) {
+      const match = text.match(/http:\/\/\S+/);
+      if (match && URL.canParse(match[0])) serverUrl = match[0];
+    }
+    if (serverUrl && text.includes("Routes:") && text.includes("page")) break;
+  }
+
+  expect(serverUrl).toBeTruthy();
+  expect(text).toContain("/demos/bubbles");
+  expect(text).toContain("/demos/nested/page");
+  expect(text).not.toContain("/demos\\bubbles");
+  expect(text).not.toContain("/demos\\nested");
+
+  const bubbles = await fetch(new URL("/demos/bubbles", serverUrl));
+  expect(bubbles.status).toBe(200);
+  expect(await bubbles.text()).toContain("<title>Bubbles</title>");
+
+  const nested = await fetch(new URL("/demos/nested/page", serverUrl));
+  expect(nested.status).toBe(200);
+  expect(await nested.text()).toContain("<title>Nested</title>");
+
+  const home = await fetch(new URL("/", serverUrl));
+  expect(home.status).toBe(200);
+  expect(await home.text()).toContain("<title>Home</title>");
+});
+
+// https://github.com/oven-sh/bun/issues/24031
+test.concurrent("glob pattern subdirectory routes use forward slashes on Windows", async () => {
+  await using dir = tempDir("html-glob-subdir-routes", {
+    "dist/index.html": `<!DOCTYPE html><html><head><title>Home</title></head><body>Home</body></html>`,
+    "dist/components/buttons.html": `<!DOCTYPE html><html><head><title>Buttons</title></head><body>Buttons</body></html>`,
+    "dist/components/forms.html": `<!DOCTYPE html><html><head><title>Forms</title></head><body>Forms</body></html>`,
+  });
+
+  await using process = Bun.spawn({
+    cmd: [bunExe(), "./dist/**/*.html", "--port=0", "--hostname=127.0.0.1"],
+    env: { ...bunEnv, NODE_ENV: "production", NO_COLOR: "1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const decoder = new TextDecoder();
+  let text = "";
+  let serverUrl = "";
+  for await (const chunk of process.stdout as ReadableStream<Uint8Array>) {
+    text += decoder.decode(chunk, { stream: true });
+    if (!serverUrl) {
+      const match = text.match(/http:\/\/\S+/);
+      if (match && URL.canParse(match[0])) serverUrl = match[0];
+    }
+    if (serverUrl && text.includes("Routes:") && text.includes("forms")) break;
+  }
+
+  expect(serverUrl).toBeTruthy();
+  expect(text).toContain("/components/buttons");
+  expect(text).toContain("/components/forms");
+  expect(text).not.toContain("/components\\buttons");
+  expect(text).not.toContain("/components\\forms");
+
+  const buttons = await fetch(new URL("/components/buttons", serverUrl));
+  expect(buttons.status).toBe(200);
+  expect(await buttons.text()).toContain("<title>Buttons</title>");
+
+  const forms = await fetch(new URL("/components/forms", serverUrl));
+  expect(forms.status).toBe(200);
+  expect(await forms.text()).toContain("<title>Forms</title>");
+
+  const home = await fetch(new URL("/", serverUrl));
+  expect(home.status).toBe(200);
+  expect(await home.text()).toContain("<title>Home</title>");
 });

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -693,7 +693,6 @@ test.concurrent("subdirectory routes use forward slashes on Windows", async () =
     env: { ...bunEnv, NODE_ENV: "production", NO_COLOR: "1" },
     cwd: String(dir),
     stdout: "pipe",
-    stderr: "pipe",
   });
 
   const decoder = new TextDecoder();


### PR DESCRIPTION
Fixes #24031. 

Closes #28892
Closes #24179.

## Problem

On Windows, running `bun ./dist/**/*.html` (or passing multiple HTML entry points in subdirectories) produced routes with backslashes:

```
Routes:
  ├── / → dist\index.html
  └── /components\buttons → dist\components\buttons.html
```

Requesting `/components/buttons` returned 404 because the route was registered as `/components\buttons`.

## Cause

`src/js/internal/html.ts:143` checked `path.platform === "win32"`. `node:path` has no `.platform` property, so the condition is always false and the backslash normalization of the longest common path prefix never ran. With a backslash prefix and forward-slash-normalized file paths, the `startsWith` check failed and execution fell through to `path.relative()`, which on Windows also returns backslash-separated paths that were never normalized.

## Fix

- `path.platform` → `process.platform` (inlined at build time per `src/js/CLAUDE.md`, so non-Windows builds are unaffected)
- Normalize the `path.relative()` result on Windows as well

## Verification

New test in `test/js/bun/http/bun-serve-html-entry.test.ts` spawns `bun ./dist/**/*.html` with a file in a subdirectory and asserts both the printed route table and an actual fetch use forward slashes.

On Windows x64 against current main:

```
error: expect(received).toContain(expected)
Expected to contain: "/components/buttons"
Received: "... /components\\buttons → dist\\components\\buttons.html ..."
(fail) subdirectory routes use forward slashes on Windows
```

With this change on Windows x64:

```
(pass) subdirectory routes use forward slashes on Windows [1102.31ms]
```

The test also passes on Linux and macOS, where paths already use forward slashes. Because the fix is gated behind `process.platform === "win32"` (a build-time constant), there is no observable change on non-Windows builds, so fail-before cannot be demonstrated on a Linux test runner. The Windows evidence above is the fail-before proof.

Credit to @ImpulseB23 (#28892) and @lekoala (#24179) for the original patches.
