### PR TITLE
install: skip overlong PAX paths in streaming tarball extraction

### DIFF
--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -799,12 +799,8 @@ impl TarballStream {
         let rest: &[OSPathChar] = tokenize_rest_after_first(&pathname[..]);
 
         let mut norm_buf = OSPathBuffer::uninit();
-        // `normalize_buf_t` writes into a fixed-size OSPathBuffer and assumes
-        // the input fits. PAX tar headers can carry arbitrarily long paths,
-        // so skip entries that would overflow (same guard as
-        // `Archiver::extract_to_dir`). On Windows a bare UNC volume name
-        // normalizes to one character longer than its input and we write a
-        // trailing NUL afterwards, so keep one slot of headroom.
+        // PAX paths are unbounded; +1 covers the Windows UNC/drive case
+        // where `normalize_buf_t` grows output by one, plus the NUL below.
         if rest.len() + 1 >= norm_buf.len() {
             self.phase = Phase::WantData;
             self.out_fd = None;

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -799,6 +799,15 @@ impl TarballStream {
         let rest: &[OSPathChar] = tokenize_rest_after_first(&pathname[..]);
 
         let mut norm_buf = OSPathBuffer::uninit();
+        // `normalize_buf_t` writes into a fixed-size OSPathBuffer and assumes
+        // the input fits. PAX tar headers can carry arbitrarily long paths,
+        // so skip entries that would overflow (same guard as
+        // `Archiver::extract_to_dir`).
+        if rest.len() >= norm_buf.len() {
+            self.phase = Phase::WantData;
+            self.out_fd = None;
+            return Ok(());
+        }
         let normalized =
             resolve_path::normalize_buf_t::<OSPathChar, platform::Auto>(rest, &mut norm_buf[..]);
         let norm_len = normalized.len();

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -802,8 +802,10 @@ impl TarballStream {
         // `normalize_buf_t` writes into a fixed-size OSPathBuffer and assumes
         // the input fits. PAX tar headers can carry arbitrarily long paths,
         // so skip entries that would overflow (same guard as
-        // `Archiver::extract_to_dir`).
-        if rest.len() >= norm_buf.len() {
+        // `Archiver::extract_to_dir`). On Windows a bare UNC volume name
+        // normalizes to one character longer than its input and we write a
+        // trailing NUL afterwards, so keep one slot of headroom.
+        if rest.len() + 1 >= norm_buf.len() {
             self.phase = Phase::WantData;
             self.out_fd = None;
             return Ok(());

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1494,7 +1494,10 @@ impl Archiver {
                     // at its original `.len()`; therefore `remaining[remaining.len()] == 0`.
                     let pathname: &[OSPathChar] = remaining;
 
-                    if pathname.len() >= normalized_buf.len() {
+                    // On Windows a bare UNC volume name normalizes to one
+                    // character longer than its input and we write a
+                    // trailing NUL afterwards, so keep one slot of headroom.
+                    if pathname.len() + 1 >= normalized_buf.len() {
                         if options.log {
                             bun_core::warn!(
                                 "Skipping entry with a path longer than the maximum path length: {}\n",

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1494,9 +1494,8 @@ impl Archiver {
                     // at its original `.len()`; therefore `remaining[remaining.len()] == 0`.
                     let pathname: &[OSPathChar] = remaining;
 
-                    // On Windows a bare UNC volume name normalizes to one
-                    // character longer than its input and we write a
-                    // trailing NUL afterwards, so keep one slot of headroom.
+                    // +1: `normalize_buf_t` can grow a Windows UNC/drive
+                    // input by one, and we write a NUL after it.
                     if pathname.len() + 1 >= normalized_buf.len() {
                         if options.log {
                             bun_core::warn!(

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -423,7 +423,9 @@ describe("streaming tarball extraction", () => {
 
     const pkgRoot = join(String(dir), "node_modules", "stream-pkg");
     expect(readFileSync(join(pkgRoot, "after.txt"), "utf8")).toBe("after\n");
-    expect(existsSync(join(pkgRoot, "package.json"))).toBe(true);
+    // The overlong entry must produce no on-disk artifact, not even under
+    // the truncated ustar fallback name.
+    expect(await readdirSorted(pkgRoot)).toEqual(["after.txt", "package.json"]);
     expect(exitCode).toBe(0);
   });
 

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -376,6 +376,57 @@ describe("streaming tarball extraction", () => {
     expect(exitCode).toBe(0);
   });
 
+  // The streaming extractor normalizes each entry's path into a fixed-size
+  // OSPathBuffer. PAX extended headers can carry paths of arbitrary length,
+  // so an entry longer than that buffer must be skipped rather than
+  // overrunning it. The buffered extractor already has this guard; this
+  // covers the streaming path.
+  test("streaming extract skips an overlong PAX path instead of crashing", async () => {
+    // Longer than OSPathBuffer on every platform: 1024 on macOS/BSD,
+    // 4096 on Linux, 32767 u16 units on Windows. Built from hash output
+    // so gzip cannot collapse it; the compressed body must span multiple
+    // HTTP chunks for the streaming path to commit.
+    let longName = "";
+    let seed = createHash("sha256").update("overlong-pax").digest();
+    while (longName.length < 40_000) {
+      longName += seed.toString("hex");
+      seed = createHash("sha256").update(seed).digest();
+    }
+    longName = longName.slice(0, 40_000);
+
+    const { tgz, shasum, integrity } = buildTarball([
+      {
+        path: "package.json",
+        body: Buffer.from(JSON.stringify({ name: "stream-pkg", version: "1.0.0" }) + "\n"),
+      },
+      { path: longName, body: Buffer.from("unreachable\n") },
+      { path: "after.txt", body: Buffer.from("after\n") },
+    ]);
+    expect(tgz.length).toBeGreaterThan(4096);
+
+    await using reg = await makeRegistry(tgz, shasum, integrity, 512);
+    using dir = tempDir("streaming-extract-overlong-pax", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "stream-pkg": "1.0.0" },
+      }),
+      "bunfig.toml": `[install]\nregistry = "${reg.url}"\n`,
+    });
+
+    // The crafted tarball is small; lower the threshold so the streaming
+    // extractor commits to it instead of falling back to the buffered path.
+    const { stderr, exitCode } = await runInstall(String(dir), {
+      BUN_INSTALL_STREAMING_MIN_SIZE: "1",
+    });
+    expect(stderr).toContain("Streamed ");
+
+    const pkgRoot = join(String(dir), "node_modules", "stream-pkg");
+    expect(readFileSync(join(pkgRoot, "after.txt"), "utf8")).toBe("after\n");
+    expect(existsSync(join(pkgRoot, "package.json"))).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
   test("streaming rejects a tarball whose integrity does not match", async () => {
     // Serve the valid tarball but advertise the integrity of a
     // *different* blob. Extraction will stream to completion (so we


### PR DESCRIPTION
## What

`TarballStream::begin_entry` copies each entry's pathname into a fixed-size `OSPathBuffer` via `normalize_buf_t` without checking the input length first. PAX extended headers can carry paths of arbitrary length, so a crafted registry tarball with a path longer than the buffer aborts the install with:

```
panic: range end index 40000 out of range for slice of length 4096
```

The buffered extractor (`Archiver::extract_to_dir`) already has this guard at [`src/libarchive/lib.rs:1497`](https://github.com/oven-sh/bun/blob/468dac3cfd66c6b1d3de397ac37ffcbf98c94021/src/libarchive/lib.rs#L1497); this adds the same check to the streaming path and skips the entry, matching the behaviour for other unrepresentable entries (empty, `.`/`..`, absolute on Windows).

## Why

The streaming extractor is the default for any registry tarball above 2 MiB, so a malicious package can crash `bun install` for anyone depending on it. Since the Rust port it is a clean panic/abort (DoS only, not memory corruption), but it still takes down the whole install.

This adopts the remaining piece of #31160 by @pc-style. The buffered-path length guard from that PR landed separately in #31339, and the leading-`..` guard for the streaming path was already present; only the streaming-path length guard remained.

## How verified

New test in `test/cli/install/bun-install-streaming-extract.test.ts` serves a tarball containing a 40 000-character PAX `path` (longer than `OSPathBuffer` on every platform) from a drip-feed local registry so the streaming extractor commits to it, then asserts the install completes, the entry following the overlong one is extracted correctly, and the `Streamed` verbose line confirms the streaming path ran.

Without the fix (`bun bd` with `src/` stashed) the spawned install aborts with the panic above and the test fails; with the fix the full file (10 tests) passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-streaming-extract.test.ts
bun test v1.4.0 (9ff04fdd8)

test/cli/install/bun-install-streaming-extract.test.ts:
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (streaming) [994.60ms]
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (buffered) [508.96ms]
(pass) streaming tarball extraction > streaming extract succeeds when the first chunk is smaller than the gzip header [405.89ms]
(pass) streaming tarball extraction > tarballs below BUN_INSTALL_STREAMING_MIN_SIZE take the buffered path [487.45ms]
417 |     // The crafted tarball is small; lower the threshold so the streaming
418 |     // extractor commits to it instead of falling back to the buffered path.
419 |     const { stderr, exitCode } = await runInstall(String(dir), {
420 |       BUN_INSTALL_STREAMING_MIN_SIZE: "1",
421 |     });
422 |     expect(stderr).toContain("Streamed ");
                         ^
error: expect(received).toContain(expected)

Expected to contain: "Streamed "
Received: "Enque
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (f7354c45b)

test/cli/install/bun-install-streaming-extract.test.ts:
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (streaming) [48.24ms]
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (buffered) [29.20ms]
(pass) streaming tarball extraction > streaming extract succeeds when the first chunk is smaller than the gzip header [131.74ms]
(pass) streaming tarball extraction > tarballs below BUN_INSTALL_STREAMING_MIN_SIZE take the buffered path [40.06ms]
(pass) streaming tarball extraction > streaming extract skips an overlong PAX path instead of crashing [15.07ms]
(pass) streaming tarball extraction > streaming rejects a tarball whose integrity does not match [18.15ms]
(pass) streaming tarball extraction > drain threshold holds off extraction until enough bytes arrive (default) [292.28ms]
(pass) streaming tarball extraction > drain threshold holds off extraction until enough bytes arrive (override) [287.88ms]
(pass) buffered extract: damaged-block retry resets header state (upstream semantics) [5.80ms]
(pass) buffered extract rejects a registry tarball whose decompressed size exceeds the li
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-streaming-extract.test.ts
bun test v1.4.0 (9ff04fdd8)

test/cli/install/bun-install-streaming-extract.test.ts:
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (streaming) [1431.88ms]
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (buffered) [649.68ms]
(pass) streaming tarball extraction > streaming extract succeeds when the first chunk is smaller than the gzip header [502.36ms]
(pass) streaming tarball extraction > tarballs below BUN_INSTALL_STREAMING_MIN_SIZE take the buffered path [631.39ms]
(pass) streaming tarball extraction > streaming extract skips an overlong PAX path instead of crashing [551.60ms]
(pass) streaming tarball extraction > streaming rejects a tarball whose integrity does not match [504.40ms]
(pass) streaming tarball extraction > drain threshold holds off extraction until enough bytes arrive (default) [690.77ms]
(pass) streaming tarball extraction > drain threshold holds off extraction until enough bytes arrive (override) [612.84ms]
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 754ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cc obj/packages/bun-usockets/src/context.c.o
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/TarballStream.rs                       |  7 +++
 src/libarchive/lib.rs                              |  4 +-
 .../install/bun-install-streaming-extract.test.ts  | 53 ++++++++++++++++++++++
 3 files changed, 63 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/install/TarballStream.rs                                3      4      0
src/libarchive/lib.rs                                       2      2      0
test/cli/install/bun-install-streaming-extract.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->