### PR TITLE
net: stop surfacing TLS traffic on the socket that tls.connect({ socket }) / new TLSSocket(socket) took over

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -181,6 +181,8 @@ static int us_ssl_socket_sni_ex_idx = -1;
  * owned by other engines (the JS-stream SSL wrapper used for TLS-over-duplex)
  * whose BIOs do not point at the loop's shared BIO data. */
 static int us_ssl_is_socket_ex_idx = -1;
+/* TLS output produced while ssl_handshake_held (struct us_ssl_held_output). */
+static int us_ssl_held_output_idx = -1;
 /* (SSL) inline-reject clients: (void*)1 when the rejectUnauthorized policy
  * was installed, and the LAST X509 error recorded while walking the chain
  * (node's ssl.verifyError() verdict) as (void*)(intptr_t). */
@@ -265,6 +267,62 @@ static void us_ssl_reneg_state_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
                                     int index, long argl, void *argp) {
   (void)parent; (void)ad; (void)index; (void)argl; (void)argp;
   us_free(ptr);
+}
+
+/* What node's TLSWrap keeps in its enc_out_ BIO while
+ * has_active_write_issued_by_prev_listener_: the handshake flight (and
+ * anything else SSL emits) until the previous owner's plaintext is out. */
+struct us_ssl_held_output {
+  unsigned int len, cap, off; /* off: already written (draining after release) */
+  char data[];
+};
+
+static void us_ssl_held_output_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
+                                    int index, long argl, void *argp) {
+  (void)parent; (void)ad; (void)index; (void)argl; (void)argp;
+  us_free(ptr);
+}
+
+/* After release: write out what was held. 1 = nothing pending any more. A
+ * short write leaves the rest for the next writable event (raw_write re-arms
+ * it), ahead of anything SSL emits meanwhile (BIO_s_custom_write keeps
+ * appending while the buffer exists). */
+static int us_ssl_drain_held_output(struct us_socket_t *s) {
+  SSL *ssl = s_ssl(s);
+  struct us_ssl_held_output *held = SSL_get_ex_data(ssl, us_ssl_held_output_idx);
+  if (!held) return 1;
+  while (held->off < held->len) {
+    int written = us_socket_raw_write(s, held->data + held->off, (int)(held->len - held->off));
+    if (written <= 0) return 0;
+    held->off += (unsigned int)written;
+  }
+  SSL_set_ex_data(ssl, us_ssl_held_output_idx, NULL);
+  us_free(held);
+  return 1;
+}
+
+static int us_ssl_output_held(struct us_socket_t *s) {
+  return s->ssl_handshake_held || SSL_get_ex_data(s_ssl(s), us_ssl_held_output_idx) != NULL;
+}
+
+/* 0 on allocation failure. */
+static int us_ssl_hold_output(SSL *ssl, const char *data, unsigned int length) {
+  struct us_ssl_held_output *held = SSL_get_ex_data(ssl, us_ssl_held_output_idx);
+  unsigned int len = held ? held->len : 0;
+  if (!held || len + length > held->cap) {
+    unsigned int cap = held ? held->cap : 4096;
+    while (cap < len + length) cap *= 2;
+    struct us_ssl_held_output *grown = us_realloc(held, sizeof(*held) + cap);
+    if (!grown) return 0;
+    if (!held) grown->off = 0;
+    grown->len = len;
+    grown->cap = cap;
+    held = grown;
+    SSL_set_ex_data(ssl, us_ssl_held_output_idx, held);
+  }
+  memcpy(held->data + held->len, data, length);
+  held->len += length;
+  return 1;
 }
 
 /* A new resumable session is ready (for TLS 1.3, the peer's NewSessionTicket
@@ -457,6 +515,7 @@ static void us_ex_idx_init(void) {
   us_ssl_socket_sni_ex_idx =
       SSL_get_ex_new_index(0, NULL, NULL, NULL, us_socket_sni_resolver_free);
   us_ssl_is_socket_ex_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+  us_ssl_held_output_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_held_output_free);
   us_ssl_inline_reject_enabled_ex_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
   us_ssl_inline_reject_err_ex_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
   us_ssl_pending_session_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_pending_session_free);
@@ -676,6 +735,15 @@ static int BIO_s_custom_write(BIO *bio, const char *data, int length) {
    * (node's post-verify destroy cancels its queued Finished the same way). */
   if (loop_ssl_data->ssl_socket &&
       us_ssl_inline_reject_tripped(loop_ssl_data->ssl_socket)) {
+    BIO_clear_retry_flags(bio);
+    return length;
+  }
+
+  if (loop_ssl_data->ssl_socket && us_ssl_output_held(loop_ssl_data->ssl_socket)) {
+    struct us_socket_t *s = loop_ssl_data->ssl_socket;
+    if (!us_ssl_hold_output(s_ssl(s), data, (unsigned int)length)) {
+      s->ssl_fatal_error = 1;
+    }
     BIO_clear_retry_flags(bio);
     return length;
   }
@@ -1810,6 +1878,7 @@ void us_internal_ssl_attach(struct us_socket_t *s, SSL_CTX *ctx,
   s->ssl_read_wants_write = 0;
   s->ssl_fatal_error = 0;
   s->ssl_raw_tap = 0;
+  s->ssl_handshake_held = 0;
   s->ssl_shutdown_after_spill = 0;
   s->ssl_close_after_spill = 0;
   s->ssl_end_delivered = 0;
@@ -2142,8 +2211,13 @@ struct us_socket_t *us_internal_ssl_close(struct us_socket_t *s, int code, void 
    * ciphertext already reported as written: SSL sealed it, so it can only be
    * delivered, never re-sent. Mirror ssl_shutdown_after_spill; defer at most once. */
   if ((code == LIBUS_SOCKET_CLOSE_CODE_FAST_SHUTDOWN || code == LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN)
-      && !reason
-      && !s->ssl_close_after_spill && !s->ssl_fatal_error && !us_socket_is_closed(s)) {
+      && !reason && !s->ssl_fatal_error && !us_socket_is_closed(s)) {
+    /* A second graceful close while the first waits for the spill (both halves
+     * of an upgradeTLS pair close the shared socket): the pending one finishes
+     * the job once the spill has drained. */
+    if (s->ssl_close_after_spill) {
+      return s;
+    }
     struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)s->group->loop->data.ssl_data;
     if (loop_ssl_data && !ssl_drain_spill(loop_ssl_data, s)) {
       s->ssl_close_after_spill = 1;
@@ -2158,6 +2232,15 @@ struct us_socket_t *us_internal_ssl_close(struct us_socket_t *s, int code, void 
    * connect, but no bytes were ever exchanged. Firing on_handshake(0) here
    * lands in JS after onConnectError already tore down `this`/its handlers. */
   if (ssl_gone(s) || (us_internal_poll_type(&s->p) & POLL_TYPE_KIND_MASK) == POLL_TYPE_SEMI_SOCKET) {
+    return us_internal_socket_close_raw(s, code, reason);
+  }
+  /* A held handshake never started: nothing of TLS goes on the wire, but the
+   * owner hears about it like any other close before the handshake finished. */
+  if (s->ssl_handshake_held) {
+    if (s->ssl_handshake_state != HANDSHAKE_COMPLETED) {
+      ssl_trigger_handshake_econnreset(s);
+      if (ssl_gone(s) || us_socket_is_closed(s)) return s;
+    }
     return us_internal_socket_close_raw(s, code, reason);
   }
   ssl_set_loop_data(s);
@@ -2397,6 +2480,10 @@ struct us_socket_t *us_internal_ssl_on_end(struct us_socket_t *s) {
 }
 
 struct us_socket_t *us_internal_ssl_on_writable(struct us_socket_t *s) {
+  /* Nothing of TLS is in flight yet; the event is for the previous owner's
+   * plaintext (see ssl_handshake_held). Then what the hold kept back goes,
+   * before anything else of ours. */
+  if (s->ssl_handshake_held || !us_ssl_drain_held_output(s)) return us_dispatch_writable(s);
   ssl_set_loop_data(s);
   {
     struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)s->group->loop->data.ssl_data;
@@ -2739,7 +2826,8 @@ restart:
  * and the expensive crypto work is the first step, so deprioritising
  * mid-handshake sockets keeps fully-established ones responsive under load. */
 int us_internal_ssl_is_low_prio(struct us_socket_t *s) {
-  return SSL_in_init(s_ssl(s));
+  /* The handshake budget is for handshakes; a held socket is still plaintext. */
+  return !s->ssl_handshake_held && SSL_in_init(s_ssl(s));
 }
 
 /* ── Socket-level accessors / write / shutdown ───────────────────────────── */
@@ -2871,6 +2959,11 @@ int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
 
 void us_internal_ssl_shutdown(struct us_socket_t *s) {
   if (us_socket_is_closed(s) || us_internal_ssl_is_shut_down(s)) return;
+  if (s->ssl_handshake_held) {
+    /* TLS never started: a plain FIN, no close_notify. */
+    us_internal_socket_raw_shutdown(s);
+    return;
+  }
 
   /* Spilled ciphertext is data the layers above already count as written;
    * a FIN/close_notify now would cut it off. Finish the shutdown from the
@@ -3012,6 +3105,22 @@ struct us_socket_t *us_socket_adopt_tls(struct us_socket_t *s,
    * land in the old (TCP) owner. Caller stashes ext, sets kind, fires its own
    * onOpen, then calls us_socket_start_tls_handshake() to send ClientHello. */
   return new_s;
+}
+
+void us_socket_hold_tls_output(struct us_socket_t *s) {
+  if (!s->ssl || us_socket_is_closed(s)) return;
+  us_ex_idx_ensure();
+  s->ssl_handshake_held = 1;
+}
+
+void us_socket_release_tls_output(struct us_socket_t *s) {
+  if (!s->ssl || us_socket_is_closed(s) || !s->ssl_handshake_held) return;
+  s->ssl_handshake_held = 0;
+  /* A JS write parked meanwhile goes out with the next writable event. */
+  s->ssl_write_wants_read = 1;
+  if (!us_ssl_drain_held_output(s) || us_socket_is_closed(s)) return;
+  ssl_set_loop_data(s);
+  ssl_update_handshake(s);
 }
 
 void us_socket_start_tls_handshake(struct us_socket_t *s) {

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -316,6 +316,9 @@ struct us_socket_t {
    * the driver's epilogue via ssl_pending_detach. */
   unsigned char ssl_in_use : 1;
   unsigned char ssl_pending_detach : 1;
+  /* us_socket_hold_tls_output .. us_socket_release_tls_output: SSL's output
+   * is buffered (us_ssl_held_output) instead of written. */
+  unsigned char ssl_handshake_held : 1;
   /* Peer FIN was dispatched as on_end on a half-open socket; readable interest is never re-added and on_end never re-fires. */
   unsigned char read_eof : 1;
   /* The close code passed to the deferred close (e.g. a reset requested from

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -380,6 +380,11 @@ struct us_socket_t *us_socket_tls_feed(us_socket_r s, const char *data, int leng
 /* Send ClientHello after adopt_tls. Separate so the caller can repoint the
  * ext slot before any dispatch can fire. */
 void us_socket_start_tls_handshake(us_socket_r s) nonnull_fn_decl;
+/* node's has_active_write_issued_by_prev_listener_: from hold until release,
+ * whatever SSL emits (the handshake flight) is kept back so the previous
+ * owner's queued plaintext reaches the wire first; input is processed. */
+void us_socket_hold_tls_output(us_socket_r s) nonnull_fn_decl;
+void us_socket_release_tls_output(us_socket_r s) nonnull_fn_decl;
 
 /* ── Listen ───────────────────────────────────────────────────────────────
  * The listener owns: an embedded group for accepted sockets, the SSL_CTX

--- a/src/js/internal/net/streamTLS.ts
+++ b/src/js/internal/net/streamTLS.ts
@@ -1,0 +1,51 @@
+// The stream-level TLS engine (upgradeDuplexToTLS) over an existing stream. A
+// net.Socket with a native handle is read and written below JS (node's TLSWrap
+// over the parent's handle) and hands over what it had already buffered; any
+// other Duplex is driven from its events (node's JSStreamSocket):
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L566-L579.
+const upgradeDuplexToTLS = $newRustFunction("runtime/socket/socket.rs", "jsUpgradeDuplexToTLS", 2);
+
+function upgradeStreamToTLS(owner: { destroyed: boolean }, connection, options) {
+  const { Socket } = require("node:net");
+  if (connection instanceof Socket) {
+    options.transport = connection._handle;
+    options.deferHandshake = hasUnflushedWrites(connection);
+  }
+  const [handle, events, nativeTransport] = upgradeDuplexToTLS(connection, options);
+  if (nativeTransport) {
+    // Already-buffered bytes go to feedBuffered, not flow(); an EOF already
+    // taken off the wire is stream state (a later one arrives natively).
+    connection.pause();
+    const ended = connection._readableState?.ended;
+    process.nextTick(feedBuffered, owner, connection, events[0], ended ? events[1] : undefined);
+    if (options.deferHandshake) startTLSHandshakeWhenFlushed(owner, connection, handle);
+  } else {
+    connection.on("data", events[0]);
+    connection.on("end", events[1]);
+    connection.on("drain", events[2]);
+    connection.on("close", events[3]);
+  }
+  return [handle, events];
+}
+
+function feedBuffered(owner, connection, feed, end) {
+  if (owner.destroyed || connection.destroyed) return;
+  let chunk;
+  while ((chunk = connection.read()) !== null) feed(chunk);
+  end?.();
+}
+
+// Plaintext still queued on `connection` must reach the wire before any TLS
+// record (node's wrapHasActiveWriteFromPrevOwner): the native side holds our
+// output until the empty write queued behind it completes.
+function hasUnflushedWrites(connection): boolean {
+  return connection.writableLength > 0;
+}
+
+function startTLSHandshakeWhenFlushed(owner, connection, handle) {
+  connection.write("", err => {
+    if (!err && !owner.destroyed && !connection.destroyed) handle.startTLSHandshake();
+  });
+}
+
+export default { upgradeStreamToTLS, hasUnflushedWrites, startTLSHandshakeWhenFlushed };

--- a/src/js/node/_http2_upgrade.ts
+++ b/src/js/node/_http2_upgrade.ts
@@ -1,5 +1,5 @@
 const { Duplex } = require("node:stream");
-const upgradeDuplexToTLS = $newRustFunction("runtime/socket/socket.rs", "jsUpgradeDuplexToTLS", 2);
+const { upgradeStreamToTLS } = require("internal/net/streamTLS");
 const kSharedCreds = Symbol.for("::buntlssharedcreds::");
 
 interface NativeHandle {
@@ -71,9 +71,11 @@ function UpgradeContext(
 // Duplex stream methods — called with `this` = tlsSocket (standard stream API)
 // ---------------------------------------------------------------------------
 
-// _read: called by stream machinery when the H2 session wants data.
-// Resume the native TLS handle so it feeds decrypted data via the data callback.
-// Mirrors net.ts Socket.prototype._read which calls socket.resume().
+// _read: called by stream machinery when the H2 session wants data. Undoes
+// socketData's backpressure: resuming the native TLS handle resumes the raw
+// socket's reads when it is a net.Socket (read natively); rawSocket.resume()
+// covers a JS Duplex fed through 'data' events. Mirrors net.ts
+// Socket.prototype._read which calls socket.resume().
 function tlsSocketRead(this: TLSProxySocket) {
   const h = this._ctx.nativeHandle;
   if (h) {
@@ -139,9 +141,14 @@ function tlsSocketFinal(this: TLSProxySocket, callback: () => void) {
 function socketOpen() {}
 
 // data: called with decrypted plaintext after the TLS layer decrypts incoming data.
-// Push into tlsSocket so the H2 session's _read() receives these frames.
-function socketData(this: TLSProxySocket, _socket: NativeHandle, chunk: Buffer) {
+// Push into tlsSocket so the H2 session's _read() receives these frames. When
+// the session is not keeping up, stop reading: a net.Socket rawSocket is read
+// natively below its stream, so only pausing the TLS handle (which pauses that
+// socket's fd) stops it; rawSocket.pause() covers a JS Duplex fed via 'data'.
+function socketData(this: TLSProxySocket, socket: NativeHandle, chunk: Buffer) {
+  this._ctx.rawSocket._unrefTimer?.();
   if (!this.push(chunk)) {
+    socket.pause();
     this._ctx.rawSocket.pause();
   }
 }
@@ -262,6 +269,8 @@ function onTlsClose(this: TLSProxySocket) {
   raw.removeListener("end", ev[1]);
   raw.removeListener("drain", ev[2]);
   raw.removeListener("close", ev[3]);
+  // The raw socket goes down with the session's TLS socket, as in node.
+  raw.destroy();
 }
 
 // ---------------------------------------------------------------------------
@@ -286,9 +295,9 @@ function noop() {}
 // targets the H2 connectionListener instead of a generic secureConnection event.
 //
 // Data flow after upgrade:
-//   rawSocket (TCP) → upgradeDuplexToTLS (native TLS layer) → socket callbacks
-//     → tlsSocket.push() → H2 session reads
-//   H2 session writes → tlsSocket._write() → handle.$write() → native TLS layer → rawSocket
+//   rawSocket (read natively when it is a net.Socket, else via 'data') → native
+//     TLS layer → socket callbacks → tlsSocket.push() → H2 session reads
+//   H2 session writes → tlsSocket._write() → handle.$write() → native TLS layer → rawSocket.write()
 //
 // CRITICAL: We do NOT set tlsSocket._handle to the native TLS handle.
 // If we did, the H2FrameParser constructor would detect it as a JSTLSSocket
@@ -334,15 +343,15 @@ function upgradeRawSocketToH2(
   // socket: callbacks — bind to tlsSocket since they are invoked with the native handle as `this`
   let handle: NativeHandle, events: UpgradeContextType["events"];
   try {
-    // upgradeDuplexToTLS wraps rawSocket with a TLS layer in server mode (isServer: true).
-    // The native side will:
-    //   1. Read encrypted data from rawSocket via events[0..3]
+    // upgradeStreamToTLS wraps rawSocket with a TLS layer in server mode (isServer: true)
+    // and wires rawSocket's bytes/end/drain/close into it. The native side will:
+    //   1. Read encrypted data from rawSocket
     //   2. Decrypt it through the TLS engine (with ALPN negotiation for "h2")
     //   3. Call our socket callbacks below with the decrypted plaintext
     //
     // ALPNProtocols: server.ALPNProtocols is a Buffer in wire format (e.g. <Buffer 02 68 32>
     // for ["h2"]). The native SSLConfig expects an ArrayBuffer, so we slice the underlying buffer.
-    [handle, events] = upgradeDuplexToTLS(rawSocket, {
+    [handle, events] = upgradeStreamToTLS(tlsSocket, rawSocket, {
       isServer: true,
       tls: {
         secureContext: server[kSharedCreds]().context,
@@ -378,14 +387,6 @@ function upgradeRawSocketToH2(
   // intercept data at the native level and bypass our Duplex push path.
   tlsSocket._ctx.nativeHandle = handle;
   tlsSocket._ctx.events = events;
-
-  // Wire up the raw TCP socket to feed encrypted data into the TLS layer.
-  // events[0..3] are native event handlers returned by upgradeDuplexToTLS that
-  // the native TLS engine expects to receive data/end/drain/close through.
-  rawSocket.on("data", events[0]);
-  rawSocket.on("end", events[1]);
-  rawSocket.on("drain", events[2]);
-  rawSocket.on("close", events[3]);
 
   // When the TLS socket closes (e.g. H2 session destroyed), clean up the raw socket
   // listeners to prevent memory leaks and stale callback references.

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2455,8 +2455,6 @@ Socket.prototype.ref = function ref() {
     return this;
   }
   socket.ref();
-  // Its fd is a TLS layer's now; that is what holds the loop (node: one uv handle).
-  if (socket.fdIsTLS) this[kTLSLayer]?._handle?.ref();
   return this;
 };
 
@@ -2651,7 +2649,6 @@ Socket.prototype.unref = function unref() {
     return this;
   }
   socket.unref();
-  if (socket.fdIsTLS) this[kTLSLayer]?._handle?.unref();
   return this;
 };
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -43,6 +43,7 @@ const { kTimeout, getTimerDuration } = require("internal/timers");
 const { validateFunction, validateNumber, validateAbortSignal, validatePort, validateBoolean, validateInt32, validateString } = require("internal/validators"); // prettier-ignore
 const { isIPv4, isIPv6, isIP } = require("internal/net/isIP");
 const { kArmHandshakeTimeout, kSecureConnectDone, kVerifyError } = require("internal/net/symbols");
+const { upgradeStreamToTLS, hasUnflushedWrites, startTLSHandshakeWhenFlushed } = require("internal/net/streamTLS");
 
 const ArrayPrototypeIncludes = Array.prototype.includes;
 const ArrayPrototypeJoin = Array.prototype.join;
@@ -117,9 +118,9 @@ const newDetachedSocket = $newRustFunction("node_net_binding.rs", "newDetachedSo
 const doConnect = $newRustFunction("node_net_binding.rs", "doConnect", 2);
 
 const addServerName = $newRustFunction("Listener.rs", "jsAddServerName", 3);
-const upgradeDuplexToTLS = $newRustFunction("runtime/socket/socket.rs", "jsUpgradeDuplexToTLS", 2);
-// tls.connect({ socket }) upgrade: hostname policy stays with this JS layer.
-const upgradeTLSDeferred = $newRustFunction("runtime/socket/socket.rs", "jsUpgradeTLSDeferred", 2);
+// fd adoption for tls.connect({ socket }) / new TLSSocket(socket): hostname
+// policy stays with this JS layer and the wrapped socket stops seeing bytes.
+const nodeNetUpgradeTLS = $newRustFunction("runtime/socket/socket.rs", "jsNodeNetUpgradeTLS", 2);
 const isNamedPipeSocket = $newRustFunction("runtime/socket/socket.rs", "jsIsNamedPipeSocket", 1);
 const getBufferedAmount = $newRustFunction("runtime/socket/socket.rs", "jsGetBufferedAmount", 1);
 
@@ -147,9 +148,8 @@ const kSyncWriteFd = Symbol("kSyncWriteFd");
 const kSetKeepAliveInitialDelay = Symbol("kSetKeepAliveInitialDelay");
 const kConnectOptions = Symbol("connect-options");
 const kAttach = Symbol("kAttach");
-const kCloseRawConnection = Symbol("kCloseRawConnection");
+const kTLSLayer = Symbol("kTLSLayer");
 const kupgraded = Symbol("kupgraded");
-const kAdoptedTLSRaw = Symbol("kAdoptedTLSRaw");
 const ksocket = Symbol("ksocket");
 const khandlers = Symbol("khandlers");
 const kclosed = Symbol("closed");
@@ -1886,16 +1886,97 @@ Socket.prototype[kAttach] = function (port, socket) {
   SocketHandlers.drain(socket);
 };
 
-Socket.prototype[kCloseRawConnection] = function () {
-  const connection = this[kupgraded];
-  connection.connecting = false;
-  connection._handle = null;
-  connection.unref();
-  connection.destroy();
-};
+// A TLS socket lives and dies with the stream it wraps:
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L740
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L977
+function tieToWrappedStream(self, connection) {
+  connection[kTLSLayer] = self;
+  connection.on("close", () => {
+    if (!self.destroyed) self.destroy();
+  });
+  connection.on("error", err => {
+    if (!self.destroyed) self.destroy(err);
+  });
+}
+
+// `connection`'s fd goes to a native TLS socket that becomes `self._handle`;
+// `connection` keeps its handle (node's `_parentWrap`) but sees no more bytes.
+// Already-buffered bytes go along (node's initRead); still-queued plaintext
+// goes out before any TLS record (node's wrapHasActiveWriteFromPrevOwner):
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L502-L613
+function adoptConnection(self, connection, data, handlers, isServer, tls) {
+  let pending: Buffer | undefined;
+  if (connection.readableLength) {
+    const chunks: Buffer[] = [];
+    let chunk;
+    while ((chunk = connection.read()) !== null) {
+      if (!$isTypedArrayView(chunk)) {
+        self.destroy($ERR_STREAM_WRAP("Stream has StringDecoder set or is in objectMode"));
+        return false;
+      }
+      chunks.push(chunk);
+    }
+    pending = chunks.length === 1 ? chunks[0] : Buffer.concat(chunks);
+  }
+  // The TLS layer reads from here on, so the fd holds the loop again even if
+  // `connection` had stopped reading (readStop).
+  restorePausedHold(connection, connection._handle);
+  const deferHandshake = hasUnflushedWrites(connection);
+  const result = nodeNetUpgradeTLS(connection._handle, {
+    data,
+    tls,
+    socket: handlers,
+    isServer,
+    deferHandshake,
+    initialData: pending,
+  });
+  if (!result) {
+    self._handle = null;
+    self.destroy(new Error("Invalid socket"));
+    return false;
+  }
+  self._handle = result[1];
+  if (deferHandshake) startTLSHandshakeWhenFlushed(self, connection, result[1]);
+  return true;
+}
+
+// tls.connect({ socket }) over an established `connection`.
+function upgradeClientConnection(self, connection, overStream, tls) {
+  self[kupgraded] = connection;
+  const data = { self, req: { oncomplete: afterConnect } };
+  // A named pipe has no fd the TLS engine can adopt; it runs over the stream.
+  if (overStream || isNamedPipeSocket(connection._handle)) {
+    self._handle = upgradeStreamToTLS(self, connection, {
+      data,
+      tls,
+      socket: self[khandlers],
+    })[0];
+    return;
+  }
+  adoptConnection(self, connection, data, self[khandlers], false, tls);
+}
+
+// new tls.TLSSocket(connection, { isServer: true }) over an accepted socket.
+function adoptServerConnection(self, connection, tls) {
+  if (self.destroyed || connection.destroyed || !connection._handle) {
+    self.destroy();
+    return;
+  }
+  // (A user 'connection' listener, which runs after the server's, may have
+  // written by now: that is the pending-writes case.)
+  if (adoptConnection(self, connection, self, serverHandlersFor(self), true, tls)) {
+    self.emit(kUpgradeAttached);
+  }
+}
 
 Socket.prototype.connect = function connect(...args) {
   $debug("Socket.prototype.connect");
+  // A TLS layer runs over this socket's connection: report what connect(2)
+  // would rather than tear the connection out from under it.
+  if ((this.connecting || this._handle) && this[kTLSLayer] && !this[kTLSLayer].destroyed) {
+    process.nextTick(destroyNT, this, new ErrnoException(uv().UV_EISCONN, "connect"));
+    return this;
+  }
   {
     const [options, connectListener] =
       $isArray(args[0]) && args[0][normalizedArgsSymbol] ? args[0] : normalizeArgs(args);
@@ -1997,9 +2078,12 @@ Socket.prototype.connect = function connect(...args) {
       // secureConnecting tracks. Node reports false here. A provided
       // net.Socket keeps its existing accounting (its own connect lifecycle
       // drives this flag).
-      if (!(connection instanceof Socket)) {
+      if (connection instanceof Socket) {
+        this._parent = connection;
+      } else {
         this.connecting = false;
       }
+      tieToWrappedStream(this, connection);
       if (connectListener != null) this.once("secureConnect", connectListener);
       try {
         // reset the underlying writable object when establishing a new connection
@@ -2007,97 +2091,21 @@ Socket.prototype.connect = function connect(...args) {
         // https://github.com/nodejs/node/blob/c5cfdd48497fe9bd8dbd55fd1fca84b321f48ec1/lib/net.js#L311
         // https://github.com/nodejs/node/blob/c5cfdd48497fe9bd8dbd55fd1fca84b321f48ec1/lib/net.js#L1126
         this._undestroy();
-        const socket = connection._handle;
-        if (!upgradeDuplex && socket) {
-          // if is named pipe socket we can upgrade it using the same wrapper than we use for duplex
-          upgradeDuplex = isNamedPipeSocket(socket) || hasUnflushedWrites(connection);
-        }
-        if (upgradeDuplex) {
-          this[kupgraded] = connection;
-          const [result, events] = upgradeDuplexToTLS(connection, {
-            data: { self: this, req: { oncomplete: afterConnect } },
-            tls,
-            socket: this[khandlers],
-          });
-          connection.on("data", events[0]);
-          connection.on("end", events[1]);
-          connection.on("drain", events[2]);
-          connection.on("close", events[3]);
-          this._handle = result;
+        if (!(connection instanceof Socket) || (connection._handle && !connection.connecting)) {
+          upgradeClientConnection(this, connection, upgradeDuplex, tls);
         } else {
-          // upgradeTLS requires an established socket; a socket that is still
-          // connecting (e.g. tls.connect({ socket: net.connect(port) })) must be
-          // upgraded once it emits 'connect'.
-          if (socket && !connection.connecting) {
-            this[kupgraded] = connection;
-            const result = upgradeTLSDeferred(socket, {
-              data: { self: this, req: { oncomplete: afterConnect } },
-              tls,
-              socket: this[khandlers],
-              isServer: false,
-            });
-            if (result) {
-              const [raw, tls] = result;
-              // replace socket
-              connection._handle = raw;
-              raw[kAdoptedTLSRaw] = true;
-              this.once("end", this[kCloseRawConnection]);
-              raw.connecting = false;
-              this._handle = tls;
-            } else {
-              this._handle = null;
-              throw new Error("Invalid socket");
+          // A connecting net.Socket (e.g. tls.connect({ socket: net.connect(port) }))
+          // has no fd to adopt / no transport to write to until 'connect'.
+          connection.once("connect", () => {
+            const destroyed = this.destroyed;
+            const connectionDestroyed = connection.destroyed;
+            if (destroyed || connectionDestroyed || !connection._handle) {
+              if (!connectionDestroyed) connection.destroy();
+              if (!destroyed) this.destroy();
+              return;
             }
-          } else {
-            // wait to be connected
-            connection.once("connect", () => {
-              // The TLS socket may have been destroyed before the underlying
-              // socket connected (e.g. tls.connect({ socket }).destroy()); don't
-              // start a handshake on a dead socket.
-              if (this.destroyed) {
-                connection.destroy();
-                return;
-              }
-              const socket = connection._handle;
-              if (!upgradeDuplex && socket) {
-                // if is named pipe socket we can upgrade it using the same wrapper than we use for duplex
-                upgradeDuplex = isNamedPipeSocket(socket) || hasUnflushedWrites(connection);
-              }
-              if (upgradeDuplex) {
-                this[kupgraded] = connection;
-                const [result, events] = upgradeDuplexToTLS(connection, {
-                  data: { self: this, req: { oncomplete: afterConnect } },
-                  tls,
-                  socket: this[khandlers],
-                });
-                connection.on("data", events[0]);
-                connection.on("end", events[1]);
-                connection.on("drain", events[2]);
-                connection.on("close", events[3]);
-                this._handle = result;
-              } else {
-                this[kupgraded] = connection;
-                const result = upgradeTLSDeferred(socket, {
-                  data: { self: this, req: { oncomplete: afterConnect } },
-                  tls,
-                  socket: this[khandlers],
-                  isServer: false,
-                });
-                if (result) {
-                  const [raw, tls] = result;
-                  // replace socket
-                  connection._handle = raw;
-                  raw[kAdoptedTLSRaw] = true;
-                  this.once("end", this[kCloseRawConnection]);
-                  raw.connecting = false;
-                  this._handle = tls;
-                } else {
-                  this._handle = null;
-                  throw new Error("Invalid socket");
-                }
-              }
-            });
-          }
+            upgradeClientConnection(this, connection, upgradeDuplex, tls);
+          });
         }
       } catch (error) {
         process.nextTick(emitErrorAndCloseNextTick, this, error);
@@ -2164,12 +2172,11 @@ Socket.prototype._destroy = function _destroy(err, callback) {
   $debug("Socket.prototype._destroy");
 
   this.connecting = false;
-  // Tear down a wrapped generic duplex with this socket: the native handle's
-  // close only flushes close_notify and lets the wrapper drain; without an
-  // explicit destroy here a late RST on the underlying transport can surface
-  // as an unhandled error after this socket is gone.
+  // The wrapped stream goes down with this socket, as in node:
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L686
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L253
   const upgraded = this[kupgraded];
-  if (upgraded && !(upgraded instanceof Socket) && !upgraded.destroyed) {
+  if (upgraded && !upgraded.destroyed) {
     upgraded.destroy?.();
   }
 
@@ -2221,7 +2228,7 @@ Socket.prototype._destroy = function _destroy(err, callback) {
       // Enqueue closing the socket as a microtask, so that the socket can be
       // accessible when an `error` event is handled in the `next tick queue`.
       queueMicrotask(() => closeSocketHandle(this, isException, true));
-    } else if (currentHandle[kAdoptedTLSRaw]) {
+    } else if (currentHandle.fdIsTLS) {
       // Shared-fd TLS pair: defer the close two check-phase turns
       // (test-tls-socket-close); see closeAdoptedTLSRawNT.
       currentHandle.pause?.();
@@ -2296,13 +2303,6 @@ Object.defineProperty(Socket.prototype, "pending", {
   },
 });
 
-// Queued/in-flight plain writes would be stranded on the retired TCP wrapper
-// if the fd were adopted; such sockets use the stream-level TLS engine, whose
-// ciphertext queues behind the pending writes (order + callbacks preserved).
-function hasUnflushedWrites(connection) {
-  return connection.writableLength > 0 || connection[kwriteCallback] != null;
-}
-
 function drainOnreadTail(self, fromRead?) {
   if (self[kOnreadTail] === undefined) return false;
   if (fromRead) self[kOnreadReadRequested] = true;
@@ -2361,78 +2361,23 @@ Socket.prototype.pause = function pause() {
 // ServerHandlers — the shared accepted-socket handler table, with per-socket
 // state carried via `data` (mirrors tls.createServer's one-handler-for-all model).
 Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, tls) {
-  const socket = connection._handle;
-  if (!socket || connection.encrypted || hasUnflushedWrites(connection)) {
-    // No adoptable fd (generic Duplex / not yet connected), TLS over TLS (the
-    // fd belongs to the outer SSL layer), or pending plain writes that must
-    // flush first: run the TLS engine over the stream itself.
-    const [result, events] = upgradeDuplexToTLS(connection, {
+  this[kupgraded] = connection;
+  if (connection instanceof Socket) this._parent = connection;
+  tieToWrappedStream(this, connection);
+  const handle = connection._handle;
+  if (!handle || connection.encrypted || isNamedPipeSocket(handle)) {
+    // No adoptable fd (generic Duplex, not yet connected, named pipe) or TLS
+    // over TLS (the fd belongs to the outer SSL layer): run the TLS engine over
+    // the stream itself.
+    this._handle = upgradeStreamToTLS(this, connection, {
       data: this,
       tls,
       socket: serverHandlersFor(this),
       isServer: true,
-    });
-    connection.on("data", events[0]);
-    connection.on("end", events[1]);
-    connection.on("drain", events[2]);
-    connection.on("close", events[3]);
-    this[kupgraded] = connection;
-    this._handle = result;
+    })[0];
     return;
   }
-  this[kupgraded] = connection;
-  process.nextTick(() => {
-    if (this.destroyed || connection.destroyed) {
-      this.destroy();
-      return;
-    }
-    const handle = connection._handle;
-    if (!handle) {
-      this.destroy();
-      return;
-    }
-    // Writes may have been queued between the wrap and this tick (a user
-    // 'connection' listener runs after the server's): those bytes must flush
-    // before any TLS output, so fall back to the stream-level engine.
-    if (hasUnflushedWrites(connection)) {
-      const [result, events] = upgradeDuplexToTLS(connection, {
-        data: this,
-        tls,
-        socket: serverHandlersFor(this),
-        isServer: true,
-      });
-      connection.on("data", events[0]);
-      connection.on("end", events[1]);
-      connection.on("drain", events[2]);
-      connection.on("close", events[3]);
-      this._handle = result;
-      this.emit(kUpgradeAttached);
-      return;
-    }
-    // Bytes that already arrived before the wrap were pulled off the fd into
-    // the connection's readable buffer; hand them to the TLS engine so the
-    // handshake doesn't stall.
-    const pending = connection.read();
-    const result = handle.upgradeTLS({
-      data: this,
-      tls,
-      socket: serverHandlersFor(this),
-      isServer: true,
-      initialData: pending || undefined,
-    });
-    if (!result) {
-      this._handle = null;
-      this.destroy(new Error("Invalid socket"));
-      return;
-    }
-    const [raw, tlsHandle] = result;
-    connection._handle = raw;
-    raw[kAdoptedTLSRaw] = true;
-    this.once("end", this[kCloseRawConnection]);
-    raw.connecting = false;
-    this._handle = tlsHandle;
-    this.emit(kUpgradeAttached);
-  });
+  process.nextTick(adoptServerConnection, this, connection, tls);
 };
 
 Socket.prototype.read = function read(size) {
@@ -2510,6 +2455,8 @@ Socket.prototype.ref = function ref() {
     return this;
   }
   socket.ref();
+  // Its fd is a TLS layer's now; that is what holds the loop (node: one uv handle).
+  if (socket.fdIsTLS) this[kTLSLayer]?._handle?.ref();
   return this;
 };
 
@@ -2704,6 +2651,7 @@ Socket.prototype.unref = function unref() {
     return this;
   }
   socket.unref();
+  if (socket.fdIsTLS) this[kTLSLayer]?._handle?.unref();
   return this;
 };
 

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -889,10 +889,10 @@ TLSSocket.prototype._final = function _final(callback) {
   // tls.connect()). Node's native TLSWrap.DoShutdown likewise flushes the
   // handshake output before the underlying stream's FIN.
   // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/src/crypto/crypto_tls.cc#L1203
-  // A never-connected TLSSocket (e.g. new tls.TLSSocket().end(cb)) has no handle
-  // and no handshake to wait for; finish immediately like NetSocket._final's
-  // no-handle fast path, otherwise the deferred callback would never fire.
-  if (!this._handle) return callback();
+  // No handle: a never-connected TLSSocket (new tls.TLSSocket().end(cb)) has
+  // nothing to wait for; one wrapping a live net.Socket gets its handle shortly
+  // ('connect' / next tick) and waits like the handshaking case.
+  if (!this._handle && !(this._parent && !this._parent.destroyed && this.secureConnecting)) return callback();
   if (this.secureConnecting) {
     // kSecureConnectDone rather than 'secureConnect': server-side sockets
     // never emit the user event (node parity), but every handshake table

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -67,6 +67,21 @@ pub(crate) struct UpgradedDuplex {
     /// The transport delivered EOF (its 'end' event fired). Teardown payloads
     /// (close_notify) are dropped after this; see [`Self::call_write_or_end`].
     pub transport_eof: Cell<bool>,
+    /// The handle-backed socket this engine runs over, when there is one: its
+    /// `NativeCallbacks::TlsTransport` delivers data/end/drain/close, ciphertext
+    /// goes straight into it, flow control reaches it, and teardown hands it
+    /// back. (`end()` still goes through the JS stream, which owns that state.)
+    pub transport: JsCell<Transport>,
+    /// `Some` while output is held behind the transport's queued plaintext
+    /// (node's `has_active_write_issued_by_prev_listener_`); see `release_output`.
+    pub held_output: JsCell<Option<Vec<u8>>>,
+}
+
+/// See [`UpgradedDuplex::transport`].
+pub enum Transport {
+    None,
+    Tcp(bun_ptr::RefPtr<super::TCPSocket>),
+    Tls(bun_ptr::RefPtr<super::TLSSocket>),
 }
 
 bun_event_loop::impl_timer_owner!(UpgradedDuplex; from_timer_ptr => event_loop_timer);
@@ -231,17 +246,8 @@ impl UpgradedDuplex {
         // duplex whose write side already ended (TLS-inception teardown) only
         // surface a spurious EPIPE - drop them. Ordinary data writes skip the
         // probe so write-after-end still errors like node.
-        let teardown = data.is_none() || self.wrapper_ref().is_some_and(|w| w.is_shutdown());
+        let teardown = data.is_none() || self.is_shutdown();
         if teardown {
-            // A teardown payload (close_notify) after the transport's readable
-            // side ended has no reader behind it: node writes nothing there,
-            // and a transport that forwards into an auto-ended net.Socket
-            // throws writeAfterFIN (EPIPE). The trailing end() is not a write
-            // and still goes through the writableEnded probe below, so a
-            // half-open transport sees our FIN.
-            if data.is_some() && self.transport_eof.get() {
-                return;
-            }
             match duplex.get(&global, "writableEnded") {
                 Ok(Some(ended)) if ended.to_boolean() => return,
                 Ok(_) => {}
@@ -283,13 +289,16 @@ impl UpgradedDuplex {
 
     fn write_encrypted(&self, encoded_data: &[u8]) {
         self.reset_timeout();
-
-        // Possible scenarios:
-        // Scenario 1: will not write if vm is shutting down (we cannot do anything about it)
-        // Scenario 2: will not write if a exception is thrown (will be handled by onError)
-        // Scenario 3: will be queued in memory and will be flushed later
-        // Scenario 4: no write/end function exists (will be handled by onError)
-        self.call_write_or_end(Some(encoded_data), true);
+        let held = self.held_output.with_mut(|h| match h.as_mut() {
+            Some(h) => {
+                h.extend_from_slice(encoded_data);
+                true
+            }
+            None => false,
+        });
+        if !held {
+            self.write_to_transport(encoded_data);
+        }
     }
 
     #[uws_callback(export = "UpgradedDuplex__flush")]
@@ -299,7 +308,9 @@ impl UpgradedDuplex {
         }
     }
 
-    fn on_internal_receive_data(&self, data: &[u8]) {
+    /// Ciphertext from the transport (a JS `data` chunk, or a handle-backed
+    /// socket's native read via `NativeCallbacks::TlsTransport`).
+    pub(crate) fn on_transport_data(&self, data: &[u8]) {
         if let Some(w) = self.wrapper_ref() {
             self.reset_timeout();
             w.receive_data(data);
@@ -409,7 +420,83 @@ impl UpgradedDuplex {
             pending_data: JsCell::new(Vec::new()),
             pending_end: Cell::new(false),
             transport_eof: Cell::new(false),
+            transport: JsCell::new(Transport::None),
+            held_output: JsCell::new(None),
         }
+    }
+
+    pub(crate) fn has_transport(&self) -> bool {
+        !matches!(self.transport.get(), Transport::None)
+    }
+
+    /// The transport's queued plaintext is out: send what was held, stop holding.
+    pub(crate) fn release_output(&self) {
+        if let Some(held) = self.held_output.replace(None) {
+            if !held.is_empty() {
+                self.write_to_transport(&held);
+            }
+        }
+    }
+
+    fn write_to_transport(&self, data: &[u8]) {
+        // A close_notify after the transport's readable side ended has no
+        // reader: node writes nothing there, and a transport forwarding into an
+        // auto-ended net.Socket would throw writeAfterFIN. The trailing end()
+        // still goes out, so a half-open transport sees our FIN.
+        if self.transport_eof.get() && self.is_shutdown() {
+            return;
+        }
+        match self.transport.get() {
+            Transport::Tcp(t) => t.write_from_engine(data),
+            Transport::Tls(t) => t.write_from_engine(data),
+            Transport::None => self.call_write_or_end(Some(data), true),
+        }
+    }
+
+    #[uws_callback(export = "UpgradedDuplex__pause")]
+    pub(crate) fn pause(&self) -> bool {
+        match self.transport.get() {
+            Transport::Tcp(t) => t.pause_reads(),
+            Transport::Tls(t) => t.pause_reads(),
+            Transport::None => return false,
+        }
+        true
+    }
+
+    #[uws_callback(export = "UpgradedDuplex__resume")]
+    pub(crate) fn resume(&self) -> bool {
+        match self.transport.get() {
+            Transport::Tcp(t) => t.resume_reads(),
+            Transport::Tls(t) => t.resume_reads(),
+            Transport::None => return false,
+        }
+        true
+    }
+
+    fn release_transport(&self) {
+        match self.transport.replace(Transport::None) {
+            Transport::Tcp(t) => t.clear_native_callback(),
+            Transport::Tls(t) => t.clear_native_callback(),
+            Transport::None => {}
+        }
+    }
+
+    /// The transport's EOF (its JS `end` event, or natively).
+    pub(crate) fn on_transport_end(&self) {
+        self.transport_eof.set(true);
+        if self.wrapper_ref().is_some() {
+            (self.handlers.on_end)(self.handlers.ctx);
+        } else {
+            // EOF before `start_tls` ran. Hold it so `drain_pending` reports it
+            // in order, after any bytes staged in the same window.
+            self.pending_end.set(true);
+        }
+    }
+
+    /// The transport can take more (natively, or a Duplex's `drain`).
+    pub(crate) fn on_transport_writable(&self) {
+        self.flush();
+        (self.handlers.on_writable)(self.handlers.ctx);
     }
 
     pub(crate) fn get_js_handlers(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
@@ -680,6 +767,7 @@ impl UpgradedDuplex {
         self.pending_data.set(Vec::new());
         self.pending_end.set(false);
         self.transport_eof.set(false);
+        self.release_transport();
     }
 }
 
@@ -711,7 +799,7 @@ fn on_received_data(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
                 if let Some(array_buffer) = data_arg.as_array_buffer(global) {
                     // yay we can read the data
                     let payload = array_buffer.slice();
-                    this.on_internal_receive_data(payload);
+                    this.on_transport_data(payload);
                 } else {
                     // node.js errors in this case with the same error, lets keep it consistent
                     let error_value = global
@@ -736,16 +824,7 @@ fn on_end(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
 
     if let Some(self_ptr) = host_fn::get_function_data(function) {
         // SAFETY: see host-fn note above.
-        let this = unsafe { &*self_ptr.cast::<UpgradedDuplex>() };
-
-        this.transport_eof.set(true);
-        if this.wrapper_ref().is_some() {
-            (this.handlers.on_end)(this.handlers.ctx);
-        } else {
-            // EOF before `start_tls` ran. Hold it so `drain_pending` reports it
-            // in order, after any bytes staged in the same window.
-            this.pending_end.set(true);
-        }
+        unsafe { &*self_ptr.cast::<UpgradedDuplex>() }.on_transport_end();
     }
     Ok(JSValue::UNDEFINED)
 }
@@ -758,11 +837,7 @@ fn on_writable(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue>
 
     if let Some(self_ptr) = host_fn::get_function_data(function) {
         // SAFETY: see host-fn note above.
-        let this = unsafe { &*self_ptr.cast::<UpgradedDuplex>() };
-        // flush pending data
-        this.flush();
-        // call onWritable (will flush on demand)
-        (this.handlers.on_writable)(this.handlers.ctx);
+        unsafe { &*self_ptr.cast::<UpgradedDuplex>() }.on_transport_writable();
     }
 
     Ok(JSValue::UNDEFINED)

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -425,11 +425,8 @@ impl UpgradedDuplex {
         }
     }
 
-    pub(crate) fn has_transport(&self) -> bool {
-        !matches!(self.transport.get(), Transport::None)
-    }
-
     /// The transport's queued plaintext is out: send what was held, stop holding.
+    #[uws_callback(export = "UpgradedDuplex__release_output")]
     pub(crate) fn release_output(&self) {
         if let Some(held) = self.held_output.replace(None) {
             if !held.is_empty() {

--- a/src/runtime/socket/mod.rs
+++ b/src/runtime/socket/mod.rs
@@ -119,7 +119,7 @@ pub use udp_socket::UDPSocket;
 pub mod socket {
     pub use super::socket_body::{
         js_create_socket_pair, js_get_buffered_amount, js_is_named_pipe_socket,
-        js_set_socket_options, js_upgrade_duplex_to_tls, js_upgrade_tls_deferred, testing_ap_is,
+        js_node_net_upgrade_tls, js_set_socket_options, js_upgrade_duplex_to_tls, testing_ap_is,
     };
 }
 

--- a/src/runtime/socket/mod.rs
+++ b/src/runtime/socket/mod.rs
@@ -85,10 +85,8 @@ pub use ssl_config::{SSLConfig, SSLConfigFromJs, resolve_reject_unauthorized, tl
 pub use handlers::{Handlers, SocketConfig};
 pub use listener::Listener;
 pub use socket_address::SocketAddress;
-pub(crate) use socket_body::DuplexUpgradeContext;
-pub use socket_body::{
-    Flags as SocketFlags, NativeCallbacks, NewSocket, SocketMode, TCPSocket, TLSSocket,
-};
+pub(crate) use socket_body::{DuplexUpgradeContext, NativeCallbacks};
+pub use socket_body::{Flags as SocketFlags, NewSocket, SocketMode, TCPSocket, TLSSocket};
 
 #[cfg(windows)]
 pub use windows_named_pipe_context::WindowsNamedPipeContext;

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -556,9 +556,13 @@ impl<const SSL: bool> NewSocket<SSL> {
             + ssl_cost
     }
 
+    pub(crate) fn has_native_callback(&self) -> bool {
+        !matches!(self.native_callback.get(), NativeCallbacks::None)
+    }
+
     /// On `false` the rejected `callback` (and the ref it holds) is dropped.
     pub(crate) fn attach_native_callback(&self, callback: NativeCallbacks) -> bool {
-        if !matches!(self.native_callback.get(), NativeCallbacks::None) {
+        if self.has_native_callback() {
             return false;
         }
         self.native_callback.set(callback);
@@ -772,17 +776,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {
         let _keep = this.ref_guard();
-        match this.socket.get().socket {
-            // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
-            uws::InternalSocket::Connected(s) => {
-                bun_opaque::opaque_deref_mut(s).release_tls_output()
-            }
-            // SAFETY: same allocation, runtime-side type (uws_sys shim).
-            uws::InternalSocket::UpgradedDuplex(d) => {
-                unsafe { &*d.cast::<UpgradedDuplex>() }.release_output()
-            }
-            _ => {}
-        }
+        this.socket.get().release_tls_output();
         Ok(JSValue::UNDEFINED)
     }
 
@@ -3375,6 +3369,22 @@ impl<const SSL: bool> NewSocket<SSL> {
         Ok(result)
     }
 
+    /// The TLS half over this `raw` half's fd (`upgradeTLS`); it holds the
+    /// loop for both, as node's single uv handle does.
+    fn tls_layer(&self) -> Option<bun_ptr::ThisPtr<TLSSocket>> {
+        if !self.flags.get().contains(Flags::BYPASS_TLS) {
+            return None;
+        }
+        let uws::InternalSocket::Connected(s) = self.socket.get().socket else {
+            return None;
+        };
+        let s = uws::us_socket_t::opaque_mut(s);
+        if s.kind() != uws::SocketKind::BunSocketTls {
+            return None;
+        }
+        *s.ext::<Option<bun_ptr::ThisPtr<TLSSocket>>>()
+    }
+
     #[bun_jsc::host_fn(method)]
     pub(crate) fn js_ref(
         this: &Self,
@@ -3382,13 +3392,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {
         jsc::mark_binding!();
-        this.update_flags(|f| f.remove(Flags::ENGINE_OUTPUT_HOLD));
-        if this.socket.get().is_established() {
-            this.poll_ref.with_mut(|p| p.ref_(js_loop_ctx()));
-        } else {
-            // `connect_finish` holds the loop until then; `on_open` applies this.
-            this.ref_pollref_on_connect.set(true);
-        }
+        this.set_ref(true);
         Ok(JSValue::UNDEFINED)
     }
 
@@ -3399,21 +3403,34 @@ impl<const SSL: bool> NewSocket<SSL> {
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {
         jsc::mark_binding!();
+        this.set_ref(false);
+        Ok(JSValue::UNDEFINED)
+    }
+
+    /// `ref()` / `unref()`: this socket's hold on the loop, and its TLS layer's
+    /// when it is the `raw` half of an upgrade (node: one uv handle for both).
+    pub(crate) fn set_ref(&self, hold: bool) {
+        if let Some(tls) = self.tls_layer() {
+            tls.set_ref(hold);
+        }
         // A stream-level TLS engine's tail parked here keeps the loop until it
         // drains (node: the uv write req does), whatever node:net decides.
-        if !this.buffered_data_for_node_net.get().is_empty()
-            && matches!(this.native_callback.get(), NativeCallbacks::TlsTransport(_))
+        if !hold
+            && !self.buffered_data_for_node_net.get().is_empty()
+            && matches!(self.native_callback.get(), NativeCallbacks::TlsTransport(_))
         {
-            this.update_flags(|f| f.insert(Flags::ENGINE_OUTPUT_HOLD));
-            return Ok(JSValue::UNDEFINED);
+            self.update_flags(|f| f.insert(Flags::ENGINE_OUTPUT_HOLD));
+            return;
         }
-        this.update_flags(|f| f.remove(Flags::ENGINE_OUTPUT_HOLD));
-        if this.socket.get().is_established() {
-            this.poll_ref.with_mut(|p| p.unref(js_loop_ctx()));
+        self.update_flags(|f| f.remove(Flags::ENGINE_OUTPUT_HOLD));
+        if !self.socket.get().is_established() {
+            // `connect_finish` holds the loop until then; `on_open` applies this.
+            self.ref_pollref_on_connect.set(hold);
+        } else if hold {
+            self.poll_ref.with_mut(|p| p.ref_(js_loop_ctx()));
         } else {
-            this.ref_pollref_on_connect.set(false);
+            self.poll_ref.with_mut(|p| p.unref(js_loop_ctx()));
         }
-        Ok(JSValue::UNDEFINED)
     }
 
     pub fn finalize(&self) {
@@ -3750,9 +3767,9 @@ impl<const SSL: bool> NewSocket<SSL> {
 
         // `this` becomes the `raw` half (see `twin`): it follows the fd into
         // the new `us_socket_t` but is never in its ext slot.
-        // SAFETY: `if SSL` returned above, so `Self` is `TCPSocket`.
-        let raw: bun_ptr::ThisPtr<TCPSocket> =
-            unsafe { bun_ptr::ThisPtr::new(this.as_ctx_ptr().cast::<TCPSocket>()) };
+        let raw: &TCPSocket = (this as &dyn core::any::Any)
+            .downcast_ref::<TCPSocket>()
+            .expect("SSL sockets returned above");
         // Preserve `socket.unref()` across the upgrade — node:tls callers
         // that unref the underlying TCP socket before upgrading must not
         // suddenly hold the loop open via the TLS wrapper.
@@ -4141,14 +4158,15 @@ impl_socket_js_class!(TLSSocket, js_TLSSocket);
 // NativeCallbacks — direct callbacks on HTTP2 when available
 // ──────────────────────────────────────────────────────────────────────────
 
-pub enum NativeCallbacks {
+pub(crate) enum NativeCallbacks {
     H2(RefPtr<H2FrameParser>),
     /// This socket is the transport under a stream-level TLS engine
     /// (`upgradeDuplexToTLS` over a handle-backed net.Socket: named pipes,
     /// TLS over TLS, Http2SecureServer's injected sockets). Its bytes and EOF
     /// go to that engine, never to the JS handlers — node's TLSWrap taking
-    /// over the parent's stream.
-    TlsTransport(RefPtr<TLSSocket>),
+    /// over the parent's stream. The engine clears this slot from its own
+    /// teardown (`release_transport`) before it is freed.
+    TlsTransport(bun_ptr::BackRef<UpgradedDuplex>),
     None,
 }
 
@@ -4160,15 +4178,10 @@ impl NativeCallbacks {
     pub(crate) fn on_data(&self, data: &[u8]) -> JsResult<bool> {
         let h2 = match self {
             NativeCallbacks::H2(h2) => h2.as_ptr(),
-            NativeCallbacks::TlsTransport(inner) => {
-                let Some(engine) = Self::engine(inner) else {
-                    // The engine's teardown detaches us before its socket goes.
-                    debug_assert!(false, "TlsTransport outlived its engine");
-                    return Ok(false);
-                };
-                // Own +1 across the feed: decrypted data re-enters JS, which
-                // may close this transport and drop the cell's ref.
-                let _keep = inner.clone();
+            // Copied out: decrypted data re-enters JS, which may close this
+            // transport and overwrite the cell `self` borrows.
+            NativeCallbacks::TlsTransport(engine) => {
+                let engine = *engine;
                 engine.on_transport_data(data);
                 return Ok(true);
             }
@@ -4181,11 +4194,9 @@ impl NativeCallbacks {
     pub(crate) fn on_writable(&self) -> bool {
         let h2 = match self {
             NativeCallbacks::H2(h2) => h2.as_ptr(),
-            NativeCallbacks::TlsTransport(inner) => {
-                if let Some(engine) = Self::engine(inner) {
-                    let _keep = inner.clone();
-                    engine.on_transport_writable();
-                }
+            NativeCallbacks::TlsTransport(engine) => {
+                let engine = *engine;
+                engine.on_transport_writable();
                 // node:net's own drain handler still runs for the wrapped socket.
                 return false;
             }
@@ -4198,11 +4209,9 @@ impl NativeCallbacks {
 
     /// `false`: also dispatch to the JS handlers.
     pub(crate) fn on_end(&self) -> bool {
-        if let NativeCallbacks::TlsTransport(inner) = self {
-            if let Some(engine) = Self::engine(inner) {
-                let _keep = inner.clone();
-                engine.on_transport_end();
-            }
+        if let NativeCallbacks::TlsTransport(engine) = self {
+            let engine = *engine;
+            engine.on_transport_end();
         }
         // node:net's own end handler still runs the wrapped socket's
         // half-open logic.
@@ -4213,21 +4222,8 @@ impl NativeCallbacks {
     pub(crate) fn on_close(self) {
         match self {
             NativeCallbacks::H2(h2) => h2.on_native_close(),
-            NativeCallbacks::TlsTransport(inner) => {
-                if let Some(engine) = Self::engine(&inner) {
-                    engine.close();
-                }
-            }
+            NativeCallbacks::TlsTransport(engine) => engine.close(),
             NativeCallbacks::None => {}
-        }
-    }
-
-    fn engine(inner: &RefPtr<TLSSocket>) -> Option<&UpgradedDuplex> {
-        match inner.socket.get().socket {
-            // SAFETY: same allocation, runtime-side type (uws_sys shim); live
-            // while `inner.socket` names it.
-            uws::InternalSocket::UpgradedDuplex(d) => Some(unsafe { &*d.cast::<UpgradedDuplex>() }),
-            _ => None,
         }
     }
 }
@@ -4892,19 +4888,12 @@ pub fn js_upgrade_duplex_to_tls(
         verify_error: JsCell::new(None),
     });
     // A handle-backed transport hands its bytes to the engine below JS.
-    let feed = || NativeCallbacks::TlsTransport(RefPtr::from_this(tls));
-    let linked = if let Some(t) = transport.as_class_ref::<TCPSocket>() {
-        t.attach_native_callback(feed())
-            .then(|| Transport::Tcp(t.ref_guard()))
-    } else if let Some(t) = transport.as_class_ref::<TLSSocket>() {
-        t.attach_native_callback(feed())
-            .then(|| Transport::Tls(t.ref_guard()))
-    } else {
-        None
-    };
-    let native_transport = transport.as_class_ref::<TCPSocket>().is_some()
-        || transport.as_class_ref::<TLSSocket>().is_some();
-    if native_transport && linked.is_none() {
+    let transport_tcp = transport.as_class_ref::<TCPSocket>();
+    let transport_tls = transport.as_class_ref::<TLSSocket>();
+    let native_transport = transport_tcp.is_some() || transport_tls.is_some();
+    let transport_taken = transport_tcp.is_some_and(|t| t.has_native_callback())
+        || transport_tls.is_some_and(|t| t.has_native_callback());
+    if transport_taken {
         // Its reads already go somewhere else (an HTTP/2 session, another TLS
         // layer); `data` events would never come either. Sole owner so far.
         tls.get().deref();
@@ -5034,11 +5023,19 @@ pub fn js_upgrade_duplex_to_tls(
     .register();
     DuplexUpgradeContext::start_tls(duplex_context_ref);
 
-    duplex_context_ref
-        .upgrade
-        .transport
-        .set(linked.unwrap_or(Transport::None));
-    let native_transport = duplex_context_ref.upgrade.has_transport();
+    let engine = bun_ptr::BackRef::new(&duplex_context_ref.upgrade);
+    let linked = if let Some(t) = transport_tcp {
+        let attached = t.attach_native_callback(NativeCallbacks::TlsTransport(engine));
+        debug_assert!(attached, "checked free above; nothing since ran JS");
+        Transport::Tcp(t.ref_guard())
+    } else if let Some(t) = transport_tls {
+        let attached = t.attach_native_callback(NativeCallbacks::TlsTransport(engine));
+        debug_assert!(attached, "checked free above; nothing since ran JS");
+        Transport::Tls(t.ref_guard())
+    } else {
+        Transport::None
+    };
+    duplex_context_ref.upgrade.transport.set(linked);
     if defer_handshake && native_transport {
         duplex_context_ref.upgrade.held_output.set(Some(Vec::new()));
     }

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2796,7 +2796,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
 
         let socket = self.socket.get();
-        if socket.is_shutdown() || socket.is_closed() || self.flags.get().contains(Flags::REJECTED) {
+        if socket.is_shutdown() || socket.is_closed() || self.flags.get().contains(Flags::REJECTED)
+        {
             return WriteResult::Success {
                 wrote: -1,
                 total: buffer.slice().len() + self.buffered_data_for_node_net.get().len() as usize,

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -4890,7 +4890,6 @@ pub fn js_upgrade_duplex_to_tls(
     // A handle-backed transport hands its bytes to the engine below JS.
     let transport_tcp = transport.as_class_ref::<TCPSocket>();
     let transport_tls = transport.as_class_ref::<TLSSocket>();
-    let native_transport = transport_tcp.is_some() || transport_tls.is_some();
     let transport_taken = transport_tcp.is_some_and(|t| t.has_native_callback())
         || transport_tls.is_some_and(|t| t.has_native_callback());
     if transport_taken {
@@ -5024,17 +5023,17 @@ pub fn js_upgrade_duplex_to_tls(
     DuplexUpgradeContext::start_tls(duplex_context_ref);
 
     let engine = bun_ptr::BackRef::new(&duplex_context_ref.upgrade);
-    let linked = if let Some(t) = transport_tcp {
-        let attached = t.attach_native_callback(NativeCallbacks::TlsTransport(engine));
-        debug_assert!(attached, "checked free above; nothing since ran JS");
-        Transport::Tcp(t.ref_guard())
-    } else if let Some(t) = transport_tls {
-        let attached = t.attach_native_callback(NativeCallbacks::TlsTransport(engine));
-        debug_assert!(attached, "checked free above; nothing since ran JS");
-        Transport::Tls(t.ref_guard())
-    } else {
-        Transport::None
+    let linked = match (transport_tcp, transport_tls) {
+        (Some(t), _) if t.attach_native_callback(NativeCallbacks::TlsTransport(engine)) => {
+            Transport::Tcp(t.ref_guard())
+        }
+        (_, Some(t)) if t.attach_native_callback(NativeCallbacks::TlsTransport(engine)) => {
+            Transport::Tls(t.ref_guard())
+        }
+        // Checked free above and nothing since ran JS; a Duplex otherwise.
+        _ => Transport::None,
     };
+    let native_transport = !matches!(linked, Transport::None);
     duplex_context_ref.upgrade.transport.set(linked);
     if defer_handshake && native_transport {
         duplex_context_ref.upgrade.held_output.set(Some(Vec::new()));

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -23,7 +23,7 @@ use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSValue, JsRef, JsResult, 
 use bun_jsc::SysErrorJsc;
 // `bun_jsc::VirtualMachine` is the *module* (alias of `virtual_machine`); name the
 // struct directly so `VirtualMachine::get()` resolves as an associated fn.
-use super::upgraded_duplex::{Handlers as UpgradedDuplexHandlers, UpgradedDuplex};
+use super::upgraded_duplex::{Handlers as UpgradedDuplexHandlers, Transport, UpgradedDuplex};
 use crate::crypto::boringssl_jsc::err_to_js as boringssl_err_to_js;
 use crate::node::{BlobOrStringOrBuffer, StringObjects, StringOrBuffer};
 use crate::socket::{SSLConfig, SSLConfigFromJs};
@@ -303,8 +303,8 @@ pub struct NewSocket<const SSL: bool> {
     pub(crate) flags: Cell<Flags>,
     pub(crate) ref_count: bun_ptr::RefCount<Self>,
     /// The callbacks this socket dispatches to: shared with its listener and
-    /// sibling sockets (server), or with its own reconnects and TLS twin
-    /// (client). `None` once the socket has gone idle or been detached, which
+    /// sibling sockets (server), or with its own reconnects (client). `None`
+    /// once the socket has gone idle or been detached, which
     /// every dispatch entry point treats as "nothing left to call".
     ///
     /// `Rc`, not a raw pointer: JS dispatch is reentrant (a `close` handler can
@@ -328,12 +328,11 @@ pub struct NewSocket<const SSL: bool> {
     pub(crate) bytes_written: Cell<u64>,
 
     pub(crate) native_callback: JsCell<NativeCallbacks>,
-    /// `upgradeTLS` produces two `TLSSocket` wrappers over one
-    /// `us_socket_t` (the encrypted view + the raw-bytes view node:net
-    /// expects at index 0). The encrypted half holds a ref on the raw half
-    /// here so a single `onClose` can retire both — no `Handlers.clone()`,
-    /// no second context.
-    pub(crate) twin: JsCell<Option<RefPtr<Self>>>,
+    /// After `upgradeTLS`, the encrypted half's ref on the original socket —
+    /// now the `raw` half over the same `us_socket_t` (index 0 of `[raw, tls]`,
+    /// node:net's `_parent` handle). It is never in the ext slot, so close and
+    /// writable are chained to it from here. Unused on a `TCPSocket`.
+    pub(crate) twin: JsCell<Option<RefPtr<TCPSocket>>>,
     /// Owned copy of the handshake verify error, so `getAuthorizationError()`
     /// keeps its verdict after detach (the live error borrows the `SSL`, and
     /// EPROTO reasons are stack-copied in uSockets).
@@ -445,7 +444,7 @@ impl<const SSL: bool> Drop for ScopeExit<SSL> {
 impl<const SSL: bool> NewSocket<SSL> {
     /// Hold a ref on `self` for the guard's lifetime (across re-entrant calls).
     #[inline]
-    fn ref_guard(&self) -> RefPtr<Self> {
+    pub(crate) fn ref_guard(&self) -> RefPtr<Self> {
         // SAFETY: `self` is the live heap allocation.
         unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
     }
@@ -549,13 +548,9 @@ impl<const SSL: bool> NewSocket<SSL> {
     pub(crate) fn memory_cost(&self) -> usize {
         // Per-socket SSL state (SSL*, BIO pair, handshake buffers) is ~40 KB
         // off-heap. Reporting it lets the GC apply pressure when JS churns
-        // through short-lived TLS connections. The raw `[raw, tls]` upgrade
-        // twin shares the same SSL* — only the encrypted half reports it.
-        let ssl_cost: usize = if SSL && !self.flags.get().contains(Flags::BYPASS_TLS) {
-            40 * 1024
-        } else {
-            0
-        };
+        // through short-lived TLS connections. (The `raw` half of an upgrade
+        // is a TCPSocket, so the shared SSL* is counted once.)
+        let ssl_cost: usize = if SSL { 40 * 1024 } else { 0 };
         core::mem::size_of::<Self>()
             + self.buffered_data_for_node_net.get().capacity() as usize
             + ssl_cost
@@ -570,10 +565,43 @@ impl<const SSL: bool> NewSocket<SSL> {
         true
     }
 
-    pub(crate) fn detach_native_callback(&self) {
-        if let NativeCallbacks::H2(h2) = self.native_callback.replace(NativeCallbacks::None) {
-            h2.on_native_close();
+    /// Ciphertext from the stream-level TLS engine this socket transports;
+    /// queued behind whatever node:net still had buffered here.
+    pub(crate) fn write_from_engine(&self, data: &[u8]) {
+        let socket = self.socket.get();
+        if socket.is_detached() || socket.is_closed() || socket.is_shutdown() {
+            return;
         }
+        if self.buffered_data_for_node_net.get().is_empty() {
+            let wrote = self.write_maybe_corked(data);
+            if wrote < 0 {
+                return;
+            }
+            let wrote = usize::try_from(wrote).expect("int cast");
+            if wrote < data.len() {
+                self.buffered_data_for_node_net
+                    .with_mut(|b| b.extend_from_slice(&data[wrote..]));
+                if !self.poll_ref.get().is_active() {
+                    self.update_flags(|f| f.insert(Flags::ENGINE_OUTPUT_HOLD));
+                    self.poll_ref.with_mut(|p| p.ref_(js_loop_ctx()));
+                }
+            }
+        } else {
+            self.buffered_data_for_node_net
+                .with_mut(|b| b.extend_from_slice(data));
+        }
+    }
+
+    /// This socket is going away under whatever consumed it natively.
+    pub(crate) fn detach_native_callback(&self) {
+        self.native_callback
+            .replace(NativeCallbacks::None)
+            .on_close();
+    }
+
+    /// The native consumer is done with this socket (nothing to notify).
+    pub(crate) fn clear_native_callback(&self) {
+        self.native_callback.set(NativeCallbacks::None);
     }
 
     /// Connect to `self.connection` (must be `Some`). Reads the field directly
@@ -717,9 +745,43 @@ impl<const SSL: bool> NewSocket<SSL> {
         if this.flags.get().contains(Flags::BYPASS_TLS) {
             return Ok(JSValue::UNDEFINED);
         }
-        if this.flags.get().contains(Flags::IS_PAUSED) {
-            let resumed = this.socket.get().resume_stream();
-            this.update_flags(|f| f.set(Flags::IS_PAUSED, !resumed));
+        this.resume_reads();
+        Ok(JSValue::UNDEFINED)
+    }
+
+    pub(crate) fn resume_reads(&self) {
+        if self.flags.get().contains(Flags::IS_PAUSED) {
+            let resumed = self.socket.get().resume_stream();
+            self.update_flags(|f| f.set(Flags::IS_PAUSED, !resumed));
+        }
+    }
+
+    /// A plain socket whose fd a TLS layer has taken over (`upgradeTLS`'s
+    /// `raw` half): it closes with that layer rather than on its own.
+    #[bun_jsc::host_fn(getter)]
+    pub(crate) fn get_fd_is_tls(this: &Self, _global: &JSGlobalObject) -> JsResult<JSValue> {
+        Ok(JSValue::from(this.flags.get().contains(Flags::BYPASS_TLS)))
+    }
+
+    /// node:net: the wrapped socket's queued plaintext is out; let the TLS
+    /// output held behind it (`deferHandshake`) go.
+    #[bun_jsc::host_fn(method)]
+    pub(crate) fn start_tls_handshake(
+        this: &Self,
+        _global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let _keep = this.ref_guard();
+        match this.socket.get().socket {
+            // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
+            uws::InternalSocket::Connected(s) => {
+                bun_opaque::opaque_deref_mut(s).release_tls_output()
+            }
+            // SAFETY: same allocation, runtime-side type (uws_sys shim).
+            uws::InternalSocket::UpgradedDuplex(d) => {
+                unsafe { &*d.cast::<UpgradedDuplex>() }.release_output()
+            }
+            _ => {}
         }
         Ok(JSValue::UNDEFINED)
     }
@@ -742,7 +804,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         Ok(JSValue::UNDEFINED)
     }
 
-    fn pause_reads(&self) {
+    pub(crate) fn pause_reads(&self) {
         if !self.flags.get().contains(Flags::IS_PAUSED) {
             let paused = self.socket.get().pause_stream();
             self.update_flags(|f| f.set(Flags::IS_PAUSED, paused));
@@ -930,7 +992,30 @@ impl<const SSL: bool> NewSocket<SSL> {
         if this.socket.get().is_detached() {
             return Ok(());
         }
+        // The `raw` half shares this fd and never gets its own dispatch;
+        // plaintext node:net had queued on it before the upgrade drains first.
+        if let Some(raw) = this
+            .twin
+            .get()
+            .as_ref()
+            .filter(|_| SSL)
+            .map(|t| t.this_ptr())
+        {
+            if raw.flags.get().contains(Flags::BYPASS_TLS)
+                && !raw.buffered_data_for_node_net.get().is_empty()
+            {
+                let _guard = RefPtr::from_this(this);
+                TCPSocket::on_writable(raw, SocketHandler::<false>::from_any(_socket.socket))?;
+                if this.socket.get().is_detached() {
+                    return Ok(());
+                }
+            }
+        }
         if this.native_callback.get().on_writable() {
+            return Ok(());
+        }
+        // (A `TlsTransport` engine ran JS there, which may have closed us.)
+        if !this.has_handlers() || this.socket.get().is_detached() {
             return Ok(());
         }
         let handlers = this.get_handlers();
@@ -1056,8 +1141,8 @@ impl<const SSL: bool> NewSocket<SSL> {
     /// point checks [`has_handlers`](Self::has_handlers) first.
     ///
     /// Returns a fresh `Rc`, so JS re-entrancy from the caller (a `close`
-    /// handler that reconnects, an `upgradeTLS` that transfers the handlers to
-    /// a twin) cannot free the callbacks the caller is still reading.
+    /// handler that reconnects) cannot free the callbacks the caller is still
+    /// reading.
     pub(crate) fn get_handlers(&self) -> Rc<Handlers> {
         self.handlers_opt().expect("No handlers set on Socket")
     }
@@ -1077,11 +1162,6 @@ impl<const SSL: bool> NewSocket<SSL> {
     #[inline]
     fn handlers_are(&self, handlers: &Rc<Handlers>) -> bool {
         matches!(self.handlers.get(), Some(h) if Rc::ptr_eq(h, handlers))
-    }
-
-    #[inline]
-    fn take_handlers(&self) -> Option<Rc<Handlers>> {
-        self.handlers.with_mut(|h| h.take())
     }
 
     /// The event-loop exit drains microtasks, during which a synchronous
@@ -1346,16 +1426,27 @@ impl<const SSL: bool> NewSocket<SSL> {
     /// `debug_assert!` to catch.
     pub(crate) fn detach_for_reconnect(&self) {
         let old = self.socket.get();
-        let Some(ext) = old.ext::<*mut c_void>() else {
-            return;
-        };
-        // SAFETY: ext slot is sized for `*mut c_void`; single-threaded.
-        unsafe { *ext = core::ptr::null_mut() };
+        // The `raw` half of an upgrade owns neither the ext slot nor the fd
+        // (node:net refuses to reconnect such a socket; this is the backstop):
+        // it just stops being that half. The TLS half's `twin` chain skips a
+        // socket without BYPASS_TLS.
+        let raw_half = self.flags.get().contains(Flags::BYPASS_TLS);
+        if raw_half {
+            self.update_flags(|f| f.remove(Flags::BYPASS_TLS));
+        } else {
+            let Some(ext) = old.ext::<*mut c_void>() else {
+                return;
+            };
+            // SAFETY: ext slot is sized for `*mut c_void`; single-threaded.
+            unsafe { *ext = core::ptr::null_mut() };
+        }
         self.socket.set(SocketHandler::<SSL>::DETACHED);
         self.buffered_data_for_node_net
             .with_mut(|b| b.clear_and_free());
         self.detach_native_callback();
-        old.close(uws::CloseCode::Failure);
+        if !raw_half {
+            old.close(uws::CloseCode::Failure);
+        }
         self.poll_ref.with_mut(|p| p.unref(js_loop_ctx()));
         if self.flags.get().contains(Flags::IS_ACTIVE) {
             self.update_flags(|f| f.remove(Flags::IS_ACTIVE));
@@ -1692,6 +1783,13 @@ impl<const SSL: bool> NewSocket<SSL> {
         if this.socket.get().is_detached() {
             return Ok(());
         }
+        if this.native_callback.get().on_end() {
+            return Ok(());
+        }
+        // (That may have run JS that closed this socket.)
+        if !this.has_handlers() || this.socket.get().is_detached() {
+            return Ok(());
+        }
         let handlers = this.get_handlers();
         log!(
             "onEnd {}",
@@ -1831,20 +1929,25 @@ impl<const SSL: bool> NewSocket<SSL> {
         // verdict: protocol error, peer alert, EOF mid-handshake) never has a
         // usable transport either — node destroys the underlying socket before
         // user code can write again. Cover that flavor too, so the shared-fd
-        // twin of an `upgradeTLS` pair cannot push plaintext through its
+        // raw half of an `upgradeTLS` pair cannot push plaintext through its
         // BYPASS_TLS write path in the window before JS tears the pair down.
         let transport_unusable = reject_unauthorized || (SSL && success == 0);
 
         // `REJECTED` is set before the callback runs so no write path can
         // deliver application data to a peer that is about to be rejected —
-        // including the raw twin of an `upgradeTLS` pair, which shares the fd.
+        // including the raw half of an `upgradeTLS` pair, which shares the fd.
         this.update_flags(|f| {
             f.set(Flags::AUTHORIZED, authorized && !verify_failed);
             f.set(Flags::HOSTNAME_MISMATCH, hostname_mismatch);
             f.set(Flags::REJECTED, transport_unusable);
         });
         if transport_unusable {
-            if let Some(twin) = this.twin.get().as_ref() {
+            if let Some(twin) = this
+                .twin
+                .get()
+                .as_ref()
+                .filter(|t| t.flags.get().contains(Flags::BYPASS_TLS))
+            {
                 twin.update_flags(|f| f.insert(Flags::REJECTED));
             }
         } else if SSL {
@@ -2090,6 +2193,32 @@ impl<const SSL: bool> NewSocket<SSL> {
         err: c_int,
         reason: Option<*mut c_void>,
     ) -> JsResult<()> {
+        // The upgradeTLS `raw` half shares this us_socket_t and never gets its
+        // own dispatch; it hears about the close after the TLS half has (node:
+        // the TLS layer sees the EOF/error first, then its parent goes down).
+        let raw = this
+            .twin
+            .with_mut(|t| t.take())
+            .filter(|r| r.flags.get().contains(Flags::BYPASS_TLS));
+        // The fd is gone for it too; whatever the TLS half's close handler does
+        // with it meanwhile (end(), write()) is a no-op, as before the upgrade
+        // split them.
+        if let Some(raw) = raw.as_ref() {
+            raw.socket.set(SocketHandler::<false>::DETACHED);
+        }
+        let result = Self::on_close_impl(this, err);
+        if let Some(raw) = raw {
+            crate::dispatch::fold(TCPSocket::on_close(
+                raw.this_ptr(),
+                SocketHandler::<false>::from_any(socket.socket),
+                err,
+                reason,
+            ));
+        }
+        result
+    }
+
+    fn on_close_impl(this: bun_ptr::ThisPtr<Self>, err: c_int) -> JsResult<()> {
         jsc::mark_binding!();
         // A late close on a socket that already released its Handlers through
         // a path that did not route back through this dispatch - e.g. a
@@ -2115,18 +2244,6 @@ impl<const SSL: bool> NewSocket<SSL> {
         );
         this.detach_native_callback();
         this.socket.set(SocketHandler::<SSL>::DETACHED);
-        // The upgradeTLS raw twin shares the same us_socket_t so it never
-        // gets its own dispatch — fire its (pre-upgrade) close handler
-        // here, then retire it. `raw.twin == None` so this doesn't
-        // recurse, and `onClose` derefs the +1 we took at creation.
-        if let Some(raw) = this.twin.with_mut(|t| t.take()) {
-            // `on_close` consumes the twin's +1 via its `CloseTeardown`, so
-            // hand over the raw pointer rather than letting `RefPtr::drop`
-            // release it a second time. This frame is the twin's trampoline for
-            // the event, so what its handlers left pending is folded here and
-            // this socket's own close proceeds regardless.
-            crate::dispatch::fold(Self::on_close(raw.into_this_ptr(), socket, err, reason));
-        }
         let cleanup = CloseTeardown {
             socket: this,
             entered: Rc::clone(&handlers),
@@ -2525,7 +2642,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         if socket.is_shutdown() || socket.is_closed() {
             return -1;
         }
-        if SSL && self.flags.get().contains(Flags::REJECTED) {
+        if self.flags.get().contains(Flags::REJECTED) {
             return -1;
         }
         let res = socket.raw_writev(iov);
@@ -2541,11 +2658,11 @@ impl<const SSL: bool> NewSocket<SSL> {
             return -1;
         }
         let flags = self.flags.get();
-        if SSL && flags.contains(Flags::REJECTED) {
+        if flags.contains(Flags::REJECTED) {
             return -1;
         }
 
-        // The raw [raw, tls] upgrade twin shares the TLS half's us_socket_t
+        // The raw [raw, tls] upgrade half shares the TLS half's us_socket_t
         // (`s->ssl` is set) but must write raw bytes: write_check_error would
         // route it through the SSL-encrypting us_socket_write, and its fatal
         // signal is never set for TLS sockets anyway.
@@ -2679,7 +2796,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
 
         let socket = self.socket.get();
-        if socket.is_shutdown() || socket.is_closed() {
+        if socket.is_shutdown() || socket.is_closed() || self.flags.get().contains(Flags::REJECTED) {
             return WriteResult::Success {
                 wrote: -1,
                 total: buffer.slice().len() + self.buffered_data_for_node_net.get().len() as usize,
@@ -3038,7 +3155,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // A TLS socket whose handshake was rejected has no usable transport:
         // never push the buffered tail at it, and report no error (the
         // rejection is surfaced by the handshake path, not by the flush).
-        if SSL && self.flags.get().contains(Flags::REJECTED) {
+        if self.flags.get().contains(Flags::REJECTED) {
             return 0;
         }
         // R-2: every mutated field is `Cell`/`JsCell`, so `&self` carries no
@@ -3053,8 +3170,8 @@ impl<const SSL: bool> NewSocket<SSL> {
             // the initial write does: once the peer is gone the kernel rejects
             // every retry (EPIPE/ECONNRESET), and treating that as would-block
             // kept this buffer parked forever (the FIN-terminated-response hang).
-            // BYPASS_TLS twins keep the raw write path; TLS errors propagate
-            // through the SSL layer.
+            // The BYPASS_TLS raw half keeps the raw write path; TLS errors
+            // propagate through the SSL layer.
             let res: i32 = if self.flags.get().contains(Flags::BYPASS_TLS) {
                 self.do_socket_write(self.buffered_data_for_node_net.get().slice())
             } else {
@@ -3093,6 +3210,17 @@ impl<const SSL: bool> NewSocket<SSL> {
         let _ = self.try_write_empty_packet();
         self.socket.get().flush();
 
+        if self.buffered_data_for_node_net.get().is_empty() {
+            let flags = self.flags.get();
+            if flags.contains(Flags::ENGINE_OUTPUT_HOLD) {
+                self.update_flags(|f| f.remove(Flags::ENGINE_OUTPUT_HOLD));
+                self.poll_ref.with_mut(|p| p.unref(js_loop_ctx()));
+            }
+            if flags.contains(Flags::SHUTDOWN_AFTER_FLUSH) {
+                self.update_flags(|f| f.remove(Flags::SHUTDOWN_AFTER_FLUSH));
+                self.socket.get().shutdown();
+            }
+        }
         if self.can_end_after_flush() {
             self.mark_inactive();
         }
@@ -3157,6 +3285,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         let [arg] = callframe.arguments_as_array::<1>();
         if callframe.arguments_count() > 0 && arg.to_boolean() {
             this.socket.get().shutdown_read();
+        } else if !this.buffered_data_for_node_net.get().is_empty() {
+            this.update_flags(|f| f.insert(Flags::SHUTDOWN_AFTER_FLUSH));
         } else {
             this.socket.get().shutdown();
         }
@@ -3251,6 +3381,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {
         jsc::mark_binding!();
+        this.update_flags(|f| f.remove(Flags::ENGINE_OUTPUT_HOLD));
         if this.socket.get().is_established() {
             this.poll_ref.with_mut(|p| p.ref_(js_loop_ctx()));
         } else {
@@ -3267,6 +3398,15 @@ impl<const SSL: bool> NewSocket<SSL> {
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {
         jsc::mark_binding!();
+        // A stream-level TLS engine's tail parked here keeps the loop until it
+        // drains (node: the uv write req does), whatever node:net decides.
+        if !this.buffered_data_for_node_net.get().is_empty()
+            && matches!(this.native_callback.get(), NativeCallbacks::TlsTransport(_))
+        {
+            this.update_flags(|f| f.insert(Flags::ENGINE_OUTPUT_HOLD));
+            return Ok(JSValue::UNDEFINED);
+        }
+        this.update_flags(|f| f.remove(Flags::ENGINE_OUTPUT_HOLD));
         if this.socket.get().is_established() {
             this.poll_ref.with_mut(|p| p.unref(js_loop_ctx()));
         } else {
@@ -3344,11 +3484,10 @@ impl<const SSL: bool> NewSocket<SSL> {
 
     /// In-place TCP→TLS upgrade. The underlying `us_socket_t` is
     /// `adoptTLS`'d into the per-VM TLS group with a fresh (or
-    /// SecureContext-shared) `SSL_CTX*`. Returns `[raw, tls]` — two
-    /// `TLSSocket` wrappers over one fd: `tls` is the encrypted view that
-    /// owns dispatch; `raw` has `bypass_tls` set so node:net's
-    /// `socket._handle` can pipe pre-handshake/tunnelled bytes via
-    /// `us_socket_raw_write`. No second context, no `Handlers.clone()`.
+    /// SecureContext-shared) `SSL_CTX*`. Returns `[raw, tls]`: `tls` is a new
+    /// `TLSSocket`, the encrypted view that owns dispatch; `raw` is this
+    /// socket itself, now with `BYPASS_TLS` (writes skip SSL, its handlers see
+    /// the ciphertext) — node:net keeps it as the wrapped socket's `_handle`.
     #[bun_jsc::host_fn(method)]
     pub(crate) fn upgrade_tls(
         this: &Self,
@@ -3363,14 +3502,15 @@ impl<const SSL: bool> NewSocket<SSL> {
         Self::upgrade_tls_impl(this, global, opts, false)
     }
 
-    /// `defers_server_identity`: node:tls owns hostname policy in its JS layer
-    /// (`checkServerIdentity`), so its internal entry point sets it; the public
-    /// `upgradeTLS` never does.
+    /// `for_node_net`: node:tls owns hostname policy in its JS layer
+    /// (`checkServerIdentity`), and its wrapped `net.Socket` goes quiet the way
+    /// node's `_parentWrap` does — `raw` keeps the fd for close/destroy but is
+    /// not shown the ciphertext. The public `upgradeTLS` does neither.
     fn upgrade_tls_impl(
         this: &Self,
         global: &JSGlobalObject,
         opts: JSValue,
-        defers_server_identity: bool,
+        for_node_net: bool,
     ) -> JsResult<JSValue> {
         if SSL {
             return Ok(JSValue::UNDEFINED);
@@ -3385,6 +3525,11 @@ impl<const SSL: bool> NewSocket<SSL> {
                 "upgradeTLS requires an established socket"
             )));
         };
+        // Already the `raw` half of an upgrade (its handlers see ciphertext and
+        // may well call this again): same no-op as on a TLSSocket.
+        if this.flags.get().contains(Flags::BYPASS_TLS) {
+            return Ok(JSValue::UNDEFINED);
+        }
         if opts.is_empty_or_undefined_or_null() || opts.is_boolean() || !opts.is_object() {
             return Err(global.throw(format_args!("Expected options object")));
         }
@@ -3406,12 +3551,18 @@ impl<const SSL: bool> NewSocket<SSL> {
         // Bytes already consumed from the wire before the upgrade (e.g. the
         // ClientHello sitting in the readable buffer of the socket being
         // wrapped); fed into the TLS engine once the upgrade is wired up.
-        let initial_data: Vec<u8> = match opts.get_truthy(global, "initialData")? {
-            Some(v) => StringOrBuffer::from_js(global, v)?
-                .map(|data| data.slice().to_vec())
-                .unwrap_or_default(),
-            None => Vec::new(),
-        };
+        let initial_data = bytes_from_js(
+            global,
+            opts.get(global, "initialData")?
+                .unwrap_or(JSValue::UNDEFINED),
+        )?;
+        // node:net only: the wrapped socket still has plaintext queued, so TLS
+        // output waits for `startTLSHandshake` (node's
+        // `has_active_write_issued_by_prev_listener_`).
+        let defer_handshake = for_node_net
+            && opts
+                .get_truthy(global, "deferHandshake")?
+                .is_some_and(|v| v.to_boolean());
         // Client mode: a standalone `new TLSSocket(socket, { isServer })` is NOT
         // a SocketListener, so these handlers have no listener to release. The
         // server-ness lives in the SSL accept state (adopt_tls
@@ -3531,7 +3682,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             ),
         };
         let mut initial_flags = Flags::initial(reject_unauthorized);
-        initial_flags.set(Flags::DEFERS_SERVER_IDENTITY, defers_server_identity);
+        initial_flags.set(Flags::DEFERS_SERVER_IDENTITY, for_node_net);
         initial_flags.set(Flags::TLS_SERVER_ROLE, is_server);
         let tls: bun_ptr::ThisPtr<TLSSocket> = TLSSocket::new(TLSSocket {
             ref_count: bun_ptr::RefCount::init(),
@@ -3596,82 +3747,32 @@ impl<const SSL: bool> NewSocket<SSL> {
             }
         };
 
-        // Retire the original TCP wrapper before any TLS dispatch can run
-        // back into JS — it must not see two live owners on one fd. Its
-        // *Handlers are TRANSFERRED to the raw twin (the `[raw, tls]`
-        // contract is: index 0 keeps the pre-upgrade callbacks and sees
-        // ciphertext, index 1 gets the new ones and sees plaintext).
-        let raw_handlers = this.take_handlers();
+        // `this` becomes the `raw` half (see `twin`): it follows the fd into
+        // the new `us_socket_t` but is never in its ext slot.
+        // SAFETY: `if SSL` returned above, so `Self` is `TCPSocket`.
+        let raw: bun_ptr::ThisPtr<TCPSocket> =
+            unsafe { bun_ptr::ThisPtr::new(this.as_ctx_ptr().cast::<TCPSocket>()) };
         // Preserve `socket.unref()` across the upgrade — node:tls callers
         // that unref the underlying TCP socket before upgrading must not
         // suddenly hold the loop open via the TLS wrapper.
         let was_reffed = this.poll_ref.get().is_active();
-        // Capture before downgrade so the cached `data` (net.ts stores
-        // `{self: net.Socket}` there) survives onto the raw twin.
-        let original_data: JSValue =
-            Self::data_get_cached(this.get_this_value(global)).unwrap_or(JSValue::UNDEFINED);
-        original_data.ensure_still_alive();
-        if this.flags.get().contains(Flags::IS_ACTIVE) {
-            this.poll_ref.with_mut(|p| p.disable());
-            this.update_flags(|f| f.remove(Flags::IS_ACTIVE));
-            // Do NOT mark_inactive raw_handlers — ownership of the
-            // active_connections=1 it holds is transferring to `raw`.
-            this.this_value.with_mut(|r| r.downgrade());
-        }
-        // Release the retired TCP wrapper's ref on EVERY exit past this point,
-        // including the `?` early-returns below.
-        // SAFETY: `this` owns the outstanding ref this guard consumes; the JS
-        // wrapper's own +1 keeps the allocation alive across the whole call.
-        let _guard = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
+        // `tls` holds the loop from here on.
+        this.poll_ref.with_mut(|p| p.unref(js_loop_ctx()));
         this.detach_native_callback();
-        this.socket.set(SocketHandler::<SSL>::DETACHED);
+        this.update_flags(|f| f.insert(Flags::BYPASS_TLS));
+        this.socket
+            .set(SocketHandler::<SSL>::from(new_raw.as_ptr()));
 
         // Only NOW is it safe for dispatch to fire: ext + kind point at `tls`.
         *uws::us_socket_t::opaque_mut(new_raw.as_ptr()).ext() = Some(tls);
         tls.socket
             .set(SocketHandler::<true>::from(new_raw.as_ptr()));
         tls.ref_();
-
-        // The `raw` half — same `us_socket_t*`, ORIGINAL pre-upgrade
-        // *Handlers, writes bypass SSL. Dispatch reaches it via the
-        // `ssl_raw_tap` ciphertext hook, never via the ext slot.
-        let raw = TLSSocket::new(TLSSocket {
-            ref_count: bun_ptr::RefCount::init(),
-            handlers: JsCell::new(raw_handlers),
-            socket: Cell::new(SocketHandler::<true>::from(new_raw.as_ptr())),
-            owned_ssl_ctx: JsCell::new(None),
-            connection: JsCell::new(None),
-            local_binding: JsCell::new(None),
-            protos: JsCell::new(None),
-            server_name: JsCell::new(None),
-            // is_active so the chained `raw.on_close` → `mark_inactive` path
-            // releases `raw_handlers`. No poll_ref — `tls` keeps the loop
-            // alive. active_connections=1 was already on raw_handlers from
-            // `this`.
-            flags: Cell::new(Flags::BYPASS_TLS | Flags::IS_ACTIVE | Flags::OWNED_PROTOS),
-            this_value: JsCell::new(JsRef::empty()),
-            poll_ref: JsCell::new(KeepAlive::init()),
-            ref_pollref_on_connect: Cell::new(true),
-            buffered_data_for_node_net: JsCell::new(Vec::new()),
-            bytes_written: Cell::new(0),
-            native_callback: JsCell::new(NativeCallbacks::None),
-            twin: JsCell::new(None),
-            verify_error: JsCell::new(None),
-        });
-        let raw_ref = raw;
-        raw_ref.ref_();
-        // SAFETY: `raw` came from `TLSSocket::new` (heap::alloc); intrusive +1 held.
-        tls.twin
-            .set(Some(unsafe { RefPtr::from_raw(raw.as_ptr()) }));
-        // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
-        bun_opaque::opaque_deref_mut(new_raw.as_ptr()).set_ssl_raw_tap(true);
+        tls.twin.set(Some(raw.ref_guard()));
 
         let tls_js_value = tls.get_this_value(global);
-        let raw_js_value = raw_ref.get_this_value(global);
+        let raw_js_value = raw.get_this_value(global);
         TLSSocket::data_set_cached(tls_js_value, global, default_data);
-        // `raw` keeps the pre-upgrade `data` so its callbacks emit on the
-        // original net.Socket, not the TLS one.
-        TLSSocket::data_set_cached(raw_js_value, global, original_data);
 
         tls.mark_active();
         if was_reffed {
@@ -3691,21 +3792,31 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
         // Fire onOpen with the right `this`, then send ClientHello. Doing
         // it before ext was repointed would have ALPN/onOpen land in the
-        // dead TCPSocket.
+        // raw half's handlers.
         // What settling in the new socket's `on_open` left pending (a
         // terminating VM) is not run over: the handshake re-enters JS.
+        if defer_handshake {
+            bun_opaque::opaque_deref_mut(new_raw.as_ptr()).hold_tls_output();
+        }
         TLSSocket::on_open(tls, tls.socket.get())?;
-        bun_opaque::opaque_deref_mut(new_raw.as_ptr()).start_tls_handshake();
-        // The socket being wrapped may have had its readable interest off (an
-        // accepted socket nobody was reading yet — its ClientHello is still in
-        // the kernel buffer); make sure the adopted TLS socket is reading so
-        // the handshake can be driven. A no-op when it was already reading.
-        bun_opaque::opaque_deref_mut(new_raw.as_ptr()).resume();
-        // Feed bytes that arrived before the upgrade (already pulled off the fd
-        // by the plain-TCP layer) into the TLS engine exactly as if they had
-        // just been received — for a server-side wrap this is the ClientHello.
-        if !initial_data.is_empty() {
-            bun_opaque::opaque_deref_mut(new_raw.as_ptr()).tls_feed(initial_data.as_slice());
+        if !tls.socket.get().is_detached() {
+            bun_opaque::opaque_deref_mut(new_raw.as_ptr()).start_tls_handshake();
+            // The socket being wrapped may have had its readable interest off (an
+            // accepted socket nobody was reading yet — its ClientHello is still in
+            // the kernel buffer); make sure the adopted TLS socket is reading so
+            // the handshake can be driven. A no-op when it was already reading.
+            bun_opaque::opaque_deref_mut(new_raw.as_ptr()).resume();
+            // Feed bytes that arrived before the upgrade (already pulled off the fd
+            // by the plain-TCP layer) into the TLS engine exactly as if they had
+            // just been received — for a server-side wrap this is the ClientHello.
+            if !initial_data.is_empty() {
+                bun_opaque::opaque_deref_mut(new_raw.as_ptr()).tls_feed(initial_data.as_slice());
+            }
+        }
+        // After `initial_data`: those bytes already went through `raw`'s
+        // handlers once on their way in.
+        if !for_node_net {
+            bun_opaque::opaque_deref_mut(new_raw.as_ptr()).set_ssl_raw_tap(true);
         }
 
         let array = JSValue::create_empty_array(global, 2)?;
@@ -4031,6 +4142,12 @@ impl_socket_js_class!(TLSSocket, js_TLSSocket);
 
 pub enum NativeCallbacks {
     H2(RefPtr<H2FrameParser>),
+    /// This socket is the transport under a stream-level TLS engine
+    /// (`upgradeDuplexToTLS` over a handle-backed net.Socket: named pipes,
+    /// TLS over TLS, Http2SecureServer's injected sockets). Its bytes and EOF
+    /// go to that engine, never to the JS handlers — node's TLSWrap taking
+    /// over the parent's stream.
+    TlsTransport(RefPtr<TLSSocket>),
     None,
 }
 
@@ -4042,6 +4159,18 @@ impl NativeCallbacks {
     pub(crate) fn on_data(&self, data: &[u8]) -> JsResult<bool> {
         let h2 = match self {
             NativeCallbacks::H2(h2) => h2.as_ptr(),
+            NativeCallbacks::TlsTransport(inner) => {
+                let Some(engine) = Self::engine(inner) else {
+                    // The engine's teardown detaches us before its socket goes.
+                    debug_assert!(false, "TlsTransport outlived its engine");
+                    return Ok(false);
+                };
+                // Own +1 across the feed: decrypted data re-enters JS, which
+                // may close this transport and drop the cell's ref.
+                let _keep = inner.clone();
+                engine.on_transport_data(data);
+                return Ok(true);
+            }
             NativeCallbacks::None => return Ok(false),
         };
         // SAFETY: `on_native_read` takes a keepalive; `h2` stays live across re-entry.
@@ -4051,11 +4180,54 @@ impl NativeCallbacks {
     pub(crate) fn on_writable(&self) -> bool {
         let h2 = match self {
             NativeCallbacks::H2(h2) => h2.as_ptr(),
+            NativeCallbacks::TlsTransport(inner) => {
+                if let Some(engine) = Self::engine(inner) {
+                    let _keep = inner.clone();
+                    engine.on_transport_writable();
+                }
+                // node:net's own drain handler still runs for the wrapped socket.
+                return false;
+            }
             NativeCallbacks::None => return false,
         };
         // SAFETY: `on_native_writable` takes a keepalive; `h2` stays live across re-entry.
         unsafe { (*h2).on_native_writable() };
         true
+    }
+
+    /// `false`: also dispatch to the JS handlers.
+    pub(crate) fn on_end(&self) -> bool {
+        if let NativeCallbacks::TlsTransport(inner) = self {
+            if let Some(engine) = Self::engine(inner) {
+                let _keep = inner.clone();
+                engine.on_transport_end();
+            }
+        }
+        // node:net's own end handler still runs the wrapped socket's
+        // half-open logic.
+        false
+    }
+
+    /// The transport closed under the engine.
+    pub(crate) fn on_close(self) {
+        match self {
+            NativeCallbacks::H2(h2) => h2.on_native_close(),
+            NativeCallbacks::TlsTransport(inner) => {
+                if let Some(engine) = Self::engine(&inner) {
+                    engine.close();
+                }
+            }
+            NativeCallbacks::None => {}
+        }
+    }
+
+    fn engine(inner: &RefPtr<TLSSocket>) -> Option<&UpgradedDuplex> {
+        match inner.socket.get().socket {
+            // SAFETY: same allocation, runtime-side type (uws_sys shim); live
+            // while `inner.socket` names it.
+            uws::InternalSocket::UpgradedDuplex(d) => Some(unsafe { &*d.cast::<UpgradedDuplex>() }),
+            _ => None,
+        }
     }
 }
 
@@ -4066,6 +4238,17 @@ impl NativeCallbacks {
 enum WriteResult {
     Fail,
     Success { wrote: i32, total: usize },
+}
+
+/// An optional string/buffer argument, copied out (it is fed to C after calls
+/// that re-enter JS).
+fn bytes_from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Vec<u8>> {
+    if value.is_empty_or_undefined_or_null() {
+        return Ok(Vec::new());
+    }
+    Ok(StringOrBuffer::from_js(global, value)?
+        .map(|d| d.slice().to_vec())
+        .unwrap_or_default())
 }
 
 pub(crate) struct StoredVerifyError {
@@ -4079,7 +4262,7 @@ pub(crate) struct StoredVerifyError {
 
 bitflags::bitflags! {
     #[derive(Clone, Copy, PartialEq, Eq)]
-    pub struct Flags: u16 {
+    pub struct Flags: u32 {
         const IS_ACTIVE            = 1 << 0;
         /// Prevent onClose from calling into JavaScript while we are finalizing
         const FINALIZING           = 1 << 1;
@@ -4109,6 +4292,13 @@ bitflags::bitflags! {
         const TLS_SERVER_ROLE      = 1 << 14;
         /// node:net's `pauseOnConnect`: paused in `on_open` (plain; free for a socket that was registered with `LIBUS_SOCKET_OPEN_PAUSED`) or after the handshake (TLS).
         const PAUSE_ON_CONNECT     = 1 << 15;
+        /// `shutdown()` arrived with bytes still in `buffered_data_for_node_net`
+        /// (a stream-level TLS engine's tail): the FIN follows them.
+        const SHUTDOWN_AFTER_FLUSH = 1 << 16;
+        /// We took a loop ref for a stream-level TLS engine's parked output on
+        /// an otherwise unref'd socket (node: a uv write req holds the loop);
+        /// dropped when it drains or JS ref()/unref()s.
+        const ENGINE_OUTPUT_HOLD   = 1 << 17;
     }
 }
 
@@ -4445,7 +4635,7 @@ impl DuplexUpgradeContext {
                 }
                 this.ssl_config.set(None); // Drop frees.
                 // Bytes the peer sent while this task was still queued were
-                // staged by `UpgradedDuplex::on_internal_receive_data` (the
+                // staged by `UpgradedDuplex::on_transport_data` (the
                 // engine did not exist yet to receive them). Feed them now
                 // that StartTLS is fully done, so the replay is ordered
                 // exactly like an ordinary post-start delivery. Without this
@@ -4529,10 +4719,10 @@ impl DuplexUpgradeContext {
 // Free-standing host functions
 // ──────────────────────────────────────────────────────────────────────────
 
-/// node:tls's `tls.connect({ socket })` entry point: same upgrade as the
-/// public `upgradeTLS`, but hostname policy stays with node's JS layer.
+/// node:tls's `tls.connect({ socket })` / `new TLSSocket(socket)` entry
+/// point: see `for_node_net` on `upgrade_tls_impl`.
 #[bun_jsc::host_fn]
-pub fn js_upgrade_tls_deferred(
+pub fn js_node_net_upgrade_tls(
     global: &JSGlobalObject,
     callframe: &CallFrame,
 ) -> JsResult<JSValue> {
@@ -4642,6 +4832,14 @@ pub fn js_upgrade_duplex_to_tls(
         default_data = v;
         default_data.ensure_still_alive();
     }
+    let transport = opts
+        .get_truthy(global, "transport")?
+        .unwrap_or(JSValue::UNDEFINED);
+    // A handle-backed transport still has plaintext queued in JS: hold our
+    // output until `startTLSHandshake`.
+    let defer_handshake = opts
+        .get_truthy(global, "deferHandshake")?
+        .is_some_and(|v| v.to_boolean());
 
     let reject_unauthorized = upgrade_reject_policy(
         handlers.vm,
@@ -4692,6 +4890,27 @@ pub fn js_upgrade_duplex_to_tls(
         twin: JsCell::new(None),
         verify_error: JsCell::new(None),
     });
+    // A handle-backed transport hands its bytes to the engine below JS.
+    let feed = || NativeCallbacks::TlsTransport(RefPtr::from_this(tls));
+    let linked = if let Some(t) = transport.as_class_ref::<TCPSocket>() {
+        t.attach_native_callback(feed())
+            .then(|| Transport::Tcp(t.ref_guard()))
+    } else if let Some(t) = transport.as_class_ref::<TLSSocket>() {
+        t.attach_native_callback(feed())
+            .then(|| Transport::Tls(t.ref_guard()))
+    } else {
+        None
+    };
+    let native_transport = transport.as_class_ref::<TCPSocket>().is_some()
+        || transport.as_class_ref::<TLSSocket>().is_some();
+    if native_transport && linked.is_none() {
+        // Its reads already go somewhere else (an HTTP/2 session, another TLS
+        // layer); `data` events would never come either. Sole owner so far.
+        tls.get().deref();
+        return Err(global.throw(format_args!(
+            "This socket is already consumed by another native reader"
+        )));
+    }
     let tls_ref = tls;
     let tls_js_value = tls_ref.get_this_value(global);
     TLSSocket::data_set_cached(tls_js_value, global, default_data);
@@ -4814,14 +5033,25 @@ pub fn js_upgrade_duplex_to_tls(
     .register();
     DuplexUpgradeContext::start_tls(duplex_context_ref);
 
-    let array = JSValue::create_empty_array(global, 2)?;
+    duplex_context_ref
+        .upgrade
+        .transport
+        .set(linked.unwrap_or(Transport::None));
+    let native_transport = duplex_context_ref.upgrade.has_transport();
+    if defer_handshake && native_transport {
+        duplex_context_ref.upgrade.held_output.set(Some(Vec::new()));
+    }
+
+    let array = JSValue::create_empty_array(global, 3)?;
     array.put_index(global, 0, tls_js_value)?;
-    // data, end, drain and close events must be reported
+    // The engine's intake as JS functions: all four for a Duplex; a
+    // handle-backed transport only uses `data`, for what it had buffered.
     array.put_index(
         global,
         1,
         duplex_context_ref.upgrade.get_js_handlers(global)?,
     )?;
+    array.put_index(global, 2, JSValue::from(native_transport))?;
 
     Ok(array)
 }

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -3369,8 +3369,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         Ok(result)
     }
 
-    /// The TLS half over this `raw` half's fd (`upgradeTLS`); it holds the
-    /// loop for both, as node's single uv handle does.
+    /// The TLS half sharing this `raw` half's fd after `upgradeTLS`.
     fn tls_layer(&self) -> Option<bun_ptr::ThisPtr<TLSSocket>> {
         if !self.flags.get().contains(Flags::BYPASS_TLS) {
             return None;
@@ -3407,8 +3406,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         Ok(JSValue::UNDEFINED)
     }
 
-    /// `ref()` / `unref()`: this socket's hold on the loop, and its TLS layer's
-    /// when it is the `raw` half of an upgrade (node: one uv handle for both).
+    /// `ref()`/`unref()`; a `raw` half forwards to its TLS layer (node: one uv handle).
     pub(crate) fn set_ref(&self, hold: bool) {
         if let Some(tls) = self.tls_layer() {
             tls.set_ref(hold);
@@ -3765,8 +3763,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             }
         };
 
-        // `this` becomes the `raw` half (see `twin`): it follows the fd into
-        // the new `us_socket_t` but is never in its ext slot.
+        // `this` becomes the `raw` half (see `twin`).
         let raw: &TCPSocket = (this as &dyn core::any::Any)
             .downcast_ref::<TCPSocket>()
             .expect("SSL sockets returned above");
@@ -4164,8 +4161,7 @@ pub(crate) enum NativeCallbacks {
     /// (`upgradeDuplexToTLS` over a handle-backed net.Socket: named pipes,
     /// TLS over TLS, Http2SecureServer's injected sockets). Its bytes and EOF
     /// go to that engine, never to the JS handlers — node's TLSWrap taking
-    /// over the parent's stream. The engine clears this slot from its own
-    /// teardown (`release_transport`) before it is freed.
+    /// over the parent's stream. Cleared by the engine's `release_transport`.
     TlsTransport(bun_ptr::BackRef<UpgradedDuplex>),
     None,
 }
@@ -4178,8 +4174,7 @@ impl NativeCallbacks {
     pub(crate) fn on_data(&self, data: &[u8]) -> JsResult<bool> {
         let h2 = match self {
             NativeCallbacks::H2(h2) => h2.as_ptr(),
-            // Copied out: decrypted data re-enters JS, which may close this
-            // transport and overwrite the cell `self` borrows.
+            // Copied out: the feed re-enters JS, which may overwrite this cell.
             NativeCallbacks::TlsTransport(engine) => {
                 let engine = *engine;
                 engine.on_transport_data(data);

--- a/src/runtime/socket/sockets.classes.ts
+++ b/src/runtime/socket/sockets.classes.ts
@@ -28,6 +28,7 @@ function generate(ssl) {
         fn: "pauseFromJS",
         length: 0,
       },
+      ...(ssl ? { startTLSHandshake: { fn: "startTLSHandshake", length: 0 } } : { fdIsTLS: { getter: "getFdIsTLS" } }),
 
       getTLSFinishedMessage: {
         fn: "getTLSFinishedMessage",

--- a/src/runtime/socket/uws_dispatch.rs
+++ b/src/runtime/socket/uws_dispatch.rs
@@ -195,8 +195,13 @@ unsafe extern "C" fn us_dispatch_ssl_raw_tap(
     // at construction.
     let tls: bun_ptr::ThisPtr<TLSSocket> =
         s_ref.ext::<Option<bun_ptr::ThisPtr<TLSSocket>>>().unwrap();
-    if let Some(raw) = tls.twin.get().as_ref() {
-        let raw: *mut TLSSocket = raw.as_ptr();
+    if let Some(raw) = tls
+        .twin
+        .get()
+        .as_ref()
+        .filter(|r| r.flags.get().contains(super::SocketFlags::BYPASS_TLS))
+    {
+        let raw: *mut super::TCPSocket = raw.as_ptr();
         // A negative length from the C side means there is nothing to deliver;
         // never panic across the `extern "C"` boundary.
         let Ok(len) = usize::try_from(len) else {
@@ -209,9 +214,9 @@ unsafe extern "C" fn us_dispatch_ssl_raw_tap(
         // is live for `ThisPtr::new`; dispatch is single-threaded so no
         // aliasing `&mut` exists.
         crate::dispatch::fold(unsafe {
-            TLSSocket::on_data(
+            super::TCPSocket::on_data(
                 bun_ptr::ThisPtr::new(raw),
-                NewSocketHandler::<true>::from(s),
+                NewSocketHandler::<false>::from(s),
                 slice,
             )
         });

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -223,6 +223,7 @@ unsafe extern "C" {
     safe fn UpgradedDuplex__abandon_js_side(this: &mut UpgradedDuplex);
     safe fn UpgradedDuplex__pause(this: &mut UpgradedDuplex) -> bool;
     safe fn UpgradedDuplex__resume(this: &mut UpgradedDuplex) -> bool;
+    safe fn UpgradedDuplex__release_output(this: &mut UpgradedDuplex);
 }
 impl UpgradedDuplex {
     /// Forwarded to the handle-backed transport, if any.
@@ -233,6 +234,10 @@ impl UpgradedDuplex {
     #[inline]
     pub(crate) fn resume(&mut self) -> bool {
         UpgradedDuplex__resume(self)
+    }
+    #[inline]
+    pub(crate) fn release_output(&mut self) {
+        UpgradedDuplex__release_output(self)
     }
     #[inline]
     pub(crate) fn ssl_error(&self) -> us_bun_verify_error_t {

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -221,8 +221,19 @@ unsafe extern "C" {
     safe fn UpgradedDuplex__shutdown_read(this: &mut UpgradedDuplex);
     safe fn UpgradedDuplex__close(this: &mut UpgradedDuplex);
     safe fn UpgradedDuplex__abandon_js_side(this: &mut UpgradedDuplex);
+    safe fn UpgradedDuplex__pause(this: &mut UpgradedDuplex) -> bool;
+    safe fn UpgradedDuplex__resume(this: &mut UpgradedDuplex) -> bool;
 }
 impl UpgradedDuplex {
+    /// Forwarded to the handle-backed transport, if any.
+    #[inline]
+    pub(crate) fn pause(&mut self) -> bool {
+        UpgradedDuplex__pause(self)
+    }
+    #[inline]
+    pub(crate) fn resume(&mut self) -> bool {
+        UpgradedDuplex__resume(self)
+    }
     #[inline]
     pub(crate) fn ssl_error(&self) -> us_bun_verify_error_t {
         UpgradedDuplex__ssl_error(self)

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -517,6 +517,18 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
         )
     }
 
+    /// Let TLS output held behind the previous owner's writes go
+    /// (`us_socket_hold_tls_output` / the duplex engine's held output).
+    pub fn release_tls_output(&self) {
+        on_socket!(self.socket;
+            connected s => s.release_tls_output(),
+            connecting _c => {},
+            detached => {},
+            duplex d => d.release_output(),
+            pipe _p => {},
+        )
+    }
+
     pub fn resume_stream(&self) -> bool {
         on_socket!(self.socket;
             connected s => if s.is_established() { s.resume(); true } else { false },

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -517,8 +517,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
         )
     }
 
-    /// Let TLS output held behind the previous owner's writes go
-    /// (`us_socket_hold_tls_output` / the duplex engine's held output).
+    /// Counterpart of `us_socket_hold_tls_output` / the duplex engine's held output.
     pub fn release_tls_output(&self) {
         on_socket!(self.socket;
             connected s => s.release_tls_output(),

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -512,7 +512,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
             connected s => if s.is_established() { s.pause(); true } else { false },
             connecting _c => false,
             detached => true,
-            duplex _d => false, // TODO: pause/resume upgraded duplex
+            duplex d => d.pause(),
             pipe p => p.pause_stream(),
         )
     }
@@ -522,7 +522,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
             connected s => if s.is_established() { s.resume(); true } else { false },
             connecting _c => false,
             detached => true,
-            duplex _d => false, // TODO: pause/resume upgraded duplex
+            duplex d => d.resume(),
             pipe p => p.resume_stream(),
         )
     }

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -306,6 +306,17 @@ impl us_socket_t {
         c::us_socket_start_tls_handshake(self);
     }
 
+    /// Keep SSL's output back (the previous owner still has plaintext queued
+    /// for this fd) until `release_tls_output`; input is processed normally.
+    pub fn hold_tls_output(&mut self) {
+        c::us_socket_hold_tls_output(self);
+    }
+
+    /// Flush what `hold_tls_output` kept back and carry on.
+    pub fn release_tls_output(&mut self) {
+        c::us_socket_release_tls_output(self);
+    }
+
     /// Feed bytes that were already read off the wire (e.g. a ClientHello the
     /// plain-TCP layer consumed before the upgrade) through the same decrypt
     /// path as bytes arriving from the kernel.
@@ -597,6 +608,8 @@ mod c {
             length: i32,
         ) -> *mut us_socket_t;
         pub(super) safe fn us_socket_start_tls_handshake(s: &mut us_socket_t);
+        pub(super) safe fn us_socket_hold_tls_output(s: &mut us_socket_t);
+        pub(super) safe fn us_socket_release_tls_output(s: &mut us_socket_t);
     }
 }
 

--- a/test/js/bun/net/socket-retention.test.ts
+++ b/test/js/bun/net/socket-retention.test.ts
@@ -130,11 +130,11 @@ test("active TCP socket wrapper survives GC until closed", async () => {
 // making a tight GC bound unreliable there. The Strong-release path this
 // guards is platform-independent, so Linux/macOS coverage suffices.
 test.skipIf(isWindows)("upgradeTLS raw + tls wrappers are both collectable after close", async () => {
-  // upgradeTLS produces two TLSSocket wrappers (the raw passthrough and the
-  // TLS socket) sharing one underlying connection. When the connection closes,
-  // the raw socket is cleaned up via WrappedHandler.onClose which must release
-  // its strong ref so both wrappers can be GC'd. A missed transition here pins
-  // one of them forever.
+  // upgradeTLS leaves two wrappers sharing one underlying connection: the
+  // original socket (now the raw passthrough) and the TLSSocket. When the
+  // connection closes, the raw half is closed from the TLS half's onClose,
+  // which must release its strong ref so both wrappers can be GC'd. A missed
+  // transition here pins one of them forever.
   await using tlsServer = Bun.serve({
     port: 0,
     tls: tlsCert,
@@ -144,6 +144,7 @@ test.skipIf(isWindows)("upgradeTLS raw + tls wrappers are both collectable after
   });
 
   const baseline = heapStats().objectTypeCounts.TLSSocket || 0;
+  const baselineTCP = heapStats().objectTypeCounts.TCPSocket || 0;
 
   for (let i = 0; i < 5; i++) {
     const { promise: done, resolve } = Promise.withResolvers<void>();
@@ -183,10 +184,14 @@ test.skipIf(isWindows)("upgradeTLS raw + tls wrappers are both collectable after
   }
 
   // All upgradeTLS-created wrappers should be collectable now. We created
-  // 5 × 2 = 10 TLSSocket wrappers; if the Strong release on close is missed,
-  // they all pin and the count stays ≥ baseline + 10.
+  // 5 TLSSocket wrappers; if the Strong release on close is missed, they all
+  // pin and the count stays ≥ baseline + 5.
   const count = await gcUntilCountAtMost("TLSSocket", baseline + 2);
   expect(count).toBeLessThanOrEqual(baseline + 2);
+  // The raw halves (the original TCPSockets) are released from the TLS half's
+  // close; a missed chain there pins them instead.
+  const countTCP = await gcUntilCountAtMost("TCPSocket", baselineTCP + 2);
+  expect(countTCP).toBeLessThanOrEqual(baselineTCP + 2);
 });
 
 test("tls.connect over a Duplex roots the origin and listener thunks through the wrapper, not as Strong handles", async () => {

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -836,6 +836,111 @@ describe.concurrent("socket", () => {
       expect(rawData.byteLength).toBeGreaterThanOrEqual(1980);
     }
   });
+  it("upgradeTLS: the tls half's close handler still fires when the raw half's close handler ends it", async () => {
+    using listener = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls,
+      socket: {
+        data(s) {
+          s.end();
+        },
+        open() {},
+        close() {},
+        error() {},
+      },
+    });
+    const rawClosed = Promise.withResolvers<void>();
+    const tlsClosed = Promise.withResolvers<void>();
+    let secure: Socket | undefined;
+    const socket = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: listener.port,
+      socket: {
+        data() {},
+        open() {},
+        close() {
+          secure?.end();
+          rawClosed.resolve();
+        },
+        error() {},
+      },
+    });
+    [, secure] = socket.upgradeTLS({
+      tls: { rejectUnauthorized: false },
+      socket: {
+        handshake(s) {
+          s.write("hello");
+        },
+        data() {},
+        close() {
+          tlsClosed.resolve();
+        },
+        error() {},
+      },
+    });
+    await Promise.all([rawClosed.promise, tlsClosed.promise]);
+    expect().pass();
+  });
+  it("upgradeTLS: the raw half's close handler still fires when the tls half's close handler ends it", async () => {
+    using listener = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls,
+      socket: {
+        data(s) {
+          s.end();
+        },
+        open() {},
+        close() {},
+        error() {},
+      },
+    });
+    const rawClosed = Promise.withResolvers<void>();
+    const tlsClosed = Promise.withResolvers<void>();
+    const socket = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: listener.port,
+      socket: { data() {}, open() {}, close: () => rawClosed.resolve(), error() {} },
+    });
+    const [raw] = socket.upgradeTLS({
+      tls: { rejectUnauthorized: false },
+      socket: {
+        handshake(s) {
+          s.write("hello");
+        },
+        data() {},
+        close() {
+          raw.end();
+          tlsClosed.resolve();
+        },
+        error() {},
+      },
+    });
+    await Promise.all([rawClosed.promise, tlsClosed.promise]);
+    expect().pass();
+  });
+  it("upgradeTLS keeps the original socket as the raw half; upgrading that again is a no-op", async () => {
+    using listener = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls,
+      socket: { data() {}, open() {}, close() {}, error() {} },
+    });
+    const { promise: closed, resolve } = Promise.withResolvers<void>();
+    const socket = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: listener.port,
+      socket: { data() {}, open() {}, close: () => resolve(), error() {} },
+    });
+    const opts = { tls: { rejectUnauthorized: false }, socket: { data() {}, open() {}, close() {}, error() {} } };
+    const [raw, secure] = socket.upgradeTLS(opts);
+    expect(raw).toBe(socket);
+    expect(raw.upgradeTLS(opts)).toBeUndefined();
+    secure.end();
+    raw.end();
+    await closed;
+  });
   it("upgradeTLS feeds the initialData bytes captured at call time", async () => {
     const handshake = Promise.withResolvers<void>();
     const echoed = Promise.withResolvers<string>();

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -853,6 +853,78 @@ if (cluster.isPrimary) {
   expect(stdout).toContain("reply: echo:hi");
 }, 30_000);
 
+// https://github.com/oven-sh/bun/issues/32239
+test("round-robin worker wrapping an accepted socket in TLS does not surface the TLS traffic on that socket", async () => {
+  // A round-robin worker builds the accepted net.Socket around the fd the
+  // primary handed over (a different native handler set than a locally
+  // accepted socket). Once the worker layers TLS on top of it, none of the
+  // connection's bytes may show up on the plain socket, neither as `data` nor
+  // left in its readable buffer.
+  const dir = tempDirWithFiles("bun-test", {
+    "cert.pem": tlsCerts.cert,
+    "key.pem": tlsCerts.key,
+    "main.ts": `
+const cluster = require("node:cluster");
+const net = require("node:net");
+const tls = require("node:tls");
+const fs = require("node:fs");
+const path = require("node:path");
+const key = fs.readFileSync(path.join(__dirname, "key.pem"));
+const cert = fs.readFileSync(path.join(__dirname, "cert.pem"));
+
+if (cluster.isPrimary) {
+  const worker = cluster.fork();
+  const outcome = { reply: null, plainSocket: null };
+  const finish = () => {
+    if (outcome.reply === null || outcome.plainSocket === null) return;
+    console.log(JSON.stringify(outcome));
+    worker.kill();
+    process.exit(0);
+  };
+  worker.on("message", msg => {
+    outcome.plainSocket = msg;
+    finish();
+  });
+  cluster.on("listening", (_, address) => {
+    const client = tls.connect({ port: address.port, host: "127.0.0.1", ca: cert, servername: "localhost" }, () => {
+      client.write("hi");
+    });
+    client.setEncoding("utf8");
+    client.on("data", reply => {
+      outcome.reply = reply;
+      client.end();
+      finish();
+    });
+    client.on("error", e => {
+      outcome.reply = "client error: " + e.message;
+      finish();
+    });
+  });
+} else {
+  net
+    .createServer(plain => {
+      const secure = new tls.TLSSocket(plain, { isServer: true, key, cert });
+      let emitted = 0;
+      plain.on("data", chunk => (emitted += chunk.length));
+      plain.on("error", e => process.send({ error: "plain: " + e.message }));
+      secure.on("error", e => process.send({ error: "secure: " + e.message }));
+      secure.once("data", d => {
+        secure.end("echo:" + d);
+        process.send({ emitted, buffered: plain.readableLength });
+      });
+    })
+    .listen(0);
+}
+`,
+  });
+  const { stdout, stderr, exitCode } = await bunRun(joinP(dir, "main.ts"), bunEnv);
+  expect({ outcome: JSON.parse(stdout), stderr, exitCode }).toEqual({
+    outcome: { reply: "echo:hi", plainSocket: { emitted: 0, buffered: 0 } },
+    stderr: "",
+    exitCode: 0,
+  });
+}, 30_000);
+
 test("plain worker listening on a key already owned by a TLS shared-only handle fails with EINVAL", async () => {
   const dir = tempDirWithFiles("bun-test", {
     "cert.pem": tlsCerts.cert,

--- a/test/js/node/http2/node-http2-upgrade.test.mts
+++ b/test/js/node/http2/node-http2-upgrade.test.mts
@@ -136,6 +136,43 @@ describe("HTTP/2 upgrade via net.Server", () => {
   });
 });
 
+describe("HTTP/2 upgrade — the raw socket is taken over", () => {
+  // https://github.com/oven-sh/bun/issues/32242
+  test("nothing surfaces on the raw socket once it has been handed to the TLS layer", async () => {
+    const rawSocketHandedOver = Promise.withResolvers<() => { emitted: number; buffered: number }>();
+    const h2Server = http2.createSecureServer(TLS, (_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    h2Server.on("error", () => {});
+    const netServer = net.createServer(socket => {
+      // A listener left over from before the hand-over (a protocol sniffer,
+      // say) must not see the TLS traffic, and none of it may pile up in the
+      // raw socket's readable buffer either.
+      let emitted = 0;
+      socket.on("data", chunk => (emitted += chunk.length));
+      h2Server.emit("connection", socket);
+      rawSocketHandedOver.resolve(() => ({ emitted, buffered: socket.readableLength }));
+    });
+    const port = await new Promise<number>(resolve => {
+      netServer.listen(0, "127.0.0.1", () => resolve((netServer.address() as net.AddressInfo).port));
+    });
+
+    const client = connectClient(port);
+    try {
+      const result = await request(client, "GET", "/");
+      const surfacedOnRawSocket = await rawSocketHandedOver.promise;
+      assert.deepStrictEqual(
+        { status: result.status, body: result.body, ...surfacedOnRawSocket() },
+        { status: 200, body: "ok", emitted: 0, buffered: 0 },
+      );
+    } finally {
+      client.close();
+      netServer.close();
+    }
+  });
+});
+
 describe("HTTP/2 upgrade — multiple requests on one connection", () => {
   test("three sequential requests share the same session", async () => {
     let count = 0;

--- a/test/js/node/test/parallel/test-tls-connect-allow-half-open-option.js
+++ b/test/js/node/test/parallel/test-tls-connect-allow-half-open-option.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const common = require('../common');
+
+// This test verifies that `tls.connect()` honors the `allowHalfOpen` option.
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const tls = require('tls');
+
+{
+  const socket = tls.connect({ port: 42, lookup() {} });
+  assert.strictEqual(socket.allowHalfOpen, false);
+}
+
+{
+  const socket = tls.connect({ port: 42, allowHalfOpen: false, lookup() {} });
+  assert.strictEqual(socket.allowHalfOpen, false);
+}
+
+const server = tls.createServer({
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
+}, common.mustCall((socket) => {
+  server.close();
+
+  let message = '';
+
+  socket.setEncoding('utf8');
+  socket.on('data', (chunk) => {
+    message += chunk;
+
+    if (message === 'Hello') {
+      socket.end(message);
+      message = '';
+    }
+  });
+
+  socket.on('end', common.mustCall(() => {
+    assert.strictEqual(message, 'Bye');
+  }));
+}));
+
+server.listen(0, common.mustCall(() => {
+  const socket = tls.connect({
+    port: server.address().port,
+    rejectUnauthorized: false,
+    allowHalfOpen: true,
+  }, common.mustCall(() => {
+    let message = '';
+
+    socket.on('data', (chunk) => {
+      message += chunk;
+    });
+
+    socket.on('end', common.mustCall(() => {
+      assert.strictEqual(message, 'Hello');
+
+      setTimeout(common.mustCall(() => {
+        assert(socket.writable);
+        assert(socket.write('Bye'));
+        socket.end();
+      }), 50);
+    }));
+
+    socket.write('Hello');
+  }));
+
+  socket.setEncoding('utf8');
+}));

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -176,3 +176,91 @@ it.if(isWindows)("should be able to upgrade a named pipe connection to TLS", asy
   await test(`\\\\.\\pipe\\test\\${randomUUID()}`);
   await expectMaxObjectTypeCount(expect, "TLSSocket", 3);
 });
+
+// A named-pipe net.Socket is upgraded by running the TLS engine over the
+// stream; its pipe handle stays in place and keeps delivering bytes. Those
+// bytes belong to the TLS layer from then on and must not reach the pipe
+// socket's own `data` listeners (the TCP counterparts of these tests live in
+// node-tls-upgrade.test.ts).
+// https://github.com/oven-sh/bun/issues/32242
+it.if(isWindows)("tls.connect({ socket }) takes a named-pipe client socket over", async () => {
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  const { promise: echoed, resolve: gotEcho } = Promise.withResolvers<string>();
+  const pipeName = `\\\\.\\pipe\\test\\${randomUUID()}`;
+  const server = createServer(tls, socket => {
+    socket.on("error", reject);
+    socket.on("data", data => socket.write(data));
+  });
+  server.on("error", reject);
+  server.listen(pipeName);
+  await once(server, "listening");
+
+  const pipeSocket = net.connect(pipeName);
+  try {
+    pipeSocket.on("error", reject);
+    // Plaintext-phase listener that stays attached across the upgrade.
+    let surfaced = 0;
+    pipeSocket.on("data", chunk => (surfaced += chunk.length));
+
+    const client = connect({ socket: pipeSocket, ca: tls.cert, servername: "localhost" });
+    client.on("error", reject);
+    client.on("data", data => gotEcho(data.toString()));
+    await Promise.race([once(client, "secureConnect"), failure]);
+    client.write("Hello World!");
+    const reply = await Promise.race([echoed, failure]);
+    expect({ reply, surfaced, buffered: pipeSocket.readableLength }).toEqual({
+      reply: "Hello World!",
+      surfaced: 0,
+      buffered: 0,
+    });
+  } finally {
+    pipeSocket.destroy();
+    server.close();
+  }
+});
+
+it.if(isWindows)("tls.connect({ socket }) takes an accepted named-pipe socket over", async () => {
+  // Same as above for the socket a named-pipe server accepted, driven the way
+  // the issue drives it: the plaintext handler upgrades on the first chunk
+  // after the greeting. The mock peer answers everything with TLS-looking
+  // bytes, so some of them arrive after the upgrade: they must reach the TLS
+  // layer (which reacts to them) and must not re-enter the handler, which
+  // pre-fix made it upgrade a second time.
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  const { promise: outcome, resolve } = Promise.withResolvers<{ upgrades: number; tlsReacted: boolean }>();
+  const pipeName = `\\\\.\\pipe\\test\\${randomUUID()}`;
+  let accepted: net.Socket | undefined;
+  const server = net.createServer(socket => {
+    accepted = socket;
+    let upgrades = 0;
+    socket.on("error", reject);
+    socket.on("close", () => resolve({ upgrades, tlsReacted: false }));
+    socket.on("data", chunk => {
+      if (upgrades === 0 && chunk.toString("latin1") === "PEER_GREETING") {
+        socket.write("STARTTLS");
+        return;
+      }
+      upgrades++;
+      const secure = connect({ socket, rejectUnauthorized: false });
+      secure.on("error", () => resolve({ upgrades, tlsReacted: true }));
+      secure.on("secureConnect", () => resolve({ upgrades, tlsReacted: true }));
+    });
+  });
+  server.on("error", reject);
+  server.listen(pipeName);
+  await once(server, "listening");
+
+  const peer = net.connect(pipeName);
+  try {
+    peer.on("error", reject);
+    peer.on("connect", () => peer.write("PEER_GREETING"));
+    // First in reply to STARTTLS (this is what the handler upgrades on), then
+    // in reply to the ClientHello the upgrade sends.
+    peer.on("data", () => peer.write(Buffer.alloc(50, 0x16)));
+    expect(await Promise.race([outcome, failure])).toEqual({ upgrades: 1, tlsReacted: true });
+  } finally {
+    peer.destroy();
+    accepted?.destroy();
+    server.close();
+  }
+});

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -789,37 +789,40 @@ test.concurrent("TLS over TLS: the peer closing the outer connection closes both
   }
 });
 
-test.concurrent("TLS over TLS: reconnecting the outer socket while the inner layer is live fails with EISCONN", async () => {
-  // Same rule as for an fd-adopted socket: the outer socket is the inner
-  // layer's transport now, and connect() must not swap the connection out from
-  // under it (which would leave the inner socket with no close and its records
-  // going to an unrelated peer).
-  const { promise: failure, reject } = Promise.withResolvers<never>();
-  const outerServer = tls.createServer(serverTLS, outer => {
-    outer.on("error", () => {});
-    const inner = new tls.TLSSocket(outer, { isServer: true, ...serverTLS });
-    inner.on("error", () => {});
-    inner.on("data", chunk => inner.write(chunk));
-  });
-  outerServer.listen(0, "127.0.0.1");
-  await once(outerServer, "listening");
-  const port = (outerServer.address() as net.AddressInfo).port;
-  try {
-    const outer = tls.connect({ port, host: "127.0.0.1", ...clientTLS });
-    outer.on("error", () => {});
-    await Promise.race([once(outer, "secureConnect"), failure]);
-    const inner = tls.connect({ socket: outer, ...clientTLS });
-    inner.on("error", reject);
-    await Promise.race([once(inner, "secureConnect"), failure]);
-    inner.off("error", reject).on("error", () => {});
-    const [err] = await Promise.race([once(outer.connect(port, "127.0.0.1"), "error"), failure]);
-    expect((err as NodeJS.ErrnoException).code).toBe("EISCONN");
-    await Promise.race([once(inner, "close"), failure]);
-    expect(inner.destroyed).toBe(true);
-  } finally {
-    outerServer.close();
-  }
-});
+test.concurrent(
+  "TLS over TLS: reconnecting the outer socket while the inner layer is live fails with EISCONN",
+  async () => {
+    // Same rule as for an fd-adopted socket: the outer socket is the inner
+    // layer's transport now, and connect() must not swap the connection out from
+    // under it (which would leave the inner socket with no close and its records
+    // going to an unrelated peer).
+    const { promise: failure, reject } = Promise.withResolvers<never>();
+    const outerServer = tls.createServer(serverTLS, outer => {
+      outer.on("error", () => {});
+      const inner = new tls.TLSSocket(outer, { isServer: true, ...serverTLS });
+      inner.on("error", () => {});
+      inner.on("data", chunk => inner.write(chunk));
+    });
+    outerServer.listen(0, "127.0.0.1");
+    await once(outerServer, "listening");
+    const port = (outerServer.address() as net.AddressInfo).port;
+    try {
+      const outer = tls.connect({ port, host: "127.0.0.1", ...clientTLS });
+      outer.on("error", () => {});
+      await Promise.race([once(outer, "secureConnect"), failure]);
+      const inner = tls.connect({ socket: outer, ...clientTLS });
+      inner.on("error", reject);
+      await Promise.race([once(inner, "secureConnect"), failure]);
+      inner.off("error", reject).on("error", () => {});
+      const [err] = await Promise.race([once(outer.connect(port, "127.0.0.1"), "error"), failure]);
+      expect((err as NodeJS.ErrnoException).code).toBe("EISCONN");
+      await Promise.race([once(inner, "close"), failure]);
+      expect(inner.destroyed).toBe(true);
+    } finally {
+      outerServer.close();
+    }
+  },
+);
 
 test.concurrent("ref() on the wrapped socket still holds the event loop after the upgrade", async () => {
   // node: the wrapped socket and the TLS socket share one uv handle, so

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { once } from "events";
-import { tls as certs } from "harness";
+import { bunEnv, bunExe, tls as certs } from "harness";
 import net from "net";
 import tls from "tls";
 
@@ -59,4 +59,1150 @@ test("should be able to upgrade a paused socket and also have backpressure on it
   }
 
   expect().pass();
+});
+
+// Once a TLS layer is put on top of a net.Socket (tls.connect({ socket }),
+// new TLSSocket(socket, { isServer: true })) the bytes that socket keeps
+// receiving belong to the TLS layer: none of them may surface as `data` on the
+// wrapped socket or pile up in its readable buffer. Covered: adopting the fd
+// right away, adopting it once plaintext still queued on the socket has been
+// flushed (like node, no TLS record may overtake it), and TLS over TLS, where
+// the TLS engine runs over the outer stream (Windows named pipes, the other
+// stream-level case, are in node-tls-namedpipes.test.ts).
+// https://github.com/oven-sh/bun/issues/32239
+// https://github.com/oven-sh/bun/issues/32242
+
+const serverTLS = { key: certs.key, cert: certs.cert };
+const clientTLS = { ca: certs.cert, servername: "localhost" };
+
+async function listenTCP(onConnection: (socket: net.Socket) => void) {
+  const server = net.createServer(onConnection);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return {
+    port: (server.address() as net.AddressInfo).port,
+    [Symbol.dispose]: () => server.close(),
+  };
+}
+
+// Bytes that reach the wrapped socket itself from now on, whether emitted as
+// `data` or left sitting in its readable buffer.
+function watchSurfacing(socket: net.Socket) {
+  let emitted = 0;
+  socket.on("data", chunk => (emitted += chunk.length));
+  return () => ({ emitted, buffered: socket.readableLength });
+}
+
+// Client-side upgrade over `socket` plus a "ping" round trip through an echoing
+// TLS peer. Resolves to the echoed text; every failure rejects.
+function pingOverTLS(socket: net.Socket, reject: (err: Error) => void) {
+  const { promise, resolve } = Promise.withResolvers<string>();
+  const tlsSocket = tls.connect({ socket, ...clientTLS });
+  tlsSocket.on("error", reject);
+  tlsSocket.on("close", () => reject(new Error("TLS socket closed before the echo arrived")));
+  tlsSocket.on("secureConnect", () => tlsSocket.write("ping"));
+  tlsSocket.on("data", chunk => resolve(chunk.toString()));
+  return promise;
+}
+
+function wrapAndEcho(accepted: net.Socket, reject: (err: Error) => void) {
+  const secure = new tls.TLSSocket(accepted, { isServer: true, ...serverTLS });
+  secure.on("error", reject);
+  secure.on("data", chunk => secure.write(chunk));
+}
+
+// Server for clients that send "STARTTLS" and start the handshake right away:
+// it wraps the accepted socket as soon as the command arrives and never writes
+// anything in plaintext, so whatever the client's plaintext side sees after
+// that is TLS traffic leaking through.
+function listenOptimisticSTARTTLS(reject: (err: Error) => void) {
+  return listenTCP(accepted => {
+    accepted.on("error", reject);
+    accepted.once("data", chunk => {
+      if (chunk.toString("latin1", 0, 8) !== "STARTTLS") {
+        reject(new Error(`unexpected plaintext ${JSON.stringify(chunk.toString("latin1"))}`));
+        return;
+      }
+      // The ClientHello may already be in this chunk or arrive before the wrap
+      // lands; keep it buffered for the wrap to hand over.
+      accepted.pause();
+      if (chunk.length > 8) accepted.unshift(chunk.subarray(8));
+      wrapAndEcho(accepted, reject);
+    });
+  });
+}
+
+test.concurrent(
+  "tls.connect({ socket }) does not re-emit post-upgrade bytes on the original socket (STARTTLS) #32239",
+  async () => {
+    // The issue's shape: the plaintext handler upgrades on the first chunk after
+    // the greeting. Pre-fix the TLS bytes that followed re-entered it as `data`,
+    // so it upgraded a second time and that attempt threw "Invalid socket".
+    const { promise: failure, reject } = Promise.withResolvers<never>();
+    const { promise: outcome, resolve } = Promise.withResolvers<{ upgrades: number; invalidSocket: boolean }>();
+    using server = await listenTCP(serverSocket => {
+      serverSocket.on("error", () => {});
+      serverSocket.write("SERVER_GREETING");
+      serverSocket.on("data", () => serverSocket.write(Buffer.alloc(50, 0x16)));
+    });
+
+    const socket = net.connect(server.port, "127.0.0.1");
+    try {
+      socket.on("error", reject);
+      let upgrades = 0;
+      socket.on("data", chunk => {
+        if (upgrades === 0 && chunk.toString("latin1") === "SERVER_GREETING") {
+          socket.write("STARTTLS");
+          return;
+        }
+        upgrades++;
+        const tlsSocket = tls.connect({ socket, rejectUnauthorized: false });
+        tlsSocket.on("error", err => resolve({ upgrades, invalidSocket: err.message.includes("Invalid socket") }));
+        tlsSocket.on("secureConnect", () => reject(new Error("handshake against the mock bytes succeeded")));
+      });
+      expect(await Promise.race([outcome, failure])).toEqual({ upgrades: 1, invalidSocket: false });
+    } finally {
+      socket.destroy();
+    }
+  },
+);
+
+test.concurrent.each([
+  [
+    "fd adoption",
+    // STARTTLS has been flushed by the time tls.connect runs, so the fd is adopted.
+    (socket: net.Socket, upgrade: () => Promise<string>) =>
+      new Promise<string>(resolve => socket.write("STARTTLS", () => resolve(upgrade()))),
+  ],
+  [
+    "fd adoption behind a pending write",
+    // STARTTLS is still corked when tls.connect runs: the handshake is held
+    // until it has been flushed, so the ClientHello goes out behind it.
+    (socket: net.Socket, upgrade: () => Promise<string>) => {
+      socket.cork();
+      socket.write("STARTTLS");
+      const echoed = upgrade();
+      socket.uncork();
+      return echoed;
+    },
+  ],
+])("tls.connect({ socket }) takes the client socket over: %s", async (_, sendSTARTTLSAndUpgrade) => {
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  using server = await listenOptimisticSTARTTLS(reject);
+
+  const socket = net.connect(server.port, "127.0.0.1");
+  try {
+    socket.on("error", reject);
+    await Promise.race([once(socket, "connect"), failure]);
+    // The plaintext-phase listener stays attached, as in the issue.
+    const surfaced = watchSurfacing(socket);
+    const echoed = await Promise.race([sendSTARTTLSAndUpgrade(socket, () => pingOverTLS(socket, reject)), failure]);
+    expect({ echoed, ...surfaced() }).toEqual({ echoed: "ping", emitted: 0, buffered: 0 });
+  } finally {
+    socket.destroy();
+  }
+});
+
+test.concurrent("tls.connect({ socket }) behind a write under backpressure: the plaintext goes out first", async () => {
+  // Not corked but genuinely stuck behind the kernel: the ClientHello must
+  // still not overtake a single plaintext byte (node queues the TLS output
+  // behind the previous owner's writes). The plaintext is all 0x61 and a TLS
+  // record starts with 0x16, so the server takes plaintext up to the first
+  // 0x16 and wraps there; a byte out of order shortens that count or breaks
+  // the handshake.
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  const { promise: plaintextSeen, resolve: sawPlaintext } = Promise.withResolvers<number>();
+  const CHUNK = 1024 * 1024;
+  using server = await listenTCP(accepted => {
+    accepted.on("error", reject);
+    let seen = 0;
+    accepted.on("readable", function onReadable() {
+      let chunk: Buffer | null;
+      while ((chunk = accepted.read()) !== null) {
+        const end = chunk.indexOf(0x16);
+        if (end === -1) {
+          seen += chunk.length;
+          continue;
+        }
+        seen += end;
+        accepted.off("readable", onReadable);
+        accepted.unshift(chunk.subarray(end));
+        sawPlaintext(seen);
+        wrapAndEcho(accepted, reject);
+        return;
+      }
+    });
+  });
+
+  const socket = net.connect(server.port, "127.0.0.1");
+  try {
+    socket.on("error", reject);
+    await Promise.race([once(socket, "connect"), failure]);
+    // 1 MiB chunks until one does not go out synchronously (bounded).
+    let chunks = 0;
+    let backpressure = false;
+    do {
+      backpressure = !socket.write(Buffer.alloc(CHUNK, 0x61));
+      chunks++;
+    } while (!backpressure && chunks < 256);
+    expect(backpressure).toBe(true);
+    const echoed = await Promise.race([pingOverTLS(socket, reject), failure]);
+    expect({ echoed, plaintext: await plaintextSeen }).toEqual({ echoed: "ping", plaintext: chunks * CHUNK });
+  } finally {
+    socket.destroy();
+  }
+});
+
+test.concurrent(
+  "new TLSSocket(accepted, { isServer: true }) behind a pending write keeps bytes that arrive meanwhile for the TLS layer",
+  async () => {
+    // The server wraps while PROCEED is still corked, in flowing mode with its
+    // command listener attached; the client then sends a TLS record and, once
+    // that write has completed, has the server uncork. So the record reaches
+    // the server while its reads are held: it must wait in the kernel for the
+    // TLS layer (which rejects it: it is garbage) rather than be emitted to the
+    // command listener or dropped.
+    const { promise: failure, reject } = Promise.withResolvers<never>();
+    const { promise: wrappedOnServer, resolve: wrapped } = Promise.withResolvers<() => void>();
+    const { promise: outcome, resolve } = Promise.withResolvers<{
+      tlsLayerSawIt: boolean;
+      emitted: number;
+      buffered: number;
+    }>();
+    using server = await listenTCP(accepted => {
+      accepted.on("error", reject);
+      accepted.on("data", function onCommand(command) {
+        if (command.toString("latin1") !== "STARTTLS") {
+          reject(new Error(`unexpected plaintext ${JSON.stringify(command.toString("latin1"))}`));
+          return;
+        }
+        accepted.off("data", onCommand);
+        accepted.cork();
+        accepted.write("PROCEED");
+        const secure = new tls.TLSSocket(accepted, { isServer: true, ...serverTLS });
+        const surfaced = watchSurfacing(accepted);
+        secure.on("error", () => resolve({ tlsLayerSawIt: true, ...surfaced() }));
+        wrapped(() => accepted.uncork());
+      });
+    });
+
+    const socket = net.connect(server.port, "127.0.0.1");
+    try {
+      socket.on("error", reject);
+      await Promise.race([once(socket, "connect"), failure]);
+      socket.write("STARTTLS");
+      const uncorkServer = await Promise.race([wrappedOnServer, failure]);
+      // A TLS-record-shaped blob no server accepts. Loopback: once the write
+      // has completed the bytes are in the server's receive queue.
+      await new Promise<void>(done =>
+        socket.write(Buffer.from([0x16, 0x03, 0x01, 0x00, 0x04, 0xde, 0xad, 0xbe, 0xef]), () => done()),
+      );
+      uncorkServer();
+      expect(await Promise.race([outcome, failure])).toEqual({ tlsLayerSawIt: true, emitted: 0, buffered: 0 });
+    } finally {
+      socket.destroy();
+    }
+  },
+);
+
+test.concurrent(
+  "new TLSSocket(accepted, { isServer: true }) hands over a ClientHello buffered in several chunks",
+  async () => {
+    // Protocol sniffing: peek at the first byte with read(1) and unshift it back,
+    // which leaves the ClientHello in the readable buffer as two chunks. Both
+    // belong to the TLS layer (node's initRead drains the whole buffer).
+    const { promise: failure, reject } = Promise.withResolvers<never>();
+    using server = await listenTCP(accepted => {
+      accepted.on("error", reject);
+      accepted.once("readable", () => {
+        const first = accepted.read(1);
+        accepted.unshift(first);
+        if (first[0] !== 0x16) {
+          reject(new Error(`not a TLS record: ${first[0]}`));
+          return;
+        }
+        wrapAndEcho(accepted, reject);
+      });
+    });
+
+    const socket = net.connect(server.port, "127.0.0.1");
+    try {
+      socket.on("error", reject);
+      await Promise.race([once(socket, "connect"), failure]);
+      expect(await Promise.race([pingOverTLS(socket, reject), failure])).toBe("ping");
+    } finally {
+      socket.destroy();
+    }
+  },
+);
+
+test.concurrent(
+  "destroying the TLS socket while the wrapped socket is still flushing closes both, TLS unsent",
+  async () => {
+    // While plaintext is still queued the handshake is held; a destroy() in that
+    // window must tear both sockets down (node destroys the wrapped socket with
+    // the TLS one) and must not put a ClientHello — or anything else of TLS —
+    // on the wire behind whatever plaintext made it out.
+    const { promise: failure, reject } = Promise.withResolvers<never>();
+    const { promise: peerSaw, resolve } = Promise.withResolvers<Buffer>();
+    using server = await listenTCP(accepted => {
+      accepted.on("error", () => {});
+      const chunks: Buffer[] = [];
+      accepted.on("data", chunk => chunks.push(chunk));
+      accepted.on("close", () => resolve(Buffer.concat(chunks)));
+    });
+    const socket = net.connect(server.port, "127.0.0.1");
+    socket.on("error", reject);
+    await Promise.race([once(socket, "connect"), failure]);
+    socket.cork();
+    socket.write("plaintext");
+    const tlsSocket = tls.connect({ socket, ...clientTLS });
+    tlsSocket.on("error", () => {});
+    tlsSocket.destroy();
+    socket.uncork();
+    await Promise.race([once(socket, "close"), failure]);
+    const seen = await Promise.race([peerSaw, failure]);
+    // Whatever arrived is a prefix of the plaintext (0x16 would start a record).
+    expect({ destroyed: socket.destroyed, onlyPlaintext: "plaintext".startsWith(seen.toString("latin1")) }).toEqual({
+      destroyed: true,
+      onlyPlaintext: true,
+    });
+  },
+);
+
+test.concurrent("tls.connect({ socket }) over a not-yet-connected net.Socket upgrades once it connects", async () => {
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  using server = await listenTCP(accepted => wrapAndEcho(accepted, reject));
+  const socket = new net.Socket();
+  try {
+    const tlsSocket = tls.connect({ socket, ...clientTLS });
+    tlsSocket.on("error", reject);
+    socket.on("error", reject);
+    socket.connect(server.port, "127.0.0.1");
+    await Promise.race([once(tlsSocket, "secureConnect"), failure]);
+    tlsSocket.write("hello");
+    const [reply] = await Promise.race([once(tlsSocket, "data"), failure]);
+    expect(reply.toString()).toBe("hello");
+  } finally {
+    socket.destroy();
+  }
+});
+
+test.concurrent("reconnecting a socket whose fd a TLS layer took over fails with EISCONN", async () => {
+  // The wrapped socket keeps its handle, but the fd is the TLS layer's now:
+  // connect() on it fails (EISCONN, what connect(2) says about that fd) rather
+  // than pulling the fd out from under the TLS layer.
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  using server = await listenTCP(accepted => wrapAndEcho(accepted, reject));
+  const socket = net.connect(server.port, "127.0.0.1");
+  try {
+    socket.on("error", () => {});
+    await Promise.race([once(socket, "connect"), failure]);
+    const tlsSocket = tls.connect({ socket, ...clientTLS });
+    tlsSocket.on("error", reject);
+    await Promise.race([once(tlsSocket, "secureConnect"), failure]);
+    // The wrapped socket's error takes the TLS socket down with it (node too).
+    tlsSocket.off("error", reject).on("error", () => {});
+    const [err] = await Promise.race([once(socket.connect(server.port, "127.0.0.1"), "error"), failure]);
+    expect((err as NodeJS.ErrnoException).code).toBe("EISCONN");
+  } finally {
+    socket.destroy();
+  }
+});
+
+test.concurrent("end() right after new TLSSocket(accepted, { isServer: true }) still reaches the peer", async () => {
+  // The server-side wrap adopts the fd a tick later; an end() before that must
+  // wait for it (handshake, close_notify, FIN) instead of finishing as if there
+  // were nothing to close.
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  using server = await listenTCP(accepted => {
+    accepted.on("error", reject);
+    const secure = new tls.TLSSocket(accepted, { isServer: true, ...serverTLS });
+    secure.on("error", reject);
+    secure.end();
+  });
+  const tlsSocket = tls.connect({ port: server.port, host: "127.0.0.1", ...clientTLS });
+  try {
+    tlsSocket.on("error", reject);
+    tlsSocket.resume();
+    await Promise.race([once(tlsSocket, "end"), failure]);
+    expect(tlsSocket.destroyed || tlsSocket.readableEnded).toBe(true);
+  } finally {
+    tlsSocket.destroy();
+  }
+});
+
+test.concurrent("end() right after tls.connect({ socket }) over a flushing socket still reaches the peer", async () => {
+  // The handshake is held while the wrapped socket flushes; end() must wait
+  // for it (handshake, close_notify, FIN) instead of cutting the plaintext or
+  // the handshake short.
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  const { promise: serverSawEnd, resolve } = Promise.withResolvers<string>();
+  using server = await listenTCP(accepted => {
+    accepted.on("error", reject);
+    accepted.once("data", plaintext => {
+      accepted.pause();
+      if (plaintext.length > 9) accepted.unshift(plaintext.subarray(9));
+      const secure = new tls.TLSSocket(accepted, { isServer: true, ...serverTLS });
+      secure.on("error", reject);
+      secure.resume();
+      secure.on("end", () => resolve(plaintext.toString("latin1", 0, 9)));
+    });
+  });
+  const socket = net.connect(server.port, "127.0.0.1");
+  try {
+    socket.on("error", reject);
+    await Promise.race([once(socket, "connect"), failure]);
+    socket.cork();
+    socket.write("plaintext");
+    const tlsSocket = tls.connect({ socket, ...clientTLS });
+    tlsSocket.on("error", reject);
+    tlsSocket.end();
+    socket.uncork();
+    expect(await Promise.race([serverSawEnd, failure])).toBe("plaintext");
+  } finally {
+    socket.destroy();
+  }
+});
+
+test.concurrent("a peer that closes while the handshake is held behind stuck plaintext is noticed", async () => {
+  // The peer never reads (so the client's plaintext never flushes and the
+  // handshake never starts) and then half-closes. The TLS socket must still
+  // hear about it — reads stay on during the hold, as under node's TLSWrap —
+  // instead of both sockets hanging forever.
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  const { promise: outcome, resolve } = Promise.withResolvers<string[]>();
+  using server = await listenTCP(accepted => {
+    accepted.on("error", () => {});
+    accepted.pause();
+    accepted.end();
+  });
+  const socket = net.connect(server.port, "127.0.0.1");
+  socket.on("error", () => {});
+  await Promise.race([once(socket, "connect"), failure]);
+  let backpressure = false;
+  for (let i = 0; i < 64 && !backpressure; i++) backpressure = !socket.write(Buffer.alloc(1024 * 1024, 0x61));
+  expect(backpressure).toBe(true);
+  const events: string[] = [];
+  const tlsSocket = tls.connect({ socket, ...clientTLS });
+  tlsSocket.on("error", err => events.push((err as NodeJS.ErrnoException).code ?? err.message));
+  tlsSocket.on("close", () => {
+    events.push("close");
+    resolve(events);
+  });
+  expect(await Promise.race([outcome, failure])).toEqual(["ECONNRESET", "close"]);
+});
+
+test.concurrent(
+  "a peer that sends garbage while the handshake is held behind stuck plaintext is rejected at once",
+  async () => {
+    // Only TLS *output* is held (node's has_active_write_issued_by_prev_listener_);
+    // input still reaches the TLS layer. So a peer that never drains our
+    // plaintext (the hold never ends) but sends something that is not TLS gets
+    // the same immediate protocol error as without a hold, instead of being
+    // buffered or ignored.
+    const { promise: failure, reject } = Promise.withResolvers<never>();
+    const { promise: outcome, resolve } = Promise.withResolvers<string>();
+    using server = await listenTCP(accepted => {
+      accepted.on("error", () => {});
+      accepted.pause();
+      accepted.write("HTTP/1.1 400 Bad Request\r\n\r\n");
+    });
+    const socket = net.connect(server.port, "127.0.0.1");
+    try {
+      socket.on("error", () => {});
+      await Promise.race([once(socket, "connect"), failure]);
+      socket.cork();
+      socket.write("STARTTLS"); // stays queued: the handshake output is held for good
+      const tlsSocket = tls.connect({ socket, ...clientTLS });
+      tlsSocket.on("error", err => resolve((err as NodeJS.ErrnoException).code ?? err.message));
+      tlsSocket.on("secureConnect", () => resolve("secureConnect"));
+      expect(await Promise.race([outcome, failure])).toMatch(/^ERR_SSL_|WRONG_VERSION_NUMBER/);
+    } finally {
+      socket.destroy();
+    }
+  },
+);
+
+test.concurrent("tls.connect over a generic Duplex with a write still pending is not held up", async () => {
+  // A plain Duplex transport orders our records behind its own pending writes
+  // by itself; nothing must wait for a release that never comes.
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  const server = tls.createServer(serverTLS, secure => {
+    secure.on("error", reject);
+    secure.on("data", d => secure.write(d));
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const raw = net.connect((server.address() as net.AddressInfo).port, "127.0.0.1");
+  try {
+    raw.on("error", reject);
+    await Promise.race([once(raw, "connect"), failure]);
+    const { Duplex } = require("node:stream");
+    const duplex = new Duplex({
+      read() {},
+      write(chunk, _enc, cb) {
+        raw.write(chunk, cb); // async completion: writableLength > 0 meanwhile
+      },
+      final(cb) {
+        raw.end(cb);
+      },
+    });
+    raw.on("data", chunk => duplex.push(chunk));
+    raw.on("end", () => duplex.push(null));
+    duplex.write(Buffer.alloc(0)); // a write in flight when the wrap happens
+    const echoed = await Promise.race([pingOverTLS(duplex as unknown as net.Socket, reject), failure]);
+    expect(echoed).toBe("ping");
+  } finally {
+    raw.destroy();
+    server.close();
+  }
+});
+
+test.concurrent("TLS over TLS: ending right after a large inner write still delivers all of it", async () => {
+  // The inner layer's ciphertext goes into the outer socket natively; an
+  // end() on the outer stream must queue its FIN behind what is still parked
+  // there rather than cut it off.
+  const TOTAL = 4 * 1024 * 1024;
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  const { promise: received, resolve } = Promise.withResolvers<number>();
+  const outerServer = tls.createServer(serverTLS, outer => {
+    outer.on("error", reject);
+    const inner = new tls.TLSSocket(outer, { isServer: true, ...serverTLS });
+    inner.on("error", reject);
+    let got = 0;
+    inner.on("data", chunk => (got += chunk.length));
+    inner.on("end", () => resolve(got));
+  });
+  outerServer.listen(0, "127.0.0.1");
+  await once(outerServer, "listening");
+  const outer = tls.connect({ port: (outerServer.address() as net.AddressInfo).port, host: "127.0.0.1", ...clientTLS });
+  try {
+    outer.on("error", reject);
+    await Promise.race([once(outer, "secureConnect"), failure]);
+    const inner = tls.connect({ socket: outer, ...clientTLS });
+    inner.on("error", reject);
+    await Promise.race([once(inner, "secureConnect"), failure]);
+    inner.end(Buffer.alloc(TOTAL, 0x61), () => outer.end());
+    expect(await Promise.race([received, failure])).toBe(TOTAL);
+  } finally {
+    outer.destroy();
+    outerServer.close();
+  }
+});
+
+test.concurrent("TLS over TLS behind a pending outer write: the inner ClientHello goes out after it", async () => {
+  // Stream-level engine with native output: the inner layer's records must
+  // queue behind plaintext the outer TLS socket still has in its Writable, as
+  // node's inner TLSWrap does over the outer one.
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  const outerServer = tls.createServer(serverTLS, outer => {
+    outer.on("error", reject);
+    outer.once("data", chunk => {
+      // STARTTLS first; the ClientHello may ride in the same chunk behind it.
+      if (chunk.toString("latin1", 0, 8) !== "STARTTLS") {
+        reject(new Error(`unexpected plaintext ${JSON.stringify(chunk.toString("latin1"))}`));
+        return;
+      }
+      outer.pause();
+      if (chunk.length > 8) outer.unshift(chunk.subarray(8));
+      wrapAndEcho(outer, reject);
+    });
+  });
+  outerServer.listen(0, "127.0.0.1");
+  await once(outerServer, "listening");
+  const outer = tls.connect({ port: (outerServer.address() as net.AddressInfo).port, host: "127.0.0.1", ...clientTLS });
+  try {
+    outer.on("error", reject);
+    await Promise.race([once(outer, "secureConnect"), failure]);
+    outer.cork();
+    outer.write("STARTTLS");
+    const echoed = pingOverTLS(outer as unknown as net.Socket, reject);
+    outer.uncork();
+    expect(await Promise.race([echoed, failure])).toBe("ping");
+  } finally {
+    outer.destroy();
+    outerServer.close();
+  }
+});
+
+test.concurrent(
+  "a socket sniffed with once('data') + unshift() still hands its ClientHello to a stream-level TLS layer",
+  async () => {
+    // The wrapped socket is left flowing with no 'data' listener and the
+    // ClientHello unshifted back into it; the hand-over must get those bytes
+    // before flow() throws them away. (TLS over TLS here, so the stream-level
+    // engine is used off Windows too.)
+    const { promise: failure, reject } = Promise.withResolvers<never>();
+    const outerServer = tls.createServer(serverTLS, outer => {
+      outer.on("error", reject);
+      outer.once("data", chunk => {
+        outer.unshift(chunk);
+        const inner = new tls.TLSSocket(outer, { isServer: true, ...serverTLS });
+        inner.on("error", reject);
+        inner.on("data", d => inner.write(d));
+      });
+    });
+    outerServer.listen(0, "127.0.0.1");
+    await once(outerServer, "listening");
+    const outer = tls.connect({
+      port: (outerServer.address() as net.AddressInfo).port,
+      host: "127.0.0.1",
+      ...clientTLS,
+    });
+    try {
+      outer.on("error", reject);
+      await Promise.race([once(outer, "secureConnect"), failure]);
+      expect(await Promise.race([pingOverTLS(outer, reject), failure])).toBe("ping");
+    } finally {
+      outer.destroy();
+      outerServer.close();
+    }
+  },
+);
+
+test.concurrent(
+  "server side: a peer that closes while the handshake is held closes the wrapped socket too",
+  async () => {
+    // The accepted socket still has plaintext queued the peer will never read;
+    // the peer half-closes. Both the TLS socket and the accepted socket must
+    // finish (node: EPIPE/ECONNRESET, then close on both), not leave the accepted
+    // socket with its queued writes forever.
+    const { promise: failure, reject } = Promise.withResolvers<never>();
+    const { promise: outcome, resolve } = Promise.withResolvers<{ secureClosed: boolean; acceptedClosed: boolean }>();
+    using server = await listenTCP(accepted => {
+      accepted.on("error", () => {});
+      let backpressure = false;
+      for (let i = 0; i < 64 && !backpressure; i++) backpressure = !accepted.write(Buffer.alloc(1024 * 1024, 0x62));
+      const secure = new tls.TLSSocket(accepted, { isServer: true, ...serverTLS });
+      secure.on("error", () => {});
+      let secureClosed = false;
+      secure.on("close", () => (secureClosed = true));
+      accepted.on("close", () => resolve({ secureClosed, acceptedClosed: true }));
+    });
+    const socket = net.connect(server.port, "127.0.0.1");
+    socket.on("error", () => {});
+    await Promise.race([once(socket, "connect"), failure]);
+    socket.pause();
+    socket.end();
+    expect(await Promise.race([outcome, failure])).toEqual({ secureClosed: true, acceptedClosed: true });
+    socket.destroy();
+  },
+);
+
+test.concurrent("unref() on the wrapped socket lets the process exit while the handshake is held", async () => {
+  // node: one uv handle under both sockets, so unref() on the wrapped socket
+  // counts even though the TLS layer is what reads now.
+  using server = await listenTCP(accepted => {
+    accepted.on("error", () => {});
+    accepted.pause();
+  });
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const net = require("net"), tls = require("tls");
+       const socket = net.connect(${server.port}, "127.0.0.1", () => {
+         socket.cork();
+         socket.write("STARTTLS");
+         tls.connect({ socket, rejectUnauthorized: false }).on("error", () => {});
+         socket.unref();
+       });`,
+    ],
+    env: bunEnv,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  expect(await proc.exited).toBe(0);
+});
+
+test.concurrent(
+  "the peer ending its side does not cut off what an fd-adopted TLS socket is still writing",
+  async () => {
+    // allowHalfOpen server reads one chunk and ends its side; the client is in
+    // the middle of an 8 MiB write. The TLS socket's readable side ending must
+    // not tear the connection down under the write (node delivers all of it).
+    const TOTAL = 8 * 1024 * 1024;
+    const { promise: failure, reject } = Promise.withResolvers<never>();
+    const { promise: received, resolve } = Promise.withResolvers<number>();
+    const server = tls.createServer({ ...serverTLS, allowHalfOpen: true }, secure => {
+      secure.on("error", reject);
+      let got = 0;
+      secure.on("data", chunk => {
+        if (got === 0) secure.end("bye");
+        got += chunk.length;
+      });
+      secure.on("end", () => resolve(got));
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const socket = net.connect((server.address() as net.AddressInfo).port, "127.0.0.1");
+    try {
+      socket.on("error", reject);
+      await Promise.race([once(socket, "connect"), failure]);
+      const tlsSocket = tls.connect({ socket, ...clientTLS, allowHalfOpen: true });
+      tlsSocket.on("error", reject);
+      tlsSocket.resume();
+      await Promise.race([once(tlsSocket, "secureConnect"), failure]);
+      const writeResult = new Promise<Error | null | undefined>(r => tlsSocket.write(Buffer.alloc(TOTAL, 0x61), r));
+      tlsSocket.end();
+      expect({
+        writeErr: await Promise.race([writeResult, failure]),
+        received: await Promise.race([received, failure]),
+      }).toEqual({ writeErr: null, received: TOTAL });
+    } finally {
+      socket.destroy();
+      server.close();
+    }
+  },
+);
+
+test.concurrent("TLS over TLS: the peer closing the outer connection closes both layers cleanly", async () => {
+  // The outer TLS socket's EOF reaches the inner engine natively, from inside
+  // the outer socket's own end dispatch; the inner layer tearing both down from
+  // there must not trip the outer dispatch up.
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  const outerServer = tls.createServer(serverTLS, outer => {
+    outer.on("error", () => {});
+    const inner = new tls.TLSSocket(outer, { isServer: true, ...serverTLS });
+    inner.on("error", () => {});
+    inner.once("data", () => outer.destroy());
+  });
+  outerServer.listen(0, "127.0.0.1");
+  await once(outerServer, "listening");
+  try {
+    const outer = tls.connect({
+      port: (outerServer.address() as net.AddressInfo).port,
+      host: "127.0.0.1",
+      ...clientTLS,
+    });
+    outer.on("error", () => {});
+    await Promise.race([once(outer, "secureConnect"), failure]);
+    const inner = tls.connect({ socket: outer, ...clientTLS });
+    inner.on("error", () => {});
+    await Promise.race([once(inner, "secureConnect"), failure]);
+    inner.write("ping");
+    await Promise.race([Promise.all([once(inner, "close"), once(outer, "close")]), failure]);
+    expect([inner.destroyed, outer.destroyed]).toEqual([true, true]);
+  } finally {
+    outerServer.close();
+  }
+});
+
+test.concurrent("TLS over TLS: reconnecting the outer socket while the inner layer is live fails with EISCONN", async () => {
+  // Same rule as for an fd-adopted socket: the outer socket is the inner
+  // layer's transport now, and connect() must not swap the connection out from
+  // under it (which would leave the inner socket with no close and its records
+  // going to an unrelated peer).
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  const outerServer = tls.createServer(serverTLS, outer => {
+    outer.on("error", () => {});
+    const inner = new tls.TLSSocket(outer, { isServer: true, ...serverTLS });
+    inner.on("error", () => {});
+    inner.on("data", chunk => inner.write(chunk));
+  });
+  outerServer.listen(0, "127.0.0.1");
+  await once(outerServer, "listening");
+  const port = (outerServer.address() as net.AddressInfo).port;
+  try {
+    const outer = tls.connect({ port, host: "127.0.0.1", ...clientTLS });
+    outer.on("error", () => {});
+    await Promise.race([once(outer, "secureConnect"), failure]);
+    const inner = tls.connect({ socket: outer, ...clientTLS });
+    inner.on("error", reject);
+    await Promise.race([once(inner, "secureConnect"), failure]);
+    inner.off("error", reject).on("error", () => {});
+    const [err] = await Promise.race([once(outer.connect(port, "127.0.0.1"), "error"), failure]);
+    expect((err as NodeJS.ErrnoException).code).toBe("EISCONN");
+    await Promise.race([once(inner, "close"), failure]);
+    expect(inner.destroyed).toBe(true);
+  } finally {
+    outerServer.close();
+  }
+});
+
+test.concurrent("ref() on the wrapped socket still holds the event loop after the upgrade", async () => {
+  // node: the wrapped socket and the TLS socket share one uv handle, so
+  // ref()/unref() on either counts. A client that parks its plain socket with
+  // unref() and refs it again once it has a request in flight must get the
+  // reply rather than exit.
+  using server = await listenTCP(accepted => {
+    const secure = new tls.TLSSocket(accepted, { isServer: true, ...serverTLS });
+    secure.on("error", () => {});
+    // The condition under test is that the child stays alive while *nothing*
+    // happens on its side, so the reply has to come after a stretch of idle
+    // loop; there is no event to key it on. A child that lost its ref exits
+    // within that window and prints nothing.
+    secure.on("data", () => setTimeout(() => secure.end("late reply"), 200));
+  });
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const net = require("net"), tls = require("tls");
+       const socket = net.connect(${server.port}, "127.0.0.1", () => {
+         socket.unref();
+         const keep = setTimeout(() => {}, 10_000);
+         const t = tls.connect({ socket, rejectUnauthorized: false }, () => {
+           socket.ref();
+           clearTimeout(keep);
+           t.write("ping");
+         });
+         t.on("data", d => console.log("reply: " + d));
+       });`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "reply: late reply", exitCode: 0 });
+});
+
+test.concurrent("upgrading a setEncoding() socket with buffered input reports ERR_STREAM_WRAP", async () => {
+  // What the socket already buffered has to be handed to the TLS layer, and on
+  // a setEncoding() socket that is a string: not bytes anymore. Node's
+  // JSStreamSocket code for this is ERR_STREAM_WRAP; it must reach the TLS
+  // socket's listeners rather than stall the handshake or throw out of band.
+  const { promise: outcome, resolve } = Promise.withResolvers<string>();
+  using server = await listenTCP(accepted => {
+    accepted.on("error", () => {});
+    accepted.write("greeting");
+  });
+
+  const socket = net.connect(server.port, "127.0.0.1");
+  try {
+    socket.on("error", () => {});
+    socket.setEncoding("utf8");
+    await once(socket, "readable");
+    expect(socket.readableLength).toBeGreaterThan(0);
+    socket.cork();
+    socket.write("STARTTLS");
+    const tlsSocket = tls.connect({ socket, ...clientTLS });
+    tlsSocket.on("error", err => resolve((err as NodeJS.ErrnoException)?.code ?? String(err)));
+    tlsSocket.on("secureConnect", () => resolve("secureConnect"));
+    socket.uncork();
+    expect(await outcome).toBe("ERR_STREAM_WRAP");
+  } finally {
+    socket.destroy();
+  }
+});
+
+test.concurrent("tls.connect({ socket }) takes over a client socket that uses the onread option", async () => {
+  // onread sockets deliver through their own handler table, straight into the
+  // user's callback, so that table has to stop delivering as well.
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  using server = await listenOptimisticSTARTTLS(reject);
+
+  let upgraded = false;
+  let deliveredAfterUpgrade = 0;
+  const socket = net.connect({
+    port: server.port,
+    host: "127.0.0.1",
+    onread: {
+      buffer: Buffer.alloc(64 * 1024),
+      callback(nread: number) {
+        if (upgraded) deliveredAfterUpgrade += nread;
+        return true;
+      },
+    },
+  });
+  try {
+    socket.on("error", reject);
+    await Promise.race([once(socket, "connect"), failure]);
+    const flushed = new Promise<void>(resolve => socket.write("STARTTLS", () => resolve()));
+    await Promise.race([flushed, failure]);
+    upgraded = true;
+    const echoed = await Promise.race([pingOverTLS(socket, reject), failure]);
+    expect({ echoed, deliveredAfterUpgrade }).toEqual({ echoed: "ping", deliveredAfterUpgrade: 0 });
+  } finally {
+    socket.destroy();
+  }
+});
+
+test.concurrent.each([
+  [
+    "fd adoption",
+    // PROCEED has been flushed when the wrap runs, so the fd is adopted. The
+    // handle is paused first so that a ClientHello racing in stays in the
+    // kernel until the wrap takes the fd over.
+    (accepted: net.Socket, wrap: () => void) => {
+      accepted.pause();
+      accepted.write("PROCEED", () => wrap());
+    },
+  ],
+  [
+    "fd adoption behind a pending write",
+    // PROCEED is still corked when the wrap runs: the handshake is held until
+    // it has been flushed.
+    (accepted: net.Socket, wrap: () => void) => {
+      accepted.cork();
+      accepted.write("PROCEED");
+      wrap();
+      accepted.uncork();
+    },
+  ],
+  [
+    "fd adoption behind a write issued right after the wrap",
+    // Nothing is pending when the wrap runs; the write queued right behind it
+    // is what the wrap's deferred step finds. Uncorked once that step has run.
+    (accepted: net.Socket, wrap: () => void) => {
+      wrap();
+      accepted.cork();
+      accepted.write("PROCEED");
+      setImmediate(() => accepted.uncork());
+    },
+  ],
+])("new TLSSocket(accepted, { isServer: true }) takes the accepted socket over: %s", async (_, proceedAndWrap) => {
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  const { promise: surfacing, resolve: wrapped } = Promise.withResolvers<ReturnType<typeof watchSurfacing>>();
+  using server = await listenTCP(accepted => {
+    accepted.on("error", reject);
+    accepted.once("data", command => {
+      if (command.toString("latin1") !== "STARTTLS") {
+        reject(new Error(`unexpected plaintext ${JSON.stringify(command.toString("latin1"))}`));
+        return;
+      }
+      proceedAndWrap(accepted, () => wrapAndEcho(accepted, reject));
+      wrapped(watchSurfacing(accepted));
+    });
+  });
+
+  const socket = net.connect(server.port, "127.0.0.1");
+  try {
+    socket.on("error", reject);
+    await Promise.race([once(socket, "connect"), failure]);
+    socket.write("STARTTLS");
+    const [proceed] = await Promise.race([once(socket, "data"), failure]);
+    expect(proceed.toString("latin1")).toBe("PROCEED");
+    const echoed = await Promise.race([pingOverTLS(socket, reject), failure]);
+    const surfaced = await surfacing;
+    expect({ echoed, ...surfaced() }).toEqual({ echoed: "ping", emitted: 0, buffered: 0 });
+  } finally {
+    socket.destroy();
+  }
+});
+
+test.concurrent(
+  "new TLSSocket(accepted, { isServer: true }) hands an already buffered ClientHello over once",
+  async () => {
+    // Paused-mode STARTTLS: the ClientHello that PROCEED triggers is sitting in
+    // the accepted socket's readable buffer when the wrap runs, so the wrap has
+    // to take it from there. Like node's initRead that hand-over read()s the
+    // buffer, so a `data` listener attached by then sees those bytes once — and
+    // nothing after them (pre-fix they were also pushed back into the buffer, and
+    // the rest of the session followed).
+    const { promise: failure, reject } = Promise.withResolvers<never>();
+    const { promise: serverSide, resolve } = Promise.withResolvers<{
+      handedOver: number;
+      emitted: number;
+      buffered: number;
+    }>();
+    using server = await listenTCP(accepted => {
+      accepted.on("error", reject);
+      accepted.once("data", command => {
+        if (command.toString("latin1") !== "STARTTLS") {
+          reject(new Error(`unexpected plaintext ${JSON.stringify(command.toString("latin1"))}`));
+          return;
+        }
+        accepted.pause();
+        accepted.write("PROCEED");
+        accepted.once("readable", () => {
+          const handedOver = accepted.readableLength;
+          const secure = new tls.TLSSocket(accepted, { isServer: true, ...serverTLS });
+          secure.on("error", reject);
+          const surfaced = watchSurfacing(accepted);
+          secure.once("data", () => resolve({ handedOver, ...surfaced() }));
+        });
+      });
+    });
+
+    const socket = net.connect(server.port, "127.0.0.1");
+    try {
+      socket.on("error", reject);
+      await Promise.race([once(socket, "connect"), failure]);
+      socket.write("STARTTLS");
+      const [proceed] = await Promise.race([once(socket, "data"), failure]);
+      expect(proceed.toString("latin1")).toBe("PROCEED");
+      const tlsSocket = tls.connect({ socket, ...clientTLS });
+      tlsSocket.on("error", reject);
+      tlsSocket.on("secureConnect", () => tlsSocket.write("ping"));
+      const result = await Promise.race([serverSide, failure]);
+      expect(result.handedOver).toBeGreaterThan(0);
+      expect(result).toEqual({ handedOver: result.handedOver, emitted: result.handedOver, buffered: 0 });
+    } finally {
+      socket.destroy();
+    }
+  },
+);
+
+test.concurrent(
+  "TLS over TLS takes the outer TLSSocket over on both ends, including bytes it had already buffered",
+  async () => {
+    // A TLSSocket used as the transport always goes through the stream-level
+    // engine. The server wraps in paused mode, so the inner ClientHello is
+    // already sitting in the outer socket's readable buffer when the wrap runs
+    // and has to be handed over from there. Like node's initRead, that hand-over
+    // read()s the buffer, which also emits those (and only those) bytes to a
+    // `data` listener that is already attached; everything received afterwards
+    // must stay with the inner TLS layer.
+    const { promise: failure, reject } = Promise.withResolvers<never>();
+    const { promise: serverSide, resolve: innerSecured } =
+      Promise.withResolvers<() => { handedOver: number; emitted: number; buffered: number }>();
+    const outerServer = tls.createServer(serverTLS, outer => {
+      outer.on("error", reject);
+      outer.once("data", command => {
+        if (command.toString("latin1") !== "STARTTLS") {
+          reject(new Error(`unexpected command ${JSON.stringify(command.toString("latin1"))}`));
+          return;
+        }
+        outer.pause();
+        outer.write("PROCEED");
+        outer.once("readable", () => {
+          const handedOver = outer.readableLength;
+          const inner = new tls.TLSSocket(outer, { isServer: true, ...serverTLS });
+          inner.on("error", reject);
+          inner.on("data", chunk => inner.write(chunk));
+          const surfaced = watchSurfacing(outer);
+          inner.on("secure", () => innerSecured(() => ({ handedOver, ...surfaced() })));
+        });
+      });
+    });
+    outerServer.listen(0, "127.0.0.1");
+    await once(outerServer, "listening");
+
+    const outer = tls.connect({
+      port: (outerServer.address() as net.AddressInfo).port,
+      host: "127.0.0.1",
+      ...clientTLS,
+    });
+    try {
+      outer.on("error", reject);
+      await Promise.race([once(outer, "secureConnect"), failure]);
+      outer.write("STARTTLS");
+      const [proceed] = await Promise.race([once(outer, "data"), failure]);
+      expect(proceed.toString("latin1")).toBe("PROCEED");
+      const clientSurfaced = watchSurfacing(outer);
+      const echoed = await Promise.race([pingOverTLS(outer, reject), failure]);
+      // Sampled once the echo is back, i.e. after the server side has finished
+      // dispatching everything the client sent.
+      const server = (await Promise.race([serverSide, failure]))();
+      expect(server.handedOver).toBeGreaterThan(0);
+      expect({ echoed, client: clientSurfaced(), server }).toEqual({
+        echoed: "ping",
+        client: { emitted: 0, buffered: 0 },
+        server: { handedOver: server.handedOver, emitted: server.handedOver, buffered: 0 },
+      });
+    } finally {
+      outer.destroy();
+      outerServer.close();
+    }
+  },
+);
+
+test.concurrent(
+  "tls.connect({ socket }) does not retain the TLS traffic in the original socket's readable buffer",
+  async () => {
+    // Nothing listens on the wrapped socket and it is not flowing (postgres.js
+    // drops its plaintext listeners before upgrading): pre-fix every byte the
+    // connection received was also pushed into that buffer and kept there for
+    // the life of the connection.
+    const TOTAL = 512 * 1024;
+    const chunk = Buffer.alloc(64 * 1024, 0x61);
+    const { promise: failure, reject } = Promise.withResolvers<never>();
+    const server = tls.createServer(serverTLS, secure => {
+      secure.on("error", reject);
+      for (let sent = 0; sent < TOTAL; sent += chunk.length) secure.write(chunk);
+      secure.end();
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const socket = net.connect((server.address() as net.AddressInfo).port, "127.0.0.1");
+    try {
+      socket.on("error", reject);
+      const tlsSocket = tls.connect({ socket, ...clientTLS });
+      tlsSocket.on("error", reject);
+      let received = 0;
+      tlsSocket.on("data", data => (received += data.length));
+      await Promise.race([once(tlsSocket, "end"), failure]);
+      expect({ received, buffered: socket.readableLength }).toEqual({ received: TOTAL, buffered: 0 });
+    } finally {
+      socket.destroy();
+      server.close();
+    }
+  },
+);
+
+test.concurrent("a socket whose TLS session is over can reconnect as a plain socket", async () => {
+  // The second connection must see exactly its own data: nothing retained from
+  // the TLS session that used the socket before, and nothing still diverted to
+  // that TLS layer.
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  const secureServer = tls.createServer(serverTLS, secure => {
+    secure.on("error", () => {});
+    secure.end();
+  });
+  secureServer.listen(0, "127.0.0.1");
+  await once(secureServer, "listening");
+  using plainServer = await listenTCP(accepted => {
+    accepted.on("error", reject);
+    accepted.on("data", data => accepted.end(data));
+  });
+
+  const socket = net.connect((secureServer.address() as net.AddressInfo).port, "127.0.0.1");
+  try {
+    socket.on("error", reject);
+    tls.connect({ socket, ...clientTLS }).on("error", reject);
+    // The peer ending the TLS session tears the wrapped socket down with it.
+    await Promise.race([once(socket, "close"), failure]);
+
+    socket.connect(plainServer.port, "127.0.0.1");
+    await Promise.race([once(socket, "connect"), failure]);
+    let received = "";
+    socket.on("data", data => (received += data));
+    socket.write("plain again");
+    await Promise.race([once(socket, "end"), failure]);
+    expect(received).toBe("plain again");
+  } finally {
+    socket.destroy();
+    secureServer.close();
+  }
+});
+
+test.concurrent("TLS traffic keeps the wrapped socket's idle timeout alive, as in node", async () => {
+  // Node links the TLSSocket to the net.Socket it wraps (`_parent`) and
+  // refreshes both idle timers on activity; the wrapped socket itself no
+  // longer sees any bytes, so without that link it times out mid-session no
+  // matter how busy the TLS layer is.
+  const IDLE = 1000;
+  const { promise: failure, reject } = Promise.withResolvers<never>();
+  using server = await listenTCP(accepted => wrapAndEcho(accepted, reject));
+  const socket = net.connect(server.port, "127.0.0.1");
+  try {
+    socket.on("error", reject);
+    await Promise.race([once(socket, "connect"), failure]);
+    const tlsSocket = tls.connect({ socket, ...clientTLS });
+    tlsSocket.on("error", reject);
+    expect(tlsSocket._parent).toBe(socket);
+    await Promise.race([once(tlsSocket, "secureConnect"), failure]);
+    let parentTimedOut = false;
+    socket.setTimeout(IDLE, () => (parentTimedOut = true));
+    // Back-to-back ping/echo round trips (each far shorter than IDLE) until
+    // well past IDLE since the timer was armed.
+    const started = Date.now();
+    tlsSocket.write("ping");
+    await Promise.race([
+      new Promise<void>(resolve => {
+        tlsSocket.on("data", () => {
+          if (Date.now() - started > IDLE * 2.5) resolve();
+          else tlsSocket.write("ping");
+        });
+      }),
+      failure,
+    ]);
+    expect(parentTimedOut).toBe(false);
+  } finally {
+    socket.setTimeout(0);
+    socket.destroy();
+  }
 });

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -862,6 +862,34 @@ test.concurrent("ref() on the wrapped socket still holds the event loop after th
   expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "reply: late reply", exitCode: 0 });
 });
 
+test.concurrent("unref() on the wrapped socket releases the event loop after the upgrade", async () => {
+  // The other direction of the test above: once the TLS layer is up, unref()
+  // on the wrapped socket alone must let the process exit (node: one handle).
+  using server = await listenTCP(accepted => {
+    const secure = new tls.TLSSocket(accepted, { isServer: true, ...serverTLS });
+    secure.on("error", () => {});
+  });
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const net = require("net"), tls = require("tls");
+       const socket = net.connect(${server.port}, "127.0.0.1", () => {
+         const t = tls.connect({ socket, rejectUnauthorized: false }, () => {
+           t.on("data", () => {});
+           console.log("secured");
+           socket.unref();
+         });
+       });`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "secured", exitCode: 0 });
+});
+
 test.concurrent("upgrading a setEncoding() socket with buffered input reports ERR_STREAM_WRAP", async () => {
   // What the socket already buffered has to be handed to the TLS layer, and on
   // a setEncoding() socket that is a string: not bytes anymore. Node's


### PR DESCRIPTION
Fixes #32239. Fixes #32242. Fixes #40646. Consolidates #32241, #32243 and #32372 (@Sids15, credited as co-author).

### Problem

After `tls.connect({ socket })` or `new tls.TLSSocket(socket, { isServer: true })` puts a TLS layer on a `net.Socket`, that socket kept receiving the connection's ciphertext as `data`: a STARTTLS handler still attached re-enters and upgrades again (`Invalid socket`, #32239); with no listener (postgres.js) the ciphertext piles up in the socket's readable buffer for the life of the connection (4 GB retained on a 4 GB transfer, #32241).

### What Node does

`new TLSSocket(sock)` keeps the original `net.Socket` alive (`tlsSocket._parent` / `_parentWrap`) *with its own handle*, for close/destroy/address/ref — but `TLSWrap` does `stream->PushStreamListener(this)`, so every read on that handle goes to the TLS layer and the parent never sees another byte. Output is held while the parent still has writes queued (`wrapHasActiveWriteFromPrevOwner`). Anything that is not a handle-backed `net.Socket` is wrapped in a `JSStreamSocket` fed from `data` events; `initRead` drains whatever the parent had already buffered into the engine.

### Fix

The upgrade is now modelled the same way, and almost entirely natively:

- **The wrapped socket keeps its own handle.** `upgradeTLS` no longer creates a second `TLSSocket` "raw twin" and swaps it in as `connection._handle`: the original `TCPSocket` follows the fd into the adopted `us_socket_t` (`BYPASS_TLS`: writes skip SSL; close/writable are chained to it from the TLS half). For the public `Bun.Socket.upgradeTLS()`, `raw === socket` now (same handlers, same `data`), and upgrading a raw half again returns `undefined`. node:net's `kAdoptedTLSRaw`/`kCloseRawConnection` bookkeeping is gone; a `fdIsTLS` getter tells `_destroy`/`connect()` the fd belongs to a TLS layer.
- **No ciphertext into the parent.** The node:net entry point (`jsNodeNetUpgradeTLS`) doesn't enable the `ssl_raw_tap`, so nothing of the TLS stream is dispatched to JS. Whatever the parent had already buffered (every chunk) is handed over as `initialData`; strings (after `setEncoding`) fail with `ERR_STREAM_WRAP` like Node's JSStreamSocket.
- **Pending plaintext writes: TLS output held natively** (`us_socket_hold_tls_output` / `us_socket_release_tls_output`, node's `has_active_write_issued_by_prev_listener_`): the fd is adopted immediately; whatever SSL emits (the handshake flight) is kept in a per-SSL buffer instead of written, while input is processed as usual (so garbage or a FIN during the hold is an ordinary mid-handshake failure). node:net queues an empty write behind the plaintext and calls `startTLSHandshake()` from its callback; release writes the buffer out ahead of anything newer. Plaintext still queued natively drains through the raw half first (the TLS half chains `writable` to it). A close while held reports `ECONNRESET` like any close before the handshake finished and puts no TLS bytes on the wire. The stream-level engine gets the same hold (`held_output`) when its handle-backed transport still has JS writes queued, writes its ciphertext into that transport natively (`write_from_engine`), and a `shutdown()` with engine output still parked waits for it.
- **A still-connecting `net.Socket` is upgraded on `'connect'`** (TCP, named pipe, or an outer TLS socket alike), as Node's `TLSSocket._start` waits for `'connect'` before `_handle.start()`; there is no fd to adopt and no transport to write a ClientHello into before that.
- **Stream-level engine transports fed natively.** `upgradeDuplexToTLS` over a handle-backed `net.Socket` (named pipes, TLS over TLS, `Http2SecureServer#emit('connection')`) takes `transport: connection._handle`; `NativeCallbacks::TlsTransport` routes that socket's data/end/close into the engine (never through JS or the parent's listeners), and the engine's pause/resume reach the transport (backpressure for these paths, previously a TODO). A plain `Duplex` keeps the `data`-event wiring, as Node's JSStreamSocket does. `kTLSUpgradeSink` and the per-chunk sink checks in the four data handlers are gone; `internal/net/streamTLS.ts` is the one helper for net.ts and `_http2_upgrade.ts`.
- **Lifecycle parity**: `TLSSocket._parent` is set (idle timeouts on the parent are refreshed by TLS activity; `ref()`/`unref()` on either socket count); the TLS socket is destroyed when the wrapped stream closes/errors and the wrapped stream is destroyed with the TLS socket (`_wrapHandle`/`doClose`); `_final` waits for a handle that is still on its way; `connect()` on a socket whose fd a TLS layer owns fails with `EISCONN` instead of pulling the fd out from under it; the HTTP/2 raw-socket upgrade destroys the raw socket with the session and pauses the native handle for backpressure.
- `upgrade_tls_impl`: `initialData` is fed before the tap is enabled, so the public `upgradeTLS({ initialData })` no longer shows `raw` those bytes a second time.

### Verification

`test/js/node/tls/node-tls-upgrade.test.ts` (34 cases: STARTTLS repro, client fd adoption immediate / behind a corked write / behind real backpressure, `onread`, server adoption immediate / behind a pending write / write issued after the wrap, bytes arriving while writes are pending, ClientHello buffered in one and in several chunks, `setEncoding` → `ERR_STREAM_WRAP`, TLS over TLS incl. peer close of the outer layer, no-listener retention, reconnect after TLS / `EISCONN` while wrapped, parent idle timeout, `ref()`/`unref()` through the parent, destroy / `end()` / peer FIN / peer flood while the handshake is held (client and server side), half-open write not cut off), `test/js/bun/net/socket.test.ts` (`raw === socket`, double upgrade, close-handler cross-calls), `socket-retention.test.ts` (raw halves collectable), `node-http2-upgrade.test.mts`, `cluster.test.ts`, `node-tls-namedpipes.test.ts` (Windows). `test/js/node/{tls,net,http2}`, `test/js/bun/net` and all vendored `test-tls-*`/`test-https-*`/`test-net-*`/`test-http2-*` node tests pass as on main (plus `test-tls-connect-allow-half-open-option.js`, newly vendored). Scripts driving client/server STARTTLS, TLS-over-TLS, pending-write, destroy-while-flushing, multi-chunk ClientHello, parent-dies-before-adoption and reconnect print the same results under this build and Node 26. TLS bulk-write throughput (1 KiB / 16 KiB writes, release build) is unchanged within noise.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/tls/node-tls-namedpipes.test.ts, test/js/node/cluster.test.ts, test/js/bun/net/socket.test.ts, test/js/bun/net/socket-retention.test.ts

<!-- robobun:evidence:end -->