### PR TITLE
Bun.write: borrow TypedArray sources instead of snapshotting on the JS thread

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4993,6 +4993,54 @@ pub(crate) fn write_file_with_source_destination(
 // writeFileInternal / writeFile (Bun.write)
 // ──────────────────────────────────────────────────────────────────────────
 
+/// Creates a `Bytes`-backed `Blob` that borrows `data`'s ArrayBuffer in place
+/// instead of copying it, so large `Bun.write(path, typedArray)` payloads
+/// don't stall the JS thread snapshotting into a memfd or Vec. The buffer is
+/// pinned (JS cannot detach it) and GC-protected; both are released by the
+/// store's allocator `free`, which MUST therefore run on the JS thread. The
+/// only caller is `write_file_internal` for regular-file destinations, where
+/// the sole surviving store ref is dropped in `WriteFile::then` /
+/// `WriteFileWindows::run_from_js_thread`.
+///
+/// Returns `None` when `data` is not buffer-backed, is empty, or is resizable
+/// (a concurrent shrink would invalidate the borrowed slice).
+fn borrow_array_buffer_for_write(global_this: &JSGlobalObject, data: JSValue) -> Option<Blob> {
+    let buffer = data.as_pinned_arraybuffer(global_this)?;
+    if buffer.byte_len == 0 || buffer.resizable {
+        data.unpin_array_buffer();
+        return None;
+    }
+    data.protect();
+
+    fn free(ptr: *mut c_void, _buf: &mut [u8], _a: bun_alloc::Alignment, _ra: usize) {
+        let value = JSValue::from_encoded(ptr as usize);
+        value.unpin_array_buffer();
+        value.unprotect();
+    }
+    static VTABLE: bun_alloc::AllocatorVTable = bun_alloc::AllocatorVTable::free_only(free);
+
+    // SAFETY: `buffer.ptr[..byte_len]` is the pinned+protected ArrayBuffer's
+    // storage, kept valid until `free` releases both.
+    let bytes = unsafe {
+        store::Bytes::from_raw_parts(
+            buffer.ptr,
+            buffer.byte_len as SizeType,
+            buffer.byte_len as SizeType,
+            bun_alloc::StdAllocator {
+                ptr: data.0 as *mut c_void,
+                vtable: &VTABLE,
+            },
+        )
+    };
+    let store = StoreRef::from(Store::new(Store {
+        data: store::Data::Bytes(bytes),
+        mime_type: bun_http_types::MimeType::NONE,
+        ref_count: bun_ptr::ThreadSafeRefCount::init(),
+        is_all_ascii: None,
+    }));
+    Some(Blob::init_with_store(store, global_this))
+}
+
 /// ## Errors
 /// - If `path_or_blob` is a detached blob
 /// ## Panics
@@ -5282,6 +5330,18 @@ pub(crate) fn write_file_internal(
         // Check for Archive - allows Bun.write() and S3 writes to accept Archive instances
         if let Some(archive) = data.as_class_ref::<Archive>() {
             break 'brk Blob::init_with_store(archive.store_ref().clone(), global_this);
+        }
+
+        // For ArrayBuffer/TypedArray sources going to a regular file, borrow
+        // the bytes in place so the pool-thread write reads them directly
+        // (matching `fs.promises.writeFile`), instead of `Blob::get`
+        // snapshotting the whole payload into a memfd/Vec on this thread.
+        // S3 destinations keep the copying path because the store may outlive
+        // the JS-thread drop there.
+        if !destination_blob.is_s3() {
+            if let Some(blob) = borrow_array_buffer_for_write(global_this, data) {
+                break 'brk blob;
+            }
         }
 
         break 'brk Blob::get::<false, false>(global_this, data)?;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4993,17 +4993,11 @@ pub(crate) fn write_file_with_source_destination(
 // writeFileInternal / writeFile (Bun.write)
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Creates a `Bytes`-backed `Blob` that borrows `data`'s ArrayBuffer in place
-/// instead of copying it, so large `Bun.write(path, typedArray)` payloads
-/// don't stall the JS thread snapshotting into a memfd or Vec. The buffer is
-/// pinned (JS cannot detach it) and GC-protected; both are released by the
-/// store's allocator `free`, which MUST therefore run on the JS thread. The
-/// only caller is `write_file_internal` for regular-file destinations, where
-/// the sole surviving store ref is dropped in `WriteFile::then` /
-/// `WriteFileWindows::run_from_js_thread`.
-///
-/// Returns `None` when `data` is not buffer-backed, is empty, or is resizable
-/// (a concurrent shrink would invalidate the borrowed slice).
+/// A `Bytes` store that borrows `data`'s pinned+protected ArrayBuffer in place.
+/// The store's allocator `free` releases the pin+protect, so the last
+/// `StoreRef` drop MUST be on the JS thread (`WriteFile::then` /
+/// `WriteFileWindows::run_from_js_thread` are). `None` for non-buffer, empty,
+/// or resizable input.
 fn borrow_array_buffer_for_write(global_this: &JSGlobalObject, data: JSValue) -> Option<Blob> {
     let buffer = data.as_pinned_arraybuffer(global_this)?;
     if buffer.byte_len == 0 || buffer.resizable {
@@ -5332,12 +5326,8 @@ pub(crate) fn write_file_internal(
             break 'brk Blob::init_with_store(archive.store_ref().clone(), global_this);
         }
 
-        // For ArrayBuffer/TypedArray sources going to a regular file, borrow
-        // the bytes in place so the pool-thread write reads them directly
-        // (matching `fs.promises.writeFile`), instead of `Blob::get`
-        // snapshotting the whole payload into a memfd/Vec on this thread.
-        // S3 destinations keep the copying path because the store may outlive
-        // the JS-thread drop there.
+        // Borrow buffer sources instead of `Blob::get`'s O(n) JS-thread copy.
+        // S3 excluded: its store may outlive the JS-thread drop the borrow needs.
         if !destination_blob.is_s3() {
             if let Some(blob) = borrow_array_buffer_for_write(global_this, data) {
                 break 'brk blob;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4993,11 +4993,6 @@ pub(crate) fn write_file_with_source_destination(
 // writeFileInternal / writeFile (Bun.write)
 // ──────────────────────────────────────────────────────────────────────────
 
-/// A `Bytes` store that borrows `data`'s pinned+protected ArrayBuffer in place.
-/// The store's allocator `free` releases the pin+protect, so the last
-/// `StoreRef` drop MUST be on the JS thread (`WriteFile::then` /
-/// `WriteFileWindows::run_from_js_thread` are). `None` for non-buffer, empty,
-/// or resizable input.
 fn borrow_array_buffer_for_write(global_this: &JSGlobalObject, data: JSValue) -> Option<Blob> {
     let buffer = data.as_pinned_arraybuffer(global_this)?;
     if buffer.byte_len == 0 || buffer.resizable {
@@ -5014,7 +5009,9 @@ fn borrow_array_buffer_for_write(global_this: &JSGlobalObject, data: JSValue) ->
     static VTABLE: bun_alloc::AllocatorVTable = bun_alloc::AllocatorVTable::free_only(free);
 
     // SAFETY: `buffer.ptr[..byte_len]` is the pinned+protected ArrayBuffer's
-    // storage, kept valid until `free` releases both.
+    // storage, kept valid until `free` above releases both. `free` runs
+    // unprotect/unpin, so the last `StoreRef` drop MUST be on the JS thread;
+    // `WriteFile::then` / `WriteFileWindows::run_from_js_thread` are.
     let bytes = unsafe {
         store::Bytes::from_raw_parts(
             buffer.ptr,
@@ -5326,7 +5323,6 @@ pub(crate) fn write_file_internal(
             break 'brk Blob::init_with_store(archive.store_ref().clone(), global_this);
         }
 
-        // Borrow buffer sources instead of `Blob::get`'s O(n) JS-thread copy.
         // S3 excluded: its store may outlive the JS-thread drop the borrow needs.
         if !destination_blob.is_s3() {
             if let Some(blob) = borrow_array_buffer_for_write(global_this, data) {

--- a/test/js/bun/io/bun-write-typed-array-nonblocking.test.ts
+++ b/test/js/bun/io/bun-write-typed-array-nonblocking.test.ts
@@ -61,13 +61,19 @@ test("Bun.write(path, typedArray) writes the correct bytes for borrowed ArrayBuf
       ["DataView", new DataView(buf.buffer, buf.byteOffset, buf.byteLength)],
       ["offset view", new Uint8Array(buf.buffer, buf.byteOffset + 1024, 512 * 1024)],
     ];
+    const writers = {
+      "Bun.write": (p, i) => Bun.write(p, i),
+      "BunFile.write": (p, i) => Bun.file(p).write(i),
+    };
     const results = {};
-    for (const [name, input] of cases) {
-      const wrote = await Bun.write(out, input);
-      const expectedBytes =
-        input instanceof ArrayBuffer ? new Uint8Array(input) : new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
-      const got = fs.readFileSync(out);
-      results[name] = { wrote, len: got.length, ok: Buffer.compare(got, expectedBytes) === 0 };
+    for (const [how, write] of Object.entries(writers)) {
+      for (const [name, input] of cases) {
+        const wrote = await write(out, input);
+        const expectedBytes =
+          input instanceof ArrayBuffer ? new Uint8Array(input) : new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+        const got = fs.readFileSync(out);
+        results[how + " " + name] = { wrote, len: got.length, ok: Buffer.compare(got, expectedBytes) === 0 };
+      }
     }
     console.log(JSON.stringify(results));
   `;
@@ -79,12 +85,14 @@ test("Bun.write(path, typedArray) writes the correct bytes for borrowed ArrayBuf
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual({
-    "Uint8Array": { wrote: 1 << 20, len: 1 << 20, ok: true },
-    "ArrayBuffer": { wrote: 1 << 20, len: 1 << 20, ok: true },
-    "DataView": { wrote: 1 << 20, len: 1 << 20, ok: true },
-    "offset view": { wrote: 512 * 1024, len: 512 * 1024, ok: true },
-  });
+  const expected: Record<string, unknown> = {};
+  for (const how of ["Bun.write", "BunFile.write"]) {
+    expected[`${how} Uint8Array`] = { wrote: 1 << 20, len: 1 << 20, ok: true };
+    expected[`${how} ArrayBuffer`] = { wrote: 1 << 20, len: 1 << 20, ok: true };
+    expected[`${how} DataView`] = { wrote: 1 << 20, len: 1 << 20, ok: true };
+    expected[`${how} offset view`] = { wrote: 512 * 1024, len: 512 * 1024, ok: true };
+  }
+  expect(JSON.parse(stdout)).toEqual(expected);
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/io/bun-write-typed-array-nonblocking.test.ts
+++ b/test/js/bun/io/bun-write-typed-array-nonblocking.test.ts
@@ -59,7 +59,7 @@ test("Bun.write(path, typedArray) writes the correct bytes for borrowed ArrayBuf
       ["Uint8Array", buf],
       ["ArrayBuffer", buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)],
       ["DataView", new DataView(buf.buffer, buf.byteOffset, buf.byteLength)],
-      ["offset view", new Uint8Array(buf.buffer, buf.byteOffset + 1024, 4096)],
+      ["offset view", new Uint8Array(buf.buffer, buf.byteOffset + 1024, 512 * 1024)],
     ];
     const results = {};
     for (const [name, input] of cases) {
@@ -83,7 +83,7 @@ test("Bun.write(path, typedArray) writes the correct bytes for borrowed ArrayBuf
     "Uint8Array": { wrote: 1 << 20, len: 1 << 20, ok: true },
     "ArrayBuffer": { wrote: 1 << 20, len: 1 << 20, ok: true },
     "DataView": { wrote: 1 << 20, len: 1 << 20, ok: true },
-    "offset view": { wrote: 4096, len: 4096, ok: true },
+    "offset view": { wrote: 512 * 1024, len: 512 * 1024, ok: true },
   });
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/io/bun-write-typed-array-nonblocking.test.ts
+++ b/test/js/bun/io/bun-write-typed-array-nonblocking.test.ts
@@ -26,8 +26,8 @@ test("Bun.write(path, largeTypedArray) does not block the JS thread copying the 
     // best of a few runs to filter out scheduler noise.
     function bestOf(arr) { return Math.min(...arr); }
     const small = [], large = [];
-    for (let i = 0; i < 2; i++) small.push(await sample(1 << 20));
-    for (let i = 0; i < 2; i++) large.push(await sample(64 << 20));
+    for (let i = 0; i < 3; i++) small.push(await sample(1 << 20));
+    for (let i = 0; i < 3; i++) large.push(await sample(128 << 20));
     console.log(JSON.stringify({ small_ms: bestOf(small), large_ms: bestOf(large) }));
   `;
   await using proc = Bun.spawn({
@@ -39,10 +39,11 @@ test("Bun.write(path, largeTypedArray) does not block the JS thread copying the 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   const { small_ms, large_ms } = JSON.parse(stdout);
-  // With the O(n) snapshot, 64MB took roughly 64x the 1MB sample. With the
+  // With the O(n) snapshot, 128MB took roughly 128x the 1MB sample. With the
   // buffer borrowed in place, the synchronous portion is constant regardless
-  // of size.
-  expect(large_ms).toBeLessThan(Math.max(small_ms, 1) * 8);
+  // of size. The 0.05ms floor keeps the threshold meaningful on fast release
+  // builds where the 1MB sample completes in a few microseconds.
+  expect(large_ms).toBeLessThan(Math.max(small_ms, 0.05) * 16);
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/io/bun-write-typed-array-nonblocking.test.ts
+++ b/test/js/bun/io/bun-write-typed-array-nonblocking.test.ts
@@ -47,7 +47,7 @@ test("Bun.write(path, largeTypedArray) does not block the JS thread copying the 
   expect(exitCode).toBe(0);
 });
 
-test("Bun.write(path, typedArray) writes the correct bytes for borrowed ArrayBuffer sources", async () => {
+test.concurrent("Bun.write(path, typedArray) writes the correct bytes for borrowed ArrayBuffer sources", async () => {
   using dir = tempDir("bun-write-large-buffer-content", {});
   const script = `
     const crypto = require("crypto");
@@ -56,11 +56,16 @@ test("Bun.write(path, typedArray) writes the correct bytes for borrowed ArrayBuf
     const out = path.join(process.cwd(), "out.bin");
     // large enough to have skipped the synchronous <256KB fast path.
     const buf = crypto.randomBytes(1 << 20);
+    const resizable = new ArrayBuffer(512 * 1024, { maxByteLength: 1 << 20 });
+    new Uint8Array(resizable).set(new Uint8Array(buf.buffer, buf.byteOffset, 512 * 1024));
     const cases = [
       ["Uint8Array", buf],
       ["ArrayBuffer", buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)],
       ["DataView", new DataView(buf.buffer, buf.byteOffset, buf.byteLength)],
       ["offset view", new Uint8Array(buf.buffer, buf.byteOffset + 1024, 512 * 1024)],
+      // resizable and empty inputs exercise the borrow -> None fallback.
+      ["resizable", new Uint8Array(resizable)],
+      ["empty", new Uint8Array(0)],
     ];
     const writers = {
       "Bun.write": (p, i) => Bun.write(p, i),
@@ -92,12 +97,14 @@ test("Bun.write(path, typedArray) writes the correct bytes for borrowed ArrayBuf
     expected[`${how} ArrayBuffer`] = { wrote: 1 << 20, len: 1 << 20, ok: true };
     expected[`${how} DataView`] = { wrote: 1 << 20, len: 1 << 20, ok: true };
     expected[`${how} offset view`] = { wrote: 512 * 1024, len: 512 * 1024, ok: true };
+    expected[`${how} resizable`] = { wrote: 512 * 1024, len: 512 * 1024, ok: true };
+    expected[`${how} empty`] = { wrote: 0, len: 0, ok: true };
   }
   expect(JSON.parse(stdout)).toEqual(expected);
   expect(exitCode).toBe(0);
 });
 
-test("Bun.write(path, typedArray) releases its pin+protect on the source ArrayBuffer", async () => {
+test.concurrent("Bun.write(path, typedArray) releases its pin+protect on the source ArrayBuffer", async () => {
   using dir = tempDir("bun-write-large-buffer-gcstress", {});
   const script = `
     const { heapStats } = require("bun:jsc");

--- a/test/js/bun/io/bun-write-typed-array-nonblocking.test.ts
+++ b/test/js/bun/io/bun-write-typed-array-nonblocking.test.ts
@@ -87,3 +87,54 @@ test("Bun.write(path, typedArray) writes the correct bytes for borrowed ArrayBuf
   });
   expect(exitCode).toBe(0);
 });
+
+test("Bun.write(path, typedArray) releases its pin+protect on the source ArrayBuffer", async () => {
+  using dir = tempDir("bun-write-large-buffer-gcstress", {});
+  const script = `
+    const { heapStats } = require("bun:jsc");
+    const path = require("path");
+    const out = path.join(process.cwd(), "out.bin");
+    function protectedBufferCount() {
+      const c = heapStats().protectedObjectTypeCounts;
+      return (c.Uint8Array ?? 0) + (c.Buffer ?? 0) + (c.ArrayBuffer ?? 0) + (c.JSArrayBuffer ?? 0);
+    }
+    await Bun.write(out, new Uint8Array(1));
+    Bun.gc(true);
+    const base = protectedBufferCount();
+
+    for (let i = 0; i < 64; i++) {
+      await Bun.write(out, new Uint8Array(300 * 1024).fill(i & 0xff));
+      Bun.gc(true);
+    }
+    const afterSuccess = protectedBufferCount();
+
+    let rejected = 0;
+    for (let i = 0; i < 16; i++) {
+      try {
+        await Bun.write(process.cwd(), new Uint8Array(300 * 1024));
+      } catch {
+        rejected++;
+      }
+      Bun.gc(true);
+    }
+    const afterError = protectedBufferCount();
+
+    console.log(JSON.stringify({ base, afterSuccess, afterError, rejected }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { base, afterSuccess, afterError, rejected } = JSON.parse(stdout);
+  // every Bun.write call protects the source while the pool-thread write runs
+  // and releases it on completion; a missed release would leave these counts
+  // climbing by one per iteration.
+  expect(afterSuccess).toBeLessThanOrEqual(base + 2);
+  expect(afterError).toBeLessThanOrEqual(base + 2);
+  expect(rejected).toBe(16);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/io/bun-write-typed-array-nonblocking.test.ts
+++ b/test/js/bun/io/bun-write-typed-array-nonblocking.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Bun.write(path, typedArray) used to snapshot the entire payload on the JS
+// thread before scheduling the write: on Linux that was memfd_create +
+// ftruncate + pwrite64(len), elsewhere a full memcpy, so the synchronous
+// portion of the call scaled O(n) with the buffer size (roughly 0.75ms/MB
+// on the memfd path). The pool-thread write now reads the pinned ArrayBuffer
+// directly, matching fs.promises.writeFile.
+test("Bun.write(path, largeTypedArray) does not block the JS thread copying the payload", async () => {
+  using dir = tempDir("bun-write-large-buffer-nonblock", {});
+  const script = `
+    const path = require("path");
+    const out = path.join(process.cwd(), "out.bin");
+    async function sample(bytes) {
+      const buf = Buffer.alloc(bytes, 0x5a);
+      // warm up: open/creat/truncate the destination once so both samples pay the same fs cost.
+      await Bun.write(out, new Uint8Array(1));
+      const t0 = performance.now();
+      const promise = Bun.write(out, buf);
+      const sync = performance.now() - t0;
+      const wrote = await promise;
+      if (wrote !== bytes) throw new Error("wrote " + wrote + " expected " + bytes);
+      return sync;
+    }
+    // best of a few runs to filter out scheduler noise.
+    function bestOf(arr) { return Math.min(...arr); }
+    const small = [], large = [];
+    for (let i = 0; i < 2; i++) small.push(await sample(1 << 20));
+    for (let i = 0; i < 2; i++) large.push(await sample(64 << 20));
+    console.log(JSON.stringify({ small_ms: bestOf(small), large_ms: bestOf(large) }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { small_ms, large_ms } = JSON.parse(stdout);
+  // With the O(n) snapshot, 64MB took roughly 64x the 1MB sample. With the
+  // buffer borrowed in place, the synchronous portion is constant regardless
+  // of size.
+  expect(large_ms).toBeLessThan(Math.max(small_ms, 1) * 8);
+  expect(exitCode).toBe(0);
+});
+
+test("Bun.write(path, typedArray) writes the correct bytes for borrowed ArrayBuffer sources", async () => {
+  using dir = tempDir("bun-write-large-buffer-content", {});
+  const script = `
+    const crypto = require("crypto");
+    const fs = require("fs");
+    const path = require("path");
+    const out = path.join(process.cwd(), "out.bin");
+    // large enough to have skipped the synchronous <256KB fast path.
+    const buf = crypto.randomBytes(1 << 20);
+    const cases = [
+      ["Uint8Array", buf],
+      ["ArrayBuffer", buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)],
+      ["DataView", new DataView(buf.buffer, buf.byteOffset, buf.byteLength)],
+      ["offset view", new Uint8Array(buf.buffer, buf.byteOffset + 1024, 4096)],
+    ];
+    const results = {};
+    for (const [name, input] of cases) {
+      const wrote = await Bun.write(out, input);
+      const expectedBytes =
+        input instanceof ArrayBuffer ? new Uint8Array(input) : new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+      const got = fs.readFileSync(out);
+      results[name] = { wrote, len: got.length, ok: Buffer.compare(got, expectedBytes) === 0 };
+    }
+    console.log(JSON.stringify(results));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    "Uint8Array": { wrote: 1 << 20, len: 1 << 20, ok: true },
+    "ArrayBuffer": { wrote: 1 << 20, len: 1 << 20, ok: true },
+    "DataView": { wrote: 1 << 20, len: 1 << 20, ok: true },
+    "offset view": { wrote: 4096, len: 4096, ok: true },
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`Bun.write(path, typedArray)` (and `Bun.file(path).write(typedArray)`) no longer copy the entire payload on the JS thread before scheduling the pool-thread write.

## Why

`write_file_internal` converted a TypedArray/ArrayBuffer source to a Blob via `Blob::get` -> `try_create`, which on Linux (>= 8 MB) did `memfd_create` + `ftruncate` + `pwrite64(len)` and otherwise a full `.to_vec()` memcpy, all on the calling thread. That made the synchronous portion of an "async" API O(n) in the payload:

```
strace -f -e trace=memfd_create,ftruncate,pwrite64,write bun repro.mjs
[main tid] memfd_create("memfd-num-0")
[main tid] ftruncate(fd, 536870912)
[main tid] pwrite64(memfd, 536870912) <0.377 s>   <-- JS thread frozen here
[pool tid] write(file, ...)
```

A 500 MB write stalled a 1 ms heartbeat for ~378 ms; `fs.promises.writeFile` on the same buffer stalled it ~20 ms.

## How

For regular-file destinations, pin the ArrayBuffer (so JS cannot detach it) and GC-protect the value, then build the `Bytes` store as a borrowed view whose allocator `free` releases the pin+protect. `WriteFile::then` / `WriteFileWindows::run_from_js_thread` drop that store on the JS thread, so the release is safe. The pool thread's `do_write_loop` reads the user's buffer directly, the same pattern `fs.promises.writeFile` already uses via `StringOrBuffer::Buffer`.

S3 destinations keep the copying path (the store may outlive the JS-thread drop there), and resizable ArrayBuffers fall back to the copy path so a concurrent shrink can't invalidate the borrowed slice.

## Measurements

Synchronous portion of `Bun.write(path, buf)` (time between the call and the returned Promise), 256 MB buffer, this container:

| | before | after |
| :-- | --: | --: |
| Linux release | ~110 ms | ~2 ms |
| Linux debug+ASAN | ~110 ms | ~2 ms |
| memfd disabled (.to_vec fallback) | ~160 ms | ~2 ms |

1 ms `setInterval` max gap during `await Bun.write(out, 256 MB)`:

| | before | after | `fs.promises.writeFile` |
| :-- | --: | --: | --: |
| max loop gap | 99-118 ms | 21 ms | 4-6 ms |

## Verification

`test/js/bun/io/bun-write-typed-array-nonblocking.test.ts` asserts the 64 MB synchronous portion is within 8x of the 1 MB sample (before: ~25x, after: ~1x) and round-trips Uint8Array / ArrayBuffer / DataView / offset-view content at 1 MB through the borrowed path.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/io/bun-write-typed-array-nonblocking.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/171] gen ErrorCode+*.h
[2/171] gen JSEvent.lut.h
Generating /workspace/bun/build/debug/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindings/webcore/JSEvent.cpp
[3/171] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[4/171] gen JSBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[5/171] gen cpp.rs (cppbind)
[6/171] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 6 sinks, 72 exported symbols
Generating /workspace/bun/build/debug/codegen/JSSink.lut.h from /workspace/bun/build/debug/codegen/JSSink.lut.txt
[7/171] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[8/171] gen JS modules (bundle-modules)
Preprocess modules (11467ms)
Bundle modules (58ms)
Postprocesss modules (162ms)
Bundle Functions (787ms)
Generate Code (17ms)

[1
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (fed3e454b)

test/js/bun/io/bun-write-typed-array-nonblocking.test.ts:
(pass) Bun.write(path, largeTypedArray) does not block the JS thread copying the payload [517.01ms]
(pass) Bun.write(path, typedArray) writes the correct bytes for borrowed ArrayBuffer sources [39.30ms]
(pass) Bun.write(path, typedArray) releases its pin+protect on the source ArrayBuffer [64.24ms]

 3 pass
 0 fail
 11 expect() calls
Ran 3 tests across 1 file. [834.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/io/bun-write-typed-array-nonblocking.test.ts
bun test v1.4.0 (6163626b1)

test/js/bun/io/bun-write-typed-array-nonblocking.test.ts:
(pass) Bun.write(path, largeTypedArray) does not block the JS thread copying the payload [1339.77ms]
(pass) Bun.write(path, typedArray) writes the correct bytes for borrowed ArrayBuffer sources [1236.55ms]
(pass) Bun.write(path, typedArray) releases its pin+protect on the source ArrayBuffer [2928.79ms]

 3 pass
 0 fail
 11 expect() calls
Ran 3 tests across 1 file. [6.49s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 851ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/128] gen ErrorCode+*.h
[2/128] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[3/128] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[4/128] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindings/webcore/JSEvent.cpp
[5/128] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 6 sinks, 72 exported symbols
Generating /workspace/bun/build/release/codegen/JSSink.lut.h from /workspace/bun/build/release/codegen/JSSink.lut.txt
[6/128] gen cpp.rs (cppbind)
[7/128] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[8/128] gen JS modules (bundle-modules)
Preprocess modules (9935ms)
Bundle modules (83ms)
Postprocesss modules (184ms)
Bundle Functions (728ms)
Generate Code (39ms)

[10.99s] Bundled "src/js" for production
  2569 kb
  193 internal modules
  1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Blob.rs                        |  46 ++++++
 .../io/bun-write-typed-array-nonblocking.test.ts   | 156 +++++++++++++++++++++
 2 files changed, 202 insertions(+)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/webcore/Blob.rs                                   8     11      0
test/js/bun/io/bun-write-typed-array-nonblocking.test.ts      5      9      0
```

</details>

<!-- robobun:evidence:end -->