### PR TITLE
fetch: only reject WHATWG redirect statuses under redirect: 'error'

### DIFF
--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -578,8 +578,7 @@ pub unsafe extern "C" fn Bun__X509__checkHost(
 /// Certificate name bytes (IA5 / Latin-1) for error messages.
 struct NameBytes<'a>(&'a [u8]);
 
-/// Returns `true` iff `name` contains no characters that would require
-/// escaping in a subjectAltName entry (Node's `IsSafeAltName`, non-UTF-8 path).
+/// Node's `IsSafeAltName` (see `src/jsc/bindings/ncrypto.cpp`).
 #[inline]
 fn is_safe_alt_name(name: &[u8]) -> bool {
     name.iter()

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -578,10 +578,18 @@ pub unsafe extern "C" fn Bun__X509__checkHost(
 /// Certificate name bytes (IA5 / Latin-1) for error messages.
 struct NameBytes<'a>(&'a [u8]);
 
+/// Returns `true` iff `name` contains no characters that would require
+/// escaping in a subjectAltName entry (Node's `IsSafeAltName`, non-UTF-8 path).
+#[inline]
+fn is_safe_alt_name(name: &[u8]) -> bool {
+    name.iter()
+        .all(|&c| (b' '..=b'~').contains(&c) && !matches!(c, b'"' | b'\\' | b',' | b'\''))
+}
+
 impl core::fmt::Display for NameBytes<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use core::fmt::Write;
-        if X509::is_safe_alt_name(self.0, false) {
+        if is_safe_alt_name(self.0) {
             for &byte in self.0 {
                 f.write_char(char::from(byte))?;
             }

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -587,13 +587,6 @@ fn is_safe_alt_name(name: &[u8]) -> bool {
 /// Certificate name bytes (IA5 / Latin-1) for error messages.
 struct NameBytes<'a>(&'a [u8]);
 
-/// Node's `IsSafeAltName` (see `src/jsc/bindings/ncrypto.cpp`).
-#[inline]
-fn is_safe_alt_name(name: &[u8]) -> bool {
-    name.iter()
-        .all(|&c| (b' '..=b'~').contains(&c) && !matches!(c, b'"' | b'\\' | b',' | b'\''))
-}
-
 impl core::fmt::Display for NameBytes<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use core::fmt::Write;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -5046,260 +5046,234 @@ impl<'a> HTTPClient<'a> {
                 && !location.is_empty()
                 && self.remaining_redirect_count > 0
             {
-                match status_code {
-                    302 | 301 | 307 | 308 | 303 => {
-                        // https://fetch.spec.whatwg.org/#http-redirect-fetch step 11:
-                        // "If internalResponse's status is not 303, request's body
-                        // is non-null, and request's body's source is null, then
-                        // return a network error." A ReadableStream body has no
-                        // source to replay from, so only 303 (which drops the body
-                        // and switches to GET) may be followed.
-                        if status_code != 303
-                            && matches!(
-                                self.state.original_request_body,
-                                HTTPRequestBody::Stream(_)
-                            )
+                // https://fetch.spec.whatwg.org/#http-redirect-fetch step 11:
+                // "If internalResponse's status is not 303, request's body
+                // is non-null, and request's body's source is null, then
+                // return a network error." A ReadableStream body has no
+                // source to replay from, so only 303 (which drops the body
+                // and switches to GET) may be followed.
+                if status_code != 303
+                    && matches!(self.state.original_request_body, HTTPRequestBody::Stream(_))
+                {
+                    return Err(crate::Error::RequestBodyNotReusable);
+                }
+                let is_same_origin;
+
+                {
+                    if let Some(i) = strings::index_of(location, b"://") {
+                        let mut string_builder = StringBuilder::default();
+
+                        let is_protocol_relative = i == 0;
+                        let protocol_name: &[u8] = if is_protocol_relative {
+                            self.url.display_protocol()
+                        } else {
+                            &location[0..i]
+                        };
+                        let is_http =
+                            strings::eql_case_insensitive_ascii(protocol_name, b"http", true);
+                        if is_http
+                            || strings::eql_case_insensitive_ascii(protocol_name, b"https", true)
                         {
-                            return Err(crate::Error::RequestBodyNotReusable);
+                        } else {
+                            return Err(crate::Error::UnsupportedRedirectProtocol);
                         }
-                        let is_same_origin;
 
+                        if (protocol_name.len() * usize::from(is_protocol_relative))
+                            + location.len()
+                            > MAX_REDIRECT_URL_LENGTH
                         {
-                            if let Some(i) = strings::index_of(location, b"://") {
-                                let mut string_builder = StringBuilder::default();
+                            return Err(crate::Error::RedirectURLTooLong);
+                        }
 
-                                let is_protocol_relative = i == 0;
-                                let protocol_name: &[u8] = if is_protocol_relative {
-                                    self.url.display_protocol()
-                                } else {
-                                    &location[0..i]
-                                };
-                                let is_http = strings::eql_case_insensitive_ascii(
-                                    protocol_name,
-                                    b"http",
-                                    true,
-                                );
-                                if is_http
-                                    || strings::eql_case_insensitive_ascii(
-                                        protocol_name,
-                                        b"https",
-                                        true,
-                                    )
-                                {
-                                } else {
-                                    return Err(crate::Error::UnsupportedRedirectProtocol);
-                                }
+                        string_builder.count(location);
 
-                                if (protocol_name.len() * usize::from(is_protocol_relative))
-                                    + location.len()
-                                    > MAX_REDIRECT_URL_LENGTH
-                                {
-                                    return Err(crate::Error::RedirectURLTooLong);
-                                }
-
-                                string_builder.count(location);
-
-                                if is_protocol_relative {
-                                    if is_http {
-                                        string_builder.count(b"http");
-                                    } else {
-                                        string_builder.count(b"https");
-                                    }
-                                }
-
-                                string_builder.allocate()?;
-
-                                if is_protocol_relative {
-                                    if is_http {
-                                        let _ = string_builder.append(b"http");
-                                    } else {
-                                        let _ = string_builder.append(b"https");
-                                    }
-                                }
-
-                                let _ = string_builder.append(location);
-
-                                debug_assert!(string_builder.cap == string_builder.len);
-
-                                let input =
-                                    BunString::borrow_utf8(string_builder.allocated_slice());
-                                let normalized_url =
-                                    OwnedString::new(bun_url::href_from_string(&input));
-                                if normalized_url.tag() == BunStringTag::Dead {
-                                    // URL__getHref failed, dont pass dead tagged string to toOwnedSlice.
-                                    return Err(crate::Error::RedirectURLInvalid);
-                                }
-                                let normalized_url_str = normalized_url.to_owned_slice();
-
-                                // SAFETY: self-borrow — `normalized_url_str` is moved into
-                                // `self.redirect` below, which lives as long as `self` (≥ `'a`).
-                                let new_url: URL<'a> =
-                                    unsafe { URL::parse(&normalized_url_str).erase_lifetime() };
-                                is_same_origin = strings::eql_case_insensitive_ascii(
-                                    strings::without_trailing_slash(new_url.origin),
-                                    strings::without_trailing_slash(self.url.origin),
-                                    true,
-                                );
-                                self.url = new_url;
-                                // connected_url still borrows from the previous hop's buffer
-                                // until doRedirect releases the socket, so park it in
-                                // prev_redirect for doRedirect to free instead of leaking it.
-                                debug_assert!(self.prev_redirect.is_empty());
-                                self.prev_redirect =
-                                    core::mem::replace(&mut self.redirect, normalized_url_str);
-                            } else if location.starts_with(b"//") {
-                                let mut string_builder = StringBuilder::default();
-
-                                let protocol_name = self.url.display_protocol();
-
-                                if protocol_name.len() + 1 + location.len()
-                                    > MAX_REDIRECT_URL_LENGTH
-                                {
-                                    return Err(crate::Error::RedirectURLTooLong);
-                                }
-
-                                let is_http = strings::eql_case_insensitive_ascii(
-                                    protocol_name,
-                                    b"http",
-                                    true,
-                                );
-
-                                if is_http {
-                                    string_builder.count(b"http:");
-                                } else {
-                                    string_builder.count(b"https:");
-                                }
-
-                                string_builder.count(location);
-
-                                string_builder.allocate()?;
-
-                                if is_http {
-                                    let _ = string_builder.append(b"http:");
-                                } else {
-                                    let _ = string_builder.append(b"https:");
-                                }
-
-                                let _ = string_builder.append(location);
-
-                                debug_assert!(string_builder.cap == string_builder.len);
-
-                                let input =
-                                    BunString::borrow_utf8(string_builder.allocated_slice());
-                                let normalized_url =
-                                    OwnedString::new(bun_url::href_from_string(&input));
-                                if normalized_url.tag() == BunStringTag::Dead {
-                                    return Err(crate::Error::RedirectURLInvalid);
-                                }
-                                let normalized_url_str = normalized_url.to_owned_slice();
-
-                                // SAFETY: self-borrow — `normalized_url_str` is moved into
-                                // `self.redirect` below, which lives as long as `self` (≥ `'a`).
-                                let new_url: URL<'a> =
-                                    unsafe { URL::parse(&normalized_url_str).erase_lifetime() };
-                                is_same_origin = strings::eql_case_insensitive_ascii(
-                                    strings::without_trailing_slash(new_url.origin),
-                                    strings::without_trailing_slash(self.url.origin),
-                                    true,
-                                );
-                                self.url = new_url;
-                                debug_assert!(self.prev_redirect.is_empty());
-                                self.prev_redirect =
-                                    core::mem::replace(&mut self.redirect, normalized_url_str);
+                        if is_protocol_relative {
+                            if is_http {
+                                string_builder.count(b"http");
                             } else {
-                                let original_url = self.url.clone();
-
-                                let base = BunString::borrow_utf8(original_url.href);
-                                let rel = BunString::borrow_utf8(location);
-                                let new_url_ = OwnedString::new(bun_url::join(&base, &rel));
-
-                                if new_url_.is_empty() {
-                                    return Err(crate::Error::InvalidRedirectURL);
-                                }
-
-                                let new_url = new_url_.to_owned_slice();
-                                let parsed_url = URL::parse(&new_url);
-                                if !parsed_url.has_http_like_protocol() {
-                                    return Err(crate::Error::UnsupportedRedirectProtocol);
-                                }
-                                // SAFETY: self-borrow — `new_url` is moved into `self.redirect`
-                                // below, which lives as long as `self` (≥ `'a`).
-                                self.url = unsafe { parsed_url.erase_lifetime() };
-                                is_same_origin = strings::eql_case_insensitive_ascii(
-                                    strings::without_trailing_slash(self.url.origin),
-                                    strings::without_trailing_slash(original_url.origin),
-                                    true,
-                                );
-                                debug_assert!(self.prev_redirect.is_empty());
-                                self.prev_redirect =
-                                    core::mem::replace(&mut self.redirect, new_url);
+                                string_builder.count(b"https");
                             }
                         }
 
-                        // If one of the following is true
-                        // - internalResponse's status is 301 or 302 and request's method is `POST`
-                        // - internalResponse's status is 303 and request's method is not `GET` or `HEAD`
-                        // then:
-                        if ((status_code == 301 || status_code == 302)
-                            && self.method == Method::POST)
-                            || (status_code == 303
-                                && self.method != Method::GET
-                                && self.method != Method::HEAD)
-                        {
-                            // - Set request's method to `GET` and request's body to null.
-                            self.method = Method::GET;
+                        string_builder.allocate()?;
 
-                            // https://github.com/oven-sh/bun/issues/6053
-                            if self.header_entries.len() > 0 {
-                                // - For each headerName of request-body-header name, delete headerName from request's header list.
-                                let mut i: usize = 0;
-                                while i < self.header_entries.len() {
-                                    let names = self.header_entries.items_name();
-                                    let name = self.header_str(names[i]);
-                                    if REQUEST_BODY_HEADERS
-                                        .get_ascii_case_insensitive(name)
-                                        .is_some()
-                                    {
-                                        let _ = self.header_entries.ordered_remove(i);
-                                    } else {
-                                        i += 1;
-                                    }
-                                }
+                        if is_protocol_relative {
+                            if is_http {
+                                let _ = string_builder.append(b"http");
+                            } else {
+                                let _ = string_builder.append(b"https");
                             }
                         }
 
-                        // Cross-origin redirect: re-derive SNI / cert
-                        // verification / Host from the redirect target. See
-                        // `InternalStateFlags::clear_hostname_on_redirect`.
-                        if !is_same_origin {
-                            self.state.flags.clear_hostname_on_redirect = true;
+                        let _ = string_builder.append(location);
+
+                        debug_assert!(string_builder.cap == string_builder.len);
+
+                        let input = BunString::borrow_utf8(string_builder.allocated_slice());
+                        let normalized_url = OwnedString::new(bun_url::href_from_string(&input));
+                        if normalized_url.tag() == BunStringTag::Dead {
+                            // URL__getHref failed, dont pass dead tagged string to toOwnedSlice.
+                            return Err(crate::Error::RedirectURLInvalid);
+                        }
+                        let normalized_url_str = normalized_url.to_owned_slice();
+
+                        // SAFETY: self-borrow — `normalized_url_str` is moved into
+                        // `self.redirect` below, which lives as long as `self` (≥ `'a`).
+                        let new_url: URL<'a> =
+                            unsafe { URL::parse(&normalized_url_str).erase_lifetime() };
+                        is_same_origin = strings::eql_case_insensitive_ascii(
+                            strings::without_trailing_slash(new_url.origin),
+                            strings::without_trailing_slash(self.url.origin),
+                            true,
+                        );
+                        self.url = new_url;
+                        // connected_url still borrows from the previous hop's buffer
+                        // until doRedirect releases the socket, so park it in
+                        // prev_redirect for doRedirect to free instead of leaking it.
+                        debug_assert!(self.prev_redirect.is_empty());
+                        self.prev_redirect =
+                            core::mem::replace(&mut self.redirect, normalized_url_str);
+                    } else if location.starts_with(b"//") {
+                        let mut string_builder = StringBuilder::default();
+
+                        let protocol_name = self.url.display_protocol();
+
+                        if protocol_name.len() + 1 + location.len() > MAX_REDIRECT_URL_LENGTH {
+                            return Err(crate::Error::RedirectURLTooLong);
                         }
 
-                        // https://fetch.spec.whatwg.org/#concept-http-redirect-fetch
-                        // If request's current URL's origin is not same origin with
-                        // locationURL's origin, then for each headerName of CORS
-                        // non-wildcard request-header name, delete headerName from
-                        // request's header list.
-                        if !is_same_origin && self.header_entries.len() > 0 {
-                            let mut i = 0;
-                            while i < self.header_entries.len() {
-                                let name = self.header_str(self.header_entries.items_name()[i]);
-                                if CROSS_ORIGIN_STRIPPED_REQUEST_HEADERS
-                                    .get_ascii_case_insensitive(name)
-                                    .is_some()
-                                {
-                                    let _ = self.header_entries.ordered_remove(i);
-                                } else {
-                                    i += 1;
-                                }
-                            }
+                        let is_http =
+                            strings::eql_case_insensitive_ascii(protocol_name, b"http", true);
+
+                        if is_http {
+                            string_builder.count(b"http:");
+                        } else {
+                            string_builder.count(b"https:");
                         }
-                        self.state.flags.is_redirect_pending = true;
-                        if self.method.has_request_body() {
-                            self.state.flags.resend_request_body_on_redirect = true;
+
+                        string_builder.count(location);
+
+                        string_builder.allocate()?;
+
+                        if is_http {
+                            let _ = string_builder.append(b"http:");
+                        } else {
+                            let _ = string_builder.append(b"https:");
+                        }
+
+                        let _ = string_builder.append(location);
+
+                        debug_assert!(string_builder.cap == string_builder.len);
+
+                        let input = BunString::borrow_utf8(string_builder.allocated_slice());
+                        let normalized_url = OwnedString::new(bun_url::href_from_string(&input));
+                        if normalized_url.tag() == BunStringTag::Dead {
+                            return Err(crate::Error::RedirectURLInvalid);
+                        }
+                        let normalized_url_str = normalized_url.to_owned_slice();
+
+                        // SAFETY: self-borrow — `normalized_url_str` is moved into
+                        // `self.redirect` below, which lives as long as `self` (≥ `'a`).
+                        let new_url: URL<'a> =
+                            unsafe { URL::parse(&normalized_url_str).erase_lifetime() };
+                        is_same_origin = strings::eql_case_insensitive_ascii(
+                            strings::without_trailing_slash(new_url.origin),
+                            strings::without_trailing_slash(self.url.origin),
+                            true,
+                        );
+                        self.url = new_url;
+                        debug_assert!(self.prev_redirect.is_empty());
+                        self.prev_redirect =
+                            core::mem::replace(&mut self.redirect, normalized_url_str);
+                    } else {
+                        let original_url = self.url.clone();
+
+                        let base = BunString::borrow_utf8(original_url.href);
+                        let rel = BunString::borrow_utf8(location);
+                        let new_url_ = OwnedString::new(bun_url::join(&base, &rel));
+
+                        if new_url_.is_empty() {
+                            return Err(crate::Error::InvalidRedirectURL);
+                        }
+
+                        let new_url = new_url_.to_owned_slice();
+                        let parsed_url = URL::parse(&new_url);
+                        if !parsed_url.has_http_like_protocol() {
+                            return Err(crate::Error::UnsupportedRedirectProtocol);
+                        }
+                        // SAFETY: self-borrow — `new_url` is moved into `self.redirect`
+                        // below, which lives as long as `self` (≥ `'a`).
+                        self.url = unsafe { parsed_url.erase_lifetime() };
+                        is_same_origin = strings::eql_case_insensitive_ascii(
+                            strings::without_trailing_slash(self.url.origin),
+                            strings::without_trailing_slash(original_url.origin),
+                            true,
+                        );
+                        debug_assert!(self.prev_redirect.is_empty());
+                        self.prev_redirect = core::mem::replace(&mut self.redirect, new_url);
+                    }
+                }
+
+                // If one of the following is true
+                // - internalResponse's status is 301 or 302 and request's method is `POST`
+                // - internalResponse's status is 303 and request's method is not `GET` or `HEAD`
+                // then:
+                if ((status_code == 301 || status_code == 302) && self.method == Method::POST)
+                    || (status_code == 303
+                        && self.method != Method::GET
+                        && self.method != Method::HEAD)
+                {
+                    // - Set request's method to `GET` and request's body to null.
+                    self.method = Method::GET;
+
+                    // https://github.com/oven-sh/bun/issues/6053
+                    if self.header_entries.len() > 0 {
+                        // - For each headerName of request-body-header name, delete headerName from request's header list.
+                        let mut i: usize = 0;
+                        while i < self.header_entries.len() {
+                            let names = self.header_entries.items_name();
+                            let name = self.header_str(names[i]);
+                            if REQUEST_BODY_HEADERS
+                                .get_ascii_case_insensitive(name)
+                                .is_some()
+                            {
+                                let _ = self.header_entries.ordered_remove(i);
+                            } else {
+                                i += 1;
+                            }
                         }
                     }
-                    _ => {}
+                }
+
+                // Cross-origin redirect: re-derive SNI / cert
+                // verification / Host from the redirect target. See
+                // `InternalStateFlags::clear_hostname_on_redirect`.
+                if !is_same_origin {
+                    self.state.flags.clear_hostname_on_redirect = true;
+                }
+
+                // https://fetch.spec.whatwg.org/#concept-http-redirect-fetch
+                // If request's current URL's origin is not same origin with
+                // locationURL's origin, then for each headerName of CORS
+                // non-wildcard request-header name, delete headerName from
+                // request's header list.
+                if !is_same_origin && self.header_entries.len() > 0 {
+                    let mut i = 0;
+                    while i < self.header_entries.len() {
+                        let name = self.header_str(self.header_entries.items_name()[i]);
+                        if CROSS_ORIGIN_STRIPPED_REQUEST_HEADERS
+                            .get_ascii_case_insensitive(name)
+                            .is_some()
+                        {
+                            let _ = self.header_entries.ordered_remove(i);
+                        } else {
+                            i += 1;
+                        }
+                    }
+                }
+                self.state.flags.is_redirect_pending = true;
+                if self.method.has_request_body() {
+                    self.state.flags.resend_request_body_on_redirect = true;
                 }
             } else if !is_proxy_connect_failure && self.redirect_type == FetchRedirect::Error {
                 // error out if redirect is not allowed

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -5038,7 +5038,8 @@ impl<'a> HTTPClient<'a> {
         }
 
         // if is no redirect or if is redirect == "manual" just proceed
-        let is_redirect = status_code >= 300 && status_code <= 399;
+        // https://fetch.spec.whatwg.org/#redirect-status
+        let is_redirect = matches!(status_code, 301 | 302 | 303 | 307 | 308);
         if is_redirect {
             if !is_proxy_connect_failure
                 && self.redirect_type == FetchRedirect::Follow

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -64,6 +64,63 @@ describe("fetch() follows a redirect on headers without waiting for the 3xx body
   });
 });
 
+// https://fetch.spec.whatwg.org/#redirect-status
+// A redirect status is 301, 302, 303, 307, or 308. Other 3xx statuses
+// (300, 304, 305, 306) are not redirects and must be returned as-is even
+// under redirect: "error".
+describe("fetch() with redirect: 'error' only rejects WHATWG redirect statuses", () => {
+  async function serve(status: number, reason: string, extra = "") {
+    const server = net.createServer(socket => {
+      socket.on("error", () => {});
+      socket.once("data", () => {
+        socket.end(`HTTP/1.1 ${status} ${reason}\r\n${extra}Content-Length: 0\r\nConnection: close\r\n\r\n`);
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as net.AddressInfo;
+    return { server, url: `http://127.0.0.1:${port}/` };
+  }
+
+  it.concurrent.each([
+    [300, "Multiple Choices", 'Location: /elsewhere\r\n'],
+    [304, "Not Modified", 'ETag: "v1"\r\n'],
+    [304, "Not Modified", 'ETag: "v1"\r\nLocation: /elsewhere\r\n'],
+    [305, "Use Proxy", 'Location: /elsewhere\r\n'],
+    [306, "unused", ""],
+  ])("%d %s is returned, not rejected", async (status, reason, extra) => {
+    const { server, url } = await serve(status, reason, extra);
+    try {
+      const res = await fetch(url, { redirect: "error", headers: { "if-none-match": '"v1"' } });
+      expect({ status: res.status, redirected: res.redirected, body: await res.text() }).toEqual({
+        status,
+        redirected: false,
+        body: "",
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  it.concurrent.each([
+    [301, "Moved Permanently"],
+    [302, "Found"],
+    [303, "See Other"],
+    [307, "Temporary Redirect"],
+    [308, "Permanent Redirect"],
+  ])("%d %s rejects with UnexpectedRedirect", async (status, reason) => {
+    const { server, url } = await serve(status, reason, "Location: /elsewhere\r\n");
+    try {
+      const outcome = await fetch(url, { redirect: "error" }).then(
+        res => ({ rejected: false as const, status: res.status }),
+        e => ({ rejected: true as const, code: e.code }),
+      );
+      expect(outcome).toEqual({ rejected: true, code: "UnexpectedRedirect" });
+    } finally {
+      server.close();
+    }
+  });
+});
+
 it("fetch() with redirect: 'manual' still exposes the 3xx response body", async () => {
   const server = net.createServer(socket => {
     socket.on("error", () => {});

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -66,9 +66,9 @@ describe("fetch() follows a redirect on headers without waiting for the 3xx body
 
 // https://fetch.spec.whatwg.org/#redirect-status
 // A redirect status is 301, 302, 303, 307, or 308. Other 3xx statuses
-// (300, 304, 305, 306) are not redirects and must be returned as-is even
-// under redirect: "error".
-describe("fetch() with redirect: 'error' only rejects WHATWG redirect statuses", () => {
+// (300, 304, 305, 306) are not redirects: they are returned as-is under
+// every redirect mode, including "error".
+describe("fetch() only treats WHATWG redirect statuses as redirects", () => {
   async function serve(status: number, reason: string, extra = "") {
     const server = net.createServer(socket => {
       socket.on("error", () => {});
@@ -81,24 +81,28 @@ describe("fetch() with redirect: 'error' only rejects WHATWG redirect statuses",
     return { server, url: `http://127.0.0.1:${port}/` };
   }
 
-  it.concurrent.each([
+  const nonRedirect3xx = [
     [300, "Multiple Choices", "Location: /elsewhere\r\n"],
     [304, "Not Modified", 'ETag: "v1"\r\n'],
     [304, "Not Modified", 'ETag: "v1"\r\nLocation: /elsewhere\r\n'],
     [305, "Use Proxy", "Location: /elsewhere\r\n"],
     [306, "unused", ""],
-  ])("%d %s is returned, not rejected", async (status, reason, extra) => {
-    const { server, url } = await serve(status, reason, extra);
-    try {
-      const res = await fetch(url, { redirect: "error", headers: { "if-none-match": '"v1"' } });
-      expect({ status: res.status, redirected: res.redirected, body: await res.text() }).toEqual({
-        status,
-        redirected: false,
-        body: "",
-      });
-    } finally {
-      server.close();
-    }
+  ] as const;
+
+  describe.each(["error", "follow"] as const)("redirect: %p", redirect => {
+    it.concurrent.each(nonRedirect3xx)("%d %s is returned as-is", async (status, reason, extra) => {
+      const { server, url } = await serve(status, reason, extra);
+      try {
+        const res = await fetch(url, { redirect, headers: { "if-none-match": '"v1"' } });
+        expect({ status: res.status, redirected: res.redirected, body: await res.text() }).toEqual({
+          status,
+          redirected: false,
+          body: "",
+        });
+      } finally {
+        server.close();
+      }
+    });
   });
 
   it.concurrent.each([
@@ -107,7 +111,7 @@ describe("fetch() with redirect: 'error' only rejects WHATWG redirect statuses",
     [303, "See Other"],
     [307, "Temporary Redirect"],
     [308, "Permanent Redirect"],
-  ])("%d %s rejects with UnexpectedRedirect", async (status, reason) => {
+  ])("redirect: 'error' rejects %d %s with UnexpectedRedirect", async (status, reason) => {
     const { server, url } = await serve(status, reason, "Location: /elsewhere\r\n");
     try {
       const outcome = await fetch(url, { redirect: "error" }).then(

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -82,15 +82,15 @@ describe("fetch() only treats WHATWG redirect statuses as redirects", () => {
   }
 
   const nonRedirect3xx = [
-    [300, "Multiple Choices", "Location: /elsewhere\r\n"],
-    [304, "Not Modified", 'ETag: "v1"\r\n'],
-    [304, "Not Modified", 'ETag: "v1"\r\nLocation: /elsewhere\r\n'],
-    [305, "Use Proxy", "Location: /elsewhere\r\n"],
-    [306, "unused", ""],
+    ["300 Multiple Choices", 300, "Multiple Choices", "Location: /elsewhere\r\n"],
+    ["304 Not Modified", 304, "Not Modified", 'ETag: "v1"\r\n'],
+    ["304 Not Modified with Location", 304, "Not Modified", 'ETag: "v1"\r\nLocation: /elsewhere\r\n'],
+    ["305 Use Proxy", 305, "Use Proxy", "Location: /elsewhere\r\n"],
+    ["306 unused", 306, "unused", ""],
   ] as const;
 
   describe.each(["error", "follow"] as const)("redirect: %p", redirect => {
-    it.concurrent.each(nonRedirect3xx)("%d %s is returned as-is", async (status, reason, extra) => {
+    it.concurrent.each(nonRedirect3xx)("%s is returned as-is", async (_label, status, reason, extra) => {
       const { server, url } = await serve(status, reason, extra);
       try {
         const res = await fetch(url, { redirect, headers: { "if-none-match": '"v1"' } });

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -82,10 +82,10 @@ describe("fetch() with redirect: 'error' only rejects WHATWG redirect statuses",
   }
 
   it.concurrent.each([
-    [300, "Multiple Choices", 'Location: /elsewhere\r\n'],
+    [300, "Multiple Choices", "Location: /elsewhere\r\n"],
     [304, "Not Modified", 'ETag: "v1"\r\n'],
     [304, "Not Modified", 'ETag: "v1"\r\nLocation: /elsewhere\r\n'],
-    [305, "Use Proxy", 'Location: /elsewhere\r\n'],
+    [305, "Use Proxy", "Location: /elsewhere\r\n"],
     [306, "unused", ""],
   ])("%d %s is returned, not rejected", async (status, reason, extra) => {
     const { server, url } = await serve(status, reason, extra);


### PR DESCRIPTION
## What does this PR do?

Per https://fetch.spec.whatwg.org/#redirect-status a redirect status is only 301, 302, 303, 307, or 308. `fetch(url, {redirect: 'error'})` was gating on the full `300..=399` range, so `300 Multiple Choices`, `304 Not Modified`, `305 Use Proxy`, and `306` all rejected with `UnexpectedRedirect` instead of being returned to the caller.

The follow and manual modes already handled these correctly (the follow arm matched only the five redirect statuses and fell through otherwise). Only the error-mode branch was too wide.

This breaks the standard conditional-request pattern: send `If-None-Match`, server replies `304 Not Modified`, use the cached copy. With `redirect: 'error'` set defensively, every successful revalidation rejected.

## Repro

```js
import net from 'node:net';
const srv = net.createServer(sock => {
  sock.once('data', () =>
    sock.end('HTTP/1.1 304 Not Modified\r\nETag: "v1"\r\nContent-Length: 0\r\n\r\n'));
});
await new Promise(r => srv.listen(0, '127.0.0.1', r));
const res = await fetch('http://127.0.0.1:' + srv.address().port, {
  redirect: 'error',
  headers: { 'if-none-match': '"v1"' },
});
console.log(res.status); // should print 304; before: rejects UnexpectedRedirect
srv.close();
```

Node/undici returns 304 here; Bun rejected.

## Fix

Narrow `is_redirect` in `src/http/lib.rs` to `matches!(status_code, 301 | 302 | 303 | 307 | 308)`. The now-redundant inner match on the same set is dropped (the large diff is rustfmt re-indenting that block).

## Verification

`test/js/web/fetch/fetch-redirect.test.ts` covers 300/304/304+Location/305/306 under both `redirect: 'error'` and `redirect: 'follow'` (returned with `redirected: false`), and 301/302/303/307/308 under `redirect: 'error'` (reject with `code: 'UnexpectedRedirect'`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch-redirect.test.ts

<!-- robobun:evidence:end -->