### PR TITLE
boringssl: restore is_safe_alt_name helper (main build break)

### DIFF
--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -575,13 +575,22 @@ pub unsafe extern "C" fn Bun__X509__checkHost(
     0
 }
 
+/// Node's `IsSafeAltName` for IA5/Latin-1 entries: true when `name` contains
+/// only printable ASCII with no `"`, `\\`, `,`, or `'`, so it can be rendered
+/// in a subjectAltName list without JSON-style quoting.
+#[inline]
+fn is_safe_alt_name(name: &[u8]) -> bool {
+    name.iter()
+        .all(|&c| matches!(c, b' '..=b'~') && !matches!(c, b'"' | b'\\' | b',' | b'\''))
+}
+
 /// Certificate name bytes (IA5 / Latin-1) for error messages.
 struct NameBytes<'a>(&'a [u8]);
 
 impl core::fmt::Display for NameBytes<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use core::fmt::Write;
-        if X509::is_safe_alt_name(self.0, false) {
+        if is_safe_alt_name(self.0) {
             for &byte in self.0 {
                 f.write_char(char::from(byte))?;
             }
@@ -729,4 +738,35 @@ pub fn check_server_identity(ssl_ptr: &mut boring::SSL, hostname: &[u8]) -> bool
     ssl_ptr
         .peer_leaf_certificate()
         .is_some_and(|x509| check_x509_server_identity(x509, hostname))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NameBytes, is_safe_alt_name};
+
+    #[test]
+    fn safe_alt_name_matches_node() {
+        assert!(is_safe_alt_name(b"good.example.com"));
+        assert!(is_safe_alt_name(b"http://example.com/a%2Cb"));
+        assert!(is_safe_alt_name(b" ~"));
+        for &c in b"\"\\,'" {
+            assert!(!is_safe_alt_name(&[c]));
+        }
+        assert!(!is_safe_alt_name(b"ab\x1f"));
+        assert!(!is_safe_alt_name(b"ab\x7f"));
+        assert!(!is_safe_alt_name(b"ex\xe4mple.com"));
+    }
+
+    #[test]
+    fn name_bytes_quoting() {
+        let fmt = |s: &[u8]| NameBytes(s).to_string();
+        assert_eq!(fmt(b"good.example.com"), "good.example.com");
+        assert_eq!(
+            fmt(b"good.example.com, DNS:evil.example.com"),
+            r#""good.example.com\u002c DNS:evil.example.com""#
+        );
+        assert_eq!(fmt(b"\"quoted\""), r#""\"quoted\"""#);
+        assert_eq!(fmt(b"ex\xe4mple.com"), r#""ex\u00e4mple.com""#);
+        assert_eq!(fmt(b"a\\b"), r#""a\\b""#);
+    }
 }


### PR DESCRIPTION
## What

Fixes the E0433 compile error on main since ff512eaa5f.

## Why

Merge-order race: #36252 removed the `x509::is_safe_alt_name` helper and its `use x509 as X509` alias (the only caller had been rewritten), and #36165 then landed a new call to `X509::is_safe_alt_name` in the `NameBytes` `Display` impl that was written against the pre-#36252 tree. Every lane on [build 86151](https://buildkite.com/bun/bun/builds/86151) fails with:

```
error[E0433]: cannot find type `X509` in this scope
   --> src/boringssl/lib.rs:584:12
    |
584 |         if X509::is_safe_alt_name(self.0, false) {
```

## Fix

Restore the helper as a private `fn is_safe_alt_name(name: &[u8]) -> bool` next to `NameBytes`. The sole caller passed `utf8 = false`, so the UTF-8 branch is dropped; the body is otherwise the same port of Node's `IsSafeAltName` (`src/jsc/bindings/ncrypto.cpp:753`) that #36252 removed.

## Verification

- `cargo check -p bun_boringssl` and `cargo clippy -p bun_boringssl --tests` are clean
- `cargo test -p bun_boringssl --lib` runs the two new unit tests (`safe_alt_name_matches_node`, `name_bytes_quoting`)
- `bun bd test test/js/node/tls/node-tls-connect-hostname-verification.test.ts -t "altname mismatch reason"` passes all three escaping cases added in #36165