### PR TITLE
install: let libarchive gunzip buffered tarballs instead of inflating into memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,7 +952,6 @@ dependencies = [
  "bun_uws",
  "bun_which",
  "bun_wyhash",
- "bun_zlib",
  "bytemuck",
  "const_format",
  "enum-map",

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -306,7 +306,7 @@ impl<'a> InternalState<'a> {
                     && buffer.len() > 16
                     && buffer.len() < 1024 * 1024 * 1024
                 {
-                    let estimated_size: u32 = u32::from_ne_bytes(
+                    let estimated_size: u32 = u32::from_le_bytes(
                         buffer[buffer.len() - 4..][..4]
                             .try_into()
                             .expect("infallible: size matches"),

--- a/src/install/Cargo.toml
+++ b/src/install/Cargo.toml
@@ -71,4 +71,3 @@ bun_url.workspace = true
 bun_uws.workspace = true
 bun_which.workspace = true
 bun_wyhash.workspace = true
-bun_zlib.workspace = true

--- a/src/install/error.rs
+++ b/src/install/error.rs
@@ -256,8 +256,6 @@ pub enum Error {
     #[error(transparent)]
     Transpiler(#[from] bun_transpiler::Error),
     #[error(transparent)]
-    Zlib(#[from] bun_zlib::ZlibError),
-    #[error(transparent)]
     Paths(#[from] bun_paths::Error),
     #[error(transparent)]
     PathOptions(#[from] bun_paths::path_options::Error),
@@ -418,7 +416,6 @@ impl Error {
             Self::Parsers(e) => e.name(),
             Self::Bunfig(e) => e.name(),
             Self::Transpiler(e) => e.name(),
-            Self::Zlib(e) => <&'static str>::from(e),
             Self::Paths(e) => e.name(),
             Self::PathOptions(e) => <&'static str>::from(e),
             Self::Fmt(_) => "FmtError",

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -23,8 +23,6 @@ use bun_resolver::fs::FileSystem;
 use bun_sys::FdDirExt;
 type Error = crate::Error;
 
-const MAX_DECOMPRESSED_TARBALL_SIZE: usize = 2 * 1024 * 1024 * 1024;
-
 pub struct ExtractTarball {
     pub(crate) name: StringOrTinyString,
     pub(crate) resolution: Resolution,
@@ -281,12 +279,9 @@ impl ExtractTarball {
             };
 
             use bun_libarchive::Archiver;
-            use bun_zlib as Zlib;
             let mut zlib_pool = Npm::Registry::BodyPool::get();
             zlib_pool.reset();
             // `defer Npm.Registry.BodyPool.release(zlib_pool)` → PoolGuard's Drop releases.
-
-            let mut esimated_output_size: usize = 0;
 
             let time_started_for_verbose_logs: u64 = if PackageManager::verbose_install() {
                 bun_core::Timespec::now_allow_mocked_time().ns()
@@ -294,77 +289,53 @@ impl ExtractTarball {
                 0
             };
 
-            {
-                // Last 4 bytes of a gzip-compressed file are the uncompressed size.
-                if tgz_bytes.len() > 16 {
-                    // If the file claims to be larger than 16 bytes and smaller than 64 MB, we'll preallocate the buffer.
-                    // If it's larger than that, we'll do it incrementally. We want to avoid OOMing.
-                    let last_4_bytes: u32 = u32::from_ne_bytes(
-                        tgz_bytes[tgz_bytes.len() - 4..][..4]
-                            .try_into()
-                            .expect("infallible: size matches"),
-                    );
-                    if last_4_bytes > 16 && last_4_bytes < 64 * 1024 * 1024 {
-                        // It's okay if this fails. We will just allocate as we go and that will error if we run out of memory.
-                        esimated_output_size = last_4_bytes as usize;
-                        if zlib_pool.list.capacity() == 0 {
-                            let _ = zlib_pool.list.try_reserve_exact(last_4_bytes as usize);
-                        } else {
-                            let _ = zlib_pool.ensure_unused_capacity(last_4_bytes as usize);
+            // libarchive gunzips on the fly (`BufferReadStream::open_read`),
+            // so hand it the compressed bytes and never buffer the full tar.
+            // Small tarballs still try libdeflate first for speed; the gzip
+            // ISIZE trailer (size mod 2^32) is only trusted when small.
+            let mut decompressed_in_memory = false;
+            if bun_core::FeatureFlags::is_libdeflate_enabled() && tgz_bytes.len() > 16 {
+                let isize: u32 = u32::from_le_bytes(
+                    tgz_bytes[tgz_bytes.len() - 4..][..4]
+                        .try_into()
+                        .expect("infallible: size matches"),
+                );
+                if isize > 16 && isize < 64 * 1024 * 1024 {
+                    if zlib_pool.list.capacity() == 0 {
+                        let _ = zlib_pool.list.try_reserve_exact(isize as usize);
+                    } else {
+                        let _ = zlib_pool.ensure_unused_capacity(isize as usize);
+                    }
+                    if zlib_pool.list.capacity() > 16 {
+                        use bun_libdeflate_sys::libdeflate;
+                        if let Some(mut decompressor) = libdeflate::OwnedDecompressor::new() {
+                            zlib_pool.list.clear();
+                            let result = decompressor.decompress_to_vec(
+                                tgz_bytes,
+                                &mut zlib_pool.list,
+                                libdeflate::Encoding::Gzip,
+                            );
+                            if result.status == libdeflate::Status::Success {
+                                decompressed_in_memory = true;
+                            }
                         }
                     }
                 }
             }
 
-            let mut needs_to_decompress = true;
-            if bun_core::FeatureFlags::is_libdeflate_enabled()
-                && zlib_pool.list.capacity() > 16
-                && esimated_output_size > 0
-            {
-                use bun_libdeflate_sys::libdeflate;
-                if let Some(mut decompressor) = libdeflate::OwnedDecompressor::new() {
-                    zlib_pool.list.clear();
-                    let result = decompressor.decompress_to_vec(
-                        tgz_bytes,
-                        &mut zlib_pool.list,
-                        libdeflate::Encoding::Gzip,
-                    );
-                    if result.status == libdeflate::Status::Success {
-                        needs_to_decompress = false;
-                    }
-                    // If libdeflate fails for any reason, fallback to zlib.
-                }
-            }
-
-            if needs_to_decompress {
+            let tar_input: &[u8] = if decompressed_in_memory {
+                &zlib_pool.list
+            } else {
                 zlib_pool.list.clear();
-                let mut zlib_entry =
-                    Zlib::ZlibReaderArrayList::init(tgz_bytes, &mut zlib_pool.list)?;
-                zlib_entry.max_output_size = MAX_DECOMPRESSED_TARBALL_SIZE;
-                if let Err(err) = zlib_entry.read_all(true) {
-                    log.add_error_fmt(
-                        None,
-                        bun_ast::Loc::EMPTY,
-                        format_args!(
-                            "{} decompressing \"{}\" to \"{}\"",
-                            err,
-                            bun_fmt::s(name),
-                            bun_core::fmt::fmt_path_u8(tmpname.as_bytes(), Default::default()),
-                        ),
-                    );
-                    return Err(crate::Error::InstallFailed);
-                }
-            }
+                tgz_bytes
+            };
 
             if PackageManager::verbose_install() {
-                let decompressing_ended_at: u64 = bun_core::Timespec::now_allow_mocked_time().ns();
-                let elapsed = decompressing_ended_at - time_started_for_verbose_logs;
                 bun_core::pretty_errorln!(
-                    "[{}] Extract {}<r> (decompressed {} tgz file in {})",
+                    "[{}] Extract {}<r> ({} tgz file)",
                     bun_fmt::s(name),
                     bun_fmt::s(tmpname.as_bytes()),
                     bun_core::fmt::size(tgz_bytes.len(), Default::default()),
-                    bun_core::fmt::fmt_duration_one_decimal(elapsed),
                 );
             }
 
@@ -395,7 +366,7 @@ impl ExtractTarball {
                     };
 
                     let _ = Archiver::extract_to_dir(
-                        &zlib_pool.list,
+                        tar_input,
                         extract_destination.fd(),
                         None,
                         &mut dirname_reader,
@@ -433,7 +404,7 @@ impl ExtractTarball {
                 }
                 _ => {
                     let _ = Archiver::extract_to_dir(
-                        &zlib_pool.list,
+                        tar_input,
                         extract_destination.fd(),
                         None,
                         &mut (),

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2470,7 +2470,7 @@ pub mod JSZlib {
                 //  +---+---+---+---+---+---+---+---+
                 //  |     CRC32     |     ISIZE     |
                 //  +---+---+---+---+---+---+---+---+
-                let estimated_size: u32 = u32::from_ne_bytes(
+                let estimated_size: u32 = u32::from_le_bytes(
                     compressed[compressed.len() - 4..][..4]
                         .try_into()
                         .expect("infallible: size matches"),

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -191,7 +191,7 @@ pub struct ZlibReaderArrayList<'a> {
     pub(crate) state: ZlibReaderArrayListState,
     /// Decompression-bomb guard: `read_all` errors instead of growing the
     /// output past this many bytes. Defaults to unbounded.
-    pub max_output_size: usize,
+    pub(crate) max_output_size: usize,
 }
 
 impl<'a> Drop for ZlibReaderArrayList<'a> {

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -6,7 +6,7 @@
 // the buffered extractor would produce.
 
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, readdirSorted, tempDir } from "harness";
+import { bunEnv, bunExe, isMacOS, readdirSorted, tempDir } from "harness";
 import { createHash } from "node:crypto";
 import { createWriteStream, existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
@@ -208,7 +208,7 @@ async function runInstall(cwd: string, extraEnv: Record<string, string> = {}) {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout, stderr, exitCode };
+  return { stdout, stderr, exitCode, resourceUsage: proc.resourceUsage() };
 }
 
 describe("streaming tarball extraction", () => {
@@ -637,19 +637,18 @@ test("buffered extract: damaged-block retry resets header state (upstream semant
 
 // -------------------------------------------------------------------
 // Buffered extract: the decompressed tar is never materialised in
-// memory. libarchive gunzips on the fly, so a ~few-MB .tgz that
-// inflates to more than 2 GiB installs without the ~2.3 GB RSS spike
-// the old pre-decompress path caused, and without hitting any
-// artificial 2 GiB cap. Covers `file:` dependencies, which always take
-// the buffered path.
+// memory. libarchive gunzips on the fly, so a highly compressible .tgz
+// installs without an RSS spike of roughly its decompressed size.
+// Covers `file:` dependencies, which always take the buffered path.
 // -------------------------------------------------------------------
-test("buffered extract installs a local tarball whose decompressed size exceeds 2 GiB", async () => {
-  // 2.25 GiB of zeros: above the old 2 GiB in-memory decompression
-  // cap, a multiple of 512 so the tar entry needs no trailing pad
-  // block, and its gzip ISIZE footer is far above the 64 MB libdeflate
-  // preallocation cutoff so libarchive (not libdeflate) decompresses.
-  const PAYLOAD_SIZE = 2304 * 1024 * 1024;
-  const ZERO_CHUNK = Buffer.alloc(64 * 1024 * 1024);
+test("buffered extract does not hold the decompressed local tarball in memory", async () => {
+  // 256 MiB of zeros: above the 64 MB gzip ISIZE cutoff that gates the
+  // libdeflate fast path, so libarchive (not libdeflate) decompresses,
+  // and a multiple of 512 so the tar entry needs no trailing pad block.
+  // The old path inflated this into a ~256 MB Vec before extraction,
+  // which shows up directly in the child's maxRSS.
+  const PAYLOAD_SIZE = 256 * 1024 * 1024;
+  const ZERO_CHUNK = Buffer.alloc(8 * 1024 * 1024);
 
   const pkgJson = Buffer.from(JSON.stringify({ name: "oversized-pkg", version: "1.0.0" }) + "\n");
 
@@ -662,7 +661,7 @@ test("buffered extract installs a local tarball whose decompressed size exceeds 
   });
 
   // Stream the tar through gzip straight to disk so the test process
-  // never holds the 2.25 GiB uncompressed archive in memory.
+  // never holds the uncompressed archive in memory either.
   const tgzPath = join(String(dir), "oversized-pkg.tgz");
   {
     const gzip = createGzip({ level: 1 });
@@ -682,20 +681,31 @@ test("buffered extract installs a local tarball whose decompressed size exceeds 
     await new Promise<void>((resolve, reject) => {
       out.once("close", resolve);
       out.once("error", reject);
+      gzip.once("error", reject);
       gzip.end();
     });
   }
 
-  // Sanity: the .tgz itself stays tiny even though it inflates far past
-  // 2 GiB; this is exactly the case that used to fail with `ZlibError`.
-  expect(statSync(tgzPath).size).toBeLessThan(32 * 1024 * 1024);
+  // Sanity: the .tgz itself stays tiny; this is exactly the case that
+  // used to fail with `ZlibError` once the decompressed size crossed 2 GiB.
+  expect(statSync(tgzPath).size).toBeLessThan(8 * 1024 * 1024);
 
-  const { stderr, exitCode } = await runInstall(String(dir));
+  const { stderr, exitCode, resourceUsage } = await runInstall(String(dir));
 
   expect(stderr).not.toContain("ZlibError");
-  expect(stderr).not.toContain("decompressing");
-  expect(existsSync(join(String(dir), "node_modules", "oversized-pkg", "package.json"))).toBe(true);
   const big = statSync(join(String(dir), "node_modules", "oversized-pkg", "data.bin"));
   expect(big.size).toBe(PAYLOAD_SIZE);
   expect(exitCode).toBe(0);
+
+  // The property under test: extraction never held the 256 MiB
+  // decompressed tar in memory. With the old pre-decompress path the
+  // child's maxRSS was well over 3x PAYLOAD_SIZE (Vec growth
+  // reallocations): ~780 MB release, ~1 GB debug+ASAN. Streaming
+  // through libarchive it stays at baseline (~40 MB release, ~240 MB
+  // debug+ASAN), so the midpoint gives wide margin both ways without
+  // needing to branch on build type.
+  // `ru_maxrss` is bytes on Darwin, kilobytes on Linux and Windows.
+  const maxRssBytes = (resourceUsage?.maxRSS ?? 0) * (isMacOS ? 1 : 1024);
+  expect(maxRssBytes).toBeGreaterThan(0);
+  expect(maxRssBytes).toBeLessThan(2 * PAYLOAD_SIZE);
 });

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, readdirSorted, tempDir } from "harness";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createWriteStream, existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import { join } from "node:path";
 import { createGzip, gzipSync } from "node:zlib";
@@ -636,111 +636,66 @@ test("buffered extract: damaged-block retry resets header state (upstream semant
 });
 
 // -------------------------------------------------------------------
-// Buffered extract: the gzip stream inside a registry tarball is fully
-// controlled by whoever published the package, so its decompressed
-// size must be bounded. A ~1-3 MB download that inflates to 2.25 GiB
-// has to surface a clean per-package decompression error instead of
-// growing the decompression buffer without limit and installing a
-// multi-gigabyte file.
+// Buffered extract: the decompressed tar is never materialised in
+// memory. libarchive gunzips on the fly, so a ~few-MB .tgz that
+// inflates to more than 2 GiB installs without the ~2.3 GB RSS spike
+// the old pre-decompress path caused, and without hitting any
+// artificial 2 GiB cap. Covers `file:` dependencies, which always take
+// the buffered path.
 // -------------------------------------------------------------------
-test("buffered extract rejects a registry tarball whose decompressed size exceeds the limit", async () => {
-  // 2.25 GiB of zeros: comfortably above the 2 GiB decompression cap,
-  // a multiple of 512 so the tar entry needs no trailing pad block,
-  // and its gzip ISIZE footer is far above the 64 MB libdeflate
-  // preallocation cutoff so the streaming zlib reader is what runs.
+test("buffered extract installs a local tarball whose decompressed size exceeds 2 GiB", async () => {
+  // 2.25 GiB of zeros: above the old 2 GiB in-memory decompression
+  // cap, a multiple of 512 so the tar entry needs no trailing pad
+  // block, and its gzip ISIZE footer is far above the 64 MB libdeflate
+  // preallocation cutoff so libarchive (not libdeflate) decompresses.
   const PAYLOAD_SIZE = 2304 * 1024 * 1024;
   const ZERO_CHUNK = Buffer.alloc(64 * 1024 * 1024);
 
   const pkgJson = Buffer.from(JSON.stringify({ name: "oversized-pkg", version: "1.0.0" }) + "\n");
 
-  // Stream the tar through gzip so the test process never holds the
-  // 2.25 GiB uncompressed archive in memory; only the small compressed
-  // tarball is kept around.
-  const gzip = createGzip({ level: 9 });
-  const compressed: Buffer[] = [];
-  gzip.on("data", c => compressed.push(c as Buffer));
-  const gzipDone = new Promise<void>((resolve, reject) => {
-    gzip.on("end", resolve);
-    gzip.on("error", reject);
+  using dir = tempDir("oversized-decompress", {
+    "package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "oversized-pkg": "file:./oversized-pkg.tgz" },
+    }),
   });
-  const writeTar = (chunk: Buffer) =>
-    new Promise<void>((resolve, reject) => gzip.write(chunk, err => (err ? reject(err) : resolve())));
 
-  await writeTar(tarHeader("package/package.json", pkgJson.length, "0"));
-  await writeTar(pkgJson);
-  await writeTar(pad512(pkgJson.length));
-  await writeTar(tarHeader("package/data.bin", PAYLOAD_SIZE, "0"));
-  for (let written = 0; written < PAYLOAD_SIZE; written += ZERO_CHUNK.length) {
-    await writeTar(ZERO_CHUNK);
-  }
-  await writeTar(Buffer.alloc(1024, 0)); // two zero blocks = end-of-archive
-  gzip.end();
-  await gzipDone;
+  // Stream the tar through gzip straight to disk so the test process
+  // never holds the 2.25 GiB uncompressed archive in memory.
+  const tgzPath = join(String(dir), "oversized-pkg.tgz");
+  {
+    const gzip = createGzip({ level: 1 });
+    const out = createWriteStream(tgzPath);
+    gzip.pipe(out);
+    const writeTar = (chunk: Buffer) =>
+      new Promise<void>((resolve, reject) => gzip.write(chunk, err => (err ? reject(err) : resolve())));
 
-  const tgz = Buffer.concat(compressed);
-  // Sanity: the download itself stays tiny even though it inflates far
-  // past the cap — that is exactly the case the bound exists for.
-  expect(tgz.length).toBeLessThan(8 * 1024 * 1024);
-  const shasum = createHash("sha1").update(tgz).digest("hex");
-  const integrity = "sha512-" + createHash("sha512").update(tgz).digest("base64");
-
-  const server: Server = createServer((req, res) => {
-    const url = new URL(req.url!, "http://x");
-    if (url.pathname.endsWith("/oversized-pkg")) {
-      const body = JSON.stringify({
-        name: "oversized-pkg",
-        "dist-tags": { latest: "1.0.0" },
-        versions: {
-          "1.0.0": {
-            name: "oversized-pkg",
-            version: "1.0.0",
-            dist: {
-              shasum,
-              integrity,
-              tarball: `http://127.0.0.1:${port}/oversized-pkg/-/oversized-pkg-1.0.0.tgz`,
-            },
-          },
-        },
-      });
-      res.setHeader("content-type", "application/json");
-      res.end(body);
-      return;
+    await writeTar(tarHeader("package/package.json", pkgJson.length, "0"));
+    await writeTar(pkgJson);
+    await writeTar(pad512(pkgJson.length));
+    await writeTar(tarHeader("package/data.bin", PAYLOAD_SIZE, "0"));
+    for (let written = 0; written < PAYLOAD_SIZE; written += ZERO_CHUNK.length) {
+      await writeTar(ZERO_CHUNK);
     }
-    if (url.pathname.endsWith("/oversized-pkg-1.0.0.tgz")) {
-      res.setHeader("content-type", "application/octet-stream");
-      res.setHeader("content-length", String(tgz.length));
-      res.end(tgz);
-      return;
-    }
-    res.statusCode = 404;
-    res.end("not found");
-  });
-  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
-  const port = (server.address() as { port: number }).port;
-
-  try {
-    using dir = tempDir("oversized-decompress", {
-      "package.json": JSON.stringify({
-        name: "app",
-        version: "1.0.0",
-        dependencies: { "oversized-pkg": "1.0.0" },
-      }),
-      "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${port}/"\n`,
+    await writeTar(Buffer.alloc(1024, 0)); // two zero blocks = end-of-archive
+    await new Promise<void>((resolve, reject) => {
+      out.once("close", resolve);
+      out.once("error", reject);
+      gzip.end();
     });
-
-    // Force the buffered extractor: that is the code path that has to
-    // bound the decompressed output of a downloaded gzip stream.
-    const { stderr, exitCode } = await runInstall(String(dir), {
-      BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL: "1",
-      BUN_INSTALL_STREAMING_MIN_SIZE: String(1024 * 1024 * 1024),
-    });
-
-    // The package must be reported as failing to decompress instead of
-    // being expanded without a size limit and installed.
-    expect(stderr).toContain('decompressing "oversized-pkg"');
-    expect(existsSync(join(String(dir), "node_modules", "oversized-pkg", "data.bin"))).toBe(false);
-    expect(exitCode).not.toBe(0);
-  } finally {
-    await new Promise<void>(resolve => server.close(() => resolve()));
   }
+
+  // Sanity: the .tgz itself stays tiny even though it inflates far past
+  // 2 GiB; this is exactly the case that used to fail with `ZlibError`.
+  expect(statSync(tgzPath).size).toBeLessThan(32 * 1024 * 1024);
+
+  const { stderr, exitCode } = await runInstall(String(dir));
+
+  expect(stderr).not.toContain("ZlibError");
+  expect(stderr).not.toContain("decompressing");
+  expect(existsSync(join(String(dir), "node_modules", "oversized-pkg", "package.json"))).toBe(true);
+  const big = statSync(join(String(dir), "node_modules", "oversized-pkg", "data.bin"));
+  expect(big.size).toBe(PAYLOAD_SIZE);
+  expect(exitCode).toBe(0);
 });

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -686,13 +686,13 @@ test("buffered extract does not hold the decompressed local tarball in memory", 
     });
   }
 
-  // Sanity: the .tgz itself stays tiny; this is exactly the case that
-  // used to fail with `ZlibError` once the decompressed size crossed 2 GiB.
+  // Sanity: the .tgz itself stays tiny, so holding the compressed bytes
+  // in memory is negligible relative to PAYLOAD_SIZE.
   expect(statSync(tgzPath).size).toBeLessThan(8 * 1024 * 1024);
 
   const { stderr, exitCode, resourceUsage } = await runInstall(String(dir));
 
-  expect(stderr).not.toContain("ZlibError");
+  expect(stderr).not.toContain("error:");
   const big = statSync(join(String(dir), "node_modules", "oversized-pkg", "data.bin"));
   expect(big.size).toBe(PAYLOAD_SIZE);
   expect(exitCode).toBe(0);


### PR DESCRIPTION
### Repro

```sh
W=$(mktemp -d); export BUN_INSTALL_CACHE_DIR=$W/cache
# build a ~21 MB .tgz whose decompressed tar is 2050 MiB of zeros
bun -e '
  import {createWriteStream} from "node:fs"; import {createGzip} from "node:zlib";
  function oct(n,w){return n.toString(8).padStart(w-1,"0")+"\0"}
  function hdr(name,size){const b=Buffer.alloc(512,0);b.write(name,0,100);b.write(oct(0o644,8),100);b.write(oct(0,8),108);b.write(oct(0,8),116);b.write(oct(size,12),124);b.write(oct(0,12),136);b.fill(" ",148,156);b.write("0",156);b.write("ustar\0",257);b.write("00",263);let s=0;for(let i=0;i<512;i++)s+=b[i];b.write(oct(s,8),148);return b}
  const gz=createGzip({level:1}),out=createWriteStream(process.argv[1]);gz.pipe(out);
  const w=b=>new Promise(r=>gz.write(b)?r():gz.once("drain",r));
  const pj=Buffer.from(JSON.stringify({name:"pkg",version:"1.0.0"}));
  await w(hdr("package/package.json",pj.length));await w(pj);await w(Buffer.alloc(512-pj.length%512));
  const mb=2050;await w(hdr("package/big.bin",mb<<20));const z=Buffer.alloc(1<<20);for(let i=0;i<mb;i++)await w(z);
  await w(Buffer.alloc(1024));await new Promise(r=>gz.end(()=>out.once("close",r)));
' $W/pkg.tgz
printf '{"name":"root","dependencies":{"pkg":"file:./pkg.tgz"}}' > $W/package.json
(cd $W && bun install)
```

On 1.4.0-canary and main:
```
error: ZlibError decompressing "pkg" to ".xxx-1.pkg"
error: InstallFailed extracting tarball from pkg
error: pkg@file:./pkg.tgz failed to resolve
```

### Cause

`ExtractTarball::extract()` (the buffered path used for every `file:` tarball and for the HTTP fallback when streaming is disabled) first decompresses the entire gzip stream into a `Vec<u8>` via `ZlibReaderArrayList`, capped at `MAX_DECOMPRESSED_TARBALL_SIZE = 2 GiB`, then hands the decompressed tar to `Archiver::extract_to_dir`. Hitting the cap surfaces as a bare `ZlibError`. Below the cap, peak RSS is roughly the decompressed size plus growth-doubling slack: a 256 MiB package costs ~780 MB RSS just for the intermediate buffer.

libarchive already supports reading gzipped input directly: `BufferReadStream::open_read` registers `archive_read_support_filter_gzip`, backed by the same vendored zlib-ng the removed pre-decompress used.

### Fix

Hand the compressed `.tgz` bytes straight to `Archiver::extract_to_dir` and let libarchive gunzip block-by-block. The 2 GiB cap and intermediate buffer are gone.

The libdeflate fast path is kept for tarballs whose gzip ISIZE trailer reports under 64 MB (unchanged threshold), so small npm packages keep the faster decoder. The trailer is now read as little-endian per RFC 1952 (was native-endian); the same one-token change is applied at the two sibling sites in `src/http/InternalState.rs` and `src/runtime/api/BunObject.rs`.

Dead code removed with the pre-decompress: `bun_install::Error::Zlib` and the `bun_zlib` workspace dependency in `bun_install`; `ZlibReaderArrayList::max_output_size` narrowed to `pub(crate)` now its external writer is gone.

### Verification

```
$ bun bd test test/cli/install/bun-install-streaming-extract.test.ts
 10 pass  0 fail
```

`buffered extract does not hold the decompressed local tarball in memory` replaces the previous `buffered extract rejects ...` test (which asserted the cap). It installs a 256 MiB local tarball and asserts the child's `maxRSS` stays under `2 * PAYLOAD_SIZE`. On the released bun it peaks at ~780 MB release / ~1 GB debug+ASAN and fails; with this change it stays at baseline (~40 MB release / ~240 MB debug+ASAN) and passes.

Also ran `bun-install-tarball-integrity.test.ts` (16 pass) and `bun-install-registry.test.ts` (229 pass) to confirm the common paths are unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-streaming-extract.test.ts

<!-- robobun:evidence:end -->