### PR TITLE
install: bound tar-header preallocation and remove temp dir on failed extraction

### DIFF
--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -893,13 +893,15 @@ impl TarballStream {
 
                 #[cfg(any(target_os = "linux", target_os = "android"))]
                 {
-                    let size: usize = usize::try_from(entry.size().max(0)).expect("int cast");
+                    // The header's size field is attacker-controlled; cap so a
+                    // size lie can't fallocate more than one entry's worth of
+                    // real disk before the truncated body is detected. The
+                    // buffered path bounds this by the decompressed tar length;
+                    // here the stream is incomplete, so use a fixed ceiling.
+                    const PREALLOCATE_CEILING: i64 = 64 * 1024 * 1024;
+                    let size = entry.size().max(0).min(PREALLOCATE_CEILING);
                     if size > 1_000_000 {
-                        let _ = bun_sys::preallocate_file(
-                            fd.native(),
-                            0,
-                            i64::try_from(size).expect("int cast"),
-                        );
+                        let _ = bun_sys::preallocate_file(fd.native(), 0, size);
                     }
                 }
 

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -899,7 +899,7 @@ impl TarballStream {
                     // buffered path bounds this by the decompressed tar length;
                     // here the stream is incomplete, so use a fixed ceiling.
                     const PREALLOCATE_CEILING: i64 = 64 * 1024 * 1024;
-                    let size = entry.size().max(0).min(PREALLOCATE_CEILING);
+                    let size = entry.size().clamp(0, PREALLOCATE_CEILING);
                     if size > 1_000_000 {
                         let _ = bun_sys::preallocate_file(fd.native(), 0, size);
                     }

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -181,6 +181,35 @@ pub(crate) fn uses_streaming_extraction() -> bool {
         .unwrap_or(false)
 }
 
+/// RAII owner of a temporary extraction directory under `parent`. Removes
+/// `parent/name` on drop unless [`commit`](Self::commit) is called after the
+/// directory has been renamed into the cache. This keeps failed extractions
+/// (decompression errors, truncated tarballs, rename failures) from leaking an
+/// extraction directory per attempt in `$TMPDIR`.
+struct TempExtractionDir<'a> {
+    parent: Fd,
+    name: &'a ZStr,
+}
+
+impl<'a> TempExtractionDir<'a> {
+    #[inline]
+    fn new(parent: Fd, name: &'a ZStr) -> Self {
+        Self { parent, name }
+    }
+
+    /// Disarm the drop guard after the directory has been renamed away.
+    #[inline]
+    fn commit(self) {
+        core::mem::forget(self);
+    }
+}
+
+impl Drop for TempExtractionDir<'_> {
+    fn drop(&mut self) {
+        let _ = Dir::borrow(&self.parent).delete_tree(self.name.as_bytes());
+    }
+}
+
 impl ExtractTarball {
     /// Derive the display name and a filesystem-safe basename for this
     /// package. Shared by the buffered `extract()` path below and the
@@ -256,6 +285,7 @@ impl ExtractTarball {
         let mut resolved: &'static [u8] = b"";
         let tmpname =
             FileSystem::tmpname(tmpname_suffix, &mut tmpname_buf.0, bun_core::fast_random())?;
+        let tmpdir_guard = TempExtractionDir::new(self.temp_dir, tmpname);
         {
             let extract_destination = match bun_sys::make_path::make_open_path(
                 tmpdir,
@@ -439,7 +469,9 @@ impl ExtractTarball {
             }
         }
 
-        self.move_to_cache_directory(log, tmpname, name, basename, resolved)
+        let result = self.move_to_cache_directory(log, tmpname, name, basename, resolved)?;
+        tmpdir_guard.commit();
+        Ok(result)
     }
 
     /// Rename the freshly-extracted temp directory into the cache, read

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -188,25 +188,30 @@ pub(crate) fn uses_streaming_extraction() -> bool {
 /// extraction directory per attempt in `$TMPDIR`.
 struct TempExtractionDir<'a> {
     parent: Fd,
-    name: &'a ZStr,
+    name: Option<&'a ZStr>,
 }
 
 impl<'a> TempExtractionDir<'a> {
     #[inline]
     fn new(parent: Fd, name: &'a ZStr) -> Self {
-        Self { parent, name }
+        Self {
+            parent,
+            name: Some(name),
+        }
     }
 
     /// Disarm the drop guard after the directory has been renamed away.
     #[inline]
-    fn commit(self) {
-        core::mem::forget(self);
+    fn commit(mut self) {
+        self.name = None;
     }
 }
 
 impl Drop for TempExtractionDir<'_> {
     fn drop(&mut self) {
-        let _ = Dir::borrow(&self.parent).delete_tree(self.name.as_bytes());
+        if let Some(name) = self.name {
+            let _ = Dir::borrow(&self.parent).delete_tree(name.as_bytes());
+        }
     }
 }
 

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1889,8 +1889,13 @@ impl Archiver {
                                     // The header's size field is attacker-controlled; a
                                     // malicious tarball can claim 8 GiB for a 100-byte body
                                     // and fallocate that much real disk before the short body
-                                    // is detected. A tar entry's body is stored inline in the
-                                    // archive stream, so it cannot exceed `file_buffer.len()`.
+                                    // is detected. Bound by the input buffer: for callers
+                                    // that pre-decompress (package extraction, `bun create`)
+                                    // a tar entry's body is stored inline in `file_buffer`
+                                    // so this is exact; callers that hand a compressed
+                                    // buffer to libarchive's gzip filter (`Bun.Archive`)
+                                    // under-preallocate here, which is acceptable since
+                                    // preallocation is best-effort.
                                     let prealloc = size.min(file_buffer.len());
                                     if prealloc > 1_000_000 {
                                         let _ = bun_sys::preallocate_file(

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1886,11 +1886,17 @@ impl Archiver {
                                 // #define    MAX_WRITE    (1024 * 1024)
                                 #[cfg(any(target_os = "linux", target_os = "android"))]
                                 {
-                                    if size > 1_000_000 {
+                                    // The header's size field is attacker-controlled; a
+                                    // malicious tarball can claim 8 GiB for a 100-byte body
+                                    // and fallocate that much real disk before the short body
+                                    // is detected. A tar entry's body is stored inline in the
+                                    // archive stream, so it cannot exceed `file_buffer.len()`.
+                                    let prealloc = size.min(file_buffer.len());
+                                    if prealloc > 1_000_000 {
                                         let _ = bun_sys::preallocate_file(
                                             file_handle.native(),
                                             0,
-                                            i64::try_from(size).expect("int cast"),
+                                            i64::try_from(prealloc).expect("int cast"),
                                         );
                                     }
                                 }

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1889,13 +1889,13 @@ impl Archiver {
                                     // The header's size field is attacker-controlled; a
                                     // malicious tarball can claim 8 GiB for a 100-byte body
                                     // and fallocate that much real disk before the short body
-                                    // is detected. Bound by the input buffer: for callers
-                                    // that pre-decompress (package extraction, `bun create`)
-                                    // a tar entry's body is stored inline in `file_buffer`
-                                    // so this is exact; callers that hand a compressed
-                                    // buffer to libarchive's gzip filter (`Bun.Archive`)
-                                    // under-preallocate here, which is acceptable since
-                                    // preallocation is best-effort.
+                                    // is detected. Bound by the input buffer length: when
+                                    // `file_buffer` is already the raw tar (pre-decompressed)
+                                    // this is exact; when it is the compressed gzip stream
+                                    // (libarchive's filter gunzips on the fly) it
+                                    // under-preallocates, which is acceptable since
+                                    // preallocation is best-effort. Either way the cap is at
+                                    // most what the caller actually supplied.
                                     let prealloc = size.min(file_buffer.len());
                                     if prealloc > 1_000_000 {
                                         let _ = bun_sys::preallocate_file(

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -709,3 +709,119 @@ test("buffered extract does not hold the decompressed local tarball in memory", 
   expect(maxRssBytes).toBeGreaterThan(0);
   expect(maxRssBytes).toBeLessThan(2 * PAYLOAD_SIZE);
 });
+
+// -------------------------------------------------------------------
+// Buffered extract: a tarball whose ustar header declares a size far
+// larger than the body that follows must fail to extract without
+// leaving its temporary extraction directory behind, and without
+// allocating the declared size on disk. The body of a tar entry is
+// stored inline in the (already-decompressed) archive stream, so the
+// declared size is attacker-controlled and unbounded.
+// -------------------------------------------------------------------
+describe("buffered extract: malformed tarball cleanup", () => {
+  function treeSize(root: string): number {
+    let total = 0;
+    for (const entry of readdirSync(root, { withFileTypes: true })) {
+      const full = join(root, entry.name);
+      if (entry.isDirectory()) total += treeSize(full);
+      else if (entry.isFile()) total += statSync(full).size;
+    }
+    return total;
+  }
+
+  function leakedExtractionDirs(root: string): string[] {
+    // Temp extraction dirs are `.<hex>-<n>.<name>` directly under $TMPDIR.
+    return readdirSync(root, { withFileTypes: true })
+      .filter(d => d.isDirectory() && d.name.startsWith("."))
+      .map(d => d.name);
+  }
+
+  async function runInstallIsolated(root: string) {
+    const tmp = join(root, "bun-tmp");
+    const cache = join(root, "bun-cache");
+    mkdirSync(tmp, { recursive: true });
+    mkdirSync(cache, { recursive: true });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: root,
+      env: {
+        ...bunEnv,
+        BUN_TMPDIR: tmp,
+        TMPDIR: tmp,
+        TEMP: tmp,
+        TMP: tmp,
+        BUN_INSTALL_CACHE_DIR: cache,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode, tmp, cache };
+  }
+
+  test("tar header size far exceeding body fails cleanly without leaking temp disk", async () => {
+    // A valid package.json entry followed by a file entry whose header
+    // claims 16 MiB but whose body is only 100 bytes; libarchive reports
+    // a truncated archive once it runs out of input. 16 MiB is well above
+    // the 1 MB preallocation threshold, so the unfixed build fallocated
+    // the full declared size on Linux before failing.
+    const DECLARED = 16 * 1024 * 1024;
+    const pj = Buffer.from(JSON.stringify({ name: "pkg", version: "1.0.0" }));
+    const body = Buffer.alloc(100, 0x78);
+    const tar = Buffer.concat([
+      tarHeader("package/package.json", pj.length, "0"),
+      pj,
+      pad512(pj.length),
+      tarHeader("package/big.bin", DECLARED, "0"),
+      body,
+      pad512(body.length),
+      Buffer.alloc(1024, 0),
+    ]);
+    const tgz = gzipSync(tar);
+    // The tarball itself is tiny; the damage is in the declared size.
+    expect(tgz.length).toBeLessThan(1024);
+
+    using dir = tempDir("tar-size-lie", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { pkg: "file:./pkg.tgz" },
+      }),
+    });
+    writeFileSync(join(String(dir), "pkg.tgz"), tgz);
+
+    // Run twice to confirm the leak does not accumulate per attempt.
+    let lastStderr = "";
+    for (let i = 0; i < 2; i++) {
+      const { stderr, exitCode, tmp, cache } = await runInstallIsolated(String(dir));
+      lastStderr = stderr;
+      expect(stderr).toContain("extracting tarball");
+      expect(exitCode).not.toBe(0);
+      // The failed extraction's temp directory must be gone.
+      expect({ leaked: leakedExtractionDirs(tmp) }).toEqual({ leaked: [] });
+      // Nothing close to the declared size was left anywhere under the
+      // test-isolated tmp or cache directories.
+      expect(treeSize(tmp) + treeSize(cache)).toBeLessThan(1024 * 1024);
+    }
+    expect(existsSync(join(String(dir), "node_modules", "pkg"))).toBe(false);
+    expect(lastStderr).not.toBe("");
+  });
+
+  test("a tarball that fails to decompress does not leak its temp directory", async () => {
+    // Not a gzip stream at all: the buffered extractor creates its temp
+    // directory, then the zlib reader fails immediately.
+    using dir = tempDir("tar-bad-gzip", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { pkg: "file:./pkg.tgz" },
+      }),
+    });
+    writeFileSync(join(String(dir), "pkg.tgz"), Buffer.from("this is not a gzip stream"));
+
+    const { stderr, exitCode, tmp } = await runInstallIsolated(String(dir));
+    expect(stderr).toContain("error:");
+    expect({ leaked: leakedExtractionDirs(tmp) }).toEqual({ leaked: [] });
+    expect(exitCode).not.toBe(0);
+  });
+});

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -714,9 +714,8 @@ test("buffered extract does not hold the decompressed local tarball in memory", 
 // Buffered extract: a tarball whose ustar header declares a size far
 // larger than the body that follows must fail to extract without
 // leaving its temporary extraction directory behind, and without
-// allocating the declared size on disk. The body of a tar entry is
-// stored inline in the (already-decompressed) archive stream, so the
-// declared size is attacker-controlled and unbounded.
+// allocating the declared size on disk. The declared size is
+// attacker-controlled and unbounded relative to the input.
 // -------------------------------------------------------------------
 describe("buffered extract: malformed tarball cleanup", () => {
   function treeSize(root: string): number {
@@ -809,7 +808,7 @@ describe("buffered extract: malformed tarball cleanup", () => {
 
   test("a tarball that fails to decompress does not leak its temp directory", async () => {
     // Not a gzip stream at all: the buffered extractor creates its temp
-    // directory, then the zlib reader fails immediately.
+    // directory, then libarchive fails to open the input as an archive.
     using dir = tempDir("tar-bad-gzip", {
       "package.json": JSON.stringify({
         name: "app",


### PR DESCRIPTION
### Problem

A 155-byte `.tgz` can fill the disk. If a tarball entry's ustar header declares a size far larger than the body that follows (e.g. `77777777777` octal = 8 GiB - 1), `bun install` on Linux `fallocate`s the full declared size before the truncated body is detected. The extraction then fails cleanly with `error: Fail extracting tarball`, but the temp extraction directory (under `$TMPDIR` or `<cache>/.tmp/`) is never removed. Each retry leaks another fully-allocated copy.

```text
error: Fail extracting tarball from pkg
$ ls -la $TMPDIR/.5ec7df3e75ef9ed3-1.pkg/
-rw-r--r-- 1 root root 16777216 big.bin       # fallocated to the header's declared size
-rw-r--r-- 1 root root       32 package.json
```

The temp-directory leak applies to every buffered extraction failure (zlib/decompression errors, truncated input, rename-into-cache failures), not just header size lies: the buffered `ExtractTarball::extract` path creates the temp directory up front and returns early on any error without removing it.

### Cause

- `Archiver::extract_to_dir` / `TarballStream::begin_entry` call `bun_sys::preallocate_file(fd, 0, entry.size())` on Linux. `entry.size()` is the attacker-controlled ustar header field, and `fallocate` mode 0 allocates real blocks.
- `ExtractTarball::extract` creates its temp directory via `make_open_path`, then returns on every error path (decompression, `Archiver::extract_to_dir`, `move_to_cache_directory`) without removing it. The streaming extractor already cleans up in `TarballStream::finish`; the buffered path (used for `file:` tarballs and any registry tarball below the 2 MiB streaming threshold) does not.

### Fix

- `Archiver::extract_to_dir` caps preallocation at `file_buffer.len()`: a tar entry's body is stored inline in the already-decompressed archive stream, so the body cannot exceed that length.
- `TarballStream::begin_entry` caps preallocation at 64 MiB. The stream length is not known at header time, so this is a fixed ceiling; the streaming path already deletes its temp directory on failure, so this only bounds the transient disk spike.
- `ExtractTarball::extract` wraps its temp directory in a `TempExtractionDir` RAII guard that `delete_tree`s on drop, committed only after `move_to_cache_directory` succeeds. The temp-directory cleanup here overlaps with #33979, which addresses the broader concurrent-publish race; this PR covers the error-path leak with an RAII guard per review direction and can be rebased over whichever lands first.

### Verification

New tests in `test/cli/install/bun-install-streaming-extract.test.ts` under `buffered extract: malformed tarball cleanup`:

- `tar header size far exceeding body fails cleanly without leaking temp disk`: a `file:` tarball with a 16 MiB header lie and 100-byte body, installed twice with an isolated `$TMPDIR`/cache; asserts the install fails, the temp directory is empty afterward, and total disk under tmp+cache stays below 1 MiB.
- `a tarball that fails to decompress does not leak its temp directory`: a `file:` dep whose bytes are not a gzip stream; asserts the install fails and the temp directory is empty.

Both fail on main (leaked `.xxxxxxxx-1.pkg` directory containing a 16 MiB `big.bin` on Linux) and pass with the fix. The rest of `bun-install-streaming-extract.test.ts` and `bun-install-tarball-integrity.test.ts` pass unchanged.

The first commit restores the `is_safe_alt_name` helper in `src/boringssl/lib.rs` so main builds; it was removed by #36252 but a caller was added by #36165. Drop it if the dedicated fix lands first.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-streaming-extract.test.ts

<!-- robobun:evidence:end -->