### PR TITLE
test(tls): bind the Bun.connect hostname-verify listener to 127.0.0.1 (host-dependent ECONNREFUSED)

### DIFF
--- a/test/js/node/tls/node-tls-connect-hostname-verification.test.ts
+++ b/test/js/node/tls/node-tls-connect-hostname-verification.test.ts
@@ -192,9 +192,15 @@ describe("Bun.connect TLS hostname verification", () => {
   // A client that trusts ca1 and connects to "localhost" passes chain
   // validation, but the certificate is not valid for "localhost", so the
   // socket must not be reported as authorized.
+  //
+  // Bind the listener to 127.0.0.1 rather than "localhost": Bun.listen
+  // resolves the bind host without AI_ADDRCONFIG while Bun.connect resolves
+  // with it, so on a host whose only IPv6 address is loopback the listener
+  // can end up on ::1 while the client dials 127.0.0.1 and gets ECONNREFUSED
+  // (Node's net.connect behaves the same way).
   test("reports authorized=false when a CA-trusted cert does not match the connected hostname", async () => {
     const listener = Bun.listen({
-      hostname: "localhost",
+      hostname: "127.0.0.1",
       port: 0,
       tls: { key: serverKey, cert: serverCert },
       socket: {


### PR DESCRIPTION
## What

`Bun.connect TLS hostname verification > reports authorized=false when a CA-trusted cert does not match the connected hostname` in `test/js/node/tls/node-tls-connect-hostname-verification.test.ts` fails with `ECONNREFUSED` on hosts whose only configured IPv6 address is loopback (e.g. a container with `::1 localhost` in `/etc/hosts` and no global IPv6):

```
error: Failed to connect
 syscall: "connect",
   errno: -111,
    code: "ECONNREFUSED"
      at async <anonymous> (test/js/node/tls/node-tls-connect-hostname-verification.test.ts:211:35)
```

## Why this is not a runtime bug

- `Bun.listen({hostname: "localhost"})` resolves via `getaddrinfo` with `AI_PASSIVE` only (no `AI_ADDRCONFIG`, `bsd.c:bsd_create_listen_socket`) and binds the first result, `::1`.
- `Bun.connect({hostname: "localhost"})` resolves via Bun's DNS layer, which passes `AI_ADDRCONFIG` on Unix (`dns.rs:get_hints`). On a host with no non-loopback IPv6 address, `AI_ADDRCONFIG` filters `::1`, leaving only `127.0.0.1`. Happy-eyeballs runs but never sees `::1`.

Node v26.3.0 behaves identically:

```
$ node -e 'const net=require("net");const s=net.createServer();s.listen(0,"localhost",()=>{console.log(s.address());net.connect({port:s.address().port,host:"localhost",autoSelectFamily:true}).on("connect",()=>console.log("ok")).on("error",e=>{console.log(e.code);s.close()})});'
{ address: '::1', family: 'IPv6', port: 41315 }
ECONNREFUSED
```

## Fix

Bind the listener to `127.0.0.1`. The client still connects to the name `"localhost"`, so the assertion this test exists for (that `Bun.connect` verifies the presented certificate against its `hostname` option when no `serverName` is given) is unchanged: the certificate is for `CN=agent1`, not `localhost`, and must remain unauthorized. Connecting to `"localhost"` reaches `127.0.0.1` on every host configuration that maps `localhost` to `127.0.0.1` at all.

Same root cause as #35160 (different test).

## Verification

On a host with `::1 localhost` first and no global IPv6:

```
before:  7 pass  1 fail (ECONNREFUSED)
after:   8 pass  0 fail
```

Test-only change.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/tls/node-tls-connect-hostname-verification.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/tls/node-tls-connect-hostname-verification.test.ts
bun test v1.4.0 (f581bdc26)

test/js/node/tls/node-tls-connect-hostname-verification.test.ts:
(pass) tls.connect hostname verification without explicit servername > rejects an IP address as options.servername [152.06ms]
(pass) tls.connect hostname verification without explicit servername > rejects a CA-trusted cert whose CN does not match host [736.76ms]
(pass) tls.connect hostname verification without explicit servername > reports authorized=false on hostname mismatch with rejectUnauthorized=false [191.79ms]
(pass) tls.connect hostname verification without explicit servername > invokes checkServerIdentity with host when servername is omitted [86.64ms]
(pass) Bun.connect TLS altname mismatch reason > quotes and escapes a DNS altname containing a comma [61.04ms]
(pass) Bun.connect TLS altname mismatch reason > quotes and escapes a DNS altname containing double quotes [33.60ms]
(pass) Bun.connect TLS altname mismatch reason > quotes and escapes a DNS altname containing a non-ASCII byte [34.66ms]
(pass) Bun.connect TLS hostname verification > reports authorized=false when a CA-trusted cert does not match the connected hostname [51.60ms]

 8 pass
 0 fail
Ran 8 tests across 1 file. [4.45s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/tls/node-tls-connect-hostname-verification.test.ts | 8 +++++++-
 1 file changed, 7 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…node/tls/node-tls-connect-hostname-verification.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->