### PR TITLE
sys: widen Tag::readlink / symlinkat / copy_file back to pub (main build break)

### DIFF
--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1325,7 +1325,7 @@ impl Tag {
     pub(crate) const pread: Tag = Tag(36);
     pub(crate) const pwrite: Tag = Tag(37);
     pub const read: Tag = Tag(38);
-    pub(crate) const readlink: Tag = Tag(39);
+    pub const readlink: Tag = Tag(39);
     pub const rename: Tag = Tag(40);
     pub(crate) const stat: Tag = Tag(41);
     pub(crate) const statfs: Tag = Tag(42);
@@ -4202,7 +4202,7 @@ mod windows_impl {
     pub(crate) fn linkat_tmpfile(_tmpfd: Fd, _dirfd: Fd, _name: &ZStr) -> Maybe<()> {
         Err(Error::new(E::ENOTSUP, Tag::link))
     }
-    pub(crate) fn symlinkat(target: &ZStr, dirfd: impl AsFd, dest: &ZStr) -> Maybe<()> {
+    pub fn symlinkat(target: &ZStr, dirfd: impl AsFd, dest: &ZStr) -> Maybe<()> {
         let dirfd = dirfd.as_fd();
         // Resolve `dest` against `dirfd`, then symlink via libuv.
         let mut db = bun_core::PathBuffer::default();
@@ -7918,7 +7918,7 @@ pub fn copy_file(in_: Fd, out: Fd) -> Maybe<()> {
     copy_file::copy_file(in_, out)
 }
 #[cfg(windows)]
-pub(crate) fn copy_file(in_: Fd, out: Fd) -> Maybe<()> {
+pub fn copy_file(in_: Fd, out: Fd) -> Maybe<()> {
     // Windows `bun.copyFile` takes paths, not fds; fd-based callers (e.g.
     // `move_file_z_with_handle`'s EXDEV fallback) get the read/write loop.
     let mut buf = [0u8; 64 * 1024];


### PR DESCRIPTION
## What

`bun bd` on main (since f48c850381) fails to compile:

```
error[E0624]: associated constant `readlink` is private
    --> src/runtime/shell/builtin/mv.rs:525:76
525 |                 return Err(bun_sys::Error::from_code(E::ENAMETOOLONG, Tag::readlink));
     |                                                                            ^^^^^^^^ private associated constant
    ::: src/sys/lib.rs:1328:5
1328 |     pub(crate) const readlink: Tag = Tag(39);
```

and on the two Windows targets additionally:

```
src/runtime/shell/builtin/mv.rs:529:22: error[E0603]: function `symlinkat` is private
src/runtime/shell/builtin/mv.rs:580:34: error[E0603]: function `copy_file` is private
```

## Cause

Merge-order race between two PRs that were each green on their own base:

- #36184 narrowed `Tag::readlink`, the Windows `symlinkat`, and the `cfg(windows)` `copy_file` to `pub(crate)` in `bun_sys` (nothing outside the crate referenced them at the time).
- #36338 then landed shell `mv`'s EXDEV fallback, whose `move_across_devices` (in `bun_runtime`) calls all three.

## Fix

Widen the three items back to `pub`. The POSIX `symlinkat` / `copy_file` were already `pub`, so this also restores platform parity.

## Verification

```
$ bun run rust:check-all
10 ok, 0 failed, 0 skipped (of 10)

$ bun bd test test/js/bun/shell/commands/mv.test.ts
 12 pass
 0 fail
```

Without this change `bun bd` fails at the `bun_runtime` compile step, so the gate's stash-src build reproduces the failure.