### PR TITLE
primordials: stop calling prototype methods to find iterator returns

### DIFF
--- a/src/js/internal/primordials.js
+++ b/src/js/internal/primordials.js
@@ -44,6 +44,10 @@ const copyProps = (src, dest) => {
   });
 };
 
+// The iterator-returning methods of Map/Set. Matched by key rather than by calling each
+// zero-argument method, which would invoke user code on a monkey-patched prototype.
+const iteratorReturningKeys = ["entries", "keys", "values", Symbol.iterator];
+
 const makeSafe = (unsafe, safe) => {
   const unsafePrototype = unsafe.prototype;
   const safePrototype = safe.prototype;
@@ -54,16 +58,17 @@ const makeSafe = (unsafe, safe) => {
     ArrayPrototypeForEach(Reflect.ownKeys(unsafePrototype), key => {
       if (!Reflect.getOwnPropertyDescriptor(safePrototype, key)) {
         const desc = Reflect.getOwnPropertyDescriptor(unsafePrototype, key);
-        if (typeof desc.value === "function" && desc.value.length === 0) {
-          const called = desc.value.$call(dummy) || {};
-          if (Symbol.iterator in (typeof called === "object" ? called : {})) {
-            const createIterator = uncurryThis(desc.value);
-            next ??= uncurryThis(createIterator(dummy).next);
-            const SafeIterator = createSafeIterator(createIterator, next);
-            desc.value = function () {
-              return new SafeIterator(this);
-            };
-          }
+        if (
+          typeof desc.value === "function" &&
+          desc.value.length === 0 &&
+          ArrayPrototypeIncludes(iteratorReturningKeys, key)
+        ) {
+          const createIterator = uncurryThis(desc.value);
+          next ??= uncurryThis(createIterator(dummy).next);
+          const SafeIterator = createSafeIterator(createIterator, next);
+          desc.value = function () {
+            return new SafeIterator(this);
+          };
         }
         Reflect.defineProperty(safePrototype, key, desc);
       }
@@ -80,6 +85,7 @@ const makeSafe = (unsafe, safe) => {
 const StringIterator = uncurryThis(String.prototype[Symbol.iterator]);
 const StringIteratorPrototype = Reflect.getPrototypeOf(StringIterator(""));
 const ArrayPrototypeForEach = uncurryThis(Array.prototype.forEach);
+const ArrayPrototypeIncludes = uncurryThis(Array.prototype.includes);
 const ArrayPrototypeSymbolIterator = uncurryThis(Array.prototype[Symbol.iterator]);
 const ArrayIteratorPrototypeNext = uncurryThis(Array.prototype[Symbol.iterator]().next);
 const SafeArrayIterator = createSafeIterator(ArrayPrototypeSymbolIterator, ArrayIteratorPrototypeNext);

--- a/test/js/node/util/primordials-monkeypatching.test.ts
+++ b/test/js/node/util/primordials-monkeypatching.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// internal/primordials builds SafeSet/SafeMap by wrapping the iterator-returning methods of
+// Set/Map. It must not invoke user-defined prototype methods while doing so. Node: `ok` / 0.
+const modules = ["node:fs", "node:util", "node:assert", "node:worker_threads", "node:http2"];
+
+test.concurrent.each(modules)("%s does not invoke monkey-patched Set.prototype methods", async module => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `Set.prototype.hi = function () { throw new Error("BOOM") };
+       try { require(${JSON.stringify(module)}); console.log("ok") } catch (e) { console.log("CAUGHT:", e.message) }`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("ok\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent.each(["Set", "Map"])("monkey-patched %s.prototype method is never called", async name => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `let calls = 0;
+       ${name}.prototype.hi = function () { calls++ };
+       require("node:fs");
+       console.log("calls=" + calls)`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("calls=0\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+// Guards against "fixing" the bug by simply not wrapping anything: entries/keys/values/
+// Symbol.iterator must still be replaced with the null-prototype SafeIterator, which is what
+// keeps util.inspect working after Array.prototype[Symbol.iterator] is tampered with.
+test.concurrent("Safe collections keep their iterator wrappers", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const util = require("node:util");
+       const value = { nested: new Set(["x"]), map: new Map([["a", 1]]) };
+       Array.prototype[Symbol.iterator] = function () { throw new Error("TAMPERED") };
+       console.log(util.inspect(value));`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("{ nested: Set(1) { 'x' }, map: Map(1) { 'a' => 1 } }\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`require("node:fs")` calls functions the user has attached to `Set.prototype`:

```js
Set.prototype.hi = function () { throw new Error("x") };
require("node:fs"); // throws in Bun, fine in Node v22
```

Not fs-specific: `fs`, `util`, `assert`, `worker_threads`, `http2`, `path`, `events`, `stream`, `url`, `crypto`, `http` and `net` all trigger it. `os` does not.

Fixes #18890.

## Why

`makeSafe` in `src/js/internal/primordials.js` worked out which `Map`/`Set` methods return iterators by calling every zero-argument function on the prototype:

```js
if (typeof desc.value === "function" && desc.value.length === 0) {
  const called = desc.value.$call(dummy) || {};
```

Primordials initialize on the first builtin module load rather than at realm bootstrap, so by then user code has already had the chance to patch the prototype. A one-argument function is not called, which pins it to the `desc.value.length === 0` guard.

The iterator-returning keys are fixed by the spec, so this matches on the key instead of probing by calling. Old and new select byte-identical key sets for `Map` and `Set` on a clean realm. `WeakSet`/`WeakMap` are unaffected: no `Symbol.iterator`, so they take the `copyProps` branch. `constructor` stays excluded by the existing `safePrototype` guard.

One gap left alone as out of scope: overriding `Set.prototype.values` itself before primordials load still reaches user code via `createIterator(dummy).next`. Node avoids that by capturing primordials at realm bootstrap, which lazy module loading cannot replicate without a much larger change.

## How did you verify your code works?

`bun bd test test/js/node/util/primordials-monkeypatching.test.ts` gives 8 pass / 0 fail. The same file gives 7 fail / 1 pass under `USE_SYSTEM_BUN=1`, so the tests fail without the change and pass with it.

The new test covers five builtin modules loading without invoking a patched method, a patched method on `Set.prototype`/`Map.prototype` never being called, and `entries`/`keys`/`values`/`Symbol.iterator` still being replaced with the null-prototype `SafeIterator`. That last one guards against "fixing" this by simply not wrapping anything.

Not placed in `test/regression/issue/`: `git log -S` shows the probe came in with 6c7a0e5a79 (#7101) and behaved this way from the start, so it was never a regression.
