### PR TITLE
shell: make $.braces() quote-aware (match bash and Bun's own shell)

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -479,7 +479,17 @@ pub(crate) fn braces(
     }
 
     if expansion_count == 0 {
-        return bun_string_jsc::to_js_array(global, &[brace_str]);
+        // No `{…}` group formed an expansion. The lexer has already stripped
+        // quoting (`'…'`/`"…"`/`\x`), so reconstruct the single output word
+        // from the token text rather than echoing the raw input.
+        let mut word: Vec<u8> = Vec::with_capacity(brace_slice.slice().len());
+        for tok in &lexer_output.tokens {
+            if let Braces::Token::Text(txt) = tok {
+                word.extend_from_slice(txt.slice());
+            }
+        }
+        let s = BunString::from_bytes(&word[..]);
+        return bun_string_jsc::to_js_array(global, &[s]);
     }
 
     // Hard cap before preallocation: `calculate_expanded_amount` saturates to

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -479,9 +479,7 @@ pub(crate) fn braces(
     }
 
     if expansion_count == 0 {
-        // No `{…}` group formed an expansion. The lexer has already stripped
-        // quoting (`'…'`/`"…"`/`\x`), so reconstruct the single output word
-        // from the token text rather than echoing the raw input.
+        // Return the (quote-stripped) token text, not the raw input.
         let mut word: Vec<u8> = Vec::with_capacity(brace_slice.slice().len());
         for tok in &lexer_output.tokens {
             if let Braces::Token::Text(txt) = tok {

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -285,7 +285,7 @@ impl Expansion {
         for (i, &b) in me.current_out.iter().enumerate() {
             if next_meta < me.meta_offsets.len() && me.meta_offsets[next_meta] as usize == i {
                 next_meta += 1;
-            } else if matches!(b, b'{' | b'}' | b',' | b'\\') {
+            } else if matches!(b, b'{' | b'}' | b',' | b'\\' | b'\'' | b'"' | b'$') {
                 escaped.push(b'\\');
             }
             escaped.push(b);

--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -1135,13 +1135,19 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
                         self.eat_double_quoted()?;
                         continue;
                     }
-                    c if c == u32::from(b'$')
-                        && self.chars.peek_raw() == Some(u32::from(b'\'')) =>
-                    {
-                        let _ = self.chars.eat_raw();
-                        self.eat_ansi_c_quoted()?;
-                        continue;
-                    }
+                    c if c == u32::from(b'$') => match self.chars.peek_raw() {
+                        Some(q) if q == u32::from(b'\'') => {
+                            let _ = self.chars.eat_raw();
+                            self.eat_ansi_c_quoted()?;
+                            continue;
+                        }
+                        Some(q) if q == u32::from(b'"') => {
+                            let _ = self.chars.eat_raw();
+                            self.eat_double_quoted()?;
+                            continue;
+                        }
+                        _ => {}
+                    },
                     c if c == u32::from(b'{') => {
                         brace_stack.push(OpenBrace {
                             tok_idx: u32::try_from(self.tokens.len()).expect("int cast"),

--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -1138,11 +1138,8 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
                     c if c == u32::from(b'$')
                         && self.chars.peek_raw() == Some(u32::from(b'\'')) =>
                     {
-                        // `$'…'` (ANSI-C quoting): for brace-expansion purposes
-                        // the content is literal and the `$` is consumed. C-style
-                        // escape sequences are not processed here.
                         let _ = self.chars.eat_raw();
-                        self.eat_single_quoted()?;
+                        self.eat_ansi_c_quoted()?;
                         continue;
                     }
                     c if c == u32::from(b'{') => {
@@ -1176,6 +1173,10 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
                     }
                     _ => {}
                 }
+            } else if char == u32::from(b'\n') {
+                // `\<newline>` is a line continuation (bash): both characters
+                // are removed.
+                continue;
             }
 
             // if (char_stack.push(char) == char_stack.Error.StackFull) {
@@ -1323,7 +1324,8 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
 
     /// Consume a double-quoted span: `{`, `,`, `}` are literal text, both quote
     /// characters are dropped, and `\` is an escape only before `"`/`\`/`$`/`` ` ``
-    /// (bash quote-removal). An unterminated quote consumes to end of input.
+    /// /newline (bash quote-removal). An unterminated quote consumes to end of
+    /// input.
     fn eat_double_quoted(&mut self) -> Result<(), AllocError> {
         while let Some(c) = self.chars.eat_raw() {
             if c == u32::from(b'"') {
@@ -1341,8 +1343,34 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
                         self.append_char(next)?;
                         continue;
                     }
+                    Some(next) if next == u32::from(b'\n') => {
+                        // `\<newline>` is a line continuation: both removed.
+                        let _ = self.chars.eat_raw();
+                        continue;
+                    }
                     _ => {}
                 }
+            }
+            self.append_char(c)?;
+        }
+        Ok(())
+    }
+
+    /// Consume a `$'…'` span: the `$` and both quote characters are dropped,
+    /// the content is literal for brace purposes, and a `\X` pair is reduced to
+    /// `X` so an escaped `'` does not terminate the span. Other ANSI-C escape
+    /// translations (e.g. `\n` → LF) are not performed here. An unterminated
+    /// quote consumes to end of input.
+    fn eat_ansi_c_quoted(&mut self) -> Result<(), AllocError> {
+        while let Some(c) = self.chars.eat_raw() {
+            if c == u32::from(b'\'') {
+                return Ok(());
+            }
+            if c == u32::from(b'\\') {
+                if let Some(next) = self.chars.eat_raw() {
+                    self.append_char(next)?;
+                }
+                continue;
             }
             self.append_char(c)?;
         }

--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -234,6 +234,28 @@ impl<const E: StringEncoding> CharIter for ShellCharIter<E> {
     }
 }
 
+impl<const E: StringEncoding> ShellCharIter<E> {
+    /// Return the current codepoint without backslash-escape processing.
+    #[inline]
+    fn peek_raw(&self) -> Option<u32> {
+        match &self.src {
+            ShellSrc::Ascii(a) => Some(a.index()?.char),
+            ShellSrc::Unicode(u) => Some(u.index()?.char),
+        }
+    }
+
+    /// Consume and return one codepoint without backslash-escape processing.
+    #[inline]
+    fn eat_raw(&mut self) -> Option<u32> {
+        let ch = self.peek_raw()?;
+        match &mut self.src {
+            ShellSrc::Ascii(a) => a.eat(false),
+            ShellSrc::Unicode(u) => u.eat(false),
+        }
+        Some(ch)
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 
 bun_core::declare_scope!(BRACES, visible);
@@ -1105,6 +1127,24 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
             if !escaped {
                 // `char` is u32 (CodepointType unified across encodings).
                 match char {
+                    c if c == u32::from(b'\'') => {
+                        self.eat_single_quoted()?;
+                        continue;
+                    }
+                    c if c == u32::from(b'"') => {
+                        self.eat_double_quoted()?;
+                        continue;
+                    }
+                    c if c == u32::from(b'$')
+                        && self.chars.peek_raw() == Some(u32::from(b'\'')) =>
+                    {
+                        // `$'…'` (ANSI-C quoting): for brace-expansion purposes
+                        // the content is literal and the `$` is consumed. C-style
+                        // escape sequences are not processed here.
+                        let _ = self.chars.eat_raw();
+                        self.eat_single_quoted()?;
+                        continue;
+                    }
                     c if c == u32::from(b'{') => {
                         brace_stack.push(OpenBrace {
                             tok_idx: u32::try_from(self.tokens.len()).expect("int cast"),
@@ -1267,6 +1307,47 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
     fn eat(&mut self) -> Option<<Chars<ENCODING> as CharIter>::InputChar> {
         self.chars.eat()
     }
+
+    /// Consume a single-quoted span: everything up to the next `'` is literal
+    /// text (including `\`), and both quote characters are dropped.
+    /// An unterminated quote consumes to end of input.
+    fn eat_single_quoted(&mut self) -> Result<(), AllocError> {
+        while let Some(c) = self.chars.eat_raw() {
+            if c == u32::from(b'\'') {
+                return Ok(());
+            }
+            self.append_char(c)?;
+        }
+        Ok(())
+    }
+
+    /// Consume a double-quoted span: `{`, `,`, `}` are literal text, both quote
+    /// characters are dropped, and `\` is an escape only before `"`/`\`/`$`/`` ` ``
+    /// (bash quote-removal). An unterminated quote consumes to end of input.
+    fn eat_double_quoted(&mut self) -> Result<(), AllocError> {
+        while let Some(c) = self.chars.eat_raw() {
+            if c == u32::from(b'"') {
+                return Ok(());
+            }
+            if c == u32::from(b'\\') {
+                match self.chars.peek_raw() {
+                    Some(next)
+                        if next == u32::from(b'"')
+                            || next == u32::from(b'\\')
+                            || next == u32::from(b'$')
+                            || next == u32::from(b'`') =>
+                    {
+                        let _ = self.chars.eat_raw();
+                        self.append_char(next)?;
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+            self.append_char(c)?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -1298,6 +1379,40 @@ mod tests {
                     Token::Comma,
                     Token::Text(SmolStr::from_slice(b"b").unwrap()),
                     Token::Close,
+                    Token::Eof,
+                ],
+            ),
+            // Single-quoted span: braces/commas literal, quote chars dropped.
+            TestCase(
+                b"{a,'x,y'}",
+                vec![
+                    Token::Open(ExpansionVariants::default()),
+                    Token::Text(SmolStr::from_slice(b"a").unwrap()),
+                    Token::Comma,
+                    Token::Text(SmolStr::from_slice(b"x,y").unwrap()),
+                    Token::Close,
+                    Token::Eof,
+                ],
+            ),
+            // Double-quoted span: same.
+            TestCase(
+                br#"a"{b,c}""#,
+                vec![
+                    Token::Text(SmolStr::from_slice(b"a{b,c}").unwrap()),
+                    Token::Eof,
+                ],
+            ),
+            // Backslash-escaped quote is a literal quote byte.
+            TestCase(
+                br"\'{a,b}\'",
+                vec![
+                    Token::Text(SmolStr::from_slice(b"'").unwrap()),
+                    Token::Open(ExpansionVariants::default()),
+                    Token::Text(SmolStr::from_slice(b"a").unwrap()),
+                    Token::Comma,
+                    Token::Text(SmolStr::from_slice(b"b").unwrap()),
+                    Token::Close,
+                    Token::Text(SmolStr::from_slice(b"'").unwrap()),
                     Token::Eof,
                 ],
             ),

--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -1174,8 +1174,7 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
                     _ => {}
                 }
             } else if char == u32::from(b'\n') {
-                // `\<newline>` is a line continuation (bash): both characters
-                // are removed.
+                // `\<newline>` line continuation: drop both.
                 continue;
             }
 
@@ -1309,9 +1308,7 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
         self.chars.eat()
     }
 
-    /// Consume a single-quoted span: everything up to the next `'` is literal
-    /// text (including `\`), and both quote characters are dropped.
-    /// An unterminated quote consumes to end of input.
+    /// `'…'`: content literal (including `\`); quote chars dropped.
     fn eat_single_quoted(&mut self) -> Result<(), AllocError> {
         while let Some(c) = self.chars.eat_raw() {
             if c == u32::from(b'\'') {
@@ -1322,10 +1319,7 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
         Ok(())
     }
 
-    /// Consume a double-quoted span: `{`, `,`, `}` are literal text, both quote
-    /// characters are dropped, and `\` is an escape only before `"`/`\`/`$`/`` ` ``
-    /// /newline (bash quote-removal). An unterminated quote consumes to end of
-    /// input.
+    /// `"…"`: content literal; `\` escapes only `"`/`\`/`$`/`` ` ``/LF (bash).
     fn eat_double_quoted(&mut self) -> Result<(), AllocError> {
         while let Some(c) = self.chars.eat_raw() {
             if c == u32::from(b'"') {
@@ -1344,7 +1338,6 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
                         continue;
                     }
                     Some(next) if next == u32::from(b'\n') => {
-                        // `\<newline>` is a line continuation: both removed.
                         let _ = self.chars.eat_raw();
                         continue;
                     }
@@ -1356,11 +1349,8 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
         Ok(())
     }
 
-    /// Consume a `$'…'` span: the `$` and both quote characters are dropped,
-    /// the content is literal for brace purposes, and a `\X` pair is reduced to
-    /// `X` so an escaped `'` does not terminate the span. Other ANSI-C escape
-    /// translations (e.g. `\n` → LF) are not performed here. An unterminated
-    /// quote consumes to end of input.
+    /// `$'…'`: content literal; `\X` reduced to `X` so `\'` does not close
+    /// (full ANSI-C escape translation is not performed here).
     fn eat_ansi_c_quoted(&mut self) -> Result<(), AllocError> {
         while let Some(c) = self.chars.eat_raw() {
             if c == u32::from(b'\'') {

--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -1146,6 +1146,11 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
                             self.eat_double_quoted()?;
                             continue;
                         }
+                        Some(q) if q == u32::from(b'{') => {
+                            let _ = self.chars.eat_raw();
+                            self.eat_dollar_brace()?;
+                            continue;
+                        }
                         _ => {}
                     },
                     c if c == u32::from(b'{') => {
@@ -1351,6 +1356,26 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
                 }
             }
             self.append_char(c)?;
+        }
+        Ok(())
+    }
+
+    /// `${…}`: bash §3.5.1 — `${` inhibits brace expansion until the
+    /// depth-matched `}`. The whole span (including `$`, `{`, `}`) is text.
+    fn eat_dollar_brace(&mut self) -> Result<(), AllocError> {
+        self.append_char(u32::from(b'$'))?;
+        self.append_char(u32::from(b'{'))?;
+        let mut depth: u32 = 1;
+        while let Some(c) = self.chars.eat_raw() {
+            self.append_char(c)?;
+            if c == u32::from(b'{') {
+                depth += 1;
+            } else if c == u32::from(b'}') {
+                depth -= 1;
+                if depth == 0 {
+                    return Ok(());
+                }
+            }
         }
         Ok(())
     }

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -128,6 +128,68 @@ console.log(JSON.stringify(Bun.$.braces("{" + inner)));`,
   });
 });
 
+// `$.braces()` tokenized the raw string with no quote state, so `{`, `,`, `}`
+// inside `'…'`/`"…"` were treated as brace metacharacters and the quote
+// characters were left in the output. Bun's own `$` shell already handled the
+// same source text correctly because it brace-expands over atoms the shell
+// lexer has already quote-parsed. Each expected value below is the exact
+// `printf '[%s]\n' <input>` output under bash 5.2.
+describe("$.braces is quote-aware (bash 5.2)", () => {
+  const cases: [string, string[]][] = [
+    // Single-quoted span: literal content, quote characters dropped.
+    ["a'{b,c}'", ["a{b,c}"]],
+    ["'{a,b}'", ["{a,b}"]],
+    ["{a,'x,y'}", ["a", "x,y"]],
+    ["{a,'{b,c}'}", ["a", "{b,c}"]],
+    ["pre{a,'b,c','d,e'}post", ["preapost", "preb,cpost", "pred,epost"]],
+    ["{a,''}", ["a", ""]],
+    ["'a'\"b\"{c,d}", ["abc", "abd"]],
+    ["'a\\b'", ["a\\b"]],
+    // Double-quoted span: literal content, `\` escapes only `"`/`\`/`$`/`` ` ``.
+    ['a"{b,c}"', ["a{b,c}"]],
+    ['{a,"x,y"}', ["a", "x,y"]],
+    ['"a\\"b"', ['a"b']],
+    ['"a\\\\b"', ["a\\b"]],
+    ['"a\\nb"', ["a\\nb"]],
+    ['"a\\{b,c\\}"', ["a\\{b,c\\}"]],
+    // `$'…'`: literal content for brace purposes, `$` consumed along with the
+    // quotes (C-style escape sequences inside are not processed here).
+    ["$'{a,b}'", ["{a,b}"]],
+    ["{x,$'a,b'}", ["x", "a,b"]],
+    // Backslash outside quotes removes itself and makes the next char literal.
+    ["a\\{b,c\\}", ["a{b,c}"]],
+    ["\\'{a,b}\\'", ["'a'", "'b'"]],
+    ['\\"{a,b}\\"', ['"a"', '"b"']],
+    // Unicode content inside a quoted span.
+    ["{😂,'🫵,🤣'}", ["😂", "🫵,🤣"]],
+    // No brace group: the quote-stripped text is returned, not the raw input.
+    ["'hello'", ["hello"]],
+    ["x\\y", ["xy"]],
+    // An unterminated quote consumes to end of input (no throw).
+    ["'{a,b}", ["{a,b}"]],
+  ];
+
+  for (const [input, expected] of cases) {
+    test(`$.braces(${JSON.stringify(input)}) → ${JSON.stringify(expected)}`, () => {
+      expect($.braces(input)).toEqual(expected);
+    });
+  }
+
+  test("the shell still treats a literal quote byte inside a brace word as data", async () => {
+    // `\'` in shell source is a literal `'` byte in the expanded word. The
+    // brace expander must not start a quote span at that byte (the shell path
+    // backslash-escapes it before handing it to the brace lexer).
+    const out = (await $`echo ${{ raw: "{a,\\'x,y\\'}" }}`.text()).trim();
+    expect(out.split(" ")).toEqual(["a", "'x", "y'"]);
+    // And a quote byte arriving via JS interpolation is data too.
+    const out2 = (await $`echo {a,${"'x,y'"}}`.text()).trim();
+    expect(out2.split(" ")).toEqual(["a", "'x,y'"]);
+    // `$` inside a brace variant survives expansion.
+    const out3 = (await $`echo {a,${"$b"}}c`.text()).trim();
+    expect(out3.split(" ")).toEqual(["ac", "$bc"]);
+  });
+});
+
 // A shell word combining brace + glob (`src/*.{ts,tsx}`, `{src,lib}/*.ts`) was
 // brace-expanded but the resulting `*` patterns were never globbed (the
 // brace-expand state always transitioned to Done instead of re-entering glob).

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -145,21 +145,26 @@ describe("$.braces is quote-aware (bash 5.2)", () => {
     ["{a,''}", ["a", ""]],
     ["'a'\"b\"{c,d}", ["abc", "abd"]],
     ["'a\\b'", ["a\\b"]],
-    // Double-quoted span: literal content, `\` escapes only `"`/`\`/`$`/`` ` ``.
+    // Double-quoted span: literal content, `\` escapes only `"`/`\`/`$`/`` ` ``/LF.
     ['a"{b,c}"', ["a{b,c}"]],
     ['{a,"x,y"}', ["a", "x,y"]],
     ['"a\\"b"', ['a"b']],
     ['"a\\\\b"', ["a\\b"]],
     ['"a\\nb"', ["a\\nb"]],
     ['"a\\{b,c\\}"', ["a\\{b,c\\}"]],
+    ['"a\\\nb"', ["ab"]],
     // `$'…'`: literal content for brace purposes, `$` consumed along with the
-    // quotes (C-style escape sequences inside are not processed here).
+    // quotes. `\'` does not terminate the span.
     ["$'{a,b}'", ["{a,b}"]],
     ["{x,$'a,b'}", ["x", "a,b"]],
-    // Backslash outside quotes removes itself and makes the next char literal.
+    ["$'\\'{a,b}'", ["'{a,b}"]],
+    ["$'{a,\\'b}'", ["{a,'b}"]],
+    // Backslash outside quotes removes itself and makes the next char literal,
+    // or both characters for `\<newline>` (line continuation).
     ["a\\{b,c\\}", ["a{b,c}"]],
     ["\\'{a,b}\\'", ["'a'", "'b'"]],
     ['\\"{a,b}\\"', ['"a"', '"b"']],
+    ["a\\\nb", ["ab"]],
     // Unicode content inside a quoted span.
     ["{😂,'🫵,🤣'}", ["😂", "🫵,🤣"]],
     // No brace group: the quote-stripped text is returned, not the raw input.

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -156,6 +156,9 @@ describe("$.braces is quote-aware (bash 5.2)", () => {
     ["{x,$'a,b'}", ["x", "a,b"]],
     ["$'\\'{a,b}'", ["'{a,b}"]],
     ["$'{a,\\'b}'", ["{a,'b}"]],
+    // `$"…"`: treated like `"…"` with the `$` consumed.
+    ['$"{a,b}"', ["{a,b}"]],
+    ['a$"{b,c}"d', ["a{b,c}d"]],
     // Backslash outside quotes removes itself and makes the next char literal,
     // or both characters for `\<newline>` (line continuation).
     ["a\\{b,c\\}", ["a{b,c}"]],

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -159,6 +159,13 @@ describe("$.braces is quote-aware (bash 5.2)", () => {
     // `$"…"`: treated like `"…"` with the `$` consumed.
     ['$"{a,b}"', ["{a,b}"]],
     ['a$"{b,c}"d', ["a{b,c}d"]],
+    // `${…}`: inhibits brace expansion until the depth-matched `}` (bash §3.5.1;
+    // parameter expansion itself is not performed here).
+    ["${a,b}", ["${a,b}"]],
+    ["{x,${a,b}}", ["x", "${a,b}"]],
+    ["${x:-{a,b}}", ["${x:-{a,b}}"]],
+    ["${a}{b,c}", ["${a}b", "${a}c"]],
+    ["\\${a,b}", ["$a", "$b"]],
     // Backslash outside quotes removes itself and makes the next char literal,
     // or both characters for `\<newline>` (line continuation).
     ["a\\{b,c\\}", ["a{b,c}"]],

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -128,12 +128,9 @@ console.log(JSON.stringify(Bun.$.braces("{" + inner)));`,
   });
 });
 
-// `$.braces()` tokenized the raw string with no quote state, so `{`, `,`, `}`
-// inside `'…'`/`"…"` were treated as brace metacharacters and the quote
-// characters were left in the output. Bun's own `$` shell already handled the
-// same source text correctly because it brace-expands over atoms the shell
-// lexer has already quote-parsed. Each expected value below is the exact
-// `printf '[%s]\n' <input>` output under bash 5.2.
+// `{`, `,`, `}` inside `'…'`/`"…"`/`$'…'` are literal and the quote chars are
+// dropped; the `$` shell already got this right (it quote-parses first). Each
+// expected value is the `printf '[%s]\n' <input>` output under bash 5.2.
 describe("$.braces is quote-aware (bash 5.2)", () => {
   const cases: [string, string[]][] = [
     // Single-quoted span: literal content, quote characters dropped.


### PR DESCRIPTION
## What

`$.braces()` passed its input straight to the brace lexer, which tracked a backslash-escape flag but had no quote state. A `{`, `}`, or `,` inside single or double quotes was treated as a metacharacter, and the quote characters themselves were left in the output words:

```js
$.braces("a'{b,c}'")   // ["a'b'", "a'c'"]   bash: a{b,c}
$.braces("'{a,b}'")    // ["'a'", "'b'"]     bash: {a,b}
$.braces("{a,'x,y'}")  // ["a", "'x", "y'"]  bash: a  x,y   (quoted comma is not a separator)
```

Bun's own `$` shell gets the identical source text right (`await $`echo a'{b,c}'d`.text()` is `"a{b,c}d\n"`) because it brace-expands over atoms its own lexer has already quote-parsed. The exported helper and the shell disagreed.

## Fix

- `src/shell_parser/braces.rs`: the lexer now recognizes `'...'` / `"..."` / `$'...'` / `$"..."` spans; their content is literal text and the quote characters are dropped. Inside double quotes `\` escapes only `"`/`\`/`$`/`` ` ``/LF. Inside `$'...'`, `\X` is reduced to `X` so `\'` does not close the span (full ANSI-C escape translation is not performed). `${...}` inhibits brace expansion until the depth-matched `}` (bash §3.5.1). `\<newline>` is dropped (line continuation). An unterminated quote consumes to end of input rather than throwing.
- `src/runtime/shell/states/Expansion.rs`: `do_brace_expand` already backslash-escapes non-metacharacter bytes before handing the word to the brace lexer; add `'`, `"`, `$` to that set so literal quote bytes (from `\'` in source, or from JS `${...}` interpolation) stay data and do not open a quote span in the now-quote-aware lexer.
- `src/runtime/api/BunObject.rs`: when no `{...}` group forms an expansion, return the quote-stripped token text rather than echoing the raw input, so `$.braces("'hello'")` is `["hello"]` and `$.braces("a\\{b,c\\}")` is `["a{b,c}"]`.

## Out of scope

`$.braces()` performs no parameter, command, arithmetic, or process expansion, so the following are left as pre-existing behaviour:

- `$(...)`, `` `...` ``, `<(...)`, `>(...)`: a `,` inside is still a brace separator (as on main).
- `${...}` containing a quoted or escaped `}` in a `:-` default (e.g. `${x:-'}'}`): the span closes at the first depth-matched `}` rather than bash's full parameter-expansion boundary.
- ANSI-C escape translation inside `$'...'` (e.g. `\n` → LF): `\X` is reduced to `X` for span-boundary correctness only.

## Verification

`test/js/bun/shell/brace.test.ts` gains a `$.braces is quote-aware (bash 5.2)` block covering single/double/ANSI-C/`$"..."` spans, double-quote backslash rules, `\<newline>` continuation, adjacent quote spans, unicode inside quotes, backslash-escaped quotes, `${...}` inhibition, and a shell-side control test that a literal `'` byte reaching brace expansion via `\'` or JS interpolation stays data. Each expected value is the `printf '[%s]\n' <input>` output under bash 5.2.

Before: the new cases fail. After: all 76 tests in the file pass, `bunshell.test.ts` / `lex.test.ts` / `parse.test.ts` unchanged.