### PR TITLE
event_loop: stop re-draining thread-pool completions mid-tick

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -97,12 +97,7 @@ function getNodeParallelTestTimeout(testPath) {
   if (testPath.includes("test-cluster-")) return 60_000; // cluster IPC + socket-handle passing is process-heavy under runner concurrency
   if (testPath.includes("-docker-")) return 60_000;
   if (testPath.includes("test-stdin-pipe-large")) return 60_000; // pipes 1MB stdin->stdout through an extra child process; slow under runner concurrency
-  // test-fs-read-stream-pos.js exit condition is a pure timing race (writer must append
-  // between two consecutive ReadStream preads) with a 90s upstream safety timer; solo
-  // runtimes are ~1s on linux-x64 but 1-40s on Windows since #34834 raised its timer
-  // resolution, and aarch64 CI retries running alone have exceeded 20s (builds 85866,
-  // 85400). 120s lets the safety timer fire.
-  if (testPath.includes("test-fs-read-stream-pos")) return 120_000;
+  if (testPath.includes("test-fs-read-stream-pos")) return 120_000; // upstream arms a 90s safety timer; let it fire
   if (!isCI) return 60_000; // everything slower in debug mode
   if (options["step"]?.includes("-asan-")) return 60_000;
   return 20_000;
@@ -640,14 +635,7 @@ async function runTests() {
   const parallelSafeLimit = parallelism > 1 ? limit : pLimit(parallelSafeWidth);
   const isParallelSafeTest = testPath => {
     const p = testPath.replaceAll("\\", "/");
-    if (!p.includes("js/node/test/parallel/") && !p.includes("js/bun/test/parallel/")) return false;
-    // test-fs-read-stream-pos.js arms a common.mustCallAtLeast per stream; under
-    // I/O-heavy neighbours (e.g. test-fs-read-stream-fd-leak) the 1ms append
-    // interval is starved long enough for a stream to catch cur == EOF and get
-    // zero 'data' events, failing the mustCallAtLeast check on exit. Run it in
-    // the serial phase so the writer keeps its 1ms cadence.
-    if (p.endsWith("test-fs-read-stream-pos.js")) return false;
-    return true;
+    return p.includes("js/node/test/parallel/") || p.includes("js/bun/test/parallel/");
   };
   console.log("parallel-safe width", parallelSafeWidth);
   const validationApplies = basename(execPath).includes("asan") || !isCI;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1039,12 +1039,7 @@ impl VirtualMachine {
                 + self.active_tasks
                 + el.tasks.readable_length()
                 + (el.has_pending_refs() as usize)
-                // A cross-thread completion posted via `queueTaskConcurrently`
-                // (`ConcurrentCppTask::run_owned` → `postTaskTo`) drops its
-                // `concurrent_ref` on the work-pool thread before the JS
-                // thread observes it, so `has_pending_refs()` alone is not
-                // sufficient; a task still sitting in `concurrent_tasks` is
-                // work `tick()` must run.
+                // A posted-but-not-yet-drained cross-thread task is work to run.
                 + (!el.concurrent_tasks.is_empty() as usize)
                 > 0)
     }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1039,6 +1039,13 @@ impl VirtualMachine {
                 + self.active_tasks
                 + el.tasks.readable_length()
                 + (el.has_pending_refs() as usize)
+                // A cross-thread completion posted via `queueTaskConcurrently`
+                // (`ConcurrentCppTask::run_owned` → `postTaskTo`) drops its
+                // `concurrent_ref` on the work-pool thread before the JS
+                // thread observes it, so `has_pending_refs()` alone is not
+                // sufficient; a task still sitting in `concurrent_tasks` is
+                // work `tick()` must run.
+                + (!el.concurrent_tasks.is_empty() as usize)
                 > 0)
     }
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -67,6 +67,19 @@ MessagePort::MessagePort(ScriptExecutionContext& context, Ref<MessagePortPipe>&&
 
 MessagePort::~MessagePort()
 {
+    // Release the listener / jsRef keepalives if the wrapper was collected
+    // before peerClosed() reached jsUnref(); otherwise the ref outlives the
+    // port and the event loop never idles.
+    if (m_listenerLoopRefActive) {
+        m_listenerLoopRefActive = false;
+        if (auto* context = scriptExecutionContext())
+            context->unrefEventLoop();
+    }
+    if (m_hasRef) {
+        m_hasRef = false;
+        if (auto* context = scriptExecutionContext())
+            context->unrefEventLoop();
+    }
     if (!m_isDetached)
         m_pipe->close(m_side, MessagePortPipe::CloseKind::Collected);
 }

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -67,10 +67,11 @@ MessagePort::MessagePort(ScriptExecutionContext& context, Ref<MessagePortPipe>&&
 
 MessagePort::~MessagePort()
 {
-    if (auto* context = scriptExecutionContext()) {
-        if (m_listenerLoopRefActive)
-            context->unrefEventLoop();
-        if (m_hasRef)
+    // jsRef() takes a self-ref() alongside m_hasRef, so the destructor cannot
+    // run while m_hasRef is set. The listener keepalive takes no self-ref.
+    ASSERT(!m_hasRef);
+    if (m_listenerLoopRefActive) {
+        if (auto* context = scriptExecutionContext())
             context->unrefEventLoop();
     }
     if (!m_isDetached)

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -67,17 +67,10 @@ MessagePort::MessagePort(ScriptExecutionContext& context, Ref<MessagePortPipe>&&
 
 MessagePort::~MessagePort()
 {
-    // Release the listener / jsRef keepalives if the wrapper was collected
-    // before peerClosed() reached jsUnref(); otherwise the ref outlives the
-    // port and the event loop never idles.
-    if (m_listenerLoopRefActive) {
-        m_listenerLoopRefActive = false;
-        if (auto* context = scriptExecutionContext())
+    if (auto* context = scriptExecutionContext()) {
+        if (m_listenerLoopRefActive)
             context->unrefEventLoop();
-    }
-    if (m_hasRef) {
-        m_hasRef = false;
-        if (auto* context = scriptExecutionContext())
+        if (m_hasRef)
             context->unrefEventLoop();
     }
     if (!m_isDetached)

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -610,6 +610,10 @@ impl EventLoop {
         // scopeguard closure would alias `&mut self`).
 
         let ctx = self.vm();
+        // One snapshot of thread-pool completions per tick, like libuv's
+        // `uv__work_done`. Completions that arrive while this batch is being
+        // processed are picked up by the next tick (after immediates/timers),
+        // so a self-feeding chain can't starve the check/timer phases.
         self.tick_concurrent();
         self.process_gc_timer();
 
@@ -620,7 +624,6 @@ impl EventLoop {
 
         loop {
             while self.tick_with_count(ctx) > 0 {
-                self.tick_concurrent();
                 self.global_ref().handle_rejected_promises();
             }
             if self
@@ -631,16 +634,13 @@ impl EventLoop {
                 self.entered_event_loop_count -= 1;
                 return;
             }
-            self.tick_concurrent();
             if self.tasks.readable_length() > 0 {
                 continue;
             }
             break;
         }
 
-        while self.tick_with_count(ctx) > 0 {
-            self.tick_concurrent();
-        }
+        while self.tick_with_count(ctx) > 0 {}
 
         self.global_ref().handle_rejected_promises();
 

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -609,23 +609,18 @@ impl EventLoop {
         // The scope/counter cleanup is inlined at each return site below (a
         // scopeguard closure would alias `&mut self`).
 
-        // A previous tick() can leave the termination exception on the VM with
-        // tasks still queued (it was set mid-batch and `tick_with_count`
-        // returned 0). Callers like the worker run loop's
-        // `tick(); while is_event_loop_alive() { tick(); ... }` pair may call
-        // straight back in because `is_event_loop_alive()` only looks at queue
-        // lengths. Running the next batch with the exception pending re-enters
-        // `executeCallImpl` under `scope.assertNoException()`.
+        // Same guard as after `drain_microtasks` below: a prior tick() that
+        // aborted mid-batch on termination can leave tasks queued with the
+        // exception pending, and some callers re-enter without checking.
         if scope.has_exception() {
             self.entered_event_loop_count -= 1;
             return;
         }
 
         let ctx = self.vm();
-        // One snapshot of thread-pool completions per tick, like libuv's
-        // `uv__work_done`. Completions that arrive while this batch is being
-        // processed are picked up by the next tick (after immediates/timers),
-        // so a self-feeding chain can't starve the check/timer phases.
+        // One snapshot of thread-pool completions per tick (libuv's
+        // `uv__work_done`); new arrivals wait for the next iteration so a
+        // self-feeding chain can't starve the check/timer phases.
         self.tick_concurrent();
         self.process_gc_timer();
 

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -609,6 +609,18 @@ impl EventLoop {
         // The scope/counter cleanup is inlined at each return site below (a
         // scopeguard closure would alias `&mut self`).
 
+        // A previous tick() can leave the termination exception on the VM with
+        // tasks still queued (it was set mid-batch and `tick_with_count`
+        // returned 0). Callers like the worker run loop's
+        // `tick(); while is_event_loop_alive() { tick(); ... }` pair may call
+        // straight back in because `is_event_loop_alive()` only looks at queue
+        // lengths. Running the next batch with the exception pending re-enters
+        // `executeCallImpl` under `scope.assertNoException()`.
+        if scope.has_exception() {
+            self.entered_event_loop_count -= 1;
+            return;
+        }
+
         let ctx = self.vm();
         // One snapshot of thread-pool completions per tick, like libuv's
         // `uv__work_done`. Completions that arrive while this batch is being
@@ -639,8 +651,6 @@ impl EventLoop {
             }
             break;
         }
-
-        while self.tick_with_count(ctx) > 0 {}
 
         self.global_ref().handle_rejected_promises();
 

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -294,3 +294,35 @@ it("setImmediate fires between chained thread-pool completions (no mid-tick re-d
   expect(JSON.parse(stdout.trim())).toEqual({ calls: 200, sameTick: 0 });
   expect(exitCode).toBe(0);
 });
+
+it("a chain of awaited WebCrypto operations keeps the event loop alive", async () => {
+  // ConcurrentCppTask refs the loop on the JS thread and unrefs on the pool
+  // thread after postTaskTo'ing the result back. If the JS thread's
+  // is_event_loop_alive() runs between that unref and the next tick()'s
+  // concurrent-queue drain, it must still count the posted-but-not-yet-popped
+  // result as work; otherwise the process exits with the promise pending.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { subtle } = globalThis.crypto;
+        (async () => {
+          const key = await subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, true, ['sign', 'verify']);
+          const data = Buffer.from('x');
+          const sig = await subtle.sign('HMAC', key, data);
+          for (let i = 0; i < 50; i++) {
+            if (!(await subtle.verify('HMAC', key, sig, data))) throw new Error('bad');
+          }
+          console.log('DONE');
+        })();
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("DONE");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -249,33 +249,35 @@ it("should defer microtasks when an exception is thrown in an immediate", async 
 it("setImmediate fires between chained thread-pool completions (no mid-tick re-drain)", async () => {
   // Node's event loop takes one snapshot of thread-pool completions per poll
   // iteration and runs the check phase (setImmediate) before the next poll.
-  // So a chain of `fs.read cb -> nextTick -> fs.read -> ...` (the ReadStream
-  // pattern) observes a setImmediate fire between every pair of read
+  // So a chain of `threadpool cb -> nextTick -> threadpool op -> ...` (the
+  // fs.ReadStream pattern) observes a setImmediate fire between every pair of
   // callbacks. When Bun's tick() re-drained the concurrent queue mid-tick, a
   // fast completion that landed while tasks were still being processed ran
   // before immediates and timers, so a due setInterval (the writer in
   // test-fs-read-stream-pos.js) could be starved for the duration of a
   // stream's read chain.
+  //
+  // crypto.pbkdf2 completes via enqueue_task_concurrent on every platform; on
+  // Windows fs.read goes through libuv's own callback and would not exercise
+  // the mid-tick re-drain path.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
-        const fs = require('fs');
-        const fd = fs.openSync(process.execPath, 'r');
+        const crypto = require('crypto');
         let immediateTicks = 0;
         let lastTicks = -1;
-        let reads = 0;
+        let calls = 0;
         let sameTick = 0;
         (function imm() { immediateTicks++; setImmediate(imm); })();
         function go() {
-          fs.read(fd, Buffer.allocUnsafe(1), 0, 1, 0, () => {
-            reads++;
+          crypto.pbkdf2('a', 'b', 1, 8, 'sha256', () => {
+            calls++;
             if (immediateTicks === lastTicks) sameTick++;
             lastTicks = immediateTicks;
-            if (reads >= 200) {
-              fs.closeSync(fd);
-              console.log(JSON.stringify({ reads, sameTick }));
+            if (calls >= 200) {
+              console.log(JSON.stringify({ calls, sameTick }));
               process.exit(0);
             }
             process.nextTick(go);
@@ -289,6 +291,6 @@ it("setImmediate fires between chained thread-pool completions (no mid-tick re-d
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(JSON.parse(stdout.trim())).toEqual({ reads: 200, sameTick: 0 });
+  expect(JSON.parse(stdout.trim())).toEqual({ calls: 200, sameTick: 0 });
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -245,3 +245,50 @@ describe.each(["with", "without"])("setImmediate %s timers running", mode => {
 it("should defer microtasks when an exception is thrown in an immediate", async () => {
   expect(await bunRun(["run", path.join(import.meta.dir, "timers-immediate-exception-fixture.js")])).toSpawn();
 });
+
+it("setImmediate fires between chained thread-pool completions (no mid-tick re-drain)", async () => {
+  // Node's event loop takes one snapshot of thread-pool completions per poll
+  // iteration and runs the check phase (setImmediate) before the next poll.
+  // So a chain of `fs.read cb -> nextTick -> fs.read -> ...` (the ReadStream
+  // pattern) observes a setImmediate fire between every pair of read
+  // callbacks. When Bun's tick() re-drained the concurrent queue mid-tick, a
+  // fast completion that landed while tasks were still being processed ran
+  // before immediates and timers, so a due setInterval (the writer in
+  // test-fs-read-stream-pos.js) could be starved for the duration of a
+  // stream's read chain.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const fs = require('fs');
+        const fd = fs.openSync(process.execPath, 'r');
+        let immediateTicks = 0;
+        let lastTicks = -1;
+        let reads = 0;
+        let sameTick = 0;
+        (function imm() { immediateTicks++; setImmediate(imm); })();
+        function go() {
+          fs.read(fd, Buffer.allocUnsafe(1), 0, 1, 0, () => {
+            reads++;
+            if (immediateTicks === lastTicks) sameTick++;
+            lastTicks = immediateTicks;
+            if (reads >= 200) {
+              fs.closeSync(fd);
+              console.log(JSON.stringify({ reads, sameTick }));
+              process.exit(0);
+            }
+            process.nextTick(go);
+          });
+        }
+        setImmediate(go);
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({ reads: 200, sameTick: 0 });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/workers/message-port-pipe.test.ts
+++ b/test/js/web/workers/message-port-pipe.test.ts
@@ -388,7 +388,7 @@ describe("MessagePort pipe", () => {
     expect(stderr).toBe("");
     expect(stdout).toBe("");
     expect(exitCode).toBe(0);
-  }, 15_000);
+  });
 });
 
 // worker.postMessage / parentPort.postMessage go through the same coalesced

--- a/test/js/web/workers/message-port-pipe.test.ts
+++ b/test/js/web/workers/message-port-pipe.test.ts
@@ -363,6 +363,32 @@ describe("MessagePort pipe", () => {
     expect(stdout.trim()).toBe("OK");
     expect(exitCode).toBe(0);
   });
+
+  test("collecting a listening port after its peer closes releases the listener loop ref", async () => {
+    // hasPendingActivity() is false once the peer is closed and no messages are
+    // queued, so the wrapper can be collected before the deferred peerClosed()
+    // task runs. ~MessagePort must release the listener ref itself or the loop
+    // never idles.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { MessageChannel } = require('node:worker_threads');
+          const { port1, port2 } = new MessageChannel();
+          port2.once('message', () => {});
+          port1.close();
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  }, 15_000);
 });
 
 // worker.postMessage / parentPort.postMessage go through the same coalesced


### PR DESCRIPTION
Replaces the CI runner workaround from #36478 with a fix for the event-loop ordering it was working around.

### Repro

```js
const crypto = require('crypto');
let immediateTicks = 0, lastTicks = -1, calls = 0, sameTick = 0;
(function imm() { immediateTicks++; setImmediate(imm); })();
(function go() {
  crypto.pbkdf2('a', 'b', 1, 8, 'sha256', () => {
    calls++;
    if (immediateTicks === lastTicks) sameTick++;
    lastTicks = immediateTicks;
    if (calls >= 200) { console.log({ calls, sameTick }); process.exit(0); }
    process.nextTick(go);
  });
})();
```

Node prints `{ calls: 200, sameTick: 0 }` on every platform. Bun prints `sameTick` 10-150: the immediate (and any due timer) does not fire between some pairs of chained thread-pool callbacks. Same shape with `fs.read` on POSIX (on Windows `fs.read` completes via libuv's own callback and already interleaves).

### Cause

`EventLoop::tick()` re-drained `concurrent_tasks` inside its `while tick_with_count() > 0` loop and again after the microtask drain. A thread-pool completion that arrived while tasks were still being processed was promoted and run in the same `tick()`, so a self-feeding chain (the `fs.ReadStream` pattern: read cb → `push` → `nextTick` → `_read` → read) ran entirely inside one `tick()` before `auto_tick*` reached the immediate or timer phase. The inner-loop `tickConcurrent()` dates to 0ce709d96a (2022) and is not a recent regression; #36175 and #34834 changed CI scheduling enough to surface it via `test-fs-read-stream-pos.js`.

libuv delivers thread-pool completions once per poll (`uv__work_done` moves `loop->wq` into a local queue and processes that; new completions wait for the next poll, after the check and timer phases). So in Node a `setImmediate` fires between every pair of chained callbacks.

### Fix

Drop the mid-tick `tick_concurrent()` calls. The unconditional one at the top of `tick()` is the once-per-iteration snapshot, same as `uv__work_done`; completions that land during processing are picked up by the next `tick()`, after `auto_tick*` has run immediates and timers. Tasks enqueued from the JS thread via `enqueue_task` still drain in the same tick (the loop around `drain_microtasks` stays). The unreachable trailing `while tick_with_count > 0 {}` is removed with it.

Three places relied on `tick()` returning with `concurrent_tasks` empty; all are pre-existing latent bugs that the re-drain masked:

* **`is_event_loop_alive_excluding_immediates()`** checked `tasks.readable_length()` and `has_pending_refs()` but not `concurrent_tasks`. `ConcurrentCppTask::run_owned` (the WebCrypto path) unrefs on the work-pool thread after `postTaskTo`ing the result back, so the result can sit in `concurrent_tasks` with `concurrent_ref == 0` and the run loop exits with the promise still pending. A posted-but-not-yet-drained cross-thread task is work to run; count it.
* **`tick()` re-entry with the termination exception pending.** A worker being terminated mid-batch leaves the rest of the batch in `el.tasks` with the termination exception on the VM. The worker run loop's `tick(); while is_event_loop_alive() { tick(); ... }` calls straight back in. The ManagedTask arm runs `initial_stat_error_on_main_thread`, whose `stat_to_js_stats` wrapper (`call_zero_is_throw_at` → `assert_no_exception`) skips termination and returns `Ok`, so `listener.call()` reaches `executeCallImpl` → `scope.assertNoException()` and aborts. Guard `tick()` at entry the same way it already guards after `drain_microtasks`.
* **`MessagePort::~MessagePort()` did not release its listener/jsRef loop refs.** `hasPendingActivity()` is false once the peer has closed and no messages are queued, so the wrapper can be collected before the deferred `notifyPeerClosed` task runs. The task's `ThreadSafeWeakPtr` then resolves to null (and the pipe side's `ctxId` was zeroed by `~MessagePort` → `pipe->close()`), so `peerClosed()` → `jsUnref()` never fires and the listener ref outlives the port. Release it in the destructor so collection is as good as an explicit `close()` for loop-ref accounting.

#36479 takes the alternative route of keeping the re-drain but gating it on pending immediates and a due-timer probe; this PR removes it outright to match libuv's one-batch-per-poll semantics. The three fix-ups above are correctness fixes in their own right that the gated approach would leave latent.

### Verification

New tests:

* `node-timers.test.ts` `setImmediate fires between chained thread-pool completions`: asserts `sameTick == 0` for 200 chained `crypto.pbkdf2` callbacks. Fails on the release canary with `sameTick` 10-25 (linux x64, windows x64), passes with the change. Node is always 0.
* `node-timers.test.ts` `a chain of awaited WebCrypto operations keeps the event loop alive`: 50 sequential `await subtle.verify()` calls must all resolve before exit. Regression guard for the `is_event_loop_alive` change.
* `message-port-pipe.test.ts` `collecting a listening port after its peer closes releases the listener loop ref`: regression guard for the `~MessagePort` change.

`test-fs-read-stream-pos.js` per-stream hit rate (writer lands between two consecutive ReadStream preads), 3s sample:

| | before | after |
|---|---|---|
| node linux x64 | 8-15% | |
| bun linux x64 release | 1-4% | n/a |
| bun linux x64 debug | 1-4% | 52-66% |
| bun win x64 release | 0-0.5% | n/a |

On Windows each ReadStream's pread chain finishes in ~500us so no 1ms timer is due inside that window regardless of ordering; the test's own 90s safety timer handles that tail, which is why the 120s runner ceiling stays.

Regression sweep (debug build, linux x64) against the same tests on main: `fs.test.ts`, `promises.test.js`, `node-stream.test.js`, `serve.test.ts`, `node-http.test.ts`, `worker_threads.test.ts`, `fetch.test.ts`, `spawn.test.ts`, `child_process.test.ts`, `node-timers.test.ts`, `setImmediate.test.js`, the upstream `test-timers-immediate*` / `test-fs-read-stream*` / `test-webcrypto-*` / `test-worker-message-port-*` sets, `fs.watchFile.test.ts`, `message-port-pipe.test.ts`. No new failures vs main. Windows debug: `node-timers.test.ts` 20/20, `zlib.test.js` 387/387, `password.test.ts` 69/69, `worker_threads.test.ts` 91/91.

Reverts the `isParallelSafeTest` exclusion from #36478; keeps the 120s ceiling so the upstream 90s safety timer can fire on Windows.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/timers/node-timers.test.ts

<!-- robobun:evidence:end -->