### PR TITLE
node:http2: pushStream failure reports only via callback, not stream 'error'

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3289,11 +3289,9 @@ class ServerHttp2Stream extends Http2Stream {
     try {
       parser.pushPromise(this.id, pushId, headers, sensitiveNames);
     } catch (err) {
-      // pushPromise() can throw synchronously (invalid token, invalid pseudo-header, oversized
-      // block). The pushed stream was already created by getNextStream's streamStart; tear it
-      // down so the connection count and its context root do not leak. node reports this failure
-      // only through the callback (its stream object doesn't exist yet on this path), so destroy
-      // without an error argument: the pushed stream must not emit 'error'.
+      // pushPromise() throws synchronously on an invalid header block. The pushed stream was
+      // already created by getNextStream's streamStart; tear it down without an error so the
+      // callback is the only error channel, matching node.
       if (pushedStream && !pushedStream.destroyed) {
         // The PUSH_PROMISE never reached the wire; sending RST_STREAM for the reserved id would
         // be a protocol violation (the peer sees an idle stream). The skipped reset dispatch is

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3291,15 +3291,16 @@ class ServerHttp2Stream extends Http2Stream {
     } catch (err) {
       // pushPromise() can throw synchronously (invalid token, invalid pseudo-header, oversized
       // block). The pushed stream was already created by getNextStream's streamStart; tear it
-      // down so the connection count and its context root do not leak, and report the error
-      // through the callback like node does.
+      // down so the connection count and its context root do not leak. node reports this failure
+      // only through the callback (its stream object doesn't exist yet on this path), so destroy
+      // without an error argument: the pushed stream must not emit 'error'.
       if (pushedStream && !pushedStream.destroyed) {
         // The PUSH_PROMISE never reached the wire; sending RST_STREAM for the reserved id would
         // be a protocol violation (the peer sees an idle stream). The skipped reset dispatch is
         // also what releases the session's bookkeeping - do that explicitly.
         pushedStream[kNeverAnnounced] = true;
         session[kReleaseUnannouncedStream](pushId);
-        pushedStream.destroy(pushedStream.listenerCount("error") > 0 ? err : undefined);
+        pushedStream.destroy();
       }
       process.nextTick(callback, err);
       return;

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1,6 +1,7 @@
 import { bunEnv, bunExe, isASAN, isCI, isDebug, nodeExe } from "harness";
 import { createTest } from "node-harness";
 import { AsyncLocalStorage } from "node:async_hooks";
+import dc from "node:diagnostics_channel";
 import fs from "node:fs";
 import http2 from "node:http2";
 import https from "node:https";
@@ -3082,7 +3083,6 @@ it("http2 pushStream failure reports only via callback, never via stream 'error'
   // teardown must stay silent: the callback is the sole error channel. The diagnostics_channel
   // publish is the only way user code can observe the pushed stream before the callback, so use
   // it to attach a listener and prove nothing is emitted.
-  const dc = require("node:diagnostics_channel");
   const pushedStreams = [];
   const onCreated = ({ stream, headers }) => {
     if (headers[":path"] !== "/pushed") return;

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3091,10 +3091,6 @@ it("http2 pushStream failure reports only via callback, never via stream 'error'
   };
   dc.subscribe("http2.server.stream.created", onCreated);
 
-  let uncaught;
-  const onUncaught = err => (uncaught = err);
-  process.on("uncaughtException", onUncaught);
-
   const server = http2.createServer();
   const { promise: callbackResult, resolve: onCallback } = Promise.withResolvers();
   server.on("stream", stream => {
@@ -3121,11 +3117,9 @@ it("http2 pushStream failure reports only via callback, never via stream 'error'
     // Let any scheduled 'error'/'close' emissions from destroy() run.
     await new Promise(resolve => setImmediate(resolve));
     expect(pushedStreams).toEqual([{ event: "close", destroyed: true }]);
-    expect(uncaught).toBeUndefined();
     client.close();
   } finally {
     dc.unsubscribe("http2.server.stream.created", onCreated);
-    process.removeListener("uncaughtException", onUncaught);
     server.close();
   }
 });

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3076,6 +3076,60 @@ it("http2 pushStream reports header values containing CR, LF, or NUL through the
   }
 });
 
+it("http2 pushStream failure reports only via callback, never via stream 'error'", async () => {
+  // node creates the ServerHttp2Stream only after pushPromise succeeds, so a validation
+  // failure never reaches a stream 'error' event. bun must create the stream first, but the
+  // teardown must stay silent: the callback is the sole error channel. The diagnostics_channel
+  // publish is the only way user code can observe the pushed stream before the callback, so use
+  // it to attach a listener and prove nothing is emitted.
+  const dc = require("node:diagnostics_channel");
+  const pushedStreams = [];
+  const onCreated = ({ stream, headers }) => {
+    if (headers[":path"] !== "/pushed") return;
+    stream.on("error", err => pushedStreams.push({ event: "error", code: err?.code }));
+    stream.on("close", () => pushedStreams.push({ event: "close", destroyed: stream.destroyed }));
+  };
+  dc.subscribe("http2.server.stream.created", onCreated);
+
+  let uncaught;
+  const onUncaught = err => (uncaught = err);
+  process.on("uncaughtException", onUncaught);
+
+  const server = http2.createServer();
+  const { promise: callbackResult, resolve: onCallback } = Promise.withResolvers();
+  server.on("stream", stream => {
+    stream.pushStream({ ":path": "/pushed", "x-bad": "a\nb" }, (err, pushed) => {
+      onCallback({ code: err?.code, pushed });
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+  try {
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    client.on("error", () => {});
+    const { promise: done, resolve: onEnd, reject: onError } = Promise.withResolvers();
+    const req = client.request({ ":path": "/" });
+    req.on("error", onError);
+    req.resume();
+    req.on("end", onEnd);
+    await done;
+
+    const result = await callbackResult;
+    expect(result).toEqual({ code: "ERR_HTTP2_INVALID_HEADER_VALUE", pushed: undefined });
+    // Let any scheduled 'error'/'close' emissions from destroy() run.
+    await new Promise(resolve => setImmediate(resolve));
+    expect(pushedStreams).toEqual([{ event: "close", destroyed: true }]);
+    expect(uncaught).toBeUndefined();
+    client.close();
+  } finally {
+    dc.unsubscribe("http2.server.stream.created", onCreated);
+    process.removeListener("uncaughtException", onUncaught);
+    server.close();
+  }
+});
+
 it("http2 option range error messages use the options. prefix", () => {
   for (const opt of ["maxSessionInvalidFrames", "maxSessionRejectedStreams", "unknownProtocolTimeout"]) {
     let error;


### PR DESCRIPTION
## What

`ServerHttp2Stream.pushStream` tore down the reserved pushed stream with

```ts
pushedStream.destroy(pushedStream.listenerCount("error") > 0 ? err : undefined);
```

Branching on `listenerCount` is a workaround, and it diverges from Node: in `lib/internal/http2/core.js` the `ServerHttp2Stream` for a push is constructed only after `pushPromise` succeeds, so a validation failure is reported solely through the callback (`process.nextTick(callback, err); return;`) and no stream `'error'` is ever emitted on that path.

## Fix

Destroy the reserved stream without an error argument. The callback remains the only error channel.

```ts
pushedStream.destroy();
```

## Verification

New test in `test/js/node/http2/node-http2.test.js` subscribes to the `http2.server.stream.created` diagnostics channel (the only way user code can observe the pushed stream before the callback runs), attaches an `'error'` listener, and calls `pushStream` with an invalid header value. It asserts:

- the callback receives `ERR_HTTP2_INVALID_HEADER_VALUE`
- the pushed stream emits `'close'` but never `'error'`
- no `uncaughtException` fires

On `main` the test fails: the pushed stream emits `'error'` with `ERR_HTTP2_INVALID_HEADER_VALUE` when a listener is attached.

```
error: expect(received).toEqual(expected)
  [
    {
+     "code": "ERR_HTTP2_INVALID_HEADER_VALUE",
+     "event": "error",
+   },
+   {
      "destroyed": true,
      "event": "close",
    },
  ]
```

Full `test/js/node/http2/node-http2.test.js` suite: 309 pass, 6 skip, 0 fail.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (ff0bdae4a)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [843.68ms]
(pass) node none > Client Basics > should be able to send a POST request [567.45ms]
(pass) node none > Client Basics > constants [19.02ms]
(pass) node none > Client Basics > getDefaultSettings [7.48ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [23.60ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.14ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.78ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.31ms]
(pass) node none > Client Basics > should be able to send data using end [600.98ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [591.45ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release without fix: 93 failed, 6 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.80ms]
(pass) node none > Client Basics > getDefaultSettings [0.15ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.48ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.14ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.05ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.13ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [1.83ms]
(pass) node none > Client Basics > is possible to abort request [1.03ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.77ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.68ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [0.98ms]
783 |           client.on("error", reject);
784 |           const req = client.request({ ":path": "/", "test-hea
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (ff0bdae4a)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [1117.56ms]
(pass) node none > Client Basics > should be able to send a POST request [755.50ms]
(pass) node none > Client Basics > constants [30.17ms]
(pass) node none > Client Basics > getDefaultSettings [11.72ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [28.36ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.69ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.48ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.03ms]
(pass) node none > Client Basics > should be able to send data using end [778.43ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [758.54ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receivin
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 745ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (9275ms)
Bundle modules (40ms)
Postprocesss modules (26ms)
Bundle Functions (652ms)
Generate Code (20ms)

[10.03s] Bundled "src/js" for production
  2569 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 5m 01s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.0-canary.1+ff0bdae4a
[build] done
bun test v1.4.0-canary.1 (ff0bdae4a)

test/js/node/http2/node-htt
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                  |  9 +++----
 test/js/node/http2/node-http2.test.js | 48 +++++++++++++++++++++++++++++++++++
 2 files changed, 52 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/node/http2.ts                       3      3      0
test/js/node/http2/node-http2.test.js      3      5      0
```

</details>

<!-- robobun:evidence:end -->