### PR TITLE
sql: assert Structure offset matches column count instead of silently dropping the value

### DIFF
--- a/src/jsc/bindings/SQLClient.cpp
+++ b/src/jsc/bindings/SQLClient.cpp
@@ -328,8 +328,18 @@ static JSC::JSValue toJS(JSC::Structure* structure, DataCell* cells, uint32_t co
                 if (names.has_value()) {
                     auto name = names.value()[i];
                     object->putDirect(vm, Identifier::fromString(vm, name.name.toWTFString()), value);
-
-                } else if (structure && structure->isValidOffset(i)) {
+                } else {
+                    // Invariant: when no `names` array was passed, the cached
+                    // Structure was built from exactly this column set
+                    // (CachedStructure::build_from_columns only takes the
+                    // Structure path when non_duplicated_count <=
+                    // maxInlineCapacity, and this fast path requires
+                    // !hasDuplicateColumns && !hasIndexedColumns, so every
+                    // column index has a matching offset). Never drop a column
+                    // value silently; if this fires, structure construction and
+                    // the row's column count have diverged.
+                    RELEASE_ASSERT_WITH_MESSAGE(structure && structure->isValidOffset(i),
+                        "SQL row column %u has no matching Structure offset", i);
                     object->putDirectOffset(vm, i, value);
                 }
             }
@@ -380,7 +390,14 @@ static JSC::JSValue toJS(JSC::Structure* structure, DataCell* cells, uint32_t co
                             auto name = names.value()[structureOffsetIndex++];
                             object->putDirect(vm, Identifier::fromString(vm, name.name.toWTFString()), value);
                         }
-                    } else if (structure && structure->isValidOffset(structureOffsetIndex)) {
+                    } else {
+                        // Invariant: JSC__createStructure added one property
+                        // transition per named column from the same field set
+                        // this row was decoded against, so the k-th named cell
+                        // always has offset k. Never drop a column value
+                        // silently.
+                        RELEASE_ASSERT_WITH_MESSAGE(structure && structure->isValidOffset(structureOffsetIndex),
+                            "SQL row named column has no matching Structure offset (index %u)", structureOffsetIndex);
                         object->putDirectOffset(vm, structureOffsetIndex++, value);
                     }
                 } else if (cell.isDuplicateColumn()) {

--- a/src/jsc/bindings/SQLClient.cpp
+++ b/src/jsc/bindings/SQLClient.cpp
@@ -305,16 +305,9 @@ static JSC::JSValue toJS(JSC::Structure* structure, DataCell* cells, uint32_t co
     {
         auto* object = structure ? JSC::constructEmptyObject(vm, structure) : JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 0);
 
-        // TODO: once we have more tests for this, let's add another branch for
-        // "only mixed names and mixed indexed columns, no duplicates"
-        // then we cna remove this sort and instead do two passes.
-        if (flags.hasIndexedColumns() && flags.hasNamedColumns()) {
-            // sort the cells by if they're named or indexed, put named first.
-            // this is to conform to the Structure offsets from earlier.
-            std::sort(cells, cells + count, [](DataCell& a, DataCell& b) {
-                return a.isNamedColumn() && !b.isNamedColumn();
-            });
-        }
+        // cells[i] corresponds to fields[i]: the slow path below advances
+        // structureOffsetIndex only on named cells, so it visits them in the
+        // same order JSC__createStructure assigned the offsets. No sort needed.
 
         // Fast path: named columns only, no duplicate columns
         if (flags.hasNamedColumns() && !flags.hasDuplicateColumns() && !flags.hasIndexedColumns()) {

--- a/src/jsc/bindings/SQLClient.cpp
+++ b/src/jsc/bindings/SQLClient.cpp
@@ -329,15 +329,8 @@ static JSC::JSValue toJS(JSC::Structure* structure, DataCell* cells, uint32_t co
                     auto name = names.value()[i];
                     object->putDirect(vm, Identifier::fromString(vm, name.name.toWTFString()), value);
                 } else {
-                    // Invariant: when no `names` array was passed, the cached
-                    // Structure was built from exactly this column set
-                    // (CachedStructure::build_from_columns only takes the
-                    // Structure path when non_duplicated_count <=
-                    // maxInlineCapacity, and this fast path requires
-                    // !hasDuplicateColumns && !hasIndexedColumns, so every
-                    // column index has a matching offset). Never drop a column
-                    // value silently; if this fires, structure construction and
-                    // the row's column count have diverged.
+                    // CachedStructure::build_from_columns guarantees one offset
+                    // per column on this path; never drop a value silently.
                     RELEASE_ASSERT_WITH_MESSAGE(structure && structure->isValidOffset(i),
                         "SQL row column %u has no matching Structure offset", i);
                     object->putDirectOffset(vm, i, value);
@@ -391,11 +384,8 @@ static JSC::JSValue toJS(JSC::Structure* structure, DataCell* cells, uint32_t co
                             object->putDirect(vm, Identifier::fromString(vm, name.name.toWTFString()), value);
                         }
                     } else {
-                        // Invariant: JSC__createStructure added one property
-                        // transition per named column from the same field set
-                        // this row was decoded against, so the k-th named cell
-                        // always has offset k. Never drop a column value
-                        // silently.
+                        // JSC__createStructure added one offset per named
+                        // column; never drop a value silently.
                         RELEASE_ASSERT_WITH_MESSAGE(structure && structure->isValidOffset(structureOffsetIndex),
                             "SQL row named column has no matching Structure offset (index %u)", structureOffsetIndex);
                         object->putDirectOffset(vm, structureOffsetIndex++, value);

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -816,11 +816,17 @@ impl JSMySQLConnection {
         // outlives this fn (held via `request`'s intrusive ref), satisfying
         // the `ParentRef` liveness invariant.
         let cached_structure: Option<ParentRef<CachedStructure>> = match result_mode {
-            ResultMode::Objects => self.js_value.get().try_get().map(|value| {
-                let cs = statement.structure(value, &self.global_object);
+            ResultMode::Objects => {
+                // Always build the Structure for object-mode rows so
+                // `JSC__constructObjectFromDataCell` never sees neither a
+                // Structure nor a names array (which would trip its
+                // RELEASE_ASSERT). Matches the postgres path: a missing
+                // js_value just means no write-barrier owner.
+                let owner = self.js_value.get().try_get().unwrap_or(JSValue::ZERO);
+                let cs = statement.structure(owner, &self.global_object);
                 structure = cs.js_value().unwrap_or(JSValue::UNDEFINED);
-                ParentRef::new(cs)
-            }),
+                Some(ParentRef::new(cs))
+            }
             // no need to check for duplicate fields or structure
             ResultMode::Raw | ResultMode::Values => None,
         };

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -817,11 +817,8 @@ impl JSMySQLConnection {
         // the `ParentRef` liveness invariant.
         let cached_structure: Option<ParentRef<CachedStructure>> = match result_mode {
             ResultMode::Objects => {
-                // Always build the Structure for object-mode rows so
-                // `JSC__constructObjectFromDataCell` never sees neither a
-                // Structure nor a names array (which would trip its
-                // RELEASE_ASSERT). Matches the postgres path: a missing
-                // js_value just means no write-barrier owner.
+                // Build unconditionally (matches postgres) so toJS always has
+                // either a Structure or a names array.
                 let owner = self.js_value.get().try_get().unwrap_or(JSValue::ZERO);
                 let cs = statement.structure(owner, &self.global_object);
                 structure = cs.js_value().unwrap_or(JSValue::UNDEFINED);

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -2436,9 +2436,17 @@ impl PostgresSQLConnection {
                 } else {
                     &mut stack_buf[..statement.fields.len().min(max_inline)]
                 };
-                // make sure all cells are reset if reader short breaks the fields will just be null which is better than undefined behavior
-                for c in cells.iter_mut() {
-                    *c = DataCell::SQLDataCell::default();
+                // Seed every cell as null *and* tag it with its column's
+                // classification so a short DataRow (fewer values than the
+                // RowDescription declared) still hands `toJS` a cells array
+                // whose named/indexed/duplicate flags match the Structure that
+                // was built from the same fields. `put_impl` overwrites the
+                // cells the DataRow does supply.
+                for (i, c) in cells.iter_mut().enumerate() {
+                    *c = DataCell::SQLDataCell::null_for_column(
+                        i as u32,
+                        &statement.fields[i].name_or_index,
+                    );
                 }
                 putter.list = cells;
 

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -2436,12 +2436,8 @@ impl PostgresSQLConnection {
                 } else {
                     &mut stack_buf[..statement.fields.len().min(max_inline)]
                 };
-                // Seed every cell as null *and* tag it with its column's
-                // classification so a short DataRow (fewer values than the
-                // RowDescription declared) still hands `toJS` a cells array
-                // whose named/indexed/duplicate flags match the Structure that
-                // was built from the same fields. `put_impl` overwrites the
-                // cells the DataRow does supply.
+                // Seed with the field's column kind so a short DataRow still
+                // matches the Structure built from these fields.
                 for (i, c) in cells.iter_mut().enumerate() {
                     *c = DataCell::SQLDataCell::null_for_column(
                         i as u32,

--- a/src/sql_jsc/shared/SQLDataCell.rs
+++ b/src/sql_jsc/shared/SQLDataCell.rs
@@ -264,6 +264,27 @@ impl SQLDataCell {
         SQLDataCell::default()
     }
 
+    /// A `Null`-tagged cell pre-classified for `column` at ordinal `position`.
+    /// Used to seed the per-row cell buffer so a DataRow that supplies fewer
+    /// values than the RowDescription declared still carries each field's
+    /// duplicate/indexed/named flag into `JSC__constructObjectFromDataCell`,
+    /// keeping the "one Structure offset per named cell" invariant intact.
+    #[inline]
+    pub(crate) fn null_for_column(position: u32, column: &ColumnIdentifier) -> SQLDataCell {
+        SQLDataCell {
+            is_indexed_column: match column {
+                ColumnIdentifier::Duplicate => 2,
+                ColumnIdentifier::Index(_) => 1,
+                ColumnIdentifier::Name(_) => 0,
+            },
+            index: match column {
+                ColumnIdentifier::Index(i) => *i,
+                _ => position,
+            },
+            ..SQLDataCell::default()
+        }
+    }
+
     #[inline]
     pub(crate) fn int4(value: i32) -> SQLDataCell {
         SQLDataCell {

--- a/src/sql_jsc/shared/SQLDataCell.rs
+++ b/src/sql_jsc/shared/SQLDataCell.rs
@@ -264,11 +264,9 @@ impl SQLDataCell {
         SQLDataCell::default()
     }
 
-    /// A `Null`-tagged cell pre-classified for `column` at ordinal `position`.
-    /// Used to seed the per-row cell buffer so a DataRow that supplies fewer
-    /// values than the RowDescription declared still carries each field's
-    /// duplicate/indexed/named flag into `JSC__constructObjectFromDataCell`,
-    /// keeping the "one Structure offset per named cell" invariant intact.
+    /// A `Null`-tagged cell pre-classified for `column` at ordinal `position`,
+    /// seeding the row buffer so cells a short DataRow never fills still carry
+    /// the right named/indexed/duplicate flag into `toJS`.
     #[inline]
     pub(crate) fn null_for_column(position: u32, column: &ColumnIdentifier) -> SQLDataCell {
         SQLDataCell {

--- a/test/js/sql/sql-postgres-short-data-row.fixture.ts
+++ b/test/js/sql/sql-postgres-short-data-row.fixture.ts
@@ -89,5 +89,6 @@ await run("MIXED_EMPTY", mixedRowDescription, []);
 await run("MIXED_FULL", mixedRowDescription, ["va", "v7"]);
 // Two named columns with an indexed one between them: each named value must
 // land on its own key (Structure offsets are assigned in RowDescription order).
+await run("INTERLEAVED_SHORT", interleavedRowDescription, ["vfoo"]);
 await run("INTERLEAVED", interleavedRowDescription, ["vfoo", "v5", "vbar"]);
 console.log("FIXTURE_DONE");

--- a/test/js/sql/sql-postgres-short-data-row.fixture.ts
+++ b/test/js/sql/sql-postgres-short-data-row.fixture.ts
@@ -17,11 +17,17 @@ import {
 // cached row Structure has a single property and the other 61 fields are
 // duplicates.
 const COLUMNS = 62;
-const rowDescription = pgRowDescription(
+const dupRowDescription = pgRowDescription(
   Array.from({ length: COLUMNS }, () => ({ name: "c", typeOid: 25, format: 0 as const })),
 );
+// One named column and one all-digit column name, so the row builder has to
+// handle both a Structure offset and putDirectIndex in the same row.
+const mixedRowDescription = pgRowDescription([
+  { name: "a", typeOid: 25, format: 0 as const },
+  { name: "7", typeOid: 25, format: 0 as const },
+]);
 
-async function run(label: string, rowValues: string[]) {
+async function run(label: string, rowDescription: Buffer, rowValues: string[]) {
   const { server, port } = await listeningServer(socket => {
     let startup = true;
     socket.on("data", data => {
@@ -61,11 +67,17 @@ async function run(label: string, rowValues: string[]) {
 
 // The DataRow declares zero of the 62 described columns: the row's single
 // named property must come back as null and nothing else may be written.
-await run("EMPTY_ROW", []);
+await run("EMPTY_ROW", dupRowDescription, []);
 // A DataRow that supplies all 62 declared columns still resolves the duplicate
 // column name following the established "last one wins" rule.
 await run(
   "FULL_ROW",
+  dupRowDescription,
   Array.from({ length: COLUMNS }, (_, i) => "v" + i),
 );
+// A short DataRow against a mixed named + indexed RowDescription must still
+// surface both keys as null; the indexed column must not be silently dropped.
+await run("MIXED_EMPTY", mixedRowDescription, []);
+// And the full row keeps both values at their respective keys.
+await run("MIXED_FULL", mixedRowDescription, ["va", "v7"]);
 console.log("FIXTURE_DONE");

--- a/test/js/sql/sql-postgres-short-data-row.fixture.ts
+++ b/test/js/sql/sql-postgres-short-data-row.fixture.ts
@@ -26,6 +26,13 @@ const mixedRowDescription = pgRowDescription([
   { name: "a", typeOid: 25, format: 0 as const },
   { name: "7", typeOid: 25, format: 0 as const },
 ]);
+// Multiple named columns interleaved with an indexed one: the slow path must
+// write each named value to its own Structure offset without reordering.
+const interleavedRowDescription = pgRowDescription([
+  { name: "foo", typeOid: 25, format: 0 as const },
+  { name: "5", typeOid: 25, format: 0 as const },
+  { name: "bar", typeOid: 25, format: 0 as const },
+]);
 
 async function run(label: string, rowDescription: Buffer, rowValues: string[]) {
   const { server, port } = await listeningServer(socket => {
@@ -80,4 +87,7 @@ await run(
 await run("MIXED_EMPTY", mixedRowDescription, []);
 // And the full row keeps both values at their respective keys.
 await run("MIXED_FULL", mixedRowDescription, ["va", "v7"]);
+// Two named columns with an indexed one between them: each named value must
+// land on its own key (Structure offsets are assigned in RowDescription order).
+await run("INTERLEAVED", interleavedRowDescription, ["vfoo", "v5", "vbar"]);
 console.log("FIXTURE_DONE");

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12773,6 +12773,9 @@ test("data row that omits columns declared in the row description yields nulls f
   // still surface both keys: the indexed column "7" is not silently dropped.
   expect(stdout).toContain('MIXED_EMPTY {"7":null,"a":null}');
   expect(stdout).toContain('MIXED_FULL {"7":"v7","a":"va"}');
+  // Two named columns interleaved with an indexed one: each named value lands
+  // on its own key (the slow path visits cells in RowDescription order).
+  expect(stdout).toContain('INTERLEAVED {"5":"v5","foo":"vfoo","bar":"vbar"}');
   expect(stdout).toContain("FIXTURE_DONE");
   expect(filteredStderr).toBe("");
   expect(exitCode).toBe(0);

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12775,6 +12775,7 @@ test("data row that omits columns declared in the row description yields nulls f
   expect(stdout).toContain('MIXED_FULL {"7":"v7","a":"va"}');
   // Two named columns interleaved with an indexed one: each named value lands
   // on its own key (the slow path visits cells in RowDescription order).
+  expect(stdout).toContain('INTERLEAVED_SHORT {"5":null,"foo":"vfoo","bar":null}');
   expect(stdout).toContain('INTERLEAVED {"5":"v5","foo":"vfoo","bar":"vbar"}');
   expect(stdout).toContain("FIXTURE_DONE");
   expect(filteredStderr).toBe("");

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12769,6 +12769,10 @@ test("data row that omits columns declared in the row description yields nulls f
   // existing duplicate-column-name behavior).
   expect(stdout).toContain('EMPTY_ROW {"c":null}');
   expect(stdout).toContain('FULL_ROW {"c":"v61"}');
+  // A short DataRow against a mixed named + digit-named RowDescription must
+  // still surface both keys: the indexed column "7" is not silently dropped.
+  expect(stdout).toContain('MIXED_EMPTY {"7":null,"a":null}');
+  expect(stdout).toContain('MIXED_FULL {"7":"v7","a":"va"}');
   expect(stdout).toContain("FIXTURE_DONE");
   expect(filteredStderr).toBe("");
   expect(exitCode).toBe(0);


### PR DESCRIPTION
## What

`SQLClient.cpp`'s row builder guarded `putDirectOffset(vm, i, value)` with `else if (structure && structure->isValidOffset(i))` at two sites and silently skipped the write when the guard failed, so a result row could come back missing a column with no error.

## Why the invariant holds

When no `names` array is passed, the cached `Structure` was built from exactly this row's column set:

- `CachedStructure::build_from_columns` only takes the Structure path when `non_duplicated_count <= JSFinalObject::maxInlineCapacity`; above that it stores the column identifiers and `toJS` uses `putDirect` with the name instead.
- `JSC__createStructure` adds one property transition per named column from that same set.
- The fast path requires `!hasDuplicateColumns && !hasIndexedColumns`, so `count == non_duplicated_count == structure offsets`.
- The cached Structure is reset on every `RowDescription` / column-definition change, so it never goes stale.

## The one hole

A short Postgres DataRow (fewer values than the RowDescription declared; a real server never does this but the fault-injection fixture `sql-postgres-short-data-row.fixture.ts` does) left the unfilled cells at `SQLDataCell::default()`, which has `is_indexed_column = 0` (named). In the slow path that meant more "named" cells than the Structure had offsets, and the guard was quietly dropping the extras.

## Fix

- Seed every cell with its field's `ColumnIdentifier` classification (`null_for_column`) before decoding, so a short DataRow still carries correct duplicate/indexed/named flags.
- Make the MySQL Objects path build the Structure unconditionally (matching the Postgres path), so the `putDirectOffset` branch is never reached with neither a Structure nor a names array.
- Replace both silent skips with `RELEASE_ASSERT_WITH_MESSAGE` so any future divergence between the cached Structure and the row's column set crashes with a clear message instead of returning a partial row.

## Verification

- `test/js/sql/sql.test.ts` (including the short-DataRow fixture that previously depended on the silent skip): pass
- `test/js/sql/postgres-multi-statement-fields.test.ts`, `postgres-datarow-overrun.test.ts`, `postgres-frame-boundary.test.ts`, `postgres-simple-query-pipeline.test.ts`, `postgres-prepared-pipeline-reorder.test.ts`, `sql-prepare-false.test.ts`, `wire-frames.test.ts`: pass

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql.test.ts
bun test v1.4.0 (842c620c1)

test/js/sql/sql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) text-format json[] with a malformed boolean literal returns an error instead of looping [1866.27ms]
(pass) rejects Postgres connection options containing null bytes [91.00ms]
(pass) shared createInstance validation (no server) > rejects username containing null bytes [143.52ms]
(pass) shared createInstance validation (no server) > rejects password containing null bytes [10.00ms]
(pass) shared createInstance validation (no server) > rejects database containing null bytes [6.74ms]
(pass) shared createInstance validation (no server) > SSL_CTX creation failure throws the structured BoringSSL error [18.66ms]
(pass) shared createInstance validation (no server) > postgres: rejects tls that is neither a boolean nor an object [16.04ms]
(pass) shared createInstance valida
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (00727050d)

test/js/sql/sql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) text-format json[] with a malformed boolean literal returns an error instead of looping [35.57ms]
(pass) rejects Postgres connection options containing null bytes [1.65ms]
(pass) shared createInstance validation (no server) > rejects username containing null bytes [2.35ms]
(pass) shared createInstance validation (no server) > rejects password containing null bytes [0.18ms]
(pass) shared createInstance validation (no server) > rejects database containing null bytes [0.10ms]
(pass) shared createInstance validation (no server) > SSL_CTX creation failure throws the structured BoringSSL error [0.37ms]
(pass) shared createInstance validation (no server) > postgres: rejects tls that is neither a boolean nor an object [0.29ms]
(pass) shared createInstance validation (no server) > mysql: rejects tls that is neither a boolean nor an object [0.27ms]
(pass) shared createInstance validation (no server) > rejects simple 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql.test.ts
bun test v1.4.0 (842c620c1)

test/js/sql/sql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) text-format json[] with a malformed boolean literal returns an error instead of looping [1866.53ms]
(pass) rejects Postgres connection options containing null bytes [91.93ms]
(pass) shared createInstance validation (no server) > rejects username containing null bytes [145.11ms]
(pass) shared createInstance validation (no server) > rejects password containing null bytes [9.94ms]
(pass) shared createInstance validation (no server) > rejects database containing null bytes [6.54ms]
(pass) shared createInstance validation (no server) > SSL_CTX creation failure throws the structured BoringSSL error [18.33ms]
(pass) shared createInstance validation (no server) > postgres: rejects tls that is neither a boolean nor an object [15.70ms]
(pass) shared createInstance validat
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 727ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen cpp.rs (cppbind)
[2/23] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[3/23] gen JS modules (bundle-modules)
Preprocess modules (8855ms)
Bundle modules (61ms)
Postprocesss modules (445ms)
Bundle Functions (918ms)
Generate Code (23ms)

[10.33s] Bundled "src/js" for production
  2569 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/SQLClient.cpp                     | 26 +++++++++----------
 src/sql_jsc/mysql/JSMySQLConnection.rs             | 11 +++++---
 src/sql_jsc/postgres/PostgresSQLConnection.rs      | 10 +++++---
 src/sql_jsc/shared/SQLDataCell.rs                  | 19 ++++++++++++++
 test/js/sql/sql-postgres-short-data-row.fixture.ts | 29 +++++++++++++++++++---
 test/js/sql/sql.test.ts                            |  8 ++++++
 6 files changed, 80 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/SQLClient.cpp                          3      6      0
src/sql_jsc/mysql/JSMySQLConnection.rs                  2      3      0
src/sql_jsc/postgres/PostgresSQLConnection.rs           3      3      0
src/sql_jsc/shared/SQLDataCell.rs                       4      3      0
test/js/sql/sql-postgres-short-data-row.fixture.ts      3      5      0
test/js/sql/sql.test.ts                                 3      3      0
```

</details>

<!-- robobun:evidence:end -->