### PR TITLE
node:zlib: allow growable SharedArrayBuffer in async write()

### DIFF
--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -355,10 +355,8 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
                         .throw());
                 }
             };
-            // A growable SharedArrayBuffer (resizable && shared) grows in place
-            // and never shrinks, so the captured pointer/length remains a valid
-            // prefix for the duration of the threadpool write. Only a non-shared
-            // resizable ArrayBuffer can shrink out from under it.
+            // Growable SharedArrayBuffer only grows in place; the captured
+            // (ptr, len) stays valid. Only non-shared resizable can shrink.
             if in_buf.resizable && !in_buf.shared {
                 return Err(global_this
                     .err(

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -355,7 +355,11 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
                         .throw());
                 }
             };
-            if in_buf.resizable {
+            // A growable SharedArrayBuffer (resizable && shared) grows in place
+            // and never shrinks, so the captured pointer/length remains a valid
+            // prefix for the duration of the threadpool write. Only a non-shared
+            // resizable ArrayBuffer can shrink out from under it.
+            if in_buf.resizable && !in_buf.shared {
                 return Err(global_this
                     .err(
                         ErrorCode::INVALID_ARG_VALUE,
@@ -403,7 +407,7 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
                 )
                 .throw());
         }
-        if out_buf.resizable {
+        if out_buf.resizable && !out_buf.shared {
             return Err(global_this
                 .err(
                     ErrorCode::INVALID_ARG_VALUE,

--- a/test/js/node/zlib/zlib-handle-bounds-check.test.ts
+++ b/test/js/node/zlib/zlib-handle-bounds-check.test.ts
@@ -465,8 +465,9 @@ describe.concurrent("zlib native handle argument validation", () => {
   });
 
   // A growable SharedArrayBuffer grows in place and never shrinks, so the
-  // pointer/length captured for the threadpool write stays a valid prefix. The
-  // resizable-buffer rejection above must not apply to it.
+  // pointer/length captured for the threadpool write stays a valid prefix even
+  // across a concurrent grow(). The resizable-buffer rejection above must not
+  // apply to it.
   test.concurrent("write() accepts an output buffer backed by a growable SharedArrayBuffer", async () => {
     expect(
       await run(
@@ -475,8 +476,11 @@ describe.concurrent("zlib native handle argument validation", () => {
          const ws = new Uint32Array(2);
          const { promise, resolve } = Promise.withResolvers();
          h.init(15, 6, 8, 0, ws, resolve, undefined);
-         const out = new Uint8Array(new SharedArrayBuffer(64, { maxByteLength: 128 }));
+         const sab = new SharedArrayBuffer(64, { maxByteLength: 128 });
+         if (!sab.growable) throw new Error("SharedArrayBuffer is not growable");
+         const out = new Uint8Array(sab);
          h.write(zlib.constants.Z_FINISH, Buffer.from("hello"), 0, 5, out, 0, 64);
+         sab.grow(128);
          await promise;
          const written = 64 - ws[0];
          console.log("ok " + zlib.inflateRawSync(Buffer.from(out.slice(0, written))).toString());`,
@@ -492,10 +496,13 @@ describe.concurrent("zlib native handle argument validation", () => {
          const ws = new Uint32Array(2);
          const { promise, resolve } = Promise.withResolvers();
          h.init(15, 6, 8, 0, ws, resolve, undefined);
-         const input = new Uint8Array(new SharedArrayBuffer(16, { maxByteLength: 64 }));
+         const sab = new SharedArrayBuffer(16, { maxByteLength: 64 });
+         if (!sab.growable) throw new Error("SharedArrayBuffer is not growable");
+         const input = new Uint8Array(sab);
          input.set(Buffer.from("hello world"));
          const out = Buffer.alloc(1024);
          h.write(zlib.constants.Z_FINISH, input, 0, 11, out, 0, 1024);
+         sab.grow(64);
          await promise;
          const written = 1024 - ws[0];
          console.log("ok " + zlib.inflateRawSync(out.subarray(0, written)).toString());`,

--- a/test/js/node/zlib/zlib-handle-bounds-check.test.ts
+++ b/test/js/node/zlib/zlib-handle-bounds-check.test.ts
@@ -463,4 +463,43 @@ describe.concurrent("zlib native handle argument validation", () => {
       exitCode: 0,
     });
   });
+
+  // A growable SharedArrayBuffer grows in place and never shrinks, so the
+  // pointer/length captured for the threadpool write stays a valid prefix. The
+  // resizable-buffer rejection above must not apply to it.
+  test.concurrent("write() accepts an output buffer backed by a growable SharedArrayBuffer", async () => {
+    expect(
+      await run(
+        `const C = zlib.createDeflateRaw()._handle.constructor;
+         const h = new C(zlib.constants.DEFLATERAW);
+         const ws = new Uint32Array(2);
+         const { promise, resolve } = Promise.withResolvers();
+         h.init(15, 6, 8, 0, ws, resolve, undefined);
+         const out = new Uint8Array(new SharedArrayBuffer(64, { maxByteLength: 128 }));
+         h.write(zlib.constants.Z_FINISH, Buffer.from("hello"), 0, 5, out, 0, 64);
+         await promise;
+         const written = 64 - ws[0];
+         console.log("ok " + zlib.inflateRawSync(Buffer.from(out.slice(0, written))).toString());`,
+      ),
+    ).toEqual({ stdout: "ok hello", exitCode: 0 });
+  });
+
+  test.concurrent("write() accepts an input buffer backed by a growable SharedArrayBuffer", async () => {
+    expect(
+      await run(
+        `const C = zlib.createDeflateRaw()._handle.constructor;
+         const h = new C(zlib.constants.DEFLATERAW);
+         const ws = new Uint32Array(2);
+         const { promise, resolve } = Promise.withResolvers();
+         h.init(15, 6, 8, 0, ws, resolve, undefined);
+         const input = new Uint8Array(new SharedArrayBuffer(16, { maxByteLength: 64 }));
+         input.set(Buffer.from("hello world"));
+         const out = Buffer.alloc(1024);
+         h.write(zlib.constants.Z_FINISH, input, 0, 11, out, 0, 1024);
+         await promise;
+         const written = 1024 - ws[0];
+         console.log("ok " + zlib.inflateRawSync(out.subarray(0, written)).toString());`,
+      ),
+    ).toEqual({ stdout: "ok hello world", exitCode: 0 });
+  });
 });


### PR DESCRIPTION
## What

The async `write()` path in the native zlib binding rejects `in`/`out` buffers whose backing store has `ArrayBuffer.resizable` set, because a resize mid-write would invalidate the pointer/length captured for the threadpool. But `ArrayBuffer.resizable` is also set for a growable `SharedArrayBuffer` (see the field doc in `src/jsc/array_buffer.rs`), which grows in place and never shrinks: the captured pointer/length stays a valid prefix for the duration of the write, so there is no reason to reject it.

## Repro

```js
const zlib = require("node:zlib");
const h = zlib.createDeflateRaw()._handle;
const out = new Uint8Array(new SharedArrayBuffer(64, { maxByteLength: 128 }));
h.write(zlib.constants.Z_NO_FLUSH, null, 0, 0, out, 0, 64);
```

Before:
```
ERR_INVALID_ARG_VALUE: The "out" argument must not be backed by a resizable ArrayBuffer
```

## Fix

Narrow both checks in `CompressionStream::write` to `resizable && !shared`. The existing error text ("must not be backed by a resizable ArrayBuffer") is now accurate: it fires only for an actual resizable `ArrayBuffer`, never for a growable `SharedArrayBuffer`.

## Verification

`test/js/node/zlib/zlib-handle-bounds-check.test.ts`:
- `write() accepts an output buffer backed by a growable SharedArrayBuffer`: drives a fresh handle through `write()` with a growable-SAB-backed output view and round-trips the compressed result through `inflateRawSync`.
- `write() accepts an input buffer backed by a growable SharedArrayBuffer`: same for the input side.
- The two existing `write() rejects ... resizable ArrayBuffer` tests still pass, so non-shared resizable buffers are still rejected with `ERR_INVALID_ARG_VALUE`.

Fail-before (src/ stashed): both new tests fail with the subprocess throwing `ERR_INVALID_ARG_VALUE`.
Pass-after: 38/38 tests pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/zlib/zlib-handle-bounds-check.test.ts
bun test v1.4.0 (9b307ac86)

test/js/node/zlib/zlib-handle-bounds-check.test.ts:
(pass) zlib native handle bounds checking > writeSync rejects in_len exceeding input buffer [248.33ms]
(pass) zlib native handle bounds checking > writeSync rejects out_len exceeding output buffer [14.19ms]
(pass) zlib native handle bounds checking > writeSync rejects in_off + in_len exceeding input buffer [11.25ms]
(pass) zlib native handle bounds checking > writeSync rejects out_off + out_len exceeding output buffer [10.65ms]
(pass) zlib native handle bounds checking > writeSync allows valid bounds [10.55ms]
(pass) zlib native handle bounds checking > writeSync allows valid offset + length within bounds [9.77ms]
(pass) zlib native handle bounds checking > writeSync allows null input (flush only) [5.95ms]
(pass) zlib native handle writeState > writeSync updates the writeState array [6.04ms]
(pass) zlib native handle writeState > write completion with a detached writeState backing store does not crash [169
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/zlib/zlib-handle-bounds-check.test.ts:
(pass) zlib native handle bounds checking > writeSync rejects in_len exceeding input buffer [2.64ms]
(pass) zlib native handle bounds checking > writeSync rejects out_len exceeding output buffer [0.23ms]
(pass) zlib native handle bounds checking > writeSync rejects in_off + in_len exceeding input buffer [0.16ms]
(pass) zlib native handle bounds checking > writeSync rejects out_off + out_len exceeding output buffer [0.16ms]
(pass) zlib native handle bounds checking > writeSync allows valid bounds [0.18ms]
(pass) zlib native handle bounds checking > writeSync allows valid offset + length within bounds [0.15ms]
(pass) zlib native handle bounds checking > writeSync allows null input (flush only) [0.17ms]
(pass) zlib native handle writeState > writeSync updates the writeState array [0.40ms]
(pass) zlib native handle writeState > write completion with a detached writeState backing store does not crash [47.63ms]
(pass) zlib native handle driven outside the zlib.ts lifecycle > zlib: init() after close() throws [41.17ms]
(pass) zlib native handle driven outside the zlib.ts lifecycle > z
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/zlib/zlib-handle-bounds-check.test.ts
bun test v1.4.0 (9b307ac86)

test/js/node/zlib/zlib-handle-bounds-check.test.ts:
(pass) zlib native handle bounds checking > writeSync rejects in_len exceeding input buffer [225.21ms]
(pass) zlib native handle bounds checking > writeSync rejects out_len exceeding output buffer [12.87ms]
(pass) zlib native handle bounds checking > writeSync rejects in_off + in_len exceeding input buffer [10.16ms]
(pass) zlib native handle bounds checking > writeSync rejects out_off + out_len exceeding output buffer [9.48ms]
(pass) zlib native handle bounds checking > writeSync allows valid bounds [9.03ms]
(pass) zlib native handle bounds checking > writeSync allows valid offset + length within bounds [5.86ms]
(pass) zlib native handle bounds checking > writeSync allows null input (flush only) [5.14ms]
(pass) zlib native handle writeState > writeSync updates the writeState array [5.70ms]
(pass) zlib native handle writeState > write completion with a detached writeState backing store does not crash [1634.
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 740ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (9237ms)
Bundle modules (52ms)
Postprocesss modules (203ms)
Bundle Functions (774ms)
Generate Code (48ms)

[10.33s] Bundled "src/js" for production
  2569 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/node/node_zlib_binding.rs              |  6 ++-
 test/js/node/zlib/zlib-handle-bounds-check.test.ts | 46 ++++++++++++++++++++++
 2 files changed, 50 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/runtime/node/node_zlib_binding.rs                   3      4      0
test/js/node/zlib/zlib-handle-bounds-check.test.ts      1      6      0
```

</details>

<!-- robobun:evidence:end -->