### PR TITLE
AbortSignal.any: bail after iterable validation throws

### DIFF
--- a/src/jsc/bindings/webcore/JSAbortSignal.cpp
+++ b/src/jsc/bindings/webcore/JSAbortSignal.cpp
@@ -329,6 +329,7 @@ static inline JSC::EncodedJSValue jsAbortSignalConstructorFunction_anyBody(JSC::
         }
         i++;
     });
+    RETURN_IF_EXCEPTION(throwScope, {});
 
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJSNewlyCreated<IDLInterface<AbortSignal>>(*lexicalGlobalObject, *uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), throwScope, AbortSignal::any(*context, WTF::move(signals)))));
 }

--- a/test/js/web/abort/abort.test.ts
+++ b/test/js/web/abort/abort.test.ts
@@ -33,6 +33,42 @@ describe("AbortSignal", () => {
     expect(await server.exited).toBe(0);
   });
 
+  // The per-element TypeError is thrown inside forEachInIterable's callback.
+  // Without a RETURN_IF_EXCEPTION after the loop, AbortSignal::any(...) still
+  // runs: a dependent signal is created and wired to any valid sources that
+  // appeared before the bad element, and the wrapper is returned with the
+  // TypeError still pending. Under GC pressure that pending exception was seen
+  // to be consumed so the caller received a live signal instead of a throw.
+  test("AbortSignal.any() rejects a non-AbortSignal element without allocating a dependent signal", async () => {
+    const src = `
+      const { heapStats } = require("bun:jsc");
+      const c = new AbortController();
+      Bun.gc(true);
+      const before = heapStats().objectTypeCounts.AbortSignal ?? 0;
+      let threw = 0;
+      let returned = 0;
+      const N = 256;
+      for (let i = 0; i < N; i++) {
+        try {
+          const r = AbortSignal.any([c.signal, 1]);
+          returned += r instanceof AbortSignal ? 1 : 0;
+        } catch (e) {
+          threw += e?.code === "ERR_INVALID_ARG_TYPE" ? 1 : 0;
+        }
+      }
+      const ghosts = (heapStats().objectTypeCounts.AbortSignal ?? 0) - before;
+      process.stdout.write(JSON.stringify({ threw, returned, ghosts, N }));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout);
+    expect({ threw: out.threw, returned: out.returned }).toEqual({ threw: out.N, returned: 0 });
+    // Without the exception check the count here is exactly N.
+    expect(out.ghosts).toBeLessThan(out.N / 4);
+    expect(exitCode).toBe(0);
+  });
+
   test("AbortSignal.any() should fire abort event", async () => {
     async function testAny(signalToAbort: number) {
       const { promise, resolve } = Promise.withResolvers();


### PR DESCRIPTION
`AbortSignal.any([c.signal, 1])` throws `ERR_INVALID_ARG_TYPE` for the non-AbortSignal element inside the `forEachInIterable` callback, but `jsAbortSignalConstructorFunction_anyBody` had no `RETURN_IF_EXCEPTION` after the loop. `AbortSignal::any(...)` then ran against the partially-validated source list, allocated a dependent signal and its JS wrapper, and `RELEASE_AND_RETURN`'d that wrapper with the TypeError still pending on the VM.

The user-visible symptom from the fuzz harness was that under GC pressure a native step along that path consumed the pending exception, so the caller received a fresh non-aborted `AbortSignal` instead of the throw (1-2 per 300 probes in a seeded mixed-workload run; a quiet in-process loop never fires). Node always throws.

## Cause

```cpp
forEachInIterable(lexicalGlobalObject, argument0.value(), [&](VM& vm, JSGlobalObject*, JSValue item) {
    if (auto* signal = JSAbortSignal::toWrapped(vm, item)) signals.append(signal);
    else Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, makeString("signals["_s, i, "]"_s), "AbortSignal"_s, item);
    i++;
});
// <-- no RETURN_IF_EXCEPTION(throwScope, {}) here
RELEASE_AND_RETURN(throwScope, JSValue::encode(toJSNewlyCreated<...>(... AbortSignal::any(*context, WTF::move(signals)))));
```

Every other `forEachInIterable` caller in the tree (`JSDOMConvertSequences.h`) has the check; the `undefined`/`null` branch just above it in the same function already does the equivalent `INVALID_ARG_TYPE(...); return {};`.

## Fix

Add `RETURN_IF_EXCEPTION(throwScope, {});` after the loop so a per-element validation error returns before `AbortSignal::any` creates a dependent signal on a partially-validated source list.

## Verification

The intermittent swallow is not reproducible in a standalone snippet, but the wrapper allocation it depends on is deterministic: `heapStats().objectTypeCounts.AbortSignal` grows by exactly N across N failing calls.

```
$ USE_SYSTEM_BUN=1 bun test test/js/web/abort/abort.test.ts -t "without allocating"
(fail) expect(received).toBeLessThan(expected)
       Expected: < 64
       Received: 257

$ bun bd test test/js/web/abort/abort.test.ts -t "without allocating"
(pass) { threw: 256, returned: 0, ghosts: 1 }
```

The full `test/js/web/abort/` suite (18 tests) and `test/js/deno/abort/abort-controller.test.ts` continue to pass.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/abort/abort.test.ts
bun test v1.4.0 (60a261d3d)

test/js/web/abort/abort.test.ts:
(pass) AbortSignal > spawn test [232.84ms]
(pass) AbortSignal > AbortSignal.timeout(n) should not freeze the process [370.87ms]
63 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
64 |     expect(stderr).toBe("");
65 |     const out = JSON.parse(stdout);
66 |     expect({ threw: out.threw, returned: out.returned }).toEqual({ threw: out.N, returned: 0 });
67 |     // Without the exception check the count here is exactly N.
68 |     expect(out.ghosts).toBeLessThan(out.N / 4);
                            ^
error: expect(received).toBeLessThan(expected)

Expected: < 64
Received: 257

      at <anonymous> (/workspace/bun/test/js/web/abort/abort.test.ts:68:24)
(fail) AbortSignal > AbortSignal.any() rejects a non-AbortSignal element without allocating a dependent signal [1368.21ms]
(pass) AbortSignal > AbortSignal.any() should fire abort event [20.58ms]
(pass) AbortSignal > .signal.rea
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/abort/abort.test.ts:
(pass) AbortSignal > spawn test [13.84ms]
(pass) AbortSignal > AbortSignal.timeout(n) should not freeze the process [28.53ms]
63 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
64 |     expect(stderr).toBe("");
65 |     const out = JSON.parse(stdout);
66 |     expect({ threw: out.threw, returned: out.returned }).toEqual({ threw: out.N, returned: 0 });
67 |     // Without the exception check the count here is exactly N.
68 |     expect(out.ghosts).toBeLessThan(out.N / 4);
                            ^
error: expect(received).toBeLessThan(expected)

Expected: < 64
Received: 257

      at <anonymous> (/workspace/bun/test/js/web/abort/abort.test.ts:68:24)
(fail) AbortSignal > AbortSignal.any() rejects a non-AbortSignal element without allocating a dependent signal [31.58ms]
(pass) AbortSignal > AbortSignal.any() should fire abort event [0.63ms]
(pass) AbortSignal > .signal.reason should be a DOMException [0.13ms]
(pass) AbortSignal > .signal.reason should be a DOMException for timeout [10.94ms]
(pass) AbortSignal > awaiting AbortSigna
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/abort/abort.test.ts
bun test v1.4.0 (60a261d3d)

test/js/web/abort/abort.test.ts:
(pass) AbortSignal > spawn test [234.17ms]
(pass) AbortSignal > AbortSignal.timeout(n) should not freeze the process [368.58ms]
(pass) AbortSignal > AbortSignal.any() rejects a non-AbortSignal element without allocating a dependent signal [1428.84ms]
(pass) AbortSignal > AbortSignal.any() should fire abort event [32.54ms]
(pass) AbortSignal > .signal.reason should be a DOMException [16.72ms]
(pass) AbortSignal > .signal.reason should be a DOMException for timeout [25.68ms]
(pass) AbortSignal > awaiting AbortSignal.timeout(n) abort event with nothing else ref'd does not hang (#33334) [333.47ms]
(pass) AbortSignal > AbortSignal.timeout with equal deadlines fire in creation order [303.33ms]

 8 pass
 0 fail
 19 expect() calls
Ran 8 tests across 1 file. [4.98s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 725ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 11s
[3/7] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-1.cpp.o
[4/7] link bun-profile
[6/7] strip bun
[6/7] bun-profile --revision
1.4.0-canary.1+60a261d3d
[build] done
bun test v1.4.0-canary.1 (60a261d3d)

test/js/web/abort/abort.test.ts:
(pass) AbortSignal > spawn test [9.72ms]
(pass) AbortSignal > AbortSignal.timeout(n) should not freeze the process [22.44ms]
(pass) AbortSignal > AbortSignal.any() rejects a non-AbortSignal element
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSAbortSignal.cpp |  1 +
 test/js/web/abort/abort.test.ts            | 36 ++++++++++++++++++++++++++++++
 2 files changed, 37 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/jsc/bindings/webcore/JSAbortSignal.cpp      1      1      0
test/js/web/abort/abort.test.ts                 1      1      0
```

</details>

<!-- robobun:evidence:end -->