### PR TITLE
test(node-http): halve headersTimeout in test-http-server-request-timeouts-mixed

### DIFF
--- a/test/expected-durations.json
+++ b/test/expected-durations.json
@@ -25002,7 +25002,7 @@
   },
   "js/node/test/sequential/test-http-server-request-timeouts-mixed.js": {
     "default": 3153,
-    "asan": 6255,
+    "asan": 9384,
     "musl": 3154,
     "windows": 3174
   },

--- a/test/expected-durations.json
+++ b/test/expected-durations.json
@@ -25001,10 +25001,10 @@
     "windows": 616
   },
   "js/node/test/sequential/test-http-server-request-timeouts-mixed.js": {
-    "default": 6306,
-    "asan": 12509,
-    "musl": 6307,
-    "windows": 6348
+    "default": 3153,
+    "asan": 6255,
+    "musl": 3154,
+    "windows": 3174
   },
   "js/node/test/sequential/test-http2-large-file.js": {
     "default": 154,

--- a/test/js/node/test/sequential/test-http-server-request-timeouts-mixed.js
+++ b/test/js/node/test/sequential/test-http-server-request-timeouts-mixed.js
@@ -16,9 +16,10 @@ const responseTimeout = 'HTTP/1.1 408 Request Timeout\r\n';
 
 // Upstream Node uses platformTimeout(2000). Every delay below is a ratio of
 // headersTimeout, so halving the base keeps the same relative margins while
-// halving wall-clock time (the narrowest window, request2's 408 before the
-// 1.4x checkpoint, is 0.075 * headersTimeout and stays above 150 ms on debug
-// builds where platformTimeout doubles the value).
+// halving wall-clock time. The narrowest window (request2's 408 before the
+// 1.4x checkpoint) is 0.075 * headersTimeout: 75 ms on release lanes
+// including release+ASAN where process.features.debug is false, and 150 ms on
+// local debug builds where platformTimeout doubles the value.
 const headersTimeout = common.platformTimeout(1000);
 const connectionsCheckingInterval = headersTimeout / 8;
 

--- a/test/js/node/test/sequential/test-http-server-request-timeouts-mixed.js
+++ b/test/js/node/test/sequential/test-http-server-request-timeouts-mixed.js
@@ -14,7 +14,12 @@ const requestBodyPart3 = '1234567890';
 const responseOk = 'HTTP/1.1 200 OK\r\n';
 const responseTimeout = 'HTTP/1.1 408 Request Timeout\r\n';
 
-const headersTimeout = common.platformTimeout(2000);
+// Upstream Node uses platformTimeout(2000). Every delay below is a ratio of
+// headersTimeout, so halving the base keeps the same relative margins while
+// halving wall-clock time (the narrowest window, request2's 408 before the
+// 1.4x checkpoint, is 0.075 * headersTimeout and stays above 150 ms on debug
+// builds where platformTimeout doubles the value).
+const headersTimeout = common.platformTimeout(1000);
 const connectionsCheckingInterval = headersTimeout / 8;
 
 const server = createServer({


### PR DESCRIPTION
### What

`test/js/node/test/sequential/test-http-server-request-timeouts-mixed.js` is the upstream Node.js `headersTimeout` / `requestTimeout` interleave test. It was the slowest vendored sequential http test at ~12.5 s on the debian 13 x64-asan lane (build #86086).

### Cause

The test schedules every write and every assertion at a multiple of `headersTimeout` (0.2x, 0.6x, 0.8x, 1.4x, 1.5x, 3.125x). Upstream sets the base to `common.platformTimeout(2000)`, so the last callback fires at 3.125 * 2000 = 6.25 s on release lanes and 3.125 * 4000 = 12.5 s on debug builds where `process.features.debug` makes `platformTimeout` double its argument. On the CI asan lane (a release build with `process.features.debug === false`) the schedule is 6.25 s; the remaining ~6 s of the observed 12.5 s is LSAN / `BUN_DESTRUCT_VM_ON_EXIT` / `validateExceptionChecks` teardown the runner adds there.

### Change

Lower the base to `common.platformTimeout(1000)`. All delays scale with this value and `connectionsCheckingInterval = headersTimeout / 8` scales with it too, so every relative margin is preserved. The narrowest window is request2's 408 arriving before the 1.4x checkpoint (`0.075 * headersTimeout`): 75 ms on every CI lane (all release, including asan), 150 ms on local debug builds.

The 408 status line and the `common.mustCall(..., 4)` / `mustCallAtLeast` / `mustNotCall` assertions are untouched, so coverage is the same as upstream; only the clock is compressed. Same pattern as `sequential/test-performance-eventloopdelay.js` (#33622).

`test/expected-durations.json` updated so shard bin-packing reflects the new cost until the next regeneration. The asan entry only drops from 12509 to ~9384 because the schedule halves (6250 -> 3125) but the per-process LSAN/VM-destruct teardown does not.

### Verification

Local timing:

| build | before | after |
|---|---|---|
| `bun bd` (debug+ASAN) | 16.3 s | 10.8 s |
| `./build/debug/bun-debug` | 15.5 s | 9.2 s |
| release+ASAN, CI runner env | n/a | 9.25 s |

Stability at `platformTimeout(1000)`:

| config | idle | under CPU load |
|---|---|---|
| debug+ASAN (`bun bd`) | 30/30 | 10/10 @ 8-way, 10/10 @ 14-way |
| release+ASAN + CI env* | 30/30 | 20/20 @ 8-way |

*`BUN_JSC_validateExceptionChecks=1`, `BUN_JSC_dumpSimulatedThrows=1`, `BUN_DESTRUCT_VM_ON_EXIT=1`, `BUN_FEATURE_FLAG_NO_ORPHANS=1`, LSAN enabled with `test/leaksan.supp`; the exact env `scripts/runner.node.mjs` sets for `sequential/` on the asan lane.

Lower candidates were rejected: a fixed 800 ms base flakes 2/30 on the request2 window under debug+ASAN; 640 ms flakes 16/20.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->