### PR TITLE
bundler: bundle require() calls made through createRequire(import.meta.url) bindings

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -260,14 +260,10 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub(crate) bundler_feature_flag_ref: Ref,
 
     /// Local binding of `createRequire` imported from "module"/"node:module"
-    /// (only set when bundling). Used to detect
-    /// `const req = createRequire(import.meta.url)` during the visit pass.
+    /// (only set when bundling).
     pub(crate) create_require_ref: Ref,
-    /// Refs of `const` bindings initialized with `createRequire(import.meta.url)`.
-    /// Calls on these with a static string argument resolve relative to the
-    /// current module, exactly like `require()`, so e_call bundles them the
-    /// same way instead of leaving a runtime lookup that breaks when the
-    /// output file is moved away from node_modules.
+    /// `const` bindings initialized with `createRequire(import.meta.url)`.
+    /// e_call bundles string-literal calls on these like `require()`.
     pub(crate) create_require_target_refs: RefMap,
     /// Set to true when visiting an if/ternary condition. feature() calls are only valid in this context.
     pub(crate) in_branch_condition: bool,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -258,6 +258,17 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// When visiting e_call, if the target ref matches this, we replace the call with
     /// a boolean based on whether the feature flag is enabled.
     pub(crate) bundler_feature_flag_ref: Ref,
+
+    /// Local binding of `createRequire` imported from "module"/"node:module"
+    /// (only set when bundling). Used to detect
+    /// `const req = createRequire(import.meta.url)` during the visit pass.
+    pub(crate) create_require_ref: Ref,
+    /// Refs of `const` bindings initialized with `createRequire(import.meta.url)`.
+    /// Calls on these with a static string argument resolve relative to the
+    /// current module, exactly like `require()`, so e_call bundles them the
+    /// same way instead of leaving a runtime lookup that breaks when the
+    /// output file is moved away from node_modules.
+    pub(crate) create_require_target_refs: RefMap,
     /// Set to true when visiting an if/ternary condition. feature() calls are only valid in this context.
     pub(crate) in_branch_condition: bool,
 
@@ -3866,6 +3877,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // `ClauseItem.alias` is an arena-owned `StoreStr` valid for 'a.
             let alias: &'a [u8] = item.alias.slice();
             self.check_for_non_bmp_code_point(item.alias_loc, alias);
+
+            if self.options.bundle
+                && !self.is_source_runtime()
+                && alias == b"createRequire"
+                && (path.text == b"module" || path.text == b"node:module")
+            {
+                self.create_require_ref = r#ref;
+            }
 
             // ensure every e_import_identifier holds the namespace
             if self.options.features.hot_module_reloading {
@@ -8766,6 +8785,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             response_ref: Ref::NONE,
             bun_app_namespace_ref: Ref::NONE,
             bundler_feature_flag_ref: Ref::NONE,
+            create_require_ref: Ref::NONE,
+            create_require_target_refs: Default::default(),
             in_branch_condition: false,
             has_classic_runtime_warned: false,
             macro_call_count: 0,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -317,10 +317,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.react_compiler_candidate_name = Some(id.r#ref);
                     self.react_compiler_in_react_hoc = in_hoc;
                 }
-                // The visit may inline `import.meta.url` to a string (CJS output
-                // format, Bake), so the argument shape is captured before
-                // visiting. The callee ref is only resolved by the visit, so it
-                // is checked afterwards.
+                // The visit may inline `import.meta.url` to a string (CJS output,
+                // Bake), so check the argument shape first; callee refs only
+                // resolve during the visit, so that check happens after.
                 let arg_was_import_meta_url = was_const
                     && self.create_require_ref.is_valid()
                     && matches!(decl.binding.data, BData::BIdentifier(_))
@@ -371,9 +370,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
 
-                // Track `const req = createRequire(import.meta.url)` so e_call can
-                // bundle `req("...")` like a regular `require("...")`. Restricted
-                // to `const` so the binding can never be reassigned.
+                // `const` only, so the binding can never be reassigned.
                 if arg_was_import_meta_url
                     && let BData::BIdentifier(id) = decl.binding.data
                     && let Some(value) = decl.value

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -352,6 +352,35 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
 
+                // Track `const req = createRequire(import.meta.url)` so e_call can
+                // bundle `req("...")` like a regular `require("...")`. Restricted
+                // to `const` so the binding can never be reassigned.
+                if was_const
+                    && self.create_require_ref.is_valid()
+                    && let BData::BIdentifier(id) = decl.binding.data
+                    && let Some(value) = decl.value
+                    && let Some(call) = value.data.e_call()
+                    && call.args.len_u32() == 1
+                {
+                    let target_ref = match &call.target.data {
+                        ExprData::EIdentifier(ident) => Some(ident.ref_),
+                        ExprData::EImportIdentifier(ident) => Some(ident.ref_),
+                        _ => None,
+                    };
+                    let arg_is_import_meta_url = match &call.args.slice()[0].data {
+                        ExprData::EDot(dot) => {
+                            matches!(dot.target.data, ExprData::EImportMeta(_))
+                                && (dot.name == b"url" || dot.name == b"filename")
+                        }
+                        _ => false,
+                    };
+                    if arg_is_import_meta_url
+                        && target_ref.is_some_and(|r| r.eql(self.create_require_ref))
+                    {
+                        self.create_require_target_refs.insert(id.r#ref, ());
+                    }
+                }
+
                 if self.should_unwrap_common_js_to_esm() {
                     if prev_require_to_convert_count < self.imports_to_convert_from_require.len() {
                         if let BData::BIdentifier(id) = decl.binding.data {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -317,6 +317,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.react_compiler_candidate_name = Some(id.r#ref);
                     self.react_compiler_in_react_hoc = in_hoc;
                 }
+                // The visit may inline `import.meta.url` to a string (CJS output
+                // format, Bake), so the argument shape is captured before
+                // visiting. The callee ref is only resolved by the visit, so it
+                // is checked afterwards.
+                let arg_was_import_meta_url = was_const
+                    && self.create_require_ref.is_valid()
+                    && matches!(decl.binding.data, BData::BIdentifier(_))
+                    && match val.data.e_call() {
+                        Some(call) if call.args.len_u32() == 1 => {
+                            match &call.args.slice()[0].data {
+                                ExprData::EDot(dot) => {
+                                    matches!(dot.target.data, ExprData::EImportMeta(_))
+                                        && (dot.name == b"url" || dot.name == b"filename")
+                                }
+                                _ => false,
+                            }
+                        }
+                        _ => false,
+                    };
                 self.visit_expr_in_out(
                     &mut val,
                     ExprIn {
@@ -355,28 +374,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // Track `const req = createRequire(import.meta.url)` so e_call can
                 // bundle `req("...")` like a regular `require("...")`. Restricted
                 // to `const` so the binding can never be reassigned.
-                if was_const
-                    && self.create_require_ref.is_valid()
+                if arg_was_import_meta_url
                     && let BData::BIdentifier(id) = decl.binding.data
                     && let Some(value) = decl.value
                     && let Some(call) = value.data.e_call()
-                    && call.args.len_u32() == 1
                 {
                     let target_ref = match &call.target.data {
                         ExprData::EIdentifier(ident) => Some(ident.ref_),
                         ExprData::EImportIdentifier(ident) => Some(ident.ref_),
                         _ => None,
                     };
-                    let arg_is_import_meta_url = match &call.args.slice()[0].data {
-                        ExprData::EDot(dot) => {
-                            matches!(dot.target.data, ExprData::EImportMeta(_))
-                                && (dot.name == b"url" || dot.name == b"filename")
-                        }
-                        _ => false,
-                    };
-                    if arg_is_import_meta_url
-                        && target_ref.is_some_and(|r| r.eql(self.create_require_ref))
-                    {
+                    if target_ref.is_some_and(|r| r.eql(self.create_require_ref)) {
                         self.create_require_target_refs.insert(id.r#ref, ());
                     }
                 }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2007,6 +2007,30 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        // Calls through a `const req = createRequire(import.meta.url)` binding
+        // resolve relative to the current module, exactly like `require()`, so
+        // bundle static string arguments the same way. Dynamic arguments keep
+        // calling the binding at runtime.
+        if !p.create_require_target_refs.is_empty() && e_.args.len_u32() == 1 {
+            let target_ref = match &e_.target.data {
+                Data::EIdentifier(ident) => Some(ident.ref_),
+                _ => None,
+            };
+            if let Some(target_ref) = target_ref
+                && p.create_require_target_refs.contains_key(&target_ref)
+                && matches!(e_.args.slice()[0].data, Data::EString(..))
+            {
+                let first = e_.args.slice()[0];
+                let state = TransposeState {
+                    is_require_immediately_assigned_to_decl: in_.is_immediately_assigned_to_decl,
+                    ..Default::default()
+                };
+                *e = p.transpose_require(first, &state);
+                p.ignore_usage(target_ref);
+                return;
+            }
+        }
+
         if matches!(e_.target.data, Data::ERequireCallTarget) {
             e_.can_be_unwrapped_if_unused = E::CallUnwrap::Never;
 

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2007,10 +2007,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        // Calls through a `const req = createRequire(import.meta.url)` binding
-        // resolve relative to the current module, exactly like `require()`, so
-        // bundle static string arguments the same way. Dynamic arguments keep
-        // calling the binding at runtime.
+        // A call through a `const req = createRequire(import.meta.url)` binding
+        // resolves like `require()`: bundle string-literal arguments the same
+        // way and leave dynamic arguments as runtime calls on the binding.
         if !p.create_require_target_refs.is_empty() && e_.args.len_u32() == 1 {
             let target_ref = match &e_.target.data {
                 Data::EIdentifier(ident) => Some(ident.ref_),

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2858,6 +2858,57 @@ describe("bundler", () => {
       expect(out).not.toContain("require_foo\u2014bar");
     },
   });
+  // https://github.com/oven-sh/bun/issues/36564
+  // `const req = createRequire(import.meta.url)` resolves relative to the
+  // current module, so calls with a static string must be bundled like
+  // require(). The entry lives in /src while the output is /out.js, so an
+  // unbundled runtime lookup would fail to find the files.
+  itBundled("edgecase/CreateRequireImportMetaUrl", {
+    files: {
+      "/src/entry.js": /* js */ `
+        import { createRequire } from "module";
+        const require = createRequire(import.meta.url);
+        const data = require("./data.json");
+        const util = require("./util.cjs");
+        console.log(JSON.stringify(data), util.add(1, 2));
+      `,
+      "/src/data.json": `{ "hello": "world" }`,
+      "/src/util.cjs": /* js */ `
+        module.exports.add = (a, b) => a + b;
+      `,
+    },
+    target: "bun",
+    run: { stdout: `{"hello":"world"} 3` },
+  });
+  itBundled("edgecase/CreateRequireNodeModuleAliased", {
+    files: {
+      "/src/entry.js": /* js */ `
+        import { createRequire as cr } from "node:module";
+        const myRequire = cr(import.meta.filename);
+        console.log(myRequire("./data.json").value);
+      `,
+      "/src/data.json": `{ "value": 42 }`,
+    },
+    target: "node",
+    run: { stdout: "42" },
+  });
+  itBundled("edgecase/CreateRequireDynamicArgumentUntouched", {
+    files: {
+      // A non-string argument keeps calling the binding at runtime; the target
+      // file sits next to the output so the runtime lookup still resolves.
+      "/src/entry.js": /* js */ `
+        import { createRequire } from "module";
+        const require2 = createRequire(import.meta.url);
+        const name = "./dy" + "namic.cjs";
+        console.log(require2(name).x);
+      `,
+      "/dynamic.cjs": /* js */ `
+        module.exports.x = "dyn";
+      `,
+    },
+    target: "bun",
+    run: { stdout: "dyn" },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2880,6 +2880,21 @@ describe("bundler", () => {
     target: "bun",
     run: { stdout: `{"hello":"world"} 3` },
   });
+  itBundled("edgecase/CreateRequireImportMetaUrlCjsFormat", {
+    // With CJS output format the visit pass inlines import.meta.url to a
+    // string, which must not defeat the createRequire detection.
+    files: {
+      "/src/entry.js": /* js */ `
+        import { createRequire } from "module";
+        const require2 = createRequire(import.meta.url);
+        console.log(require2("./data.json").value);
+      `,
+      "/src/data.json": `{ "value": "cjs-ok" }`,
+    },
+    target: "node",
+    format: "cjs",
+    run: { stdout: "cjs-ok" },
+  });
   itBundled("edgecase/CreateRequireNodeModuleAliased", {
     files: {
       "/src/entry.js": /* js */ `


### PR DESCRIPTION
### Problem

Fixes #36564

When a dependency creates its own require in ESM (css-tree does this, which is how playwright users hit it):

```js
import { createRequire } from 'module';
const require = createRequire(import.meta.url);
const patch = require('../data/patch.json');
```

the bundler copied the call through verbatim. In the output, `import.meta.url` points at the bundle, so the relative lookup resolves against the output location and throws at runtime once the bundle is moved away from `node_modules`:

```
error: Cannot find module '../data/patch.json' from '/path/to/output/index.js'
```

The build succeeds silently, so nothing warns about this until the bundle runs.

### Fix

Calls through a binding created by `createRequire(import.meta.url)` resolve relative to the current source file, exactly like `require()`, so the bundler now bundles them the same way:

- At parse time, record the local binding of `createRequire` imported from `"module"`/`"node:module"` (bundling only, skipping the runtime shim source).
- While visiting declarations, record `const` bindings initialized with `createRequire(import.meta.url)` (or `import.meta.filename`). Restricting to `const` guarantees the binding is never reassigned.
- In `e_call`, calls on a recorded binding with a single static string argument go through the same `transpose_require` path as a regular `require("...")`, creating an import record so the target is bundled. Dynamic arguments, property accesses like `req.resolve`, and non-const bindings are left untouched.

### Verification

New tests in `test/bundler/bundler_edgecase.test.ts` place the entry in `/src` while the output is `/out.js`, so an untraced runtime lookup cannot accidentally resolve. They fail on released bun with `Cannot find module './data.json' from .../out.js` and pass with this change. A third test checks dynamic arguments still call the binding at runtime.

The original css-tree repro (bundle moved out of the project) now runs correctly, and `bundler_edgecase`, `bundler_cjs2esm`, `bundler_bun`, `esbuild/default`, and `compile/Bun.embeddedFiles` suites pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->