### PR TITLE
bun:sqlite: finalize outstanding prepared statements on close via sqlite3_next_stmt

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -112,15 +112,15 @@ const db = new Database("./mydb.sqlite");
 
 ### `.close(throwOnError: boolean = false)`
 
-To close a database connection but allow existing queries to finish, call `.close(false)`:
+To close a database connection, call `.close()`:
 
 ```ts db.ts icon="/icons/typescript.svg" highlight={3}
 const db = new Database();
 // ... do stuff
-db.close(false);
+db.close();
 ```
 
-To close the database and throw an error if there are any pending queries, call `.close(true)`:
+Any prepared statements that were not finalized are finalized as part of closing, so the connection (and the database file) is released immediately. Using a statement after its database was closed throws an error. Pass `true` to throw if the connection fails to close:
 
 ```ts db.ts icon="/icons/typescript.svg" highlight={3}
 const db = new Database();
@@ -129,8 +129,8 @@ db.close(true);
 ```
 
 <Note>
-  `close(false)` is called automatically when the database is garbage collected. It is safe to call multiple times but
-  has no effect after the first.
+  `close()` is called automatically when the database is garbage collected. It is safe to call multiple times but has
+  no effect after the first.
 </Note>
 
 ### `using` statement

--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -129,8 +129,8 @@ db.close(true);
 ```
 
 <Note>
-  `close()` is called automatically when the database is garbage collected. It is safe to call multiple times but has
-  no effect after the first.
+  `close()` is called automatically when the database is garbage collected. It is safe to call multiple times but has no
+  effect after the first.
 </Note>
 
 ### `using` statement

--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -120,7 +120,7 @@ const db = new Database();
 db.close();
 ```
 
-Any prepared statements that were not finalized are finalized as part of closing, so the connection (and the database file) is released immediately. Using a statement after its database was closed throws an error. Pass `true` to throw if the connection fails to close:
+Any prepared statements that were not finalized are finalized as part of closing, so the connection (and the database file) is released immediately. Using a statement after its database was closed throws an error, except `toString()`, which returns an empty string. Pass `true` to throw if the connection fails to close:
 
 ```ts db.ts icon="/icons/typescript.svg" highlight={3}
 const db = new Database();

--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -120,7 +120,7 @@ const db = new Database();
 db.close();
 ```
 
-Any prepared statements that were not finalized are finalized as part of closing, so the connection (and the database file) is released immediately. Using a statement after its database was closed throws an error, except `toString()`, which returns an empty string. Pass `true` to throw if the connection fails to close:
+Any prepared statements that were not finalized are finalized as part of closing, so the connection (and the database file) is released immediately. Using a statement after its database was closed throws an error, except `toString()`, which returns an empty string, and `finalize()`, which stays safe to call. Pass `true` to throw if the connection fails to close:
 
 ```ts db.ts icon="/icons/typescript.svg" highlight={3}
 const db = new Database();

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -264,9 +264,11 @@ declare module "bun:sqlite" {
     /**
      * Close the database connection.
      *
-     * It is safe to call this method multiple times. If the database is already
-     * closed, this is a no-op. Running queries after the database has been
-     * closed throws an error.
+     * Prepared statements that were not finalized are finalized as part of
+     * closing, so the connection is released immediately. It is safe to call
+     * this method multiple times. If the database is already closed, this is
+     * a no-op. Running queries or using statements after the database has
+     * been closed throws an error.
      *
      * @example
      * ```ts
@@ -274,14 +276,12 @@ declare module "bun:sqlite" {
      * ```
      * This is called automatically when the database instance is garbage collected.
      *
-     * Internally, this calls `sqlite3_close_v2`.
+     * Internally, this calls `sqlite3_close`.
      */
     close(
       /**
-       * If `true`, throw an error if the database is in use
+       * If `true`, throw an error if the connection fails to close
        * @default false
-       *
-       * When `true`, this calls `sqlite3_close` instead of `sqlite3_close_v2`.
        *
        * Learn more in the [sqlite3 documentation](https://www.sqlite.org/c3ref/close.html).
        *

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -269,7 +269,7 @@ declare module "bun:sqlite" {
      * this method multiple times. If the database is already closed, this is
      * a no-op. Running queries or using statements after the database has
      * been closed throws an error, except statement `toString()`, which
-     * returns an empty string.
+     * returns an empty string, and `finalize()`, which stays safe to call.
      *
      * @example
      * ```ts

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -268,7 +268,8 @@ declare module "bun:sqlite" {
      * closing, so the connection is released immediately. It is safe to call
      * this method multiple times. If the database is already closed, this is
      * a no-op. Running queries or using statements after the database has
-     * been closed throws an error.
+     * been closed throws an error, except statement `toString()`, which
+     * returns an empty string.
      *
      * @example
      * ```ts

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -429,6 +429,11 @@ class Database implements SqliteTypes.Database {
   #cachedQueriesKeys: string[] = [];
   #cachedQueriesLengths: number[] = [];
   #cachedQueriesValues: Statement[] = [];
+  // Statements created by query() after the cache filled up. Held weakly so GC
+  // can still collect them, but tracked so close() can finalize the survivors;
+  // otherwise sqlite3_close() fails with SQLITE_BUSY ("database is locked").
+  #uncachedQueryStatements?: Set<WeakRef<Statement>>;
+  #uncachedQueryRegistry?: FinalizationRegistry<WeakRef<Statement>>;
   filename;
   #hasClosed = false;
   get handle() {
@@ -526,6 +531,14 @@ class Database implements SqliteTypes.Database {
     this.#cachedQueriesKeys.length = 0;
     this.#cachedQueriesValues.length = 0;
     this.#cachedQueriesLengths.length = 0;
+
+    const uncached = this.#uncachedQueryStatements;
+    if (uncached) {
+      for (const ref of uncached) {
+        ref.deref()?.finalize?.();
+      }
+      uncached.clear();
+    }
   }
 
   run(query, ...params) {
@@ -590,6 +603,14 @@ class Database implements SqliteTypes.Database {
       this.#cachedQueriesKeys.push(query);
       this.#cachedQueriesLengths.push(query.length);
       this.#cachedQueriesValues.push(stmt);
+    } else {
+      const statements = (this.#uncachedQueryStatements ??= new Set());
+      const registry = (this.#uncachedQueryRegistry ??= new FinalizationRegistry(ref => {
+        this.#uncachedQueryStatements?.delete(ref);
+      }));
+      const ref = new WeakRef(stmt);
+      statements.add(ref);
+      registry.register(stmt, ref);
     }
 
     return stmt;

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -429,11 +429,6 @@ class Database implements SqliteTypes.Database {
   #cachedQueriesKeys: string[] = [];
   #cachedQueriesLengths: number[] = [];
   #cachedQueriesValues: Statement[] = [];
-  // Statements created by query() after the cache filled up. Held weakly so GC
-  // can still collect them, but tracked so close() can finalize the survivors;
-  // otherwise sqlite3_close() fails with SQLITE_BUSY ("database is locked").
-  #uncachedQueryStatements?: Set<WeakRef<Statement>>;
-  #uncachedQueryRegistry?: FinalizationRegistry<WeakRef<Statement>>;
   filename;
   #hasClosed = false;
   get handle() {
@@ -531,14 +526,6 @@ class Database implements SqliteTypes.Database {
     this.#cachedQueriesKeys.length = 0;
     this.#cachedQueriesValues.length = 0;
     this.#cachedQueriesLengths.length = 0;
-
-    const uncached = this.#uncachedQueryStatements;
-    if (uncached) {
-      for (const ref of uncached) {
-        ref.deref()?.finalize?.();
-      }
-      uncached.clear();
-    }
   }
 
   run(query, ...params) {
@@ -603,14 +590,6 @@ class Database implements SqliteTypes.Database {
       this.#cachedQueriesKeys.push(query);
       this.#cachedQueriesLengths.push(query.length);
       this.#cachedQueriesValues.push(stmt);
-    } else {
-      const statements = (this.#uncachedQueryStatements ??= new Set());
-      const registry = (this.#uncachedQueryRegistry ??= new FinalizationRegistry(ref => {
-        this.#uncachedQueryStatements?.delete(ref);
-      }));
-      const ref = new WeakRef(stmt);
-      statements.add(ref);
-      registry.register(stmt, ref);
     }
 
     return stmt;

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -194,11 +194,11 @@ static inline JSC::JSValue jsBigIntFromSQLite(JSC::JSGlobalObject* globalObject,
     if (castedThis->stmt == nullptr || castedThis->version_db == nullptr) [[unlikely]] {                           \
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s)); \
         return {};                                                                                                 \
-    }                                                                                                              \
-    if (castedThis->version_db->finalizedStatementsOnClose) [[unlikely]] {                                         \
-        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));     \
-        return {};                                                                                                 \
     }
+
+namespace WebCore {
+class JSSQLStatement;
+}
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VersionSqlite3);
 
@@ -215,11 +215,10 @@ public:
     sqlite3* db;
     std::atomic<uint64_t> version;
     size_t reference_count;
-    // close() finalized every statement on this connection, so statement
-    // wrappers hold dangling sqlite3_stmt pointers they must never pass to
-    // sqlite again. Stays false on the sqlite3_close_v2() paths (GC release,
-    // termination), where outstanding statements remain valid.
-    bool finalizedStatementsOnClose = false;
+    // Live statement wrappers on this connection. close() finalizes each one
+    // and nulls its stmt pointer, like better-sqlite3's CloseHandles() and
+    // node:sqlite's FinalizeStatements().
+    WTF::Vector<WebCore::JSSQLStatement*> statements;
 
     void release()
     {
@@ -478,6 +477,7 @@ public:
         JSSQLStatement* ptr = new (NotNull, JSC::allocateCell<JSSQLStatement>(globalObject->vm())) JSSQLStatement(structure, *globalObject, stmt, version_db, memorySizeChange);
         if (version_db) {
             ++version_db->reference_count;
+            version_db->statements.append(ptr);
         }
         ptr->finishCreation(globalObject->vm());
         return ptr;
@@ -945,11 +945,11 @@ static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindin
     int count = 0;
 
     // Reading a property off `target` can run arbitrary JS (getters, Proxy
-    // traps), which can call statement.finalize() and free `stmt`, or close
-    // the database, which finalizes `stmt` via sqlite3_next_stmt().
-    // Re-validate before touching `stmt` again after any callback into JS.
+    // traps), which can call statement.finalize() or db.close() and free
+    // `stmt`. Re-validate before touching `stmt` again after any callback
+    // into JS.
     const auto& statementStillAlive = [&]() -> bool {
-        if (versionDB->finalizedStatementsOnClose) [[unlikely]] {
+        if (versionDB->db != db) [[unlikely]] {
             if (!scope.exception())
                 throwException(globalObject, scope, createError(globalObject, "Database has closed"_s));
             return false;
@@ -1163,7 +1163,7 @@ static JSC::JSValue rebindStatement(JSC::JSGlobalObject* lexicalGlobalObject, JS
         } else {
             value = array->getDirectIndex(lexicalGlobalObject, i);
             RETURN_IF_EXCEPTION(scope, {});
-            if (versionDB->finalizedStatementsOnClose) [[unlikely]] {
+            if (versionDB->db != db) [[unlikely]] {
                 throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
                 return {};
             }
@@ -1548,16 +1548,16 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
 
                 SQLiteBindingsMap bindings { static_cast<uint16_t>(count > -1 ? count : 0), strict };
                 JSC::JSValue reb = rebindStatement(lexicalGlobalObject, bindingsAliveScope.value(), scope, db, versionDB, sql.stmt, bindings, safeIntegers, nullptr);
-                // A close() during binding finalized sql.stmt; keep the
-                // auto-destructor from finalizing it again.
-                if (versionDB->finalizedStatementsOnClose) [[unlikely]]
-                    sql.stmt = nullptr;
-                RETURN_IF_EXCEPTION(scope, {});
-
                 if (versionDB->db != db) [[unlikely]] {
-                    throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
+                    // A close() during binding finalized sql.stmt via its
+                    // sqlite3_next_stmt() sweep; keep the auto-destructor
+                    // from finalizing it again.
+                    sql.stmt = nullptr;
+                    if (!scope.exception())
+                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
                     return {};
                 }
+                RETURN_IF_EXCEPTION(scope, {});
 
                 if (!reb.isNumber()) [[unlikely]] {
                     return JSValue::encode(reb); /* this means an error */
@@ -1858,12 +1858,22 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
         return JSValue::encode(jsUndefined());
     }
 
-    // Finalize every outstanding prepared statement so sqlite3_close() cannot
-    // fail with SQLITE_BUSY; wrappers see finalizedStatementsOnClose.
+    // Finalize every outstanding statement so sqlite3_close() cannot fail
+    // with SQLITE_BUSY, nulling each wrapper's handle so it never touches
+    // freed memory.
+    for (auto* statement : versionDB->statements) {
+        if (statement->stmt) {
+            sqlite3_finalize(statement->stmt);
+            statement->stmt = nullptr;
+        }
+    }
+    versionDB->statements.clear();
+
+    // Backstop for statements not owned by a wrapper, e.g. the transient one
+    // in jsSQLStatementExecuteFunction when a bound getter calls close().
     while (sqlite3_stmt* stmt = sqlite3_next_stmt(db, nullptr)) {
         sqlite3_finalize(stmt);
     }
-    versionDB->finalizedStatementsOnClose = true;
 
     int statusCode = sqlite3_close(db);
     if (statusCode != SQLITE_OK) {
@@ -2282,10 +2292,6 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
                         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
                         return {};
                     }
-                    if (castedThis->version_db->finalizedStatementsOnClose) [[unlikely]] {
-                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
-                        return {};
-                    }
                     status = sqlite3_step(stmt);
                 } while (status == SQLITE_ROW);
             } else {
@@ -2296,10 +2302,6 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
                     RETURN_IF_EXCEPTION(scope, {});
                     if (castedThis->stmt != stmt) [[unlikely]] {
                         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
-                        return {};
-                    }
-                    if (castedThis->version_db->finalizedStatementsOnClose) [[unlikely]] {
-                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
                         return {};
                     }
                     status = sqlite3_step(stmt);
@@ -2448,10 +2450,6 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows, (JSC::JSGlo
                         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
                         return {};
                     }
-                    if (castedThis->version_db->finalizedStatementsOnClose) [[unlikely]] {
-                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
-                        return {};
-                    }
                     status = sqlite3_step(stmt);
                 } while (status == SQLITE_ROW);
             }
@@ -2540,10 +2538,6 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRawRows, (JSC::JS
 
                     if (castedThis->stmt != stmt) [[unlikely]] {
                         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
-                        return {};
-                    }
-                    if (castedThis->version_db->finalizedStatementsOnClose) [[unlikely]] {
-                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
                         return {};
                     }
 
@@ -2648,12 +2642,6 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementToStringFunction, (JSC::JSGlobalObject * 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     CHECK_THIS
-
-    // After close() the stmt pointer is dangling; report the same empty
-    // string a finalized statement produces.
-    if (castedThis->version_db && castedThis->version_db->finalizedStatementsOnClose) [[unlikely]] {
-        RELEASE_AND_RETURN(scope, JSValue::encode(jsEmptyString(vm)));
-    }
 
     char* string = sqlite3_expanded_sql(castedThis->stmt);
     if (!string) {
@@ -2871,9 +2859,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFunctionFinalize, (JSC::JSGlobalObject * 
     CHECK_THIS
 
     if (castedThis->stmt) {
-        if (!(castedThis->version_db && castedThis->version_db->finalizedStatementsOnClose)) {
-            sqlite3_finalize(castedThis->stmt);
-        }
+        sqlite3_finalize(castedThis->stmt);
         castedThis->stmt = nullptr;
     }
 
@@ -2894,7 +2880,10 @@ void JSSQLStatement::finishCreation(VM& vm)
 
 JSSQLStatement::~JSSQLStatement()
 {
-    if (this->stmt && !(this->version_db && this->version_db->finalizedStatementsOnClose)) {
+    if (this->version_db) {
+        this->version_db->statements.removeFirst(this);
+    }
+    if (this->stmt) {
         sqlite3_finalize(this->stmt);
     }
 
@@ -2933,12 +2922,7 @@ JSC::JSValue JSSQLStatement::rebind(JSC::JSGlobalObject* lexicalGlobalObject, JS
         return {};
     }
 
-    // A getter can also close the database, which finalizes `stmt` without
-    // nulling this wrapper's pointer.
-    if (this->version_db->finalizedStatementsOnClose) [[unlikely]] {
-        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
-        return {};
-    }
+
 
     if (val.isNumber()) {
         RELEASE_AND_RETURN(scope, val);

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -45,6 +45,7 @@
 #include "wtf/BitVector.h"
 #include "wtf/FastBitVector.h"
 #include "wtf/Vector.h"
+#include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <atomic>
 #include "wtf/LazyRef.h"
@@ -218,7 +219,7 @@ public:
     // Live statement wrappers on this connection. close() finalizes each one
     // and nulls its stmt pointer, like better-sqlite3's CloseHandles() and
     // node:sqlite's FinalizeStatements().
-    WTF::Vector<WebCore::JSSQLStatement*> statements;
+    WTF::HashSet<WebCore::JSSQLStatement*> statements;
 
     void release()
     {
@@ -477,7 +478,7 @@ public:
         JSSQLStatement* ptr = new (NotNull, JSC::allocateCell<JSSQLStatement>(globalObject->vm())) JSSQLStatement(structure, *globalObject, stmt, version_db, memorySizeChange);
         if (version_db) {
             ++version_db->reference_count;
-            version_db->statements.append(ptr);
+            version_db->statements.add(ptr);
         }
         ptr->finishCreation(globalObject->vm());
         return ptr;
@@ -2881,7 +2882,7 @@ void JSSQLStatement::finishCreation(VM& vm)
 JSSQLStatement::~JSSQLStatement()
 {
     if (this->version_db) {
-        this->version_db->statements.removeFirst(this);
+        this->version_db->statements.remove(this);
     }
     if (this->stmt) {
         sqlite3_finalize(this->stmt);

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -2922,8 +2922,6 @@ JSC::JSValue JSSQLStatement::rebind(JSC::JSGlobalObject* lexicalGlobalObject, JS
         return {};
     }
 
-
-
     if (val.isNumber()) {
         RELEASE_AND_RETURN(scope, val);
     } else {

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -225,11 +225,10 @@ public:
     sqlite3* db;
     std::atomic<uint64_t> version;
     size_t reference_count;
-    // Set when close() finalized every statement on the connection via
-    // sqlite3_next_stmt(). Statement wrappers then hold dangling sqlite3_stmt
-    // pointers and must not pass them to sqlite again. The termination path
-    // and release() leave this false: they close with sqlite3_close_v2(),
-    // which keeps outstanding statements valid until each is finalized.
+    // close() finalized every statement on this connection, so statement
+    // wrappers hold dangling sqlite3_stmt pointers they must never pass to
+    // sqlite again. Stays false on the sqlite3_close_v2() paths (GC release,
+    // termination), where outstanding statements remain valid.
     bool finalizedStatementsOnClose = false;
 
     void release()
@@ -1559,9 +1558,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
 
                 SQLiteBindingsMap bindings { static_cast<uint16_t>(count > -1 ? count : 0), strict };
                 JSC::JSValue reb = rebindStatement(lexicalGlobalObject, bindingsAliveScope.value(), scope, db, versionDB, sql.stmt, bindings, safeIntegers, nullptr);
-                // close() during binding already finalized sql.stmt via
-                // sqlite3_next_stmt(); keep the auto-destructor from
-                // finalizing it again.
+                // A close() during binding finalized sql.stmt; keep the
+                // auto-destructor from finalizing it again.
                 if (versionDB->finalizedStatementsOnClose) [[unlikely]]
                     sql.stmt = nullptr;
                 RETURN_IF_EXCEPTION(scope, {});
@@ -1870,10 +1868,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
         return JSValue::encode(jsUndefined());
     }
 
-    // Finalize every outstanding prepared statement on this connection so
-    // sqlite3_close() cannot fail with SQLITE_BUSY. Statement wrappers detect
-    // this through version_db->finalizedStatementsOnClose and never touch
-    // their now-freed sqlite3_stmt again.
+    // Finalize every outstanding prepared statement so sqlite3_close() cannot
+    // fail with SQLITE_BUSY; wrappers see finalizedStatementsOnClose.
     while (sqlite3_stmt* stmt = sqlite3_next_stmt(db, nullptr)) {
         sqlite3_finalize(stmt);
     }

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -2544,11 +2544,9 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRawRows, (JSC::JS
                         RELEASE_AND_RETURN(scope, {});
                     }
                     resultArray->push(lexicalGlobalObject, row);
-
-                    if (scope.exception()) [[unlikely]] {
-                        sqlite3_reset(stmt);
-                        RELEASE_AND_RETURN(scope, {});
-                    }
+                    // No sqlite3_reset here: push() can run user code that
+                    // finalizes `stmt` (statement.finalize() or db.close()).
+                    RETURN_IF_EXCEPTION(scope, {});
 
                     if (castedThis->stmt != stmt) [[unlikely]] {
                         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -194,11 +194,19 @@ static inline JSC::JSValue jsBigIntFromSQLite(JSC::JSGlobalObject* globalObject,
     if (castedThis->stmt == nullptr || castedThis->version_db == nullptr) [[unlikely]] {                           \
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s)); \
         return {};                                                                                                 \
+    }                                                                                                              \
+    if (castedThis->version_db->finalizedStatementsOnClose) [[unlikely]] {                                         \
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));     \
+        return {};                                                                                                 \
     }
 
 #define CHECK_PREPARED_JIT                                                                                         \
     if (castedThis->stmt == nullptr || castedThis->version_db == nullptr) [[unlikely]] {                           \
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s)); \
+        return {};                                                                                                 \
+    }                                                                                                              \
+    if (castedThis->version_db->finalizedStatementsOnClose) [[unlikely]] {                                         \
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));     \
         return {};                                                                                                 \
     }
 
@@ -217,6 +225,12 @@ public:
     sqlite3* db;
     std::atomic<uint64_t> version;
     size_t reference_count;
+    // Set when close() finalized every statement on the connection via
+    // sqlite3_next_stmt(). Statement wrappers then hold dangling sqlite3_stmt
+    // pointers and must not pass them to sqlite again. The termination path
+    // and release() leave this false: they close with sqlite3_close_v2(),
+    // which keeps outstanding statements valid until each is finalized.
+    bool finalizedStatementsOnClose = false;
 
     void release()
     {
@@ -937,14 +951,20 @@ static inline bool rebindValue(JSC::JSGlobalObject* lexicalGlobalObject, sqlite3
 #undef CHECK_BIND
 }
 
-static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindingsMap& bindings, JSC::JSObject* target, JSC::ThrowScope& scope, sqlite3* db, sqlite3_stmt* stmt, bool safeIntegers, JSSQLStatement* statement)
+static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindingsMap& bindings, JSC::JSObject* target, JSC::ThrowScope& scope, sqlite3* db, VersionSqlite3* versionDB, sqlite3_stmt* stmt, bool safeIntegers, JSSQLStatement* statement)
 {
     int count = 0;
 
     // Reading a property off `target` can run arbitrary JS (getters, Proxy
-    // traps), which can call statement.finalize() and free `stmt`. Re-validate
-    // before touching `stmt` again after any callback into JS.
+    // traps), which can call statement.finalize() and free `stmt`, or close
+    // the database, which finalizes `stmt` via sqlite3_next_stmt().
+    // Re-validate before touching `stmt` again after any callback into JS.
     const auto& statementStillAlive = [&]() -> bool {
+        if (versionDB->finalizedStatementsOnClose) [[unlikely]] {
+            if (!scope.exception())
+                throwException(globalObject, scope, createError(globalObject, "Database has closed"_s));
+            return false;
+        }
         if (statement && statement->stmt != stmt) [[unlikely]] {
             if (!scope.exception())
                 throwException(globalObject, scope, createError(globalObject, "Statement has finalized"_s));
@@ -1117,7 +1137,7 @@ static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindin
     return jsNumber(count);
 }
 
-static JSC::JSValue rebindStatement(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue values, JSC::ThrowScope& scope, sqlite3* db, sqlite3_stmt* stmt, SQLiteBindingsMap& bindings, bool safeIntegers, JSSQLStatement* statement)
+static JSC::JSValue rebindStatement(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue values, JSC::ThrowScope& scope, sqlite3* db, VersionSqlite3* versionDB, sqlite3_stmt* stmt, SQLiteBindingsMap& bindings, bool safeIntegers, JSSQLStatement* statement)
 {
     sqlite3_clear_bindings(stmt);
     JSC::JSArray* array = dynamicDowncast<JSC::JSArray>(values);
@@ -1125,7 +1145,7 @@ static JSC::JSValue rebindStatement(JSC::JSGlobalObject* lexicalGlobalObject, JS
 
     if (!array) {
         if (JSC::JSObject* object = values.getObject()) {
-            auto res = rebindObject(lexicalGlobalObject, bindings, object, scope, db, stmt, safeIntegers, statement);
+            auto res = rebindObject(lexicalGlobalObject, bindings, object, scope, db, versionDB, stmt, safeIntegers, statement);
             RETURN_IF_EXCEPTION(scope, {});
             return res;
         }
@@ -1154,6 +1174,10 @@ static JSC::JSValue rebindStatement(JSC::JSGlobalObject* lexicalGlobalObject, JS
         } else {
             value = array->getDirectIndex(lexicalGlobalObject, i);
             RETURN_IF_EXCEPTION(scope, {});
+            if (versionDB->finalizedStatementsOnClose) [[unlikely]] {
+                throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
+                return {};
+            }
             if (statement && statement->stmt != stmt) [[unlikely]] {
                 throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
                 return {};
@@ -1534,7 +1558,12 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
                 int count = sqlite3_bind_parameter_count(sql.stmt);
 
                 SQLiteBindingsMap bindings { static_cast<uint16_t>(count > -1 ? count : 0), strict };
-                JSC::JSValue reb = rebindStatement(lexicalGlobalObject, bindingsAliveScope.value(), scope, db, sql.stmt, bindings, safeIntegers, nullptr);
+                JSC::JSValue reb = rebindStatement(lexicalGlobalObject, bindingsAliveScope.value(), scope, db, versionDB, sql.stmt, bindings, safeIntegers, nullptr);
+                // close() during binding already finalized sql.stmt via
+                // sqlite3_next_stmt(); keep the auto-destructor from
+                // finalizing it again.
+                if (versionDB->finalizedStatementsOnClose) [[unlikely]]
+                    sql.stmt = nullptr;
                 RETURN_IF_EXCEPTION(scope, {});
 
                 if (versionDB->db != db) [[unlikely]] {
@@ -1841,23 +1870,23 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
         return JSValue::encode(jsUndefined());
     }
 
-    // sqlite3_close_v2 is used for automatic GC cleanup
-    int statusCode;
-    if (shouldThrowOnError) {
-        statusCode = sqlite3_close(db);
-        if (statusCode == SQLITE_BUSY) {
-            // Statements whose JS wrappers are already unreachable still pin
-            // their sqlite3_stmt until GC runs their destructors. Collect now
-            // and retry once before reporting the connection as busy.
-            vm.heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);
-            statusCode = sqlite3_close(db);
-        }
-    } else {
-        statusCode = sqlite3_close_v2(db);
+    // Finalize every outstanding prepared statement on this connection so
+    // sqlite3_close() cannot fail with SQLITE_BUSY. Statement wrappers detect
+    // this through version_db->finalizedStatementsOnClose and never touch
+    // their now-freed sqlite3_stmt again.
+    while (sqlite3_stmt* stmt = sqlite3_next_stmt(db, nullptr)) {
+        sqlite3_finalize(stmt);
     }
+    versionDB->finalizedStatementsOnClose = true;
+
+    int statusCode = sqlite3_close(db);
     if (statusCode != SQLITE_OK) {
-        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, WTF::String::fromUTF8(sqlite3_errstr(statusCode))));
-        return {};
+        if (shouldThrowOnError) {
+            throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, WTF::String::fromUTF8(sqlite3_errstr(statusCode))));
+            return {};
+        }
+        // Non-strict close() never throws; defer the close instead.
+        sqlite3_close_v2(db);
     }
 
     versionDB->db = nullptr;
@@ -2266,6 +2295,10 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
                         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
                         return {};
                     }
+                    if (castedThis->version_db->finalizedStatementsOnClose) [[unlikely]] {
+                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
+                        return {};
+                    }
                     status = sqlite3_step(stmt);
                 } while (status == SQLITE_ROW);
             } else {
@@ -2276,6 +2309,10 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
                     RETURN_IF_EXCEPTION(scope, {});
                     if (castedThis->stmt != stmt) [[unlikely]] {
                         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
+                        return {};
+                    }
+                    if (castedThis->version_db->finalizedStatementsOnClose) [[unlikely]] {
+                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
                         return {};
                     }
                     status = sqlite3_step(stmt);
@@ -2424,6 +2461,10 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows, (JSC::JSGlo
                         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
                         return {};
                     }
+                    if (castedThis->version_db->finalizedStatementsOnClose) [[unlikely]] {
+                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
+                        return {};
+                    }
                     status = sqlite3_step(stmt);
                 } while (status == SQLITE_ROW);
             }
@@ -2514,6 +2555,10 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRawRows, (JSC::JS
 
                     if (castedThis->stmt != stmt) [[unlikely]] {
                         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
+                        return {};
+                    }
+                    if (castedThis->version_db->finalizedStatementsOnClose) [[unlikely]] {
+                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
                         return {};
                     }
 
@@ -2618,6 +2663,12 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementToStringFunction, (JSC::JSGlobalObject * 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     CHECK_THIS
+
+    // After close() the stmt pointer is dangling; report the same empty
+    // string a finalized statement produces.
+    if (castedThis->version_db && castedThis->version_db->finalizedStatementsOnClose) [[unlikely]] {
+        RELEASE_AND_RETURN(scope, JSValue::encode(jsEmptyString(vm)));
+    }
 
     char* string = sqlite3_expanded_sql(castedThis->stmt);
     if (!string) {
@@ -2835,7 +2886,9 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFunctionFinalize, (JSC::JSGlobalObject * 
     CHECK_THIS
 
     if (castedThis->stmt) {
-        sqlite3_finalize(castedThis->stmt);
+        if (!(castedThis->version_db && castedThis->version_db->finalizedStatementsOnClose)) {
+            sqlite3_finalize(castedThis->stmt);
+        }
         castedThis->stmt = nullptr;
     }
 
@@ -2856,7 +2909,7 @@ void JSSQLStatement::finishCreation(VM& vm)
 
 JSSQLStatement::~JSSQLStatement()
 {
-    if (this->stmt) {
+    if (this->stmt && !(this->version_db && this->version_db->finalizedStatementsOnClose)) {
         sqlite3_finalize(this->stmt);
     }
 
@@ -2885,13 +2938,20 @@ JSC::JSValue JSSQLStatement::rebind(JSC::JSGlobalObject* lexicalGlobalObject, JS
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* stmt = this->stmt;
 
-    auto val = rebindStatement(lexicalGlobalObject, values, scope, this->version_db->db, stmt, this->m_bindingNames, this->useBigInt64, this);
+    auto val = rebindStatement(lexicalGlobalObject, values, scope, this->version_db->db, this->version_db, stmt, this->m_bindingNames, this->useBigInt64, this);
     RETURN_IF_EXCEPTION(scope, {});
 
     // A getter invoked while binding can finalize this statement; the callers
     // cache `stmt` before binding and call sqlite3_step() on it afterwards.
     if (this->stmt != stmt) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
+        return {};
+    }
+
+    // A getter can also close the database, which finalizes `stmt` without
+    // nulling this wrapper's pointer.
+    if (this->version_db->finalizedStatementsOnClose) [[unlikely]] {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
         return {};
     }
 

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -200,16 +200,6 @@ static inline JSC::JSValue jsBigIntFromSQLite(JSC::JSGlobalObject* globalObject,
         return {};                                                                                                 \
     }
 
-#define CHECK_PREPARED_JIT                                                                                         \
-    if (castedThis->stmt == nullptr || castedThis->version_db == nullptr) [[unlikely]] {                           \
-        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s)); \
-        return {};                                                                                                 \
-    }                                                                                                              \
-    if (castedThis->version_db->finalizedStatementsOnClose) [[unlikely]] {                                         \
-        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));     \
-        return {};                                                                                                 \
-    }
-
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VersionSqlite3);
 
 class VersionSqlite3 {

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -1877,15 +1877,16 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
 
     int statusCode = sqlite3_close(db);
     if (statusCode != SQLITE_OK) {
-        if (shouldThrowOnError) {
-            throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, WTF::String::fromUTF8(sqlite3_errstr(statusCode))));
-            return {};
-        }
-        // Non-strict close() never throws; defer the close instead.
+        // The statements are already gone, so the connection is unusable
+        // either way: defer the close and retire the handle.
         sqlite3_close_v2(db);
     }
-
     versionDB->db = nullptr;
+
+    if (statusCode != SQLITE_OK && shouldThrowOnError) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, WTF::String::fromUTF8(sqlite3_errstr(statusCode))));
+        return {};
+    }
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -1842,7 +1842,19 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
     }
 
     // sqlite3_close_v2 is used for automatic GC cleanup
-    int statusCode = shouldThrowOnError ? sqlite3_close(db) : sqlite3_close_v2(db);
+    int statusCode;
+    if (shouldThrowOnError) {
+        statusCode = sqlite3_close(db);
+        if (statusCode == SQLITE_BUSY) {
+            // Statements whose JS wrappers are already unreachable still pin
+            // their sqlite3_stmt until GC runs their destructors. Collect now
+            // and retry once before reporting the connection as busy.
+            vm.heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);
+            statusCode = sqlite3_close(db);
+        }
+    } else {
+        statusCode = sqlite3_close_v2(db);
+    }
     if (statusCode != SQLITE_OK) {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, WTF::String::fromUTF8(sqlite3_errstr(statusCode))));
         return {};

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1718,7 +1718,7 @@ it("reports changes in Statement#run", () => {
 });
 
 it("#13082", async () => {
-  async function run() {
+  async function run(op) {
     const stmt = (() => {
       const db = new Database(":memory:");
       let stmt = db.prepare("select 1");
@@ -1728,15 +1728,14 @@ it("#13082", async () => {
     Bun.gc(true);
     await Bun.sleep(100);
     Bun.gc(true);
-    stmt.all();
-    stmt.get();
-    stmt.run();
+    stmt[op]();
   }
 
-  const count = 100;
+  const ops = ["all", "get", "run"];
+  const count = 99;
   const runs = new Array(count);
   for (let i = 0; i < count; i++) {
-    runs[i] = run();
+    runs[i] = run(ops[i % ops.length]);
   }
 
   const results = await Promise.allSettled(runs);

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1549,7 +1549,7 @@ it("close(true) finalizes outstanding prepared statements instead of throwing", 
   db.exec("INSERT INTO foo (name) VALUES ('foo')");
   const prepared = db.prepare("SELECT * FROM foo");
   expect(() => db.close(true)).not.toThrow();
-  expect(() => prepared.all()).toThrow("Database has closed");
+  expect(() => prepared.all()).toThrow("Statement has finalized");
 });
 
 it("close(true) finalizes query() statements created after the cache filled up (#36572)", () => {
@@ -1572,7 +1572,7 @@ it("close(true) finalizes query() statements past the cache limit that are still
   }
   expect(() => db.close(true)).not.toThrow();
   for (const stmt of statements) {
-    expect(() => stmt.all()).toThrow(/Database has closed|Statement has finalized/);
+    expect(() => stmt.all()).toThrow("Statement has finalized");
   }
 });
 
@@ -1632,7 +1632,7 @@ it("should dispose even if a prepared statement is still live", () => {
       prepared = db.prepare("SELECT * FROM foo");
     }
   }).not.toThrow();
-  expect(() => prepared.get()).toThrow("Database has closed");
+  expect(() => prepared.get()).toThrow("Statement has finalized");
 });
 
 it("should dispose", () => {
@@ -1742,7 +1742,7 @@ it("#13082", async () => {
   const results = await Promise.allSettled(runs);
   for (const result of results) {
     expect(result.status).toBe("rejected");
-    expect(result.reason.message).toBe("Database has closed");
+    expect(result.reason.message).toBe("Statement has finalized");
   }
 });
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { constants, Database, SQLiteError } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
-import { existsSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "fs";
+import { existsSync, readdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, isMacOS, isMacOSVersionAtLeast, isWindows, tempDir } from "harness";
 import { tmpdir } from "os";
 import path from "path";
@@ -1543,14 +1543,13 @@ it("should close with WAL enabled", () => {
   expect(readdirSync(dir).sort()).toEqual(["empty.txt", "my.db"]);
 });
 
-it("close(true) should throw an error if the database is in use", () => {
+it("close(true) finalizes outstanding prepared statements instead of throwing", () => {
   const db = new Database(":memory:");
   db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
   db.exec("INSERT INTO foo (name) VALUES ('foo')");
   const prepared = db.prepare("SELECT * FROM foo");
-  expect(() => db.close(true)).toThrow("database is locked");
-  prepared.finalize();
   expect(() => db.close(true)).not.toThrow();
+  expect(() => prepared.all()).toThrow("Database has closed");
 });
 
 it("close(true) finalizes query() statements created after the cache filled up (#36572)", () => {
@@ -1572,7 +1571,9 @@ it("close(true) finalizes query() statements past the cache limit that are still
     statements.push(db.query(`SELECT a + ${i} AS v FROM foo`));
   }
   expect(() => db.close(true)).not.toThrow();
-  expect(statements.every(stmt => stmt.isFinalized)).toBe(true);
+  for (const stmt of statements) {
+    expect(() => stmt.all()).toThrow(/Database has closed|Statement has finalized/);
+  }
 });
 
 it("close(true) succeeds after unreferenced query() statements were GC'd (#36572)", () => {
@@ -1608,16 +1609,30 @@ it("close() should NOT throw an error if the database is in use", () => {
   expect(() => db.close()).not.toThrow("database is locked");
 });
 
-it("should dispose AND throw an error if the database is in use", () => {
+it("close() releases the database file so it can be deleted immediately (#36572)", () => {
+  using dir = tempDir("sqlite-close-unlink", {});
+  const file = path.join(String(dir), "x.sqlite");
+  const db = new Database(file);
+  db.exec("CREATE TABLE t (a INTEGER)");
+  db.prepare("SELECT a FROM t").all();
+  db.close();
+  // On Windows this throws EBUSY if the statement above kept the
+  // connection (and the file handle) open past close().
+  rmSync(file);
+  expect(existsSync(file)).toBe(false);
+});
+
+it("should dispose even if a prepared statement is still live", () => {
+  let prepared;
   expect(() => {
-    let prepared;
     {
       using db = new Database(":memory:");
       db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
       db.exec("INSERT INTO foo (name) VALUES ('foo')");
       prepared = db.prepare("SELECT * FROM foo");
     }
-  }).toThrow("database is locked");
+  }).not.toThrow();
+  expect(() => prepared.get()).toThrow("Database has closed");
 });
 
 it("should dispose", () => {

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1739,7 +1739,11 @@ it("#13082", async () => {
     runs[i] = run();
   }
 
-  await Promise.allSettled(runs);
+  const results = await Promise.allSettled(runs);
+  for (const result of results) {
+    expect(result.status).toBe("rejected");
+    expect(result.reason.message).toBe("Database has closed");
+  }
 });
 
 // The internal SQL.run / SQL.prepare / SQL.isInTransaction helpers used to
@@ -1943,6 +1947,57 @@ it("all() reports an error when a result-row push finalizes the statement", asyn
       rows: [{ a: 3 }, { a: 2 }, { a: 1 }],
     }),
   );
+  expect(exitCode).toBe(0);
+});
+
+// A result-row push can also close the whole database (which finalizes every
+// statement) and then throw; the raw() loop must not touch the freed stmt.
+// Run in a subprocess because the unsafe variant resets freed memory and the
+// Array.prototype accessor affects every array in the process.
+it("raw() does not touch the statement when a result-row push closes the database and throws", async () => {
+  const src = `
+    const { Database } = require("bun:sqlite");
+    const out = {};
+
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE t (a INTEGER)");
+    db.run("INSERT INTO t VALUES (1), (2), (3)");
+
+    const stmt = db.query("SELECT a FROM t ORDER BY a ASC");
+    Object.defineProperty(Array.prototype, 0, {
+      configurable: true,
+      get() {
+        return undefined;
+      },
+      set(_row) {
+        db.close();
+        throw new Error("boom");
+      },
+    });
+
+    let message = "did not throw";
+    try {
+      stmt.raw();
+    } catch (e) {
+      message = e.message;
+    }
+    delete Array.prototype[0];
+    out.closeDuringRaw = message;
+
+    console.log(JSON.stringify(out));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe(JSON.stringify({ closeDuringRaw: "boom" }));
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1553,6 +1553,53 @@ it("close(true) should throw an error if the database is in use", () => {
   expect(() => db.close(true)).not.toThrow();
 });
 
+it("close(true) finalizes query() statements created after the cache filled up (#36572)", () => {
+  const db = new Database(":memory:");
+  db.exec("CREATE TABLE foo (a INTEGER)");
+  // One more distinct query string than MAX_QUERY_CACHE_SIZE, so the last
+  // statement does not fit in the query cache.
+  for (let i = 0; i <= Database.MAX_QUERY_CACHE_SIZE; i++) {
+    db.query(`SELECT a + ${i} AS v FROM foo`).all();
+  }
+  expect(() => db.close(true)).not.toThrow();
+});
+
+it("close(true) finalizes query() statements past the cache limit that are still referenced (#36572)", () => {
+  const db = new Database(":memory:");
+  db.exec("CREATE TABLE foo (a INTEGER)");
+  const statements = [];
+  for (let i = 0; i <= Database.MAX_QUERY_CACHE_SIZE; i++) {
+    statements.push(db.query(`SELECT a + ${i} AS v FROM foo`));
+  }
+  expect(() => db.close(true)).not.toThrow();
+  expect(statements.every(stmt => stmt.isFinalized)).toBe(true);
+});
+
+it("close(true) succeeds after unreferenced query() statements were GC'd (#36572)", () => {
+  const db = new Database(":memory:");
+  db.exec("CREATE TABLE foo (a INTEGER)");
+  for (let i = 0; i <= Database.MAX_QUERY_CACHE_SIZE * 2; i++) {
+    db.query(`SELECT a + ${i} AS v FROM foo`).all();
+  }
+  // Collects the statement wrappers; close(true) must not fail over
+  // statements that are pending sweep.
+  Bun.gc(true);
+  expect(() => db.close(true)).not.toThrow();
+});
+
+it("close(true) works when query() statements past the cache limit were already finalized", () => {
+  const db = new Database(":memory:");
+  db.exec("CREATE TABLE foo (a INTEGER)");
+  const statements = [];
+  for (let i = 0; i <= Database.MAX_QUERY_CACHE_SIZE; i++) {
+    statements.push(db.query(`SELECT a + ${i} AS v FROM foo`));
+  }
+  for (const stmt of statements) {
+    stmt.finalize();
+  }
+  expect(() => db.close(true)).not.toThrow();
+});
+
 it("close() should NOT throw an error if the database is in use", () => {
   const db = new Database(":memory:");
   db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");


### PR DESCRIPTION
## Repro

```js
import { Database } from "bun:sqlite";

const db = new Database(":memory:");
db.run("create table t (a integer)");

// 21 distinct SQL strings, each run through db.query()
for (let i = 0; i < 21; i++) db.query(`select a + ${i} as v from t`).all();

db.close(true); // error: database is locked
```

The threshold is exactly `Database.MAX_QUERY_CACHE_SIZE` (default 20). With a file-backed database and non-strict `close()`, nothing throws but the file handle stays open until GC, which on Windows makes the database file undeletable right after closing it.

## Cause

`query()` only tracks the first `MAX_QUERY_CACHE_SIZE` distinct statements; later ones are prepared but stored nowhere, so `close()` could not finalize them and `sqlite3_close()` returned `SQLITE_BUSY`.

## Fix

Per review, the mechanism mirrors better-sqlite3's `CloseHandles()` and node:sqlite's `FinalizeStatements()`:

- `VersionSqlite3` keeps a list of live `JSSQLStatement` wrappers, linked at creation (next to the existing `reference_count` increment) and unlinked in the destructor.
- `close()` walks that list, `sqlite3_finalize`s each statement and nulls the wrapper's handle, then runs a `sqlite3_next_stmt()` sweep as a backstop for statements not owned by a wrapper (e.g. the transient statement in `db.run()` when a bound-parameter getter closes the database mid-bind), then calls `sqlite3_close()`, which can no longer return `SQLITE_BUSY`.
- Because a nulled handle is indistinguishable from an explicitly finalized statement, the existing "Statement has finalized" re-validation paths cover all post-close use; no new per-statement state. The bind paths re-check the connection after running user code, and `raw()`'s push-exception path no longer resets a statement that user code may have finalized.
- If `sqlite3_close()` somehow still fails, the handle is retired via `sqlite3_close_v2()` so the connection never ends up half-alive.

The termination path and GC `release()` still use `sqlite3_close_v2()` without touching the list, so their outstanding statements stay valid until each is finalized, as before.

Behavior change, reflected in docs and types: `close(true)` no longer throws `database is locked` over outstanding prepared statements; it finalizes them, matching better-sqlite3 and node:sqlite. Using a statement after close throws `Statement has finalized`, matching node.

## Verification

Without the fix:

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/sqlite/sqlite.test.js -t 36572
(fail) close(true) finalizes query() statements created after the cache filled up (#36572)
  error: database is locked
(fail) close(true) finalizes query() statements past the cache limit that are still referenced (#36572)
```

With the fix: `bun bd test test/js/bun/sqlite/` 115 pass, `test/js/node/sqlite/` 115 pass, `test/regression/issue/14709.test.ts` 5 pass, bun-types 14 pass.

Fixes #36572

Closes #35604
Closes #33307 
Closes https://github.com/oven-sh/bun/issues/11418

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/sqlite/sqlite.test.js

<!-- robobun:evidence:end -->