### PR TITLE
AbortSignal.abort(): defer the default reason so GC can't collect it before the wrapper exists

### DIFF
--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -126,6 +126,14 @@ impl AbortSignal {
         WebCore__AbortSignal__abortReason(self)
     }
 
+    /// Same value the JS `signal.reason` getter returns: materializes (and
+    /// caches) the default `DOMException` for a signal created by
+    /// `AbortSignal.abort()` / `AbortController.abort()` / `AbortSignal.timeout()`.
+    /// Prefer this over [`abort_reason`], whose raw-weak read can observe `null`.
+    pub fn js_reason(&self, global: &JSGlobalObject) -> JSValue {
+        WebCore__AbortSignal__jsReason(self, global)
+    }
+
     pub fn reason_if_aborted(&self, global: &JSGlobalObject) -> Option<AbortReason> {
         let mut reason: u8 = 0;
         let js_reason = WebCore__AbortSignal__reasonIfAborted(self, global, &mut reason);

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -126,8 +126,7 @@ impl AbortSignal {
         WebCore__AbortSignal__abortReason(self)
     }
 
-    /// Same value the JS `signal.reason` getter returns; materializes the
-    /// default `DOMException` that [`abort_reason`]'s raw-weak read misses.
+    /// Same as JS `signal.reason`; materializes the default `DOMException` that [`abort_reason`] misses.
     pub fn js_reason(&self, global: &JSGlobalObject) -> JSValue {
         WebCore__AbortSignal__jsReason(self, global)
     }

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -31,7 +31,6 @@ bun_opaque::opaque_ffi! {
 // or out-param keep raw pointers and stay `unsafe fn`.
 unsafe extern "C" {
     safe fn WebCore__AbortSignal__aborted(arg0: &AbortSignal) -> bool;
-    safe fn WebCore__AbortSignal__abortReason(arg0: &AbortSignal) -> JSValue;
     // safe: `arg1` is an opaque round-trip pointer C++ stores into the listener
     // entry and forwards to `arg_fn2` on abort (never dereferenced as Rust
     // data) — same contract as `cleanNativeBindings` / `queueMicrotaskCallback`.
@@ -121,12 +120,7 @@ impl AbortSignal {
         WebCore__AbortSignal__aborted(self)
     }
 
-    /// This function is not threadsafe. JSValue cannot safely be passed between threads.
-    pub fn abort_reason(&self) -> JSValue {
-        WebCore__AbortSignal__abortReason(self)
-    }
-
-    /// Same as JS `signal.reason`; materializes the default `DOMException` that [`abort_reason`] misses.
+    /// Same value the JS `signal.reason` getter returns.
     pub fn js_reason(&self, global: &JSGlobalObject) -> JSValue {
         WebCore__AbortSignal__jsReason(self, global)
     }

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -126,10 +126,8 @@ impl AbortSignal {
         WebCore__AbortSignal__abortReason(self)
     }
 
-    /// Same value the JS `signal.reason` getter returns: materializes (and
-    /// caches) the default `DOMException` for a signal created by
-    /// `AbortSignal.abort()` / `AbortController.abort()` / `AbortSignal.timeout()`.
-    /// Prefer this over [`abort_reason`], whose raw-weak read can observe `null`.
+    /// Same value the JS `signal.reason` getter returns; materializes the
+    /// default `DOMException` that [`abort_reason`]'s raw-weak read misses.
     pub fn js_reason(&self, global: &JSGlobalObject) -> JSValue {
         WebCore__AbortSignal__jsReason(self, global)
     }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5659,12 +5659,6 @@ extern "C" bool WebCore__AbortSignal__aborted(WebCore::AbortSignal* arg0)
     return abortSignal->aborted();
 }
 
-extern "C" JSC::EncodedJSValue WebCore__AbortSignal__abortReason(WebCore::AbortSignal* arg0)
-{
-    WebCore::AbortSignal* abortSignal = reinterpret_cast<WebCore::AbortSignal*>(arg0);
-    return JSC::JSValue::encode(abortSignal->reason().getValue(jsNull()));
-}
-
 // Same value the JS `signal.reason` getter returns: lazily materializes the
 // `DOMException` for a common abort reason and caches it, so repeated reads
 // (native or JS) observe the identical object.

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5701,7 +5701,8 @@ extern "C" void WebCore__AbortSignal__cleanNativeBindings(WebCore::AbortSignal* 
 extern "C" WebCore::AbortSignal* WebCore__AbortSignal__addListener(WebCore::AbortSignal* abortSignal, void* ctx, void (*callback)(void* ctx, JSC::EncodedJSValue reason))
 {
     if (abortSignal->aborted()) {
-        callback(ctx, JSC::JSValue::encode(abortSignal->reason().getValue(jsNull())));
+        auto* globalObject = abortSignal->scriptExecutionContext()->jsGlobalObject();
+        callback(ctx, JSC::JSValue::encode(abortSignal->jsReason(*globalObject)));
         return abortSignal;
     }
     abortSignal->addNativeCallback(std::make_tuple(ctx, callback));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5701,8 +5701,9 @@ extern "C" void WebCore__AbortSignal__cleanNativeBindings(WebCore::AbortSignal* 
 extern "C" WebCore::AbortSignal* WebCore__AbortSignal__addListener(WebCore::AbortSignal* abortSignal, void* ctx, void (*callback)(void* ctx, JSC::EncodedJSValue reason))
 {
     if (abortSignal->aborted()) {
-        auto* globalObject = static_cast<WebCore::EventTarget*>(abortSignal)->scriptExecutionContext()->jsGlobalObject();
-        callback(ctx, JSC::JSValue::encode(abortSignal->jsReason(*globalObject)));
+        auto* context = static_cast<WebCore::EventTarget*>(abortSignal)->scriptExecutionContext();
+        auto reason = context ? abortSignal->jsReason(*context->jsGlobalObject()) : abortSignal->reason().getValue(jsNull());
+        callback(ctx, JSC::JSValue::encode(reason));
         return abortSignal;
     }
     abortSignal->addNativeCallback(std::make_tuple(ctx, callback));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5701,7 +5701,7 @@ extern "C" void WebCore__AbortSignal__cleanNativeBindings(WebCore::AbortSignal* 
 extern "C" WebCore::AbortSignal* WebCore__AbortSignal__addListener(WebCore::AbortSignal* abortSignal, void* ctx, void (*callback)(void* ctx, JSC::EncodedJSValue reason))
 {
     if (abortSignal->aborted()) {
-        auto* globalObject = abortSignal->scriptExecutionContext()->jsGlobalObject();
+        auto* globalObject = static_cast<WebCore::EventTarget*>(abortSignal)->scriptExecutionContext()->jsGlobalObject();
         callback(ctx, JSC::JSValue::encode(abortSignal->jsReason(*globalObject)));
         return abortSignal;
     }

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -119,7 +119,6 @@ CPP_DECL JSC::JSPromise* JSC__JSModuleLoader__loadAndEvaluateModule(JSC::JSGloba
 #pragma mark - WebCore::AbortSignal
 
 CPP_DECL bool WebCore__AbortSignal__aborted(WebCore::AbortSignal* arg0);
-CPP_DECL JSC::EncodedJSValue WebCore__AbortSignal__abortReason(WebCore::AbortSignal* arg0);
 CPP_DECL WebCore::AbortSignal* WebCore__AbortSignal__addListener(WebCore::AbortSignal* arg0, void* arg1, void(* ArgFn2)(void* arg0, JSC::EncodedJSValue JSValue1));
 CPP_DECL void WebCore__AbortSignal__cleanNativeBindings(WebCore::AbortSignal* arg0, void* arg1);
 CPP_DECL JSC::EncodedJSValue WebCore__AbortSignal__create(JSC::JSGlobalObject* arg0);

--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -58,11 +58,9 @@ Ref<AbortSignal> AbortSignal::abort(JSDOMGlobalObject& globalObject, ScriptExecu
 {
     UNUSED_PARAM(globalObject);
     ASSERT(reason);
-    // The default DOMException is deferred to jsReason(): m_reason is a
-    // JSC::Weak with no owner until the JSAbortSignal wrapper is created by
-    // the caller's toJSNewlyCreated(), so an eager allocation here could be
-    // collected by a GC triggered during that wrapper allocation. The explicit
-    // argument is rooted by the binding's EnsureStillAliveScope on argument0.
+    // Defer the default DOMException to jsReason(): m_reason is a JSC::Weak
+    // with no owner until toJSNewlyCreated() creates the wrapper, so an eager
+    // allocation here could be collected by a GC during that allocation.
     auto signal = adoptRef(*new AbortSignal(&context, Aborted::Yes, reason));
     if (reason.isUndefined())
         signal->m_commonReason = CommonAbortReason::UserAbort;

--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -58,9 +58,7 @@ Ref<AbortSignal> AbortSignal::abort(JSDOMGlobalObject& globalObject, ScriptExecu
 {
     UNUSED_PARAM(globalObject);
     ASSERT(reason);
-    // Defer the default DOMException to jsReason(): m_reason is a JSC::Weak
-    // with no owner until toJSNewlyCreated() creates the wrapper, so an eager
-    // allocation here could be collected by a GC during that allocation.
+    // Defer the default to jsReason(); m_reason's JSC::Weak has no owner until toJSNewlyCreated().
     auto signal = adoptRef(*new AbortSignal(&context, Aborted::Yes, reason));
     if (reason.isUndefined())
         signal->m_commonReason = CommonAbortReason::UserAbort;

--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -56,10 +56,17 @@ Ref<AbortSignal> AbortSignal::create(ScriptExecutionContext* context)
 // https://dom.spec.whatwg.org/#dom-abortsignal-abort
 Ref<AbortSignal> AbortSignal::abort(JSDOMGlobalObject& globalObject, ScriptExecutionContext& context, JSC::JSValue reason)
 {
+    UNUSED_PARAM(globalObject);
     ASSERT(reason);
+    // The default DOMException is deferred to jsReason(): m_reason is a
+    // JSC::Weak with no owner until the JSAbortSignal wrapper is created by
+    // the caller's toJSNewlyCreated(), so an eager allocation here could be
+    // collected by a GC triggered during that wrapper allocation. The explicit
+    // argument is rooted by the binding's EnsureStillAliveScope on argument0.
+    auto signal = adoptRef(*new AbortSignal(&context, Aborted::Yes, reason));
     if (reason.isUndefined())
-        reason = toJS(&globalObject, &globalObject, DOMException::create(ExceptionCode::AbortError));
-    return adoptRef(*new AbortSignal(&context, Aborted::Yes, reason));
+        signal->m_commonReason = CommonAbortReason::UserAbort;
+    return signal;
 }
 
 // https://dom.spec.whatwg.org/#dom-abortsignal-timeout
@@ -82,7 +89,7 @@ Ref<AbortSignal> AbortSignal::any(ScriptExecutionContext& context, const Vector<
 
     auto abortedSignalIndex = signals.findIf([](auto& signal) { return signal->aborted(); });
     if (abortedSignalIndex != notFound) {
-        resultSignal->signalAbort(signals[abortedSignalIndex]->reason().getValue());
+        resultSignal->signalAbort(signals[abortedSignalIndex]->jsReason(*context.jsGlobalObject()));
         return resultSignal;
     }
 
@@ -370,7 +377,7 @@ void AbortSignal::throwIfAborted(JSC::JSGlobalObject& lexicalGlobalObject)
 
     Ref vm = lexicalGlobalObject.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    throwException(&lexicalGlobalObject, scope, m_reason.getValue());
+    throwException(&lexicalGlobalObject, scope, jsReason(lexicalGlobalObject));
 }
 
 WebCoreOpaqueRoot root(AbortSignal* signal)

--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -54,9 +54,8 @@ Ref<AbortSignal> AbortSignal::create(ScriptExecutionContext* context)
 }
 
 // https://dom.spec.whatwg.org/#dom-abortsignal-abort
-Ref<AbortSignal> AbortSignal::abort(JSDOMGlobalObject& globalObject, ScriptExecutionContext& context, JSC::JSValue reason)
+Ref<AbortSignal> AbortSignal::abort(ScriptExecutionContext& context, JSC::JSValue reason)
 {
-    UNUSED_PARAM(globalObject);
     ASSERT(reason);
     // Defer the default to jsReason(); m_reason's JSC::Weak has no owner until toJSNewlyCreated().
     auto signal = adoptRef(*new AbortSignal(&context, Aborted::Yes, reason));

--- a/src/jsc/bindings/webcore/AbortSignal.h
+++ b/src/jsc/bindings/webcore/AbortSignal.h
@@ -76,7 +76,7 @@ public:
     WEBCORE_EXPORT ~AbortSignal();
     using NativeCallbackTuple = std::tuple<void*, void (*)(void*, JSC::EncodedJSValue)>;
 
-    static Ref<AbortSignal> abort(JSDOMGlobalObject&, ScriptExecutionContext&, JSC::JSValue reason);
+    static Ref<AbortSignal> abort(ScriptExecutionContext&, JSC::JSValue reason);
     static Ref<AbortSignal> timeout(ScriptExecutionContext&, uint64_t milliseconds);
     static Ref<AbortSignal> any(ScriptExecutionContext&, const Vector<RefPtr<AbortSignal>>&);
 

--- a/src/jsc/bindings/webcore/JSAbortSignal.cpp
+++ b/src/jsc/bindings/webcore/JSAbortSignal.cpp
@@ -272,7 +272,7 @@ static inline JSC::EncodedJSValue jsAbortSignalConstructorFunction_abortBody(JSC
     EnsureStillAliveScope argument0 = callFrame->argument(0);
     auto reason = convert<IDLAny>(*lexicalGlobalObject, argument0.value());
     RETURN_IF_EXCEPTION(throwScope, {});
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJSNewlyCreated<IDLInterface<AbortSignal>>(*lexicalGlobalObject, *uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), throwScope, AbortSignal::abort(*uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), *context, WTF::move(reason)))));
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJSNewlyCreated<IDLInterface<AbortSignal>>(*lexicalGlobalObject, *uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), throwScope, AbortSignal::abort(*context, WTF::move(reason)))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsAbortSignalConstructorFunction_abort, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -9042,7 +9042,7 @@ impl H2FrameParser {
                     let signal_ = unsafe { &mut *signal_ptr };
                     if signal_.aborted() {
                         stream.state = StreamState::IDLE;
-                        let wrapped = Bun__wrapAbortError(global_object, signal_.abort_reason());
+                        let wrapped = Bun__wrapAbortError(global_object, signal_.js_reason(global_object));
                         this.abort_stream(&mut stream, wrapped);
                         return Ok(JSValue::js_number(stream_id as f64));
                     }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -9042,7 +9042,8 @@ impl H2FrameParser {
                     let signal_ = unsafe { &mut *signal_ptr };
                     if signal_.aborted() {
                         stream.state = StreamState::IDLE;
-                        let wrapped = Bun__wrapAbortError(global_object, signal_.js_reason(global_object));
+                        let wrapped =
+                            Bun__wrapAbortError(global_object, signal_.js_reason(global_object));
                         this.abort_stream(&mut stream, wrapped);
                         return Ok(JSValue::js_number(stream_id as f64));
                     }

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -765,7 +765,7 @@ impl FSWatcher {
 
     pub(crate) fn emit_if_aborted(&self) {
         let reason = match self.signal.get() {
-            Some(s) if s.aborted() => Some(s.abort_reason()),
+            Some(s) if s.aborted() => Some(s.js_reason(&self.global_this)),
             _ => None,
         };
         if let Some(err) = reason {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1629,9 +1629,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     if let Some(sig) = signal.0 {
         let sig = bun_ptr::BackRef::from(sig);
         if sig.aborted() {
-            // `js_reason()` is the same object `signal.reason` returns, and
-            // materializes the default `DOMException` for `AbortSignal.abort()`
-            // whose `m_reason` weak may not have survived wrapper creation.
             let reason = sig.js_reason(global_this);
             if let HTTPRequestBody::ReadableStream(stream_ref) = &body {
                 if let Some(stream) = stream_ref.get(global_this) {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1629,9 +1629,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     if let Some(sig) = signal.0 {
         let sig = bun_ptr::BackRef::from(sig);
         if sig.aborted() {
-            // `abort_reason()` is the stored `m_reason` (same object as
-            // `signal.reason`), not a reconstructed DOMException.
-            let reason = sig.abort_reason();
+            // `js_reason()` is the same object `signal.reason` returns, and
+            // materializes the default `DOMException` for `AbortSignal.abort()`
+            // whose `m_reason` weak may not have survived wrapper creation.
+            let reason = sig.js_reason(global_this);
             if let HTTPRequestBody::ReadableStream(stream_ref) = &body {
                 if let Some(stream) = stream_ref.get(global_this) {
                     stream.cancel_with_reason(global_this, reason);

--- a/test/js/web/abort/abort-controller-gc-reason.test.ts
+++ b/test/js/web/abort/abort-controller-gc-reason.test.ts
@@ -152,6 +152,53 @@ describe("AbortController GC", () => {
     });
   });
 
+  // collectContinuously is very slow on Windows CI; the code under test is
+  // identical across platforms.
+  test.skipIf(isWindows)(
+    "AbortSignal.abort()'s default reason survives GC for fetch / throwIfAborted / any",
+    async () => {
+      // The default DOMException for AbortSignal.abort() was stored in
+      // m_reason (a JSC::Weak) before the JSAbortSignal wrapper existed, so a
+      // GC during toJSNewlyCreated()'s allocation could collect it and fetch
+      // would reject with `null`. collectContinuously makes that GC likely.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const bad = [];
+            for (let i = 0; i < 10000; i++) {
+              const sig = AbortSignal.abort();
+              const err = await fetch("http://127.0.0.1:1/", { signal: sig }).catch(e => e);
+              if (err?.name !== "AbortError") bad.push("fetch rejection " + Bun.inspect(err));
+              else if (err !== sig.reason) bad.push("fetch rejection !== signal.reason");
+            }
+            for (let i = 0; i < 10000; i++) {
+              const signal = AbortSignal.abort();
+              try { signal.throwIfAborted(); bad.push("throwIfAborted did not throw"); }
+              catch (e) {
+                if (e?.name !== "AbortError") bad.push("throwIfAborted " + Bun.inspect(e));
+                else if (e !== signal.reason) bad.push("throwIfAborted !== signal.reason");
+              }
+              const source = AbortSignal.abort();
+              const any = AbortSignal.any([source]);
+              if (any.reason?.name !== "AbortError") bad.push("any.reason " + Bun.inspect(any.reason));
+              else if (any.reason !== source.reason) bad.push("any.reason !== source.reason");
+            }
+            console.log(bad.length ? "bad=" + bad.length + " first=" + bad[0] : "bad=0");
+          `,
+        ],
+        env: { ...bunEnv, BUN_JSC_collectContinuously: "1" },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr }).toEqual({ stdout: "bad=0", stderr: "" });
+      expect(exitCode).toBe(0);
+    },
+    60_000,
+  );
+
   test("signal.reason survives GC with many controllers", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -518,10 +518,16 @@ describe("AbortSignal", () => {
           else if (err !== sig.reason) bad.push("fetch rejection !== signal.reason");
         }
         for (let i = 0; i < 10000; i++) {
-          try { AbortSignal.abort().throwIfAborted(); bad.push("throwIfAborted did not throw"); }
-          catch (e) { if (e?.name !== "AbortError") bad.push("throwIfAborted " + Bun.inspect(e)); }
-          const anyReason = AbortSignal.any([AbortSignal.abort()]).reason;
-          if (anyReason?.name !== "AbortError") bad.push("any.reason " + Bun.inspect(anyReason));
+          const signal = AbortSignal.abort();
+          try { signal.throwIfAborted(); bad.push("throwIfAborted did not throw"); }
+          catch (e) {
+            if (e?.name !== "AbortError") bad.push("throwIfAborted " + Bun.inspect(e));
+            else if (e !== signal.reason) bad.push("throwIfAborted !== signal.reason");
+          }
+          const source = AbortSignal.abort();
+          const any = AbortSignal.any([source]);
+          if (any.reason?.name !== "AbortError") bad.push("any.reason " + Bun.inspect(any.reason));
+          else if (any.reason !== source.reason) bad.push("any.reason !== source.reason");
         }
         console.log(bad.length ? "bad=" + bad.length + " first=" + bad[0] : "bad=0");
       `;

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -531,11 +531,7 @@ describe("AbortSignal", () => {
         stderr: "pipe",
         stdout: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stdout: stdout.trim(), stderr }).toEqual({ stdout: "bad=0", stderr: "" });
       expect(exitCode).toBe(0);
     },

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -499,50 +499,6 @@ describe("AbortSignal", () => {
       expect(stream.locked).toBe(false);
     }
   });
-
-  // collectContinuously is very slow on Windows CI; the code under test is
-  // identical across platforms.
-  it.skipIf(isWindows)(
-    "AbortSignal.abort()'s default reason survives GC until fetch reads it",
-    async () => {
-      // The default DOMException for AbortSignal.abort() was stored in
-      // m_reason (a JSC::Weak) before the JSAbortSignal wrapper existed, so a
-      // GC during toJSNewlyCreated()'s allocation could collect it and fetch
-      // would reject with `null`. collectContinuously makes that GC likely.
-      const script = `
-        const bad = [];
-        for (let i = 0; i < 10000; i++) {
-          const sig = AbortSignal.abort();
-          const err = await fetch("http://127.0.0.1:1/", { signal: sig }).catch(e => e);
-          if (err?.name !== "AbortError") bad.push("fetch rejection " + Bun.inspect(err));
-          else if (err !== sig.reason) bad.push("fetch rejection !== signal.reason");
-        }
-        for (let i = 0; i < 10000; i++) {
-          const signal = AbortSignal.abort();
-          try { signal.throwIfAborted(); bad.push("throwIfAborted did not throw"); }
-          catch (e) {
-            if (e?.name !== "AbortError") bad.push("throwIfAborted " + Bun.inspect(e));
-            else if (e !== signal.reason) bad.push("throwIfAborted !== signal.reason");
-          }
-          const source = AbortSignal.abort();
-          const any = AbortSignal.any([source]);
-          if (any.reason?.name !== "AbortError") bad.push("any.reason " + Bun.inspect(any.reason));
-          else if (any.reason !== source.reason) bad.push("any.reason !== source.reason");
-        }
-        console.log(bad.length ? "bad=" + bad.length + " first=" + bad[0] : "bad=0");
-      `;
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", script],
-        env: { ...bunEnv, BUN_JSC_collectContinuously: "1" },
-        stderr: "pipe",
-        stdout: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout: stdout.trim(), stderr }).toEqual({ stdout: "bad=0", stderr: "" });
-      expect(exitCode).toBe(0);
-    },
-    60_000,
-  );
 });
 
 describe("Headers", () => {

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -499,6 +499,48 @@ describe("AbortSignal", () => {
       expect(stream.locked).toBe(false);
     }
   });
+
+  // collectContinuously is very slow on Windows CI; the code under test is
+  // identical across platforms.
+  it.skipIf(isWindows)(
+    "AbortSignal.abort()'s default reason survives GC until fetch reads it",
+    async () => {
+      // The default DOMException for AbortSignal.abort() was stored in
+      // m_reason (a JSC::Weak) before the JSAbortSignal wrapper existed, so a
+      // GC during toJSNewlyCreated()'s allocation could collect it and fetch
+      // would reject with `null`. collectContinuously makes that GC likely.
+      const script = `
+        const bad = [];
+        for (let i = 0; i < 10000; i++) {
+          const sig = AbortSignal.abort();
+          const err = await fetch("http://127.0.0.1:1/", { signal: sig }).catch(e => e);
+          if (err?.name !== "AbortError") bad.push("fetch rejection " + Bun.inspect(err));
+          else if (err !== sig.reason) bad.push("fetch rejection !== signal.reason");
+        }
+        for (let i = 0; i < 10000; i++) {
+          try { AbortSignal.abort().throwIfAborted(); bad.push("throwIfAborted did not throw"); }
+          catch (e) { if (e?.name !== "AbortError") bad.push("throwIfAborted " + Bun.inspect(e)); }
+          const anyReason = AbortSignal.any([AbortSignal.abort()]).reason;
+          if (anyReason?.name !== "AbortError") bad.push("any.reason " + Bun.inspect(anyReason));
+        }
+        console.log(bad.length ? "bad=" + bad.length + " first=" + bad[0] : "bad=0");
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: { ...bunEnv, BUN_JSC_collectContinuously: "1" },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect({ stdout: stdout.trim(), stderr }).toEqual({ stdout: "bad=0", stderr: "" });
+      expect(exitCode).toBe(0);
+    },
+    60_000,
+  );
 });
 
 describe("Headers", () => {


### PR DESCRIPTION
Fixes a flake of `test/js/web/fetch/fetch.stream.test.ts` on aarch64:

```
TypeError: null is not an object (evaluating 'err.name')
✗ fetch() with streaming > should be able to fail properly when reading from readable stream with timeout -1
```

Seen on main (build 86266, darwin aarch64) and ~15 unrelated PR branches since build ~85697. Went red on every retry in build 86380.

## Cause

`AbortSignal::abort()` with no argument creates its default `DOMException` and stores it in `m_reason`, a `JSValueInWrappedObject` that holds cell values in a `JSC::Weak`:

```cpp
if (reason.isUndefined())
    reason = toJS(&globalObject, &globalObject, DOMException::create(ExceptionCode::AbortError));
return adoptRef(*new AbortSignal(&context, Aborted::Yes, reason));  // m_reason(reason) -> setWeakly
```

At that point there is no JS wrapper to own it. The caller's `toJSNewlyCreated()` allocates the `JSAbortSignal` wrapper next, and if that allocation triggers a GC the `DOMException` has no root (the `reason` local is out of scope in release builds) so it is collected and the weak clears. From then on `WebCore__AbortSignal__abortReason` returned `jsNull()`, and `fetch()`'s pre-aborted fast path (#33950, `src/runtime/webcore/fetch.rs:1634`) rejected the promise with `null`. A user-supplied `reason` is safe: the binding's `EnsureStillAliveScope argument0` roots it through the wrapper allocation.

The window has existed since #33950 landed; it started being hit in CI after #35356 and #35849 shifted GC scheduling. Debug builds do not reproduce it because `-O0` leaves the `reason` local on the stack for the conservative scanner.

## Repro

```console
$ BUN_JSC_collectContinuously=1 bun -e '
let n=0; for (let i=0;i<200000;i++)
  await fetch("http://127.0.0.1:1/",{signal:AbortSignal.abort()}).catch(e => { if (e===null) n++ });
console.log(n)'
79
```

## Fix

`AbortSignal::abort()` records `CommonAbortReason::UserAbort` for the default case and leaves `m_reason` undefined, the same deferral `AbortController.abort()` and `AbortSignal.timeout()` already use. `jsReason()` materializes (and caches with a write barrier on the wrapper) the `DOMException` on first access, which is always after the wrapper exists. `toJS(CommonAbortReason::UserAbort)` produces the same `DOMException("The operation was aborted.", "AbortError")` the eager path did.

The places that read `m_reason` raw now go through `jsReason()` so they see the deferred value:

- `throwIfAborted()` (would have thrown `undefined`)
- `AbortSignal::any()`'s already-aborted-source branch (would have set the result's reason to `undefined`)
- `WebCore__AbortSignal__addListener`'s already-aborted branch
- the Rust `abort_reason()` callers in `fetch.rs` / `h2_frame_parser.rs` / `node_fs_watcher.rs` now call the new `js_reason()` wrapper

`AbortSignal::abort_reason()` (and its C++ shim `WebCore__AbortSignal__abortReason` / `headers.h` decl) are removed: those were the only callers, and after the deferral the raw-weak read is a footgun.

## Verification

New test in `test/js/web/abort/abort-controller-gc-reason.test.ts` spawns a child with `BUN_JSC_collectContinuously=1` and asserts 10k `fetch({signal: AbortSignal.abort()})` rejections, 10k `throwIfAborted()`, and 10k `AbortSignal.any([AbortSignal.abort()]).reason` all observe an `AbortError` `DOMException` with the same identity as `signal.reason`.

```
release main:  bad=10 first=fetch rejection null   (fail)
release fix:   bad=0                               (pass)
```

Debug+ASAN does not reproduce the fail-before (the local survives on the stack at `-O0`); the release build does. `test/js/web/fetch/fetch.stream.test.ts`, `test/js/web/abort/abort.test.ts`, the `fs.watch` abort tests and `timer-gc-roots.test.ts` all pass; `rust:check-all` passes on all 10 targets.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch.stream.test.ts test/js/web/abort/abort-controller-gc-reason.test.ts

<!-- robobun:evidence:end -->