### PR TITLE
worker: don't re-enter JS from socket on_open / CJS require / process emit once terminate() has fired the trap

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1215,6 +1215,8 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
     auto* process = globalObject->processObject();
     auto& wrapped = process->wrapped();
     auto& vm = JSC::getVM(globalObject);
+    if (vm.hasPendingTerminationException()) [[unlikely]]
+        return true;
 
     // node parity (exitWithUndefinedFatalException): the internal fatal-exception
     // handler is monkey-patchable as process._fatalException. If user code
@@ -1225,6 +1227,8 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
         JSValue fatalException = process->get(globalObject, Identifier::fromString(vm, "_fatalException"_s));
         if (fatalScope.exception()) {
             (void)fatalScope.tryClearException();
+            if (vm.hasPendingTerminationException()) [[unlikely]]
+                return true;
         } else if (!fatalException.isCallable()) {
             Bun__Process__exit(globalObject, 6);
             return true;
@@ -1242,6 +1246,8 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
     auto uncaughtExceptionMonitor = Identifier::fromString(JSC::getVM(globalObject), "uncaughtExceptionMonitor"_s);
     if (wrapped.listenerCount(uncaughtExceptionMonitor) > 0) {
         wrapped.emit(uncaughtExceptionMonitor, args);
+        if (vm.hasPendingTerminationException()) [[unlikely]]
+            return true;
     }
 
     auto uncaughtExceptionIdent = Identifier::fromString(JSC::getVM(globalObject), "uncaughtException"_s);
@@ -1253,6 +1259,8 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
         (void)call(lexicalGlobalObject, capture, args, "uncaughtExceptionCaptureCallback"_s);
         if (auto ex = scope.exception()) {
             (void)scope.tryClearException();
+            if (vm.hasPendingTerminationException()) [[unlikely]]
+                return true;
             // if an exception is thrown in the uncaughtException handler, we abort
             Bun__logUnhandledException(JSValue::encode(JSValue(ex)));
             Bun__Process__exit(lexicalGlobalObject, 1);
@@ -1346,9 +1354,12 @@ extern "C" int Bun__handleUnhandledRejection(JSC::JSGlobalObject* lexicalGlobalO
     if (!lexicalGlobalObject->inherits(Zig::GlobalObject::info()))
         return false;
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+    if (vm.hasPendingTerminationException()) [[unlikely]]
+        return true;
     auto* process = globalObject->processObject();
 
-    auto eventType = Identifier::fromString(JSC::getVM(globalObject), "unhandledRejection"_s);
+    auto eventType = Identifier::fromString(vm, "unhandledRejection"_s);
     auto& wrapped = process->wrapped();
     if (wrapped.listenerCount(eventType) > 0) {
         MarkedArgumentBuffer args;
@@ -1365,17 +1376,22 @@ extern "C" bool Bun__VM__allowRejectionHandledWarning(void* vm);
 
 extern "C" bool Bun__emitHandledPromiseEvent(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue promise)
 {
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(JSC::getVM(lexicalGlobalObject));
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     if (!lexicalGlobalObject->inherits(Zig::GlobalObject::info()))
         return false;
+    if (vm.hasPendingTerminationException()) [[unlikely]]
+        return true;
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto* process = globalObject->processObject();
 
-    auto eventType = Identifier::fromString(JSC::getVM(globalObject), "rejectionHandled"_s);
+    auto eventType = Identifier::fromString(vm, "rejectionHandled"_s);
 
     if (Bun__VM__allowRejectionHandledWarning(globalObject->bunVM())) {
-        Process::emitWarning(globalObject, jsString(globalObject->vm(), String("Promise rejection was handled asynchronously"_s)), jsString(globalObject->vm(), String("PromiseRejectionHandledWarning"_s)), jsUndefined(), jsUndefined());
+        Process::emitWarning(globalObject, jsString(vm, String("Promise rejection was handled asynchronously"_s)), jsString(vm, String("PromiseRejectionHandledWarning"_s)), jsUndefined(), jsUndefined());
         CLEAR_IF_EXCEPTION(scope);
+        if (vm.hasPendingTerminationException()) [[unlikely]]
+            return true;
     }
     auto& wrapped = process->wrapped();
     if (wrapped.listenerCount(eventType) > 0) {

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1322,6 +1322,8 @@ extern "C" void Bun__promises__emitUnhandledRejectionWarning(JSC::JSGlobalObject
 {
     auto& vm = globalObject->vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    if (vm.hasPendingTerminationException()) [[unlikely]]
+        return;
     auto warning = JSC::createError(globalObject, "Unhandled promise rejection. This error originated either by "
                                                   "throwing inside of an async function without a catch block, "
                                                   "or by rejecting a promise which was not handled with .catch(). "
@@ -1332,19 +1334,27 @@ extern "C" void Bun__promises__emitUnhandledRejectionWarning(JSC::JSGlobalObject
     JSValue reasonStack {};
     auto is_errorlike = Bun__promises__isErrorLike(globalObject, JSValue::decode(reason));
     CLEAR_IF_EXCEPTION(scope);
+    if (vm.hasPendingTerminationException()) [[unlikely]]
+        return;
     if (is_errorlike) {
         reasonStack = JSValue::decode(reason).get(globalObject, vm.propertyNames->stack);
         CLEAR_IF_EXCEPTION(scope);
+        if (vm.hasPendingTerminationException()) [[unlikely]]
+            return;
         warning->putDirect(vm, vm.propertyNames->stack, reasonStack);
     }
     if (!reasonStack) {
         reasonStack = JSValue::decode(Bun__noSideEffectsToString(vm, globalObject, reason));
         CLEAR_IF_EXCEPTION(scope);
+        if (vm.hasPendingTerminationException()) [[unlikely]]
+            return;
     }
     if (!reasonStack) reasonStack = jsUndefined();
 
     Process::emitWarning(globalObject, reasonStack, jsString(globalObject->vm(), "UnhandledPromiseRejectionWarning"_str), jsUndefined(), jsUndefined());
     CLEAR_IF_EXCEPTION(scope);
+    if (vm.hasPendingTerminationException()) [[unlikely]]
+        return;
     Process::emitWarningErrorInstance(globalObject, warning);
     CLEAR_IF_EXCEPTION(scope);
 }

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -209,6 +209,8 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
     auto* created_error = JSC::ErrorInstance::create(globalObject, structure, message, options, nullptr, JSC::RuntimeType::TypeNothing, data.type, true);
     if (auto* thrown_exception = scope.exception()) [[unlikely]] {
         (void)scope.tryClearException();
+        if (vm.hasPendingTerminationException()) [[unlikely]]
+            return created_error;
         // TODO investigate what can throw here and whether it will throw non-objects
         // (this is better than before where we would have returned nullptr from createError if any
         // exception were thrown by ErrorInstance::create)

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -247,9 +247,6 @@ bool JSCommonJSModule::load(JSC::VM& vm, Zig::GlobalObject* globalObject)
         this->m_filename.get());
 
     if (auto exception = scope.exception()) {
-        // tryClearException() cannot clear a termination, and JSMap::remove
-        // with it still pending bails out (and RELEASE_ASSERTs in the HashMapImpl
-        // path). The worker is dying, so leave the entry in place.
         if (vm.hasPendingTerminationException()) [[unlikely]]
             return false;
         (void)scope.tryClearException();
@@ -1271,9 +1268,8 @@ ALWAYS_INLINE EncodedJSValue finishRequireWithError(Zig::GlobalObject* globalObj
     auto& vm = JSC::getVM(globalObject);
     JSC::JSValue exception = throwScope.exception();
     ASSERT(exception);
-    // tryClearException() cannot clear a termination, and JSMap::remove with it
-    // still pending returns false, tripping the assert below. The worker is
-    // dying, so leave the entry in place and propagate.
+    // tryClearException() cannot clear a termination, and JSMap::remove with
+    // it still pending returns false, tripping ASSERT(wasRemoved).
     if (vm.hasPendingTerminationException()) [[unlikely]]
         RELEASE_AND_RETURN(throwScope, {});
     (void)throwScope.tryClearException();

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -247,6 +247,11 @@ bool JSCommonJSModule::load(JSC::VM& vm, Zig::GlobalObject* globalObject)
         this->m_filename.get());
 
     if (auto exception = scope.exception()) {
+        // tryClearException() cannot clear a termination, and JSMap::remove
+        // with it still pending bails out (and RELEASE_ASSERTs in the HashMapImpl
+        // path). The worker is dying, so leave the entry in place.
+        if (vm.hasPendingTerminationException()) [[unlikely]]
+            return false;
         (void)scope.tryClearException();
 
         // On error, remove the module from the require map/
@@ -1263,8 +1268,14 @@ const JSC::ClassInfo RequireFunctionPrototype::s_info = { "require"_s, &Base::s_
 
 ALWAYS_INLINE EncodedJSValue finishRequireWithError(Zig::GlobalObject* globalObject, JSC::ThrowScope& throwScope, JSC::JSValue specifierValue)
 {
+    auto& vm = JSC::getVM(globalObject);
     JSC::JSValue exception = throwScope.exception();
     ASSERT(exception);
+    // tryClearException() cannot clear a termination, and JSMap::remove with it
+    // still pending returns false, tripping the assert below. The worker is
+    // dying, so leave the entry in place and propagate.
+    if (vm.hasPendingTerminationException()) [[unlikely]]
+        RELEASE_AND_RETURN(throwScope, {});
     (void)throwScope.tryClearException();
 
     // On error, remove the module from the require map/
@@ -1574,6 +1585,8 @@ static JSC::SourceCode commonJSModuleSyntheticSourceCode(const SourceOrigin& sou
                                 moduleObject->m_dirname.get(),
                                 moduleObject->m_filename.get());
                             if (auto exception = scope.exception()) {
+                                if (vm.hasPendingTerminationException()) [[unlikely]]
+                                    return;
                                 (void)scope.tryClearException();
 
                                 // On error, remove the module from the require map

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -620,6 +620,11 @@ pub(crate) fn decode_ipc_message(
     global: &JSGlobalObject,
     known_newline: Option<u32>,
 ) -> Result<DecodeIPCMessageResult, IPCDecodeError> {
+    // The previous message's JS handler may have taken a worker's termination
+    // trap; JSONParse with it pending trips LiteralParser's state assert.
+    if global.bun_vm().script_execution_status() != crate::ScriptExecutionStatus::Running {
+        return Err(IPCDecodeError::JSTerminated);
+    }
     match mode {
         Mode::Advanced => advanced::decode_ipc_message(data, global),
         Mode::Json => json::decode_ipc_message(data, global, known_newline),

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1084,7 +1084,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             needs_deref,
         };
 
-        if vm.is_shutting_down() {
+        if vm.script_execution_status() != jsc::ScriptExecutionStatus::Running {
             drop(cleanup);
             return Ok(());
         }
@@ -1196,6 +1196,9 @@ impl<const SSL: bool> NewSocket<SSL> {
             Ok(v) => v,
             Err(e) => global.take_exception(e),
         };
+        if global.has_exception() {
+            return Ok(());
+        }
 
         if let Some(err_val) = result.to_error() {
             // TODO: properly propagate exception upwards
@@ -1750,7 +1753,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         let mut callback = handlers.on_handshake();
         let mut is_open = false;
 
-        if handlers.vm.is_shutting_down() {
+        if handlers.vm.script_execution_status() != jsc::ScriptExecutionStatus::Running {
             // `on_close` skips its JS dispatch during shutdown, so the native
             // close is still safe here.
             if reject_unauthorized {

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1463,12 +1463,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
 
         let handlers = this.get_handlers();
-        // A worker's terminate() can land between spin()'s check and this
-        // dispatch; `is_shutting_down` is still false then, but entering JS
-        // fires the trap and leaves the TerminationException pending for the
-        // second call below. The other on_* callbacks guard their single JS
-        // entry with `is_shutting_down()`; this one has two, so it needs the
-        // worker-aware gate.
+        // Two JS entries below (resolve_promise then callback.call); a worker
+        // terminate() raised in the first trips assertNoException() in the
+        // second, and is_shutting_down() is still false at that point.
         if handlers.vm.script_execution_status() != jsc::ScriptExecutionStatus::Running {
             return;
         }

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1885,7 +1885,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             return Ok(());
         }
         let handlers = this.get_handlers();
-        if handlers.vm.is_shutting_down() {
+        if handlers.vm.script_execution_status() != jsc::ScriptExecutionStatus::Running {
             return Ok(());
         }
         let callback = handlers.on_session();
@@ -1932,7 +1932,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             return Ok(());
         }
         let handlers = this.get_handlers();
-        if handlers.vm.is_shutting_down() {
+        if handlers.vm.script_execution_status() != jsc::ScriptExecutionStatus::Running {
             return Ok(());
         }
         let callback = handlers.on_keylog();

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1521,6 +1521,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             this.mark_inactive();
         }
         if !SSL
+            && !global.has_exception()
             && !this.socket.get().is_detached()
             && this.buffered_data_for_node_net.get().len() > 0
         {

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1463,6 +1463,15 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
 
         let handlers = this.get_handlers();
+        // A worker's terminate() can land between spin()'s check and this
+        // dispatch; `is_shutting_down` is still false then, but entering JS
+        // fires the trap and leaves the TerminationException pending for the
+        // second call below. The other on_* callbacks guard their single JS
+        // entry with `is_shutting_down()`; this one has two, so it needs the
+        // worker-aware gate.
+        if handlers.vm.script_execution_status() != jsc::ScriptExecutionStatus::Running {
+            return;
+        }
         let callback = handlers.on_open();
         let handshake_callback = handlers.on_handshake();
 
@@ -1472,6 +1481,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         this.mark_active();
         // TODO: properly propagate exception upwards
         let _ = handlers.resolve_promise(this_value);
+        if global.has_exception() {
+            return;
+        }
 
         if SSL {
             // only calls open callback if handshake callback is provided

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1466,9 +1466,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
 
         let handlers = this.get_handlers();
-        // Two JS entries below (resolve_promise then callback.call); a worker
-        // terminate() raised in the first trips assertNoException() in the
-        // second, and is_shutting_down() is still false at that point.
+        // Multiple JS entries below; a worker terminate() raised in one trips
+        // assertNoException() in the next, and is_shutting_down() is still
+        // false at that point.
         if handlers.vm.script_execution_status() != jsc::ScriptExecutionStatus::Running {
             return;
         }
@@ -1755,8 +1755,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         let mut is_open = false;
 
         if handlers.vm.script_execution_status() != jsc::ScriptExecutionStatus::Running {
-            // `on_close` skips its JS dispatch during shutdown, so the native
-            // close is still safe here.
+            // `on_close` is single-JS-entry, so the native close it routes
+            // through here just takes the trap and returns.
             if reject_unauthorized {
                 this.reject_unauthorized_connection();
             }

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -397,3 +397,52 @@ test.skipIf(!isDebug)(
   },
   120_000,
 );
+
+// Regression: Bun__handleUncaughtException probed process._fatalException (a
+// JS get(), where the worker's termination trap fires) and then called
+// wrapped.emit("uncaughtException") with the sticky TerminationException
+// still pending after tryClearException(), tripping
+// Interpreter::executeCallImpl's scope.assertNoException(). The sibling
+// rejectionHandled / unhandledRejection emit paths share the guard.
+test.skipIf(!isDebug)(
+  "terminate() while a worker is emitting process 'uncaughtException' does not trip assertNoException()",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const src =
+          "process.on('uncaughtException', () => {});" +
+          "setInterval(() => { for (let i = 0; i < 50; i++) setTimeout(() => { throw new Error('e'); }, 0); }, 1);" +
+          "require('node:worker_threads').parentPort.postMessage('up');";
+        for (let r = 0; r < 15; r++) {
+          const ws = [];
+          for (let i = 0; i < 6; i++) {
+            const w = new Worker(src, { eval: true });
+            w.on("error", () => {});
+            ws.push(w);
+          }
+          await Promise.race([
+            Promise.all(ws.map((w) => new Promise((res) => w.once("message", res)))),
+            Bun.sleep(1500),
+          ]);
+          await Bun.sleep((r * 37) % 250);
+          await Promise.all(ws.map((w) => w.terminate()));
+        }
+        console.log("PASS");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("PASS\n");
+    expect(exitCode).toBe(0);
+  },
+  120_000,
+);

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, tls } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir, tls } from "harness";
 import { join } from "path";
 
 // Worker VM startup/teardown is much slower under debug and/or ASAN; these
@@ -339,36 +339,38 @@ test.skipIf(!isDebug)(
 test.skipIf(!isDebug)(
   "terminate() while a worker is inside require() does not trip ASSERT(wasRemoved)",
   async () => {
+    // Build the CJS graph in the outer test so cleanup is guaranteed even when
+    // the subprocess SIGABRTs (the fail-before behavior) or is SIGKILLed by
+    // the outer timeout; process.on('exit') inside the subprocess would not
+    // run on either path.
+    const N = 200;
+    const files: Record<string, string> = {
+      "w.mjs":
+        `postMessage('ready');\n` +
+        `while (true) {\n` +
+        `  for (const k of Object.keys(require.cache)) delete require.cache[k];\n` +
+        `  require('./c0.cjs');\n` +
+        `}\n`,
+    };
+    for (let i = 0; i < N; i++) {
+      const a = (i + 1) % N;
+      const b = (i * 13 + 5) % N;
+      files[`c${i}.cjs`] = `require('./c${a}.cjs');\nrequire('./c${b}.cjs');\nexports.id = ${i};\n`;
+    }
+    using dir = tempDir("cjsreq", files);
+
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `
-        import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
-        import { tmpdir } from "node:os";
-        import { join } from "node:path";
-        const N = 200;
-        const dir = mkdtempSync(join(tmpdir(), "cjsreq-"));
-        for (let i = 0; i < N; i++) {
-          const a = (i + 1) % N, b = (i * 13 + 5) % N;
-          writeFileSync(join(dir, "c" + i + ".cjs"),
-            "require('./c" + a + ".cjs');\\nrequire('./c" + b + ".cjs');\\nexports.id = " + i + ";\\n");
-        }
-        writeFileSync(join(dir, "w.mjs"),
-          "const D = " + JSON.stringify(dir + "/") + ";\\n" +
-          "postMessage('ready');\\n" +
-          "while (true) {\\n" +
-          "  for (const k of Object.keys(require.cache)) delete require.cache[k];\\n" +
-          "  require(D + 'c0.cjs');\\n" +
-          "}\\n");
-        process.on("exit", () => { try { rmSync(dir, { recursive: true, force: true }); } catch {} });
         // Three lanes, each terminates its worker at a sweep of offsets so at
         // least one lands mid-require. The worker spends ~all its time inside
         // require(), so the unpatched build aborts within the first few
         // iterations.
         async function lane(offset) {
           for (let i = 0; i < 25; i++) {
-            const w = new Worker(join(dir, "w.mjs"));
+            const w = new Worker("./w.mjs");
             w.onerror = () => {};
             await new Promise((res) => {
               w.onmessage = () => res();
@@ -383,6 +385,7 @@ test.skipIf(!isDebug)(
       `,
       ],
       env: bunEnv,
+      cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -259,3 +259,73 @@ describe.skipIf(!isDebug)(
     );
   },
 );
+
+// Regression: NewSocket::on_open was the only socket dispatch missing the
+// shutdown guard. It resolves the Bun.connect() promise (entering JS, where
+// the worker's termination trap fires and leaves the TerminationException
+// pending) and then calls the JS `open` handler, which trips
+// Interpreter::executeCallImpl's scope.assertNoException() and SIGABRTs the
+// whole process. Hits from Bun.connect, net.connect, and tls.connect alike
+// (they share on_open). Release WebKit compiles that ASSERT out, so this is
+// debug-only; the exception-scope verifier makes it fire on the first hit.
+test.skipIf(!isDebug)(
+  "terminate() while a worker's Bun.connect() open is firing does not trip assertNoException()",
+  async () => {
+    // Each round keeps LANES loopback connects in flight per worker and
+    // terminates once the worker reports steady state, so terminate() lands
+    // while on_open is hot. Debug+ASAN makes each round ~5s, so the pass
+    // time is ~60s; the unpatched build aborts in the first few rounds.
+    const ROUNDS = 12;
+    const WORKERS = 4;
+    const LANES = 32;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const net = require("node:net");
+        const srv = net.createServer((c) => { c.on("error", () => {}); c.end(); });
+        await new Promise((r) => srv.listen(0, "127.0.0.1", r));
+        const port = srv.address().port;
+        const src =
+          "const { parentPort, workerData: d } = require('node:worker_threads');" +
+          "let opens = 0;" +
+          "function lane() {" +
+          "  Bun.connect({ hostname: '127.0.0.1', port: d.port, socket: {" +
+          "    open(s) { if (++opens === ${LANES}) parentPort.postMessage('hot'); s.end(); }," +
+          "    data() {}, close() { setImmediate(lane); }," +
+          "    connectError() { setImmediate(lane); }, error() {} } })" +
+          "    .catch(() => setImmediate(lane));" +
+          "}" +
+          "for (let i = 0; i < ${LANES}; i++) lane();";
+        for (let r = 0; r < ${ROUNDS}; r++) {
+          const ws = [];
+          for (let i = 0; i < ${WORKERS}; i++) {
+            const w = new Worker(src, { eval: true, workerData: { port } });
+            w.on("error", () => {});
+            ws.push(w);
+          }
+          await Promise.all(ws.map((w) => new Promise((res) => {
+            w.once("message", res);
+            setTimeout(res, 3000);
+          })));
+          await Bun.sleep(r % 3);
+          await Promise.all(ws.map((w) => w.terminate()));
+        }
+        srv.close();
+        console.log("PASS");
+      `,
+      ],
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("PASS\n");
+    expect(exitCode).toBe(0);
+  },
+  120_000,
+);

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -299,17 +299,21 @@ test.skipIf(!isDebug)(
           "    .catch(() => setImmediate(lane));" +
           "}" +
           "for (let i = 0; i < ${LANES}; i++) lane();";
+        function ready(w) {
+          return new Promise((res, rej) => {
+            w.once("message", res);
+            w.once("error", rej);
+            w.once("exit", (c) => rej(new Error("worker exited " + c + " before ready")));
+          });
+        }
         for (let r = 0; r < ${ROUNDS}; r++) {
           const ws = [];
           for (let i = 0; i < ${WORKERS}; i++) {
             const w = new Worker(src, { eval: true, workerData: { port } });
-            w.on("error", () => {});
             ws.push(w);
           }
-          await Promise.all(ws.map((w) => new Promise((res) => {
-            w.once("message", res);
-            setTimeout(res, 3000);
-          })));
+          await Promise.all(ws.map(ready));
+          for (const w of ws) w.on("error", () => {});
           await Bun.sleep(r % 3);
           await Promise.all(ws.map((w) => w.terminate()));
         }
@@ -371,11 +375,11 @@ test.skipIf(!isDebug)(
         async function lane(offset) {
           for (let i = 0; i < 25; i++) {
             const w = new Worker("./w.mjs");
-            w.onerror = () => {};
-            await new Promise((res) => {
+            await new Promise((res, rej) => {
               w.onmessage = () => res();
-              setTimeout(res, 2000);
+              w.onerror = (e) => rej(e.error ?? e);
             });
+            w.onerror = () => {};
             await Bun.sleep(offset + (i % 10) * 5);
             await w.terminate();
           }
@@ -414,20 +418,25 @@ test.skipIf(!isDebug)(
         `
         const { Worker } = require("node:worker_threads");
         const src =
-          "process.on('uncaughtException', () => {});" +
-          "setInterval(() => { for (let i = 0; i < 50; i++) setTimeout(() => { throw new Error('e'); }, 0); }, 1);" +
-          "require('node:worker_threads').parentPort.postMessage('up');";
+          "const { parentPort } = require('node:worker_threads');" +
+          "let first = true;" +
+          "process.on('uncaughtException', () => { if (first) { first = false; parentPort.postMessage('hot'); } });" +
+          "setInterval(() => { for (let i = 0; i < 50; i++) setTimeout(() => { throw new Error('e'); }, 0); }, 1);";
+        function ready(w) {
+          return new Promise((res, rej) => {
+            w.once("message", res);
+            w.once("error", rej);
+            w.once("exit", (c) => rej(new Error("worker exited " + c + " before ready")));
+          });
+        }
         for (let r = 0; r < 15; r++) {
           const ws = [];
           for (let i = 0; i < 6; i++) {
             const w = new Worker(src, { eval: true });
-            w.on("error", () => {});
             ws.push(w);
           }
-          await Promise.race([
-            Promise.all(ws.map((w) => new Promise((res) => w.once("message", res)))),
-            Bun.sleep(1500),
-          ]);
+          await Promise.all(ws.map(ready));
+          for (const w of ws) w.on("error", () => {});
           await Bun.sleep((r * 37) % 250);
           await Promise.all(ws.map((w) => w.terminate()));
         }

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -329,3 +329,68 @@ test.skipIf(!isDebug)(
   },
   120_000,
 );
+
+// Regression: terminate() during a synchronous require() of a deep CJS graph.
+// finishRequireWithError (and JSCommonJSModule::load's error branch) did
+// tryClearException() then requireMap()->remove() with the sticky
+// TerminationException still pending, so JSMap::remove bailed and
+// ASSERT(wasRemoved) SIGABRTed the process. Release builds compile the assert
+// out and leave the throwing module cached for a dying VM, so debug-only.
+test.skipIf(!isDebug)(
+  "terminate() while a worker is inside require() does not trip ASSERT(wasRemoved)",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+        import { tmpdir } from "node:os";
+        import { join } from "node:path";
+        const N = 200;
+        const dir = mkdtempSync(join(tmpdir(), "cjsreq-"));
+        for (let i = 0; i < N; i++) {
+          const a = (i + 1) % N, b = (i * 13 + 5) % N;
+          writeFileSync(join(dir, "c" + i + ".cjs"),
+            "require('./c" + a + ".cjs');\\nrequire('./c" + b + ".cjs');\\nexports.id = " + i + ";\\n");
+        }
+        writeFileSync(join(dir, "w.mjs"),
+          "const D = " + JSON.stringify(dir + "/") + ";\\n" +
+          "postMessage('ready');\\n" +
+          "while (true) {\\n" +
+          "  for (const k of Object.keys(require.cache)) delete require.cache[k];\\n" +
+          "  require(D + 'c0.cjs');\\n" +
+          "}\\n");
+        process.on("exit", () => { try { rmSync(dir, { recursive: true, force: true }); } catch {} });
+        // Three lanes, each terminates its worker at a sweep of offsets so at
+        // least one lands mid-require. The worker spends ~all its time inside
+        // require(), so the unpatched build aborts within the first few
+        // iterations.
+        async function lane(offset) {
+          for (let i = 0; i < 25; i++) {
+            const w = new Worker(join(dir, "w.mjs"));
+            w.onerror = () => {};
+            await new Promise((res) => {
+              w.onmessage = () => res();
+              setTimeout(res, 2000);
+            });
+            await Bun.sleep(offset + (i % 10) * 5);
+            await w.terminate();
+          }
+        }
+        await Promise.all([lane(0), lane(20), lane(60)]);
+        console.log("PASS");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("PASS\n");
+    expect(exitCode).toBe(0);
+  },
+  120_000,
+);


### PR DESCRIPTION
A worker's `terminate()` lands while the worker thread is inside a native dispatch, the first JS entry fires the termination trap and leaves the sticky `TerminationException` pending, and the second JS entry (or a downcast of the exception value) trips a debug-build assertion and aborts the whole process. Six sites of this class:

### `NewSocket::on_open` / `on_keylog` / `on_session` (socket_body.rs)

`on_open` was the only `NewSocket` dispatch entry point without a shutdown guard before its JS calls, and unlike the others it enters JS twice: `handlers.resolve_promise()` (the `Bun.connect()` promise) and then `callback.call()` (the user's `open` handler). When `terminate()` lands between `WebWorker::spin`'s `has_requested_terminate()` check and the socket dispatch inside `auto_tick_active`, the first call raises the `TerminationException` and the second trips `Interpreter::executeCallImpl`'s `scope.assertNoException()`:

```
ASSERTION FAILED: !exception()
ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
  <- Interpreter::executeCallImpl <- JSC::call <- Bun__JSValue__call
  <- NewSocket::on_open (callback.call of the JS `open` handler)
  <- us_internal_dispatch_ready_poll <- us_loop_run_bun_tick <- auto_tick_active
  <- WebWorker::spin
```

Reproduces from `Bun.connect`, `net.connect`, and `tls.connect` alike (they share `on_open<SSL>`). `on_keylog` and `on_session` (TLS-only, reached via `node:tls`/`node:http2`'s keylog/session callbacks) have the same two-JS-entry shape behind the weaker `is_shutting_down()` gate.

Fix: gate `on_open`/`on_keylog`/`on_session` on `script_execution_status() != Running` (which covers a worker's `has_requested_terminate()`; `is_shutting_down()` is still false at this point), and in `on_open` bail out of the second JS entry if `resolve_promise` left an exception pending.

### `finishRequireWithError` (JSCommonJSModule.cpp)

`finishRequireWithError` (and two sibling error-path cleanup sites) did `tryClearException()` then `requireMap()->remove()`. `tryClearException()` cannot clear a termination, so when `terminate()` landed mid-`require()` of a deep CJS graph, `JSMap::remove` ran with the exception still pending, bailed out, and `ASSERT(wasRemoved)` aborted:

```
ASSERTION FAILED: wasRemoved
JSCommonJSModule.cpp(1273) : EncodedJSValue Bun::finishRequireWithError(...)
```

Fix: skip the require-map cleanup when `vm.hasPendingTerminationException()` and let the termination propagate.

### `Bun__handleUncaughtException` / `Bun__handleUnhandledRejection` / `Bun__emitHandledPromiseEvent` / `Bun__promises__emitUnhandledRejectionWarning` (BunProcess.cpp)

`Bun__handleUncaughtException` probes `process._fatalException` (a JS `get()`, where the trap fires) and then calls `wrapped.emit("uncaughtException")` with the termination still pending after `tryClearException()`:

```
ASSERTION FAILED: !exception()
ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
  <- Interpreter::executeCallImpl <- JSC::call <- EventEmitter::fireEventListeners
  <- Bun__handleUncaughtException (wrapped.emit "uncaughtException")
  <- VirtualMachine::uncaught_exception <- report_unhandled_error
  <- Bun__JSTimeout__call <- drain_timers <- auto_tick_active <- WebWorker::spin
```

`Bun__emitHandledPromiseEvent` and `Bun__promises__emitUnhandledRejectionWarning` have the same `CLEAR_IF_EXCEPTION` → next-emit shape. The Rust callers only gate on `is_shutting_down()`.

Fix: guard each emit entry point and each `tryClearException()` follow-up on `vm.hasPendingTerminationException()`, matching the existing `NodeTimerObject.cpp` pattern.

### `ErrorCodeCache::createError` (ErrorCode.cpp)

The fallback branch did `tryClearException()` then `uncheckedDowncast<JSObject>(thrown_exception->value())`; on termination that value is not a `JSObject` and the downcast reaches `reportZappedCellAndCrash` (seen from `node:http2`'s `ERR_HTTP2_STREAM_ERROR` path inside a terminating worker).

Fix: on termination, return the (possibly partial) `created_error` instead; the caller's `throwException` is a no-op with termination pending.

### Verification

Three `skipIf(!isDebug)` tests (release WebKit compiles these asserts out). On a debug build, without the src/ changes:

```
(fail) terminate() while a worker's Bun.connect() open is firing ...      stderr: "ASSERTION FAILED: !exception() ... ExceptionScope.h(61)"
(fail) terminate() while a worker is inside require() ...                 stderr: "ASSERTION FAILED: wasRemoved ... JSCommonJSModule.cpp(1273)"
(fail) terminate() while a worker is emitting process 'uncaughtException' stderr: "ASSERTION FAILED: !exception() ... ExceptionScope.h(61)"
```

With the src/ changes all three pass (socket ~50s, CJS ~6s, process ~33s on debug+ASAN). The `on_keylog`/`on_session`/`ErrorCodeCache` sites are reached via `node:http2` over TLS and reproduce on a release-asan build; they use the same `script_execution_status()` / `hasPendingTerminationException()` guards proven by the three tests above.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->