### PR TITLE
RuntimeTranspilerStore: don't report TerminationException as uncaught on worker.terminate()

### DIFF
--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -237,19 +237,19 @@ impl RuntimeTranspilerStore {
         event_loop: NonNull<EventLoop>,
         global: &JSGlobalObject,
         vm: NonNull<VirtualMachine>,
-    ) {
+    ) -> Result<(), crate::JsTerminated> {
         let batch = self.queue.pop_batch();
         // SAFETY: `vm` is the live owning VM (caller is the JS-thread tick loop).
         let jsc_vm = unsafe { (*vm.as_ptr()).jsc_vm() };
         let mut iter = batch.iterator();
         let first = iter.next();
         if first.is_null() {
-            return;
+            return Ok(());
         }
         // we run just one job first to see if there are more
         // SAFETY: `first` is a live job popped from the intrusive queue.
         if let Err(err) = unsafe { (*first).run_from_js_thread() } {
-            global.report_uncaught_exception_from_error(err);
+            crate::task::report_error_or_terminate(global, err)?;
         }
         loop {
             let job = iter.next();
@@ -258,18 +258,15 @@ impl RuntimeTranspilerStore {
             }
             // if there are more, we need to drain the microtasks from the previous run
             // SAFETY: `event_loop` is the VM's live event-loop self-pointer.
-            if unsafe { (*event_loop.as_ptr()).drain_microtasks_with_global(global, jsc_vm) }
-                .is_err()
-            {
-                return;
-            }
+            unsafe { (*event_loop.as_ptr()).drain_microtasks_with_global(global, jsc_vm) }?;
             // SAFETY: `job` is a live job popped from the intrusive queue.
             if let Err(err) = unsafe { (*job).run_from_js_thread() } {
-                global.report_uncaught_exception_from_error(err);
+                crate::task::report_error_or_terminate(global, err)?;
             }
         }
 
         // immediately after this is called, the microtasks will be drained again.
+        Ok(())
     }
 
     pub fn transpile(

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -349,7 +349,7 @@ pub(crate) fn run_task(
         }
         task_tag::RuntimeTranspilerStore => {
             let store = cast!(RuntimeTranspilerStore);
-            store.run_from_js_thread(el.into(), global, vm.into());
+            store.run_from_js_thread(el.into(), global, vm.into())?;
         }
 
         // ── hot-reload (early-returns from the drain loop) ───────────────

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -137,46 +137,47 @@ test(
 test.skipIf(!isDebug)(
   "terminate() while dynamic-import transpiler jobs are in flight does not report TerminationException as uncaught",
   async () => {
+    // w.mjs lives in the temp dir so it can use relative ./modN imports;
+    // main.mjs uses the global Web Worker (no preloads): node:worker_threads
+    // injects a "node:worker_threads" preload whose load_preloads spin uses the
+    // non-termination-aware wait_for_promise and independently hits the WebKit
+    // assertNoException() termination bug.
     using dir = tempDir("worker-terminate-dynimport", {
       "mod0.mjs": "export default 0; ++++;",
       "mod1.mjs": "export default 1; ++++;",
       "mod2.mjs": "export default 2; ++++;",
       "mod3.mjs": "export default 3; ++++;",
+      "w.mjs": `
+        postMessage("ready");
+        let k = 0;
+        while (true) {
+          const i = k % 4;
+          try { await import("./mod" + i + ".mjs?v=" + ((k / 4) | 0)); } catch {}
+          k++;
+        }
+      `,
+      "main.mjs": `
+        const rounds = 60;
+        function one(delay) {
+          return new Promise((resolve) => {
+            const w = new Worker(new URL("./w.mjs", import.meta.url).href);
+            w.onerror = () => {};
+            // Key terminate off the ready signal so every round is past
+            // startup and inside the import loop.
+            w.onmessage = () => setTimeout(() => { w.terminate(); setTimeout(resolve, 5); }, delay);
+          });
+        }
+        async function lane(offset) {
+          for (let i = 0; i < rounds; i++) await one((i * 7 + offset) % 30);
+        }
+        await Promise.all([lane(0), lane(3)]);
+        console.log("survived");
+      `,
     });
-    const rounds = 100;
-    // Uses the global Web Worker (no preloads); node:worker_threads injects a
-    // "node:worker_threads" preload whose load_preloads spin uses the non-
-    // termination-aware wait_for_promise and independently hits the WebKit
-    // assertNoException() termination bug.
-    const code = `
-      import { writeFileSync } from "node:fs";
-      import { join } from "node:path";
-      const D = ${JSON.stringify(String(dir) + "/")};
-      writeFileSync(join(D, "w.mjs"),
-        'const D = ' + JSON.stringify(D) + ';' +
-        'postMessage("ready");' +
-        'let k = 0;' +
-        'while (true) {' +
-        '  const i = k % 4;' +
-        '  try { await import(D + "mod" + i + ".mjs?v=" + ((k / 4) | 0)); } catch {}' +
-        '  k++;' +
-        '}');
-      function one(delay) {
-        return new Promise((resolve) => {
-          const w = new Worker(join(D, "w.mjs"));
-          w.onmessage = () => {}; w.onerror = () => {};
-          setTimeout(() => { w.terminate(); setTimeout(resolve, 5); }, delay);
-        });
-      }
-      async function lane(offset) {
-        for (let i = 0; i < ${rounds}; i++) await one(20 + ((i * 37 + offset) % 120));
-      }
-      await Promise.all([lane(0), lane(17)]);
-      console.log("survived");
-    `;
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", code],
+      cmd: [bunExe(), "main.mjs"],
       env: bunEnv,
+      cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, tls } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir, tls } from "harness";
 import { join } from "path";
 
 // Worker VM startup/teardown is much slower under debug and/or ASAN; these
@@ -119,6 +119,76 @@ test(
     expect(exitCode).toBe(0);
   },
   timeout,
+);
+
+// Regression: RuntimeTranspilerStore::run_from_js_thread reported the
+// TerminationException as an uncaught exception. A worker dynamic-importing
+// in a loop and terminated mid-iteration has an in-flight TranspilerJob whose
+// JS-thread completion (AsyncModule::fulfill -> promise resolve/reject) raises
+// the TerminationException; the old report_uncaught_exception_from_error path
+// then reached Bun__handleUncaughtException -> process->get("_fatalException"),
+// whose static-property reification transitions process's Structure mid-walk
+// and trips ASSERT(object->structure() == this) in Structure::storedPrototype.
+//
+// Modules have a syntax error so the fetch promise rejects: the rejected
+// ModuleLoadTopSettled branch does not call loadModule -> hostLoadImportedModule,
+// whose separate scope.assertNoException() termination bug (WebKit-side) would
+// otherwise also fire here.
+test.skipIf(!isDebug)(
+  "terminate() while dynamic-import transpiler jobs are in flight does not report TerminationException as uncaught",
+  async () => {
+    using dir = tempDir("worker-terminate-dynimport", {
+      "mod0.mjs": "export default 0; ++++;",
+      "mod1.mjs": "export default 1; ++++;",
+      "mod2.mjs": "export default 2; ++++;",
+      "mod3.mjs": "export default 3; ++++;",
+    });
+    const rounds = 100;
+    // Uses the global Web Worker (no preloads); node:worker_threads injects a
+    // "node:worker_threads" preload whose load_preloads spin uses the non-
+    // termination-aware wait_for_promise and independently hits the WebKit
+    // assertNoException() termination bug.
+    const code = `
+      import { writeFileSync } from "node:fs";
+      import { join } from "node:path";
+      const D = ${JSON.stringify(String(dir) + "/")};
+      writeFileSync(join(D, "w.mjs"),
+        'const D = ' + JSON.stringify(D) + ';' +
+        'postMessage("ready");' +
+        'let k = 0;' +
+        'while (true) {' +
+        '  const i = k % 4;' +
+        '  try { await import(D + "mod" + i + ".mjs?v=" + ((k / 4) | 0)); } catch {}' +
+        '  k++;' +
+        '}');
+      function one(delay) {
+        return new Promise((resolve) => {
+          const w = new Worker(join(D, "w.mjs"));
+          w.onmessage = () => {}; w.onerror = () => {};
+          setTimeout(() => { w.terminate(); setTimeout(resolve, 5); }, delay);
+        });
+      }
+      async function lane(offset) {
+        for (let i = 0; i < ${rounds}; i++) await one(20 + ((i * 37 + offset) % 120));
+      }
+      await Promise.all([lane(0), lane(17)]);
+      console.log("survived");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, stdout, exitCode, signalCode: proc.signalCode }).toEqual({
+      stderr: "",
+      stdout: "survived\n",
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+  timeout * 2,
 );
 
 // Regression: the per-VM c-ares channel was destroyed in deinit_runtime_state


### PR DESCRIPTION
## Repro

A worker dynamic-importing in a loop and terminated mid-iteration aborts the process on debug builds:

```
ASSERTION FAILED: isCompilationThread() || Thread::mayBeGCThread() || object->structure() == this
StructureInlinesLight.h(56) : JSValue JSC::Structure::storedPrototype(const JSObject *) const
```

Stack (raw-stack symbolized; gdb DWARF is broken on `bun-debug`):

```
Structure::storedPrototype                  (StructureInlinesLight.h:56)
JSObject::getPropertySlot<false>            (JSObject.h:1220)
JSObject::get                               (JSObjectInlines.h:135)
Bun__handleUncaughtException                (BunProcess.cpp:1225, process->get("_fatalException"))
VirtualMachine::report_uncaught_exception   (VirtualMachine.rs:5037)
report_uncaught_exception_from_error        (JSGlobalObject.rs:1398)
RuntimeTranspilerStore::run_from_js_thread  (RuntimeTranspilerStore.rs:251)
run_task                                    (dispatch.rs:353)
```

## Cause

When `worker.terminate()` lands between a `TranspilerJob` dispatching back to the JS thread and its `AsyncModule::fulfill` call completing, `from_js_host_call_generic`'s post-FFI trap check raises the TerminationException and returns `Err(JsError::Thrown)`. `RuntimeTranspilerStore::run_from_js_thread` handed that straight to `report_uncaught_exception_from_error`, which has no termination filter (unlike `report_active_exception_as_unhandled` / `report_error_or_terminate`), so `Bun__handleUncaughtException` ran its `process->get("_fatalException")` prototype walk with the TerminationException still armed.

`_fatalException` is a `Function` entry in Process's static hash table. `getOwnNonIndexPropertySlot` → `getOwnStaticPropertySlot` → `setUpStaticFunctionSlot` reifies it via `putDirectNativeFunction`, which transitions `process`'s Structure. The `Structure*` loaded at the top of `getPropertySlot`'s loop is then stale when `structure->storedPrototype(object)` checks `object->structure() == this`, tripping the assert.

## Fix

Route the error through `report_error_or_terminate` (the same helper the `AnyTask` / `ManagedTask` / `CppTask` dispatch arms already use), which recognises both `JsError::Terminated` and a pending `TerminationException` value and propagates `JsTerminated` to unwind the tick loop instead of reporting. `run_from_js_thread` now returns `Result<(), JsTerminated>` so `dispatch::run_task` can `?`-propagate it like the other arms.

A genuine non-termination exception from `AsyncModule::fulfill` still reaches `report_uncaught_exception` inside `report_error_or_terminate`.

## Verification

New debug-gated stress test in `test/js/web/workers/worker-terminate-lifetime.test.ts` spawns 2 lanes × 100 workers, each dynamic-importing syntax-error modules in a loop and terminated after 20-140 ms. On an unfixed debug build: 3/3 abort with the `storedPrototype` assert within 3-5 s. With the fix: 5/5 survive.

The imported modules intentionally have a syntax error so the fetch promise rejects and the `ModuleLoadTopSettled` microtask takes its Rejected branch (no `loadModule` → `hostLoadImportedModule` → `resolve()`), avoiding the separate WebKit-level `scope.assertNoException()` termination bug in `continueDynamicImport` (tracked separately). The test uses the global Web `Worker` for the same reason: `node:worker_threads` injects a `"node:worker_threads"` preload whose `load_preloads` spin uses the non-termination-aware `wait_for_promise` and independently hits that WebKit assert.

## Related

- #33939 fixes the `TranspilerJob` UAF (VM freed while the pool-side parse is still reading it). That PR's body notes this `storedPrototype` assert as out-of-scope; this is the follow-up.
- #35678 adds a `scriptExecutionStatus() != Running` guard in `Bun__handleUncaughtException` itself, which would also happen to stop this symptom; this PR fixes it at the source (the dispatch site that should not be reporting termination as uncaught in the first place) and matches the existing `report_error_or_terminate` pattern.
- The `continueDynamicImport` `assertNoException()` bug (also surfaced by the original multi-lane repro once this assert no longer fires first) lives in `JSModuleLoader.cpp` in the prebuilt WebKit and is tracked separately.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->