### PR TITLE
sourcemap: accept absent/null/short sourcesContent in runtime decoder

### DIFF
--- a/src/sourcemap/lib.rs
+++ b/src/sourcemap/lib.rs
@@ -922,15 +922,18 @@ pub(crate) fn parse_json(source: &[u8], hint: ParseUrlResultHint) -> crate::Resu
         return Err(crate::Error::InvalidSourceMap);
     };
 
-    let sources_content = match json
-        .get(b"sourcesContent")
-        .ok_or(crate::Error::InvalidSourceMap)?
-        .data
-    {
-        bun_ast::ExprData::EArrayJSON(arr) => arr,
-        _ => return Err(crate::Error::InvalidSourceMap),
+    // `sourcesContent` is optional per the source-map v3 spec. Absent or `null`
+    // is treated as no-content-available; a present non-array/non-null is
+    // rejected. A present array may be shorter than `sources` (the per-index
+    // bounds check below covers that).
+    let sources_content = match json.get(b"sourcesContent") {
+        None => None,
+        Some(expr) => match expr.data {
+            bun_ast::ExprData::EArrayJSON(arr) => Some(arr),
+            bun_ast::ExprData::ENull(_) => None,
+            _ => return Err(crate::Error::InvalidSourceMap),
+        },
     };
-    let sources_content = sources_content.get();
 
     let sources_paths = match json
         .get(b"sources")
@@ -942,15 +945,11 @@ pub(crate) fn parse_json(source: &[u8], hint: ParseUrlResultHint) -> crate::Resu
     };
     let sources_paths = sources_paths.get();
 
-    if sources_content.items().len() != sources_paths.items().len() {
-        return Err(crate::Error::InvalidSourceMap);
-    }
-
     let source_only = matches!(hint, ParseUrlResultHint::SourceOnly(_));
 
     // `Vec<Box<[u8]>>` drops automatically on error.
     let source_paths_slice: Option<Vec<Box<[u8]>>> = if !source_only {
-        let mut v: Vec<Box<[u8]>> = Vec::with_capacity(sources_content.items().len());
+        let mut v: Vec<Box<[u8]>> = Vec::with_capacity(sources_paths.items().len());
         for item in sources_paths.items() {
             let Some(s) = item.as_str() else {
                 return Err(crate::Error::InvalidSourceMap);
@@ -1041,12 +1040,12 @@ pub(crate) fn parse_json(source: &[u8], hint: ParseUrlResultHint) -> crate::Resu
         ParseUrlResultHint::MappingsOnly => (None, None),
     };
 
-    let content_slice: Option<Box<[u8]>> = match source_index {
-        Some(idx)
+    let content_slice: Option<Box<[u8]>> = match (source_index, sources_content) {
+        (Some(idx), Some(sources_content))
             if !matches!(hint, ParseUrlResultHint::MappingsOnly)
-                && (idx as usize) < sources_content.items().len() =>
+                && (idx as usize) < sources_content.get().items().len() =>
         'content: {
-            let item = &sources_content.items()[idx as usize];
+            let item = &sources_content.get().items()[idx as usize];
             let Some(str) = item.as_str() else {
                 break 'content None;
             };

--- a/test/js/node/module/sourcemap.test.js
+++ b/test/js/node/module/sourcemap.test.js
@@ -246,3 +246,54 @@ test("error.stack of // @bun code with a truncated VLQ in sourceMappingURL warns
   expect(stdout).toBe("");
   expect(exitCode).toBe(1);
 });
+
+// `sourcesContent` is optional per the source-map v3 spec. The runtime decoder
+// must accept maps where it is absent, `null`, or shorter than `sources`, and
+// still remap error.stack via `mappings` + `sources`.
+test.concurrent.each([
+  ["absent", undefined],
+  ["null", null],
+  ["empty array", []],
+  ["[null]", [null]],
+])("error.stack of // @bun code remaps with sourcesContent %s", async (label, sourcesContent) => {
+  // Generated line 3 col 2 -> original.ts line 5 col 3 (all 0-based in VLQ).
+  const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  const vlq = v => {
+    let out = "";
+    let x = v < 0 ? (-v << 1) | 1 : v << 1;
+    do {
+      let d = x & 31;
+      x >>>= 5;
+      if (x) d |= 32;
+      out += B64[d];
+    } while (x);
+    return out;
+  };
+  const seg = vlq(2) + vlq(0) + vlq(4) + vlq(2);
+  const map = { version: 3, sources: ["original.ts"], names: [], mappings: ";;" + seg + ";" };
+  if (sourcesContent !== undefined) map.sourcesContent = sourcesContent;
+
+  using dir = tempDir("sourcemap-optional-sourcescontent", {
+    "entry.js":
+      `// @bun\n` +
+      `function t() {\n` +
+      `  throw new Error("SC");\n` +
+      `}\n` +
+      `try { t(); } catch (e) { console.log(String(e.stack).split("\\n")[1].trim()); }\n` +
+      `//# sourceMappingURL=entry.js.map\n`,
+    "entry.js.map": JSON.stringify(map),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("Could not decode sourcemap");
+  expect(stdout.trim()).toContain("original.ts:5:3");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

The runtime source-map decoder (`parse_json` in `src/sourcemap/lib.rs`, used to remap `error.stack` for `// @bun`-pragma files with an external `.map` or inline data-URL) rejected any map whose `sourcesContent` was absent or `null`:

```
warn: Could not decode sourcemap in '<file>': InvalidSourceMap
```

and left the stack unmapped. It also rejected maps where `sourcesContent.length != sources.length`.

Per the source-map v3 spec, `sourcesContent` is optional. Node's `--enable-source-maps` and other consumers accept all of these shapes. The same decoder already accepted `sourcesContent: [null]` and `[""]`.

## Repro

```js
// @bun
function t() {
  throw new Error("SC");
}
try { t(); } catch (e) { console.log(String(e.stack).split("\n")[1].trim()); }
//# sourceMappingURL=entry.js.map
```

with `entry.js.map`:
```json
{"version":3,"sources":["original.ts"],"names":[],"mappings":";;EAIE;"}
```

Before: `at t (entry.js:3:18)` plus the `InvalidSourceMap` warning.
After: `at t (original.ts:5:3)`.

## Cause

`parse_json` did:

```rust
let sources_content = match json
    .get(b"sourcesContent")
    .ok_or(crate::Error::InvalidSourceMap)?   // absent -> error
    .data
{
    bun_ast::ExprData::EArrayJSON(arr) => arr,
    _ => return Err(crate::Error::InvalidSourceMap),  // null -> error
};
// ...
if sources_content.items().len() != sources_paths.items().len() {
    return Err(crate::Error::InvalidSourceMap);       // short -> error
}
```

## Fix

Treat absent or `null` `sourcesContent` as `None` (no content available) and drop the strict length equality check. The per-index bounds check that guards the content lookup already handles short arrays. A present value that is neither an array nor `null` is still rejected.

Reach is bounded: user-supplied maps are only consulted for `// @bun`-pragma files, and `bun build`'s own maps always carry `sourcesContent`, so this only affects pragma'd files whose map came from another tool. The `StandaloneModuleGraph` serializer is left unchanged since it consumes bun's own bundler output and actually embeds the content.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/node/module/sourcemap.test.js -t sourcesContent
  3 fail (absent, null, empty array), 1 pass ([null] control)

bun bd test test/js/node/module/sourcemap.test.js
  18 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/sourcemap.test.js
bun test v1.4.0 (2d4a731f2)

test/js/node/module/sourcemap.test.js:
(pass) SourceMap class exists [6.56ms]
(pass) SourceMap constructor requires payload [4.80ms]
(pass) SourceMap payload must be an object [2.68ms]
(pass) SourceMap instance has expected methods [3.40ms]
(pass) SourceMap payload getter [1.56ms]
(pass) SourceMap lineLengths getter [2.12ms]
(pass) SourceMap lineLengths undefined when not provided [1.80ms]
(pass) SourceMap findEntry returns mapping data [2.93ms]
(pass) SourceMap findOrigin returns origin data [2.57ms]
(pass) SourceMap with names returns name property correctly [3.93ms]
(pass) SourceMap without names has undefined name property [2.87ms]
(pass) SourceMap with invalid name index has undefined name property [2.67ms]
(pass) SourceMap handles mappings with truncated VLQ segments without crashing [302.63ms]
(pass) error.stack of // @bun code with a truncated VLQ in sourceMappingURL warns and degrades gracefully [394.96ms]
291 |     stdout: "pipe",
292 |     stderr: "pipe",
293
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/module/sourcemap.test.js:
(pass) SourceMap class exists [0.04ms]
(pass) SourceMap constructor requires payload [0.12ms]
(pass) SourceMap payload must be an object [0.04ms]
(pass) SourceMap instance has expected methods [0.06ms]
(pass) SourceMap payload getter [0.02ms]
(pass) SourceMap lineLengths getter [0.02ms]
(pass) SourceMap lineLengths undefined when not provided [0.02ms]
(pass) SourceMap findEntry returns mapping data [0.06ms]
(pass) SourceMap findOrigin returns origin data [0.04ms]
(pass) SourceMap with names returns name property correctly [0.06ms]
(pass) SourceMap without names has undefined name property [0.02ms]
(pass) SourceMap with invalid name index has undefined name property [0.02ms]
(pass) SourceMap handles mappings with truncated VLQ segments without crashing [14.71ms]
(pass) error.stack of // @bun code with a truncated VLQ in sourceMappingURL warns and degrades gracefully [17.47ms]
291 |     stdout: "pipe",
292 |     stderr: "pipe",
293 |   });
294 | 
295 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
296 |   expect(stderr).not.toCo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/sourcemap.test.js
bun test v1.4.0 (2d4a731f2)

test/js/node/module/sourcemap.test.js:
(pass) SourceMap class exists [7.84ms]
(pass) SourceMap constructor requires payload [4.62ms]
(pass) SourceMap payload must be an object [2.95ms]
(pass) SourceMap instance has expected methods [3.36ms]
(pass) SourceMap payload getter [1.64ms]
(pass) SourceMap lineLengths getter [2.13ms]
(pass) SourceMap lineLengths undefined when not provided [1.82ms]
(pass) SourceMap findEntry returns mapping data [2.95ms]
(pass) SourceMap findOrigin returns origin data [2.58ms]
(pass) SourceMap with names returns name property correctly [3.96ms]
(pass) SourceMap without names has undefined name property [2.47ms]
(pass) SourceMap with invalid name index has undefined name property [3.29ms]
(pass) SourceMap handles mappings with truncated VLQ segments without crashing [300.81ms]
(pass) error.stack of // @bun code with a truncated VLQ in sourceMappingURL warns and degrades gracefully [309.47ms]
(pass) error.stack of // @bun code remaps with sourcesC
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 676ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sourcemap/lib.rs                  | 33 +++++++++++------------
 test/js/node/module/sourcemap.test.js | 51 +++++++++++++++++++++++++++++++++++
 2 files changed, 67 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/sourcemap/lib.rs                       3      3      0
test/js/node/module/sourcemap.test.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->