### PR TITLE
sourcemap: reject negative VLQ fields before the Ordinal debug_assert

### DIFF
--- a/src/jsc/bindings/highway_sourcemap.cpp
+++ b/src/jsc/bindings/highway_sourcemap.cpp
@@ -265,7 +265,7 @@ static constexpr ShufTable BuildShufTable()
 alignas(16) static constexpr ShufTable kShufTable = BuildShufTable();
 
 // Wrapping i32 add/sub. Signed overflow is UB in C++; the Rust scalar path
-// (`Ordinal::add_scalar`, release build) wraps, and the subsequent `< 0`
+// (`i32::wrapping_add` in Mapping.rs) wraps, and the subsequent `< 0`
 // range check catches the wrapped result. Doing the arithmetic in the
 // unsigned domain gives the same defined-wrap behaviour here. With the
 // accumulator in [0, i32::MAX] (range-checked on the previous segment) and

--- a/src/sourcemap/Mapping.rs
+++ b/src/sourcemap/Mapping.rs
@@ -602,7 +602,7 @@ pub fn parse(
                 ..Default::default()
             });
         }
-        source_index += source_index_delta.value;
+        source_index = source_index.wrapping_add(source_index_delta.value);
 
         if source_index < 0 || source_index >= sources_count {
             return ParseResult::Fail(ParseResultFail {
@@ -698,7 +698,7 @@ pub fn parse(
                     remain = &remain[name_index_delta.start..];
 
                     if options.allow_names {
-                        name_index += name_index_delta.value;
+                        name_index = name_index.wrapping_add(name_index_delta.value);
                         if !has_names {
                             if mapping.ensure_with_names().is_err() {
                                 return ParseResult::Fail(ParseResultFail {

--- a/src/sourcemap/Mapping.rs
+++ b/src/sourcemap/Mapping.rs
@@ -554,8 +554,10 @@ pub fn parse(
 
         needs_sort = needs_sort || generated_column_delta.value < 0;
 
-        let generated_column =
-            generated.columns.zero_based().wrapping_add(generated_column_delta.value);
+        let generated_column = generated
+            .columns
+            .zero_based()
+            .wrapping_add(generated_column_delta.value);
         if generated_column < 0 {
             return ParseResult::Fail(ParseResultFail {
                 msg: b"Invalid generated column value",
@@ -626,7 +628,10 @@ pub fn parse(
             });
         }
 
-        let original_line = original.lines.zero_based().wrapping_add(original_line_delta.value);
+        let original_line = original
+            .lines
+            .zero_based()
+            .wrapping_add(original_line_delta.value);
         if original_line < 0 {
             return ParseResult::Fail(ParseResultFail {
                 msg: b"Invalid original line value",
@@ -651,8 +656,10 @@ pub fn parse(
             });
         }
 
-        let original_column =
-            original.columns.zero_based().wrapping_add(original_column_delta.value);
+        let original_column = original
+            .columns
+            .zero_based()
+            .wrapping_add(original_column_delta.value);
         if original_column < 0 {
             return ParseResult::Fail(ParseResultFail {
                 msg: b"Invalid original column value",

--- a/src/sourcemap/Mapping.rs
+++ b/src/sourcemap/Mapping.rs
@@ -554,8 +554,9 @@ pub fn parse(
 
         needs_sort = needs_sort || generated_column_delta.value < 0;
 
-        generated.columns = generated.columns.add_scalar(generated_column_delta.value);
-        if generated.columns.zero_based() < 0 {
+        let generated_column =
+            generated.columns.zero_based().wrapping_add(generated_column_delta.value);
+        if generated_column < 0 {
             return ParseResult::Fail(ParseResultFail {
                 msg: b"Invalid generated column value",
                 err: crate::Error::InvalidGeneratedColumnValue,
@@ -564,6 +565,7 @@ pub fn parse(
                 },
             });
         }
+        generated.columns = Ordinal::from_zero_based(generated_column);
 
         remain = &remain[generated_column_delta.start..];
 
@@ -624,8 +626,8 @@ pub fn parse(
             });
         }
 
-        original.lines = original.lines.add_scalar(original_line_delta.value);
-        if original.lines.zero_based() < 0 {
+        let original_line = original.lines.zero_based().wrapping_add(original_line_delta.value);
+        if original_line < 0 {
             return ParseResult::Fail(ParseResultFail {
                 msg: b"Invalid original line value",
                 err: crate::Error::InvalidOriginalLineValue,
@@ -634,6 +636,7 @@ pub fn parse(
                 },
             });
         }
+        original.lines = Ordinal::from_zero_based(original_line);
         remain = &remain[original_line_delta.start..];
 
         // Read the original column
@@ -648,8 +651,9 @@ pub fn parse(
             });
         }
 
-        original.columns = original.columns.add_scalar(original_column_delta.value);
-        if original.columns.zero_based() < 0 {
+        let original_column =
+            original.columns.zero_based().wrapping_add(original_column_delta.value);
+        if original_column < 0 {
             return ParseResult::Fail(ParseResultFail {
                 msg: b"Invalid original column value",
                 err: crate::Error::InvalidOriginalColumnValue,
@@ -658,6 +662,7 @@ pub fn parse(
                 },
             });
         }
+        original.columns = Ordinal::from_zero_based(original_column);
         remain = &remain[original_column_delta.start..];
 
         if remain.len() > 0 {

--- a/src/sourcemap_jsc/JSSourceMap.rs
+++ b/src/sourcemap_jsc/JSSourceMap.rs
@@ -267,6 +267,9 @@ impl JSSourceMap {
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
         let [line_number, column_number] = get_line_column(global, frame)?;
+        if line_number < 0 || column_number < 0 {
+            return Ok(JSValue::create_empty_object(global, 0));
+        }
 
         let Some(mapping) = this.sourcemap.find_mapping(
             Ordinal::from_zero_based(line_number),
@@ -296,6 +299,9 @@ impl JSSourceMap {
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
         let [line_number, column_number] = get_line_column(global, frame)?;
+        if line_number < 0 || column_number < 0 {
+            return Ok(JSValue::create_empty_object(global, 0));
+        }
 
         let Some(mapping) = this.sourcemap.find_mapping(
             Ordinal::from_zero_based(line_number),

--- a/test/js/bun/sourcemap/negative-vlq-mapping.test.ts
+++ b/test/js/bun/sourcemap/negative-vlq-mapping.test.ts
@@ -93,4 +93,79 @@ describe.concurrent("sourcemap: negative VLQ delta in mappings is rejected, not 
     });
     expect(exitCode).toBe(0);
   });
+
+  // "+/////D" is VLQ for i32::MAX. With overflow-checks on (dev profile), an
+  // unchecked `+=` on the running source/name index would panic before the
+  // range check can reject it.
+  test("new module.SourceMap({mappings}) with i32::MAX source-index delta throws", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { SourceMap } = require("node:module");
+         try {
+           new SourceMap({ version: 3, sources: ["a","b"], names: [], mappings: "ACAA,A+/////DAA" });
+           console.log("no-throw");
+         } catch (e) {
+           console.log("threw:" + String(e.message));
+         }`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, stdout: stdout.trim() }).toEqual({
+      stderr: "",
+      stdout: expect.stringMatching(/^threw:.*source index/i),
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("new module.SourceMap({mappings}) with i32::MAX name-index delta is accepted", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { SourceMap } = require("node:module");
+         new SourceMap({ version: 3, sources: ["a"], names: ["n","m"], mappings: "AAAAC,AAAA+/////D" });
+         console.log("ok");`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, stdout: stdout.trim() }).toEqual({ stderr: "", stdout: "ok" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("SourceMap findEntry/findOrigin with negative line/column return empty objects", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { SourceMap } = require("node:module");
+         const sm = new SourceMap({ version: 3, sources: ["a"], names: [], mappings: "AAAA" });
+         console.log(JSON.stringify({
+           entryNegLine: sm.findEntry(-1, 0),
+           entryNegCol: sm.findEntry(0, -1),
+           originNegLine: sm.findOrigin(-1, 0),
+           originNegCol: sm.findOrigin(0, -1),
+         }));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      entryNegLine: {},
+      entryNegCol: {},
+      originNegLine: {},
+      originNegCol: {},
+    });
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/sourcemap/negative-vlq-mapping.test.ts
+++ b/test/js/bun/sourcemap/negative-vlq-mapping.test.ts
@@ -43,11 +43,7 @@ describe.concurrent("sourcemap: negative VLQ delta in mappings is rejected, not 
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toContain(errName);
       expect(stdout).toContain("at t (");
       expect(stdout).toContain(join(String(dir), "entry.js"));
@@ -66,11 +62,7 @@ describe.concurrent("sourcemap: negative VLQ delta in mappings is rejected, not 
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toContain(errName);
       expect(stdout).toContain("at t (");
       expect(exitCode).toBe(0);
@@ -94,11 +86,7 @@ describe.concurrent("sourcemap: negative VLQ delta in mappings is rejected, not 
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stderr, stdout: stdout.trim() }).toEqual({
       stderr: "",
       stdout: expect.stringMatching(/^threw:.*generated column/i),

--- a/test/js/bun/sourcemap/negative-vlq-mapping.test.ts
+++ b/test/js/bun/sourcemap/negative-vlq-mapping.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+// A `// @bun`-pragma'd file is not re-transpiled, so the sidecar / inline
+// source map is parsed as-is when error.stack is formatted. A negative
+// relative VLQ delta that takes a running field below zero must be rejected
+// as an invalid map (warn + fall back to unmapped positions), not trip the
+// `Ordinal::from_zero_based` debug_assert in assertions-enabled builds.
+
+const body =
+  `// @bun\n` +
+  `function t() {\n` +
+  `  throw new Error("NEGVLQ");\n` +
+  `}\n` +
+  `try { t(); } catch (e) { console.log(String(e.stack).split("\\n")[1].trim()); }\n`;
+
+function makeMap(mappings: string) {
+  return JSON.stringify({
+    version: 3,
+    sources: ["orig.ts"],
+    sourcesContent: ["a\nb\nc\n"],
+    names: [],
+    mappings,
+  });
+}
+
+describe.concurrent("sourcemap: negative VLQ delta in mappings is rejected, not asserted", () => {
+  for (const [field, mappings, errName] of [
+    ["generated column", ";;D;", "InvalidGeneratedColumnValue"],
+    ["original line", ";;AADA;", "InvalidOriginalLineValue"],
+    ["original column", ";;AAAD;", "InvalidOriginalColumnValue"],
+  ] as const) {
+    test(`external .map: negative ${field}`, async () => {
+      using dir = tempDir("negvlq-ext", {
+        "entry.js": body + `//# sourceMappingURL=entry.js.map\n`,
+        "entry.js.map": makeMap(mappings),
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).toContain(errName);
+      expect(stdout).toContain("at t (");
+      expect(stdout).toContain(join(String(dir), "entry.js"));
+      expect(exitCode).toBe(0);
+    });
+
+    test(`inline data-URL map: negative ${field}`, async () => {
+      const b64 = Buffer.from(makeMap(mappings)).toString("base64");
+      using dir = tempDir("negvlq-inl", {
+        "entry.js": body + `//# sourceMappingURL=data:application/json;base64,${b64}\n`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).toContain(errName);
+      expect(stdout).toContain("at t (");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test("new module.SourceMap({mappings}) with negative generated column throws", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { SourceMap } = require("node:module");
+         try {
+           new SourceMap({ version: 3, sources: ["a"], names: [], mappings: "D" });
+           console.log("no-throw");
+         } catch (e) {
+           console.log("threw:" + String(e.message));
+         }`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect({ stderr, stdout: stdout.trim() }).toEqual({
+      stderr: "",
+      stdout: expect.stringMatching(/^threw:.*generated column/i),
+    });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

A `// @bun`-pragma'd file whose sidecar or inline source map contains a negative relative VLQ delta (e.g. `mappings: ";;D;"`, 4 bytes) aborts an assertions-enabled build (debug, release-asan, canary-assert CI) the first time `error.stack` is formatted:

```
panic: assertion failed: int >= 0
```

Release builds already handle this gracefully (`warn: Could not decode sourcemap ...: InvalidGeneratedColumnValue`, unmapped positions, exit 0). The same ordering bug also aborts `new require("node:module").SourceMap({ mappings: "D" })` on assert builds.

## Why

`bun_sourcemap::mapping::parse` accumulated the decoded delta via `Ordinal::add_scalar`, which routes through `Ordinal::from_zero_based` and its `debug_assert!(int >= 0)`, **before** checking the result against zero. In release the assert is compiled out, the wrap happens, and the `< 0` check rejects it; in assert builds the assert fires first.

## Fix

Compute the new value as a raw `i32` with `wrapping_add` (matching release semantics and the Highway kernel's `WrapAdd`), check `< 0`, and only then construct the `Ordinal`. Applied to all three range-checked `Ordinal` fields (generated column, original line, original column). The SIMD hand-off at the top of `parse` is unaffected: the C++ kernel restores its saved state before bailing on an anomaly, so those values are already non-negative.

Sibling paths to the same assert-build abort class, closed in the same change:

- `source_index` / `name_index` in the same parse loop used unchecked `+=`, which panics on overflow in the dev profile before the range check runs; both now use `wrapping_add` like the Highway kernel.
- `SourceMap#findEntry` / `#findOrigin` fed the raw `coerce_to_i32` result into `Ordinal::from_zero_based` with no guard; a negative argument now returns `{}` (matching Node.js and release behavior).
- Updated the `WrapAdd` rationale comment in `highway_sourcemap.cpp` to reference `i32::wrapping_add` now that the scalar path no longer goes through `Ordinal::add_scalar`.

## Verification

```
$ bun bd test test/js/bun/sourcemap/negative-vlq-mapping.test.ts
 10 pass  0 fail
```

Without the `src/` change all 10 cases abort on `int >= 0` / `attempt to add with overflow`. Existing `test/js/bun/sourcemap/` and `test/js/node/module/sourcemap*` suites pass unchanged (79 pass, 0 fail).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/sourcemap/negative-vlq-mapping.test.ts
bun test v1.4.0 (ff299d657)

test/js/bun/sourcemap/negative-vlq-mapping.test.ts:
(fail) sourcemap: negative VLQ delta in mappings is rejected, not asserted > external .map: negative generated column [5005.52ms]
  ^ this test timed out after 5000ms.
(fail) sourcemap: negative VLQ delta in mappings is rejected, not asserted > inline data-URL map: negative generated column [5004.86ms]
  ^ this test timed out after 5000ms.
(fail) sourcemap: negative VLQ delta in mappings is rejected, not asserted > external .map: negative original line [5002.79ms]
  ^ this test timed out after 5000ms.
(fail) sourcemap: negative VLQ delta in mappings is rejected, not asserted > inline data-URL map: negative original line [5014.12ms]
  ^ this test timed out after 5000ms.
(fail) sourcemap: negative VLQ delta in mappings is rejected, not asserted > external .map: negative original column [5009.91ms]
  ^ this test timed out after 5000ms.

# Unhandled error between tests
-------------------------------
42 |     
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (f57d6bca3)

test/js/bun/sourcemap/negative-vlq-mapping.test.ts:
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > external .map: negative generated column [19.76ms]
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > external .map: negative original line [15.55ms]
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > inline data-URL map: negative original line [14.78ms]
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > external .map: negative original column [14.39ms]
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > inline data-URL map: negative generated column [17.74ms]
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > new module.SourceMap({mappings}) with i32::MAX name-index delta is accepted [11.76ms]
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > SourceMap findEntry/findOrigin with negative line/column return empty objects [9.56ms]
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > inline data-URL map: negative original column
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/sourcemap/negative-vlq-mapping.test.ts
bun test v1.4.0 (ff299d657)

test/js/bun/sourcemap/negative-vlq-mapping.test.ts:
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > external .map: negative generated column [325.57ms]
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > external .map: negative original line [274.83ms]
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > inline data-URL map: negative original line [285.65ms]
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > inline data-URL map: negative generated column [345.71ms]
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > external .map: negative original column [328.00ms]
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > inline data-URL map: negative original column [278.45ms]
(pass) sourcemap: negative VLQ delta in mappings is rejected, not asserted > new module.SourceMap({mappings}) with negative generated c
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 692ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/highway_sourcemap.cpp             |   2 +-
 src/sourcemap/Mapping.rs                           |  28 +++-
 src/sourcemap_jsc/JSSourceMap.rs                   |   6 +
 test/js/bun/sourcemap/negative-vlq-mapping.test.ts | 171 +++++++++++++++++++++
 4 files changed, 198 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/highway_sourcemap.cpp                  1      1      0
src/sourcemap/Mapping.rs                                4      4      0
src/sourcemap_jsc/JSSourceMap.rs                        2      1      0
test/js/bun/sourcemap/negative-vlq-mapping.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->