### PR TITLE
process.chdir: publish an immutable cwd slice so no thread sees a torn cwd

### DIFF
--- a/src/bundler/HTMLImportManifest.rs
+++ b/src/bundler/HTMLImportManifest.rs
@@ -188,7 +188,7 @@ pub(crate) fn write<W: Write + ?Sized>(
         &options.root_dir[..]
     } else {
         // SAFETY: FileSystem singleton is initialized before bundling.
-        FileSystem::get().top_level_dir
+        FileSystem::get().top_level_dir()
     };
 
     writer.write_all(b"{")?;

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -73,7 +73,7 @@ impl<'a> HTMLScanner<'a> {
         // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
         let path_to_use: &[u8] = if input_path.len() > 1 && input_path[0] == b'/' {
             resolve_path::join_abs_string::<platform::Auto>(
-                fs::FileSystem::instance().top_level_dir,
+                fs::FileSystem::instance().top_level_dir(),
                 &[&input_path[1..]],
             )
         }

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -404,7 +404,7 @@ impl<'a> LinkerContext<'a> {
         path: &bun_paths::fs::Path<'static>,
         arena: &Bump,
     ) -> Result<bun_paths::fs::Path<'static>, BunError> {
-        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
+        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir();
         generic_path_with_pretty_initialized(path, self.options.target, top_level_dir, arena)
     }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1012,7 +1012,7 @@ pub mod bv2_impl {
                             {
                                 b"/"
                             } else {
-                                bun_resolver::fs::FileSystem::instance().top_level_dir
+                                bun_resolver::fs::FileSystem::instance().top_level_dir()
                             }
                         } else {
                             source_dir
@@ -2588,7 +2588,8 @@ pub mod bv2_impl {
                     bun_paths::resolve_path::platform::Loose,
                     false,
                 >(
-                    bun_resolver::fs::FileSystem::get().top_level_dir, path.text
+                    bun_resolver::fs::FileSystem::get().top_level_dir(),
+                    path.text,
                 );
                 // SAFETY: arena outlives the bundle pass; raw-pointer detour erases the
                 // `&self` lifetime so the resulting `&'static [u8]` doesn't pin `self`.
@@ -5917,7 +5918,7 @@ pub mod bv2_impl {
             let out = generic_path_with_pretty_initialized(
                 path,
                 target,
-                self.transpiler.fs().top_level_dir,
+                self.transpiler.fs().top_level_dir(),
                 bump,
             )?;
             Ok(out)
@@ -6522,12 +6523,12 @@ pub mod bv2_impl {
                                     } else {
                                         #[cfg(windows)]
                                         let mut buf = bun_paths::path_buffer_pool::get();
+                                        let top_level_dir = Fs::FileSystem::get().top_level_dir();
                                         let specifier_to_use: &[u8] = if loader == Loader::Html
-                                            && import_record.path.text.starts_with(
-                                                Fs::FileSystem::instance().top_level_dir,
-                                            ) {
-                                            let specifier_to_use = &import_record.path.text
-                                                [Fs::FileSystem::instance().top_level_dir.len()..];
+                                            && import_record.path.text.starts_with(top_level_dir)
+                                        {
+                                            let specifier_to_use =
+                                                &import_record.path.text[top_level_dir.len()..];
                                             #[cfg(windows)]
                                             {
                                                 &*bun_paths::resolve_path::path_to_posix_buf::<u8>(
@@ -6634,7 +6635,7 @@ pub mod bv2_impl {
                                 bun_paths::resolve_path::platform::Loose,
                                 false,
                             >(
-                                self.transpiler.fs().top_level_dir, path.text
+                                self.transpiler.fs().top_level_dir(), path.text
                             );
                             if loader == Loader::Html && entry.kind == bake_types::CacheKind::Asset
                             {

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -644,7 +644,7 @@ impl Linker {
                         }
                     }
 
-                    let top_level_dir = self.fs().top_level_dir;
+                    let top_level_dir = self.fs().top_level_dir();
                     let mut base: &[u8] =
                         bun_paths::resolve_path::relative(top_level_dir, source_path);
                     if let Some(dot) = strings::last_index_of_char(base, b'.') {
@@ -676,12 +676,12 @@ impl Linker {
 
     pub(crate) fn resolve_result_hash_key(&self, resolve_result: &resolver::Result) -> u64 {
         let path = resolve_result.path_const().expect("unreachable");
-        let fs = self.fs();
+        let top_level_dir = self.fs().top_level_dir();
         let mut hash_key = path.text;
 
         // Shorter hash key is faster to hash
-        if strings::starts_with(path.text, fs.top_level_dir) {
-            hash_key = &path.text[fs.top_level_dir.len()..];
+        if strings::starts_with(path.text, top_level_dir) {
+            hash_key = &path.text[top_level_dir.len()..];
         }
 
         bun_wyhash::hash(hash_key)

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -189,7 +189,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                 source_ref.path.text.as_ptr(),
                 source_ref.path.pretty.as_ptr(),
             ) {
-                let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
+                let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir();
                 let new_path = bun_core::handle_oom(generic_path_with_pretty_initialized(
                     &source_ref.path,
                     c.options.target,

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1867,9 +1867,10 @@ impl<'a> BundleOptions<'a> {
 
         // Reborrow the raw `*mut Log`
         // for the duration of this call only.
+        let top_level_dir = fs.top_level_dir();
         opts.external = init_external_modules(
             &mut fs.fs,
-            fs.top_level_dir,
+            top_level_dir,
             &transform
                 .external
                 .iter()

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -420,7 +420,7 @@ impl<'a> Transpiler<'a> {
     }
 
     fn _resolve_entry_point(&mut self, entry_point: &[u8]) -> crate::Result<resolver::Result> {
-        let top_level_dir = self.fs().top_level_dir;
+        let top_level_dir = self.fs().top_level_dir();
         match self.resolver.resolve_with_framework(
             top_level_dir,
             entry_point,
@@ -468,7 +468,7 @@ impl<'a> Transpiler<'a> {
                 // so compute `busted` directly instead.
                 let busted: bool = 'name: {
                     // Neither buster name below would fit `cache_bust_buf`.
-                    if self.fs().top_level_dir.len() + entry_point.len() + 4
+                    if self.fs().top_level_dir().len() + entry_point.len() + 4
                         > bun_paths::MAX_PATH_BYTES
                     {
                         break 'name false;
@@ -494,7 +494,7 @@ impl<'a> Transpiler<'a> {
 
                     // `".."` needs no platform separator rewrite.
                     let parts: [&[u8]; 2] = [entry_point, b".."];
-                    let top_level_dir = self.fs().top_level_dir;
+                    let top_level_dir = self.fs().top_level_dir();
 
                     let buster_name = bun_paths::resolve_path::join_abs_string_buf_z::<
                         bun_paths::platform::Auto,
@@ -717,7 +717,7 @@ impl<'a> Transpiler<'a> {
 
         if auto_jsx {
             // Most of the time, this will already be cached
-            let top_level_dir = self.fs().top_level_dir;
+            let top_level_dir = self.fs().top_level_dir();
             if let Ok(Some(root_dir)) = self.resolver.read_dir_info(top_level_dir) {
                 if let Some(tsconfig) = root_dir.tsconfig_json() {
                     // If we don't explicitly pass JSX, try to get it from the root tsconfig
@@ -774,7 +774,7 @@ impl<'a> Transpiler<'a> {
                 // (or a parent) is unreadable, readDirInfo may return null;
                 // bail out of .env file loading in that case, but process
                 // env vars were already loaded above.
-                let top_level_dir = self.fs().top_level_dir;
+                let top_level_dir = self.fs().top_level_dir();
                 let dir_info = match self.resolver.read_dir_info(top_level_dir) {
                     Ok(Some(d)) => d,
                     _ => return Ok(()),
@@ -2663,7 +2663,7 @@ impl<'a> Transpiler<'a> {
         // snapshot entry points so the `&mut self` resolver call
         // does not conflict with the `&self.options` borrow.
         let entries: Vec<Box<[u8]>> = self.options.entry_points.to_vec();
-        let top_level_dir = self.fs().top_level_dir;
+        let top_level_dir = self.fs().top_level_dir();
 
         for _entry in entries.iter() {
             let entry: &[u8] = if NORMALIZE_ENTRY_POINT {
@@ -2898,7 +2898,7 @@ impl<'a> Transpiler<'a> {
 
         let mut file_path = Fs::Path::init(file_path_text);
 
-        let top_level_dir = self.fs().top_level_dir;
+        let top_level_dir = self.fs().top_level_dir();
         let rel = bun_paths::resolve_path::relative(top_level_dir, file_path_text);
         file_path.pretty = crate::linker::dupe(rel);
 

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1726,7 +1726,7 @@ impl<'a> Printer<'a> {
 
         // Capture the `'static` cwd slice
         // before borrowing `fs.fs` mutably.
-        let top_level_dir = fs.top_level_dir;
+        let top_level_dir = fs.top_level_dir();
         // Erase to raw so the `entries_mutex` reborrow below doesn't conflict
         // with the `&mut self` borrow `read_directory` took.
         let entries_option: *const Fs::EntriesOption =

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -632,7 +632,7 @@ impl RuntimeTranspilerCache {
         // `abs_buf` (no NUL-terminating `_z` variant), so go straight to the
         // underlying joiner with the same `top_level_dir` + `Loose` platform
         // that `absBufZ` used.
-        let top = FileSystem::instance().top_level_dir;
+        let top = FileSystem::instance().top_level_dir();
 
         if let Some(dir) = env_var::XDG_CACHE_HOME.get() {
             let parts: &[&[u8]] = &[dir, b"bun", b"@t@"];

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1103,11 +1103,11 @@ impl VirtualMachine {
     }
 
     /// Safe accessor for the process-lifetime cwd string
-    /// (`vm.transpiler.fs.top_level_dir`). The `FileSystem` singleton is
+    /// (`vm.transpiler.fs.top_level_dir()`). The `FileSystem` singleton is
     /// allocated once during VM init and never freed.
     #[inline]
     pub fn top_level_dir(&self) -> &'static [u8] {
-        self.fs().top_level_dir
+        self.fs().top_level_dir()
     }
 
     /// Safe `&mut Debugger` accessor — the [`JsCell`] escape hatch applied to
@@ -5037,34 +5037,38 @@ impl VirtualMachine {
     }
 
     pub fn set_process_cwd(&mut self, to: &bun_core::ZStr) -> bun_sys::Result<()> {
-        let fs = self.transpiler.fs_mut();
+        let fs = self.fs();
         bun_sys::chdir(to)?;
         let mut buf = bun_paths::PathBuffer::uninit();
-        let into_cwd_len = match bun_sys::getcwd(&mut buf[..]) {
+        let mut len = match bun_sys::getcwd(&mut buf[..]) {
             bun_sys::Result::Ok(r) => r,
             bun_sys::Result::Err(err) => {
                 let mut rollback = bun_paths::PathBuffer::uninit();
-                let _ = bun_sys::chdir(bun_paths::resolve_path::z(fs.top_level_dir, &mut rollback));
+                let _ = bun_sys::chdir(bun_paths::resolve_path::z(
+                    fs.top_level_dir(),
+                    &mut rollback,
+                ));
                 return bun_sys::Result::Err(err);
             }
         };
-        fs.top_level_dir_buf[..into_cwd_len].copy_from_slice(&buf[..into_cwd_len]);
-        fs.top_level_dir_buf[into_cwd_len] = 0;
-        // SAFETY: `top_level_dir_buf` is a process-lifetime field of the
-        // FileSystem singleton, so the detached borrow never outlives its
-        // backing storage.
-        fs.top_level_dir =
-            unsafe { bun_ptr::detach_lifetime(&fs.top_level_dir_buf[..into_cwd_len]) };
-        let len = fs.top_level_dir.len();
-        if fs.top_level_dir_buf[len - 1] != bun_paths::SEP {
-            fs.top_level_dir_buf[len] = bun_paths::SEP;
-            fs.top_level_dir_buf[len + 1] = 0;
-            // SAFETY: see above.
-            fs.top_level_dir =
-                unsafe { bun_ptr::detach_lifetime(&fs.top_level_dir_buf[..len + 1]) };
+        if len > 0 && buf[len - 1] != bun_paths::SEP && len < buf.len() {
+            buf[len] = bun_paths::SEP;
+            len += 1;
         }
-        bun_core::set_top_level_dir(fs.top_level_dir);
+        fs.set_top_level_dir(Self::intern_cwd(fs, &buf[..len]));
         Ok(())
+    }
+
+    /// Deduplicated `DirnameStore` intern so `top_level_dir` is immutable and bounded.
+    fn intern_cwd(fs: &bun_resolver::fs::FileSystem, cwd: &[u8]) -> &'static [u8] {
+        static CACHE: bun_core::Mutex<Vec<&'static [u8]>> = bun_core::Mutex::new(Vec::new());
+        let mut cache = CACHE.lock();
+        if let Some(&s) = cache.iter().find(|&&s| s == cwd) {
+            return s;
+        }
+        let s = bun_core::handle_oom(fs.dirname_store().append(cwd));
+        cache.push(s);
+        s
     }
 
     /// Replaces the global object between test files so each file runs in a fresh realm.
@@ -6661,7 +6665,7 @@ impl VirtualMachine {
         let frames = exception.stack.frames();
         let top_frame = frames.first();
         let dir = bun_core::env_var::GITHUB_WORKSPACE::get()
-            .unwrap_or_else(|| bun_bundler::bun_fs::FileSystem::instance().top_level_dir);
+            .unwrap_or_else(|| bun_bundler::bun_fs::FileSystem::instance().top_level_dir());
         bun_core::Output::flush();
 
         let writer = bun_core::Output::error_writer();

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -861,6 +861,7 @@ where
             unsafe { (*ctx).flush_evictions() };
         });
         let fs: &mut FileSystem = FileSystem::instance();
+        let top_level_dir = fs.top_level_dir();
         let rfs: &mut Fs::file_system::RealFS = &mut fs.fs;
         #[cfg(windows)]
         let _ = (changed_files, parents, file_descriptors, rfs);
@@ -904,11 +905,8 @@ where
                     if self.verbose {
                         Self::debug(format_args!(
                             "File changed: {}",
-                            // Note: `fs.relative_to(file_path)` would borrow `&*fs`
-                            // while `rfs = &mut fs.fs` is live; inline the body so the
-                            // split-borrow on `fs.top_level_dir` is visible to borrowck.
                             bstr::BStr::new(bun_paths::resolve_path::relative(
-                                fs.top_level_dir,
+                                top_level_dir,
                                 file_path
                             ))
                         ));
@@ -1257,7 +1255,7 @@ where
                                         Self::debug(format_args!(
                                             "File change: {}",
                                             bstr::BStr::new(bun_paths::resolve_path::relative(
-                                                fs.top_level_dir,
+                                                top_level_dir,
                                                 abs_path,
                                             ))
                                         ));
@@ -1270,7 +1268,7 @@ where
                             Self::debug(format_args!(
                                 "Dir change: {} (affecting {})",
                                 bstr::BStr::new(bun_paths::resolve_path::relative(
-                                    fs.top_level_dir,
+                                    top_level_dir,
                                     file_path
                                 )),
                                 affected_len
@@ -1357,7 +1355,7 @@ impl<'a> HotReloaderCtx for bun_bundler::BundleV2<'a> {
     }
 
     fn watcher_top_level_dir(&self) -> &'static [u8] {
-        FileSystem::get().top_level_dir
+        FileSystem::get().top_level_dir()
     }
 
     fn install_bun_watcher(

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -170,16 +170,8 @@ pub mod fs {
 
     // ── FileSystem ───────────────────────────────────────────────────────
 
-    /// Process-global filesystem facade for the resolver: holds the cached
-    /// top-level dir, the real-FS backend, and the dirname/filename interning
-    /// stores.
+    /// Process-global resolver filesystem facade. cwd: [`FileSystem::top_level_dir`].
     pub struct FileSystem {
-        pub top_level_dir: &'static [u8],
-
-        // used on subsequent updates (process.chdir writes here and re-slices
-        // `top_level_dir` to point into it).
-        pub top_level_dir_buf: bun_paths::PathBuffer,
-
         pub fs: Implementation,
         pub dirname_store: &'static DirnameStore,
         pub filename_store: &'static FilenameStore,
@@ -301,11 +293,10 @@ pub mod fs {
             // `Err`). `cwd` is passed as raw bytes — POSIX paths are not
             // guaranteed UTF-8, and the lower tier stores/serves bytes.
             bun_paths::fs::FileSystem::init(cwd);
+            bun_core::set_top_level_dir(cwd);
             // SAFETY: see above.
             unsafe {
                 (*INSTANCE.get()).write(FileSystem {
-                    top_level_dir: cwd,
-                    top_level_dir_buf: bun_paths::PathBuffer::uninit(),
                     fs: Implementation::init(cwd),
                     dirname_store: DirnameStore::instance(),
                     filename_store: FilenameStore::instance(),
@@ -347,13 +338,13 @@ pub mod fs {
         /// absolute path slice.
         pub fn abs_buf<'b>(&self, parts: &[&[u8]], buf: &'b mut [u8]) -> &'b [u8] {
             use bun_paths::resolve_path::{join_abs_string_buf, platform};
-            join_abs_string_buf::<platform::Loose>(self.top_level_dir, buf, parts)
+            join_abs_string_buf::<platform::Loose>(self.top_level_dir(), buf, parts)
         }
 
         /// Returns `None` on overflow.
         pub fn abs_buf_checked<'b>(&self, parts: &[&[u8]], buf: &'b mut [u8]) -> Option<&'b [u8]> {
             use bun_paths::resolve_path::{join_abs_string_buf_checked, platform};
-            join_abs_string_buf_checked::<platform::Loose>(self.top_level_dir, buf, parts)
+            join_abs_string_buf_checked::<platform::Loose>(self.top_level_dir(), buf, parts)
         }
 
         /// Normalizes `str` (separators, `.`/`..` segments) into `buf`.
@@ -366,7 +357,7 @@ pub mod fs {
         /// into the resolver-shared threadlocal join buffer.
         pub fn abs(&self, parts: &[&[u8]]) -> &[u8] {
             use bun_paths::resolve_path::{join_abs_string, platform};
-            join_abs_string::<platform::Loose>(self.top_level_dir, parts)
+            join_abs_string::<platform::Loose>(self.top_level_dir(), parts)
         }
 
         /// Like `abs`, but interns the joined path into `DirnameStore` and
@@ -376,7 +367,7 @@ pub mod fs {
             parts: &[&[u8]],
         ) -> core::result::Result<&'static [u8], bun_alloc::AllocError> {
             use bun_paths::resolve_path::{join_abs_string, platform};
-            let joined = join_abs_string::<platform::Loose>(self.top_level_dir, parts);
+            let joined = join_abs_string::<platform::Loose>(self.top_level_dir(), parts);
             // Route through DirnameStore so
             // the resolver's `&'static [u8]` storage contract holds.
             DirnameStore::instance()
@@ -395,30 +386,25 @@ pub mod fs {
         /// `top_level_dir` to `to`. Returns a slice into the resolver-shared
         /// threadlocal relative buffer; caller must dup before the next call.
         pub fn relative_to(&self, to: &[u8]) -> &'static [u8] {
-            bun_paths::resolve_path::relative(self.top_level_dir, to)
+            bun_paths::resolve_path::relative(self.top_level_dir(), to)
         }
 
-        /// Cached cwd captured at `FileSystem::init`.
+        /// Process cwd, via the `bun_core` RwLock (tear-safe under `process.chdir`).
         #[inline]
         pub fn top_level_dir(&self) -> &'static [u8] {
-            self.top_level_dir
+            bun_core::top_level_dir()
         }
 
-        /// `dir` must be
-        /// `'static` (interned in `DirnameStore` or a process-lifetime buffer
-        /// like `cwd_buf`). Takes `&mut self` — callers hold `&'static mut
-        /// FileSystem` from `instance()`; only called during single-threaded
-        /// CLI init.
+        /// `dir` must borrow immutable process-lifetime storage (e.g. `DirnameStore`).
         #[inline]
-        pub fn set_top_level_dir(&mut self, dir: &'static [u8]) {
-            self.top_level_dir = dir;
+        pub fn set_top_level_dir(&self, dir: &'static [u8]) {
             bun_core::set_top_level_dir(dir);
         }
 
         /// `top_level_dir` with any trailing separator stripped (root `/` is
         /// left intact).
         pub fn top_level_dir_without_trailing_slash(&self) -> &'static [u8] {
-            let d = self.top_level_dir;
+            let d = self.top_level_dir();
             if d.len() > 1 && d.last() == Some(&bun_paths::SEP) {
                 &d[..d.len() - 1]
             } else {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1345,7 +1345,7 @@ impl<'a> Resolver<'a> {
                             });
                         }
                     }
-                    break 'brk Fs::FileSystem::instance().top_level_dir;
+                    break 'brk self.fs_ref().top_level_dir();
                 }
             }
 
@@ -1362,7 +1362,7 @@ impl<'a> Resolver<'a> {
                 //     let _ = self.flush_debug_logs(FlushMode::Fail);
                 // }
                 // return ResultUnion::Failure(crate::Error::MissingResolveDir);
-                break 'brk Fs::FileSystem::instance().top_level_dir;
+                break 'brk self.fs_ref().top_level_dir();
             }
 
             // This can also be hit if you use plugins with non-file namespaces,
@@ -1374,7 +1374,7 @@ impl<'a> Resolver<'a> {
                 //     let _ = self.flush_debug_logs(FlushMode::Fail);
                 // }
                 // return ResultUnion::Failure(crate::Error::InvalidResolveDir);
-                break 'brk Fs::FileSystem::instance().top_level_dir;
+                break 'brk self.fs_ref().top_level_dir();
             }
 
             break 'brk source_dir_resolver
@@ -1531,7 +1531,7 @@ impl<'a> Resolver<'a> {
                         // resolver's lifetime; the `'static` erase only releases the `&self` borrow.
                         let path: &'static [u8] =
                             unsafe { &*std::ptr::from_ref::<[u8]>(path.as_ref()) };
-                        let top = self.fs_ref().top_level_dir;
+                        let top = self.fs_ref().top_level_dir();
                         return self.resolve(top, path, ast::ImportKind::EntryPointBuild);
                     }
                 }
@@ -2885,7 +2885,7 @@ impl<'a> Resolver<'a> {
                         // network drive). Report it as a catchable resolve
                         // error; the `Metadata::Resolve` msg carries the text
                         // for `import.meta.resolveSync` & co.
-                        let top_level_dir = self.fs_ref().top_level_dir;
+                        let top_level_dir = self.fs_ref().top_level_dir();
                         self.log_mut().add_resolve_error(
                             None,
                             bun_ast::Range::NONE,
@@ -4178,7 +4178,7 @@ impl<'a> Resolver<'a> {
         let mut input_path = raw_input_path;
 
         if is_dot_slash(input_path) || input_path == b"." {
-            input_path = self.fs_ref().top_level_dir;
+            input_path = self.fs_ref().top_level_dir();
         }
 
         // A path longer than MAX_PATH_BYTES cannot name a real directory.

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -793,7 +793,7 @@ fn register_macro(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsRe
 }
 
 fn get_cwd(global_this: &JSGlobalObject, _: &JSObject) -> JSValue {
-    EncodedSlice::from_bytes(bun_resolver::fs::FileSystem::get().top_level_dir).to_js(global_this)
+    EncodedSlice::from_bytes(bun_resolver::fs::FileSystem::get().top_level_dir()).to_js(global_this)
 }
 
 fn get_origin(global_this: &JSGlobalObject, _: &JSObject) -> JSValue {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -335,7 +335,7 @@ fn spawn_maybe_sync(
     // outlives this call frame.
     let jsc_vm: &mut jsc::VirtualMachineRef = global_this.bun_vm().as_mut();
 
-    let mut cwd: &[u8] = bun_resolver::fs::FileSystem::get().top_level_dir;
+    let mut cwd: &[u8] = bun_resolver::fs::FileSystem::get().top_level_dir();
     let mut user_specified_cwd = false;
 
     let mut stdio: [Stdio; 3] = [Stdio::Ignore, Stdio::Pipe, Stdio::Inherit];

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -2067,7 +2067,7 @@ fn spawn_cmd_prepare<T: SpawnCmdTarget>(
         bun_core::heap::into_raw(Box::new(bun_core::ffi::zeroed::<
             bun_sys::windows::libuv::Pipe,
         >()));
-    let cwd = FileSystem::get().top_level_dir;
+    let cwd = FileSystem::get().top_level_dir();
     let spawn_options = SpawnOptions {
         stdin: stdin_opt,
         stdout: stdout_opt,

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -155,7 +155,7 @@ impl FileSystemRouter {
                     root_dir_path = Utf8Bytes::Borrowed(path::resolve_path::join_abs_string_buf::<
                         path::platform::Auto,
                     >(
-                        Fs::FileSystem::instance().top_level_dir,
+                        Fs::FileSystem::instance().top_level_dir(),
                         &mut out_buf,
                         &parts,
                     ));
@@ -909,7 +909,7 @@ impl MatchedRoute {
             if let Some(ref base_dir) = this.base_dir {
                 base_dir.leak()
             } else {
-                Fs::FileSystem::get().top_level_dir
+                Fs::FileSystem::get().top_level_dir()
             },
             &origin_url,
             if let Some(ref prefix) = this.asset_prefix {

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -292,7 +292,7 @@ impl JSBundleCompletionTask {
         let mut outbuf = paths::path_buffer_pool::get();
         // SAFETY: `FileSystem::instance()` is the process-lifetime singleton
         // initialized during VM startup before any `Bun.build` is reachable.
-        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
+        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir();
 
         // Always get an absolute path for the outfile to ensure it works
         // correctly with PE metadata operations.
@@ -701,7 +701,7 @@ impl JSBundleCompletionTask {
                 let dir = this.config.dir.list.clone();
                 // SAFETY: `FileSystem::instance()` is the process-lifetime singleton
                 // initialized during VM startup before any `Bun.build` is reachable.
-                let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
+                let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir();
 
                 let mut to_assign_on_sourcemap = JSValue::ZERO;
                 for (i, output_file) in output_files.iter_mut().enumerate() {

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -596,7 +596,7 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
         Ok(fs) => fs,
         Err(err) => return Err(global.throw_error(err, generic_action)),
     };
-    let top_level_dir: &'static [u8] = bun_resolver::fs::FileSystem::get().top_level_dir;
+    let top_level_dir: &'static [u8] = bun_resolver::fs::FileSystem::get().top_level_dir();
 
     // `.bun_watcher = undefined` → `Watcher.init(DevServer, dev, fs, ...)`
     // SAFETY: `Watcher::init` only stores `p` as an opaque `*mut ()` ctx; it does

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1802,7 +1802,7 @@ impl JSFrameworkRouter {
             paths::platform::Auto,
         >(
             // SAFETY: FileSystem::instance() returns the process-global singleton; live for the program.
-            bun_resolver::fs::FileSystem::get().top_level_dir,
+            bun_resolver::fs::FileSystem::get().top_level_dir(),
             root.slice(),
         ))
         .into();

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -682,7 +682,7 @@ impl Framework {
         }
 
         for fsr in clone.file_system_router_types.iter_mut() {
-            let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
+            let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir();
             fsr.root = arena_erase(arena.alloc_slice_copy(paths::resolve_path::join_abs::<
                 paths::platform::Auto,
             >(top_level_dir, fsr.root)));
@@ -725,7 +725,7 @@ impl Framework {
             return;
         }
 
-        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
+        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir();
         let mut result = match r.resolve(top_level_dir, *path, bun_ast::ImportKind::Stmt) {
             Ok(res) => res,
             Err(err) => {
@@ -1354,7 +1354,7 @@ impl Default for ReactFastRefresh {
 
 #[inline]
 fn resolve_or_null(r: &mut bun_resolver::Resolver, path: &[u8]) -> Option<&'static [u8]> {
-    let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
+    let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir();
     match r.resolve(top_level_dir, path, bun_ast::ImportKind::Stmt) {
         // `path_const().text` is `&'static [u8]` already (`FilenameStore`-
         // backed; see note in `resolve_helper` above and `bun_ptr::Interned`).

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -361,7 +361,7 @@ impl Framework {
             );
         }
         for fsr in self.file_system_router_types.iter_mut() {
-            let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
+            let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir();
             fsr.root = Cow::Owned(
                 bun_paths::resolve_path::join_abs::<bun_paths::platform::Auto>(
                     top_level_dir,
@@ -407,7 +407,7 @@ impl Framework {
             }
             return;
         }
-        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
+        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir();
         match r.resolve(top_level_dir, path, bun_ast::ImportKind::Stmt) {
             Ok(mut result) => {
                 let p = result.path().expect("just resolved");

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -981,7 +981,7 @@ impl BunxCommand {
         // `path_buf` is a stack local so
         // `bun_which::which`'s returned slice can borrow it for the rest of exec().
         let mut path_buf = PathBuffer::uninit();
-        let top_level_dir: &[u8] = fs.top_level_dir;
+        let top_level_dir: &[u8] = fs.top_level_dir();
 
         let mut absolute_in_cache_dir_buf = PathBuffer::uninit();
         let buf_total = absolute_in_cache_dir_buf.len();

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -295,7 +295,7 @@ impl CreateCommand {
                 .dirname_store
                 .append_slice(bun_paths::resolve_path::join_abs::<
                     bun_paths::platform::Loose,
-                >(filesystem.top_level_dir, dirname))?;
+                >(filesystem.top_level_dir(), dirname))?;
 
         let mut progress = Progress {
             supports_ansi_escape_codes: Output::enable_ansi_colors_stderr(),
@@ -1235,7 +1235,7 @@ impl CreateCommand {
         // `bun_resolver::fs::FileSystem` (the inline shim) has no `relative_to`; call
         // the resolver path helper directly with the singleton's `top_level_dir`.
         let rel_destination =
-            bun_paths::resolve_path::relative(filesystem.top_level_dir, destination);
+            bun_paths::resolve_path::relative(filesystem.top_level_dir(), destination);
         let is_empty_destination = rel_destination.is_empty();
 
         if is_empty_destination {
@@ -1307,7 +1307,7 @@ impl CreateCommand {
             let positional = positionals[0];
 
             'outer: {
-                let parts = [filesystem.top_level_dir, positional];
+                let parts = [filesystem.top_level_dir(), positional];
                 let outdir_path = filesystem.abs_buf(&parts, home_dir_buf);
                 let len = outdir_path.len();
                 home_dir_buf[len] = 0;
@@ -1359,7 +1359,7 @@ impl CreateCommand {
                 }
 
                 'outer: {
-                    let parts = [filesystem.top_level_dir, BUN_CREATE_DIR, positional];
+                    let parts = [filesystem.top_level_dir(), BUN_CREATE_DIR, positional];
                     let outdir_path = filesystem.abs_buf(&parts, home_dir_buf);
                     let len = outdir_path.len();
                     home_dir_buf[len] = 0;
@@ -1800,7 +1800,7 @@ impl Example {
             }
 
             {
-                let parts = [filesystem.top_level_dir, BUN_CREATE_DIR];
+                let parts = [filesystem.top_level_dir(), BUN_CREATE_DIR];
                 let outdir_path = filesystem.abs_buf(&parts, home_dir_buf);
                 folders[1] = bun_sys::Dir::open(outdir_path)
                     .unwrap_or_else(|_| bun_sys::Dir::from_fd(bun_sys::Fd::invalid()));

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -803,7 +803,7 @@ pub(crate) fn run_scripts_with_filter(
     let selected = FilterArg::select_packages(
         &*ctx,
         &mut this_transpiler.resolver,
-        fsinstance.top_level_dir,
+        fsinstance.top_level_dir(),
     )?;
 
     let mut scripts: Vec<ScriptConfig> = Vec::new();
@@ -936,7 +936,7 @@ pub(crate) fn run_scripts_with_filter(
             RunCommand::find_shell(
                 // SAFETY: env_ptr is the live process-lifetime DotEnv loader.
                 unsafe { (*env_ptr).get(b"PATH") }.unwrap_or(b""),
-                fsinstance.top_level_dir,
+                fsinstance.top_level_dir(),
             )
             .ok_or(crate::Error::MissingShell)?
         }

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -1464,7 +1464,7 @@ impl Template {
             return false;
         };
         // SAFETY: FileSystem::instance() returns the process-global singleton.
-        let top_level_dir = Fs::FileSystem::get().top_level_dir;
+        let top_level_dir = Fs::FileSystem::get().top_level_dir();
         bun_which::which(&mut *pathbuffer, path, top_level_dir, b"claude").is_some()
     }
 

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -888,7 +888,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
     )?;
     // SAFETY: `configure_env_for_run` fully writes the slot on the success path.
     let this_transpiler = unsafe { this_transpiler_slot.assume_init_mut() };
-    let cwd: &[u8] = bun_resolver::fs::FileSystem::get().top_level_dir;
+    let cwd: &[u8] = bun_resolver::fs::FileSystem::get().top_level_dir();
 
     // SAFETY: transpiler.env is a process-lifetime *mut Loader set in init.
     let env_ptr: *mut DotEnvLoader = this_transpiler.env;

--- a/src/runtime/cli/open.rs
+++ b/src/runtime/cli/open.rs
@@ -489,7 +489,7 @@ impl EditorContext {
                     editor_,
                     // SAFETY: see note above — exclusive per-call reborrow.
                     unsafe { &mut *buf_ptr },
-                    Fs::FileSystem::instance().top_level_dir,
+                    Fs::FileSystem::instance().top_level_dir(),
                     &mut out,
                 ) {
                     self.editor = Some(editor_);
@@ -520,7 +520,7 @@ impl EditorContext {
                 editor_,
                 // SAFETY: see note above — exclusive per-call reborrow.
                 unsafe { &mut *buf_ptr },
-                Fs::FileSystem::instance().top_level_dir,
+                Fs::FileSystem::instance().top_level_dir(),
                 &mut out,
             ) {
                 self.editor = Some(editor_);
@@ -548,7 +548,7 @@ impl EditorContext {
             env,
             // SAFETY: see note above — exclusive per-call reborrow.
             unsafe { &mut *buf_ptr },
-            Fs::FileSystem::instance().top_level_dir,
+            Fs::FileSystem::instance().top_level_dir(),
             &mut out,
         ) {
             self.editor = Some(editor_);

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -362,7 +362,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             // SAFETY: `FileSystem::instance()` is initialised during
             // `PackageManager::init` (CLI startup); the singleton lives for
             // process lifetime.
-            let top_level_dir: &[u8] = Fs::FileSystem::get().top_level_dir;
+            let top_level_dir: &[u8] = Fs::FileSystem::get().top_level_dir();
             let output_path = Path::resolve_path::join_abs::<Path::platform::Auto>(
                 top_level_dir,
                 pm.options.bin_path.as_bytes(),

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -142,7 +142,7 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
     ) -> Result<Context<'a, DIRECTORY_PUBLISH>, FromTarballError> {
         let mut abs_buf = PathBuffer::uninit();
         let abs_tarball_path = join_abs_string_buf_z::<path::platform::Auto>(
-            FileSystem::instance().top_level_dir,
+            FileSystem::instance().top_level_dir(),
             &mut abs_buf,
             &[tarball_path],
         );

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -625,7 +625,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         }
 
         // SAFETY: `Transpiler::init` always sets `fs` to the process singleton.
-        let top_level_dir = unsafe { (*this_transpiler.fs).top_level_dir };
+        let top_level_dir = unsafe { (*this_transpiler.fs).top_level_dir() };
         let root_dir_info: bun_resolver::DirInfoRef =
             match this_transpiler.resolver.read_dir_info(top_level_dir) {
                 Err(err) => {
@@ -1415,7 +1415,7 @@ impl Run<'_> {
         if entry == b"." {
             // SAFETY: `vm.transpiler.fs` is the process-static `FileSystem`
             // singleton (set in `Transpiler::init`).
-            let tld = unsafe { (*vm.transpiler.fs).top_level_dir };
+            let tld = unsafe { (*vm.transpiler.fs).top_level_dir() };
             if !tld.is_empty() {
                 entry = tld;
             }
@@ -2490,7 +2490,7 @@ impl RunCommand {
         // load module and run that module
         // TODO: run module resolution here - try the next condition if the module can't be found
         // SAFETY: `Transpiler::init` always sets `fs` to the process singleton.
-        let fs_top_level_dir = unsafe { (*this_transpiler.fs).top_level_dir };
+        let fs_top_level_dir = unsafe { (*this_transpiler.fs).top_level_dir() };
         bun_core::scoped_log!(
             RUN_LOG,
             "Try resolve `{}` in `{}`",
@@ -2507,7 +2507,7 @@ impl RunCommand {
                         .get()
                         .unwrap_or(false);
             // SAFETY: `Transpiler::init` always sets `fs`; resolver-cache lifetime.
-            let top_level_dir = unsafe { (*this_transpiler.fs).top_level_dir };
+            let top_level_dir = unsafe { (*this_transpiler.fs).top_level_dir() };
             let resolved = match this_transpiler.resolver.resolve(
                 top_level_dir,
                 target_name,
@@ -2617,7 +2617,7 @@ impl RunCommand {
             let _ = force_using_bun;
             // SAFETY: `Transpiler::init` always sets `fs`; resolver-cache lifetime.
             let fs = unsafe { &mut *this_transpiler.fs };
-            let top_level_dir = fs.top_level_dir;
+            let top_level_dir = fs.top_level_dir();
             let path = env_loader.get(b"PATH").unwrap_or(b"");
             let mut path_for_which = path;
             if bin_dirs_only {
@@ -3511,7 +3511,7 @@ impl RunCommand {
         this_transpiler.configure_linker();
 
         // SAFETY: `Transpiler::fs` is the non-null process-static singleton.
-        let top_level_dir = unsafe { (*this_transpiler.fs).top_level_dir };
+        let top_level_dir = unsafe { (*this_transpiler.fs).top_level_dir() };
         let Some(root_dir_info) = this_transpiler
             .resolver
             .read_dir_info(top_level_dir)

--- a/src/runtime/cli/test/ChangedFilesFilter.rs
+++ b/src/runtime/cli/test/ChangedFilesFilter.rs
@@ -68,7 +68,7 @@ pub(crate) fn filter<'a>(
     test_files: &'a mut [Interned],
     changed_since: &[u8],
 ) -> core::result::Result<Result<'a>, crate::Error> {
-    let top_level_dir: &[u8] = bun_resolver::fs::FileSystem::get().top_level_dir;
+    let top_level_dir: &[u8] = bun_resolver::fs::FileSystem::get().top_level_dir();
 
     // If this process was restarted by the --watch file watcher, it
     // recorded exactly which files changed in this env var before

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -100,13 +100,12 @@ impl<'a> Scanner<'a> {
 
     #[inline]
     fn top_level_dir(&self) -> &'static [u8] {
-        // SAFETY: field-precise projection; never spans the mutably-borrowed `fs` field.
-        unsafe { (*self.fs).top_level_dir }
+        bun_core::top_level_dir()
     }
 
     #[inline]
     fn filename_store(&self) -> &'static fs::FilenameStore {
-        // SAFETY: same as `top_level_dir`.
+        // SAFETY: field-precise projection; never spans the mutably-borrowed `fs` field.
         unsafe { (*self.fs).filename_store }
     }
 

--- a/src/runtime/cli/test/Timings.rs
+++ b/src/runtime/cli/test/Timings.rs
@@ -109,7 +109,7 @@ impl Timings {
     }
 
     fn key_for(abs_path: &[u8]) -> Vec<u8> {
-        let rel = bun_paths::resolve_path::relative(FileSystem::get().top_level_dir, abs_path);
+        let rel = bun_paths::resolve_path::relative(FileSystem::get().top_level_dir(), abs_path);
         let mut key = rel.to_vec();
         if cfg!(windows) {
             bun_paths::resolve_path::platform_to_posix_in_place(&mut key[..]);

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -152,7 +152,7 @@ pub(crate) fn run_as_coordinator(
         files: sorted,
         costs,
         // SAFETY: FileSystem singleton is initialized before any test runner code runs.
-        cwd: FileSystem::get().top_level_dir,
+        cwd: FileSystem::get().top_level_dir(),
         argv,
         envps,
         // Coordinator borrows the workers slice while each Worker holds a raw

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -164,7 +164,7 @@ pub struct TestFailure {
 /// How a test file is named in the JUnit document: relative to the project
 /// root when inside it, else as given.
 pub(crate) fn junit_file_name(path: &[u8]) -> &[u8] {
-    let top = FileSystem::instance().top_level_dir;
+    let top = FileSystem::instance().top_level_dir();
     if strings::has_prefix(path, top) {
         without_leading_path_separator(&path[top.len()..])
     } else {
@@ -339,7 +339,7 @@ impl TestFailure {
             }
         }
         body.push(b'\n');
-        let dir = FileSystem::instance().top_level_dir;
+        let dir = FileSystem::instance().top_level_dir();
         for frame in exception.stack.frames() {
             let source_url = frame.source_url.to_utf8();
             let file = jsc::ZigStackFrame::relative_source_url(dir, source_url.slice());
@@ -1469,7 +1469,7 @@ impl CommandLineReporter {
         // SAFETY: thread-local Box pinned for the thread; sole `&mut` for the
         // collection loop below (single-threaded CLI report path).
         let map = unsafe { &mut *map.as_ptr() };
-        let relative_dir = FileSystem::get().top_level_dir;
+        let relative_dir = FileSystem::get().top_level_dir();
         let mut byte_ranges: Vec<&mut ByteRangeMapping> = Vec::with_capacity(map.len());
         for entry in map.values_mut() {
             if !coverage::is_ignored(opts, relative_dir, entry.source_url.slice()) {
@@ -1527,7 +1527,7 @@ fn print_coverage_reports_<const COLORS: bool>(
     opts: &mut CodeCoverageOptions,
     reports: &[CodeCoverageReport<'_>],
 ) -> bun_sys::Result<()> {
-    let relative_dir = FileSystem::get().top_level_dir;
+    let relative_dir = FileSystem::get().top_level_dir();
     let thresholds = opts.fractions;
 
     let fractions: Vec<Fraction> = reports.iter().map(|r| r.fraction(&thresholds)).collect();
@@ -2032,7 +2032,7 @@ impl TestCommand {
                                 pretty_errorln!(
                                     "Test filter <b>{}<r> had no matches in --cwd={}",
                                     bun_fmt::quote(arg),
-                                    bun_fmt::quote(FileSystem::instance().top_level_dir)
+                                    bun_fmt::quote(FileSystem::instance().top_level_dir())
                                 );
                             } else {
                                 pretty_errorln!(
@@ -2111,14 +2111,14 @@ impl TestCommand {
             let dir_to_scan: &[u8] = 'brk: {
                 if !ctx.debug.test_directory.is_empty() {
                     dir_to_scan_owned = resolve_path::join_abs::<bun_path::platform::Auto>(
-                        scanner.fs().top_level_dir,
+                        scanner.fs().top_level_dir(),
                         &ctx.debug.test_directory,
                     )
                     .into();
                     break 'brk &dir_to_scan_owned;
                 }
 
-                break 'brk scanner.fs().top_level_dir;
+                break 'brk scanner.fs().top_level_dir();
             };
 
             match scanner.scan(dir_to_scan) {
@@ -2129,7 +2129,7 @@ impl TestCommand {
                         pretty_errorln!(
                             "<red>Failed to scan non-existent root directory for tests:<r> {} in --cwd={}",
                             bun_fmt::quote(dir_to_scan),
-                            bun_fmt::quote(FileSystem::instance().top_level_dir)
+                            bun_fmt::quote(FileSystem::instance().top_level_dir())
                         );
                     } else {
                         pretty_errorln!(
@@ -2423,7 +2423,7 @@ impl TestCommand {
                     // Be very clear to ai.
                     Output::err_generic(
                         "0 test files matching **{{.test,.spec,_test_,_spec_}}.{{js,ts,jsx,tsx}} in --cwd={}",
-                        (bun_fmt::quote(FileSystem::instance().top_level_dir),),
+                        (bun_fmt::quote(FileSystem::instance().top_level_dir()),),
                     );
                 } else {
                     // Be friendlier to humans.
@@ -2435,7 +2435,7 @@ impl TestCommand {
                 if Output::is_ai_agent() {
                     pretty_errorln!(
                         "<yellow>The following filters did not match any test files in --cwd={}:<r>",
-                        bun_fmt::quote(FileSystem::instance().top_level_dir)
+                        bun_fmt::quote(FileSystem::instance().top_level_dir())
                     );
                 } else {
                     pretty_errorln!(
@@ -2829,7 +2829,7 @@ impl TestCommand {
             .filename_store
             .append_slice(resolution.path_pair.primary.text)
             .expect("oom");
-        let file_title = resolve_path::relative(FileSystem::instance().top_level_dir, file_path);
+        let file_title = resolve_path::relative(FileSystem::instance().top_level_dir(), file_path);
         let file_id = jest::Jest::runner()
             .unwrap()
             .get_or_put_file(file_path)

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -329,7 +329,7 @@ impl UpdateInteractiveCommand {
         while let Some((workspace_path, workspace_update_idxs)) = it.next() {
             // Build the package.json path for this workspace
             // SAFETY: `FileSystem::init` ran during `PackageManager::init`.
-            let root_dir = FileSystem::get().top_level_dir;
+            let root_dir = FileSystem::get().top_level_dir();
             let mut path_buf = PathBuffer::uninit();
             let package_json_path =
                 Self::build_package_json_path(root_dir, workspace_path, &mut path_buf);
@@ -459,7 +459,7 @@ impl UpdateInteractiveCommand {
         while let Some((workspace_path, updates_for_workspace)) = workspace_it.next() {
             // Build the package.json path for this workspace
             // SAFETY: `FileSystem::init` ran during `PackageManager::init`.
-            let root_dir = FileSystem::get().top_level_dir;
+            let root_dir = FileSystem::get().top_level_dir();
             let mut path_buf = PathBuffer::uninit();
             let package_json_path =
                 Self::build_package_json_path(root_dir, workspace_path, &mut path_buf);

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -820,7 +820,7 @@ impl UpgradeCommand {
                     let Some(unzip_exe) = which(
                         &mut unzip_path_buf,
                         env_loader.map.get(b"PATH").unwrap_or(b""),
-                        filesystem.top_level_dir,
+                        filesystem.top_level_dir(),
                         b"unzip",
                     ) else {
                         let _ = sys::unlinkat(&save_dir, tmpname);

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -755,7 +755,7 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
     // failure and `VirtualMachine::init` propagates it via `?`, so a VM that
     // failed to build its transpiler never reaches `load_preloads` (this hook
     // only runs via `reload_entry_point*`, which operate on an already-`Ok` VM).
-    let top_level_dir: *const [u8] = Fs::FileSystem::get().top_level_dir;
+    let top_level_dir: *const [u8] = Fs::FileSystem::get().top_level_dir();
     // SAFETY: per fn contract.
     let global_cache = if unsafe { &*vm }.standalone_module_graph.is_none() {
         GlobalCache::read_only
@@ -3471,7 +3471,7 @@ fn transpile_source_code_inner(
                 // need to copy the ~12 borrowed slices out (perf: was a
                 // per-asset-import `url::URL::clone`).
                 let origin = unsafe { &(*jsc_vm).origin };
-                let top_level_dir = Fs::FileSystem::get().top_level_dir;
+                let top_level_dir = Fs::FileSystem::get().top_level_dir();
                 crate::api::bun_object::get_public_path_with_asset_prefix(
                     specifier,
                     top_level_dir,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7449,7 +7449,7 @@ impl NodeFS {
             let path_slice = args.path.slice();
             // SAFETY: instance() returns the leaked singleton; INSTANCE_LOADED checked above.
             let fs = FileSystem::get();
-            let parts = [fs.top_level_dir, path_slice];
+            let parts = [fs.top_level_dir(), path_slice];
             let inbuf_len = inbuf.len();
             let Some(joined) = fs.abs_buf_checked(&parts, &mut inbuf[..inbuf_len - 1]) else {
                 return Err(sys::Error {

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -830,7 +830,7 @@ impl StatWatcher {
 
         // SAFETY: `FileSystem::instance()` is initialized at process start
         // (`FileSystem::init` runs before any JS module loads).
-        let top_level_dir = fs::FileSystem::get().top_level_dir;
+        let top_level_dir = fs::FileSystem::get().top_level_dir();
         let parts: [&[u8]; 1] = [slice];
         let file_path =
             Path::join_abs_string_buf::<platform::Auto>(top_level_dir, &mut buf[..], &parts);

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -1117,7 +1117,7 @@ impl FSWatcher {
         };
         // SAFETY: `FileSystem::instance()` returns the process-global singleton
         // initialized at startup; never null once init has run.
-        let cwd = bun_resolver::fs::FileSystem::get().top_level_dir;
+        let cwd = bun_resolver::fs::FileSystem::get().top_level_dir();
         let joined_buf_len = joined_buf.len();
         let Some(joined) = Path::join_abs_string_buf_checked::<platform::Auto>(
             cwd,

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -502,7 +502,7 @@ mod _impl {
         // path=cwd, dest=target so the
         // resulting Node SystemError carries `path: cwd`, `dest: target` and the
         // `chdir '<cwd>' -> '<target>'` message format (test-process-chdir-errormessage).
-        let prev_cwd: Box<[u8]> = Box::from(fs.top_level_dir);
+        let prev_cwd: Box<[u8]> = Box::from(fs.top_level_dir());
         match vm.set_process_cwd(slice) {
             bun_sys::Result::Ok(()) => {
                 vm.test_isolation_scope(|state| {
@@ -516,7 +516,7 @@ mod _impl {
                 let without_trailing_slash = strings::without_trailing_slash;
                 bun_string_jsc::create_utf8_for_js(
                     global_object,
-                    without_trailing_slash(fs.top_level_dir),
+                    without_trailing_slash(fs.top_level_dir()),
                 )
             }
             bun_sys::Result::Err(e) => {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1129,7 +1129,7 @@ where
 
         let bb = DevErrorPage {
             message,
-            cwd: bun_resolver::fs::FileSystem::get().top_level_dir,
+            cwd: bun_resolver::fs::FileSystem::get().top_level_dir(),
             exceptions,
             log: Some(log),
         }
@@ -3023,7 +3023,7 @@ where
 
         let bb = DevErrorPage {
             message: b"Stream error during server-side rendering",
-            cwd: bun_resolver::fs::FileSystem::get().top_level_dir,
+            cwd: bun_resolver::fs::FileSystem::get().top_level_dir(),
             exceptions: &exception_list,
             log: None,
         }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -594,7 +594,7 @@ impl AnyRoute {
         let cwd: &[u8] = if StandaloneModuleGraph::is_bun_standalone_file_path(path_slice) {
             StandaloneModuleGraph::BASE_PUBLIC_PATH_WITH_DEFAULT_SUFFIX.as_bytes()
         } else {
-            FileSystem::instance().top_level_dir
+            FileSystem::instance().top_level_dir()
         };
 
         let abs_path = FileSystem::instance().abs(&[path_slice]);

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1308,7 +1308,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     }
                 };
                 #[cfg(not(windows))]
-                let cwd = bun_resolver::fs::FileSystem::get().top_level_dir;
+                let cwd = bun_resolver::fs::FileSystem::get().top_level_dir();
 
                 // SAFETY: bun_vm() returns the live thread-local VM pointer.
                 let main = global_this.bun_vm().as_mut().main();

--- a/test/js/node/worker_threads/worker-chdir-resolve-race.test.ts
+++ b/test/js/node/worker_threads/worker-chdir-resolve-race.test.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// process.chdir() on the main thread used to rewrite the resolver FileSystem
+// singleton's top_level_dir buffer in place and re-slice it in two steps.
+// A Worker resolving a relative dynamic import between those steps saw the
+// old slice length with a fresh NUL byte inside it, rejecting with a path
+// like ".../d1\0/mod.mjs" (and aborting on assert builds).
+test("process.chdir on main thread does not tear Worker relative import() resolution", async () => {
+  using dir = tempDir("worker-chdir-resolve-race", {
+    "d1/mod.mjs": `export const tag = "ONE";\n`,
+    "d2/mod.mjs": `export const tag = "TWO";\n`,
+    "run.mjs": /* js */ `
+      import path from "node:path";
+      import { Worker } from "node:worker_threads";
+      const base = path.dirname(import.meta.filename);
+      const D1 = path.join(base, "d1"), D2 = path.join(base, "d2");
+      process.chdir(D1);
+      const wsrc =
+        'const { parentPort } = require("node:worker_threads");\\n' +
+        'let ok = 0; const errs = [];\\n' +
+        'for (let i = 0; i < 2000; i++) {\\n' +
+        '  try { await import("./mod.mjs?i=" + i); ok++; }\\n' +
+        '  catch (e) { errs.push(String(e.message).slice(0, 160)); }\\n' +
+        '}\\n' +
+        'parentPort.postMessage({ ok, nerr: errs.length, errs: errs.slice(0, 3) });\\n';
+      let stop = false, n = 0;
+      const churn = (async () => {
+        while (!stop) {
+          n++;
+          process.chdir(n & 1 ? D2 : D1);
+          if ((n & 255) === 0) await new Promise(r => setImmediate(r));
+        }
+      })();
+      const results = await Promise.all(Array.from({ length: 2 }, () => new Promise(res => {
+        const w = new Worker(wsrc, { eval: true });
+        w.on("message", m => { res(m); w.terminate(); });
+        w.on("error", e => { res({ ok: 0, nerr: 1, errs: [String(e.message)] }); w.terminate(); });
+        w.on("exit", code => res({ ok: 0, nerr: 1, errs: ["worker exited " + code] }));
+      })));
+      stop = true; await churn;
+      console.log(JSON.stringify({
+        nerr: results.reduce((a, r) => a + r.nerr, 0),
+        errs: results.flatMap(r => r.errs).slice(0, 3),
+      }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const out = JSON.parse(stdout.trim());
+  // Both d1 and d2 contain mod.mjs, so every import must succeed: any failure
+  // here observed a torn cwd. The pre-fix failure mode shows an interior NUL
+  // ("\u0000") in the rejected module path.
+  expect(out).toEqual({ nerr: 0, errs: [] });
+  expect(exitCode).toBe(0);
+}, 60_000);
+
+// The same race from the other side: a Web Worker may call process.chdir(),
+// and the main thread (which never calls chdir) reads the cached cwd through
+// fs.realpathSync("."), Bun.pathToFileURL(), path.resolve() and Bun.which().
+// With the in-place buffer rewrite, the main thread saw a mix of the two
+// directory names ("yy", "y", "x\0yyyy...") and assert builds aborted on the
+// interior NUL.
+test("process.chdir in a Web Worker does not tear main-thread cwd readers", async () => {
+  const tool = isWindows ? "" : "#!/bin/sh\n";
+  using dir = tempDir("worker-chdir-cwd-readers", {
+    "x/rel/tool": tool,
+    "y/.keep": "",
+    "yy/.keep": "",
+    "yyyyyyyyyyyyyyyy/rel/tool": tool,
+    "flip.cjs": /* js */ `
+      const path = require("node:path");
+      const A = path.join(__dirname, "x");
+      const B = path.join(__dirname, "yyyyyyyyyyyyyyyy");
+      let i = 0;
+      const tick = () => {
+        for (let k = 0; k < 200; k++) process.chdir(i++ & 1 ? A : B);
+        setImmediate(tick);
+      };
+      tick();
+    `,
+    "run.mjs": /* js */ `
+      import fs from "node:fs";
+      import path from "node:path";
+      const base = path.dirname(import.meta.filename);
+      const A = path.join(base, "x"), B = path.join(base, "yyyyyyyyyyyyyyyy");
+      process.chdir(A);
+      const realA = fs.realpathSync(A), realB = fs.realpathSync(B);
+      // Every reader below must produce one of these two values.
+      const ok = new Set([
+        realA, realB,
+        Bun.pathToFileURL(path.join(realA, "rel")).href, Bun.pathToFileURL(path.join(realB, "rel")).href,
+        path.join(realA, "f"), path.join(realB, "f"),
+        path.join(realA, "rel", "tool"), path.join(realB, "rel", "tool"),
+      ]);
+      const which = process.platform !== "win32";
+      if (which) for (const d of [A, B]) fs.chmodSync(path.join(d, "rel", "tool"), 0o755);
+      const workers = Array.from({ length: 4 }, () => new Worker(path.join(base, "flip.cjs")));
+      const bad = {};
+      const check = v => { if (!ok.has(v)) bad[v] = (bad[v] || 0) + 1; };
+      for (let i = 0; i < 2000; i++) {
+        try { check(fs.realpathSync(".")); } catch (e) { check("realpath:" + e.code); }
+        check(Bun.pathToFileURL("rel").href);
+        check(path.resolve("f"));
+        if (which) check(Bun.which("tool", { PATH: "rel" }));
+      }
+      for (const w of workers) w.terminate();
+      console.log(JSON.stringify(bad));
+      process.exit(0);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  // Only the two directories the workers chdir into can ever be the cwd. Any
+  // other key is a torn path (the pre-fix output has "/yy", "/y" and "%00").
+  expect(JSON.parse(stdout.trim())).toEqual({});
+  expect(exitCode).toBe(0);
+}, 60_000);

--- a/test/js/node/worker_threads/worker-chdir-resolve-race.test.ts
+++ b/test/js/node/worker_threads/worker-chdir-resolve-race.test.ts
@@ -84,6 +84,7 @@ test("process.chdir in a Web Worker does not tear main-thread cwd readers", asyn
       let i = 0;
       const tick = () => {
         for (let k = 0; k < 200; k++) process.chdir(i++ & 1 ? A : B);
+        if (i === 200) postMessage("flipping");
         setImmediate(tick);
       };
       tick();
@@ -105,6 +106,13 @@ test("process.chdir in a Web Worker does not tear main-thread cwd readers", asyn
       const which = process.platform !== "win32";
       if (which) for (const d of [A, B]) fs.chmodSync(path.join(d, "rel", "tool"), 0o755);
       const workers = Array.from({ length: 4 }, () => new Worker(path.join(base, "flip.cjs")));
+      // Each worker posts "flipping" after its first chdir batch, so the read
+      // loop below always overlaps live churn instead of passing vacuously. A
+      // worker that fails to load rejects here (stderr + nonzero exit).
+      await Promise.all(workers.map(w => new Promise((res, rej) => {
+        w.onmessage = res;
+        w.onerror = e => rej(new Error("worker failed: " + e.message));
+      })));
       const bad = {};
       const check = v => { if (!ok.has(v)) bad[v] = (bad[v] || 0) + 1; };
       for (let i = 0; i < 2000; i++) {


### PR DESCRIPTION
### Problem
- `process.chdir()` on one thread corrupts the cached cwd every other thread reads. A Worker import fails with `Cannot find module '/tmp/.../d1\0/mod.mjs'`. While a Web Worker calls chdir, the main thread gets `fs.realpathSync(".")` = `.../yy` (a different directory) and `Bun.pathToFileURL("rel")` = `.../x/%00yyyy/rel`. `path.resolve`, `Bun.which`, `fs.watch` and `Bun.build` tear the same way. Assert builds abort: `panic: ZStr::as_cstr: interior NUL would truncate the C view`.
- Cause: `VirtualMachine::set_process_cwd` (`src/jsc/VirtualMachine.rs`) overwrote the singleton's `top_level_dir_buf` in place, with no lock, while other threads held `&'static` slices into it. The `top_level_dir` field was a plain 16-byte store read by about 90 sites.

### Fix
- `set_process_cwd` interns the new cwd into `DirnameStore` through a deduplicated cache (`intern_cwd`). A published slice is never mutated.
- The `top_level_dir` field and `top_level_dir_buf` are removed. `FileSystem::top_level_dir()` reads the RwLock-guarded `bun_core::top_level_dir()`. Every reader goes through the method, so the (ptr, len) pair cannot tear. `FileSystem::init` seeds the lock.
- Correct because the cache is now what readers already assume: an immutable process-lifetime slice.
- Verified: `test/js/node/worker_threads/worker-chdir-resolve-race.test.ts`, both directions (stock bun fails 2 of 2). Also Node's `test-process-chdir*.js`, `test/cli/test/isolation.test.ts`, `test/js/node/worker_threads/`.

### Background
- The resolver `FileSystem` (`src/resolver/lib.rs`) is a process-global singleton. `top_level_dir` is its cached cwd. The resolver, bundler threads, Worker VMs and `node:fs` join relative paths against it.
- `DirnameStore` is an append-only, mutex-protected string arena for the whole process, so its slices are `&'static`.
- `bun_core::top_level_dir()` (`src/bun_core/Global.rs`) already kept the cwd behind a `RwLock<&'static [u8]>` because a split ptr/len could tear. The resolver kept its own unsynchronized copy.

<details><summary>Notes</summary>

Repro for the Worker direction: the main thread flips `process.chdir()` between two sibling dirs while 2 Workers loop `await import("./mod.mjs?i=" + i)`. Both dirs contain `mod.mjs`, so any rejection proves a torn cwd.

Repro for the main-thread direction: 4 Web Workers flip `process.chdir()` between `x` and `yyyyyyyyyyyyyyyy` (different lengths) while the main thread, which never calls chdir, reads `fs.realpathSync(".")`, `Bun.pathToFileURL("rel")`, `path.resolve("f")` and `Bun.which("tool", { PATH: "rel" })`. Stock 1.4.0 produces 125+ torn values in 2000 iterations, for example `.../yy`, `.../y/f`, `.../x\0/f`, `.../x//rel/tool`, `file:///.../x%00yyyyyyyyyyyyyy/rel`. 1.3.14 behaves the same, so this is not a regression.

Other panic sites seen on assert builds, all the same root cause: `open_dir_absolute_z <- Resolver::dir_info_cached_miss` (worker startup, main-thread `import()`, the `Bun.build` bundle thread), `path_watcher::watch <- NodeFS::watch`, `NodeFS::realpath_inner`, and `Internal Assertion Failure: Invalid cache key "/.../dA/\0BBBB/"` from `Resolver::assert_valid_cache_key` on the bundle thread. The debug test runner itself hit the bundle-thread abort while running `test/bundler/esbuild/default.test.ts`, because `itBundled` calls `process.chdir` around every `Bun.build()`.

`intern_cwd` keeps a `Mutex<Vec<&'static [u8]>>` of interned cwds and does a linear scan. Growth is bounded by the number of distinct directories a process chdirs into. Repeated chdir between the same directories interns each once.

The mechanical migration (`.top_level_dir` to `.top_level_dir()`) touches about 45 files. Two double-read sites in `bundle_v2.rs` and `linker.rs` were hoisted to a single local so one resolve uses one cwd. `rust:check-all` passed on all targets on the first version of this change. `cargo clippy --workspace` is clean on the rebase onto current main.

Other suites run on the rebased debug build: `test/js/node/process/process.test.js` (one pre-existing failure: `$USER` unset in the container), `test/js/bun/spawn/spawn-renamed-cwd.test.ts`, `test/js/bun/util/which.test.ts`, `test/js/bun/glob/scan.test.ts` (recursive-scan cases exceed their 30 s budget on a debug build regardless of this change).

Whether a Web Worker should be allowed to call `process.chdir()` at all (node:worker_threads workers throw `ERR_WORKER_UNSUPPORTED_OPERATION`) is a separate policy question. This change makes the cache safe regardless of which thread writes it.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/worker_threads/worker-chdir-resolve-race.test.ts

<!-- robobun:evidence:end -->