### PR TITLE
test(install): drop stale kB-to-bytes scaling of resourceUsage().maxRSS

### DIFF
--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -6,7 +6,7 @@
 // the buffered extractor would produce.
 
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isMacOS, readdirSorted, tempDir } from "harness";
+import { bunEnv, bunExe, readdirSorted, tempDir } from "harness";
 import { createHash } from "node:crypto";
 import { createWriteStream, existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
@@ -704,8 +704,12 @@ test("buffered extract does not hold the decompressed local tarball in memory", 
   // through libarchive it stays at baseline (~40 MB release, ~240 MB
   // debug+ASAN), so the midpoint gives wide margin both ways without
   // needing to branch on build type.
-  // `ru_maxrss` is bytes on Darwin, kilobytes on Linux and Windows.
-  const maxRssBytes = (resourceUsage?.maxRSS ?? 0) * (isMacOS ? 1 : 1024);
-  expect(maxRssBytes).toBeGreaterThan(0);
+  // `Subprocess.resourceUsage().maxRSS` is normalised to bytes on every
+  // platform. The > 1 MiB lower bound guards that unit: any bun process
+  // peaks well above 1 MiB in bytes but under 1_048_576 in kB, so a
+  // regression to kB trips the lower bound instead of vacuously passing
+  // the upper one.
+  const maxRssBytes = resourceUsage?.maxRSS ?? 0;
+  expect(maxRssBytes).toBeGreaterThan(1024 * 1024);
   expect(maxRssBytes).toBeLessThan(2 * PAYLOAD_SIZE);
 });


### PR DESCRIPTION
Fixes `test/cli/install/bun-install-streaming-extract.test.ts` red on main (every non-macOS lane, build [86466](https://buildkite.com/bun/bun/builds/86466)).

### Failure

```
error: expect(received).toBeLessThan(expected)
Expected: < 536870912
Received: 333065486336
```

### Cause

#36541 (b4aa3a0b34) added `buffered extract does not hold the decompressed local tarball in memory`, which scaled `Subprocess.resourceUsage().maxRSS` by 1024 on Linux/Windows under the assumption that it reports kilobytes there (raw `ru_maxrss` semantics). That assumption was already stale when it merged: #36087 (f68e504ae4, merged ~11h earlier the same day) had normalised `resourceUsage().maxRSS` to bytes on every platform (`RusageFields::maxrss` multiplies by 1024 on non-Apple Unix; Windows stores `PeakWorkingSetSize` undivided). #36541 was branched before #36087 landed and was not rebased over it.

Dividing the CI values by the extra 1024 gives ~80-90 MB on release lanes and ~325 MB on the x64-asan lane, well under the 512 MB bound and consistent with the comment's stated baselines.

### Fix

Drop the per-platform scaling: `resourceUsage().maxRSS` is already bytes everywhere. Tighten the existing `> 0` lower bound to `> 1 MiB` so a future regression back to kilobytes trips that bound instead of making the upper bound vacuously pass (matches the unit guard in `test/harness.ts`'s `runFixtureMaxRSS`).

The test's regression guard is unchanged: the old pre-decompress path that #36541 removed would still produce ~780 MB release / ~1 GB debug+ASAN peak RSS and fail the `< 512 MB` upper bound.

Test-only change; no src/ diff for fail-before.

### Verification

```
bun bd test test/cli/install/bun-install-streaming-extract.test.ts
  10 pass, 0 fail
```