### PR TITLE
install: restore the slow-lifecycle-script warning from #7719

### DIFF
--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -61,9 +61,8 @@ impl LifecycleScriptTimeLog {
         }
 
         if let Some(longest) = self.list.iter().max_by_key(|e| e.duration) {
-            // extra \n prints a blank line after this one
             bun_core::warn!(
-                "{}'s {} script took {}\n",
+                "{}'s {} script took {}",
                 BStr::new(&longest.package_name),
                 lockfile::Scripts::NAMES[longest.script_id as usize],
                 bun_fmt::fmt_duration_one_decimal(longest.duration),

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -48,9 +48,9 @@ impl LifecycleScriptTimeLog {
         self.mutex.unlock();
     }
 
-    /// Print the single slowest entry as a warning. Safe to call when no
-    /// entries were recorded.
-    pub(crate) fn print(&mut self) {
+    /// Print the single slowest entry as a warning and clear the log. Safe to
+    /// call when no entries were recorded.
+    pub(crate) fn print_and_clear(&mut self) {
         #[cfg(debug_assertions)]
         {
             assert!(

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -51,8 +51,9 @@ impl LifecycleScriptTimeLog {
     /// Print the single slowest entry as a warning. Safe to call when no
     /// entries were recorded.
     pub(crate) fn print(&mut self) {
-        if bun_core::env::IS_DEBUG {
-            debug_assert!(
+        #[cfg(debug_assertions)]
+        {
+            assert!(
                 self.mutex.try_lock(),
                 "LifecycleScriptTimeLog.print is not intended to be thread-safe"
             );

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -48,8 +48,6 @@ impl LifecycleScriptTimeLog {
         self.mutex.unlock();
     }
 
-    /// Print the single slowest entry as a warning and clear the log. Safe to
-    /// call when no entries were recorded.
     pub(crate) fn print_and_clear(&mut self) {
         #[cfg(debug_assertions)]
         {

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -34,13 +34,42 @@ pub struct LifecycleScriptTimeLog {
     list: Vec<LifecycleScriptTimeLogEntry>,
 }
 
-pub struct LifecycleScriptTimeLogEntry {}
+pub struct LifecycleScriptTimeLogEntry {
+    pub(crate) package_name: Box<[u8]>,
+    pub(crate) script_id: u8,
+    /// nanoseconds
+    pub(crate) duration: u64,
+}
 
 impl LifecycleScriptTimeLog {
     pub(crate) fn append_concurrent(&mut self, entry: LifecycleScriptTimeLogEntry) {
         self.mutex.lock();
         self.list.push(entry);
         self.mutex.unlock();
+    }
+
+    /// Print the single slowest entry as a warning. Safe to call when no
+    /// entries were recorded.
+    pub(crate) fn print(&mut self) {
+        if bun_core::env::IS_DEBUG {
+            debug_assert!(
+                self.mutex.try_lock(),
+                "LifecycleScriptTimeLog.print is not intended to be thread-safe"
+            );
+            self.mutex.unlock();
+        }
+
+        if let Some(longest) = self.list.iter().max_by_key(|e| e.duration) {
+            // extra \n prints a blank line after this one
+            bun_core::warn!(
+                "{}'s {} script took {}\n",
+                BStr::new(&longest.package_name),
+                lockfile::Scripts::NAMES[longest.script_id as usize],
+                bun_fmt::fmt_duration_one_decimal(longest.duration),
+            );
+            Output::flush();
+        }
+        self.list.clear();
     }
 }
 

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1034,7 +1034,7 @@ fn print_install_summary(
     if this.options.do_.summary() {
         print_summary_tree(this, install_summary, log_level)?;
 
-        this.lifecycle_script_time_log.print();
+        this.lifecycle_script_time_log.print_and_clear();
 
         if !did_meta_hash_change {
             this.summary.remove = 0;

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1034,6 +1034,8 @@ fn print_install_summary(
     if this.options.do_.summary() {
         print_summary_tree(this, install_summary, log_level)?;
 
+        this.lifecycle_script_time_log.print();
+
         if !did_meta_hash_change {
             this.summary.remove = 0;
             this.summary.add = 0;

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -910,9 +910,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                     }
                 }
 
-                // Foreground scripts are the root package's own, which the user just
-                // watched run live; the summary warning is for background dependency
-                // scripts whose duration was otherwise invisible.
+                // Foreground (root-package) scripts were already echoed live; warn only for background deps.
                 if !self.foreground
                     && let Some(nanos) = maybe_duration
                     && nanos > MIN_MILLISECONDS_TO_LOG * bun_core::time::NS_PER_MS

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -910,18 +910,22 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                     }
                 }
 
-                if let Some(nanos) = maybe_duration {
-                    if nanos > MIN_MILLISECONDS_TO_LOG * bun_core::time::NS_PER_MS {
-                        let entry = LifecycleScriptTimeLogEntry {
-                            package_name: self.package_name.clone(),
-                            script_id: self.current_script_index,
-                            duration: nanos,
-                        };
-                        // SAFETY: see [`Self::manager_mut`].
-                        unsafe { self.manager_mut() }
-                            .lifecycle_script_time_log
-                            .append_concurrent(entry);
-                    }
+                // Foreground scripts are the root package's own, which the user just
+                // watched run live; the summary warning is for background dependency
+                // scripts whose duration was otherwise invisible.
+                if !self.foreground
+                    && let Some(nanos) = maybe_duration
+                    && nanos > MIN_MILLISECONDS_TO_LOG * bun_core::time::NS_PER_MS
+                {
+                    let entry = LifecycleScriptTimeLogEntry {
+                        package_name: self.package_name.clone(),
+                        script_id: self.current_script_index,
+                        duration: nanos,
+                    };
+                    // SAFETY: see [`Self::manager_mut`].
+                    unsafe { self.manager_mut() }
+                        .lifecycle_script_time_log
+                        .append_concurrent(entry);
                 }
 
                 if let Some(ctx) = &self.ctx {

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -676,6 +676,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             (*this).remaining_fds = 0;
             (*this).started_at =
                 bun_core::Timespec::now(bun_core::TimespecMockMode::AllowMockedTime).ns();
+            (*this).timer = Some(Timer::start());
             // Store the allocation-rooted `this` in the intrusive heap — not a `&mut self`
             // reborrow, whose SB tag would be invalidated by the field accesses below.
             (*manager)
@@ -911,7 +912,11 @@ impl<'a> LifecycleScriptSubprocess<'a> {
 
                 if let Some(nanos) = maybe_duration {
                     if nanos > MIN_MILLISECONDS_TO_LOG * bun_core::time::NS_PER_MS {
-                        let entry = LifecycleScriptTimeLogEntry {};
+                        let entry = LifecycleScriptTimeLogEntry {
+                            package_name: self.package_name.clone(),
+                            script_id: self.current_script_index,
+                            duration: nanos,
+                        };
                         // SAFETY: see [`Self::manager_mut`].
                         unsafe { self.manager_mut() }
                             .lifecycle_script_time_log

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -2135,6 +2135,50 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       return dependenciesList;
     }
 
+    test("slow lifecycle script prints a warning", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+      await mkdir(join(packageDir, "slow-pkg"));
+      await writeFile(
+        join(packageDir, "slow-pkg", "package.json"),
+        JSON.stringify({
+          name: "slow-pkg",
+          version: "1.0.0",
+          scripts: {
+            postinstall: `${bunExe()} -e 'Bun.sleepSync(750)'`,
+          },
+        }),
+      );
+      await writeFile(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.0.0",
+          dependencies: {
+            "slow-pkg": "file:./slow-pkg",
+          },
+          trustedDependencies: ["slow-pkg"],
+        }),
+      );
+
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: testEnv,
+      });
+
+      const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+      expect(err).not.toContain("error:");
+      expect(err).toMatch(/warn: slow-pkg's postinstall script took \d/);
+      expect(out).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+    });
+
     test("reach max concurrent scripts", async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1511,9 +1511,10 @@ export async function runBunInstall(
   return { out, err, exited };
 }
 
-// stderr with `slow filesystem` warning removed
+// stderr with timing-dependent warnings removed (debug/ASAN builds can push any
+// lifecycle script over the 500ms slow-script threshold)
 export function stderrForInstall(err: string) {
-  return err.replace(/warn: Slow filesystem.*/g, "");
+  return err.replace(/warn: Slow filesystem.*/g, "").replace(/warn: .*'s \S+ script took .*\n?\n?/g, "");
 }
 
 export async function runBunUpdate(


### PR DESCRIPTION
## What

The `warn: <pkg>'s <script> script took <duration>` line from #7719 has been silently dead since early 2024: #8456 dropped the `Timer.start()` call in `spawnNextScript`, and #8943 dropped the `printAndDeinit` call from the install summary. The Rust port then copied the already-broken scaffolding verbatim (`LifecycleScriptSubprocess.timer` initialised to `None` and never set, `LifecycleScriptTimeLogEntry` an empty struct, no print path), so the warning has not fired since.

Flagged by @Jarred-Sumner on #36576.

## Fix

- `spawn_next_script_inner`: start `timer` alongside `started_at`.
- `handle_exit`: record `{package_name, script_id, duration}` when a background script exceeds 500ms. Foreground (root-package) scripts are skipped since they're already echoed live to the terminal; that mode was added after this feature had already died, so the combination never shipped either way.
- `LifecycleScriptTimeLog::print_and_clear()`: find the longest entry and `warn!` it (port of the Zig `printAndDeinit`).
- `print_install_summary`: call it between the tree and the "N packages installed" line, matching the original #7719 placement.
- `stderrForInstall()` (harness): also strip this warning, same as the existing slow-filesystem warning handling, since debug/ASAN builds can push any lifecycle-script subprocess over 500ms.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test bun-install-lifecycle-scripts.test.ts -t "slow lifecycle script prints"
  2 fail  (Received: "Saved lockfile\n")

$ bun bd test bun-install-lifecycle-scripts.test.ts -t "slow lifecycle script prints"
  2 pass
```

Full `bun-install-lifecycle-scripts.test.ts`: 119 pass, 3 fail (the 3 are pre-existing `node: command not found` env failures, reproduced on main). `bun run rust:check-all` passes on all 10 targets.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts

<!-- robobun:evidence:end -->