### PR TITLE
udp(macOS): keep partial recvmsg batch when a later call fails

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -168,21 +168,20 @@ int bsd_recvmmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct udp_recvbuf *recvbuf, int fl
     }
 
     for (int i = 0; i < LIBUS_UDP_RECV_COUNT; ++i) {
-        while (1) {
-            ssize_t ret = recvmsg(fd, &recvbuf->msgvec[i].msg_hdr, flags);
-            if (ret < 0) {
-                if (errno == EINTR) continue;
-                if (errno == EAGAIN || errno == EWOULDBLOCK) return i;
-                /* Keep the i datagrams already in recvbuf. XNU's so_error is
-                 * one-shot, so the mid-batch error is consumed and lost here;
-                 * this matches recvmmsg(2)/recvmsg_x semantics (see recvmmsg
-                 * BUGS), and the next send() to the dead peer will re-raise
-                 * the ICMP error. */
-                return i > 0 ? i : (int) ret;
-            }
-            recvbuf->msgvec[i].msg_len = ret;
-            break;
+        /* bsd_recvmsg handles EINTR and carries the US_FAULT_RECVMSG hook, so
+         * this path is reachable from tests on any macOS version via
+         * BUN_FEATURE_FLAG_DISABLE_SENDRECVMSG_X. */
+        ssize_t ret = bsd_recvmsg(fd, &recvbuf->msgvec[i].msg_hdr, flags);
+        if (ret < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) return i;
+            /* Keep the i datagrams already in recvbuf. XNU's so_error is
+             * one-shot, so the mid-batch error is consumed and lost here;
+             * this matches recvmmsg(2)/recvmsg_x semantics (see recvmmsg
+             * BUGS), and the next send() to the dead peer will re-raise
+             * the ICMP error. */
+            return i > 0 ? i : (int) ret;
         }
+        recvbuf->msgvec[i].msg_len = ret;
     }
     return LIBUS_UDP_RECV_COUNT;
 #else

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -173,6 +173,11 @@ int bsd_recvmmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct udp_recvbuf *recvbuf, int fl
             if (ret < 0) {
                 if (errno == EINTR) continue;
                 if (errno == EAGAIN || errno == EWOULDBLOCK) return i;
+                /* Keep the i datagrams already in recvbuf. XNU's so_error is
+                 * one-shot, so the mid-batch error is consumed and lost here;
+                 * this matches recvmmsg(2)/recvmsg_x semantics (see recvmmsg
+                 * BUGS), and the next send() to the dead peer will re-raise
+                 * the ICMP error. */
                 return i > 0 ? i : (int) ret;
             }
             recvbuf->msgvec[i].msg_len = ret;

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -173,7 +173,7 @@ int bsd_recvmmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct udp_recvbuf *recvbuf, int fl
             if (ret < 0) {
                 if (errno == EINTR) continue;
                 if (errno == EAGAIN || errno == EWOULDBLOCK) return i;
-                return ret;
+                return i > 0 ? i : (int) ret;
             }
             recvbuf->msgvec[i].msg_len = ret;
             break;

--- a/src/analytics/lib.rs
+++ b/src/analytics/lib.rs
@@ -462,6 +462,12 @@ pub mod generate_header {
 
         #[cfg(target_os = "macos")]
         fn detect_use_msgx_on_macos_15_6_or_later() -> bool {
+            if env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_SENDRECVMSG_X
+                .get()
+                .unwrap_or(false)
+            {
+                return false;
+            }
             let parsed = semver::Version::parse_utf8(for_os().version);
             let version = parsed.version.min();
             parsed.valid && (version.major, version.minor) >= (15, 6)

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -228,6 +228,9 @@ pub mod feature_flag {
     // The RedisClient supports auto-pipelining by default. This flag disables that behavior.
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING, "BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK, "BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK", {});
+    // Force the per-message recvmsg/sendmsg fallback on macOS instead of the
+    // batched recvmsg_x/sendmsg_x syscalls (as if running on macOS < 15.6).
+    new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_SENDRECVMSG_X, "BUN_FEATURE_FLAG_DISABLE_SENDRECVMSG_X", {});
     // Fall back to the scalar byte-at-a-time VLQ decode in
     // bun_sourcemap::mapping::parse (skips the Highway-dispatched path).
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_SIMD_SOURCEMAP, "BUN_FEATURE_FLAG_DISABLE_SIMD_SOURCEMAP", {});

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -1,7 +1,8 @@
 import { udpSocket } from "bun";
+import { socketFaultInjection } from "bun:internal-for-testing";
 import { heapStats } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, disableAggressiveGCScope, isWindows, randomPort } from "harness";
+import { bunEnv, bunExe, disableAggressiveGCScope, isMacOS, isWindows, randomPort } from "harness";
 import path from "node:path";
 import { dataCases, dataTypes } from "./testdata";
 
@@ -608,3 +609,65 @@ test("sendMany() sends every packet of a larger-than-one-batch call", async () =
     server.close();
   }
 });
+
+// bsd_recvmmsg's per-message recvmsg fallback (macOS < 15.6, or forced via
+// BUN_FEATURE_FLAG_DISABLE_SENDRECVMSG_X) must keep datagrams already received
+// in the current batch when a later recvmsg in the same batch returns a
+// non-EAGAIN error, matching recvmmsg(2)/recvmsg_x semantics. Previously it
+// returned the raw error and the already-received datagrams were dropped.
+test.skipIf(!isMacOS || !socketFaultInjection.available())(
+  "recvmsg fallback: mid-batch recvmsg error keeps already-received datagrams",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+        const out = (s) => process.stdout.write(s + "\\n");
+        const client = await Bun.udpSocket({
+          port: 0,
+          hostname: "127.0.0.1",
+          socket: {
+            data(_socket, data) {
+              out("DATA: " + Buffer.from(data).toString());
+              client.close();
+              server.close();
+            },
+            error(_socket, err) {
+              out("ERROR: " + err.code);
+            },
+          },
+        });
+        const server = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1" });
+        // Fail the 2nd recvmsg on this fd (i=1 in bsd_recvmmsg's loop) with
+        // ECONNREFUSED. i=0 will have already filled recvbuf[0] with the real
+        // datagram below; the fixed code returns i (1) instead of -1.
+        fault.set({ syscall: "recvmsg", action: "errno", errno: "ECONNREFUSED", after: 1, repeat: 1 });
+        server.send("hello", client.port, "127.0.0.1");
+        // Nothing else to do; the data/error handler closes both sockets.
+        // If neither fires (drop), the test runner's default timeout fails the
+        // parent test, not this subprocess.
+        setTimeout(() => {
+          out("TIMEOUT");
+          client.close();
+          server.close();
+        }, 5000).unref();
+      `,
+      ],
+      env: { ...bunEnv, BUN_FEATURE_FLAG_DISABLE_SENDRECVMSG_X: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const stderr = rawStderr
+      .split("\n")
+      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+      .join("\n");
+    // Before the fix: stdout is "ERROR: ECONNREFUSED" (datagram dropped).
+    // After the fix: stdout is "DATA: hello" (datagram delivered; the mid-batch
+    // error is consumed, matching recvmmsg(2) semantics).
+    expect({ stdout: stdout.trim(), stderr }).toEqual({ stdout: "DATA: hello", stderr: "" });
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
## What

Consistency fix in `bsd_recvmmsg`'s per-message fallback loop (macOS < 15.6, when `recvmsg_x` is unavailable per `Bun__doesMacOSVersionSupportSendRecvMsgX`), plus test infrastructure to reach that path deterministically.

## Why

If `recvmsg` fails with a non-`EAGAIN` error after `i` datagrams have already been received into `recvbuf`, the function returned the raw error code. `loop.c:948-979` then takes the error branch without ever calling `on_data`, so those `i` datagrams are silently dropped. When `on_recv_error == NULL` (QUIC), the socket is also closed.

The typical trigger is a connected `Bun.udpSocket({connect: {...}})`: BSDs surface a pending ICMP error (e.g. port-unreachable from an earlier send) on the next `recv`. So: peer sends 3 datagrams then exits; our next send draws ICMP; the readable event fires; `recvmsg` succeeds for i=0..2, then i=3 returns `-1/ECONNREFUSED`. Before this change the app sees only an `error` callback and the 3 datagrams are gone. Node/libuv delivers all 3 messages (`uv__udp_recvmsg` invokes `recv_cb` per datagram, so it structurally cannot discard a received batch).

## Fix

Return the partial count when `i > 0`, bringing the macOS recv fallback in line with the two sibling arms in the same file that already do this correctly:
- Windows recv, `bsd.c:155`: `return i > 0 ? i : (int) ret;`
- macOS send, `bsd.c:122`: `if (... || i > 0) return i;`

The fallback loop now calls `bsd_recvmsg` instead of raw `recvmsg`, which already handles `EINTR` and carries the `US_FAULT_RECVMSG` hook. This simplifies the loop body (no more inner `while(1)` / `EINTR` handling) and makes the path reachable from fault-injection tests.

### Error semantics

XNU's `so_error` is one-shot: the `recvmsg` call that reports `ECONNREFUSED` also clears it, so the next `bsd_recvmmsg` gets `EAGAIN` at i=0 and `on_recv_error` is not invoked for that particular error. The mid-batch error is consumed and discarded in favour of delivering the data. This matches the documented behavior of the `recvmmsg(2)` syscall this loop stands in for (man page BUGS: "if an error occurs after at least one message has been received, the call succeeds, and returns the number of messages received. The error code is lost"), and of the `recvmsg_x` path used on macOS >= 15.6. The next `send()` to the dead peer draws a fresh ICMP and surfaces `ECONNREFUSED` then. Preserving the error would mean stashing `errno` alongside the partial count and having `loop.c` call `on_data(i)` then `on_recv_error(errno)`, which is a larger interface change than this consistency fix.

## Testing

Added `BUN_FEATURE_FLAG_DISABLE_SENDRECVMSG_X` (mirrors `BUN_FEATURE_FLAG_DISABLE_EPOLL_PWAIT2`) so the fallback path can be forced on any macOS version, and a test in `test/js/bun/udp/udp_socket.test.ts` that arms `US_FAULT_RECVMSG` with `after: 1, repeat: 1`. The subprocess sends one datagram; i=0 receives it via the real `recvmsg`, i=1 is the injected `ECONNREFUSED`. Without the fix the loop returns `-1` and the `error` handler fires with the datagram dropped; with the fix it returns `1` and `on_data` delivers the datagram.

The test is gated on `isMacOS && socketFaultInjection.available()`. `socketFaultInjection` defaults to on for ASAN builds only (scripts/build/config.ts:903), so it runs under local `bun bd` on macOS and on any macOS ASAN CI lane; today's macOS release CI lanes skip it (same visibility as `websocket-syscall-fault.test.ts`). It cannot satisfy a stash-`src/` fail-before check because the fault hook routing and the feature flag are both part of this PR.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/udp/udp_socket.test.ts

<!-- robobun:evidence:end -->