### PR TITLE
structuredClone/postMessage: add fast path for bare primitive values

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -4456,12 +4456,8 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
         && messagePorts.isEmpty();
 
     if (canUseFastPath) {
-        // A bare non-cell JSValue (int32/double/bool/null/undefined, plus BigInt32 when
-        // USE(BIGINT32)) has no heap identity and is safe to carry across threads as-is.
-        // Ordering is load-bearing: on JSVALUE64 the empty JSValue satisfies isCell()==true,
-        // so it continues to the cell branch below; this check must not be rewritten as
-        // isPrimitive() or hoisted above canUseFastPath (SerializationForStorage callers
-        // like bun:jsc serialize() depend on getting real wire bytes).
+        // Not isPrimitive(): on JSVALUE64 the empty JSValue has isCell()==true and must keep
+        // falling through to the full serializer below.
         if (!value.isCell())
             return SerializedScriptValue::createPrimitiveFastPath(value);
 

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -4202,6 +4202,14 @@ SerializedScriptValue::SerializedScriptValue(WTF::FixedVector<SimpleCloneableVal
     m_memoryCost = computeMemoryCost();
 }
 
+SerializedScriptValue::SerializedScriptValue(JSC::JSValue fastPathPrimitive)
+    : m_fastPathPrimitive(fastPathPrimitive)
+    , m_fastPath(FastPath::Primitive)
+{
+    ASSERT(!fastPathPrimitive.isCell());
+    m_memoryCost = computeMemoryCost();
+}
+
 SerializedScriptValue::SerializedScriptValue(const String& fastPathString)
     : m_fastPathString(fastPathString)
     , m_fastPath(FastPath::String)
@@ -4254,6 +4262,8 @@ size_t SerializedScriptValue::computeMemoryCost() const
 
     // Account for fast path string memory usage
     switch (m_fastPath) {
+    case FastPath::Primitive:
+        break;
     case FastPath::String:
         ASSERT(m_simpleInMemoryPropertyTable.isEmpty());
         cost += m_fastPathString.sizeInBytes();
@@ -4446,6 +4456,15 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
         && messagePorts.isEmpty();
 
     if (canUseFastPath) {
+        // A bare non-cell JSValue (int32/double/bool/null/undefined, plus BigInt32 when
+        // USE(BIGINT32)) has no heap identity and is safe to carry across threads as-is.
+        // Ordering is load-bearing: on JSVALUE64 the empty JSValue satisfies isCell()==true,
+        // so it continues to the cell branch below; this check must not be rewritten as
+        // isPrimitive() or hoisted above canUseFastPath (SerializationForStorage callers
+        // like bun:jsc serialize() depend on getting real wire bytes).
+        if (!value.isCell())
+            return SerializedScriptValue::createPrimitiveFastPath(value);
+
         bool canUseStringFastPath = false;
         bool canUseObjectFastPath = false;
         bool canUseArrayFastPath = false;
@@ -4760,6 +4779,11 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     return result;
 }
 
+Ref<SerializedScriptValue> SerializedScriptValue::createPrimitiveFastPath(JSC::JSValue value)
+{
+    return adoptRef(*new SerializedScriptValue(value));
+}
+
 Ref<SerializedScriptValue> SerializedScriptValue::createStringFastPath(const String& string)
 {
     return adoptRef(*new SerializedScriptValue(Bun::toCrossThreadShareable(string)));
@@ -4870,6 +4894,10 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
     VM& vm = lexicalGlobalObject.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     switch (m_fastPath) {
+    case FastPath::Primitive:
+        if (didFail)
+            *didFail = false;
+        return m_fastPathPrimitive;
     case FastPath::String:
         if (didFail)
             *didFail = false;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -4467,20 +4467,18 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
         JSObject* object = nullptr;
         JSArray* array = nullptr;
         Structure* structure = nullptr;
-        if (value.isCell()) {
-            auto* cell = value.asCell();
-            if (cell->isString()) {
-                canUseStringFastPath = true;
-            } else if (cell->isObject()) {
-                object = cell->getObject();
-                structure = object->structure();
+        auto* cell = value.asCell();
+        if (cell->isString()) {
+            canUseStringFastPath = true;
+        } else if (cell->isObject()) {
+            object = cell->getObject();
+            structure = object->structure();
 
-                if (auto* jsArray = dynamicDowncast<JSArray>(object)) {
-                    canUseArrayFastPath = true;
-                    array = jsArray;
-                } else if (isObjectFastPathCandidate(structure)) {
-                    canUseObjectFastPath = true;
-                }
+            if (auto* jsArray = dynamicDowncast<JSArray>(object)) {
+                canUseArrayFastPath = true;
+                array = jsArray;
+            } else if (isObjectFastPathCandidate(structure)) {
+                canUseObjectFastPath = true;
             }
         }
 

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -71,6 +71,7 @@ using DenseArrayElement = std::variant<JSC::JSValue, WTF::String, SimpleCloneabl
 
 enum class FastPath : uint8_t {
     None,
+    Primitive,
     String,
     SimpleObject,
     SimpleArray,
@@ -113,6 +114,9 @@ public:
     WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(JSC::JSGlobalObject&, JSC::JSValue, SerializationForStorage = SerializationForStorage::No, SerializationErrorMode = SerializationErrorMode::Throwing, SerializationContext = SerializationContext::Default, SerializationForCrossProcessTransfer = SerializationForCrossProcessTransfer::No);
 
     static RefPtr<SerializedScriptValue> convert(JSC::JSGlobalObject& globalObject, JSC::JSValue value) { return create(globalObject, value, SerializationForStorage::Yes); }
+
+    // Fast path for postMessage with a bare non-cell primitive (int32/double/bool/null/undefined)
+    static Ref<SerializedScriptValue> createPrimitiveFastPath(JSC::JSValue);
 
     // Fast path for postMessage with pure strings
     static Ref<SerializedScriptValue> createStringFastPath(const String& string);
@@ -159,6 +163,8 @@ private:
 #endif
     );
 
+    // Constructor for primitive fast path (non-cell JSValue)
+    explicit SerializedScriptValue(JSC::JSValue fastPathPrimitive);
     // Constructor for string fast path
     explicit SerializedScriptValue(const String& fastPathString);
     explicit SerializedScriptValue(WTF::FixedVector<SimpleInMemoryPropertyTableEntry>&& object);
@@ -183,6 +189,8 @@ private:
 
     // Fast path for postMessage with pure strings - avoids serialization overhead
     String m_fastPathString;
+    // Fast path for postMessage with a bare non-cell primitive. Only valid when m_fastPath == Primitive.
+    JSC::JSValue m_fastPathPrimitive {};
     FastPath m_fastPath { FastPath::None };
     size_t m_memoryCost { 0 };
 

--- a/src/jsc/bindings/webcore/StructuredClone.cpp
+++ b/src/jsc/bindings/webcore/StructuredClone.cpp
@@ -56,8 +56,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionStructuredClone, (JSC::JSGlobalObject * globa
     auto serializeOptions = convertDictionary<StructuredSerializeOptions>(*globalObject, options);
     RETURN_IF_EXCEPTION(throwScope, {});
 
-    // A non-cell JSValue (int32/double/bool/null/undefined) has no heap identity and structured
-    // clone is the identity function on it. With nothing to transfer, skip the round-trip.
+    // Structured clone is the identity function on a non-cell JSValue.
     if (serializeOptions.transfer.isEmpty() && !value.isCell())
         return JSValue::encode(value);
 

--- a/src/jsc/bindings/webcore/StructuredClone.cpp
+++ b/src/jsc/bindings/webcore/StructuredClone.cpp
@@ -56,6 +56,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionStructuredClone, (JSC::JSGlobalObject * globa
     auto serializeOptions = convertDictionary<StructuredSerializeOptions>(*globalObject, options);
     RETURN_IF_EXCEPTION(throwScope, {});
 
+    // A non-cell JSValue (int32/double/bool/null/undefined) has no heap identity and structured
+    // clone is the identity function on it. With nothing to transfer, skip the round-trip.
+    if (serializeOptions.transfer.isEmpty() && !value.isCell())
+        return JSValue::encode(value);
+
     Vector<RefPtr<MessagePort>> ports;
     ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(*globalObject, value, WTF::move(serializeOptions.transfer), ports);
     if (serialized.hasException()) {

--- a/test/js/web/structured-clone-fastpath.test.ts
+++ b/test/js/web/structured-clone-fastpath.test.ts
@@ -1,6 +1,6 @@
+import { deserialize, serialize } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
 import { isASAN, rss } from "harness";
-import { serialize, deserialize } from "bun:jsc";
 
 describe("Structured Clone Fast Path", () => {
   // === Primitive fast path tests ===

--- a/test/js/web/structured-clone-fastpath.test.ts
+++ b/test/js/web/structured-clone-fastpath.test.ts
@@ -10,19 +10,25 @@ describe("Structured Clone Fast Path", () => {
       ["int32", 42],
       ["int32 negative", -17],
       ["int32 zero", 0],
+      ["int32 max", 2147483647],
+      ["int32 min", -2147483648],
       ["double", 3.14159],
       ["double -0", -0],
       ["double NaN", NaN],
       ["double Infinity", Infinity],
       ["double -Infinity", -Infinity],
       ["double max safe int", Number.MAX_SAFE_INTEGER],
+      ["double int32 max + 1", 2147483648],
       ["true", true],
       ["false", false],
       ["null", null],
       ["undefined", undefined],
-      ["small BigInt", 1n],
-      ["large BigInt", 2n ** 80n],
-      ["negative BigInt", -(2n ** 80n)],
+      ["BigInt 0n", 0n],
+      ["BigInt 1n", 1n],
+      ["BigInt int32 max", 2147483647n],
+      ["BigInt int32 min", -2147483648n],
+      ["BigInt heap", 2n ** 80n],
+      ["BigInt heap negative", -(2n ** 80n)],
     ];
 
     test.each(cases)("structuredClone(%s) round-trips", (_, value) => {
@@ -38,19 +44,23 @@ describe("Structured Clone Fast Path", () => {
 
     test.each(cases)("postMessage(%s) round-trips via MessageChannel", async (_, value) => {
       const { port1, port2 } = new MessageChannel();
-      const { promise, resolve } = Promise.withResolvers();
-      port2.onmessage = (e: MessageEvent) => resolve(e.data);
-      port1.postMessage(value);
-      const result = await promise;
-      if (typeof value === "number" && Number.isNaN(value)) {
-        expect(result).toBeNaN();
-      } else if (Object.is(value, -0)) {
-        expect(Object.is(result, -0)).toBe(true);
-      } else {
-        expect(result).toBe(value);
+      try {
+        const { promise, resolve, reject } = Promise.withResolvers();
+        port2.onmessage = (e: MessageEvent) => resolve(e.data);
+        port2.onmessageerror = reject;
+        port1.postMessage(value);
+        const result = await promise;
+        if (typeof value === "number" && Number.isNaN(value)) {
+          expect(result).toBeNaN();
+        } else if (Object.is(value, -0)) {
+          expect(Object.is(result, -0)).toBe(true);
+        } else {
+          expect(result).toBe(value);
+        }
+      } finally {
+        port1.close();
+        port2.close();
       }
-      port1.close();
-      port2.close();
     });
 
     test("bun:jsc serialize() still produces real bytes for primitives", () => {
@@ -78,6 +88,7 @@ describe("Structured Clone Fast Path", () => {
         for (const [, value] of cases) {
           const { promise, resolve, reject } = Promise.withResolvers();
           worker.onmessage = (e: MessageEvent) => resolve(e.data);
+          worker.onmessageerror = reject;
           worker.onerror = reject;
           worker.postMessage(value);
           const result = await promise;
@@ -103,11 +114,9 @@ describe("Structured Clone Fast Path", () => {
     });
 
     test("structuredClone of bare primitive skips the CloneSerializer", () => {
-      // Reference: an empty Map has no structured-clone fast path and always goes
-      // through the full CloneSerializer. Before the primitive fast path existed,
-      // structuredClone(42) took the same serializer path and ran at roughly half
-      // the cost of the Map (observed ratio 0.5-0.8). On the fast path it returns
-      // the value immediately and is an order of magnitude cheaper.
+      // An empty Map has no fast path and always pays the full CloneSerializer cost.
+      // A fast-pathed primitive must cost an order of magnitude less than that; off
+      // the fast path it runs at roughly half the Map cost.
       const N = 2_000;
       for (let i = 0; i < 500; i++) {
         structuredClone(42);

--- a/test/js/web/structured-clone-fastpath.test.ts
+++ b/test/js/web/structured-clone-fastpath.test.ts
@@ -1,7 +1,136 @@
 import { describe, expect, test } from "bun:test";
 import { isASAN, rss } from "harness";
+import { serialize, deserialize } from "bun:jsc";
 
 describe("Structured Clone Fast Path", () => {
+  // === Primitive fast path tests ===
+
+  describe("bare primitive values", () => {
+    const cases: Array<[string, unknown]> = [
+      ["int32", 42],
+      ["int32 negative", -17],
+      ["int32 zero", 0],
+      ["double", 3.14159],
+      ["double -0", -0],
+      ["double NaN", NaN],
+      ["double Infinity", Infinity],
+      ["double -Infinity", -Infinity],
+      ["double max safe int", Number.MAX_SAFE_INTEGER],
+      ["true", true],
+      ["false", false],
+      ["null", null],
+      ["undefined", undefined],
+      ["small BigInt", 1n],
+      ["large BigInt", 2n ** 80n],
+      ["negative BigInt", -(2n ** 80n)],
+    ];
+
+    test.each(cases)("structuredClone(%s) round-trips", (_, value) => {
+      const cloned = structuredClone(value);
+      if (typeof value === "number" && Number.isNaN(value)) {
+        expect(cloned).toBeNaN();
+      } else if (Object.is(value, -0)) {
+        expect(Object.is(cloned, -0)).toBe(true);
+      } else {
+        expect(cloned).toBe(value);
+      }
+    });
+
+    test.each(cases)("postMessage(%s) round-trips via MessageChannel", async (_, value) => {
+      const { port1, port2 } = new MessageChannel();
+      const { promise, resolve } = Promise.withResolvers();
+      port2.onmessage = (e: MessageEvent) => resolve(e.data);
+      port1.postMessage(value);
+      const result = await promise;
+      if (typeof value === "number" && Number.isNaN(value)) {
+        expect(result).toBeNaN();
+      } else if (Object.is(value, -0)) {
+        expect(Object.is(result, -0)).toBe(true);
+      } else {
+        expect(result).toBe(value);
+      }
+      port1.close();
+      port2.close();
+    });
+
+    test("bun:jsc serialize() still produces real bytes for primitives", () => {
+      // SerializationForStorage::Yes must bypass every fast path and emit wire bytes.
+      for (const [, value] of cases) {
+        const buf = serialize(value);
+        expect(buf.byteLength).toBeGreaterThan(0);
+        const back = deserialize(buf);
+        if (typeof value === "number" && Number.isNaN(value)) {
+          expect(back).toBeNaN();
+        } else if (Object.is(value, -0)) {
+          expect(Object.is(back, -0)).toBe(true);
+        } else {
+          expect(back).toBe(value);
+        }
+      }
+    });
+
+    test("postMessage of primitives round-trips across a Worker thread", async () => {
+      const url = URL.createObjectURL(
+        new Blob([`self.onmessage = e => self.postMessage(e.data);`], { type: "application/javascript" }),
+      );
+      const worker = new Worker(url);
+      try {
+        for (const [, value] of cases) {
+          const { promise, resolve, reject } = Promise.withResolvers();
+          worker.onmessage = (e: MessageEvent) => resolve(e.data);
+          worker.onerror = reject;
+          worker.postMessage(value);
+          const result = await promise;
+          if (typeof value === "number" && Number.isNaN(value)) {
+            expect(result).toBeNaN();
+          } else if (Object.is(value, -0)) {
+            expect(Object.is(result, -0)).toBe(true);
+          } else {
+            expect(result).toBe(value);
+          }
+        }
+      } finally {
+        worker.terminate();
+        URL.revokeObjectURL(url);
+      }
+    });
+
+    test("structuredClone(primitive, {transfer: [buffer]}) still detaches the buffer", () => {
+      const buf = new ArrayBuffer(8);
+      const cloned = structuredClone(42, { transfer: [buf] });
+      expect(cloned).toBe(42);
+      expect(buf.byteLength).toBe(0);
+    });
+
+    test("structuredClone of bare primitive skips the CloneSerializer", () => {
+      // Reference: an empty Map has no structured-clone fast path and always goes
+      // through the full CloneSerializer. Before the primitive fast path existed,
+      // structuredClone(42) took the same serializer path and ran at roughly half
+      // the cost of the Map (observed ratio 0.5-0.8). On the fast path it returns
+      // the value immediately and is an order of magnitude cheaper.
+      const N = 2_000;
+      for (let i = 0; i < 500; i++) {
+        structuredClone(42);
+        structuredClone(new Map());
+      }
+
+      // Take the best of three runs for each to reduce scheduler/GC noise.
+      let primTime = Infinity;
+      let mapTime = Infinity;
+      for (let trial = 0; trial < 3; trial++) {
+        let t0 = performance.now();
+        for (let i = 0; i < N; i++) structuredClone(42);
+        primTime = Math.min(primTime, performance.now() - t0);
+
+        t0 = performance.now();
+        for (let i = 0; i < N; i++) structuredClone(new Map());
+        mapTime = Math.min(mapTime, performance.now() - t0);
+      }
+
+      expect(primTime).toBeLessThan(mapTime * 0.25);
+    });
+  });
+
   test("structuredClone should work with empty object", () => {
     const object = {};
     const cloned = structuredClone(object);


### PR DESCRIPTION
## What

`port.postMessage(1)`, `structuredClone(42)`, and the like fell off the structured-clone fast path into the full `CloneSerializer`. This adds `FastPath::Primitive` so a bare non-cell `JSValue` (int32, double, boolean, `null`, `undefined`, and `BigInt32` where enabled) is carried as-is.

## Why

The `canUseFastPath` block in `SerializedScriptValue::create` only looked at `value.isCell()` candidates (strings, `JSArray`, flat objects). A non-cell value fell past the block into the full serializer: transfer-list scan, `ObjectPool`/`HashSet` setup, `Vector<uint8_t>` heap alloc, version header + tag writes, plus a symmetric `CloneDeserializer` on receive.

A non-cell `JSValue` has no heap identity and is safe to carry across threads as-is. The existing `SimpleObject` fast path already stores primitive property values as bare cross-thread `JSValue`s, so this follows the same established pattern for the top-level value.

## How

- `SerializedScriptValue.h`: add `FastPath::Primitive`, `m_fastPathPrimitive`, `createPrimitiveFastPath`, and the matching private ctor.
- `SerializedScriptValue.cpp`: inside `if (canUseFastPath)` and before the `value.isCell()` branch, `if (!value.isCell()) return createPrimitiveFastPath(value);`. Ordering is load-bearing: on `JSVALUE64` the empty `JSValue` satisfies `isCell() == true` and keeps going down the existing branch; `SerializationForStorage` callers (`bun:jsc` `serialize()`) are already excluded by `canUseFastPath` and keep producing real bytes. Add the `Primitive` arm to both the `computeMemoryCost` and `deserialize` switches.
- `StructuredClone.cpp`: when the transfer list is empty and the value is non-cell, return it directly without constructing a `SerializedScriptValue`.

## Measurement

Release build, 1M iterations of `structuredClone(42)`:

| | before | after |
| --- | --- | --- |
| `structuredClone(42)` | ~532 ns/op | identity return |
| ratio vs `structuredClone(new Map())` (full serializer) | 0.52-0.78 | 0.005 |

## Testing

Added to `test/js/web/structured-clone-fastpath.test.ts`:

- Round-trip of every non-cell primitive (int32, doubles incl. `-0`/`NaN`/`Infinity`, booleans, `null`, `undefined`, small/large/negative BigInt) via `structuredClone`, `MessageChannel`, and a cross-thread `Worker` echo.
- `bun:jsc` `serialize()` still produces real bytes for every primitive (the `SerializationForStorage::Yes` path is unchanged).
- `structuredClone(42, { transfer: [buf] })` still detaches the buffer.
- `structuredClone(42)` runs at <0.25x the cost of `structuredClone(new Map())` (fails at ~0.5x on the previous build, passes at ~0.005x here).

Regression-checked against `test/js/web/workers/{structured-clone,structuredClone-classes,message-channel,message-port-pipe,worker-postmessage-transfer}.test.ts`, `test/js/web/broadcastchannel/broadcast-channel.test.ts`, and `test/js/node/worker_threads/worker_threads.test.ts` (553 tests, all pass).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/structured-clone-fastpath.test.ts
bun test v1.4.0 (cf9046958)

test/js/web/structured-clone-fastpath.test.ts:
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32) round-trips [5.71ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32 negative) round-trips [0.81ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32 zero) round-trips [0.46ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32 max) round-trips [1.02ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32 min) round-trips [0.44ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(double) round-trips [0.46ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(double -0) round-trips [0.54ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(double NaN) round-trips [0.52ms]
(pass) Structured Clone Fast Path > bare primitive values > struc
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/structured-clone-fastpath.test.ts:
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32) round-trips [0.14ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32 negative) round-trips [0.01ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32 zero) round-trips
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32 max) round-trips
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32 min) round-trips
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(double) round-trips
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(double -0) round-trips [0.01ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(double NaN) round-trips
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(double Infinity) round-trips
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(double -Infinity) round-trips
(pass) Structured Clone Fast Path > bare primitive values > structure
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/structured-clone-fastpath.test.ts
bun test v1.4.0 (cf9046958)

test/js/web/structured-clone-fastpath.test.ts:
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32) round-trips [5.25ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32 negative) round-trips [0.58ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32 zero) round-trips [0.34ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32 max) round-trips [0.29ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32 min) round-trips [0.32ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(double) round-trips [0.30ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(double -0) round-trips [0.37ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(double NaN) round-trips [0.35ms]
(pass) Structured Clone Fast Path > bare primitive values > struc
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 969ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/27] gen cpp.rs (cppbind)
[1/27] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 40s
[23/27] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-0.cpp.o
[24/27] link bun-profile
[26/27] strip bun
[26/27] bun-profile --revision
1.4.0-canary.1+cf9046958
[build] done
bun test v1.4.0-canary.1 (cf9046958)

test/js/web/structured-clone-fastpath.test.ts:
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32) round-trips [0.10ms]
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32 negative) round-trips
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int32 zero) round-trips
(pass) Structured Clone Fast Path > bare primitive values > structuredClone(int3
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/SerializedScriptValue.cpp |  50 +++++---
 src/jsc/bindings/webcore/SerializedScriptValue.h   |   8 ++
 src/jsc/bindings/webcore/StructuredClone.cpp       |   4 +
 test/js/web/structured-clone-fastpath.test.ts      | 138 +++++++++++++++++++++
 4 files changed, 186 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcore/SerializedScriptValue.cpp      7      8      0
src/jsc/bindings/webcore/SerializedScriptValue.h        2      4      0
src/jsc/bindings/webcore/StructuredClone.cpp            4      2      0
test/js/web/structured-clone-fastpath.test.ts           2      9      0
```

</details>

<!-- robobun:evidence:end -->