### PR TITLE
plugin: match onLoad filters for extensions starting with a digit

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -88,12 +88,11 @@ impl PluginRunner {
     pub fn could_be_plugin(specifier: &[u8]) -> bool {
         if let Some(last_dot) = bun_core::strings::last_index_of_char(specifier, b'.') {
             let ext = &specifier[last_dot + 1..];
-            // '.' followed by either a letter or a non-ascii character
-            // maybe there are non-ascii file extensions?
-            // we mostly want to cheaply rule out "../" and ".." and "./"
-            if !ext.is_empty()
-                && (ext[0].is_ascii_lowercase() || ext[0].is_ascii_uppercase() || ext[0] > 127)
-            {
+            // We mostly want to cheaply rule out "../", "..", "./" (and their
+            // Windows "\\" forms). Anything else after the final '.' is a real
+            // extension that a plugin filter may want to match, including
+            // numeric ones like ".1" or ".h2".
+            if !ext.is_empty() && !matches!(ext[0], b'/' | b'\\') {
                 return true;
             }
         }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -75,8 +75,7 @@ impl PluginRunner {
             && colon == 1
             && specifier.len() > 3
             && bun_paths::resolve_path::is_sep_any(specifier[2])
-            && ((specifier[0] > b'a' && specifier[0] < b'z')
-                || (specifier[0] > b'A' && specifier[0] < b'Z'))
+            && bun_paths::resolve_path::is_drive_letter(specifier[0])
         {
             return b"";
         }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -87,10 +87,6 @@ impl PluginRunner {
     pub fn could_be_plugin(specifier: &[u8]) -> bool {
         if let Some(last_dot) = bun_core::strings::last_index_of_char(specifier, b'.') {
             let ext = &specifier[last_dot + 1..];
-            // We mostly want to cheaply rule out "../", "..", "./" (and their
-            // Windows "\\" forms). Anything else after the final '.' is a real
-            // extension that a plugin filter may want to match, including
-            // numeric ones like ".1" or ".h2".
             if !ext.is_empty() && !matches!(ext[0], b'/' | b'\\') {
                 return true;
             }

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -693,6 +693,52 @@ it.concurrent("onResolve can redirect a specifier to a real file in the file nam
   expect(exitCode).toBe(0);
 });
 
+// https://github.com/oven-sh/bun/issues/4609
+it.concurrent("onLoad filters match file extensions that start with a digit", async () => {
+  using dir = tempDir("plugin-onload-numeric-ext", {
+    "preload.js": `
+      Bun.plugin({
+        name: "numeric-ext",
+        setup(build) {
+          build.onLoad({ filter: /\\.1$/ }, () => ({ exports: { v: "one" }, loader: "object" }));
+          build.onLoad({ filter: /\\.txt\\.2$/ }, () => ({ exports: { v: "two" }, loader: "object" }));
+          build.onLoad({ filter: /\\.3gp$/ }, () => ({ exports: { v: "3gp" }, loader: "object" }));
+          build.onLoad({ filter: /\\.custom$/ }, () => ({ exports: { v: "custom" }, loader: "object" }));
+        },
+      });
+    `,
+    "ok.yaml.1": "",
+    "ok.txt.2": "",
+    "video.3gp": "",
+    "ok.custom": "",
+    "entry.js": `
+      const a = await import("./ok.yaml.1");
+      const b = await import("./ok.txt.2");
+      const c = await import("./video.3gp");
+      const d = await import("./ok.custom");
+      const e = require("./ok.yaml" + ".1");
+      console.log(JSON.stringify({ a: a.v, b: b.v, c: c.v, d: d.v, e: e.v }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.js", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+    a: "one",
+    b: "two",
+    c: "3gp",
+    d: "custom",
+    e: "one",
+  });
+  expect(exitCode).toBe(0);
+});
+
 it.concurrent("a no-op onResolve that returns args.path unchanged is transparent", async () => {
   using dir = tempDir("plugin-onresolve-no-op", {
     "preload.js": `


### PR DESCRIPTION
Fixes #4609.

## Repro

```ts
// preload.ts
Bun.plugin({
  name: "t",
  setup(b) {
    b.onLoad({ filter: /\.1$/ }, () => ({ exports: { v: "1" }, loader: "object" }));
    b.onLoad({ filter: /\.custom$/ }, () => ({ exports: { v: "c" }, loader: "object" }));
  },
});
```
```ts
// index.ts
import * as a from "./ok.yaml.1";
import * as c from "./ok.custom";
console.log({ a, c });
```

`bun --preload ./preload.ts index.ts` fires the `.custom` filter but never fires the `.1` filter; `ok.yaml.1` falls through to the built-in `file` loader.

## Cause

`PluginRunner::could_be_plugin` is the cheap pre-filter that decides whether to run plugin regex filters at all. It looked at the byte immediately after the final `.` and only returned true for ASCII letters (or non-ASCII bytes). For an absolute resolved path like `/app/foo.1` or `/app/video.3gp` that byte is a digit, so the function returned false and `run_on_load_plugins` was skipped entirely.

The comment on the check says its only purpose is to rule out `./`, `../`, `..` (and their Windows `\\` forms). Those cases produce either an empty extension or one that starts with a path separator.

## Fix

Accept any non-empty extension that does not start with `/` or `\\`. This keeps the intended fast-path rejection of relative-navigation specifiers while letting numeric (`.1`, `.h2`, `.3gp`) and other legal extensions through to the regex filters.

## Verification

New test in `test/js/bun/plugin/plugins.test.ts` covers `.1`, `.txt.2`, `.3gp` (via both `import` and `require`) alongside a letter-extension control. Fails on main with the digit-extension values coming back undefined, passes with this change. Full `plugins.test.ts` (36 tests) and `bundler_plugin.test.ts` (52 tests) pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
bun test v1.4.0 (c02e8bda9)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1742.07ms]
(pass) require > beep:boop returns 42 [12.16ms]
(pass) require > object module works [9.89ms]
(pass) module > throws with require() [14.96ms]
(pass) module > async module works with async import [27.19ms]
(pass) module > sync module module works with require() [4.92ms]
(pass) module > sync module module works with require.resolve() [3.89ms]
(pass) module > sync module module works with import [6.38ms]
(pass) module > modules are overridable [99.40ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [10.92ms]
(pass) dynamic import > beep:boop returns 42 [5.92ms]
(pass) dynamic import > async:onLoad retur
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [51.35ms]
(pass) require > beep:boop returns 42 [0.35ms]
(pass) require > object module works [0.22ms]
(pass) module > throws with require() [0.26ms]
(pass) module > async module works with async import [6.43ms]
(pass) module > sync module module works with require() [0.26ms]
(pass) module > sync module module works with require.resolve() [0.14ms]
(pass) module > sync module module works with import [0.20ms]
(pass) module > modules are overridable [0.63ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [0.26ms]
(pass) dynamic import > beep:boop returns 42 [0.14ms]
(pass) dynamic import > async:onLoad returns 42 [3.79ms]
(pass) dynamic import > async object loader returns 42 [1.75ms]
(pass) import statement > SSRs `<h1>Hello world!</h1>` with Svelte [5.85ms]
(pass) erro
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
bun test v1.4.0 (c02e8bda9)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1585.16ms]
(pass) require > beep:boop returns 42 [17.32ms]
(pass) require > object module works [14.22ms]
(pass) module > throws with require() [21.24ms]
(pass) module > async module works with async import [39.47ms]
(pass) module > sync module module works with require() [8.03ms]
(pass) module > sync module module works with require.resolve() [6.39ms]
(pass) module > sync module module works with import [11.48ms]
(pass) module > modules are overridable [33.49ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [113.91ms]
(pass) dynamic import > beep:boop returns 42 [13.25ms]
(pass) dynamic import > async:onLoad r
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1630ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/se
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/transpiler.rs          | 10 ++-------
 test/js/bun/plugin/plugins.test.ts | 46 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 48 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/bundler/transpiler.rs               2      3      0
test/js/bun/plugin/plugins.test.ts      3      1      0
```

</details>

<!-- robobun:evidence:end -->