### PR TITLE
install: resolve workspace: deps on the root package

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -322,8 +322,7 @@ pub struct PackageManager {
     /// could be any of the workspaces.
     pub root_package_id: RootPackageId,
 
-    /// Name hash of the workspace root's package.json, for resolving
-    /// `workspace:` deps that name the root (which is not in `workspace_paths`).
+    /// Name hash of the workspace root's package.json (not in `workspace_paths`).
     pub(crate) workspace_root_name_hash: PackageNameHash,
 
     pub(crate) thread_pool: ThreadPool,

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -322,6 +322,11 @@ pub struct PackageManager {
     /// could be any of the workspaces.
     pub root_package_id: RootPackageId,
 
+    /// Name hash of the workspace root's package.json, set the first time it
+    /// is parsed. Used to resolve `workspace:` dependencies that name the
+    /// root package (the root is never in `workspace_paths`).
+    pub(crate) workspace_root_name_hash: PackageNameHash,
+
     pub(crate) thread_pool: ThreadPool,
     pub(crate) task_batch: thread_pool::Batch,
     pub(crate) task_queue: TaskDependencyQueue,
@@ -1909,6 +1914,7 @@ pub fn init(
         wr!(to_update, false);
         wr!(update_requests, Box::default());
         wr!(root_package_id, RootPackageId::default());
+        wr!(workspace_root_name_hash, 0);
         wr!(task_batch, thread_pool::Batch::default());
         wr!(task_queue, TaskDependencyQueue::default());
         wr!(manifests, PackageManifestMap::default());
@@ -2341,6 +2347,7 @@ fn init_with_runtime_once(
         wr!(update_requests, Box::default());
         wr!(root_package_json_name_at_time_of_init, Box::default());
         wr!(root_package_id, RootPackageId::default());
+        wr!(workspace_root_name_hash, 0);
         wr!(task_batch, thread_pool::Batch::default());
         wr!(task_queue, TaskDependencyQueue::default());
         wr!(manifests, PackageManifestMap::default());

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -322,9 +322,8 @@ pub struct PackageManager {
     /// could be any of the workspaces.
     pub root_package_id: RootPackageId,
 
-    /// Name hash of the workspace root's package.json, set the first time it
-    /// is parsed. Used to resolve `workspace:` dependencies that name the
-    /// root package (the root is never in `workspace_paths`).
+    /// Name hash of the workspace root's package.json, for resolving
+    /// `workspace:` deps that name the root (which is not in `workspace_paths`).
     pub(crate) workspace_root_name_hash: PackageNameHash,
 
     pub(crate) thread_pool: ThreadPool,

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2639,7 +2639,10 @@ fn get_or_put_resolved_package(
                         // No member has this name; fall back to the root package.
                         if name_hash != 0 {
                             if let Some(root) = this.lockfile.root_package() {
-                                if root.name_hash == name_hash {
+                                let buf = this.lockfile.buffers.string_bytes.as_slice();
+                                if root.name_hash == name_hash
+                                    && root.name.slice(buf) == name.slice(buf)
+                                {
                                     success_fn(this, dependency_id, 0);
                                     return Ok(Some(ResolvedPackageResult {
                                         package: *this.lockfile.packages.get(0),

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2636,8 +2636,7 @@ fn get_or_put_resolved_package(
                 match this.lockfile.workspace_paths.get(&name_hash).copied() {
                     Some(p) => p,
                     None => {
-                        // No member has this name; fall back to the root package
-                        // (which is not in `workspace_paths`) when the names match.
+                        // No member has this name; fall back to the root package.
                         if name_hash != 0 {
                             if let Some(root) = this.lockfile.root_package() {
                                 if root.name_hash == name_hash {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2636,11 +2636,8 @@ fn get_or_put_resolved_package(
                 match this.lockfile.workspace_paths.get(&name_hash).copied() {
                     Some(p) => p,
                     None => {
-                        // A workspace member may depend on the workspace root
-                        // package by name via `workspace:`. The root is package id
-                        // 0 and is never registered in `workspace_paths` (only
-                        // members are), so match it here when no member has this
-                        // name.
+                        // No member has this name; fall back to the root package
+                        // (which is not in `workspace_paths`) when the names match.
                         if name_hash != 0 {
                             if let Some(root) = this.lockfile.root_package() {
                                 if root.name_hash == name_hash {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2632,34 +2632,30 @@ fn get_or_put_resolved_package(
         dependency::version::Tag::Workspace => {
             // package name hash should be used to find workspace path from map
             // SAFETY: `version.tag == Workspace` discriminates the union arm.
-            let workspace_path_raw: SemverString = match this
-                .lockfile
-                .workspace_paths
-                .get(&name_hash)
-                .copied()
-            {
-                Some(p) => p,
-                None => {
-                    // A workspace member may depend on the workspace root
-                    // package by name via `workspace:`. The root is package id
-                    // 0 and is never registered in `workspace_paths` (only
-                    // members are), so match it here when no member has this
-                    // name.
-                    if name_hash != 0 {
-                        if let Some(root) = this.lockfile.root_package() {
-                            if root.name_hash == name_hash {
-                                success_fn(this, dependency_id, 0);
-                                return Ok(Some(ResolvedPackageResult {
-                                    package: *this.lockfile.packages.get(0),
-                                    is_first_time: false,
-                                    task: None,
-                                }));
+            let workspace_path_raw: SemverString =
+                match this.lockfile.workspace_paths.get(&name_hash).copied() {
+                    Some(p) => p,
+                    None => {
+                        // A workspace member may depend on the workspace root
+                        // package by name via `workspace:`. The root is package id
+                        // 0 and is never registered in `workspace_paths` (only
+                        // members are), so match it here when no member has this
+                        // name.
+                        if name_hash != 0 {
+                            if let Some(root) = this.lockfile.root_package() {
+                                if root.name_hash == name_hash {
+                                    success_fn(this, dependency_id, 0);
+                                    return Ok(Some(ResolvedPackageResult {
+                                        package: *this.lockfile.packages.get(0),
+                                        is_first_time: false,
+                                        task: None,
+                                    }));
+                                }
                             }
                         }
+                        *version.workspace()
                     }
-                    *version.workspace()
-                }
-            };
+                };
             // reshaped for borrowck — `workspace_path` may borrow
             // `string_bytes`; detach the slice lifetime so the
             // `&mut PackageManager` reborrow for `get_or_put` below does not

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2630,31 +2630,36 @@ fn get_or_put_resolved_package(
             }
         }
         dependency::version::Tag::Workspace => {
-            // A workspace member may depend on the workspace root package by
-            // name via `workspace:`. The root is package id 0 and is never
-            // registered in `workspace_paths` (only members are), so match it
-            // here before the path lookup.
-            if name_hash != 0 {
-                if let Some(root) = this.lockfile.root_package() {
-                    if root.name_hash == name_hash {
-                        success_fn(this, dependency_id, 0);
-                        return Ok(Some(ResolvedPackageResult {
-                            package: *this.lockfile.packages.get(0),
-                            is_first_time: false,
-                            task: None,
-                        }));
-                    }
-                }
-            }
-
             // package name hash should be used to find workspace path from map
             // SAFETY: `version.tag == Workspace` discriminates the union arm.
-            let workspace_path_raw: SemverString = this
+            let workspace_path_raw: SemverString = match this
                 .lockfile
                 .workspace_paths
                 .get(&name_hash)
                 .copied()
-                .unwrap_or_else(|| *version.workspace());
+            {
+                Some(p) => p,
+                None => {
+                    // A workspace member may depend on the workspace root
+                    // package by name via `workspace:`. The root is package id
+                    // 0 and is never registered in `workspace_paths` (only
+                    // members are), so match it here when no member has this
+                    // name.
+                    if name_hash != 0 {
+                        if let Some(root) = this.lockfile.root_package() {
+                            if root.name_hash == name_hash {
+                                success_fn(this, dependency_id, 0);
+                                return Ok(Some(ResolvedPackageResult {
+                                    package: *this.lockfile.packages.get(0),
+                                    is_first_time: false,
+                                    task: None,
+                                }));
+                            }
+                        }
+                    }
+                    *version.workspace()
+                }
+            };
             // reshaped for borrowck — `workspace_path` may borrow
             // `string_bytes`; detach the slice lifetime so the
             // `&mut PackageManager` reborrow for `get_or_put` below does not

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2630,6 +2630,23 @@ fn get_or_put_resolved_package(
             }
         }
         dependency::version::Tag::Workspace => {
+            // A workspace member may depend on the workspace root package by
+            // name via `workspace:`. The root is package id 0 and is never
+            // registered in `workspace_paths` (only members are), so match it
+            // here before the path lookup.
+            if name_hash != 0 {
+                if let Some(root) = this.lockfile.root_package() {
+                    if root.name_hash == name_hash {
+                        success_fn(this, dependency_id, 0);
+                        return Ok(Some(ResolvedPackageResult {
+                            package: *this.lockfile.packages.get(0),
+                            is_first_time: false,
+                            task: None,
+                        }));
+                    }
+                }
+            }
+
             // package name hash should be used to find workspace path from map
             // SAFETY: `version.tag == Workspace` discriminates the union arm.
             let workspace_path_raw: SemverString = this

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1621,6 +1621,7 @@ impl Package<u64> {
         dependencies_count: u32,
         tag: Option<dependency::version::Tag>,
         workspace_ver: Option<SemverVersion>,
+        root_name_hash: PackageNameHash,
         external_alias: ExternalString,
         version: &[u8],
         key_loc: bun_ast::Loc,
@@ -1792,6 +1793,19 @@ impl Package<u64> {
                 }
             }
             dependency::version::Tag::Workspace => 'workspace: {
+                if workspace_path.is_none()
+                    && tag.is_none()
+                    && root_name_hash != 0
+                    && name_hash == root_name_hash
+                {
+                    // A `workspace:` dep on the workspace root package. The
+                    // root is not in `workspace_paths` (only members are), and
+                    // the literal after `workspace:` is a version spec, not a
+                    // path. Leave the dependency as-is;
+                    // `get_or_put_resolved_package` resolves it to package
+                    // id 0.
+                    break 'workspace;
+                }
                 if let Some(path) = workspace_path {
                     if let Some(range) = &workspace_range {
                         if let Some(ver) = workspace_version {
@@ -1829,14 +1843,7 @@ impl Package<u64> {
                     }
 
                     dependency_version.value.workspace = path;
-                } else if tag.is_some() {
-                    // Registering a new member from the `workspaces` array:
-                    // `value.workspace` is the member's path. When `tag` is
-                    // `None` this is a `workspace:` dep on a name that is not
-                    // a known member (either the root package or a typo), and
-                    // `value.workspace` is a version spec, not a path. Leave it
-                    // untouched; `get_or_put_resolved_package` handles the root
-                    // case and reports the not-found error otherwise.
+                } else {
                     // SAFETY: tag == Workspace selects the `workspace` union member.
                     // Bind the (Copy) union field first so `slice()`'s `&self`
                     // borrow has a named place to point at.
@@ -2600,6 +2607,11 @@ impl Package<u64> {
 
         total_dependencies_count = 0;
 
+        if FEATURES.is_main {
+            pm.workspace_root_name_hash = self.name_hash;
+        }
+        let root_name_hash = pm.workspace_root_name_hash;
+
         for group in &dependency_groups {
             if group.behavior.is_workspace() {
                 let mut seen_workspace_names: ArrayHashMap<
@@ -2746,6 +2758,7 @@ impl Package<u64> {
                         total_dependencies_count,
                         Some(dependency::version::Tag::Workspace),
                         workspace_version,
+                        root_name_hash,
                         external_name,
                         path_,
                         bun_ast::Loc::EMPTY,
@@ -2793,6 +2806,7 @@ impl Package<u64> {
                             total_dependencies_count,
                             None,
                             None,
+                            root_name_hash,
                             external_name,
                             version,
                             key_loc,
@@ -2843,6 +2857,7 @@ impl Package<u64> {
                 total_dependencies_count,
                 None,
                 None,
+                root_name_hash,
                 external_name,
                 b"*",
                 bun_ast::Loc::EMPTY,

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1798,9 +1798,7 @@ impl Package<u64> {
                     && root_name_hash != 0
                     && name_hash == root_name_hash
                 {
-                    // `workspace:` dep naming the root package: the root is
-                    // not in `workspace_paths`; `get_or_put_resolved_package`
-                    // resolves it to package id 0.
+                    // `workspace:` dep naming the root package; resolved to id 0 later.
                     break 'workspace;
                 }
                 if let Some(path) = workspace_path {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1798,12 +1798,9 @@ impl Package<u64> {
                     && root_name_hash != 0
                     && name_hash == root_name_hash
                 {
-                    // A `workspace:` dep on the workspace root package. The
-                    // root is not in `workspace_paths` (only members are), and
-                    // the literal after `workspace:` is a version spec, not a
-                    // path. Leave the dependency as-is;
-                    // `get_or_put_resolved_package` resolves it to package
-                    // id 0.
+                    // `workspace:` dep naming the root package: the root is
+                    // not in `workspace_paths`; `get_or_put_resolved_package`
+                    // resolves it to package id 0.
                     break 'workspace;
                 }
                 if let Some(path) = workspace_path {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1829,7 +1829,14 @@ impl Package<u64> {
                     }
 
                     dependency_version.value.workspace = path;
-                } else {
+                } else if tag.is_some() {
+                    // Registering a new member from the `workspaces` array:
+                    // `value.workspace` is the member's path. When `tag` is
+                    // `None` this is a `workspace:` dep on a name that is not
+                    // a known member (either the root package or a typo), and
+                    // `value.workspace` is a version spec, not a path. Leave it
+                    // untouched; `get_or_put_resolved_package` handles the root
+                    // case and reports the not-found error otherwise.
                     // SAFETY: tag == Workspace selects the `workspace` union member.
                     // Bind the (Copy) union field first so `slice()`'s `&self`
                     // borrow has a named place to point at.

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2118,6 +2118,7 @@ pub(crate) fn parse_into_binary_lockfile(
         root_pkg.resolutions = PackageIDSlice::new(off, len);
 
         root_pkg.meta.id = 0;
+        root_pkg.meta.origin = Origin::Local;
         // Tag as Root now so `<name>@root:` dedupes to package id 0 below.
         root_pkg.resolution = Resolution::init(crate::resolution::TaggedValue::Root);
         let root_name_hash = root_pkg.name_hash;
@@ -2775,13 +2776,6 @@ pub(crate) fn parse_into_binary_lockfile(
         // a package can list the same dependency in each dependnecy group, but only the first
         // is chosen (dev -> optional -> prod -> peer)
         let mut seen_deps: bun_collections::StringArrayHashMap<()> = Default::default();
-
-        // The two `[0]` writes are done first via
-        // sequential `&mut` accessors so the loops can take all column views
-        // immutably without overlapping exclusive borrows or `unsafe`.
-        lockfile.packages.items_resolution_mut()[0] =
-            Resolution::init(crate::resolution::TaggedValue::Root);
-        lockfile.packages.items_meta_mut()[0].origin = Origin::Local;
 
         let pkgs = lockfile.packages.slice();
         let pkg_deps = pkgs.items_dependencies();

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2118,6 +2118,10 @@ pub(crate) fn parse_into_binary_lockfile(
         root_pkg.resolutions = PackageIDSlice::new(off, len);
 
         root_pkg.meta.id = 0;
+        // Set the root resolution before the packages loop so a
+        // `<name>@root:` entry dedupes against package id 0 in
+        // `append_package_dedupe` instead of appending a second Root package.
+        root_pkg.resolution = Resolution::init(crate::resolution::TaggedValue::Root);
         let root_name_hash = root_pkg.name_hash;
         lockfile.packages.append(root_pkg)?;
         lockfile.get_or_put_id(0, root_name_hash)?;
@@ -2742,6 +2746,13 @@ pub(crate) fn parse_into_binary_lockfile(
             pkg.resolution = res;
 
             let pkg_id = lockfile.append_package_dedupe(&mut pkg)?;
+
+            if pkg_id == 0 && res.tag == ResolutionTag::Root {
+                // `<name>@root:` deduped to package id 0; carry over the bin
+                // parsed from this entry since the root package was created
+                // with a default bin above.
+                lockfile.packages.items_bin_mut()[0] = pkg.bin;
+            }
 
             let entry = pkg_map.get_or_put(pkg_path)?;
             if entry.found_existing {

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2118,9 +2118,7 @@ pub(crate) fn parse_into_binary_lockfile(
         root_pkg.resolutions = PackageIDSlice::new(off, len);
 
         root_pkg.meta.id = 0;
-        // Set the root resolution before the packages loop so a
-        // `<name>@root:` entry dedupes against package id 0 in
-        // `append_package_dedupe` instead of appending a second Root package.
+        // Tag as Root now so `<name>@root:` dedupes to package id 0 below.
         root_pkg.resolution = Resolution::init(crate::resolution::TaggedValue::Root);
         let root_name_hash = root_pkg.name_hash;
         lockfile.packages.append(root_pkg)?;
@@ -2748,9 +2746,7 @@ pub(crate) fn parse_into_binary_lockfile(
             let pkg_id = lockfile.append_package_dedupe(&mut pkg)?;
 
             if pkg_id == 0 && res.tag == ResolutionTag::Root {
-                // `<name>@root:` deduped to package id 0; carry over the bin
-                // parsed from this entry since the root package was created
-                // with a default bin above.
+                // `<name>@root:` deduped to id 0; adopt its parsed bin.
                 lockfile.packages.items_bin_mut()[0] = pkg.bin;
             }
 

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1908,6 +1908,13 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     let manager_ptr: *mut PackageManager = &raw mut *ctx.manager;
     let log_level = ctx.manager.options.log_level;
     let bump = pack_bump();
+
+    let (workspace_root_name, workspace_root_version) = read_workspace_root_name_and_version(
+        manager_ptr,
+        ctx.lockfile,
+        abs_package_json_path.as_bytes(),
+    );
+
     // Note: `workspace_package_json_cache` and `log` are disjoint fields on
     // `PackageManager`; route through raw-pointer field projections so the
     // two `&mut` borrows don't conflict.
@@ -2228,7 +2235,12 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     }
 
     // Create the edited package.json content after lifecycle scripts have run
-    let edited_package_json = edit_root_package_json(ctx.lockfile, json)?;
+    let edited_package_json = edit_root_package_json(
+        ctx.lockfile,
+        &workspace_root_name,
+        &workspace_root_version,
+        json,
+    )?;
 
     let root_dir: Dir = 'root_dir: {
         let mut path_buf = PathBuffer::uninit();
@@ -3292,10 +3304,49 @@ fn add_archive_entry(
     Ok(entry.clear())
 }
 
+fn read_workspace_root_name_and_version(
+    manager_ptr: *mut PackageManager,
+    lockfile: Option<&Lockfile>,
+    abs_package_json_path: &[u8],
+) -> (Box<[u8]>, Box<[u8]>) {
+    use bun_install::package_manager::ROOT_PACKAGE_JSON_PATH;
+    if lockfile.is_none() {
+        return (Box::default(), Box::default());
+    }
+    // SAFETY: ROOT_PACKAGE_JSON_PATH is set during PackageManager::init on the main thread.
+    let root_path: &[u8] = unsafe { ROOT_PACKAGE_JSON_PATH.read() }.as_bytes();
+    if root_path.is_empty() || root_path == abs_package_json_path {
+        return (Box::default(), Box::default());
+    }
+    let entry = match pm_workspace_cache(manager_ptr).get_with_path(
+        pm_log(manager_ptr),
+        root_path,
+        WorkspacePackageJSONCache::GetJSONOptions::default(),
+    ) {
+        WorkspacePackageJSONCache::GetResult::Entry(e) => e,
+        _ => return (Box::default(), Box::default()),
+    };
+    let name_expr = entry.root.get(b"name");
+    let name = name_expr
+        .as_ref()
+        .and_then(|e| e.as_utf8_string_literal())
+        .map(Box::<[u8]>::from)
+        .unwrap_or_default();
+    let version_expr = entry.root.get(b"version");
+    let version = version_expr
+        .as_ref()
+        .and_then(|e| e.as_utf8_string_literal())
+        .map(Box::<[u8]>::from)
+        .unwrap_or_default();
+    (name, version)
+}
+
 /// Strips workspace and catalog protocols from dependency versions then
 /// returns the printed json
 fn edit_root_package_json(
     maybe_lockfile: Option<&Lockfile>,
+    workspace_root_name: &[u8],
+    workspace_root_version: &[u8],
     json: &mut WorkspacePackageJSONCache::MapEntry,
 ) -> Result<Box<[u8]>, AllocError> {
     use bun_install_types::DependencyGroup;
@@ -3351,6 +3402,12 @@ fn edit_root_package_json(
                                     }
                                 };
 
+                                let prefix: &[u8] = match c {
+                                    b'^' => b"^",
+                                    b'~' => b"~",
+                                    b'*' => b"",
+                                    _ => unreachable!(),
+                                };
                                 let resolved = 'failed_to_resolve: {
                                     // find the current workspace version and append to package spec without `workspace:`
                                     let Some(lockfile) = maybe_lockfile else {
@@ -3359,13 +3416,22 @@ fn edit_root_package_json(
                                     let Some(workspace_version) = lockfile.workspace_versions.get(
                                         &Semver::string::Builder::string_hash(dependency_name),
                                     ) else {
+                                        if !workspace_root_version.is_empty()
+                                            && dependency_name == workspace_root_name
+                                        {
+                                            let tmp = format!(
+                                                "{}{}",
+                                                bstr::BStr::new(prefix),
+                                                bstr::BStr::new(workspace_root_version),
+                                            );
+                                            let data = pack_bump().alloc_slice_copy(tmp.as_bytes());
+                                            dependency.value = Some(Expr::init(
+                                                E::EString::init(data),
+                                                Default::default(),
+                                            ));
+                                            break 'failed_to_resolve true;
+                                        }
                                         break 'failed_to_resolve false;
-                                    };
-                                    let prefix: &[u8] = match c {
-                                        b'^' => b"^",
-                                        b'~' => b"~",
-                                        b'*' => b"",
-                                        _ => unreachable!(),
                                     };
                                     // Format on the heap then copy into the
                                     // pack arena; `EString::init` erases the

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -691,6 +691,44 @@ describe("workspaces", () => {
     });
   }
 
+  for (const { input, expected } of [
+    { input: "workspace:*", expected: "2.3.4" },
+    { input: "workspace:^", expected: "^2.3.4" },
+    { input: "workspace:~", expected: "~2.3.4" },
+  ]) {
+    test(`replaces workspace: protocol naming the root package: ${input}`, async () => {
+      await Promise.all([
+        write(
+          join(packageDir, "package.json"),
+          JSON.stringify({
+            name: "pack-workspace-root",
+            version: "2.3.4",
+            workspaces: ["pkgs/*"],
+          }),
+        ),
+        write(
+          join(packageDir, "pkgs", "pkg1", "package.json"),
+          JSON.stringify({
+            name: "pkg1",
+            version: "1.0.0",
+            dependencies: { "pack-workspace-root": input },
+          }),
+        ),
+      ]);
+
+      await runBunInstall(bunEnv, packageDir);
+      await pack(join(packageDir, "pkgs", "pkg1"), bunEnv);
+
+      const tarball = readTarball(join(packageDir, "pkgs", "pkg1", "pkg1-1.0.0.tgz"));
+      expect(tarball.entries).toMatchObject([{ "pathname": "package/package.json" }]);
+      expect(JSON.parse(tarball.entries[0].contents)).toEqual({
+        name: "pkg1",
+        version: "1.0.0",
+        dependencies: { "pack-workspace-root": expected },
+      });
+    });
+  }
+
   test("fails gracefully when workspace version fails to resolve", async () => {
     await Promise.all([
       write(

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1211,6 +1211,79 @@ test.concurrent("it should detect duplicate workspace dependencies", async () =>
   expect(await exited).toBe(1);
 });
 
+// https://github.com/oven-sh/bun/issues/2773
+for (const spec of ["workspace:*", "workspace:0.0.1", "workspace:^"]) {
+  for (const linker of ["hoisted", "isolated"] as const) {
+    test.concurrent(`workspace member can depend on root via ${spec} (${linker})`, async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      await Promise.all([
+        write(
+          packageJson,
+          JSON.stringify({
+            name: "Foo",
+            version: "0.0.1",
+            workspaces: ["bar"],
+          }),
+        ),
+        write(
+          join(packageDir, "bar", "package.json"),
+          JSON.stringify({
+            name: "Bar",
+            version: "0.0.2",
+            devDependencies: { Foo: spec },
+          }),
+        ),
+        write(join(packageDir, "index.js"), "module.exports = 42;\n"),
+      ]);
+
+      let { stderr, exited } = spawn({
+        cmd: [bunExe(), "install", `--linker=${linker}`],
+        cwd: packageDir,
+        stdout: "ignore",
+        stderr: "pipe",
+        env,
+      });
+      let [err, exit] = await Promise.all([stderr.text(), exited]);
+      expect(err).not.toContain("not found");
+      expect(err).not.toContain("failed to resolve");
+      expect(err).not.toContain("error:");
+      expect(err).toContain("Saved lockfile");
+      expect(exit).toBe(0);
+
+      // bun.lock records the root package and does not add a bogus workspace path
+      const lock = await file(join(packageDir, "bun.lock")).text();
+      expect(lock).toContain('"Foo": ["Foo@root:"');
+      expect(lock).not.toContain("bar/0.0.1");
+
+      // the member can require the root package
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", 'console.log(require("Foo"))'],
+        cwd: join(packageDir, "bar"),
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [rout, rerr, rexit] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(rerr).toBe("");
+      expect(rout).toBe("42\n");
+      expect(rexit).toBe(0);
+
+      // second install is stable
+      ({ stderr, exited } = spawn({
+        cmd: [bunExe(), "install", "--frozen-lockfile", `--linker=${linker}`],
+        cwd: packageDir,
+        stdout: "ignore",
+        stderr: "pipe",
+        env,
+      }));
+      [err, exit] = await Promise.all([stderr.text(), exited]);
+      expect(err).not.toContain("error:");
+      expect(exit).toBe(0);
+    });
+  }
+}
+
 const versions = ["workspace:1.0.0", "workspace:*", "workspace:^1.0.0", "1.0.0", "*"];
 
 for (const rootVersion of versions) {


### PR DESCRIPTION
Fixes #2773.
Fixes #5176.

### Repro

```sh
mkdir -p /tmp/mono/bar && cd /tmp/mono
cat > package.json <<'JSON'
{ "name": "Foo", "version": "0.0.1", "workspaces": ["bar"] }
JSON
cat > bar/package.json <<'JSON'
{ "name": "Bar", "version": "0.0.2", "devDependencies": { "Foo": "workspace:0.0.1" } }
JSON
bun install
```

Before:

```
error: Workspace dependency "Foo" not found

Searched in "./bar/0.0.1"
error: Foo@workspace:0.0.1 failed to resolve
```

### Cause

`lockfile.workspace_paths` only holds workspace *members*; the root package's name is never registered there. When a member declares `"Foo": "workspace:0.0.1"`, `parse_dependency` finds no entry for `Foo`, falls into the branch meant for registering new members from the `workspaces` array, and treats the version literal `0.0.1` as a directory path (joining it with the source dir to get `bar/0.0.1`). `get_or_put_resolved_package` then tries to read `bar/0.0.1/package.json` and fails.

### Fix

* Add `PackageManager.workspace_root_name_hash`, set when the root `package.json` is parsed, so later parses of workspace member `package.json` files can recognise a `workspace:` dep that names the root regardless of which `Lockfile` instance is in flight.
* `parse_dependency` (`Tag::Workspace` arm): when no member has the dependency name and it matches the root's name hash, leave the dependency untouched instead of treating the version literal as a path and inserting a bogus entry into `workspace_paths`. `workspace:<path>` deps whose name is not a known member (e.g. `"x": "workspace:."`) still fall through to the existing path-resolution branch.
* `get_or_put_resolved_package` (`Tag::Workspace` arm): after the `workspace_paths` lookup misses, check whether the dependency name matches the root package's name (hash and bytes) and resolve directly to package id 0. Running the check after the lookup preserves the existing behaviour when a member shares the root's name.
* `bun.lock` parsing: tag the root package's resolution as `Root` before walking the `packages` table so a `<name>@root:` entry dedupes to package id 0 (and adopt its `bin`), otherwise a second Root package is appended and `--frozen-lockfile` reports a spurious change.
* `bun pm pack` / `bun publish`: `edit_root_package_json` now receives the workspace root's name and version (read once from the root `package.json` via `ROOT_PACKAGE_JSON_PATH`) and falls back to them when `workspace_versions` has no entry for the dependency name, so a member's `"<root name>": "workspace:*"` is rewritten to the root's version instead of crashing.

The hoisted and isolated installers already handle `ResolutionTag::Root` reached via a dependency edge (symlink to the project root / `.bun/<name>@root` store entry), and the text lockfile already serialises and parses `<name>@root:` entries.

pnpm allows the same layout and links `bar/node_modules/<root name> -> ../..` regardless of the version spec after `workspace:`; this change matches that.

### Not covered

* The aliased form `"alias": "workspace:<root name>@<spec>"` is unchanged (it never worked before either); the fix for that belongs in `Dependency::realname()`.

### Verification

New tests in `test/cli/install/bun-workspaces.test.ts` cover `workspace:*`, `workspace:0.0.1`, and `workspace:^` under both the hoisted and isolated linkers, asserting the install succeeds, `require("<root name>")` resolves from the member, `bun.lock` records `["Foo@root:", {}]`, and `--frozen-lockfile` is stable on the second install. New tests in `test/cli/install/bun-pack.test.ts` cover `workspace:*` / `^` / `~` on the root name from a member package and assert the packed `package.json` carries the substituted version. The full `bun-workspaces.test.ts`, `isolated-install.test.ts` (including the `workspace:.` self-dependency test), `bun-lock.test.ts`, `bun-pack.test.ts`, and the workspace-filtered `bun-install.test.ts` suite pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-pack.test.ts test/cli/install/bun-workspaces.test.ts
bun test v1.4.0 (903721089)

test/cli/install/bun-pack.test.ts:
(pass) basic [386.76ms]
(pass) in subdirectory [483.07ms]
(pass) package.json names and versions > rejects name and version containing parent directory components [655.41ms]
(pass) package.json names and versions > missing name [234.60ms]
(pass) package.json names and versions > missing version [317.87ms]
(pass) package.json names and versions > missing name and version [367.02ms]
(pass) package.json names and versions > empty name [339.58ms]
(pass) package.json names and versions > empty version [227.00ms]
(pass) package.json names and versions > empty name and version [266.93ms]
(pass) package.json names and versions > missing [207.52ms]
(pass) package.json names and versions > scoped name: @scoped/pkg [322.78ms]
(pass) package.json names and versions > scoped name: @ [226.22ms]
(pass) package.json names and versions > scoped name: @/ [311.61ms]
(pass) package.json names and versions > scoped name:
... (truncated)

release without fix: 11 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/install/bun-pack.test.ts:
(pass) basic [73.38ms]
(pass) in subdirectory [258.28ms]
(pass) package.json names and versions > rejects name and version containing parent directory components [138.90ms]
(pass) package.json names and versions > missing name [34.62ms]
(pass) package.json names and versions > missing version [22.04ms]
(pass) package.json names and versions > missing name and version [72.34ms]
(pass) package.json names and versions > empty name [6.03ms]
(pass) package.json names and versions > empty version [5.69ms]
(pass) package.json names and versions > empty name and version [59.06ms]
(pass) package.json names and versions > missing [43.60ms]
(pass) package.json names and versions > scoped name: @scoped/pkg [79.48ms]
(pass) package.json names and versions > scoped name: @ [11.08ms]
(pass) package.json names and versions > scoped name: @/ [52.72ms]
(pass) package.json names and versions > scoped name: // [61.99ms]
(pass) package.json names and versions > scoped name: @// [47.49ms]
(pass) package.json names and versions > scoped name: @/s [72.59ms]
(pass) package.json names and versions > scoped name: @s [69.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-pack.test.ts test/cli/install/bun-workspaces.test.ts
bun test v1.4.0 (903721089)

test/cli/install/bun-pack.test.ts:
(pass) basic [444.38ms]
(pass) in subdirectory [969.68ms]
(pass) package.json names and versions > rejects name and version containing parent directory components [852.97ms]
(pass) package.json names and versions > missing name [448.91ms]
(pass) package.json names and versions > missing version [215.82ms]
(pass) package.json names and versions > missing name and version [286.39ms]
(pass) package.json names and versions > empty name [297.22ms]
(pass) package.json names and versions > empty version [277.85ms]
(pass) package.json names and versions > empty name and version [318.22ms]
(pass) package.json names and versions > missing [247.80ms]
(pass) package.json names and versions > scoped name: @scoped/pkg [595.55ms]
(pass) package.json names and versions > scoped name: @ [425.14ms]
(pass) package.json names and versions > scoped name: @/ [215.34ms]
(pass) package.json names and versions > scoped name:
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2028ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/52] gen cpp.rs (cppbind)
[2/52] cxx obj/src/jsc/bindings/highway_sourcemap.cpp.o
[3/52] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[4/52] cxx obj/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp.o
[5/52] cxx obj/src/jsc/bindings/napi.cpp.o
[6/52] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[6/52] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspac
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager.rs                      |  5 ++
 .../PackageManager/PackageManagerEnqueue.rs        | 29 ++++++--
 src/install/lockfile/Package.rs                    | 17 +++++
 src/install/lockfile/bun.lock.rs                   | 15 ++--
 src/runtime/cli/pack_command.rs                    | 80 ++++++++++++++++++++--
 test/cli/install/bun-pack.test.ts                  | 38 ++++++++++
 test/cli/install/bun-workspaces.test.ts            | 73 ++++++++++++++++++++
 7 files changed, 237 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/install/PackageManager.rs                           10      6      0
src/install/PackageManager/PackageManagerEnqueue.rs      7      7      0
src/install/lockfile/Package.rs                         19     16      0
src/install/lockfile/bun.lock.rs                        18      9      0
src/runtime/cli/pack_command.rs                         10      5      0
test/cli/install/bun-pack.test.ts                        1      1      0
test/cli/install/bun-workspaces.test.ts                  1      4      0
```

</details>

<!-- robobun:evidence:end -->