### PR TITLE
Set ETag header from BuildArtifact in new Response

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1479,7 +1479,7 @@ const build = await Bun.build({
 
 const artifact = build.outputs[0];
 
-// Content-Type header is automatically set
+// Content-Type and ETag headers are automatically set
 return new Response(artifact);
 ```
 

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1978,6 +1978,17 @@ impl BuildArtifact {
         jsc::bun_string_jsc::create_utf8_for_js(global_this, &buf[..written])
     }
 
+    /// Quoted entity-tag derived from `self.hash` (the same encoding the
+    /// `.hash` getter exposes). `None` when the bundler left the hash at 0
+    /// (e.g. sourcemap outputs).
+    pub(crate) fn etag_bytes(&self) -> Option<[u8; 10]> {
+        if self.hash == 0 {
+            return None;
+        }
+        let h = bun_core::fmt::truncated_hash32_bytes(self.hash);
+        Some([b'"', h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7], b'"'])
+    }
+
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_size(this: &Self, global_object: &JSGlobalObject) -> JSValue {
         // `Blob::get_size` is `&self` post-R-2 (lazy size caches are

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1978,9 +1978,6 @@ impl BuildArtifact {
         jsc::bun_string_jsc::create_utf8_for_js(global_this, &buf[..written])
     }
 
-    /// Quoted entity-tag derived from `self.hash` (the same encoding the
-    /// `.hash` getter exposes). `None` when the bundler left the hash at 0
-    /// (e.g. sourcemap outputs).
     pub(crate) fn etag_bytes(&self) -> Option<[u8; 10]> {
         if self.hash == 0 {
             return None;

--- a/src/runtime/api/output_file_jsc.rs
+++ b/src/runtime/api/output_file_jsc.rs
@@ -33,6 +33,7 @@ fn dupe_path_like(path: &[u8]) -> PathLike {
 fn set_blob_mime(blob: &mut Blob, mime: MimeType) {
     blob.content_type
         .set(crate::webcore::blob::BlobContentType::from_mime(&mime));
+    blob.content_type_was_set.set(true);
     if let Some(store) = blob.store.get().as_ref() {
         // SAFETY: `store` is the freshly-allocated backing store uniquely owned
         // by `blob`; no other borrow exists yet.

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1331,11 +1331,7 @@ impl Response {
                 }
                 if let Some(etag) = &etag {
                     if !headers.fast_has(HTTPHeaderName::ETag) {
-                        headers.put(
-                            HTTPHeaderName::ETag,
-                            &BunString::ascii(etag),
-                            global_this,
-                        )?;
+                        headers.put(HTTPHeaderName::ETag, &BunString::ascii(etag), global_this)?;
                     }
                 }
             }

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1313,7 +1313,13 @@ impl Response {
         // Perform the only remaining fallible op BEFORE heap-allocating:
         // doing it on stack locals lets `?` trigger the scopeguard and
         // `init`'s drop glue and avoids leaking the heap allocation entirely.
+        let etag = arguments[0]
+            .as_class_ref::<crate::api::BuildArtifact>()
+            .and_then(crate::api::BuildArtifact::etag_bytes);
         if let BodyValue::Blob(blob) = body.value.get() {
+            if etag.is_some() && init.headers.is_none() {
+                init.headers = Some(HeadersRef::create_empty());
+            }
             if let Some(headers) = init.headers.as_deref_mut() {
                 let content_type = blob.content_type_slice();
                 if !content_type.is_empty() && !headers.fast_has(HTTPHeaderName::ContentType) {
@@ -1322,6 +1328,15 @@ impl Response {
                         &BunString::ascii(content_type),
                         global_this,
                     )?;
+                }
+                if let Some(etag) = &etag {
+                    if !headers.fast_has(HTTPHeaderName::ETag) {
+                        headers.put(
+                            HTTPHeaderName::ETag,
+                            &BunString::ascii(etag),
+                            global_this,
+                        )?;
+                    }
                 }
             }
         }

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -408,14 +408,64 @@ describe("Bun.build", () => {
     expect(await response.text()).toMatchSnapshot("response text");
   });
 
-  test.todo("new Response(BuildArtifact) sets etag", async () => {
+  // https://github.com/oven-sh/bun/issues/3011
+  test("new Response(BuildArtifact) sets etag", async () => {
     const x = await Bun.build({
       entrypoints: [join(import.meta.dir, "./fixtures/trivial/index.js")],
       outdir: tempDirWithFiles("response-buildartifact-etag", {}),
     });
-    const response = new Response(x.outputs[0]);
-    expect(response.headers.get("etag")).toBeTruthy();
-    expect(response.headers.get("etag")).toMatchSnapshot("content-etag");
+    const artifact = x.outputs[0];
+    expect(artifact.hash).toBeTruthy();
+    const expectedEtag = `"${artifact.hash}"`;
+
+    const response = new Response(artifact);
+    expect(response.headers.get("etag")).toBe(expectedEtag);
+    expect(response.headers.get("content-type")).toBe("text/javascript;charset=utf-8");
+
+    // User-provided headers must take precedence.
+    const overridden = new Response(artifact, {
+      headers: { etag: '"custom"', "content-type": "text/plain" },
+    });
+    expect({
+      etag: overridden.headers.get("etag"),
+      "content-type": overridden.headers.get("content-type"),
+    }).toEqual({ etag: '"custom"', "content-type": "text/plain" });
+
+    // A plain Blob must not pick up an ETag.
+    expect(new Response(new Blob(["hi"])).headers.get("etag")).toBeNull();
+  });
+
+  // https://github.com/oven-sh/bun/issues/3011
+  test("Bun.serve sends BuildArtifact etag and content-type", async () => {
+    const x = await Bun.build({
+      entrypoints: [join(import.meta.dir, "./fixtures/trivial/index.js")],
+    });
+    const artifact = x.outputs[0];
+    const expectedEtag = `"${artifact.hash}"`;
+
+    await using server = Bun.serve({
+      port: 0,
+      static: { "/static": new Response(artifact) },
+      fetch: () => new Response(artifact),
+    });
+
+    const [dynamic, staticRes, notModified] = await Promise.all([
+      fetch(`${server.url}dynamic`),
+      fetch(`${server.url}static`),
+      fetch(`${server.url}static`, { headers: { "if-none-match": expectedEtag } }),
+    ]);
+
+    expect({
+      etag: dynamic.headers.get("etag"),
+      "content-type": dynamic.headers.get("content-type"),
+    }).toEqual({ etag: expectedEtag, "content-type": "text/javascript;charset=utf-8" });
+
+    expect({
+      etag: staticRes.headers.get("etag"),
+      "content-type": staticRes.headers.get("content-type"),
+    }).toEqual({ etag: expectedEtag, "content-type": "text/javascript;charset=utf-8" });
+
+    expect(notModified.status).toBe(304);
   });
 
   // test("BuildArtifact with assets", async () => {


### PR DESCRIPTION
Fixes #3011.

## What

`new Response(buildArtifact)` now sets an `ETag` header derived from `artifact.hash` (quoted, same encoding as the `.hash` getter). User-supplied `ETag` and `Content-Type` headers still take precedence.

Also fixes `Bun.serve` static routes dropping `Content-Type` when the body is a `BuildArtifact`.

## Repro

```js
const { outputs: [artifact] } = await Bun.build({ entrypoints: ["./a.ts"] });
console.log(artifact.hash);
// brhdg2tr
console.log(new Response(artifact).headers.get("etag"));
// before: null
// after:  "brhdg2tr"
```

Static route before this change: `ETag` was a content hash unrelated to `artifact.hash`, and `Content-Type` was `null`. After: both match the dynamic path.

## Cause

- `Response::constructor` only read the body as a generic `Blob` and never looked at the `BuildArtifact` wrapper, so the bundler's `hash` was lost.
- `set_blob_mime` (used when materialising `BuildArtifact`'s inner blob) set `content_type` but not `content_type_was_set`, so `has_content_type_from_user()` stayed `false` and `StaticRoute::from_js` discarded it.

## Fix

- `Response::constructor` downcasts `arguments[0]` to `BuildArtifact`, and when it has a non-zero hash, eagerly creates headers and sets `ETag` (unless the caller already supplied one). Content-Type is set in the same block so the lazy header path is unchanged for plain blobs.
- `set_blob_mime` now marks `content_type_was_set`, so the static-route snapshot keeps the bundler-assigned MIME type.
- Added `BuildArtifact::etag_bytes()` to format the quoted tag without allocating.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/bundler/bun-build-api.test.ts -t etag   # fails (etag=null)
bun bd test test/bundler/bun-build-api.test.ts -t etag                 # passes
```

Also confirmed `If-None-Match` returns 304 on the static path, and that plain `Blob` bodies still don't get an `ETag`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->