### PR TITLE
resolver: honor package.json browser field for node builtins before polyfilling

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1946,17 +1946,9 @@ impl<'a> Resolver<'a> {
                     import_path
                 };
 
-                // Honor the importing package's "browser" field before applying a
-                // builtin polyfill. Packages that ship a browser/node split commonly
-                // set `"browser": {"crypto": false}` (or remap to a shim) and guard the
-                // `require("crypto")` at runtime; bundling the polyfill anyway defeats
-                // that and can add hundreds of KB. When the browser map has an entry
-                // for this specifier, fall through to `check_package_path`, which
-                // already handles both the disabled and the remapped case.
-                //
-                // The lookup uses the bare name (no `node:` prefix) because the
-                // polyfill table below is keyed on the bare name too; the two must
-                // agree on which spellings are the same module.
+                // The importer's package.json "browser" map wins over the builtin
+                // polyfill. The lookup uses the bare name so it matches the same
+                // spellings the polyfill table below does.
                 let browser_map_overrides_builtin = self.care_about_browser_field
                     && matches!(self.dir_info_cached(source_dir), Ok(Some(info))
                     if info
@@ -1970,8 +1962,7 @@ impl<'a> Resolver<'a> {
                         }));
 
                 if browser_map_overrides_builtin {
-                    // `check_package_path` re-runs the same browser-map lookup, so
-                    // hand it the bare name it can find.
+                    // check_package_path re-runs this lookup; give it the bare name.
                     import_path = import_path_without_node_prefix;
                 } else {
                     result.jsx = self.opts.jsx.clone();

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1939,6 +1939,13 @@ impl<'a> Resolver<'a> {
 
         if check_package {
             if self.opts.polyfill_node_globals {
+                let had_node_prefix = import_path.starts_with(b"node:");
+                let import_path_without_node_prefix: &'static [u8] = if had_node_prefix {
+                    &import_path[b"node:".len()..]
+                } else {
+                    import_path
+                };
+
                 // Honor the importing package's "browser" field before applying a
                 // builtin polyfill. Packages that ship a browser/node split commonly
                 // set `"browser": {"crypto": false}` (or remap to a shim) and guard the
@@ -1946,6 +1953,10 @@ impl<'a> Resolver<'a> {
                 // that and can add hundreds of KB. When the browser map has an entry
                 // for this specifier, fall through to `check_package_path`, which
                 // already handles both the disabled and the remapped case.
+                //
+                // The lookup uses the bare name (no `node:` prefix) because the
+                // polyfill table below is keyed on the bare name too; the two must
+                // agree on which spellings are the same module.
                 let browser_map_overrides_builtin = self.care_about_browser_field
                     && matches!(self.dir_info_cached(source_dir), Ok(Some(info))
                     if info
@@ -1953,19 +1964,17 @@ impl<'a> Resolver<'a> {
                         .is_some_and(|scope| {
                             self.check_browser_map::<{ BrowserMapPathKind::PackagePath }>(
                                 &scope,
-                                import_path,
+                                import_path_without_node_prefix,
                             )
                             .is_some()
                         }));
 
-                if !browser_map_overrides_builtin {
+                if browser_map_overrides_builtin {
+                    // `check_package_path` re-runs the same browser-map lookup, so
+                    // hand it the bare name it can find.
+                    import_path = import_path_without_node_prefix;
+                } else {
                     result.jsx = self.opts.jsx.clone();
-                    let had_node_prefix = import_path.starts_with(b"node:");
-                    let import_path_without_node_prefix = if had_node_prefix {
-                        &import_path[b"node:".len()..]
-                    } else {
-                        import_path
-                    };
 
                     if let Some(fallback_module) =
                         NodeFallbackModules::map().get(import_path_without_node_prefix)

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1939,59 +1939,80 @@ impl<'a> Resolver<'a> {
 
         if check_package {
             if self.opts.polyfill_node_globals {
-                result.jsx = self.opts.jsx.clone();
-                let had_node_prefix = import_path.starts_with(b"node:");
-                let import_path_without_node_prefix = if had_node_prefix {
-                    &import_path[b"node:".len()..]
-                } else {
-                    import_path
-                };
+                // Honor the importing package's "browser" field before applying a
+                // builtin polyfill. Packages that ship a browser/node split commonly
+                // set `"browser": {"crypto": false}` (or remap to a shim) and guard the
+                // `require("crypto")` at runtime; bundling the polyfill anyway defeats
+                // that and can add hundreds of KB. When the browser map has an entry
+                // for this specifier, fall through to `check_package_path`, which
+                // already handles both the disabled and the remapped case.
+                let browser_map_overrides_builtin = self.care_about_browser_field
+                    && matches!(self.dir_info_cached(source_dir), Ok(Some(info))
+                    if info
+                        .get_enclosing_browser_scope()
+                        .is_some_and(|scope| {
+                            self.check_browser_map::<{ BrowserMapPathKind::PackagePath }>(
+                                &scope,
+                                import_path,
+                            )
+                            .is_some()
+                        }));
 
-                if let Some(fallback_module) =
-                    NodeFallbackModules::map().get(import_path_without_node_prefix)
-                {
-                    result.path_pair.primary = fallback_module.path;
-                    result.module_type = options::ModuleType::Cjs;
-                    // @ptrFromInt(@intFromPtr(...)) — cast away constness
-                    result.package_json = Some(std::ptr::from_ref::<PackageJSON>(
-                        fallback_module.package_json,
-                    ));
-                    result.flags.set_is_from_node_modules(true);
-                    return ResultUnion::Success(result);
-                }
+                if !browser_map_overrides_builtin {
+                    result.jsx = self.opts.jsx.clone();
+                    let had_node_prefix = import_path.starts_with(b"node:");
+                    let import_path_without_node_prefix = if had_node_prefix {
+                        &import_path[b"node:".len()..]
+                    } else {
+                        import_path
+                    };
 
-                if had_node_prefix {
-                    // Module resolution fails automatically for unknown node builtins
-                    if !HardcodedAlias::has(
-                        import_path_without_node_prefix,
-                        options::Target::Node,
-                        HardcodedAliasCfg::default(),
-                    ) {
-                        return ResultUnion::NotFound;
+                    if let Some(fallback_module) =
+                        NodeFallbackModules::map().get(import_path_without_node_prefix)
+                    {
+                        result.path_pair.primary = fallback_module.path;
+                        result.module_type = options::ModuleType::Cjs;
+                        // @ptrFromInt(@intFromPtr(...)) — cast away constness
+                        result.package_json = Some(std::ptr::from_ref::<PackageJSON>(
+                            fallback_module.package_json,
+                        ));
+                        result.flags.set_is_from_node_modules(true);
+                        return ResultUnion::Success(result);
                     }
 
-                    // Valid node:* modules becomes {} in the output
-                    result.path_pair.primary.namespace = b"node";
-                    result.path_pair.primary.text = import_path_without_node_prefix;
-                    result.module_type = options::ModuleType::Cjs;
-                    result.path_pair.primary.is_disabled = true;
-                    result.flags.set_is_from_node_modules(true);
-                    result.primary_side_effects_data = SideEffects::NoSideEffectsPureData;
-                    return ResultUnion::Success(result);
-                }
+                    if had_node_prefix {
+                        // Module resolution fails automatically for unknown node builtins
+                        if !HardcodedAlias::has(
+                            import_path_without_node_prefix,
+                            options::Target::Node,
+                            HardcodedAliasCfg::default(),
+                        ) {
+                            return ResultUnion::NotFound;
+                        }
 
-                // Always mark "fs" as disabled, matching Webpack v4 behavior
-                if import_path_without_node_prefix.starts_with(b"fs")
-                    && (import_path_without_node_prefix.len() == 2
-                        || import_path_without_node_prefix[2] == b'/')
-                {
-                    result.path_pair.primary.namespace = b"node";
-                    result.path_pair.primary.text = import_path_without_node_prefix;
-                    result.module_type = options::ModuleType::Cjs;
-                    result.path_pair.primary.is_disabled = true;
-                    result.flags.set_is_from_node_modules(true);
-                    result.primary_side_effects_data = SideEffects::NoSideEffectsPureData;
-                    return ResultUnion::Success(result);
+                        // Valid node:* modules becomes {} in the output
+                        result.path_pair.primary.namespace = b"node";
+                        result.path_pair.primary.text = import_path_without_node_prefix;
+                        result.module_type = options::ModuleType::Cjs;
+                        result.path_pair.primary.is_disabled = true;
+                        result.flags.set_is_from_node_modules(true);
+                        result.primary_side_effects_data = SideEffects::NoSideEffectsPureData;
+                        return ResultUnion::Success(result);
+                    }
+
+                    // Always mark "fs" as disabled, matching Webpack v4 behavior
+                    if import_path_without_node_prefix.starts_with(b"fs")
+                        && (import_path_without_node_prefix.len() == 2
+                            || import_path_without_node_prefix[2] == b'/')
+                    {
+                        result.path_pair.primary.namespace = b"node";
+                        result.path_pair.primary.text = import_path_without_node_prefix;
+                        result.module_type = options::ModuleType::Cjs;
+                        result.path_pair.primary.is_disabled = true;
+                        result.flags.set_is_from_node_modules(true);
+                        result.primary_side_effects_data = SideEffects::NoSideEffectsPureData;
+                        return ResultUnion::Success(result);
+                    }
                 }
             }
 

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -282,6 +282,37 @@ describe("bundler", () => {
       assert(out.length < 10000, `output should be a small stub, got ${out.length} bytes`);
     },
   });
+  itBundled("browser/BrowserFieldDisablesPolyfilledBuiltinNodePrefix#4928", {
+    // Same as above but with the node: prefix on the import. The polyfill table
+    // strips node: before lookup, so the browser-map check must too.
+    files: {
+      "/entry.js": /* js */ `
+        import pkg from "pkg";
+        console.log(pkg);
+      `,
+      "/node_modules/pkg/package.json": /* json */ `
+        {
+          "name": "pkg",
+          "main": "./index.js",
+          "browser": {
+            "crypto": false
+          }
+        }
+      `,
+      "/node_modules/pkg/index.js": /* js */ `
+        const nodeCrypto = require("node:crypto");
+        module.exports = typeof nodeCrypto.randomBytes;
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "undefined",
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      assert(!out.includes("createHash"), "crypto polyfill should not be bundled when browser:{crypto:false}");
+    },
+  });
   itBundled("browser/BrowserFieldRemapsPolyfilledBuiltin#4928", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -241,6 +241,108 @@ describe("bundler", () => {
     },
   });
 
+  // #4928: a package.json "browser": {"<builtin>": false} must win over the
+  // builtin polyfill for --target browser. Packages set this to keep their
+  // node-only code paths from dragging crypto/stream/buffer into browser bundles.
+  itBundled("browser/BrowserFieldDisablesPolyfilledBuiltin#4928", {
+    files: {
+      "/entry.js": /* js */ `
+        import pkg from "pkg";
+        console.log(JSON.stringify(pkg));
+      `,
+      "/node_modules/pkg/package.json": /* json */ `
+        {
+          "name": "pkg",
+          "main": "./index.js",
+          "browser": {
+            "crypto": false,
+            "stream": false
+          }
+        }
+      `,
+      "/node_modules/pkg/index.js": /* js */ `
+        const nodeCrypto = require("crypto");
+        const nodeStream = require("stream");
+        module.exports = {
+          hasRandomBytes: typeof nodeCrypto.randomBytes,
+          hasReadable: typeof nodeStream.Readable,
+        };
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: '{"hasRandomBytes":"undefined","hasReadable":"undefined"}',
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // The crypto polyfill pulls in createHash/Transform; neither should appear
+      // when the browser map disables the builtin.
+      assert(!out.includes("createHash"), "crypto polyfill should not be bundled when browser:{crypto:false}");
+      assert(!out.includes("Transform"), "stream polyfill should not be bundled when browser:{stream:false}");
+      assert(out.length < 10000, `output should be a small stub, got ${out.length} bytes`);
+    },
+  });
+  itBundled("browser/BrowserFieldRemapsPolyfilledBuiltin#4928", {
+    files: {
+      "/entry.js": /* js */ `
+        import pkg from "pkg";
+        console.log(pkg.id);
+      `,
+      "/node_modules/pkg/package.json": /* json */ `
+        {
+          "name": "pkg",
+          "main": "./index.js",
+          "browser": {
+            "crypto": "./crypto-shim.js"
+          }
+        }
+      `,
+      "/node_modules/pkg/crypto-shim.js": /* js */ `
+        module.exports = { id: "shimmed-crypto" };
+      `,
+      "/node_modules/pkg/index.js": /* js */ `
+        module.exports = require("crypto");
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "shimmed-crypto",
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      assert(out.includes("shimmed-crypto"), "browser shim should be bundled");
+      assert(!out.includes("createHash"), "crypto polyfill should not be bundled when browser map remaps it");
+    },
+  });
+  itBundled("browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope", {
+    // A browser:{events:false} in one package must not leak into a sibling package.
+    files: {
+      "/entry.js": /* js */ `
+        import disabled from "disabled-pkg";
+        import live from "live-pkg";
+        console.log(disabled, live);
+      `,
+      "/node_modules/disabled-pkg/package.json": /* json */ `
+        { "name": "disabled-pkg", "main": "./index.js", "browser": { "events": false } }
+      `,
+      "/node_modules/disabled-pkg/index.js": /* js */ `
+        const ev = require("events");
+        module.exports = typeof ev.EventEmitter;
+      `,
+      "/node_modules/live-pkg/package.json": /* json */ `
+        { "name": "live-pkg", "main": "./index.js" }
+      `,
+      "/node_modules/live-pkg/index.js": /* js */ `
+        const ev = require("events");
+        module.exports = typeof ev.EventEmitter;
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "undefined function",
+    },
+  });
+
   // unsure: do we want polyfills or no-op stuff like node:* has
   // right now all error except bun:wrap which errors at resolve time, but is included if external
   const bunModules: Record<string, "no-op" | "polyfill" | "error"> = {


### PR DESCRIPTION
Closes #4928.

### Repro

```sh
# package.json: @web3modal/ethereum@2.7.1, @web3modal/html@2.7.1,
#               @wagmi/core@1.4.1, viem@1.10.14, esbuild@0.19.2
bun build src.js --minify --outfile=out-bun.js
npx esbuild src.js --bundle --minify --outfile=out-esbuild.js
wc -c out-bun.js out-esbuild.js
```

| | before | after | esbuild |
|---|---|---|---|
| bytes | 1,411,198 | 892,714 | 876,664 |

The 534 KB gap was entirely node builtin polyfills in the bun output:

```
392594  node:crypto
 93179  node:stream
 28497  node:buffer
  8429  node:util
  7428  node:events
```

all reached via a single `require("crypto")` in `@stablelib/random/lib/source/node.js`. That package declares

```json
"browser": { "crypto": false }
```

which esbuild, webpack, and the browser-field spec all read as "replace with an empty module". Bun resolved it to the crypto polyfill instead, which transitively brought in stream, buffer, util and events.

### Cause

`resolve_without_symlinks` in `src/resolver/resolver.rs`: for `--target browser` the `polyfill_node_globals` block looks up the import in `NodeFallbackModules::map()` and returns the polyfill immediately. `check_package_path`, which is where the enclosing package.json `browser` map is consulted, runs after that block and is never reached for any specifier that has a polyfill (`crypto`, `stream`, `buffer`, `util`, `events`, `path`, `url`, ...). The existing `packagejson/BrowserMapNativeModuleDisabled` test only covers `fs`, which is not in the polyfill table and so never hit this path.

The same ordering also broke remapping: `"browser": { "crypto": "./shim.js" }` was ignored and the polyfill was bundled anyway.

### Fix

Before the polyfill lookup, consult the importer's enclosing browser scope for an entry matching the specifier. When one exists (either `false` or a remap target), skip the polyfill block and fall through to `check_package_path`, which already handles both cases. Packages without a matching `browser` entry are unaffected and continue to receive the polyfill.

### Verification

New tests in `test/bundler/bundler_browser.test.ts`:
- `browser/BrowserFieldDisablesPolyfilledBuiltin#4928`: `"browser": {"crypto": false, "stream": false}`; asserts the polyfills are absent from the output and the requires resolve to an empty stub at runtime.
- `browser/BrowserFieldRemapsPolyfilledBuiltin#4928`: `"browser": {"crypto": "./crypto-shim.js"}`; asserts the shim is bundled and the polyfill is not.
- `browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope`: a sibling package without a `browser` entry still receives the polyfill (scoping is per-package).

All three fail on 1.4.0-canary (`USE_SYSTEM_BUN=1`) and pass with this change. `bundler_browser.test.ts` (16 pass), `esbuild/packagejson.test.ts` (74 pass), `bundler_npm.test.ts` + `bundler_edgecase.test.ts` (119 pass), `test/js/bun/resolve/resolve.test.ts` (64 pass), all 0 fail.

### Remaining gap

The residual 16 KB vs esbuild on this input is unrelated: bun resolves the `development` exports condition for `lit-html` / `@lit/reactive-element` where esbuild takes `default`. Not addressed here.