### PR TITLE
fetch: cache client TLS sessions for resumption

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -191,6 +191,12 @@ static int us_ssl_pending_keylog_idx = -1;
  * received NewSessionTicket, so SSL_get_session() alone gives an unresumable
  * snapshot; node:tls's getSession()/getTLSTicket() read from here instead. */
 static int us_ssl_new_session_ref_idx = -1;
+/* Optional per-SSL sink for resumable sessions: an owner pointer plus a
+ * callback that receives each SSL_SESSION_up_ref'd session. Checked before the
+ * us_ssl_is_socket_ex_idx opt-in so consumers that don't surface a JS
+ * 'session' event (fetch) can still cache without paying the serialized
+ * pending-session queue. */
+static int us_ssl_session_sink_idx = -1;
 #ifdef _WIN32
 static INIT_ONCE us_ex_idx_once = INIT_ONCE_STATIC_INIT;
 #else
@@ -282,6 +288,20 @@ static void us_ssl_new_session_ref_free(void *parent, void *ptr, CRYPTO_EX_DATA 
   (void)parent; (void)ad; (void)index; (void)argl; (void)argp;
   if (ptr) SSL_SESSION_free((SSL_SESSION *)ptr);
 }
+
+struct us_ssl_session_sink_t {
+  void *owner;
+  void (*on_new_session)(void *owner, SSL_SESSION *session);
+  void (*on_free)(void *owner);
+};
+static void us_ssl_session_sink_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
+                                     int index, long argl, void *argp) {
+  (void)parent; (void)ad; (void)index; (void)argl; (void)argp;
+  if (!ptr) return;
+  struct us_ssl_session_sink_t *sink = ptr;
+  if (sink->on_free) sink->on_free(sink->owner);
+  us_free(sink);
+}
 /* NSS key-log lines are produced from inside SSL_do_handshake/SSL_read, so
  * they are parked on the SSL the same way new sessions are and delivered once
  * the read unwinds. The stored bytes already carry the trailing newline Node
@@ -334,12 +354,21 @@ static void ssl_flush_pending_keylog(struct us_socket_t *s) {
 }
 
 static int us_ssl_new_session_cb(SSL *ssl, SSL_SESSION *session) {
+  /* The session sink is the cheap path: hand the session to an owner-provided
+   * callback (one up_ref, no i2d serialize, no queue). Used by the HTTP
+   * client's per-origin session cache. */
+  struct us_ssl_session_sink_t *sink = SSL_get_ex_data(ssl, us_ssl_session_sink_idx);
+  if (sink && sink->on_new_session) {
+    SSL_SESSION_up_ref(session);
+    sink->on_new_session(sink->owner, session);
+    return 0;
+  }
   /* Park only for consumers that will drain the queue: SSLs attached to a
    * real us_socket_t (flushed into us_dispatch_session once the read unwinds)
    * and SSLs whose owner opted in via us_ssl_enable_pending_events (the
    * Rust SSLWrapper behind TLS-over-duplex / named pipes, which polls
-   * us_ssl_pop_pending_session after its reads). Everything else (fetch,
-   * WebSocket tunnels) has no consumer - don't queue. */
+   * us_ssl_pop_pending_session after its reads). Everything else (WebSocket
+   * tunnels) has no consumer - don't queue. */
   if (!SSL_get_ex_data(ssl, us_ssl_is_socket_ex_idx)) {
     return 0;
   }
@@ -421,6 +450,7 @@ static void us_ex_idx_init(void) {
   us_ssl_pending_session_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_pending_session_free);
   us_ssl_pending_keylog_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_pending_session_free);
   us_ssl_new_session_ref_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_new_session_ref_free);
+  us_ssl_session_sink_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_session_sink_free);
 }
 
 #ifdef _WIN32
@@ -442,6 +472,37 @@ static inline void us_ex_idx_ensure(void) {
 static inline int us_ssl_ctx_ex_idx(void) {
   us_ex_idx_ensure();
   return us_ctx_ex_idx;
+}
+
+/* Install a session sink on `ssl`: each resumable session reaching the
+ * new-session callback is SSL_SESSION_up_ref'd and passed to `on_new_session`
+ * (which takes ownership of that reference). `on_free(owner)` runs once on
+ * SSL_free. Replacing an existing sink first frees the old one. */
+void us_ssl_set_session_sink(SSL *ssl, void *owner,
+                             void (*on_new_session)(void *, SSL_SESSION *),
+                             void (*on_free)(void *)) {
+  us_ex_idx_ensure();
+  struct us_ssl_session_sink_t *sink = us_malloc(sizeof(*sink));
+  if (!sink) {
+    if (on_free) on_free(owner);
+    return;
+  }
+  sink->owner = owner;
+  sink->on_new_session = on_new_session;
+  sink->on_free = on_free;
+  struct us_ssl_session_sink_t *old = SSL_get_ex_data(ssl, us_ssl_session_sink_idx);
+  SSL_set_ex_data(ssl, us_ssl_session_sink_idx, sink);
+  if (old) {
+    if (old->on_free) old->on_free(old->owner);
+    us_free(old);
+  }
+}
+
+/* The `owner` pointer installed via us_ssl_set_session_sink, or NULL. */
+void *us_ssl_get_session_sink_owner(SSL *ssl) {
+  if (us_ssl_session_sink_idx < 0) return NULL;
+  struct us_ssl_session_sink_t *sink = SSL_get_ex_data(ssl, us_ssl_session_sink_idx);
+  return sink ? sink->owner : NULL;
 }
 
 /* TLS-over-duplex / named-pipe owners (the Rust SSLWrapper): opt this SSL

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -505,6 +505,22 @@ void *us_ssl_get_session_sink_owner(SSL *ssl) {
   return sink ? sink->owner : NULL;
 }
 
+/* Free the session sink on every socket in `group`. Called at process shutdown
+ * so LeakSanitizer doesn't report sinks on SSLs that survive until exit (the
+ * HTTP thread's keep-alive pool is never drained, and its TLS-rooted owner is
+ * not scanned as an LSAN root). */
+void us_socket_group_clear_session_sinks(struct us_socket_group_t *group) {
+  if (!group || us_ssl_session_sink_idx < 0) return;
+  for (struct us_socket_t *s = group->head_sockets; s; s = s->next) {
+    if (!s->ssl) continue;
+    struct us_ssl_session_sink_t *sink = SSL_get_ex_data(s_ssl(s), us_ssl_session_sink_idx);
+    if (!sink) continue;
+    SSL_set_ex_data(s_ssl(s), us_ssl_session_sink_idx, NULL);
+    if (sink->on_free) sink->on_free(sink->owner);
+    us_free(sink);
+  }
+}
+
 /* TLS-over-duplex / named-pipe owners (the Rust SSLWrapper): opt this SSL
  * into the parked session/keylog queues so us_ssl_new_session_cb /
  * us_ssl_keylog_cb collect them. There is no us_socket_t to flush into

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -505,22 +505,6 @@ void *us_ssl_get_session_sink_owner(SSL *ssl) {
   return sink ? sink->owner : NULL;
 }
 
-/* Free the session sink on every socket in `group`. Called at process shutdown
- * so LeakSanitizer doesn't report sinks on SSLs that survive until exit (the
- * HTTP thread's keep-alive pool is never drained, and its TLS-rooted owner is
- * not scanned as an LSAN root). */
-void us_socket_group_clear_session_sinks(struct us_socket_group_t *group) {
-  if (!group || us_ssl_session_sink_idx < 0) return;
-  for (struct us_socket_t *s = group->head_sockets; s; s = s->next) {
-    if (!s->ssl) continue;
-    struct us_ssl_session_sink_t *sink = SSL_get_ex_data(s_ssl(s), us_ssl_session_sink_idx);
-    if (!sink) continue;
-    SSL_set_ex_data(s_ssl(s), us_ssl_session_sink_idx, NULL);
-    if (sink->on_free) sink->on_free(sink->owner);
-    us_free(sink);
-  }
-}
-
 /* TLS-over-duplex / named-pipe owners (the Rust SSLWrapper): opt this SSL
  * into the parked session/keylog queues so us_ssl_new_session_cb /
  * us_ssl_keylog_cb collect them. There is no us_socket_t to flush into

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -561,6 +561,7 @@ void us_ssl_set_session_sink(struct ssl_st *ssl, void *owner,
                              void (*on_new_session)(void *, struct ssl_session_st *),
                              void (*on_free)(void *));
 void *us_ssl_get_session_sink_owner(struct ssl_st *ssl);
+void us_socket_group_clear_session_sinks(struct us_socket_group_t *group);
 
 /* Public interfaces for loops */
 

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -561,7 +561,6 @@ void us_ssl_set_session_sink(struct ssl_st *ssl, void *owner,
                              void (*on_new_session)(void *, struct ssl_session_st *),
                              void (*on_free)(void *));
 void *us_ssl_get_session_sink_owner(struct ssl_st *ssl);
-void us_socket_group_clear_session_sinks(struct us_socket_group_t *group);
 
 /* Public interfaces for loops */
 

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -554,6 +554,13 @@ int us_ssl_pop_pending_keylog(struct ssl_st *ssl, unsigned char *out, int out_ca
 /* The resumable session most recently delivered via the new-session callback,
  * or NULL if none. Borrowed; valid until the next NewSessionTicket or SSL_free. */
 struct ssl_session_st *us_ssl_get_new_session(struct ssl_st *ssl);
+/* Per-SSL session sink: each resumable session reaching the new-session
+ * callback is SSL_SESSION_up_ref'd and handed to on_new_session (which takes
+ * ownership of that reference). on_free(owner) runs once on SSL_free. */
+void us_ssl_set_session_sink(struct ssl_st *ssl, void *owner,
+                             void (*on_new_session)(void *, struct ssl_session_st *),
+                             void (*on_free)(void *));
+void *us_ssl_get_session_sink_owner(struct ssl_st *ssl);
 
 /* Public interfaces for loops */
 

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -94,30 +94,38 @@ pub unsafe fn ssl_ctx_setup(ctx: *mut boring::SSL_CTX) {
 // into the process, including pthreads locks. Failing to meet these constraints
 // may result in deadlocks, crashes, or memory corruption.
 
+// Routed through `default_alloc` (mimalloc, or libc under `cfg(bun_asan)`)
+// rather than `mimalloc` directly. The BoringSSL build already drops
+// `BORINGSSL_REQUIRE_MEMORY_HOOKS` under ASAN so Mach-O/COFF fall back to
+// libc, but on ELF the weak hook symbols still resolve to these definitions;
+// hard-coding mimalloc here put every `OPENSSL_malloc` allocation outside
+// LeakSanitizer's scanned set and any libc-backed allocation reachable only
+// via one (an SSL's ex_data array, the per-SSL session-sink owner it holds)
+// was reported as a leak at exit.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn OPENSSL_memory_alloc(size: usize) -> *mut c_void {
-    bun_alloc::mimalloc::mi_malloc(size)
+    bun_alloc::default_alloc::malloc(size)
 }
 
 // BoringSSL always expects memory to be zero'd
 /// # Safety
-/// `ptr` must be non-null and have been returned by `OPENSSL_memory_alloc`
-/// (i.e. `mi_malloc`); BoringSSL guarantees both for this hook.
+/// `ptr` must be non-null and returned by `OPENSSL_memory_alloc`; BoringSSL
+/// guarantees both for this hook.
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn OPENSSL_memory_free(ptr: *mut c_void) {
     // SAFETY: BoringSSL guarantees ptr is non-null and was returned by
-    // OPENSSL_memory_alloc above (i.e. mi_malloc).
+    // OPENSSL_memory_alloc above.
     unsafe {
-        let len = bun_alloc::usable_size(ptr.cast());
+        let len = bun_alloc::default_alloc::usable_size(ptr);
         ptr::write_bytes(ptr.cast::<u8>(), 0, len);
-        bun_alloc::mimalloc::mi_free(ptr);
+        bun_alloc::default_alloc::free(ptr);
     }
 }
 
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn OPENSSL_memory_get_size(ptr: *const c_void) -> usize {
-    // ptr was returned by mi_malloc (or is null, which usable_size handles).
-    bun_alloc::usable_size(ptr.cast())
+    // SAFETY: ptr was returned by OPENSSL_memory_alloc (null-safe).
+    unsafe { bun_alloc::default_alloc::usable_size(ptr) }
 }
 
 pub use bun_sys::posix::INET6_ADDRSTRLEN;

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -271,8 +271,7 @@ pub mod default_alloc {
     /// # Safety
     /// `ptr` must be null or a live allocation from the default allocator.
     #[inline]
-    #[cfg(any(debug_assertions, bun_asan))]
-    pub(crate) unsafe fn usable_size(ptr: *const c_void) -> usize {
+    pub unsafe fn usable_size(ptr: *const c_void) -> usize {
         if ptr.is_null() {
             return 0;
         }

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -208,6 +208,9 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER, "BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_ISOLATION_SOURCE_CACHE, "BUN_FEATURE_FLAG_DISABLE_ISOLATION_SOURCE_CACHE", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_DNS_CACHE, "BUN_FEATURE_FLAG_DISABLE_DNS_CACHE", {});
+    // Disable client-side TLS session resumption for fetch(): every fresh
+    // connect does a full handshake + chain verification.
+    new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE, "BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO, "BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO", {});
     // Force the event loop to use epoll_pwait(2) instead of epoll_pwait2(2).
     // Escape hatch for seccomp policies that block syscall 441 without

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -208,8 +208,6 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER, "BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_ISOLATION_SOURCE_CACHE, "BUN_FEATURE_FLAG_DISABLE_ISOLATION_SOURCE_CACHE", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_DNS_CACHE, "BUN_FEATURE_FLAG_DISABLE_DNS_CACHE", {});
-    // Disable client-side TLS session resumption for fetch(): every fresh
-    // connect does a full handshake + chain verification.
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE, "BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO, "BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO", {});
     // Force the event loop to use epoll_pwait(2) instead of epoll_pwait2(2).

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -55,9 +55,7 @@ pub struct HTTPContext<const SSL: bool> {
     // into the box interior; unboxing would dangle it on `Vec` realloc.
     #[expect(clippy::vec_box)]
     pub(crate) pending_h2_connects: Vec<Box<h2::PendingConnect>>,
-    /// Client-side TLS session cache for `SSL_set_session` resumption.
-    /// Only populated when `SSL`; present on both so the struct stays
-    /// const-generic-agnostic like `secure`.
+    /// Client-side TLS session cache; populated only when `SSL`.
     pub(crate) session_cache: crate::session_cache::SessionCache,
 }
 

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -18,7 +18,7 @@ use bun_uws as uws;
 bun_core::declare_scope!(HTTPContext, hidden);
 
 const POOL_SIZE: usize = 64;
-const MAX_KEEPALIVE_HOSTNAME: usize = 128;
+pub(crate) const MAX_KEEPALIVE_HOSTNAME: usize = 128;
 
 /// The const-generic `SSL` is load-bearing for monomorphization (gates hot
 /// inner-loop branches); do not demote to a runtime bool.
@@ -55,6 +55,10 @@ pub struct HTTPContext<const SSL: bool> {
     // into the box interior; unboxing would dangle it on `Vec` realloc.
     #[expect(clippy::vec_box)]
     pub(crate) pending_h2_connects: Vec<Box<h2::PendingConnect>>,
+    /// Client-side TLS session cache for `SSL_set_session` resumption.
+    /// Only populated when `SSL`; present on both so the struct stays
+    /// const-generic-agnostic like `secure`.
+    pub(crate) session_cache: crate::session_cache::SessionCache,
 }
 
 // Intrusive refcount:
@@ -1177,6 +1181,12 @@ impl<const SSL: bool> Handler<SSL> {
                         // `client` again.
                         return;
                     }
+                    // Peer chain + hostname verified: let the session sink
+                    // flush its pending TLS 1.2 ticket (parked before this
+                    // dispatch) and cache later TLS 1.3 tickets directly.
+                    // SAFETY: `ssl` is the live handle for this socket on the
+                    // HTTP thread.
+                    unsafe { crate::session_cache::arm(ssl) };
                 }
 
                 return client.first_call::<SSL>(socket);

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -162,6 +162,7 @@ impl HttpThread {
                 secure: None,
                 active_h2_sessions: Vec::new(),
                 pending_h2_connects: Vec::new(),
+                session_cache: crate::session_cache::SessionCache::new(),
             },
             https_context: NewHttpContext::<true> {
                 ref_count: Cell::new(1),
@@ -170,6 +171,7 @@ impl HttpThread {
                 secure: None,
                 active_h2_sessions: Vec::new(),
                 pending_h2_connects: Vec::new(),
+                session_cache: crate::session_cache::SessionCache::new(),
             },
             lazy_https_init: None,
             queued_tasks: Queue::new(),
@@ -530,6 +532,7 @@ impl HttpThread {
                     secure: None,
                     active_h2_sessions: Vec::new(),
                     pending_h2_connects: Vec::new(),
+                    session_cache: crate::session_cache::SessionCache::new(),
                 }));
                 if let Err(err) = custom_context.init_with_client_config(client) {
                     // `init_with_client_config` fails before `group.init()` runs.

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1069,10 +1069,6 @@ impl HttpThread {
                 );
             }
         }
-        crate::session_cache::drain_for_exit(&mut self.https_context);
-        for entry in custom_ssl_context_map().values_mut() {
-            crate::session_cache::drain_for_exit(entry.ctx_mut());
-        }
     }
 
     pub(crate) fn wakeup(&self) {

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1069,6 +1069,10 @@ impl HttpThread {
                 );
             }
         }
+        crate::session_cache::drain_for_exit(&mut self.https_context);
+        for entry in custom_ssl_context_map().values_mut() {
+            crate::session_cache::drain_for_exit(entry.ctx_mut());
+        }
     }
 
     pub(crate) fn wakeup(&self) {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -39,6 +39,8 @@ pub mod lshpack;
 pub mod proxy_tunnel;
 #[path = "SendFile.rs"]
 pub mod send_file;
+#[path = "session_cache.rs"]
+pub mod session_cache;
 #[path = "Signals.rs"]
 pub mod signals;
 #[path = "ThreadSafeStreamBuffer.rs"]
@@ -1851,6 +1853,48 @@ impl<'a> HTTPClient<'a> {
                     host_z,
                     self.alpn_offer(),
                 );
+
+                // Offer any cached TLS session for this origin and install a
+                // sink for the ticket(s) this handshake will yield. Skipped
+                // for `rejectUnauthorized:false` (a resumed handshake would
+                // launder the unverified cert's stored verify_result into a
+                // later strict caller), for the JS `checkServerIdentity`
+                // callback path (verification happens off-thread after
+                // `on_handshake`, so the sink can't be armed safely), and for
+                // unix sockets (no `(host, port)` key). The sink stays
+                // unarmed until `on_handshake` confirms `checkServerIdentity`
+                // passed.
+                if self.flags.reject_unauthorized
+                    && !self.signals.get(signals::Field::CertErrors)
+                    && self.unix_socket_path.slice().is_empty()
+                    && crate::session_cache::enabled()
+                {
+                    let hostname: &[u8] = self.connected_url.hostname;
+                    let port = self.connected_url.get_port_auto();
+                    // Same discriminator the keep-alive pool uses for direct
+                    // TLS (`HTTPContext::connect` and `release_socket`): the
+                    // Host-header SNI override / proxy-header hash.
+                    let want_tunnel = self.http_proxy.is_some() && self.url.is_https();
+                    let proxy_auth_hash = if want_tunnel || self.http_proxy.is_none() {
+                        self.proxy_auth_hash()
+                    } else {
+                        0
+                    };
+                    // SAFETY: `ssl_ptr` is live and pre-handshake (guarded by
+                    // `SSL_is_init_finished == 0` above); `get_ssl_ctx` returns
+                    // either the static `https_context` or the heap context
+                    // this client holds a strong ref on, both of which outlive
+                    // every SSL attached to their socket group.
+                    unsafe {
+                        crate::session_cache::install(
+                            ssl_ptr,
+                            self.get_ssl_ctx::<true>(),
+                            hostname,
+                            port,
+                            proxy_auth_hash,
+                        );
+                    }
+                }
             }
         } else {
             self.first_call::<IS_SSL>(socket);

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1854,44 +1854,24 @@ impl<'a> HTTPClient<'a> {
                     self.alpn_offer(),
                 );
 
-                // Offer any cached TLS session for this origin and install a
-                // sink for the ticket(s) this handshake will yield. Skipped
-                // for `rejectUnauthorized:false` (a resumed handshake would
-                // launder the unverified cert's stored verify_result into a
-                // later strict caller), for the JS `checkServerIdentity`
-                // callback path (verification happens off-thread after
-                // `on_handshake`, so the sink can't be armed safely), and for
-                // unix sockets (no `(host, port)` key). The sink stays
-                // unarmed until `on_handshake` confirms `checkServerIdentity`
-                // passed.
-                if self.flags.reject_unauthorized
-                    && !self.signals.get(signals::Field::CertErrors)
-                    && self.unix_socket_path.slice().is_empty()
-                    && crate::session_cache::enabled()
-                {
-                    let hostname: &[u8] = self.connected_url.hostname;
-                    let port = self.connected_url.get_port_auto();
-                    // Same discriminator the keep-alive pool uses for direct
-                    // TLS (`HTTPContext::connect` and `release_socket`): the
-                    // Host-header SNI override / proxy-header hash.
+                if crate::session_cache::eligible(self) {
                     let want_tunnel = self.http_proxy.is_some() && self.url.is_https();
-                    let proxy_auth_hash = if want_tunnel || self.http_proxy.is_none() {
-                        self.proxy_auth_hash()
-                    } else {
-                        0
-                    };
                     // SAFETY: `ssl_ptr` is live and pre-handshake (guarded by
                     // `SSL_is_init_finished == 0` above); `get_ssl_ctx` returns
-                    // either the static `https_context` or the heap context
-                    // this client holds a strong ref on, both of which outlive
+                    // the static `https_context` or the heap context this
+                    // client holds a strong ref on, both of which outlive
                     // every SSL attached to their socket group.
                     unsafe {
                         crate::session_cache::install(
                             ssl_ptr,
                             self.get_ssl_ctx::<true>(),
-                            hostname,
-                            port,
-                            proxy_auth_hash,
+                            self.connected_url.hostname,
+                            self.connected_url.get_port_auto(),
+                            if want_tunnel || self.http_proxy.is_none() {
+                                self.proxy_auth_hash()
+                            } else {
+                                0
+                            },
                         );
                     }
                 }

--- a/src/http/session_cache.rs
+++ b/src/http/session_cache.rs
@@ -1,0 +1,295 @@
+//! Client-side TLS session cache for `fetch()`.
+//!
+//! BoringSSL's new-session callback is the only place a resumable TLS 1.3
+//! session surfaces, and [`us_ssl_new_session_cb`] discards it for every
+//! consumer except `Bun.connect` / `node:tls`. This module gives the HTTP
+//! client a sink for those sessions so a second cold connect to an origin can
+//! offer the stored ticket via `SSL_set_session` and skip the full handshake
+//! (certificate chain walk + signature verification).
+//!
+//! The cache lives on [`HTTPContext<true>`] — one per interned `SSLConfig` —
+//! and is keyed on the same `(hostname, port, proxy_auth_hash)` tuple the
+//! keep-alive pool uses for direct TLS, so a cached session never crosses an
+//! SNI / Host-override boundary the pool wouldn't. Only handshakes that ran
+//! with `rejectUnauthorized=true` and passed `checkServerIdentity` insert,
+//! because a resumed handshake restores the stored `verify_result` without
+//! re-sending Certificate; caching an unverified session would launder it
+//! into a later strict caller.
+//!
+//! Lifetime: all access is HTTP-thread-only (interior `RefCell`, no locking).
+//! Each entry owns one `SSL_SESSION` reference, released on eviction /
+//! `Drop`. The per-SSL [`SessionSink`] is heap-allocated, stored in a
+//! BoringSSL ex_data slot on the `SSL`, and freed by the ex_data free
+//! callback when the socket's `SSL` is freed.
+
+use core::cell::RefCell;
+use core::ffi::c_void;
+use core::ptr::NonNull;
+
+use bun_boringssl_sys::{SSL, SSL_SESSION, SSL_SESSION_free, SSL_set_session};
+use bun_core::strings;
+
+use crate::http_context::MAX_KEEPALIVE_HOSTNAME;
+
+/// Per-context LRU capacity. An `SSL_SESSION` retains the peer's full cert
+/// chain (multi-KB) and there is one `HTTPContext<true>` per interned
+/// `SSLConfig`, so this stays well below rustls' 256-entry default.
+const SESSION_CACHE_CAPACITY: usize = 32;
+
+/// One owned `SSL_SESSION` reference keyed on the pool tuple. `session` is
+/// `Option` so [`SessionCache::take`] can move ownership out and let the
+/// entry drop normally.
+struct CacheEntry {
+    hostname: Box<[u8]>,
+    port: u16,
+    proxy_auth_hash: u64,
+    session: Option<NonNull<SSL_SESSION>>,
+}
+
+impl Drop for CacheEntry {
+    fn drop(&mut self) {
+        if let Some(s) = self.session.take() {
+            // SAFETY: the entry owns one reference taken by
+            // `us_ssl_new_session_cb` (`SSL_SESSION_up_ref`) before handing
+            // the pointer to [`sink_on_new_session`].
+            unsafe { SSL_SESSION_free(s.as_ptr()) };
+        }
+    }
+}
+
+/// Move-to-front LRU over a small `Vec`. Lookup is O(n) in `CAPACITY`; with
+/// 32 entries this is cheaper than a map and keeps eviction trivial.
+#[derive(Default)]
+pub(crate) struct SessionCache {
+    entries: RefCell<Vec<CacheEntry>>,
+}
+
+impl SessionCache {
+    pub(crate) const fn new() -> Self {
+        Self {
+            entries: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Remove and return the session for `(hostname, port, hash)`, passing
+    /// its +1 reference to the caller. Returns `None` for hostnames longer
+    /// than the pool's `MAX_KEEPALIVE_HOSTNAME` (the insert side skips them
+    /// too). A TLS 1.3 ticket is single-use, so this consumes the entry.
+    pub(crate) fn take(
+        &self,
+        hostname: &[u8],
+        port: u16,
+        proxy_auth_hash: u64,
+    ) -> Option<NonNull<SSL_SESSION>> {
+        if hostname.len() > MAX_KEEPALIVE_HOSTNAME {
+            return None;
+        }
+        let mut entries = self.entries.borrow_mut();
+        let idx = entries.iter().position(|e| {
+            e.port == port
+                && e.proxy_auth_hash == proxy_auth_hash
+                && strings::eql_long(&e.hostname, hostname, true)
+        })?;
+        entries.remove(idx).session.take()
+    }
+
+    /// Insert `session` (caller hands over its +1 ref). A matching key
+    /// replaces; a full cache evicts the least-recently-inserted entry.
+    fn insert(
+        &self,
+        hostname: &[u8],
+        port: u16,
+        proxy_auth_hash: u64,
+        session: NonNull<SSL_SESSION>,
+    ) {
+        if hostname.len() > MAX_KEEPALIVE_HOSTNAME {
+            // SAFETY: caller transferred one reference.
+            unsafe { SSL_SESSION_free(session.as_ptr()) };
+            return;
+        }
+        let mut entries = self.entries.borrow_mut();
+        if let Some(idx) = entries.iter().position(|e| {
+            e.port == port
+                && e.proxy_auth_hash == proxy_auth_hash
+                && strings::eql_long(&e.hostname, hostname, true)
+        }) {
+            let _ = entries.remove(idx);
+        } else if entries.len() >= SESSION_CACHE_CAPACITY {
+            let _ = entries.remove(0);
+        }
+        entries.push(CacheEntry {
+            hostname: Box::<[u8]>::from(hostname),
+            port,
+            proxy_auth_hash,
+            session: Some(session),
+        });
+    }
+}
+
+/// Per-`SSL` sink installed in `on_open` and torn down by the ex_data free
+/// callback on `SSL_free`. Box-allocated; the ex_data slot holds the raw
+/// pointer.
+pub(crate) struct SessionSink {
+    ctx: *const crate::HttpsContext,
+    hostname: Box<[u8]>,
+    port: u16,
+    proxy_auth_hash: u64,
+    /// Set once `checkServerIdentity` passes. Sessions delivered earlier
+    /// (TLS 1.2 fires inside `SSL_do_handshake`, before `on_handshake`) are
+    /// parked in `pending` instead of inserted.
+    armed: bool,
+    /// Most-recent session delivered before `armed`. Owned +1 reference.
+    pending: Option<NonNull<SSL_SESSION>>,
+}
+
+impl Drop for SessionSink {
+    fn drop(&mut self) {
+        if let Some(p) = self.pending.take() {
+            // SAFETY: `pending` owns one reference.
+            unsafe { SSL_SESSION_free(p.as_ptr()) };
+        }
+    }
+}
+
+/// FFI sink callback: receives one `SSL_SESSION_up_ref`'d session.
+extern "C" fn sink_on_new_session(owner: *mut c_void, session: *mut SSL_SESSION) {
+    let Some(session) = NonNull::new(session) else {
+        return;
+    };
+    let Some(owner) = NonNull::new(owner.cast::<SessionSink>()) else {
+        // SAFETY: +1 reference received from C with no consumer.
+        unsafe { SSL_SESSION_free(session.as_ptr()) };
+        return;
+    };
+    // SAFETY: `owner` is the Box interior installed by [`install`]; the
+    // new-session callback runs on the HTTP thread inside
+    // `SSL_read`/`SSL_do_handshake`, and nothing else holds `&mut` to the
+    // sink during that call.
+    let sink = unsafe { owner.as_ref() };
+    if sink.armed {
+        // SAFETY: `ctx` is the live `HTTPContext<true>` owning this socket's
+        // group; the context outlives every SSL attached to it (see
+        // `HTTPContext::ref_count` doc). `session_cache` is accessed via
+        // shared borrow + `RefCell`.
+        unsafe { &*sink.ctx }.session_cache.insert(
+            &sink.hostname,
+            sink.port,
+            sink.proxy_auth_hash,
+            session,
+        );
+    } else {
+        // SAFETY: unique access on the HTTP thread (see above).
+        let sink = unsafe { &mut *owner.as_ptr() };
+        if let Some(prev) = sink.pending.replace(session) {
+            // SAFETY: `pending` owned one reference.
+            unsafe { SSL_SESSION_free(prev.as_ptr()) };
+        }
+    }
+}
+
+/// FFI free callback for the ex_data slot: reclaims the Box.
+extern "C" fn sink_on_free(owner: *mut c_void) {
+    if owner.is_null() {
+        return;
+    }
+    // SAFETY: `owner` is the `Box::into_raw` from [`install`]; the ex_data
+    // free callback fires exactly once on `SSL_free`.
+    drop(unsafe { Box::from_raw(owner.cast::<SessionSink>()) });
+}
+
+unsafe extern "C" {
+    fn us_ssl_set_session_sink(
+        ssl: *mut SSL,
+        owner: *mut c_void,
+        on_new_session: Option<extern "C" fn(*mut c_void, *mut SSL_SESSION)>,
+        on_free: Option<extern "C" fn(*mut c_void)>,
+    );
+    fn us_ssl_get_session_sink_owner(ssl: *mut SSL) -> *mut c_void;
+}
+
+pub(crate) fn enabled() -> bool {
+    !bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE
+        .get()
+        .unwrap_or(false)
+}
+
+/// Look up a cached session on `ctx` for this key and, if found, offer it on
+/// `ssl` before the handshake starts. Then install a sink so new tickets from
+/// this handshake are captured. `ctx` must be the `HTTPContext<true>` that
+/// owns `ssl`'s socket.
+///
+/// # Safety
+/// `ssl` must be a live pre-handshake `SSL*`. `ctx` must be a live
+/// `HTTPContext<true>` that outlives `ssl`.
+pub(crate) unsafe fn install(
+    ssl: *mut SSL,
+    ctx: *const crate::HttpsContext,
+    hostname: &[u8],
+    port: u16,
+    proxy_auth_hash: u64,
+) {
+    debug_assert!(!ssl.is_null());
+    debug_assert!(!ctx.is_null());
+    // SAFETY: caller contract — `ctx` is live.
+    let cache = unsafe { &(*ctx).session_cache };
+    if let Some(session) = cache.take(hostname, port, proxy_auth_hash) {
+        // SAFETY: `ssl` is live and pre-handshake per caller contract;
+        // `SSL_set_session` takes its own reference, so release ours after.
+        unsafe {
+            SSL_set_session(ssl, session.as_ptr());
+            SSL_SESSION_free(session.as_ptr());
+        }
+    }
+    let sink = Box::new(SessionSink {
+        ctx,
+        hostname: Box::<[u8]>::from(hostname),
+        port,
+        proxy_auth_hash,
+        armed: false,
+        pending: None,
+    });
+    // SAFETY: `ssl` is live; ownership of the Box moves to the ex_data slot
+    // whose free callback reclaims it.
+    unsafe {
+        us_ssl_set_session_sink(
+            ssl,
+            Box::into_raw(sink).cast::<c_void>(),
+            Some(sink_on_new_session),
+            Some(sink_on_free),
+        );
+    }
+}
+
+/// Called from `on_handshake` after `checkServerIdentity` passes. Flushes any
+/// session parked before verification (TLS 1.2) and lets later tickets
+/// (TLS 1.3 post-handshake) go straight to the cache.
+///
+/// # Safety
+/// `ssl` must be a live `SSL*` on the HTTP thread.
+pub(crate) unsafe fn arm(ssl: *mut SSL) {
+    if ssl.is_null() {
+        return;
+    }
+    // SAFETY: caller contract.
+    let owner = unsafe { us_ssl_get_session_sink_owner(ssl) };
+    let Some(mut owner) = NonNull::new(owner.cast::<SessionSink>()) else {
+        return;
+    };
+    // SAFETY: `owner` is the Box interior installed by [`install`], live
+    // until `SSL_free`; HTTP-thread-only so this `&mut` is unique.
+    let sink = unsafe { owner.as_mut() };
+    if sink.armed {
+        return;
+    }
+    sink.armed = true;
+    if let Some(session) = sink.pending.take() {
+        // SAFETY: `ctx` was live at install and outlives `ssl`; see
+        // `HTTPContext::ref_count` doc.
+        unsafe { &*sink.ctx }.session_cache.insert(
+            &sink.hostname,
+            sink.port,
+            sink.proxy_auth_hash,
+            session,
+        );
+    }
+}

--- a/src/http/session_cache.rs
+++ b/src/http/session_cache.rs
@@ -174,19 +174,6 @@ unsafe extern "C" {
         on_free: Option<extern "C" fn(*mut c_void)>,
     );
     fn us_ssl_get_session_sink_owner(ssl: *mut SSL) -> *mut c_void;
-    fn us_socket_group_clear_session_sinks(group: *mut bun_uws::SocketGroup);
-}
-
-/// Release every cached `SSL_SESSION` and every per-SSL sink in `ctx`. Called
-/// at process shutdown so LeakSanitizer doesn't report them: the HTTP thread's
-/// keep-alive pool is never drained and its TLS-rooted owner is not an LSan
-/// root, so sinks on surviving SSLs and the cache's `Vec` buffer would
-/// otherwise be reported as leaked.
-pub(crate) fn drain_for_exit(ctx: &mut crate::HttpsContext) {
-    ctx.session_cache.entries.borrow_mut().clear();
-    // SAFETY: called on the HTTP thread after it stops ticking; no dispatch
-    // will touch these SSLs again. `sink_on_free` only drops the Box.
-    unsafe { us_socket_group_clear_session_sinks(&raw mut ctx.group) };
 }
 
 /// Whether this TLS client should read/write the cache. Lax verification and

--- a/src/http/session_cache.rs
+++ b/src/http/session_cache.rs
@@ -1,26 +1,12 @@
 //! Client-side TLS session cache for `fetch()`.
 //!
-//! BoringSSL's new-session callback is the only place a resumable TLS 1.3
-//! session surfaces, and [`us_ssl_new_session_cb`] discards it for every
-//! consumer except `Bun.connect` / `node:tls`. This module gives the HTTP
-//! client a sink for those sessions so a second cold connect to an origin can
-//! offer the stored ticket via `SSL_set_session` and skip the full handshake
-//! (certificate chain walk + signature verification).
-//!
-//! The cache lives on [`HTTPContext<true>`] — one per interned `SSLConfig` —
-//! and is keyed on the same `(hostname, port, proxy_auth_hash)` tuple the
-//! keep-alive pool uses for direct TLS, so a cached session never crosses an
-//! SNI / Host-override boundary the pool wouldn't. Only handshakes that ran
-//! with `rejectUnauthorized=true` and passed `checkServerIdentity` insert,
-//! because a resumed handshake restores the stored `verify_result` without
-//! re-sending Certificate; caching an unverified session would launder it
-//! into a later strict caller.
-//!
-//! Lifetime: all access is HTTP-thread-only (interior `RefCell`, no locking).
-//! Each entry owns one `SSL_SESSION` reference, released on eviction /
-//! `Drop`. The per-SSL [`SessionSink`] is heap-allocated, stored in a
-//! BoringSSL ex_data slot on the `SSL`, and freed by the ex_data free
-//! callback when the socket's `SSL` is freed.
+//! Keyed on the keep-alive pool tuple `(hostname, port, proxy_auth_hash)` and
+//! scoped to one [`HTTPContext<true>`] per interned `SSLConfig`. A sink is
+//! installed before the handshake and armed only after `checkServerIdentity`
+//! passes, so an unverified handshake never inserts: a resumed handshake
+//! restores the stored `verify_result` without a Certificate message, and
+//! caching an unverified session would launder it into a later strict caller.
+//! HTTP-thread-only.
 
 use core::cell::RefCell;
 use core::ffi::c_void;
@@ -30,35 +16,29 @@ use bun_boringssl_sys::{SSL, SSL_SESSION, SSL_SESSION_free, SSL_set_session};
 use bun_core::strings;
 
 use crate::http_context::MAX_KEEPALIVE_HOSTNAME;
+use crate::signals;
 
-/// Per-context LRU capacity. An `SSL_SESSION` retains the peer's full cert
-/// chain (multi-KB) and there is one `HTTPContext<true>` per interned
-/// `SSLConfig`, so this stays well below rustls' 256-entry default.
+/// An `SSL_SESSION` retains the peer chain, so keep this well below rustls' 256.
 const SESSION_CACHE_CAPACITY: usize = 32;
 
-/// One owned `SSL_SESSION` reference keyed on the pool tuple. `session` is
-/// `Option` so [`SessionCache::take`] can move ownership out and let the
-/// entry drop normally.
 struct CacheEntry {
     hostname: Box<[u8]>,
     port: u16,
     proxy_auth_hash: u64,
+    /// `Option` so [`SessionCache::take`] can move ownership out.
     session: Option<NonNull<SSL_SESSION>>,
 }
 
 impl Drop for CacheEntry {
     fn drop(&mut self) {
         if let Some(s) = self.session.take() {
-            // SAFETY: the entry owns one reference taken by
-            // `us_ssl_new_session_cb` (`SSL_SESSION_up_ref`) before handing
-            // the pointer to [`sink_on_new_session`].
+            // SAFETY: owns one reference from `SSL_SESSION_up_ref` in
+            // `us_ssl_new_session_cb`.
             unsafe { SSL_SESSION_free(s.as_ptr()) };
         }
     }
 }
 
-/// Move-to-front LRU over a small `Vec`. Lookup is O(n) in `CAPACITY`; with
-/// 32 entries this is cheaper than a map and keeps eviction trivial.
 #[derive(Default)]
 pub(crate) struct SessionCache {
     entries: RefCell<Vec<CacheEntry>>,
@@ -71,10 +51,8 @@ impl SessionCache {
         }
     }
 
-    /// Remove and return the session for `(hostname, port, hash)`, passing
-    /// its +1 reference to the caller. Returns `None` for hostnames longer
-    /// than the pool's `MAX_KEEPALIVE_HOSTNAME` (the insert side skips them
-    /// too). A TLS 1.3 ticket is single-use, so this consumes the entry.
+    /// Remove and return the matching session (+1 ref). TLS 1.3 tickets are
+    /// single-use, so a hit consumes the entry.
     pub(crate) fn take(
         &self,
         hostname: &[u8],
@@ -93,8 +71,7 @@ impl SessionCache {
         entries.remove(idx).session.take()
     }
 
-    /// Insert `session` (caller hands over its +1 ref). A matching key
-    /// replaces; a full cache evicts the least-recently-inserted entry.
+    /// Takes ownership of `session` (+1 ref).
     fn insert(
         &self,
         hostname: &[u8],
@@ -126,19 +103,16 @@ impl SessionCache {
     }
 }
 
-/// Per-`SSL` sink installed in `on_open` and torn down by the ex_data free
-/// callback on `SSL_free`. Box-allocated; the ex_data slot holds the raw
-/// pointer.
+/// Per-`SSL` sink. Box-allocated; the ex_data slot on the `SSL` holds the raw
+/// pointer and its free callback reclaims the Box on `SSL_free`.
 pub(crate) struct SessionSink {
     ctx: *const crate::HttpsContext,
     hostname: Box<[u8]>,
     port: u16,
     proxy_auth_hash: u64,
-    /// Set once `checkServerIdentity` passes. Sessions delivered earlier
-    /// (TLS 1.2 fires inside `SSL_do_handshake`, before `on_handshake`) are
-    /// parked in `pending` instead of inserted.
+    /// Set once `checkServerIdentity` passes. TLS 1.2 delivers the session
+    /// inside `SSL_do_handshake`, before `on_handshake` can verify the peer.
     armed: bool,
-    /// Most-recent session delivered before `armed`. Owned +1 reference.
     pending: Option<NonNull<SSL_SESSION>>,
 }
 
@@ -151,7 +125,6 @@ impl Drop for SessionSink {
     }
 }
 
-/// FFI sink callback: receives one `SSL_SESSION_up_ref`'d session.
 extern "C" fn sink_on_new_session(owner: *mut c_void, session: *mut SSL_SESSION) {
     let Some(session) = NonNull::new(session) else {
         return;
@@ -161,16 +134,13 @@ extern "C" fn sink_on_new_session(owner: *mut c_void, session: *mut SSL_SESSION)
         unsafe { SSL_SESSION_free(session.as_ptr()) };
         return;
     };
-    // SAFETY: `owner` is the Box interior installed by [`install`]; the
-    // new-session callback runs on the HTTP thread inside
-    // `SSL_read`/`SSL_do_handshake`, and nothing else holds `&mut` to the
-    // sink during that call.
+    // SAFETY: `owner` is the Box interior installed by [`install`]. Runs on
+    // the HTTP thread inside `SSL_read`/`SSL_do_handshake`; nothing else
+    // holds a borrow of the sink during that call.
     let sink = unsafe { owner.as_ref() };
     if sink.armed {
-        // SAFETY: `ctx` is the live `HTTPContext<true>` owning this socket's
-        // group; the context outlives every SSL attached to it (see
-        // `HTTPContext::ref_count` doc). `session_cache` is accessed via
-        // shared borrow + `RefCell`.
+        // SAFETY: `ctx` is the `HTTPContext<true>` owning this socket's
+        // group; it outlives every SSL attached to it.
         unsafe { &*sink.ctx }.session_cache.insert(
             &sink.hostname,
             sink.port,
@@ -187,14 +157,13 @@ extern "C" fn sink_on_new_session(owner: *mut c_void, session: *mut SSL_SESSION)
     }
 }
 
-/// FFI free callback for the ex_data slot: reclaims the Box.
 extern "C" fn sink_on_free(owner: *mut c_void) {
     if owner.is_null() {
         return;
     }
-    // SAFETY: `owner` is the `Box::into_raw` from [`install`]; the ex_data
+    // SAFETY: `owner` is the `heap::into_raw` from [`install`]; the ex_data
     // free callback fires exactly once on `SSL_free`.
-    drop(unsafe { Box::from_raw(owner.cast::<SessionSink>()) });
+    unsafe { bun_core::heap::destroy(owner.cast::<SessionSink>()) };
 }
 
 unsafe extern "C" {
@@ -205,22 +174,37 @@ unsafe extern "C" {
         on_free: Option<extern "C" fn(*mut c_void)>,
     );
     fn us_ssl_get_session_sink_owner(ssl: *mut SSL) -> *mut c_void;
+    fn us_socket_group_clear_session_sinks(group: *mut bun_uws::SocketGroup);
 }
 
-pub(crate) fn enabled() -> bool {
-    !bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE
-        .get()
-        .unwrap_or(false)
+/// Release every cached `SSL_SESSION` and every per-SSL sink in `ctx`. Called
+/// at process shutdown so LeakSanitizer doesn't report them: the HTTP thread's
+/// keep-alive pool is never drained and its TLS-rooted owner is not an LSan
+/// root, so sinks on surviving SSLs and the cache's `Vec` buffer would
+/// otherwise be reported as leaked.
+pub(crate) fn drain_for_exit(ctx: &mut crate::HttpsContext) {
+    ctx.session_cache.entries.borrow_mut().clear();
+    // SAFETY: called on the HTTP thread after it stops ticking; no dispatch
+    // will touch these SSLs again. `sink_on_free` only drops the Box.
+    unsafe { us_socket_group_clear_session_sinks(&raw mut ctx.group) };
 }
 
-/// Look up a cached session on `ctx` for this key and, if found, offer it on
-/// `ssl` before the handshake starts. Then install a sink so new tickets from
-/// this handshake are captured. `ctx` must be the `HTTPContext<true>` that
-/// owns `ssl`'s socket.
+/// Whether this TLS client should read/write the cache. Lax verification and
+/// the JS `checkServerIdentity` path are excluded because [`arm`] only runs
+/// after the native identity check in `on_handshake`; neither reaches it.
+pub(crate) fn eligible(client: &crate::HTTPClient<'_>) -> bool {
+    client.flags.reject_unauthorized
+        && !client.signals.get(signals::Field::CertErrors)
+        && client.unix_socket_path.slice().is_empty()
+        && !bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE
+            .get()
+            .unwrap_or(false)
+}
+
+/// Offer any cached session for this key and install an unarmed sink.
 ///
 /// # Safety
-/// `ssl` must be a live pre-handshake `SSL*`. `ctx` must be a live
-/// `HTTPContext<true>` that outlives `ssl`.
+/// `ssl` must be a live pre-handshake `SSL*`; `ctx` must outlive `ssl`.
 pub(crate) unsafe fn install(
     ssl: *mut SSL,
     ctx: *const crate::HttpsContext,
@@ -230,11 +214,11 @@ pub(crate) unsafe fn install(
 ) {
     debug_assert!(!ssl.is_null());
     debug_assert!(!ctx.is_null());
-    // SAFETY: caller contract — `ctx` is live.
+    // SAFETY: caller contract.
     let cache = unsafe { &(*ctx).session_cache };
     if let Some(session) = cache.take(hostname, port, proxy_auth_hash) {
-        // SAFETY: `ssl` is live and pre-handshake per caller contract;
-        // `SSL_set_session` takes its own reference, so release ours after.
+        // SAFETY: `ssl` is live and pre-handshake; `SSL_set_session` takes
+        // its own reference, so release ours after.
         unsafe {
             SSL_set_session(ssl, session.as_ptr());
             SSL_SESSION_free(session.as_ptr());
@@ -248,21 +232,18 @@ pub(crate) unsafe fn install(
         armed: false,
         pending: None,
     });
-    // SAFETY: `ssl` is live; ownership of the Box moves to the ex_data slot
-    // whose free callback reclaims it.
+    // SAFETY: `ssl` is live; Box ownership moves to the ex_data slot.
     unsafe {
         us_ssl_set_session_sink(
             ssl,
-            Box::into_raw(sink).cast::<c_void>(),
+            bun_core::heap::into_raw(sink).cast::<c_void>(),
             Some(sink_on_new_session),
             Some(sink_on_free),
         );
     }
 }
 
-/// Called from `on_handshake` after `checkServerIdentity` passes. Flushes any
-/// session parked before verification (TLS 1.2) and lets later tickets
-/// (TLS 1.3 post-handshake) go straight to the cache.
+/// Flush the parked TLS 1.2 session and admit later TLS 1.3 tickets.
 ///
 /// # Safety
 /// `ssl` must be a live `SSL*` on the HTTP thread.
@@ -283,8 +264,7 @@ pub(crate) unsafe fn arm(ssl: *mut SSL) {
     }
     sink.armed = true;
     if let Some(session) = sink.pending.take() {
-        // SAFETY: `ctx` was live at install and outlives `ssl`; see
-        // `HTTPContext::ref_count` doc.
+        // SAFETY: `ctx` outlives `ssl` per [`install`]'s contract.
         unsafe { &*sink.ctx }.session_cache.insert(
             &sink.hostname,
             sink.port,

--- a/test/js/web/fetch/fetch.tls.session-resumption-fixture.ts
+++ b/test/js/web/fetch/fetch.tls.session-resumption-fixture.ts
@@ -1,0 +1,39 @@
+// Drives two sequential fetch() requests against a local node:tls server that
+// answers with `Connection: close`, so the second request cannot reuse a
+// keep-alive socket and must open a fresh TLS connection. The server records
+// `isSessionReused()` on each secure connection; the second value is true only
+// when fetch offered a cached session via SSL_set_session.
+import tls from "node:tls";
+import type { AddressInfo } from "node:net";
+import { tls as cert } from "harness";
+
+const reused: boolean[] = [];
+const connections: tls.TLSSocket[] = [];
+
+const server = tls.createServer({ key: cert.key, cert: cert.cert });
+server.on("secureConnection", (socket: tls.TLSSocket) => {
+  connections.push(socket);
+  reused.push(socket.isSessionReused());
+  socket.once("data", () => {
+    socket.end("HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 2\r\n\r\nok");
+  });
+});
+
+await new Promise<void>((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(0, "127.0.0.1", resolve);
+});
+const port = (server.address() as AddressInfo).port;
+const url = `https://localhost:${port}/`;
+const tlsOpts = { ca: cert.cert } as const;
+
+const res1 = await fetch(url, { tls: tlsOpts });
+if ((await res1.text()) !== "ok") throw new Error("bad body 1");
+
+const res2 = await fetch(url, { tls: tlsOpts });
+if ((await res2.text()) !== "ok") throw new Error("bad body 2");
+
+console.log(JSON.stringify(reused));
+
+for (const c of connections) c.destroy();
+server.close();

--- a/test/js/web/fetch/fetch.tls.session-resumption-fixture.ts
+++ b/test/js/web/fetch/fetch.tls.session-resumption-fixture.ts
@@ -1,77 +1,134 @@
-// Drives two sequential fetch() requests against a local node:tls server that
-// answers with `Connection: close`, so the second request cannot reuse a
-// keep-alive socket and must open a fresh TLS connection. The server records
-// `isSessionReused()` per connection; the second value is true only when fetch
-// offered a cached session via SSL_set_session.
+// Observes server-side `isSessionReused()` across two sequential fetch()
+// requests that each answer with `Connection: close`, so the second cannot
+// reuse a keep-alive socket and must open a fresh TLS connection. A second
+// value of `true` means fetch offered a cached session via SSL_set_session.
 //
 // argv[2]: "TLSv1.2" | "TLSv1.3" — pins both ends so the 1.2 and 1.3 ticket
 // delivery paths (inside SSL_do_handshake vs post-handshake) are both covered.
 //
-// argv[3] == "mismatch" overrides the TLS servername to one the cert's SAN
-// does not cover. Both fetches must fail ERR_TLS_CERT_ALTNAME_INVALID (proving
-// each ran a real handshake against the cert) and the server must never
-// observe a resumed handshake. The client may RST before the server's TLS 1.3
-// handshake completes, so `reused` can have fewer than two entries there.
+// All scenarios run in one process; each uses its own server (fresh port), so
+// the per-`(hostname, port, hash)` cache key keeps them isolated.
 import tls from "node:tls";
 import type { AddressInfo } from "node:net";
 import { tls as cert } from "harness";
 
 const version = (process.argv[2] ?? "TLSv1.3") as tls.SecureVersion;
-const mode = process.argv[3] ?? "default";
 
-const reused: boolean[] = [];
-const versions: string[] = [];
-const connections: tls.TLSSocket[] = [];
-
-const server = tls.createServer({
-  key: cert.key,
-  cert: cert.cert,
-  minVersion: version,
-  maxVersion: version,
-});
-server.on("secureConnection", (socket: tls.TLSSocket) => {
-  connections.push(socket);
-  reused.push(socket.isSessionReused());
-  versions.push(socket.getProtocol() ?? "");
-  socket.on("error", () => {});
-  socket.once("data", () => {
-    socket.end("HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 2\r\n\r\nok");
+function makeServer() {
+  const reused: boolean[] = [];
+  const connections: tls.TLSSocket[] = [];
+  const server = tls.createServer({
+    key: cert.key,
+    cert: cert.cert,
+    minVersion: version,
+    maxVersion: version,
   });
-});
-server.on("tlsClientError", () => {});
+  server.on("secureConnection", (socket: tls.TLSSocket) => {
+    connections.push(socket);
+    reused.push(socket.isSessionReused());
+    if (socket.getProtocol() !== version) {
+      process.stderr.write(`negotiated ${socket.getProtocol()}, expected ${version}\n`);
+      process.exit(1);
+    }
+    socket.on("error", () => {});
+    socket.once("data", () => {
+      socket.end("HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 2\r\n\r\nok");
+    });
+  });
+  server.on("tlsClientError", () => {});
+  const listening = new Promise<number>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
+  });
+  const close = () => {
+    for (const c of connections) c.destroy();
+    server.close();
+  };
+  return { reused, listening, close };
+}
 
-await new Promise<void>((resolve, reject) => {
-  server.once("error", reject);
-  server.listen(0, "127.0.0.1", resolve);
-});
-const port = (server.address() as AddressInfo).port;
-const url = `https://localhost:${port}/`;
-const tlsOpts =
-  mode === "mismatch"
-    ? ({ ca: cert.cert, serverName: "wrong.example" } as const)
-    : ({ ca: cert.cert } as const);
+const ca = { ca: cert.cert } as const;
+async function ok(res: Response) {
+  if ((await res.text()) !== "ok") throw new Error("bad body");
+}
 
-async function attempt(n: number) {
-  if (mode === "mismatch") {
+const out: Record<string, unknown> = {};
+
+// default: second connect resumes.
+{
+  const a = makeServer();
+  const url = `https://localhost:${await a.listening}/`;
+  await ok(await fetch(url, { tls: ca }));
+  await ok(await fetch(url, { tls: ca }));
+  out.default = a.reused;
+  a.close();
+}
+
+// mismatch: trusted chain, wrong SAN. Both fetches fail
+// ERR_TLS_CERT_ALTNAME_INVALID (proving each ran a real handshake) and no
+// resumption is observed. A TLS 1.3 client may RST before the server
+// completes its side, so `reused` can have fewer than two entries.
+{
+  const a = makeServer();
+  const url = `https://localhost:${await a.listening}/`;
+  const bad = { ca: cert.cert, serverName: "wrong.example" } as const;
+  for (let i = 0; i < 2; i++) {
     try {
-      await fetch(url, { tls: tlsOpts });
-      throw new Error(`fetch ${n} resolved; expected ERR_TLS_CERT_ALTNAME_INVALID`);
+      await fetch(url, { tls: bad });
+      throw new Error(`mismatch fetch ${i} resolved; expected ERR_TLS_CERT_ALTNAME_INVALID`);
     } catch (e: any) {
       if (e?.code !== "ERR_TLS_CERT_ALTNAME_INVALID") throw e;
     }
-  } else {
-    const res = await fetch(url, { tls: tlsOpts });
-    if ((await res.text()) !== "ok") throw new Error(`bad body ${n}`);
   }
+  out.mismatch = a.reused;
+  a.close();
 }
 
-await attempt(1);
-await attempt(2);
-
-if (versions.some(v => v !== version)) {
-  throw new Error(`negotiated ${JSON.stringify(versions)}, expected ${version}`);
+// check-server-identity: a JS checkServerIdentity callback bypasses the cache
+// (verification completes off-thread after on_handshake). The first fetch
+// succeeds but never installs a sink, so the second sees an empty cache.
+{
+  const a = makeServer();
+  const url = `https://localhost:${await a.listening}/`;
+  let callbackRan = false;
+  await ok(
+    await fetch(url, {
+      tls: {
+        ca: cert.cert,
+        checkServerIdentity: (host: string, peer: tls.PeerCertificate) => {
+          callbackRan = true;
+          return tls.checkServerIdentity(host, peer);
+        },
+      },
+    }),
+  );
+  if (!callbackRan) throw new Error("checkServerIdentity callback did not run");
+  await ok(await fetch(url, { tls: ca }));
+  out.checkServerIdentity = a.reused;
+  a.close();
 }
-console.log(JSON.stringify(reused));
 
-for (const c of connections) c.destroy();
-server.close();
+// port-isolation: same hostname + SSLConfig, different port — the cache key
+// includes the port, so A's ticket must never be offered to B.
+{
+  const a = makeServer();
+  const b = makeServer();
+  await ok(await fetch(`https://localhost:${await a.listening}/`, { tls: ca }));
+  await ok(await fetch(`https://localhost:${await b.listening}/`, { tls: ca }));
+  out.portIsolation = { a: a.reused, b: b.reused };
+  a.close();
+  b.close();
+}
+
+// host-isolation: same port + SSLConfig, different connect hostname
+// (127.0.0.1 vs localhost) — the cache key includes the hostname.
+{
+  const a = makeServer();
+  const port = await a.listening;
+  await ok(await fetch(`https://localhost:${port}/`, { tls: ca }));
+  await ok(await fetch(`https://127.0.0.1:${port}/`, { tls: ca }));
+  out.hostIsolation = a.reused;
+  a.close();
+}
+
+console.log(JSON.stringify(out));

--- a/test/js/web/fetch/fetch.tls.session-resumption-fixture.ts
+++ b/test/js/web/fetch/fetch.tls.session-resumption-fixture.ts
@@ -1,23 +1,44 @@
 // Drives two sequential fetch() requests against a local node:tls server that
 // answers with `Connection: close`, so the second request cannot reuse a
 // keep-alive socket and must open a fresh TLS connection. The server records
-// `isSessionReused()` on each secure connection; the second value is true only
-// when fetch offered a cached session via SSL_set_session.
+// `isSessionReused()` per connection; the second value is true only when fetch
+// offered a cached session via SSL_set_session.
+//
+// argv[2]: "TLSv1.2" | "TLSv1.3" — pins both ends so the 1.2 and 1.3 ticket
+// delivery paths (inside SSL_do_handshake vs post-handshake) are both covered.
+//
+// argv[3] == "mismatch" overrides the TLS servername to one the cert's SAN
+// does not cover. Both fetches must fail ERR_TLS_CERT_ALTNAME_INVALID (proving
+// each ran a real handshake against the cert) and the server must never
+// observe a resumed handshake. The client may RST before the server's TLS 1.3
+// handshake completes, so `reused` can have fewer than two entries there.
 import tls from "node:tls";
 import type { AddressInfo } from "node:net";
 import { tls as cert } from "harness";
 
+const version = (process.argv[2] ?? "TLSv1.3") as tls.SecureVersion;
+const mode = process.argv[3] ?? "default";
+
 const reused: boolean[] = [];
+const versions: string[] = [];
 const connections: tls.TLSSocket[] = [];
 
-const server = tls.createServer({ key: cert.key, cert: cert.cert });
+const server = tls.createServer({
+  key: cert.key,
+  cert: cert.cert,
+  minVersion: version,
+  maxVersion: version,
+});
 server.on("secureConnection", (socket: tls.TLSSocket) => {
   connections.push(socket);
   reused.push(socket.isSessionReused());
+  versions.push(socket.getProtocol() ?? "");
+  socket.on("error", () => {});
   socket.once("data", () => {
     socket.end("HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 2\r\n\r\nok");
   });
 });
+server.on("tlsClientError", () => {});
 
 await new Promise<void>((resolve, reject) => {
   server.once("error", reject);
@@ -25,14 +46,31 @@ await new Promise<void>((resolve, reject) => {
 });
 const port = (server.address() as AddressInfo).port;
 const url = `https://localhost:${port}/`;
-const tlsOpts = { ca: cert.cert } as const;
+const tlsOpts =
+  mode === "mismatch"
+    ? ({ ca: cert.cert, serverName: "wrong.example" } as const)
+    : ({ ca: cert.cert } as const);
 
-const res1 = await fetch(url, { tls: tlsOpts });
-if ((await res1.text()) !== "ok") throw new Error("bad body 1");
+async function attempt(n: number) {
+  if (mode === "mismatch") {
+    try {
+      await fetch(url, { tls: tlsOpts });
+      throw new Error(`fetch ${n} resolved; expected ERR_TLS_CERT_ALTNAME_INVALID`);
+    } catch (e: any) {
+      if (e?.code !== "ERR_TLS_CERT_ALTNAME_INVALID") throw e;
+    }
+  } else {
+    const res = await fetch(url, { tls: tlsOpts });
+    if ((await res.text()) !== "ok") throw new Error(`bad body ${n}`);
+  }
+}
 
-const res2 = await fetch(url, { tls: tlsOpts });
-if ((await res2.text()) !== "ok") throw new Error("bad body 2");
+await attempt(1);
+await attempt(2);
 
+if (versions.some(v => v !== version)) {
+  throw new Error(`negotiated ${JSON.stringify(versions)}, expected ${version}`);
+}
 console.log(JSON.stringify(reused));
 
 for (const c of connections) c.destroy();

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -201,27 +201,43 @@ describe.concurrent("fetch-tls", () => {
   // the server observes a resumed session; without one, it's a full handshake.
   describe("client-side TLS session resumption", () => {
     const fixture = join(import.meta.dir, "fetch.tls.session-resumption-fixture.ts");
-    async function run(env: Record<string, string>) {
+    async function run(version: string, env: Record<string, string> = {}, mode = "default") {
       await using proc = Bun.spawn({
-        cmd: [bunExe(), fixture],
+        cmd: [bunExe(), fixture, version, mode],
         env: { ...bunEnv, ...env },
         stdout: "pipe",
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).not.toMatch(/AddressSanitizer|ERROR: (Leak|Thread)Sanitizer/);
-      expect(stdout.trim()).toMatch(/^\[(true|false),(true|false)\]$/);
+      expect(stdout.trim()).toMatch(/^\[((true|false),?)*\]$/);
       expect(exitCode).toBe(0);
       return JSON.parse(stdout.trim()) as boolean[];
     }
 
-    it("resumes on the second fresh connect to an origin", async () => {
-      expect(await run({})).toEqual([false, true]);
-    });
+    // TLS 1.2 delivers the session inside SSL_do_handshake (before
+    // checkServerIdentity runs), TLS 1.3 as a post-handshake NewSessionTicket;
+    // both paths must cache.
+    for (const version of ["TLSv1.2", "TLSv1.3"]) {
+      it(`resumes on the second fresh connect to an origin (${version})`, async () => {
+        expect(await run(version)).toEqual([false, true]);
+      });
 
-    it("is disabled by BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE", async () => {
-      expect(await run({ BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE: "1" })).toEqual([false, false]);
-    });
+      it(`is disabled by BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE (${version})`, async () => {
+        expect(await run(version, { BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE: "1" })).toEqual([false, false]);
+      });
+
+      // A handshake rejected by checkServerIdentity (trusted chain, wrong SAN)
+      // must not seed the cache. The fixture asserts each fetch rejects with
+      // ERR_TLS_CERT_ALTNAME_INVALID (so a fresh handshake ran), and the
+      // server must never observe a resumption. The client may RST before the
+      // server completes its side of a TLS 1.3 handshake, so fewer than two
+      // entries is acceptable.
+      it(`does not cache a session whose peer hostname was rejected (${version})`, async () => {
+        const reused = await run(version, {}, "mismatch");
+        expect(reused).not.toContain(true);
+      });
+    }
   });
 
   // Covers a family of HTTP-thread crashes (sentry BUN-2WC6 and siblings) where

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -195,6 +195,42 @@ describe.concurrent("fetch-tls", () => {
     });
   });
 
+  // A second fetch to the same origin after `Connection: close` has to open a
+  // fresh TLS connection (no keep-alive socket to reuse). With a client-side
+  // session cache, that connect offers the ticket from the first handshake and
+  // the server observes a resumed session; without one, it's a full handshake.
+  describe("client-side TLS session resumption", () => {
+    const fixture = join(import.meta.dir, "fetch.tls.session-resumption-fixture.ts");
+    async function run(env: Record<string, string>) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), fixture],
+        env: { ...bunEnv, ...env },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).not.toMatch(/AddressSanitizer|ERROR: (Leak|Thread)Sanitizer/);
+      expect(stdout.trim()).toMatch(/^\[(true|false),(true|false)\]$/);
+      expect(exitCode).toBe(0);
+      return JSON.parse(stdout.trim()) as boolean[];
+    }
+
+    it("resumes on the second fresh connect to an origin", async () => {
+      expect(await run({})).toEqual([false, true]);
+    });
+
+    it("is disabled by BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE", async () => {
+      expect(await run({ BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE: "1" })).toEqual([
+        false,
+        false,
+      ]);
+    });
+  });
+
   // Covers a family of HTTP-thread crashes (sentry BUN-2WC6 and siblings) where
   // a certificate identity failure during a handshake completed from the
   // SSL_read path, racing aborts, idle timeouts, and keepalive churn, caused a

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -199,44 +199,76 @@ describe.concurrent("fetch-tls", () => {
   // fresh TLS connection (no keep-alive socket to reuse). With a client-side
   // session cache, that connect offers the ticket from the first handshake and
   // the server observes a resumed session; without one, it's a full handshake.
+  // TLS 1.2 delivers the session inside SSL_do_handshake (before
+  // checkServerIdentity runs), TLS 1.3 as a post-handshake NewSessionTicket;
+  // both paths must cache. Each fixture run exercises every scenario against
+  // its own server (fresh port) so the cache key keeps them isolated.
   describe("client-side TLS session resumption", () => {
     const fixture = join(import.meta.dir, "fetch.tls.session-resumption-fixture.ts");
-    async function run(version: string, env: Record<string, string> = {}, mode = "default") {
+    async function run(version: string, env: Record<string, string> = {}) {
       await using proc = Bun.spawn({
-        cmd: [bunExe(), fixture, version, mode],
+        cmd: [bunExe(), fixture, version],
         env: { ...bunEnv, ...env },
         stdout: "pipe",
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).not.toMatch(/AddressSanitizer|ERROR: (Leak|Thread)Sanitizer/);
-      expect(stdout.trim()).toMatch(/^\[((true|false),?)*\]$/);
+      expect(stdout.trim()).toStartWith("{");
       expect(exitCode).toBe(0);
-      return JSON.parse(stdout.trim()) as boolean[];
+      return JSON.parse(stdout.trim()) as {
+        default: boolean[];
+        mismatch: boolean[];
+        checkServerIdentity: boolean[];
+        portIsolation: { a: boolean[]; b: boolean[] };
+        hostIsolation: boolean[];
+      };
     }
 
-    // TLS 1.2 delivers the session inside SSL_do_handshake (before
-    // checkServerIdentity runs), TLS 1.3 as a post-handshake NewSessionTicket;
-    // both paths must cache.
+    // Each run starts six TLS servers and performs ~12 handshakes in a
+    // debug+ASAN subprocess, which can exceed the default timeout when all
+    // four run under `describe.concurrent`.
+    const timeout = isASAN ? 20_000 : 10_000;
     for (const version of ["TLSv1.2", "TLSv1.3"]) {
-      it(`resumes on the second fresh connect to an origin (${version})`, async () => {
-        expect(await run(version)).toEqual([false, true]);
-      });
+      it(
+        `caches only verified sessions keyed on (host, port) (${version})`,
+        async () => {
+          const r = await run(version);
+          expect({
+            default: r.default,
+            checkServerIdentity: r.checkServerIdentity,
+            portIsolation: r.portIsolation,
+            hostIsolation: r.hostIsolation,
+          }).toEqual({
+            // Second fresh connect to the same origin resumes.
+            default: [false, true],
+            // A JS checkServerIdentity callback is excluded (verdict arrives
+            // off-thread after on_handshake), so the second fetch sees no
+            // cached ticket.
+            checkServerIdentity: [false, false],
+            // Same hostname + SSLConfig, different port: no resumption.
+            portIsolation: { a: [false], b: [false] },
+            // Same port + SSLConfig, different connect hostname: no resumption.
+            hostIsolation: [false, false],
+          });
+          // A handshake rejected by checkServerIdentity (trusted chain, wrong
+          // SAN) must not seed the cache. The fixture asserts each fetch
+          // rejects with ERR_TLS_CERT_ALTNAME_INVALID; the client may RST
+          // before the server completes its side of a TLS 1.3 handshake, so
+          // fewer than two entries is acceptable.
+          expect(r.mismatch).not.toContain(true);
+        },
+        timeout,
+      );
 
-      it(`is disabled by BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE (${version})`, async () => {
-        expect(await run(version, { BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE: "1" })).toEqual([false, false]);
-      });
-
-      // A handshake rejected by checkServerIdentity (trusted chain, wrong SAN)
-      // must not seed the cache. The fixture asserts each fetch rejects with
-      // ERR_TLS_CERT_ALTNAME_INVALID (so a fresh handshake ran), and the
-      // server must never observe a resumption. The client may RST before the
-      // server completes its side of a TLS 1.3 handshake, so fewer than two
-      // entries is acceptable.
-      it(`does not cache a session whose peer hostname was rejected (${version})`, async () => {
-        const reused = await run(version, {}, "mismatch");
-        expect(reused).not.toContain(true);
-      });
+      it(
+        `is disabled by BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE (${version})`,
+        async () => {
+          const r = await run(version, { BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE: "1" });
+          expect(r.default).toEqual([false, false]);
+        },
+        timeout,
+      );
     }
   });
 

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -208,11 +208,7 @@ describe.concurrent("fetch-tls", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).not.toMatch(/AddressSanitizer|ERROR: (Leak|Thread)Sanitizer/);
       expect(stdout.trim()).toMatch(/^\[(true|false),(true|false)\]$/);
       expect(exitCode).toBe(0);
@@ -224,10 +220,7 @@ describe.concurrent("fetch-tls", () => {
     });
 
     it("is disabled by BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE", async () => {
-      expect(await run({ BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE: "1" })).toEqual([
-        false,
-        false,
-      ]);
+      expect(await run({ BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE: "1" })).toEqual([false, false]);
     });
   });
 


### PR DESCRIPTION
## What

Give `fetch()` a client-side TLS session cache so a second cold connection to an origin resumes at 1 RTT instead of running a full handshake with certificate chain verification.

## Why

`us_ssl_ctx_from_options` sets `SSL_SESS_CACHE_NO_INTERNAL`, so BoringSSL never stores or looks up client sessions itself; the application must. `us_ssl_new_session_cb` only parks sessions for `Bun.connect` / `node:tls` sockets (the `us_ssl_is_socket_ex_idx` gate) and returns 0 for everything else. Nothing under `src/http/` ever calls `SSL_set_session`, so every fetch that misses the 64-socket keep-alive pool (more than 64 origins, a parallel cold burst, any idle gap past the 5-minute eviction) pays the full 2-RTT handshake plus chain walk. `node:https.Agent` already has a JS-side session cache (`src/js/node/https.ts`); this is specifically `fetch`.

Deno gets this by default: one `Arc<rustls::ClientConfig>` per client means rustls' `Resumption::in_memory_sessions(256)` applies.

## How

**`packages/bun-usockets/src/crypto/openssl.c`**: add a per-SSL session-sink ex_data slot (`us_ssl_session_sink_idx`) holding `{owner, on_new_session, on_free}`. `us_ssl_new_session_cb` checks it before the existing is-socket gate and, when present, calls the owner's callback with one `SSL_SESSION_up_ref`'d session (no `i2d_SSL_SESSION`, no pending queue). The slot's ex_data free callback calls `on_free(owner)` then `us_free`s the small wrapper. `us_ssl_set_session_sink` / `us_ssl_get_session_sink_owner` are exported in `libusockets.h`.

**`src/http/session_cache.rs`** (new): a 32-entry LRU living on `HTTPContext<true>` (one per interned `SSLConfig`), keyed on the same `(connect hostname, port, proxy_auth_hash)` tuple the keep-alive pool uses for direct TLS so a cached session never crosses an SNI / Host-override boundary the pool wouldn't. Entries own one `SSL_SESSION` reference; `Drop` frees it.

**`src/http/lib.rs` `HTTPClient::on_open`**: alongside SNI/ALPN setup (pre-handshake, `SSL_is_init_finished == 0`), look up the cache and call `SSL_set_session` on a hit, then install an unarmed sink carrying the cache key.

**`src/http/HTTPContext.rs` `Handler::on_handshake`**: arm the sink only after `checkServerIdentity` passes. TLS 1.2 fires the new-session callback inside `SSL_do_handshake` (before `on_handshake`), so those tickets are parked on the sink and flushed once armed; TLS 1.3 tickets arrive post-handshake and insert directly. A handshake that fails verification never seeds the cache: `close_and_fail` closes the socket, `SSL_free` drops the sink, and the parked ticket is released. Connections with `rejectUnauthorized: false`, a JS `checkServerIdentity` callback, or a unix-socket path skip the cache entirely.

Resumed connections still re-verify the hostname: BoringSSL's `ssl_crypto_x509_session_dup` copies `x509_peer` / `x509_chain` into the resumed session, so `SSL_get_peer_cert_chain` in `check_server_identity` sees the stored leaf.

`BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE=1` disables it.

## Testing

`test/js/web/fetch/fetch.tls.test.ts` gains a `client-side TLS session resumption` describe: a fixture runs a `node:tls` server that answers with `Connection: close` and records `socket.isSessionReused()` per connection, then two sequential fetches with a trusted `ca`.

```
# before (system bun)
[false, false]
# after
[false, true]
# after, with BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE=1
[false, false]
```

Related: #25185 (this covers the `fetch()` client side).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.test.ts
bun test v1.4.0 (bed49a99b)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that throws should reject [1233.53ms]
(pass) fetch-tls > fetch with rejectUnauthorized: false should not call checkServerIdentity [94.69ms]
(pass) fetch-tls > fetch with valid tls should not throw [1942.62ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [2208.06ms]
(pass) fetch-tls > can handle multiple requests with non native checkServerIdentity [2057.20ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [2007.75ms]
237 |           expect({
238 |             default: r.default,
239 |             checkServerIdentity: r.checkServerIdentity,
240 |             portIsolation: r.portIsolation,
241 |             hostIsolation: r.hostIsolation,
242 |           }).toEqual({
                   ^
error: expect(received).toEqual(expected)

  {
    "che
... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with checkServerIdentity failing should throw [40.70ms]
(pass) fetch-tls > fetch with self-sign tls should throw [75.35ms]
(pass) fetch-tls > fetch with invalid tls should throw [53.71ms]
(pass) fetch-tls > fetch with self-sign certificate tls + rejectUnauthorized: false should not throw [54.81ms]
(pass) fetch-tls > fetch with invalid tls + rejectUnauthorized: false should not throw [56.72ms]
237 |           expect({
238 |             default: r.default,
239 |             checkServerIdentity: r.checkServerIdentity,
240 |             portIsolation: r.portIsolation,
241 |             hostIsolation: r.hostIsolation,
242 |           }).toEqual({
                   ^
error: expect(received).toEqual(expected)

  {
    "checkServerIdentity": [
      false,
      false,
    ],
    "default": [
      false,
-     true,
+     false,
    ],
    "hostIsolation": [
      false,
      false,
    ],
    "portIsolation": {
      "a": [
        false,
      ],
      "b": [
        false,
      ],
    },
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.test.ts
bun test v1.4.0 (bed49a99b)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that throws should reject [1187.76ms]
(pass) fetch-tls > fetch with valid tls should not throw [1842.09ms]
(pass) fetch-tls > can handle multiple requests with non native checkServerIdentity [1927.28ms]
(pass) fetch-tls > fetch with rejectUnauthorized: false should not call checkServerIdentity [198.10ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [2127.65ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [1983.12ms]
(pass) fetch-tls > client-side TLS session resumption > caches only verified sessions keyed on (host, port) (TLSv1.2) [3721.64ms]
(pass) fetch-tls > client-side TLS session resumption > is disabled by BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE (TLSv1.3) [3815.08ms]
(pass) fetch-tls > client-side TLS session resumption > i
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     bed49a99bf
  features     baseline

22 deps, 108 codegen, 1171 objects in 3780ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[2/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/1234] gen bindgenv2
[4/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[5/1234] gen ProcessBindingFs.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingFs.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingFs.cpp
[6/1234] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/crypto/openssl.c         |  65 ++++-
 packages/bun-usockets/src/libusockets.h            |   7 +
 src/boringssl/lib.rs                               |  24 +-
 src/bun_alloc/lib.rs                               |   3 +-
 src/bun_core/env_var.rs                            |   1 +
 src/http/HTTPContext.rs                            |  10 +-
 src/http/HTTPThread.rs                             |   3 +
 src/http/lib.rs                                    |  24 ++
 src/http/session_cache.rs                          | 262 +++++++++++++++++++++
 .../fetch/fetch.tls.session-resumption-fixture.ts  | 134 +++++++++++
 test/js/web/fetch/fetch.tls.test.ts                |  77 ++++++
 11 files changed, 597 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
packages/bun-usockets/src/crypto/openssl.c                    6     12      0
packages/bun-usockets/src/libusockets.h                       3      3      0
src/boringssl/lib.rs                                          2      1      0
src/bun_alloc/lib.rs                                          2      1      0
src/bun_core/env_var.rs                                       2      3      0
src/http/HTTPContext.rs                                       5      4      0
src/http/HTTPThread.rs                                        6      5      0
src/http/lib.rs                                               6      3      0
src/http/session_cache.rs                                     1     12      0
…st/js/web/fetch/fetch.tls.session-resumption-fixture.ts      1      9      0
test/js/web/fetch/fetch.tls.test.ts                           3      9      0
```

</details>

<!-- robobun:evidence:end -->