### PR TITLE
js_parser: fold property access on multi-property object literals

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -41,8 +41,7 @@ fn e_string_eql_bytes(s: &E::EString, other: &[u8]) -> bool {
     if !s.is_utf16 {
         s.data == other
     } else {
-        let s16 = s.slice16();
-        s16.len() == other.len() && s16.iter().zip(other).all(|(&c, &b)| c == b as u16)
+        bun_core::strings::utf16_eql_string(s.slice16(), other)
     }
 }
 

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -462,6 +462,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             && !identifier_opts.is_delete_target()
                             && identifier_opts.assign_target() == js_ast::AssignTarget::None
                             && !identifier_opts.is_call_target()
+                            && !identifier_opts.is_template_tag()
                         {
                             let len = obj.properties.len_u32() as usize;
 
@@ -516,10 +517,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     break;
                                 };
 
-                                if e_string_eql_bytes(&key_str, b"__proto__") {
+                                if e_string_eql_bytes(&key_str, b"__proto__")
+                                    && !flags.contains(Flags::Property::WasShorthand)
+                                {
+                                    // Colon-form `__proto__:` sets [[Prototype]] (Annex B.3.1), not an own property.
                                     if matches!(value.data, js_ast::ExprData::ENull(_)) {
                                         has_proto_null = true;
                                     }
+                                    if !p.expr_can_be_removed_if_unused(&value) {
+                                        is_unsafe = true;
+                                        break;
+                                    }
+                                    continue;
                                 }
 
                                 if !p.expr_can_be_removed_if_unused(&value) {
@@ -534,11 +543,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
 
                             if !is_unsafe {
-                                // "{__proto__: null}.__proto__" is undefined, not null.
-                                if name != b"__proto__" {
-                                    if let Some(value) = replace {
-                                        return Some(value);
-                                    }
+                                if let Some(value) = replace {
+                                    return Some(value);
                                 }
                                 // A miss may resolve via Object.prototype unless __proto__ was nulled.
                                 if has_proto_null {

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -458,23 +458,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 js_ast::ExprData::EObject(obj) => {
                     if FeatureFlags::INLINE_PROPERTIES_IN_TRANSPILER {
-                        if p.options.features.minify_syntax {
-                            // Rewrite a property access like this:
-                            //   { f: () => {} }.f
-                            // To:
-                            //   () => {}
-                            //
-                            // To avoid thinking too much about edgecases, only do this for:
-                            //   1) Objects with a single property
-                            //   2) Not a method, not a computed property
-                            if obj.properties.len_u32() == 1
-                                && !identifier_opts.is_delete_target()
-                                && identifier_opts.assign_target() == js_ast::AssignTarget::None
-                                && !identifier_opts.is_call_target()
-                            {
+                        if p.options.features.minify_syntax
+                            && !identifier_opts.is_delete_target()
+                            && identifier_opts.assign_target() == js_ast::AssignTarget::None
+                            && !identifier_opts.is_call_target()
+                        {
+                            let len = obj.properties.len_u32() as usize;
+
+                            // Single-property fast path: "{ f: () => {} }.f" → "() => {}".
+                            // No side-effect check on the value is needed here because the
+                            // value is exactly what we return; only dropped siblings need
+                            // to be proven side-effect free.
+                            if len == 1 {
                                 let prop: &G::Property = &obj.properties.slice()[0];
                                 if let (Some(value), Some(key)) = (prop.value, prop.key) {
                                     if prop.flags.len() == 0
+                                        && prop.kind == js_ast::g::PropertyKind::Normal
                                         && matches!(key.data, js_ast::ExprData::EString(_))
                                         && e_string_eql_bytes(
                                             &key.data
@@ -486,6 +485,79 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     {
                                         return Some(value);
                                     }
+                                }
+                            }
+
+                            // General path: "{a: 1, b: 2, c: 3}.b" → "2". All dropped
+                            // property values must be side-effect free so the object
+                            // literal itself can be discarded.
+                            let mut replace: Option<Expr> = None;
+                            let mut has_proto_null = false;
+                            let mut is_unsafe = false;
+
+                            for i in 0..len {
+                                let prop: &G::Property = obj.properties.at(i);
+                                let kind = prop.kind;
+                                let flags = prop.flags;
+                                let key = prop.key;
+                                let value = prop.value;
+
+                                // "{ ...a }.a" must be preserved
+                                // "{ get a() {} }.a" must be preserved
+                                // "{ a: 1, [String.fromCharCode(97)]: 2 }.a" must be 2
+                                if kind != js_ast::g::PropertyKind::Normal
+                                    || flags.contains(Flags::Property::IsComputed)
+                                    || flags.contains(Flags::Property::IsMethod)
+                                    || flags.contains(Flags::Property::IsSpread)
+                                {
+                                    is_unsafe = true;
+                                    break;
+                                }
+
+                                let (Some(key), Some(value)) = (key, value) else {
+                                    is_unsafe = true;
+                                    break;
+                                };
+                                let js_ast::ExprData::EString(key_str) = key.data else {
+                                    // Do not attempt to compare against numeric keys
+                                    is_unsafe = true;
+                                    break;
+                                };
+
+                                // The "__proto__" key has special behavior
+                                if e_string_eql_bytes(&key_str, b"__proto__") {
+                                    if matches!(value.data, js_ast::ExprData::ENull(_)) {
+                                        // Replacing "{__proto__: null}.a" with undefined is safe
+                                        has_proto_null = true;
+                                    }
+                                }
+
+                                if !p.expr_can_be_removed_if_unused(&value) {
+                                    is_unsafe = true;
+                                    break;
+                                }
+
+                                // Later duplicate keys win
+                                if e_string_eql_bytes(&key_str, name) {
+                                    replace = Some(value);
+                                }
+                            }
+
+                            if !is_unsafe {
+                                // "{__proto__: null}.__proto__" is undefined, not null
+                                if name != b"__proto__" {
+                                    if let Some(value) = replace {
+                                        return Some(value);
+                                    }
+                                }
+                                // Only return undefined for a missing key when the
+                                // prototype has been explicitly nulled out; otherwise
+                                // the access may resolve via Object.prototype.
+                                if has_proto_null {
+                                    return Some(Expr {
+                                        data: js_ast::ExprData::EUndefined(E::Undefined),
+                                        loc: target.loc,
+                                    });
                                 }
                             }
                         }

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -465,10 +465,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         {
                             let len = obj.properties.len_u32() as usize;
 
-                            // Single-property fast path: "{ f: () => {} }.f" → "() => {}".
-                            // No side-effect check on the value is needed here because the
-                            // value is exactly what we return; only dropped siblings need
-                            // to be proven side-effect free.
+                            // "{ f: v }.f" → "v"; the sole value is returned, so no side-effect gate.
                             if len == 1 {
                                 let prop: &G::Property = &obj.properties.slice()[0];
                                 if let (Some(value), Some(key)) = (prop.value, prop.key) {
@@ -488,9 +485,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 }
                             }
 
-                            // General path: "{a: 1, b: 2, c: 3}.b" → "2". All dropped
-                            // property values must be side-effect free so the object
-                            // literal itself can be discarded.
+                            // "{a: 1, b: 2, c: 3}.b" → "2" when every dropped value is side-effect free.
                             let mut replace: Option<Expr> = None;
                             let mut has_proto_null = false;
                             let mut is_unsafe = false;
@@ -502,9 +497,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 let key = prop.key;
                                 let value = prop.value;
 
-                                // "{ ...a }.a" must be preserved
-                                // "{ get a() {} }.a" must be preserved
-                                // "{ a: 1, [String.fromCharCode(97)]: 2 }.a" must be 2
+                                // Spreads, getters/setters, methods, and computed keys make the access non-static.
                                 if kind != js_ast::g::PropertyKind::Normal
                                     || flags.contains(Flags::Property::IsComputed)
                                     || flags.contains(Flags::Property::IsMethod)
@@ -519,15 +512,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     break;
                                 };
                                 let js_ast::ExprData::EString(key_str) = key.data else {
-                                    // Do not attempt to compare against numeric keys
                                     is_unsafe = true;
                                     break;
                                 };
 
-                                // The "__proto__" key has special behavior
                                 if e_string_eql_bytes(&key_str, b"__proto__") {
                                     if matches!(value.data, js_ast::ExprData::ENull(_)) {
-                                        // Replacing "{__proto__: null}.a" with undefined is safe
                                         has_proto_null = true;
                                     }
                                 }
@@ -544,15 +534,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
 
                             if !is_unsafe {
-                                // "{__proto__: null}.__proto__" is undefined, not null
+                                // "{__proto__: null}.__proto__" is undefined, not null.
                                 if name != b"__proto__" {
                                     if let Some(value) = replace {
                                         return Some(value);
                                     }
                                 }
-                                // Only return undefined for a missing key when the
-                                // prototype has been explicitly nulled out; otherwise
-                                // the access may resolve via Object.prototype.
+                                // A miss may resolve via Object.prototype unless __proto__ was nulled.
                                 if has_proto_null {
                                     return Some(Expr {
                                         data: js_ast::ExprData::EUndefined(E::Undefined),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -444,6 +444,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // syntactic constructs as appropriate.
     pub(crate) stmt_expr_value: js_ast::ExprData,
     pub(crate) call_target: js_ast::ExprData,
+    pub(crate) template_tag: js_ast::ExprData,
     pub(crate) delete_target: js_ast::ExprData,
     pub(crate) loop_body: js_ast::StmtData,
     pub(crate) module_scope: js_ast::StoreRef<js_ast::Scope>,
@@ -8710,6 +8711,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             allow_in: true,
 
             call_target: null_expr_data(),
+            template_tag: null_expr_data(),
             delete_target: null_expr_data(),
             stmt_expr_value: null_expr_data(),
             loop_body: null_stmt_data(),

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1005,6 +1005,7 @@ impl IdentifierOpts {
     const IS_DELETE_TARGET: u8 = 1 << 2;
     const WAS_ORIGINALLY_IDENTIFIER: u8 = 1 << 3;
     const IS_CALL_TARGET: u8 = 1 << 4;
+    const IS_TEMPLATE_TAG: u8 = 1 << 5;
 
     #[inline]
     pub(crate) const fn assign_target(self) -> js_ast::AssignTarget {
@@ -1032,6 +1033,10 @@ impl IdentifierOpts {
     pub(crate) const fn is_call_target(self) -> bool {
         self.0 & Self::IS_CALL_TARGET != 0
     }
+    #[inline]
+    pub(crate) const fn is_template_tag(self) -> bool {
+        self.0 & Self::IS_TEMPLATE_TAG != 0
+    }
 
     // Builder-style helpers (this stays a packed u8 rather than a
     // named-field struct).
@@ -1057,6 +1062,11 @@ impl IdentifierOpts {
     #[inline]
     pub(crate) const fn with_is_call_target(mut self, v: bool) -> Self {
         self.0 = (self.0 & !Self::IS_CALL_TARGET) | ((v as u8) << 4);
+        self
+    }
+    #[inline]
+    pub(crate) const fn with_is_template_tag(mut self, v: bool) -> Self {
+        self.0 = (self.0 & !Self::IS_TEMPLATE_TAG) | ((v as u8) << 5);
         self
     }
 }

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -992,8 +992,8 @@ impl AsyncPrefixExpression {
     }
 }
 
-// Packed u8 — assign_target:u2, is_delete_target:b1,
-// was_originally_identifier:b1, is_call_target:b1, _padding:u3 (LSB-first).
+// Packed u8 — assign_target:u2, is_delete_target:b1, was_originally_identifier:b1,
+// is_call_target:b1, is_template_tag:b1, _padding:u2 (LSB-first).
 // Not all-bool (assign_target is a 2-bit enum), so per PORTING.md we use a
 // transparent u8 with manual shift accessors.
 #[repr(transparent)]

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -227,7 +227,9 @@ impl BinaryExpressionVisitor {
                     } else {
                         // The left operand has no side effects, but we need to preserve
                         // the comma operator semantics when used as a call target
-                        if (is_call_target || is_template_tag) && e_.right.has_value_for_this_in_call() {
+                        if (is_call_target || is_template_tag)
+                            && e_.right.has_value_for_this_in_call()
+                        {
                             // Keep the comma expression to strip "this" binding
                             e_.left = Expr {
                                 data: prefill::data::ZERO,
@@ -371,7 +373,9 @@ impl BinaryExpressionVisitor {
                         // "(null ?? fn)()" => "fn()"
                         // "(null ?? this.fn)" => "this.fn"
                         // "(null ?? this.fn)()" => "(0, this.fn)()"
-                        if (is_call_target || is_template_tag) && e_.right.has_value_for_this_in_call() {
+                        if (is_call_target || is_template_tag)
+                            && e_.right.has_value_for_this_in_call()
+                        {
                             return Expr::join_with_comma(
                                 Expr {
                                     data: ExprData::ENumber(E::Number::new(0.0)),
@@ -394,7 +398,8 @@ impl BinaryExpressionVisitor {
                     // "(0 || fn)()" => "fn()"
                     // "(0 || this.fn)" => "this.fn"
                     // "(0 || this.fn)()" => "(0, this.fn)()"
-                    if (is_call_target || is_template_tag) && e_.right.has_value_for_this_in_call() {
+                    if (is_call_target || is_template_tag) && e_.right.has_value_for_this_in_call()
+                    {
                         return Expr::join_with_comma(
                             Expr {
                                 data: prefill::data::ZERO,
@@ -416,7 +421,9 @@ impl BinaryExpressionVisitor {
                         // "(1 && fn)()" => "fn()"
                         // "(1 && this.fn)" => "this.fn"
                         // "(1 && this.fn)()" => "(0, this.fn)()"
-                        if (is_call_target || is_template_tag) && e_.right.has_value_for_this_in_call() {
+                        if (is_call_target || is_template_tag)
+                            && e_.right.has_value_for_this_in_call()
+                        {
                             return Expr::join_with_comma(
                                 Expr {
                                     data: prefill::data::ZERO,

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -117,6 +117,8 @@ impl BinaryExpressionVisitor {
 
         let is_call_target =
             matches!(p.call_target, ExprData::EBinary(ptr) if core::ptr::eq(ptr.as_ptr(), e_ptr));
+        let is_template_tag =
+            matches!(p.template_tag, ExprData::EBinary(ptr) if core::ptr::eq(ptr.as_ptr(), e_ptr));
         let was_anonymous_named_expr = e_.right.is_anonymous_named();
         let prev_decorator_class_name = p.decorator_class_name;
 
@@ -225,7 +227,7 @@ impl BinaryExpressionVisitor {
                     } else {
                         // The left operand has no side effects, but we need to preserve
                         // the comma operator semantics when used as a call target
-                        if is_call_target && e_.right.has_value_for_this_in_call() {
+                        if (is_call_target || is_template_tag) && e_.right.has_value_for_this_in_call() {
                             // Keep the comma expression to strip "this" binding
                             e_.left = Expr {
                                 data: prefill::data::ZERO,
@@ -369,7 +371,7 @@ impl BinaryExpressionVisitor {
                         // "(null ?? fn)()" => "fn()"
                         // "(null ?? this.fn)" => "this.fn"
                         // "(null ?? this.fn)()" => "(0, this.fn)()"
-                        if is_call_target && e_.right.has_value_for_this_in_call() {
+                        if (is_call_target || is_template_tag) && e_.right.has_value_for_this_in_call() {
                             return Expr::join_with_comma(
                                 Expr {
                                     data: ExprData::ENumber(E::Number::new(0.0)),
@@ -392,7 +394,7 @@ impl BinaryExpressionVisitor {
                     // "(0 || fn)()" => "fn()"
                     // "(0 || this.fn)" => "this.fn"
                     // "(0 || this.fn)()" => "(0, this.fn)()"
-                    if is_call_target && e_.right.has_value_for_this_in_call() {
+                    if (is_call_target || is_template_tag) && e_.right.has_value_for_this_in_call() {
                         return Expr::join_with_comma(
                             Expr {
                                 data: prefill::data::ZERO,
@@ -414,7 +416,7 @@ impl BinaryExpressionVisitor {
                         // "(1 && fn)()" => "fn()"
                         // "(1 && this.fn)" => "this.fn"
                         // "(1 && this.fn)()" => "(0, this.fn)()"
-                        if is_call_target && e_.right.has_value_for_this_in_call() {
+                        if (is_call_target || is_template_tag) && e_.right.has_value_for_this_in_call() {
                             return Expr::join_with_comma(
                                 Expr {
                                     data: prefill::data::ZERO,

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -693,6 +693,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let _ = in_;
         let mut e_ = expr.data.e_template().expect("infallible: variant checked");
         if e_.tag.is_some() {
+            p.template_tag = e_.tag.unwrap().data;
             p.visit_expr(e_.tag.as_mut().unwrap());
         }
 
@@ -885,6 +886,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let expr = *e;
         let mut e_ = expr.data.e_index().expect("infallible: variant checked");
         let is_call_target = matches!(p.call_target, Data::EIndex(ct) if core::ptr::eq(&raw const *e_, &raw const *ct));
+        let is_template_tag = matches!(p.template_tag, Data::EIndex(tt) if core::ptr::eq(&raw const *e_, &raw const *tt));
         let is_delete_target = matches!(p.delete_target, Data::EIndex(dt) if core::ptr::eq(&raw const *e_, &raw const *dt));
 
         // "a['b']" => "a.b"
@@ -904,6 +906,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                     if is_call_target {
                         p.call_target = dot.data;
+                    }
+                    if is_template_tag {
+                        p.template_tag = dot.data;
                     }
                     if is_delete_target {
                         p.delete_target = dot.data;
@@ -1020,6 +1025,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             if is_call_target {
                                 p.call_target = dot.data;
                             }
+                            if is_template_tag {
+                                p.template_tag = dot.data;
+                            }
                             if is_delete_target {
                                 p.delete_target = dot.data;
                             }
@@ -1041,7 +1049,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 unwrapped.loc,
                                 IdentifierOpts::default()
                                     .with_is_call_target(is_call_target)
-                                    // .is_template_tag = is_template_tag,
+                                    .with_is_template_tag(is_template_tag)
                                     .with_is_delete_target(is_delete_target)
                                     .with_assign_target(in_.assign_target),
                             ) {
@@ -1335,6 +1343,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut e_ = expr.data.e_dot().expect("infallible: variant checked");
         let is_delete_target = matches!(p.delete_target, Data::EDot(dt) if core::ptr::eq(&raw const *e_, &raw const *dt));
         let is_call_target = matches!(p.call_target, Data::EDot(ct) if core::ptr::eq(&raw const *e_, &raw const *ct));
+        let is_template_tag = matches!(p.template_tag, Data::EDot(tt) if core::ptr::eq(&raw const *e_, &raw const *tt));
 
         // `p.define: &'a Define` is `Copy`; hoist so the `dots.get` borrow is
         // tied to `'a`, not `&*p`, and `&mut self` helpers below can be called
@@ -1427,9 +1436,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 e_.name_loc,
                 IdentifierOpts::default()
                     .with_is_call_target(is_call_target)
+                    .with_is_template_tag(is_template_tag)
                     .with_assign_target(in_.assign_target)
                     .with_is_delete_target(is_delete_target),
-                // .is_template_tag = p.template_tag != null,
             ) {
                 *e = _expr;
                 return;

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1469,6 +1469,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut e_ = e.data.e_if().expect("infallible: variant checked");
         let is_call_target =
             matches!(p.call_target, Data::EIf(ct) if core::ptr::eq(&raw const *e_, &raw const *ct));
+        let is_template_tag =
+            matches!(p.template_tag, Data::EIf(tt) if core::ptr::eq(&raw const *e_, &raw const *tt));
 
         let prev_in_branch = p.in_branch_condition;
         p.in_branch_condition = true;
@@ -1502,7 +1504,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // "(1 ? fn : 2)()" => "fn()"
                 // "(1 ? this.fn : 2)" => "this.fn"
                 // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
-                if is_call_target && e_.yes.has_value_for_this_in_call() {
+                if (is_call_target || is_template_tag) && e_.yes.has_value_for_this_in_call() {
                     *e = p
                         .new_expr(E::Number::new(0.0), e_.test.loc)
                         .join_with_comma(e_.yes);
@@ -1530,7 +1532,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // "(1 ? fn : 2)()" => "fn()"
                 // "(1 ? this.fn : 2)" => "this.fn"
                 // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
-                if is_call_target && e_.no.has_value_for_this_in_call() {
+                if (is_call_target || is_template_tag) && e_.no.has_value_for_this_in_call() {
                     *e = p
                         .new_expr(E::Number::new(0.0), e_.test.loc)
                         .join_with_comma(e_.no);

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1469,8 +1469,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut e_ = e.data.e_if().expect("infallible: variant checked");
         let is_call_target =
             matches!(p.call_target, Data::EIf(ct) if core::ptr::eq(&raw const *e_, &raw const *ct));
-        let is_template_tag =
-            matches!(p.template_tag, Data::EIf(tt) if core::ptr::eq(&raw const *e_, &raw const *tt));
+        let is_template_tag = matches!(p.template_tag, Data::EIf(tt) if core::ptr::eq(&raw const *e_, &raw const *tt));
 
         let prev_in_branch = p.in_branch_condition;
         p.in_branch_condition = true;

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -48,7 +48,11 @@ bun_core::declare_scope!(cache, visible);
 /// bindings from the compiled bytecode after the module-loader rewrite, so the
 /// record no longer carries them; blobs written in the old numbering must not
 /// be read back.
-const EXPECTED_VERSION: u32 = 24;
+/// Version 25: Property access on multi-property object literals folds under
+/// minify_syntax ({a:1,b:2}.b -> 2), tagged-template tags and shorthand
+/// __proto__ are handled correctly, and the UTF-16 key compare in that fold
+/// decodes before comparing. See #3463.
+const EXPECTED_VERSION: u32 = 25;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -82,19 +82,7 @@ describe("bundler", () => {
     },
     minifySyntax: true,
     minifyWhitespace: true,
-    capture: [
-      "3",
-      "1",
-      "1",
-      "4",
-      "()=>1",
-      "1",
-      "void 0",
-      "void 0",
-      "{a:1,c:3}.missing",
-      "{}.missing",
-      "sideEffect()",
-    ],
+    capture: ["3", "1", "1", "4", "()=>1", "1", "void 0", "void 0", "{a:1,c:3}.missing", "{}.missing", "sideEffect()"],
   });
   itBundled("minify/InlineObjectLiteralPropertyAccessUnsafe", {
     files: {
@@ -151,7 +139,7 @@ describe("bundler", () => {
       `,
     },
     minifySyntax: true,
-    run: { stdout: '[3,1,4,1,null,null,3,1]\nhits=1' },
+    run: { stdout: "[3,1,4,1,null,null,3,1]\nhits=1" },
   });
   itBundled("minify/StringAdditionFolding", {
     files: {

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -96,9 +96,10 @@ describe("bundler", () => {
         capture({a: 1, set c(v) {}}.a);
         capture({a: 1, c() { return 2; }}.a);
         capture({a: 1, 5: 2, c: 3}.c);
-        capture({a: 1, b: 2}.c = 5);
-        id(delete {a: 1, b: 2}.c);
-        ({a: 1, b: 2}).c\`tag\`;
+        capture({a: 1, b: 2}.a = 5);
+        id({a: bound, b: 2}.a\`tag\`);
+        id({a: bound, b: 2}["a"]\`tag\`);
+        id({a: bound}.a\`tag\`);
       `,
     },
     minifySyntax: true,
@@ -112,12 +113,13 @@ describe("bundler", () => {
       "{a:1,set c(v){}}.a",
       "{a:1,c(){return 2}}.a",
       "{a:1,5:2,c:3}.c",
-      "{a:1,b:2}.c=5",
+      "{a:1,b:2}.a=5",
     ],
     onAfterBundle(api) {
       const code = api.readFile("/out.js");
-      expect(code).toContain("delete{a:1,b:2}.c");
-      expect(code).toContain("({a:1,b:2}).c`tag`");
+      // Both `.a` and `["a"]` tags must keep the object literal (the bracket form is rewritten to dot).
+      expect(code).toContain("id({a:bound,b:2}.a`tag`);id({a:bound,b:2}.a`tag`)");
+      expect(code).toContain("id({a:bound}.a`tag`)");
     },
   });
   itBundled("minify/InlineObjectLiteralPropertyAccessRuntime", {
@@ -125,6 +127,8 @@ describe("bundler", () => {
       "/entry.js": /* js */ `
         var hits = 0;
         const eff = (v) => { hits++; return v; };
+        const __proto__ = 42;
+        const f = function () { return this.marker; };
         console.log(JSON.stringify([
           {a: 1, b: 2, c: 3}.c,
           {a: 1, b: 2, c: 3}["a"],
@@ -134,12 +138,14 @@ describe("bundler", () => {
           {a: 1, c: 3}.missing,
           {a: eff(7), c: 3}.c,
           {a: 1, get c() { return 9; }}.a,
+          {__proto__: null, __proto__}.__proto__,
+          {a: f, b: 2, marker: "OBJ"}.a\`x\`,
         ]));
         console.log("hits=" + hits);
       `,
     },
     minifySyntax: true,
-    run: { stdout: "[3,1,4,1,null,null,3,1]\nhits=1" },
+    run: { stdout: '[3,1,4,1,null,null,3,1,42,"OBJ"]\nhits=1' },
   });
   itBundled("minify/StringAdditionFolding", {
     files: {

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -140,12 +140,15 @@ describe("bundler", () => {
           {a: 1, get c() { return 9; }}.a,
           {__proto__: null, __proto__}.__proto__,
           {a: f, b: 2, marker: "OBJ"}.a\`x\`,
+          {__proto__: null, "\\u00e9": 1}.é,
+          {__proto__: null, "caf\\u00e9": 1}.café,
+          {__proto__: null, "\\u00c3\\u00a9": 1}.é,
         ]));
         console.log("hits=" + hits);
       `,
     },
     minifySyntax: true,
-    run: { stdout: '[3,1,4,1,null,null,3,1,42,"OBJ"]\nhits=1' },
+    run: { stdout: '[3,1,4,1,null,null,3,1,42,"OBJ",1,1,null]\nhits=1' },
   });
   itBundled("minify/StringAdditionFolding", {
     files: {

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -63,6 +63,96 @@ describe("bundler", () => {
     minifySyntax: true,
     target: "bun",
   });
+  // https://github.com/oven-sh/bun/issues/3463
+  itBundled("minify/InlineObjectLiteralPropertyAccess", {
+    files: {
+      "/entry.js": /* js */ `
+        capture({a: 1, b: 2, c: 3}.c);
+        capture({a: 1, b: 2, c: 3}["a"]);
+        capture({"a": 1, b: 2, c: 3}.a);
+        capture({a: 1, a: 4}.a);
+        capture({a: () => 1, b: () => 2}.a);
+        capture({__proto__: null, a: 1}.a);
+        capture({__proto__: null, a: 1}.missing);
+        capture({__proto__: null}.__proto__);
+        capture({a: 1, c: 3}.missing);
+        capture({}.missing);
+        capture({a: sideEffect()}.a);
+      `,
+    },
+    minifySyntax: true,
+    minifyWhitespace: true,
+    capture: [
+      "3",
+      "1",
+      "1",
+      "4",
+      "()=>1",
+      "1",
+      "void 0",
+      "void 0",
+      "{a:1,c:3}.missing",
+      "{}.missing",
+      "sideEffect()",
+    ],
+  });
+  itBundled("minify/InlineObjectLiteralPropertyAccessUnsafe", {
+    files: {
+      "/entry.js": /* js */ `
+        const bound = globalThis;
+        capture({a: 1, c: unbound}.a);
+        capture({a: 1, c: bound}.a);
+        capture({a: 1, [k]: 2, c: 3}.c);
+        capture({a: 1, ...spread, c: 3}.c);
+        capture({a: 1, get c() { return 2; }}.a);
+        capture({a: 1, set c(v) {}}.a);
+        capture({a: 1, c() { return 2; }}.a);
+        capture({a: 1, 5: 2, c: 3}.c);
+        capture({a: 1, b: 2}.c = 5);
+        id(delete {a: 1, b: 2}.c);
+        ({a: 1, b: 2}).c\`tag\`;
+      `,
+    },
+    minifySyntax: true,
+    minifyWhitespace: true,
+    capture: [
+      "{a:1,c:unbound}.a",
+      "1",
+      "{a:1,[k]:2,c:3}.c",
+      "{a:1,...spread,c:3}.c",
+      "{a:1,get c(){return 2}}.a",
+      "{a:1,set c(v){}}.a",
+      "{a:1,c(){return 2}}.a",
+      "{a:1,5:2,c:3}.c",
+      "{a:1,b:2}.c=5",
+    ],
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("delete{a:1,b:2}.c");
+      expect(code).toContain("({a:1,b:2}).c`tag`");
+    },
+  });
+  itBundled("minify/InlineObjectLiteralPropertyAccessRuntime", {
+    files: {
+      "/entry.js": /* js */ `
+        var hits = 0;
+        const eff = (v) => { hits++; return v; };
+        console.log(JSON.stringify([
+          {a: 1, b: 2, c: 3}.c,
+          {a: 1, b: 2, c: 3}["a"],
+          {a: 1, a: 4}.a,
+          {__proto__: null, a: 1}.a,
+          {__proto__: null, a: 1}.missing,
+          {a: 1, c: 3}.missing,
+          {a: eff(7), c: 3}.c,
+          {a: 1, get c() { return 9; }}.a,
+        ]));
+        console.log("hits=" + hits);
+      `,
+    },
+    minifySyntax: true,
+    run: { stdout: '[3,1,4,1,null,null,3,1]\nhits=1' },
+  });
   itBundled("minify/StringAdditionFolding", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -145,10 +145,22 @@ describe("bundler", () => {
           {__proto__: null, "\\u00c3\\u00a9": 1}.é,
         ]));
         console.log("hits=" + hits);
+        (function () {
+          "use strict";
+          const obj = { fn: function () { return this; } };
+          console.log(JSON.stringify([
+            (null ?? obj.fn)\`x\` === undefined,
+            (0 || obj.fn)\`x\` === undefined,
+            (1 && obj.fn)\`x\` === undefined,
+            (1 ? obj.fn : 2)\`x\` === undefined,
+            (0 ? 2 : obj.fn)\`x\` === undefined,
+            (0, obj.fn)\`x\` === undefined,
+          ]));
+        })();
       `,
     },
     minifySyntax: true,
-    run: { stdout: '[3,1,4,1,null,null,3,1,42,"OBJ",1,1,null]\nhits=1' },
+    run: { stdout: '[3,1,4,1,null,null,3,1,42,"OBJ",1,1,null]\nhits=1\n[true,true,true,true,true,true]' },
   });
   itBundled("minify/StringAdditionFolding", {
     files: {


### PR DESCRIPTION
Fixes the minifier gap in #3463: `{a:1, b:2, c:3}.c` now folds to `3` under `--minify-syntax`, matching esbuild. Previously only the single-property form (`{c:3}.c`) folded; the code had an explicit `properties.len() == 1` guard.

### Repro

```js
// in.js
console.log({a: 1, b: 1, c: 1}["c"])
```
```sh
$ bun build --minify in.js
# before: console.log({a:1,b:1,c:1}.c);
# after:  console.log(1);
```

### Fix

`maybe_rewrite_property_access` in `src/js_parser/fold.rs` now scans every property (esbuild-style): each one must be `kind == Normal`, have no computed/method/spread flag, carry an `EString` key, and have a value that passes `expr_can_be_removed_if_unused`. The last matching key wins. A colon-form `__proto__: null` lets a miss fold to `undefined`; a shorthand `{__proto__}` is treated as an ordinary own property per Annex B.3.1. The existing single-property fast path is kept so `{f: sideEffect()}.f` still folds without a side-effect gate.

The UTF-16 branch of the file-local `e_string_eql_bytes` shim now routes through `bun_core::strings::utf16_eql_string` so a key like `"\u00e9"` compares correctly against a UTF-8 `.é` name instead of producing a false miss.

Cases that stay untouched (covered by the `Unsafe` test): spreads, computed keys, getters/setters/methods, numeric keys, unbound identifier values, assignment targets, and tagged-template tags.

### Tagged-template tags

Threading the fold through multi-property objects exposed that Bun never tracked tagged-template tag position when rewriting property accesses (esbuild gates on `!isCallTarget && !isTemplateTag`; Bun only had the first half). Added `p.template_tag` alongside `p.call_target`/`p.delete_target`, set in `e_template` before visiting the tag, and an `is_template_tag` bit on `IdentifierOpts`. The `EObject` fold and the six `has_value_for_this_in_call()` sites in `e_binary`/`e_if` (comma, `??`, `||`, `&&`, `?:` both arms) now consult it, so e.g. ``(null ?? obj.fn)`x` `` keeps the `(0, obj.fn)` wrapper instead of collapsing to ``obj.fn`x` `` and changing the tag's `this`.

`RuntimeTranspilerCache` version bumped to 25 since the runtime transpiler enables `minify_syntax` for bun-target files.

### Note on the original issue's repro

#3463 uses `const obj = {a:1,b:1,c:1}; console.log(obj["c"])` and expects `console.log(1)`. esbuild does not actually produce that (verified 0.17 through current): it emits `const obj={a:1,b:1,c:1};console.log(obj.c);`. Getting all the way to `console.log(1)` at module scope would require inlining single-use `const` object bindings, which neither tool does today. The direct `{a:1,b:1,c:1}["c"]` form, and the same pattern after single-use substitution inside a function body, now reach the fold.

### Verification

```
bun bd test test/bundler/bundler_minify.test.ts -t InlineObjectLiteralPropertyAccess
```
3 new tests (fold results, unsafe cases that must not fold, runtime correctness covering `__proto__` shorthand / UTF-16 keys / tag `this`). Also ran the full `bundler_minify`, `bundler_edgecase`, `esbuild/dce`, `esbuild/default`, and `transpiler` suites: all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts
bun test v1.4.0 (aad4c6756)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [924.75ms]
1551 |         }
1552 |       }
1553 | 
1554 |       if (capture) {
1555 |         const captures = api.captureFile(path.relative(root, outfile ?? outputPaths[0]));
1556 |         expect(captures).toEqual(capture);
                                ^
error: expect(received).toEqual(expected)

  [
-   "3",
-   "1",
-   "1",
-   "4",
-   "()=>1",
-   "1",
-   "void 0",
-   "void 0",
+   "{a:1,b:2,c:3}.c",
+   "{a:1,b:2,c:3}.a",
+   "{a:1,b:2,c:3}.a",
+   "{a:1,a:4}.a",
+   "{a:()=>1,b:()=>2}.a",
+   "{__proto__:null,a:1}.a",
+   "{__proto__:null,a:1}.missing",
+   "{__proto__:null}.__proto__",
    "{a:1,c:3}.missing",
    "{}.missing",
    "sideEffect()",
  ]

- Expected  - 8
+ Received  + 8

      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1556:26)
(fail) bundler > minify/InlineObjectLiteralPropertyAccess [626.51ms]
1551 |         }
1552 |       }
1553 | 
1554 |   
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (badf0e28d)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [109.47ms]
(pass) bundler > minify/InlineObjectLiteralPropertyAccess [7.90ms]
(pass) bundler > minify/InlineObjectLiteralPropertyAccessUnsafe [9.64ms]
runtime failed file: /tmp/bun-build-tests/bun-PEbKml/minify/InlineObjectLiteralPropertyAccessRuntime/out.js
stdout output:
[3,1,4,1,null,null,3,1,42,"OBJ",1,1,null]
hits=1
[false,false,false,false,false,false]
---
expected stdout:
[3,1,4,1,null,null,3,1,42,"OBJ",1,1,null]
hits=1
[true,true,true,true,true,true]
---
1843 |               console.log(`---`);
1844 |               console.log(`expected ${name}:`);
1845 |               console.log(expected);
1846 |               console.log(`---`);
1847 |             }
1848 |             expect(result).toBe(expected);
                                  ^
error: expect(received).toBe(expected)

  "[3,1,4,1,null,null,3,1,42,"OBJ",1,1,null]
  hits=1
- [true,true,true,true,true,true]"
+ [false,false,false,false,false,false]"

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1848:28)
(fail) bundler > minify/Inli
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts
bun test v1.4.0 (aad4c6756)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [1659.99ms]
(pass) bundler > minify/InlineObjectLiteralPropertyAccess [277.55ms]
(pass) bundler > minify/InlineObjectLiteralPropertyAccessUnsafe [789.45ms]
(pass) bundler > minify/InlineObjectLiteralPropertyAccessRuntime [820.23ms]
(pass) bundler > minify/StringAdditionFolding [369.08ms]
(pass) bundler > minify/FunctionExpressionRemoveName [183.20ms]
(pass) bundler > minify/KeepNamesPreservesNames [241.07ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [133.36ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1925.24ms]
(pass) bundler > minify/MergeAdjacentVars [1123.82ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [807.46ms]
(pass) bundler > minify/Infinity [482.47ms]
(pass) bundler > minify+whitespace/Infinity [153.68ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [705.32ms]
(pass) bundler > minify/InlineArraySpread [145.16ms]
(pass) bundler 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2568ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/fold.rs               | 97 ++++++++++++++++++++++++++++++------
 src/js_parser/p.rs                  |  2 +
 src/js_parser/parser.rs             | 14 +++++-
 src/js_parser/visit/visit_binary.rs | 17 +++++--
 src/js_parser/visit/visit_expr.rs   | 18 +++++--
 src/jsc/RuntimeTranspilerCache.rs   |  6 ++-
 test/bundler/bundler_minify.test.ts | 99 +++++++++++++++++++++++++++++++++++++
 7 files changed, 226 insertions(+), 27 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/js_parser/fold.rs                    7     11      0
src/js_parser/p.rs                       6      2      0
src/js_parser/parser.rs                  2      4      0
src/js_parser/visit/visit_binary.rs      2      2      0
src/js_parser/visit/visit_expr.rs        6      8      0
src/jsc/RuntimeTranspilerCache.rs        1      1      0
test/bundler/bundler_minify.test.ts      4      6      0
```

</details>

<!-- robobun:evidence:end -->