### PR TITLE
bundler: collapse per-file external JSX runtime imports into one per chunk

### DIFF
--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -70,10 +70,8 @@ bitflags::bitflags! {
         /// calling the "__reExport()" helper function
         const CALLS_RUNTIME_RE_EXPORT_FN = 1 << 6;
 
-        /// The parser synthesized this import to bring the automatic JSX runtime
-        /// (`jsx`/`jsxs`/`jsxDEV`/`Fragment`/`createElement`) into scope. When the
-        /// target is external and ESM, the linker collapses these per-file imports
-        /// into one per chunk.
+        /// Synthesized by the parser to import the automatic JSX runtime
+        /// (`jsx`/`jsxs`/`jsxDEV`/`Fragment`/`createElement`).
         const WAS_INJECTED_FOR_JSX_RUNTIME = 1 << 7;
 
         /// If true, this was originally written as a bare "import 'file'" statement

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -70,6 +70,12 @@ bitflags::bitflags! {
         /// calling the "__reExport()" helper function
         const CALLS_RUNTIME_RE_EXPORT_FN = 1 << 6;
 
+        /// The parser synthesized this import to bring the automatic JSX runtime
+        /// (`jsx`/`jsxs`/`jsxDEV`/`Fragment`/`createElement`) into scope. When the
+        /// target is external and ESM, the linker collapses these per-file imports
+        /// into one per chunk.
+        const WAS_INJECTED_FOR_JSX_RUNTIME = 1 << 7;
+
         /// If true, this was originally written as a bare "import 'file'" statement
         const WAS_ORIGINALLY_BARE_IMPORT = 1 << 8;
 

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1265,6 +1265,20 @@ impl EntryPoint {
     }
 }
 
+/// Per-chunk decision for a JSX-runtime import that the parser synthesized
+/// (see [`hoist_external_jsx_imports`](crate::linker_context_mod::hoist_external_jsx_imports)).
+/// Keyed by `(source_index << 32) | import_record_index` in
+/// [`JavaScriptChunk::jsx_import_rewrites`].
+pub(crate) enum JsxImportRewrite {
+    /// All of this record's items are already provided by an earlier file in
+    /// the chunk; drop the whole `import` statement.
+    Drop,
+    /// Keep this record (it's the chunk's survivor for its path) but replace
+    /// its items with the consolidated set of `(alias, ref)` pairs needed by
+    /// any file in the chunk.
+    Items(Box<[bun_ast::ClauseItem]>),
+}
+
 #[derive(Default)]
 pub struct JavaScriptChunk {
     pub(crate) files_in_chunk_order: Box<[IndexInt]>,
@@ -1278,6 +1292,12 @@ pub struct JavaScriptChunk {
     pub(crate) imports_from_other_chunks: ImportsFromOtherChunks,
     pub(crate) cross_chunk_prefix_stmts: Vec<Stmt>,
     pub(crate) cross_chunk_suffix_stmts: Vec<Stmt>,
+
+    /// Populated by [`hoist_external_jsx_imports`](crate::linker_context_mod::hoist_external_jsx_imports)
+    /// (serial, after chunks are computed and before the renamer fan-out).
+    /// Read-only thereafter; looked up by `convert_stmts_for_chunk` from
+    /// worker threads.
+    pub(crate) jsx_import_rewrites: bun_collections::HashMap<u64, JsxImportRewrite>,
 
     /// Indexes to CSS chunks. Currently this will only ever be zero or one
     /// items long, but smarter css chunking will allow multiple js entry points

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1265,17 +1265,9 @@ impl EntryPoint {
     }
 }
 
-/// Per-chunk decision for a JSX-runtime import that the parser synthesized
-/// (see [`hoist_external_jsx_imports`](crate::linker_context_mod::hoist_external_jsx_imports)).
-/// Keyed by `(source_index << 32) | import_record_index` in
-/// [`JavaScriptChunk::jsx_import_rewrites`].
+/// See [`hoist_external_jsx_imports`](crate::linker_context_mod::hoist_external_jsx_imports).
 pub(crate) enum JsxImportRewrite {
-    /// All of this record's items are already provided by an earlier file in
-    /// the chunk; drop the whole `import` statement.
     Drop,
-    /// Keep this record (it's the chunk's survivor for its path) but replace
-    /// its items with the consolidated set of `(alias, ref)` pairs needed by
-    /// any file in the chunk.
     Items(Box<[bun_ast::ClauseItem]>),
 }
 
@@ -1293,10 +1285,11 @@ pub struct JavaScriptChunk {
     pub(crate) cross_chunk_prefix_stmts: Vec<Stmt>,
     pub(crate) cross_chunk_suffix_stmts: Vec<Stmt>,
 
-    /// Populated by [`hoist_external_jsx_imports`](crate::linker_context_mod::hoist_external_jsx_imports)
-    /// (serial, after chunks are computed and before the renamer fan-out).
-    /// Read-only thereafter; looked up by `convert_stmts_for_chunk` from
-    /// worker threads.
+    /// `(source_index << 32) | import_record_index` → rewrite. Populated
+    /// serially by [`hoist_external_jsx_imports`]; read-only during the
+    /// `convert_stmts_for_chunk` worker fan-out.
+    ///
+    /// [`hoist_external_jsx_imports`]: crate::linker_context_mod::hoist_external_jsx_imports
     pub(crate) jsx_import_rewrites: bun_collections::HashMap<u64, JsxImportRewrite>,
 
     /// Indexes to CSS chunks. Currently this will only ever be zero or one

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2941,7 +2941,10 @@ pub(crate) fn hoist_external_jsx_imports(c: &mut LinkerContext<'_>, chunks: &mut
         for &source_index in js.files_in_chunk_order.iter() {
             let import_records = all_import_records[source_index as usize].as_slice();
             let parts_live = &c.graph.parts_live[source_index as usize];
-            for (part_index, part) in all_parts[source_index as usize].as_slice().iter().enumerate()
+            for (part_index, part) in all_parts[source_index as usize]
+                .as_slice()
+                .iter()
+                .enumerate()
             {
                 if !parts_live.is_set(part_index) {
                     continue;
@@ -3020,8 +3023,10 @@ pub(crate) fn hoist_external_jsx_imports(c: &mut LinkerContext<'_>, chunks: &mut
                     original_name: bun_ast::StoreStr::EMPTY,
                 })
                 .collect();
-            js.jsx_import_rewrites
-                .insert(entry.survivor_key, crate::chunk::JsxImportRewrite::Items(items));
+            js.jsx_import_rewrites.insert(
+                entry.survivor_key,
+                crate::chunk::JsxImportRewrite::Items(items),
+            );
             for key in entry.drops {
                 js.jsx_import_rewrites
                     .insert(key, crate::chunk::JsxImportRewrite::Drop);

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2892,28 +2892,17 @@ use bun_ast::{DependencyList, ImportItemStatus, PartSymbolUseMap};
 // below resolve unchanged.
 pub(crate) use crate::bundle_v2::{ImportTrackerIterator, ImportTrackerStatus};
 
-/// Collapse per-file synthetic JSX-runtime imports into one per chunk.
+/// Collapse per-file synthetic JSX-runtime imports into one per chunk (#3029).
 ///
-/// The parser injects `import { jsx, jsxs, Fragment, ... } from "<source>/jsx-runtime"`
-/// (or the `jsx-dev-runtime` / classic-runtime equivalent) into every file that
-/// lowers JSX. When that module is bundled, `scan_imports_and_exports` already
-/// binds every file's `jsx` ref to the one export; when it is external and the
-/// output keeps ES import syntax, `match_import_with_export` leaves each file's
-/// ref alone and `should_remove_import_export_stmt` passes each file's
-/// `S::Import` through, so a 1000-component bundle carries 1000 copies of the
-/// same import (issue #3029).
+/// Runs serially after chunks are computed and before `follow_all` / the
+/// renamer fan-out: per chunk, groups `WAS_INJECTED_FOR_JSX_RUNTIME` external
+/// import records by path, `symbols.merge`s duplicate `(path, alias)` refs so
+/// the renamer assigns one name, and records a [`JsxImportRewrite`] per
+/// `(source, record)` for `convert_stmts_for_chunk` to apply. The first live
+/// record per path survives with its items rewritten to the union of aliases
+/// the chunk needs; the rest are dropped.
 ///
-/// This runs serially after chunks are computed and before `follow_all`/the
-/// renamer fan-out. For each JS chunk it walks `files_in_chunk_order`, groups
-/// JSX-flagged external import records by path, union-find-merges duplicate
-/// `(path, alias)` refs so the renamer assigns one name, and records a
-/// per-chunk [`JsxImportRewrite`](crate::chunk::JsxImportRewrite): the first
-/// record seen for a path survives (its items rewritten to the union of aliases
-/// any file in the chunk needs) and the rest are dropped.
-/// `convert_stmts_for_chunk` applies the map. Because `symbols.merge` sets a
-/// global union-find link while the per-chunk survivor is chosen locally, a
-/// file in two chunks (multi-entry, no splitting) still produces correct
-/// output: each chunk's survivor binds the root name in that chunk's renamer.
+/// [`JsxImportRewrite`]: crate::chunk::JsxImportRewrite
 pub(crate) fn hoist_external_jsx_imports(c: &mut LinkerContext<'_>, chunks: &mut [Chunk]) {
     if !c.options.output_format.keep_es6_import_export_syntax() {
         return;
@@ -2934,8 +2923,6 @@ pub(crate) fn hoist_external_jsx_imports(c: &mut LinkerContext<'_>, chunks: &mut
             continue;
         };
 
-        // The parser dupes `jsx.import_source()` into each file's own arena, so
-        // key by the path bytes, not pointer identity.
         let mut by_path: Vec<(&[u8], PerPath)> = Vec::new();
 
         for &source_index in js.files_in_chunk_order.iter() {

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -795,9 +795,25 @@ impl<'a> LinkerContext<'a> {
             self.check_for_memory_corruption();
         }
 
+        hoist_external_jsx_imports(self, &mut chunks);
+
         self.graph.symbols.follow_all();
 
         Ok(chunks)
+    }
+
+    #[inline]
+    pub(crate) fn jsx_import_rewrite_for(
+        chunk: &Chunk,
+        source_index: u32,
+        import_record_index: u32,
+    ) -> Option<&crate::chunk::JsxImportRewrite> {
+        match &chunk.content {
+            crate::chunk::Content::Javascript(js) if !js.jsx_import_rewrites.is_empty() => js
+                .jsx_import_rewrites
+                .get(&((u64::from(source_index) << 32) | u64::from(import_record_index))),
+            _ => None,
+        }
     }
 
     pub(crate) fn tree_shaking_and_code_splitting(&mut self) -> Result<(), AllocError> {
@@ -2875,6 +2891,144 @@ use bun_ast::{DependencyList, ImportItemStatus, PartSymbolUseMap};
 // unqualified uses in `advance_import_tracker` / `match_import_with_export`
 // below resolve unchanged.
 pub(crate) use crate::bundle_v2::{ImportTrackerIterator, ImportTrackerStatus};
+
+/// Collapse per-file synthetic JSX-runtime imports into one per chunk.
+///
+/// The parser injects `import { jsx, jsxs, Fragment, ... } from "<source>/jsx-runtime"`
+/// (or the `jsx-dev-runtime` / classic-runtime equivalent) into every file that
+/// lowers JSX. When that module is bundled, `scan_imports_and_exports` already
+/// binds every file's `jsx` ref to the one export; when it is external and the
+/// output keeps ES import syntax, `match_import_with_export` leaves each file's
+/// ref alone and `should_remove_import_export_stmt` passes each file's
+/// `S::Import` through, so a 1000-component bundle carries 1000 copies of the
+/// same import (issue #3029).
+///
+/// This runs serially after chunks are computed and before `follow_all`/the
+/// renamer fan-out. For each JS chunk it walks `files_in_chunk_order`, groups
+/// JSX-flagged external import records by path, union-find-merges duplicate
+/// `(path, alias)` refs so the renamer assigns one name, and records a
+/// per-chunk [`JsxImportRewrite`](crate::chunk::JsxImportRewrite): the first
+/// record seen for a path survives (its items rewritten to the union of aliases
+/// any file in the chunk needs) and the rest are dropped.
+/// `convert_stmts_for_chunk` applies the map. Because `symbols.merge` sets a
+/// global union-find link while the per-chunk survivor is chosen locally, a
+/// file in two chunks (multi-entry, no splitting) still produces correct
+/// output: each chunk's survivor binds the root name in that chunk's renamer.
+pub(crate) fn hoist_external_jsx_imports(c: &mut LinkerContext<'_>, chunks: &mut [Chunk]) {
+    if !c.options.output_format.keep_es6_import_export_syntax() {
+        return;
+    }
+
+    let all_parts = c.graph.ast.items_parts();
+    let all_import_records = c.graph.ast.items_import_records();
+
+    struct PerPath {
+        survivor_key: u64,
+        // Small, fixed set: jsx / jsxs / jsxDEV / Fragment / createElement.
+        items: Vec<(bun_ast::StoreStr, Ref)>,
+        drops: Vec<u64>,
+    }
+
+    for chunk in chunks.iter_mut() {
+        let crate::chunk::Content::Javascript(js) = &mut chunk.content else {
+            continue;
+        };
+
+        // The parser dupes `jsx.import_source()` into each file's own arena, so
+        // key by the path bytes, not pointer identity.
+        let mut by_path: Vec<(&[u8], PerPath)> = Vec::new();
+
+        for &source_index in js.files_in_chunk_order.iter() {
+            let import_records = all_import_records[source_index as usize].as_slice();
+            let parts_live = &c.graph.parts_live[source_index as usize];
+            for (part_index, part) in all_parts[source_index as usize].as_slice().iter().enumerate()
+            {
+                if !parts_live.is_set(part_index) {
+                    continue;
+                }
+                for &rec_idx in part.import_record_indices.slice() {
+                    let record = &import_records[rec_idx as usize];
+                    if !record
+                        .flags
+                        .contains(bun_ast::ImportRecordFlags::WAS_INJECTED_FOR_JSX_RUNTIME)
+                        || record.source_index.is_valid()
+                    {
+                        continue;
+                    }
+
+                    let Some(bun_ast::StmtData::SImport(import)) =
+                        part.stmts.slice().first().map(|s| s.data)
+                    else {
+                        continue;
+                    };
+                    if import.import_record_index != rec_idx {
+                        continue;
+                    }
+
+                    let path = record.path.text;
+                    let entry = match by_path.iter_mut().find(|(p, _)| *p == path) {
+                        Some((_, e)) => e,
+                        None => {
+                            by_path.push((
+                                path,
+                                PerPath {
+                                    survivor_key: (u64::from(source_index) << 32)
+                                        | u64::from(rec_idx),
+                                    items: Vec::new(),
+                                    drops: Vec::new(),
+                                },
+                            ));
+                            &mut by_path.last_mut().unwrap().1
+                        }
+                    };
+
+                    let key = (u64::from(source_index) << 32) | u64::from(rec_idx);
+                    if key != entry.survivor_key {
+                        entry.drops.push(key);
+                    }
+
+                    for item in import.items.slice() {
+                        let Some(ref_) = item.name.ref_.to_nullable() else {
+                            continue;
+                        };
+                        let alias = item.alias.slice();
+                        match entry.items.iter().find(|(a, _)| a.slice() == alias) {
+                            Some(&(_, first)) => {
+                                let _ = c.graph.symbols.merge(ref_, first);
+                            }
+                            None => entry.items.push((item.alias, ref_)),
+                        }
+                    }
+                }
+            }
+        }
+
+        for (_, entry) in by_path {
+            if entry.drops.is_empty() {
+                continue;
+            }
+            let items: Box<[bun_ast::ClauseItem]> = entry
+                .items
+                .into_iter()
+                .map(|(alias, ref_)| bun_ast::ClauseItem {
+                    alias,
+                    alias_loc: Loc::EMPTY,
+                    name: bun_ast::LocRef {
+                        ref_,
+                        loc: Loc::EMPTY,
+                    },
+                    original_name: bun_ast::StoreStr::EMPTY,
+                })
+                .collect();
+            js.jsx_import_rewrites
+                .insert(entry.survivor_key, crate::chunk::JsxImportRewrite::Items(items));
+            for key in entry.drops {
+                js.jsx_import_rewrites
+                    .insert(key, crate::chunk::JsxImportRewrite::Drop);
+            }
+        }
+    }
+}
 
 /// Field-wise eq for `ImportTracker`.
 #[inline]

--- a/src/bundler/linker_context/convertStmtsForChunk.rs
+++ b/src/bundler/linker_context/convertStmtsForChunk.rs
@@ -107,6 +107,37 @@ pub(crate) fn convert_stmts_for_chunk(
                         continue 'stmt_loop;
                     }
 
+                    match LinkerContext::jsx_import_rewrite_for(
+                        chunk,
+                        source_index,
+                        s.import_record_index,
+                    ) {
+                        None => {}
+                        Some(crate::chunk::JsxImportRewrite::Drop) => continue 'stmt_loop,
+                        Some(crate::chunk::JsxImportRewrite::Items(items)) => {
+                            let items = bump.alloc_slice_fill_iter(items.iter().map(|it| {
+                                bun_ast::ClauseItem {
+                                    alias: it.alias,
+                                    alias_loc: it.alias_loc,
+                                    name: it.name,
+                                    original_name: it.original_name,
+                                }
+                            }));
+                            stmt = Stmt::alloc(
+                                S::Import {
+                                    namespace_ref: s.namespace_ref,
+                                    items: items.into(),
+                                    import_record_index: s.import_record_index,
+                                    is_single_line: s.is_single_line,
+                                    default_name: s.default_name,
+                                    star_name_loc: s.star_name_loc,
+                                    phase_defer: s.phase_defer,
+                                },
+                                stmt.loc,
+                            );
+                        }
+                    }
+
                     // Make sure these don't end up in the wrapper closure
                     if should_extract_esm_stmts_for_wrap {
                         stmts.append(StmtListWhich::OutsideWrapperPrefix, stmt);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1800,6 +1800,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             import_record
                 .flags
                 .set(bun_ast::ImportRecordFlags::IS_INTERNAL, is_internal);
+            import_record.flags.set(
+                bun_ast::ImportRecordFlags::WAS_INJECTED_FOR_JSX_RUNTIME,
+                !is_internal,
+            );
         }
         // Render the sanitized-identifier formatter into the bump arena (same
         // pattern as `transpose_require` above).

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -525,6 +525,154 @@ describe("bundler", () => {
     },
   });
 
+  // https://github.com/oven-sh/bun/issues/3029 — the bundler injects the automatic JSX
+  // runtime import into every file that lowers JSX; when that module is external, the
+  // per-file imports should collapse into one per chunk.
+  describe("jsxExternalRuntimeImportCollapsed", () => {
+    const fixture = (count: number) => {
+      const files: Record<string, string> = {
+        "/index.jsx": `
+          ${Array.from({ length: count }, (_, i) => `import { C${i} } from "./c${i}.jsx";`).join("\n")}
+          export const App = () => (<>${Array.from({ length: count }, (_, i) => `<C${i} />`).join("")}</>);
+        `,
+      };
+      for (let i = 0; i < count; i++) files[`/c${i}.jsx`] = `export const C${i} = () => <div>c${i}</div>;`;
+      return files;
+    };
+    for (const mode of ["development", "production"] as const) {
+      const dev = mode === "development";
+      const runtimeModule = dev ? "react/jsx-dev-runtime" : "react/jsx-runtime";
+      const jsxFn = dev ? "jsxDEV" : "jsx";
+      itBundled(`jsx/ExternalRuntimeImportCollapsed${dev ? "Dev" : "Prod"}`, {
+        files: fixture(4),
+        external: ["react", "react/*"],
+        env: { NODE_ENV: mode },
+        onAfterBundle(api) {
+          const out = api.readFile("out.js");
+          const imports = out.match(/^import .*$/gm) ?? [];
+          expect(imports).toHaveLength(1);
+          expect(imports[0]).toContain(JSON.stringify(runtimeModule));
+          expect(imports[0]).toContain(jsxFn);
+          expect(imports[0]).toContain("Fragment");
+          // The whole point: no per-file `jsxDEV as jsxDEV2` / `jsx as jsx2` aliases.
+          expect(out).not.toMatch(new RegExp(`\\b${jsxFn}\\d`));
+          expect(out).not.toMatch(/\bFragment\d/);
+        },
+      });
+      itBundled(`jsx/ExternalRuntimeImportCollapsedMinified${dev ? "Dev" : "Prod"}`, {
+        files: fixture(4),
+        external: ["react", "react/*"],
+        env: { NODE_ENV: mode },
+        minifyIdentifiers: true,
+        minifyWhitespace: true,
+        onAfterBundle(api) {
+          const out = api.readFile("out.js");
+          const importRe = new RegExp(`(^|;)import\\b[^;]*?from\\s*"${runtimeModule}"`, "g");
+          expect(out.match(importRe) ?? []).toHaveLength(1);
+        },
+      });
+    }
+    itBundled("jsx/ExternalRuntimeImportCollapsedMultiEntryDev", {
+      files: {
+        "/shared.jsx": `export const S = () => <span>s</span>;`,
+        "/a.jsx": `export const A = () => <i>a</i>;`,
+        "/b.jsx": `export const B = () => <i>b</i>;`,
+        "/e1.jsx": `
+          import { S } from "./shared.jsx";
+          import { A } from "./a.jsx";
+          export const E1 = () => (<><S /><A /></>);
+        `,
+        "/e2.jsx": `
+          import { S } from "./shared.jsx";
+          import { B } from "./b.jsx";
+          export const E2 = () => (<><S /><B /></>);
+        `,
+      },
+      entryPoints: ["/e1.jsx", "/e2.jsx"],
+      external: ["react", "react/*"],
+      env: { NODE_ENV: "development" },
+      onAfterBundle(api) {
+        for (const name of ["out/e1.js", "out/e2.js"]) {
+          const out = api.readFile(name);
+          const imports = out.match(/^import .*$/gm) ?? [];
+          expect({ file: name, imports }).toEqual({
+            file: name,
+            imports: [expect.stringContaining('"react/jsx-dev-runtime"')],
+          });
+          expect(out).not.toMatch(/\bjsxDEV\d/);
+        }
+      },
+    });
+    itBundled("jsx/ExternalRuntimeImportCollapsedSplittingDev", {
+      files: {
+        "/shared.jsx": `export const S = () => <span>s</span>;`,
+        "/a.jsx": `export const A = () => <i>a</i>;`,
+        "/b.jsx": `export const B = () => <i>b</i>;`,
+        "/e1.jsx": `
+          import { S } from "./shared.jsx";
+          import { A } from "./a.jsx";
+          export const E1 = () => (<><S /><A /></>);
+        `,
+        "/e2.jsx": `
+          import { S } from "./shared.jsx";
+          import { B } from "./b.jsx";
+          export const E2 = () => (<><S /><B /></>);
+        `,
+      },
+      entryPoints: ["/e1.jsx", "/e2.jsx"],
+      splitting: true,
+      external: ["react", "react/*"],
+      env: { NODE_ENV: "development" },
+      onAfterBundle(api) {
+        for (const name of ["out/e1.js", "out/e2.js"]) {
+          const out = api.readFile(name);
+          const jsxImports = (out.match(/^import .*$/gm) ?? []).filter(l => l.includes("react/jsx-dev-runtime"));
+          expect({ file: name, jsxImports }).toEqual({
+            file: name,
+            jsxImports: [expect.stringContaining('"react/jsx-dev-runtime"')],
+          });
+          expect(out).not.toMatch(/\bjsxDEV\d/);
+        }
+      },
+    });
+    itBundled("jsx/ExternalRuntimeImportCollapsedRunProd", {
+      files: {
+        "/index.jsx": `
+          import { A } from "./a.jsx";
+          import { B } from "./b.jsx";
+          const App = () => (<><A /><B /></>);
+          console.log(JSON.stringify(App()));
+        `,
+        "/a.jsx": `export const A = () => <div>a</div>;`,
+        "/b.jsx": `export const B = () => <p><em>b</em></p>;`,
+        "/node_modules/react/package.json": `{"name":"react","exports":{"./jsx-runtime":"./jsx-runtime.js"}}`,
+        "/node_modules/react/jsx-runtime.js": `
+          export const jsx = (type, props) => typeof type === "function" ? type(props) : { type, props };
+          export const jsxs = jsx;
+          export const Fragment = "fragment";
+        `,
+      },
+      external: ["react", "react/*"],
+      env: { NODE_ENV: "production" },
+      target: "bun",
+      run: {
+        stdout: JSON.stringify({
+          type: "fragment",
+          props: {
+            children: [
+              { type: "div", props: { children: "a" } },
+              { type: "p", props: { children: { type: "em", props: { children: "b" } } } },
+            ],
+          },
+        }),
+      },
+      onAfterBundle(api) {
+        const out = api.readFile("out.js");
+        expect(out.match(/^import .*$/gm) ?? []).toHaveLength(1);
+      },
+    });
+  });
+
   // Test for jsxSideEffects option - equivalent to esbuild's TestJSXSideEffects
   describe("jsxSideEffects", () => {
     itBundled("jsx/sideEffectsDefault", {


### PR DESCRIPTION
Fixes #3029.

### Repro

```
// a.js
const X = () => <div>Hello</div>;
export { X };
// index.js
import { X } from "./a.js";
const HelloWorld = () => (<><X />World</>);
export { HelloWorld };
```
```sh
bun build index.js --external react/jsx-dev-runtime
```

Before:
```js
// a.js
import { jsxDEV } from "react/jsx-dev-runtime";
var X = () => jsxDEV("div", { children: "Hello" }, ...);
// index.js
import { jsxDEV as jsxDEV2, Fragment } from "react/jsx-dev-runtime";
var HelloWorld = () => jsxDEV2(Fragment, { children: [jsxDEV2(X, {}, ...), "World"] }, ...);
```
After:
```js
// a.js
import { jsxDEV, Fragment } from "react/jsx-dev-runtime";
var X = () => jsxDEV("div", { children: "Hello" }, ...);
// index.js
var HelloWorld = () => jsxDEV(Fragment, { children: [jsxDEV(X, {}, ...), "World"] }, ...);
```

Same with `--production` (`react/jsx-runtime`): one `import { jsx, jsxs, Fragment }` instead of one per input file.

### Cause

The parser injects `import { jsx, jsxs, Fragment, ... } from "<source>/jsx-runtime"` into every file that lowers JSX. When the JSX runtime is bundled, `scan_imports_and_exports` binds every file's `jsx` ref to the one export and the per-file imports vanish. When it is external and the output keeps ES import syntax, `match_import_with_export` leaves each file's ref alone (`MatchImportKind::Ignore`) and `should_remove_import_export_stmt` passes each file's `S::Import` through, so an N-file bundle carries N `import { jsx as jsxN } from "react/jsx-runtime"` statements. esbuild behaves the same for external imports in general; this change is scoped to the bundler-synthesized JSX import, which is always a side-effect-free named import we fully control.

### Fix

- Tag the synthesized import record (`ImportRecordFlags::WAS_INJECTED_FOR_JSX_RUNTIME`).
- After chunks are computed and before `follow_all`/the renamer fan-out, `hoist_external_jsx_imports` walks each chunk's files in order, groups JSX-flagged external records by path, union-find-merges duplicate `(path, alias)` refs so the renamer assigns one name, and records a per-chunk `JsxImportRewrite`: the first record seen survives with its items rewritten to the union of aliases any file in the chunk needs; the rest are dropped.
- `convert_stmts_for_chunk` applies the rewrite.

Multi-entry without splitting (shared file in multiple chunks) and `--splitting` both produce one JSX-runtime import per chunk; each chunk's survivor binds the union-find root in that chunk's renamer.

### Verification

New `describe("jsxExternalRuntimeImportCollapsed")` in `test/bundler/bundler_jsx.test.ts` covers dev/prod, minified, multi-entry, `--splitting`, and a `run` check that executes the collapsed output against a stub `react/jsx-runtime`. 7/7 fail on 1.4.0-canary (5 imports vs expected 1, `jsxDEV2`/`jsxDEV3` aliases present); 7/7 pass on this branch.

Regression sweep (no new failures): `bundler_jsx` (40 pass / 4 todo), `bundler_edgecase` (117 pass), `esbuild/default` (151 pass), `esbuild/splitting` + `esbuild/tsconfig` (43 pass).

Note: #3029 was closed as a duplicate of #13092, which tracks the general case (one import statement per source file for any shared external, not only the JSX runtime).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts
bun test v1.4.0 (57ac54112)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1133.18ms]
(pass) bundler > jsx/AutomaticProd [792.56ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [762.73ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [760.48ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [783.85ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [852.21ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [516.77ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [356.11ms]
(pass) bundler > jsx/ClassicDev [759.28ms]
(pass) bundler > jsx/ClassicProd [757.79ms]
(pass) bundler > jsx/ClassicPragmaDev [743.00ms]
(pass) bundler > jsx/ClassicPragmaProd [802.03ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [694.81ms]
(pass) bundler > jsx/FactoryProd [851.70ms]
(pass) bundler > jsx/FactoryImportDev
... (truncated)

release without fix: 7 failed, 4 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [47.52ms]
(pass) bundler > jsx/AutomaticProd [34.09ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [28.71ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [26.35ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [34.28ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [31.44ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [15.30ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [11.38ms]
(pass) bundler > jsx/ClassicDev [42.01ms]
(pass) bundler > jsx/ClassicProd [37.25ms]
(pass) bundler > jsx/ClassicPragmaDev [31.59ms]
(pass) bundler > jsx/ClassicPragmaProd [36.73ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [33.52ms]
(pass) bundler > jsx/FactoryProd [33.72ms]
(pass) bundler > jsx/FactoryImportDev [35.73ms]
(pass) bundler > jsx/FactoryImportProd [48.27ms]
(pass) bundler > jsx/FactoryImportExplicitReactDefaultDev [21.37ms]
(pass) bundler > jsx/FactoryImportExplicitRe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts
bun test v1.4.0 (57ac54112)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1211.89ms]
(pass) bundler > jsx/AutomaticProd [864.42ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [799.31ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [819.70ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [863.33ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [874.98ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [487.41ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [374.58ms]
(pass) bundler > jsx/ClassicDev [938.13ms]
(pass) bundler > jsx/ClassicProd [894.11ms]
(pass) bundler > jsx/ClassicPragmaDev [786.88ms]
(pass) bundler > jsx/ClassicPragmaProd [774.02ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [814.48ms]
(pass) bundler > jsx/FactoryProd [845.48ms]
(pass) bundler > jsx/FactoryImportDev
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     57ac541121
  features     baseline

22 deps, 108 codegen, 1171 objects in 1222ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen bindgenv2
[2/1234] gen ErrorCode+*.h
[3/1234] fetch picohttpparser
[picohttpparser] up to date
[4/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[5/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1234] fetch zlib
[zlib] up to date
[7/1234] gen .bind.ts → GeneratedBindings.cpp
[8/1234] fetch tinycc
[tinycc] up to date
[9/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1234] subst deps/zlib/zconf.h
[11/1234] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[12/1234] subst dep
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/import_record.rs                           |   4 +
 src/bundler/Chunk.rs                               |  13 ++
 src/bundler/LinkerContext.rs                       | 146 ++++++++++++++++++++
 src/bundler/linker_context/convertStmtsForChunk.rs |  31 +++++
 src/js_parser/p.rs                                 |   4 +
 test/bundler/bundler_jsx.test.ts                   | 148 +++++++++++++++++++++
 6 files changed, 346 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/ast/import_record.rs                                2      3      0
src/bundler/Chunk.rs                                    3      3      0
src/bundler/LinkerContext.rs                            8      7      0
src/bundler/linker_context/convertStmtsForChunk.rs      1      1      0
src/js_parser/p.rs                                      1      1      0
test/bundler/bundler_jsx.test.ts                        6      8      0
```

</details>

<!-- robobun:evidence:end -->