### PR TITLE
bundler: make sourcemap `sources` relative to the map file, not outdir

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1015,11 +1015,9 @@ impl<'a> LinkerContext<'a> {
         Ok(rel)
     }
 
-    /// Absolute directory of a chunk's output file, for use as the base of
-    /// source map `sources` entries (which the spec defines as relative to the
-    /// map file itself). `chunk.final_rel_path` is not yet known at
-    /// post-process time, so this is derived from `output_dir` +
-    /// `chunk.template.rel_dir()`.
+    /// `output_dir` joined with the chunk template's directory: the base that
+    /// source-map `sources` entries are relative to. `final_rel_path` is not
+    /// yet set when the source map is generated, so the template stands in.
     pub(crate) fn source_map_chunk_abs_dir(
         output_dir: &[u8],
         template: &crate::options::PathTemplate,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1027,10 +1027,14 @@ impl<'a> LinkerContext<'a> {
         if rel_dir.is_empty() || &*rel_dir == b"." || output_dir.is_empty() {
             return Box::from(output_dir);
         }
+        // `join_abs_string_buf` requires an absolute cwd. `output_dir` may be
+        // relative (Bun.build `outdir: "dist"`), so anchor at `top_level_dir`;
+        // an absolute `output_dir` resets the join base on its own.
+        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
         let mut buf = bun_paths::path_buffer_pool::get();
         Box::from(bun_paths::resolve_path::join_abs_string_buf::<
             bun_paths::platform::Auto,
-        >(output_dir, &mut buf, &[&rel_dir]))
+        >(top_level_dir, &mut buf, &[output_dir, &rel_dir]))
     }
 
     pub(crate) fn generate_source_map_for_chunk(

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1015,6 +1015,26 @@ impl<'a> LinkerContext<'a> {
         Ok(rel)
     }
 
+    /// Absolute directory of a chunk's output file, for use as the base of
+    /// source map `sources` entries (which the spec defines as relative to the
+    /// map file itself). `chunk.final_rel_path` is not yet known at
+    /// post-process time, so this is derived from `output_dir` +
+    /// `chunk.template.rel_dir()`.
+    pub(crate) fn source_map_chunk_abs_dir(
+        output_dir: &[u8],
+        template: &crate::options::PathTemplate,
+        sanitize_parent_dirs: bool,
+    ) -> Box<[u8]> {
+        let rel_dir = template.rel_dir(sanitize_parent_dirs);
+        if rel_dir.is_empty() || &*rel_dir == b"." || output_dir.is_empty() {
+            return Box::from(output_dir);
+        }
+        let mut buf = bun_paths::path_buffer_pool::get();
+        Box::from(bun_paths::resolve_path::join_abs_string_buf::<
+            bun_paths::platform::Auto,
+        >(output_dir, &mut buf, &[&rel_dir]))
+    }
+
     pub(crate) fn generate_source_map_for_chunk(
         &mut self,
         isolated_hash: u64,

--- a/src/bundler/linker_context/postProcessCSSChunk.rs
+++ b/src/bundler/linker_context/postProcessCSSChunk.rs
@@ -160,12 +160,16 @@ pub(crate) fn post_process_css_chunk(
         // borrows the local, not `c`, avoiding the split-borrow with
         // `c.generate_source_map_for_chunk(&mut self, …)` below.
         let resolver = c.resolver.expect("resolver set in load()");
-        let output_dir = &resolver.opts.output_dir;
+        let chunk_abs_dir = crate::LinkerContext::source_map_chunk_abs_dir(
+            &resolver.opts.output_dir,
+            &chunk.template,
+            !c.options.compile,
+        );
         chunk.output_source_map = c.generate_source_map_for_chunk(
             chunk.isolated_hash,
             worker,
             &compile_results_for_source_map,
-            output_dir,
+            &chunk_abs_dir,
             can_have_shifts,
         )?;
     }

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -809,11 +809,16 @@ pub(crate) fn post_process_js_chunk(
         // local, not `c`, avoiding the split-borrow with
         // `c.generate_source_map_for_chunk(&mut self, …)`.
         let resolver = c.resolver.expect("resolver set in load()");
+        let chunk_abs_dir = LinkerContext::source_map_chunk_abs_dir(
+            &resolver.opts.output_dir,
+            &chunk.template,
+            !c.options.compile,
+        );
         chunk.output_source_map = c.generate_source_map_for_chunk(
             chunk.isolated_hash,
             worker,
             &compile_results_for_source_map,
-            &resolver.opts.output_dir,
+            &chunk_abs_dir,
             can_have_shifts,
         )?;
     }

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2377,10 +2377,9 @@ impl PathTemplate {
         )
     }
 
-    /// The chunk-relative directory this template expands into, with `[hash]`
-    /// (not yet known during post-process) substituted by a dummy value. The
-    /// hash formatter never emits a path separator, so any value yields the
-    /// correct directory depth. Result uses `/` separators.
+    /// `/`-separated directory portion of the expanded template. A missing
+    /// `[hash]` is filled with a dummy: the hash output never contains `/`,
+    /// so the directory is the same regardless of the eventual value.
     pub(crate) fn rel_dir(&self, sanitize_parent_dirs: bool) -> Box<[u8]> {
         let mut rel = Vec::<u8>::new();
         path_template_print(

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2376,6 +2376,27 @@ impl PathTemplate {
             sanitize_parent_dirs,
         )
     }
+
+    /// The chunk-relative directory this template expands into, with `[hash]`
+    /// (not yet known during post-process) substituted by a dummy value. The
+    /// hash formatter never emits a path separator, so any value yields the
+    /// correct directory depth. Result uses `/` separators.
+    pub(crate) fn rel_dir(&self, sanitize_parent_dirs: bool) -> Box<[u8]> {
+        let mut rel = Vec::<u8>::new();
+        path_template_print(
+            &mut rel,
+            &self.data,
+            &self.placeholder.dir,
+            &self.placeholder.name,
+            &self.placeholder.ext,
+            self.placeholder.hash.or(Some(0)),
+            &self.placeholder.target,
+            sanitize_parent_dirs,
+        )
+        .expect("write to Vec<u8>");
+        bun_paths::resolve_path::platform_to_posix_in_place::<u8>(&mut rel);
+        Box::from(bun_paths::resolve_path::dirname::<bun_paths::platform::Posix>(&rel))
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/test/regression/issue/03332.test.ts
+++ b/test/regression/issue/03332.test.ts
@@ -1,0 +1,132 @@
+// https://github.com/oven-sh/bun/issues/3332
+// Sourcemap `sources` entries must be relative to the .map file's own
+// directory (per the sourcemap spec), not to the build outdir.
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { tempDir } from "harness";
+
+describe("issue 3332: sourcemap sources are relative to the map file", () => {
+  test("nested outdir layout (monorepo-style root)", async () => {
+    using dir = tempDir("issue-3332", {
+      "xxx/package.json": JSON.stringify({ name: "xxx", dependencies: { "tiny-dep": "1.0.0" } }),
+      "xxx/node_modules/tiny-dep/package.json": JSON.stringify({
+        name: "tiny-dep",
+        version: "1.0.0",
+        main: "index.js",
+      }),
+      "xxx/node_modules/tiny-dep/index.js": `module.exports = { dep: "tiny" };`,
+      "xxx/repos/livex/store/src/util.ts": `export const util = () => "util";`,
+      "xxx/repos/livex/web/src/index.ts": `
+        import { util } from "../../store/src/util";
+        import dep from "tiny-dep";
+        console.log(util(), dep);
+      `,
+      "xxx/repos/livex/server/src/bundler/foo.ts": `
+        import { util } from "../../../store/src/util";
+        import dep from "tiny-dep";
+        console.log("foo", util(), dep);
+      `,
+    });
+
+    const root = path.join(String(dir), "xxx");
+    const outdir = path.join(String(dir), "out");
+
+    const result = await Bun.build({
+      root,
+      entrypoints: [
+        path.join(root, "repos/livex/web/src/index.ts"),
+        path.join(root, "repos/livex/server/src/bundler/foo.ts"),
+      ],
+      outdir,
+      sourcemap: "external",
+    });
+    expect(result.success).toBe(true);
+
+    const maps = result.outputs.filter(o => o.path.endsWith(".map"));
+    expect(maps.length).toBe(2);
+
+    for (const map of maps) {
+      // Each map lands in a subdirectory of outdir mirroring the source tree,
+      // so its directory differs from outdir. That is the case the bug broke.
+      const mapDir = path.dirname(map.path);
+      expect(mapDir).not.toBe(outdir);
+
+      const json = JSON.parse(readFileSync(map.path, "utf8"));
+      expect(Array.isArray(json.sources)).toBe(true);
+      expect(json.sources.length).toBeGreaterThanOrEqual(3);
+
+      for (const src of json.sources as string[]) {
+        const resolved = path.resolve(mapDir, src);
+        // Every source entry must resolve to a real file from the map's own
+        // directory. Before the fix these resolved under out/repos/.../xxx/...
+        // which does not exist.
+        expect(existsSync(resolved), `source ${JSON.stringify(src)} in ${map.path} -> ${resolved}`).toBe(true);
+      }
+    }
+  });
+
+  test("flat outdir (single entrypoint in outdir root) still resolves", async () => {
+    using dir = tempDir("issue-3332-flat", {
+      "src/entry.ts": `
+        import { helper } from "./lib/helper";
+        console.log(helper());
+      `,
+      "src/lib/helper.ts": `export const helper = () => "hi";`,
+    });
+
+    const outdir = path.join(String(dir), "dist");
+    const result = await Bun.build({
+      entrypoints: [path.join(String(dir), "src/entry.ts")],
+      outdir,
+      sourcemap: "external",
+    });
+    expect(result.success).toBe(true);
+
+    const [map] = result.outputs.filter(o => o.path.endsWith(".map"));
+    expect(map).toBeDefined();
+    // With a single entrypoint and no `root`, the map sits directly in outdir.
+    expect(path.dirname(map.path)).toBe(outdir);
+
+    const json = JSON.parse(readFileSync(map.path, "utf8"));
+    for (const src of json.sources as string[]) {
+      const resolved = path.resolve(path.dirname(map.path), src);
+      expect(existsSync(resolved), `source ${JSON.stringify(src)} -> ${resolved}`).toBe(true);
+    }
+  });
+
+  test("inline sourcemap in a nested chunk resolves from the map file", async () => {
+    using dir = tempDir("issue-3332-inline", {
+      "xxx/repos/app/src/util.ts": `export const util = () => 1;`,
+      "xxx/repos/app/src/entry.ts": `
+        import { util } from "./util";
+        console.log(util());
+      `,
+      "xxx/repos/other/stub.ts": `export {};`,
+    });
+
+    const root = path.join(String(dir), "xxx");
+    const outdir = path.join(String(dir), "out");
+    const result = await Bun.build({
+      root,
+      entrypoints: [path.join(root, "repos/app/src/entry.ts"), path.join(root, "repos/other/stub.ts")],
+      outdir,
+      sourcemap: "inline",
+    });
+    expect(result.success).toBe(true);
+
+    const entry = result.outputs.find(o => o.path.endsWith("entry.js"));
+    expect(entry).toBeDefined();
+    const jsDir = path.dirname(entry!.path);
+    expect(jsDir).not.toBe(outdir);
+
+    const code = readFileSync(entry!.path, "utf8");
+    const m = code.match(/sourceMappingURL=data:application\/json;[^,]+,([A-Za-z0-9+/=]+)/);
+    expect(m).toBeTruthy();
+    const json = JSON.parse(Buffer.from(m![1], "base64").toString("utf8"));
+    for (const src of json.sources as string[]) {
+      const resolved = path.resolve(jsDir, src);
+      expect(existsSync(resolved), `source ${JSON.stringify(src)} -> ${resolved}`).toBe(true);
+    }
+  });
+});

--- a/test/regression/issue/03332.test.ts
+++ b/test/regression/issue/03332.test.ts
@@ -2,7 +2,7 @@
 // Sourcemap `sources` entries must be relative to the .map file's own
 // directory (per the sourcemap spec), not to the build outdir.
 import { describe, expect, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
@@ -89,6 +89,7 @@ describe("issue 3332: sourcemap sources are relative to the map file", () => {
     expect(path.dirname(map.path)).toBe(outdir);
 
     const json = JSON.parse(readFileSync(map.path, "utf8"));
+    expect(json.sources.length).toBeGreaterThanOrEqual(2);
     for (const src of json.sources as string[]) {
       const resolved = path.resolve(path.dirname(map.path), src);
       expect(existsSync(resolved), `source ${JSON.stringify(src)} -> ${resolved}`).toBe(true);
@@ -124,9 +125,54 @@ describe("issue 3332: sourcemap sources are relative to the map file", () => {
     const m = code.match(/sourceMappingURL=data:application\/json;[^,]+,([A-Za-z0-9+/=]+)/);
     expect(m).toBeTruthy();
     const json = JSON.parse(Buffer.from(m![1], "base64").toString("utf8"));
+    expect(json.sources.length).toBeGreaterThanOrEqual(2);
     for (const src of json.sources as string[]) {
       const resolved = path.resolve(jsDir, src);
       expect(existsSync(resolved), `source ${JSON.stringify(src)} -> ${resolved}`).toBe(true);
     }
+  });
+
+  test("relative outdir with nested chunks", async () => {
+    // `Bun.build` stores a relative `outdir` verbatim; the sources-base join
+    // must still produce an absolute chunk directory. Run in a subprocess so
+    // the test can chdir without touching the harness cwd.
+    using dir = tempDir("issue-3332-reloutdir", {
+      "proj/a/util.ts": `export const u = 1;`,
+      "proj/a/entry.ts": `import { u } from "./util"; console.log(u);`,
+      "proj/b/entry.ts": `console.log("b");`,
+      "build.ts": `
+        import path from "node:path";
+        import { readFileSync, existsSync } from "node:fs";
+        const root = path.join(import.meta.dir, "proj");
+        const res = await Bun.build({
+          root,
+          entrypoints: [path.join(root, "a/entry.ts"), path.join(root, "b/entry.ts")],
+          outdir: "dist",
+          sourcemap: "external",
+        });
+        if (!res.success) { console.error(res.logs); process.exit(1); }
+        const map = res.outputs.find(o => o.path.endsWith(path.join("a", "entry.js.map")));
+        if (!map) { console.error("no map for a/entry"); process.exit(1); }
+        const mapDir = path.dirname(map.path);
+        const json = JSON.parse(readFileSync(map.path, "utf8"));
+        if (json.sources.length < 2) { console.error("too few sources", json.sources); process.exit(1); }
+        for (const s of json.sources) {
+          const r = path.resolve(mapDir, s);
+          if (!existsSync(r)) { console.error("MISS", s, "->", r); process.exit(1); }
+        }
+        console.log("OK " + json.sources.length);
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK 2");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/regression/issue/03332.test.ts
+++ b/test/regression/issue/03332.test.ts
@@ -2,9 +2,9 @@
 // Sourcemap `sources` entries must be relative to the .map file's own
 // directory (per the sourcemap spec), not to the build outdir.
 import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { tempDir } from "harness";
 
 describe("issue 3332: sourcemap sources are relative to the map file", () => {
   test("nested outdir layout (monorepo-style root)", async () => {


### PR DESCRIPTION
Fixes #3332.

### What

When `Bun.build` emits chunks into subdirectories of `outdir` (multiple entrypoints under a `root`, or a `[dir]` naming template), the `sources` array in each `.js.map` was computed relative to `outdir` instead of the directory containing the `.map` file. Per the [source map spec](https://tc39.es/ecma426/#sec-sources), `sources` entries are resolved relative to the map file (or `sourceRoot`), so debuggers following them ended up at nonexistent paths like `out/repos/livex/web/xxx/...`.

### Repro

```js
await Bun.build({
  root: "/repro/xxx",
  entrypoints: [
    "/repro/xxx/repos/livex/web/src/index.ts",
    "/repro/xxx/repos/livex/server/src/bundler/foo.ts",
  ],
  outdir: "/repro/out",
  sourcemap: "external",
});
```

Before: `out/repos/livex/web/src/index.js.map` contains `"sources": ["../xxx/node_modules/tiny-dep/index.js", ...]`, which resolves (from the map's directory) to `out/repos/livex/web/xxx/...` and does not exist.

After: `"sources": ["../../../../../xxx/node_modules/tiny-dep/index.js", ...]`, which resolves to `/repro/xxx/node_modules/tiny-dep/index.js`.

### Cause

`post_process_{js,css}_chunk` passed `resolver.opts.output_dir` as `chunk_abs_dir` to `generate_source_map_for_chunk`, so every `sources` entry was `relative(outdir, source)` regardless of where in `outdir` the chunk actually lands.

### Fix

Compute `chunk_abs_dir = output_dir + dirname(chunk.template)` at post-process time, matching esbuild's `fs.Dir(fs.Join(AbsOutputDir, TemplateToString(chunk.finalTemplate)))`. `chunk.final_rel_path` is not yet populated (its content hash depends on post-process output), but the hash formatter never emits a path separator, so substituting a dummy value in `PathTemplate::rel_dir` yields the correct directory depth even when `[hash]` appears in a directory segment of the naming template.

When `rel_dir` is empty or `.` (flat outdir), or `output_dir` is empty (no `outdir`), the previous behavior is preserved.

### Verification

New `test/regression/issue/03332.test.ts` builds a monorepo-style layout and asserts every `sources[i]` resolves from the map file's own directory for both `sourcemap: "external"` and `sourcemap: "inline"`. Fails on main with `source "../xxx/node_modules/tiny-dep/index.js" -> .../out/repos/livex/web/xxx/node_modules/tiny-dep/index.js` not existing; passes with this change. Existing `snapshotSourceMap` tests in `bundler_edgecase.test.ts`, `bundler_npm.test.ts`, and `internal-sourcemap-roundtrip.test.ts` are unaffected (all use a flat outdir).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/03332.test.ts"
bun test v1.4.0 (7fdb4fa93)

test/regression/issue/03332.test.ts:
59 |       for (const src of json.sources as string[]) {
60 |         const resolved = path.resolve(mapDir, src);
61 |         // Every source entry must resolve to a real file from the map's own
62 |         // directory. Before the fix these resolved under out/repos/.../xxx/...
63 |         // which does not exist.
64 |         expect(existsSync(resolved), `source ${JSON.stringify(src)} in ${map.path} -> ${resolved}`).toBe(true);
                                                                                                         ^
error: source "../xxx/node_modules/tiny-dep/index.js" in /tmp/issue-3332_G71gtG/out/repos/livex/web/src/index.js.map -> /tmp/issue-3332_G71gtG/out/repos/livex/web/xxx/node_modules/tiny-dep/index.js

Expected: true
Received: false

      at <anonymous> (/workspace/bun/test/regression/issue/03332.test.ts:64:101)
(fail) issue 3332: sourcemap sources are relative to the map file > nested outdir layout (mo
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/regression/issue/03332.test.ts:
59 |       for (const src of json.sources as string[]) {
60 |         const resolved = path.resolve(mapDir, src);
61 |         // Every source entry must resolve to a real file from the map's own
62 |         // directory. Before the fix these resolved under out/repos/.../xxx/...
63 |         // which does not exist.
64 |         expect(existsSync(resolved), `source ${JSON.stringify(src)} in ${map.path} -> ${resolved}`).toBe(true);
                                                                                                         ^
error: source "../xxx/node_modules/tiny-dep/index.js" in /tmp/issue-3332_6YbtUX/out/repos/livex/web/src/index.js.map - /tmp/issue-3332_6YbtUX/out/repos/livex/web/xxx/node_modules/tiny-dep/index.js

Expected: true
Received: false

      at <anonymous> (/workspace/bun/test/regression/issue/03332.test.ts:64:101)
(fail) issue 3332: sourcemap sources are relative to the map file > nested outdir layout (monorepo-style root) [57.05ms]
(pass) issue 3332: sourcemap sources are relative to the map file > flat outdir (single entrypoint in outdir root) still resolves [32.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/03332.test.ts"
bun test v1.4.0 (7fdb4fa93)

test/regression/issue/03332.test.ts:
(pass) issue 3332: sourcemap sources are relative to the map file > nested outdir layout (monorepo-style root) [280.31ms]
(pass) issue 3332: sourcemap sources are relative to the map file > flat outdir (single entrypoint in outdir root) still resolves [330.53ms]
(pass) issue 3332: sourcemap sources are relative to the map file > inline sourcemap in a nested chunk resolves from the map file [110.55ms]
(pass) issue 3332: sourcemap sources are relative to the map file > relative outdir with nested chunks [1580.97ms]

 4 pass
 0 fail
 30 expect() calls
Ran 4 tests across 1 file. [4.71s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1142ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/LinkerContext.rs                      |  22 +++
 src/bundler/linker_context/postProcessCSSChunk.rs |   8 +-
 src/bundler/linker_context/postProcessJSChunk.rs  |   7 +-
 src/bundler/options.rs                            |  20 +++
 test/regression/issue/03332.test.ts               | 178 ++++++++++++++++++++++
 5 files changed, 232 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/bundler/LinkerContext.rs                           7      5      0
src/bundler/linker_context/postProcessCSSChunk.rs      2      1      0
src/bundler/linker_context/postProcessJSChunk.rs       2      1      0
src/bundler/options.rs                                 5      2      0
test/regression/issue/03332.test.ts                    1      5      0
```

</details>

<!-- robobun:evidence:end -->