### PR TITLE
error printer: print the AggregateError header, label [cause]/[errors] blocks, and guard the .errors walk

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4793,21 +4793,22 @@ impl VirtualMachine {
         }
         self.has_terminated = true;
     }
-    /// Note: takes the concrete
-    /// `bun_core::io::Writer` since every call site passes
-    /// `Output.errorWriterBuffered()`.
+
     pub fn print_exception(
         &mut self,
-        exception: &Exception,
+        value: JSValue,
+        exception: Option<&Exception>,
         exception_list: Option<&mut ExceptionList>,
         writer: &mut bun_core::io::Writer,
         allow_side_effects: bool,
     ) {
         let mut formatter = crate::console_object::Formatter::new(self.global());
+        // `Formatter::new` leaves the stack check inert.
+        formatter.stack_check = bun_core::StackCheck::init();
         let colors = bun_core::Output::enable_ansi_colors_stderr();
         self.print_errorlike_object(
-            exception.value(),
-            Some(exception),
+            value,
+            exception,
             exception_list,
             &mut formatter,
             writer,
@@ -5145,7 +5146,7 @@ impl VirtualMachine {
     }
 
     /// Note: takes runtime bools and the concrete `bun_core::io::Writer`.
-    pub fn print_errorlike_object(
+    pub(crate) fn print_errorlike_object(
         &mut self,
         value: JSValue,
         exception: Option<&Exception>,
@@ -5155,92 +5156,6 @@ impl VirtualMachine {
         allow_ansi_color: bool,
         allow_side_effects: bool,
     ) {
-        // Note: the post-print stack/exception_list block is handled at the
-        // tail instead of via a drop guard (the body has no early-`?` returns
-        // once the AggregateError branch is taken).
-        let global_ref = self.global();
-
-        let errors = if value.is_aggregate_error(global_ref) {
-            match value.fast_get(global_ref, jsc::BuiltinName::errors) {
-                Ok(errors) => errors,
-                Err(_) => {
-                    global_ref.clear_exception();
-                    None
-                }
-            }
-        } else {
-            None
-        };
-        if let Some(errors) = errors {
-            // Note: `JSValue::for_each` takes a C-ABI fn
-            // pointer + erased ctx, so thread the captures through a struct.
-            // The C trampoline erases lifetimes via `*mut c_void`; round-trip
-            // the caller's `&mut ExceptionList` as a raw pointer so child
-            // errors append to the same list.
-            struct AggCtx<'a> {
-                formatter: *mut crate::console_object::Formatter<'a>,
-                writer: *mut bun_core::io::Writer,
-                exception_list: *mut ExceptionList,
-                allow_ansi_color: bool,
-                allow_side_effects: bool,
-                printed_member: bool,
-            }
-            extern "C" fn agg_iter(
-                _vm: *mut crate::VM,
-                _global: &JSGlobalObject,
-                ctx: *mut c_void,
-                next_value: JSValue,
-            ) {
-                // SAFETY: `ctx` is `&mut AggCtx` for the duration of `for_each`.
-                let ctx = unsafe { bun_ptr::callback_ctx::<AggCtx<'_>>(ctx) };
-                // SAFETY: per-thread VM.
-                let vm = VirtualMachine::get().as_mut();
-                let exception_list = if ctx.exception_list.is_null() {
-                    None
-                } else {
-                    // SAFETY: non-null branch; borrows the caller's stack
-                    // `ExceptionList`, live for the synchronous `for_each`.
-                    Some(unsafe { &mut *ctx.exception_list })
-                };
-                // SAFETY: `ctx.formatter` borrows the caller's stack local,
-                // live across the synchronous `for_each` call.
-                let formatter = unsafe { &mut *ctx.formatter };
-                // SAFETY: `ctx.writer` borrows the caller's stack local,
-                // live across the synchronous `for_each` call.
-                let writer = unsafe { &mut *ctx.writer };
-                ctx.printed_member = true;
-                vm.print_errorlike_object(
-                    next_value,
-                    None,
-                    exception_list,
-                    formatter,
-                    writer,
-                    ctx.allow_ansi_color,
-                    ctx.allow_side_effects,
-                );
-            }
-            let mut ctx = AggCtx {
-                formatter: std::ptr::from_mut(&mut *formatter),
-                writer: std::ptr::from_mut(&mut *writer),
-                exception_list: exception_list
-                    .as_deref_mut()
-                    .map_or(core::ptr::null_mut(), std::ptr::from_mut::<ExceptionList>),
-                allow_ansi_color,
-                allow_side_effects,
-                printed_member: false,
-            };
-            if errors
-                .for_each(global_ref, (&raw mut ctx).cast(), agg_iter)
-                .is_err()
-            {
-                global_ref.clear_exception();
-            }
-            if ctx.printed_member {
-                return;
-            }
-            // `errors` is empty or not iterable: print the AggregateError itself.
-        }
-
         let was_internal = self.print_error_from_maybe_private_data(
             value,
             exception_list.as_deref_mut(),
@@ -5257,7 +5172,7 @@ impl VirtualMachine {
                 // — semantics unchanged because
                 // `need_to_clear_parser_arena_on_deinit` is false here.
                 let zig_exception: &mut ZigException = holder.zig_exception();
-                exception_.get_stack_trace(global_ref, &mut zig_exception.stack);
+                exception_.get_stack_trace(self.global(), &mut zig_exception.stack);
                 if zig_exception.stack.frames_len > 0 {
                     let _ = Self::print_stack_trace(writer, &zig_exception.stack, allow_ansi_color);
                 }
@@ -5884,7 +5799,7 @@ impl VirtualMachine {
     fn print_error_instance_js(
         &mut self,
         error_instance: JSValue,
-        exception_list: Option<&mut ExceptionList>,
+        mut exception_list: Option<&mut ExceptionList>,
         formatter: &mut crate::console_object::Formatter,
         writer: &mut bun_core::io::Writer,
         allow_ansi_color: bool,
@@ -5903,14 +5818,15 @@ impl VirtualMachine {
         // to cover the transpiler's nested path buffers — same parity-level
         // protection the Object path gets from C++ `forEachProperty`'s
         // `vm.isSafeToRecurse()`. The formatter's `stack_check` was seated by
-        // the caller (`format2` / `Bun.inspect`).
+        // the caller (`format2` / `Bun.inspect` / `print_exception`).
         let extra_headroom: usize = if cfg!(windows) {
             // 3× PathBuffer ≈ 288 KB — empirically enough for the
             // `remap_zig_exception` → `transpile_source_code` chain on the
             // 16K-deep Error test (`bun-inspect.test.ts`).
             bun_paths::MAX_PATH_BYTES * 3
         } else {
-            0
+            // The same chain measured ~130 KB under debug+ASAN, past the 128 KB default.
+            256 * 1024
         };
         if !formatter
             .stack_check
@@ -5939,7 +5855,7 @@ impl VirtualMachine {
             // SAFETY: `exception` points into stack-local `exception_holder`.
             unsafe { &mut *exception },
             error_instance,
-            exception_list,
+            exception_list.as_deref_mut(),
             &mut exception_holder.need_to_clear_parser_arena_on_deinit,
             &mut source_code_slice,
             formatter.error_display_level != crate::console_object::ErrorDisplayLevel::Warn,
@@ -5950,8 +5866,7 @@ impl VirtualMachine {
             // SAFETY: see above.
             unsafe { &mut *exception },
             error_instance,
-            None, // Note: `exception_list` was already
-            // consumed by `remap_zig_exception` above (only writer).
+            exception_list,
             formatter,
             writer,
             allow_ansi_color,
@@ -6293,23 +6208,25 @@ impl VirtualMachine {
         }
 
         // This is usually unsafe to do, but we are protecting them each time first.
-        let mut errors_to_append: Vec<JSValue> = Vec::new();
+        let mut errors_to_append: Vec<(JSValue, bun_core::String)> = Vec::new();
         // Each appended error is unprotected at scope exit.
         // `BackRef` (constructed from `&raw mut` via `NonNull` so the tag is
         // not popped by later `errors_to_append.push` reborrows) lets the drop
         // body read the Vec safely.
-        struct UnprotectAll(bun_ptr::BackRef<Vec<JSValue>>);
+        struct UnprotectAll(bun_ptr::BackRef<Vec<(JSValue, bun_core::String)>>);
         impl Drop for UnprotectAll {
             fn drop(&mut self) {
                 // BackRef invariant: borrows the caller's stack `Vec`, live for this scope.
-                for v in self.0.iter() {
+                for (v, label) in self.0.iter() {
                     v.unprotect();
+                    label.deref();
                 }
             }
         }
         let _unprotect_guard = UnprotectAll(bun_ptr::BackRef::from(
             NonNull::new(&raw mut errors_to_append).expect("stack addr"),
         ));
+        let mut errors_omitted: u64 = 0;
 
         if is_error_instance {
             let mut saw_cause = false;
@@ -6346,7 +6263,8 @@ impl VirtualMachine {
                         saw_cause = true;
                     }
                     value.protect();
-                    errors_to_append.push(value);
+                    let label = field.dupe_ref();
+                    errors_to_append.push((value, label));
                 } else if kind.is_object()
                     || kind.is_array()
                     || value.is_primitive()
@@ -6440,7 +6358,44 @@ impl VirtualMachine {
                 if let Some(cause) = error_instance.get_own(global_ref, &key)? {
                     if cause.is_cell() && cause.js_type() == JSType::ErrorInstance {
                         cause.protect();
-                        errors_to_append.push(cause);
+                        errors_to_append.push((cause, bun_core::String::static_(b"cause")));
+                    }
+                }
+            }
+
+            // `.errors` is DontEnum (not seen above) and may have been deleted or reassigned.
+            if error_instance.is_aggregate_error(global_ref) {
+                const MAX_AGGREGATE_ERRORS_PRINTED: u64 = 100;
+                let errors = match error_instance.fast_get(global_ref, jsc::BuiltinName::errors) {
+                    Ok(errors) => {
+                        errors.filter(|errors| errors.is_cell() && errors.js_type().is_array())
+                    }
+                    Err(_) => {
+                        global_ref.clear_exception();
+                        None
+                    }
+                };
+                if let Some(errors) = errors {
+                    match errors.get_length(global_ref) {
+                        Ok(len) => {
+                            let mut appended: u64 = 0;
+                            for i in 0..len.min(MAX_AGGREGATE_ERRORS_PRINTED) as u32 {
+                                match errors.get_index(global_ref, i) {
+                                    Ok(member) => {
+                                        member.protect();
+                                        errors_to_append
+                                            .push((member, bun_core::String::static_(b"errors")));
+                                        appended += 1;
+                                    }
+                                    Err(_) => {
+                                        global_ref.clear_exception();
+                                        break;
+                                    }
+                                }
+                            }
+                            errors_omitted = len - appended;
+                        }
+                        Err(_) => global_ref.clear_exception(),
                     }
                 }
             }
@@ -6471,9 +6426,8 @@ impl VirtualMachine {
             )?;
         }
 
-        let mut exception_list = exception_list;
-        for &err in &errors_to_append {
-            // Circular-ref guard for cause chains.
+        if !errors_to_append.is_empty() {
+            // Circular-ref guard for cause / `.errors` chains.
             if formatter.map_node.is_none() {
                 let mut node = NonNull::new(console_object::formatter::visited::Pool::get_node())
                     .expect("ObjectPool::get_node always returns a valid heap node");
@@ -6482,24 +6436,57 @@ impl VirtualMachine {
                 formatter.map = core::mem::take(data);
                 formatter.map_node = Some(node);
             }
+            // The outermost error is not registered by anyone else.
+            let registered_self =
+                !bun_core::handle_oom(formatter.map.get_or_put(error_instance)).found_existing;
 
-            let entry = formatter.map.get_or_put(err).expect("unreachable");
-            if entry.found_existing {
+            let mut exception_list = exception_list;
+            for &(err, ref label) in &errors_to_append {
+                // Stack check failed (a RangeError may be pending) or the writer failed.
+                if formatter.failed {
+                    break;
+                }
+                // `formatter.format` tracks non-error members in this map itself.
+                let is_error = err.is_cell() && err.js_type() == JSType::ErrorInstance;
+                if is_error && bun_core::handle_oom(formatter.map.get_or_put(err)).found_existing {
+                    writer.write_all(b"\n")?;
+                    if !label.is_empty() {
+                        pretty_write!(writer, "<r><d>[{}]:<r> ", label)?;
+                    }
+                    pretty_write!(writer, "<r><cyan>[Circular]<r>\n")?;
+                    continue;
+                }
+
                 writer.write_all(b"\n")?;
-                pretty_write!(writer, "<r><cyan>[Circular]<r>")?;
-                continue;
+                if !label.is_empty() {
+                    pretty_write!(writer, "<r><d>[{}]:<r>\n", label)?;
+                }
+                self.print_errorlike_object(
+                    err,
+                    None,
+                    exception_list.as_deref_mut(),
+                    formatter,
+                    writer,
+                    allow_ansi_color,
+                    allow_side_effects,
+                );
+                if is_error {
+                    let _ = formatter.map.remove(&err);
+                }
             }
 
-            writer.write_all(b"\n")?;
-            self.print_error_instance_js(
-                err,
-                exception_list.as_deref_mut(),
-                formatter,
+            if registered_self {
+                let _ = formatter.map.remove(&error_instance);
+            }
+        }
+
+        if errors_omitted > 0 && !formatter.failed {
+            pretty_write!(
                 writer,
-                allow_ansi_color,
-                allow_side_effects,
+                "\n<r><d>... {} more error{}<r>\n",
+                errors_omitted,
+                if errors_omitted == 1 { "" } else { "s" }
             )?;
-            let _ = formatter.map.remove(&err);
         }
 
         Ok(())

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -292,11 +292,15 @@ public:
         // the proper singular spelling is parenthesis
         auto openingParentheses = line.reverseFind('(');
         auto closingParentheses = line.reverseFind(')');
+        bool hasParens = openingParentheses != WTF::notFound && closingParentheses != WTF::notFound;
 
-        if (openingParentheses > closingParentheses)
-            openingParentheses = WTF::notFound;
+        // One unmatched parenthesis, or `)` before `(`: stop parsing as before.
+        if (hasParens ? openingParentheses > closingParentheses : openingParentheses != closingParentheses) {
+            offset = stack.length();
+            return false;
+        }
 
-        if (openingParentheses == WTF::notFound || closingParentheses == WTF::notFound) {
+        if (!hasParens) {
             // Special case: "unknown" frames don't have parentheses but are valid
             // These appear in stack traces from certain error paths
             if (line == "unknown"_s) {
@@ -305,12 +309,18 @@ public:
                 return true;
             }
 
-            // For any other frame without parentheses, terminate parsing as before
-            offset = stack.length();
-            return false;
+            // `at /path/file.js:1:2` or `at async /path/file.js:1:2`
+            if (line.startsWith("async "_s)) {
+                frame.isAsync = true;
+                line = line.substring(6);
+                if (line.isEmpty()) {
+                    offset = stack.length();
+                    return false;
+                }
+            }
         }
 
-        auto lineInner = StringView_slice(line, openingParentheses + 1, closingParentheses);
+        auto lineInner = hasParens ? StringView_slice(line, openingParentheses + 1, closingParentheses) : line;
 
         {
             auto marker1 = 0;
@@ -382,6 +392,11 @@ public:
             }
         }
     done_block:
+
+        if (!hasParens) {
+            frame.functionName = StringView();
+            return true;
+        }
 
         StringView functionName = line.substring(0, openingParentheses - 1);
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1228,9 +1228,7 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
     unsafe { (*vm).on_after_event_loop() };
 }
 
-/// `printException` / `printErrorlikeObject` — formats `value` to stderr via
-/// `ConsoleObject::Formatter`. Dispatched here so the high tier owns the
-/// formatter.
+/// `printException` / `printErrorlikeObject`: formats `value` to stderr.
 fn print_exception(
     vm_ref: &mut VirtualMachine,
     value: JSValue,
@@ -1242,28 +1240,20 @@ fn print_exception(
     // no early returns below.
     let writer = bun_core::Output::error_writer_buffered();
 
-    let global = vm_ref.global();
-
-    if let Some(exception) = value.as_exception(vm_ref.jsc_vm) {
-        // SAFETY: `as_exception` returned a live `*mut Exception` owned by the
-        // JSC heap; we only read through it for the duration of this call.
-        let exception = unsafe { &*exception };
-        vm_ref.print_exception(exception, exception_list, writer, true);
-    } else {
-        let mut formatter = bun_jsc::console_object::Formatter::new(global);
-        // `Formatter::new` already
-        // defaults `error_display_level` to `Full` (ConsoleObject.rs:1176).
-        let colors = bun_core::Output::enable_ansi_colors_stderr();
-        vm_ref.print_errorlike_object(
-            value,
-            None,
-            exception_list,
-            &mut formatter,
-            writer,
-            colors,
-            true,
-        );
-        // `defer formatter.deinit()` → Drop.
+    match value.as_exception(vm_ref.jsc_vm) {
+        Some(exception) => {
+            // SAFETY: `as_exception` returned a live `*mut Exception` owned by the
+            // JSC heap; we only read through it for the duration of this call.
+            let exception = unsafe { &*exception };
+            vm_ref.print_exception(
+                exception.value(),
+                Some(exception),
+                exception_list,
+                writer,
+                true,
+            );
+        }
+        None => vm_ref.print_exception(value, None, exception_list, writer, true),
     }
 
     let _ = writer.flush();

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2012,11 +2012,17 @@ it.concurrent("dev error page embeds the thrown error, its stack, and build/reso
           if (pathname === "/throw") inner();
           if (pathname === "/syntax") await import("./broken.ts");
           if (pathname === "/resolve") await import("./bad-import.ts");
+          if (pathname === "/multi") await import("./broken-twice.ts");
+          if (pathname === "/aggregate") {
+            throw new AggregateError([new Error("member one"), new RangeError("member two")], "two members", {
+              cause: new TypeError("the cause"),
+            });
+          }
           return new Response("unreachable");
         },
       });
       const out = {};
-      for (const path of ["/throw", "/syntax", "/resolve"]) {
+      for (const path of ["/throw", "/syntax", "/resolve", "/multi", "/aggregate"]) {
         const res = await fetch(server.url + path.slice(1));
         const html = await res.text();
         const match = /<script id="__bunfallback" type="application\\/json">([^<]*)<\\/script>/.exec(html);
@@ -2036,6 +2042,8 @@ it.concurrent("dev error page embeds the thrown error, its stack, and build/reso
     `,
     "broken.ts": `export const a = 1;\nexport const oops = ;\n`,
     "bad-import.ts": `import { nope } from "does-not-exist-pkg";\nexport const b = nope;\n`,
+    // Several recoverable parse errors: importing this rejects with an AggregateError of BuildMessages.
+    "broken-twice.ts": `export function f() {\n  const v = {b: {},),r,};\n}\n`,
   });
   await using proc = Bun.spawn({
     cmd: [bunExe(), "server.ts"],
@@ -2047,7 +2055,7 @@ it.concurrent("dev error page embeds the thrown error, its stack, and build/reso
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const out = JSON.parse(stdout.trim().split("\n").at(-1)!);
 
-  for (const path of ["/throw", "/syntax", "/resolve"]) {
+  for (const path of ["/throw", "/syntax", "/resolve", "/multi", "/aggregate"]) {
     expect(out[path]).toMatchObject({
       status: 500,
       type: "text/html;charset=utf-8",
@@ -2095,6 +2103,23 @@ it.concurrent("dev error page embeds the thrown error, its stack, and build/reso
   expect(resolution.build.errors).toBe(1);
   expect(resolution.build.msgs[0].on).toEqual({ build: false, resolve: "does-not-exist-pkg" });
   expect(resolution.build.msgs[0].data.text).toStartWith("Cannot find package 'does-not-exist-pkg'");
+
+  // A module with several build errors rejects with an AggregateError of BuildMessages:
+  // the aggregate is listed as the exception and every member still reaches the build log.
+  const multi = out["/multi"].payload.problems;
+  expect(multi.exceptions.map(e => e.name)).toEqual(["AggregateError"]);
+  expect(multi.exceptions[0].message).toStartWith("4 errors building ");
+  expect(multi.build.errors).toBe(4);
+
+  // A thrown AggregateError lists itself, then its cause, then each member.
+  const aggregate = out["/aggregate"].payload.problems;
+  expect(aggregate.exceptions.map(e => [e.name, e.message])).toEqual([
+    ["AggregateError", "two members"],
+    ["TypeError", "the cause"],
+    ["Error", "member one"],
+    ["RangeError", "member two"],
+  ]);
+  expect(aggregate.build.errors).toBe(0);
 
   expect(stderr).toContain("boom <b>&</b>");
   expect(exitCode).toBe(0);

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, jest, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, normalizeBunSnapshot, tempDir } from "harness";
 
 test("error.cause", () => {
   const err = new Error("error 1");
@@ -10,7 +10,7 @@ test("error.cause", () => {
       .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
 "1 | import { describe, expect, jest, test } from "bun:test";
-2 | import { bunEnv, bunExe, tempDir } from "harness";
+2 | import { bunEnv, bunExe, isASAN, isDebug, normalizeBunSnapshot, tempDir } from "harness";
 3 | 
 4 | test("error.cause", () => {
 5 |   const err = new Error("error 1");
@@ -19,8 +19,9 @@ test("error.cause", () => {
 error: error 2
       at <anonymous> ([dir]/inspect-error.test.js:6:20)
 
+[cause]:
 1 | import { describe, expect, jest, test } from "bun:test";
-2 | import { bunEnv, bunExe, tempDir } from "harness";
+2 | import { bunEnv, bunExe, isASAN, isDebug, normalizeBunSnapshot, tempDir } from "harness";
 3 | 
 4 | test("error.cause", () => {
 5 |   const err = new Error("error 1");
@@ -38,15 +39,15 @@ test("Error", () => {
       .replaceAll("\\", "/")
       .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
-"30 | "
-31 | \`);
-32 | });
-33 | 
-34 | test("Error", () => {
-35 |   const err = new Error("my message");
+"31 | "
+32 | \`);
+33 | });
+34 | 
+35 | test("Error", () => {
+36 |   const err = new Error("my message");
                        ^
 error: my message
-      at <anonymous> ([dir]/inspect-error.test.js:35:19)
+      at <anonymous> ([dir]/inspect-error.test.js:36:19)
 "
 `);
 });
@@ -105,7 +106,7 @@ test("Error inside minified file (no color) ", () => {
       error: error inside long minified file!
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:86:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:87:7)"
     `);
   }
 });
@@ -134,7 +135,7 @@ test("Error inside minified file (color) ", () => {
       error: error inside long minified file!
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:114:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:115:7)"
     `);
   }
 });
@@ -148,7 +149,7 @@ test("Inserted originalLine and originalColumn do not appear in node:util.inspec
       .replaceAll(import.meta.path.replaceAll("\\", "/"), "[file]"),
   ).toMatchInlineSnapshot(`
 "Error: my message
-    at <anonymous> ([file]:143:19)"
+    at <anonymous> ([file]:144:19)"
 `);
 });
 
@@ -328,9 +329,11 @@ describe("source map remapping of the printed stack", () => {
   });
 });
 
-// The printer replaces an AggregateError with the members of its `errors`
-// property. When there is nothing to walk it has to print the AggregateError
-// itself. A deleted `errors` used to crash the process (the empty value was
+const count = (haystack, needle) => haystack.split(needle).length - 1;
+
+// The printer prints an AggregateError and then the members of its `errors`
+// property; whatever that property holds, the AggregateError itself has to be
+// printed. A deleted `errors` used to crash the process (the empty value was
 // passed to the iteration, which read it as a cell at address 0), an accessor
 // was passed to it as well, the other shapes printed nothing, and a
 // non-iterable `errors` made console.error throw.
@@ -395,20 +398,22 @@ describe.concurrent("AggregateError whose errors cannot be walked", () => {
        console.error(e);
        console.log("after");`,
     ]);
+    expect(stderr).toContain(header);
     expect(stderr).toContain("error: from the getter");
-    expect(stderr).not.toContain(header);
+    expect(stderr.indexOf("error: from the getter")).toBeGreaterThan(stderr.indexOf(header));
     expect(stdout).toBe("after\n");
     expect(exitCode).toBe(0);
   });
 
-  test("members are still printed in place of the AggregateError", async () => {
+  test("members are printed after the AggregateError", async () => {
     const { stderr, exitCode } = await run([
       "-e",
       'throw new AggregateError([new Error("first member"), new TypeError("second member")], "outer message");',
     ]);
+    expect(stderr).toContain(header);
     expect(stderr).toContain("error: first member");
     expect(stderr).toContain("TypeError: second member");
-    expect(stderr).not.toContain(header);
+    expect(stderr.indexOf("error: first member")).toBeGreaterThan(stderr.indexOf(header));
     expect(exitCode).toBe(1);
   });
 
@@ -452,7 +457,387 @@ describe.concurrent("AggregateError whose errors cannot be walked", () => {
     });
     expect(stderr).toContain("a.test.ts:");
     expect(stderr).toContain("b.test.ts:");
+    // The first load still has the members, the replayed one does not; both print the header.
+    expect(count(stderr, "AggregateError: 4 errors building ")).toBe(2);
+    expect(stderr).toContain('error: Expected identifier but found ")"');
     expect(stderr).toContain("across 2 files");
+    expect(exitCode).toBe(1);
+  });
+});
+
+async function run(code) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+// https://github.com/oven-sh/bun/issues/1352
+describe("#1352 native error printer", () => {
+  // The expected header/message strings are built at runtime so that the
+  // source-line preview the printer emits (which quotes the `-e` source)
+  // cannot accidentally satisfy the assertion.
+  const src = `
+const m1 = new Error(["err", "one"].join("-"));
+const m2 = new RangeError(["err", "two"].join("-"));
+const cause = new TypeError(["the", "cause"].join("-"));
+const agg = new AggregateError([m1, m2], ["agg", "msg"].join("-"), { cause });
+`;
+  const AGG = ["agg", "msg"].join("-");
+  const M1 = ["err", "one"].join("-");
+  const M2 = ["err", "two"].join("-");
+  const CAUSE = ["the", "cause"].join("-");
+
+  test.concurrent.each([
+    ["console.error", `${src}; console.error(agg);`, 0],
+    ["Bun.inspect", `${src}; process.stderr.write(Bun.inspect(agg));`, 0],
+    ["uncaught throw", `${src}; throw agg;`, 1],
+    ["unhandled rejection", `${src}; Promise.reject(agg);`, 1],
+  ])("AggregateError via %s prints header, [cause] and each [errors] member", async (_, code, exit) => {
+    const { stderr, exitCode } = await run(code);
+
+    expect(stderr).toContain("AggregateError: " + AGG);
+    expect(stderr).toContain("[cause]:");
+    expect(stderr).toContain("TypeError: " + CAUSE);
+    expect(stderr).toContain("[errors]:");
+    expect(stderr).toContain("error: " + M1);
+    expect(stderr).toContain("RangeError: " + M2);
+
+    // Header must precede the [cause] label which must precede [errors].
+    const hdr = stderr.indexOf("AggregateError: " + AGG);
+    const causeLabel = stderr.indexOf("[cause]:");
+    const errorsLabel = stderr.indexOf("[errors]:");
+    expect(hdr).toBeGreaterThan(-1);
+    expect(causeLabel).toBeGreaterThan(hdr);
+    expect(errorsLabel).toBeGreaterThan(causeLabel);
+    expect(exitCode).toBe(exit);
+  });
+
+  test.concurrent("AggregateError reached via a cause chain prints its members", async () => {
+    const { stderr, exitCode } = await run(`${src}; console.error(new Error("outer", { cause: agg }));`);
+
+    expect(stderr).toContain("[cause]:");
+    expect(stderr).toContain("AggregateError: " + AGG);
+    expect(stderr).toContain("[errors]:");
+    expect(stderr).toContain("error: " + M1);
+    expect(stderr).toContain("RangeError: " + M2);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("error.cause is labeled with [cause]:", async () => {
+    const { stderr, exitCode } = await run(
+      `const e = new Error(${JSON.stringify("outer-" + M1)}, { cause: new Error(${JSON.stringify("inner-" + M2)}) }); console.error(e);`,
+    );
+    const causeLabel = stderr.indexOf("[cause]:");
+    expect(causeLabel).toBeGreaterThan(-1);
+    expect(stderr.indexOf("error: inner-" + M2)).toBeGreaterThan(causeLabel);
+    expect(stderr.indexOf("error: outer-" + M1)).toBeLessThan(causeLabel);
+    expect(exitCode).toBe(0);
+  });
+
+  // After `.stack` materializes, overwrite it with another V8-format stack
+  // string that mixes paren-ful, paren-less and `at async /path:l:c` frames,
+  // followed by a malformed frame, at which parsing stops, and a well-formed
+  // one that must therefore not be printed.
+  test.concurrent.each([
+    ["an unbalanced parenthesis", "at broken (/fake-four.js:77:88"],
+    ["nothing after async", "at async "],
+  ])("reassigned Error.stack (V8 format) is honored up to a frame with %s", async (_, malformed) => {
+    const { stderr, exitCode } = await run(
+      `const e = new Error("X"); void e.stack;` +
+        `e.stack = "Error: X\\n    at fn (/fake-one.js:11:22)\\n    at /fake-two.js:33:44\\n    at async /fake-three.mjs:55:66` +
+        `\\n    ${malformed}\\n    at fine (/fake-five.js:99:11)";` +
+        `console.error(e);`,
+    );
+    expect(stderr).toContain("at fn (/fake-one.js:11:22)");
+    expect(stderr).toContain("at /fake-two.js:33:44");
+    expect(stderr).toContain("/fake-three.mjs:55:66");
+    expect(stderr).not.toContain("async /fake-three.mjs");
+    expect(stderr).not.toContain("fake-four");
+    expect(stderr).not.toContain("fake-five");
+    // Original creation site must not leak through.
+    expect(stderr).not.toContain("[eval]:1");
+    expect(exitCode).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/15859
+  test.concurrent("uncaught error printed after error.stack was read keeps all the frames of error.stack", async () => {
+    // Reading .stack makes the printer re-parse the formatted string; the
+    // top-level frame, which has no function name, used to be dropped by that
+    // parser. The imports push the TypeScript source lines away from the
+    // transpiled ones so a frame remapped twice would also show up.
+    using dir = tempDir("inspect-error-stack-reparse", {
+      "test.ts": `import * as i1 from "util";
+import * as i2 from "util";
+import * as i3 from "util";
+function err() {
+    throw new Error()
+};
+function f1(){
+    err()
+}
+function f2(){
+
+}
+try {
+    f1();
+} catch (error: any) {
+    console.log(error.stack)
+    throw error
+}
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const positions = s => [...s.matchAll(/test\.ts:(\d+:\d+)/g)].map(m => m[1]);
+    expect(positions(stdout)).toEqual(["5:15", "8:5", "14:5"]);
+    expect(positions(stderr)).toEqual(positions(stdout));
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("Promise.any rejection prints AggregateError header", async () => {
+    const { stderr, exitCode } = await run(
+      `Promise.any([Promise.reject(new Error(${JSON.stringify(M1)})), Promise.reject(new Error(${JSON.stringify(M2)}))]);`,
+    );
+    expect(stderr).toContain("AggregateError:");
+    expect(stderr).toContain("[errors]:");
+    expect(stderr).toContain("error: " + M1);
+    expect(stderr).toContain("error: " + M2);
+    expect(exitCode).toBe(1);
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/21528
+test.concurrent("uncaught AggregateError output layout", async () => {
+  using dir = tempDir("aggregate-error-layout", {
+    "index.js": `function foo() {
+  return new Error("foo!");
+}
+function bar() {
+  return new Error("bar!");
+}
+throw new AggregateError([foo(), bar()], "qux!");
+`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("");
+  expect(normalizeBunSnapshot(stderr.replace(/^Bun v.*$/m, ""), String(dir))).toMatchInlineSnapshot(`
+    "2 |   return new Error("foo!");
+    3 | }
+    4 | function bar() {
+    5 |   return new Error("bar!");
+    6 | }
+    7 | throw new AggregateError([foo(), bar()], "qux!");
+                  ^
+    AggregateError: qux!
+          at <dir>/index.js:7:11
+
+    [errors]:
+    2 |   return new Error("foo!");
+    3 | }
+    4 | function bar() {
+    5 |   return new Error("bar!");
+    6 | }
+    7 | throw new AggregateError([foo(), bar()], "qux!");
+                                  ^
+    error: foo!
+          at <dir>/index.js:7:27
+
+    [errors]:
+    2 |   return new Error("foo!");
+    3 | }
+    4 | function bar() {
+    5 |   return new Error("bar!");
+    6 | }
+    7 | throw new AggregateError([foo(), bar()], "qux!");
+                                         ^
+    error: bar!
+          at <dir>/index.js:7:34"
+  `);
+  expect(exitCode).toBe(1);
+});
+
+// The printer used to walk .errors with no cycle or depth guard and without
+// checking that the property still is an array, so every shape below crashed
+// (or lost the aggregate's own header) on every sink that reaches it.
+describe("AggregateError .errors printing is guarded", () => {
+  // Messages are assembled at runtime so the -e source preview the printer
+  // quotes cannot satisfy the assertions; counting a header therefore
+  // measures how many times the error itself was printed.
+  const SELF = ["self", "cycle"].join("-");
+  const A = ["agg", "a"].join("-");
+  const B = ["agg", "b"].join("-");
+  const C = ["plain", "c"].join("-");
+
+  const shapes = [
+    {
+      name: "errors containing the aggregate itself",
+      build: `const e = new AggregateError([], ["self", "cycle"].join("-")); e.errors.push(e);`,
+      check(stderr) {
+        expect(count(stderr, "AggregateError: " + SELF)).toBe(1);
+        expect(stderr).toContain("[errors]: [Circular]");
+      },
+    },
+    {
+      name: "two aggregates containing each other",
+      build:
+        `const e = new AggregateError([], ["agg", "a"].join("-"));` +
+        `const b = new AggregateError([e], ["agg", "b"].join("-"));` +
+        `e.errors = [b];`,
+      check(stderr) {
+        expect(count(stderr, "AggregateError: " + A)).toBe(1);
+        expect(count(stderr, "AggregateError: " + B)).toBe(1);
+        expect(stderr.indexOf("AggregateError: " + B)).toBeGreaterThan(stderr.indexOf("AggregateError: " + A));
+        expect(stderr).toContain("[errors]: [Circular]");
+      },
+    },
+    {
+      name: "a member whose cause is the aggregate",
+      build:
+        `const c = new Error(["plain", "c"].join("-"));` +
+        `const e = new AggregateError([c], ["agg", "a"].join("-"));` +
+        `c.cause = e;`,
+      check(stderr) {
+        expect(count(stderr, "AggregateError: " + A)).toBe(1);
+        expect(count(stderr, "error: " + C)).toBe(1);
+        expect(stderr).toContain("[cause]: [Circular]");
+      },
+    },
+    {
+      // Promise.any([Promise.reject({ code })]) produces this shape.
+      name: "a member that is a plain object",
+      build: `const e = new AggregateError([{ code: ["EN", "OENT"].join("") }], ["agg", "a"].join("-"));`,
+      check(stderr) {
+        expect(stderr).toContain("AggregateError: " + A);
+        expect(stderr).toContain("[errors]:");
+        expect(stderr).toContain('code: "ENOENT"');
+        expect(stderr).not.toContain("[Circular]");
+      },
+    },
+    {
+      name: "a plain-object member that refers back to the aggregate",
+      build:
+        `const o = { code: ["EN", "OENT"].join("") };` +
+        `const e = new AggregateError([o], ["agg", "a"].join("-"));` +
+        `o.parent = e;`,
+      check(stderr) {
+        expect(count(stderr, "AggregateError: " + A)).toBe(1);
+        expect(stderr).toContain('code: "ENOENT"');
+        expect(stderr).toContain("parent: [Circular]");
+      },
+    },
+    {
+      // The shapes in which `.errors` itself cannot be walked are covered by
+      // "AggregateError whose errors cannot be walked" above.
+      name: "an .errors element that throws when read",
+      build:
+        `const e = new AggregateError([new Error(["plain", "c"].join("-")), new Error("never"), new Error("never")], ["agg", "a"].join("-"));` +
+        `Object.defineProperty(e.errors, 1, { get() { throw new Error("boom"); } });`,
+      check(stderr) {
+        expect(stderr).toContain("AggregateError: " + A);
+        expect(stderr).toContain("error: " + C);
+        expect(stderr).not.toContain("error: never");
+        expect(stderr).toContain("... 2 more errors");
+      },
+    },
+  ];
+
+  describe.each([
+    ["console.error", e => `console.error(${e});`, 0],
+    ["uncaught throw", e => `throw ${e};`, 1],
+  ])("via %s", (_, sink, expectedExitCode) => {
+    test.concurrent.each(shapes)("$name", async ({ build, check }) => {
+      const { stdout, stderr, exitCode } = await run(`${build} ${sink("e")}`);
+      check(stderr, stdout);
+      expect(exitCode).toBe(expectedExitCode);
+    });
+  });
+
+  test.concurrent.each([
+    [101, "... 1 more error\n"],
+    [103, "... 3 more errors\n"],
+  ])("prints at most 100 of %i members and counts the rest", async (length, trailer) => {
+    const { stderr, exitCode } = await run(
+      `const members = Array.from({ length: ${length} }, (_, i) => new Error("member" + i));` +
+        `console.error(new AggregateError(members, ["agg", "a"].join("-")));`,
+    );
+    expect(stderr).toContain("AggregateError: " + A);
+    expect(count(stderr, "[errors]:")).toBe(100);
+    expect(stderr).toContain("error: member99\n");
+    expect(stderr).not.toContain("error: member100\n");
+    expect(stderr).toContain(trailer);
+    expect(exitCode).toBe(0);
+  });
+});
+
+// Nesting deeper than the native stack allows must stop printing instead of
+// overflowing it. console.* and Bun.inspect report that as a RangeError; the
+// uncaught-exception and unhandled-rejection reporters truncate the output.
+describe("deeply nested error chains do not overflow the stack", () => {
+  // A debug or ASAN build runs out of stack a few hundred levels down and
+  // takes tens of microseconds to construct each error; a release build prints
+  // thousands of levels (about 1500 on Linux, more on Windows, where the
+  // printer's frames are smaller) and constructs the chain in about a
+  // microsecond per error.
+  const DEPTH = isDebug || isASAN ? 3_000 : 50_000;
+  const TOP = "level" + (DEPTH - 1);
+  const deepAggregate =
+    `let e = new AggregateError([], "leaf");\n` +
+    `for (let i = 0; i < ${DEPTH}; i++)\n` +
+    `  e = new AggregateError([e], "level" + i);\n`;
+  const deepCause =
+    `let e = new Error("leaf");\n` +
+    `for (let i = 0; i < ${DEPTH}; i++)\n` +
+    `  e = new Error("level" + i, { cause: e });\n`;
+  // Each printed level has one `<name>: level<n>` header; the quoted source
+  // lines contain `"level"` and so do not match.
+  const printedLevels = stderr => count(stderr, ": level");
+
+  test.concurrent("AggregateError chain via console.error throws a RangeError", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `${deepAggregate} try { console.error(e); } catch (err) { console.log("caught", err.name); }`,
+    );
+    expect(stderr).toContain("AggregateError: " + TOP);
+    expect(printedLevels(stderr)).toBeLessThan(DEPTH);
+    expect(stdout).toBe("caught RangeError\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent.each([
+    ["AggregateError chain", deepAggregate, "AggregateError: " + TOP],
+    ["cause chain", deepCause, "error: " + TOP],
+  ])("%s via uncaught throw", async (_, build, header) => {
+    const { stderr, exitCode } = await run(`${build} throw e;`);
+    expect(stderr).toContain(header);
+    expect(printedLevels(stderr)).toBeLessThan(DEPTH);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent.each([
+    ["AggregateError chain", deepAggregate, "AggregateError: " + TOP],
+    ["cause chain", deepCause, "error: " + TOP],
+  ])("%s via unhandled rejection", async (_, build, header) => {
+    const { stderr, exitCode } = await run(`${build} Promise.reject(e);`);
+    expect(stderr).toContain(header);
+    expect(printedLevels(stderr)).toBeLessThan(DEPTH);
     expect(exitCode).toBe(1);
   });
 });

--- a/test/regression/issue/jsx-template-string-crash.test.ts
+++ b/test/regression/issue/jsx-template-string-crash.test.ts
@@ -16,10 +16,16 @@ test("JSX lexer should not crash with slice bounds issues", async () => {
 
   expect(exitCode).toBe(1);
   expect(normalizeBunSnapshot(stderr.toString().replace(/(Bun v.*)$/gm, ""))).toMatchInlineSnapshot(`
-    "1 | export function x(){return<div a=\`\`/>}
+    "AggregateError: 2 errors building "<cwd>/[eval]"
+
+    [errors]:
+
+    1 | export function x(){return<div a=\`\`/>}
                                          ^
     error: Expected "{" but found "\`"
         at <cwd>/[eval]:1:34
+
+    [errors]:
 
     1 | export function x(){return<div a=\`\`/>}
                                           ^
@@ -57,10 +63,16 @@ test.concurrent("#30959 JSX attribute with invalid '(' value parses cleanly in d
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(normalizeBunSnapshot(stderr.replace(/(Bun v.*)$/gm, ""))).toMatchInlineSnapshot(`
-    "1 | export function x(){return<r L=((}
+    "AggregateError: 2 errors building "<cwd>/[eval]"
+
+    [errors]:
+
+    1 | export function x(){return<r L=((}
                                        ^
     error: Expected "{" but found "("
         at <cwd>/[eval]:1:32
+
+    [errors]:
 
     1 | export function x(){return<r L=((}
                                          ^


### PR DESCRIPTION
Consolidates the open AggregateError printing PRs into one change: the header/ordering fix (#35174, #36580 by @TheRodzz, which independently found the same early return), and the `.errors` walk hardening (#35825, which superseded #31988, #34892 and #35820). Those are closed in favor of this PR.

### Problem

- `console.error(agg)`, `Bun.inspect(agg)`, an uncaught `throw agg` and an unhandled rejection of an `AggregateError` printed only the member errors. The aggregate's own `AggregateError: <message>` line, its stack and its `cause` were dropped, so a `Promise.any()` failure or a multi-error module build showed a list of unrelated-looking errors (#21528, #1352).
- Cause: `VirtualMachine::print_errorlike_object` special-cased `is_aggregate_error`, iterated `.errors` with `for_each` and returned before the normal printing path ran (`src/jsc/VirtualMachine.rs`, the removed block at the top of that function).
- The same walk had no cycle guard, no stack check and did not check what `.errors` currently holds, so each of these killed the process on every sink (`console.log`, `Bun.inspect`, uncaught throw, unhandled rejection): `.errors` containing the aggregate itself (SIGSEGV), two aggregates containing each other (SIGSEGV), a 3000-deep `.errors` chain (SIGSEGV), and, until #39633 landed on main, `delete agg.errors` and `.errors` redefined as an accessor.
- `delete agg.errors` happens without user code: when a second test file imports a module that failed to build, JSC's module loader replays the cached failure via `JSModuleLoader::duplicateError`, which creates an AggregateError-typed instance with no `errors` property, so `bun test` crashed at the second file (#36963). #39633 fixed that crash on main by printing the header when there are no members to walk; this PR is rebased on it and keeps its tests, three of them updated for the header now always coming first.
- A deep `cause` chain crashed the uncaught-exception and unhandled-rejection reporters too: `print_error_instance_js` has a stack check, but the formatter built for those two sinks never initialized it (`Formatter::new` leaves `stack_check` in its always-passes state).
- Appended `cause` blocks were printed with no label, so a chain read as separate errors (improves #32343).
- A stack-string problem surfaced by the #1352 repro: `V8StackTraceIterator::parseFrame` stopped at the first `at /path:line:col` frame (no function name, no parentheses), which Bun itself emits, so a reassigned `err.stack`, or one re-parsed after `err.stack` was read, lost that frame and everything after it. (The double remapping of such re-parsed frames, #15859, was fixed separately in #38296; this branch is rebased on it.)

### Fix

- `print_errorlike_object` no longer special-cases AggregateError. `print_error_instance_body` appends the `.errors` members to the same `errors_to_append` list the `cause` chain already uses, so the aggregate prints its own source preview, header and stack first, and an AggregateError reached through a `cause` also shows its members.
- `.errors` is read with `fast_get(BuiltinName::errors)`, the read #39633 introduced (an ordinary `[[Get]]`, so a getter runs and an array it returns is printed; a getter that throws is cleared), and only walked when the value is an array (deleted, non-array and throwing cases print just the header), element reads that throw stop the walk, at most 100 members are appended and the rest are reported as `... N more errors`.
- Each appended block is preceded by a dim `[cause]:` / `[errors]:` / `[<property>]:` label. The error being printed is registered in the formatter's visited set while its members print, so any chain leading back to it prints `[Circular]` once instead of printing the error again. Only Error-valued members are tracked this way: a plain-object member (what `Promise.any` produces when the inputs reject with non-errors) is handed to the regular formatter, which tracks it in the same set itself, so pre-registering it would have printed `[Circular]` in place of the object. The loop stops as soon as the formatter reports failure (stack check tripped or writer failed).
- Error-valued own properties are queued as labeled blocks at every depth. Before, that happened only while the outermost error was printing (the old guard against infinite recursion, made redundant by the visited set and the stack check); on a nested error such a property was formatted inline, and an assigned (enumerable) `cause` was then appended a second time by the non-enumerable fallback. That printed the cause twice two levels down a chain on main, and would have reached AggregateError members here, since they print as nested errors now.
- The exception list that `Bun.serve`'s development error page collects is now passed on to the nested errors as well (`print_error_instance_js` used to hand it to `remap_zig_exception` and give the body `None`), so the page lists the thrown error, then its cause and members, in print order; on main it listed only the members of a thrown AggregateError and nothing for a cause chain. BuildMessage members of a multi-error module reach the page's build log through the same list, as they did on main.
- Both uncaught sinks now go through `VirtualMachine::print_exception`, which is the one place that builds their formatter and seats `StackCheck::init()`, so the existing depth guard is live for them. Nested members are printed through `print_errorlike_object`, which routes every level through that guard.
- The guard's headroom on non-Windows goes from the 128 KB default to 384 KB. With the default, a debug+ASAN build still overflowed in about one run in four: gdb shows the SIGSEGV in bmalloc's deallocation-log flush about 130 KB below the last passing check (one print cycle runs the transpiler for the source preview). After the change, 23 runs under gdb with ASLR off and varied environment sizes plus 84 normal runs across all six sink/shape combinations had no crash. Windows already reserved more than this and is unchanged.
- `parseFrame` accepts frames with no parentheses at all (empty function name, optional `async ` prefix); a frame with exactly one parenthesis, with `)` before `(`, or with nothing after `async ` stops parsing, as every frame without parentheses did before.
- Why this is the right shape: it matches what `util.inspect` already does for these errors in Bun and Node (header first, `[cause]` and `[errors]` labeled, `[Circular]` on cycles) while keeping the native printer's layout, and it reuses the guards the `cause` chain already had instead of adding a second set to a separate walk.
- Verified with `test/js/bun/util/inspect-error.test.js` (header/labels on all four sinks and via a cause chain, exact uncaught layout snapshot for the #21528 program, 9 cycle/tampering shapes x {console.error, uncaught throw} (including plain-object members, with and without a reference back to the aggregate), member cap with 101 and 103 members (`... 1 more error` / `... 3 more errors`), deep `.errors` and `cause` chains on console/throw/reject that assert fewer levels than the chain has were printed (3000 levels under debug/ASAN, 50000 on release builds: a Windows release build printed all 3000, and main's release build on Linux segfaults after about 1450 levels of an uncaught `cause` chain), the #36963 two-test-file repro, an assigned cause on a member and two levels down a chain printed exactly once (both print it twice without the change), reassigned V8-format stack ending in a malformed frame (unbalanced parenthesis, or a bare `at async `) followed by a frame that must not be printed, and a transpiled TypeScript fixture whose uncaught output after `error.stack` was read must contain every frame of `error.stack`, including the top-level one without a function name, which only this PR's parser change keeps; it fails on main with #38296 merged). The existing development-error-page test in `test/js/bun/http/serve.test.ts` gained a module with 4 build errors (one AggregateError exception, 4 build-log entries) and a thrown AggregateError with a cause (exceptions listed as aggregate, cause, member, member); it fails on main too. 37 of the 46 tests in the inspect-error file plus `test/regression/issue/jsx-template-string-crash.test.ts` fail on main's `src/` (crash or missing header), all pass with this branch; the two build-error snapshots in the jsx test now start with the `AggregateError: 2 errors building ...` header.
- Also run: `bun-inspect.test.ts`, `inspect.test.js`, `reportError.test.ts`, `console-log.test.ts`, `console-recursive.test.ts` (pass); `inspect-error-leak.test.js` RSS delta is the same with and without the change (349-357 MB vs 350 MB under ASAN; the test itself only times out in this container); `cargo clippy` on `bun_jsc`/`bun_runtime` and `cargo fmt --check` are clean.

Example, `console.error(new AggregateError([new Error("Error 1")], "Aggregate error message.", { cause: new Error("Cause") }))`:

```
AggregateError: Aggregate error message.
      at ...

[cause]:
error: Cause
      at ...

[errors]:
error: Error 1
      at ...
```

### Background

- Native error printer: the Rust code in `src/jsc/VirtualMachine.rs` that renders an error as source preview + `name: message` + own properties + stack. It is used by `console.*` and `Bun.inspect` (through `ConsoleObject`'s formatter), and by the uncaught-exception / unhandled-rejection reporters (through `jsc_hooks::print_exception`). `util.inspect` is a separate JS implementation and was already correct.
- `errors_to_append`: the list of error objects `print_error_instance_body` prints as separate blocks after the main one. Before this PR it held error-valued own properties and the non-enumerable `cause`; `.errors` is also non-enumerable (`DontEnum`), which is why it needs explicit handling.
- `formatter.map`: the console formatter's visited set, keyed by JS object, used to print `[Circular]`. Entries are added before recursing into an object and removed afterwards, so it tracks the current path, not everything printed.
- `StackCheck`: compares the current stack pointer against the thread's stack bound; `is_safe_to_recurse_with_extra(n)` requires a platform threshold (128 KB on Linux/macOS, 256 KB on Windows) plus `n` bytes to remain. `Formatter::new` deliberately leaves it uninitialized (always passes); `StackCheck::init()` arms it. The reserve has to cover everything one print cycle does before the next check, which here includes a transpiler call for the source preview.
- `fast_get`: an ordinary property read keyed by a preallocated identifier (`BuiltinName`, `src/jsc/lib.rs`); a missing or undefined property gives `None`, a throwing getter gives `Err` with the exception pending, which the printer clears.
- `JSModuleLoader::duplicateError`: when a module's fetch/parse fails, JSC caches the error and, for later importers, throws a fresh copy that keeps the error type but not the `errors` property.

<details>
<summary>Superseded description (before the hardening was folded in) and the "missing getError frame" note</summary>

The first version of this PR only removed the early return, added the labels and fixed the two stack-string problems; #35825's cycle/depth/tampering guards and tests were folded in afterwards, along with a test for #36963, so that one change can replace #35174, #35825, #36580, #31988, #34892 and #35820.

The #1352 repro's `function getError(msg) { return new Error(msg); }` frame is absent from `err.stack` itself, not just from the printed output (wrapping the `return` in `try { } finally { }` makes it appear in both), so it is a stack capture matter and this PR does not change it.

</details>

Fixes #21528
Fixes #1352


<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->






