### PR TITLE
bundler: make per-module filename comments relative to root, not cwd

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -381,8 +381,6 @@ impl<'a> LinkerContext<'a> {
         )
     }
 
-    /// Base directory for display ("pretty") paths. See
-    /// `BundleV2::pretty_path_base_dir`.
     pub(crate) fn pretty_path_base_dir(&self) -> &[u8] {
         let root_dir: &[u8] = &self.resolver().opts.root_dir;
         if root_dir.is_empty() {

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -373,8 +373,23 @@ impl<'a> LinkerContext<'a> {
         path: &bun_paths::fs::Path<'static>,
         arena: &Bump,
     ) -> Result<bun_paths::fs::Path<'static>, BunError> {
-        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
-        generic_path_with_pretty_initialized(path, self.options.target, top_level_dir, arena)
+        generic_path_with_pretty_initialized(
+            path,
+            self.options.target,
+            self.pretty_path_base_dir(),
+            arena,
+        )
+    }
+
+    /// Base directory for display ("pretty") paths. See
+    /// `BundleV2::pretty_path_base_dir`.
+    pub(crate) fn pretty_path_base_dir(&self) -> &[u8] {
+        let root_dir: &[u8] = &self.resolver().opts.root_dir;
+        if root_dir.is_empty() {
+            bun_resolver::fs::FileSystem::get().top_level_dir
+        } else {
+            root_dir
+        }
     }
 
     pub(crate) fn should_include_part(&self, source_index: crate::IndexInt, part: &Part) -> bool {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5586,11 +5586,8 @@ pub mod bv2_impl {
             false
         }
 
-        /// Base directory for display ("pretty") paths in bundler output
-        /// (per-module `// path` comments, metafile inputs, diagnostics).
-        /// This is the configured `root` so the bundle is reproducible
-        /// regardless of the cwd `bun build` was invoked from; falls back
-        /// to cwd when no root was configured (e.g. graph-scan-only passes).
+        /// Base directory for display ("pretty") paths: the configured
+        /// bundle `root`, falling back to cwd.
         fn pretty_path_base_dir(&self) -> &[u8] {
             let root_dir: &[u8] = &self.transpiler.options.root_dir;
             if root_dir.is_empty() {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2357,13 +2357,10 @@ pub mod bv2_impl {
             }
 
             if path.pretty.as_ptr() == path.text.as_ptr() {
-                // TODO: outbase
                 let rel = bun_paths::resolve_path::relative_platform::<
                     bun_paths::resolve_path::platform::Loose,
                     false,
-                >(
-                    bun_resolver::fs::FileSystem::get().top_level_dir, path.text
-                );
+                >(self.pretty_path_base_dir(), path.text);
                 // SAFETY: arena outlives the bundle pass; raw-pointer detour erases the
                 // `&self` lifetime so the resulting `&'static [u8]` doesn't pin `self`.
                 path.pretty =
@@ -5589,6 +5586,20 @@ pub mod bv2_impl {
             false
         }
 
+        /// Base directory for display ("pretty") paths in bundler output
+        /// (per-module `// path` comments, metafile inputs, diagnostics).
+        /// This is the configured `root` so the bundle is reproducible
+        /// regardless of the cwd `bun build` was invoked from; falls back
+        /// to cwd when no root was configured (e.g. graph-scan-only passes).
+        fn pretty_path_base_dir(&self) -> &[u8] {
+            let root_dir: &[u8] = &self.transpiler.options.root_dir;
+            if root_dir.is_empty() {
+                self.transpiler.fs().top_level_dir
+            } else {
+                root_dir
+            }
+        }
+
         fn path_with_pretty_initialized(
             &self,
             path: &Fs::Path<'static>,
@@ -5601,7 +5612,7 @@ pub mod bv2_impl {
             let out = generic_path_with_pretty_initialized(
                 path,
                 target,
-                self.transpiler.fs().top_level_dir,
+                self.pretty_path_base_dir(),
                 bump,
             )?;
             Ok(out)

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -187,11 +187,10 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                 source_ref.path.text.as_ptr(),
                 source_ref.path.pretty.as_ptr(),
             ) {
-                let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
                 let new_path = bun_core::handle_oom(generic_path_with_pretty_initialized(
                     &source_ref.path,
                     c.options.target,
-                    top_level_dir,
+                    c.pretty_path_base_dir(),
                     arena,
                 ));
                 source_storage = bun_ast::Source {

--- a/test/bundler/__snapshots__/bun-build-api.test.ts.snap
+++ b/test/bundler/__snapshots__/bun-build-api.test.ts.snap
@@ -16,7 +16,7 @@ var __export = (target, all) => {
     });
 };
 
-// test/bundler/fixtures/trivial/fn.js
+// fn.js
 var exports_fn = {};
 __export(exports_fn, {
   fn: () => fn
@@ -25,7 +25,7 @@ function fn(a) {
   return a + 42;
 }
 
-// test/bundler/fixtures/trivial/index.js
+// index.js
 var NS = Promise.resolve().then(() => exports_fn);
 NS.then(({ fn: fn2 }) => {
   console.log(fn2(42));
@@ -49,7 +49,7 @@ var __export = (target, all) => {
     });
 };
 
-// test/bundler/fixtures/trivial/fn.js
+// fn.js
 var exports_fn = {};
 __export(exports_fn, {
   fn: () => fn
@@ -58,7 +58,7 @@ function fn(a) {
   return a + 42;
 }
 
-// test/bundler/fixtures/trivial/index.js
+// index.js
 var NS = Promise.resolve().then(() => exports_fn);
 NS.then(({ fn: fn2 }) => {
   console.log(fn2(42));
@@ -66,11 +66,11 @@ NS.then(({ fn: fn2 }) => {
 "
 `;
 
-exports[`Bun.build BuildArtifact properties: hash 1`] = `"est79qzq"`;
+exports[`Bun.build BuildArtifact properties: hash 1`] = `"3470z60g"`;
 
-exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"7gfnt0h6"`;
+exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"j1rmc34v"`;
 
-exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"est79qzq"`;
+exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"3470z60g"`;
 
 exports[`Bun.build BuildArtifact properties sourcemap: hash index.js.map 1`] = `"00000000"`;
 
@@ -90,7 +90,7 @@ var __export = (target, all) => {
     });
 };
 
-// test/bundler/fixtures/trivial/fn.js
+// fn.js
 var exports_fn = {};
 __export(exports_fn, {
   fn: () => fn
@@ -99,7 +99,7 @@ function fn(a) {
   return a + 42;
 }
 
-// test/bundler/fixtures/trivial/index.js
+// index.js
 var NS = Promise.resolve().then(() => exports_fn);
 NS.then(({ fn: fn2 }) => {
   console.log(fn2(42));

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -622,7 +622,7 @@ console.log('Loaded HTML!', badDefaultImport);`,
     },
     entryPointsRaw: ["in/template.html", "in/entry.js"],
     bundleErrors: {
-      "/in/entry.js": ['No matching export in "in/template.html" for import "default"'],
+      "/in/entry.js": ['No matching export in "template.html" for import "default"'],
     },
     onAfterBundle(api) {
       const templateBundle = api.readFile("out/template.html");

--- a/test/regression/issue/03039.test.ts
+++ b/test/regression/issue/03039.test.ts
@@ -24,7 +24,7 @@ function commentLines(bundle: string) {
     .sort();
 }
 
-test("bundler filename comments are independent of cwd", async () => {
+test.concurrent("bundler filename comments are independent of cwd", async () => {
   using dir = tempDir("bun-build-3039", {
     "proj/src/entry.js": `import { util } from "./util.js";\nimport { other } from "./nested/other.js";\nconsole.log(util(), other());\n`,
     "proj/src/util.js": `export function util() { return "util"; }\n`,
@@ -42,7 +42,7 @@ test("bundler filename comments are independent of cwd", async () => {
   expect(commentLines(fromTop)).toEqual(["// entry.js", "// nested/other.js", "// util.js"]);
 });
 
-test("bundler filename comments honor --root regardless of cwd", async () => {
+test.concurrent("bundler filename comments honor --root regardless of cwd", async () => {
   using dir = tempDir("bun-build-3039-root", {
     "proj/src/entry.js": `import { util } from "./util.js";\nconsole.log(util());\n`,
     "proj/src/util.js": `export function util() { return "util"; }\n`,

--- a/test/regression/issue/03039.test.ts
+++ b/test/regression/issue/03039.test.ts
@@ -1,0 +1,79 @@
+// https://github.com/oven-sh/bun/issues/3039
+// The per-module `// path` comments in bundler output were relative to the
+// process cwd, so the same inputs bundled from different working directories
+// produced different bytes. They are now relative to the bundle root (the
+// `--root` directory, defaulting to the entry point's directory / common
+// ancestor), which is stable regardless of cwd.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+async function buildFrom(cwd: string, entry: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", entry],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return stdout;
+}
+
+function commentLines(bundle: string) {
+  return bundle
+    .split("\n")
+    .filter(l => l.startsWith("// "))
+    .sort();
+}
+
+test("bundler filename comments are independent of cwd", async () => {
+  using dir = tempDir("bun-build-3039", {
+    "proj/src/entry.js": `import { util } from "./util.js";\nimport { other } from "./nested/other.js";\nconsole.log(util(), other());\n`,
+    "proj/src/util.js": `export function util() { return "util"; }\n`,
+    "proj/src/nested/other.js": `export function other() { return "other"; }\n`,
+  });
+  const root = String(dir);
+
+  const fromTop = await buildFrom(root, join("proj", "src", "entry.js"));
+  const fromProj = await buildFrom(join(root, "proj"), join("src", "entry.js"));
+  const fromSrc = await buildFrom(join(root, "proj", "src"), "entry.js");
+
+  // Output must be byte-identical across cwds.
+  expect(fromProj).toBe(fromTop);
+  expect(fromSrc).toBe(fromTop);
+
+  // Comments are relative to the derived root (the entry point's directory).
+  expect(commentLines(fromTop)).toEqual(["// entry.js", "// nested/other.js", "// util.js"]);
+});
+
+test("bundler filename comments honor --root regardless of cwd", async () => {
+  using dir = tempDir("bun-build-3039-root", {
+    "proj/src/entry.js": `import { util } from "./util.js";\nconsole.log(util());\n`,
+    "proj/src/util.js": `export function util() { return "util"; }\n`,
+  });
+  const root = String(dir);
+  const projRoot = join(root, "proj");
+
+  async function buildWithRoot(cwd: string, entry: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--root", projRoot, entry],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout;
+  }
+
+  const fromTop = await buildWithRoot(root, join("proj", "src", "entry.js"));
+  const fromSrc = await buildWithRoot(join(root, "proj", "src"), "entry.js");
+
+  expect(fromSrc).toBe(fromTop);
+  expect(commentLines(fromTop)).toEqual(["// src/entry.js", "// src/util.js"]);
+});

--- a/test/regression/issue/03039.test.ts
+++ b/test/regression/issue/03039.test.ts
@@ -1,9 +1,4 @@
 // https://github.com/oven-sh/bun/issues/3039
-// The per-module `// path` comments in bundler output were relative to the
-// process cwd, so the same inputs bundled from different working directories
-// produced different bytes. They are now relative to the bundle root (the
-// `--root` directory, defaulting to the entry point's directory / common
-// ancestor), which is stable regardless of cwd.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
@@ -41,11 +36,9 @@ test("bundler filename comments are independent of cwd", async () => {
   const fromProj = await buildFrom(join(root, "proj"), join("src", "entry.js"));
   const fromSrc = await buildFrom(join(root, "proj", "src"), "entry.js");
 
-  // Output must be byte-identical across cwds.
   expect(fromProj).toBe(fromTop);
   expect(fromSrc).toBe(fromTop);
 
-  // Comments are relative to the derived root (the entry point's directory).
   expect(commentLines(fromTop)).toEqual(["// entry.js", "// nested/other.js", "// util.js"]);
 });
 

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -108,13 +108,13 @@ test("cyclic imports with async dependencies should generate async wrappers", as
     var __esm = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
     var __promiseAll = (args) => Promise.all(args);
 
-    // src/RecursiveDependencies/StoreDependencyAsync.ts
+    // RecursiveDependencies/StoreDependencyAsync.ts
     var somePromise;
     var init_StoreDependencyAsync = __esm(async () => {
       somePromise = await Promise.resolve("Hello World");
     });
 
-    // src/RecursiveDependencies/StoreDependency.ts
+    // RecursiveDependencies/StoreDependency.ts
     function StoreDependency() {
       return "A string from StoreFunc" + somePromise;
     }
@@ -122,7 +122,7 @@ test("cyclic imports with async dependencies should generate async wrappers", as
       await init_StoreDependencyAsync();
     });
 
-    // src/RecursiveDependencies/SecondElementImport.ts
+    // RecursiveDependencies/SecondElementImport.ts
     function SecondElementImport() {
       console.log("SecondElementImport called", formValue.key);
       return formValue.key;
@@ -131,7 +131,7 @@ test("cyclic imports with async dependencies should generate async wrappers", as
       await init_BaseElement();
     });
 
-    // src/RecursiveDependencies/BaseElementImport.ts
+    // RecursiveDependencies/BaseElementImport.ts
     function BaseElementImport() {
       console.log("BaseElementImport called", SecondElementImport());
       return SecondElementImport();
@@ -140,7 +140,7 @@ test("cyclic imports with async dependencies should generate async wrappers", as
       await init_SecondElementImport();
     });
 
-    // src/RecursiveDependencies/BaseElement.ts
+    // RecursiveDependencies/BaseElement.ts
     var exports_BaseElement = {};
     __export(exports_BaseElement, {
       BaseElement: () => BaseElement,
@@ -166,7 +166,7 @@ test("cyclic imports with async dependencies should generate async wrappers", as
       };
     });
 
-    // src/RecursiveDependencies/AsyncEntryPoint.ts
+    // RecursiveDependencies/AsyncEntryPoint.ts
     var exports_AsyncEntryPoint = {};
     __export(exports_AsyncEntryPoint, {
       AsyncEntryPoint: () => AsyncEntryPoint
@@ -176,11 +176,11 @@ test("cyclic imports with async dependencies should generate async wrappers", as
       console.log("Launching AsyncEntryPoint", BaseElement2());
     }
 
-    // src/entryBuild.ts
+    // entryBuild.ts
     var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
     AsyncEntryPoint2();
 
-    //# debugId=66236CFF39257E1264756E2164756E21
+    //# debugId=B9705DFEE98A3FD164756E2164756E21
     //# sourceMappingURL=entryBuild.js.map
     "
   `);


### PR DESCRIPTION
Fixes #3039.

## What

The `// path/to/file.js` comments that the bundler emits above each module in non-minified output (and the same display path used in diagnostics and the metafile) were computed relative to the process's current working directory. Building the same inputs from different cwds produced different output bytes, so bundles weren't reproducible and snapshot tests of `Bun.build` output only passed when run from one specific directory.

## Repro

```sh
mkdir -p proj/src/nested
printf 'import {u} from "./util.js"; import {o} from "./nested/other.js"; u(); o();' > proj/src/entry.js
printf 'export function u(){}' > proj/src/util.js
printf 'export function o(){}' > proj/src/nested/other.js

(cd .            && bun build proj/src/entry.js | grep ^//)   # // proj/src/util.js ...
(cd proj         && bun build src/entry.js      | grep ^//)   # // src/util.js ...
(cd proj/src     && bun build entry.js          | grep ^//)   # // util.js ...
```

Three different outputs from the same inputs.

## Cause

`generic_path_with_pretty_initialized` already takes the base directory as a parameter, but all four of its callers passed `FileSystem::get().top_level_dir` (the cwd):

- `BundleV2::path_with_pretty_initialized`
- the inline fallback in `BundleV2::on_resolve`
- `LinkerContext::path_with_pretty_initialized`
- the fallback in `generate_code_for_file_in_chunk_js`

The bundle already computes and stores a `root_dir` (the `--root`/`root` option, defaulting to the entry point's directory for a single entry or the longest common ancestor for multiple), but it was only used for `[dir]` in naming templates.

## Fix

Add `pretty_path_base_dir()` on `BundleV2` and `LinkerContext` that returns the configured `root_dir`, falling back to cwd only when no root was configured (graph-scan-only passes). Route all four call sites through it. The snapshots in `bun-build-api.test.ts`, `bundler_html.test.ts`, and `cyclic-imports-async-bundler.test.js` are updated to reflect the now-root-relative paths; as a side effect those snapshots are now themselves cwd-independent.

## Verification

`test/regression/issue/03039.test.ts` builds a 3-module project from three different working directories and asserts the outputs are byte-identical, and that an explicit `--root` also yields identical output regardless of cwd. Both cases fail on the released binary and pass with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_html.test.ts "test/regression/issue/03039.test.ts" test/regression/issue/cyclic-imports-async-bundler.test.js
bun test v1.4.0 (04a90c276)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [861.27ms]
(pass) bundler > html/implicit-relative-paths [134.43ms]
(pass) bundler > html/multiple-assets [203.01ms]
(pass) bundler > html/image-hashing [207.96ms]
(pass) bundler > html/external-assets [232.59ms]
(pass) bundler > html/mixed-assets [907.07ms]
(pass) bundler > html/js-imports [246.55ms]
(pass) bundler > html/css-imports [734.62ms]
(pass) bundler > html/multiple-entries [714.44ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [825.66ms]
(pass) bundler > html/shared-chunks [621.04ms]
(pass) bundler > html/js-importing-html [207.97ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [562.74ms]
1348 |                 errorsLeft.splice(i, 1);
1349 |               }
1350 |             }
13
... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [222.81ms]
(pass) bundler > html/implicit-relative-paths [7.41ms]
(pass) bundler > html/multiple-assets [6.75ms]
(pass) bundler > html/image-hashing [14.14ms]
(pass) bundler > html/external-assets [5.81ms]
(pass) bundler > html/mixed-assets [98.26ms]
(pass) bundler > html/js-imports [7.16ms]
(pass) bundler > html/css-imports [6.33ms]
(pass) bundler > html/multiple-entries [86.49ms]
411 |       splitting: true,
412 |       onAfterBundle(api) {
413 |         const html = api.readFile("out/index.html");
414 |         const src = html.match(/<script[^>]*\bsrc="\.?\/?([^"]+)"/)?.[1];
415 |         expect(src).toBeDefined();
416 |         expect(api.readFile("out/" + src!)).toContain("MAIN_ENTRY_EXECUTED");
                                                  ^
error: expect(received).toContain(expected)

Expected to contain: "MAIN_ENTRY_EXECUTED"
Received: "// shared.ts\nfunction shared() {\n  return 1000;\n}\n\nexport { shared };\n"

      at onAfterBundle (/workspace/bun/test/bundler/bundler_html.test.ts:416:45)
      at <anonymous> (/workspace/bun/test/bundler/expectBundl
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_html.test.ts "test/regression/issue/03039.test.ts" test/regression/issue/cyclic-imports-async-bundler.test.js
bun test v1.4.0 (04a90c276)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [770.41ms]
(pass) bundler > html/implicit-relative-paths [171.33ms]
(pass) bundler > html/multiple-assets [344.78ms]
(pass) bundler > html/image-hashing [284.86ms]
(pass) bundler > html/external-assets [283.11ms]
(pass) bundler > html/mixed-assets [248.55ms]
(pass) bundler > html/js-imports [282.12ms]
(pass) bundler > html/css-imports [144.16ms]
(pass) bundler > html/multiple-entries [278.23ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [1024.40ms]
(pass) bundler > html/shared-chunks [355.63ms]
(pass) bundler > html/js-importing-html [376.87ms]
// 2nd.js
console.log("2nd");
// entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [292.26ms]
(pass) bundler > html/js-importing-html-and-entry-point-default-import-fails [232.56ms]
(pass) bund
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1167ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/LinkerContext.rs                       | 17 ++++-
 src/bundler/bundle_v2.rs                           | 18 ++++--
 .../linker_context/generateCodeForFileInChunkJS.rs |  3 +-
 .../__snapshots__/bun-build-api.test.ts.snap       | 18 +++---
 test/bundler/bundler_html.test.ts                  |  2 +-
 test/regression/issue/03039.test.ts                | 72 ++++++++++++++++++++++
 .../issue/cyclic-imports-async-bundler.test.js     | 16 ++---
 7 files changed, 119 insertions(+), 27 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bundler/LinkerContext.rs                                  3      3      0
src/bundler/bundle_v2.rs                                      5      4      0
…/bundler/linker_context/generateCodeForFileInChunkJS.rs      3      1      0
test/bundler/__snapshots__/bun-build-api.test.ts.snap         0      0      0
test/bundler/bundler_html.test.ts                             1      1      0
test/regression/issue/03039.test.ts                           2      5      0
…t/regression/issue/cyclic-imports-async-bundler.test.js      0      0      0
```

</details>

<!-- robobun:evidence:end -->