### PR TITLE
spawn: bound the fork-child fd sweep by actual open fds

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1662,6 +1662,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionAbort, (JSGlobalObject * globalObject, 
 #if OS(LINUX) || OS(FREEBSD)
 extern "C" ssize_t bun_close_range(unsigned int start, unsigned int end, unsigned int flags);
 #endif
+extern "C" int bun_highest_open_fd();
 
 // Clears FD_CLOEXEC on `fd` so the descriptor is inherited across execve(2).
 // On success returns the previous F_GETFD flags (>= 0) so the caller can
@@ -1854,8 +1855,13 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionExecve, (JSGlobalObject * lexicalGlobal
     if (bun_close_range(3, ~0U, /* CLOSE_RANGE_CLOEXEC */ (1U << 2)) != 0)
 #endif
     {
-        int maxfd = static_cast<int>(sysconf(_SC_OPEN_MAX));
-        if (maxfd < 0 || maxfd > 65536) maxfd = 65536;
+        int maxfd = bun_highest_open_fd();
+        if (maxfd < 0) {
+            maxfd = static_cast<int>(sysconf(_SC_OPEN_MAX));
+            if (maxfd < 0 || maxfd > 65536) maxfd = 65536;
+        } else {
+            maxfd++;
+        }
         for (int fd = 3; fd < maxfd; fd++) {
             int flags = fcntl(fd, F_GETFD);
             if (flags >= 0) fcntl(fd, F_SETFD, flags | FD_CLOEXEC);

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -13,13 +13,16 @@
 #include <signal.h>
 #include <sys/resource.h>
 #include <grp.h>
-#include <dirent.h>
 #include <atomic>
 #include <errno.h>
 
 #if OS(LINUX)
 #include <sys/syscall.h>
 #include <sys/prctl.h>
+#endif
+
+#if OS(DARWIN)
+#include <libproc.h>
 #endif
 
 extern char** environ;
@@ -32,31 +35,53 @@ extern char** environ;
 extern "C" ssize_t bun_close_range(unsigned int start, unsigned int end, unsigned int flags);
 #endif
 
-// Highest open fd via /proc/self/fd or /dev/fd; -1 if the scan is unusable.
+// Highest open fd in this process, or -1 if the scan is unusable.
 extern "C" int bun_highest_open_fd()
 {
 #if OS(LINUX)
-    DIR* d = opendir("/proc/self/fd");
-#else
-    DIR* d = opendir("/dev/fd");
-#endif
-    if (!d) return -1;
-    int self = dirfd(d);
+    int dir = open("/proc/self/fd", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (dir < 0) return -1;
+    struct linux_dirent64 {
+        uint64_t d_ino;
+        int64_t d_off;
+        uint16_t d_reclen;
+        uint8_t d_type;
+        char d_name[];
+    };
+    alignas(linux_dirent64) char buf[4096];
     int highest = -1;
-    while (struct dirent* ent = readdir(d)) {
-        const char* p = ent->d_name;
-        if (*p < '0' || *p > '9') continue;
-        int fd = 0;
-        while (*p >= '0' && *p <= '9')
-            fd = fd * 10 + (*p++ - '0');
-        if (*p != '\0') continue;
-        if (fd > highest) highest = fd;
+    for (;;) {
+        long n = syscall(SYS_getdents64, dir, buf, sizeof(buf));
+        if (n <= 0) break;
+        for (long off = 0; off < n;) {
+            auto* ent = reinterpret_cast<linux_dirent64*>(buf + off);
+            off += ent->d_reclen;
+            const char* p = ent->d_name;
+            if (*p < '0' || *p > '9') continue;
+            int fd = 0;
+            while (*p >= '0' && *p <= '9')
+                fd = fd * 10 + (*p++ - '0');
+            if (*p != '\0') continue;
+            if (fd > highest) highest = fd;
+        }
     }
-    closedir(d);
-    // A real fdescfs/procfs mount lists the scan's own dirfd. FreeBSD's
-    // default devfs /dev/fd has only static 0/1/2 nodes; reject that.
-    if (highest < self) return -1;
+    close(dir);
+    return (highest < dir) ? -1 : highest;
+#elif OS(DARWIN)
+    int n = proc_pidinfo(getpid(), PROC_PIDLISTFDS, 0, nullptr, 0);
+    if (n <= 0) return -1;
+    n += 32 * (int)sizeof(struct proc_fdinfo);
+    struct proc_fdinfo* fds = (struct proc_fdinfo*)malloc(n);
+    if (!fds) return -1;
+    n = proc_pidinfo(getpid(), PROC_PIDLISTFDS, 0, fds, n);
+    int highest = -1;
+    for (int i = 0; i < n / (int)sizeof(struct proc_fdinfo); i++)
+        if (fds[i].proc_fd > highest) highest = fds[i].proc_fd;
+    free(fds);
     return highest;
+#else
+    return -1;
+#endif
 }
 
 #if OS(LINUX)

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -32,11 +32,7 @@ extern char** environ;
 extern "C" ssize_t bun_close_range(unsigned int start, unsigned int end, unsigned int flags);
 #endif
 
-// Scan /proc/self/fd (Linux) or /dev/fd (Darwin/BSD) for the highest open fd.
-// Called in the parent before fork so the child's fallback fd sweep is bounded
-// by actual open fds instead of RLIMIT_NOFILE (which Bun raises to the hard
-// limit, typically 6 figures). Returns -1 if the scan fails; callers fall
-// back to the rlimit-derived bound.
+// Highest open fd via /proc/self/fd or /dev/fd; -1 if the scan is unusable.
 extern "C" int bun_highest_open_fd()
 {
 #if OS(LINUX)
@@ -45,6 +41,7 @@ extern "C" int bun_highest_open_fd()
     DIR* d = opendir("/dev/fd");
 #endif
     if (!d) return -1;
+    int self = dirfd(d);
     int highest = -1;
     while (struct dirent* ent = readdir(d)) {
         const char* p = ent->d_name;
@@ -56,15 +53,15 @@ extern "C" int bun_highest_open_fd()
         if (fd > highest) highest = fd;
     }
     closedir(d);
+    // A real fdescfs/procfs mount lists the scan's own dirfd. FreeBSD's
+    // default devfs /dev/fd has only static 0/1/2 nodes; reject that.
+    if (highest < self) return -1;
     return highest;
 }
 
 #if OS(LINUX)
-// Cached close_range(2) capability so the vfork child never issues a known-
-// failing syscall on every spawn. Probed once from the parent with a no-op
-// (~0U, ~0U) range that touches no fds: 5.11+ accepts CLOSE_RANGE_CLOEXEC,
-// 5.9/5.10 reject the unknown flag with EINVAL but accept flags=0, and <5.9 /
-// seccomp-blocked kernels return ENOSYS/EPERM.
+// Cached close_range(2) capability. The (~0U, ~0U) probe is a no-op range
+// above any fd table: 5.11+ -> 0, 5.9/5.10 -> EINVAL (flag), <5.9 -> ENOSYS.
 enum : int { kCloseRangeUnknown = 0,
     kCloseRangeCloexec = 1,
     kCloseRangePlain = 2,
@@ -88,30 +85,21 @@ static int closeRangeCapability()
 }
 #endif
 
-// Helper: get max fd from system, clamped to sane limits and optionally to 'end' parameter
-static inline int getMaxFd(int start, int end)
-{
-#if OS(LINUX)
-    int maxfd = static_cast<int>(sysconf(_SC_OPEN_MAX));
-#elif OS(DARWIN) || OS(FREEBSD)
-    int maxfd = getdtablesize();
-#else
-    int maxfd = 1024;
-#endif
-    if (maxfd < 0 || maxfd > 65536) maxfd = 65536;
-    // Respect the end parameter if it's a valid bound (not INT_MAX sentinel)
-    if (end >= start && end < INT_MAX) {
-        maxfd = std::min(maxfd, end + 1); // +1 because end is inclusive
-    }
-    return maxfd;
-}
-
-// Loop-based fallback for closing/cloexec fds. open_fd_hint is the parent's
-// highest open fd at call time (or -1 if unknown); the sweep never needs to
-// go past it because fds above it cannot exist in the just-forked child.
+// Loop-based fallback. open_fd_hint (-1 = unknown) bounds this best-effort
+// sweep at the parent's highest open fd; Bun-owned fds are O_CLOEXEC already.
 static inline void closeRangeLoop(int start, int end, bool cloexec_only, int open_fd_hint)
 {
-    int maxfd = (open_fd_hint >= 0) ? open_fd_hint + 1 : getMaxFd(start, end);
+    int maxfd;
+    if (open_fd_hint >= 0) {
+        maxfd = open_fd_hint + 1;
+    } else {
+#if OS(LINUX)
+        maxfd = static_cast<int>(sysconf(_SC_OPEN_MAX));
+#else
+        maxfd = getdtablesize();
+#endif
+        if (maxfd < 0 || maxfd > 65536) maxfd = 65536;
+    }
     if (end >= start && end < INT_MAX)
         maxfd = std::min(maxfd, end + 1);
     for (int fd = start; fd < maxfd; fd++) {
@@ -126,10 +114,8 @@ static inline void closeRangeLoop(int start, int end, bool cloexec_only, int ope
     }
 }
 
-// Platform-specific close range implementation. On Linux, cap carries the
-// probed close_range capability so a failing syscall isn't re-issued per
-// spawn; kCloseRangePlain means "close outright" is available (the vfork
-// child is about to exec, so closing is equivalent to CLOEXEC here).
+// kCloseRangePlain closes outright even when cloexec_only: the vfork child
+// is about to exec, so the effect is the same and Linux uses no errpipe.
 static inline void closeRangeOrLoop(int start, int end, bool cloexec_only, int cap, int open_fd_hint)
 {
 #if OS(LINUX)
@@ -201,9 +187,8 @@ extern "C" ssize_t posix_spawn_bun(
     sigset_t blockall, oldmask;
     int res = 0, cs = 0;
 
-    // Decide the child's fd-sweep strategy in the parent so the vfork/fork
-    // child never calls opendir/readdir (not async-signal-safe) and never
-    // re-probes a failing close_range on every spawn.
+    // Resolve the fd-sweep strategy in the parent: opendir/readdir are not
+    // async-signal-safe, so the forked child must not call them.
 #if OS(LINUX)
     const int close_range_cap = closeRangeCapability();
     const int open_fd_hint = (close_range_cap == kCloseRangeNone) ? bun_highest_open_fd() : -1;

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -13,6 +13,9 @@
 #include <signal.h>
 #include <sys/resource.h>
 #include <grp.h>
+#include <dirent.h>
+#include <atomic>
+#include <errno.h>
 
 #if OS(LINUX)
 #include <sys/syscall.h>
@@ -27,6 +30,62 @@ extern char** environ;
 
 #if OS(LINUX)
 extern "C" ssize_t bun_close_range(unsigned int start, unsigned int end, unsigned int flags);
+#endif
+
+// Scan /proc/self/fd (Linux) or /dev/fd (Darwin/BSD) for the highest open fd.
+// Called in the parent before fork so the child's fallback fd sweep is bounded
+// by actual open fds instead of RLIMIT_NOFILE (which Bun raises to the hard
+// limit, typically 6 figures). Returns -1 if the scan fails; callers fall
+// back to the rlimit-derived bound.
+extern "C" int bun_highest_open_fd()
+{
+#if OS(LINUX)
+    DIR* d = opendir("/proc/self/fd");
+#else
+    DIR* d = opendir("/dev/fd");
+#endif
+    if (!d) return -1;
+    int highest = -1;
+    while (struct dirent* ent = readdir(d)) {
+        const char* p = ent->d_name;
+        if (*p < '0' || *p > '9') continue;
+        int fd = 0;
+        while (*p >= '0' && *p <= '9')
+            fd = fd * 10 + (*p++ - '0');
+        if (*p != '\0') continue;
+        if (fd > highest) highest = fd;
+    }
+    closedir(d);
+    return highest;
+}
+
+#if OS(LINUX)
+// Cached close_range(2) capability so the vfork child never issues a known-
+// failing syscall on every spawn. Probed once from the parent with a no-op
+// (~0U, ~0U) range that touches no fds: 5.11+ accepts CLOSE_RANGE_CLOEXEC,
+// 5.9/5.10 reject the unknown flag with EINVAL but accept flags=0, and <5.9 /
+// seccomp-blocked kernels return ENOSYS/EPERM.
+enum : int { kCloseRangeUnknown = 0,
+    kCloseRangeCloexec = 1,
+    kCloseRangePlain = 2,
+    kCloseRangeNone = 3 };
+static std::atomic<int> s_closeRangeCapability { kCloseRangeUnknown };
+
+static int closeRangeCapability()
+{
+    int cap = s_closeRangeCapability.load(std::memory_order_relaxed);
+    if (cap != kCloseRangeUnknown) return cap;
+    if (bun_close_range(~0U, ~0U, CLOSE_RANGE_CLOEXEC) == 0)
+        cap = kCloseRangeCloexec;
+    else if (errno != EINVAL)
+        cap = kCloseRangeNone;
+    else if (bun_close_range(~0U, ~0U, 0) == 0)
+        cap = kCloseRangePlain;
+    else
+        cap = kCloseRangeNone;
+    s_closeRangeCapability.store(cap, std::memory_order_relaxed);
+    return cap;
+}
 #endif
 
 // Helper: get max fd from system, clamped to sane limits and optionally to 'end' parameter
@@ -47,10 +106,14 @@ static inline int getMaxFd(int start, int end)
     return maxfd;
 }
 
-// Loop-based fallback for closing/cloexec fds
-static inline void closeRangeLoop(int start, int end, bool cloexec_only)
+// Loop-based fallback for closing/cloexec fds. open_fd_hint is the parent's
+// highest open fd at call time (or -1 if unknown); the sweep never needs to
+// go past it because fds above it cannot exist in the just-forked child.
+static inline void closeRangeLoop(int start, int end, bool cloexec_only, int open_fd_hint)
 {
-    int maxfd = getMaxFd(start, end);
+    int maxfd = (open_fd_hint >= 0) ? open_fd_hint + 1 : getMaxFd(start, end);
+    if (end >= start && end < INT_MAX)
+        maxfd = std::min(maxfd, end + 1);
     for (int fd = start; fd < maxfd; fd++) {
         if (cloexec_only) {
             int current_flags = fcntl(fd, F_GETFD);
@@ -63,17 +126,24 @@ static inline void closeRangeLoop(int start, int end, bool cloexec_only)
     }
 }
 
-// Platform-specific close range implementation
-static inline void closeRangeOrLoop(int start, int end, bool cloexec_only)
+// Platform-specific close range implementation. On Linux, cap carries the
+// probed close_range capability so a failing syscall isn't re-issued per
+// spawn; kCloseRangePlain means "close outright" is available (the vfork
+// child is about to exec, so closing is equivalent to CLOEXEC here).
+static inline void closeRangeOrLoop(int start, int end, bool cloexec_only, int cap, int open_fd_hint)
 {
 #if OS(LINUX)
-    unsigned int flags = cloexec_only ? CLOSE_RANGE_CLOEXEC : 0;
-    if (bun_close_range(start, end, flags) == 0) {
-        return;
+    if (cap == kCloseRangeCloexec) {
+        if (bun_close_range(start, end, cloexec_only ? CLOSE_RANGE_CLOEXEC : 0) == 0)
+            return;
+    } else if (cap == kCloseRangePlain) {
+        if (bun_close_range(start, end, 0) == 0)
+            return;
     }
-    // Fallback for older kernels or when close_range fails
+#else
+    (void)cap;
 #endif
-    closeRangeLoop(start, end, cloexec_only);
+    closeRangeLoop(start, end, cloexec_only, open_fd_hint);
 }
 
 enum FileActionType : uint8_t {
@@ -131,6 +201,17 @@ extern "C" ssize_t posix_spawn_bun(
     sigset_t blockall, oldmask;
     int res = 0, cs = 0;
 
+    // Decide the child's fd-sweep strategy in the parent so the vfork/fork
+    // child never calls opendir/readdir (not async-signal-safe) and never
+    // re-probes a failing close_range on every spawn.
+#if OS(LINUX)
+    const int close_range_cap = closeRangeCapability();
+    const int open_fd_hint = (close_range_cap == kCloseRangeNone) ? bun_highest_open_fd() : -1;
+#else
+    const int close_range_cap = 0;
+    const int open_fd_hint = bun_highest_open_fd();
+#endif
+
 #if OS(DARWIN) || OS(FREEBSD)
     // On macOS, we use fork() which requires a self-pipe trick to detect exec failures.
     // Create a pipe for child-to-parent error communication.
@@ -176,7 +257,7 @@ extern "C" ssize_t posix_spawn_bun(
         // Write errno to pipe so parent can read it
         (void)write(errpipe[1], &err, sizeof(err));
         close(errpipe[1]);
-        closeRangeOrLoop(0, INT_MAX, false);
+        closeRangeOrLoop(0, INT_MAX, false, close_range_cap, open_fd_hint);
         rawExit(127);
 
         // should never be reached
@@ -342,7 +423,7 @@ extern "C" ssize_t posix_spawn_bun(
             envp = environ;
 
         // Close all fds > current_max_fd, preferring cloexec if available
-        closeRangeOrLoop(current_max_fd + 1, INT_MAX, true);
+        closeRangeOrLoop(current_max_fd + 1, INT_MAX, true, close_range_cap, open_fd_hint);
 
         if (execve(path, argv, envp) == -1) {
             return childFailed();

--- a/test/js/bun/spawn/spawn-close-range-fallback.test.ts
+++ b/test/js/bun/spawn/spawn-close-range-fallback.test.ts
@@ -73,6 +73,10 @@ int main(int argc, char **argv) {
   struct sock_fprog prog = { .len = sizeof(filter)/sizeof(filter[0]), .filter = filter };
   if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) { perror("no_new_privs"); return 77; }
   if (syscall(__NR_seccomp, SECCOMP_SET_MODE_FILTER, 0, &prog) != 0) { perror("seccomp"); return 77; }
+  /* Prove the filter took effect; otherwise the test would exercise the
+     close_range fast path and pass vacuously. */
+  errno = 0;
+  if (syscall(__NR_close_range, ~0U, ~0U, 0) != -1 || errno != ENOSYS) return 77;
 
   execvp(argv[1], &argv[1]);
   perror("execvp");
@@ -95,14 +99,9 @@ int main(int argc, char **argv) {
     return bin;
   };
 
-  const helperBin = tryBuild();
+  const helperBin = isLinux ? tryBuild() : null;
 
-  test("fd above the 65536 clamp does not leak into a spawned child", async () => {
-    if (helperBin == null) {
-      console.warn("SKIP: cc or linux seccomp headers unavailable");
-      return;
-    }
-
+  test.skipIf(helperBin == null)("fd above the 65536 clamp does not leak into a spawned child", async () => {
     // Outer bun: verify HIGH_FD arrived from the helper, then Bun.spawn an
     // inner bun and report which /proc/self/fd entries it sees.
     const script = `
@@ -120,7 +119,7 @@ int main(int argc, char **argv) {
     `;
 
     await using proc = Bun.spawn({
-      cmd: [helperBin, bunExe(), "-e", script],
+      cmd: [helperBin!, bunExe(), "-e", script],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -131,7 +130,7 @@ int main(int argc, char **argv) {
       return;
     }
 
-    expect(stderr).toBe("");
+    expect(stderr).not.toContain("error");
     const result = JSON.parse(stdout.trim());
     // Precondition: the helper's non-CLOEXEC fd reached the outer bun. Bun's
     // startup close_range sweep is also ENOSYS'd by seccomp, so this holds.

--- a/test/js/bun/spawn/spawn-close-range-fallback.test.ts
+++ b/test/js/bun/spawn/spawn-close-range-fallback.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDirWithFiles } from "harness";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+// On kernels where close_range(2) is unavailable (Linux <5.9, seccomp-filtered
+// containers) the fork-path spawn child falls back to an fd sweep. The sweep
+// used to walk getdtablesize() clamped to 65536, which both cost ~65k fcntl
+// calls serialized on the spawn critical path and missed fds above 65536. The
+// fix enumerates /proc/self/fd in the parent so the child's sweep is bounded
+// by the actual highest open fd.
+//
+// This test simulates the no-close_range environment with a seccomp filter
+// returning ENOSYS, opens a non-CLOEXEC fd above the old 65536 clamp, spawns,
+// and asserts the child did not inherit it.
+describe.skipIf(!isLinux)("Bun.spawn close_range fallback fd sweep", () => {
+  // Helper: raise RLIMIT_NOFILE, dup a /dev/null fd onto HIGH_FD without
+  // CLOEXEC, install a seccomp filter that ENOSYS's close_range, exec argv.
+  const HIGH_FD = 70000;
+  const helperSrc = `
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/prctl.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef __NR_close_range
+#define __NR_close_range 436
+#endif
+
+#if defined(__x86_64__)
+#define MY_AUDIT_ARCH AUDIT_ARCH_X86_64
+#elif defined(__aarch64__)
+#define MY_AUDIT_ARCH AUDIT_ARCH_AARCH64
+#else
+#define MY_AUDIT_ARCH 0
+#endif
+
+int main(int argc, char **argv) {
+  if (argc < 2) return 2;
+  if (MY_AUDIT_ARCH == 0) return 77;
+
+  struct rlimit rl;
+  if (getrlimit(RLIMIT_NOFILE, &rl) != 0) return 77;
+  if (rl.rlim_max <= ${HIGH_FD}) return 77; /* hard limit too low, skip */
+  rl.rlim_cur = rl.rlim_max;
+  if (setrlimit(RLIMIT_NOFILE, &rl) != 0) return 77;
+
+  int src = open("/dev/null", O_RDONLY);
+  if (src < 0) return 77;
+  /* F_DUPFD (not F_DUPFD_CLOEXEC): explicitly without CLOEXEC. */
+  if (fcntl(src, F_DUPFD, ${HIGH_FD}) < 0) return 77;
+  close(src);
+
+  struct sock_filter filter[] = {
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, arch)),
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, MY_AUDIT_ARCH, 1, 0),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_close_range, 0, 1),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (ENOSYS & SECCOMP_RET_DATA)),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+  };
+  struct sock_fprog prog = { .len = sizeof(filter)/sizeof(filter[0]), .filter = filter };
+  if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) { perror("no_new_privs"); return 77; }
+  if (syscall(__NR_seccomp, SECCOMP_SET_MODE_FILTER, 0, &prog) != 0) { perror("seccomp"); return 77; }
+
+  execvp(argv[1], &argv[1]);
+  perror("execvp");
+  return 127;
+}
+`;
+
+  const tryBuild = (): string | null => {
+    const dir = tempDirWithFiles("spawn-closerange", { "block_close_range.c": helperSrc });
+    const src = join(dir, "block_close_range.c");
+    const bin = join(dir, "block_close_range");
+    const compile = spawnSync("cc", ["-O0", "-o", bin, src], { stdio: "pipe" });
+    if ((compile.error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") return null;
+    if (compile.status !== 0) {
+      const stderr = compile.stderr?.toString() ?? "";
+      if (/linux\/(seccomp|filter|audit)\.h|sys\/prctl\.h/.test(stderr)) return null;
+      throw new Error(`failed to compile seccomp helper:\n${stderr}`);
+    }
+    if (!existsSync(bin)) throw new Error("seccomp helper produced no output binary");
+    return bin;
+  };
+
+  const helperBin = tryBuild();
+
+  test("fd above the 65536 clamp does not leak into a spawned child", async () => {
+    if (helperBin == null) {
+      console.warn("SKIP: cc or linux seccomp headers unavailable");
+      return;
+    }
+
+    // Outer bun: verify HIGH_FD arrived from the helper, then Bun.spawn an
+    // inner bun and report which /proc/self/fd entries it sees.
+    const script = `
+      const fs = require("node:fs");
+      const outerHas = fs.readdirSync("/proc/self/fd").includes("${HIGH_FD}");
+      const proc = Bun.spawn({
+        cmd: [${JSON.stringify(bunExe())}, "-e",
+          'process.stdout.write(require("fs").readdirSync("/proc/self/fd").join(","))'],
+        stdout: "pipe", stderr: "inherit",
+      });
+      const inner = await proc.stdout.text();
+      await proc.exited;
+      const innerHas = inner.split(",").includes("${HIGH_FD}");
+      console.log(JSON.stringify({ outerHas, innerHas }));
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [helperBin, bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    if (exitCode === 77) {
+      console.warn("SKIP: seccomp unavailable or RLIMIT_NOFILE hard limit too low");
+      return;
+    }
+
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout.trim());
+    // Precondition: the helper's non-CLOEXEC fd reached the outer bun. Bun's
+    // startup close_range sweep is also ENOSYS'd by seccomp, so this holds.
+    expect(result.outerHas).toBe(true);
+    // The assertion under test: posix_spawn_bun's child sweep caught HIGH_FD.
+    expect(result.innerHas).toBe(false);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/spawn/spawn-close-range-fallback.test.ts
+++ b/test/js/bun/spawn/spawn-close-range-fallback.test.ts
@@ -125,11 +125,7 @@ int main(int argc, char **argv) {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     if (exitCode === 77) {
       console.warn("SKIP: seccomp unavailable or RLIMIT_NOFILE hard limit too low");
       return;


### PR DESCRIPTION
`posix_spawn_bun`'s fork/vfork child walks `getdtablesize()` (clamped to 65536) doing `fcntl(F_GETFD)` + conditional `fcntl(F_SETFD)` per fd immediately before `execve`. libuv's `uv__process_child_init` never does this scan at all.

## Who pays

- **macOS**: unconditional on the fork paths (PTY spawn, setuid/setgid spawn). The parent blocks in `read(errpipe[0])` until the child's O_CLOEXEC write end closes at `execve`, so the loop is serialized on `Bun.spawn`'s critical path. Plain `Bun.spawn` uses Apple's `posix_spawn` with `POSIX_SPAWN_CLOEXEC_DEFAULT` and is unaffected.
- **Linux**: on every spawn where `close_range(2)` fails: kernels <5.11, and seccomp profiles that reject it (RHEL/CentOS 8, AL2, Debian 11, Ubuntu 20.04, gVisor, older Docker/podman). The failing `close_range` was also re-issued on every spawn, never cached.

## Repro

On Linux with `close_range` forced to ENOSYS via seccomp, 50 `Bun.spawn({cmd:["/usr/bin/true"]})`:

```
before: 50 spawns: 485.8ms (9.72ms each)
after:  50 spawns:  59.3ms (1.19ms each)
```

On an M-series Mac, fork->exec window replicating Bun's errpipe structure (40 iters, Jarred's `uvbun_spawnloop.c`):

```
getdtablesize=245760  clamped maxfd=65536
loop=0  avg 0.802 ms  max 3.326 ms
loop=1  avg 6.228 ms  max 6.950 ms
```

## Fix

The parent decides the sweep strategy once, before fork, so the child never calls `opendir`/`readdir` (not async-signal-safe) and never re-probes a failing syscall:

1. **Cache `close_range` capability (Linux).** A process-global atomic, probed once from the parent with the no-op range `(~0U, ~0U)` which touches no fds. 5.11+ accepts `CLOSE_RANGE_CLOEXEC`; 5.9/5.10 reject the unknown flag with `EINVAL` but accept `flags=0`; <5.9 / seccomp return `ENOSYS`/`EPERM`.
2. **Use `flags=0` on 5.9/5.10 (Linux).** The vfork child is about to exec anyway (and uses shared memory, not an errpipe), so closing outright is equivalent to CLOEXEC there.
3. **Bound the fallback loop.** When the loop runs (macOS/FreeBSD always; Linux when `close_range` is unavailable), the parent scans `/proc/self/fd` or `/dev/fd` for the highest open fd and the child loops only to that. O(open fds), typically a few dozen. If the scan fails (unmounted `/proc`), fall back to the old rlimit bound.

Same bound applied to `process.execve`'s fallback loop in `BunProcess.cpp`.

On the happy path (Linux with `close_range` available) the only added cost is one relaxed atomic load per spawn; the `/proc/self/fd` scan is skipped.

## Correctness

This also fixes a leak: the old `min(getdtablesize(), 65536)` clamp meant a non-CLOEXEC fd above 65536 was never swept on the fallback path and leaked into the child. Bun raises `RLIMIT_NOFILE` to the hard limit at startup, so fds above 65536 are reachable.

## Verification

`test/js/bun/spawn/spawn-close-range-fallback.test.ts` compiles a seccomp helper that ENOSYS's `close_range`, dup's `/dev/null` onto fd 70000 without CLOEXEC, execs bun, and asserts a `Bun.spawn`'d child does not inherit fd 70000. Fails on main (`innerHas: true`), passes on this branch.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-close-range-fallback.test.ts

<!-- robobun:evidence:end -->