### PR TITLE
resolver: treat "jsnext:main" like "module" in auto-main require() fallback

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5465,7 +5465,11 @@ impl<'a> Resolver<'a> {
                     // use a special per-module automatic algorithm to decide whether to
                     // use "module" or "main" based on whether the package is imported
                     // using "import" or "require".
-                    if auto_main && key == b"module" {
+                    //
+                    // "jsnext:main" is the legacy predecessor to "module" and points to
+                    // an ESM build, so it gets the same treatment. Packages like moment
+                    // ship "jsnext:main" + "main" without "module".
+                    if auto_main && (key == b"module" || key == b"jsnext:main") {
                         let mut auto_main_result = MatchResult::default();
                         let mut auto_main_found = false;
 
@@ -5510,8 +5514,9 @@ impl<'a> Resolver<'a> {
                             if self.prefer_module_field && kind != ast::ImportKind::Require {
                                 if let Some(debug) = self.debug_logs.as_mut() {
                                     debug.add_note_fmt(format_args!(
-                                        "Resolved to \"{}\" using the \"module\" field in \"{}\"",
+                                        "Resolved to \"{}\" using the \"{}\" field in \"{}\"",
                                         bstr::BStr::new(auto_main_result.path_pair.primary.text()),
+                                        bstr::BStr::new(key),
                                         bstr::BStr::new(pkg_json.source.path.text)
                                     ));
                                     debug.add_note_fmt(format_args!(

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -1015,6 +1015,66 @@ describe("bundler", () => {
       stdout: "true",
     },
   });
+  // https://github.com/oven-sh/bun/issues/5004
+  // "jsnext:main" is the legacy name for "module" and must get the same
+  // require() -> "main" fallback. moment ships "jsnext:main" + "main" only.
+  itBundled("packagejson/DualPackageHazardJsnextMainRequireOnly", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        const demo = require('demo-pkg')
+        console.log(demo())
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "main": "./main.js",
+          "jsnext:main": "./module.js"
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/main.js": `module.exports = function() { return 'main' }`,
+      "/Users/user/project/node_modules/demo-pkg/module.js": `export default function() { return 'module' }`,
+    },
+    run: {
+      stdout: "main",
+    },
+  });
+  itBundled("packagejson/DualPackageHazardJsnextMainImportOnly", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import value from 'demo-pkg'
+        console.log(value)
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "main": "./main.js",
+          "jsnext:main": "./module.js"
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/main.js": `module.exports = 'main'`,
+      "/Users/user/project/node_modules/demo-pkg/module.js": `export default 'module'`,
+    },
+    run: {
+      stdout: "module",
+    },
+  });
+  itBundled("packagejson/DualPackageHazardJsnextMainImportAndRequireSameFile", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import value from 'demo-pkg'
+        console.log(value, require('demo-pkg'))
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "main": "./main.js",
+          "jsnext:main": "./module.js"
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/main.js": `module.exports = 'main'`,
+      "/Users/user/project/node_modules/demo-pkg/module.js": `export default 'module'`,
+    },
+    run: {
+      stdout: "main main",
+    },
+  });
   itBundled("packagejson/MainFieldsA", {
     files: {
       "/Users/user/project/src/entry.js": /* js */ `


### PR DESCRIPTION
Fixes #5004.

## Repro

```js
const moment = require("moment");
console.log(moment().add(5, "minutes"));
```

```sh
bun install moment
bun build index.js --target browser --outdir ./dist
bun ./dist/index.js
```

Before:
```
TypeError: moment is not a function. (In 'moment()', 'moment' is an instance of Object)
```

## Cause

moment's `package.json` has `"main": "./moment.js"` (UMD) and `"jsnext:main": "./dist/moment.js"` (ESM with `export default hooks`), but no `"module"` field.

The browser target's default main-field order is `["browser", "module", "jsnext:main", "main"]`, so the resolver picks `jsnext:main` and emits `(init_moment(), __toCommonJS(exports_moment))` for the `require()`, which yields the namespace object `{ default: [Function], __esModule: true }` rather than the callable.

The resolver already has dual-package-hazard handling for exactly this case: when the default main-field order is in effect and `"module"` matched, fall back to `"main"` for `require()`. That check was `key == b"module"` only. `"jsnext:main"` is the legacy name for the same field (predates the `"module"` convention), so it should get the same treatment.

## Fix

Extend the auto-main condition in `load_as_file_or_directory` to include `jsnext:main`.

## Verification

After the change, bundling the repro resolves to `node_modules/moment/moment.js` and runs correctly:
```
Moment<2026-08-01T03:58:08+00:00>
```

`import moment from "moment"` is unchanged and still resolves to the ESM `dist/moment.js`.

Added `DualPackageHazardJsnextMain{RequireOnly,ImportOnly,ImportAndRequireSameFile}` to `test/bundler/esbuild/packagejson.test.ts` mirroring the existing `module` tests. `RequireOnly` and `ImportAndRequireSameFile` fail before this change with `moment is not a function`-style output.