### PR TITLE
cli: skip automatic .env loading when invoked as node

### DIFF
--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -89,6 +89,8 @@ env = false
 
 Files passed with `--env-file` still load even when default loading is disabled.
 
+When Bun is invoked as `node` (for example via `bun --bun`, `bunx --bun`, or a `node` symlink pointing at Bun), automatic `.env` loading is disabled to match Node.js. This lets tools with their own mode-aware `.env` resolution, such as Vite's `loadEnv`, pick the correct `.env.{mode}` file instead of seeing Bun's pre-populated values as shell-set overrides. Explicit `--env-file` arguments are still honored.
+
 ---
 
 ## Quotation marks

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2979,12 +2979,9 @@ impl RunCommand {
         // `Command::which()` before dispatch.
         debug_assert!(crate::cli::PRETEND_TO_BE_NODE.load(::core::sync::atomic::Ordering::Relaxed));
 
-        // Node.js does not auto-load `.env` files. When bun is invoked as `node`
-        // (via `--bun`'s shim or a `node` symlink), tools that manage their own
-        // mode-aware `.env.{mode}` files (Vite, dotenv-flow, rsbuild, ...) would
-        // otherwise see bun's pre-populated values as shell-set overrides and
-        // refuse to apply their mode file. Explicit `--env-file` is still honored.
-        // https://github.com/oven-sh/bun/issues/6338
+        // Node.js does not auto-load `.env` files; match that here so tools with
+        // their own `.env.{mode}` resolution (Vite etc.) don't see pre-populated
+        // values. Explicit `--env-file` is still honored. #6338
         ctx.args.disable_default_env_files = true;
 
         // `node --interactive [-e code]`: same gate as AutoCommand — a script

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2979,6 +2979,14 @@ impl RunCommand {
         // `Command::which()` before dispatch.
         debug_assert!(crate::cli::PRETEND_TO_BE_NODE.load(::core::sync::atomic::Ordering::Relaxed));
 
+        // Node.js does not auto-load `.env` files. When bun is invoked as `node`
+        // (via `--bun`'s shim or a `node` symlink), tools that manage their own
+        // mode-aware `.env.{mode}` files (Vite, dotenv-flow, rsbuild, ...) would
+        // otherwise see bun's pre-populated values as shell-set overrides and
+        // refuse to apply their mode file. Explicit `--env-file` is still honored.
+        // https://github.com/oven-sh/bun/issues/6338
+        ctx.args.disable_default_env_files = true;
+
         // `node --interactive [-e code]`: same gate as AutoCommand — a script
         // positional wins, and `-p` currently bypasses the REPL (see mod.rs).
         if ctx.runtime_options.interactive

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1178,6 +1178,12 @@ describe("node shim (argv0=node) does not auto-load .env files", () => {
     }));`,
     "package.json": JSON.stringify({ name: "p", scripts: { check: "node ./check.js" } }),
   };
+  const testEnv = {
+    ...bunEnv,
+    NODE_ENV: undefined,
+    PUBLICPATH: undefined,
+    VITE_PUBLIC_PATH: undefined,
+  };
 
   test.concurrent("argv0=node leaves .env keys unset", async () => {
     using dir = tempDir("dotenv-as-node", files);
@@ -1185,12 +1191,12 @@ describe("node shim (argv0=node) does not auto-load .env files", () => {
       cmd: [bunExe(), "check.js"],
       argv0: "node",
       cwd: String(dir),
-      env: { ...bunEnv, NODE_ENV: undefined },
+      env: testEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).not.toContain('".env"');
+    expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual({ PUBLICPATH: null, VITE_PUBLIC_PATH: null });
     expect(exitCode).toBe(0);
   });
@@ -1201,11 +1207,12 @@ describe("node shim (argv0=node) does not auto-load .env files", () => {
       cmd: [bunExe(), "--env-file=.env.production", "check.js"],
       argv0: "node",
       cwd: String(dir),
-      env: { ...bunEnv, NODE_ENV: undefined },
+      env: testEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual({ PUBLICPATH: "/app", VITE_PUBLIC_PATH: "/app" });
     expect(exitCode).toBe(0);
   });
@@ -1213,28 +1220,29 @@ describe("node shim (argv0=node) does not auto-load .env files", () => {
   test.concurrent("`bun --bun run <script>` does not leak .env into the node-shimmed child", async () => {
     using dir = tempDir("dotenv-bun-run", files);
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "--bun", "run", "check"],
+      cmd: [bunExe(), "--bun", "run", "--silent", "check"],
       cwd: String(dir),
-      env: { ...bunEnv, NODE_ENV: undefined },
+      env: testEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const line = stdout.split("\n").find(l => l.startsWith("{"))!;
-    expect(JSON.parse(line)).toEqual({ PUBLICPATH: null, VITE_PUBLIC_PATH: null });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ PUBLICPATH: null, VITE_PUBLIC_PATH: null });
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent("`bun index.js` (not node shim) still auto-loads .env", async () => {
+  test.concurrent("`bun check.js` (not node shim) still auto-loads .env", async () => {
     using dir = tempDir("dotenv-direct", files);
     await using proc = Bun.spawn({
       cmd: [bunExe(), "check.js"],
       cwd: String(dir),
-      env: { ...bunEnv, NODE_ENV: undefined },
+      env: testEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual({ PUBLICPATH: "/", VITE_PUBLIC_PATH: "/dev" });
     expect(exitCode).toBe(0);
   });

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1163,3 +1163,79 @@ test.skipIf(!isASAN || isWindows)(".env with a huge lying st_size does not abort
   // 1099511627792 bytes failed", SIGABRT) without ever reaching app.js.
   expect({ stdout, exitCode }).toEqual({ stdout: "reached user code\n", exitCode: 0 });
 });
+
+// https://github.com/oven-sh/bun/issues/6338
+// Node.js does not auto-load .env files, so bun invoked as `node` (via `--bun`)
+// must not either. Tools like Vite re-read `.env.{mode}` themselves and treat
+// anything already in process.env as a higher-priority shell override.
+describe("node shim (argv0=node) does not auto-load .env files", () => {
+  const files = {
+    ".env": "PUBLICPATH=/\nVITE_PUBLIC_PATH=/dev\n",
+    ".env.production": "PUBLICPATH=/app\nVITE_PUBLIC_PATH=/app\n",
+    "check.js": `console.log(JSON.stringify({
+      PUBLICPATH: process.env.PUBLICPATH ?? null,
+      VITE_PUBLIC_PATH: process.env.VITE_PUBLIC_PATH ?? null,
+    }));`,
+    "package.json": JSON.stringify({ name: "p", scripts: { check: "node ./check.js" } }),
+  };
+
+  test.concurrent("argv0=node leaves .env keys unset", async () => {
+    using dir = tempDir("dotenv-as-node", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "check.js"],
+      argv0: "node",
+      cwd: String(dir),
+      env: { ...bunEnv, NODE_ENV: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain('".env"');
+    expect(JSON.parse(stdout)).toEqual({ PUBLICPATH: null, VITE_PUBLIC_PATH: null });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("argv0=node still honors explicit --env-file", async () => {
+    using dir = tempDir("dotenv-as-node-explicit", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--env-file=.env.production", "check.js"],
+      argv0: "node",
+      cwd: String(dir),
+      env: { ...bunEnv, NODE_ENV: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual({ PUBLICPATH: "/app", VITE_PUBLIC_PATH: "/app" });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("`bun --bun run <script>` does not leak .env into the node-shimmed child", async () => {
+    using dir = tempDir("dotenv-bun-run", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--bun", "run", "check"],
+      cwd: String(dir),
+      env: { ...bunEnv, NODE_ENV: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const line = stdout.split("\n").find(l => l.startsWith("{"))!;
+    expect(JSON.parse(line)).toEqual({ PUBLICPATH: null, VITE_PUBLIC_PATH: null });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("`bun index.js` (not node shim) still auto-loads .env", async () => {
+    using dir = tempDir("dotenv-direct", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "check.js"],
+      cwd: String(dir),
+      env: { ...bunEnv, NODE_ENV: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual({ PUBLICPATH: "/", VITE_PUBLIC_PATH: "/dev" });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

When Bun is invoked as `node` (via `--bun`'s shim, `bunx --bun`, or a `node` symlink pointing at the Bun binary), it no longer auto-loads `.env` / `.env.local` / `.env.{development,production,test}` files. Explicit `--env-file` arguments are still honored, and direct `bun <file>` invocations still auto-load as before.

## Repro

```sh
mkdir repro && cd repro
printf 'PUBLICPATH=/\nVITE_PUBLIC_PATH=/dev\n' > .env
printf 'PUBLICPATH=/app\nVITE_PUBLIC_PATH=/app\n' > .env.production
cat > package.json <<'EOF'
{"scripts": {"check": "node -e \"console.log(process.env.PUBLICPATH, process.env.VITE_PUBLIC_PATH)\""}}
EOF
bun --bun run check
# before: / /dev     (.env leaked into the node-shimmed child)
# after:  undefined undefined
```

In a Vite project this meant `loadEnv('production', cwd, '')` returned `PUBLICPATH="/"` instead of `"/app"` because Vite (like dotenv) treats values already present in `process.env` as shell-set overrides that outrank `.env.{mode}` files.

## Cause

`RunAsNodeCommand` (`exec_as_if_node`) goes straight into `RunCommand::boot`, which runs `configure_defines` and calls `run_env_loader(options.env.disable_default_env_files)`. That flag defaults to `false`, so the default `.env*` set was loaded even though Node.js itself never does that. The package.json-script runner path (`configure_env_for_run`) already passes `skip_default_env = true`, but the node-shim child takes a different code path and never reached that skip.

## Fix

Set `ctx.args.disable_default_env_files = true` at the top of `exec_as_if_node`. The flag flows through `VirtualMachine::init` into `options.env.disable_default_env_files` and makes `configure_defines` skip default-file discovery while still loading process env and any explicit `--env-file` list.

## Verification

- `bun bd test test/cli/run/env.test.ts`: 96 pass / 0 fail (4 new tests)
- `bun bd test test/cli/run/as-node.test.ts test/cli/run/no-envfile.test.ts`: 20 pass / 0 fail

Related: #35481 takes a different approach (non-enumerable auto-loaded values on `process.env`) for the direct `bun <file>` case; #35710 forwards `.env` from the parent `bun run` to non-bun subprocesses. Both are orthogonal to this change.

Fixes #6338
Fixes #13614
Fixes #22496

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/env.test.ts

<!-- robobun:evidence:end -->