### PR TITLE
node:module: wire Module via LazyClassStructure and make _initPaths honor runtime NODE_PATH

### DIFF
--- a/src/js/builtins/NodeModuleObject.ts
+++ b/src/js/builtins/NodeModuleObject.ts
@@ -1,13 +1,9 @@
-// Implementation for `require('node:module')._initPaths`. Re-reads
-// `process.env.NODE_PATH`, pushes it to the native resolver's env map, and
-// refreshes `Module.globalPaths`.
+// `require('node:module')._initPaths`: re-reads NODE_PATH and refreshes `Module.globalPaths`.
 export function _initPaths() {
   const homeDir = process.platform === "win32" ? process.env.USERPROFILE : Bun.env.HOME;
   const nodePath = process.env.NODE_PATH;
 
-  // The native resolver reads NODE_PATH from its own env snapshot, so sync the
-  // current process.env value into it. This is what makes runtime-set NODE_PATH
-  // take effect for subsequent require() calls.
+  // Sync the current NODE_PATH into the native resolver's env snapshot.
   $newCppFunction("NodeModuleModule.cpp", "jsFunctionSetNodePathForRequire", 1)(nodePath);
 
   // process.execPath is $PREFIX/bin/node except on Windows where it is

--- a/src/js/builtins/NodeModuleObject.ts
+++ b/src/js/builtins/NodeModuleObject.ts
@@ -1,8 +1,14 @@
-// Implementation for `require('node:module')._initPaths`. Exists only as a
-// compatibility stub. Calling this does not affect the actual CommonJS loader.
+// Implementation for `require('node:module')._initPaths`. Re-reads
+// `process.env.NODE_PATH`, pushes it to the native resolver's env map, and
+// refreshes `Module.globalPaths`.
 export function _initPaths() {
   const homeDir = process.platform === "win32" ? process.env.USERPROFILE : Bun.env.HOME;
-  const nodePath = process.platform === "win32" ? process.env.NODE_PATH : Bun.env.NODE_PATH;
+  const nodePath = process.env.NODE_PATH;
+
+  // The native resolver reads NODE_PATH from its own env snapshot, so sync the
+  // current process.env value into it. This is what makes runtime-set NODE_PATH
+  // take effect for subsequent require() calls.
+  $newCppFunction("NodeModuleModule.cpp", "jsFunctionSetNodePathForRequire", 1)(nodePath);
 
   // process.execPath is $PREFIX/bin/node except on Windows where it is
   // $PREFIX\node.exe where $PREFIX is the root of the Node.js installation.

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -686,12 +686,10 @@ JSC_DEFINE_CUSTOM_SETTER(setterLoaded,
 JSC_DEFINE_CUSTOM_GETTER(getterUnderscoreCompile, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
     JSCommonJSModule* thisObject = dynamicDowncast<JSCommonJSModule>(JSValue::decode(thisValue));
-    if (!thisObject) [[unlikely]] {
-        return JSValue::encode(jsUndefined());
-    }
-    if (thisObject->m_overriddenCompile) {
+    if (thisObject && thisObject->m_overriddenCompile) {
         return JSValue::encode(thisObject->m_overriddenCompile.get());
     }
+    // `Module.prototype._compile` is read with the prototype as receiver; still return the function.
     return JSValue::encode(defaultGlobalObject(globalObject)->modulePrototypeUnderscoreCompileFunction());
 }
 
@@ -706,6 +704,11 @@ JSC_DEFINE_CUSTOM_SETTER(setterUnderscoreCompile,
     thisObject->m_overriddenCompile.set(globalObject->vm(), thisObject, decodedValue);
     return true;
 }
+
+// Defined in NodeModuleModule.cpp: the `Module.prototype.require` accessor that
+// Next.js and others override to hook CommonJS resolution.
+JSC_DECLARE_CUSTOM_GETTER(getterRequireFunction);
+JSC_DECLARE_CUSTOM_SETTER(setterRequireFunction);
 
 JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * globalObject, CallFrame* callframe))
 {
@@ -771,6 +774,7 @@ JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * glo
 static const struct HashTableValue JSCommonJSModulePrototypeTableValues[] = {
     { "_compile"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, getterUnderscoreCompile, setterUnderscoreCompile } },
     { "children"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, getterChildren, setterChildren } },
+    { "require"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, getterRequireFunction, setterRequireFunction } },
     { "filename"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, getterFilename, setterFilename } },
     { "id"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, getterId, setterId } },
     { "loaded"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, getterLoaded, setterLoaded } },

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -697,12 +697,19 @@ JSC_DEFINE_CUSTOM_SETTER(setterUnderscoreCompile,
     (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue,
         JSC::EncodedJSValue value, JSC::PropertyName propertyName))
 {
-    JSCommonJSModule* thisObject = dynamicDowncast<JSCommonJSModule>(JSValue::decode(thisValue));
-    if (!thisObject)
-        return false;
     JSValue decodedValue = JSValue::decode(value);
-    thisObject->m_overriddenCompile.set(globalObject->vm(), thisObject, decodedValue);
-    return true;
+    if (auto* thisObject = dynamicDowncast<JSCommonJSModule>(JSValue::decode(thisValue))) {
+        thisObject->m_overriddenCompile.set(globalObject->vm(), thisObject, decodedValue);
+        return true;
+    }
+    // `Module.prototype._compile = fn` (APM instrumentation): the receiver is the
+    // prototype, not a module instance. Replace the accessor with a data property
+    // so subsequent reads observe the override.
+    if (auto* receiver = JSValue::decode(thisValue).getObject()) {
+        receiver->putDirect(globalObject->vm(), propertyName, decodedValue, static_cast<unsigned>(PropertyAttribute::DontEnum));
+        return true;
+    }
+    return false;
 }
 
 // Defined in NodeModuleModule.cpp: the `Module.prototype.require` accessor that

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -689,7 +689,6 @@ JSC_DEFINE_CUSTOM_GETTER(getterUnderscoreCompile, (JSC::JSGlobalObject * globalO
     if (thisObject && thisObject->m_overriddenCompile) {
         return JSValue::encode(thisObject->m_overriddenCompile.get());
     }
-    // `Module.prototype._compile` is read with the prototype as receiver; still return the function.
     return JSValue::encode(defaultGlobalObject(globalObject)->modulePrototypeUnderscoreCompileFunction());
 }
 
@@ -702,9 +701,7 @@ JSC_DEFINE_CUSTOM_SETTER(setterUnderscoreCompile,
         thisObject->m_overriddenCompile.set(globalObject->vm(), thisObject, decodedValue);
         return true;
     }
-    // `Module.prototype._compile = fn` (APM instrumentation): the receiver is the
-    // prototype, not a module instance. Replace the accessor with a data property
-    // so subsequent reads observe the override.
+    // `Module.prototype._compile = fn`: replace the accessor with a data property.
     if (auto* receiver = JSValue::decode(thisValue).getObject()) {
         receiver->putDirect(globalObject->vm(), propertyName, decodedValue, static_cast<unsigned>(PropertyAttribute::DontEnum));
         return true;
@@ -712,8 +709,7 @@ JSC_DEFINE_CUSTOM_SETTER(setterUnderscoreCompile,
     return false;
 }
 
-// Defined in NodeModuleModule.cpp: the `Module.prototype.require` accessor that
-// Next.js and others override to hook CommonJS resolution.
+// `Module.prototype.require` accessor; defined in NodeModuleModule.cpp.
 JSC_DECLARE_CUSTOM_GETTER(getterRequireFunction);
 JSC_DECLARE_CUSTOM_SETTER(setterRequireFunction);
 

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -538,7 +538,7 @@ JSValue fetchBuiltinModuleWithoutResolution(
         }
         // require("module"), require("node:module")
         case SyntheticModuleType::NodeModule: {
-            return globalObject->m_nodeModuleConstructor.getInitializedOnMainThread(globalObject);
+            return globalObject->nodeModuleConstructor();
         }
         // require("process"), require("node:process")
         case SyntheticModuleType::NodeProcess: {
@@ -587,7 +587,7 @@ JSValue resolveAndFetchBuiltinModule(
         }
         // require("module"), require("node:module")
         case SyntheticModuleType::NodeModule: {
-            return globalObject->m_nodeModuleConstructor.getInitializedOnMainThread(globalObject);
+            return globalObject->nodeModuleConstructor();
         }
         // require("process"), require("node:process")
         case SyntheticModuleType::NodeProcess: {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2167,11 +2167,6 @@ void GlobalObject::finishCreation(VM& vm)
             init.set(Bun::createS3ErrorStructure(init.vm, init.owner));
         });
 
-    m_commonJSModuleObjectStructure.initLater(
-        [](const Initializer<Structure>& init) {
-            init.set(Bun::createCommonJSModuleStructure(static_cast<Zig::GlobalObject*>(init.owner)));
-        });
-
     m_JSSocketAddressDTOStructure.initLater(
         [](const Initializer<Structure>& init) {
             init.set(Bun::JSSocketAddressDTO::createStructure(init.vm, init.owner));

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -315,7 +315,9 @@ public:
     Structure* NodeVMGlobalObjectStructure() const { return m_cachedNodeVMGlobalObjectStructure.getInitializedOnMainThread(this); }
     Structure* globalProxyStructure() const { return m_cachedGlobalProxyStructure.getInitializedOnMainThread(this); }
     JSObject* lazyTestModuleObject() const { return m_lazyTestModuleObject.getInitializedOnMainThread(this); }
-    Structure* CommonJSModuleObjectStructure() const { return m_commonJSModuleObjectStructure.getInitializedOnMainThread(this); }
+    Structure* CommonJSModuleObjectStructure() const { return m_commonJSModuleClassStructure.getInitializedOnMainThread(this); }
+    JSObject* nodeModuleConstructor() const { return m_commonJSModuleClassStructure.constructorInitializedOnMainThread(this); }
+    JSObject* commonJSModulePrototype() const { return m_commonJSModuleClassStructure.prototypeInitializedOnMainThread(this); }
     Structure* JSSocketAddressDTOStructure() const { return m_JSSocketAddressDTOStructure.getInitializedOnMainThread(this); }
     Structure* JSReactElementStructure() const { return m_JSReactElementStructure.getInitializedOnMainThread(this); }
     Structure* JSMarkdownListItemMetaStructure() const { return m_JSMarkdownListItemMetaStructure.getInitializedOnMainThread(this); }
@@ -498,7 +500,6 @@ public:
     V(public, LazyPropertyOfGlobalObject<JSCell>, m_moduleRunMainFunction)                                   \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_modulePrototypeUnderscoreCompileFunction)            \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_commonJSRequireESMFromHijackedExtensionFunction)     \
-    V(public, LazyPropertyOfGlobalObject<JSObject>, m_nodeModuleConstructor)                                 \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_nodeModuleSourceMapEntryStructure)                    \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_nodeModuleSourceMapOriginStructure)                   \
                                                                                                              \
@@ -633,7 +634,7 @@ public:
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_testMatcherUtilsObject)                                \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_cachedNodeVMGlobalObjectStructure)                    \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_cachedGlobalProxyStructure)                          \
-    V(private, LazyPropertyOfGlobalObject<Structure>, m_commonJSModuleObjectStructure)                       \
+    V(public, JSC::LazyClassStructure, m_commonJSModuleClassStructure)                                       \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSSocketAddressDTOStructure)                         \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSReactElementStructure)                             \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSMarkdownListItemMetaStructure)                     \

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -7,6 +7,8 @@
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/FunctionPrototype.h>
+#include <JavaScriptCore/LazyClassStructure.h>
+#include <JavaScriptCore/LazyClassStructureInlines.h>
 #include <JavaScriptCore/LazyPropertyInlines.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
 #include <JavaScriptCore/CallData.h>
@@ -699,6 +701,24 @@ static JSValue getGlobalPathsObject(VM& vm, JSObject* moduleObject)
         static_cast<ArrayAllocationProfile*>(nullptr), 0);
 }
 
+JSC_DEFINE_HOST_FUNCTION(jsFunctionSetNodePathForRequire,
+    (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue value = callFrame->argument(0);
+    BunString str;
+    if (value.isUndefinedOrNull()) {
+        str = Bun::toString(""_s);
+    } else {
+        WTF::String wtf = value.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        str = Bun::toString(wtf);
+    }
+    Resolver__setNodePath(globalObject, &str);
+    return JSC::JSValue::encode(JSC::jsUndefined());
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsFunctionSetCJSWrapperItem, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
@@ -770,17 +790,7 @@ JSC_DEFINE_CUSTOM_SETTER(setNodeModuleWrapper,
 static JSValue getModulePrototypeObject(VM& vm, JSObject* moduleObject)
 {
     auto* globalObject = defaultGlobalObject(moduleObject->globalObject());
-    auto prototype = constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
-
-    prototype->putDirectCustomAccessor(
-        vm, WebCore::clientData(vm)->builtinNames().requirePublicName(),
-        JSC::CustomGetterSetter::create(vm, getterRequireFunction,
-            setterRequireFunction),
-        0);
-
-    prototype->putDirect(vm, Identifier::fromString(vm, "_compile"_s), globalObject->modulePrototypeUnderscoreCompileFunction());
-
-    return prototype;
+    return globalObject->commonJSModulePrototype();
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionLoad, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
@@ -1086,11 +1096,11 @@ extern "C" JSC::EncodedJSValue Bun__createNodeModuleSourceMapOriginObject(
 void addNodeModuleConstructorProperties(JSC::VM& vm,
     Zig::GlobalObject* globalObject)
 {
-    globalObject->m_nodeModuleConstructor.initLater(
-        [](const Zig::GlobalObject::Initializer<JSObject>& init) {
-            JSObject* moduleConstructor = JSModuleConstructor::create(
-                init.vm, static_cast<Zig::GlobalObject*>(init.owner));
-            init.set(moduleConstructor);
+    globalObject->m_commonJSModuleClassStructure.initLater(
+        [](LazyClassStructure::Initializer& init) {
+            auto* global = static_cast<Zig::GlobalObject*>(init.global);
+            init.setStructure(Bun::createCommonJSModuleStructure(global));
+            init.setConstructor(JSModuleConstructor::create(init.vm, global));
         });
 
     globalObject->m_nodeModuleSourceMapEntryStructure.initLater(
@@ -1187,7 +1197,7 @@ void generateNativeModule_NodeModule(JSC::JSGlobalObject* lexicalGlobalObject,
     Zig::GlobalObject* globalObject = defaultGlobalObject(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
     auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-    auto* constructor = globalObject->m_nodeModuleConstructor.getInitializedOnMainThread(globalObject);
+    auto* constructor = globalObject->nodeModuleConstructor();
     // Don't bulk-reifyAllStaticProperties here. JSObject::reifyAllStaticProperties
     // walks every PropertyCallbackAttribute back-to-back without an exception
     // check between them, and several of our callbacks (getBuiltinModulesObject,

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -618,10 +618,7 @@ JSC_DEFINE_CUSTOM_SETTER(setterRequireFunction,
         JSC::PropertyName propertyName))
 {
     auto& vm = globalObject->vm();
-    // Per-instance `m.require = fn` (e.g. on `new Module(id)`): shadow the
-    // prototype with an own property instead of overwriting the process-global
-    // overridable require. Evaluated CJS modules already have an own `require`
-    // and never reach this setter.
+    // Per-instance write: shadow on the receiver instead of the process-global hook.
     if (auto* thisModule = dynamicDowncast<JSCommonJSModule>(JSValue::decode(thisValue))) {
         thisModule->putDirect(vm, propertyName, JSValue::decode(value), 0);
         return true;

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -617,10 +617,17 @@ JSC_DEFINE_CUSTOM_SETTER(setterRequireFunction,
         JSC::EncodedJSValue value,
         JSC::PropertyName propertyName))
 {
-    globalObject->putDirect(globalObject->vm(),
-        WebCore::clientData(globalObject->vm())
-            ->builtinNames()
-            .overridableRequirePrivateName(),
+    auto& vm = globalObject->vm();
+    // Per-instance `m.require = fn` (e.g. on `new Module(id)`): shadow the
+    // prototype with an own property instead of overwriting the process-global
+    // overridable require. Evaluated CJS modules already have an own `require`
+    // and never reach this setter.
+    if (auto* thisModule = dynamicDowncast<JSCommonJSModule>(JSValue::decode(thisValue))) {
+        thisModule->putDirect(vm, propertyName, JSValue::decode(value), 0);
+        return true;
+    }
+    globalObject->putDirect(vm,
+        WebCore::clientData(vm)->builtinNames().overridableRequirePrivateName(),
         JSValue::decode(value), 0);
     return true;
 }
@@ -707,14 +714,12 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionSetNodePathForRequire,
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue value = callFrame->argument(0);
-    BunString str;
-    if (value.isUndefinedOrNull()) {
-        str = Bun::toString(""_s);
-    } else {
-        WTF::String wtf = value.toWTFString(globalObject);
+    WTF::String wtf;
+    if (!value.isUndefinedOrNull()) {
+        wtf = value.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
-        str = Bun::toString(wtf);
     }
+    BunString str = wtf.isNull() ? Bun::toString(""_s) : Bun::toString(wtf);
     Resolver__setNodePath(globalObject, &str);
     return JSC::JSValue::encode(JSC::jsUndefined());
 }

--- a/src/jsc/modules/NodeModuleModule.h
+++ b/src/jsc/modules/NodeModuleModule.h
@@ -18,10 +18,12 @@ using namespace JSC;
 
 namespace Bun {
 JSC_DECLARE_HOST_FUNCTION(jsFunctionIsModuleResolveFilenameSlowPathEnabled);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionSetNodePathForRequire);
 JSC::JSValue createStreamIterEnabledFlag(Zig::GlobalObject*);
 void addNodeModuleConstructorProperties(JSC::VM &vm, Zig::GlobalObject *globalObject);
 
 extern "C" JSC::EncodedJSValue Resolver__nodeModulePathsJSValue(BunString specifier, JSC::JSGlobalObject*, bool use_dirname);
+extern "C" void Resolver__setNodePath(JSC::JSGlobalObject*, const BunString* value);
 extern "C" bool ModuleLoader__isBuiltin(const char* data, size_t len);
 
 struct PathResolveModule {

--- a/src/jsc/resolver_jsc.rs
+++ b/src/jsc/resolver_jsc.rs
@@ -29,6 +29,20 @@ extern "C" fn Resolver__propForRequireMainPaths(global: &JSGlobalObject) -> JSVa
     node_module_paths_js_value(in_str, global, false)
 }
 
+/// Called from `Module._initPaths()` to sync the current `process.env.NODE_PATH`
+/// into the dotenv loader's map, which is what the native resolver reads
+/// (`load_node_modules` in `resolver.rs`). Writes to `process.env` from JS do
+/// not otherwise reach that map, so without this a runtime-set `NODE_PATH`
+/// never takes effect.
+#[unsafe(no_mangle)]
+extern "C" fn Resolver__setNodePath(global: &JSGlobalObject, value: &BunString) {
+    crate::mark_binding!();
+    let vm = global.bun_vm().as_mut();
+    let env_map = &mut vm.transpiler.env_mut().map;
+    let value_slice = value.to_utf8();
+    bun_core::handle_oom(env_map.put_alloc_key_and_value(b"NODE_PATH", value_slice.slice()));
+}
+
 // C++ callers pass `in_str` by value without transferring a ref:
 // `bun_core::String` is `Copy` with no `Drop` impl, so receiving it by value
 // never releases the caller's ref.

--- a/src/jsc/resolver_jsc.rs
+++ b/src/jsc/resolver_jsc.rs
@@ -29,8 +29,7 @@ extern "C" fn Resolver__propForRequireMainPaths(global: &JSGlobalObject) -> JSVa
     node_module_paths_js_value(in_str, global, false)
 }
 
-/// `Module._initPaths()`: sync `process.env.NODE_PATH` into the resolver's env
-/// map (JS `process.env` writes don't reach it otherwise).
+/// `Module._initPaths()`: sync `process.env.NODE_PATH` into the resolver's env map.
 #[unsafe(no_mangle)]
 extern "C" fn Resolver__setNodePath(global: &JSGlobalObject, value: &BunString) {
     crate::mark_binding!();

--- a/src/jsc/resolver_jsc.rs
+++ b/src/jsc/resolver_jsc.rs
@@ -29,11 +29,8 @@ extern "C" fn Resolver__propForRequireMainPaths(global: &JSGlobalObject) -> JSVa
     node_module_paths_js_value(in_str, global, false)
 }
 
-/// Called from `Module._initPaths()` to sync the current `process.env.NODE_PATH`
-/// into the dotenv loader's map, which is what the native resolver reads
-/// (`load_node_modules` in `resolver.rs`). Writes to `process.env` from JS do
-/// not otherwise reach that map, so without this a runtime-set `NODE_PATH`
-/// never takes effect.
+/// `Module._initPaths()`: sync `process.env.NODE_PATH` into the resolver's env
+/// map (JS `process.env` writes don't reach it otherwise).
 #[unsafe(no_mangle)]
 extern "C" fn Resolver__setNodePath(global: &JSGlobalObject, value: &BunString) {
     crate::mark_binding!();

--- a/src/jsc/resolver_jsc.rs
+++ b/src/jsc/resolver_jsc.rs
@@ -38,6 +38,8 @@ extern "C" fn Resolver__propForRequireMainPaths(global: &JSGlobalObject) -> JSVa
 extern "C" fn Resolver__setNodePath(global: &JSGlobalObject, value: &BunString) {
     crate::mark_binding!();
     let vm = global.bun_vm().as_mut();
+    // Serialise against a spawning worker's env-map clone (see ProxyEnvStorage).
+    let _guard = vm.proxy_env_storage.lock();
     let env_map = &mut vm.transpiler.env_mut().map;
     let value_slice = value.to_utf8();
     bun_core::handle_oom(env_map.put_alloc_key_and_value(b"NODE_PATH", value_slice.slice()));

--- a/test/js/bun/util/commonjs-module-heap-snapshot-fixture.cjs
+++ b/test/js/bun/util/commonjs-module-heap-snapshot-fixture.cjs
@@ -20,7 +20,7 @@ for (let i = 0; i < nodes.length; i += nodeStride) {
 }
 
 const propertyEdgeType = edgeTypes.indexOf("Property");
-const targetsByName = {};
+const targetsByName = { __proto__: null };
 for (let i = 0; i < edges.length; i += 4) {
   if (edges[i + 2] !== propertyEdgeType) continue;
   if (!moduleIds.has(edges[i])) continue;

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -403,11 +403,45 @@ describe.concurrent("node-module-module", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("assigning require on a new Module() does not hijack the process-global require", async () => {
+    const script = `
+      "use strict";
+      const Module = require("module");
+      const m = new Module("fake");
+      m.require = () => "hijacked";
+      const out = {
+        ownRequire: Object.prototype.hasOwnProperty.call(m, "require"),
+        mRequire: m.require("os"),
+        globalRequire: typeof require("os").platform,
+      };
+      const orig = Module.prototype._compile;
+      Module.prototype._compile = function wrapped() {};
+      out.protoCompileReplaced = Module.prototype._compile !== orig;
+      console.log(JSON.stringify(out));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      ownRequire: true,
+      mRequire: "hijacked",
+      globalRequire: "function",
+      protoCompileReplaced: true,
+    });
+    expect(exitCode).toBe(0);
+  });
+
   // https://github.com/oven-sh/bun/issues/5630
   test("Module._initPaths() picks up NODE_PATH set at runtime", async () => {
     using dir = tempDir("init-paths-runtime", {
       "lib/runtime-mod/index.js": "module.exports = 'from-runtime-node-path';",
       "lib2/runtime-mod2/index.js": "module.exports = 'from-runtime-node-path-2';",
+      "lib2/runtime-mod3/index.js": "module.exports = 3;",
       "package.json": JSON.stringify({ name: "p", type: "commonjs" }),
       "app.cjs": `
         const path = require("path");

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, ospath } from "harness";
+import { bunEnv, bunExe, ospath, tempDir } from "harness";
 import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
 import path from "path";
 
@@ -364,5 +364,94 @@ describe.concurrent("node-module-module", () => {
    ./j.cjs (seen)
    ./k.cjs (seen)`);
     expect(await proc.exited).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/5630
+  test("module.constructor is the Module constructor", async () => {
+    // Spawned so the first access to `module.constructor` happens before
+    // anything touches `require("module")`.
+    const script = `
+      const ctor = module.constructor;
+      const Module = require("module");
+      console.log(JSON.stringify({
+        ctorName: ctor && ctor.name,
+        sameAsModule: ctor === Module,
+        initPathsType: typeof (ctor && ctor._initPaths),
+        protoIsModuleProto: Object.getPrototypeOf(module) === Module.prototype,
+        protoCtor: Module.prototype.constructor === Module,
+        instanceOf: module instanceof Module,
+        newModuleCtor: new Module("x").constructor === Module,
+      }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      ctorName: "Module",
+      sameAsModule: true,
+      initPathsType: "function",
+      protoIsModuleProto: true,
+      protoCtor: true,
+      instanceOf: true,
+      newModuleCtor: true,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/5630
+  test("Module._initPaths() picks up NODE_PATH set at runtime", async () => {
+    using dir = tempDir("init-paths-runtime", {
+      "lib/runtime-mod/index.js": "module.exports = 'from-runtime-node-path';",
+      "lib2/runtime-mod2/index.js": "module.exports = 'from-runtime-node-path-2';",
+      "package.json": JSON.stringify({ name: "p", type: "commonjs" }),
+      "app.cjs": `
+        const path = require("path");
+        const out = {};
+
+        try { require("runtime-mod"); out.before = "resolved"; }
+        catch (e) { out.before = e && e.code; }
+
+        process.env.NODE_PATH = path.join(__dirname, "lib");
+        module.constructor._initPaths();
+
+        out.after = require("runtime-mod");
+        out.globalPathsHasLib = require("module").globalPaths.includes(path.join(__dirname, "lib"));
+
+        // Re-calling _initPaths with a new NODE_PATH replaces the previous one.
+        process.env.NODE_PATH = path.join(__dirname, "lib2");
+        require("module")._initPaths();
+        out.after2 = require("runtime-mod2");
+
+        // And clearing it stops resolution of a not-yet-required module.
+        delete process.env.NODE_PATH;
+        require("module")._initPaths();
+        try { require.resolve("runtime-mod3"); out.cleared = "resolved"; }
+        catch (e) { out.cleared = e && e.code; }
+
+        console.log(JSON.stringify(out));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--no-install", "app.cjs"],
+      env: { ...bunEnv, NODE_PATH: undefined },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      before: "MODULE_NOT_FOUND",
+      after: "from-runtime-node-path",
+      globalPathsHasLib: true,
+      after2: "from-runtime-node-path-2",
+      cleared: "MODULE_NOT_FOUND",
+    });
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes #5630.
Fixes #20336.

## Repro

```js
// n8n / app-module-path pattern
process.env.NODE_PATH = someDir;
module.constructor._initPaths();
require("pkg-from-someDir");
```

Node resolves `pkg-from-someDir`. Bun before this PR:

```
TypeError: module.constructor._initPaths is not a function. (In 'module.constructor._initPaths()', 'module.constructor._initPaths' is undefined)
```

And even with `require("module")._initPaths()` instead, `require("pkg-from-someDir")` still failed with `MODULE_NOT_FOUND`.

## Cause

- `m_nodeModuleConstructor` (the `require("module")` value) and `m_commonJSModuleObjectStructure` (the structure backing `module` instances) were two independent lazy properties. The CJS prototype had no `constructor` link, so `module.constructor` fell through to `Object`; `Module.prototype` was a fresh unrelated object built in `getModulePrototypeObject`, so `Object.getPrototypeOf(module) !== Module.prototype` and `module instanceof Module` was `false`.
- `_initPaths()` only wrote `Module.globalPaths`; the native resolver reads `NODE_PATH` from the dotenv loader's startup snapshot (`load_node_modules` in `resolver.rs`), which JS writes to `process.env` never reach.

## Fix

- Replace the two lazy properties with a single `LazyClassStructure` (`m_commonJSModuleClassStructure`). `init.setConstructor(JSModuleConstructor::create(...))` installs `prototype.constructor = Module`, so `module.constructor === Module`, `Module.prototype === Object.getPrototypeOf(module)` and `module instanceof Module` all hold. `getModulePrototypeObject` now returns the real prototype; the `Module.prototype.require` custom accessor moves onto it so `Module.prototype.require = ...` (Next.js) keeps working, and `getterUnderscoreCompile` returns the `_compile` function when the receiver is the prototype itself.
- `_initPaths()` now also calls a new `Resolver__setNodePath` FFI entry that writes the current `process.env.NODE_PATH` into `vm.transpiler.env_mut().map` (same store `load_node_modules` reads), so a runtime-set `NODE_PATH` takes effect for subsequent `require()` calls.

## Verification

New tests in `test/js/node/module/node-module-module.test.js` (fail on main, pass here):

- `module.constructor is the Module constructor`: spawns a fresh process that reads `module.constructor` before touching `require("module")`, then checks `=== Module`, `instanceof`, `Module.prototype.constructor`, `Object.getPrototypeOf(module)`, and `new Module().constructor`.
- `Module._initPaths() picks up NODE_PATH set at runtime`: sets `NODE_PATH` at runtime, calls `module.constructor._initPaths()`, and requires a package that only exists there; also checks that a second `_initPaths()` with a different path replaces the previous one and that clearing it stops resolution.

```
bun bd test test/js/node/module/node-module-module.test.js
# 34 pass
```

The existing `Overwriting Module.prototype.require` and `Module.prototype._compile` tests, `test-module-globalpaths-nodepath.js`, `test-module-prototype-mutation.js`, and `test/js/bun/resolve/resolve.test.ts -t NODE_PATH` all still pass.

Overlaps with #33804 (which also unifies `Module.prototype` but via a different mechanism and additionally moves instance properties to own slots) and #35124 (legacy global folders) at `getModulePrototypeObject` / `_initPaths`; whichever lands second will need a small merge.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->
