### PR TITLE
encoding: materialize 8-bit strings from UTF-8 decode when every code point fits in Latin-1

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -2476,21 +2476,95 @@ impl From<ToUTF16Error> for crate::CrateError {
     }
 }
 
+/// Result of [`to_latin1_or_utf16_alloc`]: the narrowest representation the
+/// decoded code points fit in.
+pub enum Utf8Decoded {
+    /// Every byte was ASCII; the caller already holds the 8-bit form.
+    Ascii,
+    /// Every decoded code point is `<= U+00FF`; buffer is one Latin-1 byte per
+    /// code point.
+    Latin1(Vec<u8>),
+    /// At least one code point `> U+00FF` (or a U+FFFD replacement was
+    /// emitted); buffer is UTF-16LE.
+    Utf16(Vec<u16>),
+}
+
+/// Decode UTF-8 into the narrowest JSC string representation: [`Utf8Decoded::Ascii`]
+/// when every byte is ASCII, [`Utf8Decoded::Latin1`] when every decoded code
+/// point is `<= U+00FF`, else [`Utf8Decoded::Utf16`]. Error semantics match
+/// [`to_utf16_alloc`]: with `fail_if_invalid` set invalid UTF-8 yields
+/// `Err(InvalidByteSequence)`; otherwise invalid sequences are replaced with
+/// U+FFFD and the result is always `Utf16` (U+FFFD is not Latin-1).
+///
+/// Implementation: a single Highway SIMD pass over the input bytes
+/// ([`bun_highway::classify_utf8_width`]) decides the output shape up front.
+/// `HasWide` runs the existing simdutf UTF-16 decode unchanged.
+/// `Latin1Candidate` runs the same decode and, on success, narrows the code
+/// units to one byte each via `highway_copy_u16_to_u8` (valid UTF-8 with every
+/// byte `< 0xC4` is exactly the set of code points `<= U+00FF`, so no
+/// post-decode scan is needed); a decode error means invalid UTF-8, and the
+/// replacement path yields UTF-16. simdutf's own `convert_utf8_to_latin1*` is
+/// avoided because its icelake kernel passes `__m512i` by value to a helper
+/// that does not inline in the debug-ASAN WebKit build and faults on stack
+/// alignment.
+pub fn to_latin1_or_utf16_alloc(
+    bytes: &[u8],
+    fail_if_invalid: bool,
+) -> Result<Utf8Decoded, ToUTF16Error> {
+    use highway::Utf8Width;
+    let (first, narrow) = match highway::classify_utf8_width(bytes) {
+        Utf8Width::Ascii => return Ok(Utf8Decoded::Ascii),
+        Utf8Width::Latin1Candidate(i) => (i, true),
+        Utf8Width::HasWide(i) => (i, false),
+    };
+
+    let (utf16, was_valid) = to_utf16_alloc_non_ascii(bytes, first, fail_if_invalid, false)?;
+    if narrow && was_valid {
+        let mut out: Vec<u8> = Vec::new();
+        out.try_reserve_exact(utf16.len())
+            .map_err(|_| ToUTF16Error::OutOfMemory)?;
+        // SAFETY: `out` has `>= utf16.len()` bytes of capacity (just reserved);
+        // the kernel writes exactly `utf16.len()` bytes and never reads `out`.
+        unsafe {
+            highway::copy_u16_to_u8_raw(utf16.as_ptr(), utf16.len(), out.as_mut_ptr());
+            out.set_len(utf16.len());
+        }
+        return Ok(Utf8Decoded::Latin1(out));
+    }
+    Ok(Utf8Decoded::Utf16(utf16))
+}
+
 /// `strings.toUTF16Alloc` — convert UTF-8 → UTF-16LE **iff** `bytes` contains
 /// any non-ASCII byte; pure-ASCII inputs return `Ok(None)` (caller keeps the
 /// 8-bit form). When `fail_if_invalid` is set, invalid UTF-8 yields
 /// `Err(InvalidByteSequence)`; otherwise invalid sequences are replaced with
 /// U+FFFD. When `sentinel` is set the result
 /// includes a trailing 0 u16.
+///
+/// Callers that build a JS string from the result should prefer
+/// [`to_latin1_or_utf16_alloc`], which adds a Latin-1 tier so JSC's 8-bit fast
+/// paths stay available for accented-Latin text.
 pub fn to_utf16_alloc(
     bytes: &[u8],
     fail_if_invalid: bool,
     sentinel: bool,
 ) -> Result<Option<Vec<u16>>, ToUTF16Error> {
-    let Some(_first) = first_non_ascii(bytes) else {
+    let Some(first) = first_non_ascii(bytes) else {
         return Ok(None);
     };
+    to_utf16_alloc_non_ascii(bytes, first as usize, fail_if_invalid, sentinel).map(|(v, _)| Some(v))
+}
 
+/// [`to_utf16_alloc`] for input already known to contain a non-ASCII byte at
+/// `first`. Also reports whether simdutf accepted the input as valid UTF-8
+/// (callers use this to decide whether a Latin-1 narrowing is sound without
+/// re-scanning the output).
+fn to_utf16_alloc_non_ascii(
+    bytes: &[u8],
+    first: usize,
+    fail_if_invalid: bool,
+    sentinel: bool,
+) -> Result<(Vec<u16>, bool), ToUTF16Error> {
     let out_length = simdutf::length::utf16::from::utf8(bytes);
     let cap = out_length + if sentinel { 1 } else { 0 };
     // Hot path: allocate uninitialised and let simdutf write directly into the
@@ -2519,7 +2593,7 @@ pub fn to_utf16_alloc(
         if sentinel {
             out.push(0);
         }
-        return Ok(Some(out));
+        return Ok((out, true));
     }
     if fail_if_invalid {
         return Err(ToUTF16Error::InvalidByteSequence);
@@ -2529,23 +2603,25 @@ pub fn to_utf16_alloc(
     out.try_reserve(bytes.len() + if sentinel { 1 } else { 0 })
         .map_err(|_| ToUTF16Error::OutOfMemory)?;
     let mut remaining = bytes;
-    while let Some(i) = first_non_ascii(remaining) {
-        let i = i as usize;
+    let mut i = Some(first as u32);
+    while let Some(j) = i {
+        let j = j as usize;
         // Copy ASCII prefix as-is (one u16 per byte).
-        out.extend(remaining[..i].iter().map(|&b| u16::from(b)));
-        remaining = &remaining[i..];
+        out.extend(remaining[..j].iter().map(|&b| u16::from(b)));
+        remaining = &remaining[j..];
         // Decode one codepoint via `convert_utf8_bytes_into_utf16` so the
         // number/position of U+FFFD emissions stays consistent: advance by
         // `replacement.len.max(1)`, not 1.
         let replacement = unicode_draft::convert_utf8_bytes_into_utf16(remaining);
         remaining = &remaining[(replacement.len as usize).max(1)..];
         push_codepoint_utf16(&mut out, replacement.code_point);
+        i = first_non_ascii(remaining);
     }
     out.extend(remaining.iter().map(|&b| u16::from(b)));
     if sentinel {
         out.push(0);
     }
-    Ok(Some(out))
+    Ok((out, false))
 }
 
 /// WTF-8 → UTF-16LE iff `bytes` contains any non-ASCII byte; pure-ASCII inputs return `None`.
@@ -2641,6 +2717,60 @@ mod tests {
         assert_eq!(super::first_non_ascii(b"ab\xC3"), Some(2));
         assert!(super::eql_case_insensitive_ascii(b"A", b"a", true));
         assert!(!super::eql_case_insensitive_ascii(b"Ab", b"a", true));
+    }
+
+    #[test]
+    fn to_latin1_or_utf16_alloc_tiers() {
+        use super::{Utf8Decoded, to_latin1_or_utf16_alloc};
+        assert!(matches!(
+            to_latin1_or_utf16_alloc(b"hello", false).unwrap(),
+            Utf8Decoded::Ascii
+        ));
+        // é = C3 A9 → U+00E9
+        match to_latin1_or_utf16_alloc(b"caf\xC3\xA9", false).unwrap() {
+            Utf8Decoded::Latin1(v) => assert_eq!(v, b"caf\xE9"),
+            _ => panic!("expected Latin1"),
+        }
+        // U+00FF = C3 BF (boundary)
+        match to_latin1_or_utf16_alloc(b"x\xC3\xBFx", false).unwrap() {
+            Utf8Decoded::Latin1(v) => assert_eq!(v, b"x\xFFx"),
+            _ => panic!("expected Latin1"),
+        }
+        // U+0080 = C2 80 (low boundary)
+        match to_latin1_or_utf16_alloc(b"\xC2\x80", false).unwrap() {
+            Utf8Decoded::Latin1(v) => assert_eq!(v, b"\x80"),
+            _ => panic!("expected Latin1"),
+        }
+        // U+0100 = C4 80 (just past Latin-1)
+        match to_latin1_or_utf16_alloc(b"x\xC4\x80x", false).unwrap() {
+            Utf8Decoded::Utf16(v) => assert_eq!(v, [b'x' as u16, 0x0100, b'x' as u16]),
+            _ => panic!("expected Utf16"),
+        }
+        // Overlong C0 80 passes the < 0xC4 gate but is invalid; must fall through.
+        match to_latin1_or_utf16_alloc(b"a\xC0\x80b", false).unwrap() {
+            Utf8Decoded::Utf16(v) => assert_eq!(v, [b'a' as u16, 0xFFFD, 0xFFFD, b'b' as u16]),
+            _ => panic!("expected Utf16"),
+        }
+        // Stray continuation byte.
+        match to_latin1_or_utf16_alloc(b"a\xA9b", false).unwrap() {
+            Utf8Decoded::Utf16(v) => assert_eq!(v, [b'a' as u16, 0xFFFD, b'b' as u16]),
+            _ => panic!("expected Utf16"),
+        }
+        // Truncated C3.
+        match to_latin1_or_utf16_alloc(b"a\xC3", false).unwrap() {
+            Utf8Decoded::Utf16(v) => assert_eq!(v, [b'a' as u16, 0xFFFD]),
+            _ => panic!("expected Utf16"),
+        }
+        // C3 followed by non-continuation.
+        match to_latin1_or_utf16_alloc(b"a\xC3\x41b", false).unwrap() {
+            Utf8Decoded::Utf16(v) => assert_eq!(v, [b'a' as u16, 0xFFFD, b'A' as u16, b'b' as u16]),
+            _ => panic!("expected Utf16"),
+        }
+        // fail_if_invalid propagates through the Latin-1 candidate fall-through.
+        assert!(matches!(
+            to_latin1_or_utf16_alloc(b"a\xC0\x80b", true),
+            Err(super::ToUTF16Error::InvalidByteSequence)
+        ));
     }
 
     #[test]

--- a/src/highway/lib.rs
+++ b/src/highway/lib.rs
@@ -24,6 +24,8 @@ unsafe extern "C" {
 
     fn highway_index_of_newline_or_non_ascii(haystack: *const u8, haystack_len: usize) -> usize;
 
+    fn highway_classify_utf8_width(bytes: *const u8, len: usize) -> usize;
+
     fn highway_index_of_newline_or_non_ascii_or_hash_or_at(
         haystack: *const u8,
         haystack_len: usize,
@@ -327,6 +329,50 @@ pub fn index_of_any_char(haystack: &[u8], chars: &[u8]) -> Option<usize> {
     }
 
     Some(result)
+}
+
+/// One-pass classifier for `bun_core::strings::to_latin1_or_utf16_alloc`.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum Utf8Width {
+    /// Every byte `< 0x80`.
+    Ascii,
+    /// Some byte `>= 0x80` but all `< 0xC4`: when the input is well-formed
+    /// UTF-8 every code point is `<= U+00FF`. Invalid sequences (overlongs,
+    /// strays, truncated tails) can still land here, so callers must validate.
+    /// Carries the index of the first byte `>= 0x80`.
+    Latin1Candidate(usize),
+    /// Some byte `>= 0xC4`. Carries the index of the first byte `>= 0x80`.
+    HasWide(usize),
+}
+
+/// One-pass classifier for [`Utf8Width`]. SIMD-wide; the ASCII prefix is
+/// scanned at one compare per block, then the tail at one compare per block
+/// with an early exit on the first byte `>= 0xC4`.
+#[inline(always)]
+pub fn classify_utf8_width(bytes: &[u8]) -> Utf8Width {
+    if bytes.is_empty() {
+        return Utf8Width::Ascii;
+    }
+    // SAFETY: bytes.ptr/len describe a valid readable range.
+    let packed = unsafe { highway_classify_utf8_width(bytes.as_ptr(), bytes.len()) };
+    let first = packed >> 2;
+    match packed & 3 {
+        0 => Utf8Width::Ascii,
+        1 => Utf8Width::Latin1Candidate(first),
+        _ => Utf8Width::HasWide(first),
+    }
+}
+
+/// Raw-pointer variant of [`copy_u16_to_u8`] for writing into uninitialised
+/// storage.
+///
+/// # Safety
+/// `input` must be valid for `count` reads and `output` for `count` writes,
+/// non-overlapping.
+#[inline(always)]
+pub unsafe fn copy_u16_to_u8_raw(input: *const u16, count: usize, output: *mut u8) {
+    // SAFETY: caller contract.
+    unsafe { highway_copy_u16_to_u8(input, count, output) }
 }
 
 // `&[u16]` requires

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -438,6 +438,16 @@ extern "C" BunString BunString__fromUTF8(const char* bytes, size_t length)
             return { .tag = BunStringTag::Dead };
         }
         RELEASE_ASSERT(simdutf::convert_utf8_to_utf16(bytes, length, ptr.data()) == u16Length);
+        // Narrow to an 8-bit StringImpl when every decoded code unit is
+        // <= U+00FF so downstream code keeps JSC's 8-bit fast paths.
+        if (WTF::charactersAreAllLatin1(std::span<const char16_t>(ptr))) {
+            std::span<Latin1Character> narrow;
+            auto latin1Impl = WTF::StringImpl::tryCreateUninitialized(u16Length, narrow);
+            if (latin1Impl) [[likely]] {
+                WTF::StringImpl::copyCharacters(narrow, ptr);
+                return { BunStringTag::WTFStringImpl, { .wtf = latin1Impl.leakRef() } };
+            }
+        }
         return { BunStringTag::WTFStringImpl, { .wtf = impl.leakRef() } };
     }
 

--- a/src/jsc/bindings/highway_strings.cpp
+++ b/src/jsc/bindings/highway_strings.cpp
@@ -734,6 +734,63 @@ size_t IndexOfNewlineOrNonASCIIOrHashOrAtImpl(const uint8_t* HWY_RESTRICT start_
     return search_len;
 }
 
+// One-pass classifier for UTF-8 decode. The low two bits of the return value
+// are the class: 0 = every byte < 0x80 (ASCII), 1 = some byte >= 0x80 but all
+// < 0xC4 (every well-formed code point fits in Latin-1), 2 = some byte >= 0xC4.
+// The remaining bits carry the index of the first byte >= 0x80 (or search_len
+// when the class is 0). Packed into a single scalar return so the FFI boundary
+// keeps everything in registers. Phase 1 scans ASCII-only blocks at one
+// compare per block; phase 2 continues from the first non-ASCII block at one
+// compare per block and early-exits on the first byte >= 0xC4.
+size_t ClassifyUTF8WidthImpl(const uint8_t* HWY_RESTRICT start_ptr, size_t search_len)
+{
+    D8 d;
+    const size_t N = hn::Lanes(d);
+
+    const auto vec_max_ascii = hn::Set(d, uint8_t { 0x7F });
+    const auto vec_max_latin1_lead = hn::Set(d, uint8_t { 0xC3 });
+
+    const size_t simd_text_len = search_len - (search_len % N);
+    size_t i = 0;
+
+    for (; i < simd_text_len; i += N) {
+        const auto vec = hn::LoadU(d, start_ptr + i);
+        const auto mask_non_ascii = hn::Gt(vec, vec_max_ascii);
+        if (hn::AllFalse(d, mask_non_ascii)) {
+            continue;
+        }
+        const size_t packed_first = (i + static_cast<size_t>(hn::FindFirstTrue(d, mask_non_ascii))) << 2;
+        for (; i < simd_text_len; i += N) {
+            const auto v = hn::LoadU(d, start_ptr + i);
+            if (!hn::AllFalse(d, hn::Gt(v, vec_max_latin1_lead))) {
+                return packed_first | 2;
+            }
+        }
+        for (; i < search_len; ++i) {
+            if (start_ptr[i] >= 0xC4) {
+                return packed_first | 2;
+            }
+        }
+        return packed_first | 1;
+    }
+
+    for (; i < search_len; ++i) {
+        const uint8_t c = start_ptr[i];
+        if (c < 0x80) {
+            continue;
+        }
+        const size_t packed_first = i << 2;
+        for (; i < search_len; ++i) {
+            if (start_ptr[i] >= 0xC4) {
+                return packed_first | 2;
+            }
+        }
+        return packed_first | 1;
+    }
+
+    return search_len << 2;
+}
+
 size_t IndexOfNewlineOrNonASCIIImpl(const uint8_t* HWY_RESTRICT start_ptr, size_t search_len)
 {
     ASSERT(search_len > 0);
@@ -2158,6 +2215,7 @@ HWY_EXPORT(IndexOfInterestingCharacterInMultilineCommentImpl);
 HWY_EXPORT(IndexOfInterestingCharacterInStringLiteralImpl);
 HWY_EXPORT(IndexOfNeedsEscapeForJavaScriptStringImplBacktick);
 HWY_EXPORT(IndexOfNeedsEscapeForJavaScriptStringImplQuote);
+HWY_EXPORT(ClassifyUTF8WidthImpl);
 HWY_EXPORT(IndexOfNewlineOrNonASCIIImpl);
 HWY_EXPORT(IndexOfNewlineOrNonASCIIOrHashOrAtImpl);
 HWY_EXPORT(IndexOfSpaceOrNewlineOrNonASCIIImpl);
@@ -2308,6 +2366,11 @@ size_t highway_index_of_interesting_character_in_multiline_comment(const uint8_t
 size_t highway_index_of_newline_or_non_ascii(const uint8_t* HWY_RESTRICT haystack, size_t haystack_len)
 {
     return HWY_DYNAMIC_DISPATCH(IndexOfNewlineOrNonASCIIImpl)(haystack, haystack_len);
+}
+
+size_t highway_classify_utf8_width(const uint8_t* HWY_RESTRICT bytes, size_t len)
+{
+    return HWY_DYNAMIC_DISPATCH(ClassifyUTF8WidthImpl)(bytes, len);
 }
 
 size_t highway_index_of_newline_or_non_ascii_or_hash_or_at(const uint8_t* HWY_RESTRICT haystack, size_t haystack_len)

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6817,9 +6817,8 @@ impl Internal {
             .map_err(|_| global_this.throw_out_of_memory())?
         {
             strings::Utf8Decoded::Latin1(latin1) => {
-                let return_value =
-                    BunString::create_external_globally_allocated_latin1(latin1)
-                        .transfer_to_js(global_this)?;
+                let return_value = BunString::create_external_globally_allocated_latin1(latin1)
+                    .transfer_to_js(global_this)?;
                 return_value.ensure_still_alive();
                 self.bytes = Vec::new();
                 return Ok(return_value);

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2635,8 +2635,7 @@ impl BlobExt for Blob {
             .or_else(|| self.store().and_then(|s| s.is_all_ascii));
 
         if could_be_all_ascii.is_none() || !could_be_all_ascii.unwrap() {
-            // if to_utf16_alloc returns None, it means there are no non-ASCII characters
-            let converted = match strings::to_utf16_alloc(buf, false, false) {
+            let converted = match strings::to_latin1_or_utf16_alloc(buf, false) {
                 Ok(converted) => converted,
                 Err(_) => {
                     if LIFETIME == Lifetime::Temporary {
@@ -2646,32 +2645,49 @@ impl BlobExt for Blob {
                     return Err(global.throw_out_of_memory());
                 }
             };
-            if let Some(external) = converted {
-                if LIFETIME != Lifetime::Temporary {
-                    self.set_is_ascii_flag(false);
+            match converted {
+                strings::Utf8Decoded::Ascii => {
+                    if LIFETIME != Lifetime::Temporary {
+                        self.set_is_ascii_flag(true);
+                    }
                 }
-                if LIFETIME == Lifetime::Transfer {
-                    self.detach();
+                strings::Utf8Decoded::Latin1(latin1) => {
+                    if LIFETIME != Lifetime::Temporary {
+                        self.set_is_ascii_flag(false);
+                    }
+                    if LIFETIME == Lifetime::Transfer {
+                        self.detach();
+                    }
+                    if LIFETIME == Lifetime::Temporary {
+                        // SAFETY: `Temporary` ⇒ caller passed a leaked `Box<[u8]>`; reclaim it.
+                        unsafe { drop(bun_core::heap::take(raw_bytes)) };
+                    }
+                    return BunString::create_external_globally_allocated_latin1(latin1)
+                        .transfer_to_js(global);
                 }
-                if LIFETIME == Lifetime::Temporary {
-                    // SAFETY: `Temporary` ⇒ caller passed a leaked `Box<[u8]>`; reclaim it.
-                    unsafe { drop(bun_core::heap::take(raw_bytes)) };
+                strings::Utf8Decoded::Utf16(external) => {
+                    if LIFETIME != Lifetime::Temporary {
+                        self.set_is_ascii_flag(false);
+                    }
+                    if LIFETIME == Lifetime::Transfer {
+                        self.detach();
+                    }
+                    if LIFETIME == Lifetime::Temporary {
+                        // SAFETY: `Temporary` ⇒ caller passed a leaked `Box<[u8]>`; reclaim it.
+                        unsafe { drop(bun_core::heap::take(raw_bytes)) };
+                    }
+                    // Ownership of the UTF-16 buffer transfers to JSC's external-string
+                    // finalizer (which calls back into the default allocator's `free`).
+                    // `into_raw` is the explicit ownership-transfer-to-FFI API; the
+                    // matching free lives on the C++ side.
+                    let len = external.len();
+                    let ptr = bun_core::heap::into_raw(external.into_boxed_slice())
+                        .cast::<u16>()
+                        .cast_const();
+                    // SAFETY: `ptr` came from `heap::into_raw` on a global-allocator
+                    // `Box<[u16]>`; ownership transfers to JSC's external-string finalizer.
+                    return Ok(unsafe { zig_string_to_external_u16(ptr, len, global) });
                 }
-                // Ownership of the UTF-16 buffer transfers to JSC's external-string
-                // finalizer (which calls back into the default allocator's `free`).
-                // `into_raw` is the explicit ownership-transfer-to-FFI API; the
-                // matching free lives on the C++ side.
-                let len = external.len();
-                let ptr = bun_core::heap::into_raw(external.into_boxed_slice())
-                    .cast::<u16>()
-                    .cast_const();
-                // SAFETY: `ptr` came from `heap::into_raw` on a global-allocator
-                // `Box<[u16]>`; ownership transfers to JSC's external-string finalizer.
-                return Ok(unsafe { zig_string_to_external_u16(ptr, len, global) });
-            }
-
-            if LIFETIME != Lifetime::Temporary {
-                self.set_is_ascii_flag(true);
             }
         }
 
@@ -2882,19 +2898,30 @@ impl BlobExt for Blob {
         let _free = (LIFETIME == Lifetime::Temporary).then(|| TemporaryBytes(raw_bytes));
 
         if could_be_all_ascii.is_none() || !could_be_all_ascii.unwrap() {
-            if let Some(external) = strings::to_utf16_alloc(buf, false, false)
+            match strings::to_latin1_or_utf16_alloc(buf, false)
                 .map_err(|_| global.throw_out_of_memory())?
             {
-                if LIFETIME != Lifetime::Temporary {
-                    self.set_is_ascii_flag(false);
+                strings::Utf8Decoded::Ascii => {
+                    if LIFETIME != Lifetime::Temporary {
+                        self.set_is_ascii_flag(true);
+                    }
                 }
-                let result = ZigString::init_utf16(&external).to_json_object(global);
-                drop(external);
-                return Ok(result);
-            }
-
-            if LIFETIME != Lifetime::Temporary {
-                self.set_is_ascii_flag(true);
+                strings::Utf8Decoded::Latin1(latin1) => {
+                    if LIFETIME != Lifetime::Temporary {
+                        self.set_is_ascii_flag(false);
+                    }
+                    let result = ZigString::init(&latin1).to_json_object(global);
+                    drop(latin1);
+                    return Ok(result);
+                }
+                strings::Utf8Decoded::Utf16(external) => {
+                    if LIFETIME != Lifetime::Temporary {
+                        self.set_is_ascii_flag(false);
+                    }
+                    let result = ZigString::init_utf16(&external).to_json_object(global);
+                    drop(external);
+                    return Ok(result);
+                }
             }
         }
 
@@ -6786,22 +6813,34 @@ impl Internal {
 
     pub(crate) fn to_string_owned(&mut self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         let bytes_without_bom = strings::without_utf8_bom(&self.bytes);
-        if let Some(out) = strings::to_utf16_alloc(bytes_without_bom, false, false)
+        match strings::to_latin1_or_utf16_alloc(bytes_without_bom, false)
             .map_err(|_| global_this.throw_out_of_memory())?
         {
-            let out_len = out.len();
-            // Ownership transfers to JSC's external-string finalizer.
-            let out_ptr = bun_core::heap::into_raw(out.into_boxed_slice())
-                .cast::<u16>()
-                .cast_const();
-            // SAFETY: `out_ptr` came from `heap::into_raw` on a global-allocator
-            // `Box<[u16]>`; ownership transfers to JSC's external-string finalizer.
-            let return_value =
-                unsafe { jsc::zig_string::to_external_u16(out_ptr, out_len, global_this) };
-            return_value.ensure_still_alive();
-            self.bytes = Vec::new();
-            return Ok(return_value);
-        } else if bytes_without_bom.len() != self.bytes.len() {
+            strings::Utf8Decoded::Latin1(latin1) => {
+                let return_value =
+                    BunString::create_external_globally_allocated_latin1(latin1)
+                        .transfer_to_js(global_this)?;
+                return_value.ensure_still_alive();
+                self.bytes = Vec::new();
+                return Ok(return_value);
+            }
+            strings::Utf8Decoded::Utf16(out) => {
+                let out_len = out.len();
+                // Ownership transfers to JSC's external-string finalizer.
+                let out_ptr = bun_core::heap::into_raw(out.into_boxed_slice())
+                    .cast::<u16>()
+                    .cast_const();
+                // SAFETY: `out_ptr` came from `heap::into_raw` on a global-allocator
+                // `Box<[u16]>`; ownership transfers to JSC's external-string finalizer.
+                let return_value =
+                    unsafe { jsc::zig_string::to_external_u16(out_ptr, out_len, global_this) };
+                return_value.ensure_still_alive();
+                self.bytes = Vec::new();
+                return Ok(return_value);
+            }
+            strings::Utf8Decoded::Ascii => {}
+        }
+        if bytes_without_bom.len() != self.bytes.len() {
             // If there was a UTF8 BOM, we clone it.
             // +1 WTF ref; `OwnedString` releases it on scope exit.
             let out = OwnedString::new(BunString::clone_latin1(&self.bytes[3..]));

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -22,6 +22,19 @@ fn create_external_globally_allocated_utf16(bytes: Vec<u16>) -> BunString {
     BunString::create_external_globally_allocated_utf16(bytes)
 }
 
+/// Build a Latin-1 `BunString` from an owned buffer, routing small outputs
+/// through WTF's string allocator and large ones through an external
+/// `StringImpl` (same size policy as [`encode_base64_to_bun_string`]).
+#[inline]
+fn latin1_vec_to_bun_string(bytes: Vec<u8>) -> BunString {
+    const EXTERNAL_MIN_LEN: usize = 32 * 1024;
+    if bytes.len() < EXTERNAL_MIN_LEN {
+        BunString::clone_latin1(&bytes)
+    } else {
+        create_external_globally_allocated_latin1(bytes)
+    }
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Stable Rust does not allow enum-typed const generics without
 // `#![feature(adt_const_params)]`, so we use `const ENCODING: u8` and reconstitute the enum
@@ -274,21 +287,18 @@ pub(crate) fn to_bun_string_from_owned_slice(input: Vec<u8>, encoding: Encoding)
         }
         Encoding::Latin1 => create_external_globally_allocated_latin1(input),
         Encoding::Buffer | Encoding::Utf8 => {
-            let converted = match strings::to_utf16_alloc(&input, false, false) {
-                Ok(v) => v,
-                Err(_) => {
-                    // input dropped
-                    return BunString::dead();
+            match strings::to_latin1_or_utf16_alloc(&input, false) {
+                Ok(strings::Utf8Decoded::Ascii) => {
+                    create_external_globally_allocated_latin1(input)
                 }
-            };
-
-            if let Some(utf16) = converted {
-                // input dropped at end of scope
-                return create_external_globally_allocated_utf16(utf16);
+                Ok(strings::Utf8Decoded::Latin1(latin1)) => {
+                    create_external_globally_allocated_latin1(latin1)
+                }
+                Ok(strings::Utf8Decoded::Utf16(utf16)) => {
+                    create_external_globally_allocated_utf16(utf16)
+                }
+                Err(_) => BunString::dead(),
             }
-
-            // If we get here, it means we can safely assume the string is 100% ASCII characters
-            create_external_globally_allocated_latin1(input)
         }
         Encoding::Ucs2 | Encoding::Utf16le => {
             // Avoid incomplete characters - if input length is 0 or odd, handle gracefully
@@ -378,17 +388,14 @@ fn to_bun_string_comptime<const ENCODING: u8>(input: &[u8]) -> BunString {
             str
         }
         Encoding::Buffer | Encoding::Utf8 => {
-            let converted = match strings::to_utf16_alloc(input, false, false) {
-                Ok(v) => v,
-                Err(_) => return BunString::dead(),
-            };
-            if let Some(utf16) = converted {
-                return create_external_globally_allocated_utf16(utf16);
+            match strings::to_latin1_or_utf16_alloc(input, false) {
+                Ok(strings::Utf8Decoded::Ascii) => BunString::clone_latin1(input),
+                Ok(strings::Utf8Decoded::Latin1(latin1)) => latin1_vec_to_bun_string(latin1),
+                Ok(strings::Utf8Decoded::Utf16(utf16)) => {
+                    create_external_globally_allocated_utf16(utf16)
+                }
+                Err(_) => BunString::dead(),
             }
-
-            // If we get here, it means we can safely assume the string is 100% ASCII characters
-            // For this, we rely on WebKit to manage the memory.
-            BunString::clone_latin1(input)
         }
         Encoding::Ucs2 | Encoding::Utf16le => {
             // Avoid incomplete characters

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -288,9 +288,7 @@ pub(crate) fn to_bun_string_from_owned_slice(input: Vec<u8>, encoding: Encoding)
         Encoding::Latin1 => create_external_globally_allocated_latin1(input),
         Encoding::Buffer | Encoding::Utf8 => {
             match strings::to_latin1_or_utf16_alloc(&input, false) {
-                Ok(strings::Utf8Decoded::Ascii) => {
-                    create_external_globally_allocated_latin1(input)
-                }
+                Ok(strings::Utf8Decoded::Ascii) => create_external_globally_allocated_latin1(input),
                 Ok(strings::Utf8Decoded::Latin1(latin1)) => {
                     create_external_globally_allocated_latin1(latin1)
                 }

--- a/test/js/web/encoding/utf8-decode-string-width.test.ts
+++ b/test/js/web/encoding/utf8-decode-string-width.test.ts
@@ -3,7 +3,7 @@
 // ASCII. Forcing UTF-16 for accented-Latin text doubles the string's footprint
 // and loses JSC's 8-bit fast paths (compare/hash/indexOf, YARR, JSON
 // stringifier, re-encode on write).
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import "harness";
 
 // "café résumé naïve" — é (U+00E9) and ï (U+00EF) are both <= U+00FF.

--- a/test/js/web/encoding/utf8-decode-string-width.test.ts
+++ b/test/js/web/encoding/utf8-decode-string-width.test.ts
@@ -1,0 +1,128 @@
+// UTF-8 decode should materialize an 8-bit JSC string whenever every decoded
+// code point fits in Latin-1 (<= U+00FF), not only when the input is pure
+// ASCII. Forcing UTF-16 for accented-Latin text doubles the string's footprint
+// and loses JSC's 8-bit fast paths (compare/hash/indexOf, YARR, JSON
+// stringifier, re-encode on write).
+import { test, expect, describe } from "bun:test";
+import "harness";
+
+// "café résumé naïve" — é (U+00E9) and ï (U+00EF) are both <= U+00FF.
+const latin1Text = "caf\u00e9 r\u00e9sum\u00e9 na\u00efve";
+const latin1Utf8 = new TextEncoder().encode(latin1Text);
+
+// U+00FF is the top of the Latin-1 range; its UTF-8 encoding is C3 BF, the
+// highest lead byte that still passes the candidate gate.
+const boundaryText = "x\u00ffx";
+const boundaryUtf8 = new TextEncoder().encode(boundaryText);
+
+// U+0100 (Ā) is C4 80 — one past the Latin-1 range.
+const aboveUtf8 = new TextEncoder().encode("x\u0100x");
+
+// U+2014 (EM DASH) is E2 80 94 — well above Latin-1; typical of real prose.
+const emDashUtf8 = new TextEncoder().encode("a\u2014b");
+
+describe("UTF-8 decode picks the narrowest string width", () => {
+  describe.each([
+    ["Buffer#toString('utf8')", (b: Uint8Array) => Buffer.from(b).toString("utf8")],
+    ["Buffer#utf8Slice()", (b: Uint8Array) => (Buffer.from(b) as any).utf8Slice(0, b.length)],
+    ["Blob#text()", async (b: Uint8Array) => await new Blob([b]).text()],
+    ["Response#text()", async (b: Uint8Array) => await new Response(b).text()],
+  ] as const)("%s", (_, decode) => {
+    test("accented Latin text stays 8-bit", async () => {
+      const s = await decode(latin1Utf8);
+      expect(s).toBe(latin1Text);
+      expect(s).toBeLatin1String();
+    });
+
+    test("U+00FF (C3 BF) stays 8-bit", async () => {
+      const s = await decode(boundaryUtf8);
+      expect(s).toBe(boundaryText);
+      expect(s).toBeLatin1String();
+    });
+
+    test("U+0100 (C4 80) is 16-bit", async () => {
+      const s = await decode(aboveUtf8);
+      expect(s).toBe("x\u0100x");
+      expect(s).toBeUTF16String();
+    });
+
+    test("em dash is 16-bit", async () => {
+      const s = await decode(emDashUtf8);
+      expect(s).toBe("a\u2014b");
+      expect(s).toBeUTF16String();
+    });
+
+    test("pure ASCII stays 8-bit", async () => {
+      const s = await decode(new TextEncoder().encode("hello"));
+      expect(s).toBe("hello");
+      expect(s).toBeLatin1String();
+    });
+
+    // Invalid UTF-8 whose bytes are all < 0xC4 must still take the
+    // replacement-char path (U+FFFD is not Latin-1), not be misdecoded.
+    test("overlong C0 80 under the byte gate decodes to U+FFFD", async () => {
+      const s = await decode(Uint8Array.of(0x61, 0xc0, 0x80, 0x62));
+      expect(s).toBe("a\ufffd\ufffdb");
+      expect(s).toBeUTF16String();
+    });
+
+    test("stray continuation byte under the byte gate decodes to U+FFFD", async () => {
+      const s = await decode(Uint8Array.of(0x61, 0xa9, 0x62));
+      expect(s).toBe("a\ufffdb");
+      expect(s).toBeUTF16String();
+    });
+
+    test("truncated C3 at end decodes to U+FFFD", async () => {
+      const s = await decode(Uint8Array.of(0x61, 0xc3));
+      expect(s).toBe("a\ufffd");
+      expect(s).toBeUTF16String();
+    });
+
+    test("C3 followed by non-continuation decodes to U+FFFD", async () => {
+      const s = await decode(Uint8Array.of(0x61, 0xc3, 0x41, 0x62));
+      expect(s).toBe("a\ufffdAb");
+      expect(s).toBeUTF16String();
+    });
+  });
+
+  test("Blob#json() over Latin-1-range UTF-8", async () => {
+    const body = new TextEncoder().encode(JSON.stringify({ name: latin1Text }));
+    const obj = await new Blob([body]).json();
+    expect(obj).toEqual({ name: latin1Text });
+  });
+
+  test("round-trips every code point U+0080..U+00FF", async () => {
+    let text = "";
+    for (let cp = 0x80; cp <= 0xff; cp++) text += String.fromCharCode(cp);
+    const bytes = new TextEncoder().encode(text);
+    const s = Buffer.from(bytes).toString("utf8");
+    expect(s).toBe(text);
+    expect(s.length).toBe(128);
+    expect(s).toBeLatin1String();
+  });
+
+  test("large Latin-1-range buffer stays 8-bit", async () => {
+    // > 32KB so the external-string path is exercised.
+    const unit = new TextEncoder().encode(latin1Text);
+    const big = new Uint8Array(unit.length * 2000);
+    for (let i = 0; i < 2000; i++) big.set(unit, i * unit.length);
+    expect(big.length).toBeGreaterThan(32 * 1024);
+    const s = Buffer.from(big).toString("utf8");
+    expect(s.length).toBe(latin1Text.length * 2000);
+    expect(s.startsWith(latin1Text)).toBe(true);
+    expect(s.endsWith(latin1Text)).toBe(true);
+    expect(s).toBeLatin1String();
+  });
+
+  test("Latin-1 body with one late em dash falls back to 16-bit intact", async () => {
+    const head = Buffer.alloc(4000, "\u00e9", "utf8");
+    const tail = new TextEncoder().encode("\u2014end");
+    const bytes = new Uint8Array(head.length + tail.length);
+    bytes.set(head, 0);
+    bytes.set(tail, head.length);
+    const s = Buffer.from(bytes).toString("utf8");
+    expect(s).toBeUTF16String();
+    expect(s.endsWith("\u2014end")).toBe(true);
+    expect(s.startsWith("\u00e9\u00e9")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

UTF-8 decode (`Buffer#toString('utf8')`, `Blob`/`Response` `#text()`/`#json()`, `BunString::clone_utf8`) previously had two output tiers: pure ASCII stayed 8-bit, anything else was widened to a 16-bit `StringImpl`. Accented-Latin text (`café`, `résumé`, `naïve`; every code point <= U+00FF) paid 2 bytes/char where 1 would do and lost every JSC 8-bit fast path downstream (compare/hash, `indexOf`, YARR Latin-1 matchers, `JSON.stringify`'s 8-bit writer, re-encode on socket write).

This adds a third tier so those inputs produce an 8-bit `StringImpl`.

## How

A new Highway SIMD scanner `highway_classify_utf8_width` does one pass over the input and returns `(first_non_ascii_index << 2) | class` in a single register:

- class 0 = every byte `< 0x80`
- class 1 = some byte `>= 0x80` but none `>= 0xC4` (in valid UTF-8, the exact set of strings whose every code point is `<= U+00FF`, since `U+00FF = C3 BF` and `U+0100 = C4 80`)
- class 2 = some byte `>= 0xC4`

`strings::to_latin1_or_utf16_alloc` then dispatches:

| class | action |
| --- | --- |
| `Ascii` | caller keeps the input bytes |
| `HasWide` | existing simdutf UTF-8 -> UTF-16, unchanged |
| `Latin1Candidate` | simdutf UTF-8 -> UTF-16, then `highway_copy_u16_to_u8` into a fresh `Vec<u8>`. On a simdutf decode error (overlong `C0`/`C1`, truncated tail, stray continuation: all pass the `<0xC4` gate) fall through to the UTF-16 replacement path so U+FFFD placement and `fail_if_invalid` semantics are byte-identical |

simdutf's own `convert_utf8_to_latin1*` is avoided: its icelake kernel passes `__m512i` by value to a helper that does not inline in the debug-ASAN WebKit build and faults on `vmovdqa64` stack alignment (first caller would trip it).

`to_utf16_alloc` keeps its `Option<Vec<u16>>` signature as a thin wrapper over the new core so non-string-building callers (WebSocket text frames, `sys/windows`, `bun_string_jsc`) are unchanged.

Call sites migrated: `encoding.rs` owned + borrowed UTF-8 arms, `Blob` `to_string_with_bytes` / `to_json_with_bytes` / `Internal::to_string_owned`. `BunString__fromUTF8` gains the same narrowing via WTF's `charactersAreAllLatin1` + `copyCharacters`.

Deferred: `to_utf16_alloc_maybe_buffered` (feeds `TextDecoder`) carries `[u8;3]` split-sequence state that a Latin-1 arm would have to duplicate; per-chunk strings are small. Follow-up.

## Verification

`test/js/web/encoding/utf8-decode-string-width.test.ts` asserts the backing width (`toBeLatin1String` / `toBeUTF16String`) and decoded value across `Buffer#toString`, `Buffer#utf8Slice`, `Blob#text`, `Response#text` for: accented Latin, the `U+00FF`/`U+0100` boundary, em dash, overlong `C0 80`, stray continuation, truncated `C3`, `C3`+non-continuation, full `U+0080..U+00FF` round-trip, and a >32KB buffer. 10/40 fail before, 40/40 pass after.

Release best-of-5, 100KB input through `Buffer#toString('utf8')`, same commit/toolchain:

```
                      before      after
ascii                 17-22 µs    18-21 µs   (noise)
CJK                   31-39 µs    35-37 µs   (classify early-exits on byte 0)
Latin-1 + late U+2014 29-37 µs    33-45 µs   (+ one full SIMD scan)
Latin-1 only          32-38 µs    37-47 µs   (+ classify + narrow; output now 8-bit)
```

Run-to-run spread on this host (~30%) dominates the miss-case delta. The Latin-1-only case trades ~6 µs of decode for a string that is half the size and stays on JSC's LChar paths.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/web/encoding/utf8-decode-string-width.test.ts"
bun test v1.4.0 (d2a2edae3)

test/js/web/encoding/utf8-decode-string-width.test.ts:
29 |     ["Response#text()", async (b: Uint8Array) => await new Response(b).text()],
30 |   ] as const)("%s", (_, decode) => {
31 |     test("accented Latin text stays 8-bit", async () => {
32 |       const s = await decode(latin1Utf8);
33 |       expect(s).toBe(latin1Text);
34 |       expect(s).toBeLatin1String();
                     ^
error: expect(received).toBeLatin1String()

Expected café résumé naïve to be a Latin1 string
      at <anonymous> (/workspace/bun/test/js/web/encoding/utf8-decode-string-width.test.ts:34:17)
(fail) UTF-8 decode picks the narrowest string width > Buffer#toString('utf8') > accented Latin text stays 8-bit [23.03ms]
35 |     });
36 | 
37 |     test("U+00FF (C3 BF) stays 8-bit", async () => {
38 |       const s = await decode(boundaryUtf8);
39 |       expect(s).toBe(boundaryText);
40 |       expect(s).toBeLatin1String();
                     ^
error: expect(received
... (truncated)

release without fix: 10 FAILED
bun test v1.4.0-canary.1 (df49a6e1c)

test/js/web/encoding/utf8-decode-string-width.test.ts:
29 |     ["Response#text()", async (b: Uint8Array) => await new Response(b).text()],
30 |   ] as const)("%s", (_, decode) => {
31 |     test("accented Latin text stays 8-bit", async () => {
32 |       const s = await decode(latin1Utf8);
33 |       expect(s).toBe(latin1Text);
34 |       expect(s).toBeLatin1String();
                     ^
error: expect(received).toBeLatin1String()

Expected café résumé naïve to be a Latin1 string
      at <anonymous> (/workspace/bun/test/js/web/encoding/utf8-decode-string-width.test.ts:34:17)
(fail) UTF-8 decode picks the narrowest string width > Buffer#toString('utf8') > accented Latin text stays 8-bit [8.12ms]
35 |     });
36 | 
37 |     test("U+00FF (C3 BF) stays 8-bit", async () => {
38 |       const s = await decode(boundaryUtf8);
39 |       expect(s).toBe(boundaryText);
40 |       expect(s).toBeLatin1String();
                     ^
error: expect(received).toBeLatin1String()

Expected xÿx to be a Latin1 string
      at <anonymous> (/workspace/bun/test/js/web/encoding/utf8-decode-string-width.test.ts:40:17)
(fail) UTF-8 decode picks
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/web/encoding/utf8-decode-string-width.test.ts"
bun test v1.4.0 (d2a2edae3)

test/js/web/encoding/utf8-decode-string-width.test.ts:
(pass) UTF-8 decode picks the narrowest string width > Buffer#toString('utf8') > accented Latin text stays 8-bit [12.90ms]
(pass) UTF-8 decode picks the narrowest string width > Buffer#toString('utf8') > U+00FF (C3 BF) stays 8-bit [5.68ms]
(pass) UTF-8 decode picks the narrowest string width > Buffer#toString('utf8') > U+0100 (C4 80) is 16-bit [10.16ms]
(pass) UTF-8 decode picks the narrowest string width > Buffer#toString('utf8') > em dash is 16-bit [5.54ms]
(pass) UTF-8 decode picks the narrowest string width > Buffer#toString('utf8') > pure ASCII stays 8-bit [6.80ms]
(pass) UTF-8 decode picks the narrowest string width > Buffer#toString('utf8') > overlong C0 80 under the byte gate decodes to U+FFFD [5.67ms]
(pass) UTF-8 decode picks the narrowest string width > Buffer#toString('utf8') > stray continuation byte under the byte gate decodes to U+FFFD [6.15ms]
(pass) UTF-8 decode picks the narrowest
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 3652ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] gen cpp.rs (cppbind)
[2/9] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_highway v0.0.0 (/workspace/bun/src/highway)
[1m[92m   Compiling[0m bun_hash v0.0.0 (/workspace/bun/src/hash)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/string/immutable.rs                   | 144 ++++++++++++++++++++-
 src/highway/lib.rs                                 |  46 +++++++
 src/jsc/bindings/BunString.cpp                     |  10 ++
 src/jsc/bindings/highway_strings.cpp               |  63 +++++++++
 src/runtime/webcore/Blob.rs                        | 136 ++++++++++++-------
 src/runtime/webcore/encoding.rs                    |  51 ++++----
 .../web/encoding/utf8-decode-string-width.test.ts  | 128 ++++++++++++++++++
 7 files changed, 499 insertions(+), 79 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/bun_core/string/immutable.rs                          10     21      0
src/highway/lib.rs                                         3      7      0
src/jsc/bindings/BunString.cpp                             1      6      0
src/jsc/bindings/highway_strings.cpp                       3      9      0
src/runtime/webcore/Blob.rs                                4      7      0
src/runtime/webcore/encoding.rs                            5      7      0
test/js/web/encoding/utf8-decode-string-width.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->