### PR TITLE
resolver: stop inheriting enclosing tsconfig across node_modules boundary

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6063,7 +6063,18 @@ impl<'a> Resolver<'a> {
             // Propagate the browser scope into child directories
             info.enclosing_browser_scope = parent_.enclosing_browser_scope;
             info.package_json_for_browser_field = parent_.package_json_for_browser_field;
-            info.enclosing_tsconfig_json = parent_.enclosing_tsconfig_json;
+
+            // Do not inherit the enclosing tsconfig across a "node_modules" boundary.
+            // A project-level tsconfig's `paths`/`baseUrl` must not leak into
+            // dependencies: with `"*": ["node_modules/*"]` a package's own
+            // `require("x")` would otherwise be remapped to the hoisted root copy
+            // instead of its nested one. A package that ships its own tsconfig.json
+            // still picks it up below and propagates it to its subdirectories, so
+            // workspace packages installed into node_modules keep their own path
+            // mappings.
+            if !parent_.is_node_modules() {
+                info.enclosing_tsconfig_json = parent_.enclosing_tsconfig_json;
+            }
 
             if let Some(parent_package_json) = parent_.package_json() {
                 // https://github.com/oven-sh/bun/issues/229

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1101,3 +1101,109 @@ it.skipIf(isWindows)("reports a resolution error for an absolute specifier of th
   expect(stdout).toBe("ResolveMessage ERR_MODULE_NOT_FOUND\n");
   expect(exitCode).toBe(0);
 });
+
+// https://github.com/oven-sh/bun/issues/5377
+// A project-level tsconfig `paths`/`baseUrl` mapping must not leak into packages under
+// node_modules: `outer`'s own `require("inner")` has to find its nested copy, not the
+// hoisted root one, and the project's own files must still get the mapping.
+it("tsconfig paths are not applied to imports from inside node_modules", async () => {
+  using dir = tempDir("tsconfig-paths-node-modules", {
+    "package.json": JSON.stringify({ name: "app", dependencies: { outer: "1.0.0", inner: "2.0.0" } }),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: { baseUrl: ".", paths: { "*": ["node_modules/*", "src/types/*"] } },
+    }),
+    "entry.js": `
+      const outer = require("outer");
+      const alias = require("only-via-paths");
+      console.log(JSON.stringify({ outer, alias }));
+    `,
+    "src/types/only-via-paths/index.js": `module.exports = "paths-mapped";`,
+
+    "node_modules/inner/package.json": JSON.stringify({ name: "inner", version: "2.0.0", main: "index.js" }),
+    "node_modules/inner/index.js": `module.exports = "hoisted";`,
+
+    "node_modules/outer/package.json": JSON.stringify({
+      name: "outer",
+      version: "1.0.0",
+      main: "index.js",
+      dependencies: { inner: "1.0.0" },
+    }),
+    "node_modules/outer/index.js": `module.exports = require("inner");`,
+    "node_modules/outer/node_modules/inner/package.json": JSON.stringify({
+      name: "inner",
+      version: "1.0.0",
+      main: "index.js",
+    }),
+    "node_modules/outer/node_modules/inner/index.js": `module.exports = "nested";`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ outer: "nested", alias: "paths-mapped" });
+  expect(exitCode).toBe(0);
+});
+
+it("tsconfig baseUrl is not applied to imports from inside node_modules", async () => {
+  using dir = tempDir("tsconfig-baseurl-node-modules", {
+    "package.json": JSON.stringify({ name: "app" }),
+    "tsconfig.json": JSON.stringify({ compilerOptions: { baseUrl: "./src" } }),
+    "entry.js": `console.log(require("pkg"));`,
+    "src/shadowed/index.js": `module.exports = "from-src";`,
+
+    "node_modules/pkg/package.json": JSON.stringify({ name: "pkg", main: "index.js" }),
+    "node_modules/pkg/index.js": `module.exports = require("shadowed");`,
+    "node_modules/pkg/node_modules/shadowed/package.json": JSON.stringify({ name: "shadowed", main: "index.js" }),
+    "node_modules/pkg/node_modules/shadowed/index.js": `module.exports = "from-nested-node-modules";`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("from-nested-node-modules\n");
+  expect(exitCode).toBe(0);
+});
+
+// A package inside node_modules that carries its own tsconfig.json (e.g. a workspace
+// installed into node_modules) keeps its own `paths` mapping; only the outer
+// project's tsconfig is cut off at the node_modules boundary.
+it("a package's own tsconfig paths still apply inside node_modules", async () => {
+  using dir = tempDir("tsconfig-paths-inside-package", {
+    "package.json": JSON.stringify({ name: "app" }),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: { baseUrl: ".", paths: { "*": ["node_modules/*"] } },
+    }),
+    "entry.js": `console.log(require("mylib"));`,
+
+    "node_modules/mylib/package.json": JSON.stringify({ name: "mylib", version: "1.0.0", main: "src/index.js" }),
+    "node_modules/mylib/tsconfig.json": JSON.stringify({
+      compilerOptions: { baseUrl: ".", paths: { "@utils/*": ["src/utils/*"] } },
+    }),
+    "node_modules/mylib/src/index.js": `module.exports = require("@utils/helper");`,
+    "node_modules/mylib/src/utils/helper.js": `module.exports = "own-tsconfig-paths";`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("own-tsconfig-paths\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #5377.

## Repro

```jsonc
// tsconfig.json
{ "compilerOptions": { "baseUrl": ".", "paths": { "*": ["node_modules/*", "src/types/*"] } } }
```

With `express` (which depends on `send@0.x`, which depends on `mime@1.6.0`) and anything that hoists a newer `mime` to the root:

```
$ bun -e 'console.log(typeof require("send").mime.charsets)'
undefined            # before: send's require("mime") resolved to the hoisted mime@2.x
object               # after:  send's own nested mime@1.6.0
```

Node prints `object`.

## Cause

`dir_info_uncached` propagated `enclosing_tsconfig_json` unconditionally from parent to child, so the project root's tsconfig became the enclosing tsconfig for every directory under `node_modules/`. `load_node_modules` then applied that tsconfig's `paths`/`baseUrl` before walking the nested `node_modules` chain, so a catch-all `"*": ["node_modules/*"]` entry (and similarly `baseUrl`) remapped a dependency's own bare imports to the project root's `node_modules`, skipping the nested copy the package was published against.

`mime.charsets.lookup` (the stack in the issue) is just the first thing express calls on `mime@1.x` that `mime@2.x` doesn't have.

## Fix

Stop inheriting `enclosing_tsconfig_json` when the parent directory is `node_modules`. A package that ships its own `tsconfig.json` still reads it and propagates it to its own subdirectories, so workspace packages installed into `node_modules` keep their own path mappings (covered by the third new test). Symlinked workspaces already resolve to their real path outside `node_modules` and are unaffected either way.

esbuild effectively does the same via `tsConfigForDir` returning `nil` for any directory inside `node_modules`.

## Verification

```
$ bun bd test test/js/bun/resolve/resolve.test.ts -t tsconfig
(pass) tsconfig paths are not applied to imports from inside node_modules
(pass) tsconfig baseUrl is not applied to imports from inside node_modules
(pass) a package's own tsconfig paths still apply inside node_modules
```

The first two fail on `main` (`outer` resolves to `"hoisted"` / `"from-src"`), the third passes on both and guards the workspace case.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->