### PR TITLE
HTMLRewriter: deliver Bun.file-backed transform output to Bun.serve

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -611,11 +611,14 @@ impl BufferOutputSink {
                 status_code: 200,
                 ..Default::default()
             },
-            webcore::Body::new({
-                let mut pv = webcore::body::PendingValue::new(global);
-                pv.task = Some(sink.cast::<core::ffi::c_void>());
-                webcore::body::Value::Locked(pv)
-            }),
+            // Leave the PendingValue's `task`/callbacks unset: this sink does
+            // not feed a ByteStream. A consumer that wants the body
+            // (Bun.serve, ValueBufferer, `.text()`) installs its own
+            // `on_receive_value`/`promise`, which `done()` resolves via
+            // `Value::resolve` once the rewrite completes.
+            webcore::Body::new(webcore::body::Value::Locked(
+                webcore::body::PendingValue::new(global),
+            )),
             BunString::empty(),
             false,
         )));
@@ -825,29 +828,6 @@ impl BufferOutputSink {
             // SAFETY: (*sink).response is the heap Response allocated in init()
             // and kept alive by (*sink).response_value (Strong root).
             let sink_body_value = unsafe { (*(*sink).response).get_body_value() };
-            let sink_ptr_usize = sink as usize;
-            // If a `.body` readable is already attached, stay `Locked` so
-            // `to_error_instance` delivers the error to its ByteStream; clearing
-            // to `Empty` here would strand any pending `reader.read()` forever.
-            let has_readable = match sink_body_value {
-                webcore::body::Value::Locked(l) => l.readable.has(),
-                _ => false,
-            };
-            if !has_readable
-                && matches!(sink_body_value, webcore::body::Value::Locked(l)
-                    if l.task.map_or(0, |p| p as usize) == sink_ptr_usize && l.promise.is_none())
-            {
-                // No reader and no pending read: normalize to `Empty` so
-                // `to_error_instance` takes the simple (non-`Locked`) path.
-                *sink_body_value = webcore::body::Value::Empty;
-            } else if matches!(sink_body_value, webcore::body::Value::Locked(l)
-                if l.task.map_or(0, |p| p as usize) == sink_ptr_usize && l.promise.is_some())
-            {
-                if let webcore::body::Value::Locked(l) = sink_body_value {
-                    l.on_receive_value = None;
-                    l.task = None;
-                }
-            }
             if is_async {
                 let _ = sink_body_value.to_error_instance(err.dupe(&global), &global);
                 // TODO: properly propagate exception upwards

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1921,7 +1921,13 @@ where
     fn do_render_with_body_locked(this: *mut c_void, value: &mut Body::Value) {
         // SAFETY: caller upholds the fn-level contract — `this` is the
         // `*mut RequestContext` previously registered as `lock.task`.
-        Self::do_render_with_body(unsafe { bun_ptr::callback_ctx::<Self>(this) }, value, None);
+        let this = unsafe { bun_ptr::callback_ctx::<Self>(this) };
+        // Releases the ref taken when this callback was registered.
+        let _ref = RequestContextRef(std::ptr::from_mut::<Self>(this));
+        if this.is_aborted_or_ended() {
+            return;
+        }
+        Self::do_render_with_body(this, value, None);
     }
 
     fn render_with_blob_from_body_value(&mut self) {
@@ -3267,7 +3273,12 @@ where
                     return;
                 }
 
-                // when there's no stream, we need to
+                // No stream and no producer hooks: the body will be filled in
+                // later via `Value::resolve`. Hold a ref and mark pending so
+                // `should_render_missing` does not recycle this context before
+                // the callback fires; `do_render_with_body_locked` releases it.
+                this.ref_();
+                this.flags.set_has_marked_pending(true);
                 lock.on_receive_value =
                     Some(|ctx, value| Self::do_render_with_body_locked(ctx, value));
                 lock.task = Some(std::ptr::from_mut::<Self>(this).cast::<c_void>());

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { once } from "events";
 import fs from "fs";
-import { gcTick, tls, tmpdirSync } from "harness";
+import { gcTick, tempDir, tls, tmpdirSync } from "harness";
 import { createServer as createTcpServer } from "net";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
@@ -371,6 +371,30 @@ describe("HTMLRewriter", () => {
     await Bun.write(filePath, "<div>hello</div>");
     var output = rewriter.transform(new Response(Bun.file(filePath)));
     expect(await output.text()).toBe("<div><blink>it worked!</blink></div>");
+  });
+
+  // https://github.com/oven-sh/bun/issues/6068
+  it("Bun.serve can stream a Bun.file Response through HTMLRewriter", async () => {
+    using dir = tempDir("html-rewriter-serve-file", {
+      "page.html": "<p>Hello</p>",
+    });
+
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new HTMLRewriter()
+          .on("p", {
+            element(el) {
+              el.setInnerContent("Rewritten");
+            },
+          })
+          .transform(new Response(Bun.file(join(String(dir), "page.html"))));
+      },
+    });
+
+    const res = await fetch(server.url);
+    expect(await res.text()).toBe("<p>Rewritten</p>");
+    expect(res.status).toBe(200);
   });
 
   it("supports attribute iterator", async () => {


### PR DESCRIPTION
Fixes #6068.

## Repro

```js
Bun.serve({
  port: 0,
  fetch() {
    return new HTMLRewriter()
      .on('p', { element(el) { el.setInnerContent('Rewritten'); } })
      .transform(new Response(Bun.file('./page.html')));
  },
});
```

`curl` against this server hangs until `Bun.serve()` times the request out. The same transform works standalone (`await transform(...).text()`), and both `HTMLRewriter` over a string body and `Bun.file` without `HTMLRewriter` serve fine; only the combination inside `Bun.serve` hangs.

## Cause

`BufferOutputSink::init` created the output `Response` body as `Value::Locked(PendingValue { task: Some(sink), .. })` with no `on_start_streaming` / `on_readable_stream_available` hooks. `RequestContext::do_render_with_body` treats `task.is_some()` as "a producer will feed a ByteStream", calls `to_readable_stream`, stores the resulting native stream, and replaces the body with `Value::Used`. When the async `Bun.file` read later completes and `BufferOutputSink::done()` swaps in the rewritten bytes and calls `Value::resolve`, the previous value is already `Used`, so `resolve` no-ops and the ByteStream the server is waiting on never receives data.

`ValueBufferer::buffer_locked_body_value` has the same `task.is_some()` heuristic, so feeding one `HTMLRewriter` output into another over a `Bun.file` body would also hang.

## Fix

Leave `task` and the streaming callbacks unset on the output body's `PendingValue`. The sink never reads `task` back (it reaches the body via `self.response`), and with nothing pre-registered a consumer installs its own `on_receive_value`/`promise`, which `done()` resolves through `Value::resolve` once the rewrite completes. `to_error_instance` already routes errors to any registered `on_receive_value`/`promise`/`readable`, so the `task == sink` sentinel checks in `on_finished_buffering` become unreachable and are removed.

This makes `RequestContext::do_render_with_body`'s `on_receive_value` fallthrough reachable for the first time, which exposed a latent use-after-poison under ASAN: it stored `self` as `lock.task` without taking a ref or marking the request pending, so `should_render_missing` recycled the context before the callback fired. Take a ref and mark pending there, and release the ref in `do_render_with_body_locked` (mirroring the ByteStream and promise-resolve paths).

## Verification

```
bun bd test test/js/workerd/html-rewriter.test.js -t 'Bun.serve can stream a Bun.file'
```

Fails before (5s timeout), passes after. Full `html-rewriter.test.js` suite still passes; 50 concurrent requests with half aborted mid-read complete cleanly under ASAN.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/workerd/html-rewriter.test.js
bun test v1.4.0 (fdd23a230)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [15.94ms]
(pass) HTMLRewriter > error inside element handler [10.34ms]
(pass) HTMLRewriter > error inside element handler (string) [6.62ms]
(pass) HTMLRewriter > fast async error inside element handler [34.46ms]
(pass) HTMLRewriter > slow async error inside element handler [14.07ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [177.80ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [8.20ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [514.52ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .text() on the transformed response rejects [86.30ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .arrayBuffer() on the transformed response rejects [44.41ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .body on the tra
... (truncated)

release without fix: 5 failed, 2 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [0.24ms]
(pass) HTMLRewriter > error inside element handler [1.31ms]
(pass) HTMLRewriter > error inside element handler (string) [0.13ms]
(pass) HTMLRewriter > fast async error inside element handler [8.29ms]
(pass) HTMLRewriter > slow async error inside element handler [2.37ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [9.73ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [0.13ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [10.14ms]
183 |         const transformed = rewriter().transform(res);
184 |         const text = settle(transformed.text());
185 |         release();
186 |         // Must reject with the upstream connection error, and must never
187 |         // resolve with the truncated document.
188 |         expect(await text).toEqual(rejectedWithConnectionError);
                                 ^
error: expect(received).toEqual(expected)

  {
-   "message": StringMatching /socket|connection|ECONNRESET/i,
-   "name": "TypeError
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/workerd/html-rewriter.test.js
bun test v1.4.0 (fdd23a230)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [12.14ms]
(pass) HTMLRewriter > error inside element handler [7.33ms]
(pass) HTMLRewriter > error inside element handler (string) [5.33ms]
(pass) HTMLRewriter > fast async error inside element handler [22.57ms]
(pass) HTMLRewriter > slow async error inside element handler [10.93ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [116.49ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [7.23ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [368.51ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .text() on the transformed response rejects [38.19ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .arrayBuffer() on the transformed response rejects [25.76ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .body on the tran
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1832ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/html_rewriter.rs      | 36 ++++++++---------------------------
 src/runtime/server/RequestContext.rs  | 15 +++++++++++++--
 test/js/workerd/html-rewriter.test.js | 26 ++++++++++++++++++++++++-
 3 files changed, 46 insertions(+), 31 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/runtime/api/html_rewriter.rs           3      2      0
src/runtime/server/RequestContext.rs      13      2      0
test/js/workerd/html-rewriter.test.js      3      4      0
```

</details>

<!-- robobun:evidence:end -->