### PR TITLE
resolver: pass absolute path to browser-map check for main field and index

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5053,8 +5053,10 @@ impl<'a> Resolver<'a> {
                             dec_ret!(MatchStatus::Success);
                         }
 
-                        field_abs_path =
-                            self.fs_ref().abs_buf(&[path, remap], bufs!(field_abs_path));
+                        // `remap` is relative to the package that owns the browser map.
+                        field_abs_path = self
+                            .fs_ref()
+                            .abs_buf(&[browser_scope.abs_path, remap], bufs!(field_abs_path));
                     }
                 }
             }
@@ -5271,7 +5273,9 @@ impl<'a> Resolver<'a> {
                     {
                         // Is the path disabled?
                         if remap.is_empty() {
-                            let mut _path = Path::init(index_abs_path);
+                            let new_path =
+                                self.fs_ref().abs_alloc(&index_paths).expect("unreachable");
+                            let mut _path = Path::init(new_path);
                             _path.is_disabled = true;
                             *out = MatchResult {
                                 path_pair: PathPair {
@@ -5284,7 +5288,10 @@ impl<'a> Resolver<'a> {
                             return MatchStatus::Success;
                         }
 
-                        let new_paths = [path, remap];
+                        // `remap` is relative to the package that owns the browser map,
+                        // which may be an ancestor of `path` (e.g. `demo-pkg/sub/` with
+                        // the browser map in `demo-pkg/package.json`).
+                        let new_paths = [browser_scope.abs_path, remap];
                         let remapped_abs = self.fs_ref().abs_buf(&new_paths, bufs!(remap_path));
 
                         // Is this a file

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5288,9 +5288,7 @@ impl<'a> Resolver<'a> {
                             return MatchStatus::Success;
                         }
 
-                        // `remap` is relative to the package that owns the browser map,
-                        // which may be an ancestor of `path` (e.g. `demo-pkg/sub/` with
-                        // the browser map in `demo-pkg/package.json`).
+                        // `remap` is relative to the browser scope, which may be an ancestor of `path`.
                         let new_paths = [browser_scope.abs_path, remap];
                         let remapped_abs = self.fs_ref().abs_buf(&new_paths, bufs!(remap_path));
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5001,7 +5001,7 @@ impl<'a> Resolver<'a> {
         extension_order: options::ExtOrder,
         out: &mut MatchResult,
     ) -> MatchStatus {
-        let mut field_rel_path = _field_rel_path;
+        let field_rel_path = _field_rel_path;
         // Is this a directory?
         if let Some(debug) = self.debug_logs.as_mut() {
             debug.add_note_fmt(format_args!(
@@ -5022,6 +5022,10 @@ impl<'a> Resolver<'a> {
             }};
         }
 
+        let mut field_abs_path: &[u8] = self
+            .fs_ref()
+            .abs_buf(&[path, field_rel_path], bufs!(field_abs_path));
+
         if self.care_about_browser_field {
             // Potentially remap using the "browser" field
             if let Some(browser_scope) = dir_info.get_enclosing_browser_scope() {
@@ -5029,7 +5033,7 @@ impl<'a> Resolver<'a> {
                     if let Some(remap) = self
                         .check_browser_map::<{ BrowserMapPathKind::AbsolutePath }>(
                             &browser_scope,
-                            field_rel_path,
+                            field_abs_path,
                         )
                     {
                         // Is the path disabled?
@@ -5049,13 +5053,13 @@ impl<'a> Resolver<'a> {
                             dec_ret!(MatchStatus::Success);
                         }
 
-                        field_rel_path = remap;
+                        field_abs_path = self
+                            .fs_ref()
+                            .abs_buf(&[path, remap], bufs!(field_abs_path));
                     }
                 }
             }
         }
-        let _paths = [path, field_rel_path];
-        let field_abs_path = self.fs_ref().abs_buf(&_paths, bufs!(field_abs_path));
 
         // Is this a file?
         if let Some(result) = self.load_as_file(field_abs_path, extension_order) {
@@ -5258,17 +5262,17 @@ impl<'a> Resolver<'a> {
                 const FIELD_REL_PATH: &[u8] = b"index";
 
                 if let Some(browser_json) = browser_scope.package_json() {
+                    let index_paths = [path, FIELD_REL_PATH];
+                    let index_abs_path = self.fs_ref().abs_buf(&index_paths, bufs!(remap_path));
                     if let Some(remap) = self
                         .check_browser_map::<{ BrowserMapPathKind::AbsolutePath }>(
                             &browser_scope,
-                            FIELD_REL_PATH,
+                            index_abs_path,
                         )
                     {
                         // Is the path disabled?
                         if remap.is_empty() {
-                            let paths = [path, FIELD_REL_PATH];
-                            let new_path = self.fs_ref().abs_buf(&paths, bufs!(remap_path));
-                            let mut _path = Path::init(new_path);
+                            let mut _path = Path::init(index_abs_path);
                             _path.is_disabled = true;
                             *out = MatchResult {
                                 path_pair: PathPair {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5053,9 +5053,8 @@ impl<'a> Resolver<'a> {
                             dec_ret!(MatchStatus::Success);
                         }
 
-                        field_abs_path = self
-                            .fs_ref()
-                            .abs_buf(&[path, remap], bufs!(field_abs_path));
+                        field_abs_path =
+                            self.fs_ref().abs_buf(&[path, remap], bufs!(field_abs_path));
                     }
                 }
             }

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -2183,6 +2183,49 @@ describe("bundler", () => {
       stdout: "disabled",
     },
   });
+  // A subpath that resolves to a directory's implicit "index" is checked
+  // against the enclosing package's browser map, and the remap target is
+  // resolved relative to that package (not the subdirectory).
+  itBundled("packagejson/BrowserMapSubpathDirIndex", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import value from 'demo-pkg/sub'
+        console.log(value)
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "browser": {
+            "./sub/index.js": "./browser-sub.js"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/sub/index.js": `module.exports = 'sub-index'`,
+      "/Users/user/project/node_modules/demo-pkg/browser-sub.js": `module.exports = 'browser-sub'`,
+    },
+    target: "browser",
+    run: {
+      stdout: "browser-sub",
+    },
+  });
+  itBundled("packagejson/BrowserMapSubpathDirIndexDisabled", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        console.log(require('demo-pkg/sub') === 'sub-index' ? 'loaded' : 'disabled')
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "browser": {
+            "./sub/index": false
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/sub/index.js": `module.exports = 'sub-index'`,
+    },
+    target: "browser",
+    run: {
+      stdout: "disabled",
+    },
+  });
   // When "main" points at a directory, the implicit "<dir>/index" is checked
   // against the browser map before extension resolution.
   itBundled("packagejson/BrowserMapMainFieldDirIndexNoExt", {

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -2105,4 +2105,106 @@ describe("bundler", () => {
       stdout: "browser-override",
     },
   });
+  // The "main" field value is checked against the browser map before extension
+  // resolution. Packages like jszip ship
+  //   "main": "./lib/index",
+  //   "browser": {"./lib/index": "./dist/jszip.min.js"}
+  // and expect the prebuilt bundle to be picked for browser targets.
+  itBundled("packagejson/BrowserMapMainFieldNoExt", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import value from 'demo-pkg'
+        console.log(value)
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "main": "./lib/index",
+          "browser": {
+            "./lib/index": "./dist/demo-pkg.min.js"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/lib/index.js": `module.exports = 'lib'`,
+      "/Users/user/project/node_modules/demo-pkg/dist/demo-pkg.min.js": `module.exports = 'prebuilt'`,
+    },
+    target: "browser",
+    run: {
+      stdout: "prebuilt",
+    },
+  });
+  // Extension matching for main-field browser remaps should match esbuild:
+  // the main-field value is probed as-is and with extensions appended, so an
+  // extensionless main still hits a ".js"-keyed browser entry, but a ".js"
+  // main does not hit an extensionless browser key.
+  itBundled("packagejson/BrowserMapMainFieldExtPermutations", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import a from 'pkg-a'
+        import b from 'pkg-b'
+        import c from 'pkg-c'
+        import d from 'pkg-d'
+        console.log(a, b, c, d)
+      `,
+      "/Users/user/project/node_modules/pkg-a/package.json": `{"main":"./lib/index.js","browser":{"./lib/index.js":"./browser.js"}}`,
+      "/Users/user/project/node_modules/pkg-a/lib/index.js": `module.exports = 'lib'`,
+      "/Users/user/project/node_modules/pkg-a/browser.js": `module.exports = 'browser'`,
+      "/Users/user/project/node_modules/pkg-b/package.json": `{"main":"./lib/index","browser":{"./lib/index.js":"./browser.js"}}`,
+      "/Users/user/project/node_modules/pkg-b/lib/index.js": `module.exports = 'lib'`,
+      "/Users/user/project/node_modules/pkg-b/browser.js": `module.exports = 'browser'`,
+      "/Users/user/project/node_modules/pkg-c/package.json": `{"main":"./lib/index.js","browser":{"./lib/index":"./browser.js"}}`,
+      "/Users/user/project/node_modules/pkg-c/lib/index.js": `module.exports = 'lib'`,
+      "/Users/user/project/node_modules/pkg-c/browser.js": `module.exports = 'browser'`,
+      "/Users/user/project/node_modules/pkg-d/package.json": `{"main":"./lib/index","browser":{"./lib/index":"./browser.js"}}`,
+      "/Users/user/project/node_modules/pkg-d/lib/index.js": `module.exports = 'lib'`,
+      "/Users/user/project/node_modules/pkg-d/browser.js": `module.exports = 'browser'`,
+    },
+    target: "browser",
+    run: {
+      stdout: "browser browser lib browser",
+    },
+  });
+  itBundled("packagejson/BrowserMapMainFieldDisabledNoExt", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        console.log(require('demo-pkg') === 'lib' ? 'loaded-lib' : 'disabled')
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "main": "./lib/index",
+          "browser": {
+            "./lib/index": false
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/lib/index.js": `module.exports = 'lib'`,
+    },
+    target: "browser",
+    run: {
+      stdout: "disabled",
+    },
+  });
+  // When "main" points at a directory, the implicit "<dir>/index" is checked
+  // against the browser map before extension resolution.
+  itBundled("packagejson/BrowserMapMainFieldDirIndexNoExt", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import value from 'demo-pkg'
+        console.log(value)
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "main": "./lib",
+          "browser": {
+            "./lib/index": "./browser.js"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/lib/index.js": `module.exports = 'lib'`,
+      "/Users/user/project/node_modules/demo-pkg/browser.js": `module.exports = 'browser'`,
+    },
+    target: "browser",
+    run: {
+      stdout: "browser",
+    },
+  });
 });


### PR DESCRIPTION
## What

When a package's `"main"` field and the matching `"browser"` map key are both written without an extension, `bun build --target=browser` ignores the browser remap and bundles the Node entrypoint.

```sh
mkdir -p node_modules/pkg/{lib,dist}
cat > node_modules/pkg/package.json <<'JSON'
{"name":"pkg","main":"./lib/index","browser":{"./lib/index":"./dist/pkg.min.js"}}
JSON
echo 'module.exports="LIB"' > node_modules/pkg/lib/index.js
echo 'module.exports="PREBUILT"' > node_modules/pkg/dist/pkg.min.js
echo 'console.log(require("pkg"))' > entry.js
bun build entry.js --target=browser   # bundles "LIB", should bundle "PREBUILT"
```

Real-world impact: `import "jszip"` with `jszip@3.10.1`, which ships exactly this pattern to point browsers at a prebuilt `dist/jszip.min.js`. Bun walks the full `lib/` graph instead and ends up bundling node stream/buffer/events polyfills:

| | bytes |
| - | -: |
| `bun build` before | 470,373 |
| `bun build` after | 153,024 |
| esbuild | 158,095 |

## Why

`check_browser_map::<AbsolutePath>` expects an absolute path so it can strip the package-directory prefix and look up the package-relative key. `load_from_main_field` and `load_as_index_with_browser_remapping` were passing the relative main-field value (`"./lib/index"`, `"index"`) instead, so the `starts_with(abs_path)` guard returned `None` and the whole remap branch in both functions was dead code. The only match that ever worked was the post-resolution check, which sees the resolved path *with* its extension and therefore only matches when the browser key also carries the extension.

esbuild computes `fieldAbsPath := r.fs.Join(path, fieldRelPath)` before calling `checkBrowserMap` here; this change brings both functions in line with that.

Making the remap branch reachable exposed two latent issues in the previously-dead code, also fixed here:

- the disabled (`"browser": {"./x": false}`) arm stored a slice into a threadlocal scratch buffer directly in the returned `MatchResult`; it now interns via `abs_alloc` like the sibling in `load_from_main_field`;
- the non-empty remap was joined against the subdirectory being indexed instead of the package that owns the browser map, so a subpath directory import (`require('demo-pkg/sub')` with `"./sub/index.js": "./browser-sub.js"` in `demo-pkg/package.json`) would have looked in `demo-pkg/sub/browser-sub.js` and failed. Both functions now join against `browser_scope.abs_path`.

## Verification

The four `main`/`browser` extension permutations now match esbuild exactly:

| main | browser key | esbuild | bun before | bun after |
| - | - | - | - | - |
| `./lib/index.js` | `./lib/index.js` | remap | remap | remap |
| `./lib/index` | `./lib/index.js` | remap | remap | remap |
| `./lib/index.js` | `./lib/index` | no remap | no remap | no remap |
| `./lib/index` | `./lib/index` | remap | **no remap** | remap |

New `itBundled` tests in `test/bundler/esbuild/packagejson.test.ts` cover the jszip-shaped remap, the permutation matrix above, the `false` (disabled) case, the directory-main `/index` remap, and the subpath-directory remap. All fail on the released build and pass with this change; the rest of the file is unchanged (80 pass, 9 todo).

## Not in this PR

The `packagejson/BrowserNodeModulesNoExt` todo test exercises bare subpath *file* imports (`import 'demo-pkg/no-ext'`). That needs a browser-map check inside `load_node_modules` before `load_as_file_or_directory`, which is missing entirely rather than mis-parameterised, and is left for a follow-up.

Fixes #22797
Fixes #21128