### PR TITLE
pm: let `bun pm -g bin` / `bun pm ls -g` work before any global install

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1490,6 +1490,15 @@ pub fn init(
                 }
             }
 
+            if cli.global {
+                // `-g` already fchdir'd into the global dir above; the global
+                // manifest may not exist until the first `bun add -g`. Create it
+                // so read-only queries like `bun pm -g bin` work on a fresh
+                // install instead of failing with MissingPackageJSON.
+                this_cwd = original_cwd;
+                created_package_json = true;
+                break 'child attempt_to_create_package_json_and_open()?;
+            }
             if subcommand == Subcommand::Install {
                 if cli.positionals.len() > 1 {
                     // this is `bun add <package>`.

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -483,8 +483,6 @@ impl Subcommand {
         matches!(self, Self::Audit | Self::Pm | Self::Info)
     }
 
-    /// Subcommands whose callers print "nothing to remove/update/patch" and
-    /// exit 1 when no package.json exists, instead of auto-creating one.
     pub(crate) fn wants_missing_package_json_error(self) -> bool {
         matches!(
             self,
@@ -1500,9 +1498,7 @@ pub fn init(
             }
 
             if cli.global && !subcommand.wants_missing_package_json_error() {
-                // `-g` already fchdir'd into the global dir above; create the
-                // global manifest on demand so `bun pm -g bin` etc. work on a
-                // fresh install.
+                // cwd is the global dir (fchdir'd above), so create lands there.
                 this_cwd = original_cwd;
                 created_package_json = true;
                 break 'child attempt_to_create_package_json_and_open()?;

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1490,11 +1490,21 @@ pub fn init(
                 }
             }
 
-            if cli.global {
+            if cli.global
+                && !matches!(
+                    subcommand,
+                    Subcommand::Update
+                        | Subcommand::Remove
+                        | Subcommand::Patch
+                        | Subcommand::PatchCommit
+                )
+            {
                 // `-g` already fchdir'd into the global dir above; the global
                 // manifest may not exist until the first `bun add -g`. Create it
                 // so read-only queries like `bun pm -g bin` work on a fresh
                 // install instead of failing with MissingPackageJSON.
+                // Update/Remove/Patch keep returning the error so their callers
+                // can print "nothing to remove/update/patch" and exit 1.
                 this_cwd = original_cwd;
                 created_package_json = true;
                 break 'child attempt_to_create_package_json_and_open()?;

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -483,6 +483,15 @@ impl Subcommand {
         matches!(self, Self::Audit | Self::Pm | Self::Info)
     }
 
+    /// Subcommands whose callers print "nothing to remove/update/patch" and
+    /// exit 1 when no package.json exists, instead of auto-creating one.
+    pub(crate) fn wants_missing_package_json_error(self) -> bool {
+        matches!(
+            self,
+            Self::Update | Self::Remove | Self::Patch | Self::PatchCommit
+        )
+    }
+
     // TODO: make all subcommands find root and chdir
     pub(crate) fn should_chdir_to_root(self) -> bool {
         !matches!(self, Self::Link)
@@ -1490,21 +1499,10 @@ pub fn init(
                 }
             }
 
-            if cli.global
-                && !matches!(
-                    subcommand,
-                    Subcommand::Update
-                        | Subcommand::Remove
-                        | Subcommand::Patch
-                        | Subcommand::PatchCommit
-                )
-            {
-                // `-g` already fchdir'd into the global dir above; the global
-                // manifest may not exist until the first `bun add -g`. Create it
-                // so read-only queries like `bun pm -g bin` work on a fresh
-                // install instead of failing with MissingPackageJSON.
-                // Update/Remove/Patch keep returning the error so their callers
-                // can print "nothing to remove/update/patch" and exit 1.
+            if cli.global && !subcommand.wants_missing_package_json_error() {
+                // `-g` already fchdir'd into the global dir above; create the
+                // global manifest on demand so `bun pm -g bin` etc. work on a
+                // fresh install.
                 this_cwd = original_cwd;
                 created_package_json = true;
                 break 'child attempt_to_create_package_json_and_open()?;

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -492,7 +492,22 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             Global::exit(0);
         } else if strings::eql_comptime(subcommand, b"ls") {
             let log_level = pm.options.log_level;
+            let is_global = pm.options.global;
             let load_lockfile = pm.load_lockfile_from_cwd::<true>();
+
+            if is_global && matches!(load_lockfile, LoadResult::NotFound) {
+                Output::flush();
+                Output::disable_buffering();
+                let mut cwd_buf = PathBuffer::uninit();
+                if let Ok(len) = bun_sys::getcwd(&mut cwd_buf[..]) {
+                    Output::println(format_args!(
+                        "{} node_modules (0)",
+                        bstr::BStr::new(&cwd_buf[..len]),
+                    ));
+                }
+                Global::exit(0);
+            }
+
             Self::handle_load_lockfile_errors(&load_lockfile, log_level);
 
             Output::flush();

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -499,12 +499,16 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 Output::flush();
                 Output::disable_buffering();
                 let mut cwd_buf = PathBuffer::uninit();
-                if let Ok(len) = bun_sys::getcwd(&mut cwd_buf[..]) {
-                    Output::println(format_args!(
-                        "{} node_modules (0)",
-                        bstr::BStr::new(&cwd_buf[..len]),
-                    ));
-                }
+                let path = match bun_sys::getcwd(&mut cwd_buf[..]) {
+                    Ok(len) => &cwd_buf[..len],
+                    Err(_) => {
+                        bun_core::pretty_errorln!(
+                            "<r><red>error<r>: Could not get current working directory",
+                        );
+                        Global::exit(1);
+                    }
+                };
+                Output::println(format_args!("{} node_modules (0)", bstr::BStr::new(path)));
                 Global::exit(0);
             }
 

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -944,6 +944,43 @@ test.each([
   expect(exitCode).toBe(0);
 });
 
+// https://github.com/oven-sh/bun/issues/13019
+test.each([
+  ["pm", "ls", "-g"],
+  ["pm", "-g", "ls"],
+])("bun %s %s %s prints an empty listing when no global package has been installed", async (...args) => {
+  using dir = tempDir("pm-ls-global-fresh", {
+    "cwd/.keep": "",
+  });
+  const dirStr = String(dir);
+  const bunInstallDir = join(dirStr, "bun-install");
+
+  const spawnEnv: NodeJS.Dict<string> = {
+    ...env,
+    BUN_INSTALL: bunInstallDir,
+    XDG_CACHE_HOME: join(dirStr, "xdg-cache"),
+    HOME: dirStr,
+  };
+  delete spawnEnv.BUN_INSTALL_GLOBAL_DIR;
+  delete spawnEnv.BUN_INSTALL_BIN;
+
+  expect(await exists(join(bunInstallDir, "install", "global", "package.json"))).toBeFalse();
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    cwd: join(dirStr, "cwd"),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: spawnEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("No package.json");
+  expect(stderr).not.toContain("Lockfile not found");
+  expect(stdout.trim()).toBe(`${join(bunInstallDir, "install", "global")} node_modules (0)`);
+  expect(exitCode).toBe(0);
+});
+
 test("bun pm bin without -g still requires a package.json", async () => {
   using dir = tempDir("pm-bin-local-no-pkgjson", {
     "cwd/.keep": "",

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -906,3 +906,67 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
 });
+
+// https://github.com/oven-sh/bun/issues/7501
+test.each([
+  ["pm", "-g", "bin"],
+  ["pm", "bin", "-g"],
+])("bun %s %s %s prints the global bin dir when no global package.json exists yet", async (...args) => {
+  using dir = tempDir("pm-bin-global-fresh", {
+    "cwd/.keep": "",
+  });
+  const dirStr = String(dir);
+  const bunInstallDir = join(dirStr, "bun-install");
+
+  const spawnEnv: NodeJS.Dict<string> = {
+    ...env,
+    BUN_INSTALL: bunInstallDir,
+    XDG_CACHE_HOME: join(dirStr, "xdg-cache"),
+    HOME: dirStr,
+  };
+  delete spawnEnv.BUN_INSTALL_GLOBAL_DIR;
+  delete spawnEnv.BUN_INSTALL_BIN;
+
+  expect(await exists(join(bunInstallDir, "install", "global", "package.json"))).toBeFalse();
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    cwd: join(dirStr, "cwd"),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: spawnEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("No package.json");
+  expect(stderr).not.toContain("MissingPackageJSON");
+  expect(stdout.trim()).toBe(join(bunInstallDir, "bin"));
+  expect(exitCode).toBe(0);
+});
+
+test("bun pm bin without -g still requires a package.json", async () => {
+  using dir = tempDir("pm-bin-local-no-pkgjson", {
+    "cwd/.keep": "",
+  });
+  const dirStr = String(dir);
+
+  const spawnEnv: NodeJS.Dict<string> = {
+    ...env,
+    BUN_INSTALL: join(dirStr, "bun-install"),
+    XDG_CACHE_HOME: join(dirStr, "xdg-cache"),
+    HOME: dirStr,
+  };
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "bin"],
+    cwd: join(dirStr, "cwd"),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: spawnEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("No package.json");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(1);
+});

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -970,3 +970,33 @@ test("bun pm bin without -g still requires a package.json", async () => {
   expect(stdout).toBe("");
   expect(exitCode).toBe(1);
 });
+
+test("bun remove -g with no global package.json still says nothing to remove", async () => {
+  using dir = tempDir("remove-global-fresh", {
+    "cwd/.keep": "",
+  });
+  const dirStr = String(dir);
+  const bunInstallDir = join(dirStr, "bun-install");
+
+  const spawnEnv: NodeJS.Dict<string> = {
+    ...env,
+    BUN_INSTALL: bunInstallDir,
+    XDG_CACHE_HOME: join(dirStr, "xdg-cache"),
+    HOME: dirStr,
+  };
+  delete spawnEnv.BUN_INSTALL_GLOBAL_DIR;
+  delete spawnEnv.BUN_INSTALL_BIN;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "remove", "-g", "some-pkg"],
+    cwd: join(dirStr, "cwd"),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: spawnEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("nothing to remove");
+  expect(await exists(join(bunInstallDir, "install", "global", "package.json"))).toBeFalse();
+  expect(exitCode).toBe(1);
+});


### PR DESCRIPTION
Fixes #7501.
Fixes #13019.
Fixes #6382.

## Repro

On a machine (or container) that has never run `bun add -g`:

```console
$ bun pm -g bin
error: No package.json was found for directory "/root/.bun/install/global"
note: Run "bun init" to initialize a project

$ bun pm ls -g
error: No package.json was found for directory "/root/.bun/install/global"
note: Run "bun init" to initialize a project
```

Reproduces on 1.3.14 and 1.4.0-canary.1+5f65d3785. `npm bin -g` / `npm prefix -g` / `npm ls -g` never require an install first.

## Cause

`PackageManager::init` with `-g` fchdir's into `$BUN_INSTALL/install/global` and then walks up looking for a `package.json`. On a fresh install that file does not exist yet, so every `-g` command routed through `init` (`bun pm -g bin`, `bun pm -g cache`, `bun pm ls -g`, `bun outdated -g`, `bun audit -g`, ...) failed with `MissingPackageJSON`.

The install path (`updatePackageJSONAndInstall`) already handled this by creating the global manifest and retrying `init`. Other `init` callers did not.

Separately, `bun pm ls -g` has a second failure mode: even when the global `package.json` exists (for example after `bun remove -g` deletes the last package and the lockfile along with it), `ls` would hit `handle_load_lockfile_errors` with `LoadResult::NotFound` and exit 1 with `error: Lockfile not found`.

## Fix

- Move the auto-create into `init` itself for the `cli.global` case, reusing the existing `attempt_to_create_package_json_and_open` helper that `bun add <pkg>` uses for an empty directory. Subcommands that want the dedicated "nothing to X" error (`remove`, `update`, `patch`, `patch-commit`) are excluded via `wants_missing_package_json_error()`.
- In the `ls` handler, when `-g` is set and the lockfile is `NotFound`, print the zero-count header (`<global-dir> node_modules (0)`) and exit 0 instead of treating it as an error.

Local (non-global) behavior is unchanged: `bun pm bin` / `bun pm ls` without `-g` in a directory with no `package.json` still error, and `bun pm ls` with a `package.json` but no lockfile still errors with `Lockfile not found`.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/cli/install/bun-pm.test.ts -t 'global bin dir|empty listing'
(fail) bun pm -g bin prints the global bin dir when no global package.json exists yet
(fail) bun pm bin -g prints the global bin dir when no global package.json exists yet
(fail) bun pm ls -g prints an empty listing when no global package has been installed
(fail) bun pm -g ls prints an empty listing when no global package has been installed

$ bun bd test test/cli/install/bun-pm.test.ts -t 'global bin dir|empty listing|still requires|nothing to remove'
(pass) bun pm -g bin prints the global bin dir when no global package.json exists yet
(pass) bun pm bin -g prints the global bin dir when no global package.json exists yet
(pass) bun pm ls -g prints an empty listing when no global package has been installed
(pass) bun pm -g ls prints an empty listing when no global package has been installed
(pass) bun pm bin without -g still requires a package.json
(pass) bun remove -g with no global package.json still says nothing to remove
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-pm.test.ts
bun test v1.4.0 (5b607b397)

test/cli/install/bun-pm.test.ts:
(pass) should list top-level dependency [1946.90ms]
(pass) should list all dependencies [1309.54ms]
(pass) should list top-level aliased dependency [1362.49ms]
(pass) should list aliased dependencies [1096.86ms]
(pass) should list only trusted dependencies with --trusted [1719.10ms]
(pass) should list only trusted dependencies with --all --trusted [1937.99ms]
(pass) should list trusted transitive dependencies under untrusted parents with --all --trusted (isolated) [1229.77ms]
(pass) should list nothing with --trusted when no dependencies are trusted [2159.23ms]
(pass) should remove all cache [1525.88ms]
(pass) bun pm migrate [2953.58ms]
(pass) bun whoami executes pm whoami [220.29ms]
(pass) bun pm whoami still works [179.60ms]
(pass) bun list executes pm ls [935.19ms]
(pass) bun pm list works as alias for bun pm ls [887.72ms]
(pass) bun pm ls still works [2025.03ms]
(pass) bun list --all shows full dependency tree [1438.08ms]
(pass) bun pm cac
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/install/bun-pm.test.ts:
(pass) should list top-level dependency [26.53ms]
(pass) should list all dependencies [2817.27ms]
(pass) should list top-level aliased dependency [2191.34ms]
(pass) should list aliased dependencies [124.62ms]
(pass) should list only trusted dependencies with --trusted [1870.41ms]
(pass) should list only trusted dependencies with --all --trusted [806.30ms]
(pass) should list trusted transitive dependencies under untrusted parents with --all --trusted (isolated) [385.91ms]
(pass) should list nothing with --trusted when no dependencies are trusted [832.48ms]
(pass) should remove all cache [697.96ms]
(pass) bun pm migrate [61.96ms]
(pass) bun whoami executes pm whoami [6.03ms]
(pass) bun pm whoami still works [5.11ms]
(pass) bun list executes pm ls [960.08ms]
(pass) bun pm list works as alias for bun pm ls [838.82ms]
(pass) bun pm ls still works [335.89ms]
(pass) bun list --all shows full dependency tree [2106.80ms]
(pass) bun pm cache rm resolves the cache directory from the process environment, ignoring project-local .env overrides [16.07ms]
(pass) bun pm cache rm does not create the directory name
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-pm.test.ts
bun test v1.4.0 (5b607b397)

test/cli/install/bun-pm.test.ts:
(pass) should list top-level dependency [828.86ms]
(pass) should list all dependencies [1614.55ms]
(pass) should list top-level aliased dependency [931.21ms]
(pass) should list aliased dependencies [1828.42ms]
(pass) should list only trusted dependencies with --trusted [1143.66ms]
(pass) should list only trusted dependencies with --all --trusted [1172.91ms]
(pass) should list trusted transitive dependencies under untrusted parents with --all --trusted (isolated) [1274.11ms]
(pass) should list nothing with --trusted when no dependencies are trusted [1113.70ms]
(pass) should remove all cache [1695.96ms]
(pass) bun pm migrate [2798.79ms]
(pass) bun whoami executes pm whoami [217.33ms]
(pass) bun pm whoami still works [192.30ms]
(pass) bun list executes pm ls [876.74ms]
(pass) bun pm list works as alias for bun pm ls [1037.52ms]
(pass) bun pm ls still works [1162.94ms]
(pass) bun list --all shows full dependency tree [932.68ms]
(pass) bun pm cache
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1601ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/52] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/52] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[3/52] gen cpp.rs (cppbind)
[3/52] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager.rs              |  13 +++
 src/runtime/cli/package_manager_command.rs |  19 +++++
 test/cli/install/bun-pm.test.ts            | 131 +++++++++++++++++++++++++++++
 3 files changed, 163 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/install/PackageManager.rs                   3      6      0
src/runtime/cli/package_manager_command.rs      2      1      0
test/cli/install/bun-pm.test.ts                 3      2      0
```

</details>

<!-- robobun:evidence:end -->