### PR TITLE
console: keep console.error red across inspected values

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -348,10 +348,10 @@ impl Drop for FlushOnDrop<'_> {
     }
 }
 
-/// Re-emits `after_reset` after every `\x1b[0m` so `console.error` stays red
-/// across the value formatter's per-token resets. Empty `after_reset` = passthrough.
+/// Re-emits `after_reset` after every `\x1b[0m` so `console.error` stays red through the value formatter's resets.
 struct LevelColorWriter<'a> {
     inner: &'a mut (dyn bun_io::Write + 'a),
+    /// Empty = transparent passthrough (non-error levels).
     after_reset: &'static [u8],
     /// Bytes of `RESET` matched at the tail of the previous write.
     matched: u8,

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -348,6 +348,87 @@ impl Drop for FlushOnDrop<'_> {
     }
 }
 
+/// Re-applies a base colour after every SGR reset the inner formatter emits,
+/// so the `console.error` red survives the per-token `<r>` resets the value
+/// formatter sprinkles through inspected objects/arrays.
+///
+/// `after_reset` is empty for `console.log` and friends, which makes this a
+/// transparent passthrough. `matched` tracks a partial `\x1b[0m` tail across
+/// `write_all` calls so a reset split over two writes is still recognised.
+struct LevelColorWriter<'a> {
+    inner: &'a mut (dyn bun_io::Write + 'a),
+    after_reset: &'static [u8],
+    matched: u8,
+}
+
+impl<'a> LevelColorWriter<'a> {
+    const RESET: &'static [u8] = b"\x1b[0m";
+
+    #[inline]
+    fn new(inner: &'a mut (dyn bun_io::Write + 'a), after_reset: &'static [u8]) -> Self {
+        Self {
+            inner,
+            after_reset,
+            matched: 0,
+        }
+    }
+}
+
+impl bun_io::Write for LevelColorWriter<'_> {
+    fn write_all(&mut self, mut buf: &[u8]) -> bun_io::Result<()> {
+        if self.after_reset.is_empty() {
+            return self.inner.write_all(buf);
+        }
+
+        if self.matched > 0 {
+            let need = &Self::RESET[self.matched as usize..];
+            let take = need.len().min(buf.len());
+            if buf[..take] == need[..take] {
+                self.inner.write_all(&buf[..take])?;
+                buf = &buf[take..];
+                if take == need.len() {
+                    self.inner.write_all(self.after_reset)?;
+                    self.matched = 0;
+                } else {
+                    self.matched += take as u8;
+                    return Ok(());
+                }
+            } else {
+                self.matched = 0;
+            }
+        }
+
+        while let Some(i) = strings::index_of_char_usize(buf, b'\x1b') {
+            self.inner.write_all(&buf[..i])?;
+            let rest = &buf[i..];
+            if rest.len() >= Self::RESET.len() {
+                if rest[..Self::RESET.len()] == *Self::RESET {
+                    self.inner.write_all(Self::RESET)?;
+                    self.inner.write_all(self.after_reset)?;
+                    buf = &rest[Self::RESET.len()..];
+                } else {
+                    self.inner.write_all(&rest[..1])?;
+                    buf = &rest[1..];
+                }
+            } else if *rest == Self::RESET[..rest.len()] {
+                self.inner.write_all(rest)?;
+                self.matched = rest.len() as u8;
+                return Ok(());
+            } else {
+                self.inner.write_all(&rest[..1])?;
+                buf = &rest[1..];
+            }
+        }
+
+        self.inner.write_all(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> bun_io::Result<()> {
+        self.inner.flush()
+    }
+}
+
 /// <https://console.spec.whatwg.org/#formatter>
 #[crate::host_call]
 pub extern "C" fn message_with_type_and_level(
@@ -1380,6 +1461,12 @@ pub fn format2(
         return Ok(());
     }
 
+    let level_color: &'static [u8] = if options.enable_colors && level == MessageLevel::Error {
+        pfmt!("<red>", true).as_bytes()
+    } else {
+        b""
+    };
+
     if len == 1 {
         // initialized later in this function.
         // `Formatter` has a `Drop` impl, so struct-update from a
@@ -1403,7 +1490,10 @@ pub fn format2(
                 if level == MessageLevel::Error {
                     let _ = writer.write_all(pfmt!("<r><red>", true).as_bytes());
                 }
-                fmt.format::<true>(tag, writer, vals[0], global)?;
+                {
+                    let mut colored = LevelColorWriter::new(&mut *writer, level_color);
+                    fmt.format::<true>(tag, &mut colored, vals[0], global)?;
+                }
                 if level == MessageLevel::Error {
                     let _ = writer.write_all(pfmt!("<r>", true).as_bytes());
                 }
@@ -1467,24 +1557,28 @@ pub fn format2(
         if level == MessageLevel::Error {
             let _ = writer.write_all(pfmt!("<r><red>", true).as_bytes());
         }
-        loop {
-            if any {
-                let _ = writer.write_all(b" ");
-            }
-            any = true;
+        {
+            let mut colored = LevelColorWriter::new(&mut *writer, level_color);
+            let writer: &mut dyn bun_io::Write = &mut colored;
+            loop {
+                if any {
+                    let _ = writer.write_all(b" ");
+                }
+                any = true;
 
-            tag = formatter::Tag::get(this_value, global)?;
-            if matches!(tag.tag, TagPayload::String) && !fmt.remaining().is_empty() {
-                tag.tag = TagPayload::StringPossiblyFormatted;
-            }
+                tag = formatter::Tag::get(this_value, global)?;
+                if matches!(tag.tag, TagPayload::String) && !fmt.remaining().is_empty() {
+                    tag.tag = TagPayload::StringPossiblyFormatted;
+                }
 
-            fmt.format::<true>(tag, writer, this_value, global)?;
-            if fmt.remaining().is_empty() {
-                break;
-            }
+                fmt.format::<true>(tag, writer, this_value, global)?;
+                if fmt.remaining().is_empty() {
+                    break;
+                }
 
-            this_value = fmt.remaining()[0];
-            fmt.advance_remaining();
+                this_value = fmt.remaining()[0];
+                fmt.advance_remaining();
+            }
         }
         if level == MessageLevel::Error {
             let _ = writer.write_all(pfmt!("<r>", true).as_bytes());

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -348,16 +348,12 @@ impl Drop for FlushOnDrop<'_> {
     }
 }
 
-/// Re-applies a base colour after every SGR reset the inner formatter emits,
-/// so the `console.error` red survives the per-token `<r>` resets the value
-/// formatter sprinkles through inspected objects/arrays.
-///
-/// `after_reset` is empty for `console.log` and friends, which makes this a
-/// transparent passthrough. `matched` tracks a partial `\x1b[0m` tail across
-/// `write_all` calls so a reset split over two writes is still recognised.
+/// Re-emits `after_reset` after every `\x1b[0m` so `console.error` stays red
+/// across the value formatter's per-token resets. Empty `after_reset` = passthrough.
 struct LevelColorWriter<'a> {
     inner: &'a mut (dyn bun_io::Write + 'a),
     after_reset: &'static [u8],
+    /// Bytes of `RESET` matched at the tail of the previous write.
     matched: u8,
 }
 

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -143,6 +143,42 @@ NamedError: console.error a named error
 `);
 });
 
+// https://github.com/oven-sh/bun/issues/7125
+it("console.error keeps red across inspected values", async () => {
+  await using proc = spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `console.error("This is an error message", { a: 1, b: 2 });
+       console.error("errors:", [1]);
+       console.error("nested", { outer: { inner: [1, "two", null] } });
+       console.log("not an error", { a: 1 });`,
+    ],
+    env: { ...bunEnv, FORCE_COLOR: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const err = stderr.replaceAll("\r\n", "\n");
+  // Three console.error calls, each bracketed by <r><red> ... <r>\n.
+  expect(err.match(/^\x1b\[0m\x1b\[31m/gm)?.length).toBe(3);
+  expect(err.match(/\x1b\[0m\n/g)?.length).toBe(3);
+
+  // Every SGR reset inside the body must be immediately followed by the red
+  // escape so structural punctuation (braces, brackets, keys, commas) stays
+  // red. After pairing them off, the only remaining resets are the three
+  // trailing ones directly before each newline.
+  const leftover = err.replaceAll("\x1b[0m\x1b[31m", "").match(/\x1b\[0m(?!\n)/g) ?? [];
+  expect(leftover).toEqual([]);
+
+  // console.log must be untouched: no red, and no extra trailing reset.
+  const out = stdout.replaceAll("\r\n", "\n");
+  expect(out).not.toContain("\x1b[31m");
+  expect(out.endsWith("\x1b[0m\n")).toBe(false);
+  expect(exitCode).toBe(0);
+});
+
 it("console.log with SharedArrayBuffer", () => {
   // console.log(x) === Bun.inspect(x) + "\n" written to stdout.
   expect(Bun.inspect(new ArrayBuffer(0))).toBe("ArrayBuffer(0) []");


### PR DESCRIPTION
Fixes #7125.

## Repro

```js
console.error("This is an error message", { a: 1, b: 2 });
console.error("errors:", [1]);
```

With `FORCE_COLOR=1`, only `This is an error message {` and `errors: [` render red; the object body, closing brace, and array elements print in the default foreground.

## Cause

`format2` brackets the colored body with `\x1b[0m\x1b[31m ... \x1b[0m`, but the value formatter emits `\x1b[0m` around every property key, colon, comma, and scalar it inspects. The first such reset drops the red and nothing restores it.

## Fix

Route the colored body of a `console.error` call through a thin writer wrapper that appends `\x1b[31m` after every `\x1b[0m` it passes through, so structural tokens (keys, braces, brackets, commas) stay red while value-type colors (yellow numbers, green strings) still win because they immediately follow the re-applied red. The trailing reset goes to the underlying writer directly, so the terminal state is clean at end of line. The wrapper is a passthrough when the level is not `Error`, leaving `console.log`, `Bun.inspect`, and the single-value Error printer byte-identical.

## Verification

```
$ FORCE_COLOR=1 bun -e 'console.error("This is an error message", { a: 1, b: 2 })' 2>&1 | cat -v
^[[0m^[[31mThis is an error message {
  ^[[0m^[[31ma^[[2m:^[[0m^[[31m ^[[0m^[[31m^[[33m1^[[0m^[[31m^[[0m^[[31m^[[2m,^[[0m^[[31m
  ^[[0m^[[31mb^[[2m:^[[0m^[[31m ^[[0m^[[31m^[[33m2^[[0m^[[31m^[[0m^[[31m^[[2m,^[[0m^[[31m
}^[[0m
```

New test in `test/js/web/console/console-log.test.ts` asserts that every `\x1b[0m` inside a `console.error` body is immediately followed by `\x1b[31m`, and that `console.log` output is unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-log.test.ts
bun test v1.4.0 (001c38042)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [1078.26ms]
(pass) long arrays get cutoff [4.38ms]
(pass) console.group [370.36ms]
161 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
162 | 
163 |   const err = stderr.replaceAll("\r\n", "\n");
164 |   // Three console.error calls, each bracketed by <r><red> ... <r>\n.
165 |   expect(err.match(/^\x1b\[0m\x1b\[31m/gm)?.length).toBe(3);
166 |   expect(err.match(/\x1b\[0m\n/g)?.length).toBe(3);
                                                 ^
error: expect(received).toBe(expected)

Expected: 3
Received: 7

      at <anonymous> (/workspace/bun/test/js/web/console/console-log.test.ts:166:44)
(fail) console.error keeps red across inspected values [338.18ms]
(pass) console.log with SharedArrayBuffer [5.41ms]

 4 pass
 1 fail
 2 snapshots, 11 expect() calls
Ran 5 tests across 1 file. [6.93s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (c423790f3)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [34.84ms]
(pass) long arrays get cutoff [0.28ms]
(pass) console.group [15.50ms]
(pass) console.error keeps red across inspected values [14.69ms]
(pass) console.log with SharedArrayBuffer [0.14ms]

 5 pass
 0 fail
 2 snapshots, 15 expect() calls
Ran 5 tests across 1 file. [473.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-log.test.ts
bun test v1.4.0 (001c38042)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [1329.32ms]
(pass) long arrays get cutoff [6.79ms]
(pass) console.group [415.62ms]
(pass) console.error keeps red across inspected values [422.26ms]
(pass) console.log with SharedArrayBuffer [6.62ms]

 5 pass
 0 fail
 2 snapshots, 15 expect() calls
Ran 5 tests across 1 file. [6.14s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1237ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                | 122 +++++++++++++++++++++++++++-----
 test/js/web/console/console-log.test.ts |  36 ++++++++++
 2 files changed, 142 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/ConsoleObject.rs                    11      7      0
test/js/web/console/console-log.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->