### PR TITLE
resolver: don't treat '?' in a directory name as a query-string separator

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1350,6 +1350,9 @@ pub fn index_of_char_usize(slice: &[u8], char: u8) -> Option<usize> {
 
 /// Index of the query-string `?` in a module specifier; skips `?/` (POSIX dir-name byte, #7928).
 pub fn index_of_import_query(specifier: &[u8]) -> Option<usize> {
+    if cfg!(windows) {
+        return index_of_char_usize(specifier, b'?');
+    }
     let mut from = 0usize;
     loop {
         let i = from + index_of_char_usize(&specifier[from..], b'?')?;

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1349,11 +1349,7 @@ pub fn index_of_char_usize(slice: &[u8], char: u8) -> Option<usize> {
 }
 
 /// Index of the `?` that begins a query-string suffix in a module specifier.
-///
-/// A `?` immediately followed by `/` is a POSIX directory-name byte (e.g.
-/// `./dir?/file.js`), not a query separator, and is skipped. This keeps
-/// `./foo.js?key=a/b` splitting at the first `?` while letting a file under a
-/// `?`-named directory resolve as a filesystem path. #7928
+/// Skips `?/`, which is a POSIX directory-name byte (`./dir?/file.js`). #7928
 pub fn index_of_import_query(specifier: &[u8]) -> Option<usize> {
     let mut from = 0usize;
     loop {

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1348,8 +1348,7 @@ pub fn index_of_char_usize(slice: &[u8], char: u8) -> Option<usize> {
     highway::index_of_char(slice, char)
 }
 
-/// Index of the `?` that begins a query-string suffix in a module specifier.
-/// Skips `?/`, which is a POSIX directory-name byte (`./dir?/file.js`). #7928
+/// Index of the query-string `?` in a module specifier; skips `?/` (POSIX dir-name byte, #7928).
 pub fn index_of_import_query(specifier: &[u8]) -> Option<usize> {
     let mut from = 0usize;
     loop {

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1348,6 +1348,23 @@ pub fn index_of_char_usize(slice: &[u8], char: u8) -> Option<usize> {
     highway::index_of_char(slice, char)
 }
 
+/// Index of the `?` that begins a query-string suffix in a module specifier.
+///
+/// A `?` immediately followed by `/` is a POSIX directory-name byte (e.g.
+/// `./dir?/file.js`), not a query separator, and is skipped. This keeps
+/// `./foo.js?key=a/b` splitting at the first `?` while letting a file under a
+/// `?`-named directory resolve as a filesystem path. #7928
+pub fn index_of_import_query(specifier: &[u8]) -> Option<usize> {
+    let mut from = 0usize;
+    loop {
+        let i = from + index_of_char_usize(&specifier[from..], b'?')?;
+        if specifier.get(i + 1) != Some(&b'/') {
+            return Some(i);
+        }
+        from = i + 1;
+    }
+}
+
 pub fn index_of_char_pos(slice: &[u8], char: u8, start_index: usize) -> Option<usize> {
     if start_index >= slice.len() {
         return None;

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -444,7 +444,17 @@ pub(crate) fn normalize_specifier<'a>(
     let mut query: &[u8] = b"";
 
     if let Some(i) = strings::index_of_char(slice, b'?') {
-        let i = i as usize;
+        let mut i = i as usize;
+        // A '?' that sits before a path separator is part of a directory name
+        // (POSIX allows '?' in filenames), not a query string. Only split on a
+        // '?' that appears in the final path segment. #7928
+        if strings::contains_char(&slice[i + 1..], b'/') {
+            let base = strings::last_index_of_char(slice, b'/').unwrap_or(0) + 1;
+            match strings::index_of_char(&slice[base..], b'?') {
+                Some(j) => i = base + j as usize,
+                None => return (slice, specifier, query),
+            }
+        }
         query = &slice[i..];
         slice = &slice[..i];
     }

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -443,18 +443,7 @@ pub(crate) fn normalize_specifier<'a>(
     let specifier = slice;
     let mut query: &[u8] = b"";
 
-    if let Some(i) = strings::index_of_char(slice, b'?') {
-        let mut i = i as usize;
-        // A '?' that sits before a path separator is part of a directory name
-        // (POSIX allows '?' in filenames), not a query string. Only split on a
-        // '?' that appears in the final path segment. #7928
-        if strings::contains_char(&slice[i + 1..], b'/') {
-            let base = strings::last_index_of_char(slice, b'/').unwrap_or(0) + 1;
-            match strings::index_of_char(&slice[base..], b'?') {
-                Some(j) => i = base + j as usize,
-                None => return (slice, specifier, query),
-            }
-        }
+    if let Some(i) = strings::index_of_import_query(slice) {
         query = &slice[i..];
         slice = &slice[..i];
     }

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -62,7 +62,10 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
 
   // A resolved id may carry a `?query` suffix (part of the module cache key);
   // match the native-addon extension against the path portion only.
-  const queryIndex = id.indexOf("?");
+  let queryIndex = id.indexOf("?");
+  if (process.platform !== "win32") {
+    while (queryIndex !== -1 && id.charCodeAt(queryIndex + 1) === 0x2f) queryIndex = id.indexOf("?", queryIndex + 1);
+  }
   if (queryIndex === -1 ? id.endsWith(".node") : id.endsWith(".node", queryIndex)) {
     return $internalRequire(id, this);
   }
@@ -163,7 +166,10 @@ export function internalRequire(id: string, parent: JSCommonJSModule) {
   $assert($requireMap.$get(id) === undefined, "Module " + JSON.stringify(id) + " should not be in the map");
   // `id` keys the module cache and may carry a `?query` suffix;
   // `process.dlopen` needs the on-disk path.
-  const queryIndex = id.indexOf("?");
+  let queryIndex = id.indexOf("?");
+  if (process.platform !== "win32") {
+    while (queryIndex !== -1 && id.charCodeAt(queryIndex + 1) === 0x2f) queryIndex = id.indexOf("?", queryIndex + 1);
+  }
   const filename = queryIndex === -1 ? id : id.substring(0, queryIndex);
   $assert(filename.endsWith(".node"));
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2938,17 +2938,7 @@ fn normalize_specifier_for_resolution<'a>(
     specifier_: &'a [u8],
     query_string: &mut &'a [u8],
 ) -> &'a [u8] {
-    if let Some(mut i) = bun_core::strings::index_of_char_usize(specifier_, b'?') {
-        // A '?' that sits before a path separator is part of a directory name
-        // (POSIX allows '?' in filenames), not a query string. Only split on a
-        // '?' that appears in the final path segment. #7928
-        if bun_core::strings::contains_char(&specifier_[i + 1..], b'/') {
-            let base = bun_core::strings::last_index_of_char(specifier_, b'/').unwrap_or(0) + 1;
-            match bun_core::strings::index_of_char_usize(&specifier_[base..], b'?') {
-                Some(j) => i = base + j,
-                None => return specifier_,
-            }
-        }
+    if let Some(i) = bun_core::strings::index_of_import_query(specifier_) {
         *query_string = &specifier_[i..];
         &specifier_[..i]
     } else {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2938,7 +2938,17 @@ fn normalize_specifier_for_resolution<'a>(
     specifier_: &'a [u8],
     query_string: &mut &'a [u8],
 ) -> &'a [u8] {
-    if let Some(i) = bun_core::strings::index_of_char_usize(specifier_, b'?') {
+    if let Some(mut i) = bun_core::strings::index_of_char_usize(specifier_, b'?') {
+        // A '?' that sits before a path separator is part of a directory name
+        // (POSIX allows '?' in filenames), not a query string. Only split on a
+        // '?' that appears in the final path segment. #7928
+        if bun_core::strings::contains_char(&specifier_[i + 1..], b'/') {
+            let base = bun_core::strings::last_index_of_char(specifier_, b'/').unwrap_or(0) + 1;
+            match bun_core::strings::index_of_char_usize(&specifier_[base..], b'?') {
+                Some(j) => i = base + j,
+                None => return specifier_,
+            }
+        }
         *query_string = &specifier_[i..];
         &specifier_[..i]
     } else {

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -166,11 +166,13 @@ ImportMetaObject* ImportMetaObject::create(JSC::JSGlobalObject* globalObject, JS
 
 ImportMetaObject* ImportMetaObject::createFromSpecifier(JSC::JSGlobalObject* globalObject, const String& specifier)
 {
-    // Skip `?/`: a POSIX directory-name byte (`/abs/dir?/file.js`). #7928
     auto index = specifier.find('?');
+#if !OS(WINDOWS)
+    // Skip `?/`: a POSIX directory-name byte (`/abs/dir?/file.js`). #7928
     while (index != notFound && index + 1 < specifier.length() && specifier[index + 1] == '/') {
         index = specifier.find('?', index + 1);
     }
+#endif
     URL url;
     if (index != notFound) {
         StringView view = specifier;

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -166,7 +166,13 @@ ImportMetaObject* ImportMetaObject::create(JSC::JSGlobalObject* globalObject, JS
 
 ImportMetaObject* ImportMetaObject::createFromSpecifier(JSC::JSGlobalObject* globalObject, const String& specifier)
 {
+    // A '?' immediately followed by '/' is a POSIX directory-name byte (e.g.
+    // `/abs/dir?/file.js`), not a query separator. Skip those so the file://
+    // URL's path component covers the full filesystem path. #7928
     auto index = specifier.find('?');
+    while (index != notFound && index + 1 < specifier.length() && specifier[index + 1] == '/') {
+        index = specifier.find('?', index + 1);
+    }
     URL url;
     if (index != notFound) {
         StringView view = specifier;

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -166,9 +166,7 @@ ImportMetaObject* ImportMetaObject::create(JSC::JSGlobalObject* globalObject, JS
 
 ImportMetaObject* ImportMetaObject::createFromSpecifier(JSC::JSGlobalObject* globalObject, const String& specifier)
 {
-    // A '?' immediately followed by '/' is a POSIX directory-name byte (e.g.
-    // `/abs/dir?/file.js`), not a query separator. Skip those so the file://
-    // URL's path component covers the full filesystem path. #7928
+    // Skip `?/`: a POSIX directory-name byte (`/abs/dir?/file.js`). #7928
     auto index = specifier.find('?');
     while (index != notFound && index + 1 < specifier.length() && specifier[index + 1] == '/') {
         index = specifier.find('?', index + 1);

--- a/src/jsc/bindings/ImportMetaObject.h
+++ b/src/jsc/bindings/ImportMetaObject.h
@@ -40,7 +40,8 @@ public:
     /// The rules for this function's input is a bit weird. `specifier` is an import path specifier aka a file path.
     ///
     /// - Should be an absolute path or name of a plugin module
-    /// - A '?' is handled not as a literal '?' in a file, but rather as the query string
+    /// - A '?' is handled not as a literal '?' in a file, but rather as the query string,
+    ///   unless it is immediately followed by '/' (a POSIX directory-name byte, #7928)
     /// - The string is not URL encoded, despite having a query string.
     ///
     /// caveat: It is impossible to have a module with a `?` in it's file name.

--- a/src/jsc/bindings/ImportMetaObject.h
+++ b/src/jsc/bindings/ImportMetaObject.h
@@ -40,8 +40,7 @@ public:
     /// The rules for this function's input is a bit weird. `specifier` is an import path specifier aka a file path.
     ///
     /// - Should be an absolute path or name of a plugin module
-    /// - A '?' is handled not as a literal '?' in a file, but rather as the query string,
-    ///   unless it is immediately followed by '/' (a POSIX directory-name byte, #7928)
+    /// - A '?' starts the query string unless followed by '/' (#7928)
     /// - The string is not URL encoded, despite having a query string.
     ///
     /// caveat: It is impossible to have a module with a `?` in it's file name.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3916,8 +3916,17 @@ unsafe fn normalize_specifier_for_loader<'a>(
     }
     let specifier = slice;
     let mut query: &[u8] = b"";
-    if let Some(i) = bun_core::strings::index_of_char_usize(slice, b'?') {
-        let i = i as usize;
+    if let Some(mut i) = bun_core::strings::index_of_char_usize(slice, b'?') {
+        // A '?' that sits before a path separator is part of a directory name
+        // (POSIX allows '?' in filenames), not a query string. Only split on a
+        // '?' that appears in the final path segment. #7928
+        if bun_core::strings::contains_char(&slice[i + 1..], b'/') {
+            let base = bun_core::strings::last_index_of_char(slice, b'/').unwrap_or(0) + 1;
+            match bun_core::strings::index_of_char_usize(&slice[base..], b'?') {
+                Some(j) => i = base + j,
+                None => return (slice, specifier, query),
+            }
+        }
         query = &slice[i..];
         slice = &slice[..i];
     }
@@ -4843,8 +4852,17 @@ fn normalize_specifier_for_resolution<'a>(
     specifier: &'a [u8],
     query_string: &mut &'a [u8],
 ) -> &'a [u8] {
-    if let Some(i) = bun_core::strings::index_of_char_usize(specifier, b'?') {
-        let i = i as usize;
+    if let Some(mut i) = bun_core::strings::index_of_char_usize(specifier, b'?') {
+        // A '?' that sits before a path separator is part of a directory name
+        // (POSIX allows '?' in filenames), not a query string. Only split on a
+        // '?' that appears in the final path segment. #7928
+        if bun_core::strings::contains_char(&specifier[i + 1..], b'/') {
+            let base = bun_core::strings::last_index_of_char(specifier, b'/').unwrap_or(0) + 1;
+            match bun_core::strings::index_of_char_usize(&specifier[base..], b'?') {
+                Some(j) => i = base + j,
+                None => return specifier,
+            }
+        }
         *query_string = &specifier[i..];
         &specifier[..i]
     } else {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3916,17 +3916,7 @@ unsafe fn normalize_specifier_for_loader<'a>(
     }
     let specifier = slice;
     let mut query: &[u8] = b"";
-    if let Some(mut i) = bun_core::strings::index_of_char_usize(slice, b'?') {
-        // A '?' that sits before a path separator is part of a directory name
-        // (POSIX allows '?' in filenames), not a query string. Only split on a
-        // '?' that appears in the final path segment. #7928
-        if bun_core::strings::contains_char(&slice[i + 1..], b'/') {
-            let base = bun_core::strings::last_index_of_char(slice, b'/').unwrap_or(0) + 1;
-            match bun_core::strings::index_of_char_usize(&slice[base..], b'?') {
-                Some(j) => i = base + j,
-                None => return (slice, specifier, query),
-            }
-        }
+    if let Some(i) = bun_core::strings::index_of_import_query(slice) {
         query = &slice[i..];
         slice = &slice[..i];
     }
@@ -4852,17 +4842,7 @@ fn normalize_specifier_for_resolution<'a>(
     specifier: &'a [u8],
     query_string: &mut &'a [u8],
 ) -> &'a [u8] {
-    if let Some(mut i) = bun_core::strings::index_of_char_usize(specifier, b'?') {
-        // A '?' that sits before a path separator is part of a directory name
-        // (POSIX allows '?' in filenames), not a query string. Only split on a
-        // '?' that appears in the final path segment. #7928
-        if bun_core::strings::contains_char(&specifier[i + 1..], b'/') {
-            let base = bun_core::strings::last_index_of_char(specifier, b'/').unwrap_or(0) + 1;
-            match bun_core::strings::index_of_char_usize(&specifier[base..], b'?') {
-                Some(j) => i = base + j,
-                None => return specifier,
-            }
-        }
+    if let Some(i) = bun_core::strings::index_of_import_query(specifier) {
         *query_string = &specifier[i..];
         &specifier[..i]
     } else {

--- a/test/regression/issue/07928.test.ts
+++ b/test/regression/issue/07928.test.ts
@@ -128,3 +128,68 @@ test("query string containing '/' still splits at the '?'", async () => {
   expect(decodeURIComponent(url)).toEndWith("dep.js?path=/a/b");
   expect(exitCode).toBe(0);
 });
+
+test.skipIf(isWindows)("require('./x.node') under a '?'-named directory reaches process.dlopen", async () => {
+  using dir = tempDir("issue-7928-napi", {
+    "dir?/addon.node": "",
+    "dir?/entry.cjs": `
+      const out = [];
+      for (const spec of ["./addon.node", "./addon.node?v=1"]) {
+        try { require(spec); out.push(null); }
+        catch (e) { out.push(e.constructor.name + ": " + e.message); }
+      }
+      console.log(JSON.stringify(out));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "./dir?/entry.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const [plain, withQuery] = JSON.parse(stdout.trim());
+  // An empty .node file can't be dlopen'd; both spellings must fail with the
+  // same dlopen error (proving the '?' in the directory name reached dlopen as
+  // part of the path, not as a query separator).
+  expect(plain).not.toContain("Node-API");
+  expect(plain).not.toContain("Module not found");
+  expect(withQuery).toBe(plain);
+  expect(exitCode).toBe(0);
+});
+
+// Pin the accepted trade-off: on POSIX a '?' immediately followed by '/' is a
+// path byte, so a query string that literally begins with '/' is not split.
+// Windows has no such ambiguity ('?' is invalid in paths) and keeps splitting.
+test("import('./dep.js?/x') treats ?/ as a path byte on POSIX", async () => {
+  using dir = tempDir("issue-7928-query-leading-slash", {
+    "dep.js": `export const url = import.meta.url;`,
+    "entry.js": `
+      try {
+        const m = await import("./dep.js?/x");
+        console.log(JSON.stringify({ ok: true, url: m.url }));
+      } catch (e) {
+        console.log(JSON.stringify({ ok: false, msg: String(e) }));
+      }
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const out = JSON.parse(stdout.trim());
+  if (isWindows) {
+    expect(out.ok).toBe(true);
+    expect(decodeURIComponent(out.url)).toEndWith("dep.js?/x");
+  } else {
+    expect(out.ok).toBe(false);
+  }
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/07928.test.ts
+++ b/test/regression/issue/07928.test.ts
@@ -155,6 +155,7 @@ describe.concurrent("issue 7928: '?' in a directory name", () => {
     // An empty .node file can't be dlopen'd; both spellings must fail with the
     // same dlopen error (proving the '?' in the directory name reached dlopen as
     // part of the path, not as a query separator).
+    expect(plain).toContain("addon.node");
     expect(plain).not.toContain("Node-API");
     expect(plain).not.toContain("Module not found");
     expect(withQuery).toBe(plain);
@@ -191,6 +192,7 @@ describe.concurrent("issue 7928: '?' in a directory name", () => {
       expect(decodeURIComponent(out.url)).toEndWith("dep.js?/x");
     } else {
       expect(out.ok).toBe(false);
+      expect(out.msg).toContain("dep.js?/x");
     }
     expect(exitCode).toBe(0);
   });

--- a/test/regression/issue/07928.test.ts
+++ b/test/regression/issue/07928.test.ts
@@ -3,54 +3,55 @@
 // the module resolver/loader, so files under that directory could not be
 // loaded. Windows does not allow '?' in path names, so these tests only run on
 // POSIX.
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
 import path from "node:path";
 
-test.skipIf(isWindows)("`bun test` runs tests from a directory whose name contains '?'", async () => {
-  using dir = tempDir("issue-7928-test", {
-    "some-path?/my.test.js": `
+describe.concurrent("issue 7928: '?' in a directory name", () => {
+  test.skipIf(isWindows)("`bun test` runs tests from a directory whose name contains '?'", async () => {
+    using dir = tempDir("issue-7928-test", {
+      "some-path?/my.test.js": `
       import { test, expect } from "bun:test";
       test("inside dir with ?", () => { expect(1 + 1).toBe(2); });
     `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "my.test.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const out = normalizeBunSnapshot(stdout + stderr, dir);
+    expect(out).toContain("(pass) inside dir with ?");
+    expect(out).toContain("1 pass");
+    expect(out).not.toContain("Module not found");
+    expect(out).not.toContain("FileNotFound");
+    expect(exitCode).toBe(0);
   });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "my.test.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const out = normalizeBunSnapshot(stdout + stderr, dir);
-  expect(out).toContain("(pass) inside dir with ?");
-  expect(out).toContain("1 pass");
-  expect(out).not.toContain("Module not found");
-  expect(out).not.toContain("FileNotFound");
-  expect(exitCode).toBe(0);
-});
 
-test.skipIf(isWindows)("`bun <file>` runs a file under a directory whose name contains '?'", async () => {
-  using dir = tempDir("issue-7928-run", {
-    "some-path?/main.js": `console.log("ran from dir with ?");`,
+  test.skipIf(isWindows)("`bun <file>` runs a file under a directory whose name contains '?'", async () => {
+    using dir = tempDir("issue-7928-run", {
+      "some-path?/main.js": `console.log("ran from dir with ?");`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "./some-path?/main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ran from dir with ?\n");
+    expect(exitCode).toBe(0);
   });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "./some-path?/main.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(stdout).toBe("ran from dir with ?\n");
-  expect(exitCode).toBe(0);
-});
 
-test.skipIf(isWindows)("import resolves and import.meta is correct under a '?'-named directory", async () => {
-  using dir = tempDir("issue-7928-import", {
-    "dir?/dep.js": `export const value = 42;`,
-    "dir?/entry.js": `
+  test.skipIf(isWindows)("import resolves and import.meta is correct under a '?'-named directory", async () => {
+    using dir = tempDir("issue-7928-import", {
+      "dir?/dep.js": `export const value = 42;`,
+      "dir?/entry.js": `
       import { value } from "./dep.js";
       console.log(JSON.stringify({
         value,
@@ -60,79 +61,79 @@ test.skipIf(isWindows)("import resolves and import.meta is correct under a '?'-n
         file: import.meta.file,
       }));
     `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "./dir?/entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const meta = JSON.parse(stdout.trim());
+    expect(meta).toEqual({
+      value: 42,
+      url: Bun.pathToFileURL(path.join(String(dir), "dir?", "entry.js")).href,
+      path: path.join(String(dir), "dir?", "entry.js"),
+      dir: path.join(String(dir), "dir?"),
+      file: "entry.js",
+    });
+    expect(new URL(meta.url).pathname).toEndWith("dir%3F/entry.js");
+    expect(exitCode).toBe(0);
   });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "./dir?/entry.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  const meta = JSON.parse(stdout.trim());
-  expect(meta).toEqual({
-    value: 42,
-    url: Bun.pathToFileURL(path.join(String(dir), "dir?", "entry.js")).href,
-    path: path.join(String(dir), "dir?", "entry.js"),
-    dir: path.join(String(dir), "dir?"),
-    file: "entry.js",
-  });
-  expect(new URL(meta.url).pathname).toEndWith("dir%3F/entry.js");
-  expect(exitCode).toBe(0);
-});
 
-test.skipIf(isWindows)("query-string suffix still works when a parent directory contains '?'", async () => {
-  using dir = tempDir("issue-7928-query", {
-    "dir?/dep.js": `export const url = import.meta.url;`,
-    "dir?/entry.js": `
+  test.skipIf(isWindows)("query-string suffix still works when a parent directory contains '?'", async () => {
+    using dir = tempDir("issue-7928-query", {
+      "dir?/dep.js": `export const url = import.meta.url;`,
+      "dir?/entry.js": `
       const a = await import("./dep.js");
       const b = await import("./dep.js?v=1");
       console.log(JSON.stringify({ a: a.url, b: b.url, distinct: a !== b }));
     `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "./dir?/entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const { a, b, distinct } = JSON.parse(stdout.trim());
+    expect(decodeURIComponent(a)).toEndWith("dir?/dep.js");
+    expect(decodeURIComponent(b)).toEndWith("dir?/dep.js?v=1");
+    expect(distinct).toBe(true);
+    expect(exitCode).toBe(0);
   });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "./dir?/entry.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  const { a, b, distinct } = JSON.parse(stdout.trim());
-  expect(decodeURIComponent(a)).toEndWith("dir?/dep.js");
-  expect(decodeURIComponent(b)).toEndWith("dir?/dep.js?v=1");
-  expect(distinct).toBe(true);
-  expect(exitCode).toBe(0);
-});
 
-test("query string containing '/' still splits at the '?'", async () => {
-  using dir = tempDir("issue-7928-slash-in-query", {
-    "dep.js": `export const url = import.meta.url;`,
-    "entry.js": `
+  test("query string containing '/' still splits at the '?'", async () => {
+    using dir = tempDir("issue-7928-slash-in-query", {
+      "dep.js": `export const url = import.meta.url;`,
+      "entry.js": `
       const m = await import("./dep.js?path=/a/b");
       console.log(JSON.stringify({ url: m.url }));
     `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const { url } = JSON.parse(stdout.trim());
+    expect(decodeURIComponent(url)).toEndWith("dep.js?path=/a/b");
+    expect(exitCode).toBe(0);
   });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "entry.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  const { url } = JSON.parse(stdout.trim());
-  expect(decodeURIComponent(url)).toEndWith("dep.js?path=/a/b");
-  expect(exitCode).toBe(0);
-});
 
-test.skipIf(isWindows)("require('./x.node') under a '?'-named directory reaches process.dlopen", async () => {
-  using dir = tempDir("issue-7928-napi", {
-    "dir?/addon.node": "",
-    "dir?/entry.cjs": `
+  test.skipIf(isWindows)("require('./x.node') under a '?'-named directory reaches process.dlopen", async () => {
+    using dir = tempDir("issue-7928-napi", {
+      "dir?/addon.node": "",
+      "dir?/entry.cjs": `
       const out = [];
       for (const spec of ["./addon.node", "./addon.node?v=1"]) {
         try { require(spec); out.push(null); }
@@ -140,33 +141,33 @@ test.skipIf(isWindows)("require('./x.node') under a '?'-named directory reaches 
       }
       console.log(JSON.stringify(out));
     `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "./dir?/entry.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const [plain, withQuery] = JSON.parse(stdout.trim());
+    // An empty .node file can't be dlopen'd; both spellings must fail with the
+    // same dlopen error (proving the '?' in the directory name reached dlopen as
+    // part of the path, not as a query separator).
+    expect(plain).not.toContain("Node-API");
+    expect(plain).not.toContain("Module not found");
+    expect(withQuery).toBe(plain);
+    expect(exitCode).toBe(0);
   });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "./dir?/entry.cjs"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  const [plain, withQuery] = JSON.parse(stdout.trim());
-  // An empty .node file can't be dlopen'd; both spellings must fail with the
-  // same dlopen error (proving the '?' in the directory name reached dlopen as
-  // part of the path, not as a query separator).
-  expect(plain).not.toContain("Node-API");
-  expect(plain).not.toContain("Module not found");
-  expect(withQuery).toBe(plain);
-  expect(exitCode).toBe(0);
-});
 
-// Pin the accepted trade-off: on POSIX a '?' immediately followed by '/' is a
-// path byte, so a query string that literally begins with '/' is not split.
-// Windows has no such ambiguity ('?' is invalid in paths) and keeps splitting.
-test("import('./dep.js?/x') treats ?/ as a path byte on POSIX", async () => {
-  using dir = tempDir("issue-7928-query-leading-slash", {
-    "dep.js": `export const url = import.meta.url;`,
-    "entry.js": `
+  // Pin the accepted trade-off: on POSIX a '?' immediately followed by '/' is a
+  // path byte, so a query string that literally begins with '/' is not split.
+  // Windows has no such ambiguity ('?' is invalid in paths) and keeps splitting.
+  test("import('./dep.js?/x') treats ?/ as a path byte on POSIX", async () => {
+    using dir = tempDir("issue-7928-query-leading-slash", {
+      "dep.js": `export const url = import.meta.url;`,
+      "entry.js": `
       try {
         const m = await import("./dep.js?/x");
         console.log(JSON.stringify({ ok: true, url: m.url }));
@@ -174,22 +175,23 @@ test("import('./dep.js?/x') treats ?/ as a path byte on POSIX", async () => {
         console.log(JSON.stringify({ ok: false, msg: String(e) }));
       }
     `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout.trim());
+    if (isWindows) {
+      expect(out.ok).toBe(true);
+      expect(decodeURIComponent(out.url)).toEndWith("dep.js?/x");
+    } else {
+      expect(out.ok).toBe(false);
+    }
+    expect(exitCode).toBe(0);
   });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "entry.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  const out = JSON.parse(stdout.trim());
-  if (isWindows) {
-    expect(out.ok).toBe(true);
-    expect(decodeURIComponent(out.url)).toEndWith("dep.js?/x");
-  } else {
-    expect(out.ok).toBe(false);
-  }
-  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/07928.test.ts
+++ b/test/regression/issue/07928.test.ts
@@ -1,0 +1,95 @@
+// https://github.com/oven-sh/bun/issues/7928
+// A '?' in a directory name was being treated as a query-string separator by
+// the module resolver/loader, so files under that directory could not be
+// loaded. Windows does not allow '?' in path names, so these tests only run on
+// POSIX.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
+
+test.skipIf(isWindows)("`bun test` runs tests from a directory whose name contains '?'", async () => {
+  using dir = tempDir("issue-7928-test", {
+    "some-path?/my.test.js": `
+      import { test, expect } from "bun:test";
+      test("inside dir with ?", () => { expect(1 + 1).toBe(2); });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "my.test.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const out = normalizeBunSnapshot(stdout + stderr, dir);
+  expect(out).toContain("(pass) inside dir with ?");
+  expect(out).toContain("1 pass");
+  expect(out).not.toContain("Module not found");
+  expect(out).not.toContain("FileNotFound");
+  expect(exitCode).toBe(0);
+});
+
+test.skipIf(isWindows)("`bun <file>` runs a file under a directory whose name contains '?'", async () => {
+  using dir = tempDir("issue-7928-run", {
+    "some-path?/main.js": `console.log("ran from dir with ?");`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "./some-path?/main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ran from dir with ?\n");
+  expect(exitCode).toBe(0);
+});
+
+test.skipIf(isWindows)("import resolves across a directory whose name contains '?'", async () => {
+  using dir = tempDir("issue-7928-import", {
+    "dir?/dep.js": `export const value = 42;`,
+    "dir?/entry.js": `
+      import { value } from "./dep.js";
+      console.log(JSON.stringify({ value, url: import.meta.url }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "./dir?/entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { value, url } = JSON.parse(stdout.trim());
+  expect(value).toBe(42);
+  expect(decodeURIComponent(url)).toEndWith("dir?/entry.js");
+  expect(exitCode).toBe(0);
+});
+
+test.skipIf(isWindows)("query-string suffix still works when a parent directory contains '?'", async () => {
+  using dir = tempDir("issue-7928-query", {
+    "dir?/dep.js": `export const url = import.meta.url;`,
+    "dir?/entry.js": `
+      const a = await import("./dep.js");
+      const b = await import("./dep.js?v=1");
+      console.log(JSON.stringify({ a: a.url, b: b.url, distinct: a !== b }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "./dir?/entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { a, b, distinct } = JSON.parse(stdout.trim());
+  expect(decodeURIComponent(a)).toEndWith("dir?/dep.js");
+  expect(decodeURIComponent(b)).toEndWith("dir?/dep.js?v=1");
+  expect(distinct).toBe(true);
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/07928.test.ts
+++ b/test/regression/issue/07928.test.ts
@@ -5,6 +5,7 @@
 // POSIX.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
+import path from "node:path";
 
 test.skipIf(isWindows)("`bun test` runs tests from a directory whose name contains '?'", async () => {
   using dir = tempDir("issue-7928-test", {
@@ -46,12 +47,18 @@ test.skipIf(isWindows)("`bun <file>` runs a file under a directory whose name co
   expect(exitCode).toBe(0);
 });
 
-test.skipIf(isWindows)("import resolves across a directory whose name contains '?'", async () => {
+test.skipIf(isWindows)("import resolves and import.meta is correct under a '?'-named directory", async () => {
   using dir = tempDir("issue-7928-import", {
     "dir?/dep.js": `export const value = 42;`,
     "dir?/entry.js": `
       import { value } from "./dep.js";
-      console.log(JSON.stringify({ value, url: import.meta.url }));
+      console.log(JSON.stringify({
+        value,
+        url: import.meta.url,
+        path: import.meta.path,
+        dir: import.meta.dir,
+        file: import.meta.file,
+      }));
     `,
   });
   await using proc = Bun.spawn({
@@ -63,9 +70,15 @@ test.skipIf(isWindows)("import resolves across a directory whose name contains '
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  const { value, url } = JSON.parse(stdout.trim());
-  expect(value).toBe(42);
-  expect(decodeURIComponent(url)).toEndWith("dir?/entry.js");
+  const meta = JSON.parse(stdout.trim());
+  expect(meta).toEqual({
+    value: 42,
+    url: Bun.pathToFileURL(path.join(String(dir), "dir?", "entry.js")).href,
+    path: path.join(String(dir), "dir?", "entry.js"),
+    dir: path.join(String(dir), "dir?"),
+    file: "entry.js",
+  });
+  expect(new URL(meta.url).pathname).toEndWith("dir%3F/entry.js");
   expect(exitCode).toBe(0);
 });
 
@@ -91,5 +104,27 @@ test.skipIf(isWindows)("query-string suffix still works when a parent directory 
   expect(decodeURIComponent(a)).toEndWith("dir?/dep.js");
   expect(decodeURIComponent(b)).toEndWith("dir?/dep.js?v=1");
   expect(distinct).toBe(true);
+  expect(exitCode).toBe(0);
+});
+
+test("query string containing '/' still splits at the '?'", async () => {
+  using dir = tempDir("issue-7928-slash-in-query", {
+    "dep.js": `export const url = import.meta.url;`,
+    "entry.js": `
+      const m = await import("./dep.js?path=/a/b");
+      console.log(JSON.stringify({ url: m.url }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { url } = JSON.parse(stdout.trim());
+  expect(decodeURIComponent(url)).toEndWith("dep.js?path=/a/b");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## What does this PR do?

Fixes #7928.

### Repro

```sh
mkdir -p 'some-path?'
echo 'import {test} from "bun:test"; test("x",()=>{});' > 'some-path?/my.test.js'
bun test                          # finds the file but runs 0 tests, exit 1
bun './some-path?/my.test.js'     # error: Module not found
```

### Cause

The module resolver and loader both split specifiers on the first `?` to support import query suffixes like `./foo.js?v=1`. On POSIX, `?` is a legal filename character, so `./some-path?/file.js` was split into path `./some-path` + query `?/file.js`, and the file could never be loaded. The same first-`?` split existed in `ImportMetaObject::createFromSpecifier` (so `import.meta.dir`/`path` would have been wrong) and in the CommonJS `.node` fast-path gate.

### Fix

Add `bun_core::strings::index_of_import_query`, which returns the first `?` that is **not** immediately followed by `/`. A `?/` sequence is a POSIX directory-name byte and is kept in the filesystem path; any other `?` starts the query string. This leaves `./foo.js?key=a/b` unchanged (splits at the first `?`) while letting `./dir?/file.js` and `./a?/b?/file.js?v=1` resolve correctly. On Windows, where `?` is not a legal path byte, the helper short-circuits to the original first-`?` behavior.

All seven sibling split sites now share this rule:
- four Rust normalizers (`normalize_specifier_for_resolution` x2, `normalize_specifier_for_loader`, `options::normalize_specifier`) call the new helper;
- `ImportMetaObject::createFromSpecifier` applies the equivalent skip (gated `#if !OS(WINDOWS)`);
- `CommonJS.ts` `overridableRequire` / `internalRequire` skip `?/` when locating the `.node` query suffix.

### Trade-off

On POSIX, a query string that itself begins with `/` (e.g. `import("./dep.js?/x")`) is now treated as a path byte and not split. This shape is syntactically indistinguishable from a `?`-named directory without a filesystem probe; no bundler convention uses it. Pinned with a test. Windows is unaffected.

### Verification

`test/regression/issue/07928.test.ts` covers:
- `bun test` discovering and running a file under `some-path?/`
- `bun <file>` running `./some-path?/main.js`
- cross-file `import` plus exact `import.meta.{url,path,dir,file}` inside `dir?/` (URL path component is `.../dir%3F/entry.js`)
- `?v=1` query suffix combined with a `?`-named parent directory
- `./dep.js?path=/a/b` (query containing `/`) still splits at the `?` (non-regression guard)
- `require("./addon.node")` from inside `dir?/` reaches `process.dlopen` with the full path
- the POSIX `?/` trade-off (and that Windows keeps splitting)

Six of the seven tests fail on canary with `error: Module not found`; all seven pass with this change. Existing `test/js/bun/resolve/import-query.test.ts` (15 tests) and `import-meta.test.js` continue to pass.

### Relation to #36048

\#36048 targets `?` in **filenames** (e.g. `weird?name.mjs`) via a resolve-retry + `stat()` approach; it would also fix the directory case as a side effect. This PR handles only the directory case (what #7928 reports) with a string-only check and no filesystem calls. The two are complementary.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/regression/issue/07928.test.ts

<!-- robobun:evidence:end -->