### PR TITLE
webcore: downgrade the .body getter's Strong<ReadableStream> into the wrapper's WriteBarrier

### DIFF
--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1799,7 +1799,16 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 return Ok(readable.value);
             }
         }
-        self.get_body_value().to_readable_stream(global_this)
+        // `to_readable_stream` writes a `readable_stream::Strong` into
+        // `locked.readable` for the Blob/InternalBlob and freshly-materialized
+        // Locked paths. The returned stream is cached in the wrapper's `m_body`
+        // WriteBarrier by the prototype getter, so migrate that strong root into
+        // `m_stream` immediately: the stream's captured async context can close
+        // the Response → stream → store → Response cycle, and the root makes it
+        // uncollectable (Next.js patch-fetch, #16339).
+        let stream = self.get_body_value().to_readable_stream(global_this)?;
+        self.check_body_stream_ref(global_this);
+        Ok(stream)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-body-textstream>

--- a/test/regression/issue/16339.test.ts
+++ b/test/regression/issue/16339.test.ts
@@ -41,8 +41,10 @@ const report = `
   }));
 `;
 
-test.concurrent("Response.body on a buffer body does not pin a ReadableStream GC root through async context", async () => {
-  const script = `
+test.concurrent(
+  "Response.body on a buffer body does not pin a ReadableStream GC root through async context",
+  async () => {
+    const script = `
     const { AsyncLocalStorage } = require("node:async_hooks");
     const als = new AsyncLocalStorage();
     const buf = Buffer.alloc(200, "x");
@@ -56,17 +58,20 @@ test.concurrent("Response.body on a buffer body does not pin a ReadableStream GC
     }
     ${report}
   `;
-  const { protected: p, totalStream, totalOwner } = await collectHeapAfter(script);
-  // Before the fix this reported exactly N strongly rooted ReadableStreams
-  // (and N retained Responses); after the fix the wrapper's visitChildren owns
-  // the stream and the whole cycle is collectable.
-  expect(p).toBe(0);
-  expect(totalStream).toBeLessThan(10);
-  expect(totalOwner).toBeLessThan(10);
-});
+    const { protected: p, totalStream, totalOwner } = await collectHeapAfter(script);
+    // Before the fix this reported exactly N strongly rooted ReadableStreams
+    // (and N retained Responses); after the fix the wrapper's visitChildren owns
+    // the stream and the whole cycle is collectable.
+    expect(p).toBe(0);
+    expect(totalStream).toBeLessThan(10);
+    expect(totalOwner).toBeLessThan(10);
+  },
+);
 
-test.concurrent("Request.body on a buffer body does not pin a ReadableStream GC root through async context", async () => {
-  const script = `
+test.concurrent(
+  "Request.body on a buffer body does not pin a ReadableStream GC root through async context",
+  async () => {
+    const script = `
     const { AsyncLocalStorage } = require("node:async_hooks");
     const als = new AsyncLocalStorage();
     const buf = Buffer.alloc(200, "x");
@@ -88,11 +93,12 @@ test.concurrent("Request.body on a buffer body does not pin a ReadableStream GC 
       totalOwner: stats.objectTypeCounts.Request ?? 0,
     }));
   `;
-  const { protected: p, totalStream, totalOwner } = await collectHeapAfter(script);
-  expect(p).toBe(0);
-  expect(totalStream).toBeLessThan(10);
-  expect(totalOwner).toBeLessThan(10);
-});
+    const { protected: p, totalStream, totalOwner } = await collectHeapAfter(script);
+    expect(p).toBe(0);
+    expect(totalStream).toBeLessThan(10);
+    expect(totalOwner).toBeLessThan(10);
+  },
+);
 
 test.concurrent("fetch response .body does not pin a ReadableStream GC root through async context", async () => {
   // This variant drives the Locked-body path (`locked_to_native_stream`);

--- a/test/regression/issue/16339.test.ts
+++ b/test/regression/issue/16339.test.ts
@@ -1,0 +1,124 @@
+// Regression test for https://github.com/oven-sh/bun/issues/16339
+//
+// Accessing `response.body` / `request.body` on a buffer-backed body left a
+// `readable_stream::Strong` GC root in `Body::Value::Locked.readable` instead of
+// migrating it into the wrapper's `m_stream` WriteBarrier. The ReadableStream
+// captures `asyncContext` on creation, so when the surrounding
+// AsyncLocalStorage store transitively references the Response (Next.js's
+// patch-fetch does this per unique fetch URL), the strong root makes the
+// whole cycle uncollectable.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+async function collectHeapAfter(
+  script: string,
+): Promise<{ protected: number; totalStream: number; totalOwner: number }> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).not.toBe("");
+  const result = JSON.parse(stdout);
+  expect(exitCode).toBe(0);
+  return result;
+}
+
+const N = 100;
+const report = `
+  Bun.gc(true);
+  await Bun.sleep(20);
+  Bun.gc(true);
+  const stats = require("bun:jsc").heapStats();
+  process.stdout.write(JSON.stringify({
+    protected: stats.protectedObjectTypeCounts.ReadableStream ?? 0,
+    totalStream: stats.objectTypeCounts.ReadableStream ?? 0,
+    totalOwner: stats.objectTypeCounts.Response ?? 0,
+  }));
+`;
+
+test.concurrent("Response.body on a buffer body does not pin a ReadableStream GC root through async context", async () => {
+  const script = `
+    const { AsyncLocalStorage } = require("node:async_hooks");
+    const als = new AsyncLocalStorage();
+    const buf = Buffer.alloc(200, "x");
+    for (let i = 0; i < ${N}; i++) {
+      const store = { data: null };
+      als.run(store, () => {
+        const res = new Response(buf);
+        void res.body; // materialise the stream (captures asyncContext)
+        store.data = res; // close the cycle through the ALS store
+      });
+    }
+    ${report}
+  `;
+  const { protected: p, totalStream, totalOwner } = await collectHeapAfter(script);
+  // Before the fix this reported exactly N strongly rooted ReadableStreams
+  // (and N retained Responses); after the fix the wrapper's visitChildren owns
+  // the stream and the whole cycle is collectable.
+  expect(p).toBe(0);
+  expect(totalStream).toBeLessThan(10);
+  expect(totalOwner).toBeLessThan(10);
+});
+
+test.concurrent("Request.body on a buffer body does not pin a ReadableStream GC root through async context", async () => {
+  const script = `
+    const { AsyncLocalStorage } = require("node:async_hooks");
+    const als = new AsyncLocalStorage();
+    const buf = Buffer.alloc(200, "x");
+    for (let i = 0; i < ${N}; i++) {
+      const store = { data: null };
+      als.run(store, () => {
+        const req = new Request("http://x/", { method: "POST", body: buf });
+        void req.body;
+        store.data = req;
+      });
+    }
+    Bun.gc(true);
+    await Bun.sleep(20);
+    Bun.gc(true);
+    const stats = require("bun:jsc").heapStats();
+    process.stdout.write(JSON.stringify({
+      protected: stats.protectedObjectTypeCounts.ReadableStream ?? 0,
+      totalStream: stats.objectTypeCounts.ReadableStream ?? 0,
+      totalOwner: stats.objectTypeCounts.Request ?? 0,
+    }));
+  `;
+  const { protected: p, totalStream, totalOwner } = await collectHeapAfter(script);
+  expect(p).toBe(0);
+  expect(totalStream).toBeLessThan(10);
+  expect(totalOwner).toBeLessThan(10);
+});
+
+test.concurrent("fetch response .body does not pin a ReadableStream GC root through async context", async () => {
+  // This variant drives the Locked-body path (`locked_to_native_stream`);
+  // each fetch involves a real server round-trip, so fewer iterations.
+  const fetchN = 40;
+  const script = `
+    const { AsyncLocalStorage } = require("node:async_hooks");
+    const als = new AsyncLocalStorage();
+    const payload = Buffer.alloc(200, "x");
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response(payload, { headers: { "content-type": "text/plain" } }),
+    });
+    for (let i = 0; i < ${fetchN}; i++) {
+      const store = { data: null };
+      await als.run(store, async () => {
+        const res = await fetch(server.url);
+        const stream = res.body;
+        for await (const _ of stream) {}
+        store.data = res;
+      });
+    }
+    ${report}
+  `;
+  const { protected: p, totalStream, totalOwner } = await collectHeapAfter(script);
+  expect(p).toBe(0);
+  expect(totalStream).toBeLessThan(10);
+  expect(totalOwner).toBeLessThan(10);
+});


### PR DESCRIPTION
Fixes #16339.

## Reproduction

```js
const { AsyncLocalStorage } = require('node:async_hooks');
const als = new AsyncLocalStorage();
for (let i = 0; i < 50; i++) {
  const store = { data: null };
  als.run(store, () => {
    const res = new Response(Buffer.alloc(200, 'x'));
    void res.body;     // materialise the stream (captures asyncContext)
    store.data = res;  // close the cycle through the ALS store
  });
}
Bun.gc(true);
require('bun:jsc').heapStats().protectedObjectTypeCounts.ReadableStream;
// before: 50, after: 0
```

Next.js 15.5.6 standalone (`app/[slug]` with `dynamic='force-static'`, `fetchCache='force-cache'`, one backend `fetch()` per page), 3000 unique slugs, 6000 requests, idle + GC:

|                 | `protectedObjectTypeCounts.ReadableStream` | RSS    | heapUsed | objectCount |
| --------------- | ------------------------------------------- | ------ | -------- | ----------- |
| before (df49a6e)| 3000                                        | 1593 MB| 1156 MB  | grows / URL |
| after           | 0                                           | 185 MB | 26 MB    | flat ~147k  |

## Cause

`BodyMixin::get_body` materialises the stream via `Value::to_readable_stream`, which stores a `readable_stream::Strong` in `PendingValue::readable` for the Blob/InternalBlob and freshly-materialised Locked arms. The prototype getter caches the returned value in `m_body`, so that strong root is redundant once the getter returns. Every other path that fills `locked.readable` (`to_js`, `construct_js`, `clone`) already calls `check_body_stream_ref` to downgrade the root into the wrapper's `m_stream` WriteBarrier; the `.body` getter did not.

The created stream captures `asyncContext`. Next.js's `patch-fetch` / `dedupe-fetch` run inside ALS scopes whose stores reference the Response (React cache, `workStore.pendingRevalidates`), so the strong root pins `Response → Strong → ReadableStream → asyncContext → store → Response` and one rendered page's worth of state (~390 KB per unique fetched URL) is never collected.

## Fix

Call `check_body_stream_ref` after `to_readable_stream` in `get_body`, matching the existing construct/clone paths. The wrapper's `visitChildren` now owns the stream and the whole cycle is GC-collectable.

## Verification

`test/regression/issue/16339.test.ts`: three subprocess tests covering `Response.body` on a buffer body, `Request.body` on a buffer body, and `fetch` response `.body`, each asserting `protectedObjectTypeCounts.ReadableStream === 0` after N iterations. All three fail on main (report exactly N protected streams) and pass with this change.