### PR TITLE
install: prefer non-deprecated versions when resolving a semver range

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1592,6 +1592,14 @@ impl PackageManifest {
             let version = versions[i];
             if group.satisfies(version, group_buf, &self.string_buf) {
                 let package = &packages[i];
+                if package.deprecated {
+                    if deprecated_fallback.is_none()
+                        && !Self::is_package_version_too_recent(package, minimum_release_age_ms)
+                    {
+                        *deprecated_fallback = Some(FindResult { version, package });
+                    }
+                    continue;
+                }
                 if Self::is_package_version_too_recent(package, minimum_release_age_ms) {
                     if newest_filtered.is_none() {
                         *newest_filtered = Some(version);
@@ -1623,13 +1631,8 @@ impl PackageManifest {
                         prev_package_blocked_from_age = Some(package);
                         continue;
                     }
-                } else if !package.deprecated {
-                    return Some(FindVersionResult::Found(FindResult { version, package }));
                 } else {
-                    if deprecated_fallback.is_none() {
-                        *deprecated_fallback = Some(FindResult { version, package });
-                    }
-                    continue;
+                    return Some(FindVersionResult::Found(FindResult { version, package }));
                 }
             }
         }

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1593,9 +1593,11 @@ impl PackageManifest {
             if group.satisfies(version, group_buf, &self.string_buf) {
                 let package = &packages[i];
                 if package.deprecated {
-                    if deprecated_fallback.is_none()
-                        && !Self::is_package_version_too_recent(package, minimum_release_age_ms)
-                    {
+                    if Self::is_package_version_too_recent(package, minimum_release_age_ms) {
+                        if newest_filtered.is_none() {
+                            *newest_filtered = Some(version);
+                        }
+                    } else if deprecated_fallback.is_none() {
                         *deprecated_fallback = Some(FindResult { version, package });
                     }
                     continue;
@@ -1741,6 +1743,7 @@ impl PackageManifest {
         let packages = list.values.get(&self.package_versions);
 
         let mut best_version: Option<FindResult<'_>> = None;
+        let mut deprecated_fallback: Option<FindResult<'_>> = None;
         let mut prev_package_blocked_from_age: Option<&PackageVersion> = Some(dist_result.package);
 
         let mut i: usize = versions.len();
@@ -1766,6 +1769,15 @@ impl PackageManifest {
                 if actual_tag != expected_tag {
                     continue;
                 }
+            }
+
+            if package.deprecated {
+                if deprecated_fallback.is_none()
+                    && !Self::is_package_version_too_recent(package, min_age_ms)
+                {
+                    deprecated_fallback = Some(FindResult { version, package });
+                }
+                continue;
             }
 
             if Self::is_package_version_too_recent(package, min_age_ms) {
@@ -1805,7 +1817,7 @@ impl PackageManifest {
             break;
         }
 
-        if let Some(result) = best_version {
+        if let Some(result) = best_version.or(deprecated_fallback) {
             return FindVersionResult::FoundWithFilter {
                 result,
                 newest_filtered: Some(dist_result.version),
@@ -1901,7 +1913,14 @@ impl PackageManifest {
         }
 
         if let Some(result) = deprecated_fallback {
-            return FindVersionResult::Found(result);
+            return if newest_filtered.is_some() {
+                FindVersionResult::FoundWithFilter {
+                    result,
+                    newest_filtered,
+                }
+            } else {
+                FindVersionResult::Found(result)
+            };
         }
 
         if newest_filtered.is_some() {

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -732,7 +732,13 @@ pub struct PackageVersion {
 
     /// `hasInstallScript` field in registry API.
     pub(crate) has_install_script: bool,
-    pub(crate) _padding_tail: [u8; 2],
+
+    /// `deprecated` field in registry API (presence of a deprecation message).
+    /// Used to match npm's resolution behavior: a semver range prefers the
+    /// highest non-deprecated match, only falling back to a deprecated version
+    /// if every version satisfying the range is deprecated.
+    pub(crate) deprecated: bool,
+    pub(crate) _padding_tail: [u8; 1],
 
     /// Unix timestamp when this version was published (0 if unknown)
     pub(crate) publish_timestamp_ms: f64,
@@ -760,7 +766,8 @@ impl Default for PackageVersion {
             cpu: Architecture::ALL,
             libc: Libc::NONE,
             has_install_script: false,
-            _padding_tail: [0; 2],
+            deprecated: false,
+            _padding_tail: [0; 1],
             publish_timestamp_ms: 0.0,
         }
     }
@@ -818,14 +825,18 @@ const _: () = {
         offset_of!(PackageVersion, man_dir)
             == offset_of!(PackageVersion, _padding_before_man_dir) + 4
     );
-    // gap between `has_install_script` (bool, ends at 230) and `publish_timestamp_ms` (align 8 → 232)
+    // gap between `deprecated` (bool, ends at 231) and `publish_timestamp_ms` (align 8 → 232)
     assert!(
-        offset_of!(PackageVersion, _padding_tail)
+        offset_of!(PackageVersion, deprecated)
             == offset_of!(PackageVersion, has_install_script) + size_of::<bool>()
     );
     assert!(
+        offset_of!(PackageVersion, _padding_tail)
+            == offset_of!(PackageVersion, deprecated) + size_of::<bool>()
+    );
+    assert!(
         offset_of!(PackageVersion, publish_timestamp_ms)
-            == offset_of!(PackageVersion, _padding_tail) + 2
+            == offset_of!(PackageVersion, _padding_tail) + 1
     );
 };
 
@@ -928,8 +939,9 @@ pub mod package_manifest {
         // - v0.0.5: added bundled dependencies
         // - v0.0.6: changed semver major/minor/patch to each use u64 instead of u32
         // - v0.0.7: added version publish times and extended manifest flag for minimum release age
+        // - v0.0.8: added per-version `deprecated` flag (used to avoid deprecated versions)
         const HEADER_BYTES: &'static str =
-            concat!("#!/usr/bin/env bun\n", "bun-npm-manifest-cache-v0.0.7\n");
+            concat!("#!/usr/bin/env bun\n", "bun-npm-manifest-cache-v0.0.8\n");
 
         // Field order is hardcoded (descending alignment). Re-verify if the
         // layout changes.
@@ -1836,7 +1848,7 @@ impl PackageManifest {
                 if Self::is_package_version_too_recent(result.package, min_age_ms) {
                     newest_filtered = Some(result.version);
                 }
-                if newest_filtered.is_none() {
+                if newest_filtered.is_none() && !result.package.deprecated {
                     if group.flags.is_set(Semver::query::Flags::PRE) {
                         if left
                             .version
@@ -1894,19 +1906,28 @@ impl PackageManifest {
             return self.find_by_version(left.version);
         }
 
+        // Match npm's resolution behavior: a range prefers the highest
+        // non-deprecated version that satisfies it. Only when every satisfying
+        // version is deprecated do we fall back to the highest deprecated one.
+        // Lists are sorted ascending at serialization time and scanned from the
+        // top, so the first deprecated match we see is the highest.
+        let mut deprecated_fallback: Option<FindResult<'_>> = None;
+
         if let Some(result) = self.find_by_dist_tag(b"latest") {
             if group.satisfies(result.version, group_buf, &self.string_buf) {
-                if group.flags.is_set(Semver::query::Flags::PRE) {
-                    if left
-                        .version
+                let accept_latest = if group.flags.is_set(Semver::query::Flags::PRE) {
+                    // if prerelease, use latest if semver+tag match range exactly
+                    left.version
                         .order(result.version, group_buf, &self.string_buf)
                         == core::cmp::Ordering::Equal
-                    {
-                        // if prerelease, use latest if semver+tag match range exactly
+                } else {
+                    true
+                };
+                if accept_latest {
+                    if !result.package.deprecated {
                         return Some(result);
                     }
-                } else {
-                    return Some(result);
+                    deprecated_fallback = Some(result);
                 }
             }
         }
@@ -1914,16 +1935,20 @@ impl PackageManifest {
         {
             // This list is sorted at serialization time.
             let releases = self.pkg.releases.keys.get(&self.versions);
+            let packages = self.pkg.releases.values.get(&self.package_versions);
             let mut i = releases.len();
 
             while i > 0 {
                 let version = releases[i - 1];
 
                 if group.satisfies(version, group_buf, &self.string_buf) {
-                    return Some(FindResult {
-                        version,
-                        package: &self.pkg.releases.values.get(&self.package_versions)[i - 1],
-                    });
+                    let package = &packages[i - 1];
+                    if !package.deprecated {
+                        return Some(FindResult { version, package });
+                    }
+                    if deprecated_fallback.is_none() {
+                        deprecated_fallback = Some(FindResult { version, package });
+                    }
                 }
                 i -= 1;
             }
@@ -1931,23 +1956,26 @@ impl PackageManifest {
 
         if group.flags.is_set(Semver::query::Flags::PRE) {
             let prereleases = self.pkg.prereleases.keys.get(&self.versions);
+            let packages = self.pkg.prereleases.values.get(&self.package_versions);
             let mut i = prereleases.len();
             while i > 0 {
                 let version = prereleases[i - 1];
 
                 // This list is sorted at serialization time.
                 if group.satisfies(version, group_buf, &self.string_buf) {
-                    let packages = self.pkg.prereleases.values.get(&self.package_versions);
-                    return Some(FindResult {
-                        version,
-                        package: &packages[i - 1],
-                    });
+                    let package = &packages[i - 1];
+                    if !package.deprecated {
+                        return Some(FindResult { version, package });
+                    }
+                    if deprecated_fallback.is_none() {
+                        deprecated_fallback = Some(FindResult { version, package });
+                    }
                 }
                 i -= 1;
             }
         }
 
-        None
+        deprecated_fallback
     }
 }
 
@@ -2415,6 +2443,13 @@ impl PackageManifest {
                 {
                     package_version.has_install_script = *val;
                 }
+
+                package_version.deprecated =
+                    match version_obj.and_then(|o| o.get(b"deprecated")) {
+                        Some(JSON::E::JsonValue::String(s)) => !s.slice().is_empty(),
+                        Some(JSON::E::JsonValue::Boolean(b)) => *b,
+                        _ => false,
+                    };
 
                 'bin: {
                     // bins are extremely repetitive

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -734,9 +734,6 @@ pub struct PackageVersion {
     pub(crate) has_install_script: bool,
 
     /// `deprecated` field in registry API (presence of a deprecation message).
-    /// Used to match npm's resolution behavior: a semver range prefers the
-    /// highest non-deprecated match, only falling back to a deprecated version
-    /// if every version satisfying the range is deprecated.
     pub(crate) deprecated: bool,
     pub(crate) _padding_tail: [u8; 1],
 
@@ -1476,12 +1473,14 @@ pub mod package_manifest {
                 let bin_tag_at =
                     core::mem::offset_of!(PackageVersion, bin) + core::mem::offset_of!(Bin, tag);
                 let install_script_at = core::mem::offset_of!(PackageVersion, has_install_script);
+                let deprecated_at = core::mem::offset_of!(PackageVersion, deprecated);
                 for raw_pkg in raw
                     .as_chunks::<{ core::mem::size_of::<PackageVersion>() }>()
                     .0
                 {
                     if !matches!(raw_pkg[bin_tag_at], 0..=4)
                         || !matches!(raw_pkg[install_script_at], 0 | 1)
+                        || !matches!(raw_pkg[deprecated_at], 0 | 1)
                     {
                         return Ok(None);
                     }
@@ -1577,6 +1576,7 @@ impl PackageManifest {
         group_buf: &[u8],
         minimum_release_age_ms: f64,
         newest_filtered: &mut Option<Semver::Version>,
+        deprecated_fallback: &mut Option<FindResult<'a>>,
     ) -> Option<FindVersionResult<'a>> {
         let mut prev_package_blocked_from_age: Option<&PackageVersion> = None;
         let mut best_version: Option<FindResult<'a>> = None;
@@ -1623,8 +1623,13 @@ impl PackageManifest {
                         prev_package_blocked_from_age = Some(package);
                         continue;
                     }
-                } else {
+                } else if !package.deprecated {
                     return Some(FindVersionResult::Found(FindResult { version, package }));
+                } else {
+                    if deprecated_fallback.is_none() {
+                        *deprecated_fallback = Some(FindResult { version, package });
+                    }
+                    continue;
                 }
             }
         }
@@ -1864,6 +1869,8 @@ impl PackageManifest {
             }
         }
 
+        let mut deprecated_fallback: Option<FindResult<'_>> = None;
+
         if let Some(result) = self.search_version_list(
             self.pkg.releases.keys.get(&self.versions),
             self.pkg.releases.values.get(&self.package_versions),
@@ -1871,6 +1878,7 @@ impl PackageManifest {
             group_buf,
             min_age_ms,
             &mut newest_filtered,
+            &mut deprecated_fallback,
         ) {
             return result;
         }
@@ -1883,9 +1891,14 @@ impl PackageManifest {
                 group_buf,
                 min_age_ms,
                 &mut newest_filtered,
+                &mut deprecated_fallback,
             ) {
                 return result;
             }
+        }
+
+        if let Some(result) = deprecated_fallback {
+            return FindVersionResult::Found(result);
         }
 
         if newest_filtered.is_some() {
@@ -1906,31 +1919,27 @@ impl PackageManifest {
             return self.find_by_version(left.version);
         }
 
-        // Match npm's resolution behavior: a range prefers the highest
-        // non-deprecated version that satisfies it. Only when every satisfying
-        // version is deprecated do we fall back to the highest deprecated one.
-        // Lists are sorted ascending at serialization time and scanned from the
-        // top, so the first deprecated match we see is the highest.
-        let mut deprecated_fallback: Option<FindResult<'_>> = None;
-
         if let Some(result) = self.find_by_dist_tag(b"latest") {
-            if group.satisfies(result.version, group_buf, &self.string_buf) {
-                let accept_latest = if group.flags.is_set(Semver::query::Flags::PRE) {
-                    // if prerelease, use latest if semver+tag match range exactly
-                    left.version
+            if !result.package.deprecated
+                && group.satisfies(result.version, group_buf, &self.string_buf)
+            {
+                if group.flags.is_set(Semver::query::Flags::PRE) {
+                    if left
+                        .version
                         .order(result.version, group_buf, &self.string_buf)
                         == core::cmp::Ordering::Equal
-                } else {
-                    true
-                };
-                if accept_latest {
-                    if !result.package.deprecated {
+                    {
+                        // if prerelease, use latest if semver+tag match range exactly
                         return Some(result);
                     }
-                    deprecated_fallback = Some(result);
+                } else {
+                    return Some(result);
                 }
             }
         }
+
+        // npm compat: prefer non-deprecated matches; fall back only if none exist.
+        let mut deprecated_fallback: Option<FindResult<'_>> = None;
 
         {
             // This list is sorted at serialization time.

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -2444,12 +2444,11 @@ impl PackageManifest {
                     package_version.has_install_script = *val;
                 }
 
-                package_version.deprecated =
-                    match version_obj.and_then(|o| o.get(b"deprecated")) {
-                        Some(JSON::E::JsonValue::String(s)) => !s.slice().is_empty(),
-                        Some(JSON::E::JsonValue::Boolean(b)) => *b,
-                        _ => false,
-                    };
+                package_version.deprecated = match version_obj.and_then(|o| o.get(b"deprecated")) {
+                    Some(JSON::E::JsonValue::String(s)) => !s.slice().is_empty(),
+                    Some(JSON::E::JsonValue::Boolean(b)) => *b,
+                    _ => false,
+                };
 
                 'bin: {
                     // bins are extremely repetitive

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2593,6 +2593,103 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  it("should avoid deprecated versions when resolving a range, issue#7571", async () => {
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(
+        ctx,
+        dummyRegistryForContext(ctx, urls, {
+          "0.0.3": { as: "0.0.3" },
+          "0.0.5": { as: "0.0.5", deprecated: "This is a stub types definition." },
+          latest: "0.0.5",
+        }),
+      );
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: {
+            baz: "*",
+          },
+        }),
+      );
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const err = await stderr.text();
+      expect(err).toContain("Saved lockfile");
+      expect(err).not.toContain("error:");
+      const out = await stdout.text();
+      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+        expect.stringContaining("bun install v1."),
+        "",
+        "+ baz@0.0.3 (v0.0.5 available)",
+        "",
+        "1 package installed",
+      ]);
+      expect(await exited).toBe(0);
+      expect(urls.sort()).toEqual([`${ctx.registry_url}baz`, `${ctx.registry_url}baz-0.0.3.tgz`]);
+      expect(await file(join(ctx.package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
+        name: "baz",
+        version: "0.0.3",
+        bin: {
+          "baz-run": "index.js",
+        },
+      });
+    });
+  });
+
+  it("should fall back to a deprecated version when every match is deprecated", async () => {
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(
+        ctx,
+        dummyRegistryForContext(ctx, urls, {
+          "0.0.3": { as: "0.0.3", deprecated: "old" },
+          "0.0.5": { as: "0.0.5", deprecated: "also old" },
+          latest: "0.0.5",
+        }),
+      );
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: {
+            baz: "*",
+          },
+        }),
+      );
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const err = await stderr.text();
+      expect(err).not.toContain("error:");
+      const out = await stdout.text();
+      expect(out).toContain("+ baz@0.0.5");
+      expect(await exited).toBe(0);
+      expect(urls.sort()).toEqual([`${ctx.registry_url}baz`, `${ctx.registry_url}baz-0.0.5.tgz`]);
+      expect(await file(join(ctx.package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
+        name: "baz",
+        version: "0.0.5",
+        bin: {
+          "baz-exec": "index.js",
+        },
+      });
+    });
+  });
+
   it("should install latest with prereleases", async () => {
     await withContext(defaultOpts, async ctx => {
       const urls: string[] = [];

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -954,30 +954,32 @@ describe("minimum-release-age", () => {
       expect(lockfile).not.toContain("regular-package@3.0.0");
     });
 
-    test("avoids deprecated versions when resolving a range", async () => {
-      using dir = tempDir("deprecated-avoid", {
-        "package.json": JSON.stringify({
-          dependencies: { "deprecated-package": "*" },
-        }),
-        ".npmrc": `registry=${mockRegistryUrl}`,
-      });
+    for (const spec of ["*", "latest"]) {
+      test(`avoids deprecated versions when resolving "${spec}"`, async () => {
+        using dir = tempDir("deprecated-avoid", {
+          "package.json": JSON.stringify({
+            dependencies: { "deprecated-package": spec },
+          }),
+          ".npmrc": `registry=${mockRegistryUrl}`,
+        });
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "install", "--minimum-release-age", `${5 * SECONDS_PER_DAY}`, "--no-verify"],
-        cwd: String(dir),
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+        const proc = Bun.spawn({
+          cmd: [bunExe(), "install", "--minimum-release-age", `${5 * SECONDS_PER_DAY}`, "--no-verify"],
+          cwd: String(dir),
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).not.toContain("error:");
-      expect(normalizeBunSnapshot(stdout, dir)).toContain("deprecated-package@1.0.0");
-      expect(exitCode).toBe(0);
-      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
-      expect(lockfile).toContain("deprecated-package@1.0.0");
-      expect(lockfile).not.toContain("deprecated-package@2.0.0");
-    });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).not.toContain("error:");
+        expect(normalizeBunSnapshot(stdout, dir)).toContain("deprecated-package@1.0.0");
+        expect(exitCode).toBe(0);
+        const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+        expect(lockfile).toContain("deprecated-package@1.0.0");
+        expect(lockfile).not.toContain("deprecated-package@2.0.0");
+      });
+    }
 
     test("handles exact version requests", async () => {
       using dir = tempDir("exact-version", {

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -793,13 +793,13 @@ describe("minimum-release-age", () => {
           return Response.json(packageData);
         }
 
-        // TEST PACKAGE: many-versions-package (large version count, time entries
-        // in reverse order relative to versions). Exercises the publish-time
-        // index built during manifest parse.
+        // TEST PACKAGE: deprecated-package. Newest version is age-blocked,
+        // next is deprecated, oldest is non-deprecated; range resolution must
+        // avoid the deprecated middle version with or without the age gate.
         if (url.pathname === "/deprecated-package") {
           return Response.json({
             name: "deprecated-package",
-            "dist-tags": { latest: "2.0.0" },
+            "dist-tags": { latest: "3.0.0" },
             versions: {
               "1.0.0": {
                 name: "deprecated-package",
@@ -818,14 +818,26 @@ describe("minimum-release-age", () => {
                   integrity: "sha512-dep2==",
                 },
               },
+              "3.0.0": {
+                name: "deprecated-package",
+                version: "3.0.0",
+                dist: {
+                  tarball: `${mockRegistryUrl}/deprecated-package/-/deprecated-package-3.0.0.tgz`,
+                  integrity: "sha512-dep3==",
+                },
+              },
             },
             time: {
               "1.0.0": daysAgo(30),
-              "2.0.0": daysAgo(20),
+              "2.0.0": daysAgo(10),
+              "3.0.0": daysAgo(1),
             },
           });
         }
 
+        // TEST PACKAGE: many-versions-package (large version count, time entries
+        // in reverse order relative to versions). Exercises the publish-time
+        // index built during manifest parse.
         if (url.pathname === "/many-versions-package") {
           if (manyVersionsManifest === undefined) {
             const N = 2000;

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -796,6 +796,36 @@ describe("minimum-release-age", () => {
         // TEST PACKAGE: many-versions-package (large version count, time entries
         // in reverse order relative to versions). Exercises the publish-time
         // index built during manifest parse.
+        if (url.pathname === "/deprecated-package") {
+          return Response.json({
+            name: "deprecated-package",
+            "dist-tags": { latest: "2.0.0" },
+            versions: {
+              "1.0.0": {
+                name: "deprecated-package",
+                version: "1.0.0",
+                dist: {
+                  tarball: `${mockRegistryUrl}/deprecated-package/-/deprecated-package-1.0.0.tgz`,
+                  integrity: "sha512-dep1==",
+                },
+              },
+              "2.0.0": {
+                name: "deprecated-package",
+                version: "2.0.0",
+                deprecated: "This is a stub types definition.",
+                dist: {
+                  tarball: `${mockRegistryUrl}/deprecated-package/-/deprecated-package-2.0.0.tgz`,
+                  integrity: "sha512-dep2==",
+                },
+              },
+            },
+            time: {
+              "1.0.0": daysAgo(30),
+              "2.0.0": daysAgo(20),
+            },
+          });
+        }
+
         if (url.pathname === "/many-versions-package") {
           if (manyVersionsManifest === undefined) {
             const N = 2000;
@@ -910,6 +940,31 @@ describe("minimum-release-age", () => {
       expect(lockfile).toContain("regular-package@2.0.0");
       expect(lockfile).not.toContain("regular-package@2.1.0");
       expect(lockfile).not.toContain("regular-package@3.0.0");
+    });
+
+    test("avoids deprecated versions when resolving a range", async () => {
+      using dir = tempDir("deprecated-avoid", {
+        "package.json": JSON.stringify({
+          dependencies: { "deprecated-package": "*" },
+        }),
+        ".npmrc": `registry=${mockRegistryUrl}`,
+      });
+
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--minimum-release-age", `${5 * SECONDS_PER_DAY}`, "--no-verify"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(normalizeBunSnapshot(stdout, dir)).toContain("deprecated-package@1.0.0");
+      expect(exitCode).toBe(0);
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      expect(lockfile).toContain("deprecated-package@1.0.0");
+      expect(lockfile).not.toContain("deprecated-package@2.0.0");
     });
 
     test("handles exact version requests", async () => {


### PR DESCRIPTION
Fixes #7571
Fixes #25314

## What does this PR do?



`bun install` now matches npm's version-selection rule for deprecated packages: when a semver range matches at least one non-deprecated version, pick the highest non-deprecated one; only fall back to a deprecated version when every matching version is deprecated.

## Repro

```sh
mkdir t && cd t
printf '{"name":"t","dependencies":{"@types/express-unless":"*"}}' > package.json
bun install
jq -r .version node_modules/@types/express-unless/package.json
```

Before: `2.0.3` (deprecated stub with no `index.d.ts`, so `tsc` fails with `TS2688: Cannot find type definition file for 'express-unless'`).
After: `0.5.3` (highest non-deprecated; matches `npm install`).

## Cause

The registry packument carries a per-version `deprecated` field (a string message). Bun never read it, so `find_best_version` treated deprecated versions like any other and picked the highest match. npm's resolver skips deprecated matches when a non-deprecated one is available.

This bites the DefinitelyTyped stub pattern hard: when a package ships its own types, the newest `@types/foo` releases become deprecated stubs with no `.d.ts`. A transitive `"*"` dep on `@types/foo` then resolves to a stub under Bun but to the last real types release under npm.

## Fix

- `PackageVersion` gains a `deprecated: bool` carved out of the existing tail padding (struct stays 240 bytes, no layout drift).
- Manifest cache header bumped to `v0.0.8` so caches written by older Bun (which don't carry the flag) are re-fetched.
- `PackageManifest::parse` records the flag from the packument (`"deprecated"` is a non-empty string, or `true`).
- `find_best_version` now returns the first non-deprecated match and remembers the highest deprecated match as a fallback; only when no non-deprecated version satisfies the range is the deprecated fallback returned. The `latest` dist-tag fast path applies the same skip.

## Verification

```
bun bd test test/cli/install/bun-install.test.ts -t deprecated
```

Against the issue's repro, `@types/express-unless` resolves to `0.5.3` and the `TS2688` error is gone (the remaining `@types/node` errors in that repo reproduce identically under `npm install`; they're an unrelated TS 5.0.2 vs current `@types/node` mismatch).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->
