### PR TITLE
cli(create): pass unknown short flags through to the create-* package

### DIFF
--- a/src/clap/streaming.rs
+++ b/src/clap/streaming.rs
@@ -152,31 +152,12 @@ where
                     }));
                 }
 
-                // unrecognized command
-                // if flag else arg
-                if arg_info.kind == ArgKind::Long || arg_info.kind == ArgKind::Short {
-                    if WARN_ON_UNRECOGNIZED_FLAG.load(Ordering::Relaxed) {
-                        bun_core::warn!(
-                            "unrecognized flag: {}{}\n",
-                            if arg_info.kind == ArgKind::Long {
-                                "--"
-                            } else {
-                                "-"
-                            },
-                            bstr::BStr::new(name),
-                        );
-                        Output::flush();
-                    }
-
-                    // continue parsing after unrecognized flag
-                    return self.next();
-                }
-
+                // Unrecognized long flag: optionally warn, then continue parsing.
                 if WARN_ON_UNRECOGNIZED_FLAG.load(Ordering::Relaxed) {
-                    bun_core::warn!("unrecognized argument: {}\n", bstr::BStr::new(name));
+                    bun_core::warn!("unrecognized flag: --{}\n", bstr::BStr::new(name));
                     Output::flush();
                 }
-                Ok(None)
+                self.next()
             }
             ArgKind::Short => self.chainging(Chaining { arg, index: 0 }),
             ArgKind::Positional => {
@@ -276,7 +257,19 @@ where
             }));
         }
 
-        Err(self.err(arg, Some(arg[index]), None, ArgError::InvalidArgument))
+        // Unrecognized short flag: match the long-flag behaviour (optionally warn, then
+        // continue) so `bun create pkg -t x` reaches the underlying create-* package
+        // instead of aborting. Dropping the rest of the chain is the conservative choice
+        // since the unknown flag may itself consume the remaining chars as a value.
+        if WARN_ON_UNRECOGNIZED_FLAG.load(Ordering::Relaxed) {
+            bun_core::warn!(
+                "unrecognized flag: -{}\n",
+                bstr::BStr::new(&arg[index..index + 1]),
+            );
+            Output::flush();
+        }
+        self.state = State::Normal;
+        self.next()
     }
 
     fn positional_param(&mut self) -> Option<&'p clap::Param<Id>> {
@@ -810,8 +803,22 @@ mod tests {
             },
         ];
         test_err(&params, &[b"q"], b"Invalid argument 'q'\n");
-        test_err(&params, &[b"-q"], b"Invalid argument '-q'\n");
-        // Unrecognized long flags are skipped (opt-in warning), not errors.
+        // Unrecognized short and long flags are skipped (opt-in warning), not errors.
+        test_no_err(&params, &[b"-q"], &[]);
+        test_no_err(
+            &params,
+            &[b"-aq", b"-a"],
+            &[
+                Arg {
+                    param: &params[0],
+                    value: None,
+                },
+                Arg {
+                    param: &params[0],
+                    value: None,
+                },
+            ],
+        );
         test_no_err(&params, &[b"--q"], &[]);
         test_no_err(&params, &[b"--q=1"], &[]);
         test_err(

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -318,6 +318,72 @@ it.skipIf(!isPosix)("does not busy-wait on the futex while git runs", async () =
   expect(proc.resourceUsage!.contextSwitches.voluntary).toBeLessThan(2000);
 });
 
+// https://github.com/oven-sh/bun/issues/7114
+// Unknown long flags after the template name were already skipped by the arg
+// parser, but unknown short flags aborted with "Invalid Argument '-t'" before
+// bun create ever dispatched to bunx / the local template.
+describe("forwards unknown flags past the template name (#7114)", () => {
+  it.each(["-t", "--template"])("local template with %s", async flag => {
+    using dir = tempDir("create-7114-local", {
+      "bun-create/tpl/index.js": "// hi\n",
+      "bun-create/tpl/package.json": JSON.stringify({ name: "tpl", version: "1.0.0" }),
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "create", "tpl", join(String(dir), "dest"), flag, "tabs", "--no-git", "--no-install"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...env, BUN_CREATE_DIR: join(String(dir), "bun-create") },
+    });
+
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("Invalid Argument");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("Created");
+    expect(await exists(join(String(dir), "dest", "index.js"))).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  it.each([
+    ["-t", "tabs"],
+    ["-e", "with-router"],
+    ["-tabs", ""],
+  ])("create-* package receives %s %s", async (flag, value) => {
+    const argv = value ? [flag, value] : [flag];
+    using dir = tempDir("create-7114-bunx", {});
+
+    // 404 registry: if arg parsing succeeds, bun create dispatches to bunx
+    // which will hit this and fail on the package lookup (not on '-t').
+    const urls: string[] = [];
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        urls.push(new URL(req.url).pathname);
+        return new Response("{}", { status: 404 });
+      },
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "create", "issue-7114-pkg", "./dest", ...argv, "--yes"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...env,
+        BUN_TMPDIR: String(dir),
+        TEMP: String(dir),
+        TMPDIR: String(dir),
+        npm_config_registry: `http://localhost:${server.port}/`,
+      },
+    });
+
+    const [, err] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("Invalid Argument");
+    expect(urls).toContain("/create-issue-7114-pkg");
+  });
+});
+
 it("should create template from local folder", async () => {
   const bunCreateDir = join(x_dir, "bun-create");
   const testTemplate = "test-template";


### PR DESCRIPTION
Fixes #7114
Fixes #10033

## Repro

```console
$ bun create expo ./awesome-project -t tabs
error: Invalid Argument '-t'
```

The long form `--template tabs` works; only short flags are rejected.

## Cause

`StreamingClap::normal()` already skips unrecognized **long** flags (with an opt-in warning) and continues parsing, so flags meant for the underlying `create-*` package reach it. Short flags route through `StreamingClap::chainging()`, which returned `ArgError::InvalidArgument` for any unrecognized letter, so `bun create expo ./app -t tabs` aborted in `CreateOptions::parse` before ever dispatching to bunx.

The long-flag fallback in `normal()` even had an `arg_info.kind == ArgKind::Short` branch, but it was dead code: that block is only reachable from the `ArgKind::Long` match arm.

## Fix

Make the short-flag miss path in `chainging()` mirror the long-flag one: optionally warn, reset chaining state to `Normal`, and continue parsing. The rest of a `-abc` cluster after an unknown letter is dropped rather than iterated, since the unknown flag may itself consume the remaining characters as a value. Also drop the dead `Short` branch and unreachable `Ok(None)` tail in the long-flag handler.

No caller matched on `Error::InvalidArgument` from clap to do anything other than print and exit, so the only observable change is that unknown short flags are now tolerated everywhere unknown long flags already were.

## Verification

New tests in `test/cli/install/bun-create.test.ts`:
- local template with `-t tabs` / `--template tabs` creates the project
- `bun create <pkg> ./dest -t tabs` / `-e with-router` / `-tabs` reach bunx and request `create-<pkg>` from the registry instead of aborting on the flag

```
$ USE_SYSTEM_BUN=1 bun test test/cli/install/bun-create.test.ts -t 7114
 1 pass  4 fail   # only --template passed before

$ bun bd test test/cli/install/bun-create.test.ts -t 7114
 5 pass  0 fail
```

`cargo test -p bun_clap` updated and passing (9/9).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-create.test.ts
bun test v1.4.0 (ed761304a)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [117.57ms]
(pass) should not crash > ["create",""] [122.26ms]
(pass) should not crash > ["create","--"] [145.74ms]
(pass) should not crash > ["create","--",""] [134.89ms]
(pass) should not crash > ["create","--help"] [138.67ms]
(pass) should create selected template with @ prefix [586.78ms]
(pass) should create selected template with @ prefix implicit `/create` [638.52ms]
killed 1 dangling process
(fail) should create selected template with @ prefix implicit `/create` with version [5007.70ms]
  ^ this test timed out after 5000ms.

# Unhandled error between tests
-------------------------------
80 |     stderr: "pipe",
81 |     env,
82 |   });
83 | 
84 |   const err = await stderr.text();
85 |   expect(err.split(/\r?\n/)).toContain(`error: GET https://registry.npmjs.org/@second-quick-start%2fcreate - 404`);
                                  ^
error: expect(received).toContain(expected)

Expected to c
... (truncated)

release without fix: 11 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [24.69ms]
(pass) should not crash > ["create",""] [2.09ms]
(pass) should not crash > ["create","--"] [1.74ms]
(pass) should not crash > ["create","--",""] [1.33ms]
(pass) should not crash > ["create","--help"] [1.77ms]
(pass) should create selected template with @ prefix [389.95ms]
(pass) should create selected template with @ prefix implicit `/create` [136.42ms]
(pass) should create selected template with @ prefix implicit `/create` with version [155.96ms]
155 |       },
156 |     });
157 | 
158 |     const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
159 | 
160 |     expect({ out, err, exitCode, signalCode: proc.signalCode }).toEqual({
                                                                      ^
error: expect(received).toEqual(expected)

  {
-   "err": StringNotContaining "error:",
-   "exitCode": 0,
-   "out": StringContaining "Success! owner/split-body-template loaded into split-body-template",
-   "signalCode": null,
+   "err": 
+ "[github] GET owner/split-body-template... ================
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-create.test.ts
bun test v1.4.0 (ed761304a)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [165.13ms]
(pass) should not crash > ["create",""] [109.17ms]
(pass) should not crash > ["create","--"] [129.22ms]
(pass) should not crash > ["create","--",""] [110.74ms]
(pass) should not crash > ["create","--help"] [113.99ms]
(pass) should create selected template with @ prefix [579.46ms]
(pass) should create selected template with @ prefix implicit `/create` [482.61ms]
(pass) should create selected template with @ prefix implicit `/create` with version [467.93ms]
(pass) handles a close-delimited GitHub tarball body split across packets [958.93ms]
(pass) keeps tarball entry paths within the destination when checking for conflicting files [746.44ms]
(pass) reports an error and exits when the template's package.json entry body is truncated [319.90ms]
(pass) does not busy-wait on the futex while git runs [1764.25ms]
(pass) forwards unknown flags past the template name (#7114) > local template with -t
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 848ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/clap/streaming.rs               | 57 ++++++++++++++++++--------------
 test/cli/install/bun-create.test.ts | 66 +++++++++++++++++++++++++++++++++++++
 2 files changed, 98 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/clap/streaming.rs                    2      3      0
test/cli/install/bun-create.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->