### PR TITLE
resolver: keep auto-install bound to the installed package root across nested package.json

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6205,15 +6205,14 @@ impl<'a> Resolver<'a> {
                             info.enclosing_package_json = Some(pkg);
                         }
 
-                        // id 0 is the synthetic root (user's own project), not a
-                        // cache-installed package.
-                        let enclosing_is_installed_root =
+                        let root_package_id: Install::PackageID = 0;
+                        let enclosing_is_cache_installed =
                             info.package_json_for_dependencies().is_some_and(|p| {
                                 p.package_manager_package_id != Install::INVALID_PACKAGE_ID
-                                    && p.package_manager_package_id != 0
+                                    && p.package_manager_package_id != root_package_id
                             });
                         if pkg.package_manager_package_id != Install::INVALID_PACKAGE_ID
-                            || (pkg.dependencies.map.count() > 0 && !enclosing_is_installed_root)
+                            || (pkg.dependencies.map.count() > 0 && !enclosing_is_cache_installed)
                         {
                             // NOTE: store the raw `NonNull` field (not the
                             // `&'static` accessor result) so mut-provenance flows

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6205,9 +6205,12 @@ impl<'a> Resolver<'a> {
                             info.enclosing_package_json = Some(pkg);
                         }
 
+                        // id 0 is the synthetic root (user's own project), not a
+                        // cache-installed package.
                         let enclosing_is_installed_root =
                             info.package_json_for_dependencies().is_some_and(|p| {
                                 p.package_manager_package_id != Install::INVALID_PACKAGE_ID
+                                    && p.package_manager_package_id != 0
                             });
                         if pkg.package_manager_package_id != Install::INVALID_PACKAGE_ID
                             || (pkg.dependencies.map.count() > 0 && !enclosing_is_installed_root)

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6075,13 +6075,6 @@ impl<'a> Resolver<'a> {
             info.enclosing_package_json = info
                 .enclosing_package_json
                 .or(parent_.enclosing_package_json);
-            // `package_json_for_dependencies` is used by auto-install to decide
-            // which package.json's `dependencies` constrain a bare specifier.
-            // The parent's field is already the correctly-propagated value
-            // (set when the parent was processed below), so inherit it as-is;
-            // re-deriving from `parent_.package_json` here would let a nested
-            // package.json inside an installed package override the package
-            // root. See https://github.com/oven-sh/bun/issues/6988.
             info.package_json_for_dependencies = parent_.package_json_for_dependencies;
 
             // Make sure "absRealPath" is the real path of the directory (resolving any symlinks)
@@ -6212,25 +6205,17 @@ impl<'a> Resolver<'a> {
                             info.enclosing_package_json = Some(pkg);
                         }
 
-                        if pkg.package_manager_package_id != Install::INVALID_PACKAGE_ID {
+                        let enclosing_is_installed_root =
+                            info.package_json_for_dependencies().is_some_and(|p| {
+                                p.package_manager_package_id != Install::INVALID_PACKAGE_ID
+                            });
+                        if pkg.package_manager_package_id != Install::INVALID_PACKAGE_ID
+                            || (pkg.dependencies.map.count() > 0 && !enclosing_is_installed_root)
+                        {
                             // NOTE: store the raw `NonNull` field (not the
                             // `&'static` accessor result) so mut-provenance flows
                             // through to `enqueue_dependency_to_resolve`.
                             info.package_json_for_dependencies = info.package_json;
-                        } else if pkg.dependencies.map.count() > 0 {
-                            // A nested package.json with `dependencies` only
-                            // overrides when no enclosing installed-package root
-                            // has already claimed this subtree. npm/node ignore
-                            // nested package.json dependencies for resolution;
-                            // honoring them made auto-install pick the wrong
-                            // version constraint (issue #6988).
-                            let enclosing_is_installed =
-                                info.package_json_for_dependencies().is_some_and(|p| {
-                                    p.package_manager_package_id != Install::INVALID_PACKAGE_ID
-                                });
-                            if !enclosing_is_installed {
-                                info.package_json_for_dependencies = info.package_json;
-                            }
                         }
 
                         if let Some(logs) = self.debug_logs.as_mut() {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6224,9 +6224,8 @@ impl<'a> Resolver<'a> {
                             // nested package.json dependencies for resolution;
                             // honoring them made auto-install pick the wrong
                             // version constraint (issue #6988).
-                            let enclosing_is_installed = info
-                                .package_json_for_dependencies()
-                                .is_some_and(|p| {
+                            let enclosing_is_installed =
+                                info.package_json_for_dependencies().is_some_and(|p| {
                                     p.package_manager_package_id != Install::INVALID_PACKAGE_ID
                                 });
                             if !enclosing_is_installed {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6070,23 +6070,19 @@ impl<'a> Resolver<'a> {
                 if !parent_package_json.name.is_empty() || self.care_about_bin_folder {
                     info.enclosing_package_json = Some(parent_package_json);
                 }
-
-                if parent_package_json.dependencies.map.count() > 0
-                    || parent_package_json.package_manager_package_id != Install::INVALID_PACKAGE_ID
-                {
-                    // NOTE: store the raw `NonNull` field (not the
-                    // `&'static` accessor result) so mut-provenance flows
-                    // through to `enqueue_dependency_to_resolve`.
-                    info.package_json_for_dependencies = parent_.package_json;
-                }
             }
 
             info.enclosing_package_json = info
                 .enclosing_package_json
                 .or(parent_.enclosing_package_json);
-            info.package_json_for_dependencies = info
-                .package_json_for_dependencies
-                .or(parent_.package_json_for_dependencies);
+            // `package_json_for_dependencies` is used by auto-install to decide
+            // which package.json's `dependencies` constrain a bare specifier.
+            // The parent's field is already the correctly-propagated value
+            // (set when the parent was processed below), so inherit it as-is;
+            // re-deriving from `parent_.package_json` here would let a nested
+            // package.json inside an installed package override the package
+            // root. See https://github.com/oven-sh/bun/issues/6988.
+            info.package_json_for_dependencies = parent_.package_json_for_dependencies;
 
             // Make sure "absRealPath" is the real path of the directory (resolving any symlinks)
             if !self.opts.preserve_symlinks {
@@ -6216,13 +6212,26 @@ impl<'a> Resolver<'a> {
                             info.enclosing_package_json = Some(pkg);
                         }
 
-                        if pkg.dependencies.map.count() > 0
-                            || pkg.package_manager_package_id != Install::INVALID_PACKAGE_ID
-                        {
+                        if pkg.package_manager_package_id != Install::INVALID_PACKAGE_ID {
                             // NOTE: store the raw `NonNull` field (not the
                             // `&'static` accessor result) so mut-provenance flows
                             // through to `enqueue_dependency_to_resolve`.
                             info.package_json_for_dependencies = info.package_json;
+                        } else if pkg.dependencies.map.count() > 0 {
+                            // A nested package.json with `dependencies` only
+                            // overrides when no enclosing installed-package root
+                            // has already claimed this subtree. npm/node ignore
+                            // nested package.json dependencies for resolution;
+                            // honoring them made auto-install pick the wrong
+                            // version constraint (issue #6988).
+                            let enclosing_is_installed = info
+                                .package_json_for_dependencies()
+                                .is_some_and(|p| {
+                                    p.package_manager_package_id != Install::INVALID_PACKAGE_ID
+                                });
+                            if !enclosing_is_installed {
+                                info.package_json_for_dependencies = info.package_json;
+                            }
                         }
 
                         if let Some(logs) = self.debug_logs.as_mut() {

--- a/test/regression/issue/06988.test.ts
+++ b/test/regression/issue/06988.test.ts
@@ -56,13 +56,16 @@ test("auto-install resolves transitive deps through a nested package.json (#6988
     "package.json": JSON.stringify({ name: "inner", version: "2.0.0", main: "index.js" }),
     "index.js": `module.exports = "inner@2.0.0";\n`,
   });
-  // `outer`'s entry point requires `inner` from a file that sits under a
-  // nested package.json whose `dependencies` disagree with the package root.
+  // `outer`'s entry point requires `inner` from a file that sits one level
+  // *below* a nested package.json whose `dependencies` disagree with the
+  // package root, matching the hive-js layout (ecc/src/address.js under
+  // ecc/package.json). The extra `src/` level exercises the parent
+  // propagation in `dir_info_uncached` as well as the own-package.json gate.
   const outer = buildTarball({
     "package.json": JSON.stringify({
       name: "outer",
       version: "1.0.0",
-      main: "lib/sub/entry.js",
+      main: "lib/sub/src/entry.js",
       dependencies: { inner: "^2.0.0" },
     }),
     "lib/sub/package.json": JSON.stringify({
@@ -70,7 +73,7 @@ test("auto-install resolves transitive deps through a nested package.json (#6988
       version: "1.0.0",
       dependencies: { inner: "^1.0.0" },
     }),
-    "lib/sub/entry.js": `module.exports = require("inner");\n`,
+    "lib/sub/src/entry.js": `module.exports = require("inner");\n`,
   });
 
   await using server = Bun.serve({

--- a/test/regression/issue/06988.test.ts
+++ b/test/regression/issue/06988.test.ts
@@ -1,0 +1,141 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+
+// ── minimal gzipped npm tarball builder ───────────────────────────────────
+function octal(n: number, width: number) {
+  return n.toString(8).padStart(width - 1, "0") + "\0";
+}
+function tarHeader(name: string, size: number) {
+  const buf = Buffer.alloc(512, 0);
+  buf.write(name, 0, 100, "utf8");
+  buf.write(octal(0o644, 8), 100);
+  buf.write(octal(0, 8), 108);
+  buf.write(octal(0, 8), 116);
+  buf.write(octal(size, 12), 124);
+  buf.write(octal(0, 12), 136);
+  buf.fill(" ", 148, 156);
+  buf.write("0", 156); // typeflag: regular file
+  buf.write("ustar\0", 257);
+  buf.write("00", 263);
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += buf[i];
+  buf.write(octal(sum, 8), 148);
+  return buf;
+}
+function pad512(len: number) {
+  return Buffer.alloc((512 - (len % 512)) % 512, 0);
+}
+function buildTarball(files: Record<string, string>) {
+  const chunks: Buffer[] = [];
+  for (const [name, contents] of Object.entries(files)) {
+    const body = Buffer.from(contents);
+    chunks.push(tarHeader("package/" + name, body.length), body, pad512(body.length));
+  }
+  chunks.push(Buffer.alloc(1024, 0)); // two zero blocks = end-of-archive
+  const tgz = gzipSync(Buffer.concat(chunks));
+  return { tgz, integrity: "sha512-" + createHash("sha512").update(tgz).digest("base64") };
+}
+
+// Regression test for https://github.com/oven-sh/bun/issues/6988
+//
+// `bun run <file>` auto-install resolved a top-level import into the global
+// cache, but then failed to resolve that package's own dependencies when the
+// importing file sat under a *nested* package.json inside the cached package.
+// The nested package.json's `dependencies` overrode the package root's, so
+// auto-install looked for a version constraint that was never installed.
+//
+// Real-world trigger: `@hiveio/hive-js` ships `lib/auth/ecc/package.json` with
+// `"bs58": "^3.0.0"` while the package root declares `"bs58": "^4.0.0"`.
+test("auto-install resolves transitive deps through a nested package.json (#6988)", async () => {
+  // `inner` only exists at 2.0.0. The nested package.json in `outer` asks for
+  // ^1.0.0; if the resolver honors it, resolution fails.
+  const inner = buildTarball({
+    "package.json": JSON.stringify({ name: "inner", version: "2.0.0", main: "index.js" }),
+    "index.js": `module.exports = "inner@2.0.0";\n`,
+  });
+  // `outer`'s entry point requires `inner` from a file that sits under a
+  // nested package.json whose `dependencies` disagree with the package root.
+  const outer = buildTarball({
+    "package.json": JSON.stringify({
+      name: "outer",
+      version: "1.0.0",
+      main: "lib/sub/entry.js",
+      dependencies: { inner: "^2.0.0" },
+    }),
+    "lib/sub/package.json": JSON.stringify({
+      name: "sub",
+      version: "1.0.0",
+      dependencies: { inner: "^1.0.0" },
+    }),
+    "lib/sub/entry.js": `module.exports = require("inner");\n`,
+  });
+
+  await using server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req) {
+      const url = new URL(req.url);
+      const base = `http://127.0.0.1:${server.port}`;
+      if (url.pathname === "/outer") {
+        return Response.json({
+          name: "outer",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "outer",
+              version: "1.0.0",
+              dependencies: { inner: "^2.0.0" },
+              dist: { integrity: outer.integrity, tarball: `${base}/outer/-/outer-1.0.0.tgz` },
+            },
+          },
+        });
+      }
+      if (url.pathname === "/inner") {
+        return Response.json({
+          name: "inner",
+          "dist-tags": { latest: "2.0.0" },
+          versions: {
+            "2.0.0": {
+              name: "inner",
+              version: "2.0.0",
+              dist: { integrity: inner.integrity, tarball: `${base}/inner/-/inner-2.0.0.tgz` },
+            },
+          },
+        });
+      }
+      if (url.pathname === "/outer/-/outer-1.0.0.tgz") {
+        return new Response(outer.tgz, { headers: { "content-length": String(outer.tgz.length) } });
+      }
+      if (url.pathname === "/inner/-/inner-2.0.0.tgz") {
+        return new Response(inner.tgz, { headers: { "content-length": String(inner.tgz.length) } });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  // No package.json, no node_modules: the auto-install path.
+  using dir = tempDir("autoinstall-nested-pkgjson-6988", {
+    "index.js": `console.log(require("outer"));\n`,
+    "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${server.port}/"\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "index.js"],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Before the fix this prints nothing and stderr carries either
+  // "Cannot find package 'inner'" or "ENOENT while resolving package 'inner'".
+  expect({ stdout, stderr: stderr.split("\n").filter(l => l.includes("inner")) }).toEqual({
+    stdout: "inner@2.0.0\n",
+    stderr: [],
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #6988.

## Repro

```sh
mkdir empty && cd empty
echo 'import * as hive from "@hiveio/hive-js"; console.log(typeof hive.api)' > index.js
bun run index.js
```

```
error: ENOENT while resolving package 'bs58' from '.../.bun/install/cache/@hiveio/hive-js@2.0.9@@@1/lib/auth/ecc/src/address.js'
```

## Cause

`@hiveio/hive-js` ships a nested `lib/auth/ecc/package.json` with `"bs58": "^3.0.0"` alongside the package-root `package.json`'s `"bs58": "^4.0.0"`. When `address.js` under `ecc/src/` did `require('bs58')`, `dir_info_uncached` let the nested file's `dependencies` overwrite `package_json_for_dependencies`, so the auto-install block in `load_node_modules` asked the package manager for `bs58@^3.0.0`. Only `bs58@4.0.1` (from the package root's constraint) had been installed, so `path_for_resolution` hit `ENOENT` on the cache symlink.

Node, npm, yarn, and `bun install` all ignore nested package.json `dependencies` for resolution; only the package root counts.

## Fix

In `dir_info_uncached`:

* a directory's own package.json only replaces `package_json_for_dependencies` when it is itself an installed-package root (`package_manager_package_id != INVALID`), or when no installed root already encloses it;
* child directories inherit the parent's already-propagated field directly instead of re-deriving from `parent.package_json`, which is how the nested file leaked back in for grandchildren.

User-project behaviour (a package.json with `dependencies` but no lockfile id) is unchanged: it still claims the subtree when nothing else has.

## Verification

* New `test/regression/issue/06988.test.ts` spins up a local registry with an `outer` package whose entry sits under a nested package.json that declares a conflicting `inner` constraint; fails on main with `Cannot find package 'inner'`, passes with this change.
* The original `@hiveio/hive-js` repro now prints `object` with a cold cache.
* `test/cli/run/run-autoinstall*.test.ts`, `test/cli/run/autoinstall-cached-manifest.test.ts`, `test/js/bun/resolve/resolve*.test.ts` all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/06988.test.ts"
bun test v1.4.0 (6bed89777)

test/regression/issue/06988.test.ts:
134 |   });
135 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
136 | 
137 |   // Before the fix this prints nothing and stderr carries either
138 |   // "Cannot find package 'inner'" or "ENOENT while resolving package 'inner'".
139 |   expect({ stdout, stderr: stderr.split("\n").filter(l => l.includes("inner")) }).toEqual({
                                                                                        ^
error: expect(received).toEqual(expected)

  {
-   "stderr": [],
-   "stdout": 
- "inner@2.0.0
- "
- ,
+   "stderr": [
+     "error: Cannot find package 'inner' from '/tmp/autoinstall-nested-pkgjson-6988_wZi21H/.bun-cache/outer@1.0.0@@127.0.0.1@@@1/lib/sub/src/entry.js'",
+   ],
+   "stdout": "",
  }

- Expected  - 5
+ Received  + 4

      at <anonymous> (/workspace/bun/test/regression/issue/06988.test.ts:139:83)
(fail) auto-install resolves transitive deps thr
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (87642ad59)

test/regression/issue/06988.test.ts:
(pass) auto-install resolves transitive deps through a nested package.json (#6988) [462.41ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [675.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/06988.test.ts"
bun test v1.4.0 (6bed89777)

test/regression/issue/06988.test.ts:
(pass) auto-install resolves transitive deps through a nested package.json (#6988) [849.67ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [3.38s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1066ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/resolver/resolver.rs            |  23 +++---
 test/regression/issue/06988.test.ts | 144 ++++++++++++++++++++++++++++++++++++
 2 files changed, 153 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/resolver/resolver.rs                10      9      0
test/regression/issue/06988.test.ts      1      5      0
```

</details>

<!-- robobun:evidence:end -->