### PR TITLE
error printer: show file/line for JSC parser SyntaxErrors with no stack

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -188,7 +188,14 @@ WTF::String formatStackTrace(
                 memset(&remappedFrame, 0, sizeof(ZigStackFrame));
 
                 remappedFrame.position.line_zero_based = originalLine.zeroBasedInt();
-                remappedFrame.position.column_zero_based = 0;
+                // JSC's addErrorInfo() discards the parser-error column. Querying
+                // the source map at column 0 resolves to bun's start-of-line
+                // mapping for the previous source line when the statement is
+                // indented; query past end-of-line so the lookup lands on the
+                // last mapping of the generated line instead.
+                remappedFrame.position.column_zero_based = err->column() > 0
+                    ? WTF::OrdinalNumber::fromOneBasedInt(err->column()).zeroBasedInt()
+                    : std::numeric_limits<int32_t>::max();
 
                 String sourceURLForFrame = err->sourceURL();
 
@@ -203,6 +210,8 @@ WTF::String formatStackTrace(
                         sourceURLForFrame = remappedFrame.source_url.toWTFString();
                     }
                 }
+                if (err->column() == 0)
+                    remappedFrame.position.column_zero_based = 0;
 
                 // there is always a newline before each stack frame line, ensuring that the name + message
                 // exist on the first line, even if both are empty

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -188,30 +188,16 @@ WTF::String formatStackTrace(
                 memset(&remappedFrame, 0, sizeof(ZigStackFrame));
 
                 remappedFrame.position.line_zero_based = originalLine.zeroBasedInt();
-                // JSC's addErrorInfo() discards the parser-error column. Querying
-                // the source map at column 0 resolves to bun's start-of-line
-                // mapping for the previous source line when the statement is
-                // indented; query past end-of-line so the lookup lands on the
-                // last mapping of the generated line instead.
-                remappedFrame.position.column_zero_based = err->column() > 0
-                    ? WTF::OrdinalNumber::fromOneBasedInt(err->column()).zeroBasedInt()
-                    : std::numeric_limits<int32_t>::max();
 
                 String sourceURLForFrame = err->sourceURL();
 
                 // If it's not a Zig::GlobalObject, don't bother source-mapping it.
                 if (globalObject && !sourceURLForFrame.isEmpty()) {
                     // https://github.com/oven-sh/bun/issues/3595
-                    if (!sourceURLForFrame.isEmpty()) {
-                        remappedFrame.source_url = Bun::toStringRef(sourceURLForFrame);
-                        // This ensures the lifetime of the sourceURL is accounted for correctly
-                        Bun__remapStackFramePositions(getBunVM(), &remappedFrame, 1);
-
-                        sourceURLForFrame = remappedFrame.source_url.toWTFString();
-                    }
+                    remappedFrame.source_url = Bun::toStringRef(sourceURLForFrame);
+                    Bun__remapParseErrorFrame(getBunVM(), &remappedFrame, err->line(), err->column());
+                    sourceURLForFrame = remappedFrame.source_url.toWTFString();
                 }
-                if (err->column() == 0)
-                    remappedFrame.position.column_zero_based = 0;
 
                 // there is always a newline before each stack frame line, ensuring that the name + message
                 // exist on the first line, even if both are empty

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -636,6 +636,42 @@ static void fromErrorInstance(ZigException& except, JSC::JSGlobalObject* global,
     }
 
     if (except.stack.frames_len == 0 && getFromSourceURL) {
+        // A JSC parser SyntaxError created before any JS runs has no stack, so
+        // materializeErrorInfoIfNeeded() never publishes line/column/sourceURL as
+        // JS properties. The C++ fields on ErrorInstance are still set by
+        // addErrorInfo(), so read those directly and synthesize a frame.
+        const String& nativeSourceURL = err->sourceURL();
+        if (!nativeSourceURL.isEmpty()) {
+            auto& frame = except.stack.frames_ptr[0];
+            frame.source_url.deref();
+            frame.source_url = Bun::toStringRef(nativeSourceURL);
+            bool columnUnknown = err->column() == 0;
+            if (err->line() > 0) {
+                frame.position.line_zero_based = OrdinalNumber::fromOneBasedInt(err->line()).zeroBasedInt();
+                frame.position.column_zero_based = columnUnknown ? 0 : OrdinalNumber::fromOneBasedInt(err->column()).zeroBasedInt();
+                if (auto* zigGlobal = dynamicDowncast<Zig::GlobalObject>(global)) {
+                    if (columnUnknown) {
+                        // addErrorInfo() never records the parser-error column. A
+                        // source-map lookup at column 0 resolves to bun's own
+                        // start-of-line mapping, which points at the end of the
+                        // previous source line; querying the last mapping on the
+                        // generated line (any column past the line end) reliably
+                        // lands on the correct source line. Report column 1 since
+                        // the true column is unknown.
+                        frame.position.column_zero_based = std::numeric_limits<int32_t>::max();
+                        Bun__remapStackFramePositions(zigGlobal->bunVM(), &frame, 1);
+                        frame.position.column_zero_based = 0;
+                    } else {
+                        Bun__remapStackFramePositions(zigGlobal->bunVM(), &frame, 1);
+                    }
+                }
+            }
+            except.stack.frames_len = 1;
+            frame.remapped = true;
+            except.remapped = true;
+            return;
+        }
+
         JSC::JSValue sourceURL = getNonObservable(vm, global, obj, vm.propertyNames->sourceURL);
         if (!scope.clearExceptionExceptTermination()) [[unlikely]]
             return;

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -636,35 +636,18 @@ static void fromErrorInstance(ZigException& except, JSC::JSGlobalObject* global,
     }
 
     if (except.stack.frames_len == 0 && getFromSourceURL) {
-        // A JSC parser SyntaxError created before any JS runs has no stack, so
-        // materializeErrorInfoIfNeeded() never publishes line/column/sourceURL as
-        // JS properties. The C++ fields on ErrorInstance are still set by
-        // addErrorInfo(), so read those directly and synthesize a frame.
+        // Parse-time SyntaxErrors have no JS stack, so .line/.sourceURL are
+        // never materialized; addErrorInfo() still sets the C++ fields.
         const String& nativeSourceURL = err->sourceURL();
         if (!nativeSourceURL.isEmpty()) {
             auto& frame = except.stack.frames_ptr[0];
             frame.source_url.deref();
             frame.source_url = Bun::toStringRef(nativeSourceURL);
-            bool columnUnknown = err->column() == 0;
             if (err->line() > 0) {
-                frame.position.line_zero_based = OrdinalNumber::fromOneBasedInt(err->line()).zeroBasedInt();
-                frame.position.column_zero_based = columnUnknown ? 0 : OrdinalNumber::fromOneBasedInt(err->column()).zeroBasedInt();
-                if (auto* zigGlobal = dynamicDowncast<Zig::GlobalObject>(global)) {
-                    if (columnUnknown) {
-                        // addErrorInfo() never records the parser-error column. A
-                        // source-map lookup at column 0 resolves to bun's own
-                        // start-of-line mapping, which points at the end of the
-                        // previous source line; querying the last mapping on the
-                        // generated line (any column past the line end) reliably
-                        // lands on the correct source line. Report column 1 since
-                        // the true column is unknown.
-                        frame.position.column_zero_based = std::numeric_limits<int32_t>::max();
-                        Bun__remapStackFramePositions(zigGlobal->bunVM(), &frame, 1);
-                        frame.position.column_zero_based = 0;
-                    } else {
-                        Bun__remapStackFramePositions(zigGlobal->bunVM(), &frame, 1);
-                    }
-                }
+                if (auto* zigGlobal = dynamicDowncast<Zig::GlobalObject>(global))
+                    Bun__remapParseErrorFrame(zigGlobal->bunVM(), &frame, err->line(), err->column());
+                else
+                    frame.position.line_zero_based = OrdinalNumber::fromOneBasedInt(err->line()).zeroBasedInt();
             }
             except.stack.frames_len = 1;
             frame.remapped = true;

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -636,8 +636,7 @@ static void fromErrorInstance(ZigException& except, JSC::JSGlobalObject* global,
     }
 
     if (except.stack.frames_len == 0 && getFromSourceURL) {
-        // Parse-time SyntaxErrors have no JS stack, so .line/.sourceURL are
-        // never materialized; addErrorInfo() still sets the C++ fields.
+        // Parse-time SyntaxErrors have no stack; addErrorInfo() still set the C++ fields (#5192).
         const String& nativeSourceURL = err->sourceURL();
         if (!nativeSourceURL.isEmpty()) {
             auto& frame = except.stack.frames_ptr[0];

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -456,6 +456,19 @@ bool Bun__deepMatch(
 
 extern "C" void Bun__remapStackFramePositions(void*, ZigStackFrame*, size_t);
 
+// JSC's addErrorInfo() records the parse-error line but no column; a lookup at
+// column 0 lands on the previous source line's trailing mapping, so remap via
+// the last mapping on the generated line and report column 1.
+ALWAYS_INLINE void Bun__remapParseErrorFrame(void* bunVM, ZigStackFrame* frame, unsigned line, unsigned column)
+{
+    frame->position.line_zero_based = static_cast<int32_t>(line) - 1;
+    bool columnKnown = column > 0;
+    frame->position.column_zero_based = columnKnown ? static_cast<int32_t>(column) - 1 : INT32_MAX;
+    Bun__remapStackFramePositions(bunVM, frame, 1);
+    if (!columnKnown)
+        frame->position.column_zero_based = 0;
+}
+
 namespace Inspector {
 class ScriptArguments;
 }

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -456,13 +456,11 @@ bool Bun__deepMatch(
 
 extern "C" void Bun__remapStackFramePositions(void*, ZigStackFrame*, size_t);
 
-// JSC's addErrorInfo() records the parse-error line but no column; a lookup at
-// column 0 lands on the previous source line's trailing mapping, so remap via
-// the last mapping on the generated line and report column 1.
 ALWAYS_INLINE void Bun__remapParseErrorFrame(void* bunVM, ZigStackFrame* frame, unsigned line, unsigned column)
 {
     frame->position.line_zero_based = static_cast<int32_t>(line) - 1;
     bool columnKnown = column > 0;
+    // addErrorInfo() column is 0; a lookup there lands on the previous line's tail, so query past end-of-line.
     frame->position.column_zero_based = columnKnown ? static_cast<int32_t>(column) - 1 : INT32_MAX;
     Bun__remapStackFramePositions(bunVM, frame, 1);
     if (!columnKnown)

--- a/test/regression/issue/05192.test.ts
+++ b/test/regression/issue/05192.test.ts
@@ -126,13 +126,15 @@ with ({ a: 1 }) { console.log(a); }
   expect(exitCode).toBe(1);
 });
 
-test.concurrent("JSC parse SyntaxError reported line points at the offending statement, not the line before", async () => {
-  // addErrorInfo() discards the parser-error column; a naive source-map lookup
-  // at column 0 resolves to bun's own start-of-line mapping for the *previous*
-  // source line when the offending statement is indented.
-  const { stderr, exitCode } = await run(
-    {
-      "module.mjs": `export const x = 1;
+test.concurrent(
+  "JSC parse SyntaxError reported line points at the offending statement, not the line before",
+  async () => {
+    // addErrorInfo() discards the parser-error column; a naive source-map lookup
+    // at column 0 resolves to bun's own start-of-line mapping for the *previous*
+    // source line when the offending statement is indented.
+    const { stderr, exitCode } = await run(
+      {
+        "module.mjs": `export const x = 1;
 function foo() {
   with ({ a: 1 }) {
     console.log(a);
@@ -140,11 +142,12 @@ function foo() {
 }
 foo();
 `,
-    },
-    "module.mjs",
-  );
-  expect(stderr).toContain("SyntaxError: 'with' statements are not valid in strict mode.");
-  expect(stderr).toMatch(/module\.mjs:3\b/);
-  expect(stderr).toMatch(/3 \|.*\bwith\b/);
-  expect(exitCode).toBe(1);
-});
+      },
+      "module.mjs",
+    );
+    expect(stderr).toContain("SyntaxError: 'with' statements are not valid in strict mode.");
+    expect(stderr).toMatch(/module\.mjs:3\b/);
+    expect(stderr).toMatch(/3 \|.*\bwith\b/);
+    expect(exitCode).toBe(1);
+  },
+);

--- a/test/regression/issue/05192.test.ts
+++ b/test/regression/issue/05192.test.ts
@@ -1,0 +1,150 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/5192
+//
+// When JSC (not Bun's own parser) rejects a module with a SyntaxError, the
+// ErrorInstance carries line/sourceURL on its C++ fields but those were never
+// surfaced because the error has no JS stack at module-parse time. The error
+// printed as a bare "SyntaxError: ..." with no file, line, or code frame.
+
+async function run(files: Record<string, string>, entry: string) {
+  using dir = tempDir("issue-5192", files);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), entry],
+    env: { ...bunEnv, NO_COLOR: "1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+// `with` in strict mode is caught by JSC's parser, not Bun's, so it exercises
+// the JSC ParserError path directly.
+const withInStrict = `"use strict";
+export const x = 1;
+function foo() {
+  with ({ a: 1 }) {
+    console.log(a);
+  }
+}
+foo();
+`;
+
+test.concurrent("JSC parse SyntaxError in the entry module prints file and line", async () => {
+  const { stderr, exitCode } = await run({ "entry.mjs": withInStrict }, "entry.mjs");
+  expect(stderr).toContain("SyntaxError: 'with' statements are not valid in strict mode.");
+  // File path with a line number must appear somewhere in the output.
+  expect(stderr).toMatch(/entry\.mjs:\d+/);
+  // A code frame with the `with` line must appear.
+  expect(stderr).toMatch(/\bwith\b.*\{ a: 1 \}/);
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("JSC parse SyntaxError in an imported ESM module prints file and line", async () => {
+  const { stderr, exitCode } = await run(
+    {
+      "module.mjs": withInStrict,
+      "entry.ts": `import "./module.mjs";`,
+    },
+    "entry.ts",
+  );
+  expect(stderr).toContain("SyntaxError: 'with' statements are not valid in strict mode.");
+  expect(stderr).toMatch(/module\.mjs:\d+/);
+  expect(stderr).toMatch(/\bwith\b.*\{ a: 1 \}/);
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("JSC parse SyntaxError in an imported .ts module prints file and line", async () => {
+  const { stderr, exitCode } = await run(
+    {
+      "module.ts": withInStrict,
+      "entry.ts": `import "./module.ts";`,
+    },
+    "entry.ts",
+  );
+  expect(stderr).toContain("SyntaxError: 'with' statements are not valid in strict mode.");
+  expect(stderr).toMatch(/module\.ts:\d+/);
+  expect(stderr).toMatch(/\bwith\b.*\{ a: 1 \}/);
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("JSC parse SyntaxError: 'delete x' in strict mode prints file and line", async () => {
+  const { stderr, exitCode } = await run(
+    {
+      "module.mjs": `export const x = 1;
+function fn() {
+  delete someVar;
+}
+fn();
+`,
+      "entry.mjs": `import "./module.mjs";`,
+    },
+    "entry.mjs",
+  );
+  expect(stderr).toContain("SyntaxError: Cannot delete unqualified property 'someVar' in strict mode.");
+  expect(stderr).toMatch(/module\.mjs:\d+/);
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("JSC parse SyntaxError from dynamic import() prints file and line when re-thrown", async () => {
+  const { stderr, exitCode } = await run(
+    {
+      "module.mjs": withInStrict,
+      "entry.mjs": `try {
+  await import("./module.mjs");
+} catch (e) {
+  console.error(e);
+}
+`,
+    },
+    "entry.mjs",
+  );
+  expect(stderr).toContain("SyntaxError: 'with' statements are not valid in strict mode.");
+  expect(stderr).toMatch(/module\.mjs:\d+/);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("JSC parse SyntaxError in a require()'d CJS module prints the offending line", async () => {
+  // require() has a JS stack so the `<parse>` frame comes from the .stack
+  // formatter rather than the error printer's synthetic frame; both paths had
+  // the same column-0 source-map lookup bug that resolved to the previous line.
+  const { stderr, exitCode } = await run(
+    {
+      "mod.cjs": `"use strict";
+with ({ a: 1 }) { console.log(a); }
+`,
+      "main.cjs": `require("./mod.cjs");`,
+    },
+    "main.cjs",
+  );
+  expect(stderr).toContain("SyntaxError: 'with' statements are not valid in strict mode.");
+  expect(stderr).toMatch(/mod\.cjs:2\b/);
+  expect(stderr).toMatch(/2 \|.*\bwith\b/);
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("JSC parse SyntaxError reported line points at the offending statement, not the line before", async () => {
+  // addErrorInfo() discards the parser-error column; a naive source-map lookup
+  // at column 0 resolves to bun's own start-of-line mapping for the *previous*
+  // source line when the offending statement is indented.
+  const { stderr, exitCode } = await run(
+    {
+      "module.mjs": `export const x = 1;
+function foo() {
+  with ({ a: 1 }) {
+    console.log(a);
+  }
+}
+foo();
+`,
+    },
+    "module.mjs",
+  );
+  expect(stderr).toContain("SyntaxError: 'with' statements are not valid in strict mode.");
+  expect(stderr).toMatch(/module\.mjs:3\b/);
+  expect(stderr).toMatch(/3 \|.*\bwith\b/);
+  expect(exitCode).toBe(1);
+});


### PR DESCRIPTION
Fixes #5192.

## Problem

A `SyntaxError` raised by JavaScriptCore's own parser (strict-mode `with`, `delete x` on an unqualified identifier, invalid regex literals, etc.) during module load printed only the bare message with no file, line, or code frame:

```
SyntaxError: 'with' statements are not valid in strict mode.

Bun v1.4.0 (Linux x64)
```

Bun's own parser errors already showed location; this is specific to errors JSC catches after Bun's transpiler accepted the source.

## Cause

These errors are created before any JS runs, so the `ErrorInstance` has no stack. `addErrorInfo()` records the line and sourceURL on the instance's C++ fields, but `materializeErrorInfoIfNeeded()` only publishes them as `.line`/`.sourceURL` JS properties when a stack trace exists. `fromErrorInstance()` read those JS properties, found nothing, and produced zero frames, so the code-frame printer never ran.

## Fix

`fromErrorInstance()` now reads `err->sourceURL()`/`err->line()` from the C++ fields directly and synthesizes a frame when no stack is available.

JSC never records the parser-error column (it is always 0). A source-map lookup at column 0 resolves to the printer's start-of-line mapping, which points at the tail of the *previous* source line when the offending statement is indented, so the reported line was off by one. Both the new path and the existing `<parse>` frame in `formatStackTrace()` now query past end-of-line so the lookup lands on the last mapping of the generated line, which reliably resolves to the correct source line; the column is reported as 1 since the true column is unknown.

## After

```
1 | "use strict";
2 | export const x = 1;
3 | function foo() {
4 |   with ({ a: 1 }) {
    ^
SyntaxError: 'with' statements are not valid in strict mode.
      at /tmp/t/module.mjs:4:1

Bun v1.4.0 (Linux x64)
```

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/regression/issue/05192.test.ts   # 0 pass, 7 fail
$ bun bd test test/regression/issue/05192.test.ts                 # 7 pass, 0 fail
```

Covers: direct entry, `import` of `.mjs`/`.ts`, `await import()` re-thrown via `console.error`, `require()` of CJS, and the indented-statement off-by-one.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/05192.test.ts"
bun test v1.4.0 (02618d2db)

test/regression/issue/05192.test.ts:
35 | 
36 | test.concurrent("JSC parse SyntaxError in the entry module prints file and line", async () => {
37 |   const { stderr, exitCode } = await run({ "entry.mjs": withInStrict }, "entry.mjs");
38 |   expect(stderr).toContain("SyntaxError: 'with' statements are not valid in strict mode.");
39 |   // File path with a line number must appear somewhere in the output.
40 |   expect(stderr).toMatch(/entry\.mjs:\d+/);
                      ^
error: expect(received).toMatch(expected)

Expected substring or pattern: /entry\.mjs:\d+/
Received: "SyntaxError: 'with' statements are not valid in strict mode.\n\nBun v1.4.0-debug+02618d2db (Linux x64)\n"

      at <anonymous> (/workspace/bun/test/regression/issue/05192.test.ts:40:18)
(fail) JSC parse SyntaxError in the entry module prints file and line [680.38ms]
64 |       "entry.ts": `import "./module.ts";`,
65 |     },
66 |     "entry.ts",
67 |   );
68 |   expect(stderr).toContain("SyntaxErr
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/regression/issue/05192.test.ts:
35 | 
36 | test.concurrent("JSC parse SyntaxError in the entry module prints file and line", async () => {
37 |   const { stderr, exitCode } = await run({ "entry.mjs": withInStrict }, "entry.mjs");
38 |   expect(stderr).toContain("SyntaxError: 'with' statements are not valid in strict mode.");
39 |   // File path with a line number must appear somewhere in the output.
40 |   expect(stderr).toMatch(/entry\.mjs:\d+/);
                      ^
error: expect(received).toMatch(expected)

Expected substring or pattern: /entry\.mjs:\d+/
Received: "SyntaxError: 'with' statements are not valid in strict mode.\n\nBun v1.4.0-canary.1+1498d7b77 (Linux x64)\n"

      at <anonymous> (/workspace/bun/test/regression/issue/05192.test.ts:40:18)
(fail) JSC parse SyntaxError in the entry module prints file and line [42.44ms]
50 |       "entry.ts": `import "./module.mjs";`,
51 |     },
52 |     "entry.ts",
53 |   );
54 |   expect(stderr).toContain("SyntaxError: 'with' statements are not valid in strict mode.");
55 |   expect(stderr).toMatch(/module\.mjs:\d+/);
                      ^
error: expect(received).toMatc
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/05192.test.ts"
bun test v1.4.0 (02618d2db)

test/regression/issue/05192.test.ts:
(pass) JSC parse SyntaxError in the entry module prints file and line [371.65ms]
(pass) JSC parse SyntaxError in an imported ESM module prints file and line [373.75ms]
(pass) JSC parse SyntaxError in an imported .ts module prints file and line [374.02ms]
(pass) JSC parse SyntaxError: 'delete x' in strict mode prints file and line [367.20ms]
(pass) JSC parse SyntaxError from dynamic import() prints file and line when re-thrown [348.55ms]
(pass) JSC parse SyntaxError in a require()'d CJS module prints the offending line [463.51ms]
(pass) JSC parse SyntaxError reported line points at the offending statement, not the line before [461.33ms]

 7 pass
 0 fail
 26 expect() calls
Ran 7 tests across 1 file. [5.15s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     02618d2db7
  features     baseline

22 deps, 108 codegen, 1171 objects in 2974ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] fetch picohttpparser
[picohttpparser] up to date
[2/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[4/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[5/1234] fetch zlib
[zlib] up to date
[6/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1234] fetch tinycc
[tinycc] up to date
[8/1234] gen ProcessBindingFs.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingFs.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingFs.cpp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/FormatStackTraceForJS.cpp |  11 +--
 src/jsc/bindings/ZigException.cpp          |  18 ++++
 src/jsc/bindings/headers-handwritten.h     |  11 +++
 test/regression/issue/05192.test.ts        | 153 +++++++++++++++++++++++++++++
 4 files changed, 185 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/jsc/bindings/FormatStackTraceForJS.cpp      5      2      0
src/jsc/bindings/ZigException.cpp               5      8      0
src/jsc/bindings/headers-handwritten.h          3      3      0
test/regression/issue/05192.test.ts             0      3      0
```

</details>

<!-- robobun:evidence:end -->