### PR TITLE
esm: report the importing file when a named import cannot be resolved

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "34c01d13391e00c06862a3d2c5b7fff350ac87e0";
+export const WEBKIT_VERSION = "autobuild-preview-pr-378-b5a21f5e";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/resolve/esm-link-error-location.test.ts
+++ b/test/js/bun/resolve/esm-link-error-location.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
+
+// https://github.com/oven-sh/bun/issues/5582
+// When a named import resolves to a module that does not export that name,
+// the resulting SyntaxError previously named only the imported-from module,
+// not the file that contains the failing import statement. In a large
+// project that made the offending import impossible to locate.
+describe("ESM link-time SyntaxError reports the importing file", () => {
+  async function run(cwd: string, entry: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), entry],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("entry point imports a missing named export", async () => {
+    using dir = tempDir("link-err-direct", {
+      "dep.mjs": `export const b = 1;\n`,
+      "index.mjs": `\n\nimport { a } from "./dep.mjs";\nconsole.log(a);\n`,
+    });
+    const { stderr, exitCode } = await run(String(dir), "index.mjs");
+    expect(stderr).toContain("SyntaxError: Export named 'a' not found in module");
+    expect(stderr).toContain("dep.mjs");
+    const importer = path.join(String(dir), "index.mjs");
+    expect(stderr).toContain(importer);
+    expect(stderr).toMatch(/index\.mjs:3/);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("indirect: the failing import is not in the entry point", async () => {
+    using dir = tempDir("link-err-indirect", {
+      "dep.mjs": `export const b = 1;\n`,
+      "middle.mjs": `import { nope } from "./dep.mjs";\nexport const m = nope;\n`,
+      "main.mjs": `import { m } from "./middle.mjs";\nconsole.log(m);\n`,
+    });
+    const { stderr, exitCode } = await run(String(dir), "main.mjs");
+    expect(stderr).toContain("SyntaxError: Export named 'nope' not found in module");
+    const importer = path.join(String(dir), "middle.mjs");
+    expect(stderr).toContain(importer);
+    expect(stderr).not.toContain(path.join(String(dir), "main.mjs") + ":");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("dynamic import() rejection carries importer location on the error", async () => {
+    using dir = tempDir("link-err-dynamic", {
+      "dep.mjs": `export const b = 1;\n`,
+      "importer.mjs": `import { gone } from "./dep.mjs";\nexport default gone;\n`,
+      "main.mjs": `try {\n  await import("./importer.mjs");\n  console.log("UNREACHABLE");\n} catch (e) {\n  console.log("MSG:" + e.message);\n  console.log("URL:" + e.sourceURL);\n  console.log("LINE:" + (typeof e.line === "number" && e.line > 0 ? "set" : e.line));\n}\n`,
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir), "main.mjs");
+    expect(stderr).toBe("");
+    const importer = path.join(String(dir), "importer.mjs");
+    expect({
+      msg: stdout.match(/^MSG:(.+?)'\//m)?.[1],
+      url: stdout.match(/^URL:(.*)$/m)?.[1],
+      line: stdout.match(/^LINE:(.*)$/m)?.[1],
+    }).toEqual({
+      msg: "Export named 'gone' not found in module ",
+      url: importer,
+      line: "set",
+    });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/resolve/esm-link-error-location.test.ts
+++ b/test/js/bun/resolve/esm-link-error-location.test.ts
@@ -58,11 +58,11 @@ describe("ESM link-time SyntaxError reports the importing file", () => {
     expect(stderr).toBe("");
     const importer = path.join(String(dir), "importer.mjs");
     expect({
-      msg: stdout.match(/^MSG:(.+?)'\//m)?.[1],
+      msg: stdout.match(/^MSG:(.*?not found in module)/m)?.[1],
       url: stdout.match(/^URL:(.*)$/m)?.[1],
       line: stdout.match(/^LINE:(.*)$/m)?.[1],
     }).toEqual({
-      msg: "Export named 'gone' not found in module ",
+      msg: "Export named 'gone' not found in module",
       url: importer,
       line: "set",
     });


### PR DESCRIPTION
Fixes #5582. Fixes #20667.

## Reproduction

```sh
# dep.ts
export const b = 1;
# index.ts
import { a } from "./dep.ts";
```

```
$ bun index.ts
SyntaxError: Export named 'a' not found in module '/repro/dep.ts'.
```

The error names `dep.ts` but not `index.ts`, so in a project where many files import from `dep.ts` there is no way to locate the failing `import` statement. Node prints `file:///repro/index.ts:1` with the offending line.

## Cause

The error is thrown in `CyclicModuleRecord::initializeEnvironment` during module linking, from a C++ microtask with no JS on the stack. The `SyntaxError` carries only the message text and is handed to Bun's printer with an empty stack trace, so `fromErrorInstance`'s `sourceURL`/`line`/`column` fallback finds nothing.

## Fix

JavaScriptCore change in oven-sh/WebKit#378: `ImportEntry` records the specifier's source offset (one `unsigned`), and the throw site attaches `sourceURL` / `line` / `column` (both as `ErrorInstance::m_sourceURL`/`m_lineColumn` and as `DontEnum` own properties) for the importing module. Bun's existing `ZigException.cpp::fromErrorInstance` already reads those properties and `remap_zig_exception` already remaps them through the sourcemap, so no bun-side code change is needed.

With the bump:

```
$ bun index.ts
1 | import { a } from "./dep.ts";
    ^
SyntaxError: Export named 'a' not found in module '/repro/dep.ts'.
      at /repro/index.ts:1:1
```

The indirect-export (`export { x } from "./dep"`) and ambiguous-binding cases route through the same helper and at least carry the importing module's `sourceURL`.

## Verification

`test/js/bun/resolve/esm-link-error-location.test.ts` covers the direct case, an indirect chain (entry → middle → dep) that must name `middle.mjs` and not the entry point, and a caught dynamic `import()` rejection whose `.sourceURL`/`.line` point at the importing file. All three fail on released bun and pass with the bump.

`test/js/bun/typescript/type-export.test.ts` (`import not found`) and `test/js/bun/resolve/resolve-error.test.ts` are unchanged and green.

## WebKit bump

`WEBKIT_VERSION` currently points at the preview build of oven-sh/WebKit#378 so CI can exercise the change. It will be updated to the merged `main` sha before this is undrafted. The preview built green on every WebKit CI lane (linux glibc/musl/android, macOS, windows x64/arm64, freebsd).

The gate's fail-before check cannot mechanically prove this because the fix is in the bumped prebuilt, not in `src/`; stashing `src/` leaves the bump in place. The fail-before evidence is `USE_SYSTEM_BUN=1 bun test test/js/bun/resolve/esm-link-error-location.test.ts` → 3 fail.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/resolve/esm-link-error-location.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/resolve/esm-link-error-location.test.ts
bun test v1.4.0 (d5059e897)

test/js/bun/resolve/esm-link-error-location.test.ts:
(pass) ESM link-time SyntaxError reports the importing file > entry point imports a missing named export [629.96ms]
(pass) ESM link-time SyntaxError reports the importing file > indirect: the failing import is not in the entry point [1187.18ms]
(pass) ESM link-time SyntaxError reports the importing file > dynamic import() rejection carries importer location on the error [823.39ms]

 3 pass
 0 fail
 12 expect() calls
Ran 3 tests across 1 file. [9.59s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |  2 +-
 .../js/bun/resolve/esm-link-error-location.test.ts | 71 ++++++++++++++++++++++
 2 files changed, 72 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
scripts/build/deps/webkit.ts                             1      1      0
test/js/bun/resolve/esm-link-error-location.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->
