### PR TITLE
bun test: sort every scanned directory so test-file order is stable across filesystems

### DIFF
--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -392,25 +392,6 @@ pub mod dir_entry {
     }
 }
 
-/// Per-entry hook invoked by `add_entry`/`readdir`.
-pub trait DirEntryIterator {
-    const IS_VOID: bool = false;
-    fn next(&self, entry: &mut Entry, fd: Fd);
-}
-
-impl DirEntryIterator for () {
-    const IS_VOID: bool = true;
-    fn next(&self, _entry: &mut Entry, _fd: Fd) {}
-}
-
-impl<T: DirEntryIterator + ?Sized> DirEntryIterator for &T {
-    const IS_VOID: bool = T::IS_VOID;
-    #[inline]
-    fn next(&self, entry: &mut Entry, fd: Fd) {
-        (**self).next(entry, fd)
-    }
-}
-
 pub struct DirEntry {
     // `dir` is interned in
     // DirnameStore (a process-lifetime BSSList), so `&'static` is correct.
@@ -438,12 +419,11 @@ impl DirEntry {
     // should hoist `FilenameStoreAppender::new()` once and call
     // `add_entry_with_store` directly.
 
-    pub(crate) fn add_entry_with_store<I: DirEntryIterator>(
+    pub(crate) fn add_entry_with_store(
         &mut self,
         prev_map: Option<&mut dir_entry::EntryMap>,
         entry: &bun_sys::dir_iterator::IteratorResult,
         filename_store: &mut FilenameStoreAppender,
-        iterator: I,
     ) -> crate::CrateResult<()> {
         use bun_sys::FileKind as DK;
         // `entry.name.slice()` is OS-native (`&[u16]` on Windows); the
@@ -600,12 +580,7 @@ impl DirEntry {
         // `name_hash` is its hash too — insert without re-hashing.
         self.data.put_static_key_hashed(name_hash, key, stored)?;
 
-        if !I::IS_VOID {
-            iterator.next(stored_ref, self.fd);
-        }
-
         if FeatureFlags::VERBOSE_FS {
-            // re-borrow `base()` after the `iterator.next` mutable borrow ends.
             let stored_name = stored_ref.base();
             if found_kind == Some(EntryKind::Dir) {
                 bun_core::prettyln!("   + {}/", BStr::new(stored_name));

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -686,7 +686,7 @@ pub mod fs {
     // Canonical definitions live in `fs.rs` (mounted as `crate::fs_full`).
     // Re-exported here so the public path `bun_resolver::fs::*` is preserved.
     pub use crate::fs_full::{
-        DirEntry, DirEntryIterator, Entry, EntryCache, EntryKind, EntryKindResolver, EntryLookup,
+        DirEntry, Entry, EntryCache, EntryKind, EntryKindResolver, EntryLookup,
         FilenameStoreAppender, dir_entry,
     };
 
@@ -1076,14 +1076,13 @@ pub mod fs {
 
         /// Iterate `handle` and populate a
         /// fresh `DirEntry` (re-using `prev_map` Entry slots where the name matches).
-        fn readdir<I: DirEntryIterator>(
+        fn readdir(
             &mut self,
             store_fd: bool,
             mut prev_map: Option<&mut dir_entry::EntryMap>,
             dir_: &'static [u8],
             generation: Generation,
             handle: Fd,
-            iterator: I,
         ) -> crate::CrateResult<DirEntry> {
             let mut iter = bun_sys::iterate_dir(handle);
             let mut dir = DirEntry::init(dir_, generation);
@@ -1096,12 +1095,7 @@ pub mod fs {
             let mut filename_store = FilenameStoreAppender::new();
             while let Some(entry_) = iter.next()? {
                 // debug("readdir entry {}", BStr::new(entry_.name.slice()));
-                dir.add_entry_with_store(
-                    prev_map.as_deref_mut(),
-                    &entry_,
-                    &mut filename_store,
-                    &iterator,
-                )?;
+                dir.add_entry_with_store(prev_map.as_deref_mut(), &entry_, &mut filename_store)?;
             }
 
             // debug("readdir({}, {}) = {}", handle, dir_, dir.data.count());
@@ -1147,16 +1141,6 @@ pub mod fs {
             )))
         }
 
-        pub fn read_directory(
-            &mut self,
-            dir_: &[u8],
-            handle_: Option<Fd>,
-            generation: Generation,
-            store_fd: bool,
-        ) -> crate::CrateResult<&mut EntriesOption> {
-            self.read_directory_with_iterator(dir_, handle_, generation, store_fd, ())
-        }
-
         // One of the learnings here
         //
         //   Closing file descriptors yields significant performance benefits on Linux
@@ -1167,13 +1151,12 @@ pub mod fs {
         // https://twitter.com/jarredsumner/status/1655464485245845506
         /// Caller borrows the returned `EntriesOption`. When `FeatureFlags::ENABLE_ENTRY_CACHE`
         /// is `false`, it is not safe to store this pointer past the current function call.
-        pub fn read_directory_with_iterator<I: DirEntryIterator>(
+        pub fn read_directory(
             &mut self,
             dir_maybe_trail_slash: &[u8],
             maybe_handle: Option<Fd>,
             generation: Generation,
             store_fd: bool,
-            iterator: I,
         ) -> crate::CrateResult<&'static mut EntriesOption> {
             let dir = strings::paths::without_trailing_slash_windows_path(dir_maybe_trail_slash);
 
@@ -1256,8 +1239,7 @@ pub mod fs {
                 // SAFETY: BSSMap-owned, no aliasing here (entries_mutex held).
                 unsafe { &mut (*p).data }
             });
-            let mut entries = match self.readdir(store_fd, prev, dir, generation, handle, iterator)
-            {
+            let mut entries = match self.readdir(store_fd, prev, dir, generation, handle) {
                 Ok(e) => e,
                 Err(err) => {
                     if let Some(existing) = in_place {
@@ -1597,7 +1579,7 @@ pub mod fs {
                     });
                     // SAFETY: see above — exclusive `&mut` on the prev map for the duration of `readdir`.
                     let prev = Some(unsafe { &mut (*e_ptr).data });
-                    match self.readdir(false, prev, dir, generation, handle, ()) {
+                    match self.readdir(false, prev, dir, generation, handle) {
                         Ok(new_entry) => {
                             // SAFETY: see above.
                             unsafe { (*e_ptr).data.clear() };

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3402,7 +3402,6 @@ impl<'a> Resolver<'a> {
                         in_place.map(|existing| unsafe { &mut (*existing).data }),
                         &_value,
                         &mut filename_store,
-                        (),
                     )
                     .expect("unreachable");
             }
@@ -4510,7 +4509,6 @@ impl<'a> Resolver<'a> {
                                 in_place.map(|existing| unsafe { &mut (*existing).data }),
                                 &_value,
                                 &mut filename_store,
-                                (),
                             )
                             .expect("unreachable");
                     }

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -216,7 +216,7 @@ impl<'a> Scanner<'a> {
         let raw = handle.map(bun_sys::Dir::into_raw);
         // SAFETY: borrows only the `fs` field; re-entrant access is serialised by `RealFS.entries_mutex`.
         unsafe { &mut (*fs_ptr).fs }
-            .read_directory_with_iterator(name, raw, 0, true, ())
+            .read_directory(name, raw, 0, true)
             .map_err(Into::into)
     }
 

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -10,7 +10,7 @@ use bun_output::{declare_scope, scoped_log};
 use bun_paths::resolve_path::{join_abs_string_buf, platform};
 use bun_paths::{self, PathBuffer};
 use bun_ptr::Interned;
-use bun_resolver::fs::{self as fs, DirEntryIterator, EntriesOption, FileSystem};
+use bun_resolver::fs::{self as fs, EntriesOption, FileSystem};
 use bun_sys::{self, Fd};
 
 declare_scope!(jest, hidden);
@@ -30,7 +30,6 @@ pub struct Scanner<'a> {
     pub(crate) fs: *mut FileSystem,
     pub(crate) open_dir_buf: PathBuffer,
     pub(crate) options: &'a BundleOptions<'a>,
-    pub(crate) has_iterated: bool,
     pub(crate) search_count: usize,
 }
 
@@ -61,19 +60,6 @@ impl PartialEq<crate::Error> for ScanError {
     }
 }
 
-/// Newtype around `*mut Scanner` so it can satisfy [`DirEntryIterator`]
-/// (whose `next` takes `&self`) while still allowing mutable calls.
-#[repr(transparent)]
-struct ScannerDirIter<'a>(*mut Scanner<'a>);
-impl<'a> DirEntryIterator for ScannerDirIter<'a> {
-    fn next(&self, entry: &mut fs::Entry, fd: Fd) {
-        // SAFETY: `self.0` is `&mut Scanner` for the duration of
-        // `read_directory_with_iterator`; no other live `&mut` alias exists
-        // while the resolver walks entries.
-        unsafe { (*self.0).next(entry, fd) }
-    }
-}
-
 impl<'a> Scanner<'a> {
     pub(crate) fn init(
         transpiler: &'a Transpiler,
@@ -89,7 +75,6 @@ impl<'a> Scanner<'a> {
             fs: transpiler.fs,
             test_files: results,
             open_dir_buf: PathBuffer::uninit(),
-            has_iterated: false,
             search_count: 0,
         })
     }
@@ -160,35 +145,7 @@ impl<'a> Scanner<'a> {
             }
         }
 
-        // you typed "." and we already scanned it
-        if !self.has_iterated {
-            if let EntriesOption::Entries(entries) = root {
-                let fd = entries.fd;
-                debug_assert!(fd != Fd::INVALID);
-                // Collect first so `self.next(…)` doesn't overlap the
-                // `entries.data` borrow.
-                // this branch is taken when the resolver already has
-                // `path` cached (e.g. `run_env_loader`/`read_dir_info` read the
-                // cwd before the scanner runs), so `read_directory_with_iterator`
-                // returned the cached `EntryMap` without invoking `iterator.next`.
-                // Hash-map iteration order is not stable. Sort by (lowercased)
-                // base name so test-file discovery order is deterministic —
-                // regression/issue/26851 relies on `a_*.test` running before
-                // `b_*.test` under `--bail`.
-                let mut entry_ptrs: Vec<*mut fs::Entry> = entries.data.values().copied().collect();
-                entry_ptrs.sort_by(|a, b| {
-                    // SAFETY: `EntryMap` stores `*mut Entry` into the
-                    // process-static `EntryStore`; valid for `'static`.
-                    let (an, bn) = unsafe { ((**a).base_lowercase(), (**b).base_lowercase()) };
-                    an.cmp(bn)
-                });
-                for entry_ptr in entry_ptrs {
-                    // SAFETY: `EntryMap` stores `*mut Entry` into the
-                    // process-static `EntryStore`; valid for `'static`.
-                    self.next(unsafe { &mut *entry_ptr }, fd);
-                }
-            }
-        }
+        self.process_entries_sorted(root);
 
         while let Some(entry) = self.dirs_to_scan.pop_front() {
             debug_assert!(entry.relative_dir.is_valid());
@@ -219,9 +176,10 @@ impl<'a> Scanner<'a> {
                     .append_slice(&self.open_dir_buf[..path2_len])
                     .map_err(|_| ScanError::OutOfMemory)?;
                 FileSystem::set_max_fd(child_dir.fd.native());
-                let _ = self
+                let sub = self
                     .read_dir_with_name(path2, Some(child_dir))
                     .map_err(|_| ScanError::OutOfMemory)?;
+                self.process_entries_sorted(sub);
             }
             #[cfg(windows)]
             {
@@ -239,9 +197,10 @@ impl<'a> Scanner<'a> {
                     .dirname_store
                     .append_slice(path2.as_bytes())
                     .map_err(|_| ScanError::OutOfMemory)?;
-                let _ = self
+                let sub = self
                     .read_dir_with_name(stored, Some(child_dir))
                     .map_err(|_| ScanError::OutOfMemory)?;
+                self.process_entries_sorted(sub);
             }
         }
 
@@ -254,12 +213,37 @@ impl<'a> Scanner<'a> {
         handle: Option<bun_sys::Dir>,
     ) -> crate::Result<&'static mut EntriesOption> {
         let fs_ptr = self.fs;
-        let iter = ScannerDirIter(std::ptr::from_mut::<Scanner<'a>>(self));
         let raw = handle.map(bun_sys::Dir::into_raw);
         // SAFETY: borrows only the `fs` field; re-entrant access is serialised by `RealFS.entries_mutex`.
         unsafe { &mut (*fs_ptr).fs }
-            .read_directory_with_iterator(name, raw, 0, true, iter)
+            .read_directory_with_iterator(name, raw, 0, true, ())
             .map_err(Into::into)
+    }
+
+    /// Visit a directory listing in sorted order so test-file discovery is
+    /// deterministic. Without this, files inside a subdirectory are visited in
+    /// raw `getdents`/hash-map order, which varies by filesystem and makes test
+    /// file execution order (and therefore cross-file module side effects)
+    /// machine-dependent. See issues #6655 and #26851.
+    fn process_entries_sorted(&mut self, entries_option: &mut EntriesOption) {
+        let EntriesOption::Entries(entries) = entries_option else {
+            return;
+        };
+        let fd = entries.fd;
+        debug_assert!(fd != Fd::INVALID);
+        // Collect first so `self.next(…)` doesn't overlap the `entries.data` borrow.
+        let mut entry_ptrs: Vec<*mut fs::Entry> = entries.data.values().copied().collect();
+        entry_ptrs.sort_by(|a, b| {
+            // SAFETY: `EntryMap` stores `*mut Entry` into the process-static
+            // `EntryStore`; valid for `'static`.
+            let (an, bn) = unsafe { ((**a).base_lowercase(), (**b).base_lowercase()) };
+            an.cmp(bn)
+        });
+        for entry_ptr in entry_ptrs {
+            // SAFETY: `EntryMap` stores `*mut Entry` into the process-static
+            // `EntryStore`; valid for `'static`.
+            self.next(unsafe { &mut *entry_ptr }, fd);
+        }
     }
 
     pub(crate) fn could_be_test_file<const NEEDS_TEST_SUFFIX: bool>(&self, name: &[u8]) -> bool {
@@ -356,10 +340,10 @@ impl<'a> Scanner<'a> {
 
     pub(crate) fn next(&mut self, entry: &mut fs::Entry, fd: Fd) {
         let name = entry.base_lowercase();
-        self.has_iterated = true;
         // SAFETY: `self.fs` is the process singleton.
         let real_fs = unsafe { &raw mut (*self.fs).fs };
-        // SAFETY: caller holds `entries_mutex`; the direct path is single-threaded.
+        // SAFETY: `entry.kind` locks the per-entry mutex internally; scanning runs
+        // single-threaded on the main thread before any tests start.
         match unsafe { entry.kind(real_fs, true) } {
             fs::EntryKind::Dir => {
                 if (!name.is_empty() && name[0] == b'.') || name == b"node_modules" {

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -236,8 +236,10 @@ impl<'a> Scanner<'a> {
         entry_ptrs.sort_by(|a, b| {
             // SAFETY: `EntryMap` stores `*mut Entry` into the process-static
             // `EntryStore`; valid for `'static`.
-            let (an, bn) = unsafe { ((**a).base_lowercase(), (**b).base_lowercase()) };
-            an.cmp(bn)
+            let (a, b) = unsafe { (&**a, &**b) };
+            a.base_lowercase()
+                .cmp(b.base_lowercase())
+                .then_with(|| a.base().cmp(b.base()))
         });
         for entry_ptr in entry_ptrs {
             // SAFETY: `EntryMap` stores `*mut Entry` into the process-static

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -220,11 +220,7 @@ impl<'a> Scanner<'a> {
             .map_err(Into::into)
     }
 
-    /// Visit a directory listing in sorted order so test-file discovery is
-    /// deterministic. Without this, files inside a subdirectory are visited in
-    /// raw `getdents`/hash-map order, which varies by filesystem and makes test
-    /// file execution order (and therefore cross-file module side effects)
-    /// machine-dependent. See issues #6655 and #26851.
+    /// Sort so test-file discovery order is stable across filesystems (#6655, #26851).
     fn process_entries_sorted(&mut self, entries_option: &mut EntriesOption) {
         let EntriesOption::Entries(entries) = entries_option else {
             return;

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1698,4 +1698,62 @@ describe.concurrent("test file discovery (scanner)", () => {
     expect(stderr).toContain(" 1 pass");
     expect(exitCode).toBe(0);
   });
+
+  // https://github.com/oven-sh/bun/issues/6655
+  // Previously only the top-level (resolver-cached) directory was sorted;
+  // subdirectories were visited in raw getdents/hash-map order, so the same
+  // project could run its test files in different orders on different
+  // filesystems. Because `bun test` shares the module registry across files,
+  // that made cross-file side effects (module-level caches etc.) non-deterministic.
+  test("runs test files in stable sorted order regardless of filesystem readdir order", async () => {
+    // These names give a non-alphabetical getdents order on ext4/overlayfs
+    // (htree hash: echo, alpha, golf, bravo, delta, charlie, foxtrot, hotel).
+    const names = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel"] as const;
+    const tpl = (n: string) => `import { test } from "bun:test"; test("t", () => { console.log("ORDER ${n}"); });`;
+    const files: Record<string, string> = {};
+    for (const n of names) {
+      files[`pkg/src/${n}.test.ts`] = tpl(`src/${n}`);
+      files[`pkg/lib/inner/${n}.test.ts`] = tpl(`lib/inner/${n}`);
+    }
+    files["pkg/src/Zeta.test.ts"] = tpl("src/Zeta");
+    using dir = tempDir("scanner-order", files);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const ran = stdout
+      .split("\n")
+      .filter(l => l.startsWith("ORDER "))
+      .map(l => l.slice("ORDER ".length));
+
+    // BFS over directories, entries within each directory sorted case-insensitively:
+    // pkg -> {lib, src}; lib -> {inner}; src -> 9 files; inner -> 8 files.
+    expect(ran).toEqual([
+      "src/alpha",
+      "src/bravo",
+      "src/charlie",
+      "src/delta",
+      "src/echo",
+      "src/foxtrot",
+      "src/golf",
+      "src/hotel",
+      "src/Zeta",
+      "lib/inner/alpha",
+      "lib/inner/bravo",
+      "lib/inner/charlie",
+      "lib/inner/delta",
+      "lib/inner/echo",
+      "lib/inner/foxtrot",
+      "lib/inner/golf",
+      "lib/inner/hotel",
+    ]);
+    expect(stderr).toContain(" 17 pass");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1700,11 +1700,6 @@ describe.concurrent("test file discovery (scanner)", () => {
   });
 
   // https://github.com/oven-sh/bun/issues/6655
-  // Previously only the top-level (resolver-cached) directory was sorted;
-  // subdirectories were visited in raw getdents/hash-map order, so the same
-  // project could run its test files in different orders on different
-  // filesystems. Because `bun test` shares the module registry across files,
-  // that made cross-file side effects (module-level caches etc.) non-deterministic.
   test("runs test files in stable sorted order regardless of filesystem readdir order", async () => {
     // These names give a non-alphabetical getdents order on ext4/overlayfs
     // (htree hash: echo, alpha, golf, bravo, delta, charlie, foxtrot, hotel).
@@ -1732,8 +1727,6 @@ describe.concurrent("test file discovery (scanner)", () => {
       .filter(l => l.startsWith("ORDER "))
       .map(l => l.slice("ORDER ".length));
 
-    // BFS over directories, entries within each directory sorted case-insensitively:
-    // pkg -> {lib, src}; lib -> {inner}; src -> 9 files; inner -> 8 files.
     expect(ran).toEqual([
       "src/alpha",
       "src/bravo",


### PR DESCRIPTION
## What

`bun test` discovers test files with a BFS directory walk. The root directory's entries were already being sorted (when the resolver had it cached), but every subdirectory visited from the BFS queue was processed in raw `getdents` / hash-map iteration order. That order is filesystem-dependent (ext4 htree hash, APFS, tmpfs insertion order, NTFS), so the same project ran its test files in a different order on different machines.

This change sorts every directory's entries by lowercased basename before visiting them, so discovery order is the same everywhere. The inline-readdir iterator callback and the `has_iterated` bookkeeping are no longer needed and are removed.

## Why this matters for #6655

The reproduction in #6655 has two test files in `packages/server-winston-mongodb/src/`:

- `Log.entity.test.ts` calls `getModelForClass(LogEntity)` at module-load time, which caches a typegoose model bound to mongoose's default (never-connected) connection
- `MongoDBTransport.test.ts` later calls `getModelForClass(LogEntity, { existingConnection })` and, because of typegoose's model cache, gets the already-cached model on the wrong connection, so `model.create(...)` buffers forever and the test times out

Node reproduces the same hang when those two modules are evaluated in that order in one process:

```
cached model conn readyState: 0
second getModelForClass === cached? true
model2 conn readyState: 0
Attempting create...
HUNG
```

Because `bun test` runs every file in one process with a shared module registry, whether the hang shows up depends entirely on which file runs first. On filesystems where `getdents` returned `Log.entity.test.ts` before `MongoDBTransport.test.ts` (APFS, some Docker layouts), the test hung; on ext4 here, `MongoDBTransport.test.ts` happened to come first and it passed. Copying the package to a fresh "standalone" directory changes the directory-entry order again, which is why workspace vs standalone looked like the trigger.

With this fix the discovery order is stable, so that project now fails the same way everywhere instead of appearing to be a workspace/module-resolution bug. The underlying hang is typegoose's cache, not Bun; the fix on that project's side is either `getModelForClass(LogEntity, { options: { disableCaching: true } })` or calling `deleteModel('LogEntity')` between files.

## Verification

```text
=== SYSTEM BUN (before fix) ===
deep/sub/apple.test.ts
deep/sub/zebra.test.ts
deep/sub/Mango.test.ts      <-- getdents / htree-hash order

=== DEBUG BUN (after fix) ===
deep/sub/apple.test.ts
deep/sub/Mango.test.ts
deep/sub/zebra.test.ts      <-- case-insensitive sorted
```

New test in `test/cli/test/bun-test.test.ts` creates 17 files across nested subdirectories whose ext4 htree-hash order is non-alphabetical and asserts the exact BFS-plus-sorted execution order. Fails on main, passes with this change.

Related: #6655, #26851

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->

## Deletions

The scanner was the only non-`()` implementer of `DirEntryIterator`. With the collect-then-sort model nothing hooks `readdir` per-entry anymore, so the following are removed as dead:

- `DirEntryIterator` trait and its `()` / `&T` impls (`src/resolver/fs.rs`)
- the `!I::IS_VOID` branch in `add_entry_with_store`
- the `I: DirEntryIterator` generic and `iterator` argument on `readdir` / `add_entry_with_store`
- `read_directory_with_iterator` (folded into `read_directory`)
- `ScannerDirIter` and the `has_iterated` flag (`src/runtime/cli/test/Scanner.rs`)
