### PR TITLE
resolver: fall through when the "bun" export condition target is missing

### DIFF
--- a/src/resolver/options.rs
+++ b/src/resolver/options.rs
@@ -54,6 +54,18 @@ pub struct Conditions {
     pub style: crate::package_json::ConditionsMap,
 }
 
+impl Conditions {
+    #[inline]
+    pub(crate) fn kind(&self, kind: bun_ast::ImportKind) -> &crate::package_json::ConditionsMap {
+        use bun_ast::ImportKind as K;
+        match kind {
+            K::Require | K::RequireResolve => &self.require,
+            K::At | K::AtConditional => &self.style,
+            _ => &self.import,
+        }
+    }
+}
+
 /// `Copy` tag selecting one of the extension-order lists owned by
 /// [`BundleOptions`]. Replaces the previous `*const [Box<[u8]>]`
 /// self-reference (`Resolver.extension_order` pointing into

--- a/src/resolver/options.rs
+++ b/src/resolver/options.rs
@@ -54,18 +54,6 @@ pub struct Conditions {
     pub style: crate::package_json::ConditionsMap,
 }
 
-impl Conditions {
-    #[inline]
-    pub(crate) fn kind(&self, kind: bun_ast::ImportKind) -> &crate::package_json::ConditionsMap {
-        use bun_ast::ImportKind as K;
-        match kind {
-            K::Require | K::RequireResolve => &self.require,
-            K::At | K::AtConditional => &self.style,
-            _ => &self.import,
-        }
-    }
-}
-
 /// `Copy` tag selecting one of the extension-order lists owned by
 /// [`BundleOptions`]. Replaces the previous `*const [Box<[u8]>]`
 /// self-reference (`Resolver.extension_order` pointing into

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1278,7 +1278,7 @@ pub(crate) struct ESModule<'a> {
     pub(crate) conditions: &'a ConditionsMap,
     // allocator dropped — global mimalloc
     pub(crate) module_type: &'a mut ModuleType,
-    /// Input: skip the "bun" key (second pass of the #7142 retry).
+    /// Input: skip "bun" targets, but not "bun": null (second pass of the #7142 retry).
     pub(crate) skip_bun_condition: bool,
     /// Output: the "bun" key matched and produced a target, so a failed load is worth retrying.
     pub(crate) matched_bun_condition: &'a mut bool,
@@ -2114,14 +2114,6 @@ impl<'a> ESModule<'a> {
             EntryData::Map(object) => {
                 for entry in object.list.iter() {
                     let key: &[u8] = &entry.key;
-                    if self.skip_bun_condition && key == b"bun" {
-                        if let Some(log) = self.debug_logs.as_deref_mut() {
-                            log.add_note_fmt(format_args!(
-                                "The key \"bun\" is being skipped on this retry"
-                            ));
-                        }
-                        continue;
-                    }
                     if self.conditions.contains_key(key) {
                         if let Some(log) = self.debug_logs.as_deref_mut() {
                             log.add_note_fmt(format_args!(
@@ -2142,14 +2134,8 @@ impl<'a> ESModule<'a> {
                             continue;
                         }
 
-                        if key == b"import" {
-                            *self.module_type = ModuleType::Esm;
-                        }
-
-                        if key == b"require" {
-                            *self.module_type = ModuleType::Cjs;
-                        }
-
+                        // A "bun" target is what the #7142 retry exists for; "bun": null is
+                        // not a target and stays terminal on both passes.
                         if key == b"bun"
                             && matches!(
                                 result.status,
@@ -2159,7 +2145,24 @@ impl<'a> ESModule<'a> {
                                     | Status::PackageResolve
                             )
                         {
+                            if self.skip_bun_condition {
+                                if let Some(log) = self.debug_logs.as_deref_mut() {
+                                    log.add_note_fmt(format_args!(
+                                        "The key \"bun\" is being skipped on this retry"
+                                    ));
+                                }
+                                *self.module_type = prev_module_type;
+                                continue;
+                            }
                             *self.matched_bun_condition = true;
+                        }
+
+                        if key == b"import" {
+                            *self.module_type = ModuleType::Esm;
+                        }
+
+                        if key == b"require" {
+                            *self.module_type = ModuleType::Cjs;
                         }
 
                         return result;

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -2134,8 +2134,6 @@ impl<'a> ESModule<'a> {
                             continue;
                         }
 
-                        // A "bun" target is what the #7142 retry exists for; "bun": null is
-                        // not a target and stays terminal on both passes.
                         if key == b"bun"
                             && matches!(
                                 result.status,

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1278,9 +1278,11 @@ pub(crate) struct ESModule<'a> {
     pub(crate) conditions: &'a ConditionsMap,
     // allocator dropped — global mimalloc
     pub(crate) module_type: &'a mut ModuleType,
-    /// Input: ignore the "bun" condition on a retry when its target was absent on disk (#7142).
+    /// Input: skip the "bun" key. Set on the retry pass after a resolution that went through
+    /// the "bun" condition failed to load (#7142).
     pub(crate) skip_bun_condition: bool,
-    /// Output: set to true iff the returned resolution came from matching the "bun" condition.
+    /// Output: set when the "bun" key matched and produced a target; the caller uses it to decide
+    /// whether a failed load is worth retrying with `skip_bun_condition`.
     pub(crate) matched_bun_condition: &'a mut bool,
 }
 
@@ -2117,7 +2119,7 @@ impl<'a> ESModule<'a> {
                     if self.skip_bun_condition && key == b"bun" {
                         if let Some(log) = self.debug_logs.as_deref_mut() {
                             log.add_note_fmt(format_args!(
-                                "The key \"bun\" is being skipped because its target does not exist on disk"
+                                "The key \"bun\" is being skipped on this retry"
                             ));
                         }
                         continue;

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1278,11 +1278,9 @@ pub(crate) struct ESModule<'a> {
     pub(crate) conditions: &'a ConditionsMap,
     // allocator dropped — global mimalloc
     pub(crate) module_type: &'a mut ModuleType,
-    /// Input: skip the "bun" key. Set on the retry pass after a resolution that went through
-    /// the "bun" condition failed to load (#7142).
+    /// Input: skip the "bun" key (second pass of the #7142 retry).
     pub(crate) skip_bun_condition: bool,
-    /// Output: set when the "bun" key matched and produced a target; the caller uses it to decide
-    /// whether a failed load is worth retrying with `skip_bun_condition`.
+    /// Output: the "bun" key matched and produced a target, so a failed load is worth retrying.
     pub(crate) matched_bun_condition: &'a mut bool,
 }
 

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1278,8 +1278,10 @@ pub(crate) struct ESModule<'a> {
     pub(crate) conditions: &'a ConditionsMap,
     // allocator dropped — global mimalloc
     pub(crate) module_type: &'a mut ModuleType,
-    /// Ignore the "bun" condition; retry when its target file is absent on disk (#7142).
+    /// Input: ignore the "bun" condition on a retry when its target was absent on disk (#7142).
     pub(crate) skip_bun_condition: bool,
+    /// Output: set to true iff the returned resolution came from matching the "bun" condition.
+    pub(crate) matched_bun_condition: &'a mut bool,
 }
 
 #[derive(Clone)]
@@ -2146,6 +2148,18 @@ impl<'a> ESModule<'a> {
 
                         if key == b"require" {
                             *self.module_type = ModuleType::Cjs;
+                        }
+
+                        if key == b"bun"
+                            && matches!(
+                                result.status,
+                                Status::Exact
+                                    | Status::ExactEndsWithStar
+                                    | Status::Inexact
+                                    | Status::PackageResolve
+                            )
+                        {
+                            *self.matched_bun_condition = true;
                         }
 
                         return result;

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1278,6 +1278,12 @@ pub(crate) struct ESModule<'a> {
     pub(crate) conditions: &'a ConditionsMap,
     // allocator dropped — global mimalloc
     pub(crate) module_type: &'a mut ModuleType,
+    /// When set, the "bun" export condition is ignored during resolution. This is used as a
+    /// one-shot fallback when the "bun" condition matched but the target file does not exist
+    /// on disk (e.g. a Node-targeted file tracer such as `@vercel/nft` only copied the
+    /// "node" variant). Since "bun" is Bun's own extension to the condition set, falling
+    /// through to the next matching condition keeps Node-compat semantics intact.
+    pub(crate) skip_bun_condition: bool,
 }
 
 #[derive(Clone)]
@@ -2110,6 +2116,14 @@ impl<'a> ESModule<'a> {
             EntryData::Map(object) => {
                 for entry in object.list.iter() {
                     let key: &[u8] = &entry.key;
+                    if self.skip_bun_condition && key == b"bun" {
+                        if let Some(log) = self.debug_logs.as_deref_mut() {
+                            log.add_note_fmt(format_args!(
+                                "The key \"bun\" is being skipped because its target does not exist on disk"
+                            ));
+                        }
+                        continue;
+                    }
                     if self.conditions.contains_key(key) {
                         if let Some(log) = self.debug_logs.as_deref_mut() {
                             log.add_note_fmt(format_args!(

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1278,11 +1278,8 @@ pub(crate) struct ESModule<'a> {
     pub(crate) conditions: &'a ConditionsMap,
     // allocator dropped — global mimalloc
     pub(crate) module_type: &'a mut ModuleType,
-    /// When set, the "bun" export condition is ignored during resolution. This is used as a
-    /// one-shot fallback when the "bun" condition matched but the target file does not exist
-    /// on disk (e.g. a Node-targeted file tracer such as `@vercel/nft` only copied the
-    /// "node" variant). Since "bun" is Bun's own extension to the condition set, falling
-    /// through to the next matching condition keeps Node-compat semantics intact.
+    /// Ignore the "bun" export condition; one-shot retry when its target file is absent on
+    /// disk so resolution falls through to "node"/"default" (#7142).
     pub(crate) skip_bun_condition: bool,
 }
 

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1278,8 +1278,7 @@ pub(crate) struct ESModule<'a> {
     pub(crate) conditions: &'a ConditionsMap,
     // allocator dropped — global mimalloc
     pub(crate) module_type: &'a mut ModuleType,
-    /// Ignore the "bun" export condition; one-shot retry when its target file is absent on
-    /// disk so resolution falls through to "node"/"default" (#7142).
+    /// Ignore the "bun" condition; retry when its target file is absent on disk (#7142).
     pub(crate) skip_bun_condition: bool,
 }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4920,8 +4920,6 @@ impl<'a> Resolver<'a> {
             }
             return MatchStatus::NotFound;
         }
-        let mut module_type = options::ModuleType::Unknown;
-
         let has_bun_condition = match kind {
             ast::ImportKind::Require | ast::ImportKind::RequireResolve => {
                 &self.opts.conditions.require
@@ -4930,91 +4928,17 @@ impl<'a> Resolver<'a> {
         }
         .contains_key(b"bun".as_slice());
 
-        // NOTE: keeping the `ESModule`'s borrow of `self.debug_logs` alive
-        // across the subsequent `&mut self` calls would be aliased-&mut UB, so
-        // the `ESModule` is constructed as a temporary whose
-        // borrow of `self.debug_logs` ends as soon as `resolve_imports` returns.
-        let esm_resolution = ESModule {
-            conditions: match kind {
-                ast::ImportKind::Require | ast::ImportKind::RequireResolve => {
-                    &self.opts.conditions.require
-                }
-                _ => &self.opts.conditions.import,
-            },
-            debug_logs: self.debug_logs.as_mut(),
-            module_type: &mut module_type,
-            skip_bun_condition: false,
-        }
-        .resolve_imports(import_path, &imports_map.root);
-        let _ = module_type;
-
-        let retry_without_bun = has_bun_condition
-            && matches!(
-                esm_resolution.status,
-                crate::package_json::Status::Exact
-                    | crate::package_json::Status::ExactEndsWithStar
-                    | crate::package_json::Status::Inexact
-            );
-
-        if esm_resolution.status == crate::package_json::Status::PackageResolve {
-            // https://github.com/oven-sh/bun/issues/4972
-            // Resolve a subpath import to a Bun or Node.js builtin
-            //
-            // Code example:
-            //
-            //     import { readFileSync } from '#fs';
-            //
-            // package.json:
-            //
-            //     "imports": {
-            //       "#fs": "node:fs"
-            //     }
-            //
-            if self.opts.mark_builtins_as_external || self.opts.target.is_bun() {
-                if let Some(alias) = HardcodedAlias::get(
-                    &esm_resolution.path,
-                    self.opts.target,
-                    HardcodedAliasCfg::default(),
-                ) {
-                    *out = MatchResult {
-                        path_pair: PathPair {
-                            primary: Fs::Path::init(alias.path.as_bytes()),
-                            secondary: None,
-                        },
-                        is_external: true,
-                        ..Default::default()
-                    };
-                    return MatchStatus::Success;
-                }
+        let mut retry_without_bun = false;
+        for skip_bun in [false, true] {
+            if skip_bun && !retry_without_bun {
+                break;
             }
 
-            return self.load_node_modules(
-                &esm_resolution.path,
-                kind,
-                dir_info,
-                global_cache,
-                true,
-                out,
-            );
-        }
-
-        if self
-            .handle_esm_resolution(
-                esm_resolution,
-                package_json.source.path.name().dir,
-                kind,
-                package_json,
-                b"",
-                out,
-            )
-            .is_success()
-        {
-            return MatchStatus::Success;
-        }
-
-        // #7142: same "bun"-condition fallback as in load_node_modules.
-        if retry_without_bun {
             let mut module_type = options::ModuleType::Unknown;
+            // NOTE: keeping the `ESModule`'s borrow of `self.debug_logs` alive
+            // across the subsequent `&mut self` calls would be aliased-&mut UB, so
+            // the `ESModule` is constructed as a temporary whose
+            // borrow of `self.debug_logs` ends as soon as `resolve_imports` returns.
             let esm_resolution = ESModule {
                 conditions: match kind {
                     ast::ImportKind::Require | ast::ImportKind::RequireResolve => {
@@ -5024,20 +4948,75 @@ impl<'a> Resolver<'a> {
                 },
                 debug_logs: self.debug_logs.as_mut(),
                 module_type: &mut module_type,
-                skip_bun_condition: true,
+                skip_bun_condition: skip_bun,
             }
             .resolve_imports(import_path, &imports_map.root);
             let _ = module_type;
 
-            if esm_resolution.status != crate::package_json::Status::PackageResolve {
-                return self.handle_esm_resolution(
+            if !skip_bun {
+                retry_without_bun = has_bun_condition
+                    && matches!(
+                        esm_resolution.status,
+                        crate::package_json::Status::Exact
+                            | crate::package_json::Status::ExactEndsWithStar
+                            | crate::package_json::Status::Inexact
+                    );
+            }
+
+            if esm_resolution.status == crate::package_json::Status::PackageResolve {
+                // https://github.com/oven-sh/bun/issues/4972
+                // Resolve a subpath import to a Bun or Node.js builtin
+                //
+                // Code example:
+                //
+                //     import { readFileSync } from '#fs';
+                //
+                // package.json:
+                //
+                //     "imports": {
+                //       "#fs": "node:fs"
+                //     }
+                //
+                if self.opts.mark_builtins_as_external || self.opts.target.is_bun() {
+                    if let Some(alias) = HardcodedAlias::get(
+                        &esm_resolution.path,
+                        self.opts.target,
+                        HardcodedAliasCfg::default(),
+                    ) {
+                        *out = MatchResult {
+                            path_pair: PathPair {
+                                primary: Fs::Path::init(alias.path.as_bytes()),
+                                secondary: None,
+                            },
+                            is_external: true,
+                            ..Default::default()
+                        };
+                        return MatchStatus::Success;
+                    }
+                }
+
+                return self.load_node_modules(
+                    &esm_resolution.path,
+                    kind,
+                    dir_info,
+                    global_cache,
+                    true,
+                    out,
+                );
+            }
+
+            if self
+                .handle_esm_resolution(
                     esm_resolution,
                     package_json.source.path.name().dir,
                     kind,
                     package_json,
                     b"",
                     out,
-                );
+                )
+                .is_success()
+            {
+                return MatchStatus::Success;
             }
         }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2654,29 +2654,18 @@ impl<'a> Resolver<'a> {
                                     // want problems due to Windows paths, which are very unlike URL
                                     // paths. We also want to avoid any "%" characters in the absolute
                                     // directory path accidentally being interpreted as URL escapes.
-                                    let has_bun_condition = self
-                                        .opts
-                                        .conditions
-                                        .kind(kind)
-                                        .contains_key(b"bun".as_slice());
-                                    let retry_without_bun;
+                                    let mut matched_bun = false;
                                     {
                                         let esm_resolution = ESModule {
                                             conditions: self.opts.conditions.kind(kind),
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
                                             skip_bun_condition: false,
+                                            matched_bun_condition: &mut matched_bun,
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
                                         // ESModule temporary dropped here; `self` is unborrowed.
 
-                                        retry_without_bun = has_bun_condition
-                                            && matches!(
-                                                esm_resolution.status,
-                                                crate::package_json::Status::Exact
-                                                    | crate::package_json::Status::ExactEndsWithStar
-                                                    | crate::package_json::Status::Inexact
-                                            );
                                         if self
                                             .handle_esm_resolution(
                                                 esm_resolution,
@@ -2699,7 +2688,7 @@ impl<'a> Resolver<'a> {
                                     }
 
                                     // #7142: retry without "bun" so pruned node_modules that only kept the "node" variant resolve.
-                                    if retry_without_bun {
+                                    if matched_bun {
                                         let prev_module_type = module_type;
                                         module_type = package_json.module_type;
                                         let esm_resolution = ESModule {
@@ -2707,6 +2696,7 @@ impl<'a> Resolver<'a> {
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
                                             skip_bun_condition: true,
+                                            matched_bun_condition: &mut matched_bun,
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
 
@@ -2765,6 +2755,7 @@ impl<'a> Resolver<'a> {
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
                                             skip_bun_condition: false,
+                                            matched_bun_condition: &mut matched_bun,
                                         }
                                         .resolve(
                                             b"/",
@@ -3192,15 +3183,7 @@ impl<'a> Resolver<'a> {
                                     // want problems due to Windows paths, which are very unlike URL
                                     // paths. We also want to avoid any "%" characters in the absolute
                                     // directory path accidentally being interpreted as URL escapes.
-                                    let has_bun_condition = match kind {
-                                        ast::ImportKind::Require
-                                        | ast::ImportKind::RequireResolve => {
-                                            &self.opts.conditions.require
-                                        }
-                                        _ => &self.opts.conditions.import,
-                                    }
-                                    .contains_key(b"bun".as_slice());
-                                    let retry_without_bun;
+                                    let mut matched_bun = false;
                                     {
                                         let esm_resolution = ESModule {
                                             conditions: match kind {
@@ -3213,16 +3196,10 @@ impl<'a> Resolver<'a> {
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
                                             skip_bun_condition: false,
+                                            matched_bun_condition: &mut matched_bun,
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
 
-                                        retry_without_bun = has_bun_condition
-                                            && matches!(
-                                                esm_resolution.status,
-                                                crate::package_json::Status::Exact
-                                                    | crate::package_json::Status::ExactEndsWithStar
-                                                    | crate::package_json::Status::Inexact
-                                            );
                                         if self
                                             .handle_esm_resolution(
                                                 esm_resolution,
@@ -3243,7 +3220,7 @@ impl<'a> Resolver<'a> {
                                     }
 
                                     // Same "bun"-condition fallback as the non-global-cache branch (#7142).
-                                    if retry_without_bun {
+                                    if matched_bun {
                                         let prev_module_type = module_type;
                                         module_type = options::ModuleType::Unknown;
                                         let esm_resolution = ESModule {
@@ -3257,6 +3234,7 @@ impl<'a> Resolver<'a> {
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
                                             skip_bun_condition: true,
+                                            matched_bun_condition: &mut matched_bun,
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
 
@@ -3298,6 +3276,7 @@ impl<'a> Resolver<'a> {
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
                                             skip_bun_condition: false,
+                                            matched_bun_condition: &mut matched_bun,
                                         }
                                         .resolve(
                                             b"/",
@@ -4920,17 +4899,9 @@ impl<'a> Resolver<'a> {
             }
             return MatchStatus::NotFound;
         }
-        let has_bun_condition = match kind {
-            ast::ImportKind::Require | ast::ImportKind::RequireResolve => {
-                &self.opts.conditions.require
-            }
-            _ => &self.opts.conditions.import,
-        }
-        .contains_key(b"bun".as_slice());
-
-        let mut retry_without_bun = false;
+        let mut matched_bun = false;
         for skip_bun in [false, true] {
-            if skip_bun && !retry_without_bun {
+            if skip_bun && !matched_bun {
                 break;
             }
 
@@ -4949,20 +4920,10 @@ impl<'a> Resolver<'a> {
                 debug_logs: self.debug_logs.as_mut(),
                 module_type: &mut module_type,
                 skip_bun_condition: skip_bun,
+                matched_bun_condition: &mut matched_bun,
             }
             .resolve_imports(import_path, &imports_map.root);
             let _ = module_type;
-
-            if !skip_bun {
-                retry_without_bun = has_bun_condition
-                    && matches!(
-                        esm_resolution.status,
-                        crate::package_json::Status::Exact
-                            | crate::package_json::Status::ExactEndsWithStar
-                            | crate::package_json::Status::Inexact
-                            | crate::package_json::Status::PackageResolve
-                    );
-            }
 
             if esm_resolution.status == crate::package_json::Status::PackageResolve {
                 // https://github.com/oven-sh/bun/issues/4972

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4957,20 +4957,17 @@ impl<'a> Resolver<'a> {
                     }
                 }
 
-                if self
-                    .load_node_modules(
-                        &esm_resolution.path,
-                        kind,
-                        dir_info,
-                        global_cache,
-                        true,
-                        out,
-                    )
-                    .is_success()
-                {
-                    return MatchStatus::Success;
+                match self.load_node_modules(
+                    &esm_resolution.path,
+                    kind,
+                    dir_info,
+                    global_cache,
+                    true,
+                    out,
+                ) {
+                    MatchStatus::NotFound => continue,
+                    other => return other,
                 }
-                continue;
             }
 
             if self

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2641,145 +2641,128 @@ impl<'a> Resolver<'a> {
 
                             if let Some(package_json) = pkg_dir_info.package_json() {
                                 if let Some(exports_map) = package_json.exports.as_ref() {
-                                    // The condition set is determined by the kind of import
-                                    let mut module_type = package_json.module_type;
-                                    // NOTE: keeping a single
-                                    // `ESModule` (which holds `&mut self.debug_logs`) alive across a
-                                    // `&mut self` call is aliased-&mut UB. Build a fresh short-lived
-                                    // `ESModule` per `resolve` call so its borrow ends before
-                                    // `self.handle_esm_resolution` re-borrows `self`.
-                                    // Resolve against the path "/", then join it with the absolute
-                                    // directory path. This is done because ESM package resolution uses
-                                    // URLs while our path resolution uses file system paths. We don't
-                                    // want problems due to Windows paths, which are very unlike URL
-                                    // paths. We also want to avoid any "%" characters in the absolute
-                                    // directory path accidentally being interpreted as URL escapes.
+                                    // The condition set is determined by the kind of import.
+                                    //
+                                    // The second pass skips the "bun" condition and only runs when the
+                                    // first pass matched it and still failed to resolve (#7142).
                                     let mut matched_bun = false;
-                                    {
-                                        let esm_resolution = ESModule {
-                                            conditions: self.opts.conditions.kind(kind),
-                                            debug_logs: self.debug_logs.as_mut(),
-                                            module_type: &mut module_type,
-                                            skip_bun_condition: false,
-                                            matched_bun_condition: &mut matched_bun,
+                                    for skip_bun in [false, true] {
+                                        if skip_bun && !matched_bun {
+                                            break;
                                         }
-                                        .resolve(b"/", esm.subpath, &exports_map.root);
-                                        // ESModule temporary dropped here; `self` is unborrowed.
-
-                                        if self
-                                            .handle_esm_resolution(
-                                                esm_resolution,
-                                                abs_package_path,
-                                                kind,
-                                                package_json,
-                                                esm.subpath,
-                                                out,
-                                            )
-                                            .is_success()
+                                        let mut module_type = package_json.module_type;
+                                        // NOTE: keeping a single
+                                        // `ESModule` (which holds `&mut self.debug_logs`) alive across a
+                                        // `&mut self` call is aliased-&mut UB. Build a fresh short-lived
+                                        // `ESModule` per `resolve` call so its borrow ends before
+                                        // `self.handle_esm_resolution` re-borrows `self`.
+                                        // Resolve against the path "/", then join it with the absolute
+                                        // directory path. This is done because ESM package resolution uses
+                                        // URLs while our path resolution uses file system paths. We don't
+                                        // want problems due to Windows paths, which are very unlike URL
+                                        // paths. We also want to avoid any "%" characters in the absolute
+                                        // directory path accidentally being interpreted as URL escapes.
                                         {
-                                            out.is_node_module = true;
-                                            out.module_type = module_type;
-                                            self.extension_order = prev_extension_order;
-                                            if let Some(d) = self.debug_logs.as_mut() {
-                                                d.decrease_indent();
+                                            let esm_resolution = ESModule {
+                                                conditions: match kind {
+                                                    ast::ImportKind::Require
+                                                    | ast::ImportKind::RequireResolve => {
+                                                        &self.opts.conditions.require
+                                                    }
+                                                    ast::ImportKind::At
+                                                    | ast::ImportKind::AtConditional => {
+                                                        &self.opts.conditions.style
+                                                    }
+                                                    _ => &self.opts.conditions.import,
+                                                },
+                                                debug_logs: self.debug_logs.as_mut(),
+                                                module_type: &mut module_type,
+                                                skip_bun_condition: skip_bun,
+                                                matched_bun_condition: &mut matched_bun,
                                             }
-                                            return MatchStatus::Success;
-                                        }
-                                    }
+                                            .resolve(b"/", esm.subpath, &exports_map.root);
+                                            // ESModule temporary dropped here; `self` is unborrowed.
 
-                                    // #7142: retry without "bun" so pruned node_modules that only kept the "node" variant resolve.
-                                    if matched_bun {
-                                        let prev_module_type = module_type;
-                                        module_type = package_json.module_type;
-                                        let esm_resolution = ESModule {
-                                            conditions: self.opts.conditions.kind(kind),
-                                            debug_logs: self.debug_logs.as_mut(),
-                                            module_type: &mut module_type,
-                                            skip_bun_condition: true,
-                                            matched_bun_condition: &mut matched_bun,
-                                        }
-                                        .resolve(b"/", esm.subpath, &exports_map.root);
-
-                                        if self
-                                            .handle_esm_resolution(
-                                                esm_resolution,
-                                                abs_package_path,
-                                                kind,
-                                                package_json,
-                                                esm.subpath,
-                                                out,
-                                            )
-                                            .is_success()
-                                        {
-                                            out.is_node_module = true;
-                                            out.module_type = module_type;
-                                            self.extension_order = prev_extension_order;
-                                            if let Some(d) = self.debug_logs.as_mut() {
-                                                d.decrease_indent();
-                                            }
-                                            return MatchStatus::Success;
-                                        }
-                                        module_type = prev_module_type;
-                                    }
-
-                                    // Some popular packages forget to include the extension in their
-                                    // exports map, so we try again without the extension.
-                                    //
-                                    // This is useful for browser-like environments
-                                    // where you want a file extension in the URL
-                                    // pathname by convention. Vite does this.
-                                    //
-                                    // React is an example of a package that doesn't include file extensions.
-                                    // {
-                                    //     "exports": {
-                                    //         ".": "./index.js",
-                                    //         "./jsx-runtime": "./jsx-runtime.js",
-                                    //     }
-                                    // }
-                                    //
-                                    // We limit this behavior just to ".js" files.
-                                    let extname = bun_paths::extension(esm.subpath);
-                                    if extname == b".js" && esm.subpath.len() > 3 {
-                                        let esm_resolution = ESModule {
-                                            conditions: match kind {
-                                                ast::ImportKind::Require
-                                                | ast::ImportKind::RequireResolve => {
-                                                    &self.opts.conditions.require
+                                            if self
+                                                .handle_esm_resolution(
+                                                    esm_resolution,
+                                                    abs_package_path,
+                                                    kind,
+                                                    package_json,
+                                                    esm.subpath,
+                                                    out,
+                                                )
+                                                .is_success()
+                                            {
+                                                out.is_node_module = true;
+                                                out.module_type = module_type;
+                                                self.extension_order = prev_extension_order;
+                                                if let Some(d) = self.debug_logs.as_mut() {
+                                                    d.decrease_indent();
                                                 }
-                                                ast::ImportKind::At
-                                                | ast::ImportKind::AtConditional => {
-                                                    &self.opts.conditions.style
-                                                }
-                                                _ => &self.opts.conditions.import,
-                                            },
-                                            debug_logs: self.debug_logs.as_mut(),
-                                            module_type: &mut module_type,
-                                            skip_bun_condition: false,
-                                            matched_bun_condition: &mut matched_bun,
-                                        }
-                                        .resolve(
-                                            b"/",
-                                            &esm.subpath[0..esm.subpath.len() - 3],
-                                            &exports_map.root,
-                                        );
-                                        if self
-                                            .handle_esm_resolution(
-                                                esm_resolution,
-                                                abs_package_path,
-                                                kind,
-                                                package_json,
-                                                esm.subpath,
-                                                out,
-                                            )
-                                            .is_success()
-                                        {
-                                            out.is_node_module = true;
-                                            out.module_type = module_type;
-                                            self.extension_order = prev_extension_order;
-                                            if let Some(d) = self.debug_logs.as_mut() {
-                                                d.decrease_indent();
+                                                return MatchStatus::Success;
                                             }
-                                            return MatchStatus::Success;
+                                        }
+
+                                        // Some popular packages forget to include the extension in their
+                                        // exports map, so we try again without the extension.
+                                        //
+                                        // This is useful for browser-like environments
+                                        // where you want a file extension in the URL
+                                        // pathname by convention. Vite does this.
+                                        //
+                                        // React is an example of a package that doesn't include file extensions.
+                                        // {
+                                        //     "exports": {
+                                        //         ".": "./index.js",
+                                        //         "./jsx-runtime": "./jsx-runtime.js",
+                                        //     }
+                                        // }
+                                        //
+                                        // We limit this behavior just to ".js" files.
+                                        let extname = bun_paths::extension(esm.subpath);
+                                        if extname == b".js" && esm.subpath.len() > 3 {
+                                            let esm_resolution = ESModule {
+                                                conditions: match kind {
+                                                    ast::ImportKind::Require
+                                                    | ast::ImportKind::RequireResolve => {
+                                                        &self.opts.conditions.require
+                                                    }
+                                                    ast::ImportKind::At
+                                                    | ast::ImportKind::AtConditional => {
+                                                        &self.opts.conditions.style
+                                                    }
+                                                    _ => &self.opts.conditions.import,
+                                                },
+                                                debug_logs: self.debug_logs.as_mut(),
+                                                module_type: &mut module_type,
+                                                skip_bun_condition: skip_bun,
+                                                matched_bun_condition: &mut matched_bun,
+                                            }
+                                            .resolve(
+                                                b"/",
+                                                &esm.subpath[0..esm.subpath.len() - 3],
+                                                &exports_map.root,
+                                            );
+                                            if self
+                                                .handle_esm_resolution(
+                                                    esm_resolution,
+                                                    abs_package_path,
+                                                    kind,
+                                                    package_json,
+                                                    esm.subpath,
+                                                    out,
+                                                )
+                                                .is_success()
+                                            {
+                                                out.is_node_module = true;
+                                                out.module_type = module_type;
+                                                self.extension_order = prev_extension_order;
+                                                if let Some(d) = self.debug_logs.as_mut() {
+                                                    d.decrease_indent();
+                                                }
+                                                return MatchStatus::Success;
+                                            }
                                         }
                                     }
 
@@ -3172,133 +3155,100 @@ impl<'a> Resolver<'a> {
                     Ok(dir_info_to_use_) => {
                         if let Some(pkg_dir_info) = dir_info_to_use_ {
                             let abs_package_path = pkg_dir_info.abs_path;
-                            let mut module_type = options::ModuleType::Unknown;
                             if let Some(package_json) = pkg_dir_info.package_json() {
                                 if let Some(exports_map) = package_json.exports.as_ref() {
-                                    // The condition set is determined by the kind of import
-                                    // NOTE: reshaped for borrowck — see identical note above.
-                                    // Resolve against the path "/", then join it with the absolute
-                                    // directory path. This is done because ESM package resolution uses
-                                    // URLs while our path resolution uses file system paths. We don't
-                                    // want problems due to Windows paths, which are very unlike URL
-                                    // paths. We also want to avoid any "%" characters in the absolute
-                                    // directory path accidentally being interpreted as URL escapes.
+                                    // The condition set is determined by the kind of import.
+                                    // Two-pass shape: see the note in the node_modules branch above.
                                     let mut matched_bun = false;
-                                    {
-                                        let esm_resolution = ESModule {
-                                            conditions: match kind {
-                                                ast::ImportKind::Require
-                                                | ast::ImportKind::RequireResolve => {
-                                                    &self.opts.conditions.require
-                                                }
-                                                _ => &self.opts.conditions.import,
-                                            },
-                                            debug_logs: self.debug_logs.as_mut(),
-                                            module_type: &mut module_type,
-                                            skip_bun_condition: false,
-                                            matched_bun_condition: &mut matched_bun,
+                                    for skip_bun in [false, true] {
+                                        if skip_bun && !matched_bun {
+                                            break;
                                         }
-                                        .resolve(b"/", esm.subpath, &exports_map.root);
-
-                                        if self
-                                            .handle_esm_resolution(
-                                                esm_resolution,
-                                                abs_package_path,
-                                                kind,
-                                                package_json,
-                                                esm.subpath,
-                                                out,
-                                            )
-                                            .is_success()
+                                        let mut module_type = options::ModuleType::Unknown;
+                                        // NOTE: reshaped for borrowck — see identical note above.
+                                        // Resolve against the path "/", then join it with the absolute
+                                        // directory path. This is done because ESM package resolution uses
+                                        // URLs while our path resolution uses file system paths. We don't
+                                        // want problems due to Windows paths, which are very unlike URL
+                                        // paths. We also want to avoid any "%" characters in the absolute
+                                        // directory path accidentally being interpreted as URL escapes.
                                         {
-                                            out.is_node_module = true;
-                                            if let Some(d) = self.debug_logs.as_mut() {
-                                                d.decrease_indent();
+                                            let esm_resolution = ESModule {
+                                                conditions: match kind {
+                                                    ast::ImportKind::Require
+                                                    | ast::ImportKind::RequireResolve => {
+                                                        &self.opts.conditions.require
+                                                    }
+                                                    _ => &self.opts.conditions.import,
+                                                },
+                                                debug_logs: self.debug_logs.as_mut(),
+                                                module_type: &mut module_type,
+                                                skip_bun_condition: skip_bun,
+                                                matched_bun_condition: &mut matched_bun,
                                             }
-                                            return MatchStatus::Success;
-                                        }
-                                    }
+                                            .resolve(b"/", esm.subpath, &exports_map.root);
 
-                                    // Same "bun"-condition fallback as the non-global-cache branch (#7142).
-                                    if matched_bun {
-                                        let prev_module_type = module_type;
-                                        module_type = options::ModuleType::Unknown;
-                                        let esm_resolution = ESModule {
-                                            conditions: match kind {
-                                                ast::ImportKind::Require
-                                                | ast::ImportKind::RequireResolve => {
-                                                    &self.opts.conditions.require
+                                            if self
+                                                .handle_esm_resolution(
+                                                    esm_resolution,
+                                                    abs_package_path,
+                                                    kind,
+                                                    package_json,
+                                                    esm.subpath,
+                                                    out,
+                                                )
+                                                .is_success()
+                                            {
+                                                out.is_node_module = true;
+                                                if let Some(d) = self.debug_logs.as_mut() {
+                                                    d.decrease_indent();
                                                 }
-                                                _ => &self.opts.conditions.import,
-                                            },
-                                            debug_logs: self.debug_logs.as_mut(),
-                                            module_type: &mut module_type,
-                                            skip_bun_condition: true,
-                                            matched_bun_condition: &mut matched_bun,
-                                        }
-                                        .resolve(b"/", esm.subpath, &exports_map.root);
-
-                                        if self
-                                            .handle_esm_resolution(
-                                                esm_resolution,
-                                                abs_package_path,
-                                                kind,
-                                                package_json,
-                                                esm.subpath,
-                                                out,
-                                            )
-                                            .is_success()
-                                        {
-                                            out.is_node_module = true;
-                                            if let Some(d) = self.debug_logs.as_mut() {
-                                                d.decrease_indent();
+                                                return MatchStatus::Success;
                                             }
-                                            return MatchStatus::Success;
                                         }
-                                        module_type = prev_module_type;
-                                    }
 
-                                    // Some popular packages forget to include the extension in their
-                                    // exports map, so we try again without the extension.
-                                    // (same comment as above)
-                                    //
-                                    // We limit this behavior just to ".js" files.
-                                    let extname = bun_paths::extension(esm.subpath);
-                                    if extname == b".js" && esm.subpath.len() > 3 {
-                                        let esm_resolution = ESModule {
-                                            conditions: match kind {
-                                                ast::ImportKind::Require
-                                                | ast::ImportKind::RequireResolve => {
-                                                    &self.opts.conditions.require
+                                        // Some popular packages forget to include the extension in their
+                                        // exports map, so we try again without the extension.
+                                        // (same comment as above)
+                                        //
+                                        // We limit this behavior just to ".js" files.
+                                        let extname = bun_paths::extension(esm.subpath);
+                                        if extname == b".js" && esm.subpath.len() > 3 {
+                                            let esm_resolution = ESModule {
+                                                conditions: match kind {
+                                                    ast::ImportKind::Require
+                                                    | ast::ImportKind::RequireResolve => {
+                                                        &self.opts.conditions.require
+                                                    }
+                                                    _ => &self.opts.conditions.import,
+                                                },
+                                                debug_logs: self.debug_logs.as_mut(),
+                                                module_type: &mut module_type,
+                                                skip_bun_condition: skip_bun,
+                                                matched_bun_condition: &mut matched_bun,
+                                            }
+                                            .resolve(
+                                                b"/",
+                                                &esm.subpath[0..esm.subpath.len() - 3],
+                                                &exports_map.root,
+                                            );
+                                            if self
+                                                .handle_esm_resolution(
+                                                    esm_resolution,
+                                                    abs_package_path,
+                                                    kind,
+                                                    package_json,
+                                                    esm.subpath,
+                                                    out,
+                                                )
+                                                .is_success()
+                                            {
+                                                out.is_node_module = true;
+                                                if let Some(d) = self.debug_logs.as_mut() {
+                                                    d.decrease_indent();
                                                 }
-                                                _ => &self.opts.conditions.import,
-                                            },
-                                            debug_logs: self.debug_logs.as_mut(),
-                                            module_type: &mut module_type,
-                                            skip_bun_condition: false,
-                                            matched_bun_condition: &mut matched_bun,
-                                        }
-                                        .resolve(
-                                            b"/",
-                                            &esm.subpath[0..esm.subpath.len() - 3],
-                                            &exports_map.root,
-                                        );
-                                        if self
-                                            .handle_esm_resolution(
-                                                esm_resolution,
-                                                abs_package_path,
-                                                kind,
-                                                package_json,
-                                                esm.subpath,
-                                                out,
-                                            )
-                                            .is_success()
-                                        {
-                                            out.is_node_module = true;
-                                            if let Some(d) = self.debug_logs.as_mut() {
-                                                d.decrease_indent();
+                                                return MatchStatus::Success;
                                             }
-                                            return MatchStatus::Success;
                                         }
                                     }
 
@@ -4899,6 +4849,7 @@ impl<'a> Resolver<'a> {
             }
             return MatchStatus::NotFound;
         }
+        // Two-pass shape: see the note in load_node_modules.
         let mut matched_bun = false;
         for skip_bun in [false, true] {
             if skip_bun && !matched_bun {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4960,6 +4960,7 @@ impl<'a> Resolver<'a> {
                         crate::package_json::Status::Exact
                             | crate::package_json::Status::ExactEndsWithStar
                             | crate::package_json::Status::Inexact
+                            | crate::package_json::Status::PackageResolve
                     );
             }
 
@@ -4995,14 +4996,20 @@ impl<'a> Resolver<'a> {
                     }
                 }
 
-                return self.load_node_modules(
-                    &esm_resolution.path,
-                    kind,
-                    dir_info,
-                    global_cache,
-                    true,
-                    out,
-                );
+                if self
+                    .load_node_modules(
+                        &esm_resolution.path,
+                        kind,
+                        dir_info,
+                        global_cache,
+                        true,
+                        out,
+                    )
+                    .is_success()
+                {
+                    return MatchStatus::Success;
+                }
+                continue;
             }
 
             if self

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2698,8 +2698,7 @@ impl<'a> Resolver<'a> {
                                         }
                                     }
 
-                                    // #7142: retry once without the "bun" condition so traced
-                                    // node_modules that only shipped the "node" variant resolve.
+                                    // #7142: retry without "bun" so pruned node_modules that only kept the "node" variant resolve.
                                     if retry_without_bun {
                                         let prev_module_type = module_type;
                                         module_type = package_json.module_type;
@@ -4923,6 +4922,14 @@ impl<'a> Resolver<'a> {
         }
         let mut module_type = options::ModuleType::Unknown;
 
+        let has_bun_condition = match kind {
+            ast::ImportKind::Require | ast::ImportKind::RequireResolve => {
+                &self.opts.conditions.require
+            }
+            _ => &self.opts.conditions.import,
+        }
+        .contains_key(b"bun".as_slice());
+
         // NOTE: keeping the `ESModule`'s borrow of `self.debug_logs` alive
         // across the subsequent `&mut self` calls would be aliased-&mut UB, so
         // the `ESModule` is constructed as a temporary whose
@@ -4940,6 +4947,14 @@ impl<'a> Resolver<'a> {
         }
         .resolve_imports(import_path, &imports_map.root);
         let _ = module_type;
+
+        let retry_without_bun = has_bun_condition
+            && matches!(
+                esm_resolution.status,
+                crate::package_json::Status::Exact
+                    | crate::package_json::Status::ExactEndsWithStar
+                    | crate::package_json::Status::Inexact
+            );
 
         if esm_resolution.status == crate::package_json::Status::PackageResolve {
             // https://github.com/oven-sh/bun/issues/4972
@@ -4983,14 +4998,50 @@ impl<'a> Resolver<'a> {
             );
         }
 
-        self.handle_esm_resolution(
-            esm_resolution,
-            package_json.source.path.name().dir,
-            kind,
-            package_json,
-            b"",
-            out,
-        )
+        if self
+            .handle_esm_resolution(
+                esm_resolution,
+                package_json.source.path.name().dir,
+                kind,
+                package_json,
+                b"",
+                out,
+            )
+            .is_success()
+        {
+            return MatchStatus::Success;
+        }
+
+        // #7142: same "bun"-condition fallback as in load_node_modules.
+        if retry_without_bun {
+            let mut module_type = options::ModuleType::Unknown;
+            let esm_resolution = ESModule {
+                conditions: match kind {
+                    ast::ImportKind::Require | ast::ImportKind::RequireResolve => {
+                        &self.opts.conditions.require
+                    }
+                    _ => &self.opts.conditions.import,
+                },
+                debug_logs: self.debug_logs.as_mut(),
+                module_type: &mut module_type,
+                skip_bun_condition: true,
+            }
+            .resolve_imports(import_path, &imports_map.root);
+            let _ = module_type;
+
+            if esm_resolution.status != crate::package_json::Status::PackageResolve {
+                return self.handle_esm_resolution(
+                    esm_resolution,
+                    package_json.source.path.name().dir,
+                    kind,
+                    package_json,
+                    b"",
+                    out,
+                );
+            }
+        }
+
+        MatchStatus::NotFound
     }
 
     pub(crate) fn check_browser_map<const KIND: BrowserMapPathKind>(

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2642,9 +2642,7 @@ impl<'a> Resolver<'a> {
                             if let Some(package_json) = pkg_dir_info.package_json() {
                                 if let Some(exports_map) = package_json.exports.as_ref() {
                                     // The condition set is determined by the kind of import.
-                                    //
-                                    // The second pass skips the "bun" condition and only runs when the
-                                    // first pass matched it and still failed to resolve (#7142).
+                                    // Pass 2 skips "bun" and only runs if pass 1 matched it and failed (#7142).
                                     let mut matched_bun = false;
                                     for skip_bun in [false, true] {
                                         if skip_bun && !matched_bun {
@@ -3158,7 +3156,7 @@ impl<'a> Resolver<'a> {
                             if let Some(package_json) = pkg_dir_info.package_json() {
                                 if let Some(exports_map) = package_json.exports.as_ref() {
                                     // The condition set is determined by the kind of import.
-                                    // Two-pass shape: see the note in the node_modules branch above.
+                                    // Two-pass shape as in the node_modules branch above.
                                     let mut matched_bun = false;
                                     for skip_bun in [false, true] {
                                         if skip_bun && !matched_bun {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2698,11 +2698,8 @@ impl<'a> Resolver<'a> {
                                         }
                                     }
 
-                                    // Target missing on disk: retry once without the "bun"
-                                    // condition so traced node_modules (Nitro/nft) that only
-                                    // shipped the "node" variant still resolve (#7142).
-                                    // `"bun": null` resolves to Null/PackagePathDisabled and is
-                                    // excluded above, so an explicit disable is still honored.
+                                    // #7142: retry once without the "bun" condition so traced
+                                    // node_modules that only shipped the "node" variant resolve.
                                     if retry_without_bun {
                                         let prev_module_type = module_type;
                                         module_type = package_json.module_type;

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2659,6 +2659,7 @@ impl<'a> Resolver<'a> {
                                         .conditions
                                         .kind(kind)
                                         .contains_key(b"bun".as_slice());
+                                    let retry_without_bun;
                                     {
                                         let esm_resolution = ESModule {
                                             conditions: self.opts.conditions.kind(kind),
@@ -2669,6 +2670,13 @@ impl<'a> Resolver<'a> {
                                         .resolve(b"/", esm.subpath, &exports_map.root);
                                         // ESModule temporary dropped here; `self` is unborrowed.
 
+                                        retry_without_bun = has_bun_condition
+                                            && matches!(
+                                                esm_resolution.status,
+                                                crate::package_json::Status::Exact
+                                                    | crate::package_json::Status::ExactEndsWithStar
+                                                    | crate::package_json::Status::Inexact
+                                            );
                                         if self
                                             .handle_esm_resolution(
                                                 esm_resolution,
@@ -2690,15 +2698,12 @@ impl<'a> Resolver<'a> {
                                         }
                                     }
 
-                                    // The matched export target does not exist on disk. If the
-                                    // "bun" condition is active, retry with it skipped so we
-                                    // fall through to the next matching condition (typically
-                                    // "node" or "default"). This recovers traced/pruned
-                                    // node_modules trees (e.g. Nitro/Nuxt `.output`) where
-                                    // only the "node" variant was copied. When "bun" was not
-                                    // the key that matched, the retry resolves to the same path
-                                    // and the (cached) existence check fails again.
-                                    if has_bun_condition {
+                                    // Target missing on disk: retry once without the "bun"
+                                    // condition so traced node_modules (Nitro/nft) that only
+                                    // shipped the "node" variant still resolve (#7142).
+                                    // `"bun": null` resolves to Null/PackagePathDisabled and is
+                                    // excluded above, so an explicit disable is still honored.
+                                    if retry_without_bun {
                                         let prev_module_type = module_type;
                                         module_type = package_json.module_type;
                                         let esm_resolution = ESModule {
@@ -3199,6 +3204,7 @@ impl<'a> Resolver<'a> {
                                         _ => &self.opts.conditions.import,
                                     }
                                     .contains_key(b"bun".as_slice());
+                                    let retry_without_bun;
                                     {
                                         let esm_resolution = ESModule {
                                             conditions: match kind {
@@ -3214,6 +3220,13 @@ impl<'a> Resolver<'a> {
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
 
+                                        retry_without_bun = has_bun_condition
+                                            && matches!(
+                                                esm_resolution.status,
+                                                crate::package_json::Status::Exact
+                                                    | crate::package_json::Status::ExactEndsWithStar
+                                                    | crate::package_json::Status::Inexact
+                                            );
                                         if self
                                             .handle_esm_resolution(
                                                 esm_resolution,
@@ -3233,10 +3246,8 @@ impl<'a> Resolver<'a> {
                                         }
                                     }
 
-                                    // See the comment on the identical retry in the non-global-cache
-                                    // branch above: fall through when the "bun" condition's target
-                                    // file is missing on disk.
-                                    if has_bun_condition {
+                                    // Same "bun"-condition fallback as the non-global-cache branch (#7142).
+                                    if retry_without_bun {
                                         let prev_module_type = module_type;
                                         module_type = options::ModuleType::Unknown;
                                         let esm_resolution = ESModule {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2654,21 +2654,17 @@ impl<'a> Resolver<'a> {
                                     // want problems due to Windows paths, which are very unlike URL
                                     // paths. We also want to avoid any "%" characters in the absolute
                                     // directory path accidentally being interpreted as URL escapes.
+                                    let has_bun_condition = self
+                                        .opts
+                                        .conditions
+                                        .kind(kind)
+                                        .contains_key(b"bun".as_slice());
                                     {
                                         let esm_resolution = ESModule {
-                                            conditions: match kind {
-                                                ast::ImportKind::Require
-                                                | ast::ImportKind::RequireResolve => {
-                                                    &self.opts.conditions.require
-                                                }
-                                                ast::ImportKind::At
-                                                | ast::ImportKind::AtConditional => {
-                                                    &self.opts.conditions.style
-                                                }
-                                                _ => &self.opts.conditions.import,
-                                            },
+                                            conditions: self.opts.conditions.kind(kind),
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
+                                            skip_bun_condition: false,
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
                                         // ESModule temporary dropped here; `self` is unborrowed.
@@ -2692,6 +2688,47 @@ impl<'a> Resolver<'a> {
                                             }
                                             return MatchStatus::Success;
                                         }
+                                    }
+
+                                    // The matched export target does not exist on disk. If the
+                                    // "bun" condition is active, retry with it skipped so we
+                                    // fall through to the next matching condition (typically
+                                    // "node" or "default"). This recovers traced/pruned
+                                    // node_modules trees (e.g. Nitro/Nuxt `.output`) where
+                                    // only the "node" variant was copied. When "bun" was not
+                                    // the key that matched, the retry resolves to the same path
+                                    // and the (cached) existence check fails again.
+                                    if has_bun_condition {
+                                        let prev_module_type = module_type;
+                                        module_type = package_json.module_type;
+                                        let esm_resolution = ESModule {
+                                            conditions: self.opts.conditions.kind(kind),
+                                            debug_logs: self.debug_logs.as_mut(),
+                                            module_type: &mut module_type,
+                                            skip_bun_condition: true,
+                                        }
+                                        .resolve(b"/", esm.subpath, &exports_map.root);
+
+                                        if self
+                                            .handle_esm_resolution(
+                                                esm_resolution,
+                                                abs_package_path,
+                                                kind,
+                                                package_json,
+                                                esm.subpath,
+                                                out,
+                                            )
+                                            .is_success()
+                                        {
+                                            out.is_node_module = true;
+                                            out.module_type = module_type;
+                                            self.extension_order = prev_extension_order;
+                                            if let Some(d) = self.debug_logs.as_mut() {
+                                                d.decrease_indent();
+                                            }
+                                            return MatchStatus::Success;
+                                        }
+                                        module_type = prev_module_type;
                                     }
 
                                     // Some popular packages forget to include the extension in their
@@ -2726,6 +2763,7 @@ impl<'a> Resolver<'a> {
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
+                                            skip_bun_condition: false,
                                         }
                                         .resolve(
                                             b"/",
@@ -3153,6 +3191,14 @@ impl<'a> Resolver<'a> {
                                     // want problems due to Windows paths, which are very unlike URL
                                     // paths. We also want to avoid any "%" characters in the absolute
                                     // directory path accidentally being interpreted as URL escapes.
+                                    let has_bun_condition = match kind {
+                                        ast::ImportKind::Require
+                                        | ast::ImportKind::RequireResolve => {
+                                            &self.opts.conditions.require
+                                        }
+                                        _ => &self.opts.conditions.import,
+                                    }
+                                    .contains_key(b"bun".as_slice());
                                     {
                                         let esm_resolution = ESModule {
                                             conditions: match kind {
@@ -3164,6 +3210,7 @@ impl<'a> Resolver<'a> {
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
+                                            skip_bun_condition: false,
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
 
@@ -3186,6 +3233,46 @@ impl<'a> Resolver<'a> {
                                         }
                                     }
 
+                                    // See the comment on the identical retry in the non-global-cache
+                                    // branch above: fall through when the "bun" condition's target
+                                    // file is missing on disk.
+                                    if has_bun_condition {
+                                        let prev_module_type = module_type;
+                                        module_type = options::ModuleType::Unknown;
+                                        let esm_resolution = ESModule {
+                                            conditions: match kind {
+                                                ast::ImportKind::Require
+                                                | ast::ImportKind::RequireResolve => {
+                                                    &self.opts.conditions.require
+                                                }
+                                                _ => &self.opts.conditions.import,
+                                            },
+                                            debug_logs: self.debug_logs.as_mut(),
+                                            module_type: &mut module_type,
+                                            skip_bun_condition: true,
+                                        }
+                                        .resolve(b"/", esm.subpath, &exports_map.root);
+
+                                        if self
+                                            .handle_esm_resolution(
+                                                esm_resolution,
+                                                abs_package_path,
+                                                kind,
+                                                package_json,
+                                                esm.subpath,
+                                                out,
+                                            )
+                                            .is_success()
+                                        {
+                                            out.is_node_module = true;
+                                            if let Some(d) = self.debug_logs.as_mut() {
+                                                d.decrease_indent();
+                                            }
+                                            return MatchStatus::Success;
+                                        }
+                                        module_type = prev_module_type;
+                                    }
+
                                     // Some popular packages forget to include the extension in their
                                     // exports map, so we try again without the extension.
                                     // (same comment as above)
@@ -3203,6 +3290,7 @@ impl<'a> Resolver<'a> {
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
+                                            skip_bun_condition: false,
                                         }
                                         .resolve(
                                             b"/",
@@ -4840,6 +4928,7 @@ impl<'a> Resolver<'a> {
             },
             debug_logs: self.debug_logs.as_mut(),
             module_type: &mut module_type,
+            skip_bun_condition: false,
         }
         .resolve_imports(import_path, &imports_map.root);
         let _ = module_type;

--- a/test/js/bun/resolve/import-custom-condition.test.ts
+++ b/test/js/bun/resolve/import-custom-condition.test.ts
@@ -426,9 +426,9 @@ describe("'bun' export condition falls through when its target file is missing",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toContain("pkg");
+    expect(stderr).toContain("Cannot find package 'pkg'");
     expect(stdout).toBe("");
-    expect(exitCode).not.toBe(0);
+    expect(exitCode).toBe(1);
   });
 
   it.concurrent("still fails when no other condition resolves to an existing file", async () => {
@@ -455,8 +455,8 @@ describe("'bun' export condition falls through when its target file is missing",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toContain("pkg");
+    expect(stderr).toContain("Cannot find package 'pkg'");
     expect(stdout).toBe("");
-    expect(exitCode).not.toBe(0);
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/js/bun/resolve/import-custom-condition.test.ts
+++ b/test/js/bun/resolve/import-custom-condition.test.ts
@@ -276,6 +276,37 @@ describe("'bun' export condition falls through when its target file is missing",
     expect(exitCode).toBe(0);
   });
 
+  it.concurrent("falls through when the 'bun' '#imports' target is a missing bare package", async () => {
+    using cwd = tempDir("bun-cond-fallback-imports-bare-first", {
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: { ".": "./index.mjs" },
+        imports: {
+          "#helper": {
+            bun: "bun-only-helper",
+            node: "./src/helper-node.mjs",
+          },
+        },
+      }),
+      "node_modules/pkg/index.mjs": `import { tag } from "#helper"; console.log(tag);`,
+      "node_modules/pkg/src/helper-node.mjs": `export const tag = "node-variant";`,
+      "index.mjs": `import "pkg";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(cwd),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("node-variant\n");
+    expect(exitCode).toBe(0);
+  });
+
   it.concurrent("falls through for '#imports' targeting a bare package specifier", async () => {
     using cwd = tempDir("bun-cond-fallback-imports-bare", {
       "node_modules/pkg/package.json": JSON.stringify({

--- a/test/js/bun/resolve/import-custom-condition.test.ts
+++ b/test/js/bun/resolve/import-custom-condition.test.ts
@@ -461,6 +461,35 @@ describe("'bun' export condition falls through when its target file is missing",
     expect(exitCode).toBe(1);
   });
 
+  it.concurrent("retry armed by one entry does not bypass 'bun': null in another", async () => {
+    // "./foo.js" arms the retry (bun target missing); the ".js"-stripped "./foo" entry
+    // has an explicit bun: null, which must still block on the second pass.
+    using cwd = tempDir("bun-cond-null-other-entry", {
+      "index.mjs": `import "pkg/foo.js"; console.log("loaded");`,
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: {
+          "./foo.js": { bun: "./dist/missing.mjs" },
+          "./foo": { bun: null, default: "./dist/default.mjs" },
+        },
+      }),
+      "node_modules/pkg/dist/default.mjs": `export {};`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(cwd),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("Cannot find module 'pkg/foo.js'");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
   it.concurrent("still fails when no other condition resolves to an existing file", async () => {
     using cwd = tempDir("bun-cond-no-fallback", {
       "index.mjs": `import "pkg";`,

--- a/test/js/bun/resolve/import-custom-condition.test.ts
+++ b/test/js/bun/resolve/import-custom-condition.test.ts
@@ -276,6 +276,42 @@ describe("'bun' export condition falls through when its target file is missing",
     expect(exitCode).toBe(0);
   });
 
+  it.concurrent("falls through for '#imports' targeting a bare package specifier", async () => {
+    using cwd = tempDir("bun-cond-fallback-imports-bare", {
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: { ".": "./index.mjs" },
+        imports: {
+          "#fetch": {
+            bun: "./src/fetch-bun.mjs",
+            node: "polyfill-pkg",
+          },
+        },
+      }),
+      "node_modules/pkg/index.mjs": `import { tag } from "#fetch"; console.log(tag);`,
+      "node_modules/polyfill-pkg/package.json": JSON.stringify({
+        name: "polyfill-pkg",
+        type: "module",
+        exports: { ".": "./index.mjs" },
+      }),
+      "node_modules/polyfill-pkg/index.mjs": `export const tag = "polyfill";`,
+      "index.mjs": `import "pkg";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(cwd),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("polyfill\n");
+    expect(exitCode).toBe(0);
+  });
+
   it.concurrent("falls through to 'node' condition for require()", async () => {
     using cwd = tempDir("bun-cond-fallback-require", {
       "index.cjs": `console.log(require("pkg").tag);`,

--- a/test/js/bun/resolve/import-custom-condition.test.ts
+++ b/test/js/bun/resolve/import-custom-condition.test.ts
@@ -245,6 +245,37 @@ describe("'bun' export condition falls through when its target file is missing",
     expect(exitCode).toBe(0);
   });
 
+  it.concurrent("falls through for subpath '#imports' entries", async () => {
+    using cwd = tempDir("bun-cond-fallback-imports", {
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: { ".": "./index.mjs" },
+        imports: {
+          "#fetch": {
+            bun: "./src/fetch-bun.mjs",
+            node: "./src/fetch-node.mjs",
+          },
+        },
+      }),
+      "node_modules/pkg/index.mjs": `import { tag } from "#fetch"; console.log(tag);`,
+      "node_modules/pkg/src/fetch-node.mjs": `export const tag = "node-variant";`,
+      "index.mjs": `import "pkg";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(cwd),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("node-variant\n");
+    expect(exitCode).toBe(0);
+  });
+
   it.concurrent("falls through to 'node' condition for require()", async () => {
     using cwd = tempDir("bun-cond-fallback-require", {
       "index.cjs": `console.log(require("pkg").tag);`,

--- a/test/js/bun/resolve/import-custom-condition.test.ts
+++ b/test/js/bun/resolve/import-custom-condition.test.ts
@@ -245,6 +245,36 @@ describe("'bun' export condition falls through when its target file is missing",
     expect(exitCode).toBe(0);
   });
 
+  it.concurrent("falls through when the subpath only resolves after stripping '.js'", async () => {
+    // Exercises the retry around the existing "./foo.js" -> "./foo" exports fallback.
+    using cwd = tempDir("bun-cond-fallback-strip-js", {
+      "index.mjs": `import { tag } from "pkg/foo.js"; console.log(tag);`,
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: {
+          "./foo": {
+            bun: "./dist/foo-bun.mjs",
+            node: "./dist/foo-node.mjs",
+          },
+        },
+      }),
+      "node_modules/pkg/dist/foo-node.mjs": `export const tag = "node-variant";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(cwd),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("node-variant\n");
+    expect(exitCode).toBe(0);
+  });
+
   it.concurrent("falls through for subpath '#imports' entries", async () => {
     using cwd = tempDir("bun-cond-fallback-imports", {
       "node_modules/pkg/package.json": JSON.stringify({

--- a/test/js/bun/resolve/import-custom-condition.test.ts
+++ b/test/js/bun/resolve/import-custom-condition.test.ts
@@ -213,6 +213,38 @@ describe("'bun' export condition falls through when its target file is missing",
     expect(exitCode).toBe(0);
   });
 
+  it.concurrent("falls through for wildcard subpath patterns", async () => {
+    // Mirrors `openai`'s `./_shims/auto/*` subpath which has bun/node/default variants.
+    using cwd = tempDir("bun-cond-fallback-wildcard", {
+      "index.mjs": `import { tag } from "pkg/shims/auto/runtime"; console.log(tag);`,
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: {
+          "./shims/auto/*": {
+            bun: { default: "./shims/auto/*-bun.mjs" },
+            node: { default: "./shims/auto/*-node.mjs" },
+            default: "./shims/auto/*.mjs",
+          },
+        },
+      }),
+      // Only the "node" variant was traced; "*-bun.mjs" does not exist.
+      "node_modules/pkg/shims/auto/runtime-node.mjs": `export const tag = "node-variant";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(cwd),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("node-variant\n");
+    expect(exitCode).toBe(0);
+  });
+
   it.concurrent("falls through to 'node' condition for require()", async () => {
     using cwd = tempDir("bun-cond-fallback-require", {
       "index.cjs": `console.log(require("pkg").tag);`,

--- a/test/js/bun/resolve/import-custom-condition.test.ts
+++ b/test/js/bun/resolve/import-custom-condition.test.ts
@@ -304,6 +304,35 @@ describe("'bun' export condition falls through when its target file is missing",
     expect(exitCode).toBe(0);
   });
 
+  it.concurrent("does not fall through for an explicit 'bun': null disable", async () => {
+    using cwd = tempDir("bun-cond-null-disable", {
+      "index.mjs": `import "pkg"; console.log("loaded");`,
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: {
+          ".": {
+            bun: null,
+            default: "./dist/node.mjs",
+          },
+        },
+      }),
+      "node_modules/pkg/dist/node.mjs": `export {};`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(cwd),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("pkg");
+    expect(stdout).toBe("");
+    expect(exitCode).not.toBe(0);
+  });
+
   it.concurrent("still fails when no other condition resolves to an existing file", async () => {
     using cwd = tempDir("bun-cond-no-fallback", {
       "index.mjs": `import "pkg";`,

--- a/test/js/bun/resolve/import-custom-condition.test.ts
+++ b/test/js/bun/resolve/import-custom-condition.test.ts
@@ -1,6 +1,6 @@
-import { beforeAll, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
 import { writeFileSync } from "fs";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 
 let dir: string;
 
@@ -166,4 +166,138 @@ it("custom condition when don't match condition should resolves to default", asy
   });
 
   expect(exitCode).toBe(1);
+});
+
+// https://github.com/oven-sh/bun/issues/7142
+// When a package defines a "bun" export condition but the target file is absent
+// (e.g. a Node-targeted file tracer such as Nitro/@vercel/nft only copied the
+// "node" variant into .output/server/node_modules), Bun should fall through to
+// the next matching condition instead of failing with "Cannot find package".
+describe("'bun' export condition falls through when its target file is missing", () => {
+  it.concurrent("falls through to 'node' condition (sibling package in node_modules)", async () => {
+    using cwd = tempDir("bun-cond-fallback-node", {
+      // Mirrors Nitro's traced .output layout: importer lives inside node_modules and
+      // the dependency is a sibling whose "bun" target was pruned.
+      "server/index.mjs": `import "ipx";`,
+      "server/node_modules/ipx/package.json": JSON.stringify({
+        name: "ipx",
+        type: "module",
+        exports: { ".": "./dist/index.mjs" },
+      }),
+      "server/node_modules/ipx/dist/index.mjs": `import { tag } from "ofetch"; console.log(tag);`,
+      "server/node_modules/ofetch/package.json": JSON.stringify({
+        name: "ofetch",
+        type: "module",
+        exports: {
+          ".": {
+            bun: "./dist/index.mjs",
+            node: { import: "./dist/node.mjs", require: "./dist/node.cjs" },
+            default: "./dist/index.mjs",
+          },
+        },
+      }),
+      // Only the "node" variant exists on disk; "./dist/index.mjs" was not traced.
+      "server/node_modules/ofetch/dist/node.mjs": `export const tag = "node-variant";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "server/index.mjs"],
+      env: bunEnv,
+      cwd: String(cwd),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("node-variant\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("falls through to 'node' condition for require()", async () => {
+    using cwd = tempDir("bun-cond-fallback-require", {
+      "index.cjs": `console.log(require("pkg").tag);`,
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        exports: {
+          ".": {
+            bun: "./dist/bun.cjs",
+            node: "./dist/node.cjs",
+          },
+        },
+      }),
+      "node_modules/pkg/dist/node.cjs": `module.exports.tag = "node-variant";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.cjs"],
+      env: bunEnv,
+      cwd: String(cwd),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("node-variant\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("prefers the 'bun' condition when its target file exists", async () => {
+    using cwd = tempDir("bun-cond-prefer-bun", {
+      "index.mjs": `import { tag } from "pkg"; console.log(tag);`,
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: {
+          ".": {
+            bun: "./dist/bun.mjs",
+            node: "./dist/node.mjs",
+            default: "./dist/node.mjs",
+          },
+        },
+      }),
+      "node_modules/pkg/dist/bun.mjs": `export const tag = "bun-variant";`,
+      "node_modules/pkg/dist/node.mjs": `export const tag = "node-variant";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(cwd),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("bun-variant\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("still fails when no other condition resolves to an existing file", async () => {
+    using cwd = tempDir("bun-cond-no-fallback", {
+      "index.mjs": `import "pkg";`,
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: {
+          ".": {
+            bun: "./dist/missing.mjs",
+            default: "./dist/missing.mjs",
+          },
+        },
+      }),
+      "node_modules/pkg/dist/.keep": "",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(cwd),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("pkg");
+    expect(stdout).toBe("");
+    expect(exitCode).not.toBe(0);
+  });
 });


### PR DESCRIPTION
Fixes #7142
Fixes #13545
Fixes #24848

### Problem

- Running Nitro/Nuxt `node-server` output under Bun fails with `error: Cannot find package 'ofetch' from '.../.output/server/node_modules/ipx/dist/index.mjs'`. `node .output/server/index.mjs` starts fine.
- `ofetch` (and `stripe`, `openai`, ...) declare a `"bun"` condition in `exports`. Nitro traces the tree with Node's condition set, so only the `"node"`/`"default"` target is copied into `.output/server/node_modules`; the `"bun"` target is not.
- Bun's resolver matches `"bun"` first (`package_json.rs`, `resolve_target` Map arm), gets a target, and `handle_esm_resolution` fails to load it. The exports lookup is not re-entered, so the `"node"` target that is on disk is never considered.

### Fix

- `ESModule` gains two fields: `matched_bun_condition: &mut bool` (output, set in the Map arm when the `"bun"` key is the one that produced a target) and `skip_bun_condition: bool` (input, makes the Map arm skip a `"bun"` key that produced a target and move on to the next key).
- The three places that run an exports/imports lookup and then try to load the result are each wrapped in the same two-pass loop: `for skip_bun in [false, true]`, breaking before the second pass unless the first pass set `matched_bun`. Sites: `load_node_modules` (node_modules walk, including the existing `./foo.js` to `./foo` retry), `load_node_modules` (global cache branch), and `load_package_imports`.
- The gate is "the `"bun"` key matched and produced a target, and the load that followed failed", so the retry also covers a `"bun"` target that is a directory or invalid, and an `#imports` `"bun"` target that is a bare package which does not resolve. It is not limited to a missing file.
- `"bun": null` is not a target: it neither sets `matched_bun` nor is skipped on the second pass, so an explicit disable still fails as before, including when a different exports entry (the `./foo.js` form of a `./foo` entry) is what armed the retry. No other condition's behavior changes, and the success path does no extra work.
- In `load_package_imports` the `PackageResolve` branch now returns `Pending`/`Failure` from `load_node_modules` directly and only falls through to the second pass on `NotFound`.
- Verified with `test/js/bun/resolve/import-custom-condition.test.ts` (19 tests; the 7 fallthrough cases fail on the released Bun and pass with this change, and 4 negative cases pin the `"bun"` target winning when present, `"bun": null` on both passes, and the all-missing error), and by running the Nuxt project from #7142, which now prints `Listening on http://[::]:3000`.

### Background

- An `exports`/`imports` map is a list of condition keys. The resolver walks it in package order and takes the first key present in its active condition set. Bun's set is `import`/`require`, `bun`, `node`, `default`, so a package with a `"bun"` key always resolves through it under Bun.
- The spec treats a matched target that fails to load as an error, and Node behaves that way. Bun keeps that for every condition except its own: `"bun"` is a Bun extension, so Node-oriented tooling legitimately prunes those files, and falling through selects exactly the file Node would have loaded from the same tree.
- `load_node_modules` and `load_package_imports` are the resolver entry points for bare specifiers and `#`-prefixed imports respectively; `handle_esm_resolution` turns the path an exports lookup produced into an on-disk file or `NotFound`.
