### PR TITLE
GarbageCollectionController: run a full GC + scavenge after the heap has been idle

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -85,6 +85,8 @@ new!(pub BUN_FEATURE_FLAG_DUMP_CODE: string, "BUN_FEATURE_FLAG_DUMP_CODE", {});
 new!(pub BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS: unsigned, "BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS", {});
 new!(pub BUN_GC_TIMER_DISABLE: boolean, "BUN_GC_TIMER_DISABLE", {});
 new!(pub BUN_GC_TIMER_INTERVAL: unsigned, "BUN_GC_TIMER_INTERVAL", {});
+// Disables the idle full-GC + allocator scavenge that runs after the heap has been stable for a few seconds.
+new!(pub BUN_IDLE_MEMORY_REDUCER_DISABLE: boolean, "BUN_IDLE_MEMORY_REDUCER_DISABLE", {});
 // TODO(markovejnovic): It's unclear why the default here is 100_000, but this was legacy behavior
 // so we'll keep it for now.
 new!(pub BUN_INOTIFY_COALESCE_INTERVAL: unsigned, "BUN_INOTIFY_COALESCE_INTERVAL", { default: 100_000 });

--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -160,9 +160,10 @@ impl GarbageCollectionController {
         if this.disabled {
             return;
         }
+        let jsc_vm = VirtualMachine::get().jsc_vm();
         let prev_heap_size = this.gc_last_heap_size;
-        this.perform_gc();
-        if heap_size_is_stable(prev_heap_size, this.gc_last_heap_size) {
+        let current = jsc_vm.block_bytes_allocated();
+        if heap_size_is_stable(prev_heap_size, current) {
             this.heap_size_didnt_change_for_repeating_timer_ticks_count = this
                 .heap_size_didnt_change_for_repeating_timer_ticks_count
                 .saturating_add(1);
@@ -170,21 +171,28 @@ impl GarbageCollectionController {
                 && this.heap_size_didnt_change_for_repeating_timer_ticks_count
                     >= STABLE_TICKS_BEFORE_REDUCTION
             {
-                if !this.idle_memory_reducer_disabled
-                    && this.gc_last_heap_size >= MIN_HEAP_FOR_IDLE_REDUCTION
-                    && !heap_size_is_stable(
-                        this.gc_last_reduction_heap_size,
-                        this.gc_last_heap_size,
-                    )
-                {
-                    this.perform_idle_memory_reduction();
-                }
                 this.gc_repeating_timer_fast = false;
+                if !this.idle_memory_reducer_disabled
+                    && current >= MIN_HEAP_FOR_IDLE_REDUCTION
+                    && !heap_size_is_stable(this.gc_last_reduction_heap_size, current)
+                {
+                    // collectNow(Sync, Full) inside the reducer subsumes this
+                    // tick's collectAsync; firing both would let the concurrent
+                    // collector set m_collectionScope between the two
+                    // JSLockHolders and short-circuit
+                    // deleteAllUnlinkedCodeBlocks(DeleteAllCodeIfNotCollecting).
+                    this.perform_idle_memory_reduction();
+                    let interval = this.repeat_interval();
+                    Self::arm(vm, &raw mut this.gc_repeating_timer, interval);
+                    return;
+                }
             }
         } else {
             this.heap_size_didnt_change_for_repeating_timer_ticks_count = 0;
             this.gc_repeating_timer_fast = true;
         }
+        jsc_vm.collect_async();
+        this.gc_last_heap_size = jsc_vm.block_bytes_allocated();
         let interval = this.repeat_interval();
         Self::arm(vm, &raw mut this.gc_repeating_timer, interval);
     }

--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -176,11 +176,7 @@ impl GarbageCollectionController {
                     && current >= MIN_HEAP_FOR_IDLE_REDUCTION
                     && !heap_size_is_stable(this.gc_last_reduction_heap_size, current)
                 {
-                    // collectNow(Sync, Full) inside the reducer subsumes this
-                    // tick's collectAsync; firing both would let the concurrent
-                    // collector set m_collectionScope between the two
-                    // JSLockHolders and short-circuit
-                    // deleteAllUnlinkedCodeBlocks(DeleteAllCodeIfNotCollecting).
+                    // The reducer's collectNow(Sync, Full) subsumes this tick's collect_async.
                     this.perform_idle_memory_reduction();
                     let interval = this.repeat_interval();
                     Self::arm(vm, &raw mut this.gc_repeating_timer, interval);

--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -9,10 +9,7 @@ use bun_uws as uws;
 use crate::virtual_machine::VirtualMachine;
 
 const SLOW_REPEAT_INTERVAL_MS: i32 = 30_000;
-/// Fast-interval ticks with a stable heap before we run one full GC +
-/// allocator scavenge and drop to the slow interval. 30 s at the default
-/// 1 s interval; long enough that a brief pause between requests on a busy
-/// server does not trigger a full-GC latency spike.
+/// Stable fast ticks before the one-shot full GC + scavenge and the drop to slow mode; 30 s at the default 1 s interval so a brief lull on a busy server doesn't eat a full-GC pause.
 const STABLE_TICKS_BEFORE_REDUCTION: u8 = 30;
 /// Skip the idle full GC for small heaps; the pause isn't worth the bytes.
 const MIN_HEAP_FOR_IDLE_REDUCTION: usize = 16 * 1024 * 1024;
@@ -21,10 +18,7 @@ pub struct GarbageCollectionController {
     pub gc_repeating_timer: EventLoopTimer,
     /// Written by every `perform_gc()` caller, so the fast/slow comparison sees the last such call, not strictly the last fire; external callers are one-shot so worst case is one extra 30 s slow interval.
     pub(crate) gc_last_heap_size: usize,
-    /// Heap size observed the last time we ran the idle reduction. A fresh
-    /// reduction only fires once the heap has grown past this by at least the
-    /// stability tolerance, so a truly idle process doesn't re-run full GC
-    /// every `STABLE_TICKS_BEFORE_REDUCTION` seconds.
+    /// Post-reduction heap size; another reduction only fires once the heap has grown past this by the stability tolerance, so a truly idle process doesn't re-run full GC every `STABLE_TICKS_BEFORE_REDUCTION` ticks.
     pub(crate) gc_last_reduction_heap_size: usize,
     pub(crate) heap_size_didnt_change_for_repeating_timer_ticks_count: u8,
     pub(crate) gc_timer_interval: i32,
@@ -53,9 +47,7 @@ impl Default for GarbageCollectionController {
     }
 }
 
-/// `block_bytes_allocated()` includes `extraMemorySize()`, which jitters by a
-/// few KB between eden collections on an otherwise-idle heap. Treat two
-/// samples within `max(prev/32, 64 KiB)` of each other as unchanged.
+/// `block_bytes_allocated()` includes `extraMemorySize()` which jitters a few KB between eden sweeps on an idle heap, so treat samples within `max(prev/32, 64 KiB)` as unchanged.
 #[inline]
 fn heap_size_is_stable(prev: usize, new: usize) -> bool {
     let tolerance = (prev >> 5).max(64 * 1024);
@@ -157,11 +149,7 @@ impl GarbageCollectionController {
         self.gc_last_reduction_heap_size = self.gc_last_heap_size;
     }
 
-    /// `Tag::GcRepeating` fire body: 1 s in fast mode, 30 s in slow mode.
-    /// After `STABLE_TICKS_BEFORE_REDUCTION` consecutive fast ticks with no
-    /// meaningful heap change, runs one full GC plus allocator scavenge and
-    /// drops to slow mode; heap growth beyond the stability tolerance resets
-    /// to fast mode.
+    /// `Tag::GcRepeating` fire body: 1 s fast / 30 s slow; after `STABLE_TICKS_BEFORE_REDUCTION` stable fast ticks runs one full GC + scavenge and drops to slow, heap growth past the tolerance resets to fast.
     ///
     /// # Safety
     /// `this` is the live per-VM controller; `vm` is the per-thread VM.

--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -1,4 +1,4 @@
-//! Idle GC timer: JSC's own `GCActivityCallback` (via `WTFTimer`) paces eden/full against allocation rate; this only adds a 1 s / 30 s idle `collect_async()` so a process that stops allocating still releases memory. Knobs: `BUN_GC_TIMER_INTERVAL` (ms), `BUN_GC_TIMER_DISABLE`. One per JS thread, not thread-safe.
+//! Idle GC timer: JSC's own `GCActivityCallback` (via `WTFTimer`) paces eden/full against allocation rate; this adds a 1 s / 30 s idle `collect_async()` plus a one-shot full `collectNow` + allocator scavenge after the heap has been stable for `STABLE_TICKS_BEFORE_REDUCTION` fast ticks, so a process that stops allocating still sweeps old-generation garbage and returns pages to the OS. Knobs: `BUN_GC_TIMER_INTERVAL` (ms), `BUN_GC_TIMER_DISABLE`, `BUN_IDLE_MEMORY_REDUCER_DISABLE`. One per JS thread, not thread-safe.
 
 use core::ffi::c_int;
 
@@ -9,15 +9,28 @@ use bun_uws as uws;
 use crate::virtual_machine::VirtualMachine;
 
 const SLOW_REPEAT_INTERVAL_MS: i32 = 30_000;
+/// Fast-interval ticks with a stable heap before we run one full GC +
+/// allocator scavenge and drop to the slow interval. 30 s at the default
+/// 1 s interval; long enough that a brief pause between requests on a busy
+/// server does not trigger a full-GC latency spike.
+const STABLE_TICKS_BEFORE_REDUCTION: u8 = 30;
+/// Skip the idle full GC for small heaps; the pause isn't worth the bytes.
+const MIN_HEAP_FOR_IDLE_REDUCTION: usize = 16 * 1024 * 1024;
 
 pub struct GarbageCollectionController {
     pub gc_repeating_timer: EventLoopTimer,
     /// Written by every `perform_gc()` caller, so the fast/slow comparison sees the last such call, not strictly the last fire; external callers are one-shot so worst case is one extra 30 s slow interval.
     pub(crate) gc_last_heap_size: usize,
+    /// Heap size observed the last time we ran the idle reduction. A fresh
+    /// reduction only fires once the heap has grown past this by at least the
+    /// stability tolerance, so a truly idle process doesn't re-run full GC
+    /// every `STABLE_TICKS_BEFORE_REDUCTION` seconds.
+    pub(crate) gc_last_reduction_heap_size: usize,
     pub(crate) heap_size_didnt_change_for_repeating_timer_ticks_count: u8,
     pub(crate) gc_timer_interval: i32,
     pub(crate) gc_repeating_timer_fast: bool,
     pub(crate) disabled: bool,
+    pub(crate) idle_memory_reducer_disabled: bool,
 }
 
 bun_event_loop::impl_timer_owner!(
@@ -30,12 +43,23 @@ impl Default for GarbageCollectionController {
         Self {
             gc_repeating_timer: EventLoopTimer::init_paused(TimerTag::GcRepeating),
             gc_last_heap_size: 0,
+            gc_last_reduction_heap_size: 0,
             heap_size_didnt_change_for_repeating_timer_ticks_count: 0,
             gc_timer_interval: 0,
             gc_repeating_timer_fast: true,
             disabled: false,
+            idle_memory_reducer_disabled: false,
         }
     }
+}
+
+/// `block_bytes_allocated()` includes `extraMemorySize()`, which jitters by a
+/// few KB between eden collections on an otherwise-idle heap. Treat two
+/// samples within `max(prev/32, 64 KiB)` of each other as unchanged.
+#[inline]
+fn heap_size_is_stable(prev: usize, new: usize) -> bool {
+    let tolerance = (prev >> 5).max(64 * 1024);
+    new.abs_diff(prev) <= tolerance
 }
 
 impl GarbageCollectionController {
@@ -81,6 +105,8 @@ impl GarbageCollectionController {
         }
 
         self.disabled = env_var::BUN_GC_TIMER_DISABLE::get().unwrap_or(false);
+        self.idle_memory_reducer_disabled =
+            env_var::BUN_IDLE_MEMORY_REDUCER_DISABLE::get().unwrap_or(false);
     }
 
     /// Idempotent. Must run before JSC teardown: `~RunLoop::Timer` frees the
@@ -123,7 +149,19 @@ impl GarbageCollectionController {
         self.gc_last_heap_size = vm.block_bytes_allocated();
     }
 
-    /// `Tag::GcRepeating` fire body: 1 s in fast mode, 30 s in slow mode; drops to slow after 30 fires with no heap growth.
+    fn perform_idle_memory_reduction(&mut self) {
+        let vm = VirtualMachine::get().jsc_vm();
+        vm.reduce_memory_footprint_on_idle();
+        bun_core::Global::mimalloc_cleanup(true);
+        self.gc_last_heap_size = vm.block_bytes_allocated();
+        self.gc_last_reduction_heap_size = self.gc_last_heap_size;
+    }
+
+    /// `Tag::GcRepeating` fire body: 1 s in fast mode, 30 s in slow mode.
+    /// After `STABLE_TICKS_BEFORE_REDUCTION` consecutive fast ticks with no
+    /// meaningful heap change, runs one full GC plus allocator scavenge and
+    /// drops to slow mode; heap growth beyond the stability tolerance resets
+    /// to fast mode.
     ///
     /// # Safety
     /// `this` is the live per-VM controller; `vm` is the per-thread VM.
@@ -136,11 +174,23 @@ impl GarbageCollectionController {
         }
         let prev_heap_size = this.gc_last_heap_size;
         this.perform_gc();
-        if prev_heap_size == this.gc_last_heap_size {
+        if heap_size_is_stable(prev_heap_size, this.gc_last_heap_size) {
             this.heap_size_didnt_change_for_repeating_timer_ticks_count = this
                 .heap_size_didnt_change_for_repeating_timer_ticks_count
                 .saturating_add(1);
-            if this.heap_size_didnt_change_for_repeating_timer_ticks_count >= 30 {
+            if this.gc_repeating_timer_fast
+                && this.heap_size_didnt_change_for_repeating_timer_ticks_count
+                    >= STABLE_TICKS_BEFORE_REDUCTION
+            {
+                if !this.idle_memory_reducer_disabled
+                    && this.gc_last_heap_size >= MIN_HEAP_FOR_IDLE_REDUCTION
+                    && !heap_size_is_stable(
+                        this.gc_last_reduction_heap_size,
+                        this.gc_last_heap_size,
+                    )
+                {
+                    this.perform_idle_memory_reduction();
+                }
                 this.gc_repeating_timer_fast = false;
             }
         } else {

--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -103,8 +103,7 @@ impl VM {
         JSC__VM__collectAsync(self)
     }
 
-    /// One synchronous full GC followed by `WTF::releaseFastMallocFreeMemory()`
-    /// so freed pages are decommitted. Does not delete code blocks.
+    /// Synchronous full `collectNow` (plus source-provider-cache clear and `deleteAllUnlinkedCodeBlocks`) then `WTF::releaseFastMallocFreeMemory()`; unlike [`shrink_footprint`](Self::shrink_footprint) leaves linked code blocks and JIT code alone.
     pub(crate) fn reduce_memory_footprint_on_idle(&self) {
         JSC__VM__reduceMemoryFootprintOnIdle(self)
     }

--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -30,6 +30,7 @@ unsafe extern "C" {
     safe fn JSC__VM__runGC(vm: &VM, sync: bool) -> usize;
     safe fn JSC__VM__heapSize(vm: &VM) -> usize;
     safe fn JSC__VM__collectAsync(vm: &VM);
+    safe fn JSC__VM__reduceMemoryFootprintOnIdle(vm: &VM);
     safe fn JSC__VM__setExecutionForbidden(vm: &VM, forbidden: bool);
     safe fn JSC__VM__executionForbidden(vm: &VM) -> bool;
     safe fn JSC__VM__notifyNeedTermination(vm: &VM);
@@ -100,6 +101,12 @@ impl VM {
 
     pub(crate) fn collect_async(&self) {
         JSC__VM__collectAsync(self)
+    }
+
+    /// One synchronous full GC followed by `WTF::releaseFastMallocFreeMemory()`
+    /// so freed pages are decommitted. Does not delete code blocks.
+    pub(crate) fn reduce_memory_footprint_on_idle(&self) {
+        JSC__VM__reduceMemoryFootprintOnIdle(self)
     }
 
     pub fn set_execution_forbidden(&self, forbidden: bool) {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2797,13 +2797,13 @@ void JSC__VM__collectAsync(JSC::VM* vm)
     vm->heap.collectAsync();
 }
 
-// GarbageCollectionController idle reducer: JSC__VM__runGC(sync=true)'s body (so unlinked code blocks go, linked ones stay) minus PreventCollectionAndDeleteAllCode, plus releaseFastMallocFreeMemory; collectNow (not collectSync) so sweeping completes before the allocator decommits.
+// GarbageCollectionController idle reducer: JSC__VM__runGC(sync=true)'s body (so unlinked code blocks go, linked ones stay) plus releaseFastMallocFreeMemory; collectNow (not collectSync) so sweeping completes before the allocator decommits.
 extern "C" void JSC__VM__reduceMemoryFootprintOnIdle(JSC::VM* vm)
 {
     JSC::JSLockHolder lock(*vm);
     vm->finalizeSynchronousJSExecution();
     vm->clearSourceProviderCaches();
-    vm->heap.deleteAllUnlinkedCodeBlocks(JSC::DeleteAllCodeIfNotCollecting);
+    vm->heap.deleteAllUnlinkedCodeBlocks(JSC::PreventCollectionAndDeleteAllCode);
     vm->heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);
     WTF::releaseFastMallocFreeMemory();
     dataLogLnIf(JSC::Options::logGC(), "[IdleMemoryReducer fired, heap=", vm->heap.size() / 1024, "kb]");

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2797,12 +2797,7 @@ void JSC__VM__collectAsync(JSC::VM* vm)
     vm->heap.collectAsync();
 }
 
-// Idle memory reduction for GarbageCollectionController: one synchronous full
-// GC so old-generation garbage (webpack/transpiler temporaries that outlived
-// every eden GC) is actually swept, then hand freed fastMalloc pages back to
-// the OS. Unlike VM::shrinkFootprintWhenIdle this does not delete code blocks,
-// so bytecode/JIT survive the next request. collectNow (not collectSync) so
-// the sweep completes before we ask the allocator to decommit.
+// GarbageCollectionController idle reducer: JSC__VM__runGC(sync=true)'s body (so unlinked code blocks go, linked ones stay) minus PreventCollectionAndDeleteAllCode, plus releaseFastMallocFreeMemory; collectNow (not collectSync) so sweeping completes before the allocator decommits.
 extern "C" void JSC__VM__reduceMemoryFootprintOnIdle(JSC::VM* vm)
 {
     JSC::JSLockHolder lock(*vm);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2797,6 +2797,23 @@ void JSC__VM__collectAsync(JSC::VM* vm)
     vm->heap.collectAsync();
 }
 
+// Idle memory reduction for GarbageCollectionController: one synchronous full
+// GC so old-generation garbage (webpack/transpiler temporaries that outlived
+// every eden GC) is actually swept, then hand freed fastMalloc pages back to
+// the OS. Unlike VM::shrinkFootprintWhenIdle this does not delete code blocks,
+// so bytecode/JIT survive the next request. collectNow (not collectSync) so
+// the sweep completes before we ask the allocator to decommit.
+extern "C" void JSC__VM__reduceMemoryFootprintOnIdle(JSC::VM* vm)
+{
+    JSC::JSLockHolder lock(*vm);
+    vm->finalizeSynchronousJSExecution();
+    vm->clearSourceProviderCaches();
+    vm->heap.deleteAllUnlinkedCodeBlocks(JSC::DeleteAllCodeIfNotCollecting);
+    vm->heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);
+    WTF::releaseFastMallocFreeMemory();
+    dataLogLnIf(JSC::Options::logGC(), "[IdleMemoryReducer fired, heap=", vm->heap.size() / 1024, "kb]");
+}
+
 extern "C" bool JSC__VM__hasExecutionTimeLimit(JSC::VM* vm)
 {
     JSC::JSLockHolder locker(vm);

--- a/test/js/bun/gc/gc-controller-cadence.test.ts
+++ b/test/js/bun/gc/gc-controller-cadence.test.ts
@@ -90,9 +90,9 @@ describe.skipIf(isDebug)("GarbageCollectionController eden cadence", () => {
 describe("GarbageCollectionController idle memory reducer", () => {
   // ~130 MB of retained objects/strings that stay live for the whole run, so
   // block_bytes_allocated is well above the 16 MB reducer floor and the only
-  // heap movement is the GC timer itself. 80 setInterval ticks at 50 ms with a
-  // 50 ms GC timer interval reaches 30 stable ticks before the halfway mark
-  // and then spends the rest of the run in slow mode.
+  // heap movement is the GC timer itself. 50 setInterval ticks at 50 ms with a
+  // 50 ms GC timer interval reaches 30 stable ticks around the 1.5 s mark and
+  // then spends the rest of the run in slow mode.
   const fixture = `
     const hold = [];
     for (let i = 0; i < 1024; i++) {
@@ -101,7 +101,7 @@ describe("GarbageCollectionController idle memory reducer", () => {
     }
     globalThis.__hold = hold;
     let n = 0;
-    const id = setInterval(() => { if (++n >= 80) clearInterval(id); }, 50);
+    const id = setInterval(() => { if (++n >= 50) clearInterval(id); }, 50);
   `;
 
   async function runFixture(extraEnv: Record<string, string | undefined>) {
@@ -124,22 +124,31 @@ describe("GarbageCollectionController idle memory reducer", () => {
     return { reducerFires, eden };
   }
 
-  test.concurrent("runs a full GC + scavenge once the heap has been stable", async () => {
-    const r = await runFixture({});
-    // Before the fix the reducer did not exist (0 fires).
-    expect(r.reducerFires).toBeGreaterThanOrEqual(1);
-    // The exact-equality stability check never matched (extraMemorySize jitters
-    // by a few KB each eden sweep), so the timer stayed in 50 ms fast mode for
-    // the whole 4 s (~80 eden collections). With the tolerance-based check it
-    // drops to slow mode after 30 ticks. Debug+ASAN coalesces collect requests
-    // (see the cadence tests above) so the count cannot distinguish there.
-    if (!isDebug && !isASAN) {
-      expect(r.eden).toBeLessThan(60);
-    }
-  });
+  test.concurrent(
+    "runs a full GC + scavenge once the heap has been stable",
+    async () => {
+      const r = await runFixture({});
+      // Before the fix the reducer did not exist (0 fires).
+      expect(r.reducerFires).toBeGreaterThanOrEqual(1);
+      // The exact-equality stability check never matched (extraMemorySize
+      // jitters by a few KB each eden sweep), so the timer stayed in 50 ms fast
+      // mode for the whole 2.5 s (~50 eden collections). With the
+      // tolerance-based check it drops to slow mode after 30 ticks. Debug+ASAN
+      // coalesces collect requests (see the cadence tests above) so the count
+      // cannot distinguish there.
+      if (!isDebug && !isASAN) {
+        expect(r.eden).toBeLessThan(45);
+      }
+    },
+    20_000,
+  );
 
-  test.concurrent("BUN_IDLE_MEMORY_REDUCER_DISABLE=1 turns the reducer off", async () => {
-    const r = await runFixture({ BUN_IDLE_MEMORY_REDUCER_DISABLE: "1" });
-    expect(r.reducerFires).toBe(0);
-  });
+  test.concurrent(
+    "BUN_IDLE_MEMORY_REDUCER_DISABLE=1 turns the reducer off",
+    async () => {
+      const r = await runFixture({ BUN_IDLE_MEMORY_REDUCER_DISABLE: "1" });
+      expect(r.reducerFires).toBe(0);
+    },
+    20_000,
+  );
 });

--- a/test/js/bun/gc/gc-controller-cadence.test.ts
+++ b/test/js/bun/gc/gc-controller-cadence.test.ts
@@ -111,6 +111,7 @@ describe("GarbageCollectionController idle memory reducer", () => {
         ...bunEnv,
         BUN_GC_TIMER_DISABLE: undefined,
         BUN_GC_TIMER_INTERVAL: "50",
+        BUN_IDLE_MEMORY_REDUCER_DISABLE: undefined,
         BUN_JSC_logGC: "true",
         ...extraEnv,
       },

--- a/test/js/bun/gc/gc-controller-cadence.test.ts
+++ b/test/js/bun/gc/gc-controller-cadence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 
 // Bun's GarbageCollectionController used to sample `blockBytesAllocated +
 // extraMemorySize` on every event-loop tick and arm a 16 ms one-shot whenever
@@ -77,5 +77,69 @@ describe.skipIf(isDebug)("GarbageCollectionController eden cadence", () => {
     const { eden } = await countEdenCollections({ BUN_GC_TIMER_DISABLE: "1" }, 100, 50_000);
     // Observed ~128 before the fix (env var ignored).
     expect(eden).toBeLessThan(5);
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/13666
+// After a burst of allocation (webpack compile, big JSON parse, ...) the idle
+// timer's collectAsync() picks Eden every tick because there is no allocation
+// pressure, so old-generation garbage is never swept and RSS stays at the
+// post-burst peak. The controller now runs one Full collectNow + allocator
+// scavenge once the heap has been stable for 30 ticks, and the stability check
+// tolerates the few-KB jitter in extraMemorySize between eden sweeps.
+describe("GarbageCollectionController idle memory reducer", () => {
+  // ~130 MB of retained objects/strings that stay live for the whole run, so
+  // block_bytes_allocated is well above the 16 MB reducer floor and the only
+  // heap movement is the GC timer itself. 80 setInterval ticks at 50 ms with a
+  // 50 ms GC timer interval reaches 30 stable ticks before the halfway mark
+  // and then spends the rest of the run in slow mode.
+  const fixture = `
+    const hold = [];
+    for (let i = 0; i < 1024; i++) {
+      const s = Buffer.alloc(32 * 1024).toString("base64");
+      hold.push({ id: i, s, nested: { a: s.slice(1), b: s.slice(2) } });
+    }
+    globalThis.__hold = hold;
+    let n = 0;
+    const id = setInterval(() => { if (++n >= 80) clearInterval(id); }, 50);
+  `;
+
+  async function runFixture(extraEnv: Record<string, string | undefined>) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: {
+        ...bunEnv,
+        BUN_GC_TIMER_DISABLE: undefined,
+        BUN_GC_TIMER_INTERVAL: "50",
+        BUN_JSC_logGC: "true",
+        ...extraEnv,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const reducerFires = (stderr.match(/IdleMemoryReducer fired/g) ?? []).length;
+    const eden = (stderr.match(/=> EdenCollection/g) ?? []).length;
+    expect(exitCode, stderr).toBe(0);
+    return { reducerFires, eden };
+  }
+
+  test.concurrent("runs a full GC + scavenge once the heap has been stable", async () => {
+    const r = await runFixture({});
+    // Before the fix the reducer did not exist (0 fires).
+    expect(r.reducerFires).toBeGreaterThanOrEqual(1);
+    // The exact-equality stability check never matched (extraMemorySize jitters
+    // by a few KB each eden sweep), so the timer stayed in 50 ms fast mode for
+    // the whole 4 s (~80 eden collections). With the tolerance-based check it
+    // drops to slow mode after 30 ticks. Debug+ASAN coalesces collect requests
+    // (see the cadence tests above) so the count cannot distinguish there.
+    if (!isDebug && !isASAN) {
+      expect(r.eden).toBeLessThan(60);
+    }
+  });
+
+  test.concurrent("BUN_IDLE_MEMORY_REDUCER_DISABLE=1 turns the reducer off", async () => {
+    const r = await runFixture({ BUN_IDLE_MEMORY_REDUCER_DISABLE: "1" });
+    expect(r.reducerFires).toBe(0);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes the steady-state half of #13666 (`bun --bun next dev` uses substantially more memory than `node next dev`).

### Repro

Scaffold a minimal Next.js 14.2.29 app (one static `pages/index.js`), start `bun --bun next dev`, fetch `/` every 2 s for 60 s, then idle 60 s, sampling process-tree RSS. Peak is similar to Node (~430 MB), but Bun never comes back down while Node releases ~130 MB during idle.

Running the child under `BUN_JSC_logGC=1`:

```
[GC<0x28f..>: START M 160771kb => EdenCollection ... => 105318kb]
[GC<0x28f..>: START M 160771kb => EdenCollection ... => 105318kb]
[GC<0x28f..>: START M 160771kb => EdenCollection ... => 105319kb]
...
```

6 `FullCollection` lines, all during the ~2 s webpack compile; after that, 70+ `EdenCollection` lines over a minute of idle with `h=314872kb` never moving.

### Cause

`GarbageCollectionController::perform_gc` calls `collectAsync()` with no scope. With no allocation pressure `Heap::shouldDoFullCollection()` is `false`, so every idle tick is an eden collection and the ~100 MB of webpack temporaries that were promoted during the compile are never swept. JSC's own `FullGCActivityCallback` is allocation-driven, so it never re-arms while the process is idle.

The fast/slow stability check also compared `block_bytes_allocated()` for exact equality. That value includes `extraMemorySize()`, which jitters by a few KB between eden sweeps on an otherwise-idle heap, so the counter never advanced and the timer never dropped to its 30 s slow interval either (~60 pointless eden GCs per minute on an idle server).

### Fix

- Treat two heap samples within `max(prev/32, 64 KiB)` of each other as unchanged.
- After 30 consecutive fast ticks with a stable heap (and `heap >= 16 MB`, and heap grown since the last reduction), run one `collectNow(Sync, Full)` with `clearSourceProviderCaches()` + `deleteAllUnlinkedCodeBlocks(PreventCollectionAndDeleteAllCode)` (the same work `Bun.gc(true)` already does) followed by `WTF::releaseFastMallocFreeMemory()` + `mi_collect(true)`, then drop to the 30 s slow interval.
- `BUN_IDLE_MEMORY_REDUCER_DISABLE=1` opts out of the full GC + scavenge; the tolerance-based slow-mode transition stays.

`collectNow` (not `collectSync`) so the sweep finishes before the allocator is asked to decommit. Unlike `VM::shrinkFootprintWhenIdle()` this does not `deleteAllCode`, so JIT code survives the next request.

### Result

`bun --bun next dev` on the one-page app above, process-tree RSS after 60 s warm + 60 s idle:

| | main | this PR | node 26 |
|-|-|-|-|
| tree | 512 MB | 463 MB | 388 MB |
| next-server child | 405 MB | 390 MB | 295 MB |
| parent | 106 MB | 73 MB | 94 MB |

The remaining gap to Node is mimalloc page fragmentation and JSC retaining more bytecode/structures than V8; closing that is out of scope here.

### Verification

`test/js/bun/gc/gc-controller-cadence.test.ts` spawns a process with ~130 MB of live heap and a 50 ms GC timer interval, and asserts on the `IdleMemoryReducer fired` line under `BUN_JSC_logGC` plus the eden-collection count (release only). Fails on main with `reducerFires == 0`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/gc/gc-controller-cadence.test.ts
bun test v1.4.0 (cda7a1230)

test/js/bun/gc/gc-controller-cadence.test.ts:
(skip) GarbageCollectionController eden cadence > low-allocation setInterval does not trigger an eden GC per tick
(skip) GarbageCollectionController eden cadence > BUN_GC_TIMER_DISABLE=1 disables the controller
(pass) GarbageCollectionController idle memory reducer > BUN_IDLE_MEMORY_REDUCER_DISABLE=1 turns the reducer off [3650.89ms]
128 |   test.concurrent(
129 |     "runs a full GC + scavenge once the heap has been stable",
130 |     async () => {
131 |       const r = await runFixture({});
132 |       // Before the fix the reducer did not exist (0 fires).
133 |       expect(r.reducerFires).toBeGreaterThanOrEqual(1);
                                   ^
error: expect(received).toBeGreaterThanOrEqual(expected)

Expected: >= 1
Received: 0

      at <anonymous> (/workspace/bun/test/js/bun/gc/gc-controller-cadence.test.ts:133:30)
(fail) GarbageCollectionController idle memory reducer > runs a full GC + scavenge once the
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (654a749a4)

test/js/bun/gc/gc-controller-cadence.test.ts:
(pass) GarbageCollectionController eden cadence > low-allocation setInterval does not trigger an eden GC per tick [2032.19ms]
(pass) GarbageCollectionController eden cadence > BUN_GC_TIMER_DISABLE=1 disables the controller [2049.95ms]
(pass) GarbageCollectionController idle memory reducer > runs a full GC + scavenge once the heap has been stable [2605.41ms]
(pass) GarbageCollectionController idle memory reducer > BUN_IDLE_MEMORY_REDUCER_DISABLE=1 turns the reducer off [2639.53ms]

 4 pass
 0 fail
 9 expect() calls
Ran 4 tests across 1 file. [2.87s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/gc/gc-controller-cadence.test.ts
bun test v1.4.0 (cda7a1230)

test/js/bun/gc/gc-controller-cadence.test.ts:
(skip) GarbageCollectionController eden cadence > low-allocation setInterval does not trigger an eden GC per tick
(skip) GarbageCollectionController eden cadence > BUN_GC_TIMER_DISABLE=1 disables the controller
(pass) GarbageCollectionController idle memory reducer > runs a full GC + scavenge once the heap has been stable [3319.76ms]
(pass) GarbageCollectionController idle memory reducer > BUN_IDLE_MEMORY_REDUCER_DISABLE=1 turns the reducer off [3330.37ms]

 2 pass
 2 skip
 0 fail
 4 expect() calls
Ran 4 tests across 1 file. [6.66s]
__F:0:S:2

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1064ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/52] gen cpp.rs (cppbind)
[2/52] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/52] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[9
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/env_var.rs                      |  2 +
 src/jsc/GarbageCollectionController.rs       | 52 +++++++++++++++++--
 src/jsc/VM.rs                                |  6 +++
 src/jsc/bindings/bindings.cpp                | 12 +++++
 test/js/bun/gc/gc-controller-cadence.test.ts | 76 +++++++++++++++++++++++++++-
 5 files changed, 142 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/bun_core/env_var.rs                           1      1      0
src/jsc/GarbageCollectionController.rs            9     18      0
src/jsc/VM.rs                                     3      4      0
src/jsc/bindings/bindings.cpp                     4      7      0
test/js/bun/gc/gc-controller-cadence.test.ts      1      8      0
```

</details>

<!-- robobun:evidence:end -->