### PR TITLE
worker_threads: remove the global onmessage accessor inside a node worker

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -755,29 +755,26 @@ function receiveMessageOnPort(port: MessagePort) {
 // TODO: parent port emulation is not complete
 function fakeParentPort() {
   const fake = Object.create(MessagePort.prototype);
-  let onmessageHandler: any = null;
-  Object.defineProperty(fake, "onmessage", {
-    get() {
-      return onmessageHandler;
-    },
-    set(value) {
-      if (onmessageHandler !== null) self.removeEventListener("message", onmessageHandler);
-      onmessageHandler = $isCallable(value) || (value !== null && typeof value === "object") ? value : null;
-      if (onmessageHandler !== null) self.addEventListener("message", onmessageHandler);
-    },
-  });
-
-  let onmessageerrorHandler: any = null;
-  Object.defineProperty(fake, "onmessageerror", {
-    get() {
-      return onmessageerrorHandler;
-    },
-    set(value) {
-      if (onmessageerrorHandler !== null) self.removeEventListener("messageerror", onmessageerrorHandler);
-      onmessageerrorHandler = $isCallable(value) || (value !== null && typeof value === "object") ? value : null;
-      if (onmessageerrorHandler !== null) self.addEventListener("messageerror", onmessageerrorHandler);
-    },
-  });
+  function defineHandlerAttribute(name: string, event: string) {
+    let handler: any = null;
+    const wrapper = (e: Event) => {
+      if ($isCallable(handler)) handler.$call(fake, e);
+      else if ($isCallable(handler?.handleEvent)) handler.handleEvent.$call(handler, e);
+    };
+    Object.defineProperty(fake, name, {
+      get() {
+        return handler;
+      },
+      set(value) {
+        const next = $isCallable(value) || (value !== null && typeof value === "object") ? value : null;
+        if (handler === null && next !== null) self.addEventListener(event, wrapper);
+        else if (handler !== null && next === null) self.removeEventListener(event, wrapper);
+        handler = next;
+      },
+    });
+  }
+  defineHandlerAttribute("onmessage", "message");
+  defineHandlerAttribute("onmessageerror", "messageerror");
 
   const postMessage = $newCppFunction("ZigGlobalObject.cpp", "jsFunctionPostMessage", 1);
   Object.defineProperty(fake, "postMessage", {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -755,10 +755,6 @@ function receiveMessageOnPort(port: MessagePort) {
 // TODO: parent port emulation is not complete
 function fakeParentPort() {
   const fake = Object.create(MessagePort.prototype);
-  // parentPort.onmessage must not forward to self.onmessage: in a node worker
-  // the global accessor is removed (see below), and in either kind aliasing
-  // them means code that sets both parentPort.on("message", ...) and
-  // self.onmessage receives every message twice.
   let onmessageHandler: any = null;
   Object.defineProperty(fake, "onmessage", {
     get() {
@@ -842,11 +838,7 @@ let parentPort: MessagePort | null = isMainThread ? null : fakeParentPort();
 // Gate on _isNodeWorker so a raw `new globalThis.Worker` that transitively loads
 // this module does NOT have process.abort/chdir/setuid replaced.
 if (!isMainThread && _isNodeWorker) {
-  // Node.js does not have a global `onmessage` event-handler accessor inside a
-  // worker_threads worker. Bun installs one for Web Workers, but leaving it in
-  // place here means that code which registers both parentPort.on("message", ...)
-  // and self.onmessage (as Emscripten's pthread worker shim does) receives each
-  // message twice, since parentPort is backed by the same global event target.
+  // Node has no global onmessage; parentPort shares this event target, so keeping it double-delivers.
   try {
     delete (globalThis as any).onmessage;
   } catch {}

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -755,21 +755,31 @@ function receiveMessageOnPort(port: MessagePort) {
 // TODO: parent port emulation is not complete
 function fakeParentPort() {
   const fake = Object.create(MessagePort.prototype);
+  // parentPort.onmessage must not forward to self.onmessage: in a node worker
+  // the global accessor is removed (see below), and in either kind aliasing
+  // them means code that sets both parentPort.on("message", ...) and
+  // self.onmessage receives every message twice.
+  let onmessageHandler: any = null;
   Object.defineProperty(fake, "onmessage", {
     get() {
-      return self.onmessage;
+      return onmessageHandler;
     },
     set(value) {
-      self.onmessage = value;
+      if (onmessageHandler !== null) self.removeEventListener("message", onmessageHandler);
+      onmessageHandler = $isCallable(value) || (value !== null && typeof value === "object") ? value : null;
+      if (onmessageHandler !== null) self.addEventListener("message", onmessageHandler);
     },
   });
 
+  let onmessageerrorHandler: any = null;
   Object.defineProperty(fake, "onmessageerror", {
     get() {
-      return self.onmessageerror;
+      return onmessageerrorHandler;
     },
     set(value) {
-      self.onmessageerror = value;
+      if (onmessageerrorHandler !== null) self.removeEventListener("messageerror", onmessageerrorHandler);
+      onmessageerrorHandler = $isCallable(value) || (value !== null && typeof value === "object") ? value : null;
+      if (onmessageerrorHandler !== null) self.addEventListener("messageerror", onmessageerrorHandler);
     },
   });
 
@@ -832,6 +842,14 @@ let parentPort: MessagePort | null = isMainThread ? null : fakeParentPort();
 // Gate on _isNodeWorker so a raw `new globalThis.Worker` that transitively loads
 // this module does NOT have process.abort/chdir/setuid replaced.
 if (!isMainThread && _isNodeWorker) {
+  // Node.js does not have a global `onmessage` event-handler accessor inside a
+  // worker_threads worker. Bun installs one for Web Workers, but leaving it in
+  // place here means that code which registers both parentPort.on("message", ...)
+  // and self.onmessage (as Emscripten's pthread worker shim does) receives each
+  // message twice, since parentPort is backed by the same global event target.
+  try {
+    delete (globalThis as any).onmessage;
+  } catch {}
   applyWorkerProcessOverrides();
 }
 function applyWorkerProcessOverrides() {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1756,3 +1756,59 @@ test("the SHARE_ENV founding thread's process.env stays live after the swap", as
   expect(stdout.trim()).toBe("yes,unset");
   expect(exitCode).toBe(0);
 });
+
+// https://github.com/oven-sh/bun/issues/7816
+// Emscripten's pthread worker shim registers parentPort.on("message", ...) and
+// then assigns self.onmessage. In Node the global onmessage is not an event
+// handler accessor, so only the parentPort listener fires; Bun was delivering
+// the message to both, so the pthread 'load' handler ran twice and aborted.
+test("globalThis.onmessage is not an event handler accessor inside a node:worker_threads worker", async () => {
+  const worker = new Worker(
+    /* js */ `
+      const { parentPort } = require("worker_threads");
+      let count = 0;
+      const hadOnMessage = "onmessage" in globalThis;
+      Object.assign(global, { self: global });
+      parentPort.on("message", data => {
+        globalThis.onmessage({ data });
+      });
+      self.onmessage = e => {
+        count++;
+        if (e.data === "ping") {
+          setImmediate(() => parentPort.postMessage({ count, hadOnMessage }));
+        }
+      };
+      parentPort.postMessage("ready");
+    `,
+    { eval: true },
+  );
+  try {
+    await once(worker, "message"); // "ready"
+    worker.postMessage("ping");
+    const [result] = await once(worker, "message");
+    expect(result).toEqual({ count: 1, hadOnMessage: false });
+  } finally {
+    await worker.terminate();
+  }
+});
+
+test("parentPort.onmessage works inside a node:worker_threads worker", async () => {
+  const worker = new Worker(
+    /* js */ `
+      const { parentPort } = require("worker_threads");
+      parentPort.onmessage = e => {
+        parentPort.postMessage({ echoed: e.data, handlerIsSet: typeof parentPort.onmessage === "function" });
+      };
+      parentPort.postMessage("ready");
+    `,
+    { eval: true },
+  );
+  try {
+    await once(worker, "message"); // "ready"
+    worker.postMessage("hello");
+    const [result] = await once(worker, "message");
+    expect(result).toEqual({ echoed: "hello", handlerIsSet: true });
+  } finally {
+    await worker.terminate();
+  }
+});

--- a/test/napi/node-napi-tests/test/common/index.js
+++ b/test/napi/node-napi-tests/test/common/index.js
@@ -356,8 +356,8 @@ if (typeof Bun === "object") {
     ResolveMessage,
     ErrorEvent,
     Worker,
-    onmessage,
-    onerror,
+    globalThis.onmessage,
+    globalThis.onerror,
   );
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #7816
Fixes #29211
Fixes #25860
Fixes #19453
Fixes #29635
Fixes #25454

Node.js does not expose a global `onmessage` event-handler accessor inside a `worker_threads` worker. Bun installs one for Web Workers and left it in place for node workers as well. Emscripten's pthread worker shim sets up message handling like this:

```js
parentPort.on('message', function(data) {
  onmessage({ data: data });
});
// ...
self.onmessage = (e) => { /* handle 'load', 'run', ... */ };
```

In Bun, `parentPort` is backed by the same global event target as `self`, so the same message was delivered to both the `parentPort.on` wrapper (which forwards to `globalThis.onmessage`) *and* directly to the `self.onmessage` event-handler attribute. The pthread `load` command therefore ran twice, and the second run hit Emscripten's `legacyModuleProp` abort trap:

```
RuntimeError: Aborted(Module.arguments has been replaced with plain arguments_ ...)
```

### Fix

* In a `node:worker_threads` worker (gated on the existing `_isNodeWorker` flag), delete `globalThis.onmessage` so `self.onmessage = fn` is a plain property assignment, matching Node.
* Make `parentPort.onmessage` (and `onmessageerror`) track its own listener via `self.addEventListener` / `removeEventListener` instead of aliasing `self.onmessage`, so it keeps working after the global accessor is gone.

Web Workers (`new globalThis.Worker(...)`) still have the `globalThis.onmessage` accessor; only node-style workers change.

### Verification

```js
const { init } = require("z3-solver");
const { Context } = await init();
const Z3 = Context("z3");
const S = new Z3.Solver();
const X = Z3.Int.const("X");
S.add(X.sub(42).eq(0));
console.log(await S.check());            // sat
console.log(S.model().eval(X).toString()); // 42
```

Works with both `z3-solver@4.12.4` (from #7816) and `z3-solver@5.0.0`.

### Related

#26293, #29215 and #35655 are earlier, larger attempts at this same problem (real `MessagePort` for `parentPort`, separate event target with forwarders, and removing all Web Worker globals respectively). This PR is the minimal version: it only removes the one global that causes the double delivery.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (3de4278eb)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [2836.13ms]
(pass) all worker_threads module properties are present [39.04ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [41.88ms]
(pass) all worker_threads worker instance properties are present [202.75ms]
(pass) threadId module and worker property is consistent [285.85ms]
(pass) receiveMessageOnPort works across threads [2431.95ms]
(pass) receiveMessageOnPort works as FIFO [14.17ms]
(pass) you can override globalThis.postMessage [2553.87ms]
(pass) support require in eval [2324.93ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [2629.99ms]
(pass) support require in eval for a file that doesnt exist [2576.68ms]
(pass) support worker eval that throws [2643.32ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [11223.95ms]

... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/worker_threads/worker_threads.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'markAsUncloneable' not found in module 'node:worker_threads'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [710.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (3de4278eb)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [2717.37ms]
(pass) all worker_threads module properties are present [41.05ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [46.96ms]
(pass) all worker_threads worker instance properties are present [268.60ms]
(pass) threadId module and worker property is consistent [301.68ms]
(pass) receiveMessageOnPort works across threads [2999.12ms]
(pass) receiveMessageOnPort works as FIFO [14.15ms]
(pass) you can override globalThis.postMessage [2224.87ms]
(pass) support require in eval [2921.62ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [2903.13ms]
(pass) support require in eval for a file that doesnt exist [2508.63ms]
(pass) support worker eval that throws [2940.61ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [11481.61ms]

... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1754ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/51] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/51] gen JS modules (bundle-modules)
Preprocess modules (21837ms)
Bundle modules (405ms)
Postprocesss modules (1173ms)
Bundle Functions (3626ms)
Generate Code (201ms)

[27.31s] Bundled "src/js" for production
  2561 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/38] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/worker_threads.ts                      | 41 +++++++++-------
 test/js/node/worker_threads/worker_threads.test.ts | 56 ++++++++++++++++++++++
 test/napi/node-napi-tests/test/common/index.js     |  4 +-
 3 files changed, 82 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/worker_threads.ts                           5      8      0
test/js/node/worker_threads/worker_threads.test.ts      1      2      0
test/napi/node-napi-tests/test/common/index.js          3      2      0
```

</details>

<!-- robobun:evidence:end -->