### PR TITLE
resolver: prefer .mjs "module" field over "main" for ESM import at runtime

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5505,16 +5505,10 @@ impl<'a> Resolver<'a> {
                             // both the "module" file and the "main" file in the bundle at the
                             // same time.
                             //
-                            // Additionally, if this is for the runtime, use the "main" field.
-                            // If it doesn't exist, the "module" field will be used.
-                            //
-                            // Exception for the runtime: if the "module" field resolves to a
-                            // .mjs/.mts file, it is real Node-loadable ESM rather than a
-                            // browser-targeted bundler ESM build. Prefer it for `import` so
-                            // the package's own `import "dep"` statements resolve through the
-                            // same "exports" conditions as the user's `import "dep"`, avoiding
-                            // the dual-package hazard. A ".js" "module" target keeps falling
-                            // back to "main" (see #3434 / Vue SSR).
+                            // Additionally, if this is for the runtime, use the "main" field
+                            // unless "module" resolved to .mjs/.mts: a .mjs target is real
+                            // Node-loadable ESM (#8238), whereas a .js target is typically a
+                            // browser bundler build the runtime must avoid (#3434).
                             let module_is_explicit_esm = matches!(
                                 module_type_from_ext(bun_paths::extension(
                                     out.path_pair.primary.text(),

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -565,7 +565,7 @@ pub struct Resolver<'a> {
     pub(crate) dir_cache: *mut DirInfo::HashMap,
 
     /// This is set to false for the runtime. The runtime should choose "main"
-    /// over "module" in package.json
+    /// over "module" in package.json unless "module" is .mjs/.mts (#8238 vs #3434).
     pub prefer_module_field: bool,
 
     /// This is an array of paths to resolve against. Used for passing an
@@ -5505,10 +5505,8 @@ impl<'a> Resolver<'a> {
                             // both the "module" file and the "main" file in the bundle at the
                             // same time.
                             //
-                            // Additionally, if this is for the runtime, use the "main" field
-                            // unless "module" resolved to .mjs/.mts: a .mjs target is real
-                            // Node-loadable ESM (#8238), whereas a .js target is typically a
-                            // browser bundler build the runtime must avoid (#3434).
+                            // Additionally, if this is for the runtime, use the "main" field.
+                            // If it doesn't exist, the "module" field will be used.
                             let module_is_explicit_esm = matches!(
                                 module_type_from_ext(bun_paths::extension(
                                     out.path_pair.primary.text(),

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5507,7 +5507,23 @@ impl<'a> Resolver<'a> {
                             //
                             // Additionally, if this is for the runtime, use the "main" field.
                             // If it doesn't exist, the "module" field will be used.
-                            if self.prefer_module_field && kind != ast::ImportKind::Require {
+                            //
+                            // Exception for the runtime: if the "module" field resolves to a
+                            // .mjs/.mts file, it is real Node-loadable ESM rather than a
+                            // browser-targeted bundler ESM build. Prefer it for `import` so
+                            // the package's own `import "dep"` statements resolve through the
+                            // same "exports" conditions as the user's `import "dep"`, avoiding
+                            // the dual-package hazard. A ".js" "module" target keeps falling
+                            // back to "main" (see #3434 / Vue SSR).
+                            let module_is_explicit_esm = matches!(
+                                module_type_from_ext(bun_paths::extension(
+                                    out.path_pair.primary.text(),
+                                )),
+                                Some(options::ModuleType::Esm)
+                            );
+                            if (self.prefer_module_field || module_is_explicit_esm)
+                                && kind != ast::ImportKind::Require
+                            {
                                 if let Some(debug) = self.debug_logs.as_mut() {
                                     debug.add_note_fmt(format_args!(
                                         "Resolved to \"{}\" using the \"module\" field in \"{}\"",

--- a/test/regression/issue/08238.test.ts
+++ b/test/regression/issue/08238.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // https://github.com/oven-sh/bun/issues/8238
@@ -65,11 +65,7 @@ test("runtime prefers .mjs 'module' over 'main' for ESM import to avoid dual-pac
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
   // Before the fix this printed "unset-cjs": consumer resolved via "main"
@@ -100,11 +96,7 @@ test("runtime still prefers 'main' when 'module' is .js (not explicit ESM)", asy
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
   // #3434: a .js "module" target is typically a browser bundler build; runtime
@@ -135,11 +127,7 @@ test("require() still prefers 'main' even when 'module' is .mjs", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("main");

--- a/test/regression/issue/08238.test.ts
+++ b/test/regression/issue/08238.test.ts
@@ -1,0 +1,147 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/8238
+//
+// A package without an "exports" map but with "main" (CJS) + "module" (.mjs)
+// depends on a package that does have an "exports" map routing import/require
+// to different files. At runtime Bun resolved the first package via "main",
+// whose require("dep") loaded the CJS copy, while the user's `import "dep"`
+// loaded the ESM copy: two instances, module-level state never shared.
+//
+// Real-world case: zod-i18n-map (main/module only) + zod & i18next (both have
+// exports with import/require split). z.setErrorMap() hit the ESM zod while
+// zod-i18n-map held the CJS zod's defaultErrorMap.
+test("runtime prefers .mjs 'module' over 'main' for ESM import to avoid dual-package hazard", async () => {
+  using dir = tempDir("issue-08238", {
+    // Dependency with module-level state and an exports map that splits
+    // import/require (mirrors zod / i18next).
+    "node_modules/stateful/package.json": JSON.stringify({
+      name: "stateful",
+      main: "./index.cjs",
+      exports: {
+        ".": { import: "./index.mjs", require: "./index.cjs" },
+      },
+    }),
+    "node_modules/stateful/index.mjs": `
+      let value = "unset-esm";
+      export function set(v) { value = v; }
+      export function get() { return value; }
+    `,
+    "node_modules/stateful/index.cjs": `
+      let value = "unset-cjs";
+      exports.set = v => { value = v; };
+      exports.get = () => value;
+    `,
+
+    // Consumer with main + module but no exports (mirrors zod-i18n-map).
+    // The .mjs build imports "stateful" (so it should see the ESM copy).
+    "node_modules/consumer/package.json": JSON.stringify({
+      name: "consumer",
+      main: "./dist/index.js",
+      module: "./dist/index.mjs",
+    }),
+    "node_modules/consumer/dist/index.js": `
+      const stateful = require("stateful");
+      exports.read = () => stateful.get();
+    `,
+    "node_modules/consumer/dist/index.mjs": `
+      import { get } from "stateful";
+      export const read = () => get();
+    `,
+
+    "entry.ts": `
+      import { set } from "stateful";
+      import { read } from "consumer";
+      set("hello");
+      console.log(read());
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).toBe("");
+  // Before the fix this printed "unset-cjs": consumer resolved via "main"
+  // and required the CJS copy of stateful, which never saw set("hello").
+  expect(stdout.trim()).toBe("hello");
+  expect(exitCode).toBe(0);
+});
+
+test("runtime still prefers 'main' when 'module' is .js (not explicit ESM)", async () => {
+  using dir = tempDir("issue-08238-js-module", {
+    "node_modules/pkg/package.json": JSON.stringify({
+      name: "pkg",
+      main: "./main.cjs",
+      module: "./module.js",
+    }),
+    "node_modules/pkg/main.cjs": `module.exports.which = "main";`,
+    "node_modules/pkg/module.js": `export const which = "module";`,
+    "entry.ts": `
+      import { which } from "pkg";
+      console.log(which);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).toBe("");
+  // #3434: a .js "module" target is typically a browser bundler build; runtime
+  // must keep using "main" here.
+  expect(stdout.trim()).toBe("main");
+  expect(exitCode).toBe(0);
+});
+
+test("require() still prefers 'main' even when 'module' is .mjs", async () => {
+  using dir = tempDir("issue-08238-require", {
+    "node_modules/pkg/package.json": JSON.stringify({
+      name: "pkg",
+      main: "./main.cjs",
+      module: "./module.mjs",
+    }),
+    "node_modules/pkg/main.cjs": `module.exports.which = "main";`,
+    "node_modules/pkg/module.mjs": `export const which = "module";`,
+    "entry.cjs": `
+      const { which } = require("pkg");
+      console.log(which);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("main");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #8238.

### Repro

```ts
// bun add zod@3.22.4 zod-i18n-map@2.27.0 i18next@23.7.16
import i18next from "i18next";
import { z } from "zod";
import { zodI18nMap } from "zod-i18n-map";
import translation from "zod-i18n-map/locales/es/zod.json";

i18next.init({ lng: "es", resources: { es: { zod: translation } } });
z.setErrorMap(zodI18nMap);
console.log(z.string().email().safeParse("foo").error.issues);
// before: [{ validation: "email", code: "invalid_string", path: [] }]    no message
// after:  [{ ..., message: "correo inválido", ... }]
```

### Cause

`zod-i18n-map` has `"main": "dist/index.js"` and `"module": "dist/index.mjs"` but no `"exports"` map. Since #3448 the runtime resolver unconditionally picks `main` when both exist (`prefer_module_field = false`), so `import "zod-i18n-map"` loads the CJS build, which does `require("zod")` and `require("i18next")`.

Both `zod` and `i18next` do have `"exports"` maps routing `import` and `require` to different files, so the user's `import "zod"` loads `lib/index.mjs` while zod-i18n-map's `require("zod")` loads `lib/index.js`. Two copies; `z.setErrorMap()` writes to one, zod-i18n-map reads the other's `defaultErrorMap` and an uninitialized i18next `t`, and the error map returns `{ message: undefined }`.

Node native ESM has the same behavior. The `tsx` comparison in the issue only works because without `"type": "module"`, tsx compiles the entry to CJS so every import becomes `require()` and stays on one copy.

### Fix

In the auto-main logic, when the `"module"` field resolves to a `.mjs` or `.mts` file, prefer it for ESM `import` even at runtime. A `.mjs` target is real Node-loadable ESM, so its own `import` statements resolve through the same `exports` conditions as the user's entry and everyone sees one instance.

A `.js` `"module"` target still falls back to `"main"` (these are typically browser-targeted bundler builds, which is why #3448 / #3434 exists), and `require()` always uses `"main"` regardless.

### Verification

```
$ USE_SYSTEM_BUN=1 bun test test/regression/issue/08238.test.ts
(fail) runtime prefers .mjs 'module' over 'main' ...   Received: "unset-cjs"
(pass) runtime still prefers 'main' when 'module' is .js
(pass) require() still prefers 'main' even when 'module' is .mjs

$ bun bd test test/regression/issue/08238.test.ts
(pass) runtime prefers .mjs 'module' over 'main' ...
(pass) runtime still prefers 'main' when 'module' is .js
(pass) require() still prefers 'main' even when 'module' is .mjs
```

The existing `default/RuntimeUsesMainFieldForEsm` and `default/RuntimeUsesMainFieldForCjs` bundler tests (whose `"module"` is `.js`) and all `packagejson.test.ts` tests continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/08238.test.ts"
bun test v1.4.0 (3e6788f2e)

test/regression/issue/08238.test.ts:
68 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
69 | 
70 |   expect(stderr).toBe("");
71 |   // Before the fix this printed "unset-cjs": consumer resolved via "main"
72 |   // and required the CJS copy of stateful, which never saw set("hello").
73 |   expect(stdout.trim()).toBe("hello");
                             ^
error: expect(received).toBe(expected)

Expected: "hello"
Received: "unset-cjs"

      at <anonymous> (/workspace/bun/test/regression/issue/08238.test.ts:73:25)
(fail) runtime prefers .mjs 'module' over 'main' for ESM import to avoid dual-package hazard [419.12ms]
(pass) runtime still prefers 'main' when 'module' is .js (not explicit ESM) [301.19ms]
(pass) require() still prefers 'main' even when 'module' is .mjs [332.81ms]

 2 pass
 1 fail
 8 expect() calls
Ran 3 tests across 1 file. [3.14s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/regression/issue/08238.test.ts:
68 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
69 | 
70 |   expect(stderr).toBe("");
71 |   // Before the fix this printed "unset-cjs": consumer resolved via "main"
72 |   // and required the CJS copy of stateful, which never saw set("hello").
73 |   expect(stdout.trim()).toBe("hello");
                             ^
error: expect(received).toBe(expected)

Expected: "hello"
Received: "unset-cjs"

      at <anonymous> (/workspace/bun/test/regression/issue/08238.test.ts:73:25)
(fail) runtime prefers .mjs 'module' over 'main' for ESM import to avoid dual-package hazard [18.47ms]
(pass) runtime still prefers 'main' when 'module' is .js (not explicit ESM) [14.95ms]
(pass) require() still prefers 'main' even when 'module' is .mjs [15.24ms]

 2 pass
 1 fail
 8 expect() calls
Ran 3 tests across 1 file. [211.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/08238.test.ts"
bun test v1.4.0 (3e6788f2e)

test/regression/issue/08238.test.ts:
(pass) runtime prefers .mjs 'module' over 'main' for ESM import to avoid dual-package hazard [356.48ms]
(pass) runtime still prefers 'main' when 'module' is .js (not explicit ESM) [286.33ms]
(pass) require() still prefers 'main' even when 'module' is .mjs [315.89ms]

 3 pass
 0 fail
 9 expect() calls
Ran 3 tests across 1 file. [3.04s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 725ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/52] cxx obj/src/jsc/bindings/BunProcess.cpp.o
[2/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[3/52] cxx obj/src/jsc/bindings/bindings.cpp.o
[4/52] cxx obj/src/jsc/bindings/BunObject.cpp.o
[5/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[6/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[7/52] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[8/52] cxx obj/src/jsc/bindings/highway_sourcemap.cpp.o
[9/52] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[10/52] cxx obj/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp.o
[11/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[12/52] cxx obj/src/jsc/bindings/napi.cpp.o
[13/52] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[14/52] cxx obj/src/jsc/bindings/webcore/streams/CrossRealmTransform.cpp.o
[15/52] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[16/52] cxx obj/src/j
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/resolver/resolver.rs            |  12 +++-
 test/regression/issue/08238.test.ts | 135 ++++++++++++++++++++++++++++++++++++
 2 files changed, 145 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/resolver/resolver.rs                10      5      0
test/regression/issue/08238.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->