### PR TITLE
mock.module: return a promise instead of spinning when the factory is async

### DIFF
--- a/docs/test/mocks.mdx
+++ b/docs/test/mocks.mdx
@@ -292,6 +292,24 @@ test("mock.module", async () => {
 });
 ```
 
+If the factory returns a promise (for example an `async` function, or one that returns `import()`), the already-imported module is only updated once that promise settles. In that case `mock.module()` returns a promise that resolves after the update has been applied (or rejects with the factory's error), so `await` it before reading the mocked module:
+
+```ts title="test.ts" icon="/icons/typescript.svg"
+import { test, expect, mock } from "bun:test";
+
+import { foo } from "./module";
+
+test("mock.module with an async factory", async () => {
+  expect(foo).toBe("bar");
+
+  await mock.module("./module", () => import("./module.mock"));
+
+  expect(foo).toBe("baz");
+});
+```
+
+When the module has not been imported yet, the factory is not called until the first import, and `mock.module()` returns `undefined`.
+
 ### Hoisting & Preloading
 
 To make sure a module is mocked before it's imported, use `--preload` to load your mocks before your tests run.

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -29,8 +29,16 @@ declare module "bun:test" {
      * value of `factory`. If an export didn't exist before, it is not added to
      * existing import statements. This is a consequence of how ESM works.
      *
+     * If the module is already loaded and `factory` returns a promise (an
+     * `async` function, or one returning `import()`), the existing exports are
+     * only overwritten once that promise settles, and `mock.module()` returns a
+     * promise that resolves after they have been (or rejects with the factory's
+     * error). `await` it before using the mocked module. Otherwise `mock.module()`
+     * returns `undefined`; when the module has not been loaded yet, `factory` is
+     * not called until the first import.
+     *
      * @param id module ID to mock
-     * @param factory a function returning an object used as the exports of the mocked module
+     * @param factory a function returning an object used as the exports of the mocked module, or a promise for one
      *
      * @example
      * ```ts

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -412,9 +412,13 @@ public:
     using Base = JSC::JSNonFinalObject;
 
     mutable WriteBarrier<JSObject> callbackFunctionOrCachedResult;
+    mutable WriteBarrier<JSString> specifierValue;
+    // Already-loaded module objects to patch once an async factory settles.
+    mutable WriteBarrier<JSC::JSModuleNamespaceObject> pendingNamespace;
+    mutable WriteBarrier<Bun::JSCommonJSModule> pendingCommonJSModule;
     bool hasCalledModuleMock = false;
 
-    static JSModuleMock* create(JSC::VM& vm, JSC::Structure* structure, JSC::JSObject* callback);
+    static JSModuleMock* create(JSC::VM& vm, JSC::Structure* structure, JSC::JSObject* callback, JSC::JSString* specifier);
     static Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype);
 
     DECLARE_INFO;
@@ -432,14 +436,14 @@ public:
     void finishCreation(JSC::VM&);
 
 private:
-    JSModuleMock(JSC::VM&, JSC::Structure*, JSC::JSObject* callback);
+    JSModuleMock(JSC::VM&, JSC::Structure*, JSC::JSObject* callback, JSC::JSString* specifier);
 };
 
 const JSC::ClassInfo JSModuleMock::s_info = { "ModuleMock"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSModuleMock) };
 
-JSModuleMock* JSModuleMock::create(JSC::VM& vm, JSC::Structure* structure, JSC::JSObject* callback)
+JSModuleMock* JSModuleMock::create(JSC::VM& vm, JSC::Structure* structure, JSC::JSObject* callback, JSC::JSString* specifier)
 {
-    JSModuleMock* ptr = new (NotNull, JSC::allocateCell<JSModuleMock>(vm)) JSModuleMock(vm, structure, callback);
+    JSModuleMock* ptr = new (NotNull, JSC::allocateCell<JSModuleMock>(vm)) JSModuleMock(vm, structure, callback, specifier);
     ptr->finishCreation(vm);
     return ptr;
 }
@@ -449,9 +453,10 @@ void JSModuleMock::finishCreation(JSC::VM& vm)
     Base::finishCreation(vm);
 }
 
-JSModuleMock::JSModuleMock(JSC::VM& vm, JSC::Structure* structure, JSC::JSObject* callback)
+JSModuleMock::JSModuleMock(JSC::VM& vm, JSC::Structure* structure, JSC::JSObject* callback, JSC::JSString* specifier)
     : Base(vm, structure)
     , callbackFunctionOrCachedResult(callback, JSC::WriteBarrierEarlyInit)
+    , specifierValue(specifier, JSC::WriteBarrierEarlyInit)
 {
 }
 
@@ -495,6 +500,78 @@ JSObject* JSModuleMock::executeOnce(JSC::JSGlobalObject* lexicalGlobalObject)
     this->callbackFunctionOrCachedResult.set(vm, this, object);
 
     return object;
+}
+
+static void applyModuleMockOverrides(Zig::GlobalObject* globalObject, JSC::JSModuleNamespaceObject* moduleNamespaceObject, Bun::JSCommonJSModule* commonJSModule, JSValue exportsValue)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (moduleNamespaceObject) {
+        if (auto* object = exportsValue.getObject()) {
+            JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+            object->methodTable()->getOwnPropertyNames(object, globalObject, names, DontEnumPropertiesMode::Exclude);
+            RETURN_IF_EXCEPTION(scope, );
+
+            // Read every export before overriding any, so a throwing getter leaves the
+            // namespace untouched.
+            MarkedArgumentBuffer values;
+            values.ensureCapacity(names.size());
+            for (auto& name : names) {
+                JSValue value = object->get(globalObject, name);
+                RETURN_IF_EXCEPTION(scope, );
+                values.append(value);
+            }
+            if (values.hasOverflowed()) [[unlikely]] {
+                throwOutOfMemoryError(globalObject, scope);
+                return;
+            }
+            for (size_t i = 0; i < names.size(); ++i) {
+                moduleNamespaceObject->overrideExportValue(globalObject, names[i], values.at(i));
+                RETURN_IF_EXCEPTION(scope, );
+            }
+        } else {
+            // if it's not an object, I guess we just set the default export?
+            moduleNamespaceObject->overrideExportValue(globalObject, vm.propertyNames->defaultKeyword, exportsValue);
+            RETURN_IF_EXCEPTION(scope, );
+        }
+    }
+
+    if (commonJSModule) {
+        commonJSModule->setExportsObject(exportsValue);
+        commonJSModule->hasEvaluated = true;
+    }
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionMockModuleResolved, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    Zig::GlobalObject* globalObject = defaultGlobalObject(lexicalGlobalObject);
+
+    JSValue exportsValue = callframe->argument(0);
+    auto* mock = dynamicDowncast<JSModuleMock>(callframe->argument(1));
+    if (!mock) [[unlikely]]
+        return JSValue::encode(jsUndefined());
+
+    if (auto* object = exportsValue.getObject())
+        mock->callbackFunctionOrCachedResult.set(vm, mock, object);
+
+    JSC::JSModuleNamespaceObject* moduleNamespaceObject = mock->pendingNamespace.get();
+    Bun::JSCommonJSModule* commonJSModule = mock->pendingCommonJSModule.get();
+    mock->pendingNamespace.clear();
+    mock->pendingCommonJSModule.clear();
+
+    WTF::String specifier = mock->specifierValue.get()->value(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    auto* virtualModules = globalObject->onLoadPlugins.virtualModules;
+    if (!virtualModules || virtualModules->get(specifier).get() != mock)
+        return JSValue::encode(jsUndefined());
+
+    applyModuleMockOverrides(globalObject, moduleNamespaceObject, commonJSModule, exportsValue);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    return JSValue::encode(jsUndefined());
 }
 
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsModuleMock);
@@ -590,115 +667,34 @@ extern "C" JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(JSMock__jsModuleMock, __attr
 
     JSC::JSObject* callback = callbackValue.getObject();
 
-    JSModuleMock* mock = JSModuleMock::create(vm, globalObject->mockModule.mockModuleStructure.getInitializedOnMainThread(globalObject), callback);
-
-    auto getJSValue = [&]() -> JSValue {
-        auto scope = DECLARE_THROW_SCOPE(vm);
-        JSValue result = mock->executeOnce(globalObject);
-        RETURN_IF_EXCEPTION(scope, {});
-
-        if (result && result.isObject()) {
-            while (JSC::JSPromise* promise = dynamicDowncast<JSC::JSPromise>(result)) {
-                switch (promise->status()) {
-                case JSC::JSPromise::Status::Rejected: {
-                    result = promise->result();
-                    scope.throwException(globalObject, result);
-                    return {};
-                    break;
-                }
-                case JSC::JSPromise::Status::Fulfilled: {
-                    result = promise->result();
-                    break;
-                }
-                // TODO: blocking wait for promise
-                default: {
-                    break;
-                }
-                }
-            }
-        }
-
-        return result;
-    };
-
-    bool removeFromESM = false;
-    bool removeFromCJS = false;
+    JSModuleMock* mock = JSModuleMock::create(vm, globalObject->mockModule.mockModuleStructure.getInitializedOnMainThread(globalObject), callback, specifierString);
 
     auto specifierIdent = JSC::Identifier::fromString(vm, specifierString->value(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
+
+    JSC::JSModuleNamespaceObject* moduleNamespaceObject = nullptr;
+    bool removeFromESM = false;
     if (auto* entry = globalObject->moduleLoader()->registryEntry(specifierIdent)) {
         removeFromESM = true;
         if (auto* mod = entry->record()) {
             // getModuleNamespace asserts the record has progressed past linking.
-            // A previous import that failed during link (e.g. unresolved binding)
-            // leaves the record at New/Unlinked; in that case there is no
-            // namespace to patch — drop the stale entry so the mock takes over
-            // on the next import.
             bool linked = true;
             if (auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(mod))
                 linked = cyclic->status() >= JSC::CyclicModuleRecord::Status::Linked;
             if (linked) {
-                {
-                    JSC::JSModuleNamespaceObject* moduleNamespaceObject = mod->getModuleNamespace(globalObject);
-                    RETURN_IF_EXCEPTION(scope, {});
-                    if (moduleNamespaceObject) {
-                        JSValue exportsValue = getJSValue();
-                        RETURN_IF_EXCEPTION(scope, {});
-                        auto* object = exportsValue.getObject();
-                        removeFromESM = false;
-
-                        if (object) {
-                            JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
-                            JSObject::getOwnPropertyNames(object, globalObject, names, DontEnumPropertiesMode::Exclude);
-                            RETURN_IF_EXCEPTION(scope, {});
-
-                            // Read every export before overriding any, so a throwing getter leaves the
-                            // namespace untouched.
-                            MarkedArgumentBuffer values;
-                            values.ensureCapacity(names.size());
-                            for (auto& name : names) {
-                                JSValue value = object->get(globalObject, name);
-                                RETURN_IF_EXCEPTION(scope, {});
-                                values.append(value);
-                            }
-                            if (values.hasOverflowed()) [[unlikely]] {
-                                throwOutOfMemoryError(globalObject, scope);
-                                return {};
-                            }
-                            for (size_t i = 0; i < names.size(); ++i) {
-                                moduleNamespaceObject->overrideExportValue(globalObject, names[i], values.at(i));
-                                RETURN_IF_EXCEPTION(scope, {});
-                            }
-
-                        } else {
-                            // if it's not an object, I guess we just set the default export?
-                            moduleNamespaceObject->overrideExportValue(globalObject, vm.propertyNames->defaultKeyword, exportsValue);
-                            RETURN_IF_EXCEPTION(scope, {});
-                        }
-
-                        // TODO: do we need to handle intermediate loading state here?
-                        // entry->putDirect(vm, Identifier::fromString(vm, String("evaluated"_s)), jsBoolean(true), 0);
-                        // entry->putDirect(vm, Identifier::fromString(vm, String("state"_s)), jsNumber(JSC::JSModuleLoader::Status::Ready), 0);
-                    }
-                }
+                moduleNamespaceObject = mod->getModuleNamespace(globalObject);
+                RETURN_IF_EXCEPTION(scope, {});
+                removeFromESM = moduleNamespaceObject == nullptr;
             }
         }
     }
 
-    JSValue entryValue = globalObject->requireMap()->get(globalObject, specifierString);
+    JSValue requireMapEntry = globalObject->requireMap()->get(globalObject, specifierString);
     RETURN_IF_EXCEPTION(scope, {});
-    if (entryValue) {
-        removeFromCJS = true;
-        if (auto* moduleObject = entryValue ? dynamicDowncast<Bun::JSCommonJSModule>(entryValue) : nullptr) {
-            JSValue exportsValue = getJSValue();
-            RETURN_IF_EXCEPTION(scope, {});
+    auto* commonJSModule = dynamicDowncast<Bun::JSCommonJSModule>(requireMapEntry);
+    bool removeFromCJS = !commonJSModule && !requireMapEntry.isUndefined();
 
-            moduleObject->putDirect(vm, Bun::builtinNames(vm).exportsPublicName(), exportsValue, 0);
-            moduleObject->hasEvaluated = true;
-            removeFromCJS = false;
-        }
-    }
-
+    // Removed before the factory runs: an async factory may never settle.
     if (removeFromESM) {
         auto* moduleLoader = globalObject->moduleLoader();
         WTF::Locker locker { moduleLoader->cellLock() };
@@ -709,6 +705,37 @@ extern "C" JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(JSMock__jsModuleMock, __attr
         globalObject->requireMap()->remove(globalObject, specifierString);
         RETURN_IF_EXCEPTION(scope, {});
     }
+
+    if (!moduleNamespaceObject && !commonJSModule) {
+        globalObject->onLoadPlugins.addModuleMock(vm, specifier, mock);
+        return JSValue::encode(jsUndefined());
+    }
+
+    JSValue result = mock->executeOnce(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (auto* promise = dynamicDowncast<JSC::JSPromise>(result)) {
+        if (promise->status() != JSC::JSPromise::Status::Fulfilled) {
+            // Rejected takes this path too: attaching the reaction marks the promise handled.
+            if (moduleNamespaceObject)
+                mock->pendingNamespace.set(vm, mock, moduleNamespaceObject);
+            if (commonJSModule)
+                mock->pendingCommonJSModule.set(vm, mock, commonJSModule);
+            globalObject->onLoadPlugins.addModuleMock(vm, specifier, mock);
+
+            auto* resultPromise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
+            JSFunction* onFulfilled = globalObject->mockModule.mockModuleResolvedFunction.getInitializedOnMainThread(globalObject);
+            promise->performPromiseThenWithContext(vm, globalObject, onFulfilled, jsUndefined(), resultPromise, mock);
+            return JSValue::encode(resultPromise);
+        }
+        result = promise->result();
+    }
+
+    if (auto* object = result.getObject())
+        mock->callbackFunctionOrCachedResult.set(vm, mock, object);
+
+    applyModuleMockOverrides(globalObject, moduleNamespaceObject, commonJSModule, result);
+    RETURN_IF_EXCEPTION(scope, {});
 
     globalObject->onLoadPlugins.addModuleMock(vm, specifier, mock);
 
@@ -723,6 +750,9 @@ void JSModuleMock::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Base::visitChildren(mock, visitor);
 
     visitor.append(mock->callbackFunctionOrCachedResult);
+    visitor.append(mock->specifierValue);
+    visitor.append(mock->pendingNamespace);
+    visitor.append(mock->pendingCommonJSModule);
 }
 
 DEFINE_VISIT_CHILDREN(JSModuleMock);

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -507,32 +507,33 @@ static void applyModuleMockOverrides(Zig::GlobalObject* globalObject, JSC::JSMod
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (moduleNamespaceObject) {
-        if (auto* object = exportsValue.getObject()) {
-            JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
-            object->methodTable()->getOwnPropertyNames(object, globalObject, names, DontEnumPropertiesMode::Exclude);
-            RETURN_IF_EXCEPTION(scope, );
+    // executeOnce() only checks the factory's return value, and a promise is an object.
+    auto* object = exportsValue.getObject();
+    if (!object) {
+        scope.throwException(globalObject, JSC::createTypeError(globalObject, "mock(module, fn) requires a function that returns an object"_s));
+        return;
+    }
 
-            // Read every export before overriding any, so a throwing getter leaves the
-            // namespace untouched.
-            MarkedArgumentBuffer values;
-            values.ensureCapacity(names.size());
-            for (auto& name : names) {
-                JSValue value = object->get(globalObject, name);
-                RETURN_IF_EXCEPTION(scope, );
-                values.append(value);
-            }
-            if (values.hasOverflowed()) [[unlikely]] {
-                throwOutOfMemoryError(globalObject, scope);
-                return;
-            }
-            for (size_t i = 0; i < names.size(); ++i) {
-                moduleNamespaceObject->overrideExportValue(globalObject, names[i], values.at(i));
-                RETURN_IF_EXCEPTION(scope, );
-            }
-        } else {
-            // if it's not an object, I guess we just set the default export?
-            moduleNamespaceObject->overrideExportValue(globalObject, vm.propertyNames->defaultKeyword, exportsValue);
+    if (moduleNamespaceObject) {
+        JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+        object->methodTable()->getOwnPropertyNames(object, globalObject, names, DontEnumPropertiesMode::Exclude);
+        RETURN_IF_EXCEPTION(scope, );
+
+        // Read every export before overriding any, so a throwing getter leaves the
+        // namespace untouched.
+        MarkedArgumentBuffer values;
+        values.ensureCapacity(names.size());
+        for (auto& name : names) {
+            JSValue value = object->get(globalObject, name);
+            RETURN_IF_EXCEPTION(scope, );
+            values.append(value);
+        }
+        if (values.hasOverflowed()) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return;
+        }
+        for (size_t i = 0; i < names.size(); ++i) {
+            moduleNamespaceObject->overrideExportValue(globalObject, names[i], values.at(i));
             RETURN_IF_EXCEPTION(scope, );
         }
     }

--- a/src/jsc/bindings/BunPlugin.h
+++ b/src/jsc/bindings/BunPlugin.h
@@ -10,6 +10,10 @@ BUN_DECLARE_HOST_FUNCTION(jsFunctionBunPlugin);
 BUN_DECLARE_HOST_FUNCTION(jsFunctionBunPluginClear);
 
 namespace Zig {
+JSC_DECLARE_HOST_FUNCTION(jsFunctionMockModuleResolved);
+}
+
+namespace Zig {
 
 using namespace JSC;
 

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -757,6 +757,10 @@ JSMockModule JSMockModule::create(JSC::JSGlobalObject* globalObject)
         [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSFunction>::Initializer& init) {
             init.set(JSC::JSFunction::create(init.vm, init.owner, 2, String(), jsMockFunctionWithImplementationCleanup, ImplementationVisibility::Public));
         });
+    mock.mockModuleResolvedFunction.initLater(
+        [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSFunction>::Initializer& init) {
+            init.set(JSC::JSFunction::create(init.vm, init.owner, 2, String(), Zig::jsFunctionMockModuleResolved, ImplementationVisibility::Public));
+        });
     mock.mockWithImplementationCleanupDataStructure.initLater(
         [](const JSC::LazyProperty<JSC::JSGlobalObject, Structure>::Initializer& init) {
             init.set(Bun::MockWithImplementationCleanupData::createStructure(init.vm, init.owner, init.owner->objectPrototype()));

--- a/src/jsc/bindings/JSMockFunction.h
+++ b/src/jsc/bindings/JSMockFunction.h
@@ -28,6 +28,7 @@ public:
     V(Structure, mockModuleStructure)                \
     V(Structure, activeSpySetStructure)              \
     V(JSFunction, withImplementationCleanupFunction) \
+    V(JSFunction, mockModuleResolvedFunction)        \
     V(JSC::Structure, mockWithImplementationCleanupDataStructure)
 
 #define DECLARE_JSMOCKMODULE_GC_MEMBER(T, name) \

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -1,13 +1,11 @@
 // TODO:
 // - Write tests for errors
-// - Write tests for Promise
-// - Write tests for Promise rejection
-// - Write tests for pending promise when a module already exists
 // - Write test for export * from
 // - Write test for export {foo} from "./foo"
 // - Write test for import {foo} from "./foo"; export {foo}
 
-import { expect, mock, spyOn, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { default as defaultValue, fn, iCallFn, rexported, rexportedAs, variable } from "./mock-module-fixture";
 import * as spyFixture from "./spymodule-fixture";
 
@@ -212,4 +210,244 @@ test("onResolve plugin errors surface from mock.module; an unresolvable specifie
   } finally {
     Bun.plugin.clearAll();
   }
+});
+
+// https://github.com/oven-sh/bun/issues/6751
+describe("mock.module with an async factory when the module is already loaded", () => {
+  function check(name: string, files: Record<string, string>) {
+    test.concurrent(
+      name,
+      async () => {
+        using dir = tempDir("mock-module-async-factory", {
+          "dep.ts": `export const getValue = () => "real";\nexport const other = () => "real-other";\n`,
+          "dep.mock.ts": `export const getValue = () => "mocked";\n`,
+          ...files,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "test", "fixture.test.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+          timeout: 10000,
+          killSignal: "SIGKILL",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stderr, signal: proc.signalCode }).toEqual({
+          stderr: expect.stringContaining("1 pass"),
+          signal: null,
+        });
+        expect(exitCode).toBe(0);
+      },
+      15000,
+    );
+  }
+
+  check("factory using import() does not hang and overrides the namespace", {
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      import { getValue } from "./dep";
+      await mock.module("./dep", () => import("./dep.mock"));
+      test("t", () => {
+        expect(getValue()).toBe("mocked");
+      });
+    `,
+  });
+
+  check("factory awaiting an event-loop tick does not hang and overrides the namespace", {
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      import { getValue } from "./dep";
+      await mock.module("./dep", async () => {
+        await new Promise(resolve => setImmediate(resolve));
+        return { getValue: () => "mocked" };
+      });
+      test("t", () => {
+        expect(getValue()).toBe("mocked");
+      });
+    `,
+  });
+
+  check("factory reached via a transitive static import does not hang", {
+    "consumer.ts": `
+      import { getValue } from "./dep";
+      export const callDep = () => getValue();
+    `,
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      import { callDep } from "./consumer";
+      await mock.module("./dep", () => import("./dep.mock"));
+      test("t", () => {
+        expect(callDep()).toBe("mocked");
+      });
+    `,
+  });
+
+  check("the returned promise is what signals that the override has been applied", {
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      import { getValue } from "./dep";
+      const pending = mock.module("./dep", () => import("./dep.mock"));
+      const seenBeforeSettling = getValue();
+      test("t", async () => {
+        expect(pending).toBeInstanceOf(Promise);
+        expect(seenBeforeSettling).toBe("real");
+        await expect(pending).resolves.toBeUndefined();
+        expect(getValue()).toBe("mocked");
+      });
+    `,
+  });
+
+  check("a dep loaded with require() is overridden once the factory settles", {
+    "dep.cjs": `module.exports = { getValue: () => "real" };\n`,
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      const before = require("./dep.cjs");
+      test("t", async () => {
+        expect(before.getValue()).toBe("real");
+        await mock.module("./dep.cjs", async () => {
+          await new Promise(resolve => setImmediate(resolve));
+          return { getValue: () => "mocked" };
+        });
+        expect(require("./dep.cjs").getValue()).toBe("mocked");
+      });
+    `,
+  });
+
+  check("factory that imports the module it is mocking gets the real module and leaves untouched exports alone", {
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      import { getValue, other } from "./dep";
+      await mock.module("./dep", async () => ({ ...(await import("./dep")), getValue: () => "mocked" }));
+      test("t", () => {
+        expect(getValue()).toBe("mocked");
+        expect(other()).toBe("real-other");
+      });
+    `,
+  });
+
+  check("factory rejecting propagates the rejection to the returned promise", {
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      import { getValue } from "./dep";
+      test("t", async () => {
+        const p = mock.module("./dep", async () => {
+          await new Promise(resolve => setImmediate(resolve));
+          throw new Error("factory-boom");
+        });
+        await expect(p).rejects.toThrow("factory-boom");
+        expect(getValue()).toBe("real");
+      });
+    `,
+  });
+
+  check("factory returning an already-rejected promise rejects the returned promise instead of throwing", {
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      import { getValue } from "./dep";
+      test("t", async () => {
+        const p = mock.module("./dep", async () => {
+          throw new Error("factory-boom");
+        });
+        await expect(p).rejects.toThrow("factory-boom");
+        expect(getValue()).toBe("real");
+      });
+    `,
+  });
+
+  check("a throwing export getter on the settled result rejects the promise and patches nothing", {
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      import { getValue, other } from "./dep";
+      test("t", async () => {
+        const p = mock.module("./dep", async () => {
+          await new Promise(resolve => setImmediate(resolve));
+          return {
+            getValue: () => "mocked",
+            get other() {
+              throw new Error("export getter");
+            },
+          };
+        });
+        await expect(p).rejects.toThrow("export getter");
+        expect(getValue()).toBe("real");
+        expect(other()).toBe("real-other");
+      });
+    `,
+  });
+
+  check("an entry that failed before linking is dropped even though the factory has not settled", {
+    "dep-unlinkable.ts": `
+      import { doesNotExist } from "./dep";
+      export const getValue = () => doesNotExist;
+    `,
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      test("t", async () => {
+        await expect(import("./dep-unlinkable")).rejects.toBeDefined();
+        expect(mock.module("./dep-unlinkable", () => import("./dep.mock"))).toBeUndefined();
+        const m = await import("./dep-unlinkable");
+        expect(m.getValue()).toBe("mocked");
+      });
+    `,
+  });
+
+  check("sync factory on an already-loaded module returns undefined", {
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      import { getValue } from "./dep";
+      test("t", () => {
+        const r = mock.module("./dep", () => ({ getValue: () => "mocked" }));
+        expect(r).toBeUndefined();
+        expect(getValue()).toBe("mocked");
+      });
+    `,
+  });
+
+  check("factory is not executed when the module has never been loaded", {
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      let called = 0;
+      test("t", async () => {
+        const r = mock.module("never-loaded-module", () => {
+          called++;
+          return { a: 1 };
+        });
+        expect(r).toBeUndefined();
+        expect(called).toBe(0);
+        const m = await import("never-loaded-module");
+        expect(m.a).toBe(1);
+        expect(called).toBe(1);
+      });
+    `,
+  });
+
+  check("factory returning a module namespace object overrides the already-loaded namespace", {
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      import { getValue } from "./dep";
+      import * as depMock from "./dep.mock";
+      mock.module("./dep", () => depMock);
+      test("t", () => {
+        expect(getValue()).toBe("mocked");
+      });
+    `,
+  });
+
+  check("a later mock.module() call supersedes a still-pending async factory", {
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      import { getValue } from "./dep";
+      test("t", async () => {
+        const p = mock.module("./dep", async () => {
+          await new Promise(resolve => setImmediate(resolve));
+          return { getValue: () => "A" };
+        });
+        mock.module("./dep", () => ({ getValue: () => "B" }));
+        expect(getValue()).toBe("B");
+        await p;
+        expect(getValue()).toBe("B");
+      });
+    `,
+  });
 });

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -283,6 +283,21 @@ describe("mock.module with an async factory when the module is already loaded", 
     `,
   });
 
+  // https://github.com/oven-sh/bun/issues/40007
+  check("an un-awaited factory that only awaits microtasks is applied before the first test runs", {
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      mock.module("./dep", async () => {
+        await Promise.resolve();
+        return { getValue: () => "mocked" };
+      });
+      import { getValue } from "./dep";
+      test("t", () => {
+        expect(getValue()).toBe("mocked");
+      });
+    `,
+  });
+
   check("the returned promise is what signals that the override has been applied", {
     "fixture.test.ts": `
       import { expect, test, mock } from "bun:test";
@@ -350,6 +365,25 @@ describe("mock.module with an async factory when the module is already loaded", 
           throw new Error("factory-boom");
         });
         await expect(p).rejects.toThrow("factory-boom");
+        expect(getValue()).toBe("real");
+      });
+    `,
+  });
+
+  check("a factory promise that resolves to a non-object is rejected like the synchronous case", {
+    "fixture.test.ts": `
+      import { expect, test, mock } from "bun:test";
+      import { getValue } from "./dep";
+      test("t", async () => {
+        // already fulfilled when it is returned, so it is unwrapped synchronously
+        expect(() => mock.module("./dep", async () => 42)).toThrow(
+          "mock(module, fn) requires a function that returns an object",
+        );
+        const p = mock.module("./dep", async () => {
+          await new Promise(resolve => setImmediate(resolve));
+          return 42;
+        });
+        await expect(p).rejects.toThrow("mock(module, fn) requires a function that returns an object");
         expect(getValue()).toBe("real");
       });
     `,


### PR DESCRIPTION
Fixes #6751. Fixes #40007. Addresses gap 2 of #31316.

### Problem

- `bun test` spins at 100% CPU forever when a test file statically imports a module (or a consumer of it) and then mocks it with a factory whose promise is still pending: `mock.module("./dep", () => import("./dep.mock"))`, or an `async` factory that awaits I/O.
- Cause: `JSMock__jsModuleMock` (`src/jsc/bindings/BunPlugin.cpp`) patches an already-loaded module in place, so it needs the factory's value at once. The `Pending` arm of its unwrap loop was a `// TODO: blocking wait for promise` that did nothing, so the loop re-read the same pending promise forever.
- Same function, two smaller defects: an already-rejected factory promise was thrown synchronously and reported a second time as an unhandled rejection, and the static `JSObject::getOwnPropertyNames` enumerates nothing on a module namespace object, so a factory that returned one patched nothing.

### Fix

- A plain object or an already-fulfilled promise is applied synchronously, as before. A pending or rejected promise registers the mock, stores the objects to patch on the `JSModuleMock`, and `mock.module()` returns a promise that resolves once the value has been applied, or rejects with the factory's error. A later `mock.module()` call for the same specifier wins over a late result.
- Correct because the live bindings can only change once the value exists, and the declared return type is already `void | Promise<void>`. The promise signals completion without blocking the event loop inside module evaluation. Modules that are not loaded yet are unchanged: the factory stays lazy and the call returns `undefined`.
- Exports are enumerated through `methodTable()->getOwnPropertyNames`, so a namespace object works as a factory result. A promise that resolves to a non-object throws the same TypeError as `() => 42` (adopted from #40175).
- Verified: `test/js/bun/test/mock/mock-module.test.ts`, 16 subprocess cases, 13 fail on the released binary (10 by hanging until killed). Also all of `test/js/bun/test/mock/` and `test/integration/bun-types/bun-types.test.ts`.

```ts
import { test, expect, mock } from "bun:test";
import { getValue } from "./dep"; // dep is loaded before mock.module() runs

await mock.module("./dep", () => import("./dep.mock")); // previously: 100% CPU forever

test("t", () => expect(getValue()).toBe("mocked"));
```

### Background

- `mock.module()` has two regimes. For a specifier that is not loaded yet it only records the factory in `onLoadPlugins.virtualModules`; the module loader calls it on first import and already accepts a promise there. For a loaded specifier it also rewrites the existing objects (`JSModuleNamespaceObject::overrideExportValue` for ESM, `module.exports` of the cached `JSCommonJSModule` for CJS), because live `import` bindings and `require` cache entries point at them. Only that second regime changes here.
- `JSModuleMock` is the GC cell stored in `virtualModules`. `executeOnce()` runs the factory once and caches its result for later loads.
- `JSPromise::performPromiseThenWithContext` is JSC's internal `then`: when the source promise settles it calls the handler with `(value, context)` and settles the result promise with the handler's result or exception. Attaching it to a rejected promise marks that promise handled. The streams bindings use the same mechanism.

<details><summary>Notes</summary>

**Un-awaited calls.** `mock.module()` returns a promise only in the loaded-module async case. A factory that awaits microtasks only (the #40007 repro) is applied before the first test runs even without `await`, because the runner drains microtasks after module evaluation; a test pins this. A factory that awaits I/O (`() => import()` of a file not yet loaded) has to be awaited, otherwise a read right after the call still sees the real module. `docs/test/mocks.mdx` and the `mock.module` JSDoc in `packages/bun-types/test.d.ts` say so.

**Relation to #40175.** That PR fixed the same hang by blocking: on `Pending` it drove the event loop through a new `Bun__VirtualMachine__waitForPromise` export until the factory promise settled, keeping `mock.module()` synchronous. This PR was kept because a maintainer had reviewed the promise-returning shape, and because the blocking variant still enumerated exports with the static `getOwnPropertyNames`, so `mock.module("./dep", () => import("./dep.mock"))` on a loaded `./dep` stopped hanging but left the real module in place (checked on a debug build of that branch). Its check that a promise-resolved value is an object was adopted here, credited in the commit.

**Unpatchable entries.** A registry entry whose record never linked (an import of a binding the target does not export) has no namespace object to patch; JSC asserts if one is requested. Such entries, and non-module values in the `require` cache, are removed before the factory runs, so the mock takes over on the next load. Same handling as `main`, now also while a factory is pending.

**Rejected factories.** A specifier whose factory fails stays mocked and later loads reject with the factory's error, which is what the not-yet-loaded path has always done (`executeOnce` hands every later load the same rejected promise). Under `--isolate`, `OnLoad::clear()` drops the `Strong` roots when the file finishes; a reaction that fires after that bails on the `virtualModules` check.

**Earlier revisions.** The first revision returned a promise capability and registered the mock before the factory ran; review found that `JSMap::get` returns `undefined` (truthy as a `JSValue`) on a miss, which made the lazy path dead, and that running the factory before deciding patchability left failed registry entries in place. The current revision decides patchability and removes stale entries first, defers both pending and rejected promises, and uses a bare `JSPromise` as the result. The rebase onto current main ported #39804's read-all-before-override loop into `applyModuleMockOverrides`, so it applies to the deferred path as well (the returned promise rejects and nothing is patched), and kept the `minsize` attribute from #39770.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/mock/mock-module.test.ts:
(pass) mock.module async [13.29ms]
(pass) mock.restore [4.90ms]
(pass) spyOn [2.30ms]
(pass) mocking a module that points to a file which does not resolve successfully still works [7.29ms]
(pass) mocking a non-existant relative file with a file URL [16.59ms]
(pass) mocking a non-existant relative file [12.33ms]
(pass) mocking a local file [21.71ms]
(todo) adding a default on a module with no default
(pass) mocking a package [12.35ms]
(pass) mocking a builtin [15.52ms]
(pass) a factory export getter that throws fails the import [7.48ms]
(pass) a factory export getter that throws while patching an already-imported module throws from mock.module and leaves the namespace untouched [6.76ms]
(pass) onResolve plugin errors surface from mock.module; an unresolvable specifier is still mockable [17.48ms]
231 |           stderr: "pipe",
232 |           timeout: 10000,
233 |           killSignal: "SIGKILL",
234 |         });
235 |     
... (truncated)

release without fix: 14 failed, 1 skipped
bun test v1.4.0-canary.1 (4448a2e21)

test/js/bun/test/mock/mock-module.test.ts:
(pass) mock.module async [0.37ms]
(pass) mock.restore [0.08ms]
(pass) spyOn [0.02ms]
(pass) mocking a module that points to a file which does not resolve successfully still works [0.16ms]
(pass) mocking a non-existant relative file with a file URL [0.28ms]
(pass) mocking a non-existant relative file [0.16ms]
(pass) mocking a local file [0.25ms]
(todo) adding a default on a module with no default
(pass) mocking a package [0.20ms]
(pass) mocking a builtin [0.11ms]
(pass) a factory export getter that throws fails the import [0.13ms]
(pass) a factory export getter that throws while patching an already-imported module throws from mock.module and leaves the namespace untouched [0.08ms]
199 |       });
200 |       build.onResolve({ filter: /\.mock-onresolve-invalid$/ }, () => ({ path: 42 }) as any);
201 |     },
202 |   });
203 |   try {
204 |     expect(() => mock.module("./thing.mock-onresolve-throws", () => ({ default: 1 }))).toThrow("onResolve threw");
                                                                                             ^
error: expect(received).toThrow(expected)

E
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/mock/mock-module.test.ts:
(pass) mock.module async [13.34ms]
(pass) mock.restore [4.91ms]
(pass) spyOn [1.87ms]
(pass) mocking a module that points to a file which does not resolve successfully still works [6.88ms]
(pass) mocking a non-existant relative file with a file URL [16.78ms]
(pass) mocking a non-existant relative file [12.37ms]
(pass) mocking a local file [22.21ms]
(todo) adding a default on a module with no default
(pass) mocking a package [11.93ms]
(pass) mocking a builtin [14.77ms]
(pass) a factory export getter that throws fails the import [7.52ms]
(pass) a factory export getter that throws while patching an already-imported module throws from mock.module and leaves the namespace untouched [6.75ms]
(pass) onResolve plugin errors surface from mock.module; an unresolvable specifier is still mockable [17.59ms]
(pass) mock.module with an async factory when the module is already loaded > factory using import() does not hang and overrides the
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     75fe2f1853
  features     baseline

23 deps, 129 codegen, 1172 objects in 778ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [2.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (4448a2e21)

Checked 111 installs across 104 packages (no changes) [3.00ms]
[4/1244] gen bindgenv2
[5/1244] gen ErrorCode+*.h
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] fetch zlib
[zlib] up to date
[9/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 7ms

  react-refresh.js  4.81 K
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/test/mocks.mdx                       |  18 ++
 packages/bun-types/test.d.ts              |  10 +-
 src/jsc/bindings/BunPlugin.cpp            | 225 +++++++++++++-----------
 src/jsc/bindings/BunPlugin.h              |   4 +
 src/jsc/bindings/JSMockFunction.cpp       |   4 +
 src/jsc/bindings/JSMockFunction.h         |   1 +
 test/js/bun/test/mock/mock-module.test.ts | 280 +++++++++++++++++++++++++++++-
 7 files changed, 440 insertions(+), 102 deletions(-)
```

</details>

**gate history** · 5 passed · 1 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
docs/test/mocks.mdx                            1      1      0
packages/bun-types/test.d.ts                   1      1      0
src/jsc/bindings/BunPlugin.cpp                13     26      0
src/jsc/bindings/BunPlugin.h                   1      1      0
src/jsc/bindings/JSMockFunction.cpp            5      1      0
src/jsc/bindings/JSMockFunction.h              1      1      0
test/js/bun/test/mock/mock-module.test.ts     12     23      0
```

</details>

<!-- robobun:evidence:end -->



