### PR TITLE
resolver: consult browser map for node_modules subpath imports before extension resolution

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -485,6 +485,7 @@ pub struct Resolver<'a> {
     /// Read the "browser" field in package.json files?
     /// For Bun's runtime, we don't.
     pub(crate) care_about_browser_field: bool,
+    pub(crate) browser_remap_depth: u8,
 
     pub debug_logs: Option<DebugLogs>,
     pub elapsed: u64, // tracing
@@ -623,6 +624,7 @@ impl<'a> Resolver<'a> {
             care_about_bin_folder: from.care_about_bin_folder,
             care_about_scripts: from.care_about_scripts,
             care_about_browser_field: from.care_about_browser_field,
+            browser_remap_depth: 0,
             // `DebugLogs` owns Vecs — per-worker fresh.
             debug_logs: None,
             elapsed: 0,
@@ -922,6 +924,7 @@ impl<'a> Resolver<'a> {
             log,
             extension_order: options::ExtOrder::DefaultDefault,
             care_about_browser_field,
+            browser_remap_depth: 0,
             care_about_bin_folder: false,
             care_about_scripts: false,
             debug_logs: None,
@@ -2815,7 +2818,7 @@ impl<'a> Resolver<'a> {
                             }
 
                             // Check the "browser" map
-                            if self.care_about_browser_field {
+                            if self.care_about_browser_field && self.browser_remap_depth < 32 {
                                 if let Some(browser_scope) =
                                     pkg_dir_info.get_enclosing_browser_scope()
                                 {
@@ -2852,7 +2855,8 @@ impl<'a> Resolver<'a> {
                                         }
 
                                         let remap_is_package_path = is_package_path(remap);
-                                        if self
+                                        self.browser_remap_depth += 1;
+                                        let remap_resolved = self
                                             .resolve_without_remapping(
                                                 browser_scope,
                                                 remap,
@@ -2860,8 +2864,9 @@ impl<'a> Resolver<'a> {
                                                 global_cache,
                                                 out,
                                             )
-                                            .is_success()
-                                        {
+                                            .is_success();
+                                        self.browser_remap_depth -= 1;
+                                        if remap_resolved {
                                             out.is_node_module = true;
                                             self.extension_order = prev_extension_order;
                                             if let Some(d) = self.debug_logs.as_mut() {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2814,9 +2814,7 @@ impl<'a> Resolver<'a> {
                                 }
                             }
 
-                            // Check the "browser" map before extension resolution so a key
-                            // like "./no-ext" can remap `import 'pkg/no-ext'` before it is
-                            // resolved to `no-ext.js`. Matches esbuild's tryToResolvePackage.
+                            // Check the "browser" map
                             if self.care_about_browser_field {
                                 if let Some(browser_scope) =
                                     pkg_dir_info.get_enclosing_browser_scope()
@@ -2872,10 +2870,8 @@ impl<'a> Resolver<'a> {
                                             return MatchStatus::Success;
                                         }
 
-                                        // A package-path remap recurses into load_node_modules,
-                                        // which overwrites bufs!(node_modules_check) (abs_path)
-                                        // and bufs!(esm_subpath) (esm_.subpath). Recompute both
-                                        // from stable inputs before falling through.
+                                        // A package-path remap recurses here and overwrites the
+                                        // bufs! storage backing abs_path and esm_.subpath.
                                         if remap_is_package_path {
                                             if !is_self_reference {
                                                 abs_path = match self.fs_ref().abs_buf_checked(

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2870,9 +2870,8 @@ impl<'a> Resolver<'a> {
                                             return MatchStatus::Success;
                                         }
 
-                                        // A package-path remap recurses here and overwrites the
-                                        // bufs! storage backing abs_path and esm_.subpath.
                                         if remap_is_package_path {
+                                            // recursion above clobbered these bufs! slots
                                             if !is_self_reference {
                                                 abs_path = match self.fs_ref().abs_buf_checked(
                                                     &[

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2605,7 +2605,7 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        let esm_ = crate::package_json::Package::parse(import_path, bufs!(esm_subpath));
+        let mut esm_ = crate::package_json::Package::parse(import_path, bufs!(esm_subpath));
 
         let source_dir_info = dir_info;
         let mut any_node_modules_folder = false;
@@ -2622,7 +2622,7 @@ impl<'a> Resolver<'a> {
                         break 'node_modules;
                     }
                     any_node_modules_folder = true;
-                    let abs_path: &[u8] = if is_self_reference {
+                    let mut abs_path: &[u8] = if is_self_reference {
                         dir_info.abs_path
                     } else {
                         match self.fs_ref().abs_buf_checked(
@@ -2643,7 +2643,7 @@ impl<'a> Resolver<'a> {
                     let prev_extension_order = self.extension_order;
                     // NOTE: defer restore reshaped — restored at end of block
 
-                    if let Some(ref esm) = esm_ {
+                    if let Some(esm) = esm_ {
                         let abs_package_path: &[u8] = if is_self_reference {
                             dir_info.abs_path
                         } else {
@@ -2811,6 +2811,95 @@ impl<'a> Resolver<'a> {
                                         d.decrease_indent();
                                     }
                                     return MatchStatus::NotFound;
+                                }
+                            }
+
+                            // Check the "browser" map before extension resolution so a key
+                            // like "./no-ext" can remap `import 'pkg/no-ext'` before it is
+                            // resolved to `no-ext.js`. Matches esbuild's tryToResolvePackage.
+                            if self.care_about_browser_field {
+                                if let Some(browser_scope) =
+                                    pkg_dir_info.get_enclosing_browser_scope()
+                                {
+                                    if let Some(remap) = self
+                                        .check_browser_map::<{ BrowserMapPathKind::AbsolutePath }>(
+                                            &browser_scope,
+                                            abs_path,
+                                        )
+                                    {
+                                        if remap.is_empty() {
+                                            let mut _path = Path::init(
+                                                self.fs_ref()
+                                                    .dirname_store
+                                                    .append_slice(abs_path)
+                                                    .expect("oom"),
+                                            );
+                                            _path.is_disabled = true;
+                                            *out = MatchResult {
+                                                path_pair: PathPair {
+                                                    primary: _path,
+                                                    secondary: None,
+                                                },
+                                                is_node_module: true,
+                                                package_json: browser_scope
+                                                    .package_json()
+                                                    .map(std::ptr::from_ref),
+                                                ..Default::default()
+                                            };
+                                            self.extension_order = prev_extension_order;
+                                            if let Some(d) = self.debug_logs.as_mut() {
+                                                d.decrease_indent();
+                                            }
+                                            return MatchStatus::Success;
+                                        }
+
+                                        let remap_is_package_path = is_package_path(remap);
+                                        if self
+                                            .resolve_without_remapping(
+                                                browser_scope,
+                                                remap,
+                                                kind,
+                                                global_cache,
+                                                out,
+                                            )
+                                            .is_success()
+                                        {
+                                            out.is_node_module = true;
+                                            self.extension_order = prev_extension_order;
+                                            if let Some(d) = self.debug_logs.as_mut() {
+                                                d.decrease_indent();
+                                            }
+                                            return MatchStatus::Success;
+                                        }
+
+                                        // A package-path remap recurses into load_node_modules,
+                                        // which overwrites bufs!(node_modules_check) (abs_path)
+                                        // and bufs!(esm_subpath) (esm_.subpath). Recompute both
+                                        // from stable inputs before falling through.
+                                        if remap_is_package_path {
+                                            if !is_self_reference {
+                                                abs_path = match self.fs_ref().abs_buf_checked(
+                                                    &[
+                                                        dir_info.abs_path,
+                                                        b"node_modules",
+                                                        import_path,
+                                                    ],
+                                                    bufs!(node_modules_check),
+                                                ) {
+                                                    Some(p) => p,
+                                                    None => {
+                                                        self.extension_order =
+                                                            prev_extension_order;
+                                                        break 'node_modules;
+                                                    }
+                                                };
+                                            }
+                                            esm_ = crate::package_json::Package::parse(
+                                                import_path,
+                                                bufs!(esm_subpath),
+                                            );
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2888,8 +2888,7 @@ impl<'a> Resolver<'a> {
                                                 ) {
                                                     Some(p) => p,
                                                     None => {
-                                                        self.extension_order =
-                                                            prev_extension_order;
+                                                        self.extension_order = prev_extension_order;
                                                         break 'node_modules;
                                                     }
                                                 };

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -678,6 +678,45 @@ describe("bundler", () => {
       `,
     },
   });
+  itBundled("packagejson/BrowserNodeModulesSubpathToPackageCycle", {
+    files: {
+      "/Users/user/project/src/entry.js": `import 'pkg-a/x'`,
+      "/Users/user/project/node_modules/pkg-a/package.json": /* json */ `
+        {
+          "name": "pkg-a",
+          "browser": {
+            "./x": "pkg-a/x"
+          }
+        }
+      `,
+    },
+    bundleErrors: {
+      "/Users/user/project/src/entry.js": [`Could not resolve: "pkg-a/x". Maybe you need to "bun install"?`],
+    },
+  });
+  itBundled("packagejson/ExportsShadowsBrowserSubpath", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import {value} from 'demo-pkg/sub'
+        console.log(value)
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "exports": {
+            "./sub": "./from-exports.js"
+          },
+          "browser": {
+            "./sub": "./from-browser.js"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/from-exports.js": `export let value = 'exports'`,
+      "/Users/user/project/node_modules/demo-pkg/from-browser.js": `export let value = 'browser'`,
+    },
+    run: {
+      stdout: "exports",
+    },
+  });
   itBundled("packagejson/BrowserNoExt", {
     files: {
       "/Users/user/project/src/entry.js": /* js */ `

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -564,7 +564,6 @@ describe("bundler", () => {
     },
   });
   itBundled("packagejson/BrowserNodeModulesNoExt", {
-    todo: true,
     files: {
       "/Users/user/project/src/entry.js": /* js */ `
         import {value as a} from 'demo-pkg/no-ext'
@@ -599,7 +598,6 @@ describe("bundler", () => {
     },
   });
   itBundled("packagejson/BrowserNodeModulesIndexNoExt", {
-    todo: true,
     files: {
       "/Users/user/project/src/entry.js": /* js */ `
         import {value as a} from 'demo-pkg/no-ext'
@@ -630,6 +628,53 @@ describe("bundler", () => {
         node
         browser
         browser
+      `,
+    },
+  });
+  itBundled("packagejson/BrowserNodeModulesSubpathDisabled", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        const ns = require('demo-pkg/disabled')
+        console.log(JSON.stringify([ns.value]))
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "browser": {
+            "./disabled": false
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/disabled.js": `module.exports = {value: 'node'}`,
+    },
+    run: {
+      stdout: "[null]",
+    },
+  });
+  itBundled("packagejson/BrowserNodeModulesSubpathToPackage", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import {value as a} from 'demo-pkg/to-pkg'
+        import {value as b} from 'demo-pkg/to-missing'
+        console.log(a)
+        console.log(b)
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "browser": {
+            "./to-pkg": "other-pkg",
+            "./to-missing": "missing-pkg"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/to-pkg.js": `export let value = 'node'`,
+      "/Users/user/project/node_modules/demo-pkg/to-missing.js": `export let value = 'node'`,
+      "/Users/user/project/node_modules/other-pkg/package.json": `{"main": "./index.js"}`,
+      "/Users/user/project/node_modules/other-pkg/index.js": `export let value = 'other-pkg'`,
+    },
+    run: {
+      stdout: `
+        other-pkg
+        node
       `,
     },
   });


### PR DESCRIPTION
## What

`import 'demo-pkg/no-ext'` where `demo-pkg/package.json` has `"browser": {"./no-ext": "./no-ext-browser.js"}` was resolving to `no-ext.js` (the Node file) instead of `no-ext-browser.js` under `--target=browser`.

```sh
mkdir -p node_modules/demo-pkg
cat > node_modules/demo-pkg/package.json <<'JSON'
{"browser": {"./no-ext": "./no-ext-browser.js"}}
JSON
echo 'export let value = "node"'    > node_modules/demo-pkg/no-ext.js
echo 'export let value = "browser"' > node_modules/demo-pkg/no-ext-browser.js
echo 'import {value} from "demo-pkg/no-ext"; console.log(value)' > entry.js
bun build entry.js --target=browser   # bundles "node", should bundle "browser"
```

## Why

`load_node_modules` went straight from the exports-map check to `load_as_file_or_directory(abs_path)`, so the browser map was only consulted by the post-resolution check in `check_package_path`, at which point the path already has `.js` appended and a `"./no-ext"` key can no longer match.

esbuild's `tryToResolvePackage` runs `checkBrowserMap(pkgDirInfo, absPath, absolutePathKind)` between those two steps ([resolver.go](https://github.com/evanw/esbuild/blob/main/internal/resolver/resolver.go)):

```go
if pkgDirInfo := r.dirInfoCached(absPkgPath); pkgDirInfo != nil {
    // Check the "exports" map
    if packageJSON := pkgDirInfo.packageJSON; packageJSON != nil && packageJSON.exportsMap != nil {
        ...
    }
    // Check the "browser" map
    if remapped, ok := r.checkBrowserMap(pkgDirInfo, absPath, absolutePathKind); ok {
        if remapped == nil {
            return PathPair{Primary: logger.Path{Text: absPath, ..., Flags: logger.PathDisabled}}, ...
        }
        if remappedResult, ok, ... := r.resolveWithoutRemapping(pkgDirInfo.enclosingBrowserScope, *remapped); ok {
            return remappedResult, ...
        }
    }
}
// Try node's old package resolution rules
if absolute, ok, ... := r.loadAsFileOrDirectory(absPath); ok { ... }
```

This change adds the equivalent check at the same position.

The remap target can itself be a bare package name (`"./sub": "other-pkg"`), which makes `resolve_without_remapping` recurse into `load_node_modules`. That recursion overwrites the thread-local `node_modules_check` and `esm_subpath` buffers that `abs_path` and `esm_.subpath` borrow from, so both are recomputed from stable inputs before falling through when the remap resolve fails. The recursion is also bounded via a `browser_remap_depth` counter so a cyclic remap like `{"./x": "pkg-a/x"}` falls through to the normal resolve error instead of overflowing the stack (esbuild is unbounded here and stack-overflows on the same input; released bun errors cleanly because it never takes this edge).

#36620 fixed the adjacent `load_from_main_field` / `load_as_index_with_browser_remapping` cases (wrong argument to an existing check); this is the follow-up it names for bare subpath imports, where the check was missing entirely.

## Verification

All outputs match esbuild (except the cycle case, which esbuild crashes on):

| import | browser key | esbuild | bun before | bun after |
| - | - | - | - | - |
| `demo-pkg/no-ext` | `"./no-ext": "./no-ext-browser.js"` | browser | **node** | browser |
| `demo-pkg/no-ext.js` | same | node | node | node |
| `demo-pkg/no-ext` (dir) | `"./no-ext": "./no-ext-browser/index.js"` | browser | **node** | browser |
| `demo-pkg/disabled` | `"./disabled": false` | disabled | **loaded** | disabled |
| `demo-pkg/to-pkg` | `"./to-pkg": "other-pkg"` | other-pkg | **node** | other-pkg |
| `demo-pkg/to-missing` | `"./to-missing": "missing-pkg"` | falls through | falls through | falls through |
| `pkg-a/x` | `"./x": "pkg-a/x"` (cycle) | stack overflow | resolve error | resolve error |
| `demo-pkg/sub` | `exports` + `browser` both set | exports wins | exports wins | exports wins |

Un-todos `packagejson/BrowserNodeModulesNoExt` and `packagejson/BrowserNodeModulesIndexNoExt`, and adds `SubpathDisabled`, `SubpathToPackage`, `SubpathToPackageCycle`, and `ExportsShadowsBrowserSubpath`. The first four fail on the released build and pass with this change; the last two are regression guards that pass on both. The rest of `packagejson.test.ts` is unchanged (84 pass, 7 todo).