### PR TITLE
cli: classify the subcommand past --cwd/--env-file values

### DIFF
--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -93,6 +93,7 @@ const SHARED_PARAMS: &[ParamType] = &[
     ),
     clap::param!("-g, --global                          Install globally"),
     clap::param!("--cwd <STR>                           Set a specific cwd"),
+    clap::param!("--env-file <STR>..."),
     BACKEND_PARAM,
     clap::param!(
         "--registry <STR>                      Use a specific registry by default, overriding .npmrc, bunfig.toml and environment variables"

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -116,9 +116,9 @@ impl Options {
                 } else if positional == b"--no-install" {
                     opts.no_install = true;
                 } else if positional == b"--cwd" || positional == b"--env-file" {
-                    // Value was already applied by `apply_leading_cwd()` / is
-                    // not used by bunx; step past it so it's not mistaken for
-                    // the package name.
+                    // Step past the value so it isn't mistaken for the package
+                    // name. `--cwd` before `x` was applied by the caller's
+                    // `apply_leading_cwd()`; after `x` it is not honored yet.
                     i += 1;
                 } else if positional == b"--package" || positional == b"-p" {
                     // Next argument should be the package name

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -115,6 +115,11 @@ impl Options {
                     ctx.debug.run_in_bun = true;
                 } else if positional == b"--no-install" {
                     opts.no_install = true;
+                } else if positional == b"--cwd" || positional == b"--env-file" {
+                    // Value was already applied by `apply_leading_cwd()` / is
+                    // not used by bunx; step past it so it's not mistaken for
+                    // the package name.
+                    i += 1;
                 } else if positional == b"--package" || positional == b"-p" {
                     // Next argument should be the package name
                     i += 1;

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -232,10 +232,6 @@ impl CreateOptions {
             ..Default::default()
         };
 
-        // Drop everything up to and including the `c`/`create` keyword so the
-        // template name is `positionals[0]`. A leading global flag's value
-        // (`bun --cwd dir create foo`) falls through as a positional because
-        // `params()` doesn't declare it; scanning by name keeps that harmless.
         if let Some(i) = opts
             .positionals
             .iter()

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -232,11 +232,17 @@ impl CreateOptions {
             ..Default::default()
         };
 
-        if opts.positionals.len() >= 1
-            && (opts.positionals[0] == b"c" || opts.positionals[0] == b"create")
+        // Drop everything up to and including the `c`/`create` keyword so the
+        // template name is `positionals[0]`. A leading global flag's value
+        // (`bun --cwd dir create foo`) falls through as a positional because
+        // `params()` doesn't declare it; scanning by name keeps that harmless.
+        if let Some(i) = opts
+            .positionals
+            .iter()
+            .position(|&p| p == b"c" || p == b"create")
         {
             let mut v = core::mem::take(&mut opts.positionals).into_vec();
-            v.remove(0);
+            v.drain(..=i);
             opts.positionals = v.into_boxed_slice();
         }
 

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -784,24 +784,35 @@ pub mod command {
         super::SUBCOMMAND_ARGV_INDEX.load(core::sync::atomic::Ordering::Relaxed)
     }
 
-    /// Apply a `--cwd <dir>` that preceded the subcommand keyword, for handlers
-    /// that don't route through `arguments::parse` / `CommandLineArguments::parse`.
+    /// Apply a `--cwd <dir>` / `--cwd=<dir>` that preceded the subcommand
+    /// keyword, for handlers that don't route through `arguments::parse` /
+    /// `CommandLineArguments::parse`.
     #[cold]
     pub(crate) fn apply_leading_cwd() {
+        fn chdir(dir: &[u8]) {
+            let dir_z = bun_core::ZBox::from_bytes(dir);
+            if let bun_sys::Result::Err(err) = bun_sys::chdir(&dir_z) {
+                Output::err(
+                    err,
+                    "Could not change directory to \"{}\"\n",
+                    format_args!("{}", bstr::BStr::new(dir)),
+                );
+                Global::exit(1);
+            }
+        }
         let argv = bun::argv();
         let end = subcommand_argv_index().min(argv.len());
         let mut i = 1;
-        while i + 1 < end {
-            if argv.get(i).is_some_and(|a| a.as_bytes() == b"--cwd") {
-                let dir = argv.get(i + 1).unwrap();
-                if let bun_sys::Result::Err(err) = bun_sys::chdir(dir) {
-                    Output::err(
-                        err,
-                        "Could not change directory to \"{}\"\n",
-                        format_args!("{}", bstr::BStr::new(dir)),
-                    );
-                    Global::exit(1);
+        while i < end {
+            let a = argv.get(i).map(|z| z.as_bytes()).unwrap_or(b"");
+            if a == b"--cwd" {
+                if let Some(dir) = argv.get(i + 1).filter(|_| i + 1 < end) {
+                    chdir(dir.as_bytes());
                 }
+                return;
+            }
+            if let Some(dir) = a.strip_prefix(b"--cwd=") {
+                chdir(dir);
                 return;
             }
             i += 1;
@@ -1562,10 +1573,10 @@ pub mod command {
         let start_idx = if IS_BUNX_EXE.load(core::sync::atomic::Ordering::Relaxed) {
             0
         } else {
-            subcommand_argv_index()
+            1
         };
         let argv = argv_zslice();
-        super::bunx_command::BunxCommand::exec(ctx, &argv[start_idx.min(argv.len())..])
+        super::bunx_command::BunxCommand::exec(ctx, &argv[start_idx..])
     }
 
     #[cold]
@@ -1825,14 +1836,14 @@ pub mod command {
         let mut print_help = false;
 
         {
-            let remainder = &args[cmd_idx..];
+            let remainder = &args[1..];
             let mut remainder_i: usize = 0;
             while remainder_i < remainder.len() && positional_i < positionals.len() {
                 let slice = strings::trim(remainder[remainder_i].as_bytes(), b" \t\n");
                 if !slice.is_empty() {
                     if !strings::has_prefix(slice, b"--") {
                         if positional_i == 1 {
-                            template_name_start = cmd_idx + remainder_i + 1;
+                            template_name_start = remainder_i + 2;
                         }
                         positionals[positional_i] = slice;
                         positional_i += 1;
@@ -1842,6 +1853,8 @@ pub mod command {
                             dash_dash_bun = true;
                         } else if slice == b"--help" || slice == b"-h" {
                             print_help = true;
+                        } else if slice == b"--cwd" || slice == b"--env-file" {
+                            remainder_i += 1;
                         }
                     }
                 }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -786,10 +786,26 @@ pub mod command {
 
     /// Apply a `--cwd <dir>` / `--cwd=<dir>` that preceded the subcommand
     /// keyword, for handlers that don't route through `arguments::parse` /
-    /// `CommandLineArguments::parse`.
+    /// `CommandLineArguments::parse`. Last occurrence wins (clap semantics).
     #[cold]
     pub(crate) fn apply_leading_cwd() {
-        fn chdir(dir: &[u8]) {
+        let argv = bun::argv();
+        let end = subcommand_argv_index().min(argv.len());
+        let mut last: Option<&[u8]> = None;
+        let mut i = 1;
+        while i < end {
+            let a = argv.get(i).map(|z| z.as_bytes()).unwrap_or(b"");
+            if a == b"--cwd" {
+                if let Some(dir) = argv.get(i + 1).filter(|_| i + 1 < end) {
+                    last = Some(dir.as_bytes());
+                    i += 1;
+                }
+            } else if let Some(dir) = a.strip_prefix(b"--cwd=") {
+                last = Some(dir);
+            }
+            i += 1;
+        }
+        if let Some(dir) = last {
             let dir_z = bun_core::ZBox::from_bytes(dir);
             if let bun_sys::Result::Err(err) = bun_sys::chdir(&dir_z) {
                 Output::err(
@@ -799,23 +815,6 @@ pub mod command {
                 );
                 Global::exit(1);
             }
-        }
-        let argv = bun::argv();
-        let end = subcommand_argv_index().min(argv.len());
-        let mut i = 1;
-        while i < end {
-            let a = argv.get(i).map(|z| z.as_bytes()).unwrap_or(b"");
-            if a == b"--cwd" {
-                if let Some(dir) = argv.get(i + 1).filter(|_| i + 1 < end) {
-                    chdir(dir.as_bytes());
-                }
-                return;
-            }
-            if let Some(dir) = a.strip_prefix(b"--cwd=") {
-                chdir(dir);
-                return;
-            }
-            i += 1;
         }
     }
 

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -492,14 +492,8 @@ pub use bun_install::PRETEND_TO_BE_NODE;
 /// This is set `true` during `Command.which()` if argv0 is "bunx"
 static IS_BUNX_EXE: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 
-/// argv index of the subcommand keyword (`run`, `test`, `install`, …) as
-/// located by `Command::which()`. Defaults to 1 (argv[1]). Larger when a
-/// value-taking global flag precedes the subcommand, e.g.
-/// `bun --cwd ./dir test …` → 3.
-///
-/// Handlers that re-scan raw `bun::argv()` for their own positionals read
-/// this instead of hard-coding `2` / `argv[2..]`, so the same code path
-/// handles both `bun test …` and `bun --cwd d test …`.
+/// argv index of the subcommand keyword as located by `Command::which()`.
+/// `bun test …` → 1; `bun --cwd ./dir test …` → 3.
 static SUBCOMMAND_ARGV_INDEX: core::sync::atomic::AtomicUsize =
     core::sync::atomic::AtomicUsize::new(1);
 
@@ -784,11 +778,34 @@ pub mod command {
         (0..a.len()).map(|i| a.get(i).unwrap()).collect()
     }
 
-    /// argv index of the subcommand keyword as found by [`which()`].
-    /// `bun test …` → 1; `bun --cwd ./dir test …` → 3.
+    /// See [`SUBCOMMAND_ARGV_INDEX`](super::SUBCOMMAND_ARGV_INDEX).
     #[inline]
     pub(crate) fn subcommand_argv_index() -> usize {
         super::SUBCOMMAND_ARGV_INDEX.load(core::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Apply a `--cwd <dir>` that preceded the subcommand keyword, for handlers
+    /// that don't route through `arguments::parse` / `CommandLineArguments::parse`.
+    #[cold]
+    pub(crate) fn apply_leading_cwd() {
+        let argv = bun::argv();
+        let end = subcommand_argv_index().min(argv.len());
+        let mut i = 1;
+        while i + 1 < end {
+            if argv.get(i).is_some_and(|a| a.as_bytes() == b"--cwd") {
+                let dir = argv.get(i + 1).unwrap();
+                if let bun_sys::Result::Err(err) = bun_sys::chdir(dir) {
+                    Output::err(
+                        err,
+                        "Could not change directory to \"{}\"\n",
+                        format_args!("{}", bstr::BStr::new(dir)),
+                    );
+                    Global::exit(1);
+                }
+                return;
+            }
+            i += 1;
+        }
     }
 
     pub use bun_options_types::command_tag::Tag;
@@ -944,11 +961,9 @@ pub mod command {
             && first_arg_name[0] == b'-'
             && !(first_arg_name.len() > 1 && first_arg_name[1] == b'e')
         {
-            // Step past the value of the required-value global flags in
-            // `BASE_PARAMS_` so it isn't misread as the subcommand keyword
-            // (`bun --cwd ./dir test …`, `bun --env-file .env run …`).
-            // `-c, --config` is `Values::OneOptional` and intentionally not
-            // listed: clap never consumes a separate token for it.
+            // Step past the value of the required-value `BASE_PARAMS_` flags.
+            // `-c, --config` is `Values::OneOptional`: clap never consumes a
+            // separate token for it, so it's intentionally not listed.
             if matches!(first_arg_name, b"--cwd" | b"--env-file") {
                 if iter.next().is_none() {
                     return Tag::AutoCommand;
@@ -1509,6 +1524,7 @@ pub mod command {
     #[inline(never)]
     fn exec_init() -> CmdResult {
         // InitCommand parses its own argv (no Context).
+        apply_leading_cwd();
         let argv = argv_zslice();
         let start = (subcommand_argv_index() + 1).min(argv.len());
         super::init_command::InitCommand::exec(&argv[start..])
@@ -1541,6 +1557,7 @@ pub mod command {
     #[cold]
     #[inline(never)]
     fn exec_bunx(log: &mut bun_ast::Log) -> CmdResult {
+        apply_leading_cwd();
         let ctx = init(Tag::BunxCommand, log)?;
         let start_idx = if IS_BUNX_EXE.load(core::sync::atomic::Ordering::Relaxed) {
             0
@@ -1791,6 +1808,7 @@ pub mod command {
         }
 
         // Create command wraps bunx
+        apply_leading_cwd();
         let ctx = init(Tag::CreateCommand, log)?;
         let args = argv_zslice();
         let cmd_idx = subcommand_argv_index();
@@ -1942,29 +1960,15 @@ To create a project with the official Next.js scaffolding tool, run\n\
         // Parse arguments manually since the standard flow doesn't work for standalone commands
         let cli = CommandLineArguments::parse(PmSubcommand::Info)?;
         let json_output = cli.json_output;
+        // `positionals[0]` is the `info` keyword itself.
+        let positionals = match cli.positionals {
+            [b"info", rest @ ..] => rest,
+            rest => rest,
+        };
+        let package_name: &[u8] = positionals.first().copied().unwrap_or(b"");
+        let property_path: Option<&[u8]> = positionals.get(1).copied();
         let ctx = init(Tag::InfoCommand, log)?;
         let (pm, _) = PackageManager::init(ctx, cli, Subcommand::Info)?;
-
-        // Handle arguments correctly for standalone info command
-        let mut package_name: &[u8] = b"";
-        let mut property_path: Option<&[u8]> = None;
-
-        // Find non-flag arguments after the `info` keyword.
-        let mut found_package = false;
-        let argv = bun::argv();
-        for arg in argv.iter().skip(subcommand_argv_index() + 1) {
-            // Skip flags
-            if !arg.is_empty() && arg[0] == b'-' {
-                continue;
-            }
-            if !found_package {
-                package_name = arg;
-                found_package = true;
-            } else {
-                property_path = Some(arg);
-                break;
-            }
-        }
 
         super::pm_view_command::view(pm, package_name, property_path, json_output)
     }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -492,6 +492,17 @@ pub use bun_install::PRETEND_TO_BE_NODE;
 /// This is set `true` during `Command.which()` if argv0 is "bunx"
 static IS_BUNX_EXE: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 
+/// argv index of the subcommand keyword (`run`, `test`, `install`, …) as
+/// located by `Command::which()`. Defaults to 1 (argv[1]). Larger when a
+/// value-taking global flag precedes the subcommand, e.g.
+/// `bun --cwd ./dir test …` → 3.
+///
+/// Handlers that re-scan raw `bun::argv()` for their own positionals read
+/// this instead of hard-coding `2` / `argv[2..]`, so the same code path
+/// handles both `bun test …` and `bun --cwd d test …`.
+static SUBCOMMAND_ARGV_INDEX: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(1);
+
 bun_core::declare_scope!(CLI, hidden);
 
 pub(crate) type LoaderColonList =
@@ -746,20 +757,8 @@ pub mod reserved_command {
 
     #[cold]
     pub(crate) fn exec() -> crate::Result<()> {
-        let mut command_name: &[u8] = b"";
-        for (i, arg) in bun::argv().iter().enumerate() {
-            if i == 0 {
-                continue;
-            }
-            if arg.len() > 1 && arg[0] == b'-' {
-                continue;
-            }
-            command_name = arg;
-            break;
-        }
-        if command_name.is_empty() {
-            command_name = bun::argv().get(1).map(|z| z.as_bytes()).unwrap_or(b"");
-        }
+        let idx = super::command::subcommand_argv_index();
+        let command_name: &[u8] = bun::argv().get(idx).map(|z| z.as_bytes()).unwrap_or(b"");
         pretty_error!(
             "<r><red>Uh-oh<r>. <b><yellow>bun {0}<r> is a subcommand reserved for future use by Bun.\n\nIf you were trying to run a package.json script called {0}, use <b><magenta>bun run {0}<r>.\n",
             bstr::BStr::new(command_name)
@@ -783,6 +782,13 @@ pub mod command {
     fn argv_zslice() -> Vec<&'static bun_core::ZStr> {
         let a = bun::argv();
         (0..a.len()).map(|i| a.get(i).unwrap()).collect()
+    }
+
+    /// argv index of the subcommand keyword as found by [`which()`].
+    /// `bun test …` → 1; `bun --cwd ./dir test …` → 3.
+    #[inline]
+    pub(crate) fn subcommand_argv_index() -> usize {
+        super::SUBCOMMAND_ARGV_INDEX.load(core::sync::atomic::Ordering::Relaxed)
     }
 
     pub use bun_options_types::command_tag::Tag;
@@ -930,6 +936,7 @@ pub mod command {
             return Tag::RunAsNodeCommand;
         }
 
+        let mut idx: usize = 1;
         let Some(mut first_arg_name) = iter.next() else {
             return Tag::AutoCommand;
         };
@@ -937,11 +944,26 @@ pub mod command {
             && first_arg_name[0] == b'-'
             && !(first_arg_name.len() > 1 && first_arg_name[1] == b'e')
         {
+            // Step past the value of the required-value global flags in
+            // `BASE_PARAMS_` so it isn't misread as the subcommand keyword
+            // (`bun --cwd ./dir test …`, `bun --env-file .env run …`).
+            // `-c, --config` is `Values::OneOptional` and intentionally not
+            // listed: clap never consumes a separate token for it.
+            if matches!(first_arg_name, b"--cwd" | b"--env-file") {
+                if iter.next().is_none() {
+                    return Tag::AutoCommand;
+                }
+                idx += 1;
+            }
             match iter.next() {
-                Some(n) => first_arg_name = n,
+                Some(n) => {
+                    idx += 1;
+                    first_arg_name = n;
+                }
                 None => return Tag::AutoCommand,
             }
         }
+        SUBCOMMAND_ARGV_INDEX.store(idx, core::sync::atomic::Ordering::Relaxed);
 
         type RootCommandMatcher = strings::ExactSizeMatcher<12>;
         let x = RootCommandMatcher::r#match(first_arg_name);
@@ -1488,7 +1510,8 @@ pub mod command {
     fn exec_init() -> CmdResult {
         // InitCommand parses its own argv (no Context).
         let argv = argv_zslice();
-        super::init_command::InitCommand::exec(&argv[2.min(argv.len())..])
+        let start = (subcommand_argv_index() + 1).min(argv.len());
+        super::init_command::InitCommand::exec(&argv[start..])
     }
 
     #[cold]
@@ -1498,7 +1521,7 @@ pub mod command {
         // exec handles both the non-tty path (dump the embedded completion
         // script to stdout) and the tty install path (bunx symlink, fpath/XDG
         // dir search, profile patching).
-        for a in bun::argv().iter().skip(2) {
+        for a in bun::argv().iter().skip(subcommand_argv_index() + 1) {
             if matches!(a, b"--help" | b"-h") {
                 tag_print_help(Tag::InstallCompletionsCommand, true);
                 Global::exit(0);
@@ -1522,10 +1545,10 @@ pub mod command {
         let start_idx = if IS_BUNX_EXE.load(core::sync::atomic::Ordering::Relaxed) {
             0
         } else {
-            1
+            subcommand_argv_index()
         };
         let argv = argv_zslice();
-        super::bunx_command::BunxCommand::exec(ctx, &argv[start_idx..])
+        super::bunx_command::BunxCommand::exec(ctx, &argv[start_idx.min(argv.len())..])
     }
 
     #[cold]
@@ -1770,8 +1793,9 @@ pub mod command {
         // Create command wraps bunx
         let ctx = init(Tag::CreateCommand, log)?;
         let args = argv_zslice();
+        let cmd_idx = subcommand_argv_index();
 
-        if args.len() <= 2 {
+        if args.len() <= cmd_idx + 1 {
             tag_print_help(Tag::CreateCommand, false);
             Global::exit(1);
         }
@@ -1782,15 +1806,15 @@ pub mod command {
         let mut dash_dash_bun = false;
         let mut print_help = false;
 
-        if args.len() > 2 {
-            let remainder = &args[1..];
+        {
+            let remainder = &args[cmd_idx..];
             let mut remainder_i: usize = 0;
             while remainder_i < remainder.len() && positional_i < positionals.len() {
                 let slice = strings::trim(remainder[remainder_i].as_bytes(), b" \t\n");
                 if !slice.is_empty() {
                     if !strings::has_prefix(slice, b"--") {
                         if positional_i == 1 {
-                            template_name_start = remainder_i + 2;
+                            template_name_start = cmd_idx + remainder_i + 1;
                         }
                         positionals[positional_i] = slice;
                         positional_i += 1;
@@ -1925,10 +1949,10 @@ To create a project with the official Next.js scaffolding tool, run\n\
         let mut package_name: &[u8] = b"";
         let mut property_path: Option<&[u8]> = None;
 
-        // Find non-flag arguments starting from argv[2] (after "bun info").
+        // Find non-flag arguments after the `info` keyword.
         let mut found_package = false;
         let argv = bun::argv();
-        for arg in argv.iter().skip(2) {
+        for arg in argv.iter().skip(subcommand_argv_index() + 1) {
             // Skip flags
             if !arg.is_empty() && arg[0] == b'-' {
                 continue;

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -192,10 +192,12 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
     pub(crate) fn exec(ctx: Command::Context) -> crate::Result<()> {
         // `bun_core::argv()` includes argv[0]; skip to the subcommand keyword and
         // collect into a borrowed-slice Vec so `&[&[u8]]` callers
-        // (TrustCommand/UntrustedCommand, `left_has_any_in_right`) keep their shape.
+        // (TrustCommand/UntrustedCommand) index `args[2..]` relative to the
+        // keyword. Flag probes (`--all`, `--trusted`) scan `all_args` instead
+        // so a flag placed before the keyword is still seen.
         let cmd_idx = Command::subcommand_argv_index();
-        let args_vec: Vec<&'static [u8]> = bun_core::argv().into_iter().skip(cmd_idx).collect();
-        let args: &[&[u8]] = &args_vec;
+        let all_args: Vec<&'static [u8]> = bun_core::argv().into_iter().skip(1).collect();
+        let args: &[&[u8]] = &all_args[(cmd_idx - 1).min(all_args.len())..];
 
         // Check if we're being invoked directly as "bun whoami" instead of "bun pm whoami"
         let is_direct_whoami = bun_core::argv()
@@ -535,9 +537,9 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 more_packages[0] = true;
             }
 
-            let trusted_only = strings::left_has_any_in_right(args, &[b"--trusted"]);
+            let trusted_only = strings::left_has_any_in_right(&all_args, &[b"--trusted"]);
 
-            if strings::left_has_any_in_right(args, &[b"-A", b"-a", b"--all"]) {
+            if strings::left_has_any_in_right(&all_args, &[b"-A", b"-a", b"--all"]) {
                 if trusted_only {
                     // Trust is by package name, not tree position, so a trusted
                     // package nested under an untrusted parent must still be

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -190,15 +190,16 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
     }
 
     pub(crate) fn exec(ctx: Command::Context) -> crate::Result<()> {
-        // `bun_core::argv()` includes argv[0]; skip it and collect into a
-        // borrowed-slice Vec so `&[&[u8]]` callers (TrustCommand/UntrustedCommand,
-        // `left_has_any_in_right`) keep their shape.
-        let args_vec: Vec<&'static [u8]> = bun_core::argv().into_iter().skip(1).collect();
+        // `bun_core::argv()` includes argv[0]; skip to the subcommand keyword and
+        // collect into a borrowed-slice Vec so `&[&[u8]]` callers
+        // (TrustCommand/UntrustedCommand, `left_has_any_in_right`) keep their shape.
+        let cmd_idx = Command::subcommand_argv_index();
+        let args_vec: Vec<&'static [u8]> = bun_core::argv().into_iter().skip(cmd_idx).collect();
         let args: &[&[u8]] = &args_vec;
 
         // Check if we're being invoked directly as "bun whoami" instead of "bun pm whoami"
         let is_direct_whoami = bun_core::argv()
-            .get(1)
+            .get(cmd_idx)
             .is_some_and(|arg| strings::eql_comptime(arg.as_bytes(), b"whoami"));
 
         let cli = CommandLineArguments::parse(Subcommand::Pm)?;

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -279,8 +279,9 @@ impl TrustCommand {
                 packages_to_trust.push(arg);
             }
         }
-        let trust_all =
-            strings::left_has_any_in_right(args, &[b"-a".as_slice(), b"--all".as_slice()]);
+        let trust_all = bun_core::argv()
+            .iter()
+            .any(|a| matches!(a, b"-a" | b"--all"));
 
         if !trust_all && packages_to_trust.is_empty() {
             Self::error_expected_args();

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -249,10 +249,6 @@ impl TrustCommand {
         );
         Output::flush();
 
-        if args.len() == 2 {
-            Self::error_expected_args();
-        }
-
         // Reshaped for borrowck — see `UntrustedCommand::exec`.
         // `load_lockfile` lives until `save_to_disk` near the end, so every
         // `pm`/`pm.lockfile` access in between goes through `pm_raw`.

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -509,13 +509,14 @@ impl UpgradeCommand {
     #[cold]
     pub(crate) fn exec(ctx: Command::Context) -> crate::Result<()> {
         let args = bun_core::argv();
-        if args.len() > 2 {
-            for arg in args.iter().skip(2) {
+        let start = Command::subcommand_argv_index() + 1;
+        if args.len() > start {
+            for arg in args.iter().skip(start) {
                 if !strings::contains(arg, b"--") {
                     bun_core::pretty_error!(
                         "<r><red>error<r><d>:<r> This command updates Bun itself, and does not take package names.\n<blue>note<r><d>:<r> Use `bun update"
                     );
-                    for arg_err in args.iter().skip(2) {
+                    for arg_err in args.iter().skip(start) {
                         bun_core::pretty_error!(" {}", bstr::BStr::new(arg_err));
                     }
                     bun_core::pretty_errorln!("` instead.");

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -144,3 +144,128 @@ describe("bun", () => {
     });
   });
 });
+
+// `Command::which()` scans argv for the first non-dash token to pick the
+// subcommand. It must step past the value of `--cwd` / `--env-file` so that
+// value isn't misread as the subcommand name.
+describe.concurrent("global flag before subcommand", () => {
+  async function run(cwd: string, argv: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...argv],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const files = {
+    "package.json": JSON.stringify({ name: "p", scripts: { greet: "echo hello-from-script" } }),
+    "app.ts": `console.log("ran:" + (process.env.FROM_ENV_FILE ?? "unset"));`,
+    "pass.test.ts": `import {test,expect} from "bun:test"; test("t", () => expect(1).toBe(1));`,
+    "my.env": "FROM_ENV_FILE=loaded\n",
+    "sub/package.json": JSON.stringify({
+      name: "sub",
+      scripts: { greet: "echo hello-from-sub" },
+      dependencies: {},
+    }),
+  };
+
+  for (const pre of [["--cwd", "."], ["--env-file", "my.env"], ["--cwd", ".", "--env-file", "my.env"]] as const) {
+    test(`bun ${pre.join(" ")} run <script> dispatches RunCommand`, async () => {
+      using dir = tempDir("which-run", files);
+      const { stdout, stderr, exitCode } = await run(String(dir), [...pre, "run", "greet"]);
+      expect(stderr).not.toContain("Script not found");
+      // Misroute to AutoCommand prints the `bun run` help with exit 0.
+      expect(stdout).not.toContain("Usage:");
+      expect(stdout).toContain("hello-from-script");
+      expect(exitCode).toBe(0);
+    });
+
+    test(`bun ${pre.join(" ")} test <file> dispatches TestCommand`, async () => {
+      using dir = tempDir("which-test", files);
+      const { stderr, exitCode } = await run(String(dir), [...pre, "test", "pass.test.ts"]);
+      expect(stderr).not.toContain("Script not found");
+      expect(stderr).toContain("1 pass");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test("bun --env-file my.env run app.ts loads the env file", async () => {
+    using dir = tempDir("which-env", files);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--env-file", "my.env", "run", "app.ts"]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ran:loaded\n", stderr: "", exitCode: 0 });
+  });
+
+  test("bun --cwd sub run <script> resolves scripts from the --cwd dir", async () => {
+    using dir = tempDir("which-cwd", files);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--cwd", "sub", "run", "greet"]);
+    expect(stderr).not.toContain("Script not found");
+    expect(stdout).not.toContain("Usage:");
+    expect(stdout).toContain("hello-from-sub");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun --cwd sub install dispatches InstallCommand (not add 'sub')", async () => {
+    using dir = tempDir("which-install", files);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--cwd", "sub", "install", "--dry-run"]);
+    expect(stderr).not.toContain("Script not found");
+    // A misroute to `bun add` would print "installed <pkg>" / hit the registry;
+    // a misroute to AutoCommand would print "Script not found".
+    expect(stdout + stderr).not.toMatch(/\badd\b.*\binstall\b/);
+    expect(stdout + stderr).not.toContain('"sub"');
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun --env-file my.env install does not treat the path as a package", async () => {
+    using dir = tempDir("which-install-env", files);
+    const { stdout, stderr, exitCode } = await run(String(dir), [
+      "--env-file",
+      "my.env",
+      "install",
+      "--dry-run",
+      "--cwd",
+      "sub",
+    ]);
+    // Regression guard for the #34983 revert: `.env` must not leak as a
+    // positional and `install` must not be treated as a package name.
+    expect(stdout + stderr).not.toContain("my.env");
+    expect(stderr).not.toContain("Script not found");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun --cwd . init -y -m dispatches InitCommand", async () => {
+    using dir = tempDir("which-init", { "keep/.gitkeep": "" });
+    const { stderr, exitCode } = await run(String(dir), ["--cwd", ".", "init", "-y", "-m"]);
+    expect(stderr).not.toContain("Script not found");
+    expect(fs.existsSync(`${dir}/package.json`)).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun --cwd . exec <cmd> dispatches ExecCommand", async () => {
+    using dir = tempDir("which-exec", files);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--cwd", ".", "exec", "echo from-exec"]);
+    expect(stderr).not.toContain("Script not found");
+    expect(stdout).toContain("from-exec");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun --cwd . build app.ts dispatches BuildCommand", async () => {
+    using dir = tempDir("which-build", files);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--cwd", ".", "build", "./app.ts"]);
+    expect(stderr).not.toContain("Script not found");
+    expect(stdout).toContain("FROM_ENV_FILE");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun --cwd sub add --dry-run does not misread 'sub' as a package", async () => {
+    using dir = tempDir("which-add", files);
+    const { stdout, stderr } = await run(String(dir), ["--cwd", "sub", "add", "--dry-run"]);
+    // `bun add` with no package prints usage; the point is `sub` / `add` never
+    // reach the resolver.
+    expect(stdout + stderr).not.toMatch(/GET .*\/(sub|add)\b/);
+    expect(stderr).not.toContain("Script not found");
+  });
+});

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import fs from "node:fs";
 import { tmpdir } from "node:os";
 
@@ -251,7 +251,8 @@ describe.concurrent("global flag before subcommand", () => {
     });
   }
 
-  test("bun --bun x <bin> still passes --bun through", async () => {
+  // Shebang + chmod bin stub is Unix-only; see test/regression/issue/26207.test.ts.
+  test.skipIf(isWindows)("bun --bun x <bin> still passes --bun through", async () => {
     // `--bun` is handled by bunx's own parser; stepping past leading flags
     // to find the `x` keyword must not strip it.
     using dir = tempDir("which-bunx-bun", {

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -173,7 +173,11 @@ describe.concurrent("global flag before subcommand", () => {
     }),
   };
 
-  for (const pre of [["--cwd", "."], ["--env-file", "my.env"], ["--cwd", ".", "--env-file", "my.env"]] as const) {
+  for (const pre of [
+    ["--cwd", "."],
+    ["--env-file", "my.env"],
+    ["--cwd", ".", "--env-file", "my.env"],
+  ] as const) {
     test(`bun ${pre.join(" ")} run <script> dispatches RunCommand`, async () => {
       using dir = tempDir("which-run", files);
       const { stdout, stderr, exitCode } = await run(String(dir), [...pre, "run", "greet"]);

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -240,11 +240,12 @@ describe.concurrent("global flag before subcommand", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("bun --cwd . init -y -m dispatches InitCommand", async () => {
-    using dir = tempDir("which-init", { "keep/.gitkeep": "" });
-    const { stderr, exitCode } = await run(String(dir), ["--cwd", ".", "init", "-y", "-m"]);
+  test("bun --cwd target init -y -m dispatches InitCommand in target", async () => {
+    using dir = tempDir("which-init", { "target/.gitkeep": "" });
+    const { stderr, exitCode } = await run(String(dir), ["--cwd", "target", "init", "-y", "-m"]);
     expect(stderr).not.toContain("Script not found");
-    expect(fs.existsSync(`${dir}/package.json`)).toBe(true);
+    expect(fs.existsSync(`${dir}/target/package.json`)).toBe(true);
+    expect(fs.existsSync(`${dir}/package.json`)).toBe(false);
     expect(exitCode).toBe(0);
   });
 
@@ -267,9 +268,11 @@ describe.concurrent("global flag before subcommand", () => {
   test("bun --cwd sub add --dry-run does not misread 'sub' as a package", async () => {
     using dir = tempDir("which-add", files);
     const { stdout, stderr } = await run(String(dir), ["--cwd", "sub", "add", "--dry-run"]);
-    // `bun add` with no package prints usage; the point is `sub` / `add` never
-    // reach the resolver.
     expect(stdout + stderr).not.toMatch(/GET .*\/(sub|add)\b/);
     expect(stderr).not.toContain("Script not found");
+    // Dispatching AddCommand with zero positionals prints this diagnostic;
+    // any other route (AutoCommand, or 'sub'/'add' leaking as a package name)
+    // would not.
+    expect(stderr).toContain("no package specified to add");
   });
 });

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -240,12 +240,30 @@ describe.concurrent("global flag before subcommand", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("bun --cwd target init -y -m dispatches InitCommand in target", async () => {
-    using dir = tempDir("which-init", { "target/.gitkeep": "" });
-    const { stderr, exitCode } = await run(String(dir), ["--cwd", "target", "init", "-y", "-m"]);
+  for (const cwd of [["--cwd", "target"], ["--cwd=target"]] as const) {
+    test(`bun ${cwd.join(" ")} init -y -m dispatches InitCommand in target`, async () => {
+      using dir = tempDir("which-init", { "target/.gitkeep": "" });
+      const { stderr, exitCode } = await run(String(dir), [...cwd, "init", "-y", "-m"]);
+      expect(stderr).not.toContain("Script not found");
+      expect(fs.existsSync(`${dir}/target/package.json`)).toBe(true);
+      expect(fs.existsSync(`${dir}/package.json`)).toBe(false);
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test("bun --bun x <bin> still passes --bun through", async () => {
+    // `--bun` is handled by bunx's own parser; stepping past leading flags
+    // to find the `x` keyword must not strip it.
+    using dir = tempDir("which-bunx-bun", {
+      "node_modules/.bin/probe": `#!/usr/bin/env node\nconsole.log(process.isBun ? "under-bun" : "under-node");`,
+      "package.json": JSON.stringify({ name: "p" }),
+    });
+    fs.chmodSync(`${dir}/node_modules/.bin/probe`, 0o755);
+    const baseline = await run(String(dir), ["x", "--bun", "probe"]);
+    expect(baseline.stdout.trim()).toBe("under-bun");
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--bun", "x", "probe"]);
     expect(stderr).not.toContain("Script not found");
-    expect(fs.existsSync(`${dir}/target/package.json`)).toBe(true);
-    expect(fs.existsSync(`${dir}/package.json`)).toBe(false);
+    expect(stdout.trim()).toBe("under-bun");
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
## What

`Command::which()` scans argv for the first non-dash token to pick the subcommand. It treats every dash-prefixed token as valueless, so the *value* of a global flag is read as the subcommand name:

```
$ bun --cwd ./dir test foo.test.ts
error: Script not found "test"

$ bun --env-file .env run app.ts
Usage: bun run [flags] <file or script>   # prints help instead of running

$ bun --cwd sub init -y
error: Script not found "init"
```

In each case `which()` lands on the flag's value (`./dir`, `.env`, `sub`), matches no keyword, and dispatches `AutoCommand`.

## Why the obvious patch is wrong

Having `which()` simply step past the value of `--cwd`/`--env-file`/`--config` was tried in #34983 and reverted (ff4255a): once the subcommand is classified correctly, several handlers that re-read *raw* `bun::argv()` at a hard-coded offset see the wrong token. For example `bun --env-file .env install` would reach `InstallCommand`, whose parser does not declare `--env-file`, so `.env` and `install` become positionals and it behaves like `bun add .env install`. `bun info`, `bun init`, `bun create`, `bun x`, `bun upgrade` and `bun pm trust` have the same shape (`argv().iter().skip(2)` / `&argv[2..]` / `&args[1..]`).

## Fix

* `which()` now steps past the value of the required-value `BASE_PARAMS_` flags (`--cwd`, `--env-file`) and records the argv index of the keyword it lands on in `SUBCOMMAND_ARGV_INDEX`.
* Every handler that previously sliced raw argv at a fixed offset reads `subcommand_argv_index()` instead (`exec_init`, `exec_bunx`, `bun_info`, `bun_create`, `exec_install_completions`, `reserved_command`, `upgrade_command`, `package_manager_command`). For the default `bun <cmd> ...` shape the index is 1, so behavior is unchanged.
* `CreateOptions::parse` strips positionals up to and including the `c`/`create` keyword by name rather than assuming it is at `[0]`.
* Install's `SHARED_PARAMS` gains a hidden `--env-file <STR>...` entry so the path is consumed instead of leaking into `cli.positionals` (`--cwd` and `--config` were already declared there).

`-c, --config` is intentionally **not** stepped over: it is declared `Values::OneOptional`, so the downstream clap parse never consumes a separate token for it either and the path would still surface as a positional. #34983 changes that declaration to required-value; once that lands, `--config` can be added to the skip set and will behave identically to `--cwd`.

## Verification

New tests in `test/cli/bun.test.ts` cover `run`, `test`, `build`, `exec`, `init`, `install`, `add` with `--cwd` / `--env-file` before the subcommand, plus the #34983 regression guard (`bun --env-file my.env install` must not treat the path as a package name). All 14 fail with `USE_SYSTEM_BUN=1` and pass with the fix.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/bun.test.ts

<!-- robobun:evidence:end -->

## Known limitation

For the install family (`install`/`add`/`remove`/`update`/`pm`/…), a leading `--env-file` is now accepted and its path no longer leaks as a positional, but the env file is not yet loaded: `PackageManager::init`'s `env.load(entries, &[], …)` still passes an empty explicit-files list. This was already the case for `bun install --env-file .env` on main (where the flag was unrecognized and the path mis-routed to `bun add`), so no working invocation regresses. Threading the option through to `env.load` is a separate change.

Fixes #10333