### PR TITLE
expect: show URL fields in toEqual/toStrictEqual diffs instead of 'URL {}'

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5434,12 +5434,8 @@ extern "C" [[ZIG_EXPORT(nothrow)]] bool JSC__isBigIntInInt64Range(JSC::EncodedJS
             return;
         }
 
-        // DOM wrappers (URL, Event subclasses, etc.) expose their state through accessors
-        // defined on the prototype and have no own data properties, so the own-property scan
-        // above yields an empty `{}` in jest diffs/snapshots and
-        // `Bun.inspect(..., { sorted: true })`. Walk the prototype chain for those types the
-        // way forEachProperty does so their accessors are enumerated. Other objects keep the
-        // own-properties-only behaviour pretty-format expects.
+        // DOM wrappers (URL, Event, ...) hold state only in prototype accessors; walk the
+        // chain like forEachProperty so they don't render as `{}`.
         if (object->type() == JSC::JSType(JSDOMWrapperType) || object->type() == JSC::JSType(JSEventType)) {
             size_t prototypeCount = 1;
             JSObject* iterating = object->getPrototype(globalObject).getObject();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5434,9 +5434,9 @@ extern "C" [[ZIG_EXPORT(nothrow)]] bool JSC__isBigIntInInt64Range(JSC::EncodedJS
             return;
         }
 
-        // DOM wrappers (URL, Headers, FormData, Event subclasses, etc.) expose their state
-        // through accessors defined on the prototype and have no own data properties, so the
-        // own-property scan above yields an empty `{}` in jest diffs/snapshots and
+        // DOM wrappers (URL, Event subclasses, etc.) expose their state through accessors
+        // defined on the prototype and have no own data properties, so the own-property scan
+        // above yields an empty `{}` in jest diffs/snapshots and
         // `Bun.inspect(..., { sorted: true })`. Walk the prototype chain for those types the
         // way forEachProperty does so their accessors are enumerated. Other objects keep the
         // own-properties-only behaviour pretty-format expects.

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5433,6 +5433,36 @@ extern "C" [[ZIG_EXPORT(nothrow)]] bool JSC__isBigIntInInt64Range(JSC::EncodedJS
             (void)scope.tryClearException();
             return;
         }
+
+        // DOM wrappers (URL, Headers, FormData, Event subclasses, etc.) expose their state
+        // through accessors defined on the prototype and have no own data properties, so the
+        // own-property scan above yields an empty `{}` in jest diffs/snapshots and
+        // `Bun.inspect(..., { sorted: true })`. Walk the prototype chain for those types the
+        // way forEachProperty does so their accessors are enumerated. Other objects keep the
+        // own-properties-only behaviour pretty-format expects.
+        if (object->type() == JSC::JSType(JSDOMWrapperType) || object->type() == JSC::JSType(JSEventType)) {
+            size_t prototypeCount = 1;
+            JSObject* iterating = object->getPrototype(globalObject).getObject();
+            if (scope.exception()) [[unlikely]] {
+                (void)scope.tryClearException();
+                return;
+            }
+            while (iterating && prototypeCount++ < 5
+                && !(iterating == globalObject->objectPrototype()
+                    || iterating == globalObject->functionPrototype()
+                    || (iterating->inherits<JSGlobalProxy>() && uncheckedDowncast<JSGlobalProxy>(iterating)->target() != globalObject))) {
+                iterating->methodTable()->getOwnPropertyNames(iterating, globalObject, properties, DontEnumPropertiesMode::Include);
+                if (scope.exception()) [[unlikely]] {
+                    (void)scope.tryClearException();
+                    return;
+                }
+                iterating = iterating->getPrototype(globalObject).getObject();
+                if (scope.exception()) [[unlikely]] {
+                    (void)scope.tryClearException();
+                    return;
+                }
+            }
+        }
     }
 
     auto vector = properties.data()->propertyNameVector();

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1594,6 +1594,19 @@ impl<'a> Formatter<'a> {
                             to_json_function.call(self.global_this, value, &[])?,
                             JSType::Object,
                         );
+                    } else if bun_jsc::FetchHeaders::cast_(value, self.global_this.vm()).is_some() {
+                        if let Some(to_json_function) = value.get(self.global_this, "toJSON")? {
+                            self.add_for_new_line(b"Headers ".len());
+                            writer.write_all(
+                                pretty_fmt_const::<ENABLE_ANSI_COLORS>("<r>Headers ").as_bytes(),
+                            );
+
+                            return self.print_as::<W, { Tag::Object }, ENABLE_ANSI_COLORS>(
+                                writer.ctx,
+                                to_json_function.call(self.global_this, value, &[])?,
+                                JSType::Object,
+                            );
+                        }
                     } else if let Some(timer) = value.as_class_ref::<crate::timer::TimeoutObject>() {
                         self.add_for_new_line(
                             b"Timeout(# ) ".len()

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1598,7 +1598,8 @@ impl<'a> Formatter<'a> {
                         if let Some(to_json_function) = value.get(self.global_this, "toJSON")? {
                             self.add_for_new_line(b"Headers ".len());
                             writer.write_all(
-                                pretty_fmt_const::<ENABLE_ANSI_COLORS>("<r>Headers ").as_bytes(),
+                                pretty_fmt_const::<ENABLE_ANSI_COLORS>("<r><blue>Headers<r> ")
+                                    .as_bytes(),
                             );
 
                             return self.print_as::<W, { Tag::Object }, ENABLE_ANSI_COLORS>(

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -865,20 +865,13 @@ impl<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>
         global_this: &JSGlobalObject,
         value: JSValue,
     ) -> JsResult<()> {
+        let mut name_str = ZigString::init(b"");
         if !value.js_type().is_function() {
-            let mut writer = WrappedWriter::new(self.writer);
-            let mut name_str = ZigString::init(b"");
-
             value.get_name_property(global_this, &mut name_str)?;
-            if name_str.len > 0 && !name_str.eql_comptime(b"Object") {
-                writer.print(format_args!("{} ", name_str));
-            } else {
+            if name_str.len == 0 || name_str.eql_comptime(b"Object") {
                 value
                     .get_prototype(global_this)
                     .get_name_property(global_this, &mut name_str)?;
-                if name_str.len > 0 && !name_str.eql_comptime(b"Object") {
-                    writer.print(format_args!("{} ", name_str));
-                }
             }
         }
 
@@ -888,10 +881,14 @@ impl<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>
         if self.formatter.indent == 0 {
             let _ = self.writer.write_all(b"\n");
         }
-        let mut classname = ZigString::EMPTY;
-        value.get_class_name(global_this, &mut classname)?;
-        if classname.len > 0 && !classname.eql_comptime(b"Object") {
-            let _ = self.writer.write_fmt(format_args!("{} ", classname));
+        if name_str.len > 0 && !name_str.eql_comptime(b"Object") {
+            let _ = self.writer.write_fmt(format_args!("{} ", name_str));
+        } else {
+            let mut classname = ZigString::EMPTY;
+            value.get_class_name(global_this, &mut classname)?;
+            if classname.len > 0 && !classname.eql_comptime(b"Object") {
+                let _ = self.writer.write_fmt(format_args!("{} ", classname));
+            }
         }
 
         let _ = self.writer.write_all(b"{\n");

--- a/test/regression/issue/07253.test.ts
+++ b/test/regression/issue/07253.test.ts
@@ -1,0 +1,68 @@
+// https://github.com/oven-sh/bun/issues/7253
+//
+// expect().toStrictEqual() failure on two URL objects printed `Expected: URL {}` /
+// `Received: URL {}`, hiding the actual difference. The jest/snapshot formatter
+// (forEachPropertyOrdered) only collected own property names, but URL exposes all
+// of its state via accessors on the prototype, so nothing was found. The same bug
+// made Bun.inspect(url, { sorted: true }) print `URL {}`.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+async function runFailingTest(source: string) {
+  using dir = tempDir("issue-07253", { "url.test.ts": source });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "url.test.ts"],
+    env: { ...bunEnv, NO_COLOR: "1", FORCE_COLOR: "0" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test("toStrictEqual failure diff for URL shows the differing fields", async () => {
+  const { stderr, exitCode } = await runFailingTest(`
+    import { expect, test } from "bun:test";
+    test("url", () => {
+      expect(new URL("https://www.google.com")).toStrictEqual(new URL("https://github.com"));
+    });
+  `);
+
+  expect(stderr).not.toContain("URL {}");
+  expect(stderr).toContain(`"href": "https://www.google.com/"`);
+  expect(stderr).toContain(`"href": "https://github.com/"`);
+  expect(stderr).toContain(`"host": "www.google.com"`);
+  expect(stderr).toContain(`"host": "github.com"`);
+  expect(exitCode).toBe(1);
+});
+
+test("toEqual failure diff for URL shows the differing fields", async () => {
+  const { stderr, exitCode } = await runFailingTest(`
+    import { expect, test } from "bun:test";
+    test("url", () => {
+      expect(new URL("https://a.example/?x=1")).toEqual(new URL("https://b.example/?y=2"));
+    });
+  `);
+
+  expect(stderr).not.toContain("URL {}");
+  expect(stderr).toContain(`"href": "https://a.example/?x=1"`);
+  expect(stderr).toContain(`"href": "https://b.example/?y=2"`);
+  expect(stderr).toContain(`"search": "?x=1"`);
+  expect(stderr).toContain(`"search": "?y=2"`);
+  expect(exitCode).toBe(1);
+});
+
+test("Bun.inspect with sorted: true enumerates URL prototype accessors", () => {
+  const out = Bun.inspect(new URL("https://bun.sh/docs"), { sorted: true, colors: false });
+  expect(out).not.toBe("URL {}");
+  expect(out).toContain(`href: "https://bun.sh/docs"`);
+  expect(out).toContain(`hostname: "bun.sh"`);
+  expect(out).toContain(`pathname: "/docs"`);
+});
+
+test("Bun.inspect with sorted: true does not walk the prototype for non-DOM objects", () => {
+  expect(Bun.inspect(new Number(7), { sorted: true, colors: false })).not.toContain("toFixed");
+  expect(Bun.inspect({ a: 1 }, { sorted: true, colors: false })).not.toContain("toString");
+});

--- a/test/regression/issue/07253.test.ts
+++ b/test/regression/issue/07253.test.ts
@@ -1,10 +1,4 @@
 // https://github.com/oven-sh/bun/issues/7253
-//
-// expect().toStrictEqual() failure on two URL objects printed `Expected: URL {}` /
-// `Received: URL {}`, hiding the actual difference. The jest/snapshot formatter
-// (forEachPropertyOrdered) only collected own property names, but URL exposes all
-// of its state via accessors on the prototype, so nothing was found. The same bug
-// made Bun.inspect(url, { sorted: true }) print `URL {}`.
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
@@ -54,6 +48,21 @@ test("toEqual failure diff for URL shows the differing fields", async () => {
   expect(exitCode).toBe(1);
 });
 
+test("toStrictEqual failure diff for Headers shows entries, not prototype methods", async () => {
+  const { stderr, exitCode } = await runFailingTest(`
+    import { expect, test } from "bun:test";
+    test("headers", () => {
+      expect(new Headers({ a: "1" })).toStrictEqual(new Headers({ b: "2" }));
+    });
+  `);
+
+  expect(stderr).not.toContain("Headers {}");
+  expect(stderr).not.toContain("[Function: append]");
+  expect(stderr).toContain(`"a": "1"`);
+  expect(stderr).toContain(`"b": "2"`);
+  expect(exitCode).toBe(1);
+});
+
 test("Bun.inspect with sorted: true enumerates URL prototype accessors", () => {
   const out = Bun.inspect(new URL("https://bun.sh/docs"), { sorted: true, colors: false });
   expect(out).not.toBe("URL {}");
@@ -63,6 +72,8 @@ test("Bun.inspect with sorted: true enumerates URL prototype accessors", () => {
 });
 
 test("Bun.inspect with sorted: true does not walk the prototype for non-DOM objects", () => {
-  expect(Bun.inspect(new Number(7), { sorted: true, colors: false })).not.toContain("toFixed");
-  expect(Bun.inspect({ a: 1 }, { sorted: true, colors: false })).not.toContain("toString");
+  class C {
+    method() {}
+  }
+  expect(Bun.inspect(new C(), { sorted: true, colors: false })).not.toContain("method");
 });

--- a/test/regression/issue/07253.test.ts
+++ b/test/regression/issue/07253.test.ts
@@ -16,7 +16,7 @@ async function runFailingTest(source: string) {
   return { stdout, stderr, exitCode };
 }
 
-test("toStrictEqual failure diff for URL shows the differing fields", async () => {
+test.concurrent("toStrictEqual failure diff for URL shows the differing fields", async () => {
   const { stderr, exitCode } = await runFailingTest(`
     import { expect, test } from "bun:test";
     test("url", () => {
@@ -32,7 +32,7 @@ test("toStrictEqual failure diff for URL shows the differing fields", async () =
   expect(exitCode).toBe(1);
 });
 
-test("toEqual failure diff for URL shows the differing fields", async () => {
+test.concurrent("toEqual failure diff for URL shows the differing fields", async () => {
   const { stderr, exitCode } = await runFailingTest(`
     import { expect, test } from "bun:test";
     test("url", () => {
@@ -48,7 +48,7 @@ test("toEqual failure diff for URL shows the differing fields", async () => {
   expect(exitCode).toBe(1);
 });
 
-test("toStrictEqual failure diff for Headers shows entries, not prototype methods", async () => {
+test.concurrent("toStrictEqual failure diff for Headers shows entries, not prototype methods", async () => {
   const { stderr, exitCode } = await runFailingTest(`
     import { expect, test } from "bun:test";
     test("headers", () => {


### PR DESCRIPTION
Fixes #7253.

## Repro

```ts
import { test, expect } from "bun:test";
test("url", () => {
  expect(new URL("https://www.google.com")).toStrictEqual(new URL("https://github.com"));
});
```

Before:

```
error: expect(received).toStrictEqual(expected)

Expected: URL {}
Received: URL {}
```

After:

```
error: expect(received).toStrictEqual(expected)

  URL {
    "hash": "",
-   "host": "github.com",
-   "hostname": "github.com",
-   "href": "https://github.com/",
-   "origin": "https://github.com",
+   "host": "www.google.com",
+   "hostname": "www.google.com",
+   "href": "https://www.google.com/",
+   "origin": "https://www.google.com",
    "password": "",
    "pathname": "/",
    ...
  }
```

## Cause

`JSC__JSValue__forEachPropertyOrdered` (used by the jest/snapshot formatter and `Bun.inspect({ sorted: true })`) only collected own property names. DOM wrappers like `URL` and `Event` subclasses expose all their state through accessors on the prototype and have no own data properties, so the formatter found nothing and rendered `URL {}`. `forEachProperty` (used by `console.log`) already walks the prototype chain, which is why `console.log(new URL(...))` was never affected.

## Fix

In `forEachPropertyOrdered`, after collecting own property names, also walk the prototype chain for `JSDOMWrapperType` / `JSEventType` cells (mirroring `forEachProperty`'s traversal and stop conditions). `PropertyNameArrayBuilder::add` already deduplicates. Other object types keep own-properties-only behaviour, so boxed primitives (`new Number(n)` stays `Number {}`) and user class instances are unchanged, preserving existing snapshot output.

`Headers` is also `JSDOMWrapperType` but its prototype is almost entirely methods, so the walk alone would have produced a wall of `[Function: ...]` lines with no signal. Added a `FetchHeaders` branch in the jest formatter that prints `toJSON()` output, matching the existing `FormData` branch and the console formatter's Headers handling in `jsc_hooks.rs`, so a `toStrictEqual` failure on two `Headers` now diffs the entries:

```
  Headers
  {
-   "b": "2",
+   "a": "1",
  }
```

Also fixed `handle_first_property` in the jest formatter, which emitted the object's display name twice when the object had a `Symbol.toStringTag` (the toStringTag lookup and the class-name lookup both printed). It now uses the toStringTag when present and falls back to the class name, matching the empty-object branch. This path was previously unreachable for `URL` because no properties were ever visited.

## Verification

`test/regression/issue/07253.test.ts` fails on main (4 of 5 tests, with `Expected: URL {}` / `Headers {}` in stderr) and passes with the fix. Ran `inspect.test.js`, `expect.test.js`, the snapshot suites and the console tests locally with no new failures.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/07253.test.ts"
bun test v1.4.0 (90ea0d86d)

test/regression/issue/07253.test.ts:
38 |     test("url", () => {
39 |       expect(new URL("https://a.example/?x=1")).toEqual(new URL("https://b.example/?y=2"));
40 |     });
41 |   `);
42 | 
43 |   expect(stderr).not.toContain("URL {}");
                          ^
error: expect(received).not.toContain(expected)

Expected to not contain: "URL {}"
Received: "\nurl.test.ts:\n1 | \n2 |     import { expect, test } from \"bun:test\";\n3 |     test(\"url\", () => {\n4 |       expect(new URL(\"https://a.example/?x=1\")).toEqual(new URL(\"https://b.example/?y=2\"));\n                                                    ^\nerror: expect(received).toEqual(expected)\n\nExpected: URL {}\nReceived: URL {}\n\n      at <anonymous> (/tmp/issue-07253_MFpDs2/url.test.ts:4:49)\n(fail) url [9.54ms]\n\n 0 pass\n 1 fail\n 1 expect() calls\nRan 1 test across 1 file. [436.00ms]\n"

      at <anonymous> (/workspace/bun/test/regression/issue/07253.test.ts:43:22)
(fail) toEqual failure diff for 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (e83e9da47)

test/regression/issue/07253.test.ts:
(pass) toStrictEqual failure diff for Headers shows entries, not prototype methods [63.88ms]
(pass) toEqual failure diff for URL shows the differing fields [94.47ms]
(pass) toStrictEqual failure diff for URL shows the differing fields [98.95ms]
(pass) Bun.inspect with sorted: true enumerates URL prototype accessors [0.33ms]
(pass) Bun.inspect with sorted: true does not walk the prototype for non-DOM objects [0.11ms]

 5 pass
 0 fail
 22 expect() calls
Ran 5 tests across 1 file. [339.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/07253.test.ts"
bun test v1.4.0 (90ea0d86d)

test/regression/issue/07253.test.ts:
(pass) toStrictEqual failure diff for URL shows the differing fields [819.97ms]
(pass) toStrictEqual failure diff for Headers shows entries, not prototype methods [697.79ms]
(pass) toEqual failure diff for URL shows the differing fields [1267.45ms]
(pass) Bun.inspect with sorted: true enumerates URL prototype accessors [19.64ms]
(pass) Bun.inspect with sorted: true does not walk the prototype for non-DOM objects [10.04ms]

 5 pass
 0 fail
 22 expect() calls
Ran 5 tests across 1 file. [8.34s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2712ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] gen cpp.rs (cppbind)
[2/9] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp            | 26 +++++++++++
 src/runtime/test_runner/pretty_format.rs | 37 +++++++++------
 test/regression/issue/07253.test.ts      | 79 ++++++++++++++++++++++++++++++++
 3 files changed, 129 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/jsc/bindings/bindings.cpp                10      8      0
src/runtime/test_runner/pretty_format.rs     10      6      0
test/regression/issue/07253.test.ts           1      6      0
```

</details>

<!-- robobun:evidence:end -->