### PR TITLE
install: auto-install peer deps within the intersection of all peer ranges

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2503,7 +2503,13 @@ fn get_or_put_resolved_package(
             // Auto-installing a peer: prefer a version that also satisfies
             // every other non-optional npm peer range recorded for the same
             // name, so the first-drained range does not win on its own (#8292).
-            if install_peer && behavior.is_peer() && version.tag == dependency::version::Tag::Npm {
+            // Skip when an override applies: the buffer holds raw ranges and
+            // the override rewrites every peer edge for this name identically.
+            if install_peer
+                && behavior.is_peer()
+                && version.tag == dependency::version::Tag::Npm
+                && this.lockfile.overrides.get(name_hash).is_none()
+            {
                 let lockfile_buf = this.lockfile.buffers.string_bytes.as_slice();
                 let deps = this.lockfile.buffers.dependencies.as_slice();
                 let all_peers_ok = |v: Semver::Version| -> bool {
@@ -2517,6 +2523,9 @@ fn get_or_put_resolved_package(
                         let Some(npm) = dep.version.try_npm() else {
                             return true;
                         };
+                        if npm.is_alias {
+                            return true;
+                        }
                         npm.version.satisfies(v, lockfile_buf, &manifest.string_buf)
                     })
                 };

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2506,10 +2506,7 @@ fn get_or_put_resolved_package(
             // the first-seen (often widest) peer range wins and narrower
             // sibling ranges only produce an "incorrect peer dependency"
             // warning instead of influencing the chosen version (#8292).
-            if install_peer
-                && behavior.is_peer()
-                && version.tag == dependency::version::Tag::Npm
-            {
+            if install_peer && behavior.is_peer() && version.tag == dependency::version::Tag::Npm {
                 let lockfile_buf = this.lockfile.buffers.string_bytes.as_slice();
                 let deps = this.lockfile.buffers.dependencies.as_slice();
                 let all_peers_ok = |v: Semver::Version| -> bool {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2511,23 +2511,25 @@ fn get_or_put_resolved_package(
                 && this.lockfile.overrides.get(name_hash).is_none()
             {
                 let lockfile_buf = this.lockfile.buffers.string_bytes.as_slice();
-                let deps = this.lockfile.buffers.dependencies.as_slice();
-                let all_peers_ok = |v: Semver::Version| -> bool {
-                    deps.iter().all(|dep| {
-                        if dep.name_hash != name_hash
-                            || !dep.behavior.is_peer()
-                            || dep.behavior.is_optional_peer()
-                        {
-                            return true;
-                        }
-                        let Some(npm) = dep.version.try_npm() else {
-                            return true;
-                        };
-                        if npm.is_alias {
-                            return true;
-                        }
-                        npm.version.satisfies(v, lockfile_buf, &manifest.string_buf)
+                let sibling_peer_ranges: Vec<&Semver::query::Group> = this
+                    .lockfile
+                    .buffers
+                    .dependencies
+                    .as_slice()
+                    .iter()
+                    .filter(|dep| {
+                        dep.name_hash == name_hash
+                            && dep.behavior.is_peer()
+                            && !dep.behavior.is_optional_peer()
                     })
+                    .filter_map(|dep| dep.version.try_npm())
+                    .filter(|npm| !npm.is_alias)
+                    .map(|npm| &npm.version)
+                    .collect();
+                let all_peers_ok = |v: Semver::Version| -> bool {
+                    sibling_peer_ranges
+                        .iter()
+                        .all(|g| g.satisfies(v, lockfile_buf, &manifest.string_buf))
                 };
                 if !all_peers_ok(find_result.version) {
                     if let Some(refined) = manifest.find_best_version_extra(

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2500,12 +2500,9 @@ fn get_or_put_resolved_package(
                 }
             };
 
-            // Auto-installing a peer dependency that nothing has resolved yet:
-            // prefer a version that also satisfies every other non-optional
-            // npm peer range already recorded for the same name. Without this
-            // the first-seen (often widest) peer range wins and narrower
-            // sibling ranges only produce an "incorrect peer dependency"
-            // warning instead of influencing the chosen version (#8292).
+            // Auto-installing a peer: prefer a version that also satisfies
+            // every other non-optional npm peer range recorded for the same
+            // name, so the first-drained range does not win on its own (#8292).
             if install_peer && behavior.is_peer() && version.tag == dependency::version::Tag::Npm {
                 let lockfile_buf = this.lockfile.buffers.string_bytes.as_slice();
                 let deps = this.lockfile.buffers.dependencies.as_slice();
@@ -2527,6 +2524,8 @@ fn get_or_put_resolved_package(
                     if let Some(refined) = manifest.find_best_version_extra(
                         &version.npm().version,
                         lockfile_buf,
+                        this.options.minimum_release_age_ms,
+                        this.options.minimum_release_age_excludes,
                         all_peers_ok,
                     ) {
                         find_result = refined;

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2441,7 +2441,7 @@ fn get_or_put_resolved_package(
                 },
             };
 
-            let find_result = match find_result_opt {
+            let mut find_result = match find_result_opt {
                 Some(r) => r,
                 None => {
                     'resolve_workspace_from_dist_tag: {
@@ -2499,6 +2499,43 @@ fn get_or_put_resolved_package(
                     };
                 }
             };
+
+            // Auto-installing a peer dependency that nothing has resolved yet:
+            // prefer a version that also satisfies every other non-optional
+            // npm peer range already recorded for the same name. Without this
+            // the first-seen (often widest) peer range wins and narrower
+            // sibling ranges only produce an "incorrect peer dependency"
+            // warning instead of influencing the chosen version (#8292).
+            if install_peer
+                && behavior.is_peer()
+                && version.tag == dependency::version::Tag::Npm
+            {
+                let lockfile_buf = this.lockfile.buffers.string_bytes.as_slice();
+                let deps = this.lockfile.buffers.dependencies.as_slice();
+                let all_peers_ok = |v: Semver::Version| -> bool {
+                    deps.iter().all(|dep| {
+                        if dep.name_hash != name_hash
+                            || !dep.behavior.is_peer()
+                            || dep.behavior.is_optional_peer()
+                        {
+                            return true;
+                        }
+                        let Some(npm) = dep.version.try_npm() else {
+                            return true;
+                        };
+                        npm.version.satisfies(v, lockfile_buf, &manifest.string_buf)
+                    })
+                };
+                if !all_peers_ok(find_result.version) {
+                    if let Some(refined) = manifest.find_best_version_extra(
+                        &version.npm().version,
+                        lockfile_buf,
+                        all_peers_ok,
+                    ) {
+                        find_result = refined;
+                    }
+                }
+            }
 
             // reshaped for borrowck — `manifest`/`find_result`
             // borrow `this.manifests`; detach via `BackRef` so the `&mut *this`

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1904,6 +1904,7 @@ impl PackageManifest {
     ) -> Option<FindResult<'_>> {
         let min_age_ms =
             minimum_release_age_ms.filter(|_| !self.should_exclude_from_age_filter(exclusions));
+        debug_assert!(min_age_ms.is_none() || self.pkg.has_extended_manifest);
         let age_ok = |pkg: &PackageVersion| match min_age_ms {
             Some(min) => !Self::is_package_version_too_recent(pkg, min),
             None => true,

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1927,6 +1927,7 @@ impl PackageManifest {
                         .order(result.version, group_buf, &self.string_buf)
                         == core::cmp::Ordering::Equal
                     {
+                        // if prerelease, use latest if semver+tag match range exactly
                         return Some(result);
                     }
                 } else {
@@ -1936,6 +1937,7 @@ impl PackageManifest {
         }
 
         {
+            // This list is sorted at serialization time.
             let releases = self.pkg.releases.keys.get(&self.versions);
             let packages = self.pkg.releases.values.get(&self.package_versions);
             let mut i = releases.len();
@@ -1955,6 +1957,7 @@ impl PackageManifest {
         }
 
         if group.flags.is_set(Semver::query::Flags::PRE) {
+            // This list is sorted at serialization time.
             let prereleases = self.pkg.prereleases.keys.get(&self.versions);
             let packages = self.pkg.prereleases.values.get(&self.package_versions);
             let mut i = prereleases.len();

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1950,26 +1950,33 @@ impl PackageManifest {
         None
     }
 
-    /// Like [`find_best_version`](Self::find_best_version) but only returns a
-    /// version for which `extra_ok(version)` is also true. Used when
-    /// auto-installing a peer dependency to pick a version that satisfies
-    /// every sibling peer range for the same package name, not just the
-    /// first-seen range.
+    /// [`find_best_version_with_filter`](Self::find_best_version_with_filter)
+    /// restricted to versions for which `extra_ok` also returns true.
     pub fn find_best_version_extra(
         &self,
         group: &Semver::query::Group,
         group_buf: &[u8],
+        minimum_release_age_ms: Option<f64>,
+        exclusions: Option<&[&[u8]]>,
         extra_ok: impl Fn(Semver::Version) -> bool,
     ) -> Option<FindResult<'_>> {
+        let min_age_ms = minimum_release_age_ms
+            .filter(|_| !self.should_exclude_from_age_filter(exclusions));
+        let age_ok = |pkg: &PackageVersion| match min_age_ms {
+            Some(min) => !Self::is_package_version_too_recent(pkg, min),
+            None => true,
+        };
+
         let left = group.head.head.range.left;
         if left.op == Semver::range::Op::Eql {
             let r = self.find_by_version(left.version)?;
-            return extra_ok(r.version).then_some(r);
+            return (extra_ok(r.version) && age_ok(r.package)).then_some(r);
         }
 
         if let Some(result) = self.find_by_dist_tag(b"latest") {
             if group.satisfies(result.version, group_buf, &self.string_buf)
                 && extra_ok(result.version)
+                && age_ok(result.package)
             {
                 if group.flags.is_set(Semver::query::Flags::PRE) {
                     if left
@@ -1991,7 +1998,10 @@ impl PackageManifest {
             let mut i = releases.len();
             while i > 0 {
                 let version = releases[i - 1];
-                if group.satisfies(version, group_buf, &self.string_buf) && extra_ok(version) {
+                if group.satisfies(version, group_buf, &self.string_buf)
+                    && extra_ok(version)
+                    && age_ok(&packages[i - 1])
+                {
                     return Some(FindResult {
                         version,
                         package: &packages[i - 1],
@@ -2007,7 +2017,10 @@ impl PackageManifest {
             let mut i = prereleases.len();
             while i > 0 {
                 let version = prereleases[i - 1];
-                if group.satisfies(version, group_buf, &self.string_buf) && extra_ok(version) {
+                if group.satisfies(version, group_buf, &self.string_buf)
+                    && extra_ok(version)
+                    && age_ok(&packages[i - 1])
+                {
                     return Some(FindResult {
                         version,
                         package: &packages[i - 1],

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1949,6 +1949,76 @@ impl PackageManifest {
 
         None
     }
+
+    /// Like [`find_best_version`](Self::find_best_version) but only returns a
+    /// version for which `extra_ok(version)` is also true. Used when
+    /// auto-installing a peer dependency to pick a version that satisfies
+    /// every sibling peer range for the same package name, not just the
+    /// first-seen range.
+    pub fn find_best_version_extra(
+        &self,
+        group: &Semver::query::Group,
+        group_buf: &[u8],
+        extra_ok: impl Fn(Semver::Version) -> bool,
+    ) -> Option<FindResult<'_>> {
+        let left = group.head.head.range.left;
+        if left.op == Semver::range::Op::Eql {
+            let r = self.find_by_version(left.version)?;
+            return extra_ok(r.version).then_some(r);
+        }
+
+        if let Some(result) = self.find_by_dist_tag(b"latest") {
+            if group.satisfies(result.version, group_buf, &self.string_buf)
+                && extra_ok(result.version)
+            {
+                if group.flags.is_set(Semver::query::Flags::PRE) {
+                    if left
+                        .version
+                        .order(result.version, group_buf, &self.string_buf)
+                        == core::cmp::Ordering::Equal
+                    {
+                        return Some(result);
+                    }
+                } else {
+                    return Some(result);
+                }
+            }
+        }
+
+        {
+            let releases = self.pkg.releases.keys.get(&self.versions);
+            let packages = self.pkg.releases.values.get(&self.package_versions);
+            let mut i = releases.len();
+            while i > 0 {
+                let version = releases[i - 1];
+                if group.satisfies(version, group_buf, &self.string_buf) && extra_ok(version) {
+                    return Some(FindResult {
+                        version,
+                        package: &packages[i - 1],
+                    });
+                }
+                i -= 1;
+            }
+        }
+
+        if group.flags.is_set(Semver::query::Flags::PRE) {
+            let prereleases = self.pkg.prereleases.keys.get(&self.versions);
+            let packages = self.pkg.prereleases.values.get(&self.package_versions);
+            let mut i = prereleases.len();
+            while i > 0 {
+                let version = prereleases[i - 1];
+                if group.satisfies(version, group_buf, &self.string_buf) && extra_ok(version) {
+                    return Some(FindResult {
+                        version,
+                        package: &packages[i - 1],
+                    });
+                }
+                i -= 1;
+            }
+        }
+
+        None
+    }
 }
 
 // Keys are pre-hashed string hashes, so don't re-hash them.

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1960,8 +1960,8 @@ impl PackageManifest {
         exclusions: Option<&[&[u8]]>,
         extra_ok: impl Fn(Semver::Version) -> bool,
     ) -> Option<FindResult<'_>> {
-        let min_age_ms = minimum_release_age_ms
-            .filter(|_| !self.should_exclude_from_age_filter(exclusions));
+        let min_age_ms =
+            minimum_release_age_ms.filter(|_| !self.should_exclude_from_age_filter(exclusions));
         let age_ok = |pkg: &PackageVersion| match min_age_ms {
             Some(min) => !Self::is_package_version_too_recent(pkg, min),
             None => true,

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1888,70 +1888,12 @@ impl PackageManifest {
         group: &Semver::query::Group,
         group_buf: &[u8],
     ) -> Option<FindResult<'_>> {
-        let left = group.head.head.range.left;
-        // Fast path: exact version
-        if left.op == Semver::range::Op::Eql {
-            return self.find_by_version(left.version);
-        }
-
-        if let Some(result) = self.find_by_dist_tag(b"latest") {
-            if group.satisfies(result.version, group_buf, &self.string_buf) {
-                if group.flags.is_set(Semver::query::Flags::PRE) {
-                    if left
-                        .version
-                        .order(result.version, group_buf, &self.string_buf)
-                        == core::cmp::Ordering::Equal
-                    {
-                        // if prerelease, use latest if semver+tag match range exactly
-                        return Some(result);
-                    }
-                } else {
-                    return Some(result);
-                }
-            }
-        }
-
-        {
-            // This list is sorted at serialization time.
-            let releases = self.pkg.releases.keys.get(&self.versions);
-            let mut i = releases.len();
-
-            while i > 0 {
-                let version = releases[i - 1];
-
-                if group.satisfies(version, group_buf, &self.string_buf) {
-                    return Some(FindResult {
-                        version,
-                        package: &self.pkg.releases.values.get(&self.package_versions)[i - 1],
-                    });
-                }
-                i -= 1;
-            }
-        }
-
-        if group.flags.is_set(Semver::query::Flags::PRE) {
-            let prereleases = self.pkg.prereleases.keys.get(&self.versions);
-            let mut i = prereleases.len();
-            while i > 0 {
-                let version = prereleases[i - 1];
-
-                // This list is sorted at serialization time.
-                if group.satisfies(version, group_buf, &self.string_buf) {
-                    let packages = self.pkg.prereleases.values.get(&self.package_versions);
-                    return Some(FindResult {
-                        version,
-                        package: &packages[i - 1],
-                    });
-                }
-                i -= 1;
-            }
-        }
-
-        None
+        self.find_best_version_extra(group, group_buf, None, None, |_| true)
     }
 
-    /// [`find_best_version_with_filter`](Self::find_best_version_with_filter)
-    /// restricted to versions for which `extra_ok` also returns true.
+    /// [`find_best_version`](Self::find_best_version) restricted to versions
+    /// for which `extra_ok` also returns true, optionally also applying the
+    /// `minimumReleaseAge` filter.
     pub fn find_best_version_extra(
         &self,
         group: &Semver::query::Group,

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -7767,6 +7767,43 @@ describe("yarn tests", () => {
     assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
   });
 
+  test("auto-installed peer honours overrides over sibling peer ranges", async () => {
+    await writeFile(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        version: "1.0.0",
+        dependencies: {
+          "mismatched-peer-deps-lvl0": "1.0.0",
+        },
+        overrides: {
+          "no-deps": ">=1.0.0",
+        },
+      }),
+    );
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    const err = await stderr.text();
+    const out = await stdout.text();
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("4 packages installed");
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+      name: "no-deps",
+      version: "2.0.0",
+    } as any);
+    expect(await exited).toBe(0);
+    assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+  });
+
   test("it should install in such a way that two identical packages with different peer dependencies are different instances", async () => {
     await writeFile(
       packageJson,

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -7727,10 +7727,6 @@ describe("yarn tests", () => {
 
   // https://github.com/oven-sh/bun/issues/8292
   test("auto-installed peer satisfies narrower peer range from a transitive dependency", async () => {
-    // `mismatched-peer-deps-lvl0` has peer `no-deps: <=1.1.0` and pulls in
-    // lvl1 (peer `no-deps: <=1.0.1`) and lvl2 (peer `no-deps: 1.0.0`). The
-    // auto-installed `no-deps` should be the version that satisfies all three
-    // ranges, not the first one processed.
     await writeFile(
       packageJson,
       JSON.stringify({

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -7725,6 +7725,52 @@ describe("yarn tests", () => {
     assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
   });
 
+  // https://github.com/oven-sh/bun/issues/8292
+  test("auto-installed peer satisfies narrower peer range from a transitive dependency", async () => {
+    // `mismatched-peer-deps-lvl0` has peer `no-deps: <=1.1.0` and pulls in
+    // lvl1 (peer `no-deps: <=1.0.1`) and lvl2 (peer `no-deps: 1.0.0`). The
+    // auto-installed `no-deps` should be the version that satisfies all three
+    // ranges, not the first one processed.
+    await writeFile(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        version: "1.0.0",
+        dependencies: {
+          "mismatched-peer-deps-lvl0": "1.0.0",
+        },
+      }),
+    );
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    const err = await stderr.text();
+    const out = await stdout.text();
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(err).not.toContain("incorrect peer dependency");
+    expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+      expect.stringContaining("bun install v1."),
+      "",
+      "+ mismatched-peer-deps-lvl0@1.0.0",
+      "",
+      "4 packages installed",
+    ]);
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+      name: "no-deps",
+      version: "1.0.0",
+    } as any);
+    expect(await exited).toBe(0);
+    assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+  });
+
   test("it should install in such a way that two identical packages with different peer dependencies are different instances", async () => {
     await writeFile(
       packageJson,


### PR DESCRIPTION
Fixes #8292.
Fixes #15711.

## Repro

```sh
bun add create-melange-app@latest
cat node_modules/react/package.json | grep version
```

`create-melange-app` depends on `ink` (peer `react: >=18.0.0`) which depends on `react-reconciler@0.29` (peer `react: ^18.3.1`). Before this change bun installs `react@19.2.8` with:

```
warn: incorrect peer dependency "react@19.2.8"
```

and `bun create melange-app` crashes at runtime with `TypeError: undefined is not an object (evaluating 'ReactSharedInternals.ReactCurrentOwner')`. npm resolves `react@18.3.1` for the same tree.

## Cause

Peer dependencies are deferred to a FIFO queue and drained after every non-peer edge has been resolved. The first peer drained for a given package name picks the version from the manifest; later peers for the same name reuse that version (with a warning if it doesn't satisfy their range). So ink's `>=18.0.0` range resolves `react@19` and react-reconciler's `^18.3.1` only warns.

## Fix

In `get_or_put_resolved_package`, when a peer is being auto-installed (nothing with that name exists yet), scan `lockfile.buffers.dependencies` for every other non-optional npm peer range recorded for the same name and pick the highest manifest version that satisfies all of them. When no version satisfies every range, fall back to the previous behaviour (first range wins + warning). `PackageManifest::find_best_version_extra` mirrors `find_best_version` with an extra predicate for the sibling-range check.

This only runs on the auto-install path (no `package_index` entry for the name), so a version provided by the root or any regular dependency is still preferred and the existing "incorrect peer dependency" warning for root-pinned conflicts is unchanged.

## Verification

New test in `test/cli/install/bun-install-registry.test.ts` uses the existing `mismatched-peer-deps-lvl0/1/2` fixtures (peer `no-deps` at `<=1.1.0` / `<=1.0.1` / `1.0.0`):

- **before**: installs `no-deps@1.1.0`, warns "incorrect peer dependency" twice
- **after**: installs `no-deps@1.0.0`, no warning

Real-world check: `bun add create-melange-app` now installs `react@18.3.1` with no peer warnings. The peer / hoisting / dragon / lockfile / isolated-install peer suites all pass (`-t peer`, `-t hoist`, `-t dragon`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->