### PR TITLE
bun:test: don't flag matched asymmetric matchers in toMatchObject diff

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1745,16 +1745,24 @@ bool Bun__deepMatch(
     // - two "simple" arrays
     // similar to what is done in deepEquals (canPerformFastPropertyEnumerationForIterationBun)
 
+    // When replacePropsWithAsymmetricMatchers is set, the caller wants the
+    // diff formatter to see every property where an asymmetric matcher passed,
+    // so keep iterating after the first mismatch instead of short-circuiting.
+    bool matched = true;
+
     // arrays should match exactly
     if (isArray(globalObject, objValue) && isArray(globalObject, subsetValue)) {
         if (obj->getArrayLength() != subsetObj->getArrayLength()) {
-            return false;
-        }
-        PropertyNameArrayBuilder objProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
-        obj->getPropertyNames(globalObject, objProps, DontEnumPropertiesMode::Exclude);
-        RETURN_IF_EXCEPTION(throwScope, false);
-        if (objProps.size() != subsetProps.size()) {
-            return false;
+            if (!replacePropsWithAsymmetricMatchers) return false;
+            matched = false;
+        } else {
+            PropertyNameArrayBuilder objProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
+            obj->getPropertyNames(globalObject, objProps, DontEnumPropertiesMode::Exclude);
+            RETURN_IF_EXCEPTION(throwScope, false);
+            if (objProps.size() != subsetProps.size()) {
+                if (!replacePropsWithAsymmetricMatchers) return false;
+                matched = false;
+            }
         }
     }
 
@@ -1762,7 +1770,9 @@ bool Bun__deepMatch(
         JSValue prop = obj->getIfPropertyExists(globalObject, property);
         RETURN_IF_EXCEPTION(throwScope, false);
         if (prop.isEmpty()) {
-            return false;
+            if (!replacePropsWithAsymmetricMatchers) return false;
+            matched = false;
+            continue;
         }
 
         JSValue subsetProp = subsetObj->get(globalObject, property);
@@ -1775,6 +1785,10 @@ bool Bun__deepMatch(
             if (subsetPropCell && subsetPropCell->type() == JSC::JSType(JSDOMWrapperType)) {
                 switch (matchAsymmetricMatcher(globalObject, subsetProp, prop, throwScope)) {
                 case AsymmetricMatcherResult::FAIL:
+                    if (replacePropsWithAsymmetricMatchers) {
+                        matched = false;
+                        continue;
+                    }
                     return false;
                 case AsymmetricMatcherResult::PASS:
                     if (replacePropsWithAsymmetricMatchers) {
@@ -1789,6 +1803,10 @@ bool Bun__deepMatch(
             } else if (propCell && propCell->type() == JSC::JSType(JSDOMWrapperType)) {
                 switch (matchAsymmetricMatcher(globalObject, prop, subsetProp, throwScope)) {
                 case AsymmetricMatcherResult::FAIL:
+                    if (replacePropsWithAsymmetricMatchers) {
+                        matched = false;
+                        continue;
+                    }
                     return false;
                 case AsymmetricMatcherResult::PASS:
                     if (replacePropsWithAsymmetricMatchers) {
@@ -1824,17 +1842,21 @@ bool Bun__deepMatch(
                 // property cycle detected
                 if (!didInsertProp.second || !didInsertSubset.second) continue;
                 if (!Bun__deepMatch<enableAsymmetricMatchers>(prop, seenObjProperties, subsetProp, seenSubsetProperties, globalObject, throwScope, gcBuffer, replacePropsWithAsymmetricMatchers, isMatchingObjectContaining)) {
-                    return false;
+                    if (!replacePropsWithAsymmetricMatchers) return false;
+                    matched = false;
                 }
             }
         } else {
             auto same = JSC::sameValue(globalObject, prop, subsetProp);
             RETURN_IF_EXCEPTION(throwScope, false);
-            if (!same) return false;
+            if (!same) {
+                if (!replacePropsWithAsymmetricMatchers) return false;
+                matched = false;
+            }
         }
     }
 
-    return true;
+    return matched;
 }
 
 // anonymous namespace to avoid name collision

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1745,9 +1745,6 @@ bool Bun__deepMatch(
     // - two "simple" arrays
     // similar to what is done in deepEquals (canPerformFastPropertyEnumerationForIterationBun)
 
-    // When replacePropsWithAsymmetricMatchers is set, the caller wants the
-    // diff formatter to see every property where an asymmetric matcher passed,
-    // so keep iterating after the first mismatch instead of short-circuiting.
     bool matched = true;
 
     // arrays should match exactly

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1780,7 +1780,9 @@ bool Bun__deepMatch(
 
         if constexpr (enableAsymmetricMatchers) {
             if (subsetPropCell && subsetPropCell->type() == JSC::JSType(JSDOMWrapperType)) {
-                switch (matchAsymmetricMatcher(globalObject, subsetProp, prop, throwScope)) {
+                auto result = matchAsymmetricMatcher(globalObject, subsetProp, prop, throwScope);
+                RETURN_IF_EXCEPTION(throwScope, false);
+                switch (result) {
                 case AsymmetricMatcherResult::FAIL:
                     if (replacePropsWithAsymmetricMatchers) {
                         matched = false;
@@ -1798,7 +1800,9 @@ bool Bun__deepMatch(
                     break;
                 }
             } else if (propCell && propCell->type() == JSC::JSType(JSDOMWrapperType)) {
-                switch (matchAsymmetricMatcher(globalObject, prop, subsetProp, throwScope)) {
+                auto result = matchAsymmetricMatcher(globalObject, prop, subsetProp, throwScope);
+                RETURN_IF_EXCEPTION(throwScope, false);
+                switch (result) {
                 case AsymmetricMatcherResult::FAIL:
                     if (replacePropsWithAsymmetricMatchers) {
                         matched = false;
@@ -1838,7 +1842,9 @@ bool Bun__deepMatch(
                 gcBuffer->append(subsetProp);
                 // property cycle detected
                 if (!didInsertProp.second || !didInsertSubset.second) continue;
-                if (!Bun__deepMatch<enableAsymmetricMatchers>(prop, seenObjProperties, subsetProp, seenSubsetProperties, globalObject, throwScope, gcBuffer, replacePropsWithAsymmetricMatchers, isMatchingObjectContaining)) {
+                bool nestedMatched = Bun__deepMatch<enableAsymmetricMatchers>(prop, seenObjProperties, subsetProp, seenSubsetProperties, globalObject, throwScope, gcBuffer, replacePropsWithAsymmetricMatchers, isMatchingObjectContaining);
+                RETURN_IF_EXCEPTION(throwScope, false);
+                if (!nestedMatched) {
                     if (!replacePropsWithAsymmetricMatchers) return false;
                     matched = false;
                 }

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3558,6 +3558,74 @@ describe("expect()", () => {
       expect(a1).not.toMatchObject({ 1: 1 });
       expect(a1).toMatchObject(a1);
     });
+
+    if (isBun) {
+      // https://github.com/oven-sh/bun/issues/9089
+      const stripAnsi = (/** @type {string} */ s) => s.replace(/\x1b\[[0-9;]*m/g, "");
+      const capture = (/** @type {() => void} */ fn) => {
+        try {
+          fn();
+        } catch (e) {
+          return stripAnsi(/** @type {Error} */ (e).message);
+        }
+        throw new Error("expected matcher to throw");
+      };
+
+      test("diff only flags the asymmetric matcher that actually failed", () => {
+        const msg = capture(() =>
+          expect({ a: "foobar", b: new Date(0), c: "hello" }).toMatchObject({
+            a: expect.any(Date),
+            b: expect.any(Date),
+            c: "hello",
+          }),
+        );
+        // Only `a` should be flagged; `b` matched its `expect.any(Date)` matcher.
+        expect(msg).toContain("- Expected  - 1");
+        expect(msg).toContain("+ Received  + 1");
+        expect(msg).toContain(`    "b": Any<Date>,`);
+        expect(msg).not.toContain(`-   "b":`);
+        expect(msg).not.toContain(`+   "b":`);
+      });
+
+      test("diff still replaces matching asymmetric matchers after a non-matcher mismatch", () => {
+        const msg = capture(() =>
+          expect({ a: "foobar", b: "bar", c: "baz" }).toMatchObject({
+            a: "wrong",
+            b: expect.any(String),
+            c: expect.stringContaining("az"),
+          }),
+        );
+        expect(msg).toContain("- Expected  - 1");
+        expect(msg).toContain("+ Received  + 1");
+        expect(msg).not.toContain(`-   "b":`);
+        expect(msg).not.toContain(`-   "c":`);
+      });
+
+      test("diff replaces matching asymmetric matchers in nested objects when a sibling fails", () => {
+        const msg = capture(() =>
+          expect({ outer: { a: 1, b: "x" }, ok: 42 }).toMatchObject({
+            outer: { a: 2, b: expect.any(String) },
+            ok: expect.any(Number),
+          }),
+        );
+        expect(msg).toContain("- Expected  - 1");
+        expect(msg).toContain("+ Received  + 1");
+        expect(msg).not.toContain(`-     "b":`);
+        expect(msg).not.toContain(`-   "ok":`);
+      });
+
+      test("diff replaces matching asymmetric matchers after a missing property", () => {
+        const msg = capture(() =>
+          expect({ b: new Date(0) }).toMatchObject({
+            a: "present",
+            b: expect.any(Date),
+          }),
+        );
+        expect(msg).toContain(`    "b": Any<Date>,`);
+        expect(msg).not.toContain(`-   "b":`);
+        expect(msg).not.toContain(`+   "b":`);
+      });
+    }
   });
 
   describe("toMatch()", () => {


### PR DESCRIPTION
Fixes #9089.

## What was wrong

When a `toMatchObject` assertion failed because one property's asymmetric matcher (e.g. `expect.any(Date)`) did not match, the diff output also marked every *other* asymmetric matcher in the object as a mismatch, even the ones that passed.

```ts
expect({ a: "foobar", b: new Date(), c: "hello" }).toMatchObject({
  a: expect.any(Date),   // mismatch
  b: expect.any(Date),   // matches
  c: "hello",
});
```

Before:

```
  {
-   "a": Any<Date>,
-   "b": Any<Date>,
+   "a": "foobar",
+   "b": 2026-08-01T05:30:37.115Z,
    "c": "hello",
  }

- Expected  - 2
+ Received  + 2
```

After (matches Jest):

```
  {
-   "a": Any<Date>,
+   "a": "foobar",
    "b": Any<Date>,
    "c": "hello",
  }

- Expected  - 1
+ Received  + 1
```

## Cause

`Bun__deepMatch` in `bindings.cpp` has a `replacePropsWithAsymmetricMatchers` mode: when an asymmetric matcher passes, it overwrites the received property with the matcher so the diff formatter renders identical text on both sides. But the function returned `false` on the *first* failing property, so any matcher appearing after the first mismatch was never replaced, and the text diff showed a spurious `-`/`+` pair for it. Swapping the property order so the passing matcher comes first produces the correct diff, which confirms the early-return is the root cause.

## Fix

When `replacePropsWithAsymmetricMatchers` is set, record the failure and keep iterating instead of returning, so every passing matcher still gets replaced before the diff is rendered. This applies to mismatches from failing matchers, `sameValue` mismatches, missing properties, nested-object recursion, and the array-length pre-check. Short-circuiting is unchanged when the flag is off (`Bun.deepMatch`, `expect.objectContaining`), so the fast path for passing assertions is preserved.

## Tests

Four new cases in the `toMatchObject` block of `test/js/bun/test/expect.test.js` catch the error and assert on the diff text: the issue's exact repro, a non-matcher mismatch before a passing matcher, a nested object whose sibling fails, and a missing property before a passing matcher. All four fail under `USE_SYSTEM_BUN=1` and pass with this change. The rest of `expect.test.js` (419 tests), `jest-extended.test.js`, `expect-extend.test.js`, and the snapshot property-matcher tests are unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect.test.js
bun test v1.4.0 (906cfad65)

test/js/bun/test/expect.test.js:
(pass) expect() > () [369.60ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [3.68ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.50ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.30ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.28ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.27ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.29ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.27ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.28ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.30ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.27ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.57ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.50ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.37ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.34ms]
(pass) e
... (truncated)

release without fix: 5 failed, 2 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/test/expect.test.js:
(pass) expect() > () [0.78ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.04ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.02ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect.test.js
bun test v1.4.0 (906cfad65)

test/js/bun/test/expect.test.js:
(pass) expect() > () [464.92ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [5.09ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.70ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.39ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.39ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.39ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.38ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.40ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.83ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.39ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.41ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [2.03ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.71ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.48ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.50ms]
(pass) e
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1829ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] gen cpp.rs (cppbind)
[2/9] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp   | 53 +++++++++++++++++++++++---------
 test/js/bun/test/expect.test.js | 68 +++++++++++++++++++++++++++++++++++++++++
 2 files changed, 107 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/jsc/bindings/bindings.cpp        5      5      0
test/js/bun/test/expect.test.js      2      1      0
```

</details>

<!-- robobun:evidence:end -->