### PR TITLE
process.dlopen: load context-aware V8 addons via node_register_module_v<ABI>

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -586,6 +586,38 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
     tryToDeleteIfNecessary();
 #endif
 
+#define BUN_STRINGIFY_IMPL_(x) #x
+#define BUN_STRINGIFY_(x) BUN_STRINGIFY_IMPL_(x)
+
+    // NODE_MODULE_INITIALIZER-style addons (e.g. uWebSockets.js) export
+    // node_register_module_v<ABI> instead of self-registering from a static
+    // constructor. If nothing registered during dlopen and we have no cached
+    // registration for this handle, look the symbol up and synthesize a
+    // registration so the existing self-registered path below handles it.
+    if (callCountAtStart == globalObject->napiModuleRegisterCallCount && !Bun::DLHandleMap::singleton().get(handle)) {
+#if OS(WINDOWS)
+        auto* initializer = reinterpret_cast<node::addon_context_register_func>(
+            GetProcAddress(handle, "node_register_module_v" BUN_STRINGIFY_(REPORTED_NODEJS_ABI_VERSION)));
+#else
+        auto* initializer = reinterpret_cast<node::addon_context_register_func>(
+            dlsym(handle, "node_register_module_v" BUN_STRINGIFY_(REPORTED_NODEJS_ABI_VERSION)));
+#endif
+        if (initializer) {
+            auto* mod = new node::node_module {
+                .nm_version = REPORTED_NODEJS_ABI_VERSION,
+                .nm_flags = 0,
+                .nm_dso_handle = nullptr,
+                .nm_filename = "",
+                .nm_register_func = nullptr,
+                .nm_context_register_func = initializer,
+                .nm_modname = "",
+                .nm_priv = nullptr,
+                .nm_link = nullptr,
+            };
+            node::node_module_register(mod);
+        }
+    }
+
     if (callCountAtStart != globalObject->napiModuleRegisterCallCount) {
         // Module self-registered via static constructor(s).
         // Move pending registrations into locals before iterating: an
@@ -701,8 +733,6 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
 #define dlsym GetProcAddress
 #endif
 
-    // TODO(@190n) look for node_register_module_vXYZ according to BuildOptions.reported_nodejs_version
-    // and the table at https://github.com/nodejs/node/blob/main/doc/abi_version_registry.json
     auto napi_register_module_v1 = reinterpret_cast<napi_value (*)(napi_env, napi_value)>(dlsym(handle, "napi_register_module_v1"));
 
     auto node_api_module_get_api_version_v1 = reinterpret_cast<int32_t (*)()>(dlsym(handle, "node_api_module_get_api_version_v1"));
@@ -719,10 +749,13 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
 #endif
 
         if (!scope.exception()) [[likely]] {
-            JSC::throwTypeError(globalObject, scope, "symbol 'napi_register_module_v1' not found in native module. Is this a Node API (napi) module?"_s);
+            JSC::throwTypeError(globalObject, scope, "Module did not self-register: no 'napi_register_module_v1' or 'node_register_module_v" BUN_STRINGIFY_(REPORTED_NODEJS_ABI_VERSION) "' symbol, and neither napi_module_register nor node_module_register was called"_s);
         }
         return {};
     }
+
+#undef BUN_STRINGIFY_
+#undef BUN_STRINGIFY_IMPL_
 
     // TODO(@heimskr): get the API version without node_api_module_get_api_version_v1 a different way
     int module_version = 8;

--- a/test/v8/bad-modules/binding.gyp
+++ b/test/v8/bad-modules/binding.gyp
@@ -7,6 +7,10 @@
     {
       "target_name": "no_entrypoint",
       "sources": ["no_entrypoint.cpp"],
+    },
+    {
+      "target_name": "context_aware_initializer",
+      "sources": ["context_aware_initializer.cpp"],
     }
   ]
 }

--- a/test/v8/bad-modules/context_aware_initializer.cpp
+++ b/test/v8/bad-modules/context_aware_initializer.cpp
@@ -1,0 +1,23 @@
+#include <node.h>
+
+// This module registers ONLY via NODE_MODULE_INITIALIZER (exported
+// node_register_module_v<ABI> symbol), with no static-constructor call to
+// node_module_register. uWebSockets.js uses this pattern.
+//
+// Before the fix for https://github.com/oven-sh/bun/issues/9785, loading
+// such a module failed with "symbol 'napi_register_module_v1' not found".
+
+using namespace v8;
+
+extern "C" NODE_MODULE_EXPORT void NODE_MODULE_INITIALIZER(Local<Object> exports,
+                                                           Local<Value> module,
+                                                           Local<Context> context) {
+  Isolate *isolate = Isolate::GetCurrent();
+  exports
+      ->Set(context,
+            String::NewFromUtf8(isolate, "hello", NewStringType::kNormal)
+                .ToLocalChecked(),
+            String::NewFromUtf8(isolate, "world", NewStringType::kNormal)
+                .ToLocalChecked())
+      .Check();
+}

--- a/test/v8/v8.test.ts
+++ b/test/v8/v8.test.ts
@@ -149,6 +149,23 @@ describe.skipIf(!canBuildNodeAddons()).todoIf(isBroken && isMusl)("node:v8", () 
     it("can call a basic native function", async () => {
       await checkSameOutput("test_v8_native_call");
     });
+
+    // https://github.com/oven-sh/bun/issues/9785
+    it("loads a module that exports node_register_module_v<ABI> (NODE_MODULE_INITIALIZER)", async () => {
+      const addon = join(directories.badModules, "build/Release/context_aware_initializer.node");
+      // Load in a child process: the initializer runs through the V8 shim, so a
+      // regression here must not take down the test runner.
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", `console.log(require(${JSON.stringify(addon)}).hello)`],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("napi_register_module_v1");
+      expect(stdout.replaceAll(/^\[\w+\].+\n/gm, "").trim()).toBe("world");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("primitives", () => {


### PR DESCRIPTION
### What does this PR do?

Addons built with `NODE_MODULE_INITIALIZER` directly (rather than `NODE_MODULE`, `NODE_MODULE_INIT()`, or `NAPI_MODULE`) export a single `node_register_module_v<NODE_MODULE_VERSION>` symbol and do not self-register from a static constructor. uWebSockets.js uses this pattern:

```cpp
extern "C" NODE_MODULE_EXPORT void
NODE_MODULE_INITIALIZER(Local<Object> exports, Local<Value> module, Local<Context> context) { ... }
```

Bun's loader only tried `napi_register_module_v1` after `dlopen`, so these modules failed with:

```
TypeError: symbol 'napi_register_module_v1' not found in native module. Is this a Node API (napi) module?
```

Partially fixes #9785 (loader dispatch). uWebSockets.js now reaches its `Main()` initializer; the remaining failures are unimplemented V8 C++ APIs (`node::GetCurrentEventLoop`, `v8::ArrayBuffer::*`, `v8::CFunction`, etc., ~43 symbols) tracked as part of the broader V8 API compatibility work.

### How did you fix it?

In `Process_functionDlopen`, after `dlopen` and before the self-registered check: if nothing registered during load and the handle has no cached registration, `dlsym` for `node_register_module_v<REPORTED_NODEJS_ABI_VERSION>`. If present, heap-allocate a `node::node_module` with the symbol as `nm_context_register_func` and hand it to `node_module_register`. The existing self-registered branch immediately below then runs the initializer under a V8 `HandleScope`, caches the registration in `DLHandleMap` for subsequent loads, and propagates any error. This is the same order Node.js uses in `DLOpen` (`node_register_module_v<ABI>` probed before `napi_register_module_v1`).

Also rewords the not-found error to name both entrypoints and the two register functions.

### How did you verify your code works?

New `test/v8/bad-modules/context_aware_initializer.cpp` exports only `node_register_module_v<ABI>` (no static constructor, no napi entry) and sets `exports.hello = "world"` from its initializer. The test spawns a child, requires the addon, and asserts the value.

```
USE_SYSTEM_BUN=1 bun test test/v8/v8.test.ts -t NODE_MODULE_INITIALIZER
  (fail) TypeError: symbol 'napi_register_module_v1' not found in native module

bun bd test test/v8/v8.test.ts -t NODE_MODULE_INITIALIZER
  (pass) loads a module that exports node_register_module_v<ABI> (NODE_MODULE_INITIALIZER)

bun bd test test/v8/v8.test.ts                                   # 59 pass / 0 fail
bun bd test test/js/node/process/dlopen-duplicate-load.test.ts   # 5 pass / 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/v8/v8.test.ts

<!-- robobun:evidence:end -->