### PR TITLE
ws: thread WebSocketServer maxPayload through to Bun.serve maxPayloadLength

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -71,6 +71,9 @@ let http1Fallback;
 const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
 const kTrackedConnections = Symbol("http.server.trackedConnections");
 const kHttpAllowHalfOpen = Symbol("http.server.httpAllowHalfOpen");
+const kWebSocketReload = Symbol("http.server.websocketReload");
+// Symbol.for: shared with src/js/thirdparty/ws.js.
+const kEnsureWebSocketMaxPayload = Symbol.for("::bunEnsureWebSocketMaxPayload::");
 
 // node.http trace events ('http.server.request' b/e). The agent module is
 // only created on the first request, and emission is gated per-request on the
@@ -625,34 +628,36 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
     if (tls) {
       this.serverName = tls.serverName || host || "localhost";
     }
-    this[serverSymbol] = Bun.serve<any>({
+    // Captured for server.reload() in kEnsureWebSocketMaxPayload.
+    const websocket = {
+      open(ws) {
+        ws.data.open(ws);
+      },
+      message(ws, message) {
+        ws.data.message(ws, message);
+      },
+      close(ws, code, reason) {
+        ws.data.close(ws, code, reason);
+      },
+      drain(ws) {
+        ws.data.drain(ws);
+      },
+      ping(ws, data) {
+        ws.data.ping(ws, data);
+      },
+      pong(ws, data) {
+        ws.data.pong(ws, data);
+      },
+      maxPayloadLength: this[kWebSocketReload]?.maxPayloadLength,
+    };
+    const serveOptions = {
       idleTimeout: 0, // nodejs dont have a idleTimeout by default
       tls,
       port,
       hostname: host,
       unix: socketPath,
       reusePort,
-      // Bindings to be used for WS Server
-      websocket: {
-        open(ws) {
-          ws.data.open(ws);
-        },
-        message(ws, message) {
-          ws.data.message(ws, message);
-        },
-        close(ws, code, reason) {
-          ws.data.close(ws, code, reason);
-        },
-        drain(ws) {
-          ws.data.drain(ws);
-        },
-        ping(ws, data) {
-          ws.data.ping(ws, data);
-        },
-        pong(ws, data) {
-          ws.data.pong(ws, data);
-        },
-      },
+      websocket,
       maxRequestBodySize: Number.MAX_SAFE_INTEGER,
 
       onNodeHTTPRequest(
@@ -1051,7 +1056,13 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
 
         return promise;
       },
-    });
+    };
+    this[serverSymbol] = Bun.serve<any>(serveOptions);
+    this[kWebSocketReload] = {
+      maxPayloadLength: websocket.maxPayloadLength,
+      websocket,
+      onNodeHTTPRequest: serveOptions.onNodeHTTPRequest,
+    };
 
     getBunServerAllClosedPromise(this[serverSymbol]).$then(emitCloseNTServer.bind(this));
     applyServerCustomOptions(this);
@@ -1169,6 +1180,31 @@ Server.prototype.setTimeout = function (msecs, callback) {
   this.timeout = msecs;
   if (typeof callback === "function") this.on("timeout", callback);
   return this;
+};
+
+// Raise-only: the ws shim enforces smaller per-WebSocketServer limits itself,
+// and lowering here would break other WebSocketServers sharing this server.
+const kBunServeDefaultMaxPayloadLength = 16 * 1024 * 1024;
+Server.prototype[kEnsureWebSocketMaxPayload] = function (maxPayload) {
+  if (typeof maxPayload !== "number" || NumberIsNaN(maxPayload)) return;
+  // ws.js passes 0 for unlimited; Bun.serve stores a u32.
+  if (maxPayload < 1 || maxPayload > 0xffffffff) maxPayload = 0xffffffff;
+  maxPayload = MathFloor(maxPayload);
+  let ctx = this[kWebSocketReload];
+  const current = ctx?.maxPayloadLength ?? kBunServeDefaultMaxPayloadLength;
+  if (current >= maxPayload) return;
+  if (ctx === undefined) {
+    // Not listening yet: kRealListen reads this.
+    this[kWebSocketReload] = { maxPayloadLength: maxPayload };
+    return;
+  }
+  ctx.maxPayloadLength = maxPayload;
+  const bunServer = this[serverSymbol];
+  const { websocket, onNodeHTTPRequest } = ctx;
+  if (bunServer && websocket) {
+    websocket.maxPayloadLength = maxPayload;
+    bunServer.reload({ websocket, onNodeHTTPRequest });
+  }
 };
 
 function onServerRequestEvent(this: NodeHTTPServerSocket, event: NodeHTTPResponseAbortEvent) {

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -1061,7 +1061,9 @@ class BunWebSocketMocked extends EventEmitter {
 
     const maxPayload = this.#maxPayload;
     if (maxPayload > 0) {
-      const byteLength = typeof message === "string" ? Buffer.byteLength(message) : message.byteLength;
+      // string (text frame), Buffer/ArrayBuffer (.byteLength) or Blob (.size), per binaryType.
+      const byteLength =
+        typeof message === "string" ? Buffer.byteLength(message) : (message.byteLength ?? message.size);
       if (byteLength > maxPayload) {
         this.#state = ReadyState_CLOSING;
         try {

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -11,6 +11,7 @@ const ReadyState_CLOSED = 3;
 const EventEmitter = require("node:events");
 const onceObject = { once: true };
 const kBunInternals = Symbol.for("::bunternal::");
+const kEnsureWebSocketMaxPayload = Symbol.for("::bunEnsureWebSocketMaxPayload::");
 const readyStates = ["CONNECTING", "OPEN", "CLOSING", "CLOSED"];
 
 const encoder = new TextEncoder();
@@ -28,6 +29,17 @@ function sendAfterClose(state, cb) {
     const err = new Error(`WebSocket is not open: readyState ${state} (${readyStates[state]})`);
     process.nextTick(cb, err);
   }
+}
+
+// 0 = unlimited, as in npm ws's Receiver.
+function normalizeMaxPayload(maxPayload) {
+  return typeof maxPayload === "number" && maxPayload >= 1 ? Math.floor(maxPayload) : 0;
+}
+
+function createMaxPayloadError() {
+  const error = new RangeError("Max payload size exceeded");
+  error.code = "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH";
+  return error;
 }
 
 /**
@@ -1000,18 +1012,20 @@ class BunWebSocketMocked extends EventEmitter {
   #bufferedAmount = 0;
   // The default of the ServerWebSocket. The setter keeps both sides in sync.
   #binaryType = "nodebuffer";
+  #maxPayload = 0;
 
   #onclose;
   #onerror;
   #onmessage;
   #onopen;
 
-  constructor(url, protocol, extensions) {
+  constructor(url, protocol, extensions, maxPayload) {
     super();
     this.#ws = null;
     this.#state = ReadyState_CONNECTING;
     this.#url = url;
     this.#bufferedAmount = 0;
+    this.#maxPayload = maxPayload;
     this.#protocol = protocol;
     this.#extensions = extensions;
 
@@ -1045,6 +1059,20 @@ class BunWebSocketMocked extends EventEmitter {
   #message(ws, message) {
     this.#ws = ws;
 
+    const maxPayload = this.#maxPayload;
+    if (maxPayload > 0) {
+      const byteLength = typeof message === "string" ? Buffer.byteLength(message) : message.byteLength;
+      if (byteLength > maxPayload) {
+        this.#state = ReadyState_CLOSING;
+        try {
+          this.emit("error", createMaxPayloadError());
+        } finally {
+          this.#ws?.close(1009, "");
+        }
+        return;
+      }
+    }
+
     let isBinary = false;
     if (typeof message === "string") {
       if (this.#binaryType === "arraybuffer") {
@@ -1072,9 +1100,21 @@ class BunWebSocketMocked extends EventEmitter {
   }
 
   #close(ws, code, reason) {
-    this.#state = ReadyState_CLOSED;
     this.#ws = null;
 
+    // Bun.serve's native maxPayloadLength force-close: surface as ws's RangeError + 1009.
+    if (code === 1006 && typeof reason === "string" && reason.startsWith("Received too big message")) {
+      this.#state = ReadyState_CLOSING;
+      try {
+        this.emit("error", createMaxPayloadError());
+      } finally {
+        this.#state = ReadyState_CLOSED;
+        this.emit("close", 1009, "");
+      }
+      return;
+    }
+
+    this.#state = ReadyState_CLOSED;
     this.emit("close", code, reason);
   }
 
@@ -1384,8 +1424,10 @@ class WebSocketServer extends EventEmitter {
         res.end(body);
       });
 
+      this._server[kEnsureWebSocketMaxPayload]?.(normalizeMaxPayload(options.maxPayload));
       this._server.listen(port, host, backlog, callback);
     } else if (server) {
+      server[kEnsureWebSocketMaxPayload]?.(normalizeMaxPayload(options.maxPayload));
       this._server = server;
     }
 
@@ -1550,7 +1592,13 @@ class WebSocketServer extends EventEmitter {
 
     if (this._state > RUNNING) return abortHandshake(socket, 503);
 
-    const server = socket.server[kBunInternals];
+    const httpServer = socket.server;
+    const server = httpServer[kBunInternals];
+
+    const maxPayload = normalizeMaxPayload(this.options.maxPayload);
+    // noServer: takes effect from the next upgrade (this request already
+    // captured the pre-reload WebSocketContext).
+    if (!this._server) httpServer[kEnsureWebSocketMaxPayload]?.(maxPayload);
 
     let protocol = "";
     if (protocols.size) {
@@ -1561,7 +1609,7 @@ class WebSocketServer extends EventEmitter {
         ? this.options.handleProtocols(protocols, request)
         : protocols.values().next().value;
     }
-    const ws = new BunWebSocketMocked(request.url, protocol, extensions);
+    const ws = new BunWebSocketMocked(request.url, protocol, extensions, maxPayload);
 
     const headers = ["HTTP/1.1 101 Switching Protocols", "Upgrade: websocket", "Connection: Upgrade"];
     this.emit("headers", headers, request);

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -1431,3 +1431,335 @@ describe("module loading", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// https://github.com/oven-sh/bun/issues/8261
+// The `ws` WebSocketServer `maxPayload` option was ignored: Bun applied a fixed
+// 16 MiB native limit regardless of the value passed, so a smaller limit let
+// oversized frames through and a larger limit still rejected frames above the
+// native default.
+describe("WebSocketServer maxPayload", () => {
+  const SMALL = 4096;
+  // Just over Bun.serve's 16 MiB websocket default, to prove the native cap is
+  // raised without shipping a needlessly large payload through a debug build.
+  const BIG = 17 * 1024 * 1024;
+
+  it.concurrent("rejects a message larger than maxPayload with a RangeError on the server socket", async () => {
+    const wss = new WebSocketServer({ port: 0, maxPayload: SMALL });
+    const serverEvents: any[] = [];
+    const serverDone = Promise.withResolvers<void>();
+    const clientClose = Promise.withResolvers<number>();
+
+    wss.on("connection", serverWs => {
+      serverWs.on("message", m => serverEvents.push({ type: "message", length: (m as Buffer).length }));
+      serverWs.on("error", err => serverEvents.push({ type: "error", err }));
+      serverWs.on("close", code => {
+        serverEvents.push({ type: "close", code });
+        serverDone.resolve();
+      });
+    });
+
+    const ws = new WebSocket("ws://127.0.0.1:" + (wss.address() as AddressInfo).port);
+    ws.on("open", () => ws.send(new Uint8Array(64 * 1024)));
+    ws.on("close", code => clientClose.resolve(code));
+    ws.on("error", () => {});
+
+    try {
+      await serverDone.promise;
+      // Server side matches npm `ws`: 'error' (RangeError, WS_ERR_UNSUPPORTED_MESSAGE_LENGTH)
+      // fires before 'close' (1009), and no 'message' event is emitted.
+      expect(serverEvents).toHaveLength(2);
+      expect(serverEvents[0].type).toBe("error");
+      expect(serverEvents[0].err).toBeInstanceOf(RangeError);
+      expect(serverEvents[0].err.message).toBe("Max payload size exceeded");
+      expect(serverEvents[0].err.code).toBe("WS_ERR_UNSUPPORTED_MESSAGE_LENGTH");
+      expect(serverEvents[1]).toEqual({ type: "close", code: 1009 });
+      expect(await clientClose.promise).toBe(1009);
+    } finally {
+      ws.close();
+      wss.close();
+    }
+  });
+
+  it.concurrent("rejects an oversized text message the same way as a binary one", async () => {
+    const wss = new WebSocketServer({ port: 0, maxPayload: SMALL });
+    const serverOutcome = Promise.withResolvers<{ type: string; code?: string; length?: number }>();
+    const clientClose = Promise.withResolvers<number>();
+
+    wss.on("connection", serverWs => {
+      serverWs.on("message", m => serverOutcome.resolve({ type: "message", length: (m as Buffer).length }));
+      serverWs.on("error", (err: any) => serverOutcome.resolve({ type: err.constructor.name, code: err.code }));
+    });
+
+    const ws = new WebSocket("ws://127.0.0.1:" + (wss.address() as AddressInfo).port);
+    ws.on("open", () => ws.send(Buffer.alloc(SMALL + 1, "A").toString()));
+    ws.on("close", code => clientClose.resolve(code));
+    ws.on("error", () => {});
+
+    try {
+      expect(await serverOutcome.promise).toEqual({ type: "RangeError", code: "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH" });
+      expect(await clientClose.promise).toBe(1009);
+    } finally {
+      ws.close();
+      wss.close();
+    }
+  });
+
+  // npm `ws` flips the socket to CLOSING before emitting 'error' (receiverOnError), so
+  // close()/send() inside the handler are no-ops and the close code stays 1009. The
+  // server-side surface is the same whether the frame is caught by the shim's own check
+  // (just over maxPayload) or by Bun.serve's native 16 MiB cap (BIG); in the native case
+  // the transport is dropped before a close frame can be sent, so only the server side
+  // is asserted there.
+  for (const [label, size, expectedClientCode] of [
+    ["the shim's check", SMALL + 1, 1009],
+    ["the native cap", BIG, undefined],
+  ] as const) {
+    it.concurrent(`is CLOSING inside the error handler and keeps 1009 when ${label} rejects the frame`, async () => {
+      const wss = new WebSocketServer({ port: 0, maxPayload: SMALL });
+      const serverOutcome = Promise.withResolvers<{ readyStateInHandler: number; closeCode: number }>();
+      const clientClose = Promise.withResolvers<number>();
+
+      wss.on("connection", serverWs => {
+        let readyStateInHandler = -1;
+        serverWs.on("error", () => {
+          readyStateInHandler = serverWs.readyState;
+          serverWs.close(1000, "ignored");
+        });
+        serverWs.on("close", closeCode => serverOutcome.resolve({ readyStateInHandler, closeCode }));
+      });
+
+      const ws = new WebSocket("ws://127.0.0.1:" + (wss.address() as AddressInfo).port);
+      ws.on("open", () => ws.send(new Uint8Array(size)));
+      ws.on("close", code => clientClose.resolve(code));
+      ws.on("error", () => {});
+
+      try {
+        expect(await serverOutcome.promise).toEqual({ readyStateInHandler: WebSocket.CLOSING, closeCode: 1009 });
+        if (expectedClientCode !== undefined) expect(await clientClose.promise).toBe(expectedClientCode);
+      } finally {
+        ws.close();
+        wss.close();
+      }
+    });
+  }
+
+  it.concurrent("accepts a message larger than Bun.serve's 16 MiB default when maxPayload is raised", async () => {
+    const wss = new WebSocketServer({ port: 0, maxPayload: BIG + 1024 });
+    const serverOutcome = Promise.withResolvers<{ type: string; length?: number; code?: number }>();
+
+    wss.on("connection", serverWs => {
+      serverWs.on("message", m => serverOutcome.resolve({ type: "message", length: (m as Buffer).length }));
+      serverWs.on("error", () => serverOutcome.resolve({ type: "error" }));
+      serverWs.on("close", code => serverOutcome.resolve({ type: "close", code }));
+    });
+
+    const ws = new WebSocket("ws://127.0.0.1:" + (wss.address() as AddressInfo).port);
+    ws.on("open", () => ws.send(new Uint8Array(BIG)));
+    ws.on("error", () => {});
+
+    try {
+      expect(await serverOutcome.promise).toEqual({ type: "message", length: BIG });
+    } finally {
+      ws.close();
+      wss.close();
+    }
+  });
+
+  // npm `ws` treats a maxPayload that is not a positive number as unlimited
+  // (Receiver does `maxPayload | 0` and skips the check below 1), so an explicit
+  // 0 or undefined must raise the native cap rather than leave it at 16 MiB.
+  for (const maxPayload of [0, undefined]) {
+    it.concurrent(`treats maxPayload: ${maxPayload} as unlimited`, async () => {
+      const wss = new WebSocketServer({ port: 0, maxPayload });
+      const serverOutcome = Promise.withResolvers<{ type: string; length?: number; code?: number }>();
+
+      wss.on("connection", serverWs => {
+        serverWs.on("message", m => serverOutcome.resolve({ type: "message", length: (m as Buffer).length }));
+        serverWs.on("error", () => serverOutcome.resolve({ type: "error" }));
+        serverWs.on("close", code => serverOutcome.resolve({ type: "close", code }));
+      });
+
+      const ws = new WebSocket("ws://127.0.0.1:" + (wss.address() as AddressInfo).port);
+      ws.on("open", () => ws.send(new Uint8Array(BIG)));
+      ws.on("error", () => {});
+
+      try {
+        expect(await serverOutcome.promise).toEqual({ type: "message", length: BIG });
+      } finally {
+        ws.close();
+        wss.close();
+      }
+    });
+  }
+
+  it.concurrent("delivers a message that is exactly maxPayload bytes", async () => {
+    const wss = new WebSocketServer({ port: 0, maxPayload: SMALL });
+    const serverOutcome = Promise.withResolvers<{ type: string; length?: number }>();
+
+    wss.on("connection", serverWs => {
+      serverWs.on("message", m => serverOutcome.resolve({ type: "message", length: (m as Buffer).length }));
+      serverWs.on("error", () => serverOutcome.resolve({ type: "error" }));
+    });
+
+    const ws = new WebSocket("ws://127.0.0.1:" + (wss.address() as AddressInfo).port);
+    ws.on("open", () => ws.send(new Uint8Array(SMALL)));
+    ws.on("error", () => {});
+
+    try {
+      expect(await serverOutcome.promise).toEqual({ type: "message", length: SMALL });
+    } finally {
+      ws.close();
+      wss.close();
+    }
+  });
+
+  it.concurrent("raises the native limit when attached to an already-listening server (server mode)", async () => {
+    const httpServer = createServer((req, res) => res.end("ok"));
+    let connections = 0;
+    httpServer.on("connection", () => connections++);
+    httpServer.listen(0);
+    await once(httpServer, "listening");
+    let wss: WebSocketServer | undefined;
+    let ws: WebSocket | undefined;
+    try {
+      const port = (httpServer.address() as AddressInfo).port;
+
+      // Attaching with a maxPayload above Bun.serve's default reloads the native
+      // listener; plain HTTP requests and the 'connection' event on the same
+      // server must keep working across the reload. Use `Connection: close` so
+      // each fetch is a fresh TCP connection.
+      const headers = { Connection: "close" };
+      expect(await (await fetch(`http://127.0.0.1:${port}/`, { headers })).text()).toBe("ok");
+      expect(connections).toBe(1);
+
+      wss = new WebSocketServer({ server: httpServer, maxPayload: BIG + 1024 });
+      const serverOutcome = Promise.withResolvers<{ type: string; length?: number; code?: number }>();
+
+      expect(await (await fetch(`http://127.0.0.1:${port}/`, { headers })).text()).toBe("ok");
+      expect(connections).toBe(2);
+
+      wss.on("connection", serverWs => {
+        serverWs.on("message", m => serverOutcome.resolve({ type: "message", length: (m as Buffer).length }));
+        serverWs.on("error", () => serverOutcome.resolve({ type: "error" }));
+        serverWs.on("close", code => serverOutcome.resolve({ type: "close", code }));
+      });
+
+      ws = new WebSocket("ws://127.0.0.1:" + port);
+      ws.on("open", () => ws!.send(new Uint8Array(BIG)));
+      ws.on("error", () => {});
+
+      expect(await serverOutcome.promise).toEqual({ type: "message", length: BIG });
+    } finally {
+      ws?.close();
+      wss?.close();
+      httpServer.close();
+    }
+  });
+
+  // The http 'connection' event is emitted from inside uWS's connection-filter
+  // loop, so the reload this attachment triggers must not touch that list.
+  it.concurrent("can be attached with a raised maxPayload from inside the 'connection' listener", async () => {
+    const httpServer = createServer();
+    const serverOutcome = Promise.withResolvers<{ type: string; length?: number; code?: number }>();
+    let wss: WebSocketServer | undefined;
+    httpServer.once("connection", () => {
+      wss = new WebSocketServer({ server: httpServer, maxPayload: BIG + 1024 });
+      wss.on("connection", serverWs => {
+        serverWs.on("message", m => serverOutcome.resolve({ type: "message", length: (m as Buffer).length }));
+        serverWs.on("error", () => serverOutcome.resolve({ type: "error" }));
+        serverWs.on("close", code => serverOutcome.resolve({ type: "close", code }));
+      });
+    });
+    httpServer.listen(0);
+    await once(httpServer, "listening");
+
+    const ws = new WebSocket("ws://127.0.0.1:" + (httpServer.address() as AddressInfo).port);
+    ws.on("open", () => ws.send(new Uint8Array(BIG)));
+    ws.on("error", () => {});
+
+    try {
+      expect(await serverOutcome.promise).toEqual({ type: "message", length: BIG });
+    } finally {
+      ws.close();
+      wss?.close();
+      httpServer.close();
+    }
+  });
+
+  it.concurrent("enforces maxPayload in noServer mode", async () => {
+    const wss = new WebSocketServer({ noServer: true, maxPayload: SMALL });
+    const httpServer = createServer();
+    const serverOutcome = Promise.withResolvers<{ type: string; err?: any }>();
+
+    httpServer.on("upgrade", (request, socket, head) => {
+      wss.handleUpgrade(request, socket, head, ws => wss.emit("connection", ws, request));
+    });
+    wss.on("connection", serverWs => {
+      serverWs.on("message", () => serverOutcome.resolve({ type: "message" }));
+      serverWs.on("error", err => serverOutcome.resolve({ type: "error", err }));
+    });
+
+    httpServer.listen(0);
+    await once(httpServer, "listening");
+
+    const ws = new WebSocket("ws://127.0.0.1:" + (httpServer.address() as AddressInfo).port);
+    ws.on("open", () => ws.send(new Uint8Array(64 * 1024)));
+    ws.on("error", () => {});
+
+    try {
+      const outcome = await serverOutcome.promise;
+      expect(outcome.type).toBe("error");
+      expect(outcome.err).toBeInstanceOf(RangeError);
+    } finally {
+      ws.close();
+      wss.close();
+      httpServer.close();
+    }
+  });
+
+  it.concurrent("applies per-WebSocketServer limits when two share one http server", async () => {
+    const httpServer = createServer();
+    httpServer.listen(0);
+    await once(httpServer, "listening");
+
+    const strict = new WebSocketServer({ noServer: true, maxPayload: SMALL });
+    const loose = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 });
+
+    httpServer.on("upgrade", (request, socket, head) => {
+      const which = request.url === "/loose" ? loose : strict;
+      which.handleUpgrade(request, socket, head, ws => which.emit("connection", ws, request));
+    });
+
+    const strictOutcome = Promise.withResolvers<string>();
+    const looseOutcome = Promise.withResolvers<{ type: string; length?: number }>();
+    strict.on("connection", ws => {
+      ws.on("message", () => strictOutcome.resolve("message"));
+      ws.on("error", () => strictOutcome.resolve("error"));
+    });
+    loose.on("connection", ws => {
+      ws.on("message", m => looseOutcome.resolve({ type: "message", length: (m as Buffer).length }));
+      ws.on("error", () => looseOutcome.resolve({ type: "error" }));
+    });
+
+    const port = (httpServer.address() as AddressInfo).port;
+    const payload = new Uint8Array(64 * 1024);
+
+    const c1 = new WebSocket(`ws://127.0.0.1:${port}/strict`);
+    c1.on("open", () => c1.send(payload));
+    c1.on("error", () => {});
+    const c2 = new WebSocket(`ws://127.0.0.1:${port}/loose`);
+    c2.on("open", () => c2.send(payload));
+    c2.on("error", () => {});
+
+    try {
+      expect(await strictOutcome.promise).toBe("error");
+      expect(await looseOutcome.promise).toEqual({ type: "message", length: 64 * 1024 });
+    } finally {
+      c1.close();
+      c2.close();
+      strict.close();
+      loose.close();
+      httpServer.close();
+    }
+  });
+});

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -1504,6 +1504,35 @@ describe("WebSocketServer maxPayload", () => {
     }
   });
 
+  // The server socket's binaryType decides whether a binary frame arrives as a
+  // Buffer, an ArrayBuffer or a Blob; the size check must see all three.
+  for (const binaryType of ["nodebuffer", "arraybuffer", "blob"] as const) {
+    it.concurrent(`rejects an oversized binary message when binaryType is ${binaryType}`, async () => {
+      const wss = new WebSocketServer({ port: 0, maxPayload: SMALL });
+      const serverOutcome = Promise.withResolvers<{ type: string; code?: string }>();
+      const clientClose = Promise.withResolvers<number>();
+
+      wss.on("connection", serverWs => {
+        serverWs.binaryType = binaryType;
+        serverWs.on("message", m => serverOutcome.resolve({ type: "message:" + m.constructor.name }));
+        serverWs.on("error", (err: any) => serverOutcome.resolve({ type: err.constructor.name, code: err.code }));
+      });
+
+      const ws = new WebSocket("ws://127.0.0.1:" + (wss.address() as AddressInfo).port);
+      ws.on("open", () => ws.send(new Uint8Array(SMALL + 1)));
+      ws.on("close", code => clientClose.resolve(code));
+      ws.on("error", () => {});
+
+      try {
+        expect(await serverOutcome.promise).toEqual({ type: "RangeError", code: "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH" });
+        expect(await clientClose.promise).toBe(1009);
+      } finally {
+        ws.close();
+        wss.close();
+      }
+    });
+  }
+
   // npm `ws` flips the socket to CLOSING before emitting 'error' (receiverOnError), so
   // close()/send() inside the handler are no-ops and the close code stays 1009. The
   // server-side surface is the same whether the frame is caught by the shim's own check


### PR DESCRIPTION
### What

Fixes #8261, fixes #33284, fixes #36116. The `ws` package's `WebSocketServer` `maxPayload` option was ignored under Bun: the node:http server always applied `Bun.serve`'s fixed 16 MiB websocket default, so a smaller `maxPayload` let oversized frames through and a larger `maxPayload` still rejected frames at 16 MiB.

### Repro

```js
const { WebSocketServer } = require("ws");
const wss = new WebSocketServer({ port: 0, maxPayload: 4096 });
wss.on("connection", ws => {
  ws.on("message", d => console.log("server received", d.length, "bytes"));
  ws.on("error", e => console.log("server error:", e.constructor.name, e.message));
});
wss.on("listening", () => {
  const c = new WebSocket("ws://127.0.0.1:" + wss.address().port);
  c.onopen = () => c.send(new Uint8Array(64 * 1024));
  c.onclose = e => { console.log("client close", e.code); process.exit(0); };
});
```

Bun before: `server received 65536 bytes` (limit ignored). And with `maxPayload: 50 * 1024 * 1024` a 20 MiB frame was still rejected at 16 MiB.
Node + npm `ws`: `server error: RangeError Max payload size exceeded`, client close `1009`.

### Cause

`src/js/node/_http_server.ts` passed a fixed `websocket` config to `Bun.serve` at `listen()` time with no `maxPayloadLength`, so the native default (16 MiB) always applied. `ws.js` stored `maxPayload` on `this.options` but never forwarded it, and `server.upgrade()` only reads `data` and `headers`, so there was no per-connection override either.

### Fix

* `node:_http_server` captures the websocket handler object and the `onNodeHTTPRequest` closure and exposes an internal `Symbol.for("::bunEnsureWebSocketMaxPayload::")` hook. Calling it raises `Bun.serve`'s per-server websocket `maxPayloadLength` (applied before `listen()` when possible, or via `server.reload()` on an already-listening server). The limit is only ever raised (it also stays raised after that `WebSocketServer` is closed); lowering would break other `WebSocketServer` instances sharing the same http server, and every connection still enforces its own limit below the native cap.
* `ws.js` normalizes the option once (`normalizeMaxPayload`: anything that is not a positive number is unlimited, matching npm `ws`'s Receiver) and calls that hook from the `WebSocketServer` constructor (`port` and `server` modes) and from `completeUpgrade` (`noServer` mode, first time the http server is reachable), so a `maxPayload` above 16 MiB now reaches the native frame parser. In `noServer` mode the in-flight upgrade has already captured the previous context, so the raised limit applies from the next connection on.
* `ws.js` enforces each connection's own `maxPayload` in the server-side socket wrapper (`BunWebSocketMocked`). An oversized frame emits `RangeError: Max payload size exceeded` (`WS_ERR_UNSUPPORTED_MESSAGE_LENGTH`) and closes with `1009`, matching npm `ws`'s `receiverOnError`. When the native limit trips first (frame larger than every attached `maxPayload`), uWS's `Received too big message` force-close is mapped to the same server-side surface.

This keeps the memory bound at `max(16 MiB, highest attached maxPayload)` while giving per-`WebSocketServer` limits their own enforcement. Note the default case: a `WebSocketServer` constructed without `maxPayload` uses ws's 100 MiB default, so attaching one now raises the http server's native cap from 16 MiB to 100 MiB, which is the limit the same code gets under Node + ws.

### Verification

New `describe("WebSocketServer maxPayload")` block in `test/js/first_party/ws/ws.test.ts` (15 cases):

* oversized frame on a 4 KiB limit: server sees `RangeError` + `close(1009)`, no `message`, client closes `1009` (text frames, and binary frames with the server socket's `binaryType` set to each of `nodebuffer`, `arraybuffer` and `blob`)
* inside the server `error` handler the socket is already `CLOSING`, and a `close(1000)` called from the handler does not replace the `1009` close code; asserted both when the shim's own check rejects the frame and when Bun.serve's native cap does (cases carried over from #33287)
* `maxPayload: 0` and an explicit `maxPayload: undefined`: unlimited, a 17 MiB frame is delivered
* 17 MiB frame with `maxPayload` above it: delivered (native cap raised) in `port` mode, in `server` mode on an already-listening server (plain HTTP and the http `connection` event keep working across the reload), and when the `WebSocketServer` is attached from inside the http `connection` listener
* exactly-at-limit frame: delivered
* `noServer` mode: oversized frame rejected with `RangeError`
* two `WebSocketServer`s on one http server with different limits: each sees its own limit enforced

Fail-before (main's `_http_server.ts` and `ws.js`): every case except exactly-at-limit fails (oversized frames delivered; 17 MiB frames close `1006` at the 16 MiB default). Pass-after (`bun bd`): all 79 tests in `ws.test.ts` pass, as does `test/js/node/http/node-http-with-ws.test.ts`.

Rebased onto current main as a single commit (twice). First rebase: the only conflict was in `test/js/first_party/ws/ws.test.ts`, where #39435 appended a `module loading` test at the spot this PR appends its `maxPayload` block; both were kept. Second rebase: #39808 (one `binaryType` rule for both shim sockets) and #39642 (`handleUpgrade()` after an await) rewrote the `BunWebSocketMocked` constructor and the head of `completeUpgrade` in `ws.js`. Main's shape was kept: the constructor is now `(url, protocol, extensions, maxPayload)`, with main's fixed `#binaryType = "nodebuffer"` default and no `binaryType` parameter, and `completeUpgrade` keeps main's early FIN check, duplicate-upgrade guard and `abortHandshake(socket, ...)` call, with only the `maxPayload` normalization and the noServer hook call added after them. `_http_server.ts` merged cleanly.

Supersedes #33287 (closed), which enforced the limit in JavaScript only and could not accept frames above the 16 MiB native default; the review there asked for the existing `Bun.serve` option to be used, which is what this PR does. The per-connection `RangeError`/`1009` surface and its test cases from #33287 are carried here. #33801 covers the client-side `ws` `maxPayload` and is independent of this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/ws/ws.test.ts
bun test v1.4.1 (4448a2e21)

test/js/first_party/ws/ws.test.ts:
Listening: ws://127.0.0.1:35071/
(pass) WebSocket > url [1407.79ms]
Listening: ws://127.0.0.1:39951/
Received upgrade: {
  host: "127.0.0.1:39951",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "MGk83w7stxaEJygWP/5Ywg==",
}
Received connection: 127.0.0.1
(pass) WebSocket > readyState [1784.90ms]
Listening: ws://127.0.0.1:37943/
(pass) WebSocket > binaryType > (default) [1352.82ms]
Listening: ws://127.0.0.1:34243/
(pass) WebSocket > binaryType > (invalid) [1372.22ms]
Listening: ws://127.0.0.1:46803/
Received upgrade: {
  host: "127.0.0.1:46803",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "CBUS9WnhHunRlxX6AIVhOA==",
}
Received connection: 127.0.0.1
Received message: <Buffer
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (83a6f68be)

test/js/first_party/ws/ws.test.ts:
Listening: ws://127.0.0.1:33269/
(pass) WebSocket > url [23.93ms]
Listening: ws://127.0.0.1:37669/
Received upgrade: {
  host: "127.0.0.1:37669",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "c8RwCqskWyfoA24aWoRJcQ==",
}
Received connection: 127.0.0.1
(pass) WebSocket > readyState [30.77ms]
Listening: ws://127.0.0.1:34653/
(pass) WebSocket > binaryType > (default) [25.58ms]
Listening: ws://127.0.0.1:46569/
(pass) WebSocket > binaryType > (invalid) [23.73ms]
Listening: ws://127.0.0.1:46873/
Received upgrade: {
  host: "127.0.0.1:46873",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "HA1gkOTUIVMnBGsEAESB0w==",
}
Received connection: 127.0.0.1
Received message: <Buffer 00>
Received ping: <Buffer >
Received pong: <Buffer >
Received pong: <Buffer >
(pass) WebSocket > binaryType > nodebuffer [37.53ms]
Listening: ws://127.0.0.1:41199/

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/ws/ws.test.ts
bun test v1.4.1 (4448a2e21)

test/js/first_party/ws/ws.test.ts:
Listening: ws://127.0.0.1:32933/
(pass) WebSocket > url [1398.14ms]
Listening: ws://127.0.0.1:34343/
Received upgrade: {
  host: "127.0.0.1:34343",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "hK/jA8CAmE829CBasjYq9A==",
}
Received connection: 127.0.0.1
(pass) WebSocket > readyState [1823.65ms]
Listening: ws://127.0.0.1:38259/
(pass) WebSocket > binaryType > (default) [1369.84ms]
Listening: ws://127.0.0.1:46613/
(pass) WebSocket > binaryType > (invalid) [1379.07ms]
Listening: ws://127.0.0.1:41457/
Received upgrade: {
  host: "127.0.0.1:41457",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "ZBU+OmrMv6sqTpu6jCITIQ==",
}
Received connection: 127.0.0.1
Received message: <Buffer
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 643ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen cpp.rs (cppbind)
[2/23] gen JS modules (bundle-modules)
Preprocess modules (7500ms)
Bundle modules (51ms)
Postprocesss modules (35ms)
Bundle Functions (667ms)
Generate Code (19ms)

[8.28s] Bundled "src/js" for production
  2627 kb
  198 internal modules
  13 native modules
  91 internal functions across 16 files
[2/9] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_server.ts       |  82 ++++++---
 src/js/thirdparty/ws.js           |  58 +++++-
 test/js/first_party/ws/ws.test.ts | 361 ++++++++++++++++++++++++++++++++++++++
 3 files changed, 474 insertions(+), 27 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/js/node/_http_server.ts           15     15      0
src/js/thirdparty/ws.js               14     29      0
test/js/first_party/ws/ws.test.ts      5      7      0
```

</details>

<!-- robobun:evidence:end -->







