### PR TITLE
spawn: accept parent stdio fd at any stdio slot

### DIFF
--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -82,16 +82,12 @@ pub(crate) enum ResultT<T> {
 pub(crate) type Result = ResultT<SpawnOptionsStdio>;
 
 pub(crate) enum ToSpawnOptsError {
-    StdinUsedAsOut,
-    OutUsedAsStdin,
     BlobUsedAsOut,
 }
 
 impl ToSpawnOptsError {
     pub(crate) fn to_str(&self) -> &'static [u8] {
         match self {
-            Self::StdinUsedAsOut => b"Stdin cannot be used for stdout or stderr",
-            Self::OutUsedAsStdin => b"Stdout and stderr cannot be used for stdin",
             Self::BlobUsedAsOut => b"Blobs are immutable, and cannot be used for stdout/stderr",
         }
     }
@@ -243,25 +239,6 @@ impl Stdio {
                                 PathOrFileDescriptor::Fd(store_fd) => {
                                     if Some(store_fd) == fd {
                                         break 'brk SpawnOptionsStdio::Inherit;
-                                    }
-
-                                    if let Some(tag) = store_fd.stdio_tag() {
-                                        match tag {
-                                            FdStdio::StdIn => {
-                                                if i == 1 || i == 2 {
-                                                    return ResultT::Err(
-                                                        ToSpawnOptsError::StdinUsedAsOut,
-                                                    );
-                                                }
-                                            }
-                                            FdStdio::StdOut | FdStdio::StdErr => {
-                                                if i == 0 {
-                                                    return ResultT::Err(
-                                                        ToSpawnOptsError::OutUsedAsStdin,
-                                                    );
-                                                }
-                                            }
-                                        }
                                     }
 
                                     break 'brk SpawnOptionsStdio::Pipe(store_fd);
@@ -477,31 +454,9 @@ impl Stdio {
                 )));
             }
 
-            if let Some(tag) = fd.stdio_tag() {
-                match tag {
-                    FdStdio::StdIn => {
-                        if i == 1 || i == 2 {
-                            return Err(global.throw_invalid_arguments(format_args!(
-                                "stdin cannot be used for stdout or stderr"
-                            )));
-                        }
-
-                        *out_stdio = Stdio::Inherit;
-                        return Ok(());
-                    }
-                    FdStdio::StdOut | FdStdio::StdErr => {
-                        if i == 0 {
-                            return Err(global.throw_invalid_arguments(format_args!(
-                                "stdout and stderr cannot be used for stdin"
-                            )));
-                        }
-                        if (i == 1 && tag == FdStdio::StdOut) || (i == 2 && tag == FdStdio::StdErr)
-                        {
-                            *out_stdio = Stdio::Inherit;
-                            return Ok(());
-                        }
-                    }
-                }
+            if fd.stdio_tag().is_some() && file_fd == i {
+                *out_stdio = Stdio::Inherit;
+                return Ok(());
             }
 
             *out_stdio = Stdio::Fd(fd);
@@ -599,36 +554,11 @@ impl Stdio {
                 if let StoreData::File(ref file) = store.data {
                     match file.pathlike {
                         PathOrFileDescriptor::Fd(store_fd) => {
-                            if Some(store_fd) == fd {
-                                *self = Stdio::Inherit;
+                            *self = if Some(store_fd) == fd {
+                                Stdio::Inherit
                             } else {
-                                // TODO: is this supposed to be `store.data.file.pathlike.fd`?
-                                if let Some(tag) = FdStdio::from_int(i) {
-                                    match tag {
-                                        FdStdio::StdIn => {
-                                            if i == 1 || i == 2 {
-                                                return Err(global.throw_invalid_arguments(
-                                                    format_args!(
-                                                        "stdin cannot be used for stdout or stderr"
-                                                    ),
-                                                ));
-                                            }
-                                        }
-                                        FdStdio::StdOut | FdStdio::StdErr => {
-                                            if i == 0 {
-                                                return Err(global.throw_invalid_arguments(
-                                                    format_args!(
-                                                        "stdout and stderr cannot be used for stdin"
-                                                    ),
-                                                ));
-                                            }
-                                        }
-                                    }
-                                }
-
-                                *self = Stdio::Fd(store_fd);
-                            }
-
+                                Stdio::Fd(store_fd)
+                            };
                             return Ok(());
                         }
                         PathOrFileDescriptor::Path(ref path) => {

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -750,25 +750,31 @@ pub unsafe fn spawn_process_posix(
     let mut dup_stdout_to_stderr: bool = false;
 
     // stdio: [2,0,0] would dup2(2,0) then dup2(0,1), reading the clobbered
-    // fd 0. Save any source fd < 3 aside first (same as uv__process_child_init).
-    let mut saved_stdio_src: [Option<Fd>; 3] = [None; 3];
-    for (i, stdio) in stdio_options.iter().enumerate() {
+    // fd 0. Save any source fd < stdio_count aside first (same as uv__process_child_init).
+    let stdio_count = 3 + options.extra_fds.len();
+    let mut saved_stdio_src: Vec<Option<Fd>> = vec![None; stdio_count];
+    for (i, stdio) in stdio_options
+        .iter()
+        .copied()
+        .chain(options.extra_fds.iter())
+        .enumerate()
+    {
         let PosixStdio::Pipe(fd) = *stdio else {
             continue;
         };
         let src = fd.native();
-        if !(0..3).contains(&src) || usize::try_from(src).unwrap() == i {
+        if src < 0 || src as usize >= stdio_count || src as usize == i {
             continue;
         }
         // SAFETY: `fd` is a live descriptor; F_DUPFD_CLOEXEC takes an
         // integer lower bound and no pointer arguments.
-        let tmp = unsafe { libc::fcntl(fd.native(), libc::F_DUPFD_CLOEXEC, 3_i32) };
+        let tmp = unsafe { libc::fcntl(src, libc::F_DUPFD_CLOEXEC, stdio_count as libc::c_int) };
         if tmp < 0 {
             return Ok(Err(bun_sys::Error::from_code_int(
                 bun_sys::last_errno(),
                 bun_sys::Tag::dup,
             )
-            .with_fd(*fd)));
+            .with_fd(fd)));
         }
         let tmp = Fd::from_native(tmp);
         cleanup.to_close_at_end.push(tmp);
@@ -993,7 +999,7 @@ pub unsafe fn spawn_process_posix(
                 extra_fds.push(ExtraPipe::OwnedFd(fds[0]));
             }
             PosixStdio::Pipe(fd) => {
-                actions.dup2(*fd, fileno)?;
+                actions.dup2(saved_stdio_src[3 + i].unwrap_or(*fd), fileno)?;
                 // The fd was supplied by the caller (a number in the stdio array) and is
                 // not owned by us. Record it so `stdio[N]` returns the caller's fd, but
                 // mark it unowned so finalizeStreams leaves it open.

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -749,6 +749,35 @@ pub unsafe fn spawn_process_posix(
     // index spawned.{stdin,stdout,stderr} via a helper closure.
     let mut dup_stdout_to_stderr: bool = false;
 
+    // A caller-supplied fd at one stdio slot may be the target of an
+    // earlier slot's dup2 (e.g. stdio: [2, 0, 0] → dup2(2,0) clobbers fd 0
+    // before slots 1/2 read it). Like libuv's uv__process_child_init,
+    // F_DUPFD any such source fd to a temporary >= 3 in the parent and
+    // register dup2(tmp, slot) instead.
+    let mut saved_stdio_src: [Option<Fd>; 3] = [None; 3];
+    for (i, stdio) in stdio_options.iter().enumerate() {
+        let PosixStdio::Pipe(fd) = *stdio else {
+            continue;
+        };
+        let src = fd.native();
+        if !(0..3).contains(&src) || usize::try_from(src).unwrap() == i {
+            continue;
+        }
+        // SAFETY: `fd` is a live descriptor; F_DUPFD_CLOEXEC takes an
+        // integer lower bound and no pointer arguments.
+        let tmp = unsafe { libc::fcntl(fd.native(), libc::F_DUPFD_CLOEXEC, 3_i32) };
+        if tmp < 0 {
+            return Ok(Err(bun_sys::Error::from_code_int(
+                bun_sys::last_errno(),
+                bun_sys::Tag::dup,
+            )
+            .with_fd(*fd)));
+        }
+        let tmp = Fd::from_native(tmp);
+        cleanup.to_close_at_end.push(tmp);
+        saved_stdio_src[i] = Some(tmp);
+    }
+
     // The label is only referenced from the Linux memfd fast-path below.
     #[cfg_attr(
         not(any(target_os = "linux", target_os = "android")),
@@ -895,7 +924,7 @@ pub unsafe fn spawn_process_posix(
                 set_spawned_stdio(&mut spawned, i, fds[0]);
             }
             PosixStdio::Pipe(fd) => {
-                actions.dup2(*fd, fileno)?;
+                actions.dup2(saved_stdio_src[i].unwrap_or(*fd), fileno)?;
                 set_spawned_stdio(&mut spawned, i, *fd);
             }
             PosixStdio::SocketFd => {

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -749,11 +749,8 @@ pub unsafe fn spawn_process_posix(
     // index spawned.{stdin,stdout,stderr} via a helper closure.
     let mut dup_stdout_to_stderr: bool = false;
 
-    // A caller-supplied fd at one stdio slot may be the target of an
-    // earlier slot's dup2 (e.g. stdio: [2, 0, 0] → dup2(2,0) clobbers fd 0
-    // before slots 1/2 read it). Like libuv's uv__process_child_init,
-    // F_DUPFD any such source fd to a temporary >= 3 in the parent and
-    // register dup2(tmp, slot) instead.
+    // stdio: [2,0,0] would dup2(2,0) then dup2(0,1), reading the clobbered
+    // fd 0. Save any source fd < 3 aside first (same as uv__process_child_init).
     let mut saved_stdio_src: [Option<Fd>; 3] = [None; 3];
     for (i, stdio) in stdio_options.iter().enumerate() {
         let PosixStdio::Pipe(fd) = *stdio else {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1,7 +1,18 @@
 import { semver, write } from "bun";
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isLinux, isPosix, isWindows, nodeExe, runBunInstall, shellExe, tempDir, tmpdirSync } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  isLinux,
+  isPosix,
+  isWindows,
+  nodeExe,
+  runBunInstall,
+  shellExe,
+  tempDir,
+  tmpdirSync,
+} from "harness";
 import { ChildProcess, exec, execFile, execFileSync, execSync, fork, spawn, spawnSync } from "node:child_process";
 import { getEventListeners, once, setMaxListeners } from "node:events";
 import { promisify } from "node:util";

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1,7 +1,7 @@
 import { semver, write } from "bun";
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isLinux, isPosix, isWindows, nodeExe, runBunInstall, shellExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isPosix, isWindows, nodeExe, runBunInstall, shellExe, tempDir, tmpdirSync } from "harness";
 import { ChildProcess, exec, execFile, execFileSync, execSync, fork, spawn, spawnSync } from "node:child_process";
 import { getEventListeners, once, setMaxListeners } from "node:events";
 import { promisify } from "node:util";
@@ -495,6 +495,43 @@ describe("spawn()", () => {
       expect(stderr).toBe("");
       expect(stdout).toBe("OUT ERR");
       expect(exitCode).toBe(0);
+    });
+
+    // dup2 ordering hazard: stdio: [2, 0, 0] registers dup2(2,0) then
+    // dup2(0,1)/dup2(0,2), so fd 0 is clobbered before slots 1/2 read it
+    // unless the source fd is saved aside first (libuv does this via
+    // F_DUPFD in uv__process_child_init). Verify the grandchild's fds land
+    // on the ORIGINAL parent fds, not on an earlier slot's dup2 target.
+    it.skipIf(isWindows).each([
+      { stdio: [2, 0, 0], want: { fA: "ONE TWO ", fB: "", fC: "ZERO " } },
+      { stdio: [0, 2, 1], want: { fA: "ZERO ", fB: "TWO ", fC: "ONE " } },
+      { stdio: [1, 2, 0], want: { fA: "TWO ", fB: "ZERO ", fC: "ONE " } },
+    ] as const)("stdio: $stdio dups the original parent fds, not an earlier slot's target", ({ stdio, want }) => {
+      using dir = tempDir("spawn-stdio-dup-order", { fA: "", fB: "", fC: "" });
+      // Middle process has fds 0/1/2 bound to three distinct r+w files, then
+      // spawns the grandchild with the test's stdio mapping.
+      const middle = `
+        const { spawnSync } = require("child_process");
+        const r = spawnSync(process.execPath, ["-e",
+          'const fs = require("fs");' +
+          'fs.writeSync(0, "ZERO "); fs.writeSync(1, "ONE "); fs.writeSync(2, "TWO ");'
+        ], { stdio: ${JSON.stringify(stdio)} });
+        if (r.error) throw r.error;
+        process.exit(r.status);
+      `;
+      const fds = ["fA", "fB", "fC"].map(f => fs.openSync(path.join(String(dir), f), "r+"));
+      try {
+        const r = spawnSync(bunExe(), ["-e", middle], { env: bunEnv, stdio: fds });
+        expect(r.error).toBeUndefined();
+        expect(r.status).toBe(0);
+      } finally {
+        for (const fd of fds) fs.closeSync(fd);
+      }
+      expect({
+        fA: fs.readFileSync(path.join(String(dir), "fA"), "utf8"),
+        fB: fs.readFileSync(path.join(String(dir), "fB"), "utf8"),
+        fC: fs.readFileSync(path.join(String(dir), "fC"), "utf8"),
+      }).toEqual(want);
     });
   });
 

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -454,6 +454,48 @@ describe("spawn()", () => {
       expect(stdout).toBe("ok\n");
       expect(status).toBe(0);
     });
+
+    // https://github.com/oven-sh/bun/issues/7845
+    it.each([
+      [0, 0, 0],
+      [1, 1, 1],
+      [2, 0, 0],
+    ] as const)("accepts the same numeric fd at every slot: [%i, %i, %i]", async (...stdio) => {
+      const child = spawn(bunExe(), ["-e", "0"], { env: bunEnv, stdio: [...stdio] });
+      expect(child.stdin).toBeNull();
+      expect(child.stdout).toBeNull();
+      expect(child.stderr).toBeNull();
+      const [code] = await once(child, "close");
+      expect(code).toBe(0);
+      // Parent's own stdio must not have been closed by the spawn machinery.
+      expect(fs.fstatSync(0)).toBeDefined();
+      expect(fs.fstatSync(1)).toBeDefined();
+      expect(fs.fstatSync(2)).toBeDefined();
+    });
+
+    it("numeric fd is dup'd into the requested slot (stdio: [1, 1, 1])", async () => {
+      // Outer process's fd 1 is a pipe back to us. It spawns an inner child
+      // with stdio: [1, 1, 1], so the inner child's stdout AND stderr both
+      // land on that same pipe.
+      const script = `
+        const { spawnSync } = require("child_process");
+        const r = spawnSync(process.execPath, ["-e",
+          'require("fs").writeSync(1, "OUT "); require("fs").writeSync(2, "ERR")'
+        ], { stdio: [1, 1, 1] });
+        if (r.error) throw r.error;
+        process.exit(r.status ?? 1);
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("OUT ERR");
+      expect(exitCode).toBe(0);
+    });
   });
 
   it.skipIf(isWindows)(

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -514,18 +514,23 @@ describe("spawn()", () => {
     // F_DUPFD in uv__process_child_init). Verify the grandchild's fds land
     // on the ORIGINAL parent fds, not on an earlier slot's dup2 target.
     it.skipIf(isWindows).each([
-      { stdio: [2, 0, 0], want: { fA: "ONE TWO ", fB: "", fC: "ZERO " } },
-      { stdio: [0, 2, 1], want: { fA: "ZERO ", fB: "TWO ", fC: "ONE " } },
-      { stdio: [1, 2, 0], want: { fA: "TWO ", fB: "ZERO ", fC: "ONE " } },
+      { stdio: [2, 0, 0], want: { fA: "w1 w2 ", fB: "", fC: "w0 " } },
+      { stdio: [0, 2, 1], want: { fA: "w0 ", fB: "w2 ", fC: "w1 " } },
+      { stdio: [1, 2, 0], want: { fA: "w2 ", fB: "w0 ", fC: "w1 " } },
+      { stdio: ["ignore", "inherit", "inherit", 0], want: { fA: "w3 ", fB: "w1 ", fC: "w2 " } },
+      { stdio: ["ignore", "inherit", "inherit", 0, 1, 2], want: { fA: "w3 ", fB: "w1 w4 ", fC: "w2 w5 " } },
     ] as const)("stdio: $stdio dups the original parent fds, not an earlier slot's target", ({ stdio, want }) => {
       using dir = tempDir("spawn-stdio-dup-order", { fA: "", fB: "", fC: "" });
       // Middle process has fds 0/1/2 bound to three distinct r+w files, then
-      // spawns the grandchild with the test's stdio mapping.
+      // spawns the grandchild with the test's stdio mapping. The grandchild
+      // writes "w<i> " to each numeric-fd slot.
+      const writes = stdio
+        .map((s, i) => (typeof s === "number" || s === "inherit" ? `fs.writeSync(${i}, "w${i} ");` : ""))
+        .join(" ");
       const middle = `
         const { spawnSync } = require("child_process");
         const r = spawnSync(process.execPath, ["-e",
-          'const fs = require("fs");' +
-          'fs.writeSync(0, "ZERO "); fs.writeSync(1, "ONE "); fs.writeSync(2, "TWO ");'
+          'const fs = require("fs"); ${writes}'
         ], { stdio: ${JSON.stringify(stdio)} });
         if (r.error) throw r.error;
         process.exit(r.status);


### PR DESCRIPTION
Fixes #7845.

## Problem

`child_process.spawn` (and `Bun.spawn`) throw when a numeric fd 0/1/2 is placed at a different stdio slot:

```js
require('child_process').spawn('sh', ['-c', '...'], { stdio: [0, 0, 0] })
// TypeError: stdin cannot be used for stdout or stderr (ERR_INVALID_ARG_TYPE)
```

Node accepts any fd at any slot and simply `dup2()`s it into the child. The reporter's setup (apache2ctl) has fds 0/1/2 all pointing at the same tty, so `stdio: [0, 0, 0]` is equivalent to `'inherit'` there.

## Cause

`Stdio::extract` in `src/runtime/api/bun/spawn/stdio.rs` hard-rejected fd 0 at slots 1/2 and fds 1/2 at slot 0. The same rejection was duplicated on the fd-backed `Blob` paths in `as_spawn_option` and `extract_blob` (the latter was provably unreachable: it derived the tag from the slot index rather than the fd).

Removing that check exposed a second bug in `spawn_process_posix`: `PosixStdio::Pipe(fd)` registered `dup2(fd, slot)` in slot order with no save-aside, so an earlier slot's action could clobber a later slot's source fd. `stdio: [2, 0, 0]` became `dup2(2,0); dup2(0,1); dup2(0,2)` and the child got stderr at all three fds; `stdio: ['ignore', 'inherit', 'inherit', 0]` opened `/dev/null` at fd 0 before slot 3's `dup2(0, 3)` ran. This was already reachable on main via `stdio: [0, 2, 1]`.

## Fix

- `stdio.rs`: drop the rejection. If the fd matches its own slot, keep the `Inherit` fast path; otherwise fall through to `Stdio::Fd(fd)`. The parent never closes a caller-supplied fd on this path (`Readable::Fd` is dropped without `close()`, and the one error-path close is already gated on `borrows_caller_fd()`).
- `spawn_process.rs`: before the stdio loop, `F_DUPFD_CLOEXEC` any `Pipe(fd)` source fd in `[0, stdio_count)` (across both the three standard slots and `extra_fds`) to a temporary `>= stdio_count`, register `dup2(tmp, slot)` instead, and close the temporary in the parent after spawn. This is the same approach libuv takes in `uv__process_child_init`.

## Verification

New tests in `test/js/node/child_process/child_process.test.ts`:
- `stdio: [0,0,0]`, `[1,1,1]`, `[2,0,0]` spawn without throwing, return null stream handles, exit 0, and leave parent fds 0/1/2 open.
- `stdio: [1,1,1]` on an inner child with a piped outer stdout: inner stderr writes land on the outer stdout pipe, proving the dup.
- `stdio: [2,0,0]`, `[0,2,1]`, `[1,2,0]`, `['ignore','inherit','inherit',0]`, `['ignore','inherit','inherit',0,1,2]` via a middle process whose fds 0/1/2 are three distinct files: the grandchild's writes to each slot land on the original parent fds, not on an earlier slot's dup2 target. All five match Node exactly.

All nine fail on main and pass with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child_process.test.ts

<!-- robobun:evidence:end -->