### PR TITLE
mock.module: evict cached dependents when target was already loaded

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -578,8 +578,6 @@ static void evictDependentModules(Zig::GlobalObject* globalObject, const WTF::St
                     if (tainted.contains(keyStr)) {
                         // require(esm) leaves no m_children edge; m_parent is the only link back.
                         taintParent(mod->m_parent.get());
-                        if (mod->m_overriddenParent)
-                            taintParent(dynamicDowncast<Bun::JSCommonJSModule>(mod->m_overriddenParent.get()));
                         continue;
                     }
 

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -559,8 +559,29 @@ static void evictDependentModules(Zig::GlobalObject* globalObject, const WTF::St
                         (void)scope.tryClearException();
                         continue;
                     }
-                    if (tainted.contains(keyStr))
+
+                    auto taintParent = [&](Bun::JSCommonJSModule* parent) {
+                        if (!parent)
+                            return;
+                        auto* parentId = parent->m_id.get();
+                        if (!parentId)
+                            return;
+                        WTF::String parentKey = parentId->value(globalObject);
+                        if (scope.exception()) [[unlikely]] {
+                            (void)scope.tryClearException();
+                            return;
+                        }
+                        if (tainted.add(parentKey).isNewEntry)
+                            changed = true;
+                    };
+
+                    if (tainted.contains(keyStr)) {
+                        // require(esm) leaves no m_children edge; m_parent is the only link back.
+                        taintParent(mod->m_parent.get());
+                        if (mod->m_overriddenParent)
+                            taintParent(dynamicDowncast<Bun::JSCommonJSModule>(mod->m_overriddenParent.get()));
                         continue;
+                    }
 
                     bool hit = false;
                     auto checkChild = [&](JSC::JSValue childValue) {
@@ -808,10 +829,10 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
 
     JSValue entryValue = globalObject->requireMap()->get(globalObject, specifierString);
     RETURN_IF_EXCEPTION(scope, {});
-    if (entryValue) {
+    if (!entryValue.isUndefined()) {
         wasAlreadyLoaded = true;
         removeFromCJS = true;
-        if (auto* moduleObject = entryValue ? dynamicDowncast<Bun::JSCommonJSModule>(entryValue) : nullptr) {
+        if (auto* moduleObject = dynamicDowncast<Bun::JSCommonJSModule>(entryValue)) {
             JSValue exportsValue = getJSValue();
             RETURN_IF_EXCEPTION(scope, {});
 

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -12,6 +12,7 @@
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/JSMap.h>
 #include <JavaScriptCore/JSMapInlines.h>
+#include <JavaScriptCore/JSMapIterator.h>
 #include <JavaScriptCore/JSModuleLoader.h>
 #include <JavaScriptCore/ModuleRegistryEntry.h>
 #include <JavaScriptCore/CyclicModuleRecord.h>
@@ -503,6 +504,132 @@ JSObject* JSModuleMock::executeOnce(JSC::JSGlobalObject* lexicalGlobalObject)
     return object;
 }
 
+// When mock.module() overrides a module that already evaluated, modules which
+// imported it may have captured its values (e.g. `const x = new Imported()` at
+// module scope). Patching the target's live bindings does not help those
+// captures, so evict every cached module whose dependency graph reaches the
+// mocked key. The next import/require of a dependent re-evaluates it against
+// the mock.
+static void evictDependentModules(Zig::GlobalObject* globalObject, const WTF::String& mockedKey)
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
+    auto* moduleLoader = globalObject->moduleLoader();
+    auto* requireMap = globalObject->requireMap();
+
+    WTF::UncheckedKeyHashSet<WTF::String> tainted;
+    tainted.add(mockedKey);
+
+    // Fixed-point over both graphs: a module is tainted once any of its loaded
+    // dependencies is tainted. ESM edges come from AbstractModuleRecord's
+    // loadedModules() (resolved child records); CJS edges from m_children.
+    bool changed = true;
+    while (changed) {
+        changed = false;
+
+        for (auto& [key, entry] : moduleLoader->moduleMap()) {
+            if (!key.first || !entry)
+                continue;
+            WTF::String keyStr { key.first };
+            if (tainted.contains(keyStr))
+                continue;
+            auto* record = entry->record();
+            if (!record)
+                continue;
+            for (auto& [depKey, loaded] : record->loadedModules()) {
+                auto* depRecord = loaded.m_module.get();
+                if (!depRecord)
+                    continue;
+                if (tainted.contains(depRecord->moduleKey().string())) {
+                    tainted.add(keyStr);
+                    changed = true;
+                    break;
+                }
+            }
+        }
+
+        if (requireMap->size() > 0) {
+            auto iter = JSC::JSMapIterator::create(vm, globalObject->mapIteratorStructure(), requireMap, JSC::IterationKind::Entries);
+            if (scope.exception()) [[unlikely]] {
+                (void)scope.tryClearException();
+            } else {
+                JSC::JSValue keyValue;
+                JSC::JSValue entryValue;
+                while (iter->nextKeyValue(globalObject, keyValue, entryValue)) {
+                    auto* mod = dynamicDowncast<Bun::JSCommonJSModule>(entryValue);
+                    if (!mod)
+                        continue;
+                    auto* keyString = dynamicDowncast<JSC::JSString>(keyValue);
+                    if (!keyString)
+                        continue;
+                    WTF::String keyStr = keyString->value(globalObject);
+                    if (scope.exception()) [[unlikely]] {
+                        (void)scope.tryClearException();
+                        continue;
+                    }
+                    if (tainted.contains(keyStr))
+                        continue;
+
+                    bool hit = false;
+                    auto checkChild = [&](JSC::JSValue childValue) {
+                        if (hit)
+                            return;
+                        auto* child = dynamicDowncast<Bun::JSCommonJSModule>(childValue);
+                        if (!child)
+                            return;
+                        auto* childId = child->m_id.get();
+                        if (!childId)
+                            return;
+                        WTF::String childKey = childId->value(globalObject);
+                        if (scope.exception()) [[unlikely]] {
+                            (void)scope.tryClearException();
+                            return;
+                        }
+                        if (tainted.contains(childKey))
+                            hit = true;
+                    };
+
+                    if (mod->m_childrenValue) {
+                        if (auto* array = dynamicDowncast<JSC::JSArray>(mod->m_childrenValue.get())) {
+                            for (unsigned i = 0, len = array->length(); i < len && !hit; ++i) {
+                                checkChild(array->getIndex(globalObject, i));
+                                if (scope.exception()) [[unlikely]]
+                                    (void)scope.tryClearException();
+                            }
+                        }
+                    } else {
+                        for (auto& child : mod->m_children)
+                            checkChild(child.get());
+                    }
+
+                    if (hit) {
+                        tainted.add(keyStr);
+                        changed = true;
+                    }
+                }
+                if (scope.exception()) [[unlikely]]
+                    (void)scope.tryClearException();
+            }
+        }
+    }
+
+    tainted.remove(mockedKey);
+    if (tainted.isEmpty())
+        return;
+
+    {
+        WTF::Locker locker { moduleLoader->cellLock() };
+        for (auto& key : tainted)
+            moduleLoader->removeEntry(JSC::Identifier::fromString(vm, key));
+    }
+    for (auto& key : tainted) {
+        requireMap->remove(globalObject, jsString(vm, key));
+        if (scope.exception()) [[unlikely]]
+            (void)scope.tryClearException();
+    }
+}
+
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsModuleMock);
 extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callframe))
 {
@@ -630,10 +757,12 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
 
     bool removeFromESM = false;
     bool removeFromCJS = false;
+    bool wasAlreadyLoaded = false;
 
     auto specifierIdent = JSC::Identifier::fromString(vm, specifierString->value(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
     if (auto* entry = globalObject->moduleLoader()->registryEntry(specifierIdent)) {
+        wasAlreadyLoaded = true;
         removeFromESM = true;
         if (auto* mod = entry->record()) {
             // getModuleNamespace asserts the record has progressed past linking.
@@ -689,6 +818,7 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
     JSValue entryValue = globalObject->requireMap()->get(globalObject, specifierString);
     RETURN_IF_EXCEPTION(scope, {});
     if (entryValue) {
+        wasAlreadyLoaded = true;
         removeFromCJS = true;
         if (auto* moduleObject = entryValue ? dynamicDowncast<Bun::JSCommonJSModule>(entryValue) : nullptr) {
             JSValue exportsValue = getJSValue();
@@ -710,6 +840,9 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         globalObject->requireMap()->remove(globalObject, specifierString);
         RETURN_IF_EXCEPTION(scope, {});
     }
+
+    if (wasAlreadyLoaded)
+        evictDependentModules(globalObject, specifier);
 
     globalObject->onLoadPlugins.addModuleMock(vm, specifier, mock);
 

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -504,12 +504,8 @@ JSObject* JSModuleMock::executeOnce(JSC::JSGlobalObject* lexicalGlobalObject)
     return object;
 }
 
-// When mock.module() overrides a module that already evaluated, modules which
-// imported it may have captured its values (e.g. `const x = new Imported()` at
-// module scope). Patching the target's live bindings does not help those
-// captures, so evict every cached module whose dependency graph reaches the
-// mocked key. The next import/require of a dependent re-evaluates it against
-// the mock.
+// Dependents may have captured the target's values at module scope; evict them
+// so the next import/require re-evaluates against the mock.
 static void evictDependentModules(Zig::GlobalObject* globalObject, const WTF::String& mockedKey)
 {
     auto& vm = globalObject->vm();
@@ -521,9 +517,6 @@ static void evictDependentModules(Zig::GlobalObject* globalObject, const WTF::St
     WTF::UncheckedKeyHashSet<WTF::String> tainted;
     tainted.add(mockedKey);
 
-    // Fixed-point over both graphs: a module is tainted once any of its loaded
-    // dependencies is tainted. ESM edges come from AbstractModuleRecord's
-    // loadedModules() (resolved child records); CJS edges from m_children.
     bool changed = true;
     while (changed) {
         changed = false;

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -504,8 +504,6 @@ JSObject* JSModuleMock::executeOnce(JSC::JSGlobalObject* lexicalGlobalObject)
     return object;
 }
 
-// Dependents may have captured the target's values at module scope; evict them
-// so the next import/require re-evaluates against the mock.
 static void evictDependentModules(Zig::GlobalObject* globalObject, const WTF::String& mockedKey)
 {
     auto& vm = globalObject->vm();

--- a/test/js/bun/test/mock/mock-module-dependents.test.ts
+++ b/test/js/bun/test/mock/mock-module-dependents.test.ts
@@ -91,6 +91,40 @@ describe.concurrent("mock.module evicts cached dependents", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("CJS dependent that require()s an ESM intermediate", async () => {
+    using dir = tempDir("mock-module-9316-cjs-req-esm", {
+      ...fakeStoragePkg(),
+      "src/helper.ts": /* ts */ `
+        import { Storage } from "fake-storage";
+        export const helper = new Storage();
+      `,
+      "src/app.cjs": /* js */ `
+        const { helper } = require("./helper.ts");
+        module.exports.upload = (f, d) => helper.bucket().file(f).write(d);
+      `,
+      "a.test.ts": /* ts */ `
+        import { test, expect } from "bun:test";
+        const { upload } = require("./src/app.cjs");
+        test("a sees real", () => expect(upload("x", "y")).toBe("real-write"));
+      `,
+      "storage.test.ts": /* ts */ `
+        import { test, expect, mock, jest } from "bun:test";
+        mock.module("fake-storage", () => ({
+          Storage: jest.fn(() => ({
+            bucket: () => ({ file: () => ({ write: () => "mocked-write" }) }),
+          })),
+        }));
+        const { upload } = require("./src/app.cjs");
+        test("uses mock", () => expect(upload("t", "h")).toBe("mocked-write"));
+      `,
+    });
+
+    const { out, exitCode } = await runBunTest(String(dir), ["a.test.ts", "storage.test.ts"]);
+    expect(out).toContain("2 pass");
+    expect(out).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
   test("transitive dependent (mocked -> wrapper -> app)", async () => {
     using dir = tempDir("mock-module-9316-transitive", {
       ...fakeStoragePkg(),

--- a/test/js/bun/test/mock/mock-module-dependents.test.ts
+++ b/test/js/bun/test/mock/mock-module-dependents.test.ts
@@ -159,4 +159,50 @@ describe.concurrent("mock.module evicts cached dependents", () => {
     expect(out).toContain("0 fail");
     expect(exitCode).toBe(0);
   });
+
+  test("unrelated cached modules are not evicted", async () => {
+    using dir = tempDir("mock-module-9316-unrelated", {
+      ...fakeStoragePkg(),
+      "src/app.ts": /* ts */ `
+        import { Storage } from "fake-storage";
+        const storage = new Storage();
+        export const upload = (f: string, d: string) => storage.bucket().file(f).write(d);
+      `,
+      "src/unrelated.ts": /* ts */ `
+        globalThis.__evals = (globalThis.__evals ?? 0) + 1;
+        export const evals = () => globalThis.__evals;
+      `,
+      "src/unrelated.cjs": /* js */ `
+        globalThis.__cjsEvals = (globalThis.__cjsEvals ?? 0) + 1;
+        module.exports.evals = () => globalThis.__cjsEvals;
+      `,
+      "a.test.ts": /* ts */ `
+        import { test, expect } from "bun:test";
+        import { upload } from "./src/app";
+        import { evals } from "./src/unrelated";
+        require("./src/unrelated.cjs");
+        test("a sees real", () => expect(upload("x", "y")).toBe("real-write"));
+        test("a evals once", () => expect(evals()).toBe(1));
+      `,
+      "storage.test.ts": /* ts */ `
+        import { test, expect, mock, jest } from "bun:test";
+        mock.module("fake-storage", () => ({
+          Storage: jest.fn(() => ({
+            bucket: () => ({ file: () => ({ write: () => "mocked-write" }) }),
+          })),
+        }));
+        const { upload } = await import("./src/app");
+        const { evals } = await import("./src/unrelated");
+        const cjs = require("./src/unrelated.cjs");
+        test("uses mock", () => expect(upload("t", "h")).toBe("mocked-write"));
+        test("esm unrelated not re-evaluated", () => expect(evals()).toBe(1));
+        test("cjs unrelated not re-evaluated", () => expect(cjs.evals()).toBe(1));
+      `,
+    });
+
+    const { out, exitCode } = await runBunTest(String(dir), ["a.test.ts", "storage.test.ts"]);
+    expect(out).toContain("5 pass");
+    expect(out).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/test/mock/mock-module-dependents.test.ts
+++ b/test/js/bun/test/mock/mock-module-dependents.test.ts
@@ -1,10 +1,4 @@
 // https://github.com/oven-sh/bun/issues/9316
-//
-// mock.module() patches the live bindings of its target, but a dependent that
-// already evaluated and captured a value (e.g. `const x = new Imported()` at
-// module scope) keeps the real value. When the target had already been loaded
-// by an earlier test file, mock.module() must evict cached dependents so a
-// subsequent import/require re-evaluates them against the mock.
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
@@ -20,16 +14,16 @@ function fakeStoragePkg(): Record<string, string> {
   };
 }
 
-async function runBunTest(dir: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+async function runBunTest(dir: string, files: string[]) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "test"],
+    cmd: [bunExe(), "test", ...files],
     env: bunEnv,
     cwd: dir,
     stdout: "pipe",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout, stderr, exitCode };
+  return { out: stderr + stdout, exitCode };
 }
 
 describe.concurrent("mock.module evicts cached dependents", () => {
@@ -41,12 +35,12 @@ describe.concurrent("mock.module evicts cached dependents", () => {
         const storage = new Storage();
         export const upload = (f: string, d: string) => storage.bucket().file(f).write(d);
       `,
-      "tests/a.test.ts": /* ts */ `
-        import { test } from "bun:test";
-        import { upload } from "../src/app";
-        test("a", () => { upload("x", "y"); });
+      "a.test.ts": /* ts */ `
+        import { test, expect } from "bun:test";
+        import { upload } from "./src/app";
+        test("a sees real", () => expect(upload("x", "y")).toBe("real-write"));
       `,
-      "tests/storage.test.ts": /* ts */ `
+      "storage.test.ts": /* ts */ `
         import { describe, test, expect, mock, jest } from "bun:test";
         describe("storage", async () => {
           mock.module("fake-storage", () => ({
@@ -54,15 +48,15 @@ describe.concurrent("mock.module evicts cached dependents", () => {
               bucket: () => ({ file: () => ({ write: () => "mocked-write" }) }),
             })),
           }));
-          const { upload } = await import("../src/app");
+          const { upload } = await import("./src/app");
           test("uses mock", () => expect(upload("t", "h")).toBe("mocked-write"));
         });
       `,
     });
 
-    const { stdout, stderr, exitCode } = await runBunTest(String(dir));
-    expect(stderr + stdout).toContain("2 pass");
-    expect(stderr + stdout).not.toContain("real-write");
+    const { out, exitCode } = await runBunTest(String(dir), ["a.test.ts", "storage.test.ts"]);
+    expect(out).toContain("2 pass");
+    expect(out).toContain("0 fail");
     expect(exitCode).toBe(0);
   });
 
@@ -74,26 +68,26 @@ describe.concurrent("mock.module evicts cached dependents", () => {
         const storage = new Storage();
         module.exports.upload = (f, d) => storage.bucket().file(f).write(d);
       `,
-      "tests/a.test.ts": /* ts */ `
-        import { test } from "bun:test";
-        const { upload } = require("../src/app.cjs");
-        test("a", () => { upload("x", "y"); });
+      "a.test.ts": /* ts */ `
+        import { test, expect } from "bun:test";
+        const { upload } = require("./src/app.cjs");
+        test("a sees real", () => expect(upload("x", "y")).toBe("real-write"));
       `,
-      "tests/storage.test.ts": /* ts */ `
+      "storage.test.ts": /* ts */ `
         import { test, expect, mock, jest } from "bun:test";
         mock.module("fake-storage", () => ({
           Storage: jest.fn(() => ({
             bucket: () => ({ file: () => ({ write: () => "mocked-write" }) }),
           })),
         }));
-        const { upload } = require("../src/app.cjs");
+        const { upload } = require("./src/app.cjs");
         test("uses mock", () => expect(upload("t", "h")).toBe("mocked-write"));
       `,
     });
 
-    const { stdout, stderr, exitCode } = await runBunTest(String(dir));
-    expect(stderr + stdout).toContain("2 pass");
-    expect(stderr + stdout).not.toContain("real-write");
+    const { out, exitCode } = await runBunTest(String(dir), ["a.test.ts", "storage.test.ts"]);
+    expect(out).toContain("2 pass");
+    expect(out).toContain("0 fail");
     expect(exitCode).toBe(0);
   });
 
@@ -109,26 +103,26 @@ describe.concurrent("mock.module evicts cached dependents", () => {
         const storage = makeStorage();
         export const upload = (f: string, d: string) => storage.bucket().file(f).write(d);
       `,
-      "tests/a.test.ts": /* ts */ `
-        import { test } from "bun:test";
-        import { upload } from "../src/app";
-        test("a", () => { upload("x", "y"); });
+      "a.test.ts": /* ts */ `
+        import { test, expect } from "bun:test";
+        import { upload } from "./src/app";
+        test("a sees real", () => expect(upload("x", "y")).toBe("real-write"));
       `,
-      "tests/storage.test.ts": /* ts */ `
+      "storage.test.ts": /* ts */ `
         import { test, expect, mock, jest } from "bun:test";
         mock.module("fake-storage", () => ({
           Storage: jest.fn(() => ({
             bucket: () => ({ file: () => ({ write: () => "mocked-write" }) }),
           })),
         }));
-        const { upload } = await import("../src/app");
+        const { upload } = await import("./src/app");
         test("uses mock", () => expect(upload("t", "h")).toBe("mocked-write"));
       `,
     });
 
-    const { stdout, stderr, exitCode } = await runBunTest(String(dir));
-    expect(stderr + stdout).toContain("2 pass");
-    expect(stderr + stdout).not.toContain("real-write");
+    const { out, exitCode } = await runBunTest(String(dir), ["a.test.ts", "storage.test.ts"]);
+    expect(out).toContain("2 pass");
+    expect(out).toContain("0 fail");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/regression/issue/09316.test.ts
+++ b/test/regression/issue/09316.test.ts
@@ -1,0 +1,134 @@
+// https://github.com/oven-sh/bun/issues/9316
+//
+// mock.module() patches the live bindings of its target, but a dependent that
+// already evaluated and captured a value (e.g. `const x = new Imported()` at
+// module scope) keeps the real value. When the target had already been loaded
+// by an earlier test file, mock.module() must evict cached dependents so a
+// subsequent import/require re-evaluates them against the mock.
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+function fakeStoragePkg(): Record<string, string> {
+  return {
+    "node_modules/fake-storage/package.json": JSON.stringify({ name: "fake-storage", main: "./index.js" }),
+    "node_modules/fake-storage/index.js": /* js */ `
+      class Storage {
+        bucket() { return { file() { return { write() { return "real-write" } } } } }
+      }
+      module.exports = { Storage };
+    `,
+  };
+}
+
+async function runBunTest(dir: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe.concurrent("mock.module evicts cached dependents", () => {
+  test("ESM dependent cached by an earlier test file", async () => {
+    using dir = tempDir("mock-module-9316-esm", {
+      ...fakeStoragePkg(),
+      "src/app.ts": /* ts */ `
+        import { Storage } from "fake-storage";
+        const storage = new Storage();
+        export const upload = (f: string, d: string) => storage.bucket().file(f).write(d);
+      `,
+      "tests/a.test.ts": /* ts */ `
+        import { test } from "bun:test";
+        import { upload } from "../src/app";
+        test("a", () => { upload("x", "y"); });
+      `,
+      "tests/storage.test.ts": /* ts */ `
+        import { describe, test, expect, mock, jest } from "bun:test";
+        describe("storage", async () => {
+          mock.module("fake-storage", () => ({
+            Storage: jest.fn(() => ({
+              bucket: () => ({ file: () => ({ write: () => "mocked-write" }) }),
+            })),
+          }));
+          const { upload } = await import("../src/app");
+          test("uses mock", () => expect(upload("t", "h")).toBe("mocked-write"));
+        });
+      `,
+    });
+
+    const { stdout, stderr, exitCode } = await runBunTest(String(dir));
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).not.toContain("real-write");
+    expect(exitCode).toBe(0);
+  });
+
+  test("CJS dependent cached by an earlier test file", async () => {
+    using dir = tempDir("mock-module-9316-cjs", {
+      ...fakeStoragePkg(),
+      "src/app.cjs": /* js */ `
+        const { Storage } = require("fake-storage");
+        const storage = new Storage();
+        module.exports.upload = (f, d) => storage.bucket().file(f).write(d);
+      `,
+      "tests/a.test.ts": /* ts */ `
+        import { test } from "bun:test";
+        const { upload } = require("../src/app.cjs");
+        test("a", () => { upload("x", "y"); });
+      `,
+      "tests/storage.test.ts": /* ts */ `
+        import { test, expect, mock, jest } from "bun:test";
+        mock.module("fake-storage", () => ({
+          Storage: jest.fn(() => ({
+            bucket: () => ({ file: () => ({ write: () => "mocked-write" }) }),
+          })),
+        }));
+        const { upload } = require("../src/app.cjs");
+        test("uses mock", () => expect(upload("t", "h")).toBe("mocked-write"));
+      `,
+    });
+
+    const { stdout, stderr, exitCode } = await runBunTest(String(dir));
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).not.toContain("real-write");
+    expect(exitCode).toBe(0);
+  });
+
+  test("transitive dependent (mocked -> wrapper -> app)", async () => {
+    using dir = tempDir("mock-module-9316-transitive", {
+      ...fakeStoragePkg(),
+      "src/wrapper.ts": /* ts */ `
+        import { Storage } from "fake-storage";
+        export const makeStorage = () => new Storage();
+      `,
+      "src/app.ts": /* ts */ `
+        import { makeStorage } from "./wrapper";
+        const storage = makeStorage();
+        export const upload = (f: string, d: string) => storage.bucket().file(f).write(d);
+      `,
+      "tests/a.test.ts": /* ts */ `
+        import { test } from "bun:test";
+        import { upload } from "../src/app";
+        test("a", () => { upload("x", "y"); });
+      `,
+      "tests/storage.test.ts": /* ts */ `
+        import { test, expect, mock, jest } from "bun:test";
+        mock.module("fake-storage", () => ({
+          Storage: jest.fn(() => ({
+            bucket: () => ({ file: () => ({ write: () => "mocked-write" }) }),
+          })),
+        }));
+        const { upload } = await import("../src/app");
+        test("uses mock", () => expect(upload("t", "h")).toBe("mocked-write"));
+      `,
+    });
+
+    const { stdout, stderr, exitCode } = await runBunTest(String(dir));
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).not.toContain("real-write");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/09316.test.ts
+++ b/test/regression/issue/09316.test.ts
@@ -5,7 +5,7 @@
 // module scope) keeps the real value. When the target had already been loaded
 // by an earlier test file, mock.module() must evict cached dependents so a
 // subsequent import/require re-evaluates them against the mock.
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 function fakeStoragePkg(): Record<string, string> {


### PR DESCRIPTION
Fixes #9316.

### Repro

```ts
// node_modules/fake-storage/index.js (CJS)
class Storage { bucket(){ return { file(){ return { write(){ return "real-write" } } } } } }
module.exports = { Storage };

// src/app.ts
import { Storage } from "fake-storage";
const storage = new Storage();
export const upload = (f, d) => storage.bucket().file(f).write(d);

// tests/a.test.ts (runs first)
import { upload } from "../src/app";
test("a", () => { upload("x", "y"); });

// tests/storage.test.ts
mock.module("fake-storage", () => ({ Storage: jest.fn(() => ({ ... "mocked-write" ... })) }));
const { upload } = await import("../src/app");
test("uses mock", () => expect(upload("t", "h")).toBe("mocked-write"));  // fails under `bun test`
```

`bun test` (default runner, no `--isolate`) fails the second file with `Received: "real-write"`. Running `tests/storage.test.ts` on its own passes.

### Cause

`JSMock__jsModuleMock` handles an already-loaded target by writing the factory's values into its `JSModuleNamespaceObject` via `overrideExportValue` and overwriting the CJS `module.exports`. That updates the target's live bindings, but `src/app.ts` already evaluated `const storage = new Storage()` at module scope and remains cached in both the ESM registry and `require.cache`. `await import("../src/app")` returns the cached module, so `upload` keeps the real instance. No dependent walk exists.

### Fix

After the existing in-place patch, when the target was present in either cache, compute the set of cached modules whose dependency graph reaches the mocked key and evict each from both the ESM registry (`moduleLoader()->removeEntry`) and `requireMap()`:

- ESM edges: `AbstractModuleRecord::loadedModules()` (resolved child records, keyed by `moduleKey()`).
- CJS edges: `JSCommonJSModule::m_children` (or `m_childrenValue` once materialized), plus `m_parent` / `m_overriddenParent` from tainted entries since `require(esm)` early-returns from `overridableRequire` before `m_children` is appended.

The set is closed to a fixed point so indirect dependents (`mocked -> wrapper -> app`) are evicted too. The next `import`/`require` of a dependent re-evaluates it and reads the mocked bindings.

The pre-existing `if (entryValue)` requireMap guard is tightened to `if (!entryValue.isUndefined())` (`JSMap::get` returns `jsUndefined()` for a miss), so the walk is skipped when the target was never cached.

### Verification

```
bun bd test test/js/bun/test/mock/mock-module-dependents.test.ts
  4 pass (ESM dependent, CJS dependent, CJS-require(ESM) dependent, transitive)
USE_SYSTEM_BUN=1 bun test test/js/bun/test/mock/mock-module-dependents.test.ts
  4 fail (all receive "real-write")
bun bd test test/js/bun/test/mock/ test/js/bun/plugin/plugins.test.ts
  58 pass, 1 todo
bun bd test test/js/node/module/esm-registry-concurrent-gc.test.ts
  1 pass
bun bd test test/cli/test/bun-test.test.ts
  80 pass, 6 todo
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock/mock-module-dependents.test.ts
bun test v1.4.0 (587610232)

test/js/bun/test/mock/mock-module-dependents.test.ts:
84 |         test("uses mock", () => expect(upload("t", "h")).toBe("mocked-write"));
85 |       `,
86 |     });
87 | 
88 |     const { out, exitCode } = await runBunTest(String(dir), ["a.test.ts", "storage.test.ts"]);
89 |     expect(out).toContain("2 pass");
                     ^
error: expect(received).toContain(expected)

Expected to contain: "2 pass"
Received: "\na.test.ts:\n(pass) a sees real [5.53ms]\n\nstorage.test.ts:\nerror: expect(received).toBe(expected)\n\nExpected: \"mocked-write\"\nReceived: \"real-write\"\n\n(fail) uses mock [39.30ms]\n\n 1 pass\n 1 fail\n 2 expect() calls\nRan 2 tests across 2 files. [768.00ms]\nbun test v1.4.0 (587610232)\n"

      at <anonymous> (/workspace/bun/test/js/bun/test/mock/mock-module-dependents.test.ts:89:17)
(fail) mock.module evicts cached dependents > CJS dependent cached by an earlier test file [1092.86ms]
53 |         });
54 |       `,
55 |     });
56
... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/test/mock/mock-module-dependents.test.ts:
118 |         test("uses mock", () => expect(upload("t", "h")).toBe("mocked-write"));
119 |       `,
120 |     });
121 | 
122 |     const { out, exitCode } = await runBunTest(String(dir), ["a.test.ts", "storage.test.ts"]);
123 |     expect(out).toContain("2 pass");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "2 pass"
Received: "\na.test.ts:\n(pass) a sees real [0.12ms]\n\nstorage.test.ts:\nerror: expect(received).toBe(expected)\n\nExpected: \"mocked-write\"\nReceived: \"real-write\"\n\n(fail) uses mock [0.17ms]\n\n 1 pass\n 1 fail\n 2 expect() calls\nRan 2 tests across 2 files. [38.00ms]\nbun test v1.4.0-canary.1 (1498d7b77)\n"

      at <anonymous> (/workspace/bun/test/js/bun/test/mock/mock-module-dependents.test.ts:123:17)
84 |         test("uses mock", () => expect(upload("t", "h")).toBe("mocked-write"));
85 |       `,
86 |     });
87 | 
88 |     const { out, exitCode } = await runBunTest(String(dir), ["a.test.ts", "storage.test.ts"]);
89 |     expect(out).toContain("2 pass");
                     ^
error: expect(received).toCo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock/mock-module-dependents.test.ts
bun test v1.4.0 (587610232)

test/js/bun/test/mock/mock-module-dependents.test.ts:
(pass) mock.module evicts cached dependents > transitive dependent (mocked -> wrapper -> app) [835.13ms]
(pass) mock.module evicts cached dependents > unrelated cached modules are not evicted [950.56ms]
(pass) mock.module evicts cached dependents > ESM dependent cached by an earlier test file [1532.45ms]
(pass) mock.module evicts cached dependents > CJS dependent that require()s an ESM intermediate [1627.15ms]
(pass) mock.module evicts cached dependents > CJS dependent cached by an earlier test file [1816.22ms]

 5 pass
 0 fail
 15 expect() calls
Ran 5 tests across 1 file. [6.98s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2407ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/104] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/104] gen cpp.rs (cppbind)
[2/104] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunPlugin.cpp                     | 147 ++++++++++++++-
 .../bun/test/mock/mock-module-dependents.test.ts   | 208 +++++++++++++++++++++
 2 files changed, 353 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/jsc/bindings/BunPlugin.cpp                            7     15      0
test/js/bun/test/mock/mock-module-dependents.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->