### PR TITLE
test(coverage): fix class method line mapping and lcov hit counts

### DIFF
--- a/src/jsc/bindings/CodeCoverage.cpp
+++ b/src/jsc/bindings/CodeCoverage.cpp
@@ -4,6 +4,21 @@
 
 using namespace JSC;
 
+// CodeBlock::finishCreation registers every nested function expression with
+// FunctionHasExecutedCache under the owner's SourceID using the expression's
+// unlinked offsets. For a class with no explicit constructor, the synthesized
+// default constructor's offsets are into BuiltinExecutables::defaultConstructorSourceCode()
+// rather than the owner's source, and removeUnexecutedRange later fires against
+// the builtin SourceID, so the owner-side entry is never cleared. Filter it here.
+static constexpr std::pair<int, int> defaultConstructorRange(size_t sourceLength)
+{
+    return { static_cast<int>(std::char_traits<char>::length("(")), static_cast<int>(sourceLength) - 2 };
+}
+static constexpr auto kBaseDefaultCtorRange = defaultConstructorRange(std::char_traits<char>::length("(function () { })"));
+static constexpr auto kDerivedDefaultCtorRange = defaultConstructorRange(std::char_traits<char>::length("(function (...args) { super(...args); })"));
+static_assert(kBaseDefaultCtorRange == std::pair { 1, 15 });
+static_assert(kDerivedDefaultCtorRange == std::pair { 1, 38 });
+
 extern "C" bool CodeCoverage__withBlocksAndFunctions(
     JSC::VM* vmPtr,
     JSC::SourceID sourceID,
@@ -36,6 +51,11 @@ extern "C" bool CodeCoverage__withBlocksAndFunctions(
         range.m_executionCount = range.m_hasExecuted
             ? 1
             : 0; // This is a hack. We don't actually count this.
+        if (!range.m_hasExecuted) {
+            auto offsets = std::pair { range.m_startOffset, range.m_endOffset };
+            if (offsets == kBaseDefaultCtorRange || offsets == kDerivedDefaultCtorRange)
+                continue;
+        }
         basicBlocks.append(range);
     }
 

--- a/src/jsc/bindings/CodeCoverage.cpp
+++ b/src/jsc/bindings/CodeCoverage.cpp
@@ -1,23 +1,9 @@
 #include "root.h"
 #include "ZigSourceProvider.h"
+#include "CodeCoverage.h"
 #include <JavaScriptCore/ControlFlowProfiler.h>
 
 using namespace JSC;
-
-// CodeBlock::finishCreation registers every nested function expression with
-// FunctionHasExecutedCache under the owner's SourceID using the expression's
-// unlinked offsets. For a class with no explicit constructor, the synthesized
-// default constructor's offsets are into BuiltinExecutables::defaultConstructorSourceCode()
-// rather than the owner's source, and removeUnexecutedRange later fires against
-// the builtin SourceID, so the owner-side entry is never cleared. Filter it here.
-static constexpr std::pair<int, int> defaultConstructorRange(size_t sourceLength)
-{
-    return { static_cast<int>(std::char_traits<char>::length("(")), static_cast<int>(sourceLength) - 2 };
-}
-static constexpr auto kBaseDefaultCtorRange = defaultConstructorRange(std::char_traits<char>::length("(function () { })"));
-static constexpr auto kDerivedDefaultCtorRange = defaultConstructorRange(std::char_traits<char>::length("(function (...args) { super(...args); })"));
-static_assert(kBaseDefaultCtorRange == std::pair { 1, 15 });
-static_assert(kDerivedDefaultCtorRange == std::pair { 1, 38 });
 
 extern "C" bool CodeCoverage__withBlocksAndFunctions(
     JSC::VM* vmPtr,
@@ -39,25 +25,7 @@ extern "C" bool CodeCoverage__withBlocksAndFunctions(
 
     size_t functionStartOffset = basicBlocks.size();
 
-    const Vector<std::tuple<bool, unsigned, unsigned>>& functionRanges = vm.functionHasExecutedCache()->getFunctionRanges(sourceID);
-
-    basicBlocks.reserveCapacity(functionRanges.size() + basicBlocks.size());
-
-    for (const auto& functionRange : functionRanges) {
-        BasicBlockRange range;
-        range.m_hasExecuted = std::get<0>(functionRange);
-        range.m_startOffset = static_cast<int>(std::get<1>(functionRange));
-        range.m_endOffset = static_cast<int>(std::get<2>(functionRange));
-        range.m_executionCount = range.m_hasExecuted
-            ? 1
-            : 0; // This is a hack. We don't actually count this.
-        if (!range.m_hasExecuted) {
-            auto offsets = std::pair { range.m_startOffset, range.m_endOffset };
-            if (offsets == kBaseDefaultCtorRange || offsets == kDerivedDefaultCtorRange)
-                continue;
-        }
-        basicBlocks.append(range);
-    }
+    Bun::appendFunctionRangesForCoverage(basicBlocks, vm, sourceID);
 
     blockCallback(ctx, basicBlocks.begin(), basicBlocks.size(), functionStartOffset, ignoreSourceMap);
     return true;

--- a/src/jsc/bindings/CodeCoverage.h
+++ b/src/jsc/bindings/CodeCoverage.h
@@ -21,6 +21,14 @@ static constexpr auto kDerivedDefaultCtorRange = defaultConstructorRange(std::ch
 static_assert(kBaseDefaultCtorRange == std::pair { 1, 15 });
 static_assert(kDerivedDefaultCtorRange == std::pair { 1, 38 });
 
+static constexpr bool isSyntheticDefaultCtorRange(bool hasExecuted, int startOffset, int endOffset)
+{
+    if (hasExecuted)
+        return false;
+    auto offsets = std::pair { startOffset, endOffset };
+    return offsets == kBaseDefaultCtorRange || offsets == kDerivedDefaultCtorRange;
+}
+
 static inline void appendFunctionRangesForCoverage(Vector<JSC::BasicBlockRange>& out, JSC::VM& vm, JSC::SourceID sourceID)
 {
     const auto& functionRanges = vm.functionHasExecutedCache()->getFunctionRanges(sourceID);
@@ -31,11 +39,8 @@ static inline void appendFunctionRangesForCoverage(Vector<JSC::BasicBlockRange>&
         range.m_startOffset = static_cast<int>(std::get<1>(functionRange));
         range.m_endOffset = static_cast<int>(std::get<2>(functionRange));
         range.m_executionCount = range.m_hasExecuted ? 1 : 0;
-        if (!range.m_hasExecuted) {
-            auto offsets = std::pair { range.m_startOffset, range.m_endOffset };
-            if (offsets == kBaseDefaultCtorRange || offsets == kDerivedDefaultCtorRange)
-                continue;
-        }
+        if (isSyntheticDefaultCtorRange(range.m_hasExecuted, range.m_startOffset, range.m_endOffset))
+            continue;
         out.append(range);
     }
 }

--- a/src/jsc/bindings/CodeCoverage.h
+++ b/src/jsc/bindings/CodeCoverage.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "root.h"
+#include <JavaScriptCore/ControlFlowProfiler.h>
+#include <JavaScriptCore/FunctionHasExecutedCache.h>
+
+namespace Bun {
+
+// CodeBlock::finishCreation registers every nested function expression with
+// FunctionHasExecutedCache under the owner's SourceID using the expression's
+// unlinked offsets. For a class with no explicit constructor, the synthesized
+// default constructor's offsets are into BuiltinExecutables::defaultConstructorSourceCode()
+// rather than the owner's source, and removeUnexecutedRange later fires against
+// the builtin SourceID, so the owner-side entry is never cleared.
+static constexpr std::pair<int, int> defaultConstructorRange(size_t sourceLength)
+{
+    return { static_cast<int>(std::char_traits<char>::length("(")), static_cast<int>(sourceLength) - 2 };
+}
+static constexpr auto kBaseDefaultCtorRange = defaultConstructorRange(std::char_traits<char>::length("(function () { })"));
+static constexpr auto kDerivedDefaultCtorRange = defaultConstructorRange(std::char_traits<char>::length("(function (...args) { super(...args); })"));
+static_assert(kBaseDefaultCtorRange == std::pair { 1, 15 });
+static_assert(kDerivedDefaultCtorRange == std::pair { 1, 38 });
+
+static inline void appendFunctionRangesForCoverage(Vector<JSC::BasicBlockRange>& out, JSC::VM& vm, JSC::SourceID sourceID)
+{
+    const auto& functionRanges = vm.functionHasExecutedCache()->getFunctionRanges(sourceID);
+    out.reserveCapacity(functionRanges.size() + out.size());
+    for (const auto& functionRange : functionRanges) {
+        JSC::BasicBlockRange range;
+        range.m_hasExecuted = std::get<0>(functionRange);
+        range.m_startOffset = static_cast<int>(std::get<1>(functionRange));
+        range.m_endOffset = static_cast<int>(std::get<2>(functionRange));
+        range.m_executionCount = range.m_hasExecuted ? 1 : 0;
+        if (!range.m_hasExecuted) {
+            auto offsets = std::pair { range.m_startOffset, range.m_endOffset };
+            if (offsets == kBaseDefaultCtorRange || offsets == kDerivedDefaultCtorRange)
+                continue;
+        }
+        out.append(range);
+    }
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -1,6 +1,7 @@
 #include "root.h"
 #include "helpers.h"
 #include "BunCPUProfiler.h"
+#include "CodeCoverage.h"
 #include "NodeValidator.h"
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/VM.h>
@@ -136,10 +137,15 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_collectPreciseCoverage, (JSGlobalObject * gl
 
         auto functionArray = JSON::Array::create();
         for (const auto& functionRange : functionRanges) {
+            bool hasExecuted = std::get<0>(functionRange);
+            int startOffset = static_cast<int>(std::get<1>(functionRange));
+            int endOffset = static_cast<int>(std::get<2>(functionRange));
+            if (Bun::isSyntheticDefaultCtorRange(hasExecuted, startOffset, endOffset))
+                continue;
             auto range = JSON::Array::create();
-            range->pushDouble(static_cast<double>(std::get<1>(functionRange)));
-            range->pushDouble(static_cast<double>(std::get<2>(functionRange)));
-            range->pushBoolean(std::get<0>(functionRange));
+            range->pushDouble(static_cast<double>(startOffset));
+            range->pushDouble(static_cast<double>(endOffset));
+            range->pushBoolean(hasExecuted);
             functionArray->pushValue(WTF::move(range));
         }
         script->setValue("functions"_s, WTF::move(functionArray));

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -52,6 +52,7 @@ extern "C" char* mi_stats_get_json(size_t, char*);
 extern "C" char* mi_heap_dump_json(bool include_blocks, bool hash_addresses);
 
 #include <JavaScriptCore/ControlFlowProfiler.h>
+#include "CodeCoverage.h"
 
 #if OS(DARWIN)
 #if ASSERT_ENABLED
@@ -925,20 +926,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCodeCoverageForFile,
 
     size_t functionStartOffset = basicBlocks.size();
 
-    const Vector<std::tuple<bool, unsigned, unsigned>>& functionRanges = vm.functionHasExecutedCache()->getFunctionRanges(sourceID);
-
-    basicBlocks.reserveCapacity(functionRanges.size() + basicBlocks.size());
-
-    for (const auto& functionRange : functionRanges) {
-        BasicBlockRange range;
-        range.m_hasExecuted = std::get<0>(functionRange);
-        range.m_startOffset = static_cast<int>(std::get<1>(functionRange));
-        range.m_endOffset = static_cast<int>(std::get<2>(functionRange));
-        range.m_executionCount = range.m_hasExecuted
-            ? 1
-            : 0; // This is a hack. We don't actually count this.
-        basicBlocks.append(range);
-    }
+    Bun::appendFunctionRangesForCoverage(basicBlocks, vm, sourceID);
 
     return ByteRangeMapping__findExecutedLines(
         globalObject, Bun::toString(fileName), basicBlocks.begin(),

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -558,8 +558,9 @@ impl ByteRangeMapping {
                     executable_lines.set(line as usize);
                     if has_executed {
                         lines_which_have_executed.set(line as usize);
-                        let hits =
-                            u32::try_from(block.execution_count).unwrap_or(u32::MAX).max(1);
+                        let hits = u32::try_from(block.execution_count)
+                            .unwrap_or(u32::MAX)
+                            .max(1);
                         if line_hits_slice[line as usize] < hits {
                             line_hits_slice[line as usize] = hits;
                         }
@@ -699,8 +700,9 @@ impl ByteRangeMapping {
                         executable_lines.set(line as usize);
                         if has_executed {
                             lines_which_have_executed.set(line as usize);
-                            let hits =
-                                u32::try_from(block.execution_count).unwrap_or(u32::MAX).max(1);
+                            let hits = u32::try_from(block.execution_count)
+                                .unwrap_or(u32::MAX)
+                                .max(1);
                             if line_hits_slice[line as usize] < hits {
                                 line_hits_slice[line as usize] = hits;
                             }

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -229,9 +229,6 @@ pub mod text {
         executable_lines_that_havent_been_executed.set_intersection(&report.executable_lines);
 
         let mut iter = executable_lines_that_havent_been_executed.iterator::<true, true>();
-        let mut start_of_line_range: usize = 0;
-        let mut prev_line: usize = 0;
-        let mut is_first = true;
 
         // `concat!(pretty_fmt!(..), "{}")` requires a literal; split into a
         // prefix `write_all` + plain `write!` so the const-generic `ENABLE_COLORS` can
@@ -239,48 +236,42 @@ pub mod text {
         let red = pretty_fmt::<ENABLE_COLORS>("<red>");
         let comma = pretty_fmt::<ENABLE_COLORS>("<r><d>,<r>");
 
+        let mut pending: Option<(usize, usize)> = None;
+        let mut is_first = true;
+        macro_rules! flush_range {
+            ($start:expr, $end:expr) => {{
+                if is_first {
+                    is_first = false;
+                } else {
+                    writer.write_all(&comma)?;
+                }
+                writer.write_all(&red)?;
+                if $start == $end {
+                    write!(writer, "{}", $start + 1)?;
+                } else {
+                    write!(writer, "{}-{}", $start + 1, $end + 1)?;
+                }
+            }};
+        }
+
         while let Some(next_line) = iter.next() {
-            if next_line == (prev_line + 1) {
-                prev_line = next_line;
-                continue;
-            } else if is_first && start_of_line_range == 0 && prev_line == 0 {
-                start_of_line_range = next_line;
-                prev_line = next_line;
-                continue;
-            }
-
-            if is_first {
-                is_first = false;
-            } else {
-                writer.write_all(&comma)?;
-            }
-
-            if start_of_line_range == prev_line {
-                writer.write_all(&red)?;
-                write!(writer, "{}", start_of_line_range + 1)?;
-            } else {
-                writer.write_all(&red)?;
-                write!(writer, "{}-{}", start_of_line_range + 1, prev_line + 1)?;
-            }
-
-            prev_line = next_line;
-            start_of_line_range = next_line;
-        }
-
-        if prev_line != start_of_line_range {
-            if is_first {
-            } else {
-                writer.write_all(&comma)?;
-            }
-
-            if start_of_line_range == prev_line {
-                writer.write_all(&red)?;
-                write!(writer, "{}", start_of_line_range + 1)?;
-            } else {
-                writer.write_all(&red)?;
-                write!(writer, "{}-{}", start_of_line_range + 1, prev_line + 1)?;
+            match pending {
+                Some((start, prev)) if next_line == prev + 1 => {
+                    pending = Some((start, next_line));
+                }
+                Some((start, prev)) => {
+                    flush_range!(start, prev);
+                    pending = Some((next_line, next_line));
+                }
+                None => {
+                    pending = Some((next_line, next_line));
+                }
             }
         }
+        if let Some((start, prev)) = pending {
+            flush_range!(start, prev);
+        }
+        let _ = is_first;
         Ok(())
     }
 }
@@ -419,6 +410,20 @@ pub struct BasicBlockRange {
     execution_count: usize,
 }
 
+impl BasicBlockRange {
+    /// JSC synthesizes a default constructor for classes that don't declare one
+    /// (`BuiltinExecutables::defaultConstructorSourceCode`). Its `unlinkedFunctionStart`
+    /// and `unlinkedFunctionEnd` are offsets into that builtin template string, but
+    /// `CodeBlock::finishCreation` registers the range under the user's source ID, so
+    /// `FunctionHasExecutedCache::getFunctionRanges` returns it alongside real functions.
+    /// The range is fixed: `[1, 15]` for a base ctor and `[1, 38]` for a derived ctor,
+    /// and it is never marked executed (the remove path uses the builtin source ID).
+    /// Treat it as not part of the user's file.
+    fn is_jsc_default_class_constructor(&self) -> bool {
+        self.start_offset == 1 && (self.end_offset == 15 || self.end_offset == 38)
+    }
+}
+
 pub struct ByteRangeMapping {
     pub(crate) line_offset_table: line_offset_table::List,
     pub(crate) source_id: i32,
@@ -553,7 +558,11 @@ impl ByteRangeMapping {
                     executable_lines.set(line as usize);
                     if has_executed {
                         lines_which_have_executed.set(line as usize);
-                        line_hits_slice[line as usize] += 1;
+                        let hits =
+                            u32::try_from(block.execution_count).unwrap_or(u32::MAX).max(1);
+                        if line_hits_slice[line as usize] < hits {
+                            line_hits_slice[line as usize] = hits;
+                        }
                     }
                 }
 
@@ -569,6 +578,9 @@ impl ByteRangeMapping {
             for (i, function) in function_blocks.iter().enumerate() {
                 if function.end_offset < 0 || function.start_offset < 0 {
                     continue; // does not map to anything
+                }
+                if function.is_jsc_default_class_constructor() {
+                    continue;
                 }
 
                 let min: usize = usize::try_from(function.start_offset.min(function.end_offset))
@@ -601,8 +613,8 @@ impl ByteRangeMapping {
 
                 // only mark the lines as executable if the function has not executed
                 // functions that have executed have non-executable lines in them and thats fine.
-                if !did_fn_execute {
-                    let end = max_line.min(line_count);
+                if !did_fn_execute && min_line != u32::MAX {
+                    let end = (max_line + 1).min(line_count);
                     line_hits_slice[min_line as usize..end as usize].fill(0);
                     for line in min_line..end {
                         executable_lines.set(line as usize);
@@ -687,7 +699,11 @@ impl ByteRangeMapping {
                         executable_lines.set(line as usize);
                         if has_executed {
                             lines_which_have_executed.set(line as usize);
-                            line_hits_slice[line as usize] += 1;
+                            let hits =
+                                u32::try_from(block.execution_count).unwrap_or(u32::MAX).max(1);
+                            if line_hits_slice[line as usize] < hits {
+                                line_hits_slice[line as usize] = hits;
+                            }
                         }
 
                         min_line = min_line.min(line);
@@ -707,6 +723,9 @@ impl ByteRangeMapping {
             for (i, function) in function_blocks.iter().enumerate() {
                 if function.end_offset < 0 || function.start_offset < 0 {
                     continue; // does not map to anything
+                }
+                if function.is_jsc_default_class_constructor() {
+                    continue;
                 }
 
                 let min: usize = usize::try_from(function.start_offset.min(function.end_offset))
@@ -756,6 +775,15 @@ impl ByteRangeMapping {
                         if point.original.lines.zero_based() < 0 {
                             continue;
                         }
+                        // The printer emits a mapping at column 0 of each generated line that
+                        // often points at the end of the previous statement. Bytes in leading
+                        // whitespace (and keywords like `async` that get no mapping of their own)
+                        // resolve to that entry via closest-preceding lookup, which would widen
+                        // the function range onto an unrelated earlier line. Ignore those
+                        // fallback hits when computing the function's line span.
+                        if point.generated.columns.zero_based() == 0 && column_position > 0 {
+                            continue;
+                        }
 
                         let line: u32 =
                             u32::try_from(point.original.lines.zero_based()).expect("int cast");
@@ -777,7 +805,7 @@ impl ByteRangeMapping {
                 // only mark the lines as executable if the function has not executed
                 // functions that have executed have non-executable lines in them and thats fine.
                 if !did_fn_execute {
-                    let end = max_line.min(line_count);
+                    let end = (max_line + 1).min(line_count);
                     for line in min_line..end {
                         executable_lines.set(line as usize);
                         lines_which_have_executed.unset(line as usize);

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -381,7 +381,7 @@ impl<'a> Generator<'a> {
         let all = unsafe { core::slice::from_raw_parts(blocks_ptr, blocks_len) };
         let blocks: &[BasicBlockRange] = &all[0..function_start_offset];
         let mut function_blocks: &[BasicBlockRange] = &all[function_start_offset..blocks_len];
-        if function_blocks.len() > 1 {
+        if !function_blocks.is_empty() {
             function_blocks = &function_blocks[1..];
         }
 
@@ -408,20 +408,6 @@ pub struct BasicBlockRange {
     end_offset: c_int,
     has_executed: bool,
     execution_count: usize,
-}
-
-impl BasicBlockRange {
-    /// JSC synthesizes a default constructor for classes that don't declare one
-    /// (`BuiltinExecutables::defaultConstructorSourceCode`). Its `unlinkedFunctionStart`
-    /// and `unlinkedFunctionEnd` are offsets into that builtin template string, but
-    /// `CodeBlock::finishCreation` registers the range under the user's source ID, so
-    /// `FunctionHasExecutedCache::getFunctionRanges` returns it alongside real functions.
-    /// The range is fixed: `[1, 15]` for a base ctor and `[1, 38]` for a derived ctor,
-    /// and it is never marked executed (the remove path uses the builtin source ID).
-    /// Treat it as not part of the user's file.
-    fn is_jsc_default_class_constructor(&self) -> bool {
-        self.start_offset == 1 && (self.end_offset == 15 || self.end_offset == 38)
-    }
 }
 
 pub struct ByteRangeMapping {
@@ -580,9 +566,6 @@ impl ByteRangeMapping {
                 if function.end_offset < 0 || function.start_offset < 0 {
                     continue; // does not map to anything
                 }
-                if function.is_jsc_default_class_constructor() {
-                    continue;
-                }
 
                 let min: usize = usize::try_from(function.start_offset.min(function.end_offset))
                     .expect("int cast");
@@ -726,9 +709,6 @@ impl ByteRangeMapping {
                 if function.end_offset < 0 || function.start_offset < 0 {
                     continue; // does not map to anything
                 }
-                if function.is_jsc_default_class_constructor() {
-                    continue;
-                }
 
                 let min: usize = usize::try_from(function.start_offset.min(function.end_offset))
                     .expect("int cast");
@@ -777,13 +757,11 @@ impl ByteRangeMapping {
                         if point.original.lines.zero_based() < 0 {
                             continue;
                         }
-                        // The printer emits a mapping at column 0 of each generated line that
-                        // often points at the end of the previous statement. Bytes in leading
-                        // whitespace (and keywords like `async` that get no mapping of their own)
-                        // resolve to that entry via closest-preceding lookup, which would widen
-                        // the function range onto an unrelated earlier line. Ignore those
-                        // fallback hits when computing the function's line span.
-                        if point.generated.columns.zero_based() == 0 && column_position > 0 {
+                        // Generated-column-0 mappings point at the previous statement's end;
+                        // `column_position` is always > 0 here (the `>= byte_offset` check above
+                        // skips column 0), so any column-0 result is a closest-preceding fallback.
+                        if point.generated.columns.zero_based() == 0 {
+                            debug_assert!(column_position > 0);
                             continue;
                         }
 
@@ -910,7 +888,7 @@ extern "C" fn ByteRangeMapping__findExecutedLines(
     let all = unsafe { core::slice::from_raw_parts(blocks_ptr.as_ptr(), blocks_len) };
     let blocks: &[BasicBlockRange] = &all[0..function_start_offset];
     let mut function_blocks: &[BasicBlockRange] = &all[function_start_offset..blocks_len];
-    if function_blocks.len() > 1 {
+    if !function_blocks.is_empty() {
         function_blocks = &function_blocks[1..];
     }
     let url_slice = source_url.to_utf8();

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -3,10 +3,10 @@
 exports[`lcov coverage reporter: lcov-coverage-reporter-output 1`] = `
 "TN:
 SF:demo1.ts
-FNF:1
+FNF:0
 FNH:0
-DA:2,19
-DA:3,16
+DA:2,1
+DA:3,1
 DA:4,1
 LF:3
 LH:3
@@ -15,14 +15,14 @@ TN:
 SF:demo2.ts
 FNF:2
 FNH:1
-DA:2,28
-DA:4,11
-DA:6,9
+DA:2,1
+DA:4,1
+DA:6,1
 DA:9,0
 DA:10,0
-DA:11,1
-DA:14,9
+DA:11,0
+DA:14,1
 LF:7
-LH:5
+LH:4
 end_of_record"
 `;

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -192,8 +192,8 @@ test("should call only some functions", () => {
 ---------------|---------|---------|-------------------
 File           | % Funcs | % Lines | Uncovered Line #s
 ---------------|---------|---------|-------------------
-All files      |   75.00 |   83.33 |
- include-me.ts |   50.00 |   66.67 | 
+All files      |   75.00 |   75.00 |
+ include-me.ts |   50.00 |   50.00 | 6-7
  test.test.ts  |  100.00 |  100.00 | 
 ---------------|---------|---------|-------------------
 
@@ -385,8 +385,8 @@ test("should call both functions", () => {
 SF:include-me.ts
 FNF:1
 FNH:1
-DA:2,11
-DA:3,17
+DA:2,1
+DA:3,1
 LF:2
 LH:2
 end_of_record
@@ -394,13 +394,13 @@ TN:
 SF:test.test.ts
 FNF:1
 FNH:1
-DA:2,40
-DA:3,41
-DA:4,39
-DA:6,42
-DA:7,39
-DA:8,36
-DA:9,2
+DA:2,1
+DA:3,1
+DA:4,1
+DA:6,1
+DA:7,1
+DA:8,1
+DA:9,1
 LF:7
 LH:7
 end_of_record"

--- a/test/regression/issue/08290.test.ts
+++ b/test/regression/issue/08290.test.ts
@@ -21,10 +21,19 @@ test("coverage maps uncovered class methods to the correct source lines", async 
       "\n" +
       "    another() { return 2 }\n" +
       "}\n",
+    "derived.mjs":
+      "class Base { hit() { return 1 } }\n" + //
+      "export class Derived extends Base {\n" +
+      "    miss() { return 2 }\n" +
+      "}\n",
     "live.test.mjs":
       `import { test, expect } from "bun:test";\n` +
       `import { MockLive } from "./live.mock.mjs";\n` +
-      `test("x", () => { expect(new MockLive().covered()).toBe(1); });\n`,
+      `import { Derived } from "./derived.mjs";\n` +
+      `test("x", () => {\n` +
+      `  expect(new MockLive().covered()).toBe(1);\n` +
+      `  expect(new Derived().hit()).toBe(1);\n` +
+      `});\n`,
   });
 
   await using proc = Bun.spawn({
@@ -73,6 +82,20 @@ test("coverage maps uncovered class methods to the correct source lines", async 
   // consume, covered, another. The synthetic default constructor must not be
   // counted as a user function.
   expect(fnf).toBe(3);
+
+  // Derived class without an explicit constructor: the synthetic derived
+  // default constructor (and the base default constructor) must not be
+  // counted, and must not clear line 1.
+  const derived = lcov.split("end_of_record").find(r => r.includes("derived.mjs"))!;
+  const derivedFnf = Number(derived.match(/^FNF:(\d+)$/m)![1]);
+  // hit, miss only.
+  expect(derivedFnf).toBe(2);
+  const derivedDa: Record<number, number> = {};
+  for (const m of derived.matchAll(/^DA:(\d+),(\d+)$/gm)) {
+    derivedDa[Number(m[1])] = Number(m[2]);
+  }
+  expect(derivedDa[1]).toBeGreaterThan(0);
+  expect(derivedDa[3]).toBe(0);
 
   expect(text).toContain("1 pass");
   expect(stdout).toContain("bun test");

--- a/test/regression/issue/08290.test.ts
+++ b/test/regression/issue/08290.test.ts
@@ -1,0 +1,110 @@
+// https://github.com/oven-sh/bun/issues/8290
+// `bun test --coverage` line mapping for class methods was shifted, and lcov
+// reported nonzero hit counts for method bodies that never executed.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+test("coverage maps uncovered class methods to the correct source lines", async () => {
+  using dir = tempDir("cov-8290", {
+    "live.mock.mjs":
+      "export class MockLive {\n" +
+      "\n" +
+      "    calls = []\n" +
+      "\n" +
+      "    async consume(event) {\n" +
+      "        this.calls.push({ consume: { event } })\n" +
+      "    }\n" +
+      "\n" +
+      "    covered() { return 1 }\n" +
+      "\n" +
+      "    another() { return 2 }\n" +
+      "}\n",
+    "live.test.mjs":
+      `import { test, expect } from "bun:test";\n` +
+      `import { MockLive } from "./live.mock.mjs";\n` +
+      `test("x", () => { expect(new MockLive().covered()).toBe(1); });\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "test",
+      "--coverage",
+      "--coverage-reporter=text",
+      "--coverage-reporter=lcov",
+      "--coverage-dir=./coverage",
+      "live.test.mjs",
+    ],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const text = normalizeBunSnapshot(stderr, dir);
+  // `consume` is declared on lines 5-7 and `another` on line 11; neither runs.
+  // The report previously said `3-5` (shifted into the `calls = []` field) and
+  // omitted `another` entirely.
+  expect(text).toContain("5-6,11");
+  expect(text).not.toContain("3-5");
+
+  const lcov = readFileSync(path.join(String(dir), "coverage", "lcov.info"), "utf-8");
+  const mock = lcov.split("end_of_record").find(r => r.includes("live.mock.mjs"))!;
+  const da: Record<number, number> = {};
+  for (const m of mock.matchAll(/^DA:(\d+),(\d+)$/gm)) {
+    da[Number(m[1])] = Number(m[2]);
+  }
+
+  // Never-called method bodies must report 0 hits.
+  expect(da[5]).toBe(0);
+  expect(da[6]).toBe(0);
+  expect(da[11]).toBe(0);
+  // Lines that did run (class decl, field initializer, the called method) must
+  // be nonzero, and the hit count must be an execution count, not a byte count.
+  for (const line of [1, 3, 9]) {
+    expect(da[line]).toBeGreaterThan(0);
+    expect(da[line]).toBeLessThan(10);
+  }
+
+  const fnf = Number(mock.match(/^FNF:(\d+)$/m)![1]);
+  // consume, covered, another. The synthetic default constructor must not be
+  // counted as a user function.
+  expect(fnf).toBe(3);
+
+  expect(text).toContain("1 pass");
+  expect(stdout).toContain("bun test");
+  expect(exitCode).toBe(0);
+});
+
+test("coverage text reporter prints a trailing single-line uncovered range", async () => {
+  using dir = tempDir("cov-8290-trailing", {
+    "mod.ts":
+      "export function hit() {\n" + //
+      "  return 1;\n" +
+      "}\n" +
+      "export function miss() { return 2 }\n",
+    "mod.test.ts":
+      `import { test, expect } from "bun:test";\n` +
+      `import { hit } from "./mod.ts";\n` +
+      `test("x", () => { expect(hit()).toBe(1); });\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--coverage", "mod.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const text = normalizeBunSnapshot(stderr, dir);
+  // `miss` is on line 4 and is the only uncovered line. The range printer
+  // previously dropped a trailing single-line range entirely.
+  const row = text.split("\n").find(l => /^\s*mod\.ts\b/.test(l))!;
+  expect(row).toMatch(/\|\s*4\s*$/);
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/08290.test.ts
+++ b/test/regression/issue/08290.test.ts
@@ -26,13 +26,23 @@ test("coverage maps uncovered class methods to the correct source lines", async 
       "export class Derived extends Base {\n" +
       "    miss() { return 2 }\n" +
       "}\n",
+    "spin.mjs":
+      "export function spin() {\n" + //
+      "    let n = 0;\n" +
+      "    for (let i = 0; i < 5; i++) {\n" +
+      "        n++;\n" +
+      "    }\n" +
+      "    return n;\n" +
+      "}\n",
     "live.test.mjs":
       `import { test, expect } from "bun:test";\n` +
       `import { MockLive } from "./live.mock.mjs";\n` +
       `import { Derived } from "./derived.mjs";\n` +
+      `import { spin } from "./spin.mjs";\n` +
       `test("x", () => {\n` +
       `  expect(new MockLive().covered()).toBe(1);\n` +
       `  expect(new Derived().hit()).toBe(1);\n` +
+      `  expect(spin()).toBe(5);\n` +
       `});\n`,
   });
 
@@ -96,6 +106,16 @@ test("coverage maps uncovered class methods to the correct source lines", async 
   }
   expect(derivedDa[1]).toBeGreaterThan(0);
   expect(derivedDa[3]).toBe(0);
+
+  // Loop body must report the block's execution count (5 iterations), not 1.
+  // This distinguishes reading `block.execution_count` from a hardcoded 1 and
+  // from the old per-byte accumulation.
+  const spinRec = lcov.split("end_of_record").find(r => r.includes("spin.mjs"))!;
+  const spinDa: Record<number, number> = {};
+  for (const m of spinRec.matchAll(/^DA:(\d+),(\d+)$/gm)) {
+    spinDa[Number(m[1])] = Number(m[2]);
+  }
+  expect(spinDa[4]).toBe(5);
 
   expect(text).toContain("1 pass");
   expect(stdout).toContain("bun test");

--- a/test/regression/issue/08290.test.ts
+++ b/test/regression/issue/08290.test.ts
@@ -151,3 +151,47 @@ test("coverage text reporter prints a trailing single-line uncovered range", asy
   expect(row).toMatch(/\|\s*4\s*$/);
   expect(exitCode).toBe(0);
 });
+
+test("coverage no-sourcemap path reports execution counts and clears uncalled functions", async () => {
+  using dir = tempDir("cov-8290-nosm", {
+    "bunfig.toml": "[test]\ncoverageIgnoreSourcemaps = true\n",
+    "spin.mjs":
+      "export function spin() {\n" +
+      "    let n = 0;\n" +
+      "    for (let i = 0; i < 5; i++) {\n" +
+      "        n++;\n" +
+      "    }\n" +
+      "    return n;\n" +
+      "}\n" +
+      "export function miss() { return 2 }\n",
+    "spin.test.mjs":
+      `import { test, expect } from "bun:test";\n` +
+      `import { spin } from "./spin.mjs";\n` +
+      `test("x", () => { expect(spin()).toBe(5); });\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--coverage", "--coverage-reporter=lcov", "--coverage-dir=./coverage", "spin.test.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lcov = readFileSync(path.join(String(dir), "coverage", "lcov.info"), "utf-8");
+  const rec = lcov.split("end_of_record").find(r => r.includes("spin.mjs"))!;
+  const da = [...rec.matchAll(/^DA:(\d+),(\d+)$/gm)].map(m => [Number(m[1]), Number(m[2])] as const);
+
+  // Loop body ran 5x; at least one line must carry the block execution_count.
+  expect(da.some(([, hits]) => hits === 5)).toBe(true);
+  // `miss()` never ran; its lines must be cleared to 0 through the inclusive
+  // max_line bound.
+  const zeroLines = da.filter(([, hits]) => hits === 0).map(([line]) => line);
+  expect(zeroLines.length).toBeGreaterThanOrEqual(2);
+  // Every hit count is an execution count, not a byte count.
+  for (const [, hits] of da) expect(hits).toBeLessThan(10);
+
+  expect(stderr).toContain("1 pass");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #8290.

## Repro

```js
// live.mock.mjs
export class MockLive {

    calls = []

    async consume(event) {
        this.calls.push({ consume: { event } })
    }

    covered() { return 1 }

    another() { return 2 }
}
// live.test.mjs
import { test, expect } from "bun:test";
import { MockLive } from "./live.mock.mjs";
test("x", () => { expect(new MockLive().covered()).toBe(1); });
```

Before:

```console
$ bun test --coverage
 live.mock.mjs |   25.00 |   62.50 | 3-5
$ cat coverage/lcov.info
DA:6,46
DA:11,29
```

`consume` is on lines 5-7 but the report says 3-5; `another` on line 11 is missing from the uncovered column; and the lcov hit counts for never-called method bodies are 46 and 29.

After:

```console
 live.mock.mjs |   33.33 |   57.14 | 5-6,11
DA:5,0
DA:6,0
DA:11,0
```

## Cause

Four independent problems in `src/sourcemap_jsc/CodeCoverage.rs`:

1. **lcov hit counts were byte counts.** The report walks each JSC basic block byte by byte and did `line_hits[line] += 1` per byte, so `DA:N,46` meant 46 bytes of executed block on line N, not 46 executions. Now records `max(block.execution_count, 1)` per line.

2. **Off-by-one cleared range.** For an unexecuted function the lines `min_line..max_line` were cleared, an exclusive range, so the last line kept its hit count and a single-line method (`another() { return 2 }`) was never cleared. Now clears through `max_line` inclusive.

3. **Column-0 fallback widened the function span.** When computing `min_line`/`max_line` for a function, bytes in leading whitespace and the `async` keyword (which the printer emits no mapping for) resolved via closest-preceding lookup to the generated-column-0 mapping, which points at the end of the previous statement. `consume`'s span then started two lines early on `calls = []`. The function-span walk now ignores hits that resolved to a column-0 mapping from a nonzero lookup column.

4. **Synthetic default constructors counted as user functions.** JSC registers the builtin default class constructor under the user's source ID with offsets from the template string (`[1, 15]` base / `[1, 38]` derived), and it is never marked executed. With (2) fixed this began clearing line 1. These ranges are now skipped via `Bun::isSyntheticDefaultCtorRange` in a new `CodeCoverage.h`, applied at all three `getFunctionRanges` consumers (`CodeCoverage.cpp`, `BunJSCModule.h`, `JSInspectorProfiler.cpp`). The `JSInspectorProfiler.cpp` call site is a straight pass-through to the tested predicate and does not have its own class fixture under `Profiler.takePreciseCoverage`; the predicate itself is deletion-detectable through the `bun test --coverage` path for both base and derived classes.

Separately, the text reporter's range-collapsing loop dropped a trailing single-line run (so `another` on line 11 never appeared even when correctly flagged). Rewritten to track the pending run as `Option<(usize, usize)>` and always flush it.

## Snapshot updates

The existing `coverage.test.ts` snapshots captured the old behavior and now reflect the fix: hit counts are execution counts instead of byte widths, `FNF` no longer counts the synthetic constructor, the `partial coverage without nan` test now shows `6-7` in the previously-empty Uncovered column, and the demo2 `return 42` line inside an uncalled function reports `DA:11,0` instead of `DA:11,1`.

## Overlap with open PRs

Parts of this change are also in open PRs targeting other issues: the text-reporter rewrite is in #35607, #36614, and #36651; the inclusive `max_line` and a column-0 heuristic are in #36614; the default-constructor filter is in #36651. This PR is the minimal set needed to close #8290 and additionally fixes the lcov hit-count semantics, which none of those touch.

## Verification

- `bun bd test test/regression/issue/08290.test.ts`: 2 pass (both fail on main with `3-5` / blank column)
- `bun bd test test/cli/test/coverage.test.ts`: 12 pass
- `bun bd test test/cli/test/parallel.test.ts -t coverage`: 3 pass
- `bun bd test test/js/node/inspector/inspector-profiler.test.ts`: 44 pass

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/coverage.test.ts "test/regression/issue/08290.test.ts"
bun test v1.4.0 (e7d8218e7)

test/regression/issue/08290.test.ts:
65 | 
66 |   const text = normalizeBunSnapshot(stderr, dir);
67 |   // `consume` is declared on lines 5-7 and `another` on line 11; neither runs.
68 |   // The report previously said `3-5` (shifted into the `calls = []` field) and
69 |   // omitted `another` entirely.
70 |   expect(text).toContain("5-6,11");
                    ^
error: expect(received).toContain(expected)

Expected to contain: "5-6,11"
Received: "live.test.mjs:\n(pass) x\n---------------|---------|---------|-------------------\nFile           | % Funcs | % Lines | Uncovered Line #s\n---------------|---------|---------|-------------------\nAll files      |   62.50 |   90.62 |\n derived.mjs   |   25.00 |  100.00 | \n live.mock.mjs |   25.00 |   62.50 | 3-5\n live.test.mjs |  100.00 |  100.00 | \n spin.mjs      |  100.00 |  100.00 | \n---------------|---------|---------|-------------------\n\n 1 pass\n 0 fail\n 3 expect() calls\nRan 1 tes
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (4730e92bd)

test/regression/issue/08290.test.ts:
(pass) coverage maps uncovered class methods to the correct source lines [81.94ms]
(pass) coverage text reporter prints a trailing single-line uncovered range [20.74ms]
(pass) coverage no-sourcemap path reports execution counts and clears uncalled functions [14.32ms]

test/cli/test/coverage.test.ts:
bun test v1.4.0-canary.1 (4730e92bd)

demo.test.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [24.00ms]
(pass) coverage crash [29.17ms]
bun test v1.4.0-canary.1 (4730e92bd)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [14.00ms]
(pass) lcov coverage reporter [26.12ms]
(pass) coverage excludes node_modules directory [19.86ms]
(pass) coveragePathIgnorePatterns - single pattern string [16.56ms]
(pass) coveragePathIgnorePatterns - partial coverage without nan [47.81ms]
(pass) coveragePathIgnorePatterns - array of patterns [46.60ms]
(pass) coveragePathIgnorePatterns - glob patterns [16.67ms]
(pass) coveragePathIgnorePatterns - lcov reporter [16.29ms]
(pass) coveragePathIgnorePatterns - invalid config type [5.79ms]
(pass) coveragePathIgnorePatterns - invalid array item [4.56ms]
(pass) coverag
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/coverage.test.ts "test/regression/issue/08290.test.ts"
bun test v1.4.0 (e7d8218e7)

test/regression/issue/08290.test.ts:
(pass) coverage maps uncovered class methods to the correct source lines [839.48ms]
(pass) coverage text reporter prints a trailing single-line uncovered range [522.59ms]
(pass) coverage no-sourcemap path reports execution counts and clears uncalled functions [566.83ms]

test/cli/test/coverage.test.ts:
bun test v1.4.0 (e7d8218e7)

demo.test.ts:
--------------|---------|---------|-------------------
File          | % Funcs | % Lines | Uncovered Line #s
--------------|---------|---------|-------------------
All files     |  100.00 |  100.00 |
 demo.test.ts |  100.00 |  100.00 | 
--------------|---------|---------|-------------------

 0 pass
 0 fail
Ran 0 tests across 1 file. [379.00ms]
(pass) coverage crash [469.36ms]
bun test v1.4.0 (e7d8218e7)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [466.00ms]
(pass) lcov coverage reporter [573.01ms]
(pass) coverage excludes node_modules directory [578.4
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1234ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/52] gen cpp.rs (cppbind)
[2/52] cxx obj/src/jsc/bindings/highway_sourcemap.cpp.o
[3/52] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[4/52] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[5/52] cxx obj/src/jsc/bindings/webcore/streams/BunStreamSource.cpp.o
[6/52] cxx obj/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp.o
[7/52] cxx obj/src/jsc/bindings/BunObject.cpp.o
[8/52] cxx obj/src/jsc/bindings/napi.cpp.o
[9/52] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[9/52] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/CodeCoverage.cpp                 |  16 +-
 src/jsc/bindings/CodeCoverage.h                   |  48 ++++++
 src/jsc/bindings/JSInspectorProfiler.cpp          |  12 +-
 src/jsc/modules/BunJSCModule.h                    |  16 +-
 src/sourcemap_jsc/CodeCoverage.rs                 | 102 +++++------
 test/cli/test/__snapshots__/coverage.test.ts.snap |  18 +-
 test/cli/test/coverage.test.ts                    |  22 +--
 test/regression/issue/08290.test.ts               | 197 ++++++++++++++++++++++
 8 files changed, 333 insertions(+), 98 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/jsc/bindings/CodeCoverage.cpp                      3      5      0
src/jsc/bindings/CodeCoverage.h                        1      2      0
src/jsc/bindings/JSInspectorProfiler.cpp               1      2      0
src/jsc/modules/BunJSCModule.h                         2      2      0
src/sourcemap_jsc/CodeCoverage.rs                      9     24      0
test/cli/test/__snapshots__/coverage.test.ts.snap      0      0      0
test/cli/test/coverage.test.ts                         2      0      0
test/regression/issue/08290.test.ts                    3      7      0
```

</details>

<!-- robobun:evidence:end -->
