### PR TITLE
cli: match unscoped name and directory basename in `--filter`

### DIFF
--- a/docs/pm/filter.mdx
+++ b/docs/pm/filter.mdx
@@ -15,8 +15,6 @@ The `--filter` (or `-F`) flag selects packages in a monorepo by pattern. Pattern
 
 Name patterns select packages by the `name` field in `package.json`. For example, if you have packages `pkg-a`, `pkg-b` and `other`, you can match all of them with `*`, only `pkg-a` and `pkg-b` with `pkg*`, and a specific package with its full name.
 
-For scoped packages, a pattern that is not itself scoped also matches the name without the scope and the package's directory name, so `--filter db` selects a package named `@org/db` or a package in `packages/db`.
-
 ### Package Path `--filter ./<glob>`
 
 Path patterns start with `./` and select all packages in directories matching the pattern. For example, to match all packages in subdirectories of `packages`, use `--filter './packages/**'`. To match the package in `packages/foo`, use `--filter ./packages/foo`.
@@ -96,6 +94,8 @@ Filters respect your [workspace configuration](/pm/workspaces): if your `package
 # in src/bar: runs myscript in src/foo, no need to cd!
 bun run --filter foo myscript
 ```
+
+For scoped packages, a name pattern that is not itself scoped also matches the name without the scope and the package's directory name, so `bun run --filter db <script>` selects a package named `@org/db` or a package in `packages/db`.
 
 ### Parallel and sequential mode
 

--- a/docs/pm/filter.mdx
+++ b/docs/pm/filter.mdx
@@ -15,6 +15,8 @@ The `--filter` (or `-F`) flag selects packages in a monorepo by pattern. Pattern
 
 Name patterns select packages by the `name` field in `package.json`. For example, if you have packages `pkg-a`, `pkg-b` and `other`, you can match all of them with `*`, only `pkg-a` and `pkg-b` with `pkg*`, and a specific package with its full name.
 
+For scoped packages, a pattern that is not itself scoped also matches the name without the scope and the package's directory name, so `--filter db` selects a package named `@org/db` or a package in `packages/db`.
+
 ### Package Path `--filter ./<glob>`
 
 Path patterns start with `./` and select all packages in directories matching the pattern. For example, to match all packages in subdirectories of `packages`, use `--filter './packages/**'`. To match the package in `packages/foo`, use `--filter ./packages/foo`.

--- a/src/runtime/cli/filter_arg.rs
+++ b/src/runtime/cli/filter_arg.rs
@@ -241,9 +241,31 @@ impl FilterSet {
             if glob::r#match(&filter.pattern, target).matches() {
                 return true;
             }
+            // pnpm parity (#10639): a name filter that is not itself scoped also matches the
+            // package name with its `@scope/` prefix stripped and the package directory's
+            // basename, so `--filter db` selects `@org/db` and/or `packages/db`.
+            if filter.kind == PatternKind::Name && filter.pattern.first() != Some(&b'@') {
+                if let Some(unscoped) = without_scope(name) {
+                    if glob::r#match(&filter.pattern, unscoped).matches() {
+                        return true;
+                    }
+                }
+                let dir = bun_paths::basename(path);
+                if !dir.is_empty() && dir != name && glob::r#match(&filter.pattern, dir).matches() {
+                    return true;
+                }
+            }
         }
         false
     }
+}
+
+/// Returns the part of `name` after `@scope/`, or `None` if `name` is not a scoped package name.
+fn without_scope(name: &[u8]) -> Option<&[u8]> {
+    if name.first() != Some(&b'@') {
+        return None;
+    }
+    strings::index_of_char(&name[1..], b'/').map(|i| &name[i as usize + 2..])
 }
 
 pub(crate) struct PackageFilterIterator {

--- a/src/runtime/cli/filter_arg.rs
+++ b/src/runtime/cli/filter_arg.rs
@@ -242,11 +242,8 @@ impl FilterSet {
             if primary.matches() {
                 return true;
             }
-            // pnpm parity (#10639): a name filter that is not itself scoped also matches the
-            // package name with its `@scope/` prefix stripped and the package directory's
-            // basename, so `--filter db` selects `@org/db` and/or `packages/db`. Skip negated
-            // patterns: OR-ing alternatives is wrong under negation (a `!name` filter that
-            // excluded the full-name target would then "match" any alternative it fails to hit).
+            // #10639: `--filter db` also matches `@org/db` and the `packages/db` directory.
+            // Negated patterns stay exact-name: OR-ing alternatives under `!` would re-include.
             if filter.kind == PatternKind::Name
                 && !primary.is_negated()
                 && filter.pattern.first() != Some(&b'@')

--- a/src/runtime/cli/filter_arg.rs
+++ b/src/runtime/cli/filter_arg.rs
@@ -238,13 +238,19 @@ impl FilterSet {
                 PatternKind::Name => name,
                 PatternKind::Path => path,
             };
-            if glob::r#match(&filter.pattern, target).matches() {
+            let primary = glob::r#match(&filter.pattern, target);
+            if primary.matches() {
                 return true;
             }
             // pnpm parity (#10639): a name filter that is not itself scoped also matches the
             // package name with its `@scope/` prefix stripped and the package directory's
-            // basename, so `--filter db` selects `@org/db` and/or `packages/db`.
-            if filter.kind == PatternKind::Name && filter.pattern.first() != Some(&b'@') {
+            // basename, so `--filter db` selects `@org/db` and/or `packages/db`. Skip negated
+            // patterns: OR-ing alternatives is wrong under negation (a `!name` filter that
+            // excluded the full-name target would then "match" any alternative it fails to hit).
+            if filter.kind == PatternKind::Name
+                && !primary.is_negated()
+                && filter.pattern.first() != Some(&b'@')
+            {
                 if let Some(unscoped) = without_scope(name) {
                     if glob::r#match(&filter.pattern, unscoped).matches() {
                         return true;

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -277,6 +277,23 @@ describe("bun", () => {
       });
     });
 
+    test("bare name matches every @*/name package (inclusive, unlike pnpm)", () => {
+      using multi = tempDir("filter-unscoped-multi", {
+        packages: {
+          a: { "package.json": JSON.stringify({ name: "@org/db", scripts: { present: "echo ORG_DB" } }) },
+          b: { "package.json": JSON.stringify({ name: "@other/db", scripts: { present: "echo OTHER_DB" } }) },
+          c: { "package.json": JSON.stringify({ name: "@org/unrelated", scripts: { present: "echo UNRELATED" } }) },
+        },
+        "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"] }),
+      });
+      runInCwdSuccess({
+        cwd: String(multi),
+        pattern: "db",
+        target_pattern: [/ORG_DB/, /OTHER_DB/],
+        antipattern: /UNRELATED/,
+      });
+    });
+
     test("bare name matches when only the unscoped package name matches", () => {
       runInCwdSuccess({
         cwd: dir,

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -239,6 +239,107 @@ describe("bun", () => {
     });
   });
 
+  // https://github.com/oven-sh/bun/issues/10639
+  describe("unscoped name filter (pnpm parity)", () => {
+    const dir = tempDirWithFiles("filter-unscoped", {
+      packages: {
+        db: {
+          "package.json": JSON.stringify({
+            name: "@org/db",
+            scripts: { present: "echo DB_RAN" },
+          }),
+        },
+        "site-dir": {
+          "package.json": JSON.stringify({
+            name: "@org/website",
+            scripts: { present: "echo SITE_RAN" },
+          }),
+        },
+        plain: {
+          "package.json": JSON.stringify({
+            name: "plain",
+            scripts: { present: "echo PLAIN_RAN" },
+          }),
+        },
+      },
+      "package.json": JSON.stringify({
+        name: "@org/root",
+        workspaces: ["packages/*"],
+      }),
+    });
+
+    test("bare name matches the @scope/name portion", () => {
+      runInCwdSuccess({
+        cwd: dir,
+        pattern: "db",
+        target_pattern: /DB_RAN/,
+        antipattern: [/SITE_RAN/, /PLAIN_RAN/],
+      });
+    });
+
+    test("bare name matches when only the unscoped package name matches", () => {
+      runInCwdSuccess({
+        cwd: dir,
+        pattern: "website",
+        target_pattern: /SITE_RAN/,
+        antipattern: [/DB_RAN/, /PLAIN_RAN/],
+      });
+    });
+
+    test("bare name matches the package directory name", () => {
+      runInCwdSuccess({
+        cwd: dir,
+        pattern: "site-dir",
+        target_pattern: /SITE_RAN/,
+        antipattern: [/DB_RAN/, /PLAIN_RAN/],
+      });
+    });
+
+    test("bare name matches the package directory name (shared fixture)", () => {
+      runInCwdSuccess({
+        cwd: cwd_root,
+        pattern: "dirname",
+        target_pattern: /scriptc/,
+        antipattern: [/scripta/, /scriptb/, /scriptd/],
+      });
+    });
+
+    test("scoped filter does not fall back to directory name", () => {
+      const { exitCode, stdout, stderr } = spawnSync({
+        cwd: dir,
+        cmd: [bunExe(), "run", "--filter", "@org/site-dir", "present"],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(stdout.toString()).toBeEmpty();
+      expect(stderr.toString()).toMatch(/No packages matched/);
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("full scoped name still matches", () => {
+      runInCwdSuccess({
+        cwd: dir,
+        pattern: "@org/db",
+        target_pattern: /DB_RAN/,
+        antipattern: [/SITE_RAN/, /PLAIN_RAN/],
+      });
+    });
+
+    test("--parallel: bare name matches the @scope/name portion", () => {
+      const { exitCode, stdout } = spawnSync({
+        cwd: dir,
+        cmd: [bunExe(), "run", "--parallel", "--filter", "db", "present"],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(stdout.toString()).toMatch(/DB_RAN/);
+      expect(stdout.toString()).not.toMatch(/SITE_RAN/);
+      expect(exitCode).toBe(0);
+    });
+  });
+
   test("run in parallel", () => {
     runInCwdSuccess({
       cwd: cwd_root,

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -317,6 +317,28 @@ describe("bun", () => {
       expect(exitCode).not.toBe(0);
     });
 
+    test("negated filter does not fall back (still excludes the named package)", () => {
+      // `!@org/db` must exclude `@org/db` and keep the other two; the unscoped/dir
+      // fallback must not run for `!`-prefixed patterns.
+      runInCwdSuccess({
+        cwd: dir,
+        pattern: "!@org/db",
+        target_pattern: [/SITE_RAN/, /PLAIN_RAN/],
+        antipattern: /DB_RAN/,
+      });
+    });
+
+    test("negated filter does not fall back via directory name", () => {
+      // `!pkgc` excludes the package named `pkgc` (directory `dirname`); the
+      // directory-basename fallback must not re-include it.
+      runInCwdSuccess({
+        cwd: cwd_root,
+        pattern: "!pkgc",
+        target_pattern: [/scripta/, /scriptb/, /scriptd/],
+        antipattern: /scriptc/,
+      });
+    });
+
     test("full scoped name still matches", () => {
       runInCwdSuccess({
         cwd: dir,


### PR DESCRIPTION
Fixes #10639.
Fixes #25512.

## Repro

```sh
mkdir -p ws/packages/db && cd ws
echo '{"name":"@org/root","workspaces":["packages/*"]}' > package.json
echo '{"name":"@org/db","scripts":{"test":"echo DB_TEST_RAN"}}' > packages/db/package.json
bun run --filter=db test
# error: No packages matched the filter
```

pnpm's `-F db` selects `@org/db` here; bun required the full `@org/db`, a `*/db` glob, or a `./packages/db` path.

## Cause

`FilterSet::matches_path_name` in `src/runtime/cli/filter_arg.rs` glob-matches a `Name`-kind filter only against the full package name. `db` does not glob-match `@org/db` (`*` in the glob matcher does not cross `/`, so there is no implicit prefix match either).

## Fix

When a `Name` filter is not negated and does not itself start with `@`, also try matching against:

1. the package name with its `@scope/` prefix stripped, and
2. the package directory's basename.

Scoped filter values (`--filter @org/db`) and negated filter values (`--filter '!db'`) keep their existing exact-name semantics; OR-ing alternative targets under negation would re-include the package the `!` was meant to exclude. Both `bun run --filter` and `bun run --parallel --filter` go through `FilterSet::matches`, so both pick this up. `bun install`/`bun outdated`/`bun update -i` use a separate `WorkspaceFilter` code path that is left unchanged here; the docs note is scoped to `bun run` accordingly.

Unlike pnpm (which picks nothing when an unscoped filter matches more than one scoped name), this is inclusive: `--filter core` selects every `@*/core`, consistent with bun's existing glob-based filter semantics where `--filter 'pkg*'` already selects multiple packages.

## Verification

New `unscoped name filter (pnpm parity)` block in `test/cli/run/filter-workspace.test.ts` (10 tests) covers: bare name vs `@scope/name`, inclusive match across `@org/db` + `@other/db`, bare name vs unscoped-name-only, bare name vs directory-name-only, a scoped filter that must still miss, two negated filters that must still exclude, the existing full-scoped-name match, and the `--parallel` path. The six new-behavior tests fail on `USE_SYSTEM_BUN=1` and pass on this branch; the four that pin existing behavior pass on both. The full file (66 tests) and `multi-run.test.ts` (118 tests) pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/filter-workspace.test.ts

<!-- robobun:evidence:end -->