### PR TITLE
crypto: drop generateKeyPair ctx's KeyObject ref before invoking the callback

### DIFF
--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -94,12 +94,9 @@ pub unsafe fn ssl_ctx_setup(ctx: *mut boring::SSL_CTX) {
 // into the process, including pthreads locks. Failing to meet these constraints
 // may result in deadlocks, crashes, or memory corruption.
 
-// Routed through `default_alloc` (mimalloc, or libc under `cfg(bun_asan)`)
-// rather than `mimalloc` directly. The BoringSSL build already drops
-// `BORINGSSL_REQUIRE_MEMORY_HOOKS` under ASAN so Mach-O/COFF fall back to
-// libc, but on ELF the weak hook symbols still resolve to these definitions;
-// hard-coding mimalloc here put every `OPENSSL_malloc` allocation outside
-// LeakSanitizer's view.
+// `default_alloc` (mimalloc, or libc under `cfg(bun_asan)`): on ELF the weak
+// hook symbols resolve to these definitions even when the BoringSSL build
+// drops BORINGSSL_REQUIRE_MEMORY_HOOKS, so the allocator must match.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn OPENSSL_memory_alloc(size: usize) -> *mut c_void {
     bun_alloc::default_alloc::malloc(size)

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -94,30 +94,36 @@ pub unsafe fn ssl_ctx_setup(ctx: *mut boring::SSL_CTX) {
 // into the process, including pthreads locks. Failing to meet these constraints
 // may result in deadlocks, crashes, or memory corruption.
 
+// Routed through `default_alloc` (mimalloc, or libc under `cfg(bun_asan)`)
+// rather than `mimalloc` directly. The BoringSSL build already drops
+// `BORINGSSL_REQUIRE_MEMORY_HOOKS` under ASAN so Mach-O/COFF fall back to
+// libc, but on ELF the weak hook symbols still resolve to these definitions;
+// hard-coding mimalloc here put every `OPENSSL_malloc` allocation outside
+// LeakSanitizer's view.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn OPENSSL_memory_alloc(size: usize) -> *mut c_void {
-    bun_alloc::mimalloc::mi_malloc(size)
+    bun_alloc::default_alloc::malloc(size)
 }
 
 // BoringSSL always expects memory to be zero'd
 /// # Safety
-/// `ptr` must be non-null and have been returned by `OPENSSL_memory_alloc`
-/// (i.e. `mi_malloc`); BoringSSL guarantees both for this hook.
+/// `ptr` must be non-null and returned by `OPENSSL_memory_alloc`; BoringSSL
+/// guarantees both for this hook.
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn OPENSSL_memory_free(ptr: *mut c_void) {
     // SAFETY: BoringSSL guarantees ptr is non-null and was returned by
-    // OPENSSL_memory_alloc above (i.e. mi_malloc).
+    // OPENSSL_memory_alloc above.
     unsafe {
-        let len = bun_alloc::usable_size(ptr.cast());
+        let len = bun_alloc::default_alloc::usable_size(ptr);
         ptr::write_bytes(ptr.cast::<u8>(), 0, len);
-        bun_alloc::mimalloc::mi_free(ptr);
+        bun_alloc::default_alloc::free(ptr);
     }
 }
 
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn OPENSSL_memory_get_size(ptr: *const c_void) -> usize {
-    // ptr was returned by mi_malloc (or is null, which usable_size handles).
-    bun_alloc::usable_size(ptr.cast())
+    // SAFETY: ptr was returned by OPENSSL_memory_alloc (null-safe).
+    unsafe { bun_alloc::default_alloc::usable_size(ptr) }
 }
 
 pub use bun_sys::posix::INET6_ADDRSTRLEN;

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -271,8 +271,7 @@ pub mod default_alloc {
     /// # Safety
     /// `ptr` must be null or a live allocation from the default allocator.
     #[inline]
-    #[cfg(any(debug_assertions, bun_asan))]
-    pub(crate) unsafe fn usable_size(ptr: *const c_void) -> usize {
+    pub unsafe fn usable_size(ptr: *const c_void) -> usize {
         if ptr.is_null() {
             return 0;
         }

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -702,13 +702,6 @@ pub unsafe fn realloc_raw(
     Ok(new_ptr.cast::<u8>())
 }
 
-/// `mi_usable_size` — actual allocated size for a mimalloc-owned ptr.
-#[inline]
-pub fn usable_size(ptr: *const u8) -> usize {
-    // SAFETY: `mi_usable_size` is null-safe (returns 0).
-    unsafe { mimalloc::mi_usable_size(ptr.cast()) }
-}
-
 // ──────────────────────────────────────────────────────────────────────────
 // Symbols hoisted DOWN into T0 so higher tiers can re-import without cycles.
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/jsc/bindings/node/crypto/CryptoDhJob.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoDhJob.cpp
@@ -49,6 +49,12 @@ void DhJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callback)
     VM& vm = lexicalGlobalObject->vm();
     ThrowScope scope = DECLARE_THROW_SCOPE(vm);
 
+    // runTask has already produced m_result; drop the key refs before
+    // re-entering JS so a callback that never returns (process.exit) cannot
+    // strand the EVP_PKEYs past VM teardown. See KeyPairJobCtx::runFromJS.
+    m_privateKey = nullptr;
+    m_publicKey = nullptr;
+
     if (!m_result) {
         // Same message as the synchronous path so callers observe identical errors either way.
         JSObject* err = createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "diffieHellman operation failed"_s);

--- a/src/jsc/bindings/node/crypto/CryptoDhJob.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoDhJob.cpp
@@ -49,9 +49,7 @@ void DhJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callback)
     VM& vm = lexicalGlobalObject->vm();
     ThrowScope scope = DECLARE_THROW_SCOPE(vm);
 
-    // runTask has already produced m_result; drop the key refs before
-    // re-entering JS so a callback that never returns (process.exit) cannot
-    // strand the EVP_PKEYs past VM teardown. See KeyPairJobCtx::runFromJS.
+    // Drop before re-entering JS; see KeyPairJobCtx::runFromJS.
     m_privateKey = nullptr;
     m_publicKey = nullptr;
 

--- a/src/jsc/bindings/node/crypto/CryptoGenKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenKeyPair.cpp
@@ -62,10 +62,8 @@ void KeyPairJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callb
         return;
     }
 
-    // The exported JS wrappers hold their own RefPtr<KeyObjectData>; drop the
-    // ctx's ref before re-entering JS. The ctx is freed (and with it this ref)
-    // only after the callback returns, so a callback that never returns
-    // (process.exit) would otherwise strand the EVP_PKEY past VM teardown.
+    // Drop our ref before re-entering JS: the ctx is freed only after the
+    // callback returns, so process.exit() inside it would strand the EVP_PKEY.
     m_keyObj = {};
 
     Bun__EventLoop__runCallback3(

--- a/src/jsc/bindings/node/crypto/CryptoGenKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenKeyPair.cpp
@@ -48,6 +48,7 @@ void KeyPairJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callb
     if (scope.exception()) [[unlikely]] {
         JSValue exceptionValue = scope.exception();
         (void)scope.tryClearException();
+        m_keyObj = {};
         exceptionCallback(exceptionValue);
         return;
     }
@@ -56,9 +57,16 @@ void KeyPairJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callb
     if (scope.exception()) [[unlikely]] {
         JSValue exceptionValue = scope.exception();
         (void)scope.tryClearException();
+        m_keyObj = {};
         exceptionCallback(exceptionValue);
         return;
     }
+
+    // The exported JS wrappers hold their own RefPtr<KeyObjectData>; drop the
+    // ctx's ref before re-entering JS. The ctx is freed (and with it this ref)
+    // only after the callback returns, so a callback that never returns
+    // (process.exit) would otherwise strand the EVP_PKEY past VM teardown.
+    m_keyObj = {};
 
     Bun__EventLoop__runCallback3(
         lexicalGlobalObject,

--- a/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
@@ -224,6 +224,11 @@ void SignJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callback
     auto& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // runTask has already produced m_signResult / m_verifyResult; drop the key
+    // ref before re-entering JS so a callback that never returns (process.exit)
+    // cannot strand the EVP_PKEY past VM teardown. See KeyPairJobCtx::runFromJS.
+    m_keyData = nullptr;
+
     switch (m_mode) {
     case Mode::Sign: {
         if (!m_signResult) {

--- a/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
@@ -224,9 +224,7 @@ void SignJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callback
     auto& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // runTask has already produced m_signResult / m_verifyResult; drop the key
-    // ref before re-entering JS so a callback that never returns (process.exit)
-    // cannot strand the EVP_PKEY past VM teardown. See KeyPairJobCtx::runFromJS.
+    // Drop before re-entering JS; see KeyPairJobCtx::runFromJS.
     m_keyData = nullptr;
 
     switch (m_mode) {

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -1805,35 +1805,67 @@ function randomProp() {
 // RefPtr<KeyObjectData>; process.exit() inside the callback never unwinds so
 // that ref is never released and the EVP_PKEY survives past VM teardown. With
 // OPENSSL_malloc routed through the default allocator (libc under ASAN) LSan
-// reports it. The fix drops the ctx's ref before invoking the callback so the
-// JS key objects become the only owners and lastChanceToFinalize frees them.
-test.skipIf(!isASAN)(
-  "generateKeyPair: process.exit() in the callback does not strand the EVP_PKEY past VM teardown",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `require("crypto").generateKeyPair("rsa", { modulusLength: 512 }, (err, pub, priv) => {
-           if (err) { console.error(err); process.exit(2); }
-           if (pub.type !== "public" || priv.type !== "private") process.exit(3);
-           process.exit(0);
-         });`,
-      ],
-      env: {
-        ...bunEnv,
-        BUN_DESTRUCT_VM_ON_EXIT: "1",
-        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
-        LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../../leaksan.supp")}`,
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).not.toContain("LeakSanitizer");
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
-  },
+// reports it. The fix drops the ctx's ref before invoking the callback.
+describe.skipIf(!isASAN)("generateKeyPair: process.exit() in the callback does not strand the EVP_PKEY", () => {
+  const lsanEnv = {
+    ...bunEnv,
+    BUN_DESTRUCT_VM_ON_EXIT: "1",
+    ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+    LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../../leaksan.supp")}`,
+  };
   // LSan symbolizes the leak stack through llvm-symbolizer before the child
   // can exit, which is several seconds against the debug binary.
-  30_000,
-);
+  const timeout = 30_000;
+
+  test.concurrent(
+    "KeyObject output",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `require("crypto").generateKeyPair("rsa", { modulusLength: 512 }, (err, pub, priv) => {
+             if (err) { console.error(err); process.exit(2); }
+             if (pub.type !== "public" || priv.type !== "private") process.exit(3);
+             process.exit(0);
+           });`,
+        ],
+        env: lsanEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("LeakSanitizer");
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    },
+    timeout,
+  );
+
+  test.concurrent(
+    "encrypted PEM output",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `require("crypto").generateKeyPair("rsa", {
+             modulusLength: 512,
+             publicKeyEncoding: { type: "spki", format: "pem" },
+             privateKeyEncoding: { type: "pkcs8", format: "pem", cipher: "aes-256-cbc", passphrase: "secret" },
+           }, (err, pub, priv) => {
+             if (err) { console.error(err); process.exit(2); }
+             if (typeof pub !== "string" || typeof priv !== "string") process.exit(3);
+             process.exit(0);
+           });`,
+        ],
+        env: lsanEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("LeakSanitizer");
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    },
+    timeout,
+  );
+});

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -23,7 +23,7 @@ import {
   verify,
 } from "crypto";
 import fs from "fs";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows } from "harness";
 import { createContext, runInContext, runInThisContext, Script } from "node:vm";
 import path from "path";
 
@@ -1800,3 +1800,40 @@ test("ECDSA should work", async () => {
 function randomProp() {
   return "prop" + crypto.randomUUID().replace(/-/g, "");
 }
+
+// The generateKeyPair callback re-enters JS while the job ctx still owns a
+// RefPtr<KeyObjectData>; process.exit() inside the callback never unwinds so
+// that ref is never released and the EVP_PKEY survives past VM teardown. With
+// OPENSSL_malloc routed through the default allocator (libc under ASAN) LSan
+// reports it. The fix drops the ctx's ref before invoking the callback so the
+// JS key objects become the only owners and lastChanceToFinalize frees them.
+test.skipIf(!isASAN)(
+  "generateKeyPair: process.exit() in the callback does not strand the EVP_PKEY past VM teardown",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `require("crypto").generateKeyPair("rsa", { modulusLength: 512 }, (err, pub, priv) => {
+           if (err) { console.error(err); process.exit(2); }
+           if (pub.type !== "public" || priv.type !== "private") process.exit(3);
+           process.exit(0);
+         });`,
+      ],
+      env: {
+        ...bunEnv,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../../leaksan.supp")}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("LeakSanitizer");
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  },
+  // LSan symbolizes the leak stack through llvm-symbolizer before the child
+  // can exit, which is several seconds against the debug binary.
+  30_000,
+);


### PR DESCRIPTION
## What

`crypto.generateKeyPair`'s async completion (`KeyPairJobCtx::runFromJS`) kept `m_keyObj` (a `RefPtr<KeyObjectData>`) across the user callback. The Rust `ExternCtx` Drop that `delete`s the C++ ctx runs only after `then()` returns, so a callback that never returns (`process.exit()`) strands the ctx's ref. `lastChanceToFinalize` destroys the `JSPublicKeyObject`/`JSPrivateKeyObject` wrappers during VM teardown, but the stranded ctx ref keeps `KeyObjectData` (and the `EVP_PKEY` it owns) alive past the leak check.

This also routes the BoringSSL memory hooks through `bun_alloc::default_alloc` instead of hard-coding mimalloc. The ASAN build config already drops `BORINGSSL_REQUIRE_MEMORY_HOOKS` so BoringSSL falls back to libc ("Off under ASAN so BoringSSL allocs stay on the intercepted libc heap"), but on ELF the weak `OPENSSL_memory_alloc`/`free`/`get_size` symbols still resolved to our definitions, which called `mi_malloc` directly and kept every `OPENSSL_malloc` allocation invisible to LeakSanitizer on Linux. Routing through `default_alloc` makes them libc under `cfg(bun_asan)` everywhere. The crate-root `bun_alloc::usable_size` (a `mi_usable_size` wrapper whose only callers were these hooks) is deleted.

## Reproduction

With the hook change alone:

```
direct leak of 24b in run (src/runtime/node/node_crypto_binding.rs:85:21) +34 more
SUMMARY: AddressSanitizer: 1480 byte(s) leaked in 35 allocation(s).
  #6 EVP_PKEY_keygen vendor/boringssl/crypto/evp/evp_ctx.cc:419
  #7 Bun::KeyPairJobCtx::runTask src/jsc/bindings/node/crypto/CryptoGenKeyPair.cpp:23
  #8 Bun__RsaKeyPairJobCtx__runTask src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.cpp:26
```

from `test/js/node/async_hooks/async-context/async-context-crypto-generateKeyPair.js`, which calls `process.exit(0)` inside the callback. First seen as the only `[new]` failure on the x64-asan lane of build 86653 for #36598, which applies the same hook change for its own LSan visibility.

## Cause

Ownership chain at the time the callback runs:

```
stack Box<AnyTaskJob>  (libc under ASAN)
  -> ExternCtx.ctx: *mut RsaKeyPairJobCtx  (TZone/FastMalloc, not LSan-tracked)
       -> m_keyObj.m_data: KeyObjectData*  (TZone/FastMalloc, not LSan-tracked)
            -> EVPKeyPointer.pkey_: EVP_PKEY*  (OPENSSL_malloc, now libc)
```

LSan scans the libc-backed `AnyTaskJob` box and the stack but can't follow through the FastMalloc blocks, so the `EVP_PKEY` is reported as a direct leak. The two JS key wrappers hold their own `RefPtr<KeyObjectData>` but live in JSC GC cells (also not scanned as a root).

## Fix

`runFromJS` now assigns `m_keyObj = {}` once the JS values have been produced (and on the two export-failure paths before the error callback). With the ctx's ref gone, either `~VM -> lastChanceToFinalize` destroying the JS wrappers brings the refcount to zero (KeyObject output), or the refcount is already zero (string/buffer output), and `EVP_PKEY_free` runs before LSan's atexit check.

`SignJobCtx` and `DhJobCtx` get the same reset for their `RefPtr<KeyObjectData>` fields (`m_keyData`, `m_privateKey`/`m_publicKey`). `runTask` has already produced the result and the ctx has no further use for the ref, so the reset is free.

### Scope

Tested each of the other async crypto job contexts under `BUN_DESTRUCT_VM_ON_EXIT=1` + `detect_leaks=1` with `process.exit(0)` in the callback. With only the `OPENSSL_memory_alloc` hook applied and `main`'s C++:

| path | result |
| --- | --- |
| `generateKeyPair` (KeyObject output) | **leaks** 1480b / 35 allocs |
| `generateKeyPair` (PEM + passphrase output) | **leaks** 1480b / 35 allocs |
| `sign` with PEM-string key | no leak |
| `diffieHellman` | no leak |
| `generatePrime` | no leak |
| `checkPrime` | no leak |

Only `generateKeyPair` trips LSan: its `EVP_PKEY*` sits behind two FastMalloc indirections (`ctx -> KeyObjectData* -> EVP_PKEY*`) and `runFromJS` never loads the raw pointer onto the stack. The others hold their `OPENSSL_malloc` pointer either directly in the ctx or load it onto the `runFromJS` frame (for `memcpy` into the result buffer), so LSan's conservative stack scan finds it. The `SignJobCtx`/`DhJobCtx` resets are kept for consistency; `HkdfJobCtx::m_key` holds a symmetric `Vector<uint8_t>` (FastMalloc, not `OPENSSL_malloc`) and is left alone, as are `GeneratePrimeJobCtx`/`CheckPrimeJobCtx` and the `KeyPairJobCtx` passphrase, none of which are observable.

## Verification

New `isASAN`-gated tests in `crypto.key-objects.test.ts` spawn a child with `BUN_DESTRUCT_VM_ON_EXIT=1` and `detect_leaks=1`, generate an RSA key pair (once with KeyObject output, once with encrypted PEM output), and call `process.exit(0)` from the callback.

- hook change without the `m_keyObj` reset: both cases fail with the 35-allocation LSan report above
- both changes: both pass, child exits 0
- crypto.test.ts (369 tests), crypto-rsa.test.js, crypto.key-objects.test.ts, the node `test-crypto-keygen-*` parallel suite, `test-crypto-sign-verify.js`, `test-crypto-dh-stateless.js`, and all `async-context-crypto-*` fixtures pass leak-clean

### Fail-before note

The automated fail-before check stashes all of `src/` and rebuilds. With the hook reverted to mimalloc, LSan cannot see the `EVP_PKEY` allocation at all, so the new tests pass trivially on `main`. The leak only becomes observable once `OPENSSL_memory_alloc` lands on libc, which is itself one of the `src/` changes in this diff; the fail-before/pass-after demonstration above (stashing only `CryptoGenKeyPair.cpp`) is the closest mechanical proof available.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/crypto/crypto.key-objects.test.ts

<!-- robobun:evidence:end -->