### PR TITLE
resolver: pick the loader from the symlink's extension, not the target's

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4166,10 +4166,10 @@ impl VirtualMachine {
         let result_path = result
             .path_const()
             .ok_or(crate::CrateError::ModuleNotFound)?;
-        // SAFETY: `result_path.text` borrows the resolver's arena, which
+        // SAFETY: `result_path.{text,pretty}` borrow the resolver's arena, which
         // outlives `ResolveFunctionResult` (see the struct's lifetime-erasure
         // note).
-        ret.path = unsafe { bun_ptr::detach_lifetime(result_path.text) };
+        ret.path = unsafe { bun_ptr::detach_lifetime(result_path.text_for_loader()) };
         ret.result = Some(result);
 
         Ok(())

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -851,6 +851,26 @@ pub mod fs {
             PathName::init(self.text)
         }
 
+        /// The path slice whose extension should determine the loader.
+        ///
+        /// When a file-level symlink is resolved, [`set_realpath`](Self::set_realpath)
+        /// moves the pre-symlink path to `pretty` and the target's realpath to
+        /// `text`. If the symlink's own extension differs from the target's, the
+        /// loader must come from the symlink's extension (the path the user
+        /// imported), so return `pretty`. Directory-level symlinks preserve the
+        /// filename and therefore the extension, so they fall through to `text`
+        /// and keep realpath-based module dedup.
+        #[inline]
+        pub fn text_for_loader(&self) -> &'a [u8] {
+            if self.is_symlink && self.is_file() {
+                let pretty_ext = PathName::init(self.pretty).ext;
+                if !pretty_ext.is_empty() && pretty_ext != PathName::init(self.text).ext {
+                    return self.pretty;
+                }
+            }
+            self.text
+        }
+
         /// Sets `text`/`pretty` to the same slice,
         /// namespace defaults to `"file"`.
         #[inline]

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -860,11 +860,21 @@ pub mod fs {
         /// imported), so return `pretty`. Directory-level symlinks preserve the
         /// filename and therefore the extension, so they fall through to `text`
         /// and keep realpath-based module dedup.
+        ///
+        /// The guard uses [`crate::extension`] (dotfiles report no extension)
+        /// and compares case-insensitively so `.babelrc -> x.json` and
+        /// `link.js -> real.JS` both keep the realpath.
         #[inline]
         pub fn text_for_loader(&self) -> &'a [u8] {
             if self.is_symlink && self.is_file() {
-                let pretty_ext = PathName::init(self.pretty).ext;
-                if !pretty_ext.is_empty() && pretty_ext != PathName::init(self.text).ext {
+                let pretty_ext = crate::extension(self.pretty);
+                if !pretty_ext.is_empty()
+                    && !crate::strings::eql_case_insensitive_ascii(
+                        pretty_ext,
+                        crate::extension(self.text),
+                        true,
+                    )
+                {
                     return self.pretty;
                 }
             }

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -851,19 +851,9 @@ pub mod fs {
             PathName::init(self.text)
         }
 
-        /// The path slice whose extension should determine the loader.
-        ///
-        /// When a file-level symlink is resolved, [`set_realpath`](Self::set_realpath)
-        /// moves the pre-symlink path to `pretty` and the target's realpath to
-        /// `text`. If the symlink's own extension differs from the target's, the
-        /// loader must come from the symlink's extension (the path the user
-        /// imported), so return `pretty`. Directory-level symlinks preserve the
-        /// filename and therefore the extension, so they fall through to `text`
-        /// and keep realpath-based module dedup.
-        ///
-        /// The guard uses [`crate::extension`] (dotfiles report no extension)
-        /// and compares case-insensitively so `.babelrc -> x.json` and
-        /// `link.js -> real.JS` both keep the realpath.
+        /// `pretty` (the pre-`set_realpath` path) when this is a file-namespace
+        /// symlink whose own extension differs case-insensitively from the
+        /// target's; `text` otherwise. Dotfiles count as extensionless.
         #[inline]
         pub fn text_for_loader(&self) -> &'a [u8] {
             if self.is_symlink && self.is_file() {

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -655,7 +655,7 @@ pub mod fs {
                 return Some(Loader::Dataurl);
             }
 
-            let name = PathName::init(self.text_for_loader());
+            let name = self.name();
             let ext = name.ext;
 
             let result = loaders

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -655,7 +655,7 @@ pub mod fs {
                 return Some(Loader::Dataurl);
             }
 
-            let name = self.name();
+            let name = PathName::init(self.text_for_loader());
             let ext = name.ext;
 
             let result = loaders

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3868,7 +3868,7 @@ fn loader_for_path(path: &Fs::Path<'_>, loaders: &bun_ast::LoaderHashTable) -> O
     if path.is_data_url() {
         return Some(Loader::Dataurl);
     }
-    let name = path.name();
+    let name = Fs::PathName::init(path.text_for_loader());
     let ext = name.ext;
     let result = loaders
         .get(ext)

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5055,14 +5055,14 @@ unsafe fn resolve<'a>(
     let Some(result_path) = result.path_const() else {
         return Err(crate::Error::ModuleNotFound);
     };
-    // Note: `result_path.text` is a `&'_ [u8]` borrowed from the
+    // Note: `result_path.{text,pretty}` are `&'_ [u8]` borrowed from the
     // resolver's interned `'static` BSSStringList stores (see resolver/lib.rs
     // §allocators) — the same store `load_preloads` reads from. Transmute the
     // lifetime to `'a` so the caller can `cloneUTF8` it; the underlying bytes
     // outlive the program.
-    // SAFETY: `result_path.text` borrows the resolver's `'static` interned
-    // string store; detaching the borrow lifetime is sound (see Note).
-    *ret_path = unsafe { bun_ptr::detach_lifetime(result_path.text) };
+    // SAFETY: `result_path.{text,pretty}` borrow the resolver's `'static`
+    // interned string store; detaching the borrow lifetime is sound (see Note).
+    *ret_path = unsafe { bun_ptr::detach_lifetime(result_path.text_for_loader()) };
     Ok(())
 }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3868,7 +3868,7 @@ fn loader_for_path(path: &Fs::Path<'_>, loaders: &bun_ast::LoaderHashTable) -> O
     if path.is_data_url() {
         return Some(Loader::Dataurl);
     }
-    let name = Fs::PathName::init(path.text_for_loader());
+    let name = path.name();
     let ext = name.ext;
     let result = loaders
         .get(ext)

--- a/test/regression/issue/10429.test.ts
+++ b/test/regression/issue/10429.test.ts
@@ -3,10 +3,10 @@
 // extension, not the target's.
 import { describe, expect, test } from "bun:test";
 import { symlinkSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
-describe("symlink import picks loader from the symlink's extension", () => {
+describe.concurrent("symlink import picks loader from the symlink's extension", () => {
   test(".txt symlink -> .html target loads as text", async () => {
     using dir = tempDir("issue-10429-txt-to-html", {
       "template.html": "<html></html>\n",
@@ -56,9 +56,7 @@ describe("symlink import picks loader from the symlink's extension", () => {
     expect(exitCode).toBe(0);
   });
 
-  // Unprivileged file symlinks on Windows require Developer Mode; the behaviour
-  // is covered on the other platforms.
-  test.skipIf(isWindows)(".txt symlink -> .ts target loads as text, not transpiled", async () => {
+  test(".txt symlink -> .ts target loads as text, not transpiled", async () => {
     using dir = tempDir("issue-10429-txt-to-ts", {
       "mod.ts": `export const x: number = 1;\n`,
       "index.ts": /* ts */ `
@@ -129,6 +127,31 @@ describe("symlink import picks loader from the symlink's extension", () => {
 
     expect(stderr).toBe("");
     expect(JSON.parse(stdout.trim())).toEqual({ value: 42 });
+    expect(exitCode).toBe(0);
+  });
+
+  test("dotfile symlink -> .json target keeps the target's loader", async () => {
+    // A leading-dot-only basename (.babelrc) has no extension, so the guard
+    // falls back to the realpath and the .json loader applies.
+    using dir = tempDir("issue-10429-dotfile", {
+      "babelrc.json": `{"presets":["env"]}`,
+      "index.ts": /* ts */ `
+        const cfg = require("./.babelrc");
+        console.log(JSON.stringify({ type: typeof cfg, presets: cfg.presets }));
+      `,
+    });
+    symlinkSync(join(String(dir), "babelrc.json"), join(String(dir), ".babelrc"), "file");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ type: "object", presets: ["env"] });
     expect(exitCode).toBe(0);
   });
 });

--- a/test/regression/issue/10429.test.ts
+++ b/test/regression/issue/10429.test.ts
@@ -1,0 +1,134 @@
+// https://github.com/oven-sh/bun/issues/10429
+// Importing through a symlink must pick the loader from the symlink's
+// extension, not the target's.
+import { describe, expect, test } from "bun:test";
+import { symlinkSync } from "fs";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+describe("symlink import picks loader from the symlink's extension", () => {
+  test(".txt symlink -> .html target loads as text", async () => {
+    using dir = tempDir("issue-10429-txt-to-html", {
+      "template.html": "<html></html>\n",
+      "index.ts": /* ts */ `
+        import t from "./template.txt";
+        if (typeof t !== "string") {
+          throw new Error("expected string, got " + typeof t + " " + String(t));
+        }
+        console.log(JSON.stringify({ type: typeof t, value: t }));
+      `,
+    });
+    symlinkSync(join(String(dir), "template.html"), join(String(dir), "template.txt"), "file");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("HTMLBundle");
+    expect(JSON.parse(stdout.trim())).toEqual({ type: "string", value: "<html></html>\n" });
+    expect(exitCode).toBe(0);
+  });
+
+  test(".json symlink -> .txt target loads as JSON", async () => {
+    using dir = tempDir("issue-10429-json-to-txt", {
+      "data.txt": `{"a":1}`,
+      "index.ts": /* ts */ `
+        import d from "./data.json";
+        console.log(JSON.stringify({ type: typeof d, value: d }));
+      `,
+    });
+    symlinkSync(join(String(dir), "data.txt"), join(String(dir), "data.json"), "file");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ type: "object", value: { a: 1 } });
+    expect(exitCode).toBe(0);
+  });
+
+  // Unprivileged file symlinks on Windows require Developer Mode; the behaviour
+  // is covered on the other platforms.
+  test.skipIf(isWindows)(".txt symlink -> .ts target loads as text, not transpiled", async () => {
+    using dir = tempDir("issue-10429-txt-to-ts", {
+      "mod.ts": `export const x: number = 1;\n`,
+      "index.ts": /* ts */ `
+        import src from "./mod.txt";
+        console.log(JSON.stringify({ type: typeof src, hasTypeAnnotation: src.includes(": number") }));
+      `,
+    });
+    symlinkSync(join(String(dir), "mod.ts"), join(String(dir), "mod.txt"), "file");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ type: "string", hasTypeAnnotation: true });
+    expect(exitCode).toBe(0);
+  });
+
+  test("symlink with same extension as target still dedupes via realpath", async () => {
+    // When the extensions match, the module key stays the realpath so
+    // importing through the symlink and through the target yield one module
+    // instance (side effects run once).
+    using dir = tempDir("issue-10429-same-ext", {
+      "real.mjs": `globalThis.__hits = (globalThis.__hits || 0) + 1; export const hits = globalThis.__hits;`,
+      "index.ts": /* ts */ `
+        const a = await import("./link.mjs");
+        const b = await import("./real.mjs");
+        console.log(JSON.stringify({ same: a === b, hits: globalThis.__hits }));
+      `,
+    });
+    symlinkSync(join(String(dir), "real.mjs"), join(String(dir), "link.mjs"), "file");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ same: true, hits: 1 });
+    expect(exitCode).toBe(0);
+  });
+
+  test("extensionless symlink -> .js target still loads as JS", async () => {
+    // If the symlink has no extension of its own, fall back to the target's.
+    using dir = tempDir("issue-10429-no-ext", {
+      "real.js": `module.exports = 42;`,
+      "index.ts": /* ts */ `
+        const v = require("./script");
+        console.log(JSON.stringify({ value: v }));
+      `,
+    });
+    symlinkSync(join(String(dir), "real.js"), join(String(dir), "script"), "file");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ value: 42 });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #10429.

## Repro

```sh
printf '<html></html>\n' > template.html
ln -s template.html template.txt
bun -e 'import t from "./template.txt"; console.log(typeof t, String(t))'
# before: object [object HTMLBundle]
# after:  string <html></html>
```

## Cause

`Resolver::finalize_result` calls `Path::set_realpath` when the resolved file is itself a symlink, which moves the realpath into `Path.text` and stashes the pre-symlink path in `Path.pretty`. `VirtualMachine::_resolve` writes `ret.path = result_path.text`, so the realpath becomes the module key that C++ hands back to `Bun__transpileFile`, and the loader is then derived from the target's extension.

## Fix

Add `Path::text_for_loader()` which returns `.pretty` when the path is a file-namespace symlink whose own extension is non-empty and differs (case-insensitively, dotfiles treated as extensionless) from the target's, and `.text` otherwise. `_resolve()` now writes `ret.path = result_path.text_for_loader()`.

The guard keeps the change narrow: directory-level symlinks (pnpm) preserve the filename, so they always fall through to `.text` and keep realpath-based module dedup. Same-extension file symlinks (`a.mjs -> b.mjs`), dotfile symlinks (`.babelrc -> x.json`) and extensionless symlinks pointing at `.js` also keep the realpath.

When the guard triggers, the module key becomes the symlink path, so `require.resolve("./template.txt")` and `import.meta.url` report the symlink rather than the realpath. That only happens for file-level symlinks whose extension differs from their target, which is exactly the case where the two paths must be distinct modules (different loaders).

`PathResolverExt::loader()` and the bundler are unchanged; the bundler dedups on `path.text` and routing its loader through `text_for_loader()` would make the result depend on which of `./link.txt` / `./real.html` is visited first.

## Tests

`test/regression/issue/10429.test.ts` covers:
- `.txt -> .html`, `.json -> .txt`, `.txt -> .ts` (fail before, pass after)
- same-extension symlink still dedupes via realpath
- extensionless symlink pointing at `.js` still loads as JS
- dotfile symlink (`.babelrc -> babelrc.json`) keeps the target's loader

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/10429.test.ts"
bun test v1.4.0 (6da91391d)

test/regression/issue/10429.test.ts:
26 |       cwd: String(dir),
27 |       stderr: "pipe",
28 |     });
29 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
30 | 
31 |     expect(stderr).not.toContain("HTMLBundle");
                            ^
error: expect(received).not.toContain(expected)

Expected to not contain: "HTMLBundle"
Received: "1 | \n2 |         import t from \"./template.txt\";\n3 |         if (typeof t !== \"string\") {\n4 |           throw new Error(\"expected string, got \" + typeof t + \" \" + String(t));\n                        ^\nerror: expected string, got object [object HTMLBundle]\n      at /tmp/issue-10429-txt-to-html_pHsuFG/index.ts:4:21\n\nBun v1.4.0-debug+6da91391d (Linux x64)\n"

      at <anonymous> (/workspace/bun/test/regression/issue/10429.test.ts:31:24)
50 |       stderr: "pipe",
51 |     });
52 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.tex
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (8760d76b8)

test/regression/issue/10429.test.ts:
(pass) symlink import picks loader from the symlink's extension > .json symlink -> .txt target loads as JSON [212.00ms]
(pass) symlink import picks loader from the symlink's extension > .txt symlink -> .ts target loads as text, not transpiled [134.17ms]
(pass) symlink import picks loader from the symlink's extension > .txt symlink -> .html target loads as text [241.12ms]
(pass) symlink import picks loader from the symlink's extension > extensionless symlink -> .js target still loads as JS [131.92ms]
(pass) symlink import picks loader from the symlink's extension > symlink with same extension as target still dedupes via realpath [132.95ms]
(pass) symlink import picks loader from the symlink's extension > dotfile symlink -> .json target keeps the target's loader [130.99ms]

 6 pass
 0 fail
 18 expect() calls
Ran 6 tests across 1 file. [755.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/10429.test.ts"
bun test v1.4.0 (6da91391d)

test/regression/issue/10429.test.ts:
(pass) symlink import picks loader from the symlink's extension > .txt symlink -> .html target loads as text [639.01ms]
(pass) symlink import picks loader from the symlink's extension > extensionless symlink -> .js target still loads as JS [562.38ms]
(pass) symlink import picks loader from the symlink's extension > .json symlink -> .txt target loads as JSON [624.42ms]
(pass) symlink import picks loader from the symlink's extension > .txt symlink -> .ts target loads as text, not transpiled [610.08ms]
(pass) symlink import picks loader from the symlink's extension > symlink with same extension as target still dedupes via realpath [589.73ms]
(pass) symlink import picks loader from the symlink's extension > dotfile symlink -> .json target keeps the target's loader [558.17ms]

 6 pass
 0 fail
 18 expect() calls
Ran 6 tests across 1 file. [5.05s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1142ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/52] gen cpp.rs (cppbind)
[2/52] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/52] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_sys v0.0.0 (/workspace/bun/src/sys)
[1m[92m   Compiling[0m bun_url v0.0.0 (/workspace/bun/src/url)
[1m[92m   Compiling[0m bun_http_types v0.0.0 (/workspace/bun/src/http_types)
[1m[92m   Compiling[0m bun_perf v0.0.0 (/workspace/bun/src/perf)
[1m[92m   Compiling[0m bun_threading v0.0.0 (/workspace/bun/src/threading)
[1m[92m   Compiling[0m bun_spawn_sys v0.0.0 (/workspace/bun/src/spawn_sys)
[1m[92m   Compiling[0m bun_which v0.0.0 (/workspace/bun/src/which)
[1m[92m   Compiling[0m bun_libarchive v0.0.0 (/workspace/bun/src/libarchive)
[1m[92m   Com
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs           |   4 +-
 src/paths/lib.rs                    |  20 +++++
 src/runtime/jsc_hooks.rs            |   8 +-
 test/regression/issue/10429.test.ts | 157 ++++++++++++++++++++++++++++++++++++
 4 files changed, 183 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/VirtualMachine.rs                4      1      0
src/paths/lib.rs                         4      4      0
src/runtime/jsc_hooks.rs                 4      4      0
test/regression/issue/10429.test.ts      0      2      0
```

</details>

<!-- robobun:evidence:end -->