### PR TITLE
console: print built-in prototypes as {} instead of boxed value / method dump

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2285,6 +2285,21 @@ pub mod formatter {
             }
 
             use jsc::JSType as T;
+
+            // String/Number/Boolean.prototype share a JSType with their boxed
+            // instances (JSC implements them as wrapper objects around ""/0/false)
+            // but should print as plain `{}` like Node does, not as a boxed value.
+            if matches!(
+                js_type,
+                T::NumberObject | T::BooleanObject | T::StringObject | T::DerivedStringObject
+            ) && value.is_builtin_prototype_for_formatting(global_this)
+            {
+                return Ok(TagResult {
+                    tag: TagPayload::Object,
+                    cell: js_type,
+                });
+            }
+
             let tag = match js_type {
                 T::ErrorInstance => TagPayload::Error,
                 T::NumberObject => TagPayload::Double,
@@ -3245,6 +3260,9 @@ pub mod formatter {
         global_this: &JSGlobalObject,
         value: JSValue,
     ) -> JsResult<Option<ZigString>> {
+        if value.is_builtin_prototype_for_formatting(global_this) {
+            return Ok(None);
+        }
         let mut name_str = ZigString::init(b"");
         value.get_class_name(global_this, &mut name_str)?;
         if !name_str.eql_comptime(b"Object") {

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2296,7 +2296,7 @@ pub mod formatter {
             {
                 return Ok(TagResult {
                     tag: TagPayload::Object,
-                    cell: js_type,
+                    cell: T::Object,
                 });
             }
 
@@ -3260,17 +3260,18 @@ pub mod formatter {
         global_this: &JSGlobalObject,
         value: JSValue,
     ) -> JsResult<Option<ZigString>> {
+        let mut name_str = ZigString::init(b"");
+        value.get_class_name(global_this, &mut name_str)?;
+        if name_str.eql_comptime(b"Object") {
+            if value.get_prototype(global_this).eql_value(JSValue::NULL) {
+                return Ok(Some(ZigString::static_("[Object: null prototype]")));
+            }
+            return Ok(None);
+        }
         if value.is_builtin_prototype_for_formatting(global_this) {
             return Ok(None);
         }
-        let mut name_str = ZigString::init(b"");
-        value.get_class_name(global_this, &mut name_str)?;
-        if !name_str.eql_comptime(b"Object") {
-            return Ok(Some(name_str));
-        } else if value.get_prototype(global_this).eql_value(JSValue::NULL) {
-            return Ok(Some(ZigString::static_("[Object: null prototype]")));
-        }
-        Ok(None)
+        Ok(Some(name_str))
     }
 
     // `JSGlobalObject` is an opaque `UnsafeCell`-backed ZST handle; remaining

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2286,6 +2286,13 @@ impl JSValue {
     pub fn get_prototype(self, global: &JSGlobalObject) -> JSValue {
         JSC__JSValue__getPrototype(self, global)
     }
+    /// True when `self` is one of the global's well-known built-in prototype
+    /// objects (`String.prototype`, `Number.prototype`, `Array.prototype`, ...).
+    /// Used by the console formatter to print those as `{}` instead of as a
+    /// boxed primitive or a dump of every method.
+    pub fn is_builtin_prototype_for_formatting(self, global: &JSGlobalObject) -> bool {
+        JSC__JSValue__isBuiltinPrototypeForFormatting(self, global)
+    }
 
     // ── Reflection / naming. ───────────────
     /// `JSValue.getName` — function/class display name.
@@ -2670,6 +2677,10 @@ unsafe extern "C" {
     safe fn JSC__JSValue__toObject(this: JSValue, global: &JSGlobalObject) -> *mut JSObject;
     safe fn JSC__JSValue__unwrapBoxedPrimitive(global: &JSGlobalObject, this: JSValue) -> JSValue;
     safe fn JSC__JSValue__getPrototype(this: JSValue, global: &JSGlobalObject) -> JSValue;
+    safe fn JSC__JSValue__isBuiltinPrototypeForFormatting(
+        this: JSValue,
+        global: &JSGlobalObject,
+    ) -> bool;
     safe fn JSC__JSValue__getName(
         this: JSValue,
         global: &JSGlobalObject,

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5320,11 +5320,16 @@ restart:
 
         JSObject* iterating = prototypeObject.getObject();
 
-        while (iterating && !(shouldStopFormattingPrototypeWalk(globalObject, iterating) || (iterating->inherits<JSGlobalProxy>() && uncheckedDowncast<JSGlobalProxy>(iterating)->target() != globalObject)) && prototypeCount++ < 5) {
+        while (iterating && !((iterating != object && shouldStopFormattingPrototypeWalk(globalObject, iterating)) || (iterating->inherits<JSGlobalProxy>() && uncheckedDowncast<JSGlobalProxy>(iterating)->target() != globalObject)) && prototypeCount++ < 5) {
+            // Node hides the DontEnum members of a built-in prototype but shows any
+            // enumerable properties the user has added to it.
+            DontEnumPropertiesMode dontEnum = (iterating == object && isBuiltinPrototypeForFormatting(globalObject, iterating))
+                ? DontEnumPropertiesMode::Exclude
+                : DontEnumPropertiesMode::Include;
             if constexpr (nonIndexedOnly) {
-                iterating->getOwnNonIndexPropertyNames(globalObject, properties, DontEnumPropertiesMode::Include);
+                iterating->getOwnNonIndexPropertyNames(globalObject, properties, dontEnum);
             } else {
-                iterating->methodTable()->getOwnPropertyNames(iterating, globalObject, properties, DontEnumPropertiesMode::Include);
+                iterating->methodTable()->getOwnPropertyNames(iterating, globalObject, properties, dontEnum);
             }
 
             RETURN_IF_EXCEPTION(scope, void());
@@ -5481,8 +5486,10 @@ extern "C" [[ZIG_EXPORT(nothrow)]] bool JSC__isBigIntInInt64Range(JSC::EncodedJS
 
     JSC::PropertyNameArrayBuilder properties(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
     {
-
-        JSC::JSObject::getOwnPropertyNames(object, globalObject, properties, DontEnumPropertiesMode::Include);
+        DontEnumPropertiesMode dontEnum = isBuiltinPrototypeForFormatting(globalObject, object)
+            ? DontEnumPropertiesMode::Exclude
+            : DontEnumPropertiesMode::Include;
+        JSC::JSObject::getOwnPropertyNames(object, globalObject, properties, dontEnum);
         if (scope.exception()) [[unlikely]] {
             (void)scope.tryClearException();
             return;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -102,6 +102,9 @@
 #include "JavaScriptCore/TimeZoneICUBridge.h"
 
 #include "JavaScriptCore/FunctionPrototype.h"
+#include "JavaScriptCore/RegExpPrototype.h"
+#include "JavaScriptCore/AsyncIteratorPrototype.h"
+#include "JavaScriptCore/JSPromisePrototype.h"
 #include "JSFetchHeaders.h"
 #include "FetchHeaders.h"
 #include "DOMURL.h"
@@ -5139,6 +5142,55 @@ extern "C" void JSGlobalObject__throwStackOverflow(JSC::JSGlobalObject* globalOb
     throwStackOverflowError(globalObject, scope);
 }
 
+// Built-in prototype objects that the console formatter should print as a
+// plain `{}` and never enumerate as part of a prototype walk. Identity-compared
+// against the global's well-known prototypes so user classes are unaffected.
+static bool isBuiltinPrototypeForFormatting(JSC::JSGlobalObject* globalObject, JSC::JSObject* object)
+{
+    return object == globalObject->objectPrototype()
+        || object == globalObject->functionPrototype()
+        || object == globalObject->arrayPrototype()
+        || object == globalObject->stringPrototype()
+        || object == globalObject->bigIntPrototype()
+        || object == globalObject->symbolPrototype()
+        || object == globalObject->regExpPrototype()
+        || object == globalObject->iteratorPrototype()
+        || object == globalObject->asyncIteratorPrototype()
+        || object == globalObject->promisePrototype()
+        || object == globalObject->numberPrototype()
+        || object == globalObject->booleanPrototype()
+        || object == globalObject->datePrototype()
+        || object == globalObject->errorPrototype()
+        || object == globalObject->mapPrototype()
+        || object == globalObject->jsSetPrototype();
+}
+
+// Stop condition for the formatter's prototype walk: built-in prototypes plus
+// any boxed-primitive wrapper sitting in the chain (e.g. Object.create(new String("a"))
+// should not inherit the wrapper's index/length or String.prototype's methods).
+static bool shouldStopFormattingPrototypeWalk(JSC::JSGlobalObject* globalObject, JSC::JSObject* object)
+{
+    if (isBuiltinPrototypeForFormatting(globalObject, object))
+        return true;
+    switch (object->type()) {
+    case StringObjectType:
+    case DerivedStringObjectType:
+    case NumberObjectType:
+    case BooleanObjectType:
+        return true;
+    default:
+        return false;
+    }
+}
+
+extern "C" bool JSC__JSValue__isBuiltinPrototypeForFormatting(JSC::EncodedJSValue encodedValue, JSC::JSGlobalObject* globalObject)
+{
+    JSC::JSObject* object = JSC::JSValue::decode(encodedValue).getObject();
+    if (!object)
+        return false;
+    return isBuiltinPrototypeForFormatting(globalObject, object);
+}
+
 template<bool nonIndexedOnly>
 static void JSC__JSValue__forEachPropertyImpl(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* globalObject, void* arg2, void (*iter)(JSC::JSGlobalObject* arg0, void* ctx, ZigString* arg2, JSC::EncodedJSValue JSValue3, bool isSymbol, bool isPrivateSymbol))
 {
@@ -5168,7 +5220,8 @@ static void JSC__JSValue__forEachPropertyImpl(JSC::EncodedJSValue JSValue0, JSC:
             fast = false;
 
             if (JSValue proto = object->getPrototype(globalObject)) {
-                if ((structure = proto.structureOrNull())) {
+                JSObject* protoObject = proto.getObject();
+                if (protoObject && !shouldStopFormattingPrototypeWalk(globalObject, protoObject) && (structure = protoObject->structure())) {
                     prototypeObject = proto;
                     fast = canPerformFastPropertyEnumerationForIterationBun(structure);
                     prototypeCount = 1;
@@ -5245,8 +5298,9 @@ restart:
             if (prototypeCount++ < 5) {
 
                 if (JSValue proto = prototypeObject.getPrototype(globalObject)) {
-                    if (!(proto == globalObject->objectPrototype() || proto == globalObject->functionPrototype() || (proto.inherits<JSGlobalProxy>() && uncheckedDowncast<JSGlobalProxy>(proto)->target() != globalObject))) {
-                        if ((structure = proto.structureOrNull())) {
+                    JSObject* protoObject = proto.getObject();
+                    if (protoObject && !shouldStopFormattingPrototypeWalk(globalObject, protoObject) && !(proto.inherits<JSGlobalProxy>() && uncheckedDowncast<JSGlobalProxy>(proto)->target() != globalObject)) {
+                        if ((structure = protoObject->structure())) {
                             prototypeObject = proto;
                             fast = canPerformFastPropertyEnumerationForIterationBun(structure);
                             goto restart;
@@ -5266,7 +5320,7 @@ restart:
 
         JSObject* iterating = prototypeObject.getObject();
 
-        while (iterating && !(iterating == globalObject->objectPrototype() || iterating == globalObject->functionPrototype() || (iterating->inherits<JSGlobalProxy>() && uncheckedDowncast<JSGlobalProxy>(iterating)->target() != globalObject)) && prototypeCount++ < 5) {
+        while (iterating && !(shouldStopFormattingPrototypeWalk(globalObject, iterating) || (iterating->inherits<JSGlobalProxy>() && uncheckedDowncast<JSGlobalProxy>(iterating)->target() != globalObject)) && prototypeCount++ < 5) {
             if constexpr (nonIndexedOnly) {
                 iterating->getOwnNonIndexPropertyNames(globalObject, properties, DontEnumPropertiesMode::Include);
             } else {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -685,11 +685,17 @@ it("console.log on null prototype", () => {
 // https://github.com/oven-sh/bun/issues/8627
 describe("built-in prototypes print as {} and are not enumerated via the prototype chain", () => {
   it("String/Number/Boolean.prototype print as {}, not as boxed values", () => {
-    expect(Bun.inspect(String.prototype)).toBe("{}");
     expect(Bun.inspect(Number.prototype)).toBe("{}");
     expect(Bun.inspect(Boolean.prototype)).toBe("{}");
+    // String.prototype: harness.ts adds isLatin1/isUTF16 as enumerable own props, so we
+    // check that no built-in method leaks through instead of asserting exact equality.
+    // The subprocess test below covers the clean `String.prototype` -> `{}` case.
+    const sp = Bun.inspect(String.prototype);
+    expect(sp).not.toContain('"');
+    expect(sp).not.toContain("[String:");
+    expect(sp).not.toContain("charAt");
+    expect(sp).not.toContain("length");
     // nested: must not quote as "" / render as [Number: 0] / [Boolean: false]
-    expect(Bun.inspect({ x: String.prototype })).toBe("{\n  x: {},\n}");
     expect(Bun.inspect({ x: Number.prototype })).toBe("{\n  x: {},\n}");
     expect(Bun.inspect({ x: Boolean.prototype })).toBe("{\n  x: {},\n}");
     // actual boxed primitives are unaffected
@@ -729,6 +735,41 @@ describe("built-in prototypes print as {} and are not enumerated via the prototy
     }
     // Array.prototype is itself an Array
     expect(Bun.inspect(Array.prototype)).toBe("[]");
+    // Object.prototype keeps its null-prototype marker
+    expect(Bun.inspect(Object.prototype)).toBe("[Object: null prototype] {}");
+  });
+
+  it("sorted: true takes the same path", () => {
+    expect(Bun.inspect(Number.prototype, { sorted: true })).toBe("{}");
+    expect(Bun.inspect(Boolean.prototype, { sorted: true })).toBe("{}");
+    expect(Bun.inspect(Date.prototype, { sorted: true })).toBe("{}");
+    expect(Bun.inspect(Map.prototype, { sorted: true })).toBe("{}");
+    expect(Bun.inspect(Object.create(String.prototype), { sorted: true })).toBe("String {}");
+    expect(Bun.inspect(String.prototype, { sorted: true })).not.toContain("charAt");
+  });
+
+  it("user-added enumerable properties on a built-in prototype are still shown", () => {
+    // run in a subprocess so the prototype mutation doesn't leak into other tests
+    const out = Bun.spawnSync({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          Date.prototype.foo = 1;
+          process.stdout.write(Bun.inspect(Date.prototype) + "|");
+          process.stdout.write(Bun.inspect(Date.prototype, { sorted: true }) + "|");
+          String.prototype.bar = 2;
+          process.stdout.write(Bun.inspect(String.prototype) + "|");
+        `,
+      ],
+      env: bunEnv,
+    });
+    expect(out.stdout.toString()).toBe("{\n  foo: 1,\n}|{\n  foo: 1,\n}|{\n  bar: 2,\n}|");
+    expect(out.exitCode).toBe(0);
+  });
+
+  it("nested String.prototype is not colored as a string", () => {
+    expect(Bun.inspect({ x: String.prototype }, { colors: true })).not.toContain("\x1b[32m{");
   });
 
   it("user-defined class prototypes are still walked", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -682,6 +682,98 @@ it("console.log on null prototype", () => {
   expect(Bun.inspect(Object.create(null))).toBe("[Object: null prototype] {}");
 });
 
+// https://github.com/oven-sh/bun/issues/8627
+describe("built-in prototypes print as {} and are not enumerated via the prototype chain", () => {
+  it("String/Number/Boolean.prototype print as {}, not as boxed values", () => {
+    expect(Bun.inspect(String.prototype)).toBe("{}");
+    expect(Bun.inspect(Number.prototype)).toBe("{}");
+    expect(Bun.inspect(Boolean.prototype)).toBe("{}");
+    // nested: must not quote as "" / render as [Number: 0] / [Boolean: false]
+    expect(Bun.inspect({ x: String.prototype })).toBe("{\n  x: {},\n}");
+    expect(Bun.inspect({ x: Number.prototype })).toBe("{\n  x: {},\n}");
+    expect(Bun.inspect({ x: Boolean.prototype })).toBe("{\n  x: {},\n}");
+    // actual boxed primitives are unaffected
+    expect(Bun.inspect(new Number(1))).toBe("[Number: 1]");
+    expect(Bun.inspect(new Boolean(true))).toBe("[Boolean: true]");
+  });
+
+  it("Object.create(X.prototype) does not list the prototype's methods", () => {
+    expect(Bun.inspect(Object.create(String.prototype))).toBe("String {}");
+    expect(Bun.inspect(Object.create(Number.prototype))).toBe("Number {}");
+    expect(Bun.inspect(Object.create(Boolean.prototype))).toBe("Boolean {}");
+    expect(Bun.inspect(Object.create(Array.prototype))).toBe("Array {}");
+    expect(Bun.inspect(Object.create(Date.prototype))).toBe("Date {}");
+    expect(Bun.inspect(Object.create(RegExp.prototype))).toBe("RegExp {}");
+    expect(Bun.inspect(Object.create(Map.prototype))).toBe("Map {}");
+    expect(Bun.inspect(Object.create(Set.prototype))).toBe("Set {}");
+    expect(Bun.inspect(Object.create(Promise.prototype))).toBe("Promise {}");
+    // wrappers in the chain are not enumerated either
+    expect(Bun.inspect(Object.create(new String("a")))).toBe("String {}");
+    expect(Bun.inspect(Object.create(new Number(1)))).toBe("Number {}");
+    // own properties still show; inherited built-in methods do not
+    expect(Bun.inspect(Object.assign(Object.create(String.prototype), { x: 1 }))).toBe("String {\n  x: 1,\n}");
+  });
+
+  it("other built-in prototypes print as {}, not a method dump", () => {
+    for (const proto of [
+      Date.prototype,
+      RegExp.prototype,
+      Map.prototype,
+      Set.prototype,
+      Symbol.prototype,
+      BigInt.prototype,
+      Error.prototype,
+      Promise.prototype,
+    ]) {
+      expect(Bun.inspect(proto)).toBe("{}");
+    }
+    // Array.prototype is itself an Array
+    expect(Bun.inspect(Array.prototype)).toBe("[]");
+  });
+
+  it("user-defined class prototypes are still walked", () => {
+    class Foo {
+      bar() {}
+    }
+    expect(Bun.inspect(new Foo())).toBe("Foo {\n  bar: [Function: bar],\n}");
+    expect(Bun.inspect(Object.create(Foo.prototype))).toBe("Foo {\n  bar: [Function: bar],\n}");
+    class Bar extends Map {
+      baz() {}
+    }
+    // Map.prototype is now a stop point, so only Bar.prototype's own methods show
+    const s = Bun.inspect(Object.create(Bar.prototype));
+    expect(s).toContain("baz: [Function: baz]");
+    expect(s).not.toContain("clear");
+  });
+
+  it("console.log output matches", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          process.stdout.write("|");
+          console.log(String.prototype);
+          process.stdout.write("|");
+          console.log(Object.create(String.prototype));
+          process.stdout.write("|");
+          console.log(Number.prototype);
+          process.stdout.write("|");
+          console.log(Boolean.prototype);
+          process.stdout.write("|");
+          console.log(new String(""));
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe('|{}\n|String {}\n|{}\n|{}\n|[String: ""]\n');
+    expect(exitCode).toBe(0);
+  });
+});
+
 it("Symbol", () => {
   expect(Bun.inspect(Symbol())).toBe("Symbol()");
   expect(Bun.inspect(Symbol(""))).toBe("Symbol()");

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -748,9 +748,9 @@ describe("built-in prototypes print as {} and are not enumerated via the prototy
     expect(Bun.inspect(String.prototype, { sorted: true })).not.toContain("charAt");
   });
 
-  it("user-added enumerable properties on a built-in prototype are still shown", () => {
+  it("user-added enumerable properties on a built-in prototype are still shown", async () => {
     // run in a subprocess so the prototype mutation doesn't leak into other tests
-    const out = Bun.spawnSync({
+    await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
@@ -763,9 +763,12 @@ describe("built-in prototypes print as {} and are not enumerated via the prototy
         `,
       ],
       env: bunEnv,
+      stderr: "pipe",
     });
-    expect(out.stdout.toString()).toBe("{\n  foo: 1,\n}|{\n  foo: 1,\n}|{\n  bar: 2,\n}|");
-    expect(out.exitCode).toBe(0);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("{\n  foo: 1,\n}|{\n  foo: 1,\n}|{\n  bar: 2,\n}|");
+    expect(exitCode).toBe(0);
   });
 
   it("nested String.prototype is not colored as a string", () => {


### PR DESCRIPTION
Fixes #8627.

## Repro

```js
process.stdout.write("|"); console.log(String.prototype);
process.stdout.write("|"); console.log(Object.create(String.prototype));
process.stdout.write("|"); console.log(Number.prototype);
process.stdout.write("|"); console.log(Boolean.prototype);
```

Before:
```
|
|String { length: 0, anchor: [Function: anchor], big: [Function: big], ... 50 more ... }
|[Number: 0]
|[Boolean: false]
```

After (matches Node):
```
|{}
|String {}
|{}
|{}
```

## Cause

Two independent bugs in the native `console.log` / `Bun.inspect` formatter (`util.inspect` was already correct):

1. `String.prototype`, `Number.prototype` and `Boolean.prototype` share a `JSType` with their boxed instances (JSC implements them as `StringObject("")`, `NumberObject(0)`, `BooleanObject(false)`), so `Tag::get` routed them to the boxed-primitive printers. `String.prototype` ended up printing its internal value, which is the empty string.

2. `forEachPropertyImpl` walks the prototype chain to show user-defined class methods, but its stop condition only recognised `Object.prototype` and `Function.prototype`. Any other built-in prototype reached during the walk (via `Object.create(String.prototype)`, `Object.create(Date.prototype)`, etc.) had all of its non-enumerable methods listed.

## Fix

Add `isBuiltinPrototypeForFormatting`, an identity check against the global's well-known prototype pointers (`stringPrototype()`, `numberPrototype()`, `arrayPrototype()`, `datePrototype()`, `regExpPrototype()`, `mapPrototype()`, `jsSetPrototype()`, ...).

- `Tag::get`: when a `StringObject`/`DerivedStringObject`/`NumberObject`/`BooleanObject` is one of those prototypes, tag it as `Object` so it prints as `{}`.
- `get_object_name`: suppress the constructor-name prefix for built-in prototypes so they print as `{}` rather than `String {}` / `Date {}`.
- `forEachPropertyImpl`: stop the prototype walk at any built-in prototype (and at boxed-primitive wrappers sitting in the chain, so `Object.create(new String("a"))` also shows `String {}`).

User-defined class prototypes are `JSFinalObject`s that don't identity-match any global prototype, so Bun's existing behaviour of showing class methods (`class Foo { bar() {} }` → `Foo { bar: [Function: bar] }`) is unchanged.

## Verification

```sh
USE_SYSTEM_BUN=1 bun test test/js/bun/util/inspect.test.js -t "built-in prototypes"  # 5 fail
bun bd test test/js/bun/util/inspect.test.js -t "built-in prototypes"                # 5 pass
bun bd test test/js/bun/util/inspect.test.js                                         # 78 pass
bun bd test test/js/bun/console/ test/js/web/console/                                # 95 pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
bun test v1.4.0 (8d29cca09)

test/js/bun/util/inspect.test.js:
(pass) prototype [476.78ms]
(pass) getters [6.76ms]
(pass) setters [4.64ms]
(pass) getter/setters [2.89ms]
(pass) Timeout [6.18ms]
(pass) when prototype defines the same property, don't print the same property twice [3.51ms]
(pass) Blob inspect [12.74ms]
(pass) utf16 property name [71.51ms]
(pass) latin1 [4.14ms]
(pass) Request object [3.30ms]
(pass) MessageEvent [2.75ms]
(pass) MessageEvent with no data set [1.91ms]
(pass) MessageEvent with deleted data [3.73ms]
(pass) TypedArray prints [143.69ms]
(pass) BigIntArray [56.53ms]
(pass) Float32Array 42.68000030517578 [8.30ms]
(pass) Float32Array 42.68 [6.73ms]
(pass) Float64Array 42.68000030517578 [1.92ms]
(pass) Float64Array 42.68 [2.46ms]
(pass) jsx with two elements [54.52ms]
(pass) jsx with anon component [4.00ms]
(pass) jsx with fragment [8.82ms]
(pass) inspect [118.68ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [3.16ms]
(pass) latin1 supplemental > latin1 (input) "cb
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/util/inspect.test.js:
(pass) prototype [23.67ms]
(pass) getters [0.19ms]
(pass) setters [0.05ms]
(pass) getter/setters [0.03ms]
(pass) Timeout [0.11ms]
(pass) when prototype defines the same property, don't print the same property twice [0.05ms]
(pass) Blob inspect [0.63ms]
(pass) utf16 property name [1.50ms]
(pass) latin1 [0.05ms]
(pass) Request object [0.06ms]
(pass) MessageEvent [0.04ms]
(pass) MessageEvent with no data set [0.02ms]
(pass) MessageEvent with deleted data [0.04ms]
(pass) TypedArray prints [1.19ms]
(pass) BigIntArray [0.43ms]
(pass) Float32Array 42.68000030517578 [0.09ms]
(pass) Float32Array 42.68 [0.09ms]
(pass) Float64Array 42.68000030517578 [0.02ms]
(pass) Float64Array 42.68 [0.01ms]
(pass) jsx with two elements [0.87ms]
(pass) jsx with anon component [0.04ms]
(pass) jsx with fragment [0.09ms]
(pass) inspect [0.85ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [0.04ms]
(pass) latin1 supplemental > latin1 (input) "cbä" [ "cbä" ]
(pass) latin1 supplemental > latin1 (input) "cäb" [ "cäb" ]
(pass) latin1 supplemental > latin1 (input) "äbc äbc" [ "äbc äbc" ]
(pass) latin1 supp
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
bun test v1.4.0 (8d29cca09)

test/js/bun/util/inspect.test.js:
(pass) prototype [356.88ms]
(pass) getters [5.91ms]
(pass) setters [3.87ms]
(pass) getter/setters [2.40ms]
(pass) Timeout [5.16ms]
(pass) when prototype defines the same property, don't print the same property twice [2.37ms]
(pass) Blob inspect [9.54ms]
(pass) utf16 property name [64.76ms]
(pass) latin1 [4.29ms]
(pass) Request object [3.00ms]
(pass) MessageEvent [2.06ms]
(pass) MessageEvent with no data set [2.21ms]
(pass) MessageEvent with deleted data [3.03ms]
(pass) TypedArray prints [103.11ms]
(pass) BigIntArray [182.13ms]
(pass) Float32Array 42.68000030517578 [10.08ms]
(pass) Float32Array 42.68 [8.86ms]
(pass) Float64Array 42.68000030517578 [5.71ms]
(pass) Float64Array 42.68 [1.46ms]
(pass) jsx with two elements [78.52ms]
(pass) jsx with anon component [7.57ms]
(pass) jsx with fragment [16.59ms]
(pass) inspect [205.57ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [6.89ms]
(pass) latin1 supplemental > latin1 (input) "c
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1755ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/52] gen cpp.rs (cppbind)
[2/52] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/52] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs         |  29 +++++++--
 src/jsc/JSValue.rs               |  11 ++++
 src/jsc/bindings/bindings.cpp    |  77 +++++++++++++++++++---
 test/js/bun/util/inspect.test.js | 136 +++++++++++++++++++++++++++++++++++++++
 4 files changed, 240 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/jsc/ConsoleObject.rs             11      5      0
src/jsc/JSValue.rs                    3      2      0
src/jsc/bindings/bindings.cpp         7     13      0
test/js/bun/util/inspect.test.js      4      8      0
```

</details>

<!-- robobun:evidence:end -->