### PR TITLE
Bun.plugin: fix `loader: "md"` being parsed as JSON5

### DIFF
--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -267,7 +267,8 @@ inline constexpr BunLoaderType BunLoaderTypeTOML = 9;
 inline constexpr BunLoaderType BunLoaderTypeWASM = 10;
 inline constexpr BunLoaderType BunLoaderTypeNAPI = 11;
 inline constexpr BunLoaderType BunLoaderTypeYAML = 19;
-inline constexpr BunLoaderType BunLoaderTypeMD = 20;
+inline constexpr BunLoaderType BunLoaderTypeJSON5 = 20;
+inline constexpr BunLoaderType BunLoaderTypeMD = 21;
 
 #pragma mark - Stream
 

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -355,6 +355,13 @@ describe("errors", () => {
     }
   });
 
+  it("md loader renders markdown", () => {
+    globalThis.failingObject = { contents: "# Heading\n\nbody text\n", loader: "md" };
+    const mod = require("fail:my-file-md");
+    expect(mod.default).toContain("<h1>Heading</h1>");
+    expect(mod.default).toContain("<p>body text</p>");
+  });
+
   it("handles invalid 'target'", () => {
     const opts = {
       setup: () => {},


### PR DESCRIPTION
## What

A runtime `Bun.plugin` `onLoad` callback that returns `{ contents, loader: "md" }` fails with `Unexpected character` on the first `#` in the markdown, because the contents are fed to the JSON5 parser instead of the markdown renderer.

```js
Bun.plugin({
  setup(b) {
    b.onResolve({ filter: /.*/, namespace: "mdtest" }, ({ path }) => ({ path, namespace: "mdtest" }));
    b.onLoad({ filter: /.*/, namespace: "mdtest" }, () => ({
      contents: "# Heading\n\nbody text\n",
      loader: "md",
    }));
  },
});
await import("mdtest:doc");
```

```
1 | # Heading
    ^
error: Unexpected character
    at mdtest:doc:1:1
```

## Why

`headers-handwritten.h` defines `BunLoaderTypeMD = 20`, but `api::Loader` in `src/options_types/schema.rs` has `json5 = 20` and `md = 21`. `handleOnLoadResultNotPromise` maps `loader: "md"` to `BunLoaderTypeMD` and passes the byte straight to `Bun__transpileVirtualModule`, whose Rust side reads it as `api::Loader`. Byte 20 is `json5` there, so the markdown source is parsed as JSON5.

The header comment says these constants must stay in sync with the schema enum; `json5` was inserted at 20 on the Rust side without the C++ constant being bumped.

## Fix

Set `BunLoaderTypeMD = 21` and add `BunLoaderTypeJSON5 = 20` so the C++ constants line up with `api::Loader` again.

## Test

Added a case to `test/js/bun/plugin/plugins.test.ts` that returns markdown from an `onLoad` with `loader: "md"` and asserts the default export is rendered HTML. It fails on main with `BuildMessage: Unexpected character` and passes with this change.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
bun test v1.4.0 (a64530f8c)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1149.90ms]
(pass) require > beep:boop returns 42 [9.41ms]
(pass) require > object module works [8.52ms]
(pass) module > throws with require() [13.29ms]
(pass) module > async module works with async import [25.72ms]
(pass) module > sync module module works with require() [4.22ms]
(pass) module > sync module module works with require.resolve() [3.15ms]
(pass) module > sync module module works with import [5.49ms]
(pass) module > modules are overridable [26.20ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [104.21ms]
(pass) dynamic import > beep:boop returns 42 [8.10ms]
(pass) dynamic import > async:onLoad retur
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [50.56ms]
(pass) require > beep:boop returns 42 [0.38ms]
(pass) require > object module works [0.19ms]
(pass) module > throws with require() [0.28ms]
(pass) module > async module works with async import [3.32ms]
(pass) module > sync module module works with require() [0.11ms]
(pass) module > sync module module works with require.resolve() [0.06ms]
(pass) module > sync module module works with import [0.11ms]
(pass) module > modules are overridable [0.57ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [0.16ms]
(pass) dynamic import > beep:boop returns 42 [0.07ms]
(pass) dynamic import > async:onLoad returns 42 [1.49ms]
(pass) dynamic import > async object loader returns 42 [1.39ms]
(pass) import statement > SSRs `<h1>Hello world!</h1>` with Svelte [3.66ms]
(pass) erro
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
bun test v1.4.0 (a64530f8c)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1307.85ms]
(pass) require > beep:boop returns 42 [16.34ms]
(pass) require > object module works [13.25ms]
(pass) module > throws with require() [22.82ms]
(pass) module > async module works with async import [30.60ms]
(pass) module > sync module module works with require() [6.53ms]
(pass) module > sync module module works with require.resolve() [4.58ms]
(pass) module > sync module module works with import [9.88ms]
(pass) module > modules are overridable [123.25ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [8.23ms]
(pass) dynamic import > beep:boop returns 42 [7.68ms]
(pass) dynamic import > async:onLoad retu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1078ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/303] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/303] gen cpp.rs (cppbind)
[3/303] cc obj/vendor/boringssl/gen/bcm/ghash-neon-armv8-linux.S.o
[4/303] cc obj/vendor/boringssl/gen/bcm/ghash-ssse3-x86-apple.S.o
[5/303] cc obj/vendor/boringssl/gen/bcm/ghash-ssse3-x86-linux.S.o
[6/303] cc obj/vendor/boringssl/gen/bcm/ghash-neon-armv8-apple.S.o
[7/303] cc obj/vendor/boringssl/gen/bcm/co-586-apple.S.o
[8/303] cc obj/vendor/boringssl/gen/bcm/ghash-neon-armv8-win.S.o
[9/303] cc obj/vendor/boringssl/gen/bcm/ghashv8-armv8-win.S.o
[10/303] cc obj/vendor/boringssl/gen/bcm/ghash-x86-apple.S.o
[11/303] cc obj/vendor/boringssl/gen/bcm/ghash-ssse3-x86_64-apple.S.o
[12/303] cc obj/vendor/boringssl/gen/bcm/ghash-ssse3-x86_64-linux.S.o
[13/303] cc obj/vendor/boringssl/gen/bcm/ghash-x86_64-linux.S.o
[14/303] cc obj/vendor/boringssl/gen/bcm/ghashv8-armv8-apple.S.o
[15/303] cc obj/vendor/boringssl/gen/bcm/ghash-x86-linux.S.o
[16/303
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/headers-handwritten.h | 3 ++-
 test/js/bun/plugin/plugins.test.ts     | 7 +++++++
 2 files changed, 9 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/jsc/bindings/headers-handwritten.h      2      1      0
test/js/bun/plugin/plugins.test.ts          2      1      0
```

</details>

<!-- robobun:evidence:end -->