### PR TITLE
console,inspect: print SuppressedError .error and .suppressed

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6290,6 +6290,8 @@ impl VirtualMachine {
 
         if is_error_instance {
             let mut saw_cause = false;
+            let mut saw_error = false;
+            let mut saw_suppressed = false;
             // SAFETY: `is_error_instance` ⇒ object.
             let error_obj = unsafe { error_instance.get_object().unwrap_unchecked() };
             let iterator = crate::JSPropertyIterator::init(
@@ -6313,12 +6315,16 @@ impl VirtualMachine {
                 if field.eq_ascii(b"code") && code.is_some() {
                     continue;
                 }
+                if field.eq_ascii(b"cause") {
+                    saw_cause = true;
+                } else if field.eq_ascii(b"error") {
+                    saw_error = true;
+                } else if field.eq_ascii(b"suppressed") {
+                    saw_suppressed = true;
+                }
 
                 let kind = value.js_type();
                 if kind == JSType::ErrorInstance && !prev_had_errors {
-                    if field.eq_ascii(b"cause") {
-                        saw_cause = true;
-                    }
                     value.protect();
                     errors_to_append.push(value);
                 } else if kind.is_object()
@@ -6408,7 +6414,25 @@ impl VirtualMachine {
                 writer.write_all(b"\n")?;
             }
 
-            // "cause" is not enumerable, so the above loop won't see it.
+            // "error"/"suppressed"/"cause" are non-enumerable, so the loop above won't see them.
+            if !saw_error {
+                let key = bun_core::String::static_("error");
+                if let Some(inner) = error_instance.get_own(global_ref, &key)? {
+                    if !inner.is_undefined() {
+                        inner.protect();
+                        errors_to_append.push(inner);
+                    }
+                }
+            }
+            if !saw_suppressed {
+                let key = bun_core::String::static_("suppressed");
+                if let Some(inner) = error_instance.get_own(global_ref, &key)? {
+                    if !inner.is_undefined() {
+                        inner.protect();
+                        errors_to_append.push(inner);
+                    }
+                }
+            }
             if !saw_cause {
                 let key = bun_core::String::static_("cause");
                 if let Some(cause) = error_instance.get_own(global_ref, &key)? {
@@ -6457,11 +6481,15 @@ impl VirtualMachine {
                 formatter.map_node = Some(node);
             }
 
-            let entry = formatter.map.get_or_put(err).expect("unreachable");
-            if entry.found_existing {
-                writer.write_all(b"\n")?;
-                pretty_write!(writer, "<r><cyan>[Circular]<r>")?;
-                continue;
+            // Only Errors recurse here; non-Errors use `formatter.map` for their own cycle check.
+            let track = err.is_cell() && err.js_type() == JSType::ErrorInstance;
+            if track {
+                let entry = formatter.map.get_or_put(err).expect("unreachable");
+                if entry.found_existing {
+                    writer.write_all(b"\n")?;
+                    pretty_write!(writer, "<r><cyan>[Circular]<r>")?;
+                    continue;
+                }
             }
 
             writer.write_all(b"\n")?;
@@ -6473,7 +6501,9 @@ impl VirtualMachine {
                 allow_ansi_color,
                 allow_side_effects,
             )?;
-            let _ = formatter.map.remove(&err);
+            if track {
+                let _ = formatter.map.remove(&err);
+            }
         }
 
         Ok(())

--- a/test/js/bun/util/__snapshots__/inspect-error.test.js.snap
+++ b/test/js/bun/util/__snapshots__/inspect-error.test.js.snap
@@ -72,3 +72,78 @@ error: error inside long minified file!
       at [dir]/inspect-error-fixture.min.js:26:2890
       at [dir]/inspect-error.test.js:79:5"
 `;
+
+exports[`SuppressedError Bun.inspect shows .error and .suppressed 1`] = `
+"1 | const m1 = ["dispose", "error"].join(" ");
+2 | const m2 = ["original", "error"].join(" ");
+3 | const se = new SuppressedError(new Error(m1), new Error(m2), "An error was suppressed during disposal");
+               ^
+SuppressedError: An error was suppressed during disposal
+      at <cwd>/[eval]:3:12
+
+1 | const m1 = ["dispose", "error"].join(" ");
+2 | const m2 = ["original", "error"].join(" ");
+3 | const se = new SuppressedError(new Error(m1), new Error(m2), "An error was suppressed during disposal");
+                                       ^
+error: dispose error
+      at <cwd>/[eval]:3:36
+
+1 | const m1 = ["dispose", "error"].join(" ");
+2 | const m2 = ["original", "error"].join(" ");
+3 | const se = new SuppressedError(new Error(m1), new Error(m2), "An error was suppressed during disposal");
+                                                      ^
+error: original error
+      at <cwd>/[eval]:3:51"
+`;
+
+exports[`SuppressedError uncaught SuppressedError shows .error and .suppressed 1`] = `
+"1 | const m1 = ["dispose", "error"].join(" ");
+2 | const m2 = ["original", "error"].join(" ");
+3 | throw new SuppressedError(new Error(m1), new Error(m2), "An error was suppressed during disposal");
+          ^
+SuppressedError: An error was suppressed during disposal
+      at <cwd>/[eval]:3:7
+
+1 | const m1 = ["dispose", "error"].join(" ");
+2 | const m2 = ["original", "error"].join(" ");
+3 | throw new SuppressedError(new Error(m1), new Error(m2), "An error was suppressed during disposal");
+                                  ^
+error: dispose error
+      at <cwd>/[eval]:3:31
+
+1 | const m1 = ["dispose", "error"].join(" ");
+2 | const m2 = ["original", "error"].join(" ");
+3 | throw new SuppressedError(new Error(m1), new Error(m2), "An error was suppressed during disposal");
+                                                 ^
+error: original error
+      at <cwd>/[eval]:3:46
+
+Bun v<bun-version>"
+`;
+
+exports[`SuppressedError uncaught SuppressedError from \`using\` shows both thrown errors 1`] = `
+"1 | const m1 = ["error", "thrown", "from", "dispose"].join(" ");
+    ^
+SuppressedError: 
+      at <cwd>/[eval]:1:1
+
+1 | const m1 = ["error", "thrown", "from", "dispose"].join(" ");
+2 | const m2 = ["error", "thrown", "from", "body"].join(" ");
+3 | {
+4 |   using r = { [Symbol.dispose]() { throw new Error(m1); } };
+                                                 ^
+error: error thrown from dispose
+    at [Symbol.dispose] (file:NN:NN)
+      at <cwd>/[eval]:1:1
+
+1 | const m1 = ["error", "thrown", "from", "dispose"].join(" ");
+2 | const m2 = ["error", "thrown", "from", "body"].join(" ");
+3 | {
+4 |   using r = { [Symbol.dispose]() { throw new Error(m1); } };
+5 |   throw new Error(m2);
+                ^
+error: error thrown from body
+      at <cwd>/[eval]:5:13
+
+Bun v<bun-version>"
+`;

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, jest, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 
 test("error.cause", () => {
   const err = new Error("error 1");
@@ -10,7 +10,7 @@ test("error.cause", () => {
       .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
 "1 | import { describe, expect, jest, test } from "bun:test";
-2 | import { bunEnv, bunExe, tempDir } from "harness";
+2 | import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 3 | 
 4 | test("error.cause", () => {
 5 |   const err = new Error("error 1");
@@ -20,7 +20,7 @@ error: error 2
       at <anonymous> ([dir]/inspect-error.test.js:6:20)
 
 1 | import { describe, expect, jest, test } from "bun:test";
-2 | import { bunEnv, bunExe, tempDir } from "harness";
+2 | import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 3 | 
 4 | test("error.cause", () => {
 5 |   const err = new Error("error 1");
@@ -454,5 +454,125 @@ describe.concurrent("AggregateError whose errors cannot be walked", () => {
     expect(stderr).toContain("b.test.ts:");
     expect(stderr).toContain("across 2 files");
     expect(exitCode).toBe(1);
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/10336
+describe("SuppressedError", () => {
+  // Build the error message strings at runtime so they do not appear in the
+  // source-line preview that Bun.inspect includes, otherwise `toContain` would
+  // match the preview rather than the nested-error output.
+  const disposeMsg = ["dispose", "error"].join(" ");
+  const originalMsg = ["original", "error"].join(" ");
+
+  test("Bun.inspect shows .error and .suppressed", async () => {
+    const code = [
+      `const m1 = ["dispose", "error"].join(" ");`,
+      `const m2 = ["original", "error"].join(" ");`,
+      `const se = new SuppressedError(new Error(m1), new Error(m2), "An error was suppressed during disposal");`,
+      `process.stdout.write(Bun.inspect(se));`,
+    ].join("\n");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--no-addons", "-e", code],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("An error was suppressed during disposal");
+    expect(stdout).toContain(disposeMsg);
+    expect(stdout).toContain(originalMsg);
+    expect(normalizeBunSnapshot(stdout)).toMatchSnapshot();
+    expect(exitCode).toBe(0);
+  });
+
+  test("uncaught SuppressedError shows .error and .suppressed", async () => {
+    const code =
+      [
+        `const m1 = ["dispose", "error"].join(" ");`,
+        `const m2 = ["original", "error"].join(" ");`,
+        `throw new SuppressedError(new Error(m1), new Error(m2), "An error was suppressed during disposal");`,
+      ].join("\n") + "\n";
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--no-addons", "-e", code],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("An error was suppressed during disposal");
+    expect(stderr).toContain(disposeMsg);
+    expect(stderr).toContain(originalMsg);
+    expect(normalizeBunSnapshot(stderr)).toMatchSnapshot();
+    expect(exitCode).toBe(1);
+  });
+
+  test("uncaught SuppressedError from `using` shows both thrown errors", async () => {
+    const code =
+      [
+        `const m1 = ["error", "thrown", "from", "dispose"].join(" ");`,
+        `const m2 = ["error", "thrown", "from", "body"].join(" ");`,
+        `{`,
+        `  using r = { [Symbol.dispose]() { throw new Error(m1); } };`,
+        `  throw new Error(m2);`,
+        `}`,
+      ].join("\n") + "\n";
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--no-addons", "-e", code],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("error thrown from dispose");
+    expect(stderr).toContain("error thrown from body");
+    expect(normalizeBunSnapshot(stderr)).toMatchSnapshot();
+    expect(exitCode).toBe(1);
+  });
+
+  test("uncaught SuppressedError from `using` shows non-Error thrown values", async () => {
+    const code =
+      [
+        `const m = ["body", "threw", "a", "string"].join(" ");`,
+        `{`,
+        `  using r = { [Symbol.dispose]() { throw { code: "ERR_FROM_DISPOSE" }; } };`,
+        `  throw m;`,
+        `}`,
+      ].join("\n") + "\n";
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--no-addons", "-e", code],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("ERR_FROM_DISPOSE");
+    expect(stderr).toContain("body threw a string");
+    expect(exitCode).toBe(1);
+  });
+
+  test("util.inspect matches Node: .error/.suppressed only with showHidden", () => {
+    const se = new SuppressedError(new Error(disposeMsg), new Error(originalMsg), "wrapper message");
+    const plain = require("util").inspect(se);
+    expect(plain).not.toContain(disposeMsg);
+    expect(plain).not.toContain(originalMsg);
+    const hidden = require("util").inspect(se, { showHidden: true });
+    expect(hidden).toContain(disposeMsg);
+    expect(hidden).toContain(originalMsg);
+  });
+
+  test("Bun.inspect handles circular SuppressedError chains", () => {
+    const se = new SuppressedError(new Error(disposeMsg), undefined, "msg");
+    Object.defineProperty(se, "suppressed", { value: se, writable: true, enumerable: false, configurable: true });
+    const out = Bun.inspect(se);
+    expect(out).toContain(disposeMsg);
+    expect(out).toContain("[Circular]");
+  });
+
+  test("enumerable non-Error .error property is not printed twice", () => {
+    const e = new Error("boom");
+    e.error = ["payload", "string"].join(" ");
+    const out = Bun.inspect(e);
+    expect([...out.matchAll(/payload string/g)].length).toBe(1);
   });
 });


### PR DESCRIPTION
Fixes #10336.

## Problem

`SuppressedError` carries its two wrapped errors as non-enumerable own properties (`.error` and `.suppressed`). The native error formatter (`console.log` / `Bun.inspect` / uncaught-error printer) never rendered them, so this:

```js
{
  using r = { [Symbol.dispose]() { throw new Error("error thrown from dispose"); } };
  throw new Error("error thrown from body");
}
```

printed only:

```
SuppressedError:
      at repro.js:1:1
```

with no trace of either real error.

## Fix

The native formatter already looks up the non-enumerable `.cause` own property after the enumerable-property loop and appends it to the nested-error chain. Do the same for `.error` and `.suppressed`. Unlike `.cause`, these are filled by the runtime with whatever was thrown, so any non-`undefined` value is rendered (non-Error values go through the generic `reportError`-style fallback). The enumerable loop now marks these fields as seen regardless of value type so an enumerable `err.error = "..."` isn't printed twice, and the circular-ref guard only tracks Error instances since non-Error values are rendered by the generic formatter which shares the same visited map.

`util.inspect` is left unchanged to match Node (it only surfaces `.error`/`.suppressed` under `{ showHidden: true }`).

After:

```
SuppressedError:
      at repro.js:1:1

error: error thrown from dispose
    at [Symbol.dispose] (repro.js:2:46)
      at repro.js:1:1

error: error thrown from body
      at repro.js:3:13
```

Circular chains hit the existing `[Circular]` guard; nested `SuppressedError`s unwind recursively like `cause` chains already do.


<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect-error.test.js
bun test v1.4.1 (861e9ae04)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [6.50ms]
(pass) Error [3.79ms]
(pass) BuildMessage [13.51ms]
(pass) Error inside minified file (no color)  [86.35ms]
(pass) Error inside minified file (color)  [51.40ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [147.90ms]
(pass) observable properties > sourceURL is observable [6.11ms]
(pass) observable properties > line is observable [2.39ms]
(pass) observable properties > column is observable [1.96ms]
(pass) error.stack throwing an error doesn't lead to a crash [3.91ms]
(pass) source map remapping of the printed stack > external map whose original source is unavailable [356.69ms]
(pass) AggregateError whose errors cannot be walked > uncaught: errors was deleted [272.90ms]
(pass) AggregateError whose errors cannot be walked > console.error: errors is an empty array [285.08ms]
(pass) AggregateError whose errors cannot be walked > console.error: errors was deleted [361.03
... (truncated)

release without fix: 5 FAILED
bun test v1.4.1-canary.1 (861e9ae04)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [0.36ms]
(pass) Error [0.16ms]
(pass) BuildMessage [0.43ms]
(pass) Error inside minified file (no color)  [10.87ms]
(pass) Error inside minified file (color)  [4.90ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [2.58ms]
(pass) observable properties > sourceURL is observable [0.21ms]
(pass) observable properties > line is observable [0.06ms]
(pass) observable properties > column is observable [0.04ms]
(pass) error.stack throwing an error doesn't lead to a crash [0.07ms]
(pass) source map remapping of the printed stack > external map whose original source is unavailable [133.39ms]
(pass) AggregateError whose errors cannot be walked > console.error: errors was deleted [114.65ms]
(pass) source map remapping of the printed stack > transpiled modules: source deleted, and frames already remapped by error.stack [123.53ms]
(pass) AggregateError whose errors cannot be walked > uncaught: errors was deleted [113.68ms]
(pass) AggregateError whose errors cannot be walked > uncaught: errors is an empty array [107.70ms]
(pass) AggregateError whose
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect-error.test.js
bun test v1.4.1 (861e9ae04)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [6.64ms]
(pass) Error [3.81ms]
(pass) BuildMessage [13.66ms]
(pass) Error inside minified file (no color)  [89.23ms]
(pass) Error inside minified file (color)  [52.17ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [143.10ms]
(pass) observable properties > sourceURL is observable [6.32ms]
(pass) observable properties > line is observable [2.59ms]
(pass) observable properties > column is observable [2.36ms]
(pass) error.stack throwing an error doesn't lead to a crash [3.95ms]
(pass) source map remapping of the printed stack > external map whose original source is unavailable [425.63ms]
(pass) AggregateError whose errors cannot be walked > console.error: errors was deleted [362.89ms]
(pass) AggregateError whose errors cannot be walked > console.error: errors is an empty array [333.72ms]
(pass) AggregateError whose errors cannot be walked > uncaught: errors was deleted [376.14
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     7d8eba9a0f
  features     baseline

23 deps, 129 codegen, 1172 objects in 800ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (861e9ae04)

Checked 26 installs across 63 packages (no changes) [28.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (861e9ae04)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (861e9ae04)

Checked 111 installs across 104 packages (no changes) [12.00ms]
[4/1244] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[5/1244] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[6/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 41ms

  react-refresh.js  4.81
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs                          |  50 ++++++--
 .../util/__snapshots__/inspect-error.test.js.snap  |  75 ++++++++++++
 test/js/bun/util/inspect-error.test.js             | 126 ++++++++++++++++++++-
 3 files changed, 238 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/VirtualMachine.rs                                     9     14      0
…st/js/bun/util/__snapshots__/inspect-error.test.js.snap      0      0      0
test/js/bun/util/inspect-error.test.js                        9     13      0
```

</details>

<!-- robobun:evidence:end -->
