### PR TITLE
Bump WebKit: stop capturing `arguments` for shorthand-in-arrow (tsserver memory leak)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-379-df3f3fe3";
+export const WEBKIT_VERSION = "9f8f24db19e7b278394ee91ad1547ce72d331b51";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "34c01d13391e00c06862a3d2c5b7fff350ac87e0";
+export const WEBKIT_VERSION = "autobuild-preview-pr-379-df3f3fe3";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/regression/issue/09769/09769.test.ts
+++ b/test/regression/issue/09769/09769.test.ts
@@ -1,0 +1,60 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+// https://github.com/oven-sh/bun/issues/9769
+// https://github.com/oven-sh/bun/issues/15857
+//
+// JavaScriptCore's parser unconditionally marked an arrow function scope as
+// "uses eval" whenever it encountered an object-literal shorthand property
+// (e.g. `(x) => ({ x })`). That made the enclosing regular function allocate
+// and capture its `arguments` object in the closure's lexical environment.
+//
+// TypeScript's `createProgram(opts)` contains such an arrow, and its returned
+// closures therefore retained `arguments[0]` (= the options object holding
+// `oldProgram`), chaining every Program ever created. Under tsserver this
+// leaked several MB of JS heap per file save.
+
+describe("issue #9769 / #15857: shorthand property in arrow should not force the enclosing function to capture `arguments`", () => {
+  test("closure returned from a function with `(x) => ({ x })` does not retain the call arguments", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", join(import.meta.dir, "fixture.cjs")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("PASS");
+    expect(exitCode).toBe(0);
+  });
+
+  test("`arguments` still reflects the real call when the shorthand is literally `eval`", async () => {
+    // Removing the unconditional setInnerArrowFunctionUsesEval() must not change
+    // observable semantics: a shorthand `{ eval }` in an arrow still works, and
+    // `arguments` inside a nested arrow still resolves to the enclosing function's.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          function outer(a, b) {
+            const g = () => ({ eval, args: arguments.length });
+            return g();
+          }
+          const r = outer(1, 2, 3);
+          if (typeof r.eval !== "function") throw new Error("eval shorthand broken");
+          if (r.args !== 3) throw new Error("arguments in arrow broken: " + r.args);
+          console.log("PASS");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("PASS");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/09769/09769.test.ts
+++ b/test/regression/issue/09769/09769.test.ts
@@ -15,7 +15,7 @@ import { join } from "node:path";
 // `oldProgram`), chaining every Program ever created. Under tsserver this
 // leaked several MB of JS heap per file save.
 
-describe("issue #9769 / #15857: shorthand property in arrow should not force the enclosing function to capture `arguments`", () => {
+describe.concurrent("issue #9769 / #15857: shorthand property in arrow should not force the enclosing function to capture `arguments`", () => {
   test("closure returned from a function with `(x) => ({ x })` does not retain the call arguments", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "--smol", join(import.meta.dir, "fixture.cjs")],

--- a/test/regression/issue/09769/09769.test.ts
+++ b/test/regression/issue/09769/09769.test.ts
@@ -15,29 +15,31 @@ import { join } from "node:path";
 // `oldProgram`), chaining every Program ever created. Under tsserver this
 // leaked several MB of JS heap per file save.
 
-describe.concurrent("issue #9769 / #15857: shorthand property in arrow should not force the enclosing function to capture `arguments`", () => {
-  test("closure returned from a function with `(x) => ({ x })` does not retain the call arguments", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "--smol", join(import.meta.dir, "fixture.cjs")],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
+describe.concurrent(
+  "issue #9769 / #15857: shorthand property in arrow should not force the enclosing function to capture `arguments`",
+  () => {
+    test("closure returned from a function with `(x) => ({ x })` does not retain the call arguments", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--smol", join(import.meta.dir, "fixture.cjs")],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("PASS");
+      expect(exitCode).toBe(0);
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("PASS");
-    expect(exitCode).toBe(0);
-  });
 
-  test("`arguments` still reflects the real call when the shorthand is literally `eval`", async () => {
-    // Removing the unconditional setInnerArrowFunctionUsesEval() must not change
-    // observable semantics: a shorthand `{ eval }` in an arrow still works, and
-    // `arguments` inside a nested arrow still resolves to the enclosing function's.
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
+    test("`arguments` still reflects the real call when the shorthand is literally `eval`", async () => {
+      // Removing the unconditional setInnerArrowFunctionUsesEval() must not change
+      // observable semantics: a shorthand `{ eval }` in an arrow still works, and
+      // `arguments` inside a nested arrow still resolves to the enclosing function's.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
           function outer(a, b) {
             const g = () => ({ eval, args: arguments.length });
             return g();
@@ -47,14 +49,15 @@ describe.concurrent("issue #9769 / #15857: shorthand property in arrow should no
           if (r.args !== 3) throw new Error("arguments in arrow broken: " + r.args);
           console.log("PASS");
         `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("PASS");
+      expect(exitCode).toBe(0);
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("PASS");
-    expect(exitCode).toBe(0);
-  });
-});
+  },
+);

--- a/test/regression/issue/09769/09769.test.ts
+++ b/test/regression/issue/09769/09769.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
 

--- a/test/regression/issue/09769/fixture.cjs
+++ b/test/regression/issue/09769/fixture.cjs
@@ -1,0 +1,64 @@
+// The shape here mirrors TypeScript's `createProgram`: a regular function whose
+// body contains an arrow with an object-literal shorthand, and which returns
+// closures over locals. The bug caused `arguments` to be stored in the returned
+// closure's scope, so `arguments[0]` (the options object, which holds
+// `oldProgram`) was retained as long as the returned program lived.
+//
+// This is a .cjs file so the code runs in sloppy mode, matching how TypeScript's
+// typescript.js is loaded in practice (the bug reproduces in strict mode too,
+// but sloppy mode is the real-world path).
+
+// `new Function` keeps the exact source away from the transpiler: the
+// transpiler may otherwise rewrite `({ x })` in ways that hide or change the
+// pattern we are testing JSC's parser against.
+const createProgram = new Function(
+  "opts",
+  `
+  const host = {};
+  let { oldProgram } = opts;
+  oldProgram = void 0;
+
+  const worker = (resolvedTypeReferenceDirective) => ({ resolvedTypeReferenceDirective });
+
+  const program = {
+    worker,
+    isSourceOfProjectReferenceRedirect,
+  };
+  return program;
+
+  function isSourceOfProjectReferenceRedirect(f) {
+    return host && f;
+  }
+`,
+);
+
+const refs = [];
+let prog = createProgram({ oldProgram: undefined, payload: null });
+
+for (let i = 0; i < 64; i++) {
+  const opts = {
+    oldProgram: prog,
+    // Each options object carries a 1 MB payload so retention is unambiguous.
+    payload: new Uint8Array(1024 * 1024),
+  };
+  refs.push(new WeakRef(opts));
+  prog = createProgram(opts);
+}
+
+Bun.gc(true);
+Bun.gc(true);
+
+let alive = 0;
+for (const r of refs) if (r.deref()) alive++;
+
+// Before the fix every `opts` object is reachable via the closure's captured
+// `arguments`, so `alive` is 64. After the fix only the most recent one or two
+// can still be live.
+if (alive > 4) {
+  console.error(
+    `FAIL: ${alive}/64 options objects still alive after GC (closure is retaining \`arguments\`)`,
+  );
+  process.exit(1);
+}
+
+console.log("PASS");


### PR DESCRIPTION
Fixes #9769
Fixes #15857

### Repro

Running `tsserver.js` (TypeScript 5.7.2) under `bun --bun` against a 61-file TSX project and looping `reload` + `geterr` 400 times, with a full GC at each 50-save checkpoint:

| runtime | heapUsed after full GC | RSS end | per-save |
| --- | --- | --- | --- |
| Node 22 | ~92 MB (flat) | 373 MB (plateaus) | 0.33 MB |
| bun 1.4.0 | 215 → 578 MB (linear) | 1304 MB (no plateau) | 2.58 MB |
| bun + this change | ~105 MB (flat) | 266 MB (plateaus) | 0.07 MB |

### Cause

JavaScriptCore's `parseProperty` calls `setInnerArrowFunctionUsesEval()` unconditionally whenever it parses an object-literal shorthand property while `currentScope()` is an arrow function (introduced in WebKit r197296, https://bugs.webkit.org/show_bug.cgi?id=153981). Because the call is not gated on the identifier being `eval`, every `{ x }` inside an arrow sets `EvalInnerArrowFunctionFeature` on the arrow's scope. At scope pop that feature merges into the enclosing ordinary function, so `BytecodeGenerator` sees `isArgumentsUsedInInnerArrowFunction()` return true, computes `m_needsArguments = true`, creates an `arguments` object, and stores it in the function's `JSLexicalEnvironment`.

Any closure returned from such a function then retains every call argument for the closure's lifetime.

TypeScript's `createProgram(createProgramOptions)` contains exactly this pattern:

```js
actualResolveTypeReferenceDirectiveNamesWorker = (names, ...) =>
    host.resolveTypeReferenceDirectives(...)
        .map((resolvedTypeReferenceDirective) => ({ resolvedTypeReferenceDirective }));
```

`createProgram` returns ~100 closures over its locals, and `arguments[0]` is the options object holding `oldProgram`. Because `arguments` is captured in those closures' shared lexical environment, every `Program` keeps its predecessor alive. A heap snapshot after 140 saves shows a linked list of `Program` objects reachable via `JSLexicalEnvironment` → `arguments` → `[0]` → `.oldProgram` → previous `Program`:

```
closure "isSourceOfProjectReferenceRedirect" --> JSLexicalEnvironment
JSLexicalEnvironment --[arguments]--> Arguments
Arguments --[0]--> Object {oldProgram, rootNames, options, host}
Object --[oldProgram]--> Object (previous Program)
Object --[isSourceOfProjectReferenceRedirect]--> closure ...
```

### Fix

oven-sh/WebKit#379 removes the two lines. `useVariable()` on the preceding line already sets `m_usesEval` when the identifier is `eval`, and the scope-pop hook `setInnerArrowFunctionUsesEvalAndUseArgumentsIfNeeded()` (added in the same r197296 patch) propagates that correctly, as it does for `{ arguments }` via `usedVariablesContains(arguments)`. The canonical identifier path in `parsePrimaryExpression` does not perform this extra step either.

This bumps `WEBKIT_VERSION` to `9f8f24db19e7b278394ee91ad1547ce72d331b51` (merged oven-sh/WebKit#379).

### Verification

Minimal bytecode check with `BUN_JSC_dumpGeneratedBytecodes=1`:

```js
function outer(opts) {
  const host = {};
  const w = (x) => ({ x });
  return { inner, w };
  function inner() { return host; }
}
```

| | before | after |
| --- | --- | --- |
| instructions | 19 | 12 |
| `create_direct_arguments` | emitted | not emitted |
| `put_to_scope … arguments` | emitted | not emitted |

The regression test spawns a fixture that chains 64 calls through `opts.oldProgram` with a 1 MB payload each, forces GC, and asserts at most 4 `WeakRef`s survive. Before this change all 64 survive. A second test confirms `{ eval }` and `arguments` inside arrows still behave correctly.

The r197296-era `arrowfunction-lexical-bind-*` stress tests behave identically with and without this change.

Note on fail-before: the fix lives in the WebKit prebuilt (`scripts/build/deps/webkit.ts`), not in `src/`, so a fail-before check that stashes only `src/` will not see the test fail. The 64/64 retention is reproducible on any build using `WEBKIT_VERSION` at or before `34c01d13391e00c0`.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 1 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/regression/issue/09769/09769.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/regression/issue/09769/09769.test.ts"
bun test v1.4.0 (9b2c6e83d)

test/regression/issue/09769/09769.test.ts:
(pass) issue #9769 / #15857: shorthand property in arrow should not force the enclosing function to capture `arguments` > `arguments` still reflects the real call when the shorthand is literally `eval` [328.84ms]
(pass) issue #9769 / #15857: shorthand property in arrow should not force the enclosing function to capture `arguments` > closure returned from a function with `(x) => ({ x })` does not retain the call arguments [477.24ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [3.16s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts              |  2 +-
 test/regression/issue/09769/09769.test.ts | 63 ++++++++++++++++++++++++++++++
 test/regression/issue/09769/fixture.cjs   | 64 +++++++++++++++++++++++++++++++
 3 files changed, 128 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
scripts/build/deps/webkit.ts                   3      2      0
test/regression/issue/09769/09769.test.ts      1      2      0
test/regression/issue/09769/fixture.cjs        0      1      0
```

</details>

<!-- robobun:evidence:end -->