### PR TITLE
Bun.plugin: synthesize default export for loader: "object"

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -650,10 +650,7 @@ extern "C" JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(JSMock__jsModuleMock, __attr
                             // namespace untouched.
                             MarkedArgumentBuffer values;
                             values.ensureCapacity(names.size());
-                            bool hasDefault = false;
                             for (auto& name : names) {
-                                if (name == vm.propertyNames->defaultKeyword)
-                                    hasDefault = true;
                                 JSValue value = object->get(globalObject, name);
                                 RETURN_IF_EXCEPTION(scope, {});
                                 values.append(value);
@@ -664,10 +661,6 @@ extern "C" JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(JSMock__jsModuleMock, __attr
                             }
                             for (size_t i = 0; i < names.size(); ++i) {
                                 moduleNamespaceObject->overrideExportValue(globalObject, names[i], values.at(i));
-                                RETURN_IF_EXCEPTION(scope, {});
-                            }
-                            if (!hasDefault) {
-                                moduleNamespaceObject->overrideExportValue(globalObject, vm.propertyNames->defaultKeyword, object);
                                 RETURN_IF_EXCEPTION(scope, {});
                             }
 

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -650,7 +650,10 @@ extern "C" JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(JSMock__jsModuleMock, __attr
                             // namespace untouched.
                             MarkedArgumentBuffer values;
                             values.ensureCapacity(names.size());
+                            bool hasDefault = false;
                             for (auto& name : names) {
+                                if (name == vm.propertyNames->defaultKeyword)
+                                    hasDefault = true;
                                 JSValue value = object->get(globalObject, name);
                                 RETURN_IF_EXCEPTION(scope, {});
                                 values.append(value);
@@ -661,6 +664,12 @@ extern "C" JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(JSMock__jsModuleMock, __attr
                             }
                             for (size_t i = 0; i < names.size(); ++i) {
                                 moduleNamespaceObject->overrideExportValue(globalObject, names[i], values.at(i));
+                                RETURN_IF_EXCEPTION(scope, {});
+                            }
+                            // Keep the synthesized default (see generateObjectModuleSourceCode) in sync
+                            // with the new exports object. A no-op when the module has no default binding.
+                            if (!hasDefault) {
+                                moduleNamespaceObject->overrideExportValue(globalObject, vm.propertyNames->defaultKeyword, object);
                                 RETURN_IF_EXCEPTION(scope, {});
                             }
 

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -666,8 +666,6 @@ extern "C" JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(JSMock__jsModuleMock, __attr
                                 moduleNamespaceObject->overrideExportValue(globalObject, names[i], values.at(i));
                                 RETURN_IF_EXCEPTION(scope, {});
                             }
-                            // Keep the synthesized default (see generateObjectModuleSourceCode) in sync
-                            // with the new exports object. A no-op when the module has no default binding.
                             if (!hasDefault) {
                                 moduleNamespaceObject->overrideExportValue(globalObject, vm.propertyNames->defaultKeyword, object);
                                 RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -420,9 +420,12 @@ static JSValue handleVirtualModuleResult(
         }
 
         JSC::ensureStillAliveHere(object);
+        // A mock.module() factory names the export set exactly. Only the plugin
+        // "object" loader gets the implicit default.
         auto function = generateObjectModuleSourceCode(
             globalObject,
-            object);
+            object,
+            /* synthesizeDefault */ !wasModuleMock);
         auto source = JSC::SourceCode(
             JSC::SyntheticSourceProvider::create(WTF::move(function),
                 JSC::SourceOrigin(), specifier->toWTFString(BunString::ZeroCopy)));

--- a/src/jsc/modules/ObjectModule.cpp
+++ b/src/jsc/modules/ObjectModule.cpp
@@ -21,11 +21,20 @@ generateObjectModuleSourceCode(JSC::JSGlobalObject* globalObject,
         RETURN_IF_EXCEPTION(throwScope, void());
         gcUnprotectNullTolerant(object);
 
+        bool hasDefault = false;
         for (auto& entry : properties.releaseData()->propertyNameVector()) {
+            if (entry == vm.propertyNames->defaultKeyword)
+                hasDefault = true;
+
             JSValue value = object->get(globalObject, entry);
             RETURN_IF_EXCEPTION(throwScope, void());
             exportNames.append(entry);
             exportValues.append(value);
+        }
+
+        if (!hasDefault) {
+            exportNames.append(vm.propertyNames->defaultKeyword);
+            exportValues.append(object);
         }
     };
 }

--- a/src/jsc/modules/ObjectModule.cpp
+++ b/src/jsc/modules/ObjectModule.cpp
@@ -3,10 +3,10 @@
 namespace Zig {
 JSC::SyntheticSourceProvider::SyntheticSourceGenerator
 generateObjectModuleSourceCode(JSC::JSGlobalObject* globalObject,
-    JSC::JSObject* object)
+    JSC::JSObject* object, bool synthesizeDefault)
 {
     gcProtectNullTolerant(object);
-    return [object](JSC::JSGlobalObject* lexicalGlobalObject,
+    return [object, synthesizeDefault](JSC::JSGlobalObject* lexicalGlobalObject,
                JSC::Identifier moduleKey,
                Vector<JSC::Identifier, 4>& exportNames,
                JSC::MarkedArgumentBuffer& exportValues) -> void {
@@ -32,7 +32,7 @@ generateObjectModuleSourceCode(JSC::JSGlobalObject* globalObject,
             exportValues.append(value);
         }
 
-        if (!hasDefault) {
+        if (synthesizeDefault && !hasDefault) {
             exportNames.append(vm.propertyNames->defaultKeyword);
             exportValues.append(object);
         }

--- a/src/jsc/modules/ObjectModule.h
+++ b/src/jsc/modules/ObjectModule.h
@@ -4,9 +4,11 @@
 #include <JavaScriptCore/JSGlobalObject.h>
 
 namespace Zig {
+// `synthesizeDefault`: export `object` itself as `default` when it has no own
+// `default` property, like the JSON and CommonJS module generators do.
 JSC::SyntheticSourceProvider::SyntheticSourceGenerator
 generateObjectModuleSourceCode(JSC::JSGlobalObject* globalObject,
-    JSC::JSObject* object);
+    JSC::JSObject* object, bool synthesizeDefault);
 
 JSC::SyntheticSourceProvider::SyntheticSourceGenerator
 generateObjectModuleSourceCodeForJSON(JSC::JSGlobalObject* globalObject,

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1064,3 +1064,62 @@ it("object loader: an error thrown by a getter on the exports object rejects the
   });
   expect(() => require("object-loader-throwing-esmodule")).toThrow(boom);
 });
+
+// https://github.com/oven-sh/bun/issues/9987
+it.concurrent("onLoad loader: 'object' provides a default export when exports has no 'default' key", async () => {
+  using dir = tempDir("plugin-object-loader-default", {
+    "preload.ts": `
+      Bun.plugin({
+        name: "object-loader-default",
+        setup(build) {
+          build.onLoad({ filter: /\\.nodef$/ }, () => ({
+            exports: { name: "Tom", age: 10 },
+            loader: "object",
+          }));
+          build.onLoad({ filter: /\\.withdef$/ }, () => ({
+            exports: { default: "EXPLICIT", named: "NAMED" },
+            loader: "object",
+          }));
+        },
+      });
+    `,
+    "data.nodef": ``,
+    "data.withdef": ``,
+    "entry.ts": `
+      import data from "./data.nodef";
+      import { name, age } from "./data.nodef";
+      import * as ns from "./data.nodef";
+      import explicit, { named } from "./data.withdef";
+      console.log(
+        JSON.stringify({
+          data,
+          name,
+          age,
+          nsDefault: ns.default,
+          nsKeys: Object.keys(ns).sort(),
+          explicit,
+          named,
+        }),
+      );
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.ts", "entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+    data: { name: "Tom", age: 10 },
+    name: "Tom",
+    age: 10,
+    nsDefault: { name: "Tom", age: 10 },
+    nsKeys: ["age", "default", "name"],
+    explicit: "EXPLICIT",
+    named: "NAMED",
+  });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1080,16 +1080,23 @@ it.concurrent("onLoad loader: 'object' provides a default export when exports ha
             exports: { default: "EXPLICIT", named: "NAMED" },
             loader: "object",
           }));
+          build.onLoad({ filter: /\\.asyncnodef$/ }, async () => {
+            await Promise.resolve();
+            return { exports: { kind: "async" }, loader: "object" };
+          });
         },
       });
     `,
     "data.nodef": ``,
     "data.withdef": ``,
+    "data.asyncnodef": ``,
     "entry.ts": `
       import data from "./data.nodef";
       import { name, age } from "./data.nodef";
       import * as ns from "./data.nodef";
       import explicit, { named } from "./data.withdef";
+      import asyncData, { kind } from "./data.asyncnodef";
+      const required = require("./data.nodef");
       console.log(
         JSON.stringify({
           data,
@@ -1099,6 +1106,10 @@ it.concurrent("onLoad loader: 'object' provides a default export when exports ha
           nsKeys: Object.keys(ns).sort(),
           explicit,
           named,
+          asyncData,
+          kind,
+          requiredName: required.name,
+          requiredDefault: required.default,
         }),
       );
     `,
@@ -1120,6 +1131,10 @@ it.concurrent("onLoad loader: 'object' provides a default export when exports ha
     nsKeys: ["age", "default", "name"],
     explicit: "EXPLICIT",
     named: "NAMED",
+    asyncData: { kind: "async" },
+    kind: "async",
+    requiredName: "Tom",
+    requiredDefault: { name: "Tom", age: 10 },
   });
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -156,6 +156,17 @@ test("mocking a package", async () => {
   expect(require("ha-ha-ha").wow()).toBe(43);
 });
 
+// https://github.com/oven-sh/bun/issues/9987
+test("a factory without a default key exports the returned object as default", async () => {
+  const exports = { wow: () => 42 };
+  mock.module("mock-module-no-default", () => exports);
+  const ns = await import("mock-module-no-default");
+  expect(ns.default).toBe(exports);
+  expect(ns.wow).toBe(exports.wow);
+  expect(Object.keys(ns).sort()).toEqual(["default", "wow"]);
+  expect(require("mock-module-no-default").default).toBe(exports);
+});
+
 test("mocking a builtin", async () => {
   mock.module("fs/promises", () => {
     return {

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -156,15 +156,16 @@ test("mocking a package", async () => {
   expect(require("ha-ha-ha").wow()).toBe(43);
 });
 
-// https://github.com/oven-sh/bun/issues/9987
-test("a factory without a default key exports the returned object as default", async () => {
+// The plugin "object" loader adds an implicit default export (#9987). A module
+// mock does not: its export set is exactly what the factory returned.
+test("a factory without a default key does not add a default export", async () => {
   const exports = { wow: () => 42 };
   mock.module("mock-module-no-default", () => exports);
   const ns = await import("mock-module-no-default");
-  expect(ns.default).toBe(exports);
+  expect(Object.keys(ns)).toEqual(["wow"]);
+  expect("default" in ns).toBe(false);
   expect(ns.wow).toBe(exports.wow);
-  expect(Object.keys(ns).sort()).toEqual(["default", "wow"]);
-  expect(require("mock-module-no-default").default).toBe(exports);
+  expect(Object.keys(require("mock-module-no-default"))).toEqual(["wow"]);
 });
 
 test("mocking a builtin", async () => {

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -167,23 +167,6 @@ test("a factory without a default key exports the returned object as default", a
   expect(require("mock-module-no-default").default).toBe(exports);
 });
 
-test("re-mocking without a default key moves the synthesized default to the new object", async () => {
-  const first = { wow: () => 1 };
-  const second = { wow: () => 2 };
-  const third = { wow: () => 3, default: "explicit" };
-  mock.module("mock-module-remock-default", () => first);
-  const ns = await import("mock-module-remock-default");
-  expect(ns.default).toBe(first);
-
-  mock.module("mock-module-remock-default", () => second);
-  expect(ns.wow()).toBe(2);
-  expect(ns.default).toBe(second);
-
-  mock.module("mock-module-remock-default", () => third);
-  expect(ns.wow()).toBe(3);
-  expect(ns.default).toBe("explicit");
-});
-
 test("mocking a builtin", async () => {
   mock.module("fs/promises", () => {
     return {

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -167,6 +167,23 @@ test("a factory without a default key exports the returned object as default", a
   expect(require("mock-module-no-default").default).toBe(exports);
 });
 
+test("re-mocking without a default key moves the synthesized default to the new object", async () => {
+  const first = { wow: () => 1 };
+  const second = { wow: () => 2 };
+  const third = { wow: () => 3, default: "explicit" };
+  mock.module("mock-module-remock-default", () => first);
+  const ns = await import("mock-module-remock-default");
+  expect(ns.default).toBe(first);
+
+  mock.module("mock-module-remock-default", () => second);
+  expect(ns.wow()).toBe(2);
+  expect(ns.default).toBe(second);
+
+  mock.module("mock-module-remock-default", () => third);
+  expect(ns.wow()).toBe(3);
+  expect(ns.default).toBe("explicit");
+});
+
 test("mocking a builtin", async () => {
   mock.module("fs/promises", () => {
     return {


### PR DESCRIPTION
### Problem
- A runtime plugin whose `onLoad` returns `{ exports, loader: "object" }` without a `default` key fails at link time on a default import: `SyntaxError: Missing 'default' export in module '/repro/test.yml'.` (#9987).
- Cause: `generateObjectModuleSourceCode()` (`src/jsc/modules/ObjectModule.cpp:24`) registers each own property of `exports` as a named export and never adds a `default` binding. Its siblings `generateObjectModuleSourceCodeForJSON()` and `generateInternalModuleSourceCode()` (`src/jsc/bindings/ModuleLoader.cpp:121`) both do.

### Fix
- Track `hasDefault` while the loop walks the own property names. If no `default` property exists, append `default` with the whole `exports` object as its value. An explicit `exports.default` passes through unchanged.
- Correct because every other module-like content in bun already follows this rule: JSON modules, internal modules, CJS modules imported from ESM (`JSCommonJSModule.cpp:995`), and `Bun.build` for the same `loader: "object"` result (`src/js/builtins/BundlerPlugin.ts:544`). The runtime object loader was the one exception.
- `mock.module()` factories reach the same generator (`ModuleLoader.cpp:221`), but a mock names its export set exactly. The new `synthesizeDefault` parameter is `!wasModuleMock` at the one call site, so a mock's namespace keeps the shape of the factory's return value and a wrong default import still fails under `bun test` as it does in production.
- Verified: `test/js/bun/plugin/plugins.test.ts` (sync and async `onLoad`, namespace shape, explicit default, `require()`; stock bun fails it) and `test/js/bun/test/mock/mock-module.test.ts` (a mock without `default` gains none). Also ran `test/js/bun/test/mock/`, `test/bundler/bundler_plugin.test.ts`, `test/cli/test/isolation.test.ts` and `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts`.

### Background
- A synthetic module is an ES module whose exports come from C++ instead of source text. `JSC::SyntheticSourceProvider` takes a generator that fills two parallel lists, `exportNames` and `exportValues`. A name missing there is a `SyntaxError` at link time, not a runtime `undefined`.
- The `"object"` loader produces such a module. `onLoad` or `build.module()` returns `{ exports, loader: "object" }`, and `handleVirtualModuleResult` (`ModuleLoader.cpp:401`) hands `exports` to the generator. `mock.module()` reuses the path with the factory's return value, flagged by `wasModuleMock`.
- `require()` of an ES module returns the namespace (`src/js/builtins/CommonJS.ts:135`), so the new `default` key of a plugin module shows there too.

Closes #9987

<details><summary>Notes</summary>

- Supersedes the object-loader half of #28547. Its `ObjectModule.cpp` diff matched the first version of this one. Its test cases (async `onLoad`, explicit default) are folded into the plugins test here.
- The rebase onto main resolved a conflict with #39804, which changed the loop body to propagate exceptions through `RETURN_IF_EXCEPTION(throwScope, ...)`. The loop body from main is kept. Only the `hasDefault` tracking and the trailing append are new.
- Behavior change for existing code: `import * as ns` of a plugin object-loader module without `default` now lists `default` in `Object.keys(ns)`. A default import of such a module failed at link time before, so no working import changes value.
- Why mocks are excluded: an earlier version of this PR synthesized `default` for `mock.module()` too. A review found two regressions. A mock of a named-exports-only module made a wrong `import db from "./services/db"` pass under `bun test` while production still threw. `Object.entries(ns)` over such a mock gained a non-function `default` entry, which turned a passing test into a `TypeError`. The "override an already imported module" path (`JSMock__jsModuleMock`, `BunPlugin.cpp`) also never runs this generator, so first-load mocks and re-mocks would have disagreed. A synthesized default for mocks needs its own issue and a design that covers both mock paths.
- Namespace keys are sorted by JSC, so `["age", "default", "name"]` in the test is deterministic.
- Other suites run on the debug build: `test/js/bun/plugin/plugin-namespace-drive-letter.test.ts`, `test/js/node/module/esm-registry-concurrent-gc.test.ts`, `test/regression/issue/11664.test.ts`.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1257.78ms]
(pass) require > beep:boop returns 42 [8.88ms]
(pass) require > object module works [7.35ms]
(pass) module > throws with require() [14.18ms]
(pass) module > async module works with async import [22.89ms]
(pass) module > sync module module works with require() [4.30ms]
(pass) module > sync module module works with require.resolve() [3.02ms]
(pass) module > sync module module works with import [4.80ms]
(pass) module > modules are overridable [21.76ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [80.23ms]
(pass) dynamic import > beep:boop returns 42 [4.55ms]
(
... (truncated)

release without fix: 1 failed, 1 skipped
bun test v1.4.1-canary.1 (e17bd5a41)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [20.21ms]
(pass) require > beep:boop returns 42 [0.17ms]
(pass) require > object module works [0.12ms]
(pass) module > throws with require() [0.14ms]
(pass) module > async module works with async import [1.26ms]
(pass) module > sync module module works with require() [0.06ms]
(pass) module > sync module module works with require.resolve() [0.05ms]
(pass) module > sync module module works with import [0.06ms]
(pass) module > modules are overridable [0.18ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [0.08ms]
(pass) dynamic import > beep:boop returns 42 [0.05ms]
(pass) dynamic import > async:onLoad returns 42 [1.36ms]
(pass) dynamic import > async object loader returns 42 [1.23ms]
(pass) import statement > SSRs `<h1>Hello world!</h1>` with Svelte [1.64ms]
(pass) erro
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1235.75ms]
(pass) require > beep:boop returns 42 [9.96ms]
(pass) require > object module works [7.31ms]
(pass) module > throws with require() [12.82ms]
(pass) module > async module works with async import [25.68ms]
(pass) module > sync module module works with require() [3.94ms]
(pass) module > sync module module works with require.resolve() [3.48ms]
(pass) module > sync module module works with import [4.69ms]
(pass) module > modules are overridable [88.09ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [5.99ms]
(pass) dynamic import > beep:boop returns 42 [4.07ms]
(p
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 637ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/11] cxx obj/src/jsc/bindings/napi.cpp.o
[2/11] cxx obj/unified/UnifiedSource-src_jsc_modules-0.cpp.o
[3/11] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[4/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[5/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[6/11] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 244 extern-C blocks audited
[7/11] gen cpp.rs (cppbind)
[7/11] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspac
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ModuleLoader.cpp         |  5 ++-
 src/jsc/modules/ObjectModule.cpp          | 13 +++++-
 src/jsc/modules/ObjectModule.h            |  4 +-
 test/js/bun/plugin/plugins.test.ts        | 74 +++++++++++++++++++++++++++++++
 test/js/bun/test/mock/mock-module.test.ts | 12 +++++
 5 files changed, 104 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/bindings/ModuleLoader.cpp              2      0      0
src/jsc/modules/ObjectModule.cpp               1      1      0
src/jsc/modules/ObjectModule.h                 1      0      0
test/js/bun/plugin/plugins.test.ts             3      3      0
test/js/bun/test/mock/mock-module.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->
