### PR TITLE
streams: eagerly clear ReadableStream source WriteBarriers once terminal

### DIFF
--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -435,6 +435,17 @@ static void callUnderlyingSourceClose(JSC::VM& vm, JSGlobalObject* globalObject,
     }
 }
 
+// Drop the direct controller's retained user-source state once no further pull/close callbacks
+// can run (m_closed set, or the stream has left Readable). Idempotent.
+static void directStreamControllerClearSource(JSDirectStreamController* controller)
+{
+    controller->m_underlyingSource.clear();
+    controller->m_pull.clear();
+    controller->m_deferCloseReason.clear();
+    if (auto* stream = controller->m_stream.get())
+        readableStreamClearSourceBarriers(stream);
+}
+
 void JSDirectStreamController::handleError(JSGlobalObject* globalObject, JSValue error)
 {
     auto& vm = getVM(globalObject);
@@ -457,6 +468,7 @@ void JSDirectStreamController::handleError(JSGlobalObject* globalObject, JSValue
         callUnderlyingSourceClose(vm, globalObject, this, error);
         RETURN_IF_EXCEPTION(scope, );
     }
+    directStreamControllerClearSource(this);
 
     if (auto* pendingRead = m_pendingRead.get()) {
         m_pendingRead.clear();
@@ -648,6 +660,7 @@ void JSDirectStreamController::onClose(JSGlobalObject* globalObject, JSValue rea
 
     callUnderlyingSourceClose(vm, globalObject, this, reason);
     RETURN_IF_EXCEPTION(scope, );
+    directStreamControllerClearSource(this);
 
     JSValue flushed;
     {

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -678,6 +678,8 @@ void readableByteStreamControllerClearAlgorithms(JSReadableByteStreamController*
     controller->m_algorithms.method1.clear();
     controller->m_algorithms.method2.clear();
     controller->m_algorithms.algorithmContext.clear();
+    if (auto* stream = controller->m_stream.get())
+        readableStreamClearSourceBarriers(stream);
 }
 
 void readableByteStreamControllerClearPendingPullIntos(JSReadableByteStreamController* controller)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -571,6 +571,8 @@ void readableStreamDefaultControllerClearAlgorithms(JSReadableStreamDefaultContr
     controller->m_algorithms.method2.clear();
     controller->m_algorithms.algorithmContext.clear();
     controller->m_strategySizeAlgorithm.clear();
+    if (auto* stream = controller->m_stream.get())
+        readableStreamClearSourceBarriers(stream);
 }
 
 void readableStreamDefaultControllerClose(JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller)

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -256,6 +256,12 @@ void readableStreamFulfillReadIntoRequest(JSGlobalObject* globalObject, JSReadab
         readIntoRequest->chunkSteps(globalObject, chunk);
 }
 
+void readableStreamClearSourceBarriers(JSReadableStream* stream)
+{
+    stream->m_asyncContext.clear();
+    stream->m_directUnderlyingSource.clear();
+}
+
 // ReadableStreamClose(stream)
 void readableStreamClose(JSGlobalObject* globalObject, JSReadableStream* stream)
 {
@@ -324,6 +330,7 @@ void readableStreamError(JSGlobalObject* globalObject, JSReadableStream* stream,
     ASSERT(stream->m_state == ReadableStreamState::Readable);
     stream->m_state = ReadableStreamState::Errored;
     stream->m_storedError.set(vm, stream, error);
+    readableStreamClearSourceBarriers(stream);
     rejectStreamClosedPromise(vm, stream, error);
     auto* reader = stream->m_reader.get();
     if (!reader)
@@ -440,6 +447,9 @@ JSPromise* readableStreamCancel(JSGlobalObject* globalObject, JSReadableStream* 
             pendingRead->fulfill(vm, doneResult);
             RETURN_IF_EXCEPTION(scope, nullptr);
         }
+        controller->m_underlyingSource.clear();
+        controller->m_pull.clear();
+        controller->m_deferCloseReason.clear();
         sourceCancelPromise = promiseFulfilledWith(globalObject, JSC::jsUndefined());
         break;
     }
@@ -462,6 +472,8 @@ JSPromise* readableStreamCancel(JSGlobalObject* globalObject, JSReadableStream* 
     }
     }
     RETURN_IF_EXCEPTION(scope, nullptr);
+
+    readableStreamClearSourceBarriers(stream);
 
     auto* result = JSPromise::create(vm, globalObject->promiseStructure());
     sourceCancelPromise->performPromiseThenWithContext(vm, globalObject, runtime->onReturnUndefined(), jsUndefined(), result, jsUndefined());

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -221,6 +221,11 @@ void readableStreamReaderGenericRelease(JSC::JSGlobalObject*, JSReadableStreamRe
 JSC::JSPromise* readableStreamCancel(JSC::JSGlobalObject*, JSReadableStream*, JSC::JSValue reason); // userJS: yes — ReadableStreamOperations.cpp
 void readableStreamClose(JSC::JSGlobalObject*, JSReadableStream*); // userJS: yes (read-request close-steps dispatch) — ReadableStreamOperations.cpp
 void readableStreamError(JSC::JSGlobalObject*, JSReadableStream*, JSC::JSValue error); // userJS: yes (error-steps dispatch) — ReadableStreamOperations.cpp
+// Eagerly drop WriteBarriers on the stream that exist only to feed user source callbacks
+// (pull/cancel/close). Called once no more source callbacks will run: each controller's
+// ClearAlgorithms, the tail of readableStreamCancel, and the direct controller's
+// close/error. Idempotent.
+void readableStreamClearSourceBarriers(JSReadableStream*); // userJS: no — ReadableStreamOperations.cpp
 // Bun helper used by every consumer teardown: closes the stream iff its state still allows
 // it. Callers: BunStreamConsumers.cpp, BunStreamSource.cpp, JSDirectStreamController.cpp.
 void readableStreamCloseIfPossible(JSC::JSGlobalObject*, JSReadableStream*); // userJS: yes — ReadableStreamOperations.cpp

--- a/test/js/web/streams/readable-stream-terminal-barrier-release.test.ts
+++ b/test/js/web/streams/readable-stream-terminal-barrier-release.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// A ReadableStream captures the ambient AsyncLocalStorage context at construction
+// time (so pull()/cancel() observe it). Once the stream reaches a terminal state
+// and no further source callbacks can run, that captured context should be
+// released even while the stream object itself is still reachable. The same
+// applies to a type:"direct" stream's retained underlyingSource/pull after close.
+//
+// Each case holds the stream (and for controller.error, the controller) in an
+// array across GC, so the only edge to the probe object is the stream's internal
+// WriteBarrier. Before this change the probe survived every GC; with eager
+// clearing it is collectable once the terminal transition completes.
+
+const timeout = 60_000;
+
+async function run(src: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout.trim()) as { alive: number; total: number };
+}
+
+// Shared child-process scaffolding: runs `body` N times under an AsyncLocalStorage
+// store keyed by a fresh probe object tracked by a FinalizationRegistry, awaits
+// microtasks, then GC-storms and reports how many probes survived.
+function fixture(body: string) {
+  return `
+    const { AsyncLocalStorage } = require("node:async_hooks");
+    const als = new AsyncLocalStorage();
+    const N = 200;
+    const retained = [];
+    let alive = 0;
+    const registry = new FinalizationRegistry(() => { alive--; });
+
+    for (let i = 0; i < N; i++) {
+      const probe = { i };
+      alive++;
+      registry.register(probe, undefined);
+      await als.run({ probe }, async () => { ${body} });
+    }
+
+    for (let r = 0; r < 20; r++) { Bun.gc(true); await new Promise(f => setImmediate(f)); }
+    process.stdout.write(JSON.stringify({ alive, total: N }));
+    if (retained.length === 0) throw new Error("retained was cleared");
+  `;
+}
+
+describe.concurrent("ReadableStream releases its captured async context once terminal", () => {
+  test(
+    "default controller: cancel()",
+    async () => {
+      const { alive, total } = await run(
+        fixture(`
+          const rs = new ReadableStream({ pull() {} });
+          retained.push(rs);
+          await rs.cancel();
+        `),
+      );
+      expect(alive).toBeLessThan(total * 0.2);
+    },
+    timeout,
+  );
+
+  test(
+    "default controller: controller.error()",
+    async () => {
+      const { alive, total } = await run(
+        fixture(`
+          let ctrl;
+          const rs = new ReadableStream({ start(c) { ctrl = c; } });
+          retained.push(rs, ctrl);
+          ctrl.error(new Error("boom"));
+        `),
+      );
+      expect(alive).toBeLessThan(total * 0.2);
+    },
+    timeout,
+  );
+
+  test(
+    "default controller: controller.close()",
+    async () => {
+      const { alive, total } = await run(
+        fixture(`
+          let ctrl;
+          const rs = new ReadableStream({ start(c) { ctrl = c; } });
+          retained.push(rs, ctrl);
+          ctrl.close();
+        `),
+      );
+      expect(alive).toBeLessThan(total * 0.2);
+    },
+    timeout,
+  );
+
+  test(
+    "byte controller: cancel()",
+    async () => {
+      const { alive, total } = await run(
+        fixture(`
+          const rs = new ReadableStream({ type: "bytes", pull() {} });
+          retained.push(rs);
+          await rs.cancel();
+        `),
+      );
+      expect(alive).toBeLessThan(total * 0.2);
+    },
+    timeout,
+  );
+
+  test(
+    "byte controller: controller.error()",
+    async () => {
+      const { alive, total } = await run(
+        fixture(`
+          let ctrl;
+          const rs = new ReadableStream({ type: "bytes", start(c) { ctrl = c; } });
+          retained.push(rs, ctrl);
+          ctrl.error(new Error("boom"));
+        `),
+      );
+      expect(alive).toBeLessThan(total * 0.2);
+    },
+    timeout,
+  );
+
+  test(
+    "direct stream: cancel() before materialize drops the pending underlyingSource",
+    async () => {
+      // No ALS here: the probe is the underlyingSource object itself, which the
+      // DirectPending stream stores in m_directUnderlyingSource until first use.
+      const src = `
+        const N = 200;
+        const retained = [];
+        let alive = 0;
+        const registry = new FinalizationRegistry(() => { alive--; });
+        for (let i = 0; i < N; i++) {
+          const src = { type: "direct", pull() {} };
+          alive++;
+          registry.register(src, undefined);
+          const rs = new ReadableStream(src);
+          retained.push(rs);
+          await rs.cancel();
+        }
+        for (let r = 0; r < 20; r++) { Bun.gc(true); await new Promise(f => setImmediate(f)); }
+        process.stdout.write(JSON.stringify({ alive, total: N }));
+        if (retained.length === 0) throw new Error("retained was cleared");
+      `;
+      const { alive, total } = await run(src);
+      expect(alive).toBeLessThan(total * 0.2);
+    },
+    timeout,
+  );
+
+  test(
+    "direct controller: end() drops underlyingSource and async context",
+    async () => {
+      const { alive, total } = await run(
+        fixture(`
+          const src = { type: "direct", pull(c) { c.write("x"); c.end(); } };
+          const rs = new ReadableStream(src);
+          retained.push(rs);
+          for await (const _ of rs) {}
+        `),
+      );
+      expect(alive).toBeLessThan(total * 0.2);
+    },
+    timeout,
+  );
+});


### PR DESCRIPTION
Once a ReadableStream reaches a state where no more user source callbacks (pull / cancel / close) will ever run, several `WriteBarrier`s on the stream and its controller are dead weight. They keep whatever they point at (notably the construction-time `AsyncLocalStorage` snapshot and, for `type: "direct"`, the user's underlyingSource object with its closures) alive for as long as the stream itself is reachable.

## What gets cleared

**`JSReadableStream`** (via new `readableStreamClearSourceBarriers`):
- `m_asyncContext`: the ALS snapshot restored around `pull`/`cancel`. `StreamAsyncContextScope` is only entered from the controller's algorithm dispatch, so once those algorithms are cleared this slot is never read again.
- `m_directUnderlyingSource`: only consulted before materialization (`setUpDirectStreamController`, `readDirectStream`, `consumeDirectStreamToArrayBuffer`). On cancel/error it is dead.

**`JSDirectStreamController`** (via new `directStreamControllerClearSource`):
- `m_underlyingSource`, `m_pull`, `m_deferCloseReason`: once `m_closed` is set (or the stream has left Readable), `onPull`'s state check guarantees `callDirectPull` and `callUnderlyingSourceClose` never run again.

## Where it is called

- `readableStreamDefaultControllerClearAlgorithms` / `readableByteStreamControllerClearAlgorithms`: the spec's existing "no more callbacks" point for default and byte controllers. Covers `controller.close()`, `controller.error()`, and `cancelSteps`.
- `readableStreamError`: covers `ControllerKind::None` / `ControllerKind::NativeSink` streams errored via `webStreamControllerError`.
- Tail of `readableStreamCancel`: covers cancel of `None` / `Direct` / `NativeSink` streams, where no ClearAlgorithms runs. For the Direct arm, also clears the direct controller's own slots (its `onClose` early-returns because the stream is already Closed).
- `JSDirectStreamController::onClose` / `handleError`: right after `callUnderlyingSourceClose`, the last user callback.

All call sites are after the last read of the slot and the helper is idempotent.

## Verification

`test/js/web/streams/readable-stream-terminal-barrier-release.test.ts` spawns a child per case that creates 200 streams under an `als.run({ probe })` (or, for the direct-pending case, registers the underlyingSource itself), retains the stream objects, drives them to a terminal state, then GC-storms and counts live probes via a `FinalizationRegistry`.

Before this change every case reported `alive == 200`. With it, probes are collected.

```
USE_SYSTEM_BUN=1 bun test <file>    0 pass / 7 fail (Received: 200)
bun bd test <file>                  7 pass / 0 fail
```

WPT streams suite (1175 tests) and the existing stream/ALS tests still pass; a sanity script confirms `als.getStore()` inside `pull` and `cancel` still sees the captured store.