### PR TITLE
install: expand leading ~ in bunfig [install] path values

### DIFF
--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -296,8 +296,10 @@ pub fn open_global_dir(explicit_global_dir: &[u8]) -> crate::Result<bun_sys::Fd>
     }
 
     if !explicit_global_dir.is_empty() {
+        let expanded = expand_home_tilde(explicit_global_dir);
+        let dir = expanded.as_deref().unwrap_or(explicit_global_dir);
         return Dir::cwd()
-            .make_open_path(explicit_global_dir, OpenDirOptions::default())
+            .make_open_path(dir, OpenDirOptions::default())
             .map(|d| d.into_raw())
             .map_err(Into::into);
     }
@@ -487,7 +489,7 @@ impl Options {
             }
 
             if let Some(cafile) = config.cafile.as_deref() {
-                self.ca_file_name = leak_static(cafile);
+                self.ca_file_name = leak_static_expand_home(cafile);
             }
 
             if config.disable_cache.unwrap_or(false) {

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -386,10 +386,7 @@ fn leak_static(s: &[u8]) -> &'static [u8] {
     bun_core::heap::release(s.to_vec().into_boxed_slice())
 }
 
-/// Replace a leading `~` (bare or followed by a path separator) with
-/// `$HOME`/`%USERPROFILE%`. bunfig.toml path values arrive verbatim, so without
-/// this a `dir = "~/x"` entry resolves to `<cwd>/~/x`.
-/// `~user` is left untouched.
+/// `~` or `~/<rest>` → `$HOME/<rest>`. `~user` is left untouched.
 fn expand_home_tilde(path: &[u8]) -> Option<Vec<u8>> {
     if path.first() != Some(&b'~') {
         return None;

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -342,8 +342,10 @@ pub(crate) fn open_global_bin_dir(opts_: Option<&Api::BunInstall>) -> crate::Res
     if let Some(opts) = opts_ {
         if let Some(home_dir) = &opts.global_bin_dir {
             if !home_dir.is_empty() {
+                let expanded = expand_home_tilde(home_dir);
+                let bin_dir = expanded.as_deref().unwrap_or(home_dir);
                 return Dir::cwd()
-                    .make_open_path(home_dir, OpenDirOptions::default())
+                    .make_open_path(bin_dir, OpenDirOptions::default())
                     .map(|d| d.into_raw())
                     .map_err(Into::into);
             }
@@ -384,6 +386,32 @@ fn leak_static(s: &[u8]) -> &'static [u8] {
     bun_core::heap::release(s.to_vec().into_boxed_slice())
 }
 
+/// Replace a leading `~` (bare or followed by a path separator) with
+/// `$HOME`/`%USERPROFILE%`. bunfig.toml path values arrive verbatim, so without
+/// this a `dir = "~/x"` entry resolves to `<cwd>/~/x`.
+/// `~user` is left untouched.
+fn expand_home_tilde(path: &[u8]) -> Option<Vec<u8>> {
+    if path.first() != Some(&b'~') {
+        return None;
+    }
+    if path.len() > 1 && !bun_core::path_sep::is_sep_any(path[1]) {
+        return None;
+    }
+    let home = env_var::HOME.get()?;
+    let mut out = Vec::with_capacity(home.len() + path.len() - 1);
+    out.extend_from_slice(home);
+    out.extend_from_slice(&path[1..]);
+    Some(out)
+}
+
+#[inline]
+fn leak_static_expand_home(path: &[u8]) -> &'static [u8] {
+    match expand_home_tilde(path) {
+        Some(expanded) => bun_core::heap::release(expanded.into_boxed_slice()),
+        None => leak_static(path),
+    }
+}
+
 impl Options {
     pub(crate) fn load(
         &mut self,
@@ -418,7 +446,7 @@ impl Options {
 
         if let Some(config) = bun_install_ref {
             if let Some(cache_directory) = config.cache_directory.as_deref() {
-                self.cache_directory = leak_static(cache_directory);
+                self.cache_directory = leak_static_expand_home(cache_directory);
             }
 
             if let Some(scoped) = &config.scoped {
@@ -555,7 +583,7 @@ impl Options {
             // the isolated linker, so it has nothing to transfer.
 
             if let Some(global_dir) = config.global_dir.as_deref() {
-                self.explicit_global_directory = leak_static(global_dir);
+                self.explicit_global_directory = leak_static_expand_home(global_dir);
             }
         }
 

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -8,10 +8,12 @@ import {
   readdirSorted,
   runBunInstall,
   stderrForInstall,
+  tempDir,
   tmpdirSync,
   toBeValidBin,
   toHaveBins,
 } from "harness";
+import { existsSync } from "node:fs";
 import { basename, join } from "path";
 import { dummyAfterAll, dummyAfterEach, dummyBeforeAll, dummyBeforeEach, package_dir } from "./dummy.registry";
 
@@ -471,4 +473,49 @@ it("should link dependency without crashing", async () => {
 
   // This should fail with a non-zero exit code.
   expect(await exited4).toBe(1);
+});
+
+// https://github.com/oven-sh/bun/issues/10152
+it("should expand leading tilde in bunfig [install] globalDir/globalBinDir", async () => {
+  using dir = tempDir("link-tilde", {
+    "pkg/package.json": JSON.stringify({ name: "link-tilde-pkg", version: "1.0.0" }),
+    "pkg/bunfig.toml": `[install]\nglobalDir = "~/my-global"\nglobalBinDir = "~/my-gbin"\n`,
+    "home/.keep": "",
+  });
+  const dirStr = String(dir);
+  const homeDir = join(dirStr, "home");
+  const pkgDir = join(dirStr, "pkg");
+
+  const spawnEnv: NodeJS.Dict<string> = {
+    ...env,
+    HOME: homeDir,
+    USERPROFILE: homeDir,
+  };
+  for (const k of [
+    "BUN_INSTALL",
+    "BUN_INSTALL_BIN",
+    "BUN_INSTALL_GLOBAL_DIR",
+    "BUN_INSTALL_CACHE_DIR",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+  ]) {
+    delete spawnEnv[k];
+  }
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "link"],
+    cwd: pkgDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: spawnEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("error:");
+  expect(stdout).toContain('Registered "link-tilde-pkg"');
+  // The unexpanded paths would have created a literal "~" directory under cwd.
+  expect(existsSync(join(pkgDir, "~"))).toBeFalse();
+  expect(existsSync(join(homeDir, "my-global"))).toBeTrue();
+  expect(existsSync(join(homeDir, "my-gbin"))).toBeTrue();
+  expect(exitCode).toBe(0);
 });

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -982,3 +982,37 @@ test.concurrent(
     expect(exitCode).toBe(0);
   },
 );
+
+// https://github.com/oven-sh/bun/issues/26715
+test.concurrent("bun pm cache expands leading tilde from .npmrc cache=", async () => {
+  using dir = tempDir("pm-cache-npmrc-tilde", {
+    "package.json": JSON.stringify({ name: "pm-cache-npmrc-tilde", version: "1.0.0" }),
+    ".npmrc": "cache=~/npmrc-cache-tilde\n",
+    "home/.keep": "",
+  });
+  const dirStr = String(dir);
+  const homeDir = join(dirStr, "home");
+
+  const spawnEnv: NodeJS.Dict<string> = {
+    ...env,
+    HOME: homeDir,
+    USERPROFILE: homeDir,
+  };
+  delete spawnEnv.BUN_INSTALL_CACHE_DIR;
+  delete spawnEnv.BUN_INSTALL;
+  delete spawnEnv.XDG_CACHE_HOME;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "cache"],
+    cwd: dirStr,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: spawnEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("error");
+  expect(stdout.trim().replaceAll("\\", "/")).toBe(join(homeDir, "npmrc-cache-tilde").replaceAll("\\", "/"));
+  expect(await exists(join(dirStr, "~"))).toBeFalse();
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it, test } from "bun:test";
 import { exists, mkdir, writeFile } from "fs/promises";
-import { bunEnv, bunExe, bunEnv as env, readdirSorted, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, bunEnv as env, isWindows, readdirSorted, tempDir, tmpdirSync } from "harness";
 import { cpSync } from "node:fs";
 import { join } from "path";
 import {
@@ -906,3 +906,79 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
 });
+
+// https://github.com/oven-sh/bun/issues/10152
+test.concurrent.each(["~/bunfig-cache-tilde", "~"])(
+  "bun pm cache expands leading tilde in bunfig [install.cache].dir (%s)",
+  async cacheDirConfig => {
+    using dir = tempDir("pm-cache-tilde", {
+      "package.json": JSON.stringify({ name: "pm-cache-tilde", version: "1.0.0" }),
+      "bunfig.toml": `[install.cache]\ndir = ${JSON.stringify(cacheDirConfig)}\n`,
+      "home/.keep": "",
+    });
+    const dirStr = String(dir);
+    const homeDir = join(dirStr, "home");
+
+    const spawnEnv: NodeJS.Dict<string> = {
+      ...env,
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+    };
+    delete spawnEnv.BUN_INSTALL_CACHE_DIR;
+    delete spawnEnv.BUN_INSTALL;
+    delete spawnEnv.XDG_CACHE_HOME;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", "cache"],
+      cwd: dirStr,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: spawnEnv,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const expected = cacheDirConfig === "~" ? homeDir : join(homeDir, "bunfig-cache-tilde");
+    expect(stderr).not.toContain("error");
+    expect(stdout.trim().replaceAll("\\", "/")).toBe(expected.replaceAll("\\", "/"));
+    // The unexpanded path would have created a literal "~" directory under cwd.
+    expect(await exists(join(dirStr, "~"))).toBeFalse();
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent(
+  "bun pm cache leaves a path starting with '~' that is not '~' or '~/' alone (e.g. '~user')",
+  async () => {
+    using dir = tempDir("pm-cache-tilde-user", {
+      "package.json": JSON.stringify({ name: "pm-cache-tilde-user", version: "1.0.0" }),
+      "bunfig.toml": `[install.cache]\ndir = "~user/cache"\n`,
+      "home/.keep": "",
+    });
+    const dirStr = String(dir);
+    const homeDir = join(dirStr, "home");
+
+    const spawnEnv: NodeJS.Dict<string> = {
+      ...env,
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+    };
+    delete spawnEnv.BUN_INSTALL_CACHE_DIR;
+    delete spawnEnv.BUN_INSTALL;
+    delete spawnEnv.XDG_CACHE_HOME;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", "cache"],
+      cwd: dirStr,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: spawnEnv,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("error");
+    // `~user` is not the current user's home; it must not be rewritten to $HOME.
+    expect(stdout.trim().replaceAll("\\", "/")).not.toStartWith(homeDir.replaceAll("\\", "/"));
+    expect(stdout).toContain(isWindows ? "~user\\cache" : "~user/cache");
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
Fixes #10152
Fixes #26715
Fixes #25766 (the `~` case; `$HOME` env-var substitution in bunfig values is a separate feature and not handled here)

## Repro

```sh
mkdir -p /tmp/proj && echo '{"name":"proj"}' > /tmp/proj/package.json
printf '[install.cache]\ndir = "~/cache-tilde"\n' > /tmp/proj/bunfig.toml
cd /tmp/proj && bun pm cache
```

Before: `/tmp/proj/~/cache-tilde` (a literal `~` directory gets created in cwd on install).
After: `$HOME/cache-tilde`.

## Cause

bunfig.toml and .npmrc path values are stored verbatim into `Api::BunInstall`. Every consumer (`fetch_cache_directory_path`, `open_global_dir`, `open_global_bin_dir`, the `cafile` abs-path join) treats `~/x` as a relative path and joins it against cwd, so `~/x` becomes `<cwd>/~/x`.

The docs at `docs/pm/global-cache.mdx` already show `dir = "~/.bun/install/cache"` as the example value, so this is the documented behavior that never worked.

## Fix

Expand a leading `~` (bare, or followed by `/` or `\`) to `$HOME` (`%USERPROFILE%` on Windows, via `env_var::HOME`) for config-sourced `[install]` path values. The expansion lives in `PackageManagerOptions.rs`:

- `open_global_dir()` and `open_global_bin_dir()` expand inline, covering every caller including `bun add -g`, `bun link`, `bun unlink` (which pass the raw bunfig value directly, before `Options::load`).
- `Options::load` expands `cache_directory`, `explicit_global_directory`, and `ca_file_name` when copying from the config struct, covering `bun pm cache`, `bun install`, and `.npmrc` `cache=`.

`~user` is left untouched.

## Verification

```
(fail) bun pm cache expands leading tilde in bunfig [install.cache].dir (~/bunfig-cache-tilde)
  Expected: "/tmp/.../home/bunfig-cache-tilde"
  Received: "/tmp/.../~/bunfig-cache-tilde"
(fail) should expand leading tilde in bunfig [install] globalDir/globalBinDir
  expect(existsSync(join(pkgDir, "~"))).toBeFalse()  Received: true
```

both pass with the fix; `~user` guard test confirms we don't over-expand.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-link.test.ts test/cli/install/bun-pm.test.ts

<!-- robobun:evidence:end -->