### PR TITLE
resolver: skip main-field/index browser remap when the target is a bare package

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5318,8 +5318,7 @@ impl<'a> Resolver<'a> {
                         // re-derives it via `resolve_without_remapping`.
                         if !is_package_path(remap) {
                             let new_paths = [browser_scope.abs_path, remap];
-                            let remapped_abs =
-                                self.fs_ref().abs_buf(&new_paths, bufs!(remap_path));
+                            let remapped_abs = self.fs_ref().abs_buf(&new_paths, bufs!(remap_path));
 
                             // Is this a file
                             if let Some(file_result) =

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5074,10 +5074,14 @@ impl<'a> Resolver<'a> {
                             dec_ret!(MatchStatus::Success);
                         }
 
-                        // `remap` is relative to the package that owns the browser map.
-                        field_abs_path = self
-                            .fs_ref()
-                            .abs_buf(&[browser_scope.abs_path, remap], bufs!(field_abs_path));
+                        // A bare-specifier remap ("buffer") is left for the
+                        // post-resolution browser check, which routes it through
+                        // `resolve_without_remapping` for a node_modules lookup.
+                        if !is_package_path(remap) {
+                            field_abs_path = self
+                                .fs_ref()
+                                .abs_buf(&[browser_scope.abs_path, remap], bufs!(field_abs_path));
+                        }
                     }
                 }
             }
@@ -5309,35 +5313,41 @@ impl<'a> Resolver<'a> {
                             return MatchStatus::Success;
                         }
 
-                        // `remap` is relative to the browser scope, which may be an ancestor of `path`.
-                        let new_paths = [browser_scope.abs_path, remap];
-                        let remapped_abs = self.fs_ref().abs_buf(&new_paths, bufs!(remap_path));
+                        // A bare-specifier remap ("other-pkg") falls through to
+                        // `load_as_index`; the post-resolution browser check then
+                        // re-derives it via `resolve_without_remapping`.
+                        if !is_package_path(remap) {
+                            let new_paths = [browser_scope.abs_path, remap];
+                            let remapped_abs =
+                                self.fs_ref().abs_buf(&new_paths, bufs!(remap_path));
 
-                        // Is this a file
-                        if let Some(file_result) = self.load_as_file(remapped_abs, extension_order)
-                        {
-                            *out = MatchResult {
-                                dirname_fd: file_result.dirname_fd,
-                                path_pair: PathPair {
-                                    primary: Path::init(file_result.path),
-                                    secondary: None,
-                                },
-                                ..Default::default()
-                            };
-                            return MatchStatus::Success;
-                        }
-
-                        // Is it a directory with an index?
-                        if let Ok(Some(new_dir)) = self.dir_info_cached(remapped_abs) {
-                            if self
-                                .load_as_index(new_dir, extension_order, out)
-                                .is_success()
+                            // Is this a file
+                            if let Some(file_result) =
+                                self.load_as_file(remapped_abs, extension_order)
                             {
+                                *out = MatchResult {
+                                    dirname_fd: file_result.dirname_fd,
+                                    path_pair: PathPair {
+                                        primary: Path::init(file_result.path),
+                                        secondary: None,
+                                    },
+                                    ..Default::default()
+                                };
                                 return MatchStatus::Success;
                             }
-                        }
 
-                        return MatchStatus::NotFound;
+                            // Is it a directory with an index?
+                            if let Ok(Some(new_dir)) = self.dir_info_cached(remapped_abs) {
+                                if self
+                                    .load_as_index(new_dir, extension_order, out)
+                                    .is_success()
+                                {
+                                    return MatchStatus::Success;
+                                }
+                            }
+
+                            return MatchStatus::NotFound;
+                        }
                     }
                 }
             }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5074,9 +5074,7 @@ impl<'a> Resolver<'a> {
                             dec_ret!(MatchStatus::Success);
                         }
 
-                        // A bare-specifier remap ("buffer") is left for the
-                        // post-resolution browser check, which routes it through
-                        // `resolve_without_remapping` for a node_modules lookup.
+                        // Bare-specifier remaps are handled by the post-resolution browser check.
                         if !is_package_path(remap) {
                             field_abs_path = self
                                 .fs_ref()
@@ -5313,9 +5311,7 @@ impl<'a> Resolver<'a> {
                             return MatchStatus::Success;
                         }
 
-                        // A bare-specifier remap ("other-pkg") falls through to
-                        // `load_as_index`; the post-resolution browser check then
-                        // re-derives it via `resolve_without_remapping`.
+                        // Bare-specifier remaps are handled by the post-resolution browser check.
                         if !is_package_path(remap) {
                             let new_paths = [browser_scope.abs_path, remap];
                             let remapped_abs = self.fs_ref().abs_buf(&new_paths, bufs!(remap_path));

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -2310,6 +2310,58 @@ describe("bundler", () => {
       stdout: "disabled",
     },
   });
+  // A browser-map value that is a bare package name ("other-pkg", not
+  // "./other-pkg") is handled by the post-resolution browser check via
+  // `resolve_without_remapping`, not by path-joining it against the
+  // browser scope in `load_from_main_field`.
+  itBundled("packagejson/BrowserMapMainFieldToPackage", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import value from 'demo-pkg'
+        console.log(value)
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "main": "./lib/index.js",
+          "browser": {
+            "./lib/index.js": "target-pkg"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/lib/index.js": `module.exports = 'lib'`,
+      "/Users/user/project/node_modules/target-pkg/package.json": `{"main":"index.js"}`,
+      "/Users/user/project/node_modules/target-pkg/index.js": `module.exports = 'target-pkg'`,
+    },
+    target: "browser",
+    run: {
+      stdout: "target-pkg",
+    },
+  });
+  itBundled("packagejson/BrowserMapSubpathDirIndexToPackage", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import value from 'demo-pkg/sub'
+        console.log(value)
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "browser": {
+            "./sub/index.js": "target-pkg"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/sub/index.js": `module.exports = 'sub-index'`,
+      "/Users/user/project/node_modules/target-pkg/package.json": `{"main":"index.js"}`,
+      "/Users/user/project/node_modules/target-pkg/index.js": `module.exports = 'target-pkg'`,
+    },
+    target: "browser",
+    run: {
+      // esbuild resolves to target-pkg here via a pre-resolution check in
+      // `tryToResolvePackage` that Bun does not yet have; this test pins
+      // that the bare-specifier remap does not hard-error.
+      stdout: "sub-index",
+    },
+  });
   // When "main" points at a directory, the implicit "<dir>/index" is checked
   // against the browser map before extension resolution.
   itBundled("packagejson/BrowserMapMainFieldDirIndexNoExt", {


### PR DESCRIPTION
Follow-up to #36620.

## What

#36620 made the browser-map checks in `load_from_main_field` and `load_as_index_with_browser_remapping` live for the first time, and those branches treat every non-empty remap as a path relative to the browser scope. For a bare-specifier value:

```json
{
  "main": "./lib/index.js",
  "browser": { "./lib/index.js": "buffer" }
}
```

the join produces `<pkg>/buffer`, `load_as_file` misses, and `require("pkg")` now fails with `Could not resolve` where releases before #36620 resolved `node_modules/buffer` via the post-resolution browser check.

## Why

The post-resolution browser check (`check_package_path` around `resolve_without_remapping`) already handles bare-specifier remap values correctly: it re-derives the remap from the resolved absolute path and runs it through `resolve_without_remapping`, which does a `node_modules` lookup for package paths. That check still runs after `load_from_main_field` returns, so bare-specifier remaps worked before #36620 only because the in-place remap branch was dead and the original main-field value resolved normally first.

Guard both sites on `!is_package_path(remap)`: relative remaps (`./...`) are applied in place (keeping the jszip fix from #36620), and bare-specifier remaps fall through so the existing post-resolution check picks them up. This restores the pre-#36620 behavior for bare-specifier values without touching the relative case.

## Verification

| case | released | main after #36620 | this PR | esbuild |
| - | - | - | - | - |
| `main` + `./lib/index.js` -> `buffer` | `buffer` | error | `buffer` | error |
| subpath dir `./sub/index.js` -> `target-pkg` | `sub/index.js` | error | `sub/index.js` | `target-pkg` |
| `main` + `./lib/index` -> `./dist/pkg.min.js` (jszip) | `lib/index.js` | `dist/pkg.min.js` | `dist/pkg.min.js` | `dist/pkg.min.js` |

The first two rows are the regressions this PR fixes; the third is the jszip case from #36620 confirming it still works. The second row still differs from esbuild because Bun lacks the pre-resolution browser-map check in `load_node_modules` (tracked separately); the important property is that it no longer hard-errors.

New tests in `packagejson.test.ts`: `BrowserMapMainFieldToPackage` and `BrowserMapSubpathDirIndexToPackage`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 9 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/packagejson.test.ts
bun test v1.4.0 (c046761d5)

test/bundler/esbuild/packagejson.test.ts:
(pass) bundler > packagejson/Main [1754.54ms]
(pass) bundler > packagejson/trailing-comma [694.53ms]
(pass) bundler > packagejson/BadMain [1310.15ms]
(pass) bundler > packagejson/Module [683.07ms]
(pass) bundler > packagejson/BrowserString [524.61ms]
(pass) bundler > packagejson/BrowserMapRelativeToRelative [452.39ms]
(pass) bundler > packagejson/BrowserMapRelativeToModule [1276.29ms]
(pass) bundler > packagejson/BrowserMapRelativeDisabled [650.80ms]
(pass) bundler > packagejson/BrowserMapModuleToRelative [522.55ms]
(pass) bundler > packagejson/BrowserMapModuleToModule [696.40ms]
(todo) bundler > packagejson/BrowserMapModuleDisabled
(pass) bundler > packagejson/BrowserMapNativeModuleDisabled [569.71ms]
(pass) bundler > packagejson/BrowserMapAvoidMissing [425.16ms]
(pass) bundler > packagejson/BrowserOverModuleBrowser [573.78ms]
(pass) bundler > packagejson/BrowserOverMainNode [686.17ms]
(pass) bundler > packagejson/BrowserWit
... (truncated)

release without fix: 9 failed, 9 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/esbuild/packagejson.test.ts:
(pass) bundler > packagejson/Main [36.84ms]
(pass) bundler > packagejson/trailing-comma [216.80ms]
(pass) bundler > packagejson/BadMain [27.79ms]
(pass) bundler > packagejson/Module [82.69ms]
(pass) bundler > packagejson/BrowserString [23.22ms]
(pass) bundler > packagejson/BrowserMapRelativeToRelative [409.16ms]
(pass) bundler > packagejson/BrowserMapRelativeToModule [217.56ms]
(pass) bundler > packagejson/BrowserMapRelativeDisabled [153.59ms]
(pass) bundler > packagejson/BrowserMapModuleToRelative [166.50ms]
(pass) bundler > packagejson/BrowserMapModuleToModule [43.60ms]
(todo) bundler > packagejson/BrowserMapModuleDisabled
(pass) bundler > packagejson/BrowserMapNativeModuleDisabled [1031.55ms]
(pass) bundler > packagejson/BrowserMapAvoidMissing [23.80ms]
(pass) bundler > packagejson/BrowserOverModuleBrowser [23.03ms]
(pass) bundler > packagejson/BrowserOverMainNode [111.11ms]
(pass) bundler > packagejson/BrowserWithModuleBrowser [23.06ms]
(pass) bundler > packagejson/BrowserWithMainNode [312.99ms]
(todo) bundler > packagejson/BrowserNodeModulesNoExt
(todo) bundler > packagejson/Browser
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 9 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/packagejson.test.ts
bun test v1.4.0 (c046761d5)

test/bundler/esbuild/packagejson.test.ts:
(pass) bundler > packagejson/Main [846.61ms]
(pass) bundler > packagejson/trailing-comma [516.19ms]
(pass) bundler > packagejson/BadMain [983.04ms]
(pass) bundler > packagejson/Module [574.16ms]
(pass) bundler > packagejson/BrowserString [793.73ms]
(pass) bundler > packagejson/BrowserMapRelativeToRelative [522.60ms]
(pass) bundler > packagejson/BrowserMapRelativeToModule [523.41ms]
(pass) bundler > packagejson/BrowserMapRelativeDisabled [743.30ms]
(pass) bundler > packagejson/BrowserMapModuleToRelative [659.67ms]
(pass) bundler > packagejson/BrowserMapModuleToModule [946.30ms]
(todo) bundler > packagejson/BrowserMapModuleDisabled
(pass) bundler > packagejson/BrowserMapNativeModuleDisabled [420.03ms]
(pass) bundler > packagejson/BrowserMapAvoidMissing [402.90ms]
(pass) bundler > packagejson/BrowserOverModuleBrowser [457.71ms]
(pass) bundler > packagejson/BrowserOverMainNode [561.65ms]
(pass) bundler > packagejson/BrowserWithMo
... (truncated)

release with fix: 9 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c046761d54
  features     baseline

22 deps, 108 codegen, 1171 objects in 8156ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen ErrorCode+*.h
[2/1234] gen bindgenv2
[3/1234] fetch picohttpparser
[picohttpparser] up to date
[4/1234] fetch tinycc
[tinycc] up to date
[5/1234] fetch zlib
[zlib] up to date
[6/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1234] gen .bind.ts → GeneratedBindings.cpp
[8/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1234] subst deps/zlib/zlib.h
[11/1234] subst deps/zlib/zconf.h
[12/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[13/1234] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/resolver/resolver.rs                 | 61 +++++++++++++++++---------------
 test/bundler/esbuild/packagejson.test.ts | 52 +++++++++++++++++++++++++++
 2 files changed, 85 insertions(+), 28 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/resolver/resolver.rs                     22     11      0
test/bundler/esbuild/packagejson.test.ts      6      7      0
```

</details>

<!-- robobun:evidence:end -->