### PR TITLE
install: re-download cache entries that lost their package.json

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2312,7 +2312,9 @@ impl<'a> PackageInstall<'a> {
             _ => 'brk: {
                 if self.patch.is_none() {
                     let exists = match resolution_tag {
-                        resolution::Tag::Npm => 'package_json_exists: {
+                        resolution::Tag::Npm
+                        | resolution::Tag::LocalTarball
+                        | resolution::Tag::RemoteTarball => 'package_json_exists: {
                             // SAFETY: `buf` and `self.cache_dir_subpath` both derive from the
                             // same thread-local `cached_package_folder_name_buf` raw pointer
                             // (the debug_assert below checks the subpath aliases this buffer),

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1218,6 +1218,7 @@ impl<'a> PackageInstaller<'a> {
                     Global::crash();
                 }
 
+                self.summary.fail += 1;
                 return 0;
             }
             break 'brk temp;

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -746,12 +746,21 @@ pub fn cached_tarball_folder_name(
     )
 }
 
-pub fn is_folder_in_cache(this: &mut PackageManager, folder_path: &ZStr) -> bool {
-    // A cache entry is only usable if it still has a package.json. An entry with the
-    // directory present but package.json missing (interrupted extract, external cleanup,
-    // etc.) would otherwise be copied into node_modules as-is and break lifecycle-script
-    // discovery. Re-extracting over such an entry is safe: extraction renames a temp dir
-    // into place, replacing the stale directory.
+pub fn is_folder_in_cache(
+    this: &mut PackageManager,
+    folder_path: &ZStr,
+    resolution_tag: ResolutionTag,
+) -> bool {
+    let cache_dir = get_cache_directory(this);
+    if resolution_tag != ResolutionTag::Npm {
+        return sys::directory_exists_at(cache_dir, folder_path).unwrap_or(false);
+    }
+    // An npm cache entry is only usable if it still has a package.json. An entry with
+    // the directory present but package.json missing (interrupted extract, external
+    // cleanup, etc.) would otherwise be copied into node_modules as-is and break
+    // lifecycle-script discovery. Re-extracting over such an entry is safe: extraction
+    // renames a temp dir into place, replacing the stale directory. This matches the
+    // per-tag check in `PackageInstall::package_missing_from_cache`.
     // https://github.com/oven-sh/bun/issues/10423
     let folder = bun_core::strings::without_trailing_slash(folder_path.as_bytes());
     if folder.is_empty() {
@@ -766,7 +775,7 @@ pub fn is_folder_in_cache(this: &mut PackageManager, folder_path: &ZStr) -> bool
     len += b"package.json".len();
     buf[len] = 0;
     let path = ZStr::from_buf(&buf, len);
-    sys::exists_at(get_cache_directory(this), path)
+    sys::exists_at(cache_dir, path)
 }
 
 // ─────────────────────────── global directories ───────────────────────────────

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -755,13 +755,8 @@ pub fn is_folder_in_cache(
     if resolution_tag != ResolutionTag::Npm {
         return sys::directory_exists_at(cache_dir, folder_path).unwrap_or(false);
     }
-    // An npm cache entry is only usable if it still has a package.json. An entry with
-    // the directory present but package.json missing (interrupted extract, external
-    // cleanup, etc.) would otherwise be copied into node_modules as-is and break
-    // lifecycle-script discovery. Re-extracting over such an entry is safe: extraction
-    // renames a temp dir into place, replacing the stale directory. This matches the
-    // per-tag check in `PackageInstall::package_missing_from_cache`.
-    // https://github.com/oven-sh/bun/issues/10423
+    // Match `PackageInstall::package_missing_from_cache`: an npm cache entry without
+    // package.json is incomplete and must be re-extracted (#10423).
     let folder = bun_core::strings::without_trailing_slash(folder_path.as_bytes());
     if folder.is_empty() {
         return false;

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -752,25 +752,21 @@ pub fn is_folder_in_cache(
     resolution_tag: ResolutionTag,
 ) -> bool {
     let cache_dir = get_cache_directory(this);
-    if resolution_tag != ResolutionTag::Npm {
-        return sys::directory_exists_at(cache_dir, folder_path).unwrap_or(false);
+    match resolution_tag {
+        // npm and tarball extractions always write a package.json; an entry
+        // without one is incomplete and must be re-extracted (#10423).
+        ResolutionTag::Npm | ResolutionTag::LocalTarball | ResolutionTag::RemoteTarball => {
+            let mut buf = PathBuffer::uninit();
+            let path = path::resolve_path::join_z_buf::<path::platform::Auto>(
+                &mut buf.0,
+                &[folder_path.as_bytes(), b"package.json"],
+            );
+            sys::exists_at(cache_dir, path)
+        }
+        // Git/GitHub deps are allowed to have no package.json (see repository.rs
+        // and extract_tarball.rs); their completeness marker is `.bun-tag`.
+        _ => sys::directory_exists_at(cache_dir, folder_path).unwrap_or(false),
     }
-    // Match `PackageInstall::package_missing_from_cache`: an npm cache entry without
-    // package.json is incomplete and must be re-extracted (#10423).
-    let folder = bun_core::strings::without_trailing_slash(folder_path.as_bytes());
-    if folder.is_empty() {
-        return false;
-    }
-    let mut buf = PathBuffer::uninit();
-    let mut len = folder.len();
-    buf[..len].copy_from_slice(folder);
-    buf[len] = SEP;
-    len += 1;
-    buf[len..len + b"package.json".len()].copy_from_slice(b"package.json");
-    len += b"package.json".len();
-    buf[len] = 0;
-    let path = ZStr::from_buf(&buf, len);
-    sys::exists_at(cache_dir, path)
 }
 
 // ─────────────────────────── global directories ───────────────────────────────

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -747,7 +747,26 @@ pub fn cached_tarball_folder_name(
 }
 
 pub fn is_folder_in_cache(this: &mut PackageManager, folder_path: &ZStr) -> bool {
-    sys::directory_exists_at(get_cache_directory(this), folder_path).unwrap_or(false)
+    // A cache entry is only usable if it still has a package.json. An entry with the
+    // directory present but package.json missing (interrupted extract, external cleanup,
+    // etc.) would otherwise be copied into node_modules as-is and break lifecycle-script
+    // discovery. Re-extracting over such an entry is safe: extraction renames a temp dir
+    // into place, replacing the stale directory.
+    // https://github.com/oven-sh/bun/issues/10423
+    let folder = bun_core::strings::without_trailing_slash(folder_path.as_bytes());
+    if folder.is_empty() {
+        return false;
+    }
+    let mut buf = PathBuffer::uninit();
+    let mut len = folder.len();
+    buf[..len].copy_from_slice(folder);
+    buf[len] = SEP;
+    len += 1;
+    buf[len..len + b"package.json".len()].copy_from_slice(b"package.json");
+    len += b"package.json".len();
+    buf[len] = 0;
+    let path = ZStr::from_buf(&buf, len);
+    sys::exists_at(get_cache_directory(this), path)
 }
 
 // ─────────────────────────── global directories ───────────────────────────────

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -200,7 +200,8 @@ impl PackageManager {
                         });
                     // Owned NUL-terminated copy.
                     let non_patched_path = ZBox::from_bytes(&folder_path.as_bytes()[..idx]);
-                    if directories::is_folder_in_cache(self, &non_patched_path, pkg.resolution.tag) {
+                    if directories::is_folder_in_cache(self, &non_patched_path, pkg.resolution.tag)
+                    {
                         self.set_preinstall_state(pkg.meta.id, PreinstallState::ApplyPatch);
                         // yay step 1 is already done for us
                         return PreinstallState::ApplyPatch;

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -177,7 +177,7 @@ impl PackageManager {
                     return PreinstallState::Extract;
                 }
 
-                if directories::is_folder_in_cache(self, folder_path) {
+                if directories::is_folder_in_cache(self, folder_path, pkg.resolution.tag) {
                     self.set_preinstall_state(pkg.meta.id, PreinstallState::Done);
                     return PreinstallState::Done;
                 }
@@ -200,7 +200,7 @@ impl PackageManager {
                         });
                     // Owned NUL-terminated copy.
                     let non_patched_path = ZBox::from_bytes(&folder_path.as_bytes()[..idx]);
-                    if directories::is_folder_in_cache(self, &non_patched_path) {
+                    if directories::is_folder_in_cache(self, &non_patched_path, pkg.resolution.tag) {
                         self.set_preinstall_state(pkg.meta.id, PreinstallState::ApplyPatch);
                         // yay step 1 is already done for us
                         return PreinstallState::ApplyPatch;

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2338,7 +2338,9 @@ pub(crate) fn install_isolated_packages(
                         _ => 'missing_from_cache: {
                             if matches!(patch_info, installer::PatchInfo::None) {
                                 let exists = match pkg_res_tag {
-                                    ResolutionTag::Npm => {
+                                    ResolutionTag::Npm
+                                    | ResolutionTag::LocalTarball
+                                    | ResolutionTag::RemoteTarball => {
                                         // Reshaped for borrowck — capture length
                                         // instead of `save()` so the path stays unborrowed.
                                         let cache_dir_path_save = pkg_cache_dir_subpath.len();

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1400,10 +1400,7 @@ it("github dep without package.json resolves from cache on the second install", 
       },
     }),
   );
-  await Bun.write(
-    join(package_dir, "bunfig.toml"),
-    `[install]\ncache = "${cacheDir.replaceAll("\\", "\\\\")}"\n`,
-  );
+  await Bun.write(join(package_dir, "bunfig.toml"), `[install]\ncache = "${cacheDir.replaceAll("\\", "\\\\")}"\n`);
 
   {
     const { stderr, exited } = spawn({

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1384,6 +1384,67 @@ it("git dep without package.json and with default branch", async () => {
   });
 });
 
+it("github dep without package.json resolves from cache on the second install", async () => {
+  // `is_folder_in_cache` must not require package.json for GitHub deps: they are
+  // allowed to have none (their completeness marker is `.bun-tag`), so a second
+  // install with a warm cache should reuse the existing entry instead of
+  // re-downloading.
+  const cacheDir = join(package_dir, ".bun-cache");
+  const envWithCache = { ...env, BUN_INSTALL_CACHE_DIR: cacheDir };
+  await Bun.write(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      dependencies: {
+        "install-test-3": "dylan-conway/install-test-3#v1.0.0",
+      },
+    }),
+  );
+  await Bun.write(
+    join(package_dir, "bunfig.toml"),
+    `[install]\ncache = "${cacheDir.replaceAll("\\", "\\\\")}"\n`,
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env: envWithCache,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  let cacheEntry: string | undefined;
+  for (const entry of await readdirSorted(cacheDir)) {
+    if (entry.startsWith("@GH@")) cacheEntry = entry;
+  }
+  expect(cacheEntry).toBeDefined();
+  expect(await file(join(cacheDir, cacheEntry!, "package.json")).exists()).toBeFalse();
+  await Bun.write(join(cacheDir, cacheEntry!, "FROM_CACHE"), "");
+
+  await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env: envWithCache,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  expect(await file(join(package_dir, "node_modules", "install-test-3", "FROM_CACHE")).exists()).toBeTrue();
+  expect(await file(join(cacheDir, cacheEntry!, "FROM_CACHE")).exists()).toBeTrue();
+});
+
 it("should let you add the same package twice", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {} }));

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -1836,34 +1836,42 @@ cache = "${cacheDir.replaceAll("\\", "\\\\")}"
 // https://github.com/oven-sh/bun/issues/10423
 test("cache entry missing package.json is re-downloaded instead of reused", async () => {
   const cacheDir = join(packageDir, ".bun-cache");
-  await write(
-    packageJson,
-    JSON.stringify({
-      name: "foo",
-      version: "1.0.0",
-      dependencies: {
-        "no-deps": "1.0.0",
-        "uses-what-bin": "1.0.0",
-      },
-      trustedDependencies: ["uses-what-bin"],
-    }),
-  );
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        version: "1.0.0",
+        dependencies: {
+          "no-deps": "1.0.0",
+          "uses-what-bin": "1.0.0",
+          "baz": "file:baz-0.0.3.tgz",
+        },
+        trustedDependencies: ["uses-what-bin"],
+      }),
+    ),
+    cp(join(import.meta.dir, "baz-0.0.3.tgz"), join(packageDir, "baz-0.0.3.tgz")),
+  ]);
 
   await runBunInstall(env, packageDir);
   expect(await exists(join(packageDir, "node_modules", "no-deps", "package.json"))).toBeTrue();
   expect(await exists(join(packageDir, "node_modules", "uses-what-bin", "what-bin.txt"))).toBeTrue();
+  expect(await exists(join(packageDir, "node_modules", "baz", "package.json"))).toBeTrue();
 
   // Corrupt the cache: delete package.json from every cached package directory.
   // A partially-written or externally-damaged cache entry looks like this.
-  let deleted = 0;
+  let deletedNpm = 0;
+  let deletedTarball = 0;
   for (const entry of await readdirSorted(cacheDir)) {
     const pkgJson = join(cacheDir, entry, "package.json");
     if (await exists(pkgJson)) {
       await rm(pkgJson);
-      deleted++;
+      if (entry.startsWith("@T@")) deletedTarball++;
+      else deletedNpm++;
     }
   }
-  expect(deleted).toBeGreaterThan(0);
+  expect(deletedNpm).toBeGreaterThan(0);
+  expect(deletedTarball).toBeGreaterThan(0);
 
   await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
   await rm(join(packageDir, "bun.lock"), { force: true });
@@ -1891,18 +1899,27 @@ test("cache entry missing package.json is re-downloaded instead of reused", asyn
     name: "uses-what-bin",
     version: "1.0.0",
   });
+  expect(await file(join(packageDir, "node_modules", "baz", "package.json")).json()).toMatchObject({
+    name: "baz",
+    version: "0.0.3",
+  });
   expect(await exists(join(packageDir, "node_modules", "uses-what-bin", "what-bin.txt"))).toBeTrue();
   expect(exitCode).toBe(0);
 
   // The cache entry itself should have been repopulated.
-  let repopulated = 0;
+  let repopulatedNpm = 0;
+  let repopulatedTarball = 0;
   for (const entry of await readdirSorted(cacheDir)) {
     if (entry.startsWith("no-deps@") || entry.startsWith("uses-what-bin@")) {
       expect(await exists(join(cacheDir, entry, "package.json"))).toBeTrue();
-      repopulated++;
+      repopulatedNpm++;
+    } else if (entry.startsWith("@T@")) {
+      expect(await exists(join(cacheDir, entry, "package.json"))).toBeTrue();
+      repopulatedTarball++;
     }
   }
-  expect(repopulated).toBeGreaterThanOrEqual(2);
+  expect(repopulatedNpm).toBeGreaterThanOrEqual(2);
+  expect(repopulatedTarball).toBeGreaterThanOrEqual(1);
 });
 
 test("dependency from root satisfies range from dependency", async () => {

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -1895,11 +1895,14 @@ test("cache entry missing package.json is re-downloaded instead of reused", asyn
   expect(exitCode).toBe(0);
 
   // The cache entry itself should have been repopulated.
+  let repopulated = 0;
   for (const entry of await readdirSorted(cacheDir)) {
     if (entry.startsWith("no-deps@") || entry.startsWith("uses-what-bin@")) {
       expect(await exists(join(cacheDir, entry, "package.json"))).toBeTrue();
+      repopulated++;
     }
   }
+  expect(repopulated).toBeGreaterThanOrEqual(2);
 });
 
 test("dependency from root satisfies range from dependency", async () => {

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -1833,6 +1833,75 @@ cache = "${cacheDir.replaceAll("\\", "\\\\")}"
   }
 });
 
+// https://github.com/oven-sh/bun/issues/10423
+test("cache entry missing package.json is re-downloaded instead of reused", async () => {
+  const cacheDir = join(packageDir, ".bun-cache");
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "foo",
+      version: "1.0.0",
+      dependencies: {
+        "no-deps": "1.0.0",
+        "uses-what-bin": "1.0.0",
+      },
+      trustedDependencies: ["uses-what-bin"],
+    }),
+  );
+
+  await runBunInstall(env, packageDir);
+  expect(await exists(join(packageDir, "node_modules", "no-deps", "package.json"))).toBeTrue();
+  expect(await exists(join(packageDir, "node_modules", "uses-what-bin", "what-bin.txt"))).toBeTrue();
+
+  // Corrupt the cache: delete package.json from every cached package directory.
+  // A partially-written or externally-damaged cache entry looks like this.
+  let deleted = 0;
+  for (const entry of await readdirSorted(cacheDir)) {
+    const pkgJson = join(cacheDir, entry, "package.json");
+    if (await exists(pkgJson)) {
+      await rm(pkgJson);
+      deleted++;
+    }
+  }
+  expect(deleted).toBeGreaterThan(0);
+
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  await rm(join(packageDir, "bun.lock"), { force: true });
+  await rm(join(packageDir, "bun.lockb"), { force: true });
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    env,
+  });
+  const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+
+  expect(err).not.toContain("ENOENT");
+  expect(err).not.toContain("error:");
+  expect(out).toContain("packages installed");
+
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+    version: "1.0.0",
+  });
+  expect(await file(join(packageDir, "node_modules", "uses-what-bin", "package.json")).json()).toMatchObject({
+    name: "uses-what-bin",
+    version: "1.0.0",
+  });
+  expect(await exists(join(packageDir, "node_modules", "uses-what-bin", "what-bin.txt"))).toBeTrue();
+  expect(exitCode).toBe(0);
+
+  // The cache entry itself should have been repopulated.
+  for (const entry of await readdirSorted(cacheDir)) {
+    if (entry.startsWith("no-deps@") || entry.startsWith("uses-what-bin@")) {
+      expect(await exists(join(cacheDir, entry, "package.json"))).toBeTrue();
+    }
+  }
+});
+
 test("dependency from root satisfies range from dependency", async () => {
   await writeFile(
     packageJson,


### PR DESCRIPTION
## What

A `~/.bun/install/cache/<pkg>@<ver>...` directory that exists but has no `package.json` (interrupted extract, external cleanup, partial rsync, etc.) was reused as-is: it was copied into `node_modules` without `package.json`, and for packages with lifecycle scripts `bun install` printed

```
error: failed to fill lifecycle scripts for protobufjs: ENOENT
```

and still exited 0. The workaround was `bun pm cache rm`.

Fixes #10423

## Cause

`determine_preinstall_state` decides whether a resolved package already lives in the cache via `is_folder_in_cache`, which only called `sys::directory_exists_at`. An entry with the directory present but `package.json` missing was marked `PreinstallState::Done`, which short-circuits the more careful `package.json` check in `package_missing_from_cache` (and its isolated-linker equivalent), so no download was enqueued.

## Fix

`is_folder_in_cache` now probes `<folder>/package.json` instead of the bare directory. An incomplete entry falls through to `Extract` and is re-downloaded; the extraction path renames a temp dir into place via `renameat_concurrently`, which swaps out the stale directory.

`get_installed_package_scripts_count` now also increments `summary.fail` when `fill_from_package_json` fails, so any remaining path that hits this prints an error *and* exits non-zero (matching the existing `failed to enqueue` handling).

## Verification

New test in `test/cli/install/bun-install-registry.test.ts`: install `no-deps` + `uses-what-bin` (trusted), delete `package.json` from every cache entry, remove `node_modules` + lockfile, reinstall. Asserts no `ENOENT`/`error:` on stderr, both packages' `package.json` present in `node_modules`, the install script ran, exit 0, and the cache entries themselves were repopulated.

```
# without src/ changes (fail-before)
(fail) cache entry missing package.json is re-downloaded instead of reused
  Expected to not contain: "ENOENT"
  Received: "error: failed to enqueue lifecycle scripts for uses-what-bin: ENOENT"

# with src/ changes
(pass) cache entry missing package.json is re-downloaded instead of reused
```

`bun run rust:check-all` clean on all 10 targets. `isolated-install.test.ts` 56/56, `bun-add.test.ts` 54/54, `bun-install-lifecycle-scripts.test.ts` 113 pass (5 pre-existing container PATH failures, identical to main).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-add.test.ts test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->