### PR TITLE
install: honor --env-file / --no-env-file and NODE_ENV for .env loading

### DIFF
--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -64,12 +64,14 @@ process.env.FOO = "hello";
 
 ## Manually specifying `.env` files
 
-The `--env-file` flag overrides which `.env` files Bun loads. It works both when running a file with `bun` and when running `package.json` scripts.
+The `--env-file` flag overrides which `.env` files Bun loads. It works when running a file with `bun`, when running `package.json` scripts, and with `bun install` and the other package manager commands (where the loaded values are used for `$VARIABLE` substitution in `bunfig.toml` and are passed to lifecycle scripts).
 
 ```sh
 bun --env-file=.env.1 src/index.ts
 
 bun --env-file=.env.abc --env-file=.env.def run build
+
+bun install --env-file=.env.ci
 ```
 
 ## Disabling automatic `.env` loading
@@ -78,6 +80,8 @@ Use `--no-env-file` to disable Bun's automatic `.env` file loading, for example 
 
 ```sh
 bun run --no-env-file index.ts
+
+bun install --no-env-file
 ```
 
 You can also disable it in `bunfig.toml`:

--- a/docs/snippets/cli/add.mdx
+++ b/docs/snippets/cli/add.mdx
@@ -159,6 +159,14 @@ bun add <package> <@version>
   Set a specific current working directory
 </ParamField>
 
+<ParamField path="--env-file" type="string">
+  Load environment variables from the specified file(s)
+</ParamField>
+
+<ParamField path="--no-env-file" type="boolean">
+  Disable automatic loading of .env files
+</ParamField>
+
 ### Help
 
 <ParamField path="--help" type="boolean">

--- a/docs/snippets/cli/install.mdx
+++ b/docs/snippets/cli/install.mdx
@@ -14,6 +14,14 @@ bun install <name>@<version>
   Set a specific cwd
 </ParamField>
 
+<ParamField path="--env-file" type="string">
+  Load environment variables from the specified file(s)
+</ParamField>
+
+<ParamField path="--no-env-file" type="boolean">
+  Disable automatic loading of .env files
+</ParamField>
+
 ### Dependency Scope & Management
 
 <ParamField path="--production" type="boolean">

--- a/docs/snippets/cli/link.mdx
+++ b/docs/snippets/cli/link.mdx
@@ -156,6 +156,14 @@ bun link <packages>
   Set a specific current working directory
 </ParamField>
 
+<ParamField path="--env-file" type="string">
+  Load environment variables from the specified file(s)
+</ParamField>
+
+<ParamField path="--no-env-file" type="boolean">
+  Disable automatic loading of .env files
+</ParamField>
+
 ### Help
 
 <ParamField path="--help" type="boolean">

--- a/docs/snippets/cli/outdated.mdx
+++ b/docs/snippets/cli/outdated.mdx
@@ -14,6 +14,14 @@ bun outdated <filter>
   Set a specific cwd
 </ParamField>
 
+<ParamField path="--env-file" type="string">
+  Load environment variables from the specified file(s)
+</ParamField>
+
+<ParamField path="--no-env-file" type="boolean">
+  Disable automatic loading of .env files
+</ParamField>
+
 <ParamField path="-h, --help" type="boolean">
   Print this help menu
 </ParamField>

--- a/docs/snippets/cli/patch.mdx
+++ b/docs/snippets/cli/patch.mdx
@@ -164,6 +164,14 @@ bun patch <package>@<version>
   Set a specific current working directory
 </ParamField>
 
+<ParamField path="--env-file" type="string">
+  Load environment variables from the specified file(s)
+</ParamField>
+
+<ParamField path="--no-env-file" type="boolean">
+  Disable automatic loading of .env files
+</ParamField>
+
 ### Help
 
 <ParamField path="--help" type="boolean">

--- a/docs/snippets/cli/remove.mdx
+++ b/docs/snippets/cli/remove.mdx
@@ -134,6 +134,14 @@ bun remove <package>
   Set a specific cwd
 </ParamField>
 
+<ParamField path="--env-file" type="string">
+  Load environment variables from the specified file(s)
+</ParamField>
+
+<ParamField path="--no-env-file" type="boolean">
+  Disable automatic loading of .env files
+</ParamField>
+
 ### Advanced & Performance
 
 <ParamField path="--backend" type="string" default="clonefile">

--- a/docs/snippets/cli/update.mdx
+++ b/docs/snippets/cli/update.mdx
@@ -139,6 +139,14 @@ bun update <name>@<version>
   Set a specific cwd
 </ParamField>
 
+<ParamField path="--env-file" type="string">
+  Load environment variables from the specified file(s)
+</ParamField>
+
+<ParamField path="--no-env-file" type="boolean">
+  Disable automatic loading of .env files
+</ParamField>
+
 <ParamField path="--help" type="boolean">
   Print this help menu. Alias: <code>-h</code>
 </ParamField>

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -211,9 +211,6 @@ impl Loader {
         self.get_node_env() == Some(b"test")
     }
 
-    /// `.env.*` suffix derived from the process environment (`BUN_ENV` /
-    /// `NODE_ENV`). Matches `bun run`'s selection: `production` / `test`
-    /// pick their namesake, anything else (including unset) is Development.
     pub fn default_suffix(&self) -> DotEnvFileSuffix {
         if self.is_test() {
             DotEnvFileSuffix::Test

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -211,6 +211,19 @@ impl Loader {
         self.get_node_env() == Some(b"test")
     }
 
+    /// `.env.*` suffix derived from the process environment (`BUN_ENV` /
+    /// `NODE_ENV`). Matches `bun run`'s selection: `production` / `test`
+    /// pick their namesake, anything else (including unset) is Development.
+    pub fn default_suffix(&self) -> DotEnvFileSuffix {
+        if self.is_test() {
+            DotEnvFileSuffix::Test
+        } else if self.is_production() {
+            DotEnvFileSuffix::Production
+        } else {
+            DotEnvFileSuffix::Development
+        }
+    }
+
     pub fn get_node_path<'b>(
         &mut self,
         fs: &bun_paths::fs::FileSystem,

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1847,6 +1847,8 @@ pub fn init(
     };
 
     env.load_process()?;
+    let env_suffix = env.default_suffix();
+    let skip_default_env = cli.no_env_file || ctx.args.disable_default_env_files;
     // Copy the listing's basenames out under `entries_mutex`; `.data` must
     // only be probed while the lock is held.
     let env_probe_keys = {
@@ -1859,12 +1861,7 @@ pub fn init(
                 .collect(),
         )
     };
-    env.load(
-        &env_probe_keys,
-        &[],
-        dot_env::DotEnvFileSuffix::Production,
-        false,
-    )?;
+    env.load(&env_probe_keys, cli.env_files, env_suffix, skip_default_env)?;
 
     initialize_store();
 

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -93,6 +93,10 @@ const SHARED_PARAMS: &[ParamType] = &[
     ),
     clap::param!("-g, --global                          Install globally"),
     clap::param!("--cwd <STR>                           Set a specific cwd"),
+    clap::param!(
+        "--env-file <STR>...                   Load environment variables from the specified file(s)"
+    ),
+    clap::param!("--no-env-file                         Disable automatic loading of .env files"),
     BACKEND_PARAM,
     clap::param!(
         "--registry <STR>                      Use a specific registry by default, overriding .npmrc, bunfig.toml and environment variables"
@@ -436,6 +440,9 @@ pub struct CommandLineArguments {
     // CPU and OS overrides for optional dependencies
     pub(crate) cpu: Npm::Architecture,
     pub(crate) os: Npm::OperatingSystem,
+
+    pub(crate) env_files: &'static [&'static [u8]],
+    pub(crate) no_env_file: bool,
 }
 
 impl Default for CommandLineArguments {
@@ -515,6 +522,9 @@ impl Default for CommandLineArguments {
 
             cpu: Npm::Architecture::CURRENT,
             os: Npm::OperatingSystem::CURRENT,
+
+            env_files: &[],
+            no_env_file: false,
         }
     }
 }
@@ -1024,6 +1034,8 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/why<r>.
         cli.no_summary = args.flag(b"--no-summary");
         cli.ca = args.options(b"--ca");
         cli.lockfile_only = args.flag(b"--lockfile-only");
+        cli.env_files = args.options(b"--env-file");
+        cli.no_env_file = args.flag(b"--no-env-file");
 
         if let Some(linker) = args.option(b"--linker") {
             cli.node_linker = Some(match Options::NodeLinker::from_str(linker) {

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -569,23 +569,28 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             // raw pointers are already nullable, and `Option<*const T>` is a 2-word
             // (tag, ptr) pair, not niche-optimized. Casting a `[Option<*const c_char>; N]`
             // to `Argv` would interleave discriminant words and EFAULT in the kernel.
-            let mut argv: [*const c_char; 4] = if (*this).shell_bin.is_some() && !cfg!(windows) {
+            let mut argv: [*const c_char; 5] = if (*this).shell_bin.is_some() && !cfg!(windows) {
                 [
                     (*this).shell_bin.unwrap().as_ptr().cast::<c_char>(),
                     c"-c".as_ptr(),
                     combined_script.as_ptr().cast::<c_char>(),
                     core::ptr::null(),
+                    core::ptr::null(),
                 ]
             } else {
+                // `envp` already carries whatever `.env*` files `bun install`
+                // loaded; without `--no-env-file` the `bun exec` intermediary
+                // would load the script cwd's default `.env*` files on top.
                 [
                     bun_core::self_exe_path()?.as_ptr().cast::<c_char>(),
                     c"exec".as_ptr(),
+                    c"--no-env-file".as_ptr(),
                     combined_script.as_ptr().cast::<c_char>(),
                     core::ptr::null(),
                 ]
             };
             const _: () = assert!(
-                core::mem::size_of::<[*const c_char; 4]>() == 4 * core::mem::size_of::<usize>()
+                core::mem::size_of::<[*const c_char; 5]>() == 5 * core::mem::size_of::<usize>()
             );
 
             // OWNERSHIP:
@@ -666,7 +671,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                 .insert(this.cast::<LifecycleScriptSubprocess<'static>>());
             let spawned = match bun_spawn::spawn_process(
                 &spawn_options,
-                // argv is `[*const c_char; 4]` with trailing null — exactly the
+                // argv is `[*const c_char; 5]` with trailing null — exactly the
                 // `[*:null]?[*:0]const u8` layout `spawn_process` expects (1 word/elt).
                 argv.as_mut_ptr().cast(),
                 (*this).envp.as_ptr().cast::<*const c_char>(),

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -578,12 +578,10 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                     core::ptr::null(),
                 ]
             } else {
-                // `envp` already carries whatever `.env*` files `bun install`
-                // loaded; without `--no-env-file` the `bun exec` intermediary
-                // would load the script cwd's default `.env*` files on top.
                 [
                     bun_core::self_exe_path()?.as_ptr().cast::<c_char>(),
                     c"exec".as_ptr(),
+                    // envp already holds the .env* values bun install loaded.
                     c"--no-env-file".as_ptr(),
                     combined_script.as_ptr().cast::<c_char>(),
                     core::ptr::null(),

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1775,12 +1775,8 @@ impl<'a> Printer<'a> {
         env_loader.quiet = true;
 
         env_loader.load_process()?;
-        env_loader.load(
-            &entries,
-            &[] as &[&[u8]],
-            DotEnv::DotEnvFileSuffix::Production,
-            false,
-        )?;
+        let env_suffix = env_loader.default_suffix();
+        env_loader.load(&entries, &[] as &[&[u8]], env_suffix, false)?;
         let mut log = bun_ast::Log::init();
         options.load(
             &mut log,

--- a/test/cli/install/bun-install-env-file.test.ts
+++ b/test/cli/install/bun-install-env-file.test.ts
@@ -47,6 +47,7 @@ async function runInstall(
       ...bunEnv,
       NODE_ENV: undefined,
       BUN_ENV: undefined,
+      NPM_TOKEN: undefined,
       ...extraEnv,
     },
     stdout: "pipe",
@@ -93,9 +94,12 @@ describe("bun install .env loading (#12011)", () => {
     expect(auth[0]).toBe("Bearer DEV");
   });
 
-  test.concurrent("--no-env-file suppresses auto-loading; only process env is used", async () => {
-    const { auth, stderr } = await runInstall(["--no-env-file"], { NPM_TOKEN: "FROM_PROCESS" });
-    expect(auth[0]).toBe("Bearer FROM_PROCESS");
+  test.concurrent("--no-env-file suppresses auto-loading", async () => {
+    const { auth, stderr } = await runInstall(["--no-env-file"]);
+    // No .env* loaded and no NPM_TOKEN in process env, so bunfig's $NPM_TOKEN
+    // stays literal. If suppression regresses, .env.development leaks and this
+    // becomes "Bearer DEV".
+    expect(auth[0]).toBe("Bearer $NPM_TOKEN");
     expect(stderr).not.toContain(".env");
   });
 
@@ -119,28 +123,30 @@ registry = { url = "http://localhost:${server.port}/", token = "$NPM_TOKEN" }
     await using proc = Bun.spawn({
       cmd: [bunExe(), "install"],
       cwd: String(dir),
-      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined, NPM_TOKEN: "FROM_PROCESS" },
+      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined, NPM_TOKEN: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });
     const [, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(received[0]).toBe("Bearer FROM_PROCESS");
+    expect(received[0]).toBe("Bearer $NPM_TOKEN");
     expect(stderr).not.toContain(".env");
   });
 
   test.concurrent("--env-file value is consumed, not treated as a package to add", async () => {
     using dir = tempDir("install-env-missing", {
       "package.json": JSON.stringify({ name: "x", version: "1.0.0" }),
+      "bunfig.toml": `[install]\nregistry = "http://localhost:1/"\n`,
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "install", "--env-file", "does-not-exist.env"],
       cwd: String(dir),
-      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined },
+      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined, NPM_TOKEN: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("unrecognised dependency format");
     expect(stdout).not.toMatch(/add v\d/);
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/install/bun-install-env-file.test.ts
+++ b/test/cli/install/bun-install-env-file.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/12011
+// `bun install` hardcoded the dotenv suffix to Production and never looked at
+// --env-file / --no-env-file / NODE_ENV, so bunfig `$VAR` substitution always
+// used .env.production (or .env) regardless of what the user asked for.
+
+function projectFiles(port: number) {
+  return {
+    "package.json": JSON.stringify({
+      name: "env-file-install",
+      version: "1.0.0",
+      dependencies: { "no-deps": "1.0.0" },
+    }),
+    "bunfig.toml": `[install]
+cache = false
+registry = { url = "http://localhost:${port}/", token = "$NPM_TOKEN" }
+`,
+    ".env": "NPM_TOKEN=BASE\n",
+    ".env.development": "NPM_TOKEN=DEV\n",
+    ".env.production": "NPM_TOKEN=PROD\n",
+    ".env.test": "NPM_TOKEN=TESTSUFFIX\n",
+    ".env.custom": "NPM_TOKEN=CUSTOM\n",
+  };
+}
+
+async function runInstall(
+  extraArgs: string[],
+  extraEnv: Record<string, string> = {},
+): Promise<{ auth: string[]; stderr: string }> {
+  const received: string[] = [];
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      received.push(req.headers.get("authorization") ?? "<none>");
+      return new Response("{}", { status: 404 });
+    },
+  });
+
+  using dir = tempDir("install-env-file", projectFiles(server.port));
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", ...extraArgs],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      NODE_ENV: undefined,
+      BUN_ENV: undefined,
+      ...extraEnv,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { auth: received, stderr };
+}
+
+describe("bun install .env loading (#12011)", () => {
+  test.concurrent("--env-file loads the requested file for bunfig $VAR substitution", async () => {
+    const { auth, stderr } = await runInstall(["--env-file", ".env.custom"]);
+    expect(auth.length).toBeGreaterThan(0);
+    expect(auth[0]).toBe("Bearer CUSTOM");
+    expect(stderr).toContain(".env.custom");
+    expect(stderr).not.toContain(".env.production");
+  });
+
+  test.concurrent("--env-file=PATH form works", async () => {
+    const { auth } = await runInstall(["--env-file=.env.custom"]);
+    expect(auth[0]).toBe("Bearer CUSTOM");
+  });
+
+  test.concurrent("NODE_ENV=development selects .env.development", async () => {
+    const { auth, stderr } = await runInstall([], { NODE_ENV: "development" });
+    expect(auth.length).toBeGreaterThan(0);
+    expect(auth[0]).toBe("Bearer DEV");
+    expect(stderr).toContain(".env.development");
+  });
+
+  test.concurrent("NODE_ENV=production selects .env.production", async () => {
+    const { auth } = await runInstall([], { NODE_ENV: "production" });
+    expect(auth[0]).toBe("Bearer PROD");
+  });
+
+  test.concurrent("NODE_ENV=test selects .env.test", async () => {
+    const { auth } = await runInstall([], { NODE_ENV: "test" });
+    expect(auth[0]).toBe("Bearer TESTSUFFIX");
+  });
+
+  test.concurrent("default (no NODE_ENV) matches `bun run` and selects .env.development", async () => {
+    const { auth } = await runInstall([]);
+    expect(auth[0]).toBe("Bearer DEV");
+  });
+
+  test.concurrent("--no-env-file suppresses auto-loading; only process env is used", async () => {
+    const { auth, stderr } = await runInstall(["--no-env-file"], { NPM_TOKEN: "FROM_PROCESS" });
+    expect(auth[0]).toBe("Bearer FROM_PROCESS");
+    expect(stderr).not.toContain(".env");
+  });
+
+  test.concurrent("bunfig `env = false` suppresses auto-loading", async () => {
+    const received: string[] = [];
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        received.push(req.headers.get("authorization") ?? "<none>");
+        return new Response("{}", { status: 404 });
+      },
+    });
+    using dir = tempDir("install-bunfig-env-false", {
+      ...projectFiles(server.port),
+      "bunfig.toml": `env = false
+[install]
+cache = false
+registry = { url = "http://localhost:${server.port}/", token = "$NPM_TOKEN" }
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined, NPM_TOKEN: "FROM_PROCESS" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(received[0]).toBe("Bearer FROM_PROCESS");
+    expect(stderr).not.toContain(".env");
+  });
+
+  test.concurrent("--env-file value is consumed, not treated as a package to add", async () => {
+    using dir = tempDir("install-env-missing", {
+      "package.json": JSON.stringify({ name: "x", version: "1.0.0" }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--env-file", "does-not-exist.env"],
+      cwd: String(dir),
+      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("unrecognised dependency format");
+    expect(stdout).not.toMatch(/add v\d/);
+  });
+});

--- a/test/cli/install/bun-install-env-file.test.ts
+++ b/test/cli/install/bun-install-env-file.test.ts
@@ -132,6 +132,27 @@ registry = { url = "http://localhost:${server.port}/", token = "$NPM_TOKEN" }
     expect(stderr).not.toContain(".env");
   });
 
+  test.concurrent("`bun --env-file=PATH install` (flag before the subcommand) works", async () => {
+    const received: string[] = [];
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        received.push(req.headers.get("authorization") ?? "<none>");
+        return new Response("{}", { status: 404 });
+      },
+    });
+    using dir = tempDir("install-env-file-global-flag", projectFiles(server.port));
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--env-file=.env.custom", "install"],
+      cwd: String(dir),
+      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined, NPM_TOKEN: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(received[0]).toBe("Bearer CUSTOM");
+  });
+
   test.concurrent("--env-file value is consumed, not treated as a package to add", async () => {
     using dir = tempDir("install-env-missing", {
       "package.json": JSON.stringify({ name: "x", version: "1.0.0" }),
@@ -147,6 +168,63 @@ registry = { url = "http://localhost:${server.port}/", token = "$NPM_TOKEN" }
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("unrecognised dependency format");
     expect(stdout).not.toMatch(/add v\d/);
+    expect(exitCode).toBe(0);
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/31450
+// Lifecycle scripts inherit whatever `bun install` loaded from `.env*`, so the
+// flags also decide what package scripts get to see.
+async function probeLifecycleEnv(extraArgs: string[]): Promise<{ seen: string; stderr: string; exitCode: number }> {
+  using dir = tempDir("install-env-file-lifecycle", {
+    "package.json": JSON.stringify({
+      name: "env-file-lifecycle",
+      version: "1.0.0",
+      scripts: {
+        // --no-env-file on the probe itself so it reports what install passed
+        // down instead of loading the project's .env* files on its own.
+        postinstall: `${bunExe()} --no-env-file -e 'await Bun.write("probe.txt", String(process.env.INSTALL_ENV_PROBE))'`,
+      },
+    }),
+    ".env": "INSTALL_ENV_PROBE=from-dotenv\n",
+    ".env.development": "INSTALL_ENV_PROBE=from-dotenv-development\n",
+    ".env.custom": "INSTALL_ENV_PROBE=from-custom\n",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", ...extraArgs],
+    cwd: String(dir),
+    env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined, INSTALL_ENV_PROBE: undefined },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const seen = await Bun.file(`${dir}/probe.txt`).text();
+  return { seen, stderr, exitCode };
+}
+
+describe("bun install .env loading and lifecycle scripts (#31450)", () => {
+  test.concurrent("by default the postinstall script sees the loaded .env* values", async () => {
+    const { seen, stderr, exitCode } = await probeLifecycleEnv([]);
+    expect(seen).toBe("from-dotenv-development");
+    // The loader's banner quotes each file it loaded; the echoed postinstall
+    // command line also mentions `process.env`, hence matching on the quote.
+    expect(stderr).toContain('".env.development"');
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("--no-env-file keeps .env* values out of the postinstall script", async () => {
+    const { seen, stderr, exitCode } = await probeLifecycleEnv(["--no-env-file"]);
+    expect(seen).toBe("undefined");
+    expect(stderr).not.toContain('".env');
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("--no-env-file together with --env-file still loads the explicit file", async () => {
+    const { seen, stderr, exitCode } = await probeLifecycleEnv(["--no-env-file", "--env-file", ".env.custom"]);
+    expect(seen).toBe("from-custom");
+    expect(stderr).toContain('".env.custom"');
+    expect(stderr).not.toContain('".env.development"');
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes #12011.
Fixes #31450.

### Problem

- `bun install --env-file=.env.development`, `bun --env-file=.env.development install`, `bun install --no-env-file`, `NODE_ENV=development bun install`, and bunfig `env = false` all behave the same as a bare `bun install`: `.env.production` and `.env` are loaded, the requested file is not.
- The values go into bunfig `$VAR` substitution (registry url / token) and into the environment of every lifecycle script the install runs, so `.env.production` secrets reach third-party `postinstall` scripts no matter which knob is used (#31450).
- Cause: `PackageManager::init` (`src/install/PackageManager.rs`) calls `env.load(entries, &[], DotEnvFileSuffix::Production, false)`: empty `--env-file` list, hardcoded `Production` suffix, and `skip_default_env = false`. The install CLI parser never declared `--env-file` / `--no-env-file`, so the flags were dropped. `lockfile::Printer::print_with_lockfile` has the same hardcoded call.
- `bun run` has honored all of these since the flags were added (`Transpiler::run_env_loader` in `src/bundler/transpiler.rs`); install never caught up.

### Fix

- `CommandLineArguments`: declare `--env-file <STR>...` and `--no-env-file` in `SHARED_PARAMS` so every install-family subcommand accepts them, and store them in new `env_files` / `no_env_file` fields.
- `dot_env::Loader::default_suffix()`: `test` -> `Test`, `production` -> `Production`, otherwise `Development`, read from `BUN_ENV` / `NODE_ENV`. This is the rule `bun run` already applies, so install now picks the same `.env.*` file as the runtime does in the same shell.
- `PackageManager::init` passes `cli.env_files`, `env.default_suffix()`, and `cli.no_env_file || ctx.args.disable_default_env_files` to `env.load()`. The `ctx.args` term is what bunfig `env = false` / `env.file = false` sets (`src/bunfig/bunfig.rs`); the bunfig parser already wrote it, install just never read it.
- `lockfile::Printer` uses `default_suffix()` instead of the hardcoded `Production`.
- `lifecycle_script_runner`: when a lifecycle script is run through the `bun exec` intermediary (Windows, or POSIX with no shell found), pass `--no-env-file` to it. The intermediary was loading the script cwd's default `.env*` files on its own, so on Windows `bun install --no-env-file` still leaked `.env.development` into `postinstall`, and a dependency's own `.env` in its package directory was visible to its scripts. The env the install already built is passed via envp, which is exactly what the POSIX `sh -c` path has always done. Found by the Windows lanes on the lifecycle test.
- Docs: `--env-file` / `--no-env-file` added to the install-family CLI snippets and the environment-variables page.
- Intentionally not touched: `bun run --filter` (`src/runtime/cli/filter_run.rs`) and multi-run (`src/runtime/cli/multi_run.rs`) spawn the same `bun exec` intermediary on Windows and so also re-load each workspace's `.env*` there. That is a `bun run` behavior question (per-workspace `.env` loading on Windows that POSIX never did), separate from install, and is tracked separately rather than changed in this PR.
- Behavior change to be aware of: with no `NODE_ENV` set, `bun install` now loads `.env.development` where it used to load `.env.production`. That is the #12011 report, and it matches `bun run`. `-p` / `--production` (skip devDependencies) stays independent of the suffix, as it is for `bun run`.
- Verified with `test/cli/install/bun-install-env-file.test.ts`: a local `Bun.serve` registry records the `Authorization` header to observe which `.env*` file fed bunfig `$NPM_TOKEN` (both flag forms, `bun --env-file=... install`, `NODE_ENV` = development / production / test / unset, `--no-env-file`, bunfig `env = false`, and `--env-file <path>` not being read as a package name), plus a root `postinstall` probe for the #31450 angle (values reach the script by default, do not with `--no-env-file`, and `--no-env-file --env-file X` still loads `X`). Against main's build, every case except `NODE_ENV=production` fails; all 13 pass with this branch on Linux and Windows x64.
- Also ran `test/cli/install/bun-lockb.test.ts`, `npmrc.test.ts`, and the `.env` cases in `bun-pm.test.ts` on this branch: green.

### Background

- `dot_env::Loader::load(dir, env_files, suffix, skip_default_env)` (`src/dotenv/env_loader.rs`): if `env_files` is non-empty only those files are read; otherwise, unless `skip_default_env`, it reads the default set from `dir`: `.env.<suffix>.local`, `.env.local` (skipped for the test suffix), `.env.<suffix>`, `.env`. So `--no-env-file --env-file X` loads exactly `X`, and the suffix decides which of `.env.development` / `.env.production` / `.env.test` is part of the default set.
- `SHARED_PARAMS` (`src/install/PackageManager/CommandLineArguments.rs`) is the flag table every install-family subcommand (install / add / remove / update / pm / link / outdated / pack / publish / audit / info / why / patch) is built from. Install parses the full argv with its own table, which is why `bun --env-file=X install` works once the flag is declared there.
- `ctx.args.disable_default_env_files` is the field the bunfig parser sets for `env = false`; the runtime reads it in `run_env_loader`, and this PR makes install read it too.
- Lifecycle scripts are spawned as `sh -c <script>` when a shell is available; otherwise (always on Windows) as `bun exec <script>`, which runs the script through Bun's own shell. `bun exec` is a regular runtime command, so it runs the normal `.env*` auto-load in its cwd unless told not to; `--no-env-file` is the existing flag for that.

### Related

- Supersedes #31453 by @jakequade-pc, which fixed the `--env-file` / `--no-env-file` / bunfig knobs for #31450 and explicitly left the `NODE_ENV` suffix out of scope. Its lifecycle-script and `--no-env-file --env-file` coverage is folded in here (credited with a `Co-authored-by` trailer); that PR no longer merged cleanly after the env-probe refactor on main.
- Rebased onto current main; the conflicts were the `DirEntryKeys` refactor of both `env.load()` call sites.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-env-file.test.ts
bun test v1.4.0 (216f1da90)

test/cli/install/bun-install-env-file.test.ts:
60 | 
61 | describe("bun install .env loading (#12011)", () => {
62 |   test.concurrent("--env-file loads the requested file for bunfig $VAR substitution", async () => {
63 |     const { auth, stderr } = await runInstall(["--env-file", ".env.custom"]);
64 |     expect(auth.length).toBeGreaterThan(0);
65 |     expect(auth[0]).toBe("Bearer CUSTOM");
                         ^
error: expect(received).toBe(expected)

Expected: "Bearer CUSTOM"
Received: "Bearer PROD"

      at <anonymous> (/workspace/bun/test/cli/install/bun-install-env-file.test.ts:65:21)
67 |     expect(stderr).not.toContain(".env.production");
68 |   });
69 | 
70 |   test.concurrent("--env-file=PATH form works", async () => {
71 |     const { auth } = await runInstall(["--env-file=.env.custom"]);
72 |     expect(auth[0]).toBe("Bearer CUSTOM");
                         ^
error: expect(received).toBe(expected)

Expected: "Bearer CUSTOM"
Received: "Beare
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (983271bc9)

test/cli/install/bun-install-env-file.test.ts:
(pass) bun install .env loading (#12011) > --no-env-file suppresses auto-loading [1216.26ms]
(pass) bun install .env loading (#12011) > --env-file=PATH form works [2512.40ms]
(pass) bun install .env loading (#12011) > NODE_ENV=test selects .env.test [1229.56ms]
(pass) bun install .env loading (#12011) > NODE_ENV=development selects .env.development [2139.86ms]
(pass) bun install .env loading (#12011) > default (no NODE_ENV) matches `bun run` and selects .env.development [1226.51ms]
(pass) bun install .env loading (#12011) > NODE_ENV=production selects .env.production [2077.57ms]
(pass) bun install .env loading (#12011) > --env-file loads the requested file for bunfig $VAR substitution [2530.20ms]
(pass) bun install .env loading (#12011) > --env-file value is consumed, not treated as a package to add [432.25ms]
(pass) bun install .env loading (#12011) > bunfig `env = false` suppresses auto-loading [579.13ms]

 9 pass
 0 fail
 18 expect() calls
Ran 9 tests across 1 file. [2.95s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-env-file.test.ts
bun test v1.4.0 (216f1da90)

test/cli/install/bun-install-env-file.test.ts:
(pass) bun install .env loading (#12011) > --env-file=PATH form works [3107.32ms]
(pass) bun install .env loading (#12011) > --env-file loads the requested file for bunfig $VAR substitution [3231.88ms]
(pass) bun install .env loading (#12011) > NODE_ENV=production selects .env.production [3159.34ms]
(pass) bun install .env loading (#12011) > NODE_ENV=development selects .env.development [3240.11ms]
(pass) bun install .env loading (#12011) > NODE_ENV=test selects .env.test [3025.22ms]
(pass) bun install .env loading (#12011) > default (no NODE_ENV) matches `bun run` and selects .env.development [1250.46ms]
(pass) bun install .env loading (#12011) > --env-file value is consumed, not treated as a package to add [1103.13ms]
(pass) bun install .env loading (#12011) > --no-env-file suppresses auto-loading [1260.45ms]
(pass) bun install .env loading (#12011) > bunfig `env = false` suppresses auto-loading [1202.03ms]

 9 pa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1548ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/51] gen cpp.rs (cppbind)
[2/51] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/51] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
^[[1m^[[9
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/dotenv/env_loader.rs                           |  10 ++
 src/install/PackageManager.rs                      |   8 +-
 src/install/PackageManager/CommandLineArguments.rs |  12 ++
 src/install/lockfile.rs                            |   8 +-
 test/cli/install/bun-install-env-file.test.ts      | 152 +++++++++++++++++++++
 5 files changed, 181 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/dotenv/env_loader.rs                                6      2      0
src/install/PackageManager.rs                           5      4      0
src/install/PackageManager/CommandLineArguments.rs      4      1      0
src/install/lockfile.rs                                 2      3      0
test/cli/install/bun-install-env-file.test.ts           2      7      0
```

</details>

<!-- robobun:evidence:end -->


