### PR TITLE
resolver: ignore tsconfig.json inside node_modules

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6087,10 +6087,20 @@ impl<'a> Resolver<'a> {
         // }
 
         if let Some(parent_) = parent {
+            if parent_.is_node_modules() || parent_.is_inside_node_modules() {
+                info.flags
+                    .set_present(DirInfo::Flag::InsideNodeModules, true);
+            }
+
             // Propagate the browser scope into child directories
             info.enclosing_browser_scope = parent_.enclosing_browser_scope;
             info.package_json_for_browser_field = parent_.package_json_for_browser_field;
-            info.enclosing_tsconfig_json = parent_.enclosing_tsconfig_json;
+            // The enclosing tsconfig is cut off at the node_modules boundary for the
+            // same reason we skip loading tsconfig.json inside node_modules below: a
+            // project's `paths`/`baseUrl` must not rewrite a dependency's own imports.
+            if !info.is_inside_node_modules() {
+                info.enclosing_tsconfig_json = parent_.enclosing_tsconfig_json;
+            }
 
             if let Some(parent_package_json) = parent_.package_json() {
                 // https://github.com/oven-sh/bun/issues/229
@@ -6188,11 +6198,6 @@ impl<'a> Resolver<'a> {
                     }
                 }
             }
-
-            if parent_.is_node_modules() || parent_.is_inside_node_modules() {
-                info.flags
-                    .set_present(DirInfo::Flag::InsideNodeModules, true);
-            }
         }
 
         // Record if this directory has a package.json file
@@ -6263,8 +6268,20 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        // Record if this directory has a tsconfig.json or jsconfig.json file
-        if self.opts.load_tsconfig_json {
+        // Record if this directory has a tsconfig.json or jsconfig.json file.
+        //
+        // Except don't do this if we're inside a "node_modules" directory. Package
+        // authors often publish their "tsconfig.json" files to npm because of npm's
+        // default-include publishing model. These configs describe the package's own
+        // build (e.g. `paths` pointing at its `src/` TypeScript), not how a consumer
+        // should resolve or transpile the shipped code, so honoring them breaks
+        // packages that also ship `package.json#imports` and compiled `dist/` output.
+        // Node ignores tsconfig.json entirely, and esbuild explicitly skips it here
+        // for the same reason.
+        //
+        // https://github.com/oven-sh/bun/issues/10438
+        // https://github.com/oven-sh/bun/issues/5377
+        if self.opts.load_tsconfig_json && !info.is_inside_node_modules() {
             let mut tsconfig_path: Option<&[u8]> = None;
             if self.opts.tsconfig_override.is_none() {
                 if let Some(lookup) = entries!().get_comptime_query(b"tsconfig.json") {

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1101,3 +1101,142 @@ it.skipIf(isWindows)("reports a resolution error for an absolute specifier of th
   expect(stdout).toBe("ResolveMessage ERR_MODULE_NOT_FOUND\n");
   expect(exitCode).toBe(0);
 });
+
+// https://github.com/oven-sh/bun/issues/10438
+// A published package's tsconfig.json describes its own build (paths -> src/ TypeScript).
+// Resolution for consumers must use package.json#imports (-> dist/ JS), same as Node and
+// esbuild, which both ignore tsconfig.json files found inside node_modules.
+it("a node_modules package's own tsconfig paths does not override its package.json#imports", async () => {
+  using dir = tempDir("tsconfig-own-paths-node-modules", {
+    "package.json": JSON.stringify({ name: "app", type: "module" }),
+    "entry.mjs": `import { which } from "pkg"; console.log(which);`,
+
+    "node_modules/pkg/package.json": JSON.stringify({
+      name: "pkg",
+      type: "module",
+      exports: { ".": "./dist/index.js" },
+      imports: { "#internal": "./dist/internal.js" },
+    }),
+    "node_modules/pkg/tsconfig.json": JSON.stringify({
+      compilerOptions: { baseUrl: ".", paths: { "#internal": ["./src/internal.ts"] } },
+    }),
+    "node_modules/pkg/dist/index.js": `export { which } from "#internal";`,
+    "node_modules/pkg/dist/internal.js": `export const which = "dist";`,
+    // If tsconfig paths were applied, "#internal" would resolve here and the re-exported
+    // type would fail ESM linking with "export 'which' not found" (the #10438 symptom).
+    "node_modules/pkg/src/internal.ts": `export type which = never;`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("dist\n");
+  expect(exitCode).toBe(0);
+});
+
+it("a node_modules package's own tsconfig baseUrl is not applied to its imports", async () => {
+  using dir = tempDir("tsconfig-own-baseurl-node-modules", {
+    "package.json": JSON.stringify({ name: "app" }),
+    "entry.js": `console.log(require("pkg"));`,
+
+    "node_modules/pkg/package.json": JSON.stringify({ name: "pkg", main: "lib/index.js" }),
+    "node_modules/pkg/tsconfig.json": JSON.stringify({ compilerOptions: { baseUrl: "./src" } }),
+    "node_modules/pkg/lib/index.js": `module.exports = require("shadowed");`,
+    "node_modules/pkg/src/shadowed/index.js": `module.exports = "src-via-baseurl";`,
+    "node_modules/pkg/node_modules/shadowed/package.json": JSON.stringify({ name: "shadowed", main: "index.js" }),
+    "node_modules/pkg/node_modules/shadowed/index.js": `module.exports = "node-modules";`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("node-modules\n");
+  expect(exitCode).toBe(0);
+});
+
+// https://github.com/oven-sh/bun/issues/5377
+// The project's own tsconfig must keep working for project files, but must not rewrite
+// bare specifiers inside dependencies (where it would bypass nested node_modules copies).
+it("project tsconfig paths are not applied to imports from inside node_modules", async () => {
+  using dir = tempDir("tsconfig-paths-node-modules", {
+    "package.json": JSON.stringify({ name: "app", dependencies: { outer: "1.0.0", inner: "2.0.0" } }),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: { baseUrl: ".", paths: { "*": ["node_modules/*", "src/types/*"] } },
+    }),
+    "entry.js": `
+      const outer = require("outer");
+      const alias = require("only-via-paths");
+      console.log(JSON.stringify({ outer, alias }));
+    `,
+    "src/types/only-via-paths/index.js": `module.exports = "paths-mapped";`,
+
+    "node_modules/inner/package.json": JSON.stringify({ name: "inner", version: "2.0.0", main: "index.js" }),
+    "node_modules/inner/index.js": `module.exports = "hoisted";`,
+
+    "node_modules/outer/package.json": JSON.stringify({
+      name: "outer",
+      version: "1.0.0",
+      main: "index.js",
+      dependencies: { inner: "1.0.0" },
+    }),
+    "node_modules/outer/index.js": `module.exports = require("inner");`,
+    "node_modules/outer/node_modules/inner/package.json": JSON.stringify({
+      name: "inner",
+      version: "1.0.0",
+      main: "index.js",
+    }),
+    "node_modules/outer/node_modules/inner/index.js": `module.exports = "nested";`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ outer: "nested", alias: "paths-mapped" });
+  expect(exitCode).toBe(0);
+});
+
+// Guard: the app's own tsconfig can still `extends` a config that lives inside
+// node_modules. Only auto-discovery of tsconfig.json *for* a node_modules directory
+// is skipped; following an `extends` target into node_modules is unchanged.
+it("project tsconfig extends into node_modules is still honored", async () => {
+  using dir = tempDir("tsconfig-extends-node-modules", {
+    "package.json": JSON.stringify({ name: "app" }),
+    "tsconfig.json": JSON.stringify({ extends: "./node_modules/tsconfig-base/tsconfig.json" }),
+    "node_modules/tsconfig-base/package.json": JSON.stringify({ name: "tsconfig-base" }),
+    "node_modules/tsconfig-base/tsconfig.json": JSON.stringify({
+      compilerOptions: { baseUrl: "../..", paths: { "@app/*": ["src/*"] } },
+    }),
+    "src/hello.ts": `export const hello = "from-extends";`,
+    "entry.ts": `import { hello } from "@app/hello"; console.log(hello);`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("from-extends\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #10438. Fixes #13261. Fixes #5377. Fixes #15614.

## Repro

```sh
bun add @ditsmod/core@2.52.0
echo 'import { Application } from "@ditsmod/core"; console.log(typeof Application);' > main.mjs
bun main.mjs
```

Before:
```
SyntaxError: export 'ForwardRefFn' not found in './forward-ref.js'
```

After (matches `node main.mjs`):
```
function
```

## Cause

`@ditsmod/core` ships both its compiled output and its build config:

```jsonc
// package.json
"imports": { "#di": "./dist/di/index.js" }
// tsconfig.json
"paths":   { "#di": ["./src/di/index.js"] }
```

`dir_info_uncached` loaded `node_modules/@ditsmod/core/tsconfig.json` the same as any other directory and set it as the enclosing tsconfig for the package's subdirectories. `load_node_modules` then consulted that tsconfig's `paths` before `package.json#imports`, so `#di` (imported from the shipped `dist/*.js`) resolved into `src/di/` raw TypeScript, where a type-only re-export fails ESM linking.

The same mechanism also leaked the *project's* tsconfig into dependencies (#5377): with a catch-all `"*": ["node_modules/*"]` entry, a dependency's own `require("x")` was remapped to the hoisted root copy instead of its nested one.

## Fix

Match esbuild: inside `node_modules`, skip `tsconfig.json`/`jsconfig.json` auto-discovery and stop inheriting the enclosing tsconfig across the boundary, so `enclosing_tsconfig_json` is `None` for every directory under `node_modules`. esbuild's [equivalent gate](https://github.com/evanw/esbuild/blob/main/internal/resolver/resolver.go#L1639-L1653) has the same rationale: package authors publish `tsconfig.json` by accident via npm's default-include model, and those configs describe the package's build rather than how consumers should resolve it.

A project tsconfig that `extends` a file living in `node_modules` is unaffected, since `extends` resolution starts from the project's own (non-node_modules) tsconfig and calls `parse_tsconfig` directly.

## Verification

```
$ bun bd test test/js/bun/resolve/resolve.test.ts -t "tsconfig"
(pass) a node_modules package's own tsconfig paths does not override its package.json#imports
(pass) a node_modules package's own tsconfig baseUrl is not applied to its imports
(pass) project tsconfig paths are not applied to imports from inside node_modules
(pass) project tsconfig extends into node_modules is still honored
```

The first three fail on `main` (first with `SyntaxError: export 'which' not found in '#internal'`, the #10438 symptom); the fourth is a guard that passes on both.

Supersedes #36617 (that PR kept a package's own tsconfig applying inside node_modules, which is the #10438 case).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->
