### PR TITLE
test_runner: sort Set/Map entries when rendering the toEqual diff

### DIFF
--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -43,6 +43,7 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 add_newline: false,
                 flush: false,
                 quote_strings: true,
+                ordered_collections: true,
             };
             let _ = JestPrettyFormat::format(
                 MessageLevel::Debug,

--- a/src/runtime/test_runner/mod.rs
+++ b/src/runtime/test_runner/mod.rs
@@ -264,6 +264,7 @@ pub mod expect {
                 add_newline: false,
                 flush: false,
                 quote_strings: true,
+                ordered_collections: false,
             };
             JestPrettyFormat::format(
                 MessageLevel::Debug,

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -876,8 +876,7 @@ impl<'a, 'f, const IS_MAP: bool, const ENABLE_ANSI_COLORS: bool>
         if ctx.formatter.failed {
             return;
         }
-        // Each entry starts on its own line; reset so `good_time_for_a_new_line`
-        // does not depend on which entries were visited earlier in insertion order.
+        // each entry buffers from a fresh line so its bytes are order-independent
         ctx.formatter.reset_line();
         let mut buf: Vec<u8> = Vec::new();
         if ctx.formatter.write_indent(&mut buf).is_err() {

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -876,6 +876,9 @@ impl<'a, 'f, const IS_MAP: bool, const ENABLE_ANSI_COLORS: bool>
         if ctx.formatter.failed {
             return;
         }
+        // Each entry starts on its own line; reset so `good_time_for_a_new_line`
+        // does not depend on which entries were visited earlier in insertion order.
+        ctx.formatter.reset_line();
         let mut buf: Vec<u8> = Vec::new();
         if ctx.formatter.write_indent(&mut buf).is_err() {
             return;

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -122,11 +122,7 @@ pub struct FormatOptions {
     pub(crate) add_newline: bool,
     pub flush: bool,
     pub(crate) quote_strings: bool,
-    /// Sort `Set`/`Map` entries by their serialized bytes so two collections
-    /// with the same members produce the same text regardless of insertion
-    /// order. Used by the diff formatter so the line-based diff reports only
-    /// real membership differences. Off for snapshots/console output, which
-    /// preserve insertion order.
+    /// Sort `Set`/`Map` entries so the diff formatter is order-insensitive.
     pub(crate) ordered_collections: bool,
 }
 
@@ -860,8 +856,7 @@ impl<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>
     }
 }
 
-/// Collects each `Set`/`Map` entry into its own buffer so the caller can sort
-/// them before emitting. Used when [`Formatter::ordered_collections`] is set.
+/// See [`FormatOptions::ordered_collections`].
 pub(crate) struct SortedEntryCollector<'a, 'f, const IS_MAP: bool, const ENABLE_ANSI_COLORS: bool> {
     pub(crate) formatter: &'a mut Formatter<'f>,
     pub(crate) entries: Vec<Vec<u8>>,

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -757,6 +757,18 @@ impl<'a> Formatter<'a> {
         self.estimated_line_length += 1;
         Ok(())
     }
+
+    fn write_sorted_entries<W: bun_io::Write>(
+        &mut self,
+        writer: &mut WrappedWriter<'_, W>,
+        mut entries: Vec<Vec<u8>>,
+    ) {
+        entries.sort();
+        for entry in &entries {
+            writer.write_all(entry);
+        }
+        self.reset_line();
+    }
 }
 
 // split lifetimes — `&'a mut Formatter<'a>` is invariant and forces
@@ -1836,12 +1848,8 @@ impl<'a> Formatter<'a> {
                                 (&raw mut iter).cast::<c_void>(),
                                 SortedEntryCollector::<true, ENABLE_ANSI_COLORS>::for_each,
                             );
-                            let mut entries = iter.entries;
-                            entries.sort();
-                            for entry in &entries {
-                                writer.write_all(entry);
-                            }
-                            self.reset_line();
+                            let entries = iter.entries;
+                            self.write_sorted_entries(&mut writer, entries);
                             result
                         } else {
                             let mut iter = MapIterator::<W, ENABLE_ANSI_COLORS> {
@@ -1900,12 +1908,8 @@ impl<'a> Formatter<'a> {
                                 (&raw mut iter).cast::<c_void>(),
                                 SortedEntryCollector::<false, ENABLE_ANSI_COLORS>::for_each,
                             );
-                            let mut entries = iter.entries;
-                            entries.sort();
-                            for entry in &entries {
-                                writer.write_all(entry);
-                            }
-                            self.reset_line();
+                            let entries = iter.entries;
+                            self.write_sorted_entries(&mut writer, entries);
                             result
                         } else {
                             let mut iter = SetIterator::<W, ENABLE_ANSI_COLORS> {

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1841,6 +1841,7 @@ impl<'a> Formatter<'a> {
                             for entry in &entries {
                                 writer.write_all(entry);
                             }
+                            self.reset_line();
                             result
                         } else {
                             let mut iter = MapIterator::<W, ENABLE_ANSI_COLORS> {
@@ -1904,6 +1905,7 @@ impl<'a> Formatter<'a> {
                             for entry in &entries {
                                 writer.write_all(entry);
                             }
+                            self.reset_line();
                             result
                         } else {
                             let mut iter = SetIterator::<W, ENABLE_ANSI_COLORS> {

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -122,6 +122,12 @@ pub struct FormatOptions {
     pub(crate) add_newline: bool,
     pub flush: bool,
     pub(crate) quote_strings: bool,
+    /// Sort `Set`/`Map` entries by their serialized bytes so two collections
+    /// with the same members produce the same text regardless of insertion
+    /// order. Used by the diff formatter so the line-based diff reports only
+    /// real membership differences. Off for snapshots/console output, which
+    /// preserve insertion order.
+    pub(crate) ordered_collections: bool,
 }
 
 impl JestPrettyFormat {
@@ -141,6 +147,7 @@ impl JestPrettyFormat {
         if len == 1 {
             fmt = Formatter::new(global);
             fmt.quote_strings = options.quote_strings;
+            fmt.ordered_collections = options.ordered_collections;
             let tag = Tag::get(vals[0], global)?;
 
             if tag.tag == Tag::String {
@@ -187,6 +194,7 @@ impl JestPrettyFormat {
         fmt = Formatter::new(global);
         fmt.remaining_values = &vals[..len][1..];
         fmt.quote_strings = options.quote_strings;
+        fmt.ordered_collections = options.ordered_collections;
 
         let result: JsResult<()> = (|| {
             let mut this_value: JSValue = vals[0];
@@ -313,6 +321,8 @@ pub struct Formatter<'a> {
     pub(crate) failed: bool,
     pub(crate) estimated_line_length: usize,
     pub(crate) always_newline_scope: bool,
+    /// See [`FormatOptions::ordered_collections`].
+    pub(crate) ordered_collections: bool,
 }
 
 impl<'a> Formatter<'a> {
@@ -327,6 +337,7 @@ impl<'a> Formatter<'a> {
             failed: false,
             estimated_line_length: 0,
             always_newline_scope: false,
+            ordered_collections: false,
         }
     }
 
@@ -846,6 +857,75 @@ impl<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>
             return;
         }
         let _ = ctx.writer.write_all(b"\n");
+    }
+}
+
+/// Collects each `Set`/`Map` entry into its own buffer so the caller can sort
+/// them before emitting. Used when [`Formatter::ordered_collections`] is set.
+pub(crate) struct SortedEntryCollector<'a, 'f, const IS_MAP: bool, const ENABLE_ANSI_COLORS: bool> {
+    pub(crate) formatter: &'a mut Formatter<'f>,
+    pub(crate) entries: Vec<Vec<u8>>,
+}
+
+impl<'a, 'f, const IS_MAP: bool, const ENABLE_ANSI_COLORS: bool>
+    SortedEntryCollector<'a, 'f, IS_MAP, ENABLE_ANSI_COLORS>
+{
+    pub(crate) extern "C" fn for_each(
+        _: *mut VM,
+        global_object: &JSGlobalObject,
+        ctx: *mut c_void,
+        next_value: JSValue,
+    ) {
+        // SAFETY: ctx was passed as `&mut Self as *mut c_void` by the caller of for_each.
+        let Some(ctx) = (unsafe { ctx.cast::<Self>().as_mut() }) else { return };
+        if ctx.formatter.failed {
+            return;
+        }
+        let mut buf: Vec<u8> = Vec::new();
+        if ctx.formatter.write_indent(&mut buf).is_err() {
+            return;
+        }
+        if IS_MAP {
+            let Ok(key) = JSObject::get_index(next_value, global_object, 0) else { return };
+            let Ok(value) = JSObject::get_index(next_value, global_object, 1) else { return };
+            let Ok(key_tag) = Tag::get(key, global_object) else { return };
+            if ctx
+                .formatter
+                .format::<Vec<u8>, ENABLE_ANSI_COLORS>(key_tag, &mut buf, key, ctx.formatter.global_this)
+                .is_err()
+            {
+                return;
+            }
+            if bun_io::Write::write_all(&mut buf, b" => ").is_err() {
+                return;
+            }
+            let Ok(value_tag) = Tag::get(value, global_object) else { return };
+            if ctx
+                .formatter
+                .format::<Vec<u8>, ENABLE_ANSI_COLORS>(value_tag, &mut buf, value, ctx.formatter.global_this)
+                .is_err()
+            {
+                return;
+            }
+        } else {
+            let Ok(tag) = Tag::get(next_value, global_object) else { return };
+            if ctx
+                .formatter
+                .format::<Vec<u8>, ENABLE_ANSI_COLORS>(tag, &mut buf, next_value, ctx.formatter.global_this)
+                .is_err()
+            {
+                return;
+            }
+        }
+        if ctx
+            .formatter
+            .print_comma::<Vec<u8>, ENABLE_ANSI_COLORS>(&mut buf)
+            .is_err()
+        {
+            return;
+        }
+        let _ = bun_io::Write::write_all(&mut buf, b"\n");
+        ctx.entries.push(buf);
     }
 }
 
@@ -1747,15 +1827,35 @@ impl<'a> Formatter<'a> {
                         // borrows `self`/`writer.ctx`; NLL releases both once `iter`
                         // is dead after `for_each` returns.
                         let global = self.global_this;
-                        let mut iter = MapIterator::<W, ENABLE_ANSI_COLORS> {
-                            formatter: self,
-                            writer: writer.ctx,
+                        let result = if self.ordered_collections
+                            && value.js_type() != JSType::WeakMap
+                        {
+                            let mut iter = SortedEntryCollector::<true, ENABLE_ANSI_COLORS> {
+                                formatter: self,
+                                entries: Vec::new(),
+                            };
+                            let result = value.for_each(
+                                global,
+                                (&raw mut iter).cast::<c_void>(),
+                                SortedEntryCollector::<true, ENABLE_ANSI_COLORS>::for_each,
+                            );
+                            let mut entries = iter.entries;
+                            entries.sort();
+                            for entry in &entries {
+                                writer.write_all(entry);
+                            }
+                            result
+                        } else {
+                            let mut iter = MapIterator::<W, ENABLE_ANSI_COLORS> {
+                                formatter: self,
+                                writer: writer.ctx,
+                            };
+                            value.for_each(
+                                global,
+                                (&raw mut iter).cast::<c_void>(),
+                                MapIterator::<W, ENABLE_ANSI_COLORS>::for_each,
+                            )
                         };
-                        let result = value.for_each(
-                            global,
-                            (&raw mut iter).cast::<c_void>(),
-                            MapIterator::<W, ENABLE_ANSI_COLORS>::for_each,
-                        );
                         // `indent` / `quote_strings` must be restored on every exit,
                         // including thrown exceptions — restore before propagating.
                         self.indent = self.indent.saturating_sub(1);
@@ -1790,15 +1890,35 @@ impl<'a> Formatter<'a> {
                     {
                         self.indent += 1;
                         let global = self.global_this;
-                        let mut iter = SetIterator::<W, ENABLE_ANSI_COLORS> {
-                            formatter: self,
-                            writer: writer.ctx,
+                        let result = if self.ordered_collections
+                            && value.js_type() != JSType::WeakSet
+                        {
+                            let mut iter = SortedEntryCollector::<false, ENABLE_ANSI_COLORS> {
+                                formatter: self,
+                                entries: Vec::new(),
+                            };
+                            let result = value.for_each(
+                                global,
+                                (&raw mut iter).cast::<c_void>(),
+                                SortedEntryCollector::<false, ENABLE_ANSI_COLORS>::for_each,
+                            );
+                            let mut entries = iter.entries;
+                            entries.sort();
+                            for entry in &entries {
+                                writer.write_all(entry);
+                            }
+                            result
+                        } else {
+                            let mut iter = SetIterator::<W, ENABLE_ANSI_COLORS> {
+                                formatter: self,
+                                writer: writer.ctx,
+                            };
+                            value.for_each(
+                                global,
+                                (&raw mut iter).cast::<c_void>(),
+                                SetIterator::<W, ENABLE_ANSI_COLORS>::for_each,
+                            )
                         };
-                        let result = value.for_each(
-                            global,
-                            (&raw mut iter).cast::<c_void>(),
-                            SetIterator::<W, ENABLE_ANSI_COLORS>::for_each,
-                        );
                         // `indent` / `quote_strings` must be restored on every exit,
                         // including thrown exceptions — restore before propagating.
                         self.indent = self.indent.saturating_sub(1);

--- a/test/regression/issue/13015/13015.fixture.ts
+++ b/test/regression/issue/13015/13015.fixture.ts
@@ -32,3 +32,9 @@ test("Set diff with Promise after long sibling", () => {
   const long = Buffer.alloc(100, "a").toString();
   expect(new Set([p, long])).toEqual(new Set([long, p, "extra"]));
 });
+
+test("sibling after a Set is order-independent", () => {
+  const p = Promise.resolve();
+  const long = Buffer.alloc(100, "a").toString();
+  expect([new Set(["a", long]), p]).toEqual([new Set([long, "a"]), p, "extra"]);
+});

--- a/test/regression/issue/13015/13015.fixture.ts
+++ b/test/regression/issue/13015/13015.fixture.ts
@@ -26,3 +26,9 @@ test("Map diff shows only entry differences", () => {
 test("Set nested in object", () => {
   expect({ s: new Set(["y", "x"]) }).toEqual({ s: new Set(["x", "y", "z"]) });
 });
+
+test("Set diff with Promise after long sibling", () => {
+  const p = Promise.resolve();
+  const long = Buffer.alloc(100, "a").toString();
+  expect(new Set([p, long])).toEqual(new Set([long, p, "extra"]));
+});

--- a/test/regression/issue/13015/13015.fixture.ts
+++ b/test/regression/issue/13015/13015.fixture.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test";
+
+test("Set diff shows only membership differences", () => {
+  expect(new Set(["asdf", "xx"])).toEqual(new Set(["xx", "asdf", "sdf"]));
+});
+
+test("Set diff with numbers", () => {
+  expect(new Set([3, 1, 2])).toEqual(new Set([2, 4, 1]));
+});
+
+test("Map diff shows only entry differences", () => {
+  expect(
+    new Map([
+      ["b", 2],
+      ["a", 1],
+    ]),
+  ).toEqual(
+    new Map([
+      ["a", 1],
+      ["c", 3],
+      ["b", 2],
+    ]),
+  );
+});
+
+test("Set nested in object", () => {
+  expect({ s: new Set(["y", "x"]) }).toEqual({ s: new Set(["x", "y", "z"]) });
+});

--- a/test/regression/issue/13015/13015.test.ts
+++ b/test/regression/issue/13015/13015.test.ts
@@ -4,34 +4,35 @@
 // a different position showed up as both "-" and "+". The fix sorts entries by
 // their serialized form before diffing so only true membership differences are
 // reported.
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 function stripAnsi(s: string) {
   return s.replaceAll(/\x1B\[[0-9;]*m/g, "");
 }
 
-function diffLines(stderr: string, testName: string) {
-  // Pull out the diff body for a single test: lines starting with "+ " / "- " / "  "
-  // between the "error:" line and the "- Expected" summary.
+function diffBlock(stderr: string, testName: string) {
+  // Isolate the diff for a single fixture test: lines between this test's
+  // "error:" line and its "(fail) <name>" line.
   const lines = stripAnsi(stderr).split("\n");
-  const start = lines.findIndex(l => l.includes(`(fail) ${testName}`));
-  // walk backwards from the (fail) line to the preceding "error:" for this test
-  let errIdx = start;
+  const failIdx = lines.findIndex(l => l.includes(`(fail) ${testName}`));
+  if (failIdx < 0) throw new Error(`fixture test "${testName}" not found in stderr`);
+  let errIdx = failIdx;
   while (errIdx > 0 && !lines[errIdx].startsWith("error:")) errIdx--;
   let summaryIdx = errIdx;
-  while (summaryIdx < start && !lines[summaryIdx].startsWith("- Expected")) summaryIdx++;
-  return lines
+  while (summaryIdx < failIdx && !lines[summaryIdx].startsWith("- Expected")) summaryIdx++;
+  const body = lines
     .slice(errIdx + 1, summaryIdx)
     .filter(l => l.startsWith("+ ") || l.startsWith("- ") || l.startsWith("  "))
     .map(l => l.trimEnd());
+  const footer = lines.slice(summaryIdx, summaryIdx + 2).join("\n");
+  return { body, footer };
 }
 
 describe("issue #13015: toEqual diff for Set/Map is order-insensitive", () => {
   let stderr = "";
-  let exitCode = -1;
 
-  test("run fixture", async () => {
+  beforeAll(async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", import.meta.dir + "/13015.fixture.ts"],
       env: { ...bunEnv, FORCE_COLOR: "0" },
@@ -39,13 +40,12 @@ describe("issue #13015: toEqual diff for Set/Map is order-insensitive", () => {
     });
     const [, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     stderr = err;
-    exitCode = code;
-    expect(exitCode).toBe(1);
+    expect(code).toBe(1);
   });
 
   test("Set: shared element is not shown as both removed and added", () => {
-    const body = diffLines(stderr, "Set diff shows only membership differences");
-    // "xx" is in both sets; it must not appear on a +/- line.
+    const { body, footer } = diffBlock(stderr, "Set diff shows only membership differences");
+    // "xx" and "asdf" are in both sets; they must not appear on a +/- line.
     for (const line of body) {
       if (line.startsWith("+ ") || line.startsWith("- ")) {
         expect(line).not.toContain('"xx"');
@@ -54,13 +54,11 @@ describe("issue #13015: toEqual diff for Set/Map is order-insensitive", () => {
     }
     // "sdf" is only in expected, so it must appear on a "-" line.
     expect(body.some(l => l.startsWith("- ") && l.includes('"sdf"'))).toBe(true);
-    // The footer should count exactly 1 expected-only and 0 received-only lines.
-    expect(stripAnsi(stderr)).toContain("- Expected  - 1");
-    expect(stripAnsi(stderr)).toContain("+ Received  + 0");
+    expect(footer).toBe("- Expected  - 1\n+ Received  + 0");
   });
 
   test("Set: numeric members", () => {
-    const body = diffLines(stderr, "Set diff with numbers");
+    const { body, footer } = diffBlock(stderr, "Set diff with numbers");
     // 1 and 2 are in both sets.
     for (const line of body) {
       if (line.startsWith("+ ") || line.startsWith("- ")) {
@@ -70,10 +68,11 @@ describe("issue #13015: toEqual diff for Set/Map is order-insensitive", () => {
     // 4 is only in expected, 3 is only in received.
     expect(body.some(l => l.startsWith("- ") && /\b4\b/.test(l))).toBe(true);
     expect(body.some(l => l.startsWith("+ ") && /\b3\b/.test(l))).toBe(true);
+    expect(footer).toBe("- Expected  - 1\n+ Received  + 1");
   });
 
   test("Map: shared entry is not shown as both removed and added", () => {
-    const body = diffLines(stderr, "Map diff shows only entry differences");
+    const { body, footer } = diffBlock(stderr, "Map diff shows only entry differences");
     // "a" => 1 and "b" => 2 are in both maps.
     for (const line of body) {
       if (line.startsWith("+ ") || line.startsWith("- ")) {
@@ -83,10 +82,11 @@ describe("issue #13015: toEqual diff for Set/Map is order-insensitive", () => {
     }
     // "c" => 3 is only in expected.
     expect(body.some(l => l.startsWith("- ") && l.includes('"c" => 3'))).toBe(true);
+    expect(footer).toBe("- Expected  - 1\n+ Received  + 0");
   });
 
   test("Set nested in object", () => {
-    const body = diffLines(stderr, "Set nested in object");
+    const { body, footer } = diffBlock(stderr, "Set nested in object");
     // "x" and "y" are in both sets.
     for (const line of body) {
       if (line.startsWith("+ ") || line.startsWith("- ")) {
@@ -96,5 +96,6 @@ describe("issue #13015: toEqual diff for Set/Map is order-insensitive", () => {
     }
     // "z" is only in expected.
     expect(body.some(l => l.startsWith("- ") && l.includes('"z"'))).toBe(true);
+    expect(footer).toBe("- Expected  - 1\n+ Received  + 0");
   });
 });

--- a/test/regression/issue/13015/13015.test.ts
+++ b/test/regression/issue/13015/13015.test.ts
@@ -113,4 +113,19 @@ describe("issue #13015: toEqual diff for Set/Map is order-insensitive", () => {
     expect(body.some(l => l.startsWith("- ") && l.includes('"extra"'))).toBe(true);
     expect(footer).toBe("- Expected  - 1\n+ Received  + 0");
   });
+
+  test("sibling after a Set does not depend on Set insertion order", () => {
+    // Guards the post-loop reset_line() in the Tag::Set/Tag::Map sorted path:
+    // without it, estimated_line_length on exit depends on the last-inserted
+    // entry's length, so a Promise sibling right after the Set shows as both
+    // "-" and "+".
+    const { body, footer } = diffBlock(stderr, "sibling after a Set is order-independent");
+    for (const line of body) {
+      if (line.startsWith("+ ") || line.startsWith("- ")) {
+        expect(line).not.toContain("Promise");
+      }
+    }
+    expect(body.some(l => l.startsWith("- ") && l.includes('"extra"'))).toBe(true);
+    expect(footer).toBe("- Expected  - 1\n+ Received  + 0");
+  });
 });

--- a/test/regression/issue/13015/13015.test.ts
+++ b/test/regression/issue/13015/13015.test.ts
@@ -4,7 +4,7 @@
 // a different position showed up as both "-" and "+". The fix sorts entries by
 // their serialized form before diffing so only true membership differences are
 // reported.
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 function stripAnsi(s: string) {

--- a/test/regression/issue/13015/13015.test.ts
+++ b/test/regression/issue/13015/13015.test.ts
@@ -98,4 +98,19 @@ describe("issue #13015: toEqual diff for Set/Map is order-insensitive", () => {
     expect(body.some(l => l.startsWith("- ") && l.includes('"z"'))).toBe(true);
     expect(footer).toBe("- Expected  - 1\n+ Received  + 0");
   });
+
+  test("Set: shared Promise is order-independent even after a long sibling", () => {
+    // Guards the per-entry reset_line() in SortedEntryCollector: without it,
+    // formatting a Promise after a >80-char string inserts a leading newline on
+    // one side only, and the shared Promise shows as both "-" and "+".
+    const { body, footer } = diffBlock(stderr, "Set diff with Promise after long sibling");
+    for (const line of body) {
+      if (line.startsWith("+ ") || line.startsWith("- ")) {
+        expect(line).not.toContain("Promise");
+        expect(line).not.toContain("aaaa");
+      }
+    }
+    expect(body.some(l => l.startsWith("- ") && l.includes('"extra"'))).toBe(true);
+    expect(footer).toBe("- Expected  - 1\n+ Received  + 0");
+  });
 });

--- a/test/regression/issue/13015/13015.test.ts
+++ b/test/regression/issue/13015/13015.test.ts
@@ -115,10 +115,10 @@ describe("issue #13015: toEqual diff for Set/Map is order-insensitive", () => {
   });
 
   test("sibling after a Set does not depend on Set insertion order", () => {
-    // Guards the post-loop reset_line() in the Tag::Set/Tag::Map sorted path:
-    // without it, estimated_line_length on exit depends on the last-inserted
-    // entry's length, so a Promise sibling right after the Set shows as both
-    // "-" and "+".
+    // Guards the reset_line() in Formatter::write_sorted_entries (shared by
+    // Tag::Set and Tag::Map): without it, estimated_line_length on exit depends
+    // on the last-inserted entry's length, so a Promise sibling right after the
+    // collection shows as both "-" and "+".
     const { body, footer } = diffBlock(stderr, "sibling after a Set is order-independent");
     for (const line of body) {
       if (line.startsWith("+ ") || line.startsWith("- ")) {

--- a/test/regression/issue/13015/13015.test.ts
+++ b/test/regression/issue/13015/13015.test.ts
@@ -1,0 +1,100 @@
+// https://github.com/oven-sh/bun/issues/13015
+// The toEqual diff printer serialized Sets/Maps in insertion order and then
+// ran a line-based text diff, so an element present in both collections but at
+// a different position showed up as both "-" and "+". The fix sorts entries by
+// their serialized form before diffing so only true membership differences are
+// reported.
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+function stripAnsi(s: string) {
+  return s.replaceAll(/\x1B\[[0-9;]*m/g, "");
+}
+
+function diffLines(stderr: string, testName: string) {
+  // Pull out the diff body for a single test: lines starting with "+ " / "- " / "  "
+  // between the "error:" line and the "- Expected" summary.
+  const lines = stripAnsi(stderr).split("\n");
+  const start = lines.findIndex(l => l.includes(`(fail) ${testName}`));
+  // walk backwards from the (fail) line to the preceding "error:" for this test
+  let errIdx = start;
+  while (errIdx > 0 && !lines[errIdx].startsWith("error:")) errIdx--;
+  let summaryIdx = errIdx;
+  while (summaryIdx < start && !lines[summaryIdx].startsWith("- Expected")) summaryIdx++;
+  return lines
+    .slice(errIdx + 1, summaryIdx)
+    .filter(l => l.startsWith("+ ") || l.startsWith("- ") || l.startsWith("  "))
+    .map(l => l.trimEnd());
+}
+
+describe("issue #13015: toEqual diff for Set/Map is order-insensitive", () => {
+  let stderr = "";
+  let exitCode = -1;
+
+  test("run fixture", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", import.meta.dir + "/13015.fixture.ts"],
+      env: { ...bunEnv, FORCE_COLOR: "0" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    stderr = err;
+    exitCode = code;
+    expect(exitCode).toBe(1);
+  });
+
+  test("Set: shared element is not shown as both removed and added", () => {
+    const body = diffLines(stderr, "Set diff shows only membership differences");
+    // "xx" is in both sets; it must not appear on a +/- line.
+    for (const line of body) {
+      if (line.startsWith("+ ") || line.startsWith("- ")) {
+        expect(line).not.toContain('"xx"');
+        expect(line).not.toContain('"asdf"');
+      }
+    }
+    // "sdf" is only in expected, so it must appear on a "-" line.
+    expect(body.some(l => l.startsWith("- ") && l.includes('"sdf"'))).toBe(true);
+    // The footer should count exactly 1 expected-only and 0 received-only lines.
+    expect(stripAnsi(stderr)).toContain("- Expected  - 1");
+    expect(stripAnsi(stderr)).toContain("+ Received  + 0");
+  });
+
+  test("Set: numeric members", () => {
+    const body = diffLines(stderr, "Set diff with numbers");
+    // 1 and 2 are in both sets.
+    for (const line of body) {
+      if (line.startsWith("+ ") || line.startsWith("- ")) {
+        expect(line.trim()).not.toMatch(/^[+-]\s+[12],?$/);
+      }
+    }
+    // 4 is only in expected, 3 is only in received.
+    expect(body.some(l => l.startsWith("- ") && /\b4\b/.test(l))).toBe(true);
+    expect(body.some(l => l.startsWith("+ ") && /\b3\b/.test(l))).toBe(true);
+  });
+
+  test("Map: shared entry is not shown as both removed and added", () => {
+    const body = diffLines(stderr, "Map diff shows only entry differences");
+    // "a" => 1 and "b" => 2 are in both maps.
+    for (const line of body) {
+      if (line.startsWith("+ ") || line.startsWith("- ")) {
+        expect(line).not.toContain('"a" => 1');
+        expect(line).not.toContain('"b" => 2');
+      }
+    }
+    // "c" => 3 is only in expected.
+    expect(body.some(l => l.startsWith("- ") && l.includes('"c" => 3'))).toBe(true);
+  });
+
+  test("Set nested in object", () => {
+    const body = diffLines(stderr, "Set nested in object");
+    // "x" and "y" are in both sets.
+    for (const line of body) {
+      if (line.startsWith("+ ") || line.startsWith("- ")) {
+        expect(line).not.toContain('"x"');
+        expect(line).not.toContain('"y"');
+      }
+    }
+    // "z" is only in expected.
+    expect(body.some(l => l.startsWith("- ") && l.includes('"z"'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #13015.

### Repro

```js
import { test, expect } from "bun:test";
test("set diff", () => {
  expect(new Set(["asdf", "xx"])).toEqual(new Set(["xx", "asdf", "sdf"]));
});
```

Before:

```
  Set {
-   "xx",
    "asdf",
-   "sdf",
+   "xx",
  }

- Expected  - 2
+ Received  + 1
```

`"xx"` is in both sets, yet it shows as both `-` and `+`.

After:

```
  Set {
    "asdf",
-   "sdf",
    "xx",
  }

- Expected  - 1
+ Received  + 0
```

### Cause

`DiffFormatter` serializes both `received` and `expected` with `JestPrettyFormat` (which iterates Sets/Maps in insertion order) and then runs a line-based text diff on the two strings. Two Sets with the same members inserted in a different order serialize to different text, so the line diff reports spurious `-`/`+` pairs for members shared by both sides.

### Fix

Add `FormatOptions::ordered_collections` / `Formatter::ordered_collections`. When set, the `Tag::Set` / `Tag::Map` branches of `print_as` buffer each entry into its own `Vec<u8>`, sort the buffers, and emit them in sorted order. Two collections with the same members now serialize to identical text regardless of insertion order, so the line diff shows only true membership differences.

Only `DiffFormatter` enables the flag. `Bun.inspect`, `console.log`, and snapshot serialization keep insertion order. `WeakSet`/`WeakMap` are excluded from the sorted path.

### Verification

- `bun bd test test/regression/issue/13015/13015.test.ts` passes (fails on the released binary)
- `bun bd test test/js/bun/test/expect.test.js` passes (415 tests)
- `bun bd test test/js/bun/test/spyMatchers.test.ts` passes (147 tests)
- `Bun.inspect(new Set(["c","a","b"]))` and `toMatchInlineSnapshot` still print insertion order

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/13015/13015.test.ts"
bun test v1.4.0 (d385ee762)

test/regression/issue/13015/13015.test.ts:
46 |   test("Set: shared element is not shown as both removed and added", () => {
47 |     const { body, footer } = diffBlock(stderr, "Set diff shows only membership differences");
48 |     // "xx" and "asdf" are in both sets; they must not appear on a +/- line.
49 |     for (const line of body) {
50 |       if (line.startsWith("+ ") || line.startsWith("- ")) {
51 |         expect(line).not.toContain('"xx"');
                              ^
error: expect(received).not.toContain(expected)

Expected to not contain: "\"xx\""
Received: "-   \"xx\","

      at <anonymous> (/workspace/bun/test/regression/issue/13015/13015.test.ts:51:26)
(fail) issue #13015: toEqual diff for Set/Map is order-insensitive > Set: shared element is not shown as both removed and added [46.57ms]
60 |   test("Set: numeric members", () => {
61 |     const { body, footer } = diffBlock(stderr, "Set diff with numbers");
62 |     // 1 and 2 are in both sets
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (962e14c94)

test/regression/issue/13015/13015.test.ts:
(pass) issue #13015: toEqual diff for Set/Map is order-insensitive > Set: shared element is not shown as both removed and added [0.76ms]
(pass) issue #13015: toEqual diff for Set/Map is order-insensitive > Set: numeric members [0.37ms]
(pass) issue #13015: toEqual diff for Set/Map is order-insensitive > Map: shared entry is not shown as both removed and added [0.17ms]
(pass) issue #13015: toEqual diff for Set/Map is order-insensitive > Set nested in object [0.20ms]
(pass) issue #13015: toEqual diff for Set/Map is order-insensitive > Set: shared Promise is order-independent even after a long sibling [0.27ms]
(pass) issue #13015: toEqual diff for Set/Map is order-insensitive > sibling after a Set does not depend on Set insertion order [0.28ms]

 6 pass
 0 fail
 24 expect() calls
Ran 6 tests across 1 file. [418.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/13015/13015.test.ts"
bun test v1.4.0 (d385ee762)

test/regression/issue/13015/13015.test.ts:
(pass) issue #13015: toEqual diff for Set/Map is order-insensitive > Set: shared element is not shown as both removed and added [44.26ms]
(pass) issue #13015: toEqual diff for Set/Map is order-insensitive > Set: numeric members [31.02ms]
(pass) issue #13015: toEqual diff for Set/Map is order-insensitive > Map: shared entry is not shown as both removed and added [22.39ms]
(pass) issue #13015: toEqual diff for Set/Map is order-insensitive > Set nested in object [29.53ms]
(pass) issue #13015: toEqual diff for Set/Map is order-insensitive > Set: shared Promise is order-independent even after a long sibling [28.04ms]
(pass) issue #13015: toEqual diff for Set/Map is order-insensitive > sibling after a Set does not depend on Set insertion order [28.67ms]

 6 pass
 0 fail
 24 expect() calls
Ran 6 tests across 1 file. [8.06s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2131ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/51] gen cpp.rs (cppbind)
[2/51] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[3/51] cxx obj/src/jsc/bindings/webcore/streams/BunStreamSource.cpp.o
[4/51] cxx obj/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp.o
[5/51] cxx obj/src/jsc/bindings/webcore/streams/CrossRealmTransform.cpp.o
[6/51] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[7/51] cxx obj/src/jsc/bindings/BunObject.cpp.o
[8/51] cxx obj/src/jsc/bindings/napi.cpp.o
[9/51] cxx obj/src/jsc/bindings/BunProcess.cpp.o
[10/51] cxx obj/unified/UnifiedSource-src_jsc_modules-0.cpp.o
[11/51] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[12/51] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[13/51] cxx obj/src/jsc/bindings/bindings.cpp.o
[14/51] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[15/51] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[16/51] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[17/51] cxx obj/unified/UnifiedSource-src_jsc_bind
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/diff_format.rs       |   1 +
 src/runtime/test_runner/mod.rs               |   1 +
 src/runtime/test_runner/pretty_format.rs     | 155 ++++++++++++++++++++++++---
 test/regression/issue/13015/13015.fixture.ts |  40 +++++++
 test/regression/issue/13015/13015.test.ts    | 131 ++++++++++++++++++++++
 5 files changed, 312 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/runtime/test_runner/diff_format.rs            1      1      0
src/runtime/test_runner/mod.rs                    1      1      0
src/runtime/test_runner/pretty_format.rs         17     19      0
test/regression/issue/13015/13015.fixture.ts      2      3      0
test/regression/issue/13015/13015.test.ts         3      5      0
```

</details>

<!-- robobun:evidence:end -->