### PR TITLE
bundler: downgrade unresolved require() of optional peer deps to a runtime throw

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2259,6 +2259,27 @@ pub mod bv2_impl {
                                     [import_record.importer_source_index as usize]
                                     .as_mut_slice()
                                     [import_record.import_record_index as usize];
+
+                            if err == _resolver::Error::ModuleNotFound
+                                && matches!(
+                                    import_record.kind,
+                                    ImportKind::Require
+                                        | ImportKind::RequireResolve
+                                        | ImportKind::Dynamic
+                                )
+                                && !record
+                                    .flags
+                                    .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS)
+                                // SAFETY: see `transpiler` note above.
+                                && unsafe { &mut *transpiler }
+                                    .resolver
+                                    .is_optional_peer_dependency(source_dir, &import_record.specifier)
+                            {
+                                record
+                                    .flags
+                                    .insert(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS);
+                            }
+
                             handles_import_errors = record
                                 .flags
                                 .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS);
@@ -6121,6 +6142,30 @@ pub mod bv2_impl {
 
                             if err == _resolver::Error::ModuleNotFound {
                                 let add_error = bun_ast::Log::add_resolve_error_with_text_dupe;
+
+                                // A `require()`/`require.resolve()`/`import()` of a package
+                                // the importing package.json declares optional (via
+                                // `peerDependenciesMeta`/`optionalDependencies`) becomes a
+                                // runtime throw instead of a bundle-time error. The author
+                                // has declared the package may be absent; their runtime
+                                // guard (try/catch around the loader) handles it.
+                                if matches!(
+                                    import_record.kind,
+                                    ImportKind::Require
+                                        | ImportKind::RequireResolve
+                                        | ImportKind::Dynamic
+                                ) && !import_record
+                                    .flags
+                                    .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS)
+                                    && transpiler.resolver.is_optional_peer_dependency(
+                                        source_dir,
+                                        import_record.path.text,
+                                    )
+                                {
+                                    import_record
+                                        .flags
+                                        .insert(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS);
+                                }
 
                                 if !import_record
                                     .flags

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -95,6 +95,12 @@ pub struct PackageJSON {
 
     pub(crate) side_effects: SideEffects,
 
+    /// Package names listed in `peerDependenciesMeta` with `"optional": true`,
+    /// or in `optionalDependencies`. An unresolvable `require()` of one of
+    /// these is not a bundle-time error: the author has declared that the
+    /// package may be absent and has code to handle that at runtime.
+    pub(crate) optional_peer_dependencies: Vec<Box<[u8]>>,
+
     // Populated if the "browser" field is present. This field is intended to be
     // used by bundlers and lets you redirect the paths of certain 3rd-party
     // modules that don't work in the browser to other modules that shim that
@@ -148,6 +154,7 @@ impl Default for PackageJSON {
             package_manager_package_id: INVALID_PACKAGE_ID,
             dependencies: DependencyMap::default(),
             side_effects: SideEffects::default(),
+            optional_peer_dependencies: Vec::new(),
             browser_map: BrowserMap::default(),
             exports: None,
             imports: None,
@@ -201,6 +208,12 @@ impl ::bun_install_types::resolver_hooks::PackageJsonView for PackageJSON {
 }
 
 impl PackageJSON {
+    pub fn has_optional_peer_dependency(&self, package_name: &[u8]) -> bool {
+        self.optional_peer_dependencies
+            .iter()
+            .any(|d| d.as_ref() == package_name)
+    }
+
     /// Normalize path separators to forward slashes for glob matching
     /// This is needed because glob patterns use forward slashes but Windows uses backslashes
     fn normalize_path_for_glob(path: &[u8]) -> Result<Vec<u8>, bun_alloc::AllocError> {
@@ -525,6 +538,7 @@ impl PackageJSON {
             package_manager_package_id: INVALID_PACKAGE_ID,
             dependencies: DependencyMap::default(),
             side_effects: SideEffects::Unspecified,
+            optional_peer_dependencies: Vec::new(),
             exports: None,
             imports: None,
         };
@@ -792,6 +806,31 @@ impl PackageJSON {
                         }
                     }
                     package_json.side_effects = SideEffects::Map(map);
+                }
+            }
+        }
+
+        if let Some(peer_meta) = json.get(b"peerDependenciesMeta") {
+            if let js_ast::ExprData::EObjectJSON(obj) = &peer_meta.data {
+                for prop in obj.get().properties() {
+                    let js_ast::E::JsonValue::Object(meta) = &prop.value else {
+                        continue;
+                    };
+                    if let Some(js_ast::E::JsonValue::Boolean(true)) = meta.get().get(b"optional") {
+                        package_json
+                            .optional_peer_dependencies
+                            .push(Box::from(prop.key.slice()));
+                    }
+                }
+            }
+        }
+
+        if let Some(optional_deps) = json.get(b"optionalDependencies") {
+            if let js_ast::ExprData::EObjectJSON(obj) = &optional_deps.data {
+                for prop in obj.get().properties() {
+                    package_json
+                        .optional_peer_dependencies
+                        .push(Box::from(prop.key.slice()));
                 }
             }
         }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4013,6 +4013,27 @@ impl<'a> Resolver<'a> {
         self.dir_info_cached_maybe_log(false, path).ok().flatten()
     }
 
+    /// True when `specifier` names a package that the importing file's
+    /// enclosing `package.json` lists under `peerDependenciesMeta` with
+    /// `"optional": true` (or under `optionalDependencies`). Used by the
+    /// bundler to downgrade a `ModuleNotFound` for such a package from a
+    /// build error to a runtime throw.
+    pub fn is_optional_peer_dependency(&mut self, source_dir: &[u8], specifier: &[u8]) -> bool {
+        if !is_package_path(specifier) {
+            return false;
+        }
+        let Some(name) = crate::package_json::Package::parse_name(specifier) else {
+            return false;
+        };
+        let Some(dir) = self.read_dir_info_ignore_error(source_dir) else {
+            return false;
+        };
+        let Some(pkg) = dir.enclosing_package_json else {
+            return false;
+        };
+        pkg.has_optional_peer_dependency(name)
+    }
+
     // NOTE: `follow_symlinks` is `true` at every call
     // site, so it's dropped here; `enable_logging` is a plain runtime parameter
     // (it gates one cold error-formatting branch) so this large dir-walk function

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2876,4 +2876,193 @@ for (const backend of ["api", "cli"] as const) {
       },
     });
   });
+
+  // https://github.com/oven-sh/bun/issues/11836
+  // NestJS wraps optional peer deps as `loadPackage('x', ctx, () => require('x'))`.
+  // The require() is in an arrow body, so the parser's try/catch detection does
+  // not apply. The package.json `peerDependenciesMeta` entry is the signal that
+  // the author expects the package to be absent.
+  itBundled("edgecase/OptionalPeerDepRequire#11836", {
+    files: {
+      "/entry.js": /* js */ `
+        const { load } = require("framework");
+        console.log(JSON.stringify(load()));
+      `,
+      "/node_modules/framework/package.json": /* json */ `
+        {
+          "name": "framework",
+          "main": "./index.js",
+          "peerDependencies": { "missing-peer": "*" },
+          "peerDependenciesMeta": { "missing-peer": { "optional": true } }
+        }
+      `,
+      "/node_modules/framework/index.js": /* js */ `
+        function loadPackage(name, loader) {
+          try {
+            return loader();
+          } catch (e) {
+            return { error: String(e) };
+          }
+        }
+        exports.load = () => loadPackage("missing-peer", () => require("missing-peer"));
+      `,
+    },
+    target: "bun",
+    run: {
+      stdout: `{"error":"Error: Cannot require module missing-peer"}`,
+    },
+  });
+  itBundled("edgecase/OptionalPeerDepSubpath#11836", {
+    files: {
+      "/entry.js": /* js */ `
+        function optionalRequire(loader) {
+          try { return loader(); } catch { return {}; }
+        }
+        const { Socket } = optionalRequire(() => require("framework/sub"));
+        console.log(typeof Socket);
+      `,
+      "/node_modules/framework/package.json": /* json */ `
+        {
+          "name": "framework",
+          "main": "./index.js",
+          "peerDependenciesMeta": { "missing-peer": { "optional": true } }
+        }
+      `,
+      "/node_modules/framework/index.js": /* js */ `
+        module.exports = {};
+      `,
+      "/node_modules/framework/sub.js": /* js */ `
+        exports.Socket = require("missing-peer/socket-module").Socket;
+      `,
+      "/package.json": /* json */ `
+        { "name": "app" }
+      `,
+    },
+    target: "bun",
+    run: {
+      stdout: `undefined`,
+    },
+  });
+  itBundled("edgecase/OptionalDependencyRequire", {
+    files: {
+      "/entry.js": /* js */ `
+        const { probe } = require("framework");
+        console.log(probe());
+      `,
+      "/node_modules/framework/package.json": /* json */ `
+        {
+          "name": "framework",
+          "main": "./index.js",
+          "optionalDependencies": { "native-addon": "1.0.0" }
+        }
+      `,
+      "/node_modules/framework/index.js": /* js */ `
+        const loader = () => require.resolve("native-addon");
+        exports.probe = () => {
+          try { loader(); return "present"; }
+          catch { return "absent"; }
+        };
+      `,
+    },
+    target: "bun",
+    run: {
+      stdout: `absent`,
+    },
+  });
+  itBundled("edgecase/OptionalPeerDepDynamicImport", {
+    files: {
+      "/entry.js": /* js */ `
+        import { load } from "framework";
+        load().then(
+          () => console.log("ok"),
+          () => console.log("rejected"),
+        );
+      `,
+      "/node_modules/framework/package.json": /* json */ `
+        {
+          "name": "framework",
+          "main": "./index.mjs",
+          "peerDependenciesMeta": { "missing-peer": { "optional": true } }
+        }
+      `,
+      "/node_modules/framework/index.mjs": /* js */ `
+        export const load = () => import("missing-peer");
+      `,
+    },
+    target: "bun",
+    run: {
+      stdout: `rejected`,
+    },
+  });
+  itBundled("edgecase/OptionalPeerDepStaticImportStillErrors", {
+    files: {
+      "/entry.js": /* js */ `
+        import "framework";
+      `,
+      "/node_modules/framework/package.json": /* json */ `
+        {
+          "name": "framework",
+          "main": "./index.js",
+          "peerDependenciesMeta": { "missing-peer": { "optional": true } }
+        }
+      `,
+      "/node_modules/framework/index.js": /* js */ `
+        import x from "missing-peer";
+        console.log(x);
+      `,
+    },
+    target: "bun",
+    bundleErrors: {
+      "/node_modules/framework/index.js": [`Could not resolve: "missing-peer". Maybe you need to "bun install"?`],
+    },
+  });
+  itBundled("edgecase/NonOptionalPeerDepRequireStillErrors", {
+    files: {
+      "/entry.js": /* js */ `
+        require("framework");
+      `,
+      "/node_modules/framework/package.json": /* json */ `
+        {
+          "name": "framework",
+          "main": "./index.js",
+          "peerDependencies": { "required-peer": "*" },
+          "peerDependenciesMeta": { "other-peer": { "optional": true } }
+        }
+      `,
+      "/node_modules/framework/index.js": /* js */ `
+        module.exports = require("required-peer");
+      `,
+    },
+    target: "bun",
+    bundleErrors: {
+      "/node_modules/framework/index.js": [`Could not resolve: "required-peer". Maybe you need to "bun install"?`],
+    },
+  });
+  itBundled("edgecase/OptionalPeerDepResolvesWhenInstalled", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("framework").value);
+      `,
+      "/node_modules/framework/package.json": /* json */ `
+        {
+          "name": "framework",
+          "main": "./index.js",
+          "peerDependenciesMeta": { "present-peer": { "optional": true } }
+        }
+      `,
+      "/node_modules/framework/index.js": /* js */ `
+        exports.value = require("present-peer");
+      `,
+      "/node_modules/present-peer/package.json": /* json */ `
+        { "name": "present-peer", "main": "./index.js" }
+      `,
+      "/node_modules/present-peer/index.js": /* js */ `
+        module.exports = "installed";
+      `,
+    },
+    target: "bun",
+    run: {
+      stdout: `installed`,
+    },
+  });
 }


### PR DESCRIPTION
Fixes #11836.
Fixes #4803.

## Repro

```sh
# deps: @nestjs/common @nestjs/core @nestjs/platform-express reflect-metadata rxjs
# optional peers class-validator / class-transformer / @nestjs/microservices / @nestjs/websockets NOT installed
bun build src/main.ts --compile --outfile=app-bin
```

```
error: Could not resolve: "@nestjs/microservices". Maybe you need to "bun install"?
    at node_modules/@nestjs/core/nest-factory.js:57:129
error: Could not resolve: "class-transformer". Maybe you need to "bun install"?
    at node_modules/@nestjs/common/serializer/class-serializer.interceptor.js:27:21
... (8 errors)
```

`bun run src/main.ts` works fine; only the bundle fails. esbuild has the same behaviour and recommends `--external`.

## Cause

NestJS loads optional peer dependencies via a helper:

```js
loadPackage('class-transformer', 'ValidationPipe', () => require('class-transformer'))
```

The `require()` sits inside an arrow body, not inside a lexical `try` block, so `fn_or_arrow_data_visit.try_body_count` is zero and the import record does not get `HANDLES_IMPORT_ERRORS`. `bundle_v2` then emits a hard "Could not resolve" error.

But every one of these specifiers is declared in the importing package's `package.json` under `peerDependenciesMeta` with `"optional": true` (`class-transformer`/`class-validator` in `@nestjs/common`, `@nestjs/microservices`/`@nestjs/websockets` in `@nestjs/core`). The author has explicitly stated the package may be absent and has runtime code to handle it.

## Fix

`PackageJSON::parse` now reads `peerDependenciesMeta` (keys with `"optional": true`) and `optionalDependencies` into a new `optional_peer_dependencies` list.

When `resolve_import_records` / `run_resolver` hit `ModuleNotFound` for a `require()`, `require.resolve()`, or dynamic `import()`, and the specifier's package name is in the importer's enclosing package.json's optional list, the import record gets `HANDLES_IMPORT_ERRORS` instead of a bundle error. The printer then emits `(()=>{throw new Error("Cannot require module "+"x");})()` at the call site, which the package's own `try`/`catch` handles at runtime, exactly as under `bun run`.

Static `import x from 'optional-peer'` still fails the bundle (no runtime guard is possible). A peer not marked optional still fails the bundle. An installed optional peer still resolves and bundles normally.

## Verification

Seven new cases in `test/bundler/bundler_edgecase.test.ts`:

- `OptionalPeerDepRequire#11836`: the NestJS `loadPackage(.., () => require('x'))` shape; bundles, runtime throw is caught
- `OptionalPeerDepSubpath#11836`: `require('x/sub')` where `x` is the optional peer
- `OptionalDependencyRequire`: `optionalDependencies` (not `peerDependenciesMeta`) also downgrades
- `OptionalPeerDepDynamicImport`: `() => import('x')` variant
- `OptionalPeerDepStaticImportStillErrors`: static import still a bundle error
- `NonOptionalPeerDepRequireStillErrors`: a non-optional peer still a bundle error
- `OptionalPeerDepResolvesWhenInstalled`: installed optional peer resolves normally

```
$ USE_SYSTEM_BUN=1 bun test test/bundler/bundler_edgecase.test.ts -t 'OptionalPeerDep|OptionalDependency|NonOptionalPeer'
 6 pass   8 fail

$ bun bd test test/bundler/bundler_edgecase.test.ts -t 'OptionalPeerDep|OptionalDependency|NonOptionalPeer'
 14 pass  0 fail
```

`bundler_edgecase` (131 pass), `bundler_browser`, `bundler_allow_unresolved`, `bundler_cjs`, `esbuild/packagejson` all pass. The NestJS repro now bundles 754 modules and produces a working binary.

## Related

- #7621: `knex` lists every database driver and `consolidate` lists every template engine under `peerDependenciesMeta` as optional, so their `require()` calls will now bundle. Other packages in that report may still have unrelated errors.
- #23964: `@opentelemetry/api` is an optional peer of `next` and will now bundle; the `webpack/lib/...` / `react-server-dom-webpack/...` paths in that report are not declared optional, so this does not fully fix it.
- #17925 asks for unresolved `require()` in a `try` body to be left as a runtime `__require` call rather than an inline throw; that is a separate change.
- #14891 is about `@protobufjs/inquire`'s `eval("require")` pattern, which the bundler cannot analyse; not addressed here.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->
