### PR TITLE
mock.module: keep accessor exports live instead of snapshotting them

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-380-3cf0ca7b";
+export const WEBKIT_VERSION = "autobuild-preview-pr-380-abed2dbe";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-380-a59646ca";
+export const WEBKIT_VERSION = "autobuild-preview-pr-380-1ee717ba";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "34c01d13391e00c06862a3d2c5b7fff350ac87e0";
+export const WEBKIT_VERSION = "autobuild-preview-pr-380-a59646ca";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-380-1ee717ba";
+export const WEBKIT_VERSION = "autobuild-preview-pr-380-3cf0ca7b";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-380-abed2dbe";
+export const WEBKIT_VERSION = "autobuild-preview-pr-380-1b4afe55";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -660,11 +660,7 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                             JSObject::getOwnPropertyNames(object, globalObject, names, DontEnumPropertiesMode::Exclude);
                             RETURN_IF_EXCEPTION(scope, {});
 
-                            // overrideExportValue writes through to the record's current
-                            // live-exports source, which is the previous factory object (and
-                            // possibly a user-captured require() result). Clear it first so
-                            // the loop only touches the env slot, then install the new
-                            // source after.
+                            // Clear the live source so overrideExportValue's write-through does not mutate the previous factory object.
                             auto* synthetic = dynamicDowncast<JSC::SyntheticModuleRecord>(mod);
                             bool hadLiveSource = synthetic && synthetic->liveExportsSource();
                             if (hadLiveSource)

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -655,16 +655,16 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                         auto* object = exportsValue.getObject();
                         removeFromESM = false;
 
+                        // Clear the live source so overrideExportValue's write-through does not mutate the previous factory object.
+                        auto* synthetic = dynamicDowncast<JSC::SyntheticModuleRecord>(mod);
+                        bool hadLiveSource = synthetic && synthetic->liveExportsSource();
+                        if (hadLiveSource)
+                            synthetic->setLiveExportsSource(vm, nullptr);
+
                         if (object) {
                             JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
                             JSObject::getOwnPropertyNames(object, globalObject, names, DontEnumPropertiesMode::Exclude);
                             RETURN_IF_EXCEPTION(scope, {});
-
-                            // Clear the live source so overrideExportValue's write-through does not mutate the previous factory object.
-                            auto* synthetic = dynamicDowncast<JSC::SyntheticModuleRecord>(mod);
-                            bool hadLiveSource = synthetic && synthetic->liveExportsSource();
-                            if (hadLiveSource)
-                                synthetic->setLiveExportsSource(vm, nullptr);
 
                             bool hasAccessor = false;
                             for (auto& name : names) {

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -660,10 +660,21 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                             JSObject::getOwnPropertyNames(object, globalObject, names, DontEnumPropertiesMode::Exclude);
                             RETURN_IF_EXCEPTION(scope, {});
 
+                            bool hasAccessor = false;
                             for (auto& name : names) {
                                 // consistent with regular esm handling code
                                 auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-                                JSValue value = object->get(globalObject, name);
+                                PropertySlot propSlot(object, PropertySlot::InternalMethodType::GetOwnProperty);
+                                bool has = object->methodTable()->getOwnPropertySlot(object, globalObject, name, propSlot);
+                                if (scope.exception()) [[unlikely]] {
+                                    (void)scope.tryClearException();
+                                    moduleNamespaceObject->overrideExportValue(globalObject, name, jsUndefined());
+                                    RETURN_IF_EXCEPTION(scope, {});
+                                    continue;
+                                }
+                                if (has && propSlot.isAccessor())
+                                    hasAccessor = true;
+                                JSValue value = has ? propSlot.getValue(globalObject, name) : object->get(globalObject, name);
                                 if (scope.exception()) [[unlikely]] {
                                     (void)scope.tryClearException();
                                     value = jsUndefined();
@@ -672,8 +683,10 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                                 RETURN_IF_EXCEPTION(scope, {});
                             }
 
-                            if (auto* synthetic = dynamicDowncast<JSC::SyntheticModuleRecord>(mod))
-                                synthetic->setLiveExportsSource(vm, object);
+                            if (auto* synthetic = dynamicDowncast<JSC::SyntheticModuleRecord>(mod)) {
+                                if (hasAccessor || synthetic->liveExportsSource())
+                                    synthetic->setLiveExportsSource(vm, object);
+                            }
 
                         } else {
                             // if it's not an object, I guess we just set the default export?

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -660,6 +660,16 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                             JSObject::getOwnPropertyNames(object, globalObject, names, DontEnumPropertiesMode::Exclude);
                             RETURN_IF_EXCEPTION(scope, {});
 
+                            // overrideExportValue writes through to the record's current
+                            // live-exports source, which is the previous factory object (and
+                            // possibly a user-captured require() result). Clear it first so
+                            // the loop only touches the env slot, then install the new
+                            // source after.
+                            auto* synthetic = dynamicDowncast<JSC::SyntheticModuleRecord>(mod);
+                            bool hadLiveSource = synthetic && synthetic->liveExportsSource();
+                            if (hadLiveSource)
+                                synthetic->setLiveExportsSource(vm, nullptr);
+
                             bool hasAccessor = false;
                             for (auto& name : names) {
                                 // consistent with regular esm handling code
@@ -683,10 +693,8 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                                 RETURN_IF_EXCEPTION(scope, {});
                             }
 
-                            if (auto* synthetic = dynamicDowncast<JSC::SyntheticModuleRecord>(mod)) {
-                                if (hasAccessor || synthetic->liveExportsSource())
-                                    synthetic->setLiveExportsSource(vm, object);
-                            }
+                            if (synthetic && (hasAccessor || hadLiveSource))
+                                synthetic->setLiveExportsSource(vm, object);
 
                         } else {
                             // if it's not an object, I guess we just set the default export?

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -17,6 +17,7 @@
 #include <JavaScriptCore/CyclicModuleRecord.h>
 #include <JavaScriptCore/JSModuleNamespaceObject.h>
 #include <JavaScriptCore/JSModuleRecord.h>
+#include <JavaScriptCore/SyntheticModuleRecord.h>
 #include <JavaScriptCore/JSObjectInlines.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/JSTypeInfo.h>
@@ -670,6 +671,9 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                                 moduleNamespaceObject->overrideExportValue(globalObject, name, value);
                                 RETURN_IF_EXCEPTION(scope, {});
                             }
+
+                            if (auto* synthetic = dynamicDowncast<JSC::SyntheticModuleRecord>(mod))
+                                synthetic->setLiveExportsSource(vm, object);
 
                         } else {
                             // if it's not an object, I guess we just set the default export?

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1523,6 +1523,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
             } else {
                 value = slot.getValue(globalObject, propertyKey);
             }
+            RETURN_IF_EXCEPTION(scope, {});
 
             if (dynamicDowncast<JSMockFunction>(value)) {
                 return JSValue::encode(value);

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -418,6 +418,11 @@ static JSValue handleVirtualModuleResult(
                     return commonJSModule;
                 }
             }
+            if (wasModuleMock) {
+                commonJSModule->setExportsObject(object);
+                commonJSModule->hasEvaluated = true;
+                return commonJSModule;
+            }
         }
 
         JSC::ensureStillAliveHere(object);

--- a/src/jsc/modules/ObjectModule.cpp
+++ b/src/jsc/modules/ObjectModule.cpp
@@ -21,17 +21,34 @@ generateObjectModuleSourceCode(JSC::JSGlobalObject* globalObject,
         RETURN_IF_EXCEPTION(throwScope, void());
         gcUnprotectNullTolerant(object);
 
+        bool hasAccessor = false;
         for (auto& entry : properties.releaseData()->propertyNameVector()) {
             exportNames.append(entry);
 
             auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            JSValue value = object->get(globalObject, entry);
+            PropertySlot slot(object, PropertySlot::InternalMethodType::GetOwnProperty);
+            bool has = object->methodTable()->getOwnPropertySlot(object, globalObject, entry, slot);
+            if (scope.exception()) [[unlikely]] {
+                (void)scope.tryClearException();
+                exportValues.append(jsUndefined());
+                continue;
+            }
+            if (has && slot.isAccessor())
+                hasAccessor = true;
+            JSValue value = has ? slot.getValue(globalObject, entry) : object->get(globalObject, entry);
             if (scope.exception()) [[unlikely]] {
                 (void)scope.tryClearException();
                 value = jsUndefined();
             }
             exportValues.append(value);
         }
+
+        // When the factory object exposes accessor exports, pass the object as a
+        // trailing value (no matching name) so SyntheticModuleRecord can back the
+        // namespace with it and keep reads live. The environment slots still hold
+        // the snapshots above for static `import { x }` consumers.
+        if (hasAccessor)
+            exportValues.append(object);
     };
 }
 

--- a/src/jsc/modules/ObjectModule.cpp
+++ b/src/jsc/modules/ObjectModule.cpp
@@ -43,10 +43,7 @@ generateObjectModuleSourceCode(JSC::JSGlobalObject* globalObject,
             exportValues.append(value);
         }
 
-        // When the factory object exposes accessor exports, pass the object as a
-        // trailing value (no matching name) so SyntheticModuleRecord can back the
-        // namespace with it and keep reads live. The environment slots still hold
-        // the snapshots above for static `import { x }` consumers.
+        // Trailing value with no matching name: SyntheticModuleRecord::m_liveExportsSource.
         if (hasAccessor)
             exportValues.append(object);
     };

--- a/test/js/bun/plugin/module-plugins.ts
+++ b/test/js/bun/plugin/module-plugins.ts
@@ -41,6 +41,19 @@ plugin({
       };
     });
 
+    builder.module("my-virtual-module-with-accessor", () => {
+      let value = 1;
+      return {
+        exports: {
+          get value() {
+            return value;
+          },
+          increment: () => value++,
+        },
+        loader: "object",
+      };
+    });
+
     builder.onLoad({ filter: /.*/, namespace: "rejected-promise" }, async ({ path }) => {
       throw new Error("Rejected Promise");
     });

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -301,6 +301,15 @@ describe("module", () => {
       expect(there).toBeUndefined();
     }
   });
+
+  // https://github.com/oven-sh/bun/issues/7128
+  it("accessor exports are live", async () => {
+    // @ts-expect-error
+    const m = await import("my-virtual-module-with-accessor");
+    expect(m.value).toBe(1);
+    m.increment();
+    expect(m.value).toBe(2);
+  });
 });
 
 describe("dynamic import", () => {

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -166,3 +166,68 @@ test("mocking a builtin", async () => {
   const { readFile } = await import("node:fs/promises");
   expect(await readFile("hello.txt", "utf8")).toBe("hello world");
 });
+
+// https://github.com/oven-sh/bun/issues/9874
+test("mock.module: accessor exports are live bindings (ESM)", async () => {
+  mock.module("mock-module-live-esm", () => {
+    let foo = "foo";
+    return {
+      get foo() {
+        return foo;
+      },
+      updateFoo: () => {
+        foo = "bar";
+      },
+    };
+  });
+
+  const esm = await import("mock-module-live-esm");
+  expect(esm.foo).toBe("foo");
+  esm.updateFoo();
+  expect(esm.foo).toBe("bar");
+});
+
+test("mock.module: accessor exports are live bindings (CJS)", () => {
+  mock.module("mock-module-live-cjs", () => {
+    let foo = "foo";
+    return {
+      get foo() {
+        return foo;
+      },
+      updateFoo: () => {
+        foo = "bar";
+      },
+    };
+  });
+
+  const cjs = require("mock-module-live-cjs");
+  expect(cjs.foo).toBe("foo");
+  cjs.updateFoo();
+  expect(cjs.foo).toBe("bar");
+});
+
+test("mock.module: data properties and accessor properties coexist", async () => {
+  mock.module("mock-module-live-mixed", () => {
+    let v = "a";
+    return {
+      plain: 42,
+      get live() {
+        return v;
+      },
+      set: (next: string) => {
+        v = next;
+      },
+    };
+  });
+
+  const esm = await import("mock-module-live-mixed");
+  expect({ plain: esm.plain, live: esm.live }).toEqual({ plain: 42, live: "a" });
+  esm.set("b");
+  expect({ plain: esm.plain, live: esm.live }).toEqual({ plain: 42, live: "b" });
+
+  const cjs = require("mock-module-live-mixed");
+  expect({ plain: cjs.plain, live: cjs.live }).toEqual({ plain: 42, live: "b" });
+  cjs.set("c");
+  expect({ plain: cjs.plain, live: cjs.live }).toEqual({ plain: 42, live: "c" });
+  expect(esm.live).toBe("c");
+});

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -283,3 +283,41 @@ test("mock.module: spyOn on an accessor-backed mock namespace", async () => {
   ns.bump();
   expect(ns.x).toBe(3);
 });
+
+test("mock.module: partial re-mock of a data-only synthetic module keeps other keys", async () => {
+  mock.module("mock-module-partial-remock", () => ({ a: 1, b: 2 }));
+  const ns = await import("mock-module-partial-remock");
+  expect({ a: ns.a, b: ns.b }).toEqual({ a: 1, b: 2 });
+
+  mock.module("mock-module-partial-remock", () => ({ a: 99 }));
+  expect({ a: ns.a, b: ns.b }).toEqual({ a: 99, b: 2 });
+});
+
+test("mock.module: partial re-mock after an accessor-backed mock keeps un-overridden keys", async () => {
+  mock.module("mock-module-partial-accessor", () => {
+    let v = 1;
+    return {
+      get a() {
+        return v;
+      },
+      b: 2,
+      bump: () => v++,
+    };
+  });
+  const ns = await import("mock-module-partial-accessor");
+  ns.bump();
+  expect({ a: ns.a, b: ns.b }).toEqual({ a: 2, b: 2 });
+
+  mock.module("mock-module-partial-accessor", () => ({ a: 99 }));
+  expect({ a: ns.a, b: ns.b }).toEqual({ a: 99, b: 2 });
+});
+
+test("mock.module: captured require() result does not track a subsequent re-mock", () => {
+  mock.module("mock-module-cjs-capture", () => ({ wow: () => 42 }));
+  const cjs = require("mock-module-cjs-capture");
+  expect(cjs.wow()).toBe(42);
+
+  mock.module("mock-module-cjs-capture", () => ({ wow: () => 43 }));
+  expect(cjs.wow()).toBe(42);
+  expect(require("mock-module-cjs-capture").wow()).toBe(43);
+});

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -312,6 +312,35 @@ test("mock.module: partial re-mock after an accessor-backed mock keeps un-overri
   expect({ a: ns.a, b: ns.b }).toEqual({ a: 99, b: 2 });
 });
 
+test("mock.module: re-mock with an accessor after a hot data-only read invalidates the namespace IC", async () => {
+  mock.module("mock-module-ic-invalidate", () => ({ x: 1, bump: () => {} }));
+  const ns = await import("mock-module-ic-invalidate");
+
+  function readX() {
+    return ns.x;
+  }
+
+  let sum = 0;
+  for (let i = 0; i < 500000; i++) sum += readX();
+  expect(sum).toBe(500000);
+
+  let v = 100;
+  mock.module("mock-module-ic-invalidate", () => ({
+    get x() {
+      return v;
+    },
+    bump() {
+      v++;
+    },
+  }));
+
+  expect(readX()).toBe(100);
+  ns.bump();
+  expect(readX()).toBe(101);
+  for (let i = 0; i < 10; i++) ns.bump();
+  expect(readX()).toBe(111);
+});
+
 test("mock.module: captured require() result does not track a subsequent re-mock", () => {
   mock.module("mock-module-cjs-capture", () => ({ wow: () => 42 }));
   const cjs = require("mock-module-cjs-capture");

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -231,3 +231,55 @@ test("mock.module: data properties and accessor properties coexist", async () =>
   expect({ plain: cjs.plain, live: cjs.live }).toEqual({ plain: 42, live: "c" });
   expect(esm.live).toBe("c");
 });
+
+test("mock.module: re-mock after an accessor-backed mock replaces the live source", async () => {
+  mock.module("mock-module-live-remock", () => {
+    let v = 1;
+    return {
+      get x() {
+        return v;
+      },
+      bump: () => v++,
+    };
+  });
+  const ns = await import("mock-module-live-remock");
+  expect(ns.x).toBe(1);
+  ns.bump();
+  expect(ns.x).toBe(2);
+
+  mock.module("mock-module-live-remock", () => ({ x: 100, bump: () => {} }));
+  expect(ns.x).toBe(100);
+
+  let w = "a";
+  mock.module("mock-module-live-remock", () => ({
+    get x() {
+      return w;
+    },
+    bump: () => {
+      w = "b";
+    },
+  }));
+  expect(ns.x).toBe("a");
+  ns.bump();
+  expect(ns.x).toBe("b");
+});
+
+test("mock.module: spyOn on an accessor-backed mock namespace", async () => {
+  mock.module("mock-module-live-spy", () => {
+    let v = 1;
+    return {
+      get x() {
+        return v;
+      },
+      bump: () => v++,
+    };
+  });
+  const ns = await import("mock-module-live-spy");
+  const spy = spyOn(ns, "bump");
+  ns.bump();
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(ns.x).toBe(2);
+  mock.restore();
+  ns.bump();
+  expect(ns.x).toBe(3);
+});

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -350,3 +350,25 @@ test("mock.module: captured require() result does not track a subsequent re-mock
   expect(cjs.wow()).toBe(42);
   expect(require("mock-module-cjs-capture").wow()).toBe(43);
 });
+
+test("mock.module: re-mock does not mutate the previous factory object", async () => {
+  mock.module("mock-module-no-mutate", () => {
+    let v = 1;
+    return {
+      get x() {
+        return v;
+      },
+      bump: () => v++,
+    };
+  });
+  const cjs = require("mock-module-no-mutate");
+  const ns = await import("mock-module-no-mutate");
+  expect(cjs.x).toBe(1);
+  expect(ns.x).toBe(1);
+
+  mock.module("mock-module-no-mutate", () => ({ x: 100 }));
+  expect(cjs.x).toBe(1);
+  cjs.bump();
+  expect(cjs.x).toBe(2);
+  expect(ns.x).toBe(100);
+});


### PR DESCRIPTION
Fixes #9874. Fixes #7128.

### Repro

```ts
import { test, expect, mock } from "bun:test";

mock.module("./module", () => {
  let foo = "foo";
  return {
    get foo() { return foo; },
    updateFoo: () => { foo = "bar"; },
  };
});

test("mock.module live binding", async () => {
  const esm = await import("./module");
  expect(esm.foo).toBe("foo");
  esm.updateFoo();
  expect(esm.foo).toBe("bar");   // fails: Received "foo"
});
```

### Cause

`generateObjectModuleSourceCode` calls `object->get(globalObject, entry)` for each own property of the factory result and appends the value to the synthetic module's `exportValues`. For an accessor that evaluates the getter once; `SyntheticModuleRecord::tryCreateWithExportNamesAndValues` then stores the result in a `JSModuleEnvironment` slot, and `JSModuleNamespaceObject::getOwnPropertySlotCommon` reads the slot directly on every subsequent access. `fetchCommonJSModule` routes the `require()` path through the same code, so both `await import()` and `require()` observe a snapshot. The plugin `build.module` / `onLoad` `loader: "object"` path (#7128) shares `generateObjectModuleSourceCode`, so it has the same limitation.

### Fix

**require()**: when the virtual module came from `mock.module`, `handleVirtualModuleResult` assigns the factory object as `module.exports` directly (matching what `JSMock__jsModuleMock` already does for a re-mock of an already-required module). Property access goes through the original getters. A captured `require()` result therefore does not observe a later re-mock (Node/Jest semantics); a fresh `require()` does.

**await import()**: `generateObjectModuleSourceCode` still snapshots each property into the module environment (so static `import { x }` bindings, which every tier reads as a raw `variableAt(offset)` load, see a plain value), but when any own property is an accessor it also appends the factory object as a trailing `exportValue` with no matching `exportName`. On the WebKit side (oven-sh/WebKit#380) `SyntheticModuleRecord::tryCreateWithExportNamesAndValues` picks that up as `m_liveExportsSource`, and `JSModuleNamespaceObject::getOwnPropertySlotCommon` forwards namespace reads through it via an uncacheable `slot.setValue` for properties the source actually owns (others fall back to the env slot, so partial re-mocks keep un-overridden keys). Because `setValueModuleNamespace` is never called for those properties, the JIT's `ModuleNamespaceAccessCase` IC (and the DFG/FTL lowering to `GetClosureVar` that hangs off it) is never installed.

**re-mock / spyOn**: `JSModuleNamespaceObject::overrideExportValue` also writes through to the backing object when one is set, so `spyOn(ns, key)` and `mock.restore()` are observed by namespace reads; and `JSMock__jsModuleMock` swaps the backing object to the new factory on re-mock when the new factory has an accessor or a source was already set (so a data-only partial re-mock of a builtin keeps the module-namespace IC).

### Verification

New tests in `test/js/bun/test/mock/mock-module.test.ts` (ESM + CJS live bindings, mixed data/accessor, re-mock of an accessor-backed namespace, `spyOn` on one, partial re-mock of data-only and accessor-backed, captured-require contract) and `test/js/bun/plugin/plugins.test.ts` (`loader: "object"` accessor export):

```
before (bun 1.3.14):            10 pass / 7 fail in mock-module.test.ts
after  (bun bd, preview WebKit): 17 pass / 0 fail; plugins.test.ts 36/0
```

The existing `mock.module` tests (`6874/`, `6879/`, `mock-module-*`) and `test-vm-module-synthetic.js` are unchanged.

### Also in this WebKit range (34c01d1339..)

- oven-sh/WebKit#333: execution-count CodeBlock aging (gated behind `USE(BUN_JSC_ADDITIONS)`, defaults off)
- oven-sh/WebKit#377: `Dockerfile.windows` xwin hardening

> [!NOTE]
> `WEBKIT_VERSION` is pinned to the preview tag `autobuild-preview-pr-380-1b4afe55` while oven-sh/WebKit#380 is open. It must be swapped to the merged `main` sha before this lands.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 2 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.0 (433b57572)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1107.03ms]
(pass) require > beep:boop returns 42 [9.04ms]
(pass) require > object module works [7.55ms]
(pass) module > throws with require() [12.72ms]
(pass) module > async module works with async import [22.96ms]
(pass) module > sync module module works with require() [4.33ms]
(pass) module > sync module module works with require.resolve() [2.99ms]
(pass) module > sync module module works with import [4.82ms]
(pass) module > modules are overridable [86.50ms]
306 |   it("accessor exports are live", async () => {
307 |     // @ts-expect-error
308 |     const m = await import("my-virtual-m
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (cf2519804)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [29.95ms]
(pass) require > beep:boop returns 42 [0.15ms]
(pass) require > object module works [0.09ms]
(pass) module > throws with require() [0.13ms]
(pass) module > async module works with async import [1.29ms]
(pass) module > sync module module works with require() [0.07ms]
(pass) module > sync module module works with require.resolve() [0.05ms]
(pass) module > sync module module works with import [0.07ms]
(pass) module > modules are overridable [0.21ms]
(pass) module > accessor exports are live [0.08ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [0.08ms]
(pass) dynamic import > beep:boop returns 42 [0.07ms]
(pass) dynamic import > async:onLoad returns 42 [1.38ms]
(pass) dynamic import > async object loader returns 42 [1.25ms]
(pass) import statement > SSRs `<h1>
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.0 (433b57572)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1140.34ms]
(pass) require > beep:boop returns 42 [9.70ms]
(pass) require > object module works [8.83ms]
(pass) module > throws with require() [13.96ms]
(pass) module > async module works with async import [28.74ms]
(pass) module > sync module module works with require() [4.87ms]
(pass) module > sync module module works with require.resolve() [2.94ms]
(pass) module > sync module module works with import [6.46ms]
(pass) module > modules are overridable [91.96ms]
(pass) module > accessor exports are live [8.34ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [6.53ms]
(pass
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 688ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/52] cxx obj/src/jsc/bindings/highway_sourcemap.cpp.o
[2/52] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[3/52] cxx obj/src/jsc/bindings/BunObject.cpp.o
[4/52] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[5/52] cxx obj/src/jsc/bindings/napi.cpp.o
[6/52] cxx obj/unified/UnifiedSource-src_jsc_modules-0.cpp.o
[7/52] cxx obj/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp.o
[8/52] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[9/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[10/52] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[11/52] cxx obj/src/jsc/bindings/bindings.cpp.o
[12/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[13/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[14/52] cxx obj/src/jsc/bindings/webcore/streams/BunStreamSource.cpp.o
[15/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[16/52] gen cpp.rs (cppbind)
[17/52] cxx obj/src/jsc/bindings/webcore/streams/CrossRe
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts              |   2 +-
 src/jsc/bindings/BunPlugin.cpp            |  23 +++-
 src/jsc/bindings/JSMockFunction.cpp       |   1 +
 src/jsc/bindings/ModuleLoader.cpp         |   5 +
 src/jsc/modules/ObjectModule.cpp          |  16 ++-
 test/js/bun/plugin/module-plugins.ts      |  13 ++
 test/js/bun/plugin/plugins.test.ts        |   9 ++
 test/js/bun/test/mock/mock-module.test.ts | 206 ++++++++++++++++++++++++++++++
 8 files changed, 272 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
scripts/build/deps/webkit.ts                   2      6      0
src/jsc/bindings/BunPlugin.cpp                 8      9      0
src/jsc/bindings/JSMockFunction.cpp            4      1      0
src/jsc/bindings/ModuleLoader.cpp              3      1      0
src/jsc/modules/ObjectModule.cpp               2      3      0
test/js/bun/plugin/module-plugins.ts           1      1      0
test/js/bun/plugin/plugins.test.ts             1      1      0
test/js/bun/test/mock/mock-module.test.ts      4      7      0
```

</details>

<!-- robobun:evidence:end -->

