### PR TITLE
resolver: bust tsconfig-paths-mapped dirs on runtime resolve miss

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4149,12 +4149,8 @@ impl VirtualMachine {
                     let mut busted = self.transpiler.resolver.bust_dir_cache(
                         bun_paths::string_paths::without_trailing_slash_windows_path(buster_name),
                     );
-                    // The join above treats the specifier as a relative path; a
-                    // tsconfig `paths` alias needs to be mapped through the
-                    // tsconfig to find the real directory to bust. Do this even
-                    // when the naive bust above returned true, because that hit
-                    // may have been a cached negative for the literal
-                    // `<source>/<alias>/..` path probed by the baseUrl fallback.
+                    // Unconditional: the literal-join bust above may have hit
+                    // only a cached negative for `<source>/<alias>`.
                     if bun_paths::is_package_path(normalized_specifier) {
                         busted |= self.transpiler.resolver.bust_dir_cache_from_tsconfig_paths(
                             source_to_use,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4149,8 +4149,6 @@ impl VirtualMachine {
                     let mut busted = self.transpiler.resolver.bust_dir_cache(
                         bun_paths::string_paths::without_trailing_slash_windows_path(buster_name),
                     );
-                    // Unconditional: the literal-join bust above may have hit
-                    // only a cached negative for `<source>/<alias>`.
                     if bun_paths::is_package_path(normalized_specifier) {
                         busted |= self.transpiler.resolver.bust_dir_cache_from_tsconfig_paths(
                             source_to_use,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4146,9 +4146,22 @@ impl VirtualMachine {
                     };
 
                     // Only re-query if we previously had something cached.
-                    if self.transpiler.resolver.bust_dir_cache(
+                    let mut busted = self.transpiler.resolver.bust_dir_cache(
                         bun_paths::string_paths::without_trailing_slash_windows_path(buster_name),
-                    ) {
+                    );
+                    // The join above treats the specifier as a relative path; a
+                    // tsconfig `paths` alias needs to be mapped through the
+                    // tsconfig to find the real directory to bust. Do this even
+                    // when the naive bust above returned true, because that hit
+                    // may have been a cached negative for the literal
+                    // `<source>/<alias>/..` path probed by the baseUrl fallback.
+                    if bun_paths::is_package_path(normalized_specifier) {
+                        busted |= self.transpiler.resolver.bust_dir_cache_from_tsconfig_paths(
+                            source_to_use,
+                            normalized_specifier,
+                        );
+                    }
+                    if busted {
                         continue;
                     }
                     return Err(crate::CrateError::ModuleNotFound);

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2501,9 +2501,6 @@ impl<'a> Resolver<'a> {
         a || b
     }
 
-    /// Bust the dir cache for every absolute target the enclosing tsconfig's
-    /// `paths`/`baseUrl` map `specifier` to (same substitution as
-    /// [`match_tsconfig_paths`]).
     pub fn bust_dir_cache_from_tsconfig_paths(
         &mut self,
         source_dir: &[u8],
@@ -2519,133 +2516,26 @@ impl<'a> Resolver<'a> {
             return false;
         };
 
-        let mut abs_base_url: &[u8] = &tsconfig.base_url_for_paths;
-        if tsconfig.has_base_url() {
-            abs_base_url = &tsconfig.base_url;
-        }
-
-        let mut busted = false;
-        let mut bust_abs = |this: &mut Self, abs: &[u8]| {
+        fn bust_abs(this: &mut Resolver, abs: &[u8]) -> bool {
             let abs = strings::without_trailing_slash_windows_path(abs);
             let dir = bun_paths::dirname_platform(abs, bun_paths::Platform::AUTO);
             let a = this.bust_dir_cache(dir);
             let b = this.bust_dir_cache(abs);
-            busted |= a | b;
-        };
-
-        // Exact matches.
-        for (key, value) in tsconfig
-            .paths
-            .keys()
-            .iter()
-            .zip(tsconfig.paths.values().iter())
-        {
-            if strings::eql_long(key, specifier, true) {
-                for original_path in value.iter() {
-                    let mut abs: &[u8] = original_path;
-                    if !::bun_paths::is_absolute(abs) {
-                        let parts: [&[u8]; 2] = [abs_base_url, original_path.as_ref()];
-                        match self
-                            .fs_ref()
-                            .abs_buf_checked(&parts, bufs!(tsconfig_path_abs))
-                        {
-                            Some(p) => abs = p,
-                            None => continue,
-                        }
-                    }
-                    bust_abs(self, abs);
-                }
-            }
+            a | b
         }
 
-        // Wildcard match (longest prefix, then longest suffix).
-        let mut longest: Option<(&[u8], &[u8], &[Box<[u8]>])> = None;
-        let mut best_prefix: i32 = -1;
-        let mut best_suffix: i32 = -1;
-        for (key, original_paths) in tsconfig
-            .paths
-            .keys()
-            .iter()
-            .zip(tsconfig.paths.values().iter())
-        {
-            if let Some(star) = strings::index_of_char(key, b'*') {
-                let star = star as usize;
-                let prefix: &[u8] = if star == 0 { b"" } else { &key[0..star] };
-                let suffix: &[u8] = if star == key.len() - 1 {
-                    b""
-                } else {
-                    &key[star + 1..]
-                };
-                let plen = i32::try_from(prefix.len()).expect("int cast");
-                let slen = i32::try_from(suffix.len()).expect("int cast");
-                if specifier.len() >= prefix.len() + suffix.len()
-                    && specifier.starts_with(prefix)
-                    && specifier.ends_with(suffix)
-                    && (plen > best_prefix || (plen == best_prefix && slen > best_suffix))
-                {
-                    best_prefix = plen;
-                    best_suffix = slen;
-                    longest = Some((prefix, suffix, original_paths));
-                }
-            }
-        }
-        if let Some((match_prefix, match_suffix, original_paths)) = longest {
-            for original_path in original_paths.iter() {
-                let matched_text =
-                    &specifier[match_prefix.len()..specifier.len() - match_suffix.len()];
-                let total_length: Option<u32> = strings::index_of_char(original_path, b'*');
-                let prefix_end = total_length
-                    .map(|v| v as usize)
-                    .unwrap_or(original_path.len());
-                let prefix_parts: [&[u8]; 2] = [abs_base_url, &original_path[0..prefix_end]];
+        let mut busted = false;
+        self.for_each_tsconfig_paths_target(tsconfig, specifier, |this, abs| {
+            busted |= bust_abs(this, abs);
+            false
+        });
 
-                let matched_text_with_suffix = bufs!(tsconfig_match_full_buf3);
-                let mut matched_text_with_suffix_len: usize = 0;
-                if total_length.is_some() {
-                    let suffix = strings::trim_left(&original_path[prefix_end..], b"*");
-                    matched_text_with_suffix_len = matched_text.len() + suffix.len();
-                    if matched_text_with_suffix_len > matched_text_with_suffix.len() {
-                        continue;
-                    }
-                    ::bun_core::concat_into(matched_text_with_suffix, &[matched_text, suffix]);
-                }
-
-                let Some(prefix) = self
-                    .fs_ref()
-                    .abs_buf_checked(&prefix_parts, bufs!(tsconfig_match_full_buf2))
-                else {
-                    continue;
-                };
-                let parts: [&[u8]; 3] = [
-                    prefix,
-                    if matched_text_with_suffix_len > 0 {
-                        strings::trim_left(
-                            &matched_text_with_suffix[0..matched_text_with_suffix_len],
-                            b"/",
-                        )
-                    } else {
-                        b""
-                    },
-                    strings::trim_left(match_suffix, b"/"),
-                ];
-                let Some(abs) = self
-                    .fs_ref()
-                    .abs_buf_checked(&parts, bufs!(tsconfig_match_full_buf))
-                else {
-                    continue;
-                };
-                bust_abs(self, abs);
-            }
-        }
-
-        // `baseUrl` fallback: `load_node_modules` probes `baseUrl + specifier`.
         if tsconfig.has_base_url() {
-            let base: &[u8] = &tsconfig.base_url;
             if let Some(abs) = self.fs_ref().abs_buf_checked(
-                &[base, specifier],
+                &[&tsconfig.base_url, specifier],
                 bufs!(load_as_file_or_directory_via_tsconfig_base_path),
             ) {
-                bust_abs(self, abs);
+                busted |= bust_abs(self, abs);
             }
         }
 
@@ -4775,21 +4665,12 @@ impl<'a> Resolver<'a> {
 
     // This closely follows the behavior of "tryLoadModuleUsingPaths()" in the
     // official TypeScript compiler
-    pub(crate) fn match_tsconfig_paths(
+    fn for_each_tsconfig_paths_target(
         &mut self,
         tsconfig: &TSConfigJSON,
         path: &[u8],
-        kind: ast::ImportKind,
-        out: &mut MatchResult,
-    ) -> MatchStatus {
-        if let Some(debug) = self.debug_logs.as_mut() {
-            debug.add_note_fmt(format_args!(
-                "Matching \"{}\" against \"paths\" in \"{}\"",
-                bstr::BStr::new(path),
-                bstr::BStr::new(&tsconfig.abs_path)
-            ));
-        }
-
+        mut f: impl FnMut(&mut Self, &[u8]) -> bool,
+    ) -> bool {
         let mut abs_base_url: &[u8] = &tsconfig.base_url_for_paths;
 
         // The explicit base URL should take precedence over the implicit base URL
@@ -4826,11 +4707,8 @@ impl<'a> Resolver<'a> {
                                 self.fs_ref().abs_buf(&parts, bufs!(tsconfig_path_abs));
                         }
 
-                        if self
-                            .load_as_file_or_directory(absolute_original_path, kind, out)
-                            .is_success()
-                        {
-                            return MatchStatus::Success;
+                        if f(self, absolute_original_path) {
+                            return true;
                         }
                     }
                 }
@@ -4951,13 +4829,34 @@ impl<'a> Resolver<'a> {
                     continue;
                 };
 
-                if self
-                    .load_as_file_or_directory(absolute_original_path, kind, out)
-                    .is_success()
-                {
-                    return MatchStatus::Success;
+                if f(self, absolute_original_path) {
+                    return true;
                 }
             }
+        }
+
+        false
+    }
+
+    pub(crate) fn match_tsconfig_paths(
+        &mut self,
+        tsconfig: &TSConfigJSON,
+        path: &[u8],
+        kind: ast::ImportKind,
+        out: &mut MatchResult,
+    ) -> MatchStatus {
+        if let Some(debug) = self.debug_logs.as_mut() {
+            debug.add_note_fmt(format_args!(
+                "Matching \"{}\" against \"paths\" in \"{}\"",
+                bstr::BStr::new(path),
+                bstr::BStr::new(&tsconfig.abs_path)
+            ));
+        }
+
+        if self.for_each_tsconfig_paths_target(tsconfig, path, |this, abs| {
+            this.load_as_file_or_directory(abs, kind, out).is_success()
+        }) {
+            return MatchStatus::Success;
         }
 
         MatchStatus::NotFound

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2501,6 +2501,161 @@ impl<'a> Resolver<'a> {
         a || b
     }
 
+    /// Bust the directory cache for every absolute target that the enclosing
+    /// tsconfig's `paths` (and `baseUrl`) map `specifier` to. This mirrors the
+    /// substitution logic in [`match_tsconfig_paths`] so that the runtime
+    /// retry-on-miss can find files created after the first resolve cached the
+    /// parent directory listing.
+    pub fn bust_dir_cache_from_tsconfig_paths(
+        &mut self,
+        source_dir: &[u8],
+        specifier: &[u8],
+    ) -> bool {
+        if specifier.is_empty() || source_dir.is_empty() || !::bun_paths::is_absolute(source_dir) {
+            return false;
+        }
+        let Some(dir_info) = self.read_dir_info_ignore_error(source_dir) else {
+            return false;
+        };
+        let Some(tsconfig) = dir_info.enclosing_tsconfig_json else {
+            return false;
+        };
+
+        let mut abs_base_url: &[u8] = &tsconfig.base_url_for_paths;
+        if tsconfig.has_base_url() {
+            abs_base_url = &tsconfig.base_url;
+        }
+
+        let mut busted = false;
+        let mut bust_abs = |this: &mut Self, abs: &[u8]| {
+            let abs = strings::without_trailing_slash_windows_path(abs);
+            let dir = bun_paths::dirname_platform(abs, bun_paths::Platform::AUTO);
+            let a = this.bust_dir_cache(dir);
+            let b = this.bust_dir_cache(abs);
+            busted |= a | b;
+        };
+
+        // Exact matches.
+        for (key, value) in tsconfig
+            .paths
+            .keys()
+            .iter()
+            .zip(tsconfig.paths.values().iter())
+        {
+            if strings::eql_long(key, specifier, true) {
+                for original_path in value.iter() {
+                    let mut abs: &[u8] = original_path;
+                    if !::bun_paths::is_absolute(abs) {
+                        let parts: [&[u8]; 2] = [abs_base_url, original_path.as_ref()];
+                        match self
+                            .fs_ref()
+                            .abs_buf_checked(&parts, bufs!(tsconfig_path_abs))
+                        {
+                            Some(p) => abs = p,
+                            None => continue,
+                        }
+                    }
+                    bust_abs(self, abs);
+                }
+            }
+        }
+
+        // Wildcard match: same "longest prefix, then longest suffix" rule as
+        // `match_tsconfig_paths`.
+        let mut longest: Option<(&[u8], &[u8], &[Box<[u8]>])> = None;
+        let mut best_prefix: i32 = -1;
+        let mut best_suffix: i32 = -1;
+        for (key, original_paths) in tsconfig
+            .paths
+            .keys()
+            .iter()
+            .zip(tsconfig.paths.values().iter())
+        {
+            if let Some(star) = strings::index_of_char(key, b'*') {
+                let star = star as usize;
+                let prefix: &[u8] = if star == 0 { b"" } else { &key[0..star] };
+                let suffix: &[u8] = if star == key.len() - 1 {
+                    b""
+                } else {
+                    &key[star + 1..]
+                };
+                let plen = i32::try_from(prefix.len()).expect("int cast");
+                let slen = i32::try_from(suffix.len()).expect("int cast");
+                if specifier.len() >= prefix.len() + suffix.len()
+                    && specifier.starts_with(prefix)
+                    && specifier.ends_with(suffix)
+                    && (plen > best_prefix || (plen == best_prefix && slen > best_suffix))
+                {
+                    best_prefix = plen;
+                    best_suffix = slen;
+                    longest = Some((prefix, suffix, original_paths));
+                }
+            }
+        }
+        if let Some((match_prefix, match_suffix, original_paths)) = longest {
+            for original_path in original_paths.iter() {
+                let matched_text =
+                    &specifier[match_prefix.len()..specifier.len() - match_suffix.len()];
+                let total_length: Option<u32> = strings::index_of_char(original_path, b'*');
+                let prefix_end = total_length
+                    .map(|v| v as usize)
+                    .unwrap_or(original_path.len());
+                let prefix_parts: [&[u8]; 2] = [abs_base_url, &original_path[0..prefix_end]];
+
+                let matched_text_with_suffix = bufs!(tsconfig_match_full_buf3);
+                let mut matched_text_with_suffix_len: usize = 0;
+                if total_length.is_some() {
+                    let suffix = strings::trim_left(&original_path[prefix_end..], b"*");
+                    matched_text_with_suffix_len = matched_text.len() + suffix.len();
+                    if matched_text_with_suffix_len > matched_text_with_suffix.len() {
+                        continue;
+                    }
+                    ::bun_core::concat_into(matched_text_with_suffix, &[matched_text, suffix]);
+                }
+
+                let Some(prefix) = self
+                    .fs_ref()
+                    .abs_buf_checked(&prefix_parts, bufs!(tsconfig_match_full_buf2))
+                else {
+                    continue;
+                };
+                let parts: [&[u8]; 3] = [
+                    prefix,
+                    if matched_text_with_suffix_len > 0 {
+                        strings::trim_left(
+                            &matched_text_with_suffix[0..matched_text_with_suffix_len],
+                            b"/",
+                        )
+                    } else {
+                        b""
+                    },
+                    strings::trim_left(match_suffix, b"/"),
+                ];
+                let Some(abs) = self
+                    .fs_ref()
+                    .abs_buf_checked(&parts, bufs!(tsconfig_match_full_buf))
+                else {
+                    continue;
+                };
+                bust_abs(self, abs);
+            }
+        }
+
+        // `baseUrl` fallback (load_node_modules tries `baseUrl + specifier`
+        // after paths matching fails).
+        if tsconfig.has_base_url() {
+            let base: &[u8] = &tsconfig.base_url;
+            if let Some(abs) = self.fs_ref().abs_buf_checked(
+                &[base, specifier],
+                bufs!(load_as_file_or_directory_via_tsconfig_base_path),
+            ) {
+                bust_abs(self, abs);
+            }
+        }
+
+        busted
+    }
+
     pub(crate) fn load_node_modules(
         &mut self,
         import_path: &[u8],

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2501,11 +2501,9 @@ impl<'a> Resolver<'a> {
         a || b
     }
 
-    /// Bust the directory cache for every absolute target that the enclosing
-    /// tsconfig's `paths` (and `baseUrl`) map `specifier` to. This mirrors the
-    /// substitution logic in [`match_tsconfig_paths`] so that the runtime
-    /// retry-on-miss can find files created after the first resolve cached the
-    /// parent directory listing.
+    /// Bust the dir cache for every absolute target the enclosing tsconfig's
+    /// `paths`/`baseUrl` map `specifier` to (same substitution as
+    /// [`match_tsconfig_paths`]).
     pub fn bust_dir_cache_from_tsconfig_paths(
         &mut self,
         source_dir: &[u8],
@@ -2560,8 +2558,7 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        // Wildcard match: same "longest prefix, then longest suffix" rule as
-        // `match_tsconfig_paths`.
+        // Wildcard match (longest prefix, then longest suffix).
         let mut longest: Option<(&[u8], &[u8], &[Box<[u8]>])> = None;
         let mut best_prefix: i32 = -1;
         let mut best_suffix: i32 = -1;
@@ -2641,8 +2638,7 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        // `baseUrl` fallback (load_node_modules tries `baseUrl + specifier`
-        // after paths matching fails).
+        // `baseUrl` fallback: `load_node_modules` probes `baseUrl + specifier`.
         if tsconfig.has_base_url() {
             let base: &[u8] = &tsconfig.base_url;
             if let Some(abs) = self.fs_ref().abs_buf_checked(

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5036,12 +5036,8 @@ unsafe fn resolve<'a>(
                         bun_paths::string_paths::without_trailing_slash_windows_path(buster_name),
                     )
                 };
-                // The join above treats the specifier as a relative path; a
-                // tsconfig `paths` alias needs to be mapped through the
-                // tsconfig to find the real directory to bust. Do this even
-                // when the naive bust above returned true, because that hit
-                // may have been a cached negative for the literal
-                // `<source>/<alias>/..` path probed by the baseUrl fallback.
+                // Unconditional: the literal-join bust above may have hit
+                // only a cached negative for `<source>/<alias>`.
                 if bun_paths::is_package_path(normalized_specifier) {
                     // SAFETY: see above.
                     busted |= unsafe {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5036,8 +5036,6 @@ unsafe fn resolve<'a>(
                         bun_paths::string_paths::without_trailing_slash_windows_path(buster_name),
                     )
                 };
-                // Unconditional: the literal-join bust above may have hit
-                // only a cached negative for `<source>/<alias>`.
                 if bun_paths::is_package_path(normalized_specifier) {
                     // SAFETY: see above.
                     busted |= unsafe {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5031,11 +5031,27 @@ unsafe fn resolve<'a>(
 
                 // Only re-query if we previously had something cached.
                 // SAFETY: see above.
-                if unsafe {
+                let mut busted = unsafe {
                     (*vm).transpiler.resolver.bust_dir_cache(
                         bun_paths::string_paths::without_trailing_slash_windows_path(buster_name),
                     )
-                } {
+                };
+                // The join above treats the specifier as a relative path; a
+                // tsconfig `paths` alias needs to be mapped through the
+                // tsconfig to find the real directory to bust. Do this even
+                // when the naive bust above returned true, because that hit
+                // may have been a cached negative for the literal
+                // `<source>/<alias>/..` path probed by the baseUrl fallback.
+                if bun_paths::is_package_path(normalized_specifier) {
+                    // SAFETY: see above.
+                    busted |= unsafe {
+                        (*vm)
+                            .transpiler
+                            .resolver
+                            .bust_dir_cache_from_tsconfig_paths(source_to_use, normalized_specifier)
+                    };
+                }
+                if busted {
                     continue;
                 }
                 return Err(crate::Error::ModuleNotFound);

--- a/test/regression/issue/12372.test.ts
+++ b/test/regression/issue/12372.test.ts
@@ -30,11 +30,7 @@ test("tsconfig paths alias resolves files created at runtime", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("Cannot find module");
   expect(stdout.replaceAll("\r\n", "\n")).toBe(
@@ -67,15 +63,9 @@ test("tsconfig paths alias resolves files created at runtime (require)", async (
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("Cannot find module");
-  expect(stdout.replaceAll("\r\n", "\n")).toBe(
-    "from mod-1.ts\nfrom mod-2.ts\nfrom mod-3.ts\n",
-  );
+  expect(stdout.replaceAll("\r\n", "\n")).toBe("from mod-1.ts\nfrom mod-2.ts\nfrom mod-3.ts\n");
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/12372.test.ts
+++ b/test/regression/issue/12372.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/12372
+// Dynamic import() through a tsconfig `paths` alias must find files that were
+// created after the process started. The resolver caches directory listings;
+// the retry-on-miss path has to bust the cache for the *remapped* directory,
+// not the literal `<source_dir>/@/files` join.
+test("tsconfig paths alias resolves files created at runtime", async () => {
+  using dir = tempDir("issue-12372", {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: { baseUrl: ".", paths: { "@/*": ["./*"] } },
+    }),
+    "app.ts": `
+      import { mkdir, rm } from "node:fs/promises";
+      await rm("files/", { recursive: true, force: true });
+      await mkdir("files/", { recursive: true });
+      for (let i = 1; i <= 3; i++) {
+        const file = \`file-\${i}.ts\`;
+        await Bun.write("files/" + file, \`console.log("calling from \${file}")\`);
+        await import(\`@/files/\${file}\`);
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "app.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).not.toContain("Cannot find module");
+  expect(stdout.replaceAll("\r\n", "\n")).toBe(
+    "calling from file-1.ts\ncalling from file-2.ts\ncalling from file-3.ts\n",
+  );
+  expect(exitCode).toBe(0);
+});
+
+test("tsconfig paths alias resolves files created at runtime (require)", async () => {
+  using dir = tempDir("issue-12372-cjs", {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: { baseUrl: ".", paths: { "~/*": ["./gen/*"] } },
+    }),
+    "app.ts": `
+      import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+      rmSync("gen/", { recursive: true, force: true });
+      mkdirSync("gen/", { recursive: true });
+      for (let i = 1; i <= 3; i++) {
+        const file = \`mod-\${i}.ts\`;
+        writeFileSync("gen/" + file, \`module.exports = "from \${file}"\`);
+        console.log(require(\`~/\${file}\`));
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "app.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).not.toContain("Cannot find module");
+  expect(stdout.replaceAll("\r\n", "\n")).toBe(
+    "from mod-1.ts\nfrom mod-2.ts\nfrom mod-3.ts\n",
+  );
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/12372.test.ts
+++ b/test/regression/issue/12372.test.ts
@@ -2,10 +2,6 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // https://github.com/oven-sh/bun/issues/12372
-// Dynamic import() through a tsconfig `paths` alias must find files that were
-// created after the process started. The resolver caches directory listings;
-// the retry-on-miss path has to bust the cache for the *remapped* directory,
-// not the literal `<source_dir>/@/files` join.
 test("tsconfig paths alias resolves files created at runtime", async () => {
   using dir = tempDir("issue-12372", {
     "tsconfig.json": JSON.stringify({


### PR DESCRIPTION
Fixes #12372.

## Repro

```ts
// tsconfig.json: {"compilerOptions": {"baseUrl": ".", "paths": {"@/*": ["./*"]}}}
import { mkdir, rm } from "node:fs/promises";
await rm("files/", { recursive: true, force: true });
await mkdir("files/", { recursive: true });
for (let i = 1; i <= 3; i++) {
  const file = `file-${i}.ts`;
  await Bun.write("files/" + file, `console.log("calling from ${file}")`);
  await import(`@/files/${file}`);
}
```

```
calling from file-1.ts
error: Cannot find module '@/files/file-2.ts' from '/tmp/repro-12372/app.ts'
```

The relative `await import("./files/" + file)` form works.

## Cause

Both the relative and the alias path hit the same cached `DirEntry` for `files/` on the first try. The difference is the retry wrapper around `resolve_and_auto_install` (`src/runtime/jsc_hooks.rs`, `src/jsc/VirtualMachine.rs`): on `NotFound` it busts `join(source_dir, specifier, "..")` and retries once. For `./files/file-2.ts` that is `<cwd>/files`, which is the stale entry, so the retry succeeds. For `@/files/file-2.ts` it is `<cwd>/@/files`; that only removes the cached negative from the `baseUrl` probe, and the actual mapped directory is never refreshed.

## Fix

Add `Resolver::bust_dir_cache_from_tsconfig_paths`, which looks up the enclosing tsconfig for the source directory, runs the same exact/wildcard substitution as `match_tsconfig_paths`, and busts the directory cache for each mapped absolute target (and for `baseUrl + specifier`). Both runtime retry loops now call it for package-path specifiers in addition to the existing join-based bust, then retry once if either bust removed a cached entry.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/regression/issue/12372.test.ts
 0 pass  2 fail   # Cannot find module '@/files/file-2.ts'

$ bun bd test test/regression/issue/12372.test.ts
 2 pass  0 fail
```

Existing `test/js/bun/resolve/{resolve,require,import-meta,resolve-error,resolve-ts,concurrent-dynamic-import}.test.*` pass (one pre-existing debug-build timeout in `resolve.test.ts` reproduces on main without this change).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/12372.test.ts"
bun test v1.4.0 (42bd34841)

test/regression/issue/12372.test.ts:
26 |     stdout: "pipe",
27 |     stderr: "pipe",
28 |   });
29 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
30 | 
31 |   expect(stderr).not.toContain("Cannot find module");
                          ^
error: expect(received).not.toContain(expected)

Expected to not contain: "Cannot find module"
Received: "error: Cannot find module '@/files/file-2.ts' from '/tmp/issue-12372_T6Rzwn/app.ts'\n\nBun v1.4.0-debug+42bd34841 (Linux x64)\n"

      at <anonymous> (/workspace/bun/test/regression/issue/12372.test.ts:31:22)
(fail) tsconfig paths alias resolves files created at runtime [2370.71ms]
59 |     stdout: "pipe",
60 |     stderr: "pipe",
61 |   });
62 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
63 | 
64 |   expect(stderr).not.toContain("Cannot find module");
                          ^
error: expect(rec
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/regression/issue/12372.test.ts:
26 |     stdout: "pipe",
27 |     stderr: "pipe",
28 |   });
29 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
30 | 
31 |   expect(stderr).not.toContain("Cannot find module");
                          ^
error: expect(received).not.toContain(expected)

Expected to not contain: "Cannot find module"
Received: "error: Cannot find module '@/files/file-2.ts' from '/tmp/issue-12372_QsKsbA/app.ts'\n\nBun v1.4.0-canary.1+1498d7b77 (Linux x64)\n"

      at <anonymous> (/workspace/bun/test/regression/issue/12372.test.ts:31:22)
(fail) tsconfig paths alias resolves files created at runtime [138.21ms]
59 |     stdout: "pipe",
60 |     stderr: "pipe",
61 |   });
62 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
63 | 
64 |   expect(stderr).not.toContain("Cannot find module");
                          ^
error: expect(received).not.toContain(expected)

Expected to not contain: "Cannot find module"
Received: "error: Cannot find module '~/mod-2.ts' from '/tmp/issue-12372-cjs_l9G9u
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/12372.test.ts"
bun test v1.4.0 (42bd34841)

test/regression/issue/12372.test.ts:
(pass) tsconfig paths alias resolves files created at runtime [2029.15ms]
(pass) tsconfig paths alias resolves files created at runtime (require) [2325.43ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [8.95s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2174ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/402] gen cpp.rs (cppbind)
[2/402] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[3/402] cxx obj/vendor/boringssl/crypto/x509/x509spki.cc.o
[4/402] cxx obj/vendor/boringssl/crypto/x509/x509name.cc.o
[5/402] cxx obj/vendor/boringssl/crypto/x509/x_algor.cc.o
[6/402] cxx obj/vendor/boringssl/crypto/x509/x509rset.cc.o
[7/402] cxx obj/vendor/boringssl/crypto/x509/x_exten.cc.o
[8/402] cxx obj/vendor/boringssl/crypto/x509/x509cset.cc.o
[9/402] cxx obj/vendor/boringssl/crypto/x509/x_attrib.cc.o
[10/402] cxx obj/vendor/boringssl/crypto/x509/x_all.cc.o
[11/402] cxx obj/vendor/boringssl/crypto/x509/x_crl.cc.o
[12/402] cxx obj/vendor/boringssl/crypto/x509/x_req.cc.o
[13/402] cxx obj/vendor/boringssl/crypto/x509/x_x509.cc.o
[14/402] cxx obj/vendor/boringssl/crypto/x509/x_name.cc.o
[15/402] cxx obj/vendor/boringssl/gen/crypto/err_data.cc.o
[16/402] cxx obj/vendor/boringssl/crypto/x509/x_sig.cc.o
[17/402] cxx obj/vendor/boringssl/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs           | 11 ++++-
 src/resolver/resolver.rs            | 94 ++++++++++++++++++++++++++++---------
 src/runtime/jsc_hooks.rs            | 14 +++++-
 test/regression/issue/12372.test.ts | 67 ++++++++++++++++++++++++++
 4 files changed, 160 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/VirtualMachine.rs                2      4      0
src/resolver/resolver.rs                11      6      0
src/runtime/jsc_hooks.rs                 2      4      0
test/regression/issue/12372.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->