### PR TITLE
resolver: hint at `bun pm trust` when resolution fails inside a package with a blocked lifecycle script

### DIFF
--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -250,7 +250,7 @@ pub struct Scripts {
 }
 
 impl Scripts {
-    pub(crate) const NAMES: [&'static str; 6] = [
+    pub const NAMES: [&'static str; 6] = [
         "preinstall",
         "install",
         "postinstall",

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -380,14 +380,9 @@ impl ResolveMessage {
     }
 }
 
-/// When a module fails to resolve from inside `node_modules/<pkg>/...` and
-/// `<pkg>` has an install-class lifecycle script, return a hint pointing at
-/// `bun pm trust`. Bun blocks lifecycle scripts by default for packages not in
-/// `trustedDependencies`, which leaves packages that depend on their own
-/// `postinstall` (for example to rename a bundled `temp_modules/` into
-/// `node_modules/`) in a broken state with no obvious remediation.
-///
-/// Cold path: only called once resolve has already failed.
+/// If `referrer` sits inside `node_modules/<pkg>/` and `<pkg>` has a lifecycle
+/// script that Bun may have blocked, return a `bun pm trust <pkg>` hint.
+/// <https://github.com/oven-sh/bun/issues/12890>
 #[cold]
 fn blocked_lifecycle_script_note(referrer: &[u8]) -> Option<bun_ast::Data> {
     let (pkg_name, pkg_dir) = enclosing_node_modules_package(referrer)?;
@@ -404,9 +399,8 @@ fn blocked_lifecycle_script_note(referrer: &[u8]) -> Option<bun_ast::Data> {
     Some(bun_ast::range_data(None, bun_ast::Range::NONE, text))
 }
 
-/// Parse the deepest `node_modules/<name>` the referrer path sits inside.
-/// Returns the package name (with `/` as the scope separator) and the absolute
-/// package directory (a prefix of `referrer`).
+/// `(package_name, package_dir)` of the deepest `node_modules/<name>` that
+/// `referrer` sits inside. `package_dir` is a prefix of `referrer`.
 #[cold]
 fn enclosing_node_modules_package(referrer: &[u8]) -> Option<(Vec<u8>, &[u8])> {
     let nm_start = strings::last_index_of(referrer, bun_paths::NODE_MODULES_NEEDLE)?;
@@ -432,10 +426,9 @@ fn enclosing_node_modules_package(referrer: &[u8]) -> Option<(Vec<u8>, &[u8])> {
     Some((name, &referrer[..name_start + name_len]))
 }
 
-/// Probe `<pkg_dir>/package.json` for an install-class script. This is a
-/// byte-level heuristic rather than a full JSON parse: it looks for `"scripts"`
-/// and then one of the lifecycle hook keys after it. A `binding.gyp` alongside
-/// the manifest also counts, matching the auto `node-gyp rebuild` behaviour.
+/// Byte-scan `<pkg_dir>/package.json` for a `preinstall`/`install`/`postinstall`
+/// key in `"scripts"`, or a sibling `binding.gyp`. Used only for the UX hint
+/// above, so a full JSON parse is avoided.
 #[cold]
 fn first_lifecycle_script(pkg_dir: &[u8]) -> Option<&'static str> {
     let mut buf = bun_paths::path_buffer_pool::get();
@@ -447,13 +440,8 @@ fn first_lifecycle_script(pkg_dir: &[u8]) -> Option<&'static str> {
     if let Ok(bytes) = bun_sys::File::read_from(bun_sys::Fd::cwd(), manifest)
         && let Some(scripts_at) = strings::index_of(&bytes, b"\"scripts\"")
     {
-        // Bound the scan to the `"scripts"` object so a sibling key like
-        // `"dependencies": { "install": "^1.0.0" }` cannot match. `scripts` is
-        // a flat `Record<string, string>`, so the closing `}` is the first one
-        // that appears outside a JSON string. Script values are arbitrary
-        // shell commands and commonly contain literal `}` (brace expansion,
-        // `${VAR:-}`), so a naive `index_of_char(.., b'}')` would truncate
-        // early.
+        // Bound to the `"scripts"` object so a sibling key like
+        // `"dependencies": { "install": "..." }` cannot match.
         let after = &bytes[scripts_at + b"\"scripts\"".len()..];
         let end = end_of_flat_json_object(after);
         let scripts = &after[..end];
@@ -479,9 +467,8 @@ fn first_lifecycle_script(pkg_dir: &[u8]) -> Option<&'static str> {
     None
 }
 
-/// Return the byte offset just past the first `}` that is not inside a JSON
-/// string. Assumes the input sits between a flat object's opening `{` (or the
-/// key preceding it) and the rest of the document; no brace nesting is tracked.
+/// Offset of the first `}` that is not inside a JSON string. No brace nesting
+/// is tracked (sufficient for `"scripts"`, which is `Record<string, string>`).
 #[cold]
 fn end_of_flat_json_object(bytes: &[u8]) -> usize {
     let mut in_string = false;

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -309,8 +309,17 @@ impl ResolveMessage {
         msg: &bun_ast::Msg,
         referrer: &[u8],
     ) -> JsResult<JSValue> {
+        let mut cloned = msg.clone();
+        if let bun_ast::Metadata::Resolve(resolve) = &cloned.metadata
+            && resolve.err == bun_ast::Error::ModuleNotFound
+            && let Some(note) = blocked_lifecycle_script_note(referrer)
+        {
+            let mut notes = cloned.notes.into_vec();
+            notes.push(note);
+            cloned.notes = notes.into_boxed_slice();
+        }
         let resolve_error = ResolveMessage {
-            msg: msg.clone(),
+            msg: cloned,
             referrer: Some(Box::<[u8]>::from(referrer)),
             logged: Cell::new(false),
         };
@@ -369,4 +378,102 @@ impl ResolveMessage {
         // Dropping the Box drops `msg` and the owned `referrer` buffer.
         drop(self);
     }
+}
+
+/// When a module fails to resolve from inside `node_modules/<pkg>/...` and
+/// `<pkg>` has an install-class lifecycle script, return a hint pointing at
+/// `bun pm trust`. Bun blocks lifecycle scripts by default for packages not in
+/// `trustedDependencies`, which leaves packages that depend on their own
+/// `postinstall` (for example to rename a bundled `temp_modules/` into
+/// `node_modules/`) in a broken state with no obvious remediation.
+///
+/// Cold path: only called once resolve has already failed.
+#[cold]
+fn blocked_lifecycle_script_note(referrer: &[u8]) -> Option<bun_ast::Data> {
+    let (pkg_name, pkg_dir) = enclosing_node_modules_package(referrer)?;
+    let script = first_lifecycle_script(pkg_dir)?;
+
+    let mut text = Vec::new();
+    write!(
+        &mut text,
+        "\"{name}\" has a \"{script}\" script which may have been blocked. If you trust this \
+         package, run `bun pm trust {name}` and try again.",
+        name = bstr::BStr::new(&pkg_name),
+    )
+    .ok()?;
+    Some(bun_ast::range_data(None, bun_ast::Range::NONE, text))
+}
+
+/// Parse the deepest `node_modules/<name>` the referrer path sits inside.
+/// Returns the package name (with `/` as the scope separator) and the absolute
+/// package directory (a prefix of `referrer`).
+#[cold]
+fn enclosing_node_modules_package(referrer: &[u8]) -> Option<(Vec<u8>, &[u8])> {
+    let nm_start = strings::last_index_of(referrer, bun_paths::NODE_MODULES_NEEDLE)?;
+    let name_start = nm_start + bun_paths::NODE_MODULES_NEEDLE.len();
+    let rest = referrer.get(name_start..)?;
+    let next_sep = |bytes: &[u8]| bytes.iter().position(|&c| bun_paths::is_sep_any(c));
+    let name_len = if rest.first() == Some(&b'@') {
+        let scope_end = next_sep(rest)?;
+        let pkg_end = next_sep(rest.get(scope_end + 1..)?)?;
+        scope_end + 1 + pkg_end
+    } else {
+        next_sep(rest)?
+    };
+    if name_len == 0 || rest[..name_len].starts_with(b".") {
+        return None;
+    }
+    let mut name = rest[..name_len].to_vec();
+    for b in &mut name {
+        if *b == b'\\' {
+            *b = b'/';
+        }
+    }
+    Some((name, &referrer[..name_start + name_len]))
+}
+
+/// Probe `<pkg_dir>/package.json` for an install-class script. This is a
+/// byte-level heuristic rather than a full JSON parse: it looks for `"scripts"`
+/// and then one of the lifecycle hook keys after it. A `binding.gyp` alongside
+/// the manifest also counts, matching the auto `node-gyp rebuild` behaviour.
+#[cold]
+fn first_lifecycle_script(pkg_dir: &[u8]) -> Option<&'static str> {
+    let mut buf = bun_paths::path_buffer_pool::get();
+
+    let manifest = bun_paths::resolve_path::join_string_buf::<bun_paths::platform::Auto>(
+        buf.as_mut_slice(),
+        &[pkg_dir, b"package.json"],
+    );
+    if let Ok(bytes) = bun_sys::File::read_from(bun_sys::Fd::cwd(), manifest)
+        && let Some(scripts_at) = strings::index_of(&bytes, b"\"scripts\"")
+    {
+        // Bound the scan to the `"scripts"` object so a sibling key like
+        // `"dependencies": { "install": "^1.0.0" }` cannot match. `scripts` is
+        // a flat `Record<string, string>`, so the first `}` after the key
+        // closes it.
+        let after = &bytes[scripts_at + b"\"scripts\"".len()..];
+        let end = strings::index_of_char(after, b'}')
+            .map(|i| i as usize)
+            .unwrap_or(after.len());
+        let scripts = &after[..end];
+        for (hook, key) in [
+            ("preinstall", b"\"preinstall\"" as &[u8]),
+            ("install", b"\"install\""),
+            ("postinstall", b"\"postinstall\""),
+        ] {
+            if strings::contains(scripts, key) {
+                return Some(hook);
+            }
+        }
+    }
+
+    let gyp = bun_paths::resolve_path::join_string_buf::<bun_paths::platform::Auto>(
+        buf.as_mut_slice(),
+        &[pkg_dir, b"binding.gyp"],
+    );
+    if bun_sys::exists(gyp) {
+        return Some("install");
+    }
+
+    None
 }

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -443,7 +443,11 @@ fn first_lifecycle_script(pkg_dir: &[u8]) -> Option<&'static str> {
         // Bound to the `"scripts"` object so a sibling key like
         // `"dependencies": { "install": "..." }` cannot match.
         let scripts = &after[..end_of_flat_json_object(after)];
-        for hook in bun_install::lockfile::Scripts::NAMES {
+        // Only the install-family: `Scripts::get_script_entries` gates
+        // `NAMES[3..]` (preprepare/prepare/postprepare) on `ResolutionTag`
+        // and never enqueues them for registry packages, so including them
+        // would false-positive on the ubiquitous `"prepare":"husky install"`.
+        for hook in &bun_install::lockfile::Scripts::NAMES[..3] {
             if find_json_key(scripts, format!("\"{hook}\"").as_bytes()).is_some() {
                 return Some(hook);
             }

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -391,7 +391,7 @@ fn blocked_lifecycle_script_note(referrer: &[u8]) -> Option<bun_ast::Data> {
     let mut text = Vec::new();
     write!(
         &mut text,
-        "\"{name}\" has a \"{script}\" script which may have been blocked. If you trust this \
+        "The \"{script}\" script for \"{name}\" may have been blocked. If you trust this \
          package, run `bun pm trust {name}` and try again.",
         name = bstr::BStr::new(&pkg_name),
     )
@@ -426,8 +426,8 @@ fn enclosing_node_modules_package(referrer: &[u8]) -> Option<(Vec<u8>, &[u8])> {
     Some((name, &referrer[..name_start + name_len]))
 }
 
-/// Byte-scan `<pkg_dir>/package.json` for a `preinstall`/`install`/`postinstall`
-/// key in `"scripts"`, or a sibling `binding.gyp`. Used only for the UX hint
+/// Byte-scan `<pkg_dir>/package.json` for any `bun_install` lifecycle hook key
+/// inside `"scripts"`, or a sibling `binding.gyp`. Used only for the UX hint
 /// above, so a full JSON parse is avoided.
 #[cold]
 fn first_lifecycle_script(pkg_dir: &[u8]) -> Option<&'static str> {
@@ -438,19 +438,13 @@ fn first_lifecycle_script(pkg_dir: &[u8]) -> Option<&'static str> {
         &[pkg_dir, b"package.json"],
     );
     if let Ok(bytes) = bun_sys::File::read_from(bun_sys::Fd::cwd(), manifest)
-        && let Some(scripts_at) = strings::index_of(&bytes, b"\"scripts\"")
+        && let Some(after) = find_json_key(&bytes, b"\"scripts\"")
     {
         // Bound to the `"scripts"` object so a sibling key like
         // `"dependencies": { "install": "..." }` cannot match.
-        let after = &bytes[scripts_at + b"\"scripts\"".len()..];
-        let end = end_of_flat_json_object(after);
-        let scripts = &after[..end];
-        for (hook, key) in [
-            ("preinstall", b"\"preinstall\"" as &[u8]),
-            ("install", b"\"install\""),
-            ("postinstall", b"\"postinstall\""),
-        ] {
-            if strings::contains(scripts, key) {
+        let scripts = &after[..end_of_flat_json_object(after)];
+        for hook in bun_install::lockfile::Scripts::NAMES {
+            if find_json_key(scripts, format!("\"{hook}\"").as_bytes()).is_some() {
                 return Some(hook);
             }
         }
@@ -465,6 +459,27 @@ fn first_lifecycle_script(pkg_dir: &[u8]) -> Option<&'static str> {
     }
 
     None
+}
+
+/// Find `key` (including its surrounding quotes) used as a JSON object key in
+/// `bytes`: i.e. followed by optional JSON whitespace and then `:`. Returns the
+/// slice starting after the `:`. Skips occurrences that are string values
+/// (`"files":["scripts"]`) rather than keys.
+#[cold]
+fn find_json_key<'a>(bytes: &'a [u8], key: &[u8]) -> Option<&'a [u8]> {
+    let mut rest = bytes;
+    loop {
+        let at = strings::index_of(rest, key)?;
+        let after = &rest[at + key.len()..];
+        let trimmed = after
+            .iter()
+            .position(|&b| !matches!(b, b' ' | b'\t' | b'\r' | b'\n'))
+            .unwrap_or(after.len());
+        if after.get(trimmed) == Some(&b':') {
+            return Some(&after[trimmed + 1..]);
+        }
+        rest = &rest[at + key.len()..];
+    }
 }
 
 /// Offset of the first `}` that is not inside a JSON string. No brace nesting

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -449,12 +449,13 @@ fn first_lifecycle_script(pkg_dir: &[u8]) -> Option<&'static str> {
     {
         // Bound the scan to the `"scripts"` object so a sibling key like
         // `"dependencies": { "install": "^1.0.0" }` cannot match. `scripts` is
-        // a flat `Record<string, string>`, so the first `}` after the key
-        // closes it.
+        // a flat `Record<string, string>`, so the closing `}` is the first one
+        // that appears outside a JSON string. Script values are arbitrary
+        // shell commands and commonly contain literal `}` (brace expansion,
+        // `${VAR:-}`), so a naive `index_of_char(.., b'}')` would truncate
+        // early.
         let after = &bytes[scripts_at + b"\"scripts\"".len()..];
-        let end = strings::index_of_char(after, b'}')
-            .map(|i| i as usize)
-            .unwrap_or(after.len());
+        let end = end_of_flat_json_object(after);
         let scripts = &after[..end];
         for (hook, key) in [
             ("preinstall", b"\"preinstall\"" as &[u8]),
@@ -476,4 +477,23 @@ fn first_lifecycle_script(pkg_dir: &[u8]) -> Option<&'static str> {
     }
 
     None
+}
+
+/// Return the byte offset just past the first `}` that is not inside a JSON
+/// string. Assumes the input sits between a flat object's opening `{` (or the
+/// key preceding it) and the rest of the document; no brace nesting is tracked.
+#[cold]
+fn end_of_flat_json_object(bytes: &[u8]) -> usize {
+    let mut in_string = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' if in_string => i += 1,
+            b'"' => in_string = !in_string,
+            b'}' if !in_string => return i,
+            _ => {}
+        }
+        i += 1;
+    }
+    bytes.len()
 }

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -194,7 +194,12 @@ describe("ResolveMessage", () => {
           name: "has-postinstall",
           version: "1.0.0",
           main: "index.js",
-          scripts: { postinstall: "node scripts/recover-modules.js temp_modules node_modules" },
+          scripts: {
+            // `}` inside an earlier script value must not truncate the scan
+            // before the postinstall key is seen.
+            clean: "rimraf {dist,build} && echo ${CI:+done}",
+            postinstall: "node scripts/recover-modules.js temp_modules node_modules",
+          },
         }),
         "node_modules/has-postinstall/index.js": `module.exports = require("missing-inner-dep");`,
       });

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -168,6 +168,123 @@ describe("ResolveMessage", () => {
     }
     expect().pass();
   });
+
+  // https://github.com/oven-sh/bun/issues/12890
+  describe("blocked lifecycle script hint", () => {
+    async function run(files: Record<string, string>) {
+      using dir = tempDir("resolve-blocked-lifecycle", {
+        "package.json": JSON.stringify({ name: "app", version: "0.0.0" }),
+        "main.js": `require("has-postinstall");`,
+        ...files,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    it("points at `bun pm trust` when the enclosing package has a postinstall", async () => {
+      const { stderr, exitCode } = await run({
+        "node_modules/has-postinstall/package.json": JSON.stringify({
+          name: "has-postinstall",
+          version: "1.0.0",
+          main: "index.js",
+          scripts: { postinstall: "node scripts/recover-modules.js temp_modules node_modules" },
+        }),
+        "node_modules/has-postinstall/index.js": `module.exports = require("missing-inner-dep");`,
+      });
+      expect(stderr).toContain(`Cannot find package 'missing-inner-dep'`);
+      expect(stderr).toContain(
+        `"has-postinstall" has a "postinstall" script which may have been blocked. If you trust this package, run \`bun pm trust has-postinstall\``,
+      );
+      expect(exitCode).toBe(1);
+    });
+
+    it("handles scoped package names", async () => {
+      using dir = tempDir("resolve-blocked-lifecycle-scoped", {
+        "package.json": JSON.stringify({ name: "app", version: "0.0.0" }),
+        "main.js": `require("@scope/has-postinstall");`,
+        "node_modules/@scope/has-postinstall/package.json": JSON.stringify({
+          name: "@scope/has-postinstall",
+          version: "1.0.0",
+          main: "index.js",
+          scripts: { postinstall: "true" },
+        }),
+        "node_modules/@scope/has-postinstall/index.js": `module.exports = require("missing-inner-dep");`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain(`\`bun pm trust @scope/has-postinstall\``);
+      expect(exitCode).toBe(1);
+    });
+
+    it("points at `bun pm trust` when the enclosing package has a binding.gyp", async () => {
+      const { stderr, exitCode } = await run({
+        "node_modules/has-postinstall/package.json": JSON.stringify({
+          name: "has-postinstall",
+          version: "1.0.0",
+          main: "index.js",
+        }),
+        "node_modules/has-postinstall/binding.gyp": "{}",
+        "node_modules/has-postinstall/index.js": `module.exports = require("./build/Release/addon.node");`,
+      });
+      expect(stderr).toContain(`Cannot find module './build/Release/addon.node'`);
+      expect(stderr).toContain(`run \`bun pm trust has-postinstall\``);
+      expect(exitCode).toBe(1);
+    });
+
+    it("does not fire when the enclosing package has no install-class script", async () => {
+      const { stderr, exitCode } = await run({
+        "node_modules/has-postinstall/package.json": JSON.stringify({
+          name: "has-postinstall",
+          version: "1.0.0",
+          main: "index.js",
+          scripts: { test: "jest", build: "tsc" },
+          // The scan is bounded to the scripts object, so a sibling key that
+          // happens to be named like a lifecycle hook must not trigger it.
+          dependencies: { install: "^0.13.0" },
+        }),
+        "node_modules/has-postinstall/index.js": `module.exports = require("missing-inner-dep");`,
+      });
+      expect(stderr).toContain(`Cannot find package 'missing-inner-dep'`);
+      expect(stderr).not.toContain("bun pm trust");
+      expect(exitCode).toBe(1);
+    });
+
+    it("does not fire when the referrer is outside node_modules", async () => {
+      using dir = tempDir("resolve-blocked-lifecycle-root", {
+        "package.json": JSON.stringify({
+          name: "app",
+          version: "0.0.0",
+          scripts: { postinstall: "true" },
+        }),
+        "node_modules/.keep": "",
+        "main.js": `require("missing-top-level-dep");`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain(`Cannot find package 'missing-top-level-dep'`);
+      expect(stderr).not.toContain("bun pm trust");
+      expect(exitCode).toBe(1);
+    });
+  });
 });
 
 // These tests reproduce panics where the module resolver wrote past fixed-size

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -249,18 +249,18 @@ describe("ResolveMessage", () => {
       expect(exitCode).toBe(1);
     });
 
-    it("covers every hook name `bun pm trust` unblocks (prepare included)", async () => {
+    it("does not fire for a prepare-only package (prepare is never blocked for registry deps)", async () => {
       const { stderr, exitCode } = await run({
         "node_modules/has-postinstall/package.json": JSON.stringify({
           name: "has-postinstall",
           version: "1.0.0",
           main: "index.js",
-          scripts: { prepare: "tsc" },
+          scripts: { prepare: "husky install" },
         }),
-        "node_modules/has-postinstall/index.js": `module.exports = require("./dist/impl.js");`,
+        "node_modules/has-postinstall/index.js": `module.exports = require("missing-inner-dep");`,
       });
-      expect(stderr).toContain(`The "prepare" script for "has-postinstall" may have been blocked`);
-      expect(stderr).toContain(`run \`bun pm trust has-postinstall\``);
+      expect(stderr).toContain(`Cannot find package 'missing-inner-dep'`);
+      expect(stderr).not.toContain("bun pm trust");
       expect(exitCode).toBe(1);
     });
 

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -170,7 +170,7 @@ describe("ResolveMessage", () => {
   });
 
   // https://github.com/oven-sh/bun/issues/12890
-  describe("blocked lifecycle script hint", () => {
+  describe.concurrent("blocked lifecycle script hint", () => {
     async function run(files: Record<string, string>) {
       using dir = tempDir("resolve-blocked-lifecycle", {
         "package.json": JSON.stringify({ name: "app", version: "0.0.0" }),
@@ -205,7 +205,7 @@ describe("ResolveMessage", () => {
       });
       expect(stderr).toContain(`Cannot find package 'missing-inner-dep'`);
       expect(stderr).toContain(
-        `"has-postinstall" has a "postinstall" script which may have been blocked. If you trust this package, run \`bun pm trust has-postinstall\``,
+        `The "postinstall" script for "has-postinstall" may have been blocked. If you trust this package, run \`bun pm trust has-postinstall\``,
       );
       expect(exitCode).toBe(1);
     });
@@ -249,6 +249,21 @@ describe("ResolveMessage", () => {
       expect(exitCode).toBe(1);
     });
 
+    it("covers every hook name `bun pm trust` unblocks (prepare included)", async () => {
+      const { stderr, exitCode } = await run({
+        "node_modules/has-postinstall/package.json": JSON.stringify({
+          name: "has-postinstall",
+          version: "1.0.0",
+          main: "index.js",
+          scripts: { prepare: "tsc" },
+        }),
+        "node_modules/has-postinstall/index.js": `module.exports = require("./dist/impl.js");`,
+      });
+      expect(stderr).toContain(`The "prepare" script for "has-postinstall" may have been blocked`);
+      expect(stderr).toContain(`run \`bun pm trust has-postinstall\``);
+      expect(exitCode).toBe(1);
+    });
+
     it("does not fire when the enclosing package has no install-class script", async () => {
       const { stderr, exitCode } = await run({
         "node_modules/has-postinstall/package.json": JSON.stringify({
@@ -264,6 +279,41 @@ describe("ResolveMessage", () => {
       });
       expect(stderr).toContain(`Cannot find package 'missing-inner-dep'`);
       expect(stderr).not.toContain("bun pm trust");
+      expect(exitCode).toBe(1);
+    });
+
+    it('is not confused by `"scripts"` appearing as a string value', async () => {
+      const { stderr, exitCode } = await run({
+        "node_modules/has-postinstall/package.json": JSON.stringify({
+          name: "has-postinstall",
+          version: "1.0.0",
+          main: "index.js",
+          // `"scripts"` appears as an array element before any key of that
+          // name; the scan must not treat the following `dependencies` object
+          // as the scripts body.
+          files: ["scripts"],
+          dependencies: { install: "^0.13.0" },
+        }),
+        "node_modules/has-postinstall/index.js": `module.exports = require("missing-inner-dep");`,
+      });
+      expect(stderr).toContain(`Cannot find package 'missing-inner-dep'`);
+      expect(stderr).not.toContain("bun pm trust");
+      expect(exitCode).toBe(1);
+    });
+
+    it('finds the real `"scripts"` key after a `"scripts"` string value', async () => {
+      const { stderr, exitCode } = await run({
+        "node_modules/has-postinstall/package.json": JSON.stringify({
+          name: "has-postinstall",
+          version: "1.0.0",
+          main: "index.js",
+          files: ["scripts"],
+          repository: { type: "git" },
+          scripts: { postinstall: "true" },
+        }),
+        "node_modules/has-postinstall/index.js": `module.exports = require("missing-inner-dep");`,
+      });
+      expect(stderr).toContain(`The "postinstall" script for "has-postinstall" may have been blocked`);
       expect(exitCode).toBe(1);
     });
 


### PR DESCRIPTION
Fixes #12890.

## Repro

```console
$ mkdir app && cd app && echo '{"name":"x"}' > package.json
$ bun i @lark-opdev/cli
...
Blocked 2 postinstalls. Run `bun pm untrusted` for details.
$ bun node_modules/@lark-opdev/cli/bin/run --help
error: Cannot find module '@bdeefe/feishu-devtools-core/libs/common/Logger' from '.../node_modules/@lark-opdev/cli/libs/index.js'
```

`@lark-opdev/cli` ships its nested deps as `temp_modules/` and renames it to `node_modules/` in a `postinstall` (npm strips a literal `node_modules/` from published tarballs). With lifecycle scripts blocked by default, the rename never happens and the first `require()` from inside the package fails with a bare `MODULE_NOT_FOUND` and no pointer back to the install step. `bun pm trust @lark-opdev/cli` fixes it, but nothing in the error says so.

## Fix

When `ResolveMessage::create` wraps a `ModuleNotFound` whose referrer sits inside `node_modules/<pkg>/`, probe `<pkg>/package.json` for a `preinstall` / `install` / `postinstall` script (or a sibling `binding.gyp`) and attach a note via the existing `bun_ast::Msg.notes` channel. `Msg::write_format` already renders notes with a `note:` prefix, so no printer changes were needed.

After:

```console
error: Cannot find package 'missing-inner-dep' from '/tmp/app/node_modules/@scope/hp/index.js'

note: "@scope/hp" has a "postinstall" script which may have been blocked. If you trust this package, run `bun pm trust @scope/hp` and try again.
```

The script probe is a byte-level scan bounded to the `"scripts"` object (the first `}` after the key, since `scripts` is a flat `Record<string, string>`), not a full JSON parse; this keeps the cold error path free of the `bun_parsers` dep and cannot be confused by a sibling key like `"dependencies": { "install": "^0.13.0" }`. No package was added to the default trusted list.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/resolve/resolve-error.test.ts -t "blocked lifecycle"
(fail) ResolveMessage > blocked lifecycle script hint > points at `bun pm trust` when the enclosing package has a postinstall
(fail) ResolveMessage > blocked lifecycle script hint > handles scoped package names
(fail) ResolveMessage > blocked lifecycle script hint > points at `bun pm trust` when the enclosing package has a binding.gyp
(pass) ResolveMessage > blocked lifecycle script hint > does not fire when the enclosing package has no install-class script
(pass) ResolveMessage > blocked lifecycle script hint > does not fire when the referrer is outside node_modules

$ bun bd test test/js/bun/resolve/resolve-error.test.ts
27 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve-error.test.ts

<!-- robobun:evidence:end -->