### PR TITLE
install: fall back to workspace for `file:` dependency with invalid path

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2610,8 +2610,6 @@ fn get_or_put_resolved_package(
                 break 'res FolderResolutionValue::NewPackageId(package.meta.id);
             };
 
-            // file: path missing but name matches a workspace member: link the
-            // workspace package (npm tolerates this, #13195).
             if let FolderResolutionValue::Err(crate::Error::MissingPackageJSON) = res {
                 'resolve_workspace_from_folder: {
                     if !this.options.link_workspace_packages {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2523,8 +2523,9 @@ fn get_or_put_resolved_package(
 
         dependency::version::Tag::Folder => {
             let folder = *version.folder();
+            let is_workspace_dep = this.lockfile.is_workspace_dependency(dependency_id);
             let res: FolderResolutionValue = 'res: {
-                if this.lockfile.is_workspace_dependency(dependency_id) {
+                if is_workspace_dep {
                     // relative to cwd
                     // reshaped for borrowck — `folder_path` borrows
                     // `string_bytes`; detach the slice lifetime so the
@@ -2612,7 +2613,7 @@ fn get_or_put_resolved_package(
 
             if let FolderResolutionValue::Err(crate::Error::MissingPackageJSON) = res {
                 'resolve_workspace_from_folder: {
-                    if !this.options.link_workspace_packages {
+                    if !is_workspace_dep || !this.options.link_workspace_packages {
                         break 'resolve_workspace_from_folder;
                     }
                     if this.lockfile.workspace_paths.count() == 0

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2610,12 +2610,8 @@ fn get_or_put_resolved_package(
                 break 'res FolderResolutionValue::NewPackageId(package.meta.id);
             };
 
-            // If the file: path does not exist but the dependency name matches a
-            // workspace member, link to the workspace package instead of failing.
-            // npm tolerates a nonexistent file: path (it creates a dangling link) and
-            // the workspace link at the root makes resolution work regardless; users
-            // that wrote e.g. "file: *" for a sibling package expect this to succeed.
-            // https://github.com/oven-sh/bun/issues/13195
+            // file: path missing but name matches a workspace member: link the
+            // workspace package (npm tolerates this, #13195).
             if let FolderResolutionValue::Err(crate::Error::MissingPackageJSON) = res {
                 'resolve_workspace_from_folder: {
                     if !this.options.link_workspace_packages {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2654,10 +2654,7 @@ fn get_or_put_resolved_package(
                             );
                             success_fn(this, dependency_id, workspace_package_id);
                             return Ok(Some(ResolvedPackageResult {
-                                package: *this
-                                    .lockfile
-                                    .packages
-                                    .get(workspace_package_id as usize),
+                                package: *this.lockfile.packages.get(workspace_package_id as usize),
                                 is_first_time: false,
                                 task: None,
                             }));

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2610,6 +2610,62 @@ fn get_or_put_resolved_package(
                 break 'res FolderResolutionValue::NewPackageId(package.meta.id);
             };
 
+            // If the file: path does not exist but the dependency name matches a
+            // workspace member, link to the workspace package instead of failing.
+            // npm tolerates a nonexistent file: path (it creates a dangling link) and
+            // the workspace link at the root makes resolution work regardless; users
+            // that wrote e.g. "file: *" for a sibling package expect this to succeed.
+            // https://github.com/oven-sh/bun/issues/13195
+            if let FolderResolutionValue::Err(crate::Error::MissingPackageJSON) = res {
+                'resolve_workspace_from_folder: {
+                    if !this.options.link_workspace_packages {
+                        break 'resolve_workspace_from_folder;
+                    }
+                    if this.lockfile.workspace_paths.count() == 0
+                        || this.lockfile.workspace_paths.get(&name_hash).is_none()
+                    {
+                        break 'resolve_workspace_from_folder;
+                    }
+                    let Some(root_package) = this.lockfile.root_package() else {
+                        break 'resolve_workspace_from_folder;
+                    };
+                    let root_dependencies = root_package
+                        .dependencies
+                        .get(this.lockfile.buffers.dependencies.as_slice());
+                    let root_resolutions = root_package
+                        .resolutions
+                        .get(this.lockfile.buffers.resolutions.as_slice());
+
+                    debug_assert_eq!(root_dependencies.len(), root_resolutions.len());
+                    for (root_dep, &workspace_package_id) in
+                        root_dependencies.iter().zip(root_resolutions)
+                    {
+                        if workspace_package_id != invalid_package_id
+                            && root_dep.version.tag == dependency::version::Tag::Workspace
+                            && root_dep.name_hash == name_hash
+                        {
+                            bun_ast::add_warning_pretty!(
+                                this.log_mut(),
+                                None,
+                                bun_ast::Loc::EMPTY,
+                                "file dependency \"{}\" has an invalid path \"{}\"<r> <d>(using workspace package instead)<r>",
+                                bstr::BStr::new(this.lockfile.str(&name)),
+                                bstr::BStr::new(this.lockfile.str(&version.literal)),
+                            );
+                            success_fn(this, dependency_id, workspace_package_id);
+                            return Ok(Some(ResolvedPackageResult {
+                                package: *this
+                                    .lockfile
+                                    .packages
+                                    .get(workspace_package_id as usize),
+                                is_first_time: false,
+                                task: None,
+                            }));
+                        }
+                    }
+                }
+            }
+
             match res {
                 FolderResolutionValue::Err(err) => Err(err),
                 FolderResolutionValue::PackageId(package_id) => {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2202,6 +2202,100 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  // https://github.com/oven-sh/bun/issues/13195
+  it("should fall back to workspace for file: dependency with invalid path", async () => {
+    await withContext(defaultOpts, async ctx => {
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "root",
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+      );
+      await mkdir(join(ctx.package_dir, "packages", "pkg-a"), { recursive: true });
+      await mkdir(join(ctx.package_dir, "packages", "pkg-b"), { recursive: true });
+      await writeFile(
+        join(ctx.package_dir, "packages", "pkg-a", "package.json"),
+        JSON.stringify({
+          name: "pkg-a",
+          version: "1.0.0",
+        }),
+      );
+      await writeFile(
+        join(ctx.package_dir, "packages", "pkg-b", "package.json"),
+        JSON.stringify({
+          name: "pkg-b",
+          version: "1.0.0",
+          dependencies: {
+            "pkg-a": "file: *",
+          },
+        }),
+      );
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const err = await stderr.text();
+      expect(err).not.toContain("error:");
+      expect(err).toContain("Saved lockfile");
+      expect(err).toContain('warn: file dependency "pkg-a" has an invalid path');
+      const out = await stdout.text();
+      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+        expect.stringContaining("bun install v1."),
+        "",
+        "2 packages installed",
+      ]);
+      expect(await exited).toBe(0);
+      expect(ctx.requested).toBe(0);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "pkg-a", "pkg-b"]);
+      expect(ctx.package_dir).toHaveWorkspaceLink(["pkg-a", "packages/pkg-a"]);
+      expect(ctx.package_dir).toHaveWorkspaceLink(["pkg-b", "packages/pkg-b"]);
+      await access(join(ctx.package_dir, "bun.lockb"));
+    });
+  });
+
+  it("should still fail on file: dependency with invalid path when not a workspace member", async () => {
+    await withContext(defaultOpts, async ctx => {
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "root",
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+      );
+      await mkdir(join(ctx.package_dir, "packages", "pkg-b"), { recursive: true });
+      await writeFile(
+        join(ctx.package_dir, "packages", "pkg-b", "package.json"),
+        JSON.stringify({
+          name: "pkg-b",
+          version: "1.0.0",
+          dependencies: {
+            "not-a-workspace-pkg": "file: *",
+          },
+        }),
+      );
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const err = await stderr.text();
+      expect(err).toContain("error:");
+      expect(err).toContain("not-a-workspace-pkg");
+      await stdout.text();
+      expect(await exited).toBe(1);
+    });
+  });
+
   it("should edit package json correctly with git dependencies", async () => {
     await withContext(defaultOpts, async ctx => {
       const urls: string[] = [];


### PR DESCRIPTION
Fixes #13195.

### Repro

```sh
mkdir -p packages/pkg-a packages/pkg-b
echo '{"name":"root","private":true,"workspaces":["packages/*"]}' > package.json
echo '{"name":"pkg-a","version":"1.0.0"}' > packages/pkg-a/package.json
echo '{"name":"pkg-b","version":"1.0.0","dependencies":{"pkg-a":"file: *"}}' > packages/pkg-b/package.json
bun install
```

Before:

```
error: Could not find package.json for "file:packages/pkg-b/ *" dependency "pkg-a"
error: pkg-a@file: * failed to resolve
```

### Cause

A `file:` specifier is tagged as `Folder` in `dependency::Tag::infer`, and folder resolution in `get_or_put_resolved_package` tries to open `<workspace-dir>/<literal path>/package.json`. When that path does not exist the error propagates as `MissingPackageJSON` and the install fails. Unlike `Npm` and `DistTag` specifiers, `Folder` had no fallback to a workspace package of the same name.

npm tolerates this case: it creates a link to the literal path (dangling) and the top-level workspace link makes resolution work regardless.

### Fix

When folder resolution fails with `MissingPackageJSON`, check whether the dependency name matches a workspace member (gated on `link_workspace_packages`). If so, bind to the workspace package and emit a warning instead of an error. This mirrors the existing `'resolve_workspace_from_dist_tag` fallback.

After:

```
warn: file dependency "pkg-a" has an invalid path "file: *" (using workspace package instead)
Saved lockfile
```

A `file:` dependency on a name that is *not* a workspace member still errors as before.

### Verification

```
bun bd test test/cli/install/bun-install.test.ts -t "file: dependency with invalid path"
```

Both added tests pass with the fix; the workspace-fallback test fails on main with the original error.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->