### PR TITLE
event loop: count queued concurrent_tasks in is_event_loop_alive()

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1039,6 +1039,7 @@ impl VirtualMachine {
                 + self.active_tasks
                 + el.tasks.readable_length()
                 + (el.has_pending_refs() as usize)
+                + (!el.concurrent_tasks.is_empty() as usize)
                 > 0)
     }
 

--- a/test/regression/issue/11453.test.ts
+++ b/test/regression/issue/11453.test.ts
@@ -1,0 +1,122 @@
+// https://github.com/oven-sh/bun/issues/11453
+//
+// @edgedb/generate under Bun would sometimes exit 0 silently mid-connect.
+// Root cause: edgedb's RawConnection does sock.ref()/await/sock.unref() around
+// reads, and in between runs SCRAM via crypto.subtle (Bun exposes a global
+// `crypto`, so the edgedb client picks its browserCrypto adapter). When the
+// small-input digest fast path (or the completion leg of a work-queue crypto
+// op) posts its result via ScriptExecutionContext::postTaskTo, the task lands
+// in EventLoop.concurrent_tasks with no accompanying event-loop ref, and
+// is_event_loop_alive() did not look at concurrent_tasks. With the socket
+// unref'd, the liveness check saw zero and the process exited with the crypto
+// result still queued.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import { once } from "node:events";
+import net from "node:net";
+
+describe("issue #11453: crypto.subtle keeps the event loop alive after a yield", () => {
+  // Deterministic: the <64-byte SHA digest fast path computes synchronously
+  // and posts the callback via postTaskTo with no work-queue ref.
+  test.concurrent("crypto.subtle.digest (small input) awaited after setImmediate", async () => {
+    const script = `
+      (async () => {
+        await new Promise(r => setImmediate(r));
+        await crypto.subtle.digest("SHA-256", new Uint8Array(32));
+        console.log("resolved");
+      })();
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stderr)).toBe("");
+    expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`"resolved"`);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("crypto.subtle.digest (small input) awaited after setTimeout", async () => {
+    const script = `
+      (async () => {
+        await new Promise(r => setTimeout(r, 0));
+        await crypto.subtle.digest("SHA-256", new Uint8Array(32));
+        console.log("resolved");
+      })();
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stderr)).toBe("");
+    expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`"resolved"`);
+    expect(exitCode).toBe(0);
+  });
+
+  // The exact shape from edgedb's rawConn._waitForMessage: with the socket
+  // unref'd between reads, an awaited crypto.subtle op must keep the process
+  // alive until it resolves and the next sock.ref() runs.
+  test.concurrent("crypto.subtle between sock.unref() and sock.ref() on a net.Socket", async () => {
+    const server = net.createServer(socket => {
+      socket.setNoDelay();
+      socket.on("data", () => {
+        setImmediate(() => {
+          try {
+            socket.write("R");
+          } catch {}
+        });
+      });
+      socket.on("error", () => {});
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const port = (server.address() as net.AddressInfo).port;
+
+    const script = `
+      const net = require("net");
+      const sock = net.createConnection(${port}, "127.0.0.1");
+      let connR, dataR;
+      sock.on("connect", () => connR());
+      sock.on("error", e => { console.error("err", e.message); process.exit(2); });
+      sock.on("data", () => { if (dataR) { dataR(); dataR = null; } });
+      (async () => {
+        await new Promise(r => (connR = r));
+
+        // round-trip: edgedb's ref() / await data / unref() pattern
+        sock.write("x");
+        sock.ref();
+        await new Promise(r => (dataR = r));
+        sock.unref();
+
+        // Socket is now unref'd. Nothing else is ref'd. The awaited digest
+        // must keep the loop alive on its own.
+        await crypto.subtle.digest("SHA-256", new Uint8Array(32));
+
+        sock.write("y");
+        sock.ref();
+        await new Promise(r => (dataR = r));
+        sock.unref();
+
+        console.log("resolved");
+        sock.destroy();
+      })();
+    `;
+
+    try {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(normalizeBunSnapshot(stderr)).toBe("");
+      expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`"resolved"`);
+      expect(exitCode).toBe(0);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+});

--- a/test/regression/issue/11453.test.ts
+++ b/test/regression/issue/11453.test.ts
@@ -1,23 +1,10 @@
 // https://github.com/oven-sh/bun/issues/11453
-//
-// @edgedb/generate under Bun would sometimes exit 0 silently mid-connect.
-// Root cause: edgedb's RawConnection does sock.ref()/await/sock.unref() around
-// reads, and in between runs SCRAM via crypto.subtle (Bun exposes a global
-// `crypto`, so the edgedb client picks its browserCrypto adapter). When the
-// small-input digest fast path (or the completion leg of a work-queue crypto
-// op) posts its result via ScriptExecutionContext::postTaskTo, the task lands
-// in EventLoop.concurrent_tasks with no accompanying event-loop ref, and
-// is_event_loop_alive() did not look at concurrent_tasks. With the socket
-// unref'd, the liveness check saw zero and the process exited with the crypto
-// result still queued.
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
 import { once } from "node:events";
 import net from "node:net";
 
 describe("issue #11453: crypto.subtle keeps the event loop alive after a yield", () => {
-  // Deterministic: the <64-byte SHA digest fast path computes synchronously
-  // and posts the callback via postTaskTo with no work-queue ref.
   test.concurrent("crypto.subtle.digest (small input) awaited after setImmediate", async () => {
     const script = `
       (async () => {
@@ -56,9 +43,6 @@ describe("issue #11453: crypto.subtle keeps the event loop alive after a yield",
     expect(exitCode).toBe(0);
   });
 
-  // The exact shape from edgedb's rawConn._waitForMessage: with the socket
-  // unref'd between reads, an awaited crypto.subtle op must keep the process
-  // alive until it resolves and the next sock.ref() runs.
   test.concurrent("crypto.subtle between sock.unref() and sock.ref() on a net.Socket", async () => {
     const server = net.createServer(socket => {
       socket.setNoDelay();
@@ -91,8 +75,6 @@ describe("issue #11453: crypto.subtle keeps the event loop alive after a yield",
         await new Promise(r => (dataR = r));
         sock.unref();
 
-        // Socket is now unref'd. Nothing else is ref'd. The awaited digest
-        // must keep the loop alive on its own.
         await crypto.subtle.digest("SHA-256", new Uint8Array(32));
 
         sock.write("y");


### PR DESCRIPTION
Fixes the residual silent exit in #11453.

## Repro

```js
(async () => {
  await new Promise(r => setImmediate(r));
  await crypto.subtle.digest("SHA-256", new Uint8Array(32));
  console.log("resolved");
})();
```

Before: prints nothing, exits 0. Node prints `resolved`.

The same gap is what makes `@edgedb/generate` intermittently exit 0 right after `Connecting to database...`: edgedb's `rawConn._waitForMessage` does `sock.ref()` / `await` / `sock.unref()` around each read, and the client runs SCRAM via `crypto.subtle` in between (Bun exposes a global `crypto`, so the client's `adapter.crypto.node` picks `browserCrypto`). With the TLS socket `unref()`'d during the HMAC/digest work, the only thing that should be holding the loop is the pending `crypto.subtle` task.

## Cause

`ScriptExecutionContext::postTaskTo` routes through `Bun__queueTaskConcurrently` which pushes into `EventLoop.concurrent_tasks` and wakes the loop, but takes no ref. Two WebCrypto paths reach here without any other ref:

- the `<64` byte digest fast path in `CryptoAlgorithmSHA{1,224,256,384,512,3}.cpp`, which computes the hash synchronously on the main thread and posts the callback via `postTaskTo`;
- the completion leg of `dispatchAlgorithmOperation` (used by `sign`/`verify`/`encrypt`/`decrypt`/large digests), where `ConcurrentCppTask::run_owned` runs `unref_concurrently()` after `postTaskTo` has enqueued the result; between the two there is a window where `concurrent_ref == 0` with the result task sitting only in `concurrent_tasks`.

`is_event_loop_alive_excluding_immediates()` checked `el.tasks` (the drained FIFO), `has_pending_refs()` and the platform loop's `active` counter, but not `el.concurrent_tasks`. So the run loop could evaluate liveness as false and exit with the `crypto.subtle` promise still pending. `run_command.rs` already had a one-off `|| tick_concurrent_with_count() > 0` guard at the initial post-load check; the main `while is_event_loop_alive()` loop and the other callers did not.

## Fix

Include `!el.concurrent_tasks.is_empty()` in `is_event_loop_alive_excluding_immediates()`. `UnboundedQueue::is_empty` is a single `Acquire` load of `back`, and `pop_batch` swaps `back` to null, so this is an accurate and cheap read from the main thread.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/11453.test.ts`: 3 fail (empty stdout, exit 0)
- `bun bd test test/regression/issue/11453.test.ts`: 3 pass
- edgedb-shaped TLS loop (50 runs of `tls.connect` + `ref/unref` around reads + 4096 `crypto.subtle.sign` iterations): 43/50 before, 50/50 after

Fixes #11453