### PR TITLE
install: accept aliased non-GitHub git URLs in bun add / bunx

### DIFF
--- a/src/install/PackageManager/UpdateRequest.rs
+++ b/src/install/PackageManager/UpdateRequest.rs
@@ -241,8 +241,18 @@ impl UpdateRequest {
                     Some(&mut *log),
                     pm.as_deref_mut(),
                 ) {
-                    alias = None;
-                    version = ver;
+                    // Only discard the alias when the full input is itself a git
+                    // reference (e.g. the scp-style `git@host:path/repo`). For
+                    // `name@git://...` / `name@git+ssh://...` the full input
+                    // infers as DistTag, which must not clobber the already-parsed
+                    // alias + git version (issue #13891).
+                    if matches!(
+                        ver.tag,
+                        dependency::version::Tag::Git | dependency::version::Tag::Github
+                    ) {
+                        alias = None;
+                        version = ver;
+                    }
                 }
             }
             if match version.tag {

--- a/src/install/PackageManager/UpdateRequest.rs
+++ b/src/install/PackageManager/UpdateRequest.rs
@@ -231,10 +231,7 @@ impl UpdateRequest {
 
                 return Err(crate::Error::UnrecognizedDependencyFormat);
             };
-            // Re-parse to catch scp-style `user@host:path/repo`, where `user`
-            // is the SSH user, not an npm alias. A scoped alias (`/`) cannot be
-            // an SSH user, and only a Git/Github re-parse may replace the
-            // already-valid alias + git version (#13891).
+            // Catch scp-style `user@host:path/repo` where `user` was split off as the alias.
             if alias.is_some_and(|a| !a.contains(&b'/'))
                 && version.tag == dependency::version::Tag::Git
             {

--- a/src/install/PackageManager/UpdateRequest.rs
+++ b/src/install/PackageManager/UpdateRequest.rs
@@ -231,7 +231,18 @@ impl UpdateRequest {
 
                 return Err(crate::Error::UnrecognizedDependencyFormat);
             };
-            if alias.is_some() && version.tag == dependency::version::Tag::Git {
+            // This re-parse exists so an scp-style `user@host:path/repo` (where
+            // `user` would otherwise be split off as an npm alias) is kept as a
+            // single git URL. Only discard the alias when that interpretation
+            // actually holds:
+            //  * a scoped `@scope/name` alias contains `/`, which is never a
+            //    valid SSH user, so the full input cannot be scp-style;
+            //  * for `name@git://...` / `name@git+ssh://...` the full input
+            //    infers as DistTag, which must not clobber the already-parsed
+            //    alias + git version (issue #13891).
+            if alias.is_some_and(|a| !a.contains(&b'/'))
+                && version.tag == dependency::version::Tag::Git
+            {
                 if let Some(ver) = Dependency::parse_with_optional_tag(
                     placeholder,
                     None,
@@ -241,11 +252,6 @@ impl UpdateRequest {
                     Some(&mut *log),
                     pm.as_deref_mut(),
                 ) {
-                    // Only discard the alias when the full input is itself a git
-                    // reference (e.g. the scp-style `git@host:path/repo`). For
-                    // `name@git://...` / `name@git+ssh://...` the full input
-                    // infers as DistTag, which must not clobber the already-parsed
-                    // alias + git version (issue #13891).
                     if matches!(
                         ver.tag,
                         dependency::version::Tag::Git | dependency::version::Tag::Github

--- a/src/install/PackageManager/UpdateRequest.rs
+++ b/src/install/PackageManager/UpdateRequest.rs
@@ -231,15 +231,10 @@ impl UpdateRequest {
 
                 return Err(crate::Error::UnrecognizedDependencyFormat);
             };
-            // This re-parse exists so an scp-style `user@host:path/repo` (where
-            // `user` would otherwise be split off as an npm alias) is kept as a
-            // single git URL. Only discard the alias when that interpretation
-            // actually holds:
-            //  * a scoped `@scope/name` alias contains `/`, which is never a
-            //    valid SSH user, so the full input cannot be scp-style;
-            //  * for `name@git://...` / `name@git+ssh://...` the full input
-            //    infers as DistTag, which must not clobber the already-parsed
-            //    alias + git version (issue #13891).
+            // Re-parse to catch scp-style `user@host:path/repo`, where `user`
+            // is the SSH user, not an npm alias. A scoped alias (`/`) cannot be
+            // an SSH user, and only a Git/Github re-parse may replace the
+            // already-valid alias + git version (#13891).
             if alias.is_some_and(|a| !a.contains(&b'/'))
                 && version.tag == dependency::version::Tag::Git
             {

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1356,16 +1356,19 @@ for (const { desc, dep } of gitNameTests) {
 }
 
 // https://github.com/oven-sh/bun/issues/13891
-// `name@<git-url>` was rejected as "unrecognised dependency format" for every
-// git URL that did not resolve to github.com, because the re-parse that exists
-// to catch scp-style `git@host:path` inputs clobbered the already-parsed
-// alias + git version with a DistTag.
-for (const dep of [
-  "mypkg@git://bun-13891.invalid:some/repo.git",
-  "mypkg@git+ssh://bun-13891.invalid:some/repo.git",
-  "mypkg@git+ssh://git@bun-13891.invalid:some/repo.git#ref",
-  "mypkg@git+file:///bun-13891/repo.git",
-  "mypkg@git+https://bun-13891.invalid:some/repo.git",
+// `name@<git-url>` was being mis-handled for every git URL that did not
+// resolve to github.com: the re-parse that exists to catch scp-style
+// `git@host:path` inputs clobbered the already-parsed alias + git version.
+// Unscoped aliases were rejected as "unrecognised dependency format"; scoped
+// aliases went through with the full positional used as the repo URL.
+for (const { dep, name } of [
+  { dep: "mypkg@git://bun-13891.invalid:some/repo.git", name: "mypkg" },
+  { dep: "mypkg@git+ssh://bun-13891.invalid:some/repo.git", name: "mypkg" },
+  { dep: "mypkg@git+ssh://git@bun-13891.invalid:some/repo.git#ref", name: "mypkg" },
+  { dep: "mypkg@git+file:///bun-13891/repo.git", name: "mypkg" },
+  { dep: "mypkg@git+https://bun-13891.invalid:some/repo.git", name: "mypkg" },
+  { dep: "@myorg/tool@git+ssh://bun-13891.invalid:some/repo.git", name: "@myorg/tool" },
+  { dep: "@myorg/tool@git+https://bun-13891.invalid:some/repo.git", name: "@myorg/tool" },
 ]) {
   it(`should parse aliased git dependency: ${dep}`, async () => {
     await Bun.write(join(package_dir, "package.json"), JSON.stringify({ name: "foo" }));
@@ -1383,7 +1386,10 @@ for (const dep of [
 
     const err = await stderr.text();
     expect(err).not.toContain("unrecognised dependency format");
-    expect(err).toContain("mypkg");
+    // The clone error must name the package by its alias alone; when the alias
+    // was wrongly discarded the full positional appears as the package name
+    // ("git clone" for "<full literal>" / cloning repository for <full literal>).
+    expect(err).toMatch(new RegExp(`for ("${name}"|${name}\\n)`));
     expect(await exited).toBe(1);
   });
 }
@@ -1395,7 +1401,7 @@ it("should parse scp-style git dependency without treating the user as an alias"
   await Bun.write(join(package_dir, "package.json"), JSON.stringify({ name: "foo" }));
 
   const { stderr, exited } = spawn({
-    cmd: [bunExe(), "add", "git@bun-13891.invalid:some/repo.git"],
+    cmd: [bunExe(), "add", "git@127.0.0.1:some/repo.git"],
     cwd: package_dir,
     stdout: "ignore",
     stderr: "pipe",

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1396,12 +1396,14 @@ for (const { dep, name } of [
 
 // The re-parse must still prefer the unaliased interpretation for scp-style
 // inputs like `git@host:path/repo.git`, where the leading `git` is the SSH
-// user rather than an npm alias.
+// user rather than an npm alias. The host must not start with a digit
+// (Tag::infer would short-circuit to Tag::Npm and skip the re-parse).
 it("should parse scp-style git dependency without treating the user as an alias", async () => {
   await Bun.write(join(package_dir, "package.json"), JSON.stringify({ name: "foo" }));
 
+  const dep = "git@localhost:some/repo.git";
   const { stderr, exited } = spawn({
-    cmd: [bunExe(), "add", "git@127.0.0.1:some/repo.git"],
+    cmd: [bunExe(), "add", dep],
     cwd: package_dir,
     stdout: "ignore",
     stderr: "pipe",
@@ -1410,7 +1412,9 @@ it("should parse scp-style git dependency without treating the user as an alias"
 
   const err = await stderr.text();
   expect(err).not.toContain("unrecognised dependency format");
-  expect(err).not.toContain(`"git"`);
+  // The full positional is the package name (alias discarded); if the alias
+  // were kept this would be `for "git"` instead.
+  expect(err).toContain(`for "${dep}"`);
   expect(await exited).toBe(1);
 });
 

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1355,6 +1355,59 @@ for (const { desc, dep } of gitNameTests) {
   });
 }
 
+// https://github.com/oven-sh/bun/issues/13891
+// `name@<git-url>` was rejected as "unrecognised dependency format" for every
+// git URL that did not resolve to github.com, because the re-parse that exists
+// to catch scp-style `git@host:path` inputs clobbered the already-parsed
+// alias + git version with a DistTag.
+for (const dep of [
+  "mypkg@git://bun-13891.invalid:some/repo.git",
+  "mypkg@git+ssh://bun-13891.invalid:some/repo.git",
+  "mypkg@git+ssh://git@bun-13891.invalid:some/repo.git#ref",
+  "mypkg@git+file:///bun-13891/repo.git",
+  "mypkg@git+https://bun-13891.invalid:some/repo.git",
+]) {
+  it(`should parse aliased git dependency: ${dep}`, async () => {
+    await Bun.write(join(package_dir, "package.json"), JSON.stringify({ name: "foo" }));
+
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "add", dep],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      // GIT_SSH_COMMAND=false makes the ssh fallback fail immediately without
+      // touching the network; the `:some` path segment makes the https attempt
+      // a syntactic reject (non-numeric port). The clone is expected to fail.
+      env: { ...env, GIT_SSH_COMMAND: "false", GIT_TERMINAL_PROMPT: "0", GIT_ASKPASS: "false" },
+    });
+
+    const err = await stderr.text();
+    expect(err).not.toContain("unrecognised dependency format");
+    expect(err).toContain("mypkg");
+    expect(await exited).toBe(1);
+  });
+}
+
+// The re-parse must still prefer the unaliased interpretation for scp-style
+// inputs like `git@host:path/repo.git`, where the leading `git` is the SSH
+// user rather than an npm alias.
+it("should parse scp-style git dependency without treating the user as an alias", async () => {
+  await Bun.write(join(package_dir, "package.json"), JSON.stringify({ name: "foo" }));
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "git@bun-13891.invalid:some/repo.git"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env: { ...env, GIT_SSH_COMMAND: "false", GIT_TERMINAL_PROMPT: "0", GIT_ASKPASS: "false" },
+  });
+
+  const err = await stderr.text();
+  expect(err).not.toContain("unrecognised dependency format");
+  expect(err).not.toContain(`"git"`);
+  expect(await exited).toBe(1);
+});
+
 it("git dep without package.json and with default branch", async () => {
   await Bun.write(
     join(package_dir, "package.json"),


### PR DESCRIPTION
Fixes #13891.

## What

`bun add pkg@git://host:path/repo.git` and `bunx pkg@git+ssh://...` failed with:

```
error: unrecognised dependency format: pkg@git://host:path/repo.git
```

for any git URL that did not resolve to `github.com`. The same spec with a `github.com` host worked, and the unaliased form (`bun add git://host:path/repo.git`) worked.

## Cause

`UpdateRequest::parse_with_error` splits `pkg@<value>` into alias `pkg` + value, and `Tag::infer(value)` correctly returns `Tag::Git`. It then re-parses the *full* positional with a fresh `Tag::infer` to catch the scp-style `git@host:path/repo` case, where `git` is the SSH user rather than an npm alias.

For `pkg@<scheme>://...` the re-parse's `is_scp_like_path` returns false at the first `://`, so the full input falls through to `Tag::DistTag`. That DistTag result then unconditionally replaced the valid alias + git parse, and the subsequent placeholder-name check rejected it.

`github.com` URLs were unaffected because they parse as `Tag::Github` in the first step, which skips the re-parse entirely.

## Fix

Only adopt the re-parse result when it is also `Tag::Git` / `Tag::Github`. The scp-style path (where the re-parse does yield one of those) is unchanged.

## Verification

Before:
```
$ bun add mypkg@git+ssh://git@example.com:a/b.git
error: unrecognised dependency format: mypkg@git+ssh://git@example.com:a/b.git
```

After:
```
$ bun add mypkg@git+ssh://git@example.com:a/b.git
Resolving dependencies
... (git clone proceeds)
```

New tests in `test/cli/install/bun-add.test.ts` cover `git://`, `git+ssh://` (with and without `user@` and `#ref`), `git+file://`, and `git+https://` aliased specs, plus a guard that `git@host:path` still takes the scp-style (no-alias) interpretation.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-add.test.ts

<!-- robobun:evidence:end -->