### PR TITLE
install: make bun update re-resolve root peerDependencies

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2181,7 +2181,10 @@ fn get_or_put_resolved_package(
     install_peer: bool,
     success_fn: SuccessFn,
 ) -> crate::Result<Option<ResolvedPackageResult>> {
-    if install_peer && behavior.is_peer() && !should_update_dependency(this, dependency, dependency_id) {
+    if install_peer
+        && behavior.is_peer()
+        && !should_update_dependency(this, dependency, dependency_id)
+    {
         if let Some(index) = this.lockfile.package_index.get(&name_hash) {
             let resolutions = this.lockfile.packages.items_resolution();
             match index {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1956,11 +1956,6 @@ pub(crate) struct ResolvedPackageResult {
 }
 
 /// Is this dependency a direct target of the current `bun update` invocation?
-///
-/// True for any direct dependency of the active workspace when `bun update`
-/// was run without arguments, or when it matches one of the named packages.
-/// Used to force a fresh manifest resolve (instead of reusing a package that
-/// happens to already be in the lockfile and satisfy the range).
 fn should_update_dependency(
     this: &mut PackageManager,
     dependency: &Dependency,
@@ -1969,15 +1964,11 @@ fn should_update_dependency(
     if !this.to_update {
         return false;
     }
-    // reshaped for borrowck: `is_root_dependency(&self, &mut PackageManager, ...)`
-    // borrows `this.lockfile` and `this` at once. Split via raw root.
     let this_ptr: *mut PackageManager = this;
-    // SAFETY: `is_root_dependency` reads `manager.root_package_id` /
-    // `manager.workspace_name_hash` only, disjoint from `manager.lockfile`.
+    // SAFETY: `is_root_dependency` only touches `manager.{root_package_id,workspace_name_hash}`.
     (dependency.version.tag == dependency::version::Tag::Catalog
         || unsafe { &*(*this_ptr).lockfile }
             .is_root_dependency(unsafe { &mut *this_ptr }, dependency_id))
-        // no need to do a look up if update requests are empty (`bun update` with no args)
         && (this.update_requests.is_empty()
             || this.updating_packages.contains(
                 dependency.name.slice(this.lockfile.buffers.string_bytes.as_slice()),

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1955,6 +1955,35 @@ pub(crate) struct ResolvedPackageResult {
     pub task: Option<ResolvedPackageTask>,
 }
 
+/// Is this dependency a direct target of the current `bun update` invocation?
+///
+/// True for any direct dependency of the active workspace when `bun update`
+/// was run without arguments, or when it matches one of the named packages.
+/// Used to force a fresh manifest resolve (instead of reusing a package that
+/// happens to already be in the lockfile and satisfy the range).
+fn should_update_dependency(
+    this: &mut PackageManager,
+    dependency: &Dependency,
+    dependency_id: DependencyID,
+) -> bool {
+    if !this.to_update {
+        return false;
+    }
+    // reshaped for borrowck: `is_root_dependency(&self, &mut PackageManager, ...)`
+    // borrows `this.lockfile` and `this` at once. Split via raw root.
+    let this_ptr: *mut PackageManager = this;
+    // SAFETY: `is_root_dependency` reads `manager.root_package_id` /
+    // `manager.workspace_name_hash` only, disjoint from `manager.lockfile`.
+    (dependency.version.tag == dependency::version::Tag::Catalog
+        || unsafe { &*(*this_ptr).lockfile }
+            .is_root_dependency(unsafe { &mut *this_ptr }, dependency_id))
+        // no need to do a look up if update requests are empty (`bun update` with no args)
+        && (this.update_requests.is_empty()
+            || this.updating_packages.contains(
+                dependency.name.slice(this.lockfile.buffers.string_bytes.as_slice()),
+            ))
+}
+
 fn get_or_put_resolved_package_with_find_result(
     this: &mut PackageManager,
     name_hash: PackageNameHash,
@@ -1968,24 +1997,7 @@ fn get_or_put_resolved_package_with_find_result(
     install_peer: bool,
     success_fn: SuccessFn,
 ) -> crate::Result<Option<ResolvedPackageResult>> {
-    // reshaped for borrowck — `is_root_dependency(&self, &mut PackageManager, …)`
-    // borrows `this.lockfile` and `this` at once. Split via raw root.
-    let should_update = {
-        let this_ptr: *mut PackageManager = this;
-        // SAFETY: `is_root_dependency` reads `manager.root_dependency_list` /
-        // `manager.workspace_package_json_cache` only — disjoint from
-        // `manager.lockfile`.
-        this.to_update
-            // Update direct deps of the current workspace; catalogs are root-scoped.
-            && (dependency.version.tag == dependency::version::Tag::Catalog
-                || unsafe { &*(*this_ptr).lockfile }
-                    .is_root_dependency(unsafe { &mut *this_ptr }, dependency_id))
-            // no need to do a look up if update requests are empty (`bun update` with no args)
-            && (this.update_requests.is_empty()
-                || this.updating_packages.contains(
-                    dependency.name.slice(this.lockfile.buffers.string_bytes.as_slice()),
-                ))
-    };
+    let should_update = should_update_dependency(this, dependency, dependency_id);
 
     // Was this package already allocated? Let's reuse the existing one.
     //
@@ -2169,7 +2181,7 @@ fn get_or_put_resolved_package(
     install_peer: bool,
     success_fn: SuccessFn,
 ) -> crate::Result<Option<ResolvedPackageResult>> {
-    if install_peer && behavior.is_peer() {
+    if install_peer && behavior.is_peer() && !should_update_dependency(this, dependency, dependency_id) {
         if let Some(index) = this.lockfile.package_index.get(&name_hash) {
             let resolutions = this.lockfile.packages.items_resolution();
             match index {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1971,7 +1971,9 @@ fn should_update_dependency(
             .is_root_dependency(unsafe { &mut *this_ptr }, dependency_id))
         && (this.update_requests.is_empty()
             || this.updating_packages.contains(
-                dependency.name.slice(this.lockfile.buffers.string_bytes.as_slice()),
+                dependency
+                    .name
+                    .slice(this.lockfile.buffers.string_bytes.as_slice()),
             ))
 }
 

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -4967,6 +4967,48 @@ describe("update", () => {
       version: "1.1.0",
     });
   });
+  for (const args of [undefined, ["a-dep"], ["--latest"]]) {
+    const label = args ? args.join(" ") : "(no args)";
+    // https://github.com/oven-sh/bun/issues/13509
+    test(`peer dependency with stale lockfile entry: bun update ${label}`, async () => {
+      // Lock a-dep at 1.0.1 first, then widen the range. The lockfile keeps
+      // 1.0.1, and `bun update` must re-resolve instead of reusing it.
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          peerDependencies: { "a-dep": "1.0.1" },
+        }),
+      );
+      await runBunInstall(env, packageDir);
+      expect(await file(join(packageDir, "node_modules", "a-dep", "package.json")).json()).toMatchObject({
+        version: "1.0.1",
+      });
+
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          peerDependencies: { "a-dep": "^1.0.1" },
+        }),
+      );
+      await runBunInstall(env, packageDir);
+      expect(await file(join(packageDir, "node_modules", "a-dep", "package.json")).json()).toMatchObject({
+        version: "1.0.1",
+      });
+
+      await runBunUpdate(env, packageDir, args);
+      assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+
+      expect(await file(join(packageDir, "node_modules", "a-dep", "package.json")).json()).toMatchObject({
+        version: "1.0.10",
+      });
+      expect(await file(packageJson).json()).toEqual({
+        name: "foo",
+        peerDependencies: { "a-dep": "^1.0.10" },
+      });
+    });
+  }
   test("dist-tags", async () => {
     await write(
       packageJson,


### PR DESCRIPTION
Fixes #13509.

## Repro

```sh
mkdir app && cd app
echo '{"name":"repro","peerDependencies":{"typescript":"5.5.2"}}' > package.json
bun install
echo '{"name":"repro","peerDependencies":{"typescript":"^5.5.2"}}' > package.json
bun install
bun update                      # "no changes"
bun update typescript           # "installed typescript@5.5.2"
```

`bun outdated` sees the newer version but `bun update` never moves it.

## Cause

Peer dependencies are resolved in a deferred second pass with `install_peer = true`. `get_or_put_resolved_package` has a peer-reuse path that scans `package_index` for any existing entry whose resolution satisfies the requested range and short-circuits to it. That is correct for transitive peers (they piggyback on whatever sibling already provides the package) but the stale lockfile entry for `typescript@5.5.2` is still in the index, satisfies `^5.5.2`, and wins.

The `should_update` gate that forces a fresh resolve for update targets already existed in `get_or_put_resolved_package_with_find_result`, but that runs *after* the peer-reuse short-circuit, so it was never consulted for peers.

## Fix

Extract the existing check into `should_update_dependency()` and use it to skip the peer-reuse path when the dependency is a direct update target (root-level, and either `bun update` was run without args or the name matches an explicit request). Transitive peers are unaffected because `is_root_dependency` is false for them.

## Verification

New tests in the `update` describe block of `bun-install-registry.test.ts` seed the lockfile with `a-dep@1.0.1`, widen to `^1.0.1`, then run each of `bun update`, `bun update a-dep`, and `bun update --latest`. All three now land on `1.0.10` and rewrite `peerDependencies` in `package.json`. The first two fail on main (stay at `1.0.1`).

Existing `update` and `peer` test groups in `bun-install-registry.test.ts`, plus `bun-lock.test.ts -t peer` and `catalogs.test.ts -t update`, continue to pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->