### PR TITLE
install: set npm_package_name/version/json for dependency lifecycle scripts

### DIFF
--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -4,6 +4,7 @@ use std::io::Write as _;
 
 use bstr::BStr;
 
+use bun_ast::{Log, Source};
 use bun_collections::ArrayHashMap;
 use bun_core::fmt::PathSep;
 use bun_core::{Output, ZBox, fmt as bun_fmt, handle_oom};
@@ -12,9 +13,12 @@ use bun_paths::resolve_path::{join_abs_string_z, platform};
 use bun_paths::{AutoAbsPath, EnvPath};
 use bun_semver::string::Builder as SemverStringBuilder;
 use bun_sys as Syscall;
+use bun_sys::Fd;
 use bun_threading::Mutex;
 
 use crate::bun_fs::FileSystem;
+use crate::bun_json as JSON;
+use crate::initialize_store;
 
 use super::directories;
 use crate::lifecycle_script_runner::{
@@ -404,6 +408,42 @@ impl PackageManager {
 
         path.append(original_path.as_slice())?;
         script_env.put(b"PATH", path.slice())?;
+
+        // npm_package_* must describe the package whose lifecycle script is
+        // running (https://github.com/npm/rfcs/blob/main/implemented/0021-reduce-lifecycle-script-environment.md),
+        // not the root project. Read the installed package.json at `cwd` so
+        // every resolution type (npm, file:, git, tarball, workspace, root)
+        // yields the package's own name/version.
+        {
+            let package_json_path = join_abs_string_z::<platform::Auto>(cwd, &[b"package.json"]);
+            script_env.put(b"npm_package_json", package_json_path.as_bytes())?;
+
+            let mut name: Box<[u8]> = list.package_name.clone();
+            let mut version: Box<[u8]> = Box::default();
+
+            if let Ok(json_buf) = Syscall::File::read_from(Fd::cwd(), package_json_path.as_bytes())
+            {
+                let json_src =
+                    Source::init_path_string(package_json_path.as_bytes(), json_buf.as_slice());
+                let mut tmp_log = Log::init();
+                initialize_store();
+                if let Ok(parsed) = JSON::ParsedJson::parse_package_json(&json_src, &mut tmp_log) {
+                    if let Some(e) = parsed.root.get(b"name")
+                        && let Some(n) = e.as_utf8_string_literal()
+                    {
+                        name = Box::from(n);
+                    }
+                    if let Some(e) = parsed.root.get(b"version")
+                        && let Some(v) = e.as_utf8_string_literal()
+                    {
+                        version = Box::from(v);
+                    }
+                }
+            }
+
+            script_env.put(b"npm_package_name", &name)?;
+            script_env.put(b"npm_package_version", &version)?;
+        }
 
         // Ownership transfers to `LifecycleScriptSubprocess`, which
         // re-uses it across every `spawn_next_script` in the chain. Move the

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -418,7 +418,7 @@ impl PackageManager {
             let package_json_path = join_abs_string_z::<platform::Auto>(cwd, &[b"package.json"]);
             script_env.put(b"npm_package_json", package_json_path.as_bytes())?;
 
-            let mut name: Box<[u8]> = list.package_name.clone();
+            let mut name: Option<Box<[u8]>> = None;
             let mut version: Box<[u8]> = Box::default();
 
             if let Ok(json_buf) = Syscall::File::read_from(Fd::cwd(), package_json_path.as_bytes())
@@ -431,7 +431,7 @@ impl PackageManager {
                     if let Some(e) = parsed.root.get(b"name")
                         && let Some(n) = e.as_utf8_string_literal()
                     {
-                        name = Box::from(n);
+                        name = Some(Box::from(n));
                     }
                     if let Some(e) = parsed.root.get(b"version")
                         && let Some(v) = e.as_utf8_string_literal()
@@ -441,7 +441,10 @@ impl PackageManager {
                 }
             }
 
-            script_env.put(b"npm_package_name", &name)?;
+            script_env.put(
+                b"npm_package_name",
+                name.as_deref().unwrap_or(&list.package_name),
+            )?;
             script_env.put(b"npm_package_version", &version)?;
         }
 

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -409,9 +409,7 @@ impl PackageManager {
         path.append(original_path.as_slice())?;
         script_env.put(b"PATH", path.slice())?;
 
-        // npm_package_* describes the package whose script runs, not the root
-        // project. Read the on-disk manifest because the lockfile has no
-        // version for file:/git/tarball deps.
+        // npm_package_* from the on-disk manifest: lockfile has no version for file:/git deps.
         {
             let package_json_path = join_abs_string_z::<platform::Auto>(cwd, &[b"package.json"]);
             script_env.put(b"npm_package_json", package_json_path.as_bytes())?;

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -409,11 +409,9 @@ impl PackageManager {
         path.append(original_path.as_slice())?;
         script_env.put(b"PATH", path.slice())?;
 
-        // npm_package_* must describe the package whose lifecycle script is
-        // running (https://github.com/npm/rfcs/blob/main/implemented/0021-reduce-lifecycle-script-environment.md),
-        // not the root project. Read the installed package.json at `cwd` so
-        // every resolution type (npm, file:, git, tarball, workspace, root)
-        // yields the package's own name/version.
+        // npm_package_* describes the package whose script runs, not the root
+        // project. Read the on-disk manifest because the lockfile has no
+        // version for file:/git/tarball deps.
         {
             let package_json_path = join_abs_string_z::<platform::Auto>(cwd, &[b"package.json"]);
             script_env.put(b"npm_package_json", package_json_path.as_bytes())?;

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -423,16 +423,13 @@ impl PackageManager {
                     Source::init_path_string(package_json_path.as_bytes(), json_buf.as_slice());
                 let mut tmp_log = Log::init();
                 initialize_store();
-                if let Ok(parsed) = JSON::ParsedJson::parse_package_json(&json_src, &mut tmp_log) {
-                    if let Some(e) = parsed.root.get(b"name")
-                        && let Some(n) = e.as_utf8_string_literal()
-                    {
-                        name = Some(Box::from(n));
+                let mut checker = JSON::PackageJSONVersionChecker::init(&json_src, &mut tmp_log);
+                if checker.parse().is_ok() {
+                    if checker.has_found_name {
+                        name = Some(Box::from(checker.found_name()));
                     }
-                    if let Some(e) = parsed.root.get(b"version")
-                        && let Some(v) = e.as_utf8_string_literal()
-                    {
-                        version = Box::from(v);
+                    if checker.has_found_version {
+                        version = Box::from(checker.found_version());
                     }
                 }
             }

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1465,6 +1465,70 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(await file(join(packageDir, "node_modules/another-init-cwd/test.txt")).text()).toBe(packageDir);
     });
 
+    // https://github.com/oven-sh/bun/issues/12752
+    test("npm_package_name/version/json are set to the dependency's own manifest values", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+      const captureScript = `${bunExe()} -e ${JSON.stringify(
+        `require("fs").writeFileSync("env.json", JSON.stringify({` +
+          `name: process.env.npm_package_name,` +
+          `version: process.env.npm_package_version,` +
+          `json: process.env.npm_package_json,` +
+          `}))`,
+      )}`;
+
+      await mkdir(join(packageDir, "dep"), { recursive: true });
+      await Promise.all([
+        writeFile(
+          packageJson,
+          JSON.stringify({
+            name: "root-project",
+            version: "1.0.2",
+            scripts: { postinstall: captureScript },
+            dependencies: { "my-dep": "file:./dep" },
+            trustedDependencies: ["my-dep"],
+          }),
+        ),
+        writeFile(
+          join(packageDir, "dep", "package.json"),
+          JSON.stringify({
+            name: "my-dep",
+            version: "7.2.0",
+            scripts: { postinstall: captureScript },
+          }),
+        ),
+      ]);
+
+      const { stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: testEnv,
+      });
+
+      const err = await stderr.text();
+      expect(err).not.toContain("error:");
+      expect(await exited).toBe(0);
+
+      const depEnv = await file(join(packageDir, "node_modules", "my-dep", "env.json")).json();
+      expect(depEnv).toEqual({
+        name: "my-dep",
+        version: "7.2.0",
+        json: join(packageDir, "node_modules", "my-dep", "package.json"),
+      });
+
+      const rootEnv = await file(join(packageDir, "env.json")).json();
+      expect(rootEnv).toEqual({
+        name: "root-project",
+        version: "1.0.2",
+        json: join(packageDir, "package.json"),
+      });
+    });
+
     test("failing lifecycle script should print output", async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1501,7 +1501,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         ),
       ]);
 
-      const { stderr, exited } = spawn({
+      const { stdout, stderr, exited } = spawn({
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
@@ -1510,9 +1510,9 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         env: testEnv,
       });
 
-      const err = await stderr.text();
+      const [, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
       expect(err).not.toContain("error:");
-      expect(await exited).toBe(0);
+      expect(exitCode).toBe(0);
 
       const depEnv = await file(join(packageDir, "node_modules", "my-dep", "env.json")).json();
       expect(depEnv).toEqual({


### PR DESCRIPTION
### What does this PR do?

Fixes #12752.

Dependency lifecycle scripts (`preinstall`/`install`/`postinstall`/`prepare`) were spawned with `npm_package_name`, `npm_package_version`, and `npm_package_json` unset. npm/yarn/pnpm set these from the `package.json` of the package whose script is running, and native addon downloaders commonly rely on them to compute their own install path or download URL.

**Repro** (fails on canary, `name= version= json=`):

```sh
mkdir -p proj/dep && cd proj
printf '%s' '{"name":"root","version":"1.0.2","dependencies":{"my-dep":"file:./dep"},"trustedDependencies":["my-dep"]}' > package.json
printf '%s' '{"name":"my-dep","version":"7.2.0","scripts":{"postinstall":"echo name=$npm_package_name version=$npm_package_version json=$npm_package_json"}}' > dep/package.json
bun install
```

**Cause:** `spawn_package_lifecycle_scripts` cloned the base install env (which only seeds `npm_config_user_agent` / `npm_execpath` / `INIT_CWD`) and added `PATH`, but never wrote the per-package `npm_package_*` vars.

**Fix:** before building the subprocess env map, read the installed `package.json` at the script's `cwd` and set `npm_package_json`, `npm_package_name`, and `npm_package_version` from it. Reading the on-disk manifest (rather than the lockfile resolution) keeps every resolution type correct, including `file:`, git, tarball, and workspace packages whose versions are not stored in the lockfile.

### How did you verify your code works?

New test in `test/cli/install/bun-install-lifecycle-scripts.test.ts` installs a `file:` dependency with a postinstall hook that writes the three env vars to disk, and asserts both the dependency and the root project see their own manifest values:

```
(pass) lifecycle scripts > npm_package_name/version/json are set to the dependency's own manifest values
(pass) lifecycle scripts (waiter thread) > npm_package_name/version/json are set to the dependency's own manifest values
```

Fails with `{}` (all three unset) before the fix.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts

<!-- robobun:evidence:end -->