### PR TITLE
docs/types: a type:"direct" ReadableStream yields Uint8Array, not the written value

### DIFF
--- a/docs/runtime/streams.mdx
+++ b/docs/runtime/streams.mdx
@@ -68,7 +68,7 @@ const stream = new ReadableStream({
 });
 ```
 
-When using a direct `ReadableStream`, the destination handles all chunk queueing. The consumer of the stream receives exactly what is passed to `controller.write()`, without any encoding or modification.
+When using a direct `ReadableStream`, the destination handles all chunk queueing. `controller.write()` accepts a string, `ArrayBufferView`, or `ArrayBuffer`, and returns the number of bytes written. Strings are UTF-8 encoded. When the stream is read via a default reader (for example with `for await` or `getReader().read()`), chunks are delivered as `Uint8Array`, and consecutive writes may be coalesced into a single chunk.
 
 ### Handling backpressure
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -307,6 +307,17 @@ declare module "bun" {
     type?: undefined;
   }
 
+  /**
+   * Underlying source for a Bun `type: "direct"` {@link ReadableStream}.
+   *
+   * The `pull` callback is passed a {@link ReadableStreamDirectController} whose
+   * `write()` accepts a string, `ArrayBufferView`, or `ArrayBuffer` and returns the
+   * number of bytes written (strings are UTF-8 encoded). Reading the stream via a
+   * default reader yields `Uint8Array` chunks.
+   *
+   * @template R Retained for backward compatibility; the stream's chunk type is
+   * always `Uint8Array` regardless of `R`.
+   */
   interface DirectUnderlyingSource<R = any> {
     cancel?: UnderlyingSourceCancelCallback;
     pull: (controller: ReadableStreamDirectController) => void | PromiseLike<void>;

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -75,7 +75,10 @@ declare var ReadableStream: Bun.__internal.UseLibDomIfAvailable<
   {
     prototype: ReadableStream;
     new <R = any>(underlyingSource?: Bun.UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
-    new <R = any>(underlyingSource?: Bun.DirectUnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
+    new (
+      underlyingSource: Bun.DirectUnderlyingSource,
+      strategy?: QueuingStrategy<Uint8Array<ArrayBuffer>>,
+    ): ReadableStream<Uint8Array<ArrayBuffer>>;
   }
 >;
 

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -723,42 +723,47 @@ describe("@types/bun integration test", () => {
         },
         {
           code: 2339,
-          line: "streams.ts:46:19",
+          line: "streams.ts:21:16",
+          message: "Property 'write' does not exist on type 'ReadableByteStreamController'.",
+        },
+        {
+          code: 2339,
+          line: "streams.ts:53:19",
           message: "Property 'json' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
         },
         {
           code: 2339,
-          line: "streams.ts:47:19",
+          line: "streams.ts:54:19",
           message: "Property 'bytes' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
         },
         {
           code: 2339,
-          line: "streams.ts:48:19",
+          line: "streams.ts:55:19",
           message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
         },
         {
           code: 2339,
-          line: "streams.ts:49:19",
+          line: "streams.ts:56:19",
           message: "Property 'blob' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
         },
         {
           code: 2345,
-          line: "streams.ts:63:66",
+          line: "streams.ts:70:66",
           message: "Argument of type '\"brotli\"' is not assignable to parameter of type 'CompressionFormat'.",
         },
         {
           code: 2345,
-          line: "streams.ts:63:113",
+          line: "streams.ts:70:113",
           message: "Argument of type '\"brotli\"' is not assignable to parameter of type 'CompressionFormat'.",
         },
         {
           code: 2345,
-          line: "streams.ts:64:66",
+          line: "streams.ts:71:66",
           message: "Argument of type '\"zstd\"' is not assignable to parameter of type 'CompressionFormat'.",
         },
         {
           code: 2345,
-          line: "streams.ts:64:111",
+          line: "streams.ts:71:111",
           message: "Argument of type '\"zstd\"' is not assignable to parameter of type 'CompressionFormat'.",
         },
         {

--- a/test/integration/bun-types/fixture/streams.ts
+++ b/test/integration/bun-types/fixture/streams.ts
@@ -14,12 +14,19 @@ new ReadableStream<string>({
 // Not fixable because ReadableStream has no ReadableStreamConstructor interface
 // we can merge into. See https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/1941
 // for details about when/why/how TypeScript might support this.
-new ReadableStream({
+const directStream = new ReadableStream({
   type: "direct",
   async pull(controller) {
     controller.write(new TextEncoder().encode("Hello, world!"));
+    controller.write("Hello, world!");
   },
 });
+// https://github.com/oven-sh/bun/issues/16054: strings written to a type:"direct"
+// stream are UTF-8 encoded; reading via a default reader yields Uint8Array chunks.
+expectType(directStream).is<ReadableStream<Uint8Array<ArrayBuffer>>>();
+for await (const chunk of directStream) {
+  expectType(chunk).is<Uint8Array<ArrayBuffer>>();
+}
 
 declare const uint8stream: ReadableStream<Uint8Array<ArrayBuffer>>;
 


### PR DESCRIPTION
## What does this PR do?

Fixes the remaining discrepancy from #16054: the docs for direct `ReadableStream` claimed

> The consumer of the stream receives exactly what is passed to `controller.write()`, without any encoding or modification.

but reading a `type: "direct"` stream via a default reader has always routed writes through an `ArrayBufferSink` ([`JSReadableStream::materializeIfNeeded`](https://github.com/oven-sh/bun/blob/main/src/jsc/bindings/webcore/streams/JSReadableStream.cpp#L534-L535) sets up the controller with `DirectSinkKind::ArrayBuffer`), so:

```ts
const stream = new ReadableStream({
  type: "direct",
  async pull(controller) {
    controller.write("hello");
    await Bun.sleep(100);
    controller.write("world");
    controller.close();
  },
});
for await (const chunk of stream) console.log(chunk);
// Uint8Array(5) [ 104, 101, 108, 108, 111 ]
// Uint8Array(5) [ 119, 111, 114, 108, 100 ]
```

The behavior is the intended contract: `controller.write()` returns a byte count, rejects anything that is not a string/`ArrayBufferView`/`ArrayBuffer`, and the `ArrayBufferSink` batching is what makes direct streams fast. The existing test suite relies on it ([`streams.test.js`](https://github.com/oven-sh/bun/blob/main/test/js/web/streams/streams.test.js#L352-L374)).

This PR makes the docs and types agree with the behavior:

- `docs/runtime/streams.mdx`: replace the incorrect claim with an accurate description (accepts string/`ArrayBufferView`/`ArrayBuffer`, strings are UTF-8 encoded, default reader yields `Uint8Array`, consecutive writes may coalesce).
- `packages/bun-types/globals.d.ts`: tighten the `ReadableStream` constructor's `DirectUnderlyingSource` overload so `new ReadableStream({ type: "direct", ... })` infers `ReadableStream<Uint8Array<ArrayBuffer>>` instead of `ReadableStream<any>`.
- `packages/bun-types/bun.d.ts`: add JSDoc on `DirectUnderlyingSource` describing the encoding and noting the `R` generic is kept only for backward compatibility.
- `test/integration/bun-types/fixture/streams.ts`: assert the inferred chunk type.

Fixes #16054.

## How did you verify your code works?

```
bun test test/integration/bun-types/bun-types.test.ts
# 14 pass, 0 fail
```