### PR TITLE
Bun.write(file, Bun.stdin): splice a pipe source into any destination on Linux

### DIFF
--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -315,10 +315,7 @@ impl<'a> CopyFile<'a> {
         let mut total_written: u64 = 0;
         let src_fd = self.source_fd;
         let dest_fd = self.destination_fd;
-        // Only truncate destinations Bun itself opened with O_TRUNC; a
-        // user-provided fd (Bun.stdout, Bun.file(fd)) may carry O_APPEND or
-        // pre-existing bytes that ftruncate would destroy.
-        let may_ftruncate = matches!(
+        let bun_opened_dest = matches!(
             self.destination_file_store.pathlike,
             PathOrFileDescriptor::Path(_)
         );
@@ -350,7 +347,7 @@ impl<'a> CopyFile<'a> {
                     return Err(bun_errno::from_errno(err.errno as i32).into());
                 }
                 bun_sys::Result::Ok(()) => {
-                    if may_ftruncate {
+                    if bun_opened_dest {
                         // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
                         let _ = unsafe {
                             libc::ftruncate(
@@ -427,7 +424,7 @@ impl<'a> CopyFile<'a> {
                             return Err(bun_errno::from_errno(err.errno as i32).into());
                         }
                         bun_sys::Result::Ok(()) => {
-                            if may_ftruncate {
+                            if bun_opened_dest {
                                 // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
                                 let _ = unsafe {
                                     libc::ftruncate(
@@ -486,7 +483,7 @@ impl<'a> CopyFile<'a> {
                                 return Err(bun_errno::from_errno(err.errno as i32).into());
                             }
                             bun_sys::Result::Ok(()) => {
-                                if may_ftruncate {
+                                if bun_opened_dest {
                                     // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
                                     let _ = unsafe {
                                         libc::ftruncate(
@@ -899,8 +896,6 @@ impl<'a> CopyFile<'a> {
                             )
                         };
                     }
-                    // fcopyfile reports no byte count; the read/write fallback
-                    // already set read_len when it ran.
                     if self.read_len == 0 {
                         self.read_len = stat_size.min(self.max_length);
                     }

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -547,8 +547,6 @@ impl<'a> CopyFile<'a> {
                     //
                     // bun test bun-write.test | xargs echo
                     //
-                    // ENOTSUP covers a pipe source (e.g. Bun.stdin) which
-                    // fcopyfile rejects.
                     bun_sys::E::EBADF | bun_sys::E::ENOTSUP => {
                         let mut total_written: u64 = 0;
 
@@ -839,10 +837,8 @@ impl<'a> CopyFile<'a> {
                     return;
                 }
 
-                // $ echo hello | bun run script.js
-                // splice(2) needs at least one end to be a pipe; the source is.
-                // do_copy_file_range falls back to a read/write loop on
-                // EINVAL/ENOTSUP/ENOSYS if the destination cannot be spliced to.
+                // $ echo hello | bun run script.js > out.txt
+                // splice(2) only needs one end to be a pipe; the source is.
                 if bun_sys::S::ISFIFO(stat.st_mode as _) {
                     if self.destination_file_store.is_atty.unwrap_or(false) {
                         let _ = self.do_copy_file_range::<{ TryWith::Splice }, true>();

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -547,7 +547,9 @@ impl<'a> CopyFile<'a> {
                     //
                     // bun test bun-write.test | xargs echo
                     //
-                    bun_sys::E::EBADF => {
+                    // ENOTSUP covers a pipe source (e.g. Bun.stdin) which
+                    // fcopyfile rejects.
+                    bun_sys::E::EBADF | bun_sys::E::ENOTSUP => {
                         let mut total_written: u64 = 0;
 
                         // TODO: this should use non-blocking I/O.
@@ -835,10 +837,11 @@ impl<'a> CopyFile<'a> {
                     return;
                 }
 
-                // $ bun run foo.js | bun run bar.js
-                if bun_sys::S::ISFIFO(stat.st_mode as _)
-                    && bun_sys::S::ISFIFO(self.destination_file_store.mode as _)
-                {
+                // $ echo hello | bun run script.js
+                // splice(2) needs at least one end to be a pipe; the source is.
+                // do_copy_file_range falls back to a read/write loop on
+                // EINVAL/ENOTSUP/ENOSYS if the destination cannot be spliced to.
+                if bun_sys::S::ISFIFO(stat.st_mode as _) {
                     if self.destination_file_store.is_atty.unwrap_or(false) {
                         let _ = self.do_copy_file_range::<{ TryWith::Splice }, true>();
                     } else {

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -315,6 +315,13 @@ impl<'a> CopyFile<'a> {
         let mut total_written: u64 = 0;
         let src_fd = self.source_fd;
         let dest_fd = self.destination_fd;
+        // Only truncate destinations Bun itself opened with O_TRUNC; a
+        // user-provided fd (Bun.stdout, Bun.file(fd)) may carry O_APPEND or
+        // pre-existing bytes that ftruncate would destroy.
+        let may_ftruncate = matches!(
+            self.destination_file_store.pathlike,
+            PathOrFileDescriptor::Path(_)
+        );
 
         // defer { this.read_len = @truncate(total_written); }
         let read_len_slot: *mut SizeType = &raw mut self.read_len;
@@ -343,13 +350,15 @@ impl<'a> CopyFile<'a> {
                     return Err(bun_errno::from_errno(err.errno as i32).into());
                 }
                 bun_sys::Result::Ok(()) => {
-                    // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
-                    let _ = unsafe {
-                        libc::ftruncate(
-                            dest_fd.native(),
-                            i64::try_from(total_written).expect("int cast"),
-                        )
-                    };
+                    if may_ftruncate {
+                        // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
+                        let _ = unsafe {
+                            libc::ftruncate(
+                                dest_fd.native(),
+                                i64::try_from(total_written).expect("int cast"),
+                            )
+                        };
+                    }
                     return Ok(());
                 }
             }
@@ -418,13 +427,15 @@ impl<'a> CopyFile<'a> {
                             return Err(bun_errno::from_errno(err.errno as i32).into());
                         }
                         bun_sys::Result::Ok(()) => {
-                            // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
-                            let _ = unsafe {
-                                libc::ftruncate(
-                                    dest_fd.native(),
-                                    i64::try_from(total_written).expect("int cast"),
-                                )
-                            };
+                            if may_ftruncate {
+                                // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
+                                let _ = unsafe {
+                                    libc::ftruncate(
+                                        dest_fd.native(),
+                                        i64::try_from(total_written).expect("int cast"),
+                                    )
+                                };
+                            }
                             return Ok(());
                         }
                     }
@@ -475,13 +486,15 @@ impl<'a> CopyFile<'a> {
                                 return Err(bun_errno::from_errno(err.errno as i32).into());
                             }
                             bun_sys::Result::Ok(()) => {
-                                // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
-                                let _ = unsafe {
-                                    libc::ftruncate(
-                                        dest_fd.native(),
-                                        i64::try_from(total_written).expect("int cast"),
-                                    )
-                                };
+                                if may_ftruncate {
+                                    // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
+                                    let _ = unsafe {
+                                        libc::ftruncate(
+                                            dest_fd.native(),
+                                            i64::try_from(total_written).expect("int cast"),
+                                        )
+                                    };
+                                }
                                 return Ok(());
                             }
                         }
@@ -875,16 +888,22 @@ impl<'a> CopyFile<'a> {
                     self.do_close();
                     return;
                 }
-                if stat.st_size != 0
-                    && SizeType::try_from(stat.st_size).expect("int cast") > self.max_length
-                {
-                    // SAFETY: `destination_fd` is open; libc ftruncate(2).
-                    let _ = unsafe {
-                        bun_sys::darwin::ftruncate(
-                            self.destination_fd.native(),
-                            i64::try_from(self.max_length).expect("int cast"),
-                        )
-                    };
+                if stat.st_size != 0 {
+                    let stat_size = SizeType::try_from(stat.st_size).expect("int cast");
+                    if stat_size > self.max_length {
+                        // SAFETY: `destination_fd` is open; libc ftruncate(2).
+                        let _ = unsafe {
+                            bun_sys::darwin::ftruncate(
+                                self.destination_fd.native(),
+                                i64::try_from(self.max_length).expect("int cast"),
+                            )
+                        };
+                    }
+                    // fcopyfile reports no byte count; the read/write fallback
+                    // already set read_len when it ran.
+                    if self.read_len == 0 {
+                        self.read_len = stat_size.min(self.max_length);
+                    }
                 }
 
                 self.do_close();

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -565,7 +565,9 @@ impl<'a> CopyFile<'a> {
                                 self.system_error = Some(err.to_system_error());
                                 return Err(bun_errno::from_errno(err.errno as i32).into());
                             }
-                            bun_sys::Result::Ok(()) => {}
+                            bun_sys::Result::Ok(()) => {
+                                self.read_len = total_written as SizeType;
+                            }
                         }
                     }
                     _ => {

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -348,13 +348,10 @@ impl<'a> CopyFile<'a> {
                 }
                 bun_sys::Result::Ok(()) => {
                     if bun_opened_dest {
-                        // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
-                        let _ = unsafe {
-                            libc::ftruncate(
-                                dest_fd.native(),
-                                i64::try_from(total_written).expect("int cast"),
-                            )
-                        };
+                        let _ = bun_sys::ftruncate(
+                            dest_fd,
+                            i64::try_from(total_written).expect("int cast"),
+                        );
                     }
                     return Ok(());
                 }
@@ -425,13 +422,10 @@ impl<'a> CopyFile<'a> {
                         }
                         bun_sys::Result::Ok(()) => {
                             if bun_opened_dest {
-                                // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
-                                let _ = unsafe {
-                                    libc::ftruncate(
-                                        dest_fd.native(),
-                                        i64::try_from(total_written).expect("int cast"),
-                                    )
-                                };
+                                let _ = bun_sys::ftruncate(
+                                    dest_fd,
+                                    i64::try_from(total_written).expect("int cast"),
+                                );
                             }
                             return Ok(());
                         }
@@ -484,13 +478,10 @@ impl<'a> CopyFile<'a> {
                             }
                             bun_sys::Result::Ok(()) => {
                                 if bun_opened_dest {
-                                    // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
-                                    let _ = unsafe {
-                                        libc::ftruncate(
-                                            dest_fd.native(),
-                                            i64::try_from(total_written).expect("int cast"),
-                                        )
-                                    };
+                                    let _ = bun_sys::ftruncate(
+                                        dest_fd,
+                                        i64::try_from(total_written).expect("int cast"),
+                                    );
                                 }
                                 return Ok(());
                             }
@@ -888,13 +879,10 @@ impl<'a> CopyFile<'a> {
                 if stat.st_size != 0 {
                     let stat_size = SizeType::try_from(stat.st_size).expect("int cast");
                     if stat_size > self.max_length {
-                        // SAFETY: `destination_fd` is open; libc ftruncate(2).
-                        let _ = unsafe {
-                            bun_sys::darwin::ftruncate(
-                                self.destination_fd.native(),
-                                i64::try_from(self.max_length).expect("int cast"),
-                            )
-                        };
+                        let _ = bun_sys::ftruncate(
+                            self.destination_fd,
+                            i64::try_from(self.max_length).expect("int cast"),
+                        );
                     }
                     if self.read_len == 0 {
                         self.read_len = stat_size.min(self.max_length);

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -449,6 +449,36 @@ const IS_UV_FS_COPYFILE_DISABLED =
     expect(exitCode).toBe(0);
   });
 
+  // https://github.com/oven-sh/bun/issues/14054
+  // Bun.write(Bun.file(path), Bun.stdin) when stdin is a pipe. On Linux this
+  // used to fall through every fast-path branch (splice was gated on the
+  // destination also being a FIFO) and fail with
+  // "Non-regular files aren't supported yet".
+  // Bun.spawn({stdin: <buffer>}) hands the child a regular-file fd, so use sh
+  // to get a real kernel pipe on fd 0.
+  it.skipIf(isWindows)("Bun.write(Bun.file(path), Bun.stdin) drains a pipe into a file", async () => {
+    using dir = tempDir("bun-write-stdin-pipe", {});
+    const out = join(String(dir), "out.txt");
+    const size = 200_000;
+    const script = `process.stderr.write(String(await Bun.write(Bun.file(${JSON.stringify(out)}), Bun.stdin)))`;
+
+    await using proc = Bun.spawn({
+      cmd: ["sh", "-c", `head -c ${size} /dev/zero | "$BUN" -e ${JSON.stringify(script)}`],
+      env: { ...bunEnv, BUN: bunExe() },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout, resolved: stderr, written: Bun.file(out).size }).toEqual({
+      stdout: "",
+      resolved: String(size),
+      written: size,
+    });
+    expect(exitCode).toBe(0);
+  });
+
   it("Bun.file(0) survives GC", async () => {
     for (let i = 0; i < 10; i++) {
       let f = Bun.file(0);

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -450,10 +450,6 @@ const IS_UV_FS_COPYFILE_DISABLED =
   });
 
   // https://github.com/oven-sh/bun/issues/14054
-  // Bun.write(Bun.file(path), Bun.stdin) when stdin is a pipe. On Linux this
-  // used to fall through every fast-path branch (splice was gated on the
-  // destination also being a FIFO) and fail with
-  // "Non-regular files aren't supported yet".
   // Bun.spawn({stdin: <buffer>}) hands the child a regular-file fd, so use sh
   // to get a real kernel pipe on fd 0.
   it.skipIf(isWindows)("Bun.write(Bun.file(path), Bun.stdin) drains a pipe into a file", async () => {
@@ -476,6 +472,7 @@ const IS_UV_FS_COPYFILE_DISABLED =
       resolved: String(size),
       written: size,
     });
+    expect(await Bun.file(out).bytes()).toEqual(new Uint8Array(size));
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -476,6 +476,30 @@ const IS_UV_FS_COPYFILE_DISABLED =
     expect(exitCode).toBe(0);
   });
 
+  // splice(2) rejects an O_APPEND destination with EINVAL and the read/write
+  // fallback must not ftruncate a fd it did not open.
+  it.skipIf(isWindows)("Bun.write(Bun.stdout, Bun.stdin) with >> does not truncate the destination", async () => {
+    using dir = tempDir("bun-write-stdin-append", { "log.txt": "AAAAAAAAAA" });
+    const out = join(String(dir), "log.txt");
+    const script = `process.stderr.write(String(await Bun.write(Bun.stdout, Bun.stdin)))`;
+
+    await using proc = Bun.spawn({
+      cmd: ["sh", "-c", `printf bbbbb | "$BUN" -e ${JSON.stringify(script)} >> ${JSON.stringify(out)}`],
+      env: { ...bunEnv, BUN: bunExe() },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout, resolved: stderr, content: await Bun.file(out).text() }).toEqual({
+      stdout: "",
+      resolved: "5",
+      content: "AAAAAAAAAAbbbbb",
+    });
+    expect(exitCode).toBe(0);
+  });
+
   it("Bun.file(0) survives GC", async () => {
     for (let i = 0; i < 10; i++) {
       let f = Bun.file(0);


### PR DESCRIPTION
Fixes #14054.

## Repro

```sh
echo "hello world" | bun -e 'await Bun.write(Bun.file("foo.txt"), Bun.stdin)'
# error: Non-regular files aren't supported yet
#  syscall: "fstat", errno: 95
```

## Cause

The Linux file-to-file copy dispatch in `CopyFile::run_async` has three fast-path predicates before falling through to "Non-regular files aren't supported yet":

- `ISREG(src) && ISREG(dest)` → `copy_file_range`
- `ISFIFO(src) && ISFIFO(dest)` → `splice`
- `ISREG|ISCHR|ISSOCK(src)` → `sendfile`

A FIFO source with a regular-file destination matches none of them.

## Fix

`splice(2)` only requires one end to be a pipe, so drop the `ISFIFO(dest)` guard and take the splice branch for any FIFO source. `do_copy_file_range` already falls back to a read/write loop on `EINVAL`/`ENOTSUP`/`ENOSYS` if the destination can't be spliced to, so no new error handling is needed.

On macOS, also treat `ENOTSUP` from `fcopyfile` as a fallback trigger alongside the existing `EBADF` case, since the original report was macOS with `ENOTSUP`.

## Verification

```
$ head -c 5000000 /dev/urandom > src.bin
$ cat src.bin | bun-debug -e 'console.log(await Bun.write(Bun.file("out.bin"), Bun.stdin))'
5000000
$ cmp src.bin out.bin && echo ok
ok
```

The new test in `bun-write.test.js` fails on released bun with `Non-regular files aren't supported yet` and passes with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->