### PR TITLE
console: print Array subclass name prefix and skip non-enumerable own props

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4331,8 +4331,20 @@ pub mod formatter {
 
             let len = value.get_length(self.global_this)?;
 
-            // TODO: DerivedArray does not get passed along in JSType, and it's
-            // not clear why.
+            // Prefix Array subclasses with `ClassName(len) ` to match Node's
+            // util.inspect (e.g. postgres.js `Result(1) [ ... ]`). Subclass
+            // instances report `JSType::Array`, not `DerivedArray`, so the
+            // subclass check has to go through the constructor name.
+            if js_type.is_array() {
+                let mut name_str = ZigString::init(b"");
+                value.get_class_name(self.global_this, &mut name_str)?;
+                if name_str.len != 0 && !name_str.eql_comptime(b"Array") {
+                    writer.add_for_new_line(
+                        name_str.len + bun_core::fmt::digit_count(len) + "() ".len(),
+                    );
+                    writer.print(format_args!("{name_str}({len}) "));
+                }
+            }
 
             if len == 0 {
                 writer.write_all(b"[]");

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5301,6 +5301,11 @@ restart:
                 CLEAR_IF_EXCEPTION(scope);
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
+                    if constexpr (nonIndexedOnly) {
+                        // Array extra-property listing: match Node's util.inspect and
+                        // skip non-enumerable own properties entirely.
+                        continue;
+                    }
                     if (property == propertyNames->underscoreProto
                         || property == propertyNames->toStringTagSymbol || property == propertyNames->__esModule)
                         continue;

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -803,3 +803,58 @@ it("CustomEvent", () => {
     }"
   `);
 });
+
+describe("Array subclass", () => {
+  it("prints ClassName(length) prefix and skips non-enumerable own properties (#13946)", () => {
+    class Result extends Array {
+      constructor() {
+        super();
+        Object.defineProperties(this, {
+          count: { value: null, writable: true },
+          state: { value: null, writable: true },
+          command: { value: null, writable: true },
+          columns: { value: null, writable: true },
+          statement: { value: null, writable: true },
+        });
+      }
+    }
+    const r = new Result();
+    r.push({ "?column?": 1 });
+    r.count = 1;
+    r.state = { pid: 3724 };
+    r.command = "SELECT";
+    expect(Bun.inspect(r)).toBe('Result(1) [\n  {\n    "?column?": 1,\n  }\n]');
+  });
+
+  it("prints ClassName(0) [] for an empty subclass instance", () => {
+    class Empty extends Array {}
+    expect(Bun.inspect(new Empty())).toBe("Empty(0) []");
+  });
+
+  it("still prints enumerable own non-index properties on a subclass", () => {
+    class Result2 extends Array {}
+    const r = new Result2();
+    r.push(1, 2, 3);
+    r.extra = "hello";
+    expect(Bun.inspect(r)).toBe('Result2(3) [ 1, 2, 3, extra: "hello" ]');
+  });
+
+  it("omits the prefix for an anonymous subclass", () => {
+    const Anon = (() => class extends Array {})();
+    const a = new Anon();
+    a.push(1, 2);
+    expect(Bun.inspect(a)).toBe("[ 1, 2 ]");
+  });
+
+  it("plain Array skips non-enumerable own properties", () => {
+    const a = [1, 2, 3];
+    Object.defineProperty(a, "hidden", { value: 42, enumerable: false });
+    expect(Bun.inspect(a)).toBe("[ 1, 2, 3 ]");
+  });
+
+  it("plain Array keeps enumerable own non-index properties", () => {
+    const a = [1, 2, 3];
+    a.extra = "x";
+    expect(Bun.inspect(a)).toBe('[ 1, 2, 3, extra: "x" ]');
+  });
+});


### PR DESCRIPTION
Fixes #13946

## Repro

```js
class Result extends Array {
  constructor() {
    super();
    Object.defineProperties(this, {
      count: { value: null, writable: true },
      state: { value: null, writable: true },
      command: { value: null, writable: true },
    });
  }
}
const r = new Result();
r.push({ "?column?": 1 });
r.count = 1;
r.state = { pid: 3724 };
r.command = "SELECT";
console.log(r);
```

Before:
```
[
  {
    "?column?": 1,
  }, count: 1, state: {
    pid: 3724,
  }, command: "SELECT"
]
```

After (matches Node):
```
Result(1) [
  {
    "?column?": 1,
  }
]
```

## Cause

Two separate bugs in the console array printer:

1. `JSC__JSValue__forEachPropertyNonIndexed` collected own non-index names with `DontEnumPropertiesMode::Include` and then only filtered a handful of well-known DontEnum names (`__proto__`, `Symbol.toStringTag`, `__esModule`). Everything else leaked through, so postgres.js's non-enumerable `count`/`state`/`command`/`columns`/`statement` fields were spliced into the array body. Node's `util.inspect` hides non-enumerable own properties on arrays.
2. `print_array` never wrote a constructor-name prefix. Subclass instances report `JSType::Array` rather than `DerivedArray` (the `DerivedArrayType` structure is only used for `Array.prototype` itself), so the existing cell-type plumbing cannot distinguish a plain array from a subclass.

## Fix

- `forEachPropertyNonIndexed`: skip any slot with `PropertyAttribute::DontEnum`. This helper is only called from `print_array`, so the change is scoped to array extra-property listing.
- `print_array`: look up the constructor name via `get_class_name` (same helper the object printer already uses) and write `ClassName(len) ` before `[` when the name is non-empty and not `"Array"`. Anonymous subclasses and plain arrays keep the bare `[` form.

## Verification

```
$ bun bd test test/js/bun/util/inspect.test.js -t "Array subclass"
 6 pass
 0 fail
```

Fail-before with `USE_SYSTEM_BUN=1`: 4 of the 6 new assertions fail (the remaining two are regression guards for enumerable extras and anonymous subclasses, which already worked). Full `inspect.test.js` (79 tests) and the console suites under `test/js/web/console/`, `test/js/bun/console/`, `test/js/node/util/bun-inspect.test.ts` all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
bun test v1.4.0 (2af154931)

test/js/bun/util/inspect.test.js:
(pass) prototype [491.36ms]
(pass) getters [8.92ms]
(pass) setters [6.64ms]
(pass) getter/setters [3.96ms]
(pass) Timeout [9.30ms]
(pass) when prototype defines the same property, don't print the same property twice [4.70ms]
(pass) Blob inspect [14.56ms]
(pass) utf16 property name [116.24ms]
(pass) latin1 [7.08ms]
(pass) Request object [5.06ms]
(pass) MessageEvent [3.89ms]
(pass) MessageEvent with no data set [4.13ms]
(pass) MessageEvent with deleted data [4.53ms]
(pass) TypedArray prints [166.33ms]
(pass) BigIntArray [60.42ms]
(pass) Float32Array 42.68000030517578 [7.20ms]
(pass) Float32Array 42.68 [7.08ms]
(pass) Float64Array 42.68000030517578 [3.18ms]
(pass) Float64Array 42.68 [2.38ms]
(pass) jsx with two elements [51.52ms]
(pass) jsx with anon component [5.25ms]
(pass) jsx with fragment [8.60ms]
(pass) inspect [117.33ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [2.88ms]
(pass) latin1 supplemental > latin1 (input) "cb
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/util/inspect.test.js:
(pass) prototype [7.24ms]
(pass) getters [0.95ms]
(pass) setters [0.08ms]
(pass) getter/setters [0.07ms]
(pass) Timeout [0.15ms]
(pass) when prototype defines the same property, don't print the same property twice [0.07ms]
(pass) Blob inspect [0.46ms]
(pass) utf16 property name [17.46ms]
(pass) latin1 [0.10ms]
(pass) Request object [0.80ms]
(pass) MessageEvent [0.08ms]
(pass) MessageEvent with no data set [0.04ms]
(pass) MessageEvent with deleted data [0.08ms]
(pass) TypedArray prints [3.40ms]
(pass) BigIntArray [0.75ms]
(pass) Float32Array 42.68000030517578 [0.14ms]
(pass) Float32Array 42.68 [0.10ms]
(pass) Float64Array 42.68000030517578 [0.02ms]
(pass) Float64Array 42.68 [0.01ms]
(pass) jsx with two elements [0.97ms]
(pass) jsx with anon component [0.06ms]
(pass) jsx with fragment [0.18ms]
(pass) inspect [1.33ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [0.05ms]
(pass) latin1 supplemental > latin1 (input) "cbä" [ "cbä" ]
(pass) latin1 supplemental > latin1 (input) "cäb" [ "cäb" ]
(pass) latin1 supplemental > latin1 (input) "äbc äbc" [ "äbc äbc" ]
(pass) latin1 supp
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
bun test v1.4.0 (2af154931)

test/js/bun/util/inspect.test.js:
(pass) prototype [532.95ms]
(pass) getters [9.44ms]
(pass) setters [6.95ms]
(pass) getter/setters [4.18ms]
(pass) Timeout [8.73ms]
(pass) when prototype defines the same property, don't print the same property twice [4.82ms]
(pass) Blob inspect [15.70ms]
(pass) utf16 property name [119.95ms]
(pass) latin1 [6.86ms]
(pass) Request object [5.13ms]
(pass) MessageEvent [4.51ms]
(pass) MessageEvent with no data set [3.39ms]
(pass) MessageEvent with deleted data [5.85ms]
(pass) TypedArray prints [168.43ms]
(pass) BigIntArray [60.16ms]
(pass) Float32Array 42.68000030517578 [9.75ms]
(pass) Float32Array 42.68 [12.27ms]
(pass) Float64Array 42.68000030517578 [2.47ms]
(pass) Float64Array 42.68 [3.03ms]
(pass) jsx with two elements [52.67ms]
(pass) jsx with anon component [4.88ms]
(pass) jsx with fragment [9.08ms]
(pass) inspect [132.45ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [3.22ms]
(pass) latin1 supplemental > latin1 (input) "c
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1624ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/136] gen cpp.rs (cppbind)
[2/136] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/136] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m core v0.0.0 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core)
[1m[92m   Compiling[0m heck v0.5.0
[1m[92m   Compiling[0m proc-macro2 v1.0.106
[1m[92m   Compiling[0m rustversion v1.0.22
[1m[92m   Compiling[0m thiserror v2.0.18
[1m[92m   Compiling[0m siphasher v1.0.3
[1m[92m   Compiling[0m fastrand v2.4.1
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m rustix v0.38.44
[1m[92m   Compiling[0m paste v1.0.15
[1m[92m   Compiling[0m bun_jsc v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs         | 16 ++++++++++--
 src/jsc/bindings/bindings.cpp    |  5 ++++
 test/js/bun/util/inspect.test.js | 55 ++++++++++++++++++++++++++++++++++++++++
 3 files changed, 74 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/jsc/ConsoleObject.rs              9      3      0
src/jsc/bindings/bindings.cpp         3      1      0
test/js/bun/util/inspect.test.js      1      2      0
```

</details>

<!-- robobun:evidence:end -->