### PR TITLE
install: don't create package.json for `bun add --dry-run` in an empty directory

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1490,16 +1490,22 @@ pub fn init(
                 }
             }
 
-            if subcommand == Subcommand::Install {
-                if cli.positionals.len() > 1 {
-                    // this is `bun add <package>`.
-                    //
-                    // create the package.json instead of returning an error so that
-                    // `bun add <pkg>` works in an empty directory.
-                    this_cwd = original_cwd;
-                    created_package_json = true;
-                    break 'child attempt_to_create_package_json_and_open()?;
+            if (subcommand == Subcommand::Install && cli.positionals.len() > 1)
+                || subcommand == Subcommand::Add
+            {
+                // this is `bun add <package>`.
+                //
+                // create the package.json instead of returning an error so that
+                // `bun add <pkg>` works in an empty directory. For `--dry-run` we
+                // skip the write entirely and proceed with a synthetic in-memory
+                // file; `workspace_package_json_cache` is seeded below so later
+                // reads never hit disk.
+                this_cwd = original_cwd;
+                created_package_json = true;
+                if cli.dry_run {
+                    break 'child bun_sys::File::from_fd(Fd::invalid());
                 }
+                break 'child attempt_to_create_package_json_and_open()?;
             }
             return Err(crate::Error::MissingPackageJSON);
         };
@@ -1708,10 +1714,30 @@ pub fn init(
         // bun_sys exposes the non-Z `get_fd_path`;
         // append the NUL ourselves so the static `&ZStr` invariant holds.
         let root_buf = &mut *ROOT_PACKAGE_JSON_PATH_BUF.get();
-        let p = bun_sys::get_fd_path(root_package_json_file.handle, root_buf)?;
-        let plen = p.len();
+        let plen = if root_package_json_file.handle.is_valid() {
+            bun_sys::get_fd_path(root_package_json_file.handle, root_buf)?.len()
+        } else {
+            // `--dry-run` synthetic package.json: no fd to query. We just set
+            // `original_package_json_path` to `<cwd>/package.json` above; copy
+            // it here so `ROOT_PACKAGE_JSON_PATH` agrees.
+            let src = original_package_json_path.as_bytes();
+            root_buf[..src.len()].copy_from_slice(src);
+            src.len()
+        };
         root_buf[plen] = 0;
         ROOT_PACKAGE_JSON_PATH.write(ZStr::from_raw(root_buf.as_ptr(), plen));
+    }
+
+    if !root_package_json_file.handle.is_valid() {
+        // Seed the cache so `get_with_path` on the root package.json returns
+        // the synthetic `{"dependencies": {}}` instead of failing to read the
+        // (nonexistent) file from disk.
+        workspace_package_json_cache.seed_with_contents(
+            // SAFETY: see `ctx.log` deref at the workspace walk above.
+            unsafe { &mut *ctx.log },
+            original_package_json_path.as_bytes(),
+            directories::DEFAULT_PACKAGE_JSON_CONTENTS,
+        )?;
     }
 
     // Returns the resolver's BSSMap-owned

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1493,13 +1493,8 @@ pub fn init(
             if (subcommand == Subcommand::Install && cli.positionals.len() > 1)
                 || subcommand == Subcommand::Add
             {
-                // this is `bun add <package>`.
-                //
-                // create the package.json instead of returning an error so that
-                // `bun add <pkg>` works in an empty directory. For `--dry-run` we
-                // skip the write entirely and proceed with a synthetic in-memory
-                // file; `workspace_package_json_cache` is seeded below so later
-                // reads never hit disk.
+                // `bun add <pkg>` in an empty directory: create package.json,
+                // or for --dry-run proceed with a synthetic one (seeded below).
                 this_cwd = original_cwd;
                 created_package_json = true;
                 if cli.dry_run {
@@ -1717,9 +1712,7 @@ pub fn init(
         let plen = if root_package_json_file.handle.is_valid() {
             bun_sys::get_fd_path(root_package_json_file.handle, root_buf)?.len()
         } else {
-            // `--dry-run` synthetic package.json: no fd to query. We just set
-            // `original_package_json_path` to `<cwd>/package.json` above; copy
-            // it here so `ROOT_PACKAGE_JSON_PATH` agrees.
+            // --dry-run synthetic package.json: no fd; use the path we computed.
             let src = original_package_json_path.as_bytes();
             root_buf[..src.len()].copy_from_slice(src);
             src.len()
@@ -1729,9 +1722,7 @@ pub fn init(
     }
 
     if !root_package_json_file.handle.is_valid() {
-        // Seed the cache so `get_with_path` on the root package.json returns
-        // the synthetic `{"dependencies": {}}` instead of failing to read the
-        // (nonexistent) file from disk.
+        // --dry-run: seed the cache so later lookups don't hit disk.
         workspace_package_json_cache.seed_with_contents(
             // SAFETY: see `ctx.log` deref at the workspace walk above.
             unsafe { &mut *ctx.log },

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -373,7 +373,7 @@ pub struct CommandLineArguments {
     pub production: bool,
     pub(crate) frozen_lockfile: bool,
     pub(crate) no_save: bool,
-    pub(crate) dry_run: bool,
+    pub dry_run: bool,
     pub(crate) force: bool,
     pub(crate) no_cache: bool,
     pub silent: bool,

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -1024,6 +1024,8 @@ pub fn compute_cache_dir_and_subpath<'a>(
 
 // ─────────────────────────── package.json / lockfile ──────────────────────────
 
+pub const DEFAULT_PACKAGE_JSON_CONTENTS: &[u8] = b"{\"dependencies\": {}}";
+
 pub(crate) fn attempt_to_create_package_json_and_open() -> Result<File, Error> {
     let package_json_file = match Dir::cwd().create_file_z(
         z_static(b"package.json\0"),
@@ -1042,7 +1044,7 @@ pub(crate) fn attempt_to_create_package_json_and_open() -> Result<File, Error> {
         }
     };
 
-    package_json_file.pwrite_all(b"{\"dependencies\": {}}", 0)?;
+    package_json_file.pwrite_all(DEFAULT_PACKAGE_JSON_CONTENTS, 0)?;
 
     Ok(package_json_file)
 }

--- a/src/install/PackageManager/WorkspacePackageJSONCache.rs
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.rs
@@ -128,13 +128,8 @@ pub struct WorkspacePackageJSONCache {
 }
 
 impl WorkspacePackageJSONCache {
-    /// Seed a cache entry from an in-memory JSON string rather than disk.
-    ///
-    /// Used for `bun add --dry-run` in a directory without `package.json`:
-    /// we proceed as if an empty `{"dependencies":{}}` exists so resolution
-    /// can run, without ever touching the filesystem. Later `get_with_path`
-    /// calls for `abs_package_json_path` hit this entry instead of reading
-    /// from disk.
+    /// Seed a cache entry from in-memory JSON so later [`Self::get_with_path`]
+    /// calls hit it instead of reading disk (used by `bun add --dry-run`).
     pub fn seed_with_contents(
         &mut self,
         log: &mut Log,

--- a/src/install/PackageManager/WorkspacePackageJSONCache.rs
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.rs
@@ -128,6 +128,62 @@ pub struct WorkspacePackageJSONCache {
 }
 
 impl WorkspacePackageJSONCache {
+    /// Seed a cache entry from an in-memory JSON string rather than disk.
+    ///
+    /// Used for `bun add --dry-run` in a directory without `package.json`:
+    /// we proceed as if an empty `{"dependencies":{}}` exists so resolution
+    /// can run, without ever touching the filesystem. Later `get_with_path`
+    /// calls for `abs_package_json_path` hit this entry instead of reading
+    /// from disk.
+    pub fn seed_with_contents(
+        &mut self,
+        log: &mut Log,
+        abs_package_json_path: &[u8],
+        contents: &'static [u8],
+    ) -> Result<(), Error> {
+        debug_assert!(is_absolute(abs_package_json_path));
+
+        #[cfg(windows)]
+        let mut buf = PathBuffer::uninit();
+        #[cfg(not(windows))]
+        let path: &[u8] = abs_package_json_path;
+        #[cfg(windows)]
+        let path: &[u8] = {
+            buf[..abs_package_json_path.len()].copy_from_slice(abs_package_json_path);
+            bun_paths::dangerously_convert_path_to_posix_in_place::<u8>(
+                &mut buf[..abs_package_json_path.len()],
+            );
+            &buf[..abs_package_json_path.len()]
+        };
+
+        if self.map.contains_key(path) {
+            return Ok(());
+        }
+
+        let key = bun_core::ZBox::from_bytes(path);
+        let source = Source::init_path_string(key.as_bytes(), contents);
+
+        initialize_store();
+
+        let json_bump = bun_alloc::Arena::new();
+        let parsed = parse_package_json(&source, log, &json_bump, false)?;
+
+        let value = MapEntry {
+            root: bun_core::handle_oom(parsed.root.deep_clone(&json_bump)),
+            source,
+            indentation: parsed.indentation,
+            _path_storage: key,
+            json_arena: json_bump,
+            stale_contents: Vec::new(),
+        };
+
+        let entry = bun_core::handle_oom(self.map.get_or_put(path));
+        debug_assert!(!entry.found_existing);
+        *entry.value_ptr = value;
+
+        Ok(())
+    }
+
     /// Given an absolute path to a workspace package.json, return the AST
     /// and contents of the file. If the package.json is not present in the
     /// cache, it will be read from disk and parsed, and stored in the cache.

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -893,9 +893,7 @@ pub fn update_package_json_and_install_and_cli(
                         bun_core::pretty_errorln!("<r>No package.json, so nothing to patch");
                         Global::crash();
                     }
-                    // `Subcommand::Add` is the only other caller and `init()` now
-                    // creates (or, for `--dry-run`, synthesizes) the package.json for
-                    // it directly, so `MissingPackageJSON` never bubbles up here.
+                    // `init()` handles `Subcommand::Add` before this error can surface.
                     _ => {}
                 }
             }

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -895,7 +895,9 @@ pub fn update_package_json_and_install_and_cli(
                             Global::crash();
                         }
                         _ => {
-                            attempt_to_create_package_json()?;
+                            if !cli.dry_run {
+                                attempt_to_create_package_json()?;
+                            }
                             break 'brk super::init(ctx, cli, subcommand)?;
                         }
                     }

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -19,8 +19,8 @@ use super::command_line_arguments::CommandLineArguments;
 use super::package_json_editor as PackageJSONEditor;
 use super::update_request::Array as UpdateRequestArray;
 use super::{
-    Command, PackageManager, PatchCommitResult, Subcommand, UpdateRequest,
-    attempt_to_create_package_json, install_with_manager, patch_package,
+    Command, PackageManager, PatchCommitResult, Subcommand, UpdateRequest, install_with_manager,
+    patch_package,
 };
 
 fn print_package_json_into_cache_entry(entry: &mut MapEntry, root: bun_ast::Expr) {
@@ -876,35 +876,31 @@ pub fn update_package_json_and_install_and_cli(
     subcommand: Subcommand,
     cli: CommandLineArguments,
 ) -> Result<(), Error> {
-    let (manager_ptr, original_cwd) = 'brk: {
-        match super::init(ctx, cli.clone(), subcommand) {
-            Ok(v) => v,
-            Err(e) => {
-                if e == crate::Error::MissingPackageJSON {
-                    match subcommand {
-                        Subcommand::Update => {
-                            bun_core::pretty_errorln!("<r>No package.json, so nothing to update");
-                            Global::crash();
-                        }
-                        Subcommand::Remove => {
-                            bun_core::pretty_errorln!("<r>No package.json, so nothing to remove");
-                            Global::crash();
-                        }
-                        Subcommand::Patch | Subcommand::PatchCommit => {
-                            bun_core::pretty_errorln!("<r>No package.json, so nothing to patch");
-                            Global::crash();
-                        }
-                        _ => {
-                            if !cli.dry_run {
-                                attempt_to_create_package_json()?;
-                            }
-                            break 'brk super::init(ctx, cli, subcommand)?;
-                        }
+    let (manager_ptr, original_cwd) = match super::init(ctx, cli, subcommand) {
+        Ok(v) => v,
+        Err(e) => {
+            if e == crate::Error::MissingPackageJSON {
+                match subcommand {
+                    Subcommand::Update => {
+                        bun_core::pretty_errorln!("<r>No package.json, so nothing to update");
+                        Global::crash();
                     }
+                    Subcommand::Remove => {
+                        bun_core::pretty_errorln!("<r>No package.json, so nothing to remove");
+                        Global::crash();
+                    }
+                    Subcommand::Patch | Subcommand::PatchCommit => {
+                        bun_core::pretty_errorln!("<r>No package.json, so nothing to patch");
+                        Global::crash();
+                    }
+                    // `Subcommand::Add` is the only other caller and `init()` now
+                    // creates (or, for `--dry-run`, synthesizes) the package.json for
+                    // it directly, so `MissingPackageJSON` never bubbles up here.
+                    _ => {}
                 }
-
-                return Err(e);
             }
+
+            return Err(e);
         }
     };
     // `defer ctx.allocator.free(original_cwd)` — `original_cwd: Box<[u8]>` drops at scope exit.

--- a/src/runtime/cli/link_command.rs
+++ b/src/runtime/cli/link_command.rs
@@ -27,12 +27,12 @@ impl LinkCommand {
 
 fn link(ctx: command::Context) -> crate::Result<()> {
     let cli = CommandLineArguments::parse(Subcommand::Link)?;
+    let dry_run = cli.dry_run;
     let (manager, original_cwd) = match pm::init(&mut *ctx, cli, Subcommand::Link) {
         Ok(v) => v,
-        Err(bun_install::Error::MissingPackageJSON) => {
+        Err(bun_install::Error::MissingPackageJSON) if !dry_run => {
             attempt_to_create_package_json()?;
-            // Re-parse argv: `CommandLineArguments` is not `Clone`, and `parse`
-            // is deterministic over process argv.
+            // Re-parse argv: `parse` is deterministic over process argv.
             let cli = CommandLineArguments::parse(Subcommand::Link)?;
             pm::init(&mut *ctx, cli, Subcommand::Link)?
         }

--- a/src/runtime/cli/unlink_command.rs
+++ b/src/runtime/cli/unlink_command.rs
@@ -26,12 +26,12 @@ impl UnlinkCommand {
 
 fn unlink(ctx: &mut ContextData) -> crate::Result<()> {
     let cli = CommandLineArguments::parse(Subcommand::Unlink)?;
+    let dry_run = cli.dry_run;
     let (manager, _original_cwd) = match pm::init(&mut *ctx, cli, Subcommand::Unlink) {
         Ok(v) => v,
-        Err(bun_install::Error::MissingPackageJSON) => {
+        Err(bun_install::Error::MissingPackageJSON) if !dry_run => {
             attempt_to_create_package_json()?;
-            // Re-parse argv: `CommandLineArguments` is not `Clone`, and `parse`
-            // is deterministic over process argv.
+            // Re-parse argv: `parse` is deterministic over process argv.
             let cli = CommandLineArguments::parse(Subcommand::Unlink)?;
             pm::init(&mut *ctx, cli, Subcommand::Unlink)?
         }

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2643,3 +2643,26 @@ for (const cmd of ["add", "install"]) {
     expect(entries).toEqual([]);
   });
 }
+
+for (const cmd of ["link", "unlink"]) {
+  it(`should not create package.json for \`bun ${cmd} --dry-run\` in an empty directory`, async () => {
+    expect(await readdir(add_dir)).toEqual([]);
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), cmd, "--dry-run"],
+      cwd: add_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    await stdout.text();
+    // There is no package.json to link/unlink; the command should refuse
+    // rather than create one.
+    expect(err).toContain("could not find a package.json");
+    expect(await exited).not.toBe(0);
+
+    expect(await readdir(add_dir)).toEqual([]);
+  });
+}

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
-import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs/promises";
+import { access, appendFile, copyFile, mkdir, readdir, readlink, rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
 import { join, relative, resolve } from "path";
 import {
@@ -2610,3 +2610,36 @@ it("should install tarball with tarball dependencies", async () => {
   await access(join(add_dir, "node_modules", "test-parent"));
   await access(join(add_dir, "node_modules", "test-child"));
 });
+
+// https://github.com/oven-sh/bun/issues/13244
+for (const cmd of ["add", "install"]) {
+  it(`should not create package.json for \`bun ${cmd} <pkg> --dry-run\` in an empty directory`, async () => {
+    const urls: string[] = [];
+    setHandler(dummyRegistry(urls));
+
+    // `add_dir` is a fresh empty tmpdir per test.
+    expect(await readdir(add_dir)).toEqual([]);
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), cmd, "BaR", "--dry-run", "--registry", root_url + "/"],
+      cwd: add_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env: {
+        ...env,
+        BUN_INSTALL_CACHE_DIR: join(add_dir, ".cache"),
+      },
+    });
+    const err = await stderr.text();
+    const out = await stdout.text();
+    expect(err).not.toContain("error:");
+    expect(err).not.toContain("Saved lockfile");
+    expect(out).toContain("installed BaR@0.0.2");
+    expect(await exited).toBe(0);
+
+    // --dry-run must not write package.json, bun.lock, or node_modules.
+    const entries = (await readdir(add_dir)).filter(e => e !== ".cache");
+    expect(entries).toEqual([]);
+  });
+}


### PR DESCRIPTION
Fixes #13244.

## Repro

```sh
cd "$(mktemp -d)" && ls -A   # empty
bun add zod --dry-run
ls -A                        # package.json   <- created despite --dry-run
```

Same for `bun install zod --dry-run`, `bun link --dry-run` and `bun unlink --dry-run`. Expected: `--dry-run` performs no writes.

## Cause

`PackageManager::init` walks up from cwd looking for `package.json`. When none is found and the command is `bun install <pkg>`, it writes `{"dependencies": {}}` to disk so the add can proceed. `bun add`, `bun link` and `bun unlink` each catch the `MissingPackageJSON` error and call `attempt_to_create_package_json()` before retrying `init`. All of this happens before `options.load()` reads `cli.dry_run`.

## Fix

`bun add` / `bun install <pkg>`: when `cli.dry_run` is set and no `package.json` exists, `init()` holds `Fd::invalid()` for the root file instead of creating it, fills `ROOT_PACKAGE_JSON_PATH` from the computed path instead of `get_fd_path(fd)`, and seeds `workspace_package_json_cache` with an in-memory `{"dependencies": {}}` entry so every later lookup hits cache. The `bun add` create-then-retry path is folded into `init()`, so the retry wrapper in `update_package_json_and_install_and_cli` is removed.

`bun link` / `bun unlink`: under `--dry-run` the `MissingPackageJSON` error now propagates ("could not find a package.json") instead of writing a file and then failing on the missing `name`.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test cli/install/bun-add.test.ts -t 'should not create package.json'
(fail) ... bun add ...      -> ["package.json"]
(fail) ... bun install ...  -> ["package.json"]
(fail) ... bun link ...     -> "package.json missing name"
(fail) ... bun unlink ...   -> "package.json missing name"

$ bun bd test cli/install/bun-add.test.ts -t 'should not create package.json'
4 pass, 0 fail
```

Full `bun-add.test.ts` suite: 58 pass, 0 fail.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-add.test.ts

<!-- robobun:evidence:end -->