### PR TITLE
bunx, bun create: honor the project-local bunfig.toml for the spawned install

### DIFF
--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1656,12 +1656,9 @@ fn run_security_scanner(manager: &mut PackageManager, ctx: Command::Context, ori
         return;
     }
 
-    // bunx forwards the project's bunfig.toml to this `bun add`, but runs it
-    // with cwd set to the bunx cache dir. A `[install.security] scanner` named
-    // there is not installed in (or a dependency of) the cache dir's `{}`
-    // package.json, so resolving it would always fail and abort the bunx
-    // invocation. The scanner gates what enters the project's dependency
-    // tree, not one-off tool executions.
+    // The scanner gates what enters the project's dependency tree, not the
+    // bunx tool fetch (which runs in a cache dir whose `{}` package.json
+    // cannot list the scanner).
     if bun_core::env_var::feature_flag::BUN_INTERNAL_BUNX_INSTALL
         .get()
         .unwrap_or(false)

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1656,6 +1656,19 @@ fn run_security_scanner(manager: &mut PackageManager, ctx: Command::Context, ori
         return;
     }
 
+    // bunx forwards the project's bunfig.toml to this `bun add`, but runs it
+    // with cwd set to the bunx cache dir. A `[install.security] scanner` named
+    // there is not installed in (or a dependency of) the cache dir's `{}`
+    // package.json, so resolving it would always fail and abort the bunx
+    // invocation. The scanner gates what enters the project's dependency
+    // tree, not one-off tool executions.
+    if bun_core::env_var::feature_flag::BUN_INTERNAL_BUNX_INSTALL
+        .get()
+        .unwrap_or(false)
+    {
+        return;
+    }
+
     match security_scanner::perform_security_scan_after_resolution(manager, ctx, original_cwd) {
         Err(err) => {
             match err {

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -614,20 +614,19 @@ impl BunxCommand {
         true
     }
 
-    /// Refuse to forward a `bunfig.toml` discovered by walking up from the
-    /// invoking cwd unless it is (or resolves to) a regular file owned by the
-    /// current user. The walk may cross into world-writable ancestors (e.g.
-    /// `/tmp`), where another local user could plant a `bunfig.toml`
-    /// redirecting `[install] registry` to a host they control; bunx would
-    /// then fetch and execute their package. Symlinks are followed once so a
-    /// dotfile-managed config is accepted when both link and target are
-    /// uid-owned, mirroring `is_trusted_cached_binary`.
+    /// A `bunfig.toml` found by walking up into world-writable ancestors
+    /// (e.g. `/tmp`) could be planted by another local user to redirect
+    /// `[install] registry`; refuse it unless the file (or its single-hop
+    /// symlink target) is a regular file owned by the current uid or root
+    /// (root-owned is the default after Docker `COPY` + `USER node`, and an
+    /// unprivileged attacker cannot create a root-owned file).
     #[cfg(unix)]
     fn is_trusted_local_bunfig(path: &ZStr, uid: libc::uid_t) -> bool {
+        let owner_ok = |st_uid: libc::uid_t| st_uid == uid || st_uid == 0;
         let reg_ok =
-            |st: &bun_sys::Stat| st.st_uid == uid && (st.st_mode & libc::S_IFMT) == libc::S_IFREG;
+            |st: &bun_sys::Stat| owner_ok(st.st_uid) && (st.st_mode & libc::S_IFMT) == libc::S_IFREG;
         match bun_sys::lstat(path) {
-            Ok(st) if st.st_uid == uid => {
+            Ok(st) if owner_ok(st.st_uid) => {
                 let kind = st.st_mode & libc::S_IFMT;
                 if kind == libc::S_IFREG {
                     true
@@ -849,19 +848,11 @@ impl BunxCommand {
         let uid = bun_sys::windows::user_unique_id();
 
         // The spawned `bun add` runs with cwd = `bunx_cache_dir`, so it cannot
-        // discover a project-local bunfig.toml on its own. Resolve it here
-        // from the invoking directory and forward it via `--config=<path>` so
-        // `[install]` settings such as `registry` and `scopes` are honored.
-        // `--config`'s value is optional in the install arg parser, so the `=`
-        // form is required for the path to be consumed. Discovery runs before
-        // `package_fmt` so the cache directory can be namespaced per bunfig
-        // (the registry may differ per project; without this a warm cache from
-        // one project would serve another).
-        //
-        // On Unix the candidate is rejected unless it is (or resolves to) a
-        // regular file owned by the current user (see `is_trusted_local_bunfig`),
-        // so a bunfig.toml planted by another local user in a world-writable
-        // ancestor cannot redirect the install.
+        // discover a project-local bunfig.toml on its own. Walk up from the
+        // invoking directory here and forward the first one found as
+        // `--config=<path>` (the `=` form is required; the install arg parser
+        // treats a space-separated value as a positional). See
+        // `is_trusted_local_bunfig` for the ownership check.
         // SAFETY: `Transpiler::init` always sets `fs` to the process singleton.
         let top_level_dir: &[u8] = unsafe { (*this_transpiler.fs).top_level_dir };
         let local_bunfig_arg: Option<Vec<u8>> = 'find_bunfig: {
@@ -954,8 +945,7 @@ impl BunxCommand {
                 .map_err(|_| crate::Error::Alloc(bun_alloc::AllocError))?;
             }
             if let Some(arg) = &local_bunfig_arg {
-                // Namespace the cache dir by bunfig path so projects pinning
-                // different registries do not share a cache entry.
+                // Per-bunfig cache namespace: different projects' registries must not share an entry.
                 write!(&mut v, "@{:x}", hash(&arg[b"--config=".len()..]))
                     .map_err(|_| crate::Error::Alloc(bun_alloc::AllocError))?;
             }
@@ -1514,10 +1504,8 @@ impl BunxCommand {
             },
         };
 
-        // `Run::run_binary` below execs the installed tool with this same
-        // `env_loader`; the tool (e.g. a scaffolder that runs `bun install`)
-        // must not inherit the internal marker, or that grandchild install
-        // would skip the configured security scanner.
+        // Don't leak the internal marker into the tool we exec: a scaffolder's
+        // own `bun install` must still run the configured security scanner.
         env_loader.map.remove(b"BUN_INTERNAL_BUNX_INSTALL");
 
         match &spawn_result.status {

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -615,11 +615,9 @@ impl BunxCommand {
     }
 
     /// A `bunfig.toml` found by walking up into world-writable ancestors
-    /// (e.g. `/tmp`) could be planted by another local user to redirect
-    /// `[install] registry`; refuse it unless the file (or its single-hop
-    /// symlink target) is a regular file owned by the current uid or root
-    /// (root-owned is the default after Docker `COPY` + `USER node`, and an
-    /// unprivileged attacker cannot create a root-owned file).
+    /// could be planted by another local user to redirect `[install] registry`;
+    /// accept only a regular file (or one symlink hop to one) owned by the
+    /// current uid or root (an unprivileged attacker cannot create uid-0 files).
     #[cfg(unix)]
     fn is_trusted_local_bunfig(path: &ZStr, uid: libc::uid_t) -> bool {
         let owner_ok = |st_uid: libc::uid_t| st_uid == uid || st_uid == 0;

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -623,8 +623,9 @@ impl BunxCommand {
     #[cfg(unix)]
     fn is_trusted_local_bunfig(path: &ZStr, uid: libc::uid_t) -> bool {
         let owner_ok = |st_uid: libc::uid_t| st_uid == uid || st_uid == 0;
-        let reg_ok =
-            |st: &bun_sys::Stat| owner_ok(st.st_uid) && (st.st_mode & libc::S_IFMT) == libc::S_IFREG;
+        let reg_ok = |st: &bun_sys::Stat| {
+            owner_ok(st.st_uid) && (st.st_mode & libc::S_IFMT) == libc::S_IFREG
+        };
         match bun_sys::lstat(path) {
             Ok(st) if owner_ok(st.st_uid) => {
                 let kind = st.st_mode & libc::S_IFMT;

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -614,6 +614,39 @@ impl BunxCommand {
         true
     }
 
+    /// Refuse to forward a `bunfig.toml` discovered by walking up from the
+    /// invoking cwd unless it is (or resolves to) a regular file owned by the
+    /// current user. The walk may cross into world-writable ancestors (e.g.
+    /// `/tmp`), where another local user could plant a `bunfig.toml`
+    /// redirecting `[install] registry` to a host they control; bunx would
+    /// then fetch and execute their package. Symlinks are followed once so a
+    /// dotfile-managed config is accepted when both link and target are
+    /// uid-owned, mirroring `is_trusted_cached_binary`.
+    #[cfg(unix)]
+    fn is_trusted_local_bunfig(path: &ZStr, uid: libc::uid_t) -> bool {
+        let reg_ok =
+            |st: &bun_sys::Stat| st.st_uid == uid && (st.st_mode & libc::S_IFMT) == libc::S_IFREG;
+        match bun_sys::lstat(path) {
+            Ok(st) if st.st_uid == uid => {
+                let kind = st.st_mode & libc::S_IFMT;
+                if kind == libc::S_IFREG {
+                    true
+                } else if kind == libc::S_IFLNK {
+                    matches!(bun_sys::stat(path), Ok(target) if reg_ok(&target))
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+
+    #[cfg(not(unix))]
+    #[inline(always)]
+    fn is_trusted_local_bunfig(_path: &ZStr, _uid: u32) -> bool {
+        true
+    }
+
     #[cfg(unix)]
     fn is_trusted_opened_cache_dir(
         dir: Fd,
@@ -809,6 +842,72 @@ impl BunxCommand {
             };
         // Cloned to avoid borrowck overlap when PATH is reassigned below.
 
+        #[cfg(unix)]
+        // SAFETY: getuid() is always safe to call (no preconditions, never fails)
+        let uid = unsafe { libc::getuid() };
+        #[cfg(windows)]
+        let uid = bun_sys::windows::user_unique_id();
+
+        // The spawned `bun add` runs with cwd = `bunx_cache_dir`, so it cannot
+        // discover a project-local bunfig.toml on its own. Resolve it here
+        // from the invoking directory and forward it via `--config=<path>` so
+        // `[install]` settings such as `registry` and `scopes` are honored.
+        // `--config`'s value is optional in the install arg parser, so the `=`
+        // form is required for the path to be consumed. Discovery runs before
+        // `package_fmt` so the cache directory can be namespaced per bunfig
+        // (the registry may differ per project; without this a warm cache from
+        // one project would serve another).
+        //
+        // On Unix the candidate is rejected unless it is (or resolves to) a
+        // regular file owned by the current user (see `is_trusted_local_bunfig`),
+        // so a bunfig.toml planted by another local user in a world-writable
+        // ancestor cannot redirect the install.
+        // SAFETY: `Transpiler::init` always sets `fs` to the process singleton.
+        let top_level_dir: &[u8] = unsafe { (*this_transpiler.fs).top_level_dir };
+        let local_bunfig_arg: Option<Vec<u8>> = 'find_bunfig: {
+            const PREFIX: &[u8] = b"--config=";
+            let mut buf = bun_paths::path_buffer_pool::get();
+            let total = buf.len();
+            let mut dir: &[u8] = strings::without_trailing_slash(top_level_dir);
+            loop {
+                let Ok(len) = (|| {
+                    let mut cursor: &mut [u8] = &mut buf[..total - 1];
+                    write!(
+                        cursor,
+                        "--config={dir}{sep}bunfig.toml",
+                        dir = BStr::new(dir),
+                        sep = bun_paths::SEP as char,
+                    )?;
+                    Ok::<_, std::io::Error>((total - 1) - cursor.len())
+                })() else {
+                    break 'find_bunfig None;
+                };
+                buf[len] = 0;
+                let path_z = ZStr::from_buf(&buf[PREFIX.len()..], len - PREFIX.len());
+                if bun_sys::exists_z(path_z) {
+                    if !Self::is_trusted_local_bunfig(path_z, uid) {
+                        bun_core::warn!(
+                            "ignoring <b>{}<r> because it is not a regular file owned by the current user",
+                            BStr::new(path_z.as_bytes()),
+                        );
+                        Output::flush();
+                        break 'find_bunfig None;
+                    }
+                    break 'find_bunfig Some(buf[..len].to_vec());
+                }
+                match bun_paths::dirname(dir) {
+                    Some(parent) => {
+                        let parent = strings::without_trailing_slash(parent);
+                        if parent.len() >= dir.len() {
+                            break 'find_bunfig None;
+                        }
+                        dir = parent;
+                    }
+                    None => break 'find_bunfig None,
+                }
+            }
+        };
+
         let display_version: &[u8] = if update_request.version.literal.is_empty() {
             b"latest"
         } else {
@@ -853,6 +952,12 @@ impl BunxCommand {
                     BStr::new(display_version),
                 )
                 .map_err(|_| crate::Error::Alloc(bun_alloc::AllocError))?;
+            }
+            if let Some(arg) = &local_bunfig_arg {
+                // Namespace the cache dir by bunfig path so projects pinning
+                // different registries do not share a cache entry.
+                write!(&mut v, "@{:x}", hash(&arg[b"--config=".len()..]))
+                    .map_err(|_| crate::Error::Alloc(bun_alloc::AllocError))?;
             }
             break 'brk v;
         };
@@ -942,12 +1047,6 @@ impl BunxCommand {
         //     where a user can replace the directory with malicious code.
         //
         // If this format changes, please update cache clearing code in package_manager_command.rs
-        #[cfg(unix)]
-        // SAFETY: getuid() is always safe to call (no preconditions, never fails)
-        let uid = unsafe { libc::getuid() };
-        #[cfg(windows)]
-        let uid = bun_sys::windows::user_unique_id();
-
         path = {
             let mut v = Vec::new();
             let path_is_nonzero = !path.is_empty();
@@ -979,7 +1078,6 @@ impl BunxCommand {
         // `path_buf` is a stack local so
         // `bun_which::which`'s returned slice can borrow it for the rest of exec().
         let mut path_buf = PathBuffer::uninit();
-        let top_level_dir: &[u8] = fs.top_level_dir;
 
         let mut absolute_in_cache_dir_buf = PathBuffer::uninit();
         let buf_total = absolute_in_cache_dir_buf.len();
@@ -1327,8 +1425,12 @@ impl BunxCommand {
             install_param.as_slice(),
             b"--no-summary",
         ];
-        let mut args: BoundedArray<&[u8], 8> =
+        let mut args: BoundedArray<&[u8], 9> =
             BoundedArray::from_slice(&install_args).expect("unreachable"); // upper bound is known
+
+        if let Some(config_arg) = local_bunfig_arg.as_deref() {
+            args.append(config_arg).expect("unreachable"); // upper bound is known
+        }
 
         if do_cache_bust {
             // disable the manifest cache when a tag is specified
@@ -1411,6 +1513,12 @@ impl BunxCommand {
                 bun_sys::Result::Ok(result) => result,
             },
         };
+
+        // `Run::run_binary` below execs the installed tool with this same
+        // `env_loader`; the tool (e.g. a scaffolder that runs `bun install`)
+        // must not inherit the internal marker, or that grandchild install
+        // would skip the configured security scanner.
+        env_loader.map.remove(b"BUN_INTERNAL_BUNX_INSTALL");
 
         match &spawn_result.status {
             SpawnStatus::Exited(exited) => {

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -1,8 +1,8 @@
 import { spawn, spawnSync } from "bun";
 import { beforeEach, describe, expect, it } from "bun:test";
 import { chmodSync, mkdirSync } from "fs";
-import { exists, stat } from "fs/promises";
-import { bunExe, bunEnv as env, isPosix, tempDir, tls, tmpdirSync } from "harness";
+import { exists, mkdir, stat, writeFile } from "fs/promises";
+import { bunExe, bunEnv as env, isPosix, isWindows, tempDir, tls, tmpdirSync } from "harness";
 import { once } from "node:events";
 import * as nodetls from "node:tls";
 import { join } from "path";
@@ -85,6 +85,176 @@ it("should create selected template with @ prefix implicit `/create` with versio
   expect(err.split(/\r?\n/)).toContain(`error: GET https://registry.npmjs.org/@second-quick-start%2fcreate - 404`);
 
   await exited;
+});
+
+// https://github.com/oven-sh/bun/issues/13247
+// `bun create @scope/pkg` delegates to bunx, which spawns `bun add` in a temp
+// cache dir. The child could only discover the global ~/.bunfig.toml, so the
+// project-directory [install.scopes] mapping was ignored and the default npm
+// registry was queried instead.
+describe("bun create honors the project-local bunfig.toml [install.scopes]", () => {
+  async function makeCreateTarball(pkgName: string, binName: string) {
+    const root = tmpdirSync();
+    const pkgDir = join(root, "package");
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: pkgName, version: "1.0.0", bin: { [binName]: "cli.js" } }),
+    );
+    await writeFile(join(pkgDir, "cli.js"), `#!/usr/bin/env node\nconsole.log("CREATE-RAN-FROM-SCOPED-REGISTRY");\n`);
+    const tgz = join(tmpdirSync(), "pkg.tgz");
+    await Bun.$`tar -czf ${tgz} -C ${root} package`;
+    return new Uint8Array(await Bun.file(tgz).arrayBuffer());
+  }
+
+  function scopedRegistry(pkgName: string, binName: string, tgz: Uint8Array, hits: string[]) {
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const path = decodeURIComponent(new URL(req.url).pathname);
+        hits.push(path);
+        if (path.endsWith(".tgz")) return new Response(tgz);
+        return Response.json({
+          name: pkgName,
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: pkgName,
+              version: "1.0.0",
+              bin: { [binName]: "cli.js" },
+              dist: { tarball: `http://127.0.0.1:${server.port}/pkg.tgz` },
+            },
+          },
+        });
+      },
+    });
+    return server;
+  }
+
+  function isolatedEnv(home: string, tmp: string) {
+    return {
+      ...env,
+      HOME: home,
+      USERPROFILE: home,
+      XDG_CONFIG_HOME: home,
+      TEMP: tmp,
+      TMPDIR: tmp,
+      BUN_TMPDIR: tmp,
+      BUN_INSTALL_CACHE_DIR: join(tmp, ".install-cache"),
+      npm_config_registry: undefined as any,
+      NPM_CONFIG_REGISTRY: undefined as any,
+      BUN_CONFIG_REGISTRY: undefined as any,
+    };
+  }
+
+  it("resolves @scope/create-* from the cwd bunfig.toml scope", async () => {
+    const pkgName = "@bun13247test/create-package";
+    const binName = "create-package";
+    const hits: string[] = [];
+    await using srv = scopedRegistry(pkgName, binName, await makeCreateTarball(pkgName, binName), hits);
+
+    const home = tmpdirSync();
+    const tmp = tmpdirSync();
+    // Global bunfig points at an unroutable address so the test never touches
+    // the public npm registry on the failing path.
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:1/"\n`);
+    await writeFile(
+      join(x_dir, "bunfig.toml"),
+      `[install.scopes]\nbun13247test = { url = "http://127.0.0.1:${srv.port}/" }\n`,
+    );
+
+    await using proc = spawn({
+      cmd: [bunExe(), "create", "@bun13247test/package"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: isolatedEnv(home, tmp),
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(err).not.toContain("registry.npmjs.org");
+    expect({ out: out.trim(), hits }).toEqual({
+      out: "CREATE-RAN-FROM-SCOPED-REGISTRY",
+      hits: [`/${pkgName}`, "/pkg.tgz"],
+    });
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  });
+
+  it("finds a bunfig.toml in a parent directory", async () => {
+    const pkgName = "@bun13247test/create-package";
+    const binName = "create-package";
+    const hits: string[] = [];
+    await using srv = scopedRegistry(pkgName, binName, await makeCreateTarball(pkgName, binName), hits);
+
+    const home = tmpdirSync();
+    const tmp = tmpdirSync();
+    const sub = join(x_dir, "a", "b");
+    mkdirSync(sub, { recursive: true });
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:1/"\n`);
+    await writeFile(
+      join(x_dir, "bunfig.toml"),
+      `[install.scopes]\nbun13247test = { url = "http://127.0.0.1:${srv.port}/" }\n`,
+    );
+
+    await using proc = spawn({
+      cmd: [bunExe(), "create", "@bun13247test/package"],
+      cwd: sub,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: isolatedEnv(home, tmp),
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ out: out.trim(), hits }).toEqual({
+      out: "CREATE-RAN-FROM-SCOPED-REGISTRY",
+      hits: [`/${pkgName}`, "/pkg.tgz"],
+    });
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  });
+
+  // On Unix the candidate is rejected unless it is (or resolves to) a regular
+  // file owned by the current user, so a bunfig.toml planted in a
+  // world-writable ancestor cannot redirect the install. chown to another uid
+  // needs root, so exercise the regular-file check via a directory named
+  // bunfig.toml.
+  it.skipIf(isWindows)("warns and ignores an ancestor bunfig.toml that is not a trusted regular file", async () => {
+    const pkgName = "@bun13247test/create-package";
+    const binName = "create-package";
+    const hits: string[] = [];
+    await using srv = scopedRegistry(pkgName, binName, await makeCreateTarball(pkgName, binName), hits);
+
+    const home = tmpdirSync();
+    const tmp = tmpdirSync();
+    const sub = join(x_dir, "work");
+    mkdirSync(sub, { recursive: true });
+    mkdirSync(join(x_dir, "bunfig.toml"), { recursive: true });
+    await writeFile(
+      join(home, ".bunfig.toml"),
+      `[install.scopes]\nbun13247test = { url = "http://127.0.0.1:${srv.port}/" }\n`,
+    );
+
+    await using proc = spawn({
+      cmd: [bunExe(), "create", "@bun13247test/package"],
+      cwd: sub,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: isolatedEnv(home, tmp),
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(err).toContain("not a regular file owned by the current user");
+    expect(err).toContain(join(x_dir, "bunfig.toml"));
+    expect({ out: out.trim(), hits }).toEqual({
+      out: "CREATE-RAN-FROM-SCOPED-REGISTRY",
+      hits: [`/${pkgName}`, "/pkg.tgz"],
+    });
+    expect(exitCode).toBe(0);
+  });
 });
 
 // Close-delimited body (no Content-Length, no chunked) split across packets:

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -216,6 +216,45 @@ describe("bun create honors the project-local bunfig.toml [install.scopes]", () 
     expect(exitCode).toBe(0);
   });
 
+  // https://github.com/oven-sh/bun/issues/31149
+  // Forwarding the bunfig (or, without a local one, the child reading the
+  // global bunfig) brings [install.security] scanner along; the bunx cache
+  // dir's `{}` package.json cannot list the scanner as a dependency, so the
+  // install would abort with SecurityScannerNotInDependencies. The
+  // bunx-spawned install skips the scanner.
+  it("does not abort on a global [install.security] scanner", async () => {
+    const pkgName = "@bun13247test/create-package";
+    const binName = "create-package";
+    const hits: string[] = [];
+    await using srv = scopedRegistry(pkgName, binName, await makeCreateTarball(pkgName, binName), hits);
+
+    const home = tmpdirSync();
+    const tmp = tmpdirSync();
+    await writeFile(
+      join(home, ".bunfig.toml"),
+      `[install]\nregistry = "http://127.0.0.1:${srv.port}/"\n` +
+        `[install.security]\nscanner = "@not-installed/bun-security-scanner"\n`,
+    );
+
+    await using proc = spawn({
+      cmd: [bunExe(), "create", "@bun13247test/package"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: isolatedEnv(home, tmp),
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(err).not.toContain("SecurityScannerNotInDependencies");
+    expect(err).not.toContain("is configured in bunfig.toml but is not installed");
+    expect({ out: out.trim(), hits }).toEqual({
+      out: "CREATE-RAN-FROM-SCOPED-REGISTRY",
+      hits: [`/${pkgName}`, "/pkg.tgz"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
   // On Unix the candidate is rejected unless it is (or resolves to) a regular
   // file owned by the current user, so a bunfig.toml planted in a
   // world-writable ancestor cannot redirect the install. chown to another uid

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1183,6 +1183,273 @@ describe("package name aliases", () => {
   });
 });
 
+// https://github.com/oven-sh/bun/issues/5361
+// bunx spawns its internal `bun add` with cwd set to the bunx cache dir under
+// $TMPDIR, so the project-local bunfig.toml was never discovered; only the
+// global ~/.bunfig.toml (or env) was honored. In a project that pins a private
+// registry via its bunfig.toml, `bunx <tool>` silently resolved and executed
+// the package from the wrong registry.
+describe("bunx honors the project-local bunfig.toml [install] registry", () => {
+  async function makePkgTarball(tag: string, cli = `console.log("SERVED-BY-${tag}");`) {
+    const root = tmpdirSync();
+    const pkgDir = join(root, "package");
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: "px-probe", version: "1.0.0", bin: { "px-probe": "cli.js" } }),
+    );
+    await writeFile(join(pkgDir, "cli.js"), `#!/usr/bin/env node\n${cli}\n`);
+    const tgzDir = tmpdirSync();
+    const tgz = join(tgzDir, "px-probe-1.0.0.tgz");
+    await Bun.$`tar -czf ${tgz} -C ${root} package`;
+    return new Uint8Array(await Bun.file(tgz).arrayBuffer());
+  }
+
+  function registry(tgz: Uint8Array, hits: string[]) {
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const path = new URL(req.url).pathname;
+        hits.push(path);
+        if (path.endsWith(".tgz")) return new Response(tgz);
+        return Response.json({
+          name: "px-probe",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "px-probe",
+              version: "1.0.0",
+              bin: { "px-probe": "cli.js" },
+              dist: { tarball: `http://127.0.0.1:${server.port}/px-probe-1.0.0.tgz` },
+            },
+          },
+        });
+      },
+    });
+    return server;
+  }
+
+  function bunxEnv(env: Record<string, string>, home: string) {
+    return {
+      ...env,
+      HOME: home,
+      USERPROFILE: home,
+      XDG_CONFIG_HOME: home,
+      PATH: pathWithout("px-probe", env.PATH),
+      npm_config_registry: undefined as any,
+      NPM_CONFIG_REGISTRY: undefined as any,
+      BUN_CONFIG_REGISTRY: undefined as any,
+    };
+  }
+
+  it("prefers the project bunfig registry over the global one", async () => {
+    const hitsA: string[] = [];
+    const hitsB: string[] = [];
+    await using srvA = registry(await makePkgTarball("PROJECT"), hitsA);
+    await using srvB = registry(await makePkgTarball("GLOBAL"), hitsB);
+
+    const { x_dir, env } = setup();
+    const home = tmpdirSync();
+    await writeFile(join(x_dir, "package.json"), JSON.stringify({ name: "proj", version: "1.0.0" }));
+    await writeFile(join(x_dir, "bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srvA.port}/"\n`);
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srvB.port}/"\n`);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "x", "px-probe"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: bunxEnv(env, home),
+    });
+    const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+    expect({ out: out.trim(), hitsA, hitsB }).toEqual({
+      out: "SERVED-BY-PROJECT",
+      hitsA: ["/px-probe", "/px-probe-1.0.0.tgz"],
+      hitsB: [],
+    });
+    expect(err).not.toContain("error:");
+    expect(exited).toBe(0);
+  });
+
+  it("honors the cwd bunfig.toml even without a package.json in the project", async () => {
+    const hits: string[] = [];
+    await using srv = registry(await makePkgTarball("PROJECT"), hits);
+
+    const { x_dir, env } = setup();
+    const home = tmpdirSync();
+    await writeFile(join(x_dir, "bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srv.port}/"\n`);
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:1/"\n`);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "x", "px-probe"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: bunxEnv(env, home),
+    });
+    const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+    expect(out.trim()).toBe("SERVED-BY-PROJECT");
+    expect(hits).toEqual(["/px-probe", "/px-probe-1.0.0.tgz"]);
+    expect(err).not.toContain("error:");
+    expect(exited).toBe(0);
+  });
+
+  it("finds the workspace-root bunfig.toml when run from a workspace member", async () => {
+    const hitsA: string[] = [];
+    const hitsB: string[] = [];
+    await using srvA = registry(await makePkgTarball("PROJECT"), hitsA);
+    await using srvB = registry(await makePkgTarball("GLOBAL"), hitsB);
+
+    const { x_dir, env } = setup();
+    const home = tmpdirSync();
+    const appDir = join(x_dir, "packages", "app");
+    await mkdir(appDir, { recursive: true });
+    await writeFile(
+      join(x_dir, "package.json"),
+      JSON.stringify({ name: "root", version: "1.0.0", workspaces: ["packages/*"] }),
+    );
+    await writeFile(join(x_dir, "bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srvA.port}/"\n`);
+    await writeFile(join(appDir, "package.json"), JSON.stringify({ name: "app", version: "1.0.0" }));
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srvB.port}/"\n`);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "x", "px-probe"],
+      cwd: appDir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: bunxEnv(env, home),
+    });
+    const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+    expect({ out: out.trim(), hitsA, hitsB }).toEqual({
+      out: "SERVED-BY-PROJECT",
+      hitsA: ["/px-probe", "/px-probe-1.0.0.tgz"],
+      hitsB: [],
+    });
+    expect(err).not.toContain("error:");
+    expect(exited).toBe(0);
+  });
+
+  // A uid-owned symlink to a uid-owned regular file is accepted (dotfile
+  // managers commonly symlink config files).
+  it.skipIf(isWindows)("accepts a uid-owned symlinked bunfig.toml", async () => {
+    const hits: string[] = [];
+    await using srv = registry(await makePkgTarball("PROJECT"), hits);
+
+    const { x_dir, env } = setup();
+    const home = tmpdirSync();
+    const target = join(x_dir, "real-bunfig.toml");
+    await writeFile(target, `[install]\nregistry = "http://127.0.0.1:${srv.port}/"\n`);
+    symlinkSync(target, join(x_dir, "bunfig.toml"));
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:1/"\n`);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "x", "px-probe"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: bunxEnv(env, home),
+    });
+    const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+    expect(out.trim()).toBe("SERVED-BY-PROJECT");
+    expect(hits).toEqual(["/px-probe", "/px-probe-1.0.0.tgz"]);
+    expect(err).not.toContain("ignoring");
+    expect(exited).toBe(0);
+  });
+
+  // When a local bunfig.toml is forwarded, the bunx cache dir is namespaced
+  // by its path so two projects pinning different registries do not share a
+  // cache entry for the same package name.
+  it("does not serve a warm cache entry installed from a different project's registry", async () => {
+    const hitsA: string[] = [];
+    const hitsB: string[] = [];
+    await using srvA = registry(await makePkgTarball("A"), hitsA);
+    await using srvB = registry(await makePkgTarball("B"), hitsB);
+
+    const tmp = tmpdirSync();
+    const home = tmpdirSync();
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:1/"\n`);
+
+    async function runIn(srv: ReturnType<typeof registry>) {
+      const dir = tmpdirSync();
+      await writeFile(join(dir, "package.json"), JSON.stringify({ name: "p", version: "1.0.0" }));
+      await writeFile(join(dir, "bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srv.port}/"\n`);
+      await using proc = spawn({
+        cmd: [bunExe(), "x", "px-probe"],
+        cwd: dir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: {
+          ...bunEnv,
+          TEMP: tmp,
+          BUN_TMPDIR: tmp,
+          TMPDIR: tmp,
+          BUN_INSTALL_CACHE_DIR: join(dir, ".install-cache"),
+          HOME: home,
+          USERPROFILE: home,
+          XDG_CONFIG_HOME: home,
+          PATH: pathWithout("px-probe", bunEnv.PATH),
+          npm_config_registry: undefined as any,
+          NPM_CONFIG_REGISTRY: undefined as any,
+          BUN_CONFIG_REGISTRY: undefined as any,
+        },
+      });
+      const [, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      return { out: out.trim(), exited };
+    }
+
+    const a = await runIn(srvA);
+    const b = await runIn(srvB);
+
+    expect({ a, b, hitsA, hitsB }).toEqual({
+      a: { out: "SERVED-BY-A", exited: 0 },
+      b: { out: "SERVED-BY-B", exited: 0 },
+      hitsA: ["/px-probe", "/px-probe-1.0.0.tgz"],
+      hitsB: ["/px-probe", "/px-probe-1.0.0.tgz"],
+    });
+  });
+
+  // BUN_INTERNAL_BUNX_INSTALL is set for the internal `bun add` (so it can
+  // skip the [install.security] scanner from the forwarded bunfig) but must
+  // not leak into the environment of the tool bunx executes: a scaffolder
+  // that spawns `bun install` in the new project would otherwise inherit it
+  // and bypass the configured scanner for the real dependency tree.
+  it("does not leak BUN_INTERNAL_BUNX_INSTALL into the executed tool's environment", async () => {
+    const hits: string[] = [];
+    await using srv = registry(
+      await makePkgTarball("ENV", `console.log("marker=" + (process.env.BUN_INTERNAL_BUNX_INSTALL ?? "<unset>"));`),
+      hits,
+    );
+
+    const { x_dir, env } = setup();
+    const home = tmpdirSync();
+    await writeFile(join(x_dir, "bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srv.port}/"\n`);
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:1/"\n`);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "x", "px-probe"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: bunxEnv(env, home),
+    });
+    const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+    expect(out.trim()).toBe("marker=<unset>");
+    expect(err).not.toContain("error:");
+    expect(exited).toBe(0);
+  });
+});
+
 // Regression test: bunx should not crash on corrupted .bunx files (Windows only)
 // When the .bunx metadata file is corrupted (e.g., missing quote terminator in bin_path),
 // bunx should gracefully fall back to the slow path instead of panicking.


### PR DESCRIPTION
## Problem

`bunx` installs into a per-package cache directory under `$TMPDIR` and spawns `bun add` with that directory as its cwd. The child's bunfig discovery only ever saw the global `~/.bunfig.toml`; the project's local `bunfig.toml` was never read. `bun create <pkg>` delegates to the same `BunxCommand::exec`, so it was affected identically.

In a project that pins a private registry via `[install] registry` or `[install.scopes]`:

```
$ cat bunfig.toml
[install.scopes]
myorg = { url = "http://127.0.0.1:4873/" }

$ bun create @myorg/package out
error: GET https://registry.npmjs.org/@myorg%2fcreate-package - 404   # scope ignored
$ bun add @myorg/create-package
installed @myorg/create-package@1.0.0                                  # same config, works
```

## Fix

Before building the cache key, walk up from the invoking cwd and take the first `bunfig.toml` found, then:

- forward it as `--config=<abs-path>` to the spawned `bun add` (the `=` form is required because `--config`'s value is optional in the install arg parser; a space-separated path would be consumed as a positional package name);
- fold a hash of its absolute path into the bunx cache directory name so two projects pinning different registries don't share a cache entry for the same `<name>@<version>`;
- on Unix, refuse the candidate unless it is (or resolves via one symlink hop to) a regular file owned by the current user, and print a warning on refusal, so a `bunfig.toml` planted by another local user in a world-writable ancestor (e.g. `/tmp`) cannot redirect the install. This mirrors the existing `is_trusted_cached_binary` hardening in the same file.

`run_security_scanner` now returns early when `BUN_INTERNAL_BUNX_INSTALL` is set: forwarding the whole bunfig also forwards `[install.security] scanner`, which the bunx-spawned `bun add` cannot resolve from the cache dir's `{}` package.json. The marker is removed from the env before the installed tool is executed, so a scaffolder that runs `bun install` in the new project still runs the configured scanner.

When no local `bunfig.toml` exists, nothing is forwarded and behavior is unchanged (global config / env vars still apply, cache key is unchanged).

## Verification

```
$ bun bd test test/cli/install/bun-create.test.ts -t "bun create honors the project-local bunfig"
(pass) ... > resolves @scope/create-* from the cwd bunfig.toml scope
(pass) ... > finds a bunfig.toml in a parent directory
(pass) ... > warns and ignores an ancestor bunfig.toml that is not a trusted regular file

$ bun bd test test/cli/install/bunx.test.ts -t "bunx honors the project-local bunfig"
(pass) ... > prefers the project bunfig registry over the global one
(pass) ... > honors the cwd bunfig.toml even without a package.json in the project
(pass) ... > finds the workspace-root bunfig.toml when run from a workspace member
(pass) ... > accepts a uid-owned symlinked bunfig.toml
(pass) ... > does not serve a warm cache entry installed from a different project's registry
(pass) ... > does not leak BUN_INTERNAL_BUNX_INSTALL into the executed tool's environment
```

All nine fail on `main`.

Supersedes #34110 (same fix, that branch no longer merges cleanly against the `is_trusted_cache_root` signature change on main).

Fixes #13247
Fixes #5361

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-create.test.ts test/cli/install/bunx.test.ts

<!-- robobun:evidence:end -->

This also addresses the reported `bun create <npm-package>` case of #31149 (global `[install.security] scanner` aborting the bunx-spawned install with `SecurityScannerNotInDependencies`). #31150 handles the remaining local-template / grandchild-install paths of that issue, which go through `CreateCommand::exec` rather than bunx.


## Known limitation

Relative paths inside the forwarded bunfig (e.g. `[install] cafile = "./certs/ca.pem"`) still resolve against the bunx cache dir, not the project, because the child `bun add` runs with `cwd = <cache dir>`. This is not a regression (before this change the local bunfig was not read at all) and does not affect the URL-only `registry` / `scopes` settings the linked issues are about; the failure is a loud ENOENT rather than a silent wrong-registry fetch. The general fix (resolve relative `[install]` paths against the config file's directory when `--config=` is explicit) belongs in the bunfig loader and is left as a follow-up.
