### PR TITLE
pack: honor .npmignore negation patterns that reach inside an excluded directory

### DIFF
--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1666,9 +1666,6 @@ fn is_excluded<'a>(
                 if !result.matches() {
                     ignored = false;
                 } else if is_dir && ignored && negated_pattern_matches_under_dir(pattern, rel) {
-                    // The negation didn't match the directory itself, but it can
-                    // match paths beneath it. Keep the directory so those paths
-                    // are visited; files inside are still filtered individually.
                     ignored = false;
                 }
             } else if result.matches() {
@@ -1686,35 +1683,26 @@ fn is_excluded<'a>(
     }
 }
 
-/// For a negated pattern that did not match a directory, returns true if it could
-/// still match a path inside that directory. `dir_rel` is the directory path
-/// relative to the ignore file that owns `pattern`.
-///
-/// npm's ignore-walk does the equivalent check via minimatch's `partial` option
-/// when deciding whether to descend into an otherwise-excluded directory.
+/// True if `pattern` (negated) could match some path under the directory at
+/// `dir_rel`. Mirrors npm ignore-walk's minimatch `partial` test so that
+/// `*` + `!dist/**` still descends into `dist/`.
 fn negated_pattern_matches_under_dir(pattern: &Pattern, dir_rel: &[u8]) -> bool {
     debug_assert!(pattern.flags.contains(PatternFlags::NEGATED));
-
     if pattern
         .flags
         .contains(PatternFlags::LEADING_DOUBLESTAR_SLASH)
     {
-        // `!**/foo...` can match at any depth.
         return true;
     }
     if !pattern.flags.contains(PatternFlags::REL_PATH) {
-        // Single-segment negations match basenames; the directory itself was
-        // already tested above and didn't match.
         return false;
     }
-
     let glob = pattern.glob.slice();
     debug_assert!(!glob.is_empty() && glob[0] == b'!');
     partial_path_match(&glob[1..], dir_rel)
 }
 
-/// Segment-wise prefix match: returns true if some path beginning with
-/// `dir_path/` could match `glob`.
+/// True if some path starting with `dir_path/` could match `glob`.
 fn partial_path_match(glob: &[u8], dir_path: &[u8]) -> bool {
     let mut glob_rest = glob;
     let mut path_rest = dir_path;
@@ -1727,8 +1715,6 @@ fn partial_path_match(glob: &[u8], dir_path: &[u8]) -> bool {
             return true;
         }
         if path_rest.is_empty() {
-            // Directory segments are exhausted but the pattern still has at
-            // least `glob_seg` left to match deeper paths.
             return true;
         }
         let (path_seg, path_tail) = match strings::index_of_char(path_rest, b'/') {

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1598,6 +1598,7 @@ fn is_excluded<'a>(
     ignores: &'a [IgnorePatterns],
 ) -> Option<(&'a [u8], IgnorePatternsKind)> {
     let entry_name = entry.name.slice_u8();
+    let is_dir = entry.kind == bun_sys::FileKind::Directory;
 
     if dir_depth == 1 {
         // first, check files that can never be ignored. project root
@@ -1664,6 +1665,11 @@ fn is_excluded<'a>(
             if result.is_negated() {
                 if !result.matches() {
                     ignored = false;
+                } else if is_dir && ignored && negated_pattern_matches_under_dir(pattern, rel) {
+                    // The negation didn't match the directory itself, but it can
+                    // match paths beneath it. Keep the directory so those paths
+                    // are visited; files inside are still filtered individually.
+                    ignored = false;
                 }
             } else if result.matches() {
                 ignored = true;
@@ -1677,6 +1683,63 @@ fn is_excluded<'a>(
         None
     } else {
         Some((ignore_pattern, ignore_kind))
+    }
+}
+
+/// For a negated pattern that did not match a directory, returns true if it could
+/// still match a path inside that directory. `dir_rel` is the directory path
+/// relative to the ignore file that owns `pattern`.
+///
+/// npm's ignore-walk does the equivalent check via minimatch's `partial` option
+/// when deciding whether to descend into an otherwise-excluded directory.
+fn negated_pattern_matches_under_dir(pattern: &Pattern, dir_rel: &[u8]) -> bool {
+    debug_assert!(pattern.flags.contains(PatternFlags::NEGATED));
+
+    if pattern.flags.contains(PatternFlags::LEADING_DOUBLESTAR_SLASH) {
+        // `!**/foo...` can match at any depth.
+        return true;
+    }
+    if !pattern.flags.contains(PatternFlags::REL_PATH) {
+        // Single-segment negations match basenames; the directory itself was
+        // already tested above and didn't match.
+        return false;
+    }
+
+    let glob = pattern.glob.slice();
+    debug_assert!(!glob.is_empty() && glob[0] == b'!');
+    partial_path_match(&glob[1..], dir_rel)
+}
+
+/// Segment-wise prefix match: returns true if some path beginning with
+/// `dir_path/` could match `glob`.
+fn partial_path_match(glob: &[u8], dir_path: &[u8]) -> bool {
+    let mut glob_rest = glob;
+    let mut path_rest = dir_path;
+    loop {
+        let (glob_seg, glob_tail) = match strings::index_of_char(glob_rest, b'/') {
+            Some(i) => (&glob_rest[..i as usize], &glob_rest[(i as usize) + 1..]),
+            None => (glob_rest, &b""[..]),
+        };
+        if glob_seg == b"**" {
+            return true;
+        }
+        if path_rest.is_empty() {
+            // Directory segments are exhausted but the pattern still has at
+            // least `glob_seg` left to match deeper paths.
+            return true;
+        }
+        let (path_seg, path_tail) = match strings::index_of_char(path_rest, b'/') {
+            Some(i) => (&path_rest[..i as usize], &path_rest[(i as usize) + 1..]),
+            None => (path_rest, &b""[..]),
+        };
+        if !glob::r#match(glob_seg, path_seg).matches() {
+            return false;
+        }
+        if glob_tail.is_empty() {
+            return false;
+        }
+        glob_rest = glob_tail;
+        path_rest = path_tail;
     }
 }
 

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1683,9 +1683,7 @@ fn is_excluded<'a>(
     }
 }
 
-/// True if `pattern` (negated) could match some path under the directory at
-/// `dir_rel`. Mirrors npm ignore-walk's minimatch `partial` test so that
-/// `*` + `!dist/**` still descends into `dist/`.
+/// Mirrors npm ignore-walk's minimatch `partial` test so `*` + `!dist/**` still descends into `dist/`.
 fn negated_pattern_matches_under_dir(pattern: &Pattern, dir_rel: &[u8]) -> bool {
     debug_assert!(pattern.flags.contains(PatternFlags::NEGATED));
     if pattern

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1695,7 +1695,10 @@ fn is_excluded<'a>(
 fn negated_pattern_matches_under_dir(pattern: &Pattern, dir_rel: &[u8]) -> bool {
     debug_assert!(pattern.flags.contains(PatternFlags::NEGATED));
 
-    if pattern.flags.contains(PatternFlags::LEADING_DOUBLESTAR_SLASH) {
+    if pattern
+        .flags
+        .contains(PatternFlags::LEADING_DOUBLESTAR_SLASH)
+    {
         // `!**/foo...` can match at any depth.
         return true;
     }

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -1448,9 +1448,15 @@ describe(".gitignore/.npmignore", () => {
 
     // each expected list below matches `npm pack` output for the same .npmignore
     for (const [ignore, expected] of [
-      ["*\n!dist/**\n", ["package/dist/cli.js", "package/dist/lib/foo.js", "package/dist/sub/deep.js", "package/package.json"]],
+      [
+        "*\n!dist/**\n",
+        ["package/dist/cli.js", "package/dist/lib/foo.js", "package/dist/sub/deep.js", "package/package.json"],
+      ],
       ["*\n!dist/*\n", ["package/dist/cli.js", "package/package.json"]],
-      ["*\n!dist/**/*\n", ["package/dist/cli.js", "package/dist/lib/foo.js", "package/dist/sub/deep.js", "package/package.json"]],
+      [
+        "*\n!dist/**/*\n",
+        ["package/dist/cli.js", "package/dist/lib/foo.js", "package/dist/sub/deep.js", "package/package.json"],
+      ],
       ["*\n!dist/lib/foo.js\n", ["package/dist/lib/foo.js", "package/package.json"]],
       ["*\n!*/keep.js\n", ["package/package.json", "package/src/keep.js"]],
       ["*\n!**/keep.js\n", ["package/keep.js", "package/package.json", "package/src/keep.js"]],
@@ -1458,7 +1464,10 @@ describe(".gitignore/.npmignore", () => {
       // patterns that already matched npm before the fix:
       ["*\n!dist\n", ["package/package.json"]],
       ["*\n!keep.js\n", ["package/keep.js", "package/package.json"]],
-      ["*\n!dist\n!dist/**/*\n", ["package/dist/cli.js", "package/dist/lib/foo.js", "package/dist/sub/deep.js", "package/package.json"]],
+      [
+        "*\n!dist\n!dist/**/*\n",
+        ["package/dist/cli.js", "package/dist/lib/foo.js", "package/dist/sub/deep.js", "package/package.json"],
+      ],
     ] as const) {
       test(JSON.stringify(ignore), async () => {
         await setup(ignore);

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -1424,6 +1424,48 @@ describe(".gitignore/.npmignore", () => {
     const tarball = readTarball(join(packageDir, "pack-ignore-2-1.2.1.tgz"));
     expect(tarball.entries).toMatchObject([{ "pathname": "package/package.json" }]);
   });
+
+  // https://github.com/oven-sh/bun/issues/15602
+  describe("negation re-includes files inside an excluded directory", () => {
+    async function setup(ignore: string) {
+      await Promise.all([
+        write(join(packageDir, "package.json"), JSON.stringify({ name: "pack-ignore-3", version: "0.0.7" })),
+        write(join(packageDir, ".npmignore"), ignore),
+        write(join(packageDir, "dist", "cli.js"), "a"),
+        write(join(packageDir, "dist", "sub", "deep.js"), "b"),
+        write(join(packageDir, "dist", "lib", "foo.js"), "c"),
+        write(join(packageDir, "src", "index.ts"), "d"),
+        write(join(packageDir, "src", "keep.js"), "e"),
+        write(join(packageDir, "keep.js"), "f"),
+      ]);
+    }
+
+    async function packedPaths() {
+      await pack(packageDir, bunEnv);
+      const tarball = readTarball(join(packageDir, "pack-ignore-3-0.0.7.tgz"));
+      return tarball.entries.map((e: { pathname: string }) => e.pathname).sort();
+    }
+
+    // each expected list below matches `npm pack` output for the same .npmignore
+    for (const [ignore, expected] of [
+      ["*\n!dist/**\n", ["package/dist/cli.js", "package/dist/lib/foo.js", "package/dist/sub/deep.js", "package/package.json"]],
+      ["*\n!dist/*\n", ["package/dist/cli.js", "package/package.json"]],
+      ["*\n!dist/**/*\n", ["package/dist/cli.js", "package/dist/lib/foo.js", "package/dist/sub/deep.js", "package/package.json"]],
+      ["*\n!dist/lib/foo.js\n", ["package/dist/lib/foo.js", "package/package.json"]],
+      ["*\n!*/keep.js\n", ["package/package.json", "package/src/keep.js"]],
+      ["*\n!**/keep.js\n", ["package/keep.js", "package/package.json", "package/src/keep.js"]],
+      ["*\n!dist/**\ndist/sub\n", ["package/dist/cli.js", "package/dist/lib/foo.js", "package/package.json"]],
+      // patterns that already matched npm before the fix:
+      ["*\n!dist\n", ["package/package.json"]],
+      ["*\n!keep.js\n", ["package/keep.js", "package/package.json"]],
+      ["*\n!dist\n!dist/**/*\n", ["package/dist/cli.js", "package/dist/lib/foo.js", "package/dist/sub/deep.js", "package/package.json"]],
+    ] as const) {
+      test(JSON.stringify(ignore), async () => {
+        await setup(ignore);
+        expect(await packedPaths()).toEqual([...expected]);
+      });
+    }
+  });
 });
 
 describe("bins", () => {


### PR DESCRIPTION
Fixes #15602.

## Problem

With an `.npmignore` like:

```
*
!dist/**
```

`bun pm pack` prunes `dist/` at the directory level (because `*` matches it) before `!dist/**` ever gets a chance to re-include the files inside. npm handles this correctly via ignore-walk, which does a minimatch `partial` test against negated rules when deciding whether to descend into a directory.

```sh
$ mkdir -p dist src && echo a > dist/cli.js && echo b > src/index.ts
$ printf '{"name":"pkg","version":"0.0.7"}' > package.json
$ printf '*\n!dist/**\n' > .npmignore

$ bun pm pack --dry-run   # before: only package.json
$ npm pack --dry-run      # dist/cli.js, package.json
```

The same applies to `!dist/*`, `!dist/**/*`, `!dist/lib/foo.js`, `!*/keep.js`, and `!**/keep.js`.

## Fix

`is_excluded` now checks, for directory entries only: if a negated pattern doesn't match the directory itself but could match a path beneath it (segment-wise prefix match, equivalent to minimatch's `partial`), keep the directory in the walk. Files inside are still filtered individually, so only paths a negation actually matches end up in the tarball. Pattern order is preserved, so a later positive rule (e.g. `*` / `!dist/**` / `dist/sub`) still re-excludes correctly.

## Verification

New parameterized tests in `test/cli/install/bun-pack.test.ts` cover ten `.npmignore` variants; each expected file list was taken from `npm pack --dry-run` (npm 11.16.0) on the same fixture. 7 of the 10 fail on current main and all 10 pass with this change. The full `bun-pack.test.ts` suite (86 tests) passes.