### PR TITLE
Bun.serve: cancel the piped upstream fetch when the client aborts while backpressured

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3262,7 +3262,6 @@ where
             if !this.flags.has_written_status() {
                 let global_this = this.server().global_this();
                 let js_err = err.to_js(global_this);
-                this.byte_stream.set(None);
                 this.response_body_readable_stream_ref
                     .with_mut(|s| s.deinit());
                 this.run_error_handler(js_err);

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1399,7 +1399,8 @@ where
         if let Some(byte_stream) = this.byte_stream.take() {
             bun_ptr::BackRef::from(byte_stream).cancel_from_sink(None);
             any_js_calls.set(true);
-            this.response_body_readable_stream_ref.with_mut(|s| s.deinit());
+            this.response_body_readable_stream_ref
+                .with_mut(|s| s.deinit());
             this.deref();
         }
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1396,6 +1396,13 @@ where
             return;
         }
 
+        if let Some(byte_stream) = this.byte_stream.take() {
+            bun_ptr::BackRef::from(byte_stream).cancel_from_sink(None);
+            any_js_calls.set(true);
+            this.response_body_readable_stream_ref.with_mut(|s| s.deinit());
+            this.deref();
+        }
+
         // if we can, free the request now.
         if this.is_dead_request() {
             this.finalize_without_deinit();
@@ -3240,6 +3247,7 @@ where
         // SAFETY: caller passes the live `*mut RequestContext` stored as the
         // sink ctx; `_ref` keeps it alive for this call.
         let this = unsafe { &*this };
+        this.byte_stream.set(None);
 
         if this.is_aborted_or_ended() {
             return;

--- a/test/js/bun/http/serve-fetch-body-abort-backpressure-fixture.ts
+++ b/test/js/bun/http/serve-fetch-body-abort-backpressure-fixture.ts
@@ -1,0 +1,11 @@
+// Proxy under test: returns a fetch() Response whose body is the native
+// ByteStream from the upstream.
+const upstream = process.argv[2];
+
+const proxy = Bun.serve({
+  port: 0,
+  idleTimeout: 255,
+  fetch: () => fetch(upstream),
+});
+
+console.log(JSON.stringify({ proxyPort: proxy.port }));

--- a/test/js/bun/http/serve-fetch-body-abort-backpressure.test.ts
+++ b/test/js/bun/http/serve-fetch-body-abort-backpressure.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import net from "node:net";
+import { join } from "node:path";
+
+// A client that aborts while Bun.serve is holding an upstream fetch() body
+// paused for backpressure must not leave the upstream parked: on_abort has
+// to cancel the ByteStream sink so the proxy tears down its connection to
+// the upstream.
+test("client abort while a fetch() body is backpressured cancels the upstream", async () => {
+  const CHUNK = 256 * 1024;
+  const CAP_CHUNKS = 256;
+
+  let pulls = 0;
+  let cancelled = false;
+
+  await using upstream = Bun.serve({
+    port: 0,
+    idleTimeout: 255,
+    fetch() {
+      return new Response(
+        new ReadableStream({
+          async pull(controller) {
+            controller.enqueue(new Uint8Array(CHUNK));
+            pulls++;
+            if (pulls >= CAP_CHUNKS) return controller.close();
+            if (pulls % 32 === 0) await Bun.sleep(0);
+          },
+          cancel() {
+            cancelled = true;
+          },
+        }),
+        { headers: { "content-length": String(CHUNK * CAP_CHUNKS) } },
+      );
+    },
+  });
+
+  await using proxy = Bun.spawn({
+    cmd: [
+      bunExe(),
+      join(import.meta.dir, "serve-fetch-body-abort-backpressure-fixture.ts"),
+      `http://127.0.0.1:${upstream.port}/`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+
+  const reader = proxy.stdout.getReader();
+  let head = "";
+  while (!head.includes("\n")) {
+    const { value, done } = await reader.read();
+    if (done) throw new Error("proxy exited before reporting port");
+    head += Buffer.from(value).toString("utf8");
+  }
+  reader.releaseLock();
+  const { proxyPort } = JSON.parse(head.slice(0, head.indexOf("\n")));
+
+  const failed = Promise.withResolvers<never>();
+  proxy.exited.then(code => failed.reject(new Error(`proxy exited early (code ${code})`)));
+
+  const socket = net.connect(proxyPort, "127.0.0.1");
+  try {
+    const stalled = Promise.withResolvers<void>();
+    socket.on("error", e => failed.reject(e));
+    socket.on("connect", () => socket.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"));
+    socket.once("data", () => {
+      socket.pause();
+      stalled.resolve();
+    });
+    await Promise.race([stalled.promise, failed.promise]);
+
+    // Wait until the upstream pull count stops growing (backpressure engaged)
+    // or the upstream produces the whole capped body (no backpressure at all).
+    let lastPulls = -1;
+    let stableTurns = 0;
+    while (pulls < CAP_CHUNKS && stableTurns < 12) {
+      await Bun.sleep(25);
+      if (pulls === lastPulls) stableTurns++;
+      else {
+        stableTurns = 0;
+        lastPulls = pulls;
+      }
+    }
+    expect(pulls).toBeLessThan(CAP_CHUNKS / 2);
+  } finally {
+    socket.removeAllListeners("error");
+    socket.on("error", () => {});
+    socket.destroy();
+  }
+
+  // The proxy's on_abort should cancel its fetch to the upstream; the
+  // upstream's serve then cancels the ReadableStream. Poll for that signal.
+  for (let i = 0; i < 200 && !cancelled; i++) await Bun.sleep(10);
+
+  expect({ cancelled, pullsUnderCap: pulls < CAP_CHUNKS, pulls }).toMatchObject({
+    cancelled: true,
+    pullsUnderCap: true,
+  });
+  expect(proxy.exitCode).toBeNull();
+  expect(proxy.signalCode).toBeNull();
+});


### PR DESCRIPTION
Follow-up to #36087, carrying over the abort-path fix from the now-closed #35547 that the SinkHandle rewrite did not pick up.

## Repro

```js
Bun.serve({ fetch: () => fetch(upstream) });
```

Upstream streams a 64 MiB body. Client pauses after the first chunk so the proxy's `write_chunk` returns `Backpressure` and the `ByteStream` parks with `sink_paused = true`. Client then destroys the socket.

On main (f91d5c9): the upstream `ReadableStream`'s `cancel()` never fires; pulls stay at whatever count they reached when backpressure engaged, and the proxy's `RequestContext` plus the upstream FetchTasklet/socket stay parked until the upstream server's idle timeout.

## Cause

`on_abort` handles `this.sink` (the JS-stream sink path) but not `this.byte_stream` (the native `SinkHandle::ServerResponse` path). The `else` branch's `response_body_stream()` returns `None` because the body was already set to `Used`. The sink-install ref taken in `do_render_with_body` is only dropped in `end_chunk`, which is reached via `sink.end()` from `ByteStream::resume()`, and `resume()` only runs from `on_writable_byte_stream`, which never fires on a closed socket.

## Fix

- `on_abort`: when `byte_stream` is set, call `cancel_from_sink()` on it (detaches the sink and closes the producer, which aborts the upstream fetch), deinit the held `response_body_readable_stream_ref`, and drop the sink-install ref.
- `end_chunk`: clear `this.byte_stream` so the field tracks whether that ref is still held, keeping the two release sites mutually exclusive.

## Verification

`test/js/bun/http/serve-fetch-body-abort-backpressure.test.ts` stalls a raw-socket client against a proxy child, destroys the socket while the upstream is held paused, and asserts the upstream `ReadableStream.cancel()` fires and the proxy child is still alive. On main it fails with `{ cancelled: false, pulls: ~22 }`; with the fix it passes in ~1s.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 17 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-fetch-body-abort-backpressure.test.ts
bun test v1.4.0 (96b99d407)

test/js/bun/http/serve-fetch-body-abort-backpressure.test.ts:
91 | 
92 |   // The proxy's on_abort should cancel its fetch to the upstream; the
93 |   // upstream's serve then cancels the ReadableStream. Poll for that signal.
94 |   for (let i = 0; i < 200 && !cancelled; i++) await Bun.sleep(10);
95 | 
96 |   expect({ cancelled, pullsUnderCap: pulls < CAP_CHUNKS, pulls }).toMatchObject({
                                                                       ^
error: expect(received).toMatchObject(expected)

  {
-   "cancelled": true,
+   "cancelled": false,
+   "pulls": 23,
    "pullsUnderCap": true,
  }

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/bun/http/serve-fetch-body-abort-backpressure.test.ts:96:67)
(fail) client abort while a fetch() body is backpressured cancels the upstream [3134.15ms]

 0 pass
 1 fail
 2 expect() calls
Ran 1 test across 1 file. [5.33s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (9ccdf0d66)

test/js/bun/http/serve-fetch-body-abort-backpressure.test.ts:
(pass) client abort while a fetch() body is backpressured cancels the upstream [381.40ms]

 1 pass
 0 fail
 4 expect() calls
Ran 1 test across 1 file. [528.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-fetch-body-abort-backpressure.test.ts
bun test v1.4.0 (96b99d407)

test/js/bun/http/serve-fetch-body-abort-backpressure.test.ts:
(pass) client abort while a fetch() body is backpressured cancels the upstream [1065.84ms]

 1 pass
 0 fail
 4 expect() calls
Ran 1 test across 1 file. [3.29s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 774ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 238 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (9121ms)
Bundle modules (42ms)
Postprocesss modules (217ms)
Bundle Functions (724ms)
Generate Code (34ms)

[10.16s] Bundled "src/js" for production
  2558 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/RequestContext.rs               |  10 +-
 .../serve-fetch-body-abort-backpressure-fixture.ts |  11 +++
 .../serve-fetch-body-abort-backpressure.test.ts    | 102 +++++++++++++++++++++
 3 files changed, 122 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 17

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/server/RequestContext.rs                         18     19      0
…bun/http/serve-fetch-body-abort-backpressure-fixture.ts      0      2      0
…js/bun/http/serve-fetch-body-abort-backpressure.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->