### PR TITLE
install: skip .bin link recreate when the existing symlink already matches

### DIFF
--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -1320,6 +1320,21 @@ impl<'a> Linker<'a> {
             }
         }
 
+        // If the existing link already points at the intended target, the
+        // install is a no-op here. Skipping the delete+recreate lets a fully
+        // populated node_modules on a read-only mount (docker `:ro`) pass
+        // through: the unlink below would fail with EACCES/EROFS and the retry
+        // symlink would then surface the original EEXIST.
+        {
+            let mut existing = path::path_buffer_pool::get();
+            if let Ok(n) = sys::readlink(abs_dest, &mut existing) {
+                if existing[..n] == *rel_target.as_bytes() {
+                    Self::chmod_on_ok(self.err, abs_target);
+                    return;
+                }
+            }
+        }
+
         // delete and try again
         let _ = sys::delete_tree_absolute(abs_dest.as_bytes());
         if let Err(err) = sys::symlink_running_executable(rel_target, abs_dest) {

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -1301,11 +1301,7 @@ impl<'a> Linker<'a> {
                     Self::chmod_on_ok(self.err, abs_target);
                     return;
                 }
-                // Something already occupies the destination, or the tree is
-                // read-only (docker `:ro`, a protected CI cache). If a link is
-                // already there with the right target the install is a no-op
-                // here; falling through to delete+recreate would surface the
-                // original error even though nothing needs to change.
+                // Destination occupied or read-only: done if the right link is already there.
                 sys::Errno::EEXIST | sys::Errno::EPERM | sys::Errno::EACCES => {
                     let mut existing = path::path_buffer_pool::get();
                     if let Ok(n) = sys::readlink(abs_dest, &mut existing) {

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -1275,15 +1275,13 @@ impl<'a> Linker<'a> {
         debug_assert!(strings::has_prefix(rel_target.as_bytes(), b".."));
 
         match sys::symlink_running_executable(rel_target, abs_dest) {
-            sys::Result::Err(err) => {
-                if err.get_errno() != sys::Errno::EEXIST && err.get_errno() != sys::Errno::ENOENT {
-                    self.err = Some(err.into());
-                    Self::chmod_on_ok(self.err, abs_target);
-                    return;
-                }
-
-                // ENOENT means `.bin` hasn't been created yet. Should only happen if this isn't global
-                if err.get_errno() == sys::Errno::ENOENT {
+            sys::Result::Ok(()) => {
+                Self::chmod_on_ok(self.err, abs_target);
+                return;
+            }
+            sys::Result::Err(err) => match err.get_errno() {
+                // `.bin` hasn't been created yet. Should only happen if this isn't global.
+                sys::Errno::ENOENT => {
                     if global {
                         self.err = Some(err.into());
                         Self::chmod_on_ok(self.err, abs_target);
@@ -1297,42 +1295,32 @@ impl<'a> Linker<'a> {
                     let _ = sys::Dir::cwd().make_path(self.node_modules_path.slice());
                     self.node_modules_path.set_length(node_modules_path_save);
 
-                    match sys::symlink_running_executable(rel_target, abs_dest) {
-                        sys::Result::Err(real_error) => {
-                            // It was just created, no need to delete destination and symlink again
-                            self.err = Some(real_error.into());
-                            Self::chmod_on_ok(self.err, abs_target);
-                            return;
-                        }
-                        sys::Result::Ok(()) => {
+                    if let Err(real_error) = sys::symlink_running_executable(rel_target, abs_dest) {
+                        self.err = Some(real_error.into());
+                    }
+                    Self::chmod_on_ok(self.err, abs_target);
+                    return;
+                }
+                // Something already occupies the destination, or the tree is
+                // read-only (docker `:ro`, a protected CI cache). If a link is
+                // already there with the right target the install is a no-op
+                // here; falling through to delete+recreate would surface the
+                // original error even though nothing needs to change.
+                sys::Errno::EEXIST | sys::Errno::EPERM | sys::Errno::EACCES => {
+                    let mut existing = path::path_buffer_pool::get();
+                    if let Ok(n) = sys::readlink(abs_dest, &mut existing) {
+                        if existing[..n] == *rel_target.as_bytes() {
                             Self::chmod_on_ok(self.err, abs_target);
                             return;
                         }
                     }
                 }
-
-                // beyond this error can only be `.EXIST`
-                debug_assert!(err.get_errno() == sys::Errno::EEXIST);
-            }
-            sys::Result::Ok(()) => {
-                Self::chmod_on_ok(self.err, abs_target);
-                return;
-            }
-        }
-
-        // If the existing link already points at the intended target, the
-        // install is a no-op here. Skipping the delete+recreate lets a fully
-        // populated node_modules on a read-only mount (docker `:ro`) pass
-        // through: the unlink below would fail with EACCES/EROFS and the retry
-        // symlink would then surface the original EEXIST.
-        {
-            let mut existing = path::path_buffer_pool::get();
-            if let Ok(n) = sys::readlink(abs_dest, &mut existing) {
-                if existing[..n] == *rel_target.as_bytes() {
+                _ => {
+                    self.err = Some(err.into());
                     Self::chmod_on_ok(self.err, abs_target);
                     return;
                 }
-            }
+            },
         }
 
         // delete and try again

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -2448,11 +2448,6 @@ describe("binaries", () => {
     expect(binPath).toBeValidBin(join("..", "what-bin", "what-bin.js"));
     const before = lstatSync(binPath, { bigint: true });
 
-    // Emulate the `./:/app:ro` Docker-compose mount from the issue: an
-    // already-populated node_modules that cannot be written to. With the link
-    // already pointing at the right target, a second install must be a no-op
-    // rather than unlink+re-symlink (the unlink would fail, and the retry
-    // symlink would then surface EEXIST as "Failed to link what-bin").
     chmodSync(binDir, 0o555);
     let err: string, exitCode: number;
     try {

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -1,7 +1,7 @@
 import { file, spawn, write } from "bun";
 import { install_test_helpers, npm_manifest_test_helpers } from "bun:internal-for-testing";
 import { afterAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { copyFileSync, mkdirSync } from "fs";
+import { chmodSync, copyFileSync, lstatSync, mkdirSync } from "fs";
 import { cp, exists, lstat, mkdir, readlink, rm, writeFile } from "fs/promises";
 import {
   assertManifestsPopulated,
@@ -2431,6 +2431,53 @@ describe("binaries", () => {
       });
     });
   }
+
+  // https://github.com/oven-sh/bun/issues/14736
+  test.skipIf(isWindows)("reinstall keeps an already-correct .bin link untouched on a read-only tree", async () => {
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: { "what-bin": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall(env, packageDir);
+    const binDir = join(packageDir, "node_modules", ".bin");
+    const binPath = join(binDir, "what-bin");
+    expect(binPath).toBeValidBin(join("..", "what-bin", "what-bin.js"));
+    const before = lstatSync(binPath, { bigint: true });
+
+    // Emulate the `./:/app:ro` Docker-compose mount from the issue: an
+    // already-populated node_modules that cannot be written to. With the link
+    // already pointing at the right target, a second install must be a no-op
+    // rather than unlink+re-symlink (the unlink would fail, and the retry
+    // symlink would then surface EEXIST as "Failed to link what-bin").
+    chmodSync(binDir, 0o555);
+    let err: string, exitCode: number;
+    try {
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      [, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    } finally {
+      chmodSync(binDir, 0o755);
+    }
+
+    expect(err).not.toContain("Failed to link");
+    expect(err).not.toContain("error:");
+    expect(binPath).toBeValidBin(join("..", "what-bin", "what-bin.js"));
+    // ctimeNs moves whenever the inode is recreated (unlink + symlink); proves
+    // the skip even on hosts (root) where the chmod above cannot block writes.
+    const after = lstatSync(binPath, { bigint: true });
+    expect({ ino: after.ino, ctimeNs: after.ctimeNs }).toEqual({ ino: before.ino, ctimeNs: before.ctimeNs });
+    expect(exitCode).toBe(0);
+  });
+
   test("it should correctly link binaries after deleting node_modules", async () => {
     const json: any = {
       name: "foo",


### PR DESCRIPTION
Fixes #14736.

## Repro

With a project whose `node_modules` (including `node_modules/.bin/tsc`) is already fully installed and then mounted read-only (the docker-compose `./:/home/bun/app:ro` pattern from the issue, or `chmod -R a-w` as an unprivileged user):

```
$ bun install && bun index.ts
error: Failed to link typescript: EEXIST
```

## Cause

On every install, including a no-op one, the hoisted/isolated bin linker re-links each package bin. `create_symlink` in `src/install/bin.rs` handles the common case where `node_modules/.bin/<name>` already exists by unconditionally `unlink` + re-`symlink`. On a read-only tree the unlink fails (error discarded) and the retry symlink returns the original `EEXIST`, which surfaces as `Failed to link <pkg>: EEXIST` and fails the install even though nothing needed to change.

## Fix

When the first `symlink` returns `EEXIST`, `readlink` the existing destination and compare against the relative target we were about to write. If they already match, return success and skip the delete+recreate entirely. A stale link (or a non-symlink, where `readlink` fails) still falls through to the existing delete+retry path, so version upgrades and the "existing non-symlink" case keep replacing the destination.

## Verification

New test `binaries > reinstall keeps an already-correct .bin link untouched on a read-only tree` in `test/cli/install/bun-install-registry.test.ts`:

- installs `what-bin@1.0.0`, makes `node_modules/.bin` mode `0555`, reinstalls
- asserts no `Failed to link` / `error:` in stderr and exit 0
- asserts the symlink's `ino`/`ctimeNs` are unchanged, so the skip is observable even on hosts where root bypasses the chmod

Before: ctime/inode change on every reinstall; on unprivileged hosts the reinstall errors with `Failed to link what-bin: EEXIST`.
After: second install is a true no-op on the `.bin` entry.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->