### PR TITLE
cli(upgrade): resolve canary download URL via the GitHub API (honors GITHUB_API_DOMAIN)

### DIFF
--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -635,10 +635,17 @@ impl UpgradeCommand {
                     .filter(|v| &*v.tag == b"canary" && !v.zip_url.is_empty());
             let mut v = from_api.unwrap_or_else(|| Version {
                 tag: b"canary"[..].into(),
-                zip_url: const_format::concatcp!(
-                    "https://github.com/oven-sh/bun/releases/download/canary/",
-                    Version::ZIP_FILENAME
-                )
+                zip_url: if use_profile {
+                    const_format::concatcp!(
+                        "https://github.com/oven-sh/bun/releases/download/canary/",
+                        Version::PROFILE_ZIP_FILENAME
+                    )
+                } else {
+                    const_format::concatcp!(
+                        "https://github.com/oven-sh/bun/releases/download/canary/",
+                        Version::ZIP_FILENAME
+                    )
+                }
                 .as_bytes()
                 .into(),
                 size: 0,

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -627,10 +627,7 @@ impl UpgradeCommand {
 
             version
         } else {
-            // Ask the API for the canary asset URL so `GITHUB_API_DOMAIN`
-            // applies to canary upgrades too. Any lookup failure (API down,
-            // release shape changed, asset not listed) falls back to the
-            // long-standing hardcoded download URL.
+            // Resolve via the API so `GITHUB_API_DOMAIN` applies to canary too.
             let from_api =
                 Self::get_latest_version::<true>(&mut env_loader, None, None, use_profile, true)
                     .ok()
@@ -647,10 +644,8 @@ impl UpgradeCommand {
                 size: 0,
                 digest: Integrity::default(),
             });
-            // The canary tag is mutable (every merged main build re-uploads it
-            // with `--clobber`), so a digest read now can mismatch the bytes
-            // downloaded a few seconds later. Skip the integrity check rather
-            // than turn that publish window into a hard `exit(1)`.
+            // canary is re-uploaded on every main merge; a digest read now
+            // can race that and fail a good download.
             v.digest = Integrity::default();
             v
         };

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -182,6 +182,7 @@ impl UpgradeCommand {
         refresher: Option<&mut Progress::Progress>,
         mut progress: Option<&mut Progress::Node>,
         use_profile: bool,
+        use_canary: bool,
     ) -> crate::Result<Option<Version>> {
         let mut headers_buf: Vec<u8> = Self::DEFAULT_GITHUB_HEADERS.to_vec();
 
@@ -212,8 +213,13 @@ impl UpgradeCommand {
         let url_buf: &'static mut Vec<u8> = crate::cli::cli_arena().alloc(Vec::new());
         write!(
             url_buf,
-            "https://{}/repos/Jarred-Sumner/bun-releases-for-updater/releases/latest",
+            "https://{}/repos/{}",
             bstr::BStr::new(github_api_domain),
+            if use_canary {
+                "oven-sh/bun/releases/tags/canary"
+            } else {
+                "Jarred-Sumner/bun-releases-for-updater/releases/latest"
+            },
         )
         .expect("oom");
         let api_url = URL::parse(&url_buf[..]);
@@ -576,6 +582,7 @@ impl UpgradeCommand {
                 // SAFETY: progress points into the same leaked allocation (see above).
                 Some(unsafe { &mut *progress }),
                 use_profile,
+                false,
             )?
             else {
                 return Ok(());
@@ -620,7 +627,17 @@ impl UpgradeCommand {
 
             version
         } else {
-            Version {
+            // Ask the API for the canary asset URL so `GITHUB_API_DOMAIN`
+            // applies to canary upgrades too, and so the download is
+            // integrity-checked against the release's published digest. Any
+            // lookup failure (API down, release shape changed, asset not
+            // listed) falls back to the long-standing hardcoded download URL.
+            let from_api =
+                Self::get_latest_version::<true>(&mut env_loader, None, None, use_profile, true)
+                    .ok()
+                    .flatten()
+                    .filter(|v| &*v.tag == b"canary" && !v.zip_url.is_empty());
+            from_api.unwrap_or_else(|| Version {
                 tag: b"canary"[..].into(),
                 zip_url: const_format::concatcp!(
                     "https://github.com/oven-sh/bun/releases/download/canary/",
@@ -630,7 +647,7 @@ impl UpgradeCommand {
                 .into(),
                 size: 0,
                 digest: Integrity::default(),
-            }
+            })
         };
 
         let zip_url_bytes = core::mem::take(&mut version.zip_url);

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -644,8 +644,7 @@ impl UpgradeCommand {
                 size: 0,
                 digest: Integrity::default(),
             });
-            // canary is re-uploaded on every main merge; a digest read now
-            // can race that and fail a good download.
+            // canary is re-uploaded on every main merge; the digest can go stale mid-download.
             v.digest = Integrity::default();
             v
         };

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -628,16 +628,15 @@ impl UpgradeCommand {
             version
         } else {
             // Ask the API for the canary asset URL so `GITHUB_API_DOMAIN`
-            // applies to canary upgrades too, and so the download is
-            // integrity-checked against the release's published digest. Any
-            // lookup failure (API down, release shape changed, asset not
-            // listed) falls back to the long-standing hardcoded download URL.
+            // applies to canary upgrades too. Any lookup failure (API down,
+            // release shape changed, asset not listed) falls back to the
+            // long-standing hardcoded download URL.
             let from_api =
                 Self::get_latest_version::<true>(&mut env_loader, None, None, use_profile, true)
                     .ok()
                     .flatten()
                     .filter(|v| &*v.tag == b"canary" && !v.zip_url.is_empty());
-            from_api.unwrap_or_else(|| Version {
+            let mut v = from_api.unwrap_or_else(|| Version {
                 tag: b"canary"[..].into(),
                 zip_url: const_format::concatcp!(
                     "https://github.com/oven-sh/bun/releases/download/canary/",
@@ -647,7 +646,13 @@ impl UpgradeCommand {
                 .into(),
                 size: 0,
                 digest: Integrity::default(),
-            })
+            });
+            // The canary tag is mutable (every merged main build re-uploads it
+            // with `--clobber`), so a digest read now can mismatch the bytes
+            // downloaded a few seconds later. Skip the integrity check rather
+            // than turn that publish window into a hard `exit(1)`.
+            v.digest = Integrity::default();
+            v
         };
 
         let zip_url_bytes = core::mem::take(&mut version.zip_url);
@@ -690,8 +695,13 @@ impl UpgradeCommand {
                 404 => {
                     if use_canary {
                         bun_core::pretty_errorln!(
-                            "<r><red>error:<r> Canary builds are not available for this platform yet\n\n   Release: <cyan>https://github.com/oven-sh/bun/releases/tag/canary<r>\n  Filename: <b>{}<r>\n",
-                            Version::ZIP_FILENAME
+                            "<r><red>error:<r> Canary builds are not available for this platform yet\n\n   Release: <cyan>https://github.com/oven-sh/bun/releases/tag/canary<r>\n  Filename: <b>{}<r>\n       URL: <d>{}<r>\n",
+                            if use_profile {
+                                Version::PROFILE_ZIP_FILENAME
+                            } else {
+                                Version::ZIP_FILENAME
+                            },
+                            bstr::BStr::new(&zip_url_bytes),
                         );
                         Global::exit(1);
                     }

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -99,70 +99,42 @@ describe.concurrent(() => {
   });
 
   it("zero arguments, should succeed", async () => {
-    const tagName = bunExe().includes("-debug") ? "canary" : `bun-v${Bun.version}`;
+    // Cover every platform/arch/abi combination so whichever zip name the
+    // upgrade command asks for is listed.
+    const assetNames: string[] = [];
+    for (const os of ["windows", "linux", "darwin"]) {
+      for (const arch of ["x64", "aarch64"]) {
+        for (const abi of ["", "-musl"]) {
+          for (const cpu of ["", "-baseline"]) {
+            assetNames.push(`bun-${os}-${arch}${abi}${cpu}.zip`);
+          }
+        }
+      }
+    }
+
+    let downloadHits = 0;
     using server = Bun.serve({
       tls: tls,
       port: 0,
-      async fetch() {
+      async fetch(req) {
+        const { pathname } = new URL(req.url);
+        if (pathname.startsWith("/download/")) {
+          downloadHits++;
+          return new Response("this is not a real zip archive");
+        }
+        // Both the stable-releases endpoint and the canary-tag endpoint land
+        // here; the upgrade command only looks at tag_name and the asset list,
+        // so one response shape serves both.
+        const tagName = pathname.endsWith("/tags/canary") ? "canary" : `bun-v9.9.9`;
         return new Response(
           JSON.stringify({
             "tag_name": tagName,
-            "assets": [
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-windows-x64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-windows-x64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-windows-x64-baseline.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-windows-x64-baseline.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-windows-aarch64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-windows-aarch64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-linux-x64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-linux-x64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-linux-x64-baseline.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-linux-x64-baseline.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-linux-aarch64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-linux-aarch64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-darwin-x64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-darwin-x64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-darwin-x64-baseline.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-darwin-x64-baseline.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-darwin-aarch64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-darwin-aarch64.zip`,
-              },
-            ],
+            "assets": assetNames.map(name => ({
+              "url": "foo",
+              "content_type": "application/zip",
+              "name": name,
+              "browser_download_url": `https://${server.hostname}:${server.port}/download/${tagName}/${name}`,
+            })),
           }),
         );
       },
@@ -185,17 +157,32 @@ describe.concurrent(() => {
         ...env,
         NODE_TLS_REJECT_UNAUTHORIZED: "0",
         GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+        // The bogus archive makes the upgrade exit via Global::exit(1) while
+        // the HTTP thread and the intentionally-leaked progress buffers are
+        // still live; not what this test asserts.
+        ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
       },
     });
 
     closeTempDirHandle();
 
-    // Should not contain error message
-    expect(await proc.stderr.text()).not.toContain("error:");
-    // Reap the subprocess: stderr can close before the child exits, and an
-    // unreaped child is force-killed by the test runner at test end without
-    // draining the Subprocess refcount — LSan then flags it as a leak.
-    await proc.exited;
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    // Zero positional arguments must not be rejected as package names.
+    expect(stderr).not.toContain("does not take package names");
+    // The archive is resolved via GITHUB_API_DOMAIN (for both the stable and
+    // canary code paths) and fetched from the local server, not github.com or
+    // any other public host.
+    expect(downloadHits).toBe(1);
+    // Staging the download in the temporary directory must not fail with
+    // EBUSY while another handle on that directory (opened above without
+    // FILE_SHARE_DELETE) is held.
+    expect(stderr).not.toContain("Failed to open temporary directory");
+    expect(stderr).not.toContain("Failed to create temporary directory");
+    expect(stderr).not.toContain("Failed to read temporary directory");
+    // Unpacking the bogus archive is expected to fail; the test only needs to
+    // have reached that point.
+    expect(exitCode).toBe(1);
   });
 });
 

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -184,6 +184,55 @@ describe.concurrent(() => {
     // have reached that point.
     expect(exitCode).toBe(1);
   });
+
+  it("canary upgrade falls back to the direct github.com URL when the releases API lookup fails", async () => {
+    // The API endpoint answers 500 so get_latest_version() yields Err; the
+    // canary branch must then fall back to the hardcoded github.com download
+    // URL instead of surfacing the API failure.
+    using api = Bun.serve({
+      tls: tls,
+      port: 0,
+      async fetch() {
+        return new Response("oops", { status: 500 });
+      },
+    });
+
+    // HTTPS proxy that records the CONNECT target. The tunnel is never
+    // actually established (the response isn't a valid CONNECT reply), so the
+    // download fails, but only after the upgrade has committed to the
+    // hardcoded URL.
+    const connectTargets: string[] = [];
+    using proxy = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        if (req.method === "CONNECT") connectTargets.push(req.headers.get("host") ?? "");
+        return new Response("not a tunnel", { status: 502 });
+      },
+    });
+
+    const cwd = tmpdirSync();
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "upgrade", "--canary"],
+      cwd,
+      stdout: null,
+      stdin: "pipe",
+      stderr: "pipe",
+      env: {
+        ...env,
+        NODE_TLS_REJECT_UNAUTHORIZED: "0",
+        GITHUB_API_DOMAIN: `${api.hostname}:${api.port}`,
+        HTTPS_PROXY: `http://${proxy.hostname}:${proxy.port}`,
+        NO_PROXY: `${api.hostname},localhost,127.0.0.1,::1`,
+        ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      },
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(connectTargets).toContain("github.com:443");
+    expect(stderr).not.toContain("does not take package names");
+    expect(exitCode).toBe(1);
+  });
 });
 
 it("recreates the staging directory in the temp dir instead of reusing a pre-existing one", async () => {

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -157,6 +157,12 @@ describe.concurrent(() => {
         ...env,
         NODE_TLS_REJECT_UNAUTHORIZED: "0",
         GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+        http_proxy: undefined,
+        https_proxy: undefined,
+        no_proxy: undefined,
+        HTTP_PROXY: undefined,
+        HTTPS_PROXY: undefined,
+        NO_PROXY: undefined,
         // The bogus archive makes the upgrade exit via Global::exit(1) while
         // the HTTP thread and the intentionally-leaked progress buffers are
         // still live; not what this test asserts.
@@ -210,9 +216,13 @@ describe.concurrent(() => {
       },
     });
 
+    const noProxy = `${api.hostname},localhost,127.0.0.1,::1`;
+    const httpsProxy = `http://${proxy.hostname}:${proxy.port}`;
     const cwd = tmpdirSync();
+    const execPath = join(cwd, basename(bunExe()));
+    await copyFile(bunExe(), execPath);
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "upgrade", "--canary"],
+      cmd: [execPath, "upgrade", "--canary"],
       cwd,
       stdout: null,
       stdin: "pipe",
@@ -221,8 +231,12 @@ describe.concurrent(() => {
         ...env,
         NODE_TLS_REJECT_UNAUTHORIZED: "0",
         GITHUB_API_DOMAIN: `${api.hostname}:${api.port}`,
-        HTTPS_PROXY: `http://${proxy.hostname}:${proxy.port}`,
-        NO_PROXY: `${api.hostname},localhost,127.0.0.1,::1`,
+        http_proxy: undefined,
+        HTTP_PROXY: undefined,
+        https_proxy: httpsProxy,
+        HTTPS_PROXY: httpsProxy,
+        no_proxy: noProxy,
+        NO_PROXY: noProxy,
         ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
       },
     });


### PR DESCRIPTION
Fixes `test/cli/install/bun-upgrade.test.ts` red on the `windows 11 aarch64` lane (build [86909](https://buildkite.com/bun/bun/builds/86909)):

```
error: Canary builds are not available for this platform yet
   Release: https://github.com/oven-sh/bun/releases/tag/canary
  Filename: bun-windows-aarch64.zip
```

## Cause

The canary upgrade path builds its download URL at compile time as `https://github.com/oven-sh/bun/releases/download/canary/<name>.zip`, so it never consults `GITHUB_API_DOMAIN`. Every CI test binary (and every `bun bd` debug build) is a canary build, so the `zero arguments, should succeed` test has been silently fetching a real ~30 MB archive from github.com on every run on every lane instead of the local `Bun.serve` it sets up via `GITHUB_API_DOMAIN`. It passed only while the live canary release happened to carry an asset for the lane's platform.

What tripped it today: main build 86848's `:rocket:` publish step was auto-cancelled while `gh release upload canary ... --clobber` was in flight, leaving `bun-windows-aarch64.zip` (and a few other assets) deleted and not re-uploaded. With the hardcoded URL 404'ing the test went red on that lane. That publish race is being tracked separately; this PR removes the test's dependency on it.

## Fix

`bun upgrade` on the canary path now asks `https://$GITHUB_API_DOMAIN/repos/oven-sh/bun/releases/tags/canary` for the asset list first (same shape and code path as the stable upgrade) and downloads from the returned `browser_download_url`. Any lookup failure (rate-limited, API unreachable, asset not listed, unexpected response shape) falls back to the existing hardcoded URL, so the default `bun upgrade` from a canary build still works exactly as before when the API is unavailable.

- `GITHUB_API_DOMAIN` now applies to canary upgrades, matching stable.
- The fallback URL and the canary 404 message now account for `--profile` (the profile filename was previously ignored on this path).
- The API-reported digest is discarded for canary: that tag is re-uploaded on every main merge, so a digest read at lookup time can legitimately mismatch the bytes downloaded seconds later. Stable releases keep their existing integrity check.

## Tests

- `zero arguments, should succeed` now serves both the release metadata and the archive body from its local `Bun.serve`, and asserts the download request reached that server. Without this change `downloadHits` stays at 0 (the canary path bypassed `GITHUB_API_DOMAIN` and went to github.com); with it, it's 1. The bogus archive body still exercises the temporary-directory staging that #10387 covers (download then `tmpdir()` then `mkdirat` then write zip) before unpacking is expected to fail, so the EBUSY check via `openTempDirWithoutSharingDelete` is preserved and the test no longer contacts github.com or r2.dev.
- New test `canary upgrade falls back to the direct github.com URL when the releases API lookup fails`: the `GITHUB_API_DOMAIN` mock returns 500, and an `HTTPS_PROXY` (with `NO_PROXY` excluding the mock) records the subsequent `CONNECT github.com:443`, proving the hardcoded-URL fallback is reached without contacting the real host.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-upgrade.test.ts

<!-- robobun:evidence:end -->