### PR TITLE
install: don't fail --production on a missing workspace: devDependency

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -71,6 +71,23 @@ const MS_PER_S: f64 = bun_core::time::MS_PER_S as f64;
 
 // ─────────────────────────────────────────────────────────────────────────────
 
+fn features_for_dependency(this: &PackageManager, dep_id: DependencyID) -> Features {
+    let packages = this.lockfile.packages.slice();
+    let resolutions = packages.items_resolution();
+    let dependencies_lists = packages.items_dependencies();
+    for (resolution, dependencies) in resolutions.iter().zip(dependencies_lists.iter()) {
+        if dependencies.contains(dep_id) {
+            return match resolution.tag {
+                ResolutionTag::Root | ResolutionTag::Workspace | ResolutionTag::Folder => {
+                    this.options.local_package_features
+                }
+                _ => this.options.remote_package_features,
+            };
+        }
+    }
+    this.options.remote_package_features
+}
+
 pub fn enqueue_dependency_with_main(
     this: &mut PackageManager,
     id: DependencyID,
@@ -847,7 +864,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 if dependency.behavior.is_required()
                                     && dependency
                                         .behavior
-                                        .is_enabled(this.options.local_package_features)
+                                        .is_enabled(features_for_dependency(this, id))
                                 {
                                     if let Some(fail) = fail_fn {
                                         fail(this, dependency, id, err);
@@ -1418,7 +1435,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             } else if dependency.behavior.is_required()
                 && dependency
                     .behavior
-                    .is_enabled(this.options.local_package_features)
+                    .is_enabled(features_for_dependency(this, id))
             {
                 if dependency_tag == dependency::version::Tag::Workspace {
                     bun_ast::add_error_pretty!(

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1411,7 +1411,11 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                         result.package.meta.id,
                     );
                 }
-            } else if dependency.behavior.is_required() {
+            } else if dependency.behavior.is_required()
+                && dependency
+                    .behavior
+                    .is_enabled(this.options.local_package_features)
+            {
                 if dependency_tag == dependency::version::Tag::Workspace {
                     bun_ast::add_error_pretty!(
                         this.log_mut(),

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -844,7 +844,11 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 }
                                 return Ok(());
                             } else if err == crate::Error::MissingPackageJSON {
-                                if dependency.behavior.is_required() {
+                                if dependency.behavior.is_required()
+                                    && dependency
+                                        .behavior
+                                        .is_enabled(this.options.local_package_features)
+                                {
                                     if let Some(fail) = fail_fn {
                                         fail(this, dependency, id, err);
                                     } else if version.tag == dependency::version::Tag::Folder {

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1280,7 +1280,7 @@ describe("missing local-protocol devDependency is not an error when devDependenc
         env,
       });
 
-      const err = await stderr.text();
+      const err = (await stderr.text()).replaceAll("\\", "/");
       expect(err).toContain(errSubstring);
       expect(await exited).toBe(1);
     });
@@ -1306,7 +1306,7 @@ describe("missing local-protocol devDependency is not an error when devDependenc
         env,
       });
 
-      const err = await stderr.text();
+      const err = (await stderr.text()).replaceAll("\\", "/");
       expect(err).toContain(errSubstring);
       expect(await exited).toBe(1);
     });

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1211,6 +1211,97 @@ test.concurrent("it should detect duplicate workspace dependencies", async () =>
   expect(await exited).toBe(1);
 });
 
+// https://github.com/oven-sh/bun/issues/15102
+describe("missing workspace: devDependency is not an error when devDependencies are skipped", () => {
+  for (const flag of ["--production", "--omit=dev"]) {
+    test.concurrent(flag, async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          dependencies: {
+            "no-deps": "1.0.0",
+          },
+          devDependencies: {
+            "not-a-real-workspace": "workspace:*",
+          },
+        }),
+      );
+
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install", flag],
+        cwd: packageDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+
+      const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(err).not.toContain("error:");
+      expect(err).not.toContain("not found");
+      expect(out).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+
+      expect(await exists(join(packageDir, "node_modules", "no-deps", "package.json"))).toBeTrue();
+      expect(await exists(join(packageDir, "node_modules", "not-a-real-workspace"))).toBeFalse();
+    });
+  }
+
+  test.concurrent("still errors for a missing workspace: dependency in `dependencies`", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson, env } = ctx;
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "not-a-real-workspace": "workspace:*",
+        },
+      }),
+    );
+
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--production"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+
+    const err = await stderr.text();
+    expect(err).toContain('Workspace dependency "not-a-real-workspace" not found');
+    expect(await exited).toBe(1);
+  });
+
+  test.concurrent("still errors for a missing workspace: devDependency without --production", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson, env } = ctx;
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        devDependencies: {
+          "not-a-real-workspace": "workspace:*",
+        },
+      }),
+    );
+
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+
+    const err = await stderr.text();
+    expect(err).toContain('Workspace dependency "not-a-real-workspace" not found');
+    expect(await exited).toBe(1);
+  });
+});
+
 const versions = ["workspace:1.0.0", "workspace:*", "workspace:^1.0.0", "1.0.0", "*"];
 
 for (const rootVersion of versions) {

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1212,9 +1212,53 @@ test.concurrent("it should detect duplicate workspace dependencies", async () =>
 });
 
 // https://github.com/oven-sh/bun/issues/15102
-describe("missing workspace: devDependency is not an error when devDependencies are skipped", () => {
+describe("missing local-protocol devDependency is not an error when devDependencies are skipped", () => {
+  const specs = {
+    "workspace:*": 'Workspace dependency "missing-local" not found',
+    "link:missing-local": 'Package "missing-local" is not linked',
+    "file:../does-not-exist": 'package.json for "file:../does-not-exist" dependency "missing-local"',
+  } as const;
+
   for (const flag of ["--production", "--omit=dev"]) {
-    test.concurrent(flag, async () => {
+    for (const [spec, errSubstring] of Object.entries(specs)) {
+      test.concurrent(`${flag} ${spec}`, async () => {
+        using ctx = await setupTest();
+        const { packageDir, packageJson, env } = ctx;
+        await write(
+          packageJson,
+          JSON.stringify({
+            name: "foo",
+            dependencies: {
+              "no-deps": "1.0.0",
+            },
+            devDependencies: {
+              "missing-local": spec,
+            },
+          }),
+        );
+
+        const { stdout, stderr, exited } = spawn({
+          cmd: [bunExe(), "install", flag],
+          cwd: packageDir,
+          stdout: "pipe",
+          stderr: "pipe",
+          env,
+        });
+
+        const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+        expect(err).not.toContain("error:");
+        expect(err).not.toContain(errSubstring);
+        expect(out).toContain("1 package installed");
+        expect(exitCode).toBe(0);
+
+        expect(await exists(join(packageDir, "node_modules", "no-deps", "package.json"))).toBeTrue();
+        expect(await exists(join(packageDir, "node_modules", "missing-local"))).toBeFalse();
+      });
+    }
+  }
+
+  for (const [spec, errSubstring] of Object.entries(specs)) {
+    test.concurrent(`still errors for ${spec} in \`dependencies\` under --production`, async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;
       await write(
@@ -1222,84 +1266,50 @@ describe("missing workspace: devDependency is not an error when devDependencies 
         JSON.stringify({
           name: "foo",
           dependencies: {
-            "no-deps": "1.0.0",
-          },
-          devDependencies: {
-            "not-a-real-workspace": "workspace:*",
+            "missing-local": spec,
           },
         }),
       );
 
-      const { stdout, stderr, exited } = spawn({
-        cmd: [bunExe(), "install", flag],
+      const { stderr, exited } = spawn({
+        cmd: [bunExe(), "install", "--production"],
         cwd: packageDir,
-        stdout: "pipe",
+        stdout: "ignore",
         stderr: "pipe",
         env,
       });
 
-      const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
-      expect(err).not.toContain("error:");
-      expect(err).not.toContain("not found");
-      expect(out).toContain("1 package installed");
-      expect(exitCode).toBe(0);
+      const err = await stderr.text();
+      expect(err).toContain(errSubstring);
+      expect(await exited).toBe(1);
+    });
 
-      expect(await exists(join(packageDir, "node_modules", "no-deps", "package.json"))).toBeTrue();
-      expect(await exists(join(packageDir, "node_modules", "not-a-real-workspace"))).toBeFalse();
+    test.concurrent(`still errors for ${spec} devDependency without --production`, async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          devDependencies: {
+            "missing-local": spec,
+          },
+        }),
+      );
+
+      const { stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "ignore",
+        stderr: "pipe",
+        env,
+      });
+
+      const err = await stderr.text();
+      expect(err).toContain(errSubstring);
+      expect(await exited).toBe(1);
     });
   }
-
-  test.concurrent("still errors for a missing workspace: dependency in `dependencies`", async () => {
-    using ctx = await setupTest();
-    const { packageDir, packageJson, env } = ctx;
-    await write(
-      packageJson,
-      JSON.stringify({
-        name: "foo",
-        dependencies: {
-          "not-a-real-workspace": "workspace:*",
-        },
-      }),
-    );
-
-    const { stderr, exited } = spawn({
-      cmd: [bunExe(), "install", "--production"],
-      cwd: packageDir,
-      stdout: "ignore",
-      stderr: "pipe",
-      env,
-    });
-
-    const err = await stderr.text();
-    expect(err).toContain('Workspace dependency "not-a-real-workspace" not found');
-    expect(await exited).toBe(1);
-  });
-
-  test.concurrent("still errors for a missing workspace: devDependency without --production", async () => {
-    using ctx = await setupTest();
-    const { packageDir, packageJson, env } = ctx;
-    await write(
-      packageJson,
-      JSON.stringify({
-        name: "foo",
-        devDependencies: {
-          "not-a-real-workspace": "workspace:*",
-        },
-      }),
-    );
-
-    const { stderr, exited } = spawn({
-      cmd: [bunExe(), "install"],
-      cwd: packageDir,
-      stdout: "ignore",
-      stderr: "pipe",
-      env,
-    });
-
-    const err = await stderr.text();
-    expect(err).toContain('Workspace dependency "not-a-real-workspace" not found');
-    expect(await exited).toBe(1);
-  });
 });
 
 const versions = ["workspace:1.0.0", "workspace:*", "workspace:^1.0.0", "1.0.0", "*"];

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -70,6 +70,7 @@ async function setupTest(): Promise<TestCtx> {
     const env: Record<string, string> = {
       ...baseEnv,
       BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
+      BUN_INSTALL_GLOBAL_DIR: join(packageDir, ".bun-global"),
       BUN_TMPDIR: join(packageDir, ".bun-tmp"),
       TMPDIR: join(packageDir, ".bun-tmp"),
       TEMP: join(packageDir, ".bun-tmp"),


### PR DESCRIPTION
Fixes #15102.
Fixes #14134.

### Repro

```sh
mkdir app && cd app
cat > package.json <<'JSON'
{ "name": "app", "devDependencies": { "some_package": "workspace:*" } }
JSON
bun install --production
```

Before:

```
error: Workspace dependency "some_package" not found
```
exit 1.

This is the Docker-build case: a single package from a monorepo is copied into the image (without its sibling workspaces) and `bun install --production` is run. devDependencies aren't installed under `--production`, so a missing `workspace:` target there shouldn't matter. The same applies to `link:` and `file:` devDependencies whose targets live elsewhere in the monorepo.

### Cause

Bun parses every dependency group into the lockfile regardless of `--production` (the root `package.json` is parsed with `Features::main()`, which always includes `dev_dependencies`). Filtering happens later, at tree-build / resolution-verify time, via `Behavior::is_enabled(local_package_features)`.

The `Tag::Workspace | Tag::Symlink` enqueue path, and the `Tag::Folder` `MissingPackageJSON` path, emitted an error whenever the target was missing and the dependency was `is_required()`, which is just `!is_optional()`. A `devDependency` is not optional, so it errored even though `local_package_features.dev_dependencies == false`.

### Fix

Gate both error sites on `is_enabled(local_package_features)` as well, matching the existing check in `verify_resolutions`. `workspace:`, `link:`, and `file:` specifiers that reach these paths come from local packages (root / workspace member / folder), so `local_package_features` is the correct feature set.

Under `--production` / `--omit=dev` a missing `workspace:`, `link:`, or `file:` devDependency now falls through to the silent / verbose-only path instead of erroring. A missing target in `dependencies` still errors, and a missing devDependency target without `--production` still errors.

### Verification

```
bun bd test test/cli/install/bun-workspaces.test.ts -t "missing local-protocol devDependency"
```
12 pass (6 new behavior across `workspace:` / `link:` / `file:` x `--production` / `--omit=dev`, 6 regression guards). Full `bun-workspaces.test.ts` passes (75 tests).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-workspaces.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/190] gen ErrorCode+*.h
[2/190] gen JSEvent.lut.h
Generating /workspace/bun/build/debug/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindings/webcore/JSEvent.cpp
[3/190] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[4/190] gen JSBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[5/190] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 238 extern-C blocks audited
[6/190] gen BunProcess.lut.h
Generating /workspace/bun/build/debug/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[7/190] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 8 sinks, 96 exported symbols
Generating /workspace/bun/build/debug/codegen/JSSink.lut.h from /workspace/bun/build/debug/codegen/JSSink.lut.txt
[8/190] gen cpp.rs (cppbind)
[9/190] gen ZigGeneratedClasses.{cpp,h,rs}
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/install/bun-workspaces.test.ts:
(pass) dependency on workspace without version in package.json [116.14ms]
(pass) allowing negative workspace patterns [18.28ms]
(pass) dependency on same name as workspace and dist-tag [19.16ms]
Saved lockfile
(pass) successfully installs workspace when path already exists in node_modules [18.76ms]
(pass) adding workspace in workspace edits package.json with correct version (workspace:*) [18.91ms]
(pass) workspaces with invalid versions should still install [18.92ms]
(pass) workspace aliases > combination [18.63ms]
(pass) workspace aliases > version range workspace:@org/b@latest and workspace with no version [18.40ms]
(pass) workspace aliases > version range workspace:@org/b@* and workspace with no version [18.22ms]
(pass) workspace aliases > version range workspace:@org/b@1 and workspace with no version (should fail) [27.65ms]
(pass) workspace aliases > version range workspace:@org/b@1.0.0 and workspace with no version (should fail) [27.92ms]
(pass) workspace aliases > version range workspace:@org/b and workspace with no version (should fail) [28.08ms]
(pass) workspace aliases > version 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-workspaces.test.ts
bun test v1.4.0 (ba63b400b)

test/cli/install/bun-workspaces.test.ts:
(pass) dependency on workspace without version in package.json [3364.99ms]
(pass) allowing negative workspace patterns [319.95ms]
(pass) dependency on same name as workspace and dist-tag [561.18ms]
Saved lockfile
(pass) workspace aliases > combination [388.35ms]
(pass) adding workspace in workspace edits package.json with correct version (workspace:*) [424.80ms]
(pass) successfully installs workspace when path already exists in node_modules [518.11ms]
(pass) workspace aliases > version range workspace:@org/b@* and workspace with no version [183.67ms]
(pass) workspace aliases > version range workspace:@org/b@ and workspace with no version [244.58ms]
(pass) workspaces with invalid versions should still install [699.59ms]
(pass) workspace aliases > version range workspace:@org/b@latest and workspace with no version [681.44ms]
(pass) workspace aliases > version range workspace:@org/b@1.0.0 and workspace with no version (should fail
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ba63b400b0
  features     baseline

22 deps, 108 codegen, 1171 objects in 1050ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [25.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [37.00ms]
[3/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[4/1234] fetch zlib
[zlib] up to date
[5/1234] fetch picohttpparser
[picohttpparser] up to date
[6/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[7/1234] fetch tinycc
[tinycc] up to date
[8/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../PackageManager/PackageManagerEnqueue.rs        |  29 +++++-
 test/cli/install/bun-workspaces.test.ts            | 102 +++++++++++++++++++++
 2 files changed, 129 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/install/PackageManager/PackageManagerEnqueue.rs      8      5      0
test/cli/install/bun-workspaces.test.ts                  4      5      0
```

</details>

<!-- robobun:evidence:end -->