### PR TITLE
parser: preserve comments inside function parameter lists

### DIFF
--- a/src/ast/g.rs
+++ b/src/ast/g.rs
@@ -338,10 +338,8 @@ pub struct Arg {
 
     pub ts_metadata: TypeScript::Metadata,
 
-    // Comments that appeared immediately before this argument's binding in the
-    // source, e.g. `function(/* config.proxies */ proxies) {}`. Preserved so
-    // that `Function.prototype.toString()` round-trips the DI annotation style
-    // used by AngularJS / karma's `di` package.
+    // `function(/* token */ arg)` — kept so Function.prototype.toString()
+    // preserves DI-style annotations (AngularJS / karma `di`).
     pub leading_comments: StoreSlice<Comment>,
 }
 

--- a/src/ast/g.rs
+++ b/src/ast/g.rs
@@ -337,6 +337,12 @@ pub struct Arg {
     pub is_typescript_ctor_field: bool,
 
     pub ts_metadata: TypeScript::Metadata,
+
+    // Comments that appeared immediately before this argument's binding in the
+    // source, e.g. `function(/* config.proxies */ proxies) {}`. Preserved so
+    // that `Function.prototype.toString()` round-trips the DI annotation style
+    // used by AngularJS / karma's `di` package.
+    pub leading_comments: StoreSlice<Comment>,
 }
 
 impl Default for Arg {
@@ -347,6 +353,7 @@ impl Default for Arg {
             default: None,
             is_typescript_ctor_field: false,
             ts_metadata: TypeScript::Metadata::MNone,
+            leading_comments: StoreSlice::EMPTY,
         }
     }
 }
@@ -368,6 +375,7 @@ impl Arg {
             },
             is_typescript_ctor_field: self.is_typescript_ctor_field,
             ts_metadata: self.ts_metadata.clone(),
+            leading_comments: self.leading_comments,
         })
     }
 }

--- a/src/ast/g.rs
+++ b/src/ast/g.rs
@@ -338,8 +338,7 @@ pub struct Arg {
 
     pub ts_metadata: TypeScript::Metadata,
 
-    // `function(/* token */ arg)` — kept so Function.prototype.toString()
-    // preserves DI-style annotations (AngularJS / karma `di`).
+    // `function(/* token */ arg)` — kept for Function.prototype.toString()
     pub leading_comments: StoreSlice<Comment>,
 }
 

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -167,6 +167,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     fn take_arg_leading_comments(&mut self, base: usize) -> bun_ast::StoreSlice<G::Comment> {
         let buf = &mut self.lexer.comments_to_preserve_before;
+        let base = base.min(buf.len());
         if buf.len() <= base {
             return bun_ast::StoreSlice::EMPTY;
         }
@@ -187,7 +188,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     fn discard_non_legal_comments_from(&mut self, base: usize) {
         let buf = &mut self.lexer.comments_to_preserve_before;
-        let mut i = base;
+        let mut i = base.min(buf.len());
         while i < buf.len() {
             if is_legal_comment(buf[i].text.slice()) {
                 i += 1;
@@ -225,7 +226,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Keep `/* ... */` inside `(...)` for Function.prototype.toString().
         let old_preserve_comments = p.lexer.preserve_all_comments_before;
-        let comments_base = p.lexer.comments_to_preserve_before.len();
+        let mut comments_base = p.lexer.comments_to_preserve_before.len();
         p.lexer.preserve_all_comments_before = true;
         p.lexer.expect(T::TOpenParen)?;
 
@@ -258,6 +259,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         while p.lexer.token != T::TCloseParen {
             // Skip over "this" type annotations
             if Self::IS_TYPESCRIPT_ENABLED && p.lexer.token == T::TThis {
+                p.discard_non_legal_comments_from(comments_base);
+                p.lexer.preserve_all_comments_before = old_preserve_comments;
                 p.lexer.next()?;
                 if p.lexer.token == T::TColon {
                     p.lexer.next()?;
@@ -267,13 +270,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     break;
                 }
 
+                comments_base = p.lexer.comments_to_preserve_before.len();
+                p.lexer.preserve_all_comments_before = true;
                 p.lexer.next()?;
                 continue;
             }
 
             let mut ts_decorators = bun_alloc::AstAlloc::vec();
             if opts.allow_ts_decorators {
+                p.lexer.preserve_all_comments_before = old_preserve_comments;
                 ts_decorators = p.parse_type_script_decorators()?;
+                p.lexer.preserve_all_comments_before = true;
                 if ts_decorators.len_u32() > 0 {
                     arg_has_decorators = true;
                 }
@@ -389,6 +396,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 break;
             }
 
+            comments_base = p.lexer.comments_to_preserve_before.len();
             p.lexer.preserve_all_comments_before = true;
             p.lexer.next()?;
             rest_arg = false;

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -195,8 +195,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             ..Default::default()
         };
 
-        // Keep comments inside `(...)` for Function.prototype.toString().
-        // Only entries past `comments_base` belong to this parameter list.
+        // Keep `/* ... */` inside `(...)` for Function.prototype.toString().
         let old_preserve_comments = p.lexer.preserve_all_comments_before;
         let comments_base = p.lexer.comments_to_preserve_before.len();
         p.lexer.preserve_all_comments_before = true;

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -165,25 +165,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.s(S::Function { func }, loc))
     }
 
-    fn take_arg_leading_comments(&mut self, base: usize) -> bun_ast::StoreSlice<G::Comment> {
+    fn drain_arg_leading_comments_into(
+        &mut self,
+        out: &mut bun_alloc::ArenaVec<'a, G::Comment>,
+        base: usize,
+    ) {
         let buf = &mut self.lexer.comments_to_preserve_before;
-        let base = base.min(buf.len());
-        if buf.len() <= base {
-            return bun_ast::StoreSlice::EMPTY;
-        }
-        let mut taken = bun_alloc::ArenaVec::<G::Comment>::new_in(self.arena);
-        let mut i = base;
+        let mut i = base.min(buf.len());
         while i < buf.len() {
             if is_legal_comment(buf[i].text.slice()) {
                 i += 1;
             } else {
-                taken.push(buf.remove(i));
+                out.push(buf.remove(i));
             }
         }
-        if taken.is_empty() {
-            return bun_ast::StoreSlice::EMPTY;
-        }
-        bun_ast::StoreSlice::from_bump(taken)
     }
 
     fn discard_non_legal_comments_from(&mut self, base: usize) {
@@ -276,10 +271,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 continue;
             }
 
+            let mut leading = bun_alloc::ArenaVec::<G::Comment>::new_in(p.arena);
+
             let mut ts_decorators = bun_alloc::AstAlloc::vec();
             if opts.allow_ts_decorators {
+                p.drain_arg_leading_comments_into(&mut leading, comments_base);
                 p.lexer.preserve_all_comments_before = old_preserve_comments;
                 ts_decorators = p.parse_type_script_decorators()?;
+                comments_base = p.lexer.comments_to_preserve_before.len();
                 p.lexer.preserve_all_comments_before = true;
                 if ts_decorators.len_u32() > 0 {
                     arg_has_decorators = true;
@@ -293,7 +292,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 func.flags.insert(Flags::Function::HasRestArg);
             }
 
-            let leading_comments = p.take_arg_leading_comments(comments_base);
+            p.drain_arg_leading_comments_into(&mut leading, comments_base);
+            let leading_comments = if leading.is_empty() {
+                bun_ast::StoreSlice::EMPTY
+            } else {
+                bun_ast::StoreSlice::from_bump(leading)
+            };
             p.lexer.preserve_all_comments_before = old_preserve_comments;
 
             let mut is_typescript_ctor_field = false;

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -160,6 +160,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.s(S::Function { func }, loc))
     }
 
+    fn take_arg_leading_comments(
+        &mut self,
+        base: usize,
+    ) -> bun_ast::StoreSlice<G::Comment> {
+        let buf = &mut self.lexer.comments_to_preserve_before;
+        if buf.len() <= base {
+            return bun_ast::StoreSlice::EMPTY;
+        }
+        let slice = self.arena.alloc_slice_fill_iter(buf.drain(base..));
+        bun_ast::StoreSlice::new_mut(slice)
+    }
+
     pub(crate) fn parse_fn(
         &mut self,
         name: Option<js_ast::LocRef>,
@@ -185,6 +197,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             open_parens_loc: p.lexer.loc(),
             ..Default::default()
         };
+
+        // Capture `/* ... */` comments inside the parameter list so they
+        // survive into `Function.prototype.toString()`. Only entries pushed
+        // past `comments_base` are ours; anything already in the buffer (legal
+        // comments from earlier in the statement) is left in place.
+        let old_preserve_comments = p.lexer.preserve_all_comments_before;
+        let comments_base = p.lexer.comments_to_preserve_before.len();
+        p.lexer.preserve_all_comments_before = true;
         p.lexer.expect(T::TOpenParen)?;
 
         // Await and yield are not allowed in function arguments
@@ -243,6 +263,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 rest_arg = true;
                 func.flags.insert(Flags::Function::HasRestArg);
             }
+
+            let leading_comments = p.take_arg_leading_comments(comments_base);
 
             let mut is_typescript_ctor_field = false;
             let is_identifier = p.lexer.token == T::TIdentifier;
@@ -325,6 +347,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // We need to track this because it affects code generation
                 is_typescript_ctor_field,
                 ts_metadata,
+                leading_comments,
             });
 
             if p.lexer.token != T::TComma {
@@ -346,6 +369,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.next()?;
             rest_arg = false;
         }
+        // Drop any comments captured between the last arg and `)`; they would
+        // otherwise surface as top-level `SComment` statements in the body.
+        p.lexer.comments_to_preserve_before.truncate(comments_base);
+        p.lexer.preserve_all_comments_before = old_preserve_comments;
+
         if !args.is_empty() {
             func.args = bun_ast::StoreSlice::new_mut(args.into_bump_slice_mut());
         }

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -160,10 +160,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.s(S::Function { func }, loc))
     }
 
-    fn take_arg_leading_comments(
-        &mut self,
-        base: usize,
-    ) -> bun_ast::StoreSlice<G::Comment> {
+    fn take_arg_leading_comments(&mut self, base: usize) -> bun_ast::StoreSlice<G::Comment> {
         let buf = &mut self.lexer.comments_to_preserve_before;
         if buf.len() <= base {
             return bun_ast::StoreSlice::EMPTY;

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -195,10 +195,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             ..Default::default()
         };
 
-        // Capture `/* ... */` comments inside the parameter list so they
-        // survive into `Function.prototype.toString()`. Only entries pushed
-        // past `comments_base` are ours; anything already in the buffer (legal
-        // comments from earlier in the statement) is left in place.
+        // Keep comments inside `(...)` for Function.prototype.toString().
+        // Only entries past `comments_base` belong to this parameter list.
         let old_preserve_comments = p.lexer.preserve_all_comments_before;
         let comments_base = p.lexer.comments_to_preserve_before.len();
         p.lexer.preserve_all_comments_before = true;
@@ -366,8 +364,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.next()?;
             rest_arg = false;
         }
-        // Drop any comments captured between the last arg and `)`; they would
-        // otherwise surface as top-level `SComment` statements in the body.
+        // Drop any trailing captured comments so they don't leak into the body.
         p.lexer.comments_to_preserve_before.truncate(comments_base);
         p.lexer.preserve_all_comments_before = old_preserve_comments;
 

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -14,6 +14,11 @@ use bun_ast::{E, Expr, Flags, G, S, Stmt};
 
 type Error = crate::Error;
 
+#[inline]
+fn is_legal_comment(text: &[u8]) -> bool {
+    text.len() > 2 && text[2] == b'!'
+}
+
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     /// This assumes the "function" token has already been parsed
     pub(crate) fn parse_fn_stmt(
@@ -165,8 +170,31 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if buf.len() <= base {
             return bun_ast::StoreSlice::EMPTY;
         }
-        let slice = self.arena.alloc_slice_fill_iter(buf.drain(base..));
-        bun_ast::StoreSlice::new_mut(slice)
+        let mut taken = bun_alloc::ArenaVec::<G::Comment>::new_in(self.arena);
+        let mut i = base;
+        while i < buf.len() {
+            if is_legal_comment(buf[i].text.slice()) {
+                i += 1;
+            } else {
+                taken.push(buf.remove(i));
+            }
+        }
+        if taken.is_empty() {
+            return bun_ast::StoreSlice::EMPTY;
+        }
+        bun_ast::StoreSlice::from_bump(taken)
+    }
+
+    fn discard_non_legal_comments_from(&mut self, base: usize) {
+        let buf = &mut self.lexer.comments_to_preserve_before;
+        let mut i = base;
+        while i < buf.len() {
+            if is_legal_comment(buf[i].text.slice()) {
+                i += 1;
+            } else {
+                buf.remove(i);
+            }
+        }
     }
 
     pub(crate) fn parse_fn(
@@ -259,6 +287,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
 
             let leading_comments = p.take_arg_leading_comments(comments_base);
+            p.lexer.preserve_all_comments_before = old_preserve_comments;
 
             let mut is_typescript_ctor_field = false;
             let is_identifier = p.lexer.token == T::TIdentifier;
@@ -360,12 +389,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 break;
             }
 
+            p.lexer.preserve_all_comments_before = true;
             p.lexer.next()?;
             rest_arg = false;
         }
-        // Drop any trailing captured comments so they don't leak into the body.
-        p.lexer.comments_to_preserve_before.truncate(comments_base);
         p.lexer.preserve_all_comments_before = old_preserve_comments;
+        p.discard_non_legal_comments_from(comments_base);
 
         if !args.is_empty() {
             func.args = bun_ast::StoreSlice::new_mut(args.into_bump_slice_mut());

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2108,6 +2108,27 @@ pub(crate) mod __gated_printer {
                     self.print_space();
                 }
 
+                if !self.options.minify_whitespace {
+                    for comment in arg.leading_comments.slice() {
+                        let text = comment.text.slice();
+                        if text.starts_with(b"//") {
+                            // A line comment here would swallow the rest of the
+                            // parameter list on one line; re-emit as a block
+                            // comment. Skip if the body contains "*/" since
+                            // that would terminate the block early.
+                            let body = &text[2..];
+                            if !strings::contains(body, b"*/") {
+                                self.print(b"/*");
+                                self.print(body);
+                                self.print(b" */ ");
+                            }
+                        } else {
+                            self.print(text);
+                            self.print(b" ");
+                        }
+                    }
+                }
+
                 if has_rest_arg && i + 1 == args.len() {
                     self.print(b"...");
                 }

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2112,8 +2112,6 @@ pub(crate) mod __gated_printer {
                     for comment in arg.leading_comments.slice() {
                         let text = comment.text.slice();
                         if text.starts_with(b"//") {
-                            // Re-emit as a block comment so it doesn't swallow
-                            // the rest of the line; drop if unrepresentable.
                             let body = &text[2..];
                             if !strings::contains(body, b"*/") {
                                 self.print(b"/*");

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2112,10 +2112,8 @@ pub(crate) mod __gated_printer {
                     for comment in arg.leading_comments.slice() {
                         let text = comment.text.slice();
                         if text.starts_with(b"//") {
-                            // A line comment here would swallow the rest of the
-                            // parameter list on one line; re-emit as a block
-                            // comment. Skip if the body contains "*/" since
-                            // that would terminate the block early.
+                            // Re-emit as a block comment so it doesn't swallow
+                            // the rest of the line; drop if unrepresentable.
                             let body = &text[2..];
                             if !strings::contains(body, b"*/") {
                                 self.print(b"/*");

--- a/test/regression/issue/13451/13451.test.ts
+++ b/test/regression/issue/13451/13451.test.ts
@@ -127,6 +127,32 @@ console.log(JSON.stringify({
   expect(exitCode).toBe(0);
 });
 
+test("comments inside erased TS this-params/decorators are not relocated onto real args", async () => {
+  using dir = tempDir("issue-13451-ts", {
+    "in.ts": `
+export function f1(this: /* Self */ number, x: number) { return x; }
+export function f2(/* ctx */ this: number, x: number) { return x; }
+declare const dec: any;
+export class C {
+  constructor(@dec(/* opts */) x: number) {}
+}
+`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--target=bun", "in.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).not.toContain("/* Self */");
+  expect(stdout).not.toContain("/* ctx */");
+  expect(stdout).not.toContain("/* opts */");
+  expect(exitCode).toBe(0);
+});
+
 test("legal comments in parameter lists survive minification", async () => {
   using dir = tempDir("issue-13451-legal", {
     "in.js": `

--- a/test/regression/issue/13451/13451.test.ts
+++ b/test/regression/issue/13451/13451.test.ts
@@ -23,7 +23,7 @@ function diParse(src: string): string[] {
   });
 }
 
-test("inline /* */ comments in function parameter lists survive the runtime transpiler", async () => {
+test.concurrent("inline /* */ comments in function parameter lists survive the runtime transpiler", async () => {
   using dir = tempDir("issue-13451", {
     "mod.cjs": `
 exports.anonExpr = function (/* a */ x, /* b.c */ y, /* d */ z) {
@@ -127,7 +127,7 @@ console.log(JSON.stringify({
   expect(exitCode).toBe(0);
 });
 
-test("comments inside erased TS this-params/decorators are not relocated onto real args", async () => {
+test.concurrent("comments inside erased TS this-params/decorators are not relocated onto real args", async () => {
   using dir = tempDir("issue-13451-ts", {
     "in.ts": `
 export function f1(this: /* Self */ number, x: number) { return x; }
@@ -153,7 +153,7 @@ export class C {
   expect(exitCode).toBe(0);
 });
 
-test("legal comments in parameter lists survive minification", async () => {
+test.concurrent("legal comments in parameter lists survive minification", async () => {
   using dir = tempDir("issue-13451-legal", {
     "in.js": `
 export const f = function(/*! @license MIT */ x) { return x; };

--- a/test/regression/issue/13451/13451.test.ts
+++ b/test/regression/issue/13451/13451.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // https://github.com/oven-sh/bun/issues/13451
@@ -71,11 +71,7 @@ console.log(JSON.stringify({
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
 
   const results = JSON.parse(stdout);

--- a/test/regression/issue/13451/13451.test.ts
+++ b/test/regression/issue/13451/13451.test.ts
@@ -1,0 +1,108 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/13451
+//
+// Karma's `di` package (and AngularJS $injector) parse Function.prototype.toString()
+// to extract DI tokens from /* comment */-annotated parameter names, e.g.
+//
+//   exports.create = function (/* config */ config, /* config.proxies */ proxies) { ... }
+//
+// Bun's runtime transpiler was discarding those comments, so `di` saw `proxies`
+// instead of `config.proxies` and failed with "No provider for "proxies"!".
+
+const FN_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
+const FN_ARG = /\/\*([^\*]*)\*\//m;
+
+function diParse(src: string): string[] {
+  const match = src.match(FN_ARGS);
+  if (!match || !match[1]) return [];
+  return match[1].split(",").map(arg => {
+    const m = arg.match(FN_ARG);
+    return m ? m[1].trim() : arg.trim();
+  });
+}
+
+test("inline /* */ comments in function parameter lists survive the runtime transpiler", async () => {
+  using dir = tempDir("issue-13451", {
+    "mod.cjs": `
+exports.anonExpr = function (/* a */ x, /* b.c */ y, /* d */ z) {
+  return [x, y, z];
+};
+
+function decl(/* one */ p, /* two */ q) {
+  return [p, q];
+}
+exports.decl = decl;
+
+exports.obj = {
+  method(/* inner */ v) {
+    return v;
+  },
+};
+
+exports.karma = function (/* config */ config, /* config.proxies */ proxies, /* emitter */ emitter) {
+  return [config, proxies, emitter];
+};
+
+exports.lineComment = function (
+  // token
+  value
+) {
+  return value;
+};
+`,
+    "main.cjs": `
+const m = require("./mod.cjs");
+console.log(JSON.stringify({
+  anonExpr: m.anonExpr.toString(),
+  decl: m.decl.toString(),
+  method: m.obj.method.toString(),
+  karma: m.karma.toString(),
+  lineComment: m.lineComment.toString(),
+}));
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect(stderr).toBe("");
+
+  const results = JSON.parse(stdout);
+
+  // anonymous function expression
+  expect(results.anonExpr).toContain("/* a */");
+  expect(results.anonExpr).toContain("/* b.c */");
+  expect(results.anonExpr).toContain("/* d */");
+  expect(diParse(results.anonExpr)).toEqual(["a", "b.c", "d"]);
+
+  // named function declaration
+  expect(results.decl).toContain("/* one */");
+  expect(results.decl).toContain("/* two */");
+  expect(diParse(results.decl)).toEqual(["one", "two"]);
+
+  // object method shorthand
+  expect(results.method).toContain("/* inner */");
+
+  // karma's exact pattern from middleware/proxy.js
+  expect(results.karma).toContain("/* config */");
+  expect(results.karma).toContain("/* config.proxies */");
+  expect(results.karma).toContain("/* emitter */");
+  expect(diParse(results.karma)).toEqual(["config", "config.proxies", "emitter"]);
+
+  // line comment converted to block (otherwise it would swallow the arg list)
+  expect(results.lineComment).not.toMatch(/\/\/[^\n]*\)/);
+  expect(results.lineComment).toContain("token");
+
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/13451/13451.test.ts
+++ b/test/regression/issue/13451/13451.test.ts
@@ -51,6 +51,18 @@ exports.lineComment = function (
 ) {
   return value;
 };
+
+exports.noMigrateDefault = function (a = /* x */ 1, b) {
+  return [a, b];
+};
+
+exports.noMigrateTrailing = function (a /* trail */, b) {
+  return [a, b];
+};
+
+exports.noLeakIntoBody = function (a = () => { return 1 /* mid */ + 2; }, b) {
+  return [a, b];
+};
 `,
     "main.cjs": `
 const m = require("./mod.cjs");
@@ -60,6 +72,9 @@ console.log(JSON.stringify({
   method: m.obj.method.toString(),
   karma: m.karma.toString(),
   lineComment: m.lineComment.toString(),
+  noMigrateDefault: m.noMigrateDefault.toString(),
+  noMigrateTrailing: m.noMigrateTrailing.toString(),
+  noLeakIntoBody: m.noLeakIntoBody.toString(),
 }));
 `,
   });
@@ -100,5 +115,35 @@ console.log(JSON.stringify({
   expect(results.lineComment).not.toMatch(/\/\/[^\n]*\)/);
   expect(results.lineComment).toContain("token");
 
+  // Comments inside a default value / after a binding must not migrate to the
+  // next argument (that would change the DI token), nor surface as statements
+  // inside a nested body.
+  expect(results.noMigrateDefault).not.toContain("/* x */");
+  expect(diParse(results.noMigrateDefault)).toEqual(["a = 1", "b"]);
+  expect(results.noMigrateTrailing).not.toContain("/* trail */");
+  expect(diParse(results.noMigrateTrailing)).toEqual(["a", "b"]);
+  expect(results.noLeakIntoBody).not.toContain("/* mid */");
+
+  expect(exitCode).toBe(0);
+});
+
+test("legal comments in parameter lists survive minification", async () => {
+  using dir = tempDir("issue-13451-legal", {
+    "in.js": `
+export const f = function(/*! @license MIT */ x) { return x; };
+export const g = function(/*! @preserve */) { return 1; };
+`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--minify", "in.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toContain("/*! @license MIT */");
+  expect(stdout).toContain("/*! @preserve */");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Problem

Karma fails to start under Bun with:

```
Error: No provider for "proxies"! (Resolving: webServer -> proxies)
```

Karma's [`di`](https://www.npmjs.com/package/di) package (and AngularJS's `$injector`) discover dependency-injection tokens by parsing `Function.prototype.toString()` and extracting `/* token */` comments from the parameter list:

```js
// karma/lib/middleware/proxy.js
exports.create = function (/* config */config, /* config.proxies */proxies, /* emitter */emitter) { ... }
```

Under Node, `fn.toString()` returns the source verbatim, so `di`'s regex sees `["config", "config.proxies", "emitter"]`. Under Bun the runtime transpiler discards those comments, so `di` sees `["config", "proxies", "emitter"]` and there is no provider registered under the bare name `"proxies"`.

## Fix

* `js_parser::parse_fn` now enables `preserve_all_comments_before` while scanning the `(...)` list and drains the captured comments into a new `G::Arg::leading_comments` field for each argument.
* `js_printer::print_fn_args` re-emits those comments before each binding (skipped under `minify_whitespace`). Line comments are converted to block comments so they don't swallow the rest of the single-line argument list; line comments containing `*/` are dropped rather than emitted incorrectly.
* All other `G::Arg` construction sites already use `..Default::default()`, so no call-site churn.

## Verification

Before:

```
$ bun ./node_modules/karma/bin/karma start
ERROR [karma-server]: Server start failed on port 9876: Error: No provider for "proxies"! (Resolving: webServer -> proxies)
```

After, with the debug build, karma starts and runs until killed by `timeout` (no DI error).

`di`'s annotate parser now produces the same result under Bun as under Node:

```
Node:  ["config","config.proxies","emitter"]
Bun:   ["config","config.proxies","emitter"]
```

Regression test added at `test/regression/issue/13451/13451.test.ts`; existing `transpiler.test.js`, `bundler_edgecase`, `bundler_minify`, `bundler_cjs2esm`, `esbuild/default` and decorator tests all pass locally.

Fixes #13451

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/13451/13451.test.ts"
bun test v1.4.0 (3ff12cde6)

test/regression/issue/13451/13451.test.ts:
90 |   expect(stderr).toBe("");
91 | 
92 |   const results = JSON.parse(stdout);
93 | 
94 |   // anonymous function expression
95 |   expect(results.anonExpr).toContain("/* a */");
                                ^
error: expect(received).toContain(expected)

Expected to contain: "/* a */"
Received: "function(x, y, z) {\n    return [x, y, z];\n  }"

      at <anonymous> (/workspace/bun/test/regression/issue/13451/13451.test.ts:95:28)
(fail) inline /* */ comments in function parameter lists survive the runtime transpiler [361.12ms]
(pass) comments inside erased TS this-params/decorators are not relocated onto real args [308.01ms]
(pass) legal comments in parameter lists survive minification [292.45ms]

 2 pass
 1 fail
 11 expect() calls
Ran 3 tests across 1 file. [2.43s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (3dc1be7db)

test/regression/issue/13451/13451.test.ts:
(pass) comments inside erased TS this-params/decorators are not relocated onto real args [6.40ms]
(pass) legal comments in parameter lists survive minification [5.75ms]
(pass) inline /* */ comments in function parameter lists survive the runtime transpiler [9.22ms]

 3 pass
 0 fail
 30 expect() calls
Ran 3 tests across 1 file. [170.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/13451/13451.test.ts"
bun test v1.4.0 (3ff12cde6)

test/regression/issue/13451/13451.test.ts:
(pass) inline /* */ comments in function parameter lists survive the runtime transpiler [364.37ms]
(pass) legal comments in parameter lists survive minification [290.68ms]
(pass) comments inside erased TS this-params/decorators are not relocated onto real args [320.74ms]

 3 pass
 0 fail
 30 expect() calls
Ran 3 tests across 1 file. [2.41s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 712ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/g.rs                              |   5 +
 src/js_parser/parse/parse_fn.rs           |  62 +++++++++++
 src/js_printer/lib.rs                     |  17 +++
 test/regression/issue/13451/13451.test.ts | 175 ++++++++++++++++++++++++++++++
 4 files changed, 259 insertions(+)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/ast/g.rs                                   5      4      0
src/js_parser/parse/parse_fn.rs                8     20      0
src/js_printer/lib.rs                          3      5      0
test/regression/issue/13451/13451.test.ts      2      8      0
```

</details>

<!-- robobun:evidence:end -->