### PR TITLE
resolver: skip "bun" export condition for jose

### DIFF
--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -679,7 +679,10 @@ impl PackageJSON {
         }
 
         if let Some(exports_prop) = json.as_property(b"exports") {
-            if let Some(exports_map) = ExportsMap::parse(json_source, r_log, exports_prop.expr) {
+            if let Some(mut exports_map) = ExportsMap::parse(json_source, r_log, exports_prop.expr) {
+                if should_skip_bun_condition(&package_json.name) {
+                    remove_condition(&mut exports_map.root, b"bun");
+                }
                 package_json.exports = Some(exports_map);
             }
         }
@@ -1248,6 +1251,58 @@ pub struct MapEntry {
     pub(crate) key: Box<[u8]>, // owned copy
     pub(crate) key_range: bun_ast::Range,
     pub(crate) value: Entry,
+}
+
+/// Packages whose `"bun"` export condition is dropped during resolution.
+///
+/// Normally the `"bun"` condition lets a package ship a Bun-optimized entry
+/// point and Bun honors it. The packages listed here instead point `"bun"` at
+/// their browser build (pure WebCrypto, no `node:*`), which breaks Node.js
+/// consumers that `require()` them expecting `KeyObject`-based APIs. Dropping
+/// the `"bun"` key makes Bun fall through to `"import"` / `"require"` (the
+/// Node build), which Bun fully supports.
+///
+/// `jose` v4.11+ and v5 set `"bun": "./dist/browser/index.js"`; `jwks-rsa` 3.1
+/// (pulled in by `firebase-admin` 13) then fails with "The JWKS endpoint did
+/// not contain any signing keys" because every imported JWK becomes a
+/// non-extractable `CryptoKey` that `jose.exportSPKI` rejects. `jose` v6 and
+/// `jwks-rsa` 3.2+ fixed this upstream, so dropping the condition here only
+/// changes behavior for the affected range while being a no-op otherwise.
+/// See https://github.com/oven-sh/bun/issues/15932 and #10511.
+const PACKAGES_SKIP_BUN_CONDITION: &[&[u8]] = &[b"jose"];
+
+fn should_skip_bun_condition(name: &[u8]) -> bool {
+    PACKAGES_SKIP_BUN_CONDITION
+        .iter()
+        .any(|pkg| strings::eql(name, pkg))
+}
+
+/// Recursively remove `condition` from every conditional-sugar map in the
+/// exports/imports tree (maps whose keys do not start with `.`).
+fn remove_condition(entry: &mut Entry, condition: &[u8]) {
+    match &mut entry.data {
+        EntryData::Map(map) => {
+            let is_subpath_map = map
+                .list
+                .first()
+                .is_some_and(|e| strings::starts_with_char(&e.key, b'.'));
+            if !is_subpath_map {
+                map.list.retain(|e| !strings::eql(&e.key, condition));
+            }
+            for e in map.list.iter_mut() {
+                remove_condition(&mut e.value, condition);
+            }
+            for e in map.expansion_keys.iter_mut() {
+                remove_condition(&mut e.value, condition);
+            }
+        }
+        EntryData::Array(items) => {
+            for e in items.iter_mut() {
+                remove_condition(e, condition);
+            }
+        }
+        EntryData::String(_) | EntryData::Null | EntryData::Invalid => {}
+    }
 }
 
 impl Entry {

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -679,7 +679,8 @@ impl PackageJSON {
         }
 
         if let Some(exports_prop) = json.as_property(b"exports") {
-            if let Some(mut exports_map) = ExportsMap::parse(json_source, r_log, exports_prop.expr) {
+            if let Some(mut exports_map) = ExportsMap::parse(json_source, r_log, exports_prop.expr)
+            {
                 if should_skip_bun_condition(&package_json.name) {
                     remove_condition(&mut exports_map.root, b"bun");
                 }

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1254,22 +1254,9 @@ pub struct MapEntry {
     pub(crate) value: Entry,
 }
 
-/// Packages whose `"bun"` export condition is dropped during resolution.
-///
-/// Normally the `"bun"` condition lets a package ship a Bun-optimized entry
-/// point and Bun honors it. The packages listed here instead point `"bun"` at
-/// their browser build (pure WebCrypto, no `node:*`), which breaks Node.js
-/// consumers that `require()` them expecting `KeyObject`-based APIs. Dropping
-/// the `"bun"` key makes Bun fall through to `"import"` / `"require"` (the
-/// Node build), which Bun fully supports.
-///
-/// `jose` v4.11+ and v5 set `"bun": "./dist/browser/index.js"`; `jwks-rsa` 3.1
-/// (pulled in by `firebase-admin` 13) then fails with "The JWKS endpoint did
-/// not contain any signing keys" because every imported JWK becomes a
-/// non-extractable `CryptoKey` that `jose.exportSPKI` rejects. `jose` v6 and
-/// `jwks-rsa` 3.2+ fixed this upstream, so dropping the condition here only
-/// changes behavior for the affected range while being a no-op otherwise.
-/// See https://github.com/oven-sh/bun/issues/15932 and #10511.
+/// Packages whose `"bun"` export condition is dropped so resolution falls
+/// through to `"import"` / `"require"`. Listed packages point `"bun"` at a
+/// browser-only build that breaks Node-style consumers (#15932, #19629).
 const PACKAGES_SKIP_BUN_CONDITION: &[&[u8]] = &[b"jose"];
 
 fn should_skip_bun_condition(name: &[u8]) -> bool {
@@ -1278,8 +1265,6 @@ fn should_skip_bun_condition(name: &[u8]) -> bool {
         .any(|pkg| strings::eql(name, pkg))
 }
 
-/// Recursively remove `condition` from every conditional-sugar map in the
-/// exports/imports tree (maps whose keys do not start with `.`).
 fn remove_condition(entry: &mut Entry, condition: &[u8]) {
     match &mut entry.data {
         EntryData::Map(map) => {

--- a/test/js/bun/resolve/jose-bun-condition.test.ts
+++ b/test/js/bun/resolve/jose-bun-condition.test.ts
@@ -1,0 +1,198 @@
+// https://github.com/oven-sh/bun/issues/15932
+// jose v4.11+ / v5 sets "bun": "./dist/browser/index.js" in its exports map.
+// The browser build is a pure WebCrypto build whose importJWK() returns a
+// non-extractable CryptoKey; jwks-rsa 3.1 (used by firebase-admin 13) then
+// fails to extract any signing keys. Bun now drops jose's "bun" condition so
+// it falls through to the Node build, matching Node.js behavior.
+
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// jose's exports shape (v4.15.x / v5.x).
+const joseExports = {
+  ".": {
+    types: "./dist/types/index.d.ts",
+    bun: "./dist/browser/index.js",
+    deno: "./dist/browser/index.js",
+    browser: "./dist/browser/index.js",
+    worker: "./dist/browser/index.js",
+    import: "./dist/node/esm/index.js",
+    require: "./dist/node/cjs/index.js",
+  },
+  "./errors": {
+    bun: "./dist/browser/util/errors.js",
+    import: "./dist/node/esm/util/errors.js",
+    require: "./dist/node/cjs/util/errors.js",
+  },
+  "./package.json": "./package.json",
+};
+
+function fixture(extra: Record<string, string> = {}) {
+  return tempDir("jose-bun-condition", {
+    "package.json": JSON.stringify({ name: "app", private: true }),
+    "node_modules/jose/package.json": JSON.stringify({
+      name: "jose",
+      version: "4.15.9",
+      exports: joseExports,
+    }),
+    "node_modules/jose/dist/browser/index.js": "module.exports.build = 'browser';",
+    "node_modules/jose/dist/browser/util/errors.js": "module.exports.build = 'browser';",
+    "node_modules/jose/dist/node/cjs/index.js": "module.exports.build = 'node-cjs';",
+    "node_modules/jose/dist/node/cjs/util/errors.js": "module.exports.build = 'node-cjs';",
+    "node_modules/jose/dist/node/esm/index.js": "export const build = 'node-esm';",
+    "node_modules/jose/dist/node/esm/package.json": JSON.stringify({ type: "module" }),
+    "node_modules/jose/dist/node/esm/util/errors.js": "export const build = 'node-esm';",
+    "node_modules/jose/dist/types/index.d.ts": "",
+    // Control: same shape, different name. Must still pick "bun".
+    "node_modules/not-jose/package.json": JSON.stringify({
+      name: "not-jose",
+      exports: {
+        ".": {
+          bun: "./bun.js",
+          import: "./node.js",
+          require: "./node.js",
+        },
+      },
+    }),
+    "node_modules/not-jose/bun.js": "module.exports.build = 'bun';",
+    "node_modules/not-jose/node.js": "module.exports.build = 'node';",
+    ...extra,
+  });
+}
+
+async function run(dir: string, args: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe('jose "bun" export condition override', () => {
+  test("require() resolves to the node CJS build", async () => {
+    using dir = fixture();
+    const { stdout, stderr, exitCode } = await run(String(dir), [
+      "-e",
+      "console.log(require('jose').build, require('jose/errors').build)",
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("node-cjs node-cjs\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("import resolves to the node ESM build", async () => {
+    using dir = fixture({
+      "index.mjs": "import { build } from 'jose'; console.log(build);",
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir), ["index.mjs"]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("node-esm\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("only jose is overridden; other packages keep their 'bun' condition", async () => {
+    using dir = fixture();
+    const { stdout, stderr, exitCode } = await run(String(dir), [
+      "-e",
+      "console.log(require('not-jose').build)",
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("bun\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("Bun.build with target 'bun' skips jose's 'bun' condition", async () => {
+    using dir = fixture({
+      "entry.ts": "import { build } from 'jose'; console.log(build);",
+    });
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.ts`],
+      target: "bun",
+    });
+    expect(result.success).toBe(true);
+    const out = await result.outputs[0].text();
+    expect(out).toContain("node-esm");
+    expect(out).not.toContain("'browser'");
+    expect(out).not.toContain('"browser"');
+  });
+
+  test("Bun.build with target 'browser' still resolves jose to its browser build", async () => {
+    using dir = fixture({
+      "entry.ts": "import { build } from 'jose'; console.log(build);",
+    });
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.ts`],
+      target: "browser",
+    });
+    expect(result.success).toBe(true);
+    const out = await result.outputs[0].text();
+    expect(out).toContain("browser");
+  });
+
+  test("jwks-rsa retrieveSigningKeys path imports JWKs successfully (#15932)", async () => {
+    // End-to-end shape: jose.importJWK(publicJWK) followed by key export must
+    // produce a PEM, which it does from the Node build but not the browser
+    // build (the browser build creates a non-extractable CryptoKey).
+    using dir = tempDir("jose-jwks-e2e", {
+      "package.json": JSON.stringify({ name: "app", private: true }),
+      "node_modules/jose/package.json": JSON.stringify({
+        name: "jose",
+        version: "4.15.9",
+        exports: joseExports,
+      }),
+      "node_modules/jose/dist/browser/index.js": `
+        exports.importJWK = async (jwk, alg) => {
+          const data = { ...jwk }; delete data.alg; delete data.use;
+          return crypto.subtle.importKey('jwk', data,
+            { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+            jwk.ext ?? false, ['verify']);
+        };
+        exports.exportSPKI = async (key) => {
+          if (!key.extractable) throw new TypeError('CryptoKey is not extractable');
+          const der = new Uint8Array(await crypto.subtle.exportKey('spki', key));
+          return '-----BEGIN PUBLIC KEY-----\\n' + Buffer.from(der).toString('base64') + '\\n-----END PUBLIC KEY-----\\n';
+        };
+      `,
+      "node_modules/jose/dist/node/cjs/index.js": `
+        const crypto = require('crypto');
+        exports.importJWK = async (jwk) => crypto.createPublicKey({ key: jwk, format: 'jwk' });
+        exports.exportSPKI = async (key) => key.export({ type: 'spki', format: 'pem' });
+      `,
+      "node_modules/jose/dist/node/esm/package.json": JSON.stringify({ type: "module" }),
+      "node_modules/jose/dist/node/esm/index.js": `
+        import crypto from 'crypto';
+        export const importJWK = async (jwk) => crypto.createPublicKey({ key: jwk, format: 'jwk' });
+        export const exportSPKI = async (key) => key.export({ type: 'spki', format: 'pem' });
+      `,
+      // Inlined from jwks-rsa 3.1.0 src/utils.js.
+      "index.cjs": `
+        const jose = require('jose');
+        const crypto = require('crypto');
+        (async () => {
+          const { publicKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+          const jwk = publicKey.export({ format: 'jwk' });
+          jwk.use = 'sig'; jwk.alg = 'RS256'; jwk.kid = 'test-kid';
+          try {
+            const key = await jose.importJWK(jwk, 'RS256');
+            let spki;
+            switch (key[Symbol.toStringTag]) {
+              case 'CryptoKey': spki = await jose.exportSPKI(key); break;
+              default: spki = key.export({ format: 'pem', type: 'spki' });
+            }
+            console.log(JSON.stringify({ ok: spki.includes('BEGIN PUBLIC KEY') }));
+          } catch (err) {
+            console.log(JSON.stringify({ ok: false, err: err.message }));
+          }
+        })();
+      `,
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir), ["index.cjs"]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ ok: true });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/resolve/jose-bun-condition.test.ts
+++ b/test/js/bun/resolve/jose-bun-condition.test.ts
@@ -96,10 +96,7 @@ describe('jose "bun" export condition override', () => {
 
   test("only jose is overridden; other packages keep their 'bun' condition", async () => {
     using dir = fixture();
-    const { stdout, stderr, exitCode } = await run(String(dir), [
-      "-e",
-      "console.log(require('not-jose').build)",
-    ]);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["-e", "console.log(require('not-jose').build)"]);
     expect(stderr).toBe("");
     expect(stdout).toBe("bun\n");
     expect(exitCode).toBe(0);


### PR DESCRIPTION
Fixes #15932 (and the same failure in the closed #10511 for users still on jwks-rsa 3.1).

## Repro

```js
// jwks-rsa@3.1.0 + jose@4.15.9 (the versions pulled in by firebase-admin@13.0.1)
const { retrieveSigningKeys } = require("jwks-rsa/src/utils");
const crypto = require("crypto");
const { publicKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
const jwk = { ...publicKey.export({ format: "jwk" }), use: "sig", alg: "RS256", kid: "k" };
console.log((await retrieveSigningKeys([jwk])).length);
// Node: 1
// Bun before: 0  -> firebase-admin: "The JWKS endpoint did not contain any signing keys"
// Bun after: 1
```

## Cause

`jose` v4.11+ and v5 set `"bun": "./dist/browser/index.js"` in `package.json` `exports`:

```json
{ ".": { "bun": "./dist/browser/index.js", "browser": "./dist/browser/index.js",
         "import": "./dist/node/esm/index.js", "require": "./dist/node/cjs/index.js" } }
```

Bun (correctly, per the Node resolution algorithm) matches the `"bun"` key first, so it loads `dist/browser`, a pure-WebCrypto build whose `importJWK()` creates a `CryptoKey` with `extractable: jwk.ext ?? false`. `jwks-rsa` 3.1 then calls `jose.exportSPKI(key)`, which throws `TypeError: CryptoKey is not extractable`. The catch block swallows the error and every key is dropped.

Node matches `"require"` and loads `dist/node/cjs`, which returns a `KeyObject` that `jwks-rsa` can export.

## Fix

Add a small per-package override list in the resolver (`PACKAGES_SKIP_BUN_CONDITION`, currently just `"jose"`). When the parsed package name matches, the `"bun"` key is dropped from the `exports` tree so resolution falls through to `"import"` / `"require"` (the Node build, which Bun fully supports). This happens once at `package.json` parse time and only for the listed packages; the `"bun"` condition is still honored for every other package.

`jose` v6 removed the `"bun"` condition entirely and `jwks-rsa` 3.2+ / `firebase-admin` 14 already pass `ext: true`, so this only changes behavior for the affected range. `--target=browser` continues to resolve `jose` to its browser build via the `"browser"` condition.

## Verification

```
bun bd test test/js/bun/resolve/jose-bun-condition.test.ts
  6 pass, 0 fail

USE_SYSTEM_BUN=1 bun test test/js/bun/resolve/jose-bun-condition.test.ts
  2 pass (controls), 4 fail
```

Fixes #19629
