### PR TITLE
bundler: fail the build when --bytecode cannot be generated

### DIFF
--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -1088,9 +1088,6 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                                     bstr::BStr::new(&chunk.final_rel_path)
                                 ),
                             );
-                            // `output_files` was pre-sized assuming this chunk
-                            // would produce a bytecode entry; bailing here keeps
-                            // the `take()` insertion-count invariant intact.
                             return Err(crate::Error::BuildFailed);
                         }
                     }

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -1076,13 +1076,11 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                                 ..Default::default()
                             }));
                         } else {
-                            // an error
-                            // logger OOM-only
                             // Split-borrow — `static_route_visitor.c` holds a
                             // detached `&LinkerContext`; `log_disjoint` returns the
                             // disjoint `Transpiler.log` backref so no `&mut c` is
                             // materialized.
-                            let _ = c.log_disjoint().add_error_fmt(
+                            c.log_disjoint().add_error_fmt(
                                 None,
                                 bun_ast::Loc::EMPTY,
                                 format_args!(
@@ -1090,6 +1088,10 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                                     bstr::BStr::new(&chunk.final_rel_path)
                                 ),
                             );
+                            // `output_files` was pre-sized assuming this chunk
+                            // would produce a bytecode entry; bailing here keeps
+                            // the `take()` insertion-count invariant intact.
+                            return Err(crate::Error::BuildFailed);
                         }
                     }
                 }

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -493,6 +493,17 @@ pub(crate) fn write_output_files_to_disk(
                             source_index: IndexOptional::NONE,
                             bake_extra: BakeExtra::default(),
                         }));
+                    } else {
+                        // `log_disjoint`: split-borrow with `parse_graph` above.
+                        c.log_disjoint().add_error_fmt(
+                            None,
+                            Loc::EMPTY,
+                            format_args!(
+                                "Failed to generate bytecode for {}",
+                                bstr::BStr::new(&chunk.final_rel_path)
+                            ),
+                        );
+                        return Err(crate::Error::BuildFailed);
                     }
                 }
             }

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -398,7 +398,7 @@ pub(crate) fn write_output_files_to_disk(
                     Loader::Js
                 };
 
-                if loader.is_javascript_like() {
+                if matches!(chunk.content, Content::Javascript(_)) && loader.is_javascript_like() {
                     let mut fdpath = PathBuffer::uninit();
                     let source_provider_url = BunString::create_format(format_args!(
                         "{}{}",

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -173,6 +173,26 @@ describe("bundler", () => {
       expect(exitCode).toBe(1);
     });
   }
+  // A CSS chunk created from a JS entry point has a JS-like loader. Bytecode
+  // must be skipped for it, not attempted and reported as a failure.
+  test("bytecode/OutdirBytecodeSkipsCssChunk", async () => {
+    using dir = tempDir("bytecode-css", {
+      "entry.ts": `import "./styles.css"; console.log(1);`,
+      "styles.css": `.foo { color: red }`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./entry.ts", "--bytecode", "--target=bun", "--format=cjs", "--outdir", "./out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error");
+    expect(stdout).toContain("entry.js.jsc");
+    expect(stdout).toContain("entry.css");
+    expect(exitCode).toBe(0);
+  });
 
   // `import defer * as ns from "..."` must not break bytecode generation.
   // The bundler inlines the deferred module into the entry chunk (documented

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -137,6 +137,46 @@ describe("bundler", () => {
       },
     },
   });
+  // https://github.com/oven-sh/bun/issues/15528
+  // When JSC rejects the bundled output (forced here by prepending a banner
+  // that JSC's parser cannot parse; bun's own parser never sees banner text),
+  // the build must exit non-zero instead of printing the error and then
+  // reporting success. Covers both the --compile path and the --outdir path
+  // (the latter previously swallowed the failure entirely).
+  for (const [name, extraArgs] of [
+    ["compile/BytecodeFailureIsAnError", ["--compile", "--outfile", "./out"]],
+    ["bytecode/OutdirBytecodeFailureIsAnError", ["--format=cjs", "--outdir", "./out"]],
+  ] as const) {
+    test(name, async () => {
+      using dir = tempDir("bytecode-failure", {
+        "entry.ts": `console.log("Hello, world!");`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "build",
+          "./entry.ts",
+          "--bytecode",
+          "--target=bun",
+          "--banner",
+          "this is not valid js !!!",
+          ...extraArgs,
+        ],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).toContain("error: Failed to generate bytecode");
+      expect(stdout).not.toContain("compile");
+      expect(exitCode).toBe(1);
+    });
+  }
 
   // `import defer * as ns from "..."` must not break bytecode generation.
   // The bundler inlines the deferred module into the entry chunk (documented

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -167,11 +167,7 @@ describe("bundler", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toContain("error: Failed to generate bytecode");
       expect(stdout).not.toContain("compile");
       expect(exitCode).toBe(1);


### PR DESCRIPTION
Fixes #15528.

## Problem

`bun build --compile --bytecode` prints `error: Failed to generate bytecode for ...` when JSC rejects the bundled output, but then proceeds to write the executable and exit 0. CI can't detect that the binary shipped without bytecode.

The `--outdir` (non `--compile`) path was worse: it swallowed the bytecode failure entirely (no message, no `.jsc` file, exit 0).

## Repro

```sh
echo 'console.log(1)' > a.js
bun build a.js --compile --bytecode --banner='this is not valid js !!!' --outfile ./out
# error: Failed to generate bytecode for ./a.js
echo $?   # 0 (before), 1 (after)
```

The banner is prepended verbatim after bun's own parser runs, so JSC is the first thing to see the bad syntax; any real-world input that trips JSC's bytecode generator (the yargs example in the issue, sloppy-mode constructs in ESM strict mode, etc.) hits the same path.

## Fix

Both chunk-generation paths (`generateChunksInParallel.rs` for in-memory/compile, `writeOutputFilesToDisk.rs` for `--outdir`) now `return Err(BuildFailed)` after logging the bytecode error, so `bun build` exits 1 and `Bun.build()` reports `success: false`.

This also makes a latent debug assertion in `OutputFileList::take()` unreachable: the output list is pre-sized on the assumption that every JS chunk produces a bytecode entry, and leaving that slot unfilled tripped `total_insertions != output_files.len()` in debug builds.

## Verification

```
bundler > compile/BytecodeFailureIsAnError              (fails on main, passes here)
bundler > bytecode/OutdirBytecodeFailureIsAnError       (fails on main, passes here)
```

All 19 existing `Bytecode` tests in `bundler_compile.test.ts` and all of `bundler_banner.test.ts` still pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->