### PR TITLE
node:vm: don't reuse a PropertySlot across two lookups in defineOwnProperty

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1386,7 +1386,13 @@ bool NodeVMGlobalObject::defineOwnProperty(JSObject* cell, JSGlobalObject* globa
         RELEASE_AND_RETURN(scope, contextifiedObject->methodTable()->defineOwnProperty(contextifiedObject, contextifiedObject->globalObject(), propertyName, descriptor, shouldThrow));
     }
 
-    bool isDeclaredOnSandbox = contextifiedObject->getPropertySlot(globalObject, propertyName, slot);
+    // The lookup above may have filled `slot` as cacheable (e.g. a lazy global
+    // stored as a CustomGetterSetter on a non-dictionary structure). Reusing it
+    // here would trip PropertySlot's CachingDisallowed asserts if the sandbox
+    // resolves the same name via setGetterSlot/setCustom/setValue(3-arg), which
+    // happens once the sandbox has transitioned to an uncacheable dictionary.
+    PropertySlot sandboxSlot(globalObject, PropertySlot::InternalMethodType::GetOwnProperty, nullptr);
+    bool isDeclaredOnSandbox = contextifiedObject->getPropertySlot(globalObject, propertyName, sandboxSlot);
     RETURN_IF_EXCEPTION(scope, false);
 
     if (isDeclaredOnSandbox && !isDeclaredOnGlobalProxy) {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1383,3 +1383,39 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+test("node:vm Object.defineProperty on the context global when the sandbox is an uncacheable dictionary holding an accessor for a built-in", async () => {
+  // Regression: NodeVMGlobalObject::defineOwnProperty used a single PropertySlot
+  // for both the global-object lookup and the sandbox lookup. When the first
+  // lookup fills the slot as cacheable (e.g. Array is a lazy CustomGetterSetter
+  // on a non-dictionary global) and the sandbox has transitioned to an
+  // uncacheable dictionary with an accessor for the same name, the second lookup
+  // would hit setGetterSlot, which asserts the slot is still CachingDisallowed.
+  // Debug builds aborted; this test asserts the Node-matching behaviour so
+  // release lanes still exercise the path.
+  const fixture = `
+    const vm = require("node:vm");
+    const sandbox = {};
+    for (let i = 0; i < 200; i++) { sandbox["k" + i] = i; delete sandbox["k" + i]; }
+    Object.defineProperty(sandbox, "Array", { get: () => Array, configurable: true });
+    vm.createContext(sandbox);
+    const result = vm.runInContext(
+      'Object.defineProperty(this, "Array", { value: 1, configurable: true, writable: true }); Array',
+      sandbox,
+    );
+    console.log(JSON.stringify({ result, sandboxArray: sandbox.Array }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe(JSON.stringify({ result: 1, sandboxArray: 1 }));
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`NodeVMGlobalObject::defineOwnProperty` probed the global object and then the contextified sandbox with the same `PropertySlot`. When the first lookup fills the slot as cacheable and the second lookup reaches `setGetterSlot`/`setCustom`/`setValue(JSObject*,unsigned,JSValue)`, those overloads assert the slot is still `CachingDisallowed`, and a debug/ASAN build aborts.

## Repro

```
ASSERTION FAILED: m_cacheability == CachingDisallowed
vendor/WebKit/Source/JavaScriptCore/runtime/PropertySlot.h : void JSC::PropertySlot::setGetterSlot(JSObject *, unsigned int, GetterSetter *)
```

Minimal trigger (Node passes this):

```js
const vm = require("node:vm");
const sandbox = {};
for (let i = 0; i < 200; i++) { sandbox["k" + i] = i; delete sandbox["k" + i]; } // uncacheable dictionary
Object.defineProperty(sandbox, "Array", { get: () => Array, configurable: true });
vm.createContext(sandbox);
vm.runInContext(
  'Object.defineProperty(this, "Array", { value: 1, configurable: true, writable: true }); Array',
  sandbox,
);
```

Real-world: `jest` under `bun --bun` with `testEnvironment: "node"`. `jest-environment-node` copies enough globals onto the sandbox to push it to an uncacheable dictionary and installs lazy-init getters that call `Object.defineProperty(this, name, { value })` on first access.

## Why

Backtrace from the jest run (llvm-addr2line on a walked `rbp` chain at `WTFReportAssertionFailure`):

```
PropertySlot::setGetterSlot                  PropertySlot.h:328
JSObject::fillGetterPropertySlot             JSObject.cpp:2972
JSObject::getOwnNonIndexPropertySlot         JSObject.h:1117
JSObject::getPropertySlot<false>             JSObject.h:1197
NodeVMGlobalObject::defineOwnProperty        NodeVM.cpp  (contextifiedObject->getPropertySlot)
JSGlobalProxy::defineOwnProperty
objectConstructorDefineProperty
... JS getter re-entry via PropertySlot::functionGetter ...
NodeVMGlobalObject::getOwnPropertySlot       NodeVM.cpp  (slot.getValue)
JSGlobalProxy::getOwnPropertySlot
llint_slow_path_get_by_val
```

Inside `defineOwnProperty`:

1. `globalObject->JSC::JSGlobalObject::getOwnPropertySlot(..., slot)` finds `Array` as a lazy `CustomGetterSetter` on a non-dictionary structure, so `fillCustomGetterPropertySlot` calls `setCacheableCustom`, which sets `m_cacheability = CachingAllowed`.
2. `contextifiedObject->getPropertySlot(..., slot)` walks the sandbox. The sandbox is now an uncacheable dictionary holding an accessor for the same name, so `fillGetterPropertySlot` takes the uncacheable branch and calls `setGetterSlot`, which asserts `m_cacheability == CachingDisallowed`.

Release builds don't see this because `ASSERT` compiles out, but the invariant is still violated: the cached offset/structure left in the slot describes the global object, not the sandbox.

## Fix

Use a fresh `PropertySlot` for the sandbox probe. Only the boolean result is consumed afterwards, so nothing else changes. This matches the pattern already used in `NodeVMGlobalObject::put` (a dedicated `getter` slot) and at the proxy-target lookup in `getOwnPropertySlot` (`target_slot`).

## Verification

- New test in `test/js/node/vm/vm.test.ts` spawns the minimal repro and asserts the Node-matching `{ result: 1, sandboxArray: 1 }` output, so release lanes still exercise the path.
- Gate simulation: with `src/` stashed the test fails with the `setGetterSlot` assertion; with the fix it passes.
- Full `test/js/node/vm/vm.test.ts`: 213 pass / 0 fail.
- jest 29.7 + ts-jest under `bun --bun` on a debug build now runs to completion.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (822046d52)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [22.12ms]
(pass) vm > runInContext() > can return a value [15.58ms]
(pass) vm > runInContext() > can return a complex value [15.99ms]
(pass) vm > runInContext() > can return the last value [15.97ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [17.35ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.95ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.66ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [16.06ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.38ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [15.14ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [15.45ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [17.71ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release without fix: 7 failed, 62 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.50ms]
(pass) vm > runInContext() > can return a value [0.23ms]
(pass) vm > runInContext() > can return a complex value [0.22ms]
(pass) vm > runInContext() > can return the last value [0.22ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.24ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.20ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.20ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.23ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (822046d52)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [22.10ms]
(pass) vm > runInContext() > can return a value [16.33ms]
(pass) vm > runInContext() > can return a complex value [15.86ms]
(pass) vm > runInContext() > can return the last value [19.50ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [19.68ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [19.54ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [17.79ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [17.19ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.97ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [19.41ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [21.52ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [23.23ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     822046d528
  features     baseline

22 deps, 108 codegen, 1171 objects in 4074ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] fetch tinycc
[tinycc] up to date
[2/1234] fetch zlib
[zlib] up to date
[3/1234] fetch picohttpparser
[picohttpparser] up to date
[4/1234] gen bindgenv2
[5/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[6/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[7/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [128.00ms]
[9/1234] subst deps/zlib/zconf.h
[10/1234] gen .bind.ts → GeneratedBindings.cpp
[11/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVM.cpp |  8 +++++++-
 test/js/node/vm/vm.test.ts  | 36 ++++++++++++++++++++++++++++++++++++
 2 files changed, 43 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/jsc/bindings/NodeVM.cpp      3      1      0
test/js/node/vm/vm.test.ts       3      1      0
```

</details>

**self-review** · no surviving concerns

32 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->