### PR TITLE
usockets: stop the listen addrinfo loop on EADDRINUSE so listen(port, "localhost") reports the conflict

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1193,6 +1193,23 @@ int bsd_set_defer_accept(LIBUS_SOCKET_DESCRIPTOR listenFd) {
 #endif
 }
 
+#ifdef _WIN32
+#define LIBUS_ADDRINUSE WSAEADDRINUSE
+#define LIBUS_ACCES WSAEACCES
+#else
+#define LIBUS_ADDRINUSE EADDRINUSE
+#define LIBUS_ACCES EACCES
+#endif
+
+/* bind() failures that mean "this port is owned by someone else" rather than
+ * "this address family is unusable on this host". The IPv6->IPv4 fallback below
+ * exists for the latter (EAFNOSUPPORT / EADDRNOTAVAIL when IPv6 is disabled),
+ * and must not swallow the former: a second listen(port, "localhost") would
+ * otherwise quietly bind 127.0.0.1 after ::1 returned EADDRINUSE. */
+static int bsd_bind_error_is_fatal(int err) {
+    return err == LIBUS_ADDRINUSE || err == LIBUS_ACCES;
+}
+
 // return LIBUS_SOCKET_ERROR or the fd that represents listen socket
 // listen both on ipv6 and ipv4
 LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int options, int* error) {
@@ -1220,12 +1237,17 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int
             }
 
             listenAddr = a;
+            *error = 0;
             if (bsd_bind_listen_fd(listenFd, listenAddr, port, options, error) != LIBUS_SOCKET_ERROR) {
                 freeaddrinfo(result);
                 return listenFd;
             }
 
             bsd_close_socket(listenFd);
+            if (bsd_bind_error_is_fatal(*error)) {
+                freeaddrinfo(result);
+                return LIBUS_SOCKET_ERROR;
+            }
         }
     }
 
@@ -1237,12 +1259,17 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int
             }
 
             listenAddr = a;
+            *error = 0;
             if (bsd_bind_listen_fd(listenFd, listenAddr, port, options, error) != LIBUS_SOCKET_ERROR) {
                 freeaddrinfo(result);
                 return listenFd;
             }
 
             bsd_close_socket(listenFd);
+            if (bsd_bind_error_is_fatal(*error)) {
+                freeaddrinfo(result);
+                return LIBUS_SOCKET_ERROR;
+            }
         }
     }
 

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1147,6 +1147,7 @@ inline __attribute__((always_inline)) LIBUS_SOCKET_DESCRIPTOR bsd_bind_listen_fd
 ) {
 
     if (bsd_set_reuse(listenFd, options) != 0) {
+        *error = LIBUS_ERR;
         return LIBUS_SOCKET_ERROR;
     }
 
@@ -1163,6 +1164,7 @@ inline __attribute__((always_inline)) LIBUS_SOCKET_DESCRIPTOR bsd_bind_listen_fd
     if (listenAddr->ai_family == AF_INET6) {
         int enabled = (options & LIBUS_SOCKET_IPV6_ONLY) != 0;
         if (setsockopt(listenFd, IPPROTO_IPV6, IPV6_V6ONLY, &enabled, sizeof(enabled)) != 0) {
+            *error = LIBUS_ERR;
             return LIBUS_SOCKET_ERROR;
         }
     }

--- a/src/js/internal/cluster/RoundRobinHandle.ts
+++ b/src/js/internal/cluster/RoundRobinHandle.ts
@@ -31,12 +31,8 @@ export default class RoundRobinHandle {
 
     if (fd >= 0) this.server.listen({ fd, backlog });
     else if (port >= 0) {
-      // Bun: workers bind this port themselves with SO_REUSEPORT (see
-      // listenOnPrimaryHandle in node:net) because IPC handle passing is not
-      // implemented. Bind with reusePort here as well so the primary's socket
-      // does not lock workers out: on Windows, a default-security wildcard
-      // listener makes later SO_REUSEADDR binds of the same port fail with
-      // WSAEACCES.
+      // Bun: workers bind this port themselves (no IPC handle passing yet), so
+      // open the reuse group here too or the workers' binds are rejected.
       this.server.listen({
         port,
         host: address,

--- a/src/js/internal/cluster/RoundRobinHandle.ts
+++ b/src/js/internal/cluster/RoundRobinHandle.ts
@@ -31,12 +31,19 @@ export default class RoundRobinHandle {
 
     if (fd >= 0) this.server.listen({ fd, backlog });
     else if (port >= 0) {
+      // Bun: workers bind this port themselves with SO_REUSEPORT (see
+      // listenOnPrimaryHandle in node:net) because IPC handle passing is not
+      // implemented. Bind with reusePort here as well so the primary's socket
+      // does not lock workers out: on Windows, a default-security wildcard
+      // listener makes later SO_REUSEADDR binds of the same port fail with
+      // WSAEACCES.
       this.server.listen({
         port,
         host: address,
         // Currently, net module only supports `ipv6Only` option in `flags`.
         ipv6Only: !!(flags & UV_TCP_IPV6ONLY),
         backlog,
+        reusePort: true,
       });
     } else
       this.server.listen({

--- a/src/js/internal/cluster/RoundRobinHandle.ts
+++ b/src/js/internal/cluster/RoundRobinHandle.ts
@@ -31,14 +31,13 @@ export default class RoundRobinHandle {
 
     if (fd >= 0) this.server.listen({ fd, backlog });
     else if (port >= 0) {
-      // Bun: workers bind this port themselves (no IPC handle passing yet), so
-      // open the reuse group here too or the workers' binds are rejected.
       this.server.listen({
         port,
         host: address,
         // Currently, net module only supports `ipv6Only` option in `flags`.
         ipv6Only: !!(flags & UV_TCP_IPV6ONLY),
         backlog,
+        // Workers bind this port directly; open the reuse group for them.
         reusePort: true,
       });
     } else

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4026,14 +4026,13 @@ function listenInCluster(
     if (err) {
       throw new ExceptionWithHostPort(err, "bind", address, port);
     }
-    // Bun: no IPC handle passing yet, so bind here with reusePort (same as
-    // _http_server.ts does for a worker) instead of adopting the faux handle.
     server[kRealListen](
       path,
       port,
       hostname,
       exclusive,
       ipv6Only,
+      // Workers share the port via SO_REUSEPORT; matches _http_server.ts.
       true /* reusePort */,
       readableAll,
       writableAll,

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4026,13 +4026,20 @@ function listenInCluster(
     if (err) {
       throw new ExceptionWithHostPort(err, "bind", address, port);
     }
+    // Bun: IPC socket-handle passing isn't implemented yet, so the primary
+    // cannot forward accepted connections to this worker. Bind the port here
+    // with SO_REUSEPORT (SO_REUSEADDR on Windows) so multiple workers can share
+    // it, the same approach _http_server.ts uses for http.Server in a worker.
+    // Without this the second worker's bind sees EADDRINUSE now that
+    // bsd_create_listen_socket no longer silently falls back to the other
+    // loopback family. See #30603 for the full cluster round-robin rework.
     server[kRealListen](
       path,
       port,
       hostname,
       exclusive,
       ipv6Only,
-      reusePort,
+      true /* reusePort */,
       readableAll,
       writableAll,
       tls,

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4026,13 +4026,8 @@ function listenInCluster(
     if (err) {
       throw new ExceptionWithHostPort(err, "bind", address, port);
     }
-    // Bun: IPC socket-handle passing isn't implemented yet, so the primary
-    // cannot forward accepted connections to this worker. Bind the port here
-    // with SO_REUSEPORT (SO_REUSEADDR on Windows) so multiple workers can share
-    // it, the same approach _http_server.ts uses for http.Server in a worker.
-    // Without this the second worker's bind sees EADDRINUSE now that
-    // bsd_create_listen_socket no longer silently falls back to the other
-    // loopback family. See #30603 for the full cluster round-robin rework.
+    // Bun: no IPC handle passing yet, so bind here with reusePort (same as
+    // _http_server.ts does for a worker) instead of adopting the faux handle.
     server[kRealListen](
       path,
       port,

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1295,6 +1295,28 @@ describe("node:http", () => {
     const err = await promise;
     expect(err.code).toBe("EADDRINUSE");
   });
+
+  // https://github.com/oven-sh/bun/issues/15560
+  test("listen(port, 'localhost') reports EADDRINUSE instead of silently binding the other loopback family", async () => {
+    const a = createServer();
+    const b = createServer();
+    try {
+      await new Promise<void>((resolve, reject) => {
+        a.on("error", reject);
+        a.listen(0, "localhost", () => resolve());
+      });
+      const port = a.address().port;
+
+      const err = await new Promise<NodeJS.ErrnoException>((resolve, reject) => {
+        b.on("error", resolve);
+        b.listen(port, "localhost", () => reject(new Error(`second listen bound ${JSON.stringify(b.address())}`)));
+      });
+      expect(err.code).toBe("EADDRINUSE");
+    } finally {
+      b.close();
+      a.close();
+    }
+  });
 });
 
 describe("node https server", async () => {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1870,3 +1870,29 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
     target.close();
   }
 });
+
+// https://github.com/oven-sh/bun/issues/15560
+// When a host such as "localhost" resolves to more than one loopback family,
+// bsd_create_listen_socket walks every getaddrinfo result. It must not swallow
+// EADDRINUSE on one family and silently bind the other: a second server asking
+// for the same (port, "localhost") has to see EADDRINUSE, like Node.
+it('listen(port, "localhost") reports EADDRINUSE when the port is already held on localhost', async () => {
+  const a = createServer();
+  const b = createServer();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      a.on("error", reject);
+      a.listen(0, "localhost", resolve);
+    });
+    const port = (a.address() as import("node:net").AddressInfo).port;
+
+    const err = await new Promise<NodeJS.ErrnoException>((resolve, reject) => {
+      b.on("error", resolve);
+      b.listen(port, "localhost", () => reject(new Error(`second listen bound ${JSON.stringify(b.address())}`)));
+    });
+    expect(err.code).toBe("EADDRINUSE");
+  } finally {
+    b.close();
+    a.close();
+  }
+});

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1872,10 +1872,6 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
 });
 
 // https://github.com/oven-sh/bun/issues/15560
-// When a host such as "localhost" resolves to more than one loopback family,
-// bsd_create_listen_socket walks every getaddrinfo result. It must not swallow
-// EADDRINUSE on one family and silently bind the other: a second server asking
-// for the same (port, "localhost") has to see EADDRINUSE, like Node.
 it('listen(port, "localhost") reports EADDRINUSE when the port is already held on localhost', async () => {
   const a = createServer();
   const b = createServer();


### PR DESCRIPTION
Fixes #15560.

### Repro

```js
const net = require("net");
const a = net.createServer();
a.listen(0, "localhost", () => {
  const port = a.address().port;
  const b = net.createServer();
  b.on("error", e => console.log("B", e.code));
  b.listen(port, "localhost", () => console.log("B bound", b.address()));
});
```

Before: `B bound { address: '127.0.0.1', port: <same>, family: 'IPv4' }`
After (and in Node): `B EADDRINUSE`

### Cause

`bsd_create_listen_socket` calls `getaddrinfo(host)` and walks every result, IPv6 first then IPv4, so that hosts with a disabled v6 stack can still bind the v4 loopback. It treated every `bind()` failure as a reason to move on to the next `addrinfo`, so when `localhost` resolved to both `::1` and `127.0.0.1`, a second `listen(port, "localhost")` that got `EADDRINUSE` on `::1` would silently bind `127.0.0.1` instead of surfacing the error. Two dev servers both "listened on localhost:5173" and Vite's port probe never saw a conflict.

Node resolves the host once via `dns.lookup` and binds that single address, so the second listener sees `EADDRINUSE`.

### Fix

Keep walking the `addrinfo` list for errors that mean the family is unusable (`EAFNOSUPPORT`, `EADDRNOTAVAIL`, socket() failures), but stop and return the error when `bind()` reports `EADDRINUSE` or `EACCES`: those mean the port is owned, and binding the other loopback family is not a correct fallback. `packages/bun-usockets/src/bsd.c` is the shared sink for `Bun.listen`, `Bun.serve`, `net.Server` and `http.Server`, so the one change covers all of them.

### node:cluster follow-up

Stopping the addrinfo fallback exposed that `test-net-listen-shared-ports.js` on Windows only passed because of it: the primary's `RoundRobinHandle` binds the requested port and each worker then re-binds it itself, so worker2 was reaching `'listening'` by quietly taking `127.0.0.1` after `::1` reported in-use. On Linux the same test was already failing on `main` (the primary's dual-stack wildcard blocks both loopback addresses outright).

`_http_server.ts` already handles this for `http.Server` in a cluster worker by binding with `reusePort`. Do the same for `net.Server`: the primary's `RoundRobinHandle` and the worker's `listenOnPrimaryHandle` now pass `reusePort: true`, so the port is shared via `SO_REUSEPORT` (Linux) / `SO_REUSEADDR` (Windows) instead of via the addrinfo fallback. `test-net-listen-shared-ports.js` now passes on both Linux and Windows. The full cluster round-robin rework (primary stops accepting, `port: 0` resolved once) is tracked in #30603.

### Verification

```
$ bun bd test test/js/node/net/node-net.test.ts -t "EADDRINUSE when the port is already held on localhost"
(pass) listen(port, "localhost") reports EADDRINUSE when the port is already held on localhost

$ bun bd test test/js/node/http/node-http.test.ts -t "silently binding the other loopback"
(pass) node:http > listen(port, 'localhost') reports EADDRINUSE instead of silently binding the other loopback family

$ bun bd test/js/node/test/sequential/test-net-listen-shared-ports.js   # Linux and Windows
(exit 0)
```

Both new tests fail on main with `second listen bound {"address":"127.0.0.1",...}`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->