### PR TITLE
cli(run): keep signal-forwarding handler installed across deliveries

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -902,9 +902,7 @@ extern "C" int64_t Bun__currentSyncPID = 0;
 static int Bun__pendingSignalToSend = 0;
 static struct sigaction previous_actions[NSIG];
 
-// This list of signals is copied from npm, minus aliases (SIGIOT == SIGABRT,
-// SIGPOLL == SIGIO) which would double-write previous_actions[N] and lose the
-// original disposition.
+// npm's signal list minus SIGIOT/SIGPOLL (aliases of SIGABRT/SIGIO; listing both would overwrite previous_actions[N]).
 // https://github.com/npm/cli/blob/fefd509992a05c2dfddbe7bc46931c42f1da69d7/workspaces/arborist/lib/signals.js#L26-L57
 #define FOR_EACH_POSIX_SIGNAL(M) \
     M(SIGABRT);                  \

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -971,9 +971,7 @@ extern "C" void Bun__registerSignalsForForwarding()
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
     sigemptyset(&sa.sa_mask);
-    // Not SA_RESETHAND: a nested `bun run` receives the signal more than once
-    // (terminal pgroup delivery + parent runner's forward) and must keep
-    // forwarding until the child exits, not die on the second delivery.
+    // Not SA_RESETHAND: a nested runner sees the signal more than once and must not die on a repeat delivery.
     sa.sa_flags = 0;
     sa.sa_handler = [](int sig) {
         if (Bun__currentSyncPID == 0) {

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -971,12 +971,9 @@ extern "C" void Bun__registerSignalsForForwarding()
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
     sigemptyset(&sa.sa_mask);
-    // No SA_RESETHAND: a nested `bun run` receives the terminal's pgroup SIGINT
-    // *and* the SIGINT its parent `bun run` forwards. With SA_RESETHAND the
-    // second delivery hits SIG_DFL and kills the middle runner while the
-    // innermost script is still cleaning up (#14799). npm's equivalent handler
-    // is persistent; the disposition is restored by
-    // Bun__unregisterSignalsForForwarding once the child has exited.
+    // Not SA_RESETHAND: a nested `bun run` receives the signal more than once
+    // (terminal pgroup delivery + parent runner's forward) and must keep
+    // forwarding until the child exits, not die on the second delivery.
     sa.sa_flags = 0;
     sa.sa_handler = [](int sig) {
         if (Bun__currentSyncPID == 0) {

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -971,7 +971,13 @@ extern "C" void Bun__registerSignalsForForwarding()
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
     sigemptyset(&sa.sa_mask);
-    sa.sa_flags = SA_RESETHAND;
+    // No SA_RESETHAND: a nested `bun run` receives the terminal's pgroup SIGINT
+    // *and* the SIGINT its parent `bun run` forwards. With SA_RESETHAND the
+    // second delivery hits SIG_DFL and kills the middle runner while the
+    // innermost script is still cleaning up (#14799). npm's equivalent handler
+    // is persistent; the disposition is restored by
+    // Bun__unregisterSignalsForForwarding once the child has exited.
+    sa.sa_flags = 0;
     sa.sa_handler = [](int sig) {
         if (Bun__currentSyncPID == 0) {
             Bun__pendingSignalToSend = sig;

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -902,7 +902,9 @@ extern "C" int64_t Bun__currentSyncPID = 0;
 static int Bun__pendingSignalToSend = 0;
 static struct sigaction previous_actions[NSIG];
 
-// This list of signals is copied from npm.
+// This list of signals is copied from npm, minus aliases (SIGIOT == SIGABRT,
+// SIGPOLL == SIGIO) which would double-write previous_actions[N] and lose the
+// original disposition.
 // https://github.com/npm/cli/blob/fefd509992a05c2dfddbe7bc46931c42f1da69d7/workspaces/arborist/lib/signals.js#L26-L57
 #define FOR_EACH_POSIX_SIGNAL(M) \
     M(SIGABRT);                  \
@@ -917,16 +919,12 @@ static struct sigaction previous_actions[NSIG];
     M(SIGTRAP);                  \
     M(SIGSYS);                   \
     M(SIGQUIT);                  \
-    M(SIGIOT);                   \
     M(SIGIO);
 
 #if OS(LINUX)
 // SIGPWR is intentionally excluded: JSC uses it for GC thread suspend/resume
-// (see wtf/posix/ThreadingPOSIX.cpp). Overriding it here breaks GC and the
-// SA_RESETHAND disposition leaves it at SIG_DFL after one delivery, which
-// kills the process on the next collection.
+// (see wtf/posix/ThreadingPOSIX.cpp); overriding it here breaks GC.
 #define FOR_EACH_LINUX_ONLY_SIGNAL(M) \
-    M(SIGPOLL);                       \
     M(SIGSTKFLT);
 
 #endif

--- a/test/regression/issue/14799.test.ts
+++ b/test/regression/issue/14799.test.ts
@@ -86,7 +86,9 @@ test.skipIf(!isPosix)("nested bun run waits for the child on SIGINT", async () =
   const stderr = await stderrPromise;
 
   // Best-effort: don't leak the inner process if it outlived the outer runner.
-  try { process.kill(-outer.pid, "SIGKILL"); } catch {}
+  try {
+    process.kill(-outer.pid, "SIGKILL");
+  } catch {}
 
   expect(stderr).not.toContain("error");
   expect({

--- a/test/regression/issue/14799.test.ts
+++ b/test/regression/issue/14799.test.ts
@@ -1,0 +1,103 @@
+// https://github.com/oven-sh/bun/issues/14799
+//
+// A terminal Ctrl+C signals the whole foreground process group. Each `bun run`
+// in a nested chain also forwards the signal to its child, so a runner in the
+// middle of the chain receives SIGINT more than once (the terminal's delivery
+// plus its parent's forward). The forwarding handler must be persistent so the
+// second delivery does not fall through to SIG_DFL and kill the runner while
+// the innermost script is still cleaning up.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+
+test.skipIf(!isPosix)("nested bun run waits for the child on SIGINT", async () => {
+  using dir = tempDir("issue-14799", {
+    "package.json": JSON.stringify({
+      name: "issue-14799",
+      scripts: {
+        outer: `${bunExe()} run inner`,
+        inner: `${bunExe()} script.js`,
+      },
+    }),
+    "script.js": `
+      let done = 0;
+      process.on("SIGINT", () => {
+        if (done++) return;
+        setTimeout(() => {
+          console.log("cleanup done");
+          process.exit(0);
+        }, 500);
+      });
+      setInterval(() => {}, 1 << 30);
+      console.log("ready " + process.pid);
+    `,
+  });
+
+  // Start the chain in its own process group (detached => setsid) so a single
+  // kill reaches every process, the same way the terminal driver delivers
+  // Ctrl+C.
+  await using outer = Bun.spawn({
+    cmd: [bunExe(), "run", "outer"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    detached: true,
+  });
+
+  const stderrPromise = outer.stderr.text();
+  const reader = outer.stdout.getReader();
+  const decoder = new TextDecoder();
+  let stdout = "";
+  let innerPid = 0;
+  while (!innerPid) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    stdout += decoder.decode(value, { stream: true });
+    const m = stdout.match(/ready (\d+)/);
+    if (m) innerPid = Number(m[1]);
+  }
+  expect(innerPid).toBeGreaterThan(0);
+
+  // SIGINT to the whole process group (detached => outer.pid is the pgid).
+  process.kill(-outer.pid, "SIGINT");
+
+  const exitCode = await outer.exited;
+
+  // With the bug, the middle runner is killed by the second SIGINT and the
+  // outer runner returns immediately, while the innermost script is still in
+  // its 500ms cleanup timer. With the fix, the outer runner only returns once
+  // its child (and transitively the innermost script) has exited.
+  let innerAlive: boolean;
+  try {
+    process.kill(innerPid, 0);
+    innerAlive = true;
+  } catch {
+    innerAlive = false;
+  }
+
+  // The innermost script still holds the write end of the pipe, so stdout does
+  // not EOF until its cleanup has run regardless of whether the outer runner
+  // waited.
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    stdout += decoder.decode(value, { stream: true });
+  }
+  const stderr = await stderrPromise;
+
+  // Best-effort: don't leak the inner process if it outlived the outer runner.
+  try { process.kill(-outer.pid, "SIGKILL"); } catch {}
+
+  expect(stderr).not.toContain("error");
+  expect({
+    stdout,
+    innerAliveAfterOuterExit: innerAlive,
+    exitCode,
+    signalCode: outer.signalCode,
+  }).toMatchObject({
+    stdout: expect.stringContaining("cleanup done"),
+    innerAliveAfterOuterExit: false,
+    exitCode: 0,
+    signalCode: null,
+  });
+});

--- a/test/regression/issue/14799.test.ts
+++ b/test/regression/issue/14799.test.ts
@@ -22,6 +22,7 @@ test.skipIf(!isPosix)("nested bun run waits for the child on SIGINT", async () =
       let done = 0;
       process.on("SIGINT", () => {
         if (done++) return;
+        console.log("sigint received");
         setTimeout(() => {
           console.log("cleanup done");
           process.exit(0);
@@ -49,17 +50,27 @@ test.skipIf(!isPosix)("nested bun run waits for the child on SIGINT", async () =
     const reader = outer.stdout.getReader();
     const decoder = new TextDecoder();
     let stdout = "";
-    let innerPid = 0;
-    while (!innerPid) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      stdout += decoder.decode(value, { stream: true });
-      const m = stdout.match(/ready (\d+)/);
-      if (m) innerPid = Number(m[1]);
-    }
+    const readUntil = async (needle: string) => {
+      while (!stdout.includes(needle)) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        stdout += decoder.decode(value, { stream: true });
+      }
+    };
+
+    await readUntil("ready ");
+    const innerPid = Number(stdout.match(/ready (\d+)/)?.[1]);
     expect(innerPid).toBeGreaterThan(0);
 
     // SIGINT to the whole process group (detached => outer.pid is the pgid).
+    // A second SIGINT goes out once the innermost script has entered its
+    // handler: standard signals coalesce, so on a single-core scheduler the
+    // forwarded SIGINT from the first delivery could merge with the still
+    // pending pgroup SIGINT on the middle runner and leave it with only one
+    // delivery to handle. The explicit second round guarantees a repeat
+    // delivery after every runner's first handler has returned.
+    process.kill(-outer.pid, "SIGINT");
+    await readUntil("sigint received");
     process.kill(-outer.pid, "SIGINT");
 
     const exitCode = await outer.exited;

--- a/test/regression/issue/14799.test.ts
+++ b/test/regression/issue/14799.test.ts
@@ -44,62 +44,65 @@ test.skipIf(!isPosix)("nested bun run waits for the child on SIGINT", async () =
     detached: true,
   });
 
-  const stderrPromise = outer.stderr.text();
-  const reader = outer.stdout.getReader();
-  const decoder = new TextDecoder();
-  let stdout = "";
-  let innerPid = 0;
-  while (!innerPid) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    stdout += decoder.decode(value, { stream: true });
-    const m = stdout.match(/ready (\d+)/);
-    if (m) innerPid = Number(m[1]);
-  }
-  expect(innerPid).toBeGreaterThan(0);
-
-  // SIGINT to the whole process group (detached => outer.pid is the pgid).
-  process.kill(-outer.pid, "SIGINT");
-
-  const exitCode = await outer.exited;
-
-  // With the bug, the middle runner is killed by the second SIGINT and the
-  // outer runner returns immediately, while the innermost script is still in
-  // its 500ms cleanup timer. With the fix, the outer runner only returns once
-  // its child (and transitively the innermost script) has exited.
-  let innerAlive: boolean;
   try {
-    process.kill(innerPid, 0);
-    innerAlive = true;
-  } catch {
-    innerAlive = false;
+    const stderrPromise = outer.stderr.text();
+    const reader = outer.stdout.getReader();
+    const decoder = new TextDecoder();
+    let stdout = "";
+    let innerPid = 0;
+    while (!innerPid) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      stdout += decoder.decode(value, { stream: true });
+      const m = stdout.match(/ready (\d+)/);
+      if (m) innerPid = Number(m[1]);
+    }
+    expect(innerPid).toBeGreaterThan(0);
+
+    // SIGINT to the whole process group (detached => outer.pid is the pgid).
+    process.kill(-outer.pid, "SIGINT");
+
+    const exitCode = await outer.exited;
+
+    // With the bug, the middle runner is killed by the second SIGINT and the
+    // outer runner returns immediately, while the innermost script is still in
+    // its 500ms cleanup timer. With the fix, the outer runner only returns
+    // once its child (and transitively the innermost script) has exited.
+    let innerAlive: boolean;
+    try {
+      process.kill(innerPid, 0);
+      innerAlive = true;
+    } catch {
+      innerAlive = false;
+    }
+
+    // The innermost script still holds the write end of the pipe, so stdout
+    // does not EOF until its cleanup has run regardless of whether the outer
+    // runner waited.
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      stdout += decoder.decode(value, { stream: true });
+    }
+    const stderr = await stderrPromise;
+
+    expect(stderr).not.toContain("error");
+    expect({
+      stdout,
+      innerAliveAfterOuterExit: innerAlive,
+      exitCode,
+      signalCode: outer.signalCode,
+    }).toMatchObject({
+      stdout: expect.stringContaining("cleanup done"),
+      innerAliveAfterOuterExit: false,
+      exitCode: 0,
+      signalCode: null,
+    });
+  } finally {
+    // `await using outer` only disposes the one process handle; reap the whole
+    // detached group so nothing is left running on a persistent CI runner.
+    try {
+      process.kill(-outer.pid, "SIGKILL");
+    } catch {}
   }
-
-  // The innermost script still holds the write end of the pipe, so stdout does
-  // not EOF until its cleanup has run regardless of whether the outer runner
-  // waited.
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    stdout += decoder.decode(value, { stream: true });
-  }
-  const stderr = await stderrPromise;
-
-  // Best-effort: don't leak the inner process if it outlived the outer runner.
-  try {
-    process.kill(-outer.pid, "SIGKILL");
-  } catch {}
-
-  expect(stderr).not.toContain("error");
-  expect({
-    stdout,
-    innerAliveAfterOuterExit: innerAlive,
-    exitCode,
-    signalCode: outer.signalCode,
-  }).toMatchObject({
-    stdout: expect.stringContaining("cleanup done"),
-    innerAliveAfterOuterExit: false,
-    exitCode: 0,
-    signalCode: null,
-  });
 });


### PR DESCRIPTION
Fixes #14799.

## Repro

```json
{ "scripts": { "outer": "bun run inner", "inner": "bun script.js" } }
```
```js
// script.js
process.on('SIGINT', () => { console.log('Received'); setTimeout(() => { console.log('Exiting'); process.exit(); }, 1000); });
setInterval(() => {}, 1 << 30);
console.log('Waiting');
```
```console
$ bun run outer
$ bun run inner
$ bun script.js
Waiting
^CReceived
Received
user@host $ Exiting        <- prompt returns while the script is still cleaning up
```

The outermost `bun run` returns ~7ms after Ctrl+C while the innermost script is still in its 1s cleanup timer. npm waits for the child and returns after it.

## Cause

`Bun__registerSignalsForForwarding` installs a forwarding handler for SIGINT (and the rest of npm's signal set) with `SA_RESETHAND`, so the disposition drops back to `SIG_DFL` after the first delivery.

A terminal Ctrl+C signals the whole foreground process group. In a nested chain every `bun run` gets the terminal's SIGINT *and* forwards it to its child, so a runner in the middle receives the signal at least twice:

```
terminal -> pgroup SIGINT -> bun run outer, bun run inner, bun script.js
bun run outer: forward SIGINT -> bun run inner   (handler reset to SIG_DFL)
bun run inner: forward SIGINT -> bun script.js   (handler reset to SIG_DFL)
bun run inner: 2nd SIGINT (from outer's forward) -> SIG_DFL -> killed
bun run outer: wait4 sees inner died by SIGINT -> re-raise -> exit
bun script.js: still running its 1s cleanup timer
```

A single level (`bun run inner` directly) works because the top-level runner only ever sees one SIGINT.

## Fix

Drop `SA_RESETHAND`. The forwarding handler stays installed for the lifetime of the child, matching npm (the signal list and forwarding behavior were already modelled on npm per the existing comment). `Bun__unregisterSignalsForForwarding` restores the previous disposition once the child has exited, so the process-level behavior outside the wait is unchanged.

While here, drop `SIGIOT` and `SIGPOLL` from the signal list: they are aliases of `SIGABRT` and `SIGIO`, so `REGISTER_SIGNAL` ran twice for the same signal number and the second call overwrote `previous_actions[N]` with the forwarding handler itself, which the unregister then "restored". With `SA_RESETHAND` gone that leaked handler would have been permanent rather than one-shot. Impact was essentially nil (SIGABRT is re-fixed by `reset_on_posix()` in release builds, and nothing sends SIGIO), but registering each signal number exactly once makes the unregister comment true.

## Verification

New test in `test/regression/issue/14799.test.ts` spawns `bun run outer` -> `bun run inner` -> `bun script.js` in its own process group, sends SIGINT to the group, and asserts:

| | before | after |
| --- | --- | --- |
| inner still alive when outer exits | `true` | `false` |
| outer `exitCode` / `signalCode` | `130` / `SIGINT` | `0` / `null` |
| stdout | `cleanup done` | `cleanup done` |

```
git stash push -- src/ && bun bd test test/regression/issue/14799.test.ts
  (fail) nested bun run waits for the child on SIGINT
    exitCode: 130, innerAliveAfterOuterExit: true, signalCode: SIGINT

bun bd test test/regression/issue/14799.test.ts
  (pass) nested bun run waits for the child on SIGINT  x5/5
```

The existing `verify that we forward SIGINT from parent to child in bun run` and `bun run propagates SIGKILL` tests still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/14799.test.ts"
bun test v1.4.0 (9d7844e16)

test/regression/issue/14799.test.ts:
101 |     expect({
102 |       stdout,
103 |       innerAliveAfterOuterExit: innerAlive,
104 |       exitCode,
105 |       signalCode: outer.signalCode,
106 |     }).toMatchObject({
             ^
error: expect(received).toMatchObject(expected)

  {
-   "exitCode": 0,
-   "innerAliveAfterOuterExit": false,
-   "signalCode": null,
+   "exitCode": 130,
+   "innerAliveAfterOuterExit": true,
+   "signalCode": "SIGINT",
    "stdout": StringContaining "cleanup done",
  }

- Expected  - 3
+ Received  + 3

      at <anonymous> (/workspace/bun/test/regression/issue/14799.test.ts:106:8)
(fail) nested bun run waits for the child on SIGINT [1083.68ms]

 0 pass
 1 fail
 3 expect() calls
Ran 1 test across 1 file. [3.09s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (d415e1f16)

test/regression/issue/14799.test.ts:
(pass) nested bun run waits for the child on SIGINT [517.65ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [670.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/14799.test.ts"
bun test v1.4.0 (9d7844e16)

test/regression/issue/14799.test.ts:
(pass) nested bun run waits for the child on SIGINT [1135.21ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [3.18s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 753ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/c-bindings.cpp     |  11 ++--
 test/regression/issue/14799.test.ts | 119 ++++++++++++++++++++++++++++++++++++
 2 files changed, 123 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/bindings/c-bindings.cpp          8      7      0
test/regression/issue/14799.test.ts      2      6      0
```

</details>

<!-- robobun:evidence:end -->