### PR TITLE
bundler: emit namespace binding for runtime `export * from <external>`

### DIFF
--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1084,9 +1084,25 @@ pub(crate) fn scan_imports_and_exports(
                             Index::source(source_index),
                         )?;
                         col!(ast_flags_list)[id].insert(AstFlags::USES_EXPORTS_REF);
-                        col!(import_records_list)[id].as_mut_slice()[*import_record_index as usize]
-                            .flags
-                            .insert(ImportRecordFlags::CALLS_RUNTIME_RE_EXPORT_FN);
+                        {
+                            let record = &mut col!(import_records_list)[id].as_mut_slice()
+                                [*import_record_index as usize];
+                            record
+                                .flags
+                                .insert(ImportRecordFlags::CALLS_RUNTIME_RE_EXPORT_FN);
+                            // convertStmtsForChunk rewrites this external "export * from" into
+                            // "import * as ns from ..." so that __reExport can reference the
+                            // namespace object. The printer emits the "* as ns" clause based on
+                            // CONTAINS_IMPORT_STAR, which the parser never sets for a bare
+                            // "export * from", so set it here to keep the binding.
+                            if rec_source_index.is_invalid()
+                                && output_format.keep_es6_import_export_syntax()
+                            {
+                                record
+                                    .flags
+                                    .insert(ImportRecordFlags::CONTAINS_IMPORT_STAR);
+                            }
+                        }
                         re_export_uses += 1;
                     }
                 }

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1098,9 +1098,7 @@ pub(crate) fn scan_imports_and_exports(
                             if rec_source_index.is_invalid()
                                 && output_format.keep_es6_import_export_syntax()
                             {
-                                record
-                                    .flags
-                                    .insert(ImportRecordFlags::CONTAINS_IMPORT_STAR);
+                                record.flags.insert(ImportRecordFlags::CONTAINS_IMPORT_STAR);
                             }
                         }
                         re_export_uses += 1;

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1090,14 +1090,10 @@ pub(crate) fn scan_imports_and_exports(
                             record
                                 .flags
                                 .insert(ImportRecordFlags::CALLS_RUNTIME_RE_EXPORT_FN);
-                            // convertStmtsForChunk rewrites this external "export * from" into
-                            // "import * as ns from ..." so that __reExport can reference the
-                            // namespace object. The printer emits the "* as ns" clause based on
-                            // CONTAINS_IMPORT_STAR, which the parser never sets for a bare
-                            // "export * from", so set it here to keep the binding.
                             if rec_source_index.is_invalid()
                                 && output_format.keep_es6_import_export_syntax()
                             {
+                                // convertStmtsForChunk prints this as "import * as ns" for __reExport.
                                 record.flags.insert(ImportRecordFlags::CONTAINS_IMPORT_STAR);
                             }
                         }

--- a/test/bundler/esbuild/importstar.test.ts
+++ b/test/bundler/esbuild/importstar.test.ts
@@ -1,4 +1,4 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
 import { itBundled } from "../expectBundled";
 
 // Tests ported from:
@@ -1122,6 +1122,53 @@ describe("bundler", () => {
     run: {
       file: "/test.js",
       stdout: '{"bar":"bar","foo":"foo"}',
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/15997
+  itBundled("importstar/ReExportStarExternalNonEntryES6", {
+    files: {
+      "/entry.js": /* js */ `
+        import { foo, bar } from "./re-export.js";
+        console.log(foo, bar);
+      `,
+      "/re-export.js": `export * from "ext"`,
+    },
+    external: ["ext"],
+    format: "esm",
+    runtimeFiles: {
+      "/node_modules/ext/index.js": /* js */ `
+        export const foo = "foo";
+        export const bar = "bar";
+      `,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain(`import * as `);
+    },
+    run: {
+      stdout: "foo bar",
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/15997
+  itBundled("importstar/ReExportStarExternalNonEntryWithNamedImportES6", {
+    files: {
+      "/entry.js": /* js */ `
+        import { createHash, convertPrivateKey } from "./crypto-node.js";
+        console.log(typeof createHash, typeof convertPrivateKey);
+      `,
+      "/crypto-node.js": /* js */ `
+        export * from "node:crypto";
+        import { createPrivateKey } from "node:crypto";
+        export function convertPrivateKey(pem) { return createPrivateKey(pem); }
+      `,
+    },
+    target: "bun",
+    format: "esm",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toMatch(/import \* as \w+ from "(node:)?crypto"/);
+    },
+    run: {
+      stdout: "function function",
     },
   });
   itBundled("importstar/ImportDefaultNamespaceComboESBuildIssue446", {


### PR DESCRIPTION
Fixes #15997.

## Repro

```ts
// http.ts
export * from "node:crypto";
import { createPrivateKey } from "node:crypto";
export function convertPrivateKey(pem) { return createPrivateKey(pem); }

// entry.ts
import { convertPrivateKey, createHash } from "./http.ts";
console.log(typeof createHash, typeof convertPrivateKey);
```

```
$ bun build --target bun entry.ts --outfile out.js && bun out.js
ReferenceError: node_crypto is not defined
```

The bundled output contains `__reExport(exports_http, node_crypto)` followed by a bare `import "crypto";` with no `node_crypto` binding. This is the shape universal-github-app-jwt@2.2.0 (via @octokit/auth-app / @octokit/app) ships.

## Cause

When a non-entry module has `export * from "<external>"` and the output format keeps ES6 imports, `convertStmtsForChunk` rewrites the export-star into `import * as ns from "<external>"` and emits a `__reExport(exports, ns)` call that references `ns`. The printer, however, emits the `* as ns` clause only when the import record carries `CONTAINS_IMPORT_STAR`, and the parser never sets that flag for a bare `export * from` record. So the synthesized import prints as a side-effect-only `import "path"` and the `ns` reference in `__reExport` is unbound.

The entrypoint case was already fine because `happens_at_runtime` is false there and the `export * from` is printed verbatim.

## Fix

In `scanImportsAndExports`, when marking an external export-star record with `CALLS_RUNTIME_RE_EXPORT_FN` for an ESM-output chunk, also set `CONTAINS_IMPORT_STAR` so the printer emits the namespace binding. Gated on `rec_source_index.is_invalid() && output_format.keep_es6_import_export_syntax()` to match the exact condition under which `convertStmtsForChunk` synthesizes the `import * as ns` statement; the CJS path (which uses `__reExport(exports, require(path))`) is unaffected.

## Verification

Added two `itBundled` cases in `test/bundler/esbuild/importstar.test.ts` (non-entry `export * from` external, and the issue's exact shape with an additional named import from the same external). Both fail on canary with `ReferenceError: node_crypto is not defined` / missing `import * as`, and pass with this change. Existing importstar / default / edgecase / cjs / splitting bundler suites are green.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/importstar.test.ts
bun test v1.4.0 (f19ea131a)

test/bundler/esbuild/importstar.test.ts:
(pass) bundler > importstar/ImportStarUnused [830.59ms]
(pass) bundler > importstar/ImportStarCapture [428.14ms]
(pass) bundler > importstar/ImportStarNoCapture [412.73ms]
(pass) bundler > importstar/ImportStarExportImportStarUnused [384.48ms]
(pass) bundler > importstar/ImportStarExportImportStarNoCapture [418.52ms]
(pass) bundler > importstar/ImportStarExportImportStarCapture [384.88ms]
(pass) bundler > importstar/ImportStarExportStarAsUnused [401.71ms]
(pass) bundler > importstar/ImportStarExportStarAsNoCapture [388.01ms]
(pass) bundler > importstar/ImportStarExportStarAsCapture [482.06ms]
(pass) bundler > importstar/ImportStarExportStarUnused [406.33ms]
(pass) bundler > importstar/ImportStarExportStarNoCapture [376.89ms]
(pass) bundler > importstar/ImportStarExportStarCapture [375.22ms]
(pass) bundler > importstar/ImportStarCommonJSUnused [467.03ms]
(pass) bundler > importstar/ImportStarCommonJSCapture [718.57ms]
(pass) bun
... (truncated)

release without fix: 7 failed, 4 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/esbuild/importstar.test.ts:
(pass) bundler > importstar/ImportStarUnused [42.73ms]
(pass) bundler > importstar/ImportStarCapture [20.39ms]
(pass) bundler > importstar/ImportStarNoCapture [18.45ms]
(pass) bundler > importstar/ImportStarExportImportStarUnused [20.24ms]
(pass) bundler > importstar/ImportStarExportImportStarNoCapture [19.02ms]
(pass) bundler > importstar/ImportStarExportImportStarCapture [19.37ms]
(pass) bundler > importstar/ImportStarExportStarAsUnused [19.03ms]
(pass) bundler > importstar/ImportStarExportStarAsNoCapture [19.22ms]
(pass) bundler > importstar/ImportStarExportStarAsCapture [19.30ms]
(pass) bundler > importstar/ImportStarExportStarUnused [18.58ms]
(pass) bundler > importstar/ImportStarExportStarNoCapture [18.91ms]
(pass) bundler > importstar/ImportStarExportStarCapture [18.96ms]
(pass) bundler > importstar/ImportStarCommonJSUnused [18.43ms]
(pass) bundler > importstar/ImportStarCommonJSCapture [21.68ms]
(pass) bundler > importstar/ImportStarCommonJSNoCapture [18.95ms]
(pass) bundler > importstar/ImportStarAndCommonJS [3.71ms]
(pass) bundler > importstar/ImportStarNoBundleUnused [22.09ms]

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/importstar.test.ts
bun test v1.4.0 (f19ea131a)

test/bundler/esbuild/importstar.test.ts:
(pass) bundler > importstar/ImportStarUnused [828.79ms]
(pass) bundler > importstar/ImportStarCapture [469.64ms]
(pass) bundler > importstar/ImportStarNoCapture [372.27ms]
(pass) bundler > importstar/ImportStarExportImportStarUnused [449.94ms]
(pass) bundler > importstar/ImportStarExportImportStarNoCapture [433.83ms]
(pass) bundler > importstar/ImportStarExportImportStarCapture [401.29ms]
(pass) bundler > importstar/ImportStarExportStarAsUnused [416.59ms]
(pass) bundler > importstar/ImportStarExportStarAsNoCapture [391.40ms]
(pass) bundler > importstar/ImportStarExportStarAsCapture [400.54ms]
(pass) bundler > importstar/ImportStarExportStarUnused [405.83ms]
(pass) bundler > importstar/ImportStarExportStarNoCapture [368.71ms]
(pass) bundler > importstar/ImportStarExportStarCapture [402.59ms]
(pass) bundler > importstar/ImportStarCommonJSUnused [370.06ms]
(pass) bundler > importstar/ImportStarCommonJSCapture [716.26ms]
(pass) bun
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 821ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../linker_context/scanImportsAndExports.rs        | 16 +++++--
 test/bundler/esbuild/importstar.test.ts            | 49 +++++++++++++++++++++-
 2 files changed, 61 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/bundler/linker_context/scanImportsAndExports.rs      5      2      0
test/bundler/esbuild/importstar.test.ts                  2      2      0
```

</details>

<!-- robobun:evidence:end -->