### PR TITLE
js_parser: reject an optional chain as an assignment target even when minify_syntax can drop the '?.'

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5313,11 +5313,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Remove an unnecessary optional chain start when the already-visited
-    /// `target` is provably not null/undefined. Called from `e_dot` / `e_index`
-    /// / `e_call` after the assignment-target check and after the target has
-    /// been visited, so `{}?.y = 0` is still rejected as a syntax error before
-    /// any simplification happens.
+    /// Drop an unnecessary `?.` when the visited `target` is provably not null/undefined.
     pub(crate) fn maybe_simplify_optional_chain(
         &self,
         optional_chain: Option<js_ast::OptionalChain>,
@@ -5335,9 +5331,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
             Some(js_ast::OptionalChain::Continuation) => {
-                // Propagate a stripped start through the rest of the chain so
-                // later `.is_none()` checks behave as they did when this was
-                // done at parse time.
                 let target_chain = match target {
                     js_ast::ExprData::EDot(e) => Some(e.optional_chain),
                     js_ast::ExprData::EIndex(e) => Some(e.optional_chain),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5313,6 +5313,46 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    /// Remove an unnecessary optional chain start when the already-visited
+    /// `target` is provably not null/undefined. Called from `e_dot` / `e_index`
+    /// / `e_call` after the assignment-target check and after the target has
+    /// been visited, so `{}?.y = 0` is still rejected as a syntax error before
+    /// any simplification happens.
+    pub(crate) fn maybe_simplify_optional_chain(
+        &self,
+        optional_chain: Option<js_ast::OptionalChain>,
+        target: &js_ast::ExprData,
+    ) -> Option<js_ast::OptionalChain> {
+        if !self.options.features.minify_syntax {
+            return optional_chain;
+        }
+        use crate::scan::scan_side_effects::SideEffects;
+        match optional_chain {
+            Some(js_ast::OptionalChain::Start) => {
+                let result = SideEffects::to_null_or_undefined(self, target);
+                if result.ok && !result.value {
+                    return None;
+                }
+            }
+            Some(js_ast::OptionalChain::Continuation) => {
+                // Propagate a stripped start through the rest of the chain so
+                // later `.is_none()` checks behave as they did when this was
+                // done at parse time.
+                let target_chain = match target {
+                    js_ast::ExprData::EDot(e) => Some(e.optional_chain),
+                    js_ast::ExprData::EIndex(e) => Some(e.optional_chain),
+                    js_ast::ExprData::ECall(e) => Some(e.optional_chain),
+                    _ => None,
+                };
+                if target_chain == Some(None) {
+                    return None;
+                }
+            }
+            None => {}
+        }
+        optional_chain
+    }
+
     /// This is only allowed to be called if allow_runtime is true
     /// If --target=bun, this does nothing.
     pub(crate) fn record_usage_of_runtime_require(&mut self) {

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -125,9 +125,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         left: &mut Expr,
     ) -> CResult {
         p.lexer.next()?;
-        // "Remove unnecessary optional chains" is deferred to the visit pass so
-        // the assignment-target check sees the original "?." and rejects
-        // `{}?.y = 0` as a syntax error.
         let optional_start: Option<OptionalChain> = Some(OptionalChain::Start);
 
         match p.lexer.token {

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -5,7 +5,6 @@ use crate::Error;
 use crate::lexer::T;
 use crate::p::P;
 use crate::parser::DeferredErrors;
-use crate::scan::scan_side_effects::SideEffects;
 use bun_ast::expr::EFlags;
 use bun_ast::op::Level;
 use bun_ast::{E, Expr, ExprData, OpCode, OptionalChain};
@@ -126,15 +125,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         left: &mut Expr,
     ) -> CResult {
         p.lexer.next()?;
-        let mut optional_start: Option<OptionalChain> = Some(OptionalChain::Start);
-
-        // Remove unnecessary optional chains
-        if p.options.features.minify_syntax {
-            let result = SideEffects::to_null_or_undefined(p, &left.data);
-            if result.ok && !result.value {
-                optional_start = None;
-            }
-        }
+        // "Remove unnecessary optional chains" is deferred to the visit pass so
+        // the assignment-target check sees the original "?." and rejects
+        // `{}?.y = 0` as a syntax error.
+        let optional_start: Option<OptionalChain> = Some(OptionalChain::Start);
 
         match p.lexer.token {
             T::TOpenBracket => {
@@ -255,11 +249,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        // Only continue if we have started
-        if optional_start == Some(OptionalChain::Start) {
-            *optional_chain = Some(OptionalChain::Continuation);
-        }
-
+        *optional_chain = Some(OptionalChain::Continuation);
         Ok(Continuation::Next)
     }
 

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -918,6 +918,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         p.visit_expr_in_out(&mut e_.target, ExprIn::default());
 
+        e_.optional_chain = p.maybe_simplify_optional_chain(e_.optional_chain, &e_.target.data);
+
         match e_.index.data {
             Data::EPrivateIdentifier(mut private) => {
                 let name = p.load_name_from_ref(private.ref_);
@@ -1408,6 +1410,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             },
         );
 
+        e_.optional_chain = p.maybe_simplify_optional_chain(e_.optional_chain, &e_.target.data);
+
         // 'require.resolve' -> .e_require_resolve_call_target
         if matches!(e_.target.data, Data::ERequireCallTarget) && e_.name == b"resolve" {
             // we do not need to call p.recordUsageOfRuntimeRequire(); because `require`
@@ -1858,6 +1862,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 ..Default::default()
             },
         );
+
+        e_.optional_chain = p.maybe_simplify_optional_chain(e_.optional_chain, &e_.target.data);
 
         // Copy the call side effect flag over if this is a known target
         // copy the small inline payloads out first so the `match &e_.target.data`

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3418,8 +3418,71 @@ class Foo {
       expect(parsed(code, !out.endsWith(";\n"), false, bunTranspiler)).toBe(out);
     };
 
+    const expectParseError = (code, message) => {
+      try {
+        parsed(code, false, false);
+      } catch (er) {
+        var err = er;
+        if (er instanceof AggregateError) {
+          err = er.errors[0];
+        }
+        expect(err.message).toBe(message);
+        return;
+      }
+      throw new Error("Expected parse error for code\n\t" + code);
+    };
+
     it("unary operator", () => {
       expectPrinted("a = !(b, c)", "a = (b, !c)");
+    });
+
+    // https://github.com/oven-sh/bun/issues/15848
+    it("rejects an optional chain as an assignment target even when the chain target is provably non-null", () => {
+      // "Remove unnecessary optional chains" must not run before the
+      // assignment-target check: `{}?.y = 0` is always a SyntaxError.
+      expectParseError("({}?.y = 0);", "Invalid assignment target");
+      expectParseError("({}?.[y] = 0);", "Invalid assignment target");
+      expectParseError("[{}?.y] = [];", "Invalid assignment target");
+      expectParseError("[{}?.y = 0] = [];", "Invalid assignment target");
+      expectParseError("({a: {}?.y} = {});", "Invalid assignment target");
+      expectParseError("for ({}?.y of []);", "Invalid assignment target");
+      expectParseError("for ([{}?.y] of [[]]);", "Invalid assignment target");
+      expectParseError("for ([{}?.y = 0] of [[]]);", "Invalid assignment target");
+      expectParseError("({}?.y.z = 0);", "Invalid assignment target");
+      expectParseError('("x"?.y = 0);', "Invalid assignment target");
+      expectParseError("([1]?.y = 0);", "Invalid assignment target");
+      expectParseError("({}?.y += 0);", "Invalid assignment target");
+      expectParseError("({}?.y)++;", "Invalid assignment target");
+
+      // The simplification still applies in valid (non-assignment) positions.
+      expectPrinted_("x = {}?.y", "x = {}.y");
+      expectPrinted_("x = {}?.[y]", "x = {}[y]");
+      expectPrinted_("x = {}?.()", "x = {}()");
+      expectPrinted_("x = {}?.y.z", "x = {}.y.z");
+      expectPrinted_("x = []?.y", "x = [].y");
+      expectPrinted_('x = "s"?.y', 'x = "s".y');
+      expectPrinted_("delete {}?.y", "delete {}.y");
+      expectPrinted_("x = a?.y", "x = a?.y");
+    });
+
+    it("rejects an optional chain as an assignment target at runtime", async () => {
+      // https://github.com/oven-sh/bun/issues/15848
+      const source =
+        'for ([{ set y(val) { console.log("accessed") } }?.y = 0] of [[]]) ;';
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", source],
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stdout).toBe("");
+      expect(stderr).toContain("Invalid assignment target");
+      expect(exitCode).toBe(1);
     });
 
     it.todo("const inlining", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3467,19 +3467,14 @@ class Foo {
 
     it("rejects an optional chain as an assignment target at runtime", async () => {
       // https://github.com/oven-sh/bun/issues/15848
-      const source =
-        'for ([{ set y(val) { console.log("accessed") } }?.y = 0] of [[]]) ;';
+      const source = 'for ([{ set y(val) { console.log("accessed") } }?.y = 0] of [[]]) ;';
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", source],
         env: bunEnv,
         stderr: "pipe",
         stdout: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stdout).toBe("");
       expect(stderr).toContain("Invalid assignment target");
       expect(exitCode).toBe(1);


### PR DESCRIPTION
Fixes #15848.

## Repro

```js
for ([{ set y(val) { console.log("accessed") } }?.y = 0] of [[]]) ;
```

Node and every spec-compliant engine reject this with a SyntaxError (`Invalid left-hand side in assignment`). Bun printed `accessed` and exited 0.

Smaller repro: `({}?.y = 0);` is accepted and rewritten to `({}).y = 0`.

## Cause

`sfx_t_question_dot` in `parse_suffix.rs` implements an esbuild optimization that drops a `?.` when its target is provably not null/undefined (`{}`, `[]`, numbers, strings, etc.). This ran at parse time, before the visitor's `is_valid_assignment_target` check, so the visitor saw a plain `EDot` with `optional_chain: None` and accepted it as a valid target. The bug only surfaced when `minify_syntax` is enabled, which it is by default for `bun run` (via `target.is_bun()` -> `tree_shaking` -> `inlining` -> `minify_syntax`).

## Fix

Move the simplification into the visitor. `e_dot` / `e_index` / `e_call` now call `maybe_simplify_optional_chain` after visiting their target. The `is_valid_assignment_target` check at the top of `visit_expr_in_out` runs first and sees the original `Some(OptionalChain::Start)`, so `{}?.y = 0`, `[{}?.y] = []`, `for ({}?.y of []);` and friends are now rejected with `Invalid assignment target`. In non-assignment positions the simplification still applies and produces the same output as before (`x = {}?.y` -> `x = {}.y`).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (4768f8b61)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [6.99ms]
(pass) Bun.Transpiler > normalizes \r\n [8.05ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [5.70ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [10.76ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [3.36ms]
(pass) Bun.Transpiler > property access inlining > works [2.91ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.33ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [21.83ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [3.86ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [3.02ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [9.23ms]
(pass) Bun.Transpiler > TypeScript > contextua
... (truncated)

release without fix: 17 failed, 22 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.13ms]
(pass) Bun.Transpiler > normalizes \r\n [0.20ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.12ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.18ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.04ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.04ms]
141 |     });
142 |     it("bails out on optional-chain index into enum", () => {
143 |       const pre = "enum Foo { A }\nenum Bar { 'a-b' = 1 }\n";
144 |       const lastLine = out => out.trimEnd().split("\n").at(-1);
145 |       expect(lastLine(ts.parsed(pre + 'export let y = Foo["A"];', false))).toBe("export let y = 0 /* A */;");
146 |       expect(lastLine(ts.parsed(pre + 'export let y = Foo?.["A"];', false))).toBe('export let y = Foo?.["A"];');
                                                                                   ^
error: expect(received).toBe(expected)

Expected: "export let y = F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (4768f8b61)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [7.41ms]
(pass) Bun.Transpiler > normalizes \r\n [7.43ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [6.86ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [10.11ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [3.84ms]
(pass) Bun.Transpiler > property access inlining > works [3.77ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.72ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [27.80ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [4.13ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [3.56ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [10.88ms]
(pass) Bun.Transpiler > TypeScript > contextu
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4768f8b611
  features     baseline

22 deps, 108 codegen, 1171 objects in 1076ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen ErrorCode+*.h
[2/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [71.00ms]
[3/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [12.00ms]
[5/1234] fetch picohttpparser
[picohttpparser] up to date
[6/1234] gen bindgenv2
[7/1234] fetch zlib
[zlib] up to date
[8/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[10/1234] subst deps/zlib/zlib.h
[11/1234] subst deps/zlib/zconf.h
[12/1234] fetch tinycc
[tinycc] up to date
[13/1234] gen .bind.ts → GeneratedBindings.cpp
[14/1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                         | 33 +++++++++++++++++
 src/js_parser/parse/parse_suffix.rs        | 17 ++-------
 src/js_parser/visit/visit_expr.rs          |  6 ++++
 test/bundler/transpiler/transpiler.test.js | 58 ++++++++++++++++++++++++++++++
 4 files changed, 99 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/p.rs                              2      5      0
src/js_parser/parse/parse_suffix.rs             6      5      0
src/js_parser/visit/visit_expr.rs               5      2      0
test/bundler/transpiler/transpiler.test.js      3      2      0
```

</details>

<!-- robobun:evidence:end -->