### PR TITLE
bun:test: bound expect() promise waits by the test timeout

### DIFF
--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -932,6 +932,7 @@ impl Expect {
         }
 
         if let Some(promise) = return_value.as_any_promise() {
+            promise.set_handled(global_this.vm());
             let still_pending = Self::wait_for_promise_bounded_by_test(global_this, promise);
             scope.apply(vm);
             if still_pending {

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -471,8 +471,7 @@ impl Expect {
         }
     }
 
-    /// `wait_for_promise` bounded by the enclosing test's deadline.
-    /// Returns `true` if the promise is still pending when the spin stops.
+    /// `wait_for_promise` bounded by the test's deadline; returns `true` if still pending.
     fn wait_for_promise_bounded_by_test(
         global_this: &JSGlobalObject,
         promise: bun_jsc::AnyPromise,

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -471,6 +471,43 @@ impl Expect {
         }
     }
 
+    /// Spin the event loop until `promise` settles, like `wait_for_promise`,
+    /// but stop once the enclosing test's timeout deadline passes so a matcher
+    /// awaiting a promise that can only settle *after* the matcher returns
+    /// (e.g. `expect(p).resolves.toBe(x); resolve(x);`) turns into a test
+    /// timeout instead of a 100% CPU hang. Returns `true` if the promise is
+    /// still pending when the spin ends.
+    fn wait_for_promise_bounded_by_test(
+        global_this: &JSGlobalObject,
+        promise: bun_jsc::AnyPromise,
+    ) -> bool {
+        use bun_core::{Timespec, TimespecMockMode};
+        if promise.status() != js_promise::Status::Pending {
+            return false;
+        }
+        // `on_stack_entry` is set for the duration of `run_test_callback`, so the
+        // deadline is stable across the spin; read it once. EPOCH = no timeout.
+        let deadline = Jest::runner().map_or(Timespec::EPOCH, |r| r.get_active_timeout());
+        let jsc_vm = global_this.vm();
+        let bun_vm = global_this.bun_vm().as_mut();
+        while promise.status() == js_promise::Status::Pending {
+            if jsc_vm.execution_forbidden() {
+                break;
+            }
+            if !deadline.eql(&Timespec::EPOCH)
+                && deadline.order(&Timespec::now(TimespecMockMode::ForceRealTime))
+                    == core::cmp::Ordering::Less
+            {
+                break;
+            }
+            bun_vm.event_loop_mut().tick();
+            if promise.status() == js_promise::Status::Pending {
+                bun_vm.event_loop_mut().auto_tick();
+            }
+        }
+        promise.status() == js_promise::Status::Pending
+    }
+
     /// Processes the async flags (resolves/rejects), waiting for the async value if needed.
     /// If no flags, returns the original value
     /// If either flag is set, waits for the result, and returns either it as a JSValue, or null if the expectation failed (in which case if silent is false, also throws a js exception)
@@ -489,8 +526,17 @@ impl Expect {
                     let vm = global_this.vm();
                     promise.set_handled(vm);
 
-                    // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
-            global_this.bun_vm().as_mut().wait_for_promise(promise);
+                    if Self::wait_for_promise_bounded_by_test(global_this, promise) {
+                        if !silent {
+                            return Err(Self::throw_promise_matcher_error(
+                                global_this, custom_label, matcher_name, matcher_params, flags,
+                                "Expected promise to settle within the test timeout",
+                                "Received promise that is still pending: ",
+                                "[Promise]",
+                            ));
+                        }
+                        return Err(JsError::Thrown);
+                    }
 
                     let new_value = promise.result(vm);
                     match promise.status() {
@@ -893,8 +939,13 @@ impl Expect {
         }
 
         if let Some(promise) = return_value.as_any_promise() {
-            vm.wait_for_promise(promise);
+            let still_pending = Self::wait_for_promise_bounded_by_test(global_this, promise);
             scope.apply(vm);
+            if still_pending {
+                return Err(global_this.throw(format_args!(
+                    "Received function returned a promise that did not settle within the test timeout",
+                )));
+            }
             match promise.unwrap(global_this.vm(), js_promise::UnwrapMode::MarkHandled) {
                 js_promise::Unwrapped::Fulfilled(_) => {
                     return Ok((None, return_value_from_function));
@@ -1487,8 +1538,12 @@ impl Expect {
             let vm = global_this.vm();
             promise.set_handled(vm);
 
-            // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
-            global_this.bun_vm().as_mut().wait_for_promise(promise);
+            if Self::wait_for_promise_bounded_by_test(global_this, promise) {
+                return Err(global_this.throw(format_args!(
+                    "Matcher `{}` returned a promise that did not settle within the test timeout",
+                    matcher_name,
+                )));
+            }
 
             result = promise.result(vm);
             result.ensure_still_alive();

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -471,12 +471,8 @@ impl Expect {
         }
     }
 
-    /// Spin the event loop until `promise` settles, like `wait_for_promise`,
-    /// but stop once the enclosing test's timeout deadline passes so a matcher
-    /// awaiting a promise that can only settle *after* the matcher returns
-    /// (e.g. `expect(p).resolves.toBe(x); resolve(x);`) turns into a test
-    /// timeout instead of a 100% CPU hang. Returns `true` if the promise is
-    /// still pending when the spin ends.
+    /// `wait_for_promise` bounded by the enclosing test's deadline.
+    /// Returns `true` if the promise is still pending when the spin stops.
     fn wait_for_promise_bounded_by_test(
         global_this: &JSGlobalObject,
         promise: bun_jsc::AnyPromise,
@@ -485,8 +481,6 @@ impl Expect {
         if promise.status() != js_promise::Status::Pending {
             return false;
         }
-        // `on_stack_entry` is set for the duration of `run_test_callback`, so the
-        // deadline is stable across the spin; read it once. EPOCH = no timeout.
         let deadline = Jest::runner().map_or(Timespec::EPOCH, |r| r.get_active_timeout());
         let jsc_vm = global_this.vm();
         let bun_vm = global_this.bun_vm().as_mut();

--- a/test/regression/issue/14950.test.ts
+++ b/test/regression/issue/14950.test.ts
@@ -102,6 +102,24 @@ describe.concurrent("expect().resolves/.rejects on a not-yet-settled promise", (
     expect(exitCode).toBe(1);
   }, 60_000);
 
+  test("a late rejection from an abandoned toThrow async fn does not fail the next test", async () => {
+    const { stderr, exitCode, hung } = await runTestFile(
+      "issue-14950-late-reject",
+      `test("a", () => {
+           expect(async () => { await Bun.sleep(700); throw new Error("late"); }).toThrow();
+         });
+         test("b", async () => {
+           await Bun.sleep(900);
+           expect(1).toBe(1);
+         }, 5000);`,
+    );
+    expect(hung).toBe(false);
+    expect(stderr).toMatch(/1 pass/);
+    expect(stderr).toMatch(/1 fail/);
+    expect(stderr).not.toContain("Unhandled");
+    expect(exitCode).toBe(1);
+  }, 60_000);
+
   test(".resolves on an already-resolved promise still passes synchronously", async () => {
     const { stderr, exitCode, hung } = await runTestFile(
       "issue-14950-settled",

--- a/test/regression/issue/14950.test.ts
+++ b/test/regression/issue/14950.test.ts
@@ -1,7 +1,7 @@
 // https://github.com/oven-sh/bun/issues/14950
 // `expect(pendingPromise).resolves.<matcher>()` in a sync test body must not
 // hang `bun test` forever at 100% CPU; the per-test timeout has to fire.
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 async function runTestFile(name: string, body: string) {
@@ -22,11 +22,7 @@ async function runTestFile(name: string, body: string) {
     proc.kill();
   }, 20_000);
   try {
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     return { stdout, stderr, exitCode, hung };
   } finally {
     clearTimeout(watchdog);
@@ -34,112 +30,88 @@ async function runTestFile(name: string, body: string) {
 }
 
 describe.concurrent("expect().resolves/.rejects on a not-yet-settled promise", () => {
-  test(
-    ".resolves on a promise resolved after the matcher call times out instead of hanging",
-    async () => {
-      const { stderr, exitCode, hung } = await runTestFile(
-        "issue-14950-resolves",
-        `test("promise resolves after expect call", () => {
+  test(".resolves on a promise resolved after the matcher call times out instead of hanging", async () => {
+    const { stderr, exitCode, hung } = await runTestFile(
+      "issue-14950-resolves",
+      `test("promise resolves after expect call", () => {
            let resolve;
            expect(new Promise(r => (resolve = r))).resolves.toBe(25);
            resolve(25);
          });`,
-      );
-      expect(hung).toBe(false);
-      expect(stderr).toContain("still pending");
-      expect(stderr).toMatch(/timed out after \d+ms/);
-      expect(exitCode).toBe(1);
-    },
-    60_000,
-  );
+    );
+    expect(hung).toBe(false);
+    expect(stderr).toContain("still pending");
+    expect(stderr).toMatch(/timed out after \d+ms/);
+    expect(exitCode).toBe(1);
+  }, 60_000);
 
-  test(
-    ".rejects on a never-settling promise times out instead of hanging",
-    async () => {
-      const { stderr, exitCode, hung } = await runTestFile(
-        "issue-14950-rejects",
-        `test("never settles", () => {
+  test(".rejects on a never-settling promise times out instead of hanging", async () => {
+    const { stderr, exitCode, hung } = await runTestFile(
+      "issue-14950-rejects",
+      `test("never settles", () => {
            expect(new Promise(() => {})).rejects.toThrow();
          });`,
-      );
-      expect(hung).toBe(false);
-      expect(stderr).toContain("still pending");
-      expect(stderr).toMatch(/timed out after \d+ms/);
-      expect(exitCode).toBe(1);
-    },
-    60_000,
-  );
+    );
+    expect(hung).toBe(false);
+    expect(stderr).toContain("still pending");
+    expect(stderr).toMatch(/timed out after \d+ms/);
+    expect(exitCode).toBe(1);
+  }, 60_000);
 
-  test(
-    "toThrow on an async fn returning a never-settling promise times out instead of hanging",
-    async () => {
-      const { stderr, exitCode, hung } = await runTestFile(
-        "issue-14950-tothrow",
-        `test("never settles", () => {
+  test("toThrow on an async fn returning a never-settling promise times out instead of hanging", async () => {
+    const { stderr, exitCode, hung } = await runTestFile(
+      "issue-14950-tothrow",
+      `test("never settles", () => {
            expect(() => new Promise(() => {})).toThrow();
          });`,
-      );
-      expect(hung).toBe(false);
-      expect(stderr).toContain("did not settle within the test timeout");
-      expect(exitCode).toBe(1);
-    },
-    60_000,
-  );
+    );
+    expect(hung).toBe(false);
+    expect(stderr).toContain("did not settle within the test timeout");
+    expect(exitCode).toBe(1);
+  }, 60_000);
 
-  test(
-    "async custom matcher returning a never-settling promise times out instead of hanging",
-    async () => {
-      const { stderr, exitCode, hung } = await runTestFile(
-        "issue-14950-custom",
-        `const { expect, test } = require("bun:test");
+  test("async custom matcher returning a never-settling promise times out instead of hanging", async () => {
+    const { stderr, exitCode, hung } = await runTestFile(
+      "issue-14950-custom",
+      `const { expect, test } = require("bun:test");
          expect.extend({
            toNeverSettle() { return new Promise(() => {}); },
          });
          test("never settles", () => {
            expect(1).toNeverSettle();
          });`,
-      );
-      expect(hung).toBe(false);
-      expect(stderr).toContain("did not settle within the test timeout");
-      expect(exitCode).toBe(1);
-    },
-    60_000,
-  );
+    );
+    expect(hung).toBe(false);
+    expect(stderr).toContain("did not settle within the test timeout");
+    expect(exitCode).toBe(1);
+  }, 60_000);
 
-  test(
-    "a test after one that spins on .resolves still runs",
-    async () => {
-      const { stderr, exitCode, hung } = await runTestFile(
-        "issue-14950-next-test",
-        `test("hangs", () => {
+  test("a test after one that spins on .resolves still runs", async () => {
+    const { stderr, exitCode, hung } = await runTestFile(
+      "issue-14950-next-test",
+      `test("hangs", () => {
            expect(new Promise(() => {})).resolves.toBe(1);
          });
          test("runs after", () => {
            expect(1).toBe(1);
          });`,
-      );
-      expect(hung).toBe(false);
-      expect(stderr).toMatch(/1 pass/);
-      expect(stderr).toMatch(/1 fail/);
-      expect(exitCode).toBe(1);
-    },
-    60_000,
-  );
+    );
+    expect(hung).toBe(false);
+    expect(stderr).toMatch(/1 pass/);
+    expect(stderr).toMatch(/1 fail/);
+    expect(exitCode).toBe(1);
+  }, 60_000);
 
-  test(
-    ".resolves on an already-resolved promise still passes synchronously",
-    async () => {
-      const { stderr, exitCode, hung } = await runTestFile(
-        "issue-14950-settled",
-        `test("already settled", () => {
+  test(".resolves on an already-resolved promise still passes synchronously", async () => {
+    const { stderr, exitCode, hung } = await runTestFile(
+      "issue-14950-settled",
+      `test("already settled", () => {
            expect(Promise.resolve(25)).resolves.toBe(25);
          });`,
-      );
-      expect(hung).toBe(false);
-      expect(stderr).toMatch(/1 pass/);
-      expect(stderr).not.toContain("still pending");
-      expect(exitCode).toBe(0);
-    },
-    60_000,
-  );
+    );
+    expect(hung).toBe(false);
+    expect(stderr).toMatch(/1 pass/);
+    expect(stderr).not.toContain("still pending");
+    expect(exitCode).toBe(0);
+  }, 60_000);
 });

--- a/test/regression/issue/14950.test.ts
+++ b/test/regression/issue/14950.test.ts
@@ -1,0 +1,145 @@
+// https://github.com/oven-sh/bun/issues/14950
+// `expect(pendingPromise).resolves.<matcher>()` in a sync test body must not
+// hang `bun test` forever at 100% CPU; the per-test timeout has to fire.
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+async function runTestFile(name: string, body: string) {
+  using dir = tempDir(name, { "t.test.js": body });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "t.test.js", "--timeout", "500"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  // On an unfixed build the inner runner never exits (the per-test --timeout
+  // cannot interrupt the wait_for_promise spin), so kill it ourselves instead
+  // of letting the outer runner's own timeout abort the assertion.
+  let hung = false;
+  const watchdog = setTimeout(() => {
+    hung = true;
+    proc.kill();
+  }, 20_000);
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    return { stdout, stderr, exitCode, hung };
+  } finally {
+    clearTimeout(watchdog);
+  }
+}
+
+describe.concurrent("expect().resolves/.rejects on a not-yet-settled promise", () => {
+  test(
+    ".resolves on a promise resolved after the matcher call times out instead of hanging",
+    async () => {
+      const { stderr, exitCode, hung } = await runTestFile(
+        "issue-14950-resolves",
+        `test("promise resolves after expect call", () => {
+           let resolve;
+           expect(new Promise(r => (resolve = r))).resolves.toBe(25);
+           resolve(25);
+         });`,
+      );
+      expect(hung).toBe(false);
+      expect(stderr).toContain("still pending");
+      expect(stderr).toMatch(/timed out after \d+ms/);
+      expect(exitCode).toBe(1);
+    },
+    60_000,
+  );
+
+  test(
+    ".rejects on a never-settling promise times out instead of hanging",
+    async () => {
+      const { stderr, exitCode, hung } = await runTestFile(
+        "issue-14950-rejects",
+        `test("never settles", () => {
+           expect(new Promise(() => {})).rejects.toThrow();
+         });`,
+      );
+      expect(hung).toBe(false);
+      expect(stderr).toContain("still pending");
+      expect(stderr).toMatch(/timed out after \d+ms/);
+      expect(exitCode).toBe(1);
+    },
+    60_000,
+  );
+
+  test(
+    "toThrow on an async fn returning a never-settling promise times out instead of hanging",
+    async () => {
+      const { stderr, exitCode, hung } = await runTestFile(
+        "issue-14950-tothrow",
+        `test("never settles", () => {
+           expect(() => new Promise(() => {})).toThrow();
+         });`,
+      );
+      expect(hung).toBe(false);
+      expect(stderr).toContain("did not settle within the test timeout");
+      expect(exitCode).toBe(1);
+    },
+    60_000,
+  );
+
+  test(
+    "async custom matcher returning a never-settling promise times out instead of hanging",
+    async () => {
+      const { stderr, exitCode, hung } = await runTestFile(
+        "issue-14950-custom",
+        `const { expect, test } = require("bun:test");
+         expect.extend({
+           toNeverSettle() { return new Promise(() => {}); },
+         });
+         test("never settles", () => {
+           expect(1).toNeverSettle();
+         });`,
+      );
+      expect(hung).toBe(false);
+      expect(stderr).toContain("did not settle within the test timeout");
+      expect(exitCode).toBe(1);
+    },
+    60_000,
+  );
+
+  test(
+    "a test after one that spins on .resolves still runs",
+    async () => {
+      const { stderr, exitCode, hung } = await runTestFile(
+        "issue-14950-next-test",
+        `test("hangs", () => {
+           expect(new Promise(() => {})).resolves.toBe(1);
+         });
+         test("runs after", () => {
+           expect(1).toBe(1);
+         });`,
+      );
+      expect(hung).toBe(false);
+      expect(stderr).toMatch(/1 pass/);
+      expect(stderr).toMatch(/1 fail/);
+      expect(exitCode).toBe(1);
+    },
+    60_000,
+  );
+
+  test(
+    ".resolves on an already-resolved promise still passes synchronously",
+    async () => {
+      const { stderr, exitCode, hung } = await runTestFile(
+        "issue-14950-settled",
+        `test("already settled", () => {
+           expect(Promise.resolve(25)).resolves.toBe(25);
+         });`,
+      );
+      expect(hung).toBe(false);
+      expect(stderr).toMatch(/1 pass/);
+      expect(stderr).not.toContain("still pending");
+      expect(exitCode).toBe(0);
+    },
+    60_000,
+  );
+});

--- a/test/regression/issue/23865.test.ts
+++ b/test/regression/issue/23865.test.ts
@@ -16,6 +16,15 @@ test("23865", async () => {
   expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`"bun test <version> (<revision>)"`);
   expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
     "23865.fixture.ts:
+    1 | // Should not crash
+    2 | test("abc", () => {
+    3 |   expect(async () => {
+    4 |     await Bun.sleep(100);
+    5 |     throw new Error("uh oh!");
+    6 |   }).toThrow("uh oh!");
+             ^
+    error: Received function returned a promise that did not settle within the test timeout
+        at <anonymous> (file:NN:NN)
     (fail) abc
       ^ this test timed out after 50ms.
 


### PR DESCRIPTION
## What does this PR do?

`expect(promise).resolves.<matcher>()` (and `.rejects`, `expect(asyncFn).toThrow()`, and async `expect.extend` matchers) spin the event loop via `wait_for_promise` until the subject promise settles. When the promise can only settle *after* the matcher returns, the spin never ends:

```js
test("promise resolves after expect call", () => {
  let resolve;
  expect(new Promise(r => (resolve = r))).resolves.toBe(25);
  resolve(25); // unreachable while the line above is spinning
});
```

On current canary this hangs `bun test` at 100% CPU forever. In 1.1.34 the per-test timeout would fire after 5s because `handle_timeout` called `requestTermination()`; e01f4546 (#24355) removed that call to fix a crash where the termination exception escaped through `autoTick`, so nothing breaks the `wait_for_promise` loop anymore. The timer still fires inside the spin (via `auto_tick -> drain_timers -> bun_test_timeout_callback`), the runner records the timeout and tries to re-enter `BunTest::run()`, which returns immediately because `in_run_loop` is already set, and the spin continues.

This PR replaces the three `wait_for_promise` call sites in `expect.rs` with a bounded loop that also breaks once the enclosing test's deadline passes (read via `TestRunner::get_active_timeout()`, the same source `spawnSync` already uses for its own wait loop), and throws a matcher error naming the still-pending promise instead of hitting `unreachable!()` on the pending arm:

```
error: expect(received).resolves.toBe(expected)

Expected promise to settle within the test timeout
Received promise that is still pending: [Promise]

(fail) promise resolves after expect call [1009.53ms]
  ^ this test timed out after 1000ms.
```

Outside a timed test the deadline is `EPOCH` and the loop behaves exactly like `wait_for_promise`. `requestTermination()` stays removed, so #23865 stays fixed; its regression test snapshot is updated because the output now includes the new matcher error before the existing `timed out after` line.

This is a safety-net fix only (the timeout must fire; the runner must not spin forever). It does not change the matcher to return a `Promise` or give Jest parity for the un-awaited case; that is #33289, which this PR intentionally does not overlap with (no `event_loop.rs` / `Execution.rs` changes, no matcher signature changes).

Fixes #14950

## How did you verify your code works?

New `test/regression/issue/14950.test.ts` spawns six child `bun test` runs with `--timeout 500` and a 20s watchdog: `.resolves` on a post-call-resolved promise, `.rejects` on a never-settling promise, `toThrow` on an async fn returning one, an async custom matcher returning one, a second test after a hanging one, and an already-settled control. On an unpatched build the five hanging children are killed by the watchdog (`hung: true`); with the fix all six children exit on their own within ~1s and report the new matcher error plus `timed out after Nms`.

```
git stash push -- src/ && bun bd test test/regression/issue/14950.test.ts  # 1 pass 5 fail
git stash pop  && bun bd test test/regression/issue/14950.test.ts          # 6 pass 0 fail
```

Existing suites pass unchanged: `expect.test.js` (415 pass), `expect-extend.test.js` (28 pass), `jest-extended.test.js` (58 pass), `expect-assertions.test.ts` (1 pass), `test-test.test.ts` (24 pass), `23865.test.ts` (snapshot updated, 1 pass).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/14950.test.ts" "test/regression/issue/23865.test.ts"
bun test v1.4.0 (0ebfa04ff)

test/regression/issue/23865.test.ts:
12 | 
13 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
14 | 
15 |   expect(exitCode).not.toBe(0);
16 |   expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`"bun test <version> (<revision>)"`);
17 |   expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
                                            ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "23865.fixture.ts:
- 1 | // Should not crash
- 2 | test("abc", () => {
- 3 |   expect(async () => {
- 4 |     await Bun.sleep(100);
- 5 |     throw new Error("uh oh!");
- 6 |   }).toThrow("uh oh!");
-          ^
- error: Received function returned a promise that did not settle within the test timeout
-     at <anonymous> (file:NN:NN)
  (fail) abc
    ^ this test timed out after 50ms.
  
   0 pass
   1 fail
   1 expect() calls
  Ran 1 test across 1 file."
  

-
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (c14e9e3bc)

test/regression/issue/23865.test.ts:
(pass) 23865 [66.59ms]

test/regression/issue/14950.test.ts:
(pass) expect().resolves/.rejects on a not-yet-settled promise > .resolves on an already-resolved promise still passes synchronously [17.14ms]
(pass) expect().resolves/.rejects on a not-yet-settled promise > toThrow on an async fn returning a never-settling promise times out instead of hanging [528.31ms]
(pass) expect().resolves/.rejects on a not-yet-settled promise > .rejects on a never-settling promise times out instead of hanging [535.12ms]
(pass) expect().resolves/.rejects on a not-yet-settled promise > .resolves on a promise resolved after the matcher call times out instead of hanging [543.04ms]
(pass) expect().resolves/.rejects on a not-yet-settled promise > async custom matcher returning a never-settling promise times out instead of hanging [533.34ms]
(pass) expect().resolves/.rejects on a not-yet-settled promise > a test after one that spins on .resolves still runs [528.62ms]
(pass) expect().resolves/.rejects on a not-yet-settled promise > a late rejection from an abandoned toThrow async fn does not fail the next test [1419.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/14950.test.ts" "test/regression/issue/23865.test.ts"
bun test v1.4.0 (0ebfa04ff)

test/regression/issue/23865.test.ts:
(pass) 23865 [386.20ms]

test/regression/issue/14950.test.ts:
(pass) expect().resolves/.rejects on a not-yet-settled promise > .resolves on a promise resolved after the matcher call times out instead of hanging [938.29ms]
(pass) expect().resolves/.rejects on a not-yet-settled promise > async custom matcher returning a never-settling promise times out instead of hanging [907.48ms]
(pass) expect().resolves/.rejects on a not-yet-settled promise > a test after one that spins on .resolves still runs [927.71ms]
(pass) expect().resolves/.rejects on a not-yet-settled promise > toThrow on an async fn returning a never-settling promise times out instead of hanging [955.64ms]
(pass) expect().resolves/.rejects on a not-yet-settled promise > .rejects on a never-settling promise times out instead of hanging [967.70ms]
(pass) expect().resolves/.rejects on a not-yet-settled promise > .resolves on an already-reso
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 805ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/expect.rs   |  59 ++++++++++++++--
 test/regression/issue/14950.test.ts | 135 ++++++++++++++++++++++++++++++++++++
 test/regression/issue/23865.test.ts |   9 +++
 3 files changed, 198 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/runtime/test_runner/expect.rs       12      7      0
test/regression/issue/14950.test.ts      2      4      0
test/regression/issue/23865.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->