### PR TITLE
test(install): run bun-update-security-scan-all against the local dummy registry

### DIFF
--- a/test/cli/install/bun-update-security-scan-all.test.ts
+++ b/test/cli/install/bun-update-security-scan-all.test.ts
@@ -1,49 +1,80 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
+import { startRegistry, stopRegistry } from "./simple-dummy-registry";
 
-describe("bun update security scanning", () => {
-  test("bun update without arguments scans all packages", async () => {
-    await using dir = tempDir("update-scan-all", {
-      "package.json": JSON.stringify({
-        name: "test-app",
-        dependencies: {
-          "lodash": "^4.0.0",
-          "express": "^4.0.0",
-        },
-      }),
-      "bunfig.toml": `
+let registryUrl: string;
+
+beforeAll(async () => {
+  registryUrl = await startRegistry(false);
+});
+
+afterAll(() => {
+  stopRegistry();
+});
+
+function bunfig({ scanner }: { scanner: boolean }) {
+  let text = `[install]
+cache = false
+registry = "${registryUrl}/"
+`;
+  if (scanner) {
+    text += `
 [install.security]
 scanner = "./scanner.js"
-`,
-      "scanner.js": `
+`;
+  }
+  return text;
+}
+
+async function primeInstall(dir: string) {
+  await Bun.write(join(dir, "bunfig.toml"), bunfig({ scanner: false }));
+  await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
+  await Bun.write(join(dir, "bunfig.toml"), bunfig({ scanner: true }));
+}
+
+// Each test spawns two debug-build bun processes (install + update) and they run
+// concurrently, so per-test wall time is higher under CPU contention even though
+// total wall time drops. Matches bun-install-security-provider.test.ts.
+const timeout = 30_000;
+
+describe.concurrent("bun update security scanning", () => {
+  test(
+    "bun update without arguments scans all packages",
+    async () => {
+      await using dir = tempDir("update-scan-all", {
+        "package.json": JSON.stringify({
+          name: "test-app",
+          dependencies: {
+            "left-pad": "1.3.0",
+            "is-even": "1.0.0",
+          },
+        }),
+        "scanner.js": `
 let callCount = 0;
 module.exports = {
   scanner: {
     version: "1",
     scan: async function(payload) {
       callCount++;
-      
-      // Log what packages we're scanning
       const packageNames = payload.packages.map(p => p.name).sort();
       console.error("SCAN_CALL_" + callCount + ":", JSON.stringify(packageNames));
-      
       const results = [];
       for (const pkg of payload.packages) {
-        if (pkg.name === "lodash") {
+        if (pkg.name === "left-pad") {
           results.push({
-            package: "lodash",
+            package: "left-pad",
             level: "warn",
-            description: "Test warning in lodash",
-            url: "https://example.com/lodash-advisory"
+            description: "Test warning in left-pad",
+            url: "https://example.com/left-pad-advisory"
           });
         }
-        if (pkg.name === "express") {
+        if (pkg.name === "is-even") {
           results.push({
-            package: "express",
+            package: "is-even",
             level: "warn",
-            description: "Test warning in express",
-            url: "https://example.com/express-advisory"
+            description: "Test warning in is-even",
+            url: "https://example.com/is-even-advisory"
           });
         }
       }
@@ -52,75 +83,67 @@ module.exports = {
   }
 };
 `,
-    });
+      });
 
-    // First install to create lockfile (temporarily disable scanner)
-    const bunfigPath = join(dir, "bunfig.toml");
-    const bunfigContent = await Bun.file(bunfigPath).text();
-    await Bun.write(bunfigPath, ""); // Remove scanner config
-    await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-    await Bun.write(bunfigPath, bunfigContent); // Restore scanner config
+      await primeInstall(String(dir));
 
-    // Now run update without arguments - should scan ALL packages
-    const updateProc = Bun.spawn({
-      cmd: [bunExe(), "update"],
-      cwd: dir,
-      stdout: "pipe",
-      stderr: "pipe",
-      env: bunEnv,
-    });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "update"],
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      updateProc.stdout.text(),
-      updateProc.stderr.text(),
-      updateProc.exited,
-    ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Should have scanned packages
-    expect(stderr).toContain("SCAN_CALL_");
+      // The scanner ran once and received every package in the graph.
+      expect(stderr).toContain(`SCAN_CALL_1: ["is-even","is-odd","left-pad"]`);
+      expect(stderr).not.toContain("SCAN_CALL_2:");
 
-    // Should show vulnerabilities
-    expect(stdout).toContain("WARNING: lodash");
-    expect(stdout).toContain("WARNING: express");
+      expect(stdout).toContain("WARNING: left-pad");
+      expect(stdout).toContain("Test warning in left-pad");
+      expect(stdout).toContain("WARNING: is-even");
+      expect(stdout).toContain("Test warning in is-even");
+      expect(stdout).toMatch(/2 advisories \(.*2 warning.*\)/);
 
-    // Should exit with code 1 due to warnings requiring confirmation (no TTY)
-    expect(exitCode).toBe(1);
+      // Warnings require confirmation; with no TTY the update is cancelled.
+      expect(stdout).toContain("Installation cancelled");
+      expect(exitCode).toBe(1);
+    },
+    timeout,
+  );
 
-    // Should show the summary
-    expect(stdout).toMatch(/2 advisories \(.*2 warning.*\)/);
-  });
-
-  test("bun update with specific packages only scans those packages", async () => {
-    await using dir = tempDir("update-scan-specific", {
-      "package.json": JSON.stringify({
-        name: "test-app",
-        dependencies: {
-          "lodash": "4.17.20",
-          "express": "4.17.0",
-          "axios": "0.21.0",
-        },
-      }),
-      "scanner.js": `
+  test(
+    "bun update with specific packages only scans those packages",
+    async () => {
+      await using dir = tempDir("update-scan-specific", {
+        "package.json": JSON.stringify({
+          name: "test-app",
+          dependencies: {
+            "left-pad": "1.3.0",
+            "is-even": "1.0.0",
+          },
+        }),
+        "scanner.js": `
 module.exports = {
   scanner: {
     version: "1",
     scan: async function(payload) {
-      // Log which packages are being scanned
-      const packageNames = payload.packages.map(p => p.name);
+      const packageNames = payload.packages.map(p => p.name).sort();
       console.error("SCANNED_PACKAGES:", JSON.stringify(packageNames));
-      
       const results = [];
       for (const pkg of payload.packages) {
-        if (pkg.name === "lodash") {
+        if (pkg.name === "left-pad") {
           results.push({
-            package: "lodash",
+            package: "left-pad",
             level: "warn",
             description: "Test warning"
           });
         }
-        if (pkg.name === "express") {
+        if (pkg.name === "is-even") {
           results.push({
-            package: "express",
+            package: "is-even",
             level: "fatal",
             description: "Should not see this"
           });
@@ -131,97 +154,84 @@ module.exports = {
   }
 };
 `,
-    });
+      });
 
-    await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
+      await primeInstall(String(dir));
 
-    await Bun.write(
-      join(dir, "bunfig.toml"),
-      `
-[install.security]
-scanner = "./scanner.js"
-`,
-    );
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "update", "left-pad"],
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
+      });
 
-    // Update only lodash - should only scan lodash and its dependencies
-    const updateProc = Bun.spawn({
-      cmd: [bunExe(), "update", "lodash"],
-      cwd: dir,
-      stdout: "pipe",
-      stderr: "pipe",
-      env: bunEnv,
-    });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      updateProc.stdout.text(),
-      updateProc.stderr.text(),
-      updateProc.exited,
-    ]);
+      // Only the requested package is sent to the scanner.
+      expect(stderr).toContain(`SCANNED_PACKAGES: ["left-pad"]`);
+      expect(stdout).toMatch(/WARN(ING)?.*left-pad/);
+      expect(stdout).toContain("Test warning");
 
-    // Should have scanned packages
-    expect(stderr).toContain("SCANNED_PACKAGES:");
+      // is-even was not part of this update, so its fatal advisory must not surface.
+      expect(stdout).not.toContain("FATAL: is-even");
+      expect(stdout).not.toContain("Should not see this");
 
-    // Should show warning for lodash
-    expect(stdout).toMatch(/WARN(ING)?.*lodash/);
+      expect(exitCode).toBe(1);
+    },
+    timeout,
+  );
 
-    // Should NOT show fatal for express (wasn't updated)
-    expect(stdout).not.toContain("FATAL: express");
+  test(
+    "bun update respects security scanner configuration",
+    async () => {
+      await using dir = tempDir("update-no-scanner", {
+        "package.json": JSON.stringify({
+          name: "test-app",
+          dependencies: {
+            "left-pad": "1.3.0",
+          },
+        }),
+      });
 
-    // Should exit with 1 for warnings (user needs to confirm)
-    expect(exitCode).toBe(1);
-  });
+      await Bun.write(join(String(dir), "bunfig.toml"), bunfig({ scanner: false }));
+      await Bun.$`${bunExe()} install`.cwd(String(dir)).env(bunEnv).quiet();
 
-  test("bun update respects security scanner configuration", async () => {
-    await using dir = tempDir("update-no-scanner", {
-      "package.json": JSON.stringify({
-        name: "test-app",
-        dependencies: {
-          "lodash": "^4.0.0",
-        },
-      }),
-      // No bunfig.toml with scanner configuration
-    });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "update"],
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
+      });
 
-    await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Run update - should succeed without scanning
-    const updateProc = Bun.spawn({
-      cmd: [bunExe(), "update"],
-      cwd: dir,
-      stdout: "pipe",
-      stderr: "pipe",
-      env: bunEnv,
-    });
+      expect(stdout).not.toContain("WARNING:");
+      expect(stdout).not.toContain("FATAL:");
+      expect(stderr).not.toContain("Scanning");
+      expect(exitCode).toBe(0);
+    },
+    timeout,
+  );
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      updateProc.stdout.text(),
-      updateProc.stderr.text(),
-      updateProc.exited,
-    ]);
-
-    // Should succeed
-    expect(exitCode).toBe(0);
-
-    // Should not have any security warnings
-    expect(stdout).not.toContain("WARNING:");
-    expect(stdout).not.toContain("FATAL:");
-  });
-
-  test("bun update aborts on fatal vulnerabilities", async () => {
-    await using dir = tempDir("update-abort-fatal", {
-      "package.json": JSON.stringify({
-        name: "test-app",
-        dependencies: {
-          "lodash": "^4.0.0",
-        },
-      }),
-      "scanner.js": `
+  test(
+    "bun update aborts on fatal vulnerabilities",
+    async () => {
+      await using dir = tempDir("update-abort-fatal", {
+        "package.json": JSON.stringify({
+          name: "test-app",
+          dependencies: {
+            "left-pad": "1.3.0",
+          },
+        }),
+        "scanner.js": `
 module.exports = {
   scanner: {
     version: "1",
     scan: async function(payload) {
       return [{
-        package: "lodash",
+        package: "left-pad",
         level: "fatal",
         description: "Critical security vulnerability",
         url: "https://example.com/CVE-1234"
@@ -230,124 +240,51 @@ module.exports = {
   }
 };
 `,
-    });
+      });
 
-    await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
+      await primeInstall(String(dir));
 
-    await Bun.write(
-      join(dir, "bunfig.toml"),
-      `
-[install.security]
-scanner = "./scanner.js"
-`,
-    );
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "update"],
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
+      });
 
-    const updateProc = Bun.spawn({
-      cmd: [bunExe(), "update"],
-      cwd: dir,
-      stdout: "pipe",
-      stderr: "pipe",
-      env: bunEnv,
-    });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      updateProc.stdout.text(),
-      updateProc.stderr.text(),
-      updateProc.exited,
-    ]);
+      expect(stdout).toContain("FATAL: left-pad");
+      expect(stdout).toContain("Critical security vulnerability");
+      expect(stdout).toContain("https://example.com/CVE-1234");
+      expect(stdout).toContain("Installation aborted due to fatal security advisories");
+      expect(exitCode).toBe(1);
+    },
+    timeout,
+  );
 
-    // Should show the fatal vulnerability
-    expect(stdout).toContain("FATAL: lodash");
-    expect(stdout).toContain("Critical security vulnerability");
+  test.todo("bun update prompts for warnings when TTY available - requires TTY for interactive prompt");
 
-    // Should abort installation
-    expect(stdout).toContain("Installation aborted due to fatal security advisories");
-
-    // Should exit with error code
-    expect(exitCode).toBe(1);
-  });
-
-  test.todo("bun update prompts for warnings when TTY available - requires TTY for interactive prompt", async () => {
-    await using dir = tempDir("update-prompt-warnings", {
-      "package.json": JSON.stringify({
-        name: "test-app",
-        dependencies: {
-          "lodash": "^4.0.0",
-        },
-      }),
-      "bunfig.toml": `
-[install.security]  
-scanner = "./scanner.js"
-`,
-      "scanner.js": `
-module.exports = {
-  scanner: {
-    version: "1",
-    scan: async function(payload) {
-      return [{
-        package: "lodash",
-        level: "warn",
-        description: "Minor security issue"
-      }];
-    }
-  }
-};
-`,
-    });
-
-    await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-
-    // Run update with stdin to simulate TTY
-    const updateProc = Bun.spawn({
-      cmd: [bunExe(), "update"],
-      cwd: dir,
-      stdout: "pipe",
-      stderr: "pipe",
-      stdin: "pipe",
-      env: { ...bunEnv, FORCE_COLOR: "1" }, // Force color to simulate TTY
-    });
-
-    // Send 'y' to continue
-    updateProc.stdin.write("y\n");
-    updateProc.stdin.end();
-
-    const [stdout, stderr, exitCode] = await Promise.all([
-      updateProc.stdout.text(),
-      updateProc.stderr.text(),
-      updateProc.exited,
-    ]);
-
-    // Should show warning (with or without ANSI codes)
-    expect(stdout).toMatch(/WARN(ING)?.*lodash/);
-
-    // Should prompt for confirmation
-    expect(stdout).toContain("Security warnings found");
-    expect(stdout).toContain("Continue anyway?");
-
-    // Should continue after user confirmation
-    expect(stdout).toContain("Continuing with installation");
-    expect(exitCode).toBe(0);
-  });
-
-  test("bun update shows dependency paths correctly", async () => {
-    await using dir = tempDir("update-dep-paths", {
-      "package.json": JSON.stringify({
-        name: "my-app",
-        dependencies: {
-          "express": "^4.0.0",
-        },
-      }),
-      "scanner.js": `
+  test(
+    "bun update shows dependency paths correctly",
+    async () => {
+      await using dir = tempDir("update-dep-paths", {
+        "package.json": JSON.stringify({
+          name: "my-app",
+          dependencies: {
+            "is-even": "1.0.0",
+          },
+        }),
+        "scanner.js": `
 module.exports = {
   scanner: {
     version: "1",
     scan: async function(payload) {
       const results = [];
       for (const pkg of payload.packages) {
-        // Flag a transitive dependency
-        if (pkg.name === "body-parser") {
+        if (pkg.name === "is-odd") {
           results.push({
-            package: "body-parser",
+            package: "is-odd",
             level: "warn",
             description: "Transitive vulnerability"
           });
@@ -358,35 +295,25 @@ module.exports = {
   }
 };
 `,
-    });
+      });
 
-    await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
+      await primeInstall(String(dir));
 
-    await Bun.write(
-      join(dir, "bunfig.toml"),
-      `
-[install.security]
-scanner = "./scanner.js"
-`,
-    );
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "update"],
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
+      });
 
-    const updateProc = Bun.spawn({
-      cmd: [bunExe(), "update"],
-      cwd: dir,
-      stdout: "pipe",
-      stderr: "pipe",
-      stdin: "pipe",
-      env: bunEnv,
-    });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Send 'n' to not continue
-    updateProc.stdin.write("n\n");
-    updateProc.stdin.end();
-
-    const [stdout] = await Promise.all([updateProc.stdout.text(), updateProc.stderr.text(), updateProc.exited]);
-
-    // Should show the full dependency path
-    expect(stdout).toContain("WARNING: body-parser");
-    expect(stdout).toContain("via my-app › express › body-parser");
-  });
+      expect(stdout).toContain("WARNING: is-odd");
+      expect(stdout).toContain("Transitive vulnerability");
+      expect(stdout).toContain("via my-app › is-even › is-odd");
+      expect(exitCode).toBe(1);
+    },
+    timeout,
+  );
 });

--- a/test/cli/install/bun-update-security-scan-all.test.ts
+++ b/test/cli/install/bun-update-security-scan-all.test.ts
@@ -170,7 +170,7 @@ module.exports = {
 
       // Only the requested package is sent to the scanner.
       expect(stderr).toContain(`SCANNED_PACKAGES: ["left-pad"]`);
-      expect(stdout).toMatch(/WARN(ING)?.*left-pad/);
+      expect(stdout).toContain("WARNING: left-pad");
       expect(stdout).toContain("Test warning");
 
       // is-even was not part of this update, so its fatal advisory must not surface.


### PR DESCRIPTION
## What

`test/cli/install/bun-update-security-scan-all.test.ts` was installing `lodash`, `express`, and `axios` from npmjs.org in every test, serially. `express` alone pulls ~30 transitive dependencies, so the file took ~11s on release builds in CI (build #86620, windows-aarch64) and flaked with 5s timeouts when npmjs was slow:

```
(fail) bun update without arguments scans all packages [5001.77ms]
(fail) bun update respects security scanner configuration [5003.53ms]
```

## Change

Rewire the tests to the in-process `simple-dummy-registry` (left-pad / is-even / is-odd) that the neighbouring `bun-security-scanner-workspaces.test.ts` already uses, and run the five independent cases under `describe.concurrent`. No coverage is dropped:

| test | old package(s) | new package(s) |
| --- | --- | --- |
| scans all packages | lodash, express | left-pad, is-even (+ is-odd transitive) |
| specific package only | lodash, express, axios | left-pad, is-even |
| no scanner configured | lodash | left-pad |
| aborts on fatal | lodash | left-pad |
| dependency path | express > body-parser | is-even > is-odd |

Assertions tightened while I was in there:
- "scans all" now asserts the exact package set the scanner received (`["is-even","is-odd","left-pad"]`), that it was called once, and that the no-TTY cancellation message appears
- "specific package" asserts the scanner payload was exactly `["left-pad"]`, and that the untouched package's description never surfaces
- "aborts on fatal" also checks the advisory URL is printed
- "dependency path" also checks the warning description and exit code
- stdout/stderr are asserted before `exitCode` throughout
- `await using` on every spawn

The `test.todo` TTY case was already never-run; its body referenced the same npmjs packages so it's collapsed to the title.

## Timings

|   | before | after |
| --- | --- | --- |
| `bun bd test` (debug+ASAN) | 26s, 3 tests time out | ~6s, all pass |
| release (USE_SYSTEM_BUN) | 8-16s, flaky | ~0.3s |

```
$ bun bd test test/cli/install/bun-update-security-scan-all.test.ts
 5 pass
 1 todo
 0 fail
 28 expect() calls
Ran 6 tests across 1 file. [6.19s]
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/install/bun-update-security-scan-all.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/install/bun-update-security-scan-all.test.ts
bun test v1.4.0 (930662ac2)

test/cli/install/bun-update-security-scan-all.test.ts:
(todo) bun update security scanning > bun update prompts for warnings when TTY available - requires TTY for interactive prompt
(pass) bun update security scanning > bun update respects security scanner configuration [520.59ms]
(pass) bun update security scanning > bun update without arguments scans all packages [1779.09ms]
(pass) bun update security scanning > bun update with specific packages only scans those packages [1707.92ms]
(pass) bun update security scanning > bun update shows dependency paths correctly [1697.71ms]
(pass) bun update security scanning > bun update aborts on fatal vulnerabilities [1925.38ms]

 5 pass
 1 todo
 0 fail
 28 expect() calls
Ran 6 tests across 1 file. [4.42s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../install/bun-update-security-scan-all.test.ts   | 545 +++++++++------------
 1 file changed, 236 insertions(+), 309 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
test/cli/install/bun-update-security-scan-all.test.ts      3      9      0
```

</details>

<!-- robobun:evidence:end -->