### PR TITLE
test(install): make bun-pm-scan.test.ts hermetic and concurrent

### DIFF
--- a/test/cli/install/bun-pm-scan.test.ts
+++ b/test/cli/install/bun-pm-scan.test.ts
@@ -475,6 +475,7 @@ describe.concurrent("bun pm scan", () => {
             scanner: {
               version: "1",
               scan: async function() {
+                // Timing output is only printed when the scan takes >= 1000ms.
                 await new Promise(resolve => setTimeout(resolve, 1050));
                 return [];
               }

--- a/test/cli/install/bun-pm-scan.test.ts
+++ b/test/cli/install/bun-pm-scan.test.ts
@@ -31,7 +31,7 @@ beforeAll(async () => {
     if (result.exitCode !== 0) {
       throw new Error(`fixture install failed:\n${result.stderr.toString()}`);
     }
-    return Bun.file(join(String(dir), "bun.lock")).text();
+    return await Bun.file(join(String(dir), "bun.lock")).text();
   }
 
   [leftPadLock, isEvenLock, mixedLock] = await Promise.all([

--- a/test/cli/install/bun-pm-scan.test.ts
+++ b/test/cli/install/bun-pm-scan.test.ts
@@ -319,7 +319,11 @@ describe.concurrent("bun pm scan", () => {
       const [stdout, stderr, exitCode] = await runScan(dir);
 
       expect(stdout).toContain("FATAL: is-even");
-      expect(stdout).toContain("via my-app › is-even");
+      // is-even and is-odd depend on each other in the fixture registry; anchor
+      // the end of the path so a shortest-path regression that prints
+      // "… › is-even › is-odd › is-even" is caught.
+      expect(stdout).toMatch(/via my-app › is-even$/m);
+      expect(stdout).not.toContain("is-odd");
       expect(stderr).not.toContain("error:");
       expect(exitCode).toBe(1);
     });
@@ -350,7 +354,7 @@ describe.concurrent("bun pm scan", () => {
       const [stdout, stderr, exitCode] = await runScan(dir);
 
       expect(stdout).toContain("WARNING: is-odd");
-      expect(stdout).toContain("via my-app › is-even › is-odd");
+      expect(stdout).toMatch(/via my-app › is-even › is-odd$/m);
       expect(stderr).not.toContain("error:");
       expect(exitCode).toBe(1);
     });

--- a/test/cli/install/bun-pm-scan.test.ts
+++ b/test/cli/install/bun-pm-scan.test.ts
@@ -1,27 +1,77 @@
-import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
+import { startRegistry, stopRegistry } from "./simple-dummy-registry";
 
-describe("bun pm scan", () => {
+let registryUrl: string;
+
+// `bun pm scan` only reads the lockfile; it never touches node_modules or the
+// network. Resolve each dependency set once in beforeAll so individual tests
+// can drop the lockfile into a fresh dir instead of each running `bun install`.
+let leftPadLock: string;
+let isEvenLock: string;
+let mixedLock: string;
+
+const leftPadPkg = JSON.stringify({ name: "test-app", dependencies: { "left-pad": "1.3.0" } });
+const isEvenPkg = JSON.stringify({ name: "my-app", dependencies: { "is-even": "1.0.0" } });
+const mixedPkg = JSON.stringify({
+  name: "test-app",
+  dependencies: { "left-pad": "1.3.0", "is-even": "1.0.0" },
+});
+
+beforeAll(async () => {
+  registryUrl = await startRegistry(false);
+
+  async function makeLock(pkgJson: string): Promise<string> {
+    await using dir = tempDir("scan-fixture", {
+      "package.json": pkgJson,
+      "bunfig.toml": `[install]\ncache.disable = true\nregistry = "${registryUrl}/"`,
+    });
+    const result = await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet().nothrow();
+    if (result.exitCode !== 0) {
+      throw new Error(`fixture install failed:\n${result.stderr.toString()}`);
+    }
+    return Bun.file(join(String(dir), "bun.lock")).text();
+  }
+
+  [leftPadLock, isEvenLock, mixedLock] = await Promise.all([
+    makeLock(leftPadPkg),
+    makeLock(isEvenPkg),
+    makeLock(mixedPkg),
+  ]);
+});
+
+afterAll(() => {
+  stopRegistry();
+});
+
+const scannerBunfig = `[install.security]\nscanner = "./scanner.js"`;
+
+async function runScan(dir: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "scan"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return [stdout, stderr, exitCode] as const;
+}
+
+describe.concurrent("bun pm scan", () => {
   describe("configuration", () => {
     test("shows error when no security scanner configured", async () => {
       await using dir = tempDir("scan-no-config", {
-        "package.json": JSON.stringify({ name: "test", dependencies: { "left-pad": "^1.0.0" } }),
+        "package.json": leftPadPkg,
         "bun.lockb": "",
       });
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(exitCode).toBe(1);
       expect(stderr).toContain("error: no security scanner configured");
+      expect(stdout).toContain("configure a security scanner in bunfig.toml");
+      expect(exitCode).toBe(1);
     });
 
     test("shows error when lockfile doesn't exist", async () => {
@@ -30,68 +80,45 @@ describe("bun pm scan", () => {
         "bunfig.toml": `[install.security]\nscanner = "test-scanner"`,
       });
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(exitCode).toBe(1);
       expect(stderr).toContain("Lockfile not found");
       expect(stderr).toContain("Run 'bun install' first");
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
     });
 
     test("shows error when package.json doesn't exist", async () => {
-      const dir = tmpdirSync();
+      await using dir = tempDir("scan-no-package-json", {});
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(exitCode).toBe(1);
       expect(stderr).toContain("No package.json was found");
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
     });
   });
 
   describe("scanner execution", () => {
     test("scanner receives correct package format", async () => {
       await using dir = tempDir("scan-package-format", {
-        "package.json": JSON.stringify({
-          name: "test-app",
-          dependencies: {
-            express: "^4.0.0",
-          },
-        }),
-        "bunfig.toml": `[install.security]\nscanner = "./scanner.js"`,
+        "package.json": leftPadPkg,
+        "bun.lock": leftPadLock,
+        "bunfig.toml": scannerBunfig,
         "scanner.js": `
           module.exports = {
             scanner: {
               version: "1",
               scan: async function(payload) {
-                // Log the packages we receive
                 console.error("PACKAGES:", JSON.stringify(payload.packages));
-                
-                // Verify format
                 if (!Array.isArray(payload.packages)) {
                   throw new Error("packages should be an array");
                 }
-                
                 for (const pkg of payload.packages) {
                   if (!pkg.name || !pkg.version || !pkg.requestedRange || !pkg.tarball) {
-                    throw new Error("Invalid package format");
+                    throw new Error("Invalid package format: " + JSON.stringify(pkg));
                   }
                 }
-                
                 return [];
               }
             }
@@ -99,26 +126,28 @@ describe("bun pm scan", () => {
         `,
       });
 
-      await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stderr).toContain("PACKAGES:");
-      expect(exitCode).toBe(0);
+      const line = stderr.split("\n").find(l => l.startsWith("PACKAGES:"));
+      expect(line).toBeDefined();
+      const packages = JSON.parse(line!.slice("PACKAGES:".length));
+      expect(packages).toEqual([
+        {
+          name: "left-pad",
+          version: "1.3.0",
+          requestedRange: "1.3.0",
+          tarball: expect.stringMatching(/^http:\/\/localhost:\d+\/left-pad-1\.3\.0\.tgz$/),
+        },
+      ]);
       expect(stdout).toContain("No advisories found");
+      expect(exitCode).toBe(0);
     });
 
     test("scanner version validation", async () => {
       await using dir = tempDir("scan-version-check", {
-        "package.json": JSON.stringify({ name: "test", dependencies: { "left-pad": "^1.0.0" } }),
+        "package.json": leftPadPkg,
+        "bun.lock": leftPadLock,
+        "bunfig.toml": scannerBunfig,
         "scanner.js": `
           module.exports = {
             scanner: {
@@ -129,40 +158,27 @@ describe("bun pm scan", () => {
         `,
       });
 
-      await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      // Add config after install
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
-
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(exitCode).toBe(1);
       expect(stderr).toContain("Security scanner must be version 1");
+      expect(stdout).not.toContain("No advisories found");
+      expect(exitCode).toBe(1);
     });
   });
 
   describe("vulnerability detection", () => {
     test("detects fatal vulnerabilities", async () => {
       await using dir = tempDir("scan-fatal", {
-        "package.json": JSON.stringify({
-          name: "test-app",
-          dependencies: { lodash: "^4.0.0" },
-        }),
+        "package.json": leftPadPkg,
+        "bun.lock": leftPadLock,
+        "bunfig.toml": scannerBunfig,
         "scanner.js": `
           module.exports = {
             scanner: {
               version: "1",
               scan: async function(payload) {
                 return [{
-                  package: "lodash",
+                  package: "left-pad",
                   level: "fatal",
                   description: "Prototype pollution vulnerability",
                   url: "https://example.com/CVE-2024-1234"
@@ -173,39 +189,28 @@ describe("bun pm scan", () => {
         `,
       });
 
-      await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(exitCode).toBe(1);
-      expect(stdout).toContain("FATAL: lodash");
+      expect(stdout).toContain("FATAL: left-pad");
       expect(stdout).toContain("Prototype pollution vulnerability");
       expect(stdout).toContain("https://example.com/CVE-2024-1234");
       expect(stdout).toMatch(/1 advisory \(.*1 fatal.*\)/);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(1);
     });
 
     test("detects warning vulnerabilities", async () => {
       await using dir = tempDir("scan-warn", {
-        "package.json": JSON.stringify({
-          name: "test-app",
-          dependencies: { axios: "^0.21.0" },
-        }),
+        "package.json": leftPadPkg,
+        "bun.lock": leftPadLock,
+        "bunfig.toml": scannerBunfig,
         "scanner.js": `
           module.exports = {
             scanner: {
               version: "1",
               scan: async function(payload) {
                 return [{
-                  package: "axios",
+                  package: "left-pad",
                   level: "warn",
                   description: "Inefficient regular expression",
                   url: "https://example.com/advisory/123"
@@ -216,35 +221,20 @@ describe("bun pm scan", () => {
         `,
       });
 
-      await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(exitCode).toBe(1); // Still exits with 1 for warnings
-      expect(stdout).toContain("WARNING: axios");
+      expect(stdout).toContain("WARNING: left-pad");
       expect(stdout).toContain("Inefficient regular expression");
       expect(stdout).toMatch(/1 advisory \(.*1 warning.*\)/);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(1);
     });
 
     test("handles mixed vulnerabilities", async () => {
       await using dir = tempDir("scan-mixed", {
-        "package.json": JSON.stringify({
-          name: "test-app",
-          dependencies: {
-            lodash: "^4.0.0",
-            axios: "^0.21.0",
-            express: "^4.0.0",
-          },
-        }),
+        "package.json": mixedPkg,
+        "bun.lock": mixedLock,
+        "bunfig.toml": scannerBunfig,
         "scanner.js": `
           module.exports = {
             scanner: {
@@ -252,26 +242,14 @@ describe("bun pm scan", () => {
               scan: async function(payload) {
                 const results = [];
                 for (const pkg of payload.packages) {
-                  if (pkg.name === "lodash") {
-                    results.push({
-                      package: "lodash",
-                      level: "fatal",
-                      description: "Critical vulnerability"
-                    });
+                  if (pkg.name === "left-pad") {
+                    results.push({ package: "left-pad", level: "fatal", description: "Critical vulnerability" });
                   }
-                  if (pkg.name === "axios") {
-                    results.push({
-                      package: "axios", 
-                      level: "warn",
-                      description: "Minor issue"
-                    });
+                  if (pkg.name === "is-even") {
+                    results.push({ package: "is-even", level: "warn", description: "Minor issue" });
                   }
-                  if (pkg.name === "express") {
-                    results.push({
-                      package: "express",
-                      level: "warn",
-                      description: "Another minor issue"
-                    });
+                  if (pkg.name === "is-odd") {
+                    results.push({ package: "is-odd", level: "warn", description: "Another minor issue" });
                   }
                 }
                 return results;
@@ -281,33 +259,21 @@ describe("bun pm scan", () => {
         `,
       });
 
-      await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(exitCode).toBe(1);
-      expect(stdout).toContain("FATAL: lodash");
-      expect(stdout).toContain("WARNING: axios");
-      expect(stdout).toContain("WARNING: express");
+      expect(stdout).toContain("FATAL: left-pad");
+      expect(stdout).toContain("WARNING: is-even");
+      expect(stdout).toContain("WARNING: is-odd");
       expect(stdout).toMatch(/3 advisories \(.*1 fatal.*2 warnings.*\)/);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(1);
     });
 
     test("no vulnerabilities found", async () => {
       await using dir = tempDir("scan-clean", {
-        "package.json": JSON.stringify({
-          name: "test-app",
-          dependencies: { lodash: "^4.0.0" },
-        }),
-        "bunfig.toml": `[install.security]\nscanner = "./scanner.js"`,
+        "package.json": leftPadPkg,
+        "bun.lock": leftPadLock,
+        "bunfig.toml": scannerBunfig,
         "scanner.js": `
           module.exports = {
             scanner: {
@@ -318,30 +284,20 @@ describe("bun pm scan", () => {
         `,
       });
 
-      await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(exitCode).toBe(0);
       expect(stdout).toContain("No advisories found");
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
     });
   });
 
   describe("dependency paths", () => {
     test("shows correct path for direct dependencies", async () => {
       await using dir = tempDir("scan-direct-dep", {
-        "package.json": JSON.stringify({
-          name: "my-app",
-          dependencies: { express: "^4.0.0" },
-        }),
+        "package.json": isEvenPkg,
+        "bun.lock": isEvenLock,
+        "bunfig.toml": scannerBunfig,
         "scanner.js": `
           module.exports = {
             scanner: {
@@ -349,12 +305,8 @@ describe("bun pm scan", () => {
               scan: async function(payload) {
                 const results = [];
                 for (const pkg of payload.packages) {
-                  if (pkg.name === "express") {
-                    results.push({
-                      package: "express",
-                      level: "fatal",
-                      description: "Test vulnerability"
-                    });
+                  if (pkg.name === "is-even") {
+                    results.push({ package: "is-even", level: "fatal", description: "Test vulnerability" });
                   }
                 }
                 return results;
@@ -364,29 +316,19 @@ describe("bun pm scan", () => {
         `,
       });
 
-      await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stdout).toContain("FATAL: express");
-      expect(stdout).toContain("via my-app › express");
+      expect(stdout).toContain("FATAL: is-even");
+      expect(stdout).toContain("via my-app › is-even");
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(1);
     });
 
     test("shows correct path for transitive dependencies", async () => {
       await using dir = tempDir("scan-transitive-dep", {
-        "package.json": JSON.stringify({
-          name: "my-app",
-          dependencies: { express: "^4.0.0" },
-        }),
+        "package.json": isEvenPkg,
+        "bun.lock": isEvenLock,
+        "bunfig.toml": scannerBunfig,
         "scanner.js": `
           module.exports = {
             scanner: {
@@ -394,13 +336,8 @@ describe("bun pm scan", () => {
               scan: async function(payload) {
                 const results = [];
                 for (const pkg of payload.packages) {
-                  // body-parser is a dependency of express
-                  if (pkg.name === "body-parser") {
-                    results.push({
-                      package: "body-parser",
-                      level: "warn",
-                      description: "Transitive vulnerability"
-                    });
+                  if (pkg.name === "is-odd") {
+                    results.push({ package: "is-odd", level: "warn", description: "Transitive vulnerability" });
                   }
                 }
                 return results;
@@ -410,78 +347,50 @@ describe("bun pm scan", () => {
         `,
       });
 
-      await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      // body-parser might not actually be a dependency of express
-      // So we check if we found it in the scan
-      if (stdout.includes("WARNING: body-parser")) {
-        expect(stdout).toContain("via my-app › express › body-parser");
-      } else {
-        // If body-parser wasn't found, the test passes since we can't verify transitive deps
-        expect(exitCode).toBeDefined();
-      }
+      expect(stdout).toContain("WARNING: is-odd");
+      expect(stdout).toContain("via my-app › is-even › is-odd");
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(1);
     });
   });
 
   describe("error handling", () => {
     test("handles scanner crash", async () => {
       await using dir = tempDir("scan-crash", {
-        "package.json": JSON.stringify({
-          name: "test",
-          dependencies: { "left-pad": "^1.0.0" },
-        }),
+        "package.json": leftPadPkg,
+        "bun.lock": leftPadLock,
+        "bunfig.toml": scannerBunfig,
         "scanner.js": `
           module.exports = {
             scanner: {
               version: "1",
               scan: async function() {
-                process.exit(42); // Crash
+                process.exit(42);
               }
             }
           };
         `,
       });
 
-      await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(exitCode).toBe(1);
       expect(stderr).toContain("Security scanner exited with code 42");
+      expect(stdout).not.toContain("No advisories found");
+      expect(exitCode).toBe(1);
     });
 
     test("handles invalid JSON from scanner", async () => {
       await using dir = tempDir("scan-bad-json", {
-        "package.json": JSON.stringify({
-          name: "test",
-          dependencies: { "left-pad": "^1.0.0" },
-        }),
+        "package.json": leftPadPkg,
+        "bun.lock": leftPadLock,
+        "bunfig.toml": scannerBunfig,
         "scanner.js": `
           module.exports = {
             scanner: {
               version: "1",
               scan: async function() {
-                // Return something that's not an array
                 return { not: "an array" };
               }
             }
@@ -489,36 +398,25 @@ describe("bun pm scan", () => {
         `,
       });
 
-      await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(exitCode).toBe(1);
       expect(stderr).toContain("Security scanner must return an array");
+      expect(stdout).not.toContain("No advisories found");
+      expect(exitCode).toBe(1);
     });
 
     test("handles missing required fields in advisory", async () => {
       await using dir = tempDir("scan-missing-fields", {
-        "package.json": JSON.stringify({
-          name: "test",
-          dependencies: { lodash: "^4.0.0" },
-        }),
+        "package.json": leftPadPkg,
+        "bun.lock": leftPadLock,
+        "bunfig.toml": scannerBunfig,
         "scanner.js": `
           module.exports = {
             scanner: {
               version: "1",
               scan: async function() {
                 return [{
-                  package: "lodash"
+                  package: "left-pad"
                   // Missing 'level' field
                 }];
               }
@@ -527,31 +425,20 @@ describe("bun pm scan", () => {
         `,
       });
 
-      await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(exitCode).toBe(1);
       expect(stderr).toContain("missing required 'level' field");
+      expect(stdout).not.toContain("No advisories found");
+      expect(exitCode).toBe(1);
     });
   });
 
   describe("output formatting", () => {
     test("singular vs plural in summary", async () => {
       await using dir = tempDir("scan-singular", {
-        "package.json": JSON.stringify({
-          name: "test",
-          dependencies: { "left-pad": "^1.0.0" },
-        }),
+        "package.json": leftPadPkg,
+        "bun.lock": leftPadLock,
+        "bunfig.toml": scannerBunfig,
         "scanner.js": `
           module.exports = {
             scanner: {
@@ -560,11 +447,7 @@ describe("bun pm scan", () => {
                 const results = [];
                 for (const pkg of payload.packages) {
                   if (pkg.name === "left-pad") {
-                    results.push({
-                      package: "left-pad",
-                      level: "fatal",
-                      description: "Test"
-                    });
+                    results.push({ package: "left-pad", level: "fatal", description: "Test" });
                   }
                 }
                 return results;
@@ -574,37 +457,25 @@ describe("bun pm scan", () => {
         `,
       });
 
-      await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-
-      const stdout = await proc.stdout.text();
-
-      // Should say "1 advisory" not "1 advisories"
       expect(stdout).toContain("1 advisory (");
       expect(stdout).not.toContain("1 advisories");
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(1);
     });
 
     test("shows timing for slow scans", async () => {
       await using dir = tempDir("scan-slow", {
-        "package.json": JSON.stringify({
-          name: "test",
-          dependencies: { "left-pad": "^1.0.0" },
-        }),
+        "package.json": leftPadPkg,
+        "bun.lock": leftPadLock,
+        "bunfig.toml": scannerBunfig,
         "scanner.js": `
           module.exports = {
             scanner: {
               version: "1",
               scan: async function() {
-                // Simulate slow scan
-                await new Promise(resolve => setTimeout(resolve, 1200));
+                await new Promise(resolve => setTimeout(resolve, 1050));
                 return [];
               }
             }
@@ -612,65 +483,38 @@ describe("bun pm scan", () => {
         `,
       });
 
-      await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "0" }, // Enable timing output
-      });
-
-      const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
-
-      // Should show timing information for scans > 1 second
       expect(stderr).toMatch(/Scanning \d+ package[s]? took \d+ms/);
+      expect(stdout).toContain("No advisories found");
+      expect(exitCode).toBe(0);
     });
   });
 
   describe("differences from bun add/install", () => {
     test("does not show 'installation aborted' message", async () => {
       await using dir = tempDir("scan-no-abort-msg", {
-        "package.json": JSON.stringify({
-          name: "test",
-          dependencies: { lodash: "^4.0.0" },
-        }),
+        "package.json": leftPadPkg,
+        "bun.lock": leftPadLock,
+        "bunfig.toml": scannerBunfig,
         "scanner.js": `
           module.exports = {
             scanner: {
               version: "1",
               scan: async function() {
-                return [{
-                  package: "lodash",
-                  level: "fatal",
-                  description: "Critical"
-                }];
+                return [{ package: "left-pad", level: "fatal", description: "Critical" }];
               }
             }
           };
         `,
       });
 
-      await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      const [stdout, stderr, exitCode] = await runScan(dir);
 
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "pm", "scan"],
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-
-      const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
-
-      // Should NOT contain the installation aborted message
-      expect(stdout).not.toContain("installation aborted");
-      expect(stdout).not.toContain("Installation aborted");
-      expect(stderr).not.toContain("installation aborted");
-      expect(stderr).not.toContain("Installation aborted");
+      expect(stdout).toContain("FATAL: left-pad");
+      expect(stdout.toLowerCase()).not.toContain("installation aborted");
+      expect(stderr.toLowerCase()).not.toContain("installation aborted");
+      expect(exitCode).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## What

`test/cli/install/bun-pm-scan.test.ts` was resolving `express`/`lodash`/`axios` from npmjs.org once per test (14 installs total) and ran every test serially. Build #86620 clocked it at 16s on windows-aarch64; a local debug+ASAN run hit 51s with a 5s-timeout in the `express` install.

## How

- Serve packages from the in-process `SimpleRegistry` already used by the other scanner tests (`left-pad` / `is-even` / `is-odd`) instead of npmjs.org. No more public-internet dependency.
- Generate the three needed lockfiles once in `beforeAll` and drop the text into each test's temp dir. `bun pm scan` only reads the lockfile, so the 14 per-test `bun install` calls are gone (3 installs total now, in parallel).
- Run the whole suite under `describe.concurrent`; every test owns its own temp dir so there is no shared state.
- Check stdout/stderr before `exitCode`, add positive stderr assertions to the negative-path tests, and assert the actual scanner payload shape in _scanner receives correct package format_ (it used to only check for a `PACKAGES:` marker).
- Replace the always-passes `body-parser` branch in the transitive-dependency test with a deterministic assertion on `my-app › is-even › is-odd`. The previous version fell through to `expect(exitCode).toBeDefined()` whenever `body-parser` wasn't in the tree.
- Drop `tmpdirSync` in favour of `tempDir`, and trim the slow-scan `setTimeout` from 1200ms to 1050ms (the reporting threshold is `>= 1000ms`).

## Verification

`bun bd test test/cli/install/bun-pm-scan.test.ts` (debug + ASAN, Linux x64):

| | before | after |
|-|-|-|
| wall time | 51.44s | 11.4 / 13.8 / 15.0s (3 runs) |
| result | 16 pass, **1 timeout** | 17 pass |
| expect() calls | 44 | 65 |

Release build: 33.1s with 4 timeouts -> 1.9s, 17 pass.

Same 17 tests, no skips.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/install/bun-pm-scan.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/install/bun-pm-scan.test.ts
bun test v1.4.0 (fe89e9828)

test/cli/install/bun-pm-scan.test.ts:
(pass) bun pm scan > configuration > shows error when no security scanner configured [154.67ms]
(pass) bun pm scan > configuration > shows error when lockfile doesn't exist [141.38ms]
(pass) bun pm scan > configuration > shows error when package.json doesn't exist [149.06ms]
(pass) bun pm scan > scanner execution > scanner version validation [1331.58ms]
(pass) bun pm scan > scanner execution > scanner receives correct package format [1398.00ms]
(pass) bun pm scan > vulnerability detection > detects warning vulnerabilities [1366.77ms]
(pass) bun pm scan > vulnerability detection > handles mixed vulnerabilities [1395.68ms]
(pass) bun pm scan > vulnerability detection > detects fatal vulnerabilities [1502.69ms]
(pass) bun pm scan > vulnerability detection > no vulnerabilities found [1438.24ms]
(pass) bun pm scan > dependency paths > shows correct path for transitive dependencies [1406.70ms]
(pass) bun pm scan > error handling > handles scanner crash [1386.02ms]
(pass) bun pm scan > dependency paths > shows correct path for direct dependencies [1557.03ms]
(pass) bun pm scan > error handling > handles invalid JSON from scanner [1430.94ms]
(pass) bun pm scan > error handling > handles missing required fields in advisory [1430.28ms]
(pass) bun pm scan > output formatting > singular vs plural in summary [1416.65ms]
(pass) bun pm scan > differences from bun add/install > does not show 'installation aborted' message [1455.30ms]
(pass) bun pm scan > output formatting > shows timing for slow scans [2501.60ms]

 17 pass
 0 fail
 66 expect() calls
Ran 17 tests across 1 file. [9.18s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/install/bun-pm-scan.test.ts | 549 +++++++++++++----------------------
 1 file changed, 199 insertions(+), 350 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
test/cli/install/bun-pm-scan.test.ts      5      9      0
```

</details>

<!-- robobun:evidence:end -->