### PR TITLE
bun test: await async test body after an unhandled rejection before running afterEach

### DIFF
--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -161,6 +161,12 @@ pub struct ExecutionSequence {
     pub(crate) remaining_retry_count: u32,
     pub(crate) result: Result,
     pub(crate) executing: bool,
+    /// The active entry's callback returned a promise that is still pending,
+    /// so the test body itself is still running. An unhandled rejection while
+    /// this is set records the failure but does not enqueue a completion token;
+    /// the body's own promise settling (or a timeout) is what advances.
+    /// https://github.com/oven-sh/bun/issues/14644
+    pub(crate) has_pending_promise: bool,
     pub(crate) started_at: Timespec,
     /// Number of expect() calls observed in this sequence.
     pub(crate) expect_call_count: u32,
@@ -185,6 +191,7 @@ impl ExecutionSequence {
             // defaults:
             result: Result::Pending,
             executing: false,
+            has_pending_promise: false,
             started_at: Timespec::EPOCH,
             expect_call_count: 0,
             expect_assertions: ExpectAssertions::NotSet,
@@ -514,6 +521,7 @@ impl Execution {
             let entry = unsafe { entry_ptr.as_ref() };
 
             sequence.executing = false;
+            sequence.has_pending_promise = false;
             if sequence.maybe_skip {
                 sequence.maybe_skip = false;
                 sequence.active_entry = match entry.failure_skip_past {

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1173,6 +1173,24 @@ impl BunTest {
 
         done_callback.ensure_still_alive();
 
+        // If the callback returned a pending promise, note it on the sequence
+        // before draining so a rejection drained below is attributed to a
+        // still-running body and does not prematurely enqueue a completion
+        // token (on_unhandled_rejection checks this). Cleared by
+        // `advance_sequence`.
+        if !result.is_empty() {
+            if let Some(promise) = result.as_promise() {
+                // SAFETY: `as_promise` returned a non-null GC-managed JSPromise.
+                if unsafe { (*promise).status() } == PromiseStatus::Pending {
+                    // SAFETY: `UnsafeCell`-derived `*mut`; sole `&mut` for this
+                    // field write (no re-entrant `.get()` between here and drop).
+                    if let Some(sequence) = cfg_data.sequence(unsafe { &mut *this }) {
+                        sequence.has_pending_promise = true;
+                    }
+                }
+            }
+        }
+
         // Drain unhandled promise rejections.
         loop {
             // Prevent the user's Promise rejection from going into the uncaught promise rejection queue.

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -602,11 +602,14 @@ pub(crate) mod on_unhandled_rejection {
             let entry_ptr: Option<*mut bun_test::ExecutionEntry> = current_state_data
                 .entry(buntest)
                 .map(std::ptr::from_mut::<bun_test::ExecutionEntry>);
+            let mut has_pending_promise = false;
             if let Some(entry) = entry_ptr {
                 if let Some(sequence) = current_state_data.sequence(buntest) {
                     if sequence.test_entry.map(|p| p.as_ptr()) != Some(entry) {
                         // mark errors in hooks as 'unhandled error between tests'
                         current_state_data = RefDataValue::Start;
+                    } else {
+                        has_pending_promise = sequence.has_pending_promise;
                     }
                 }
             }
@@ -616,6 +619,13 @@ pub(crate) mod on_unhandled_rejection {
                 true,
                 &current_state_data,
             );
+            if has_pending_promise {
+                // The test body returned a promise that hasn't settled. Record
+                // the failure (above) but let the body finish; its own promise
+                // settling (or a timeout) is what enqueues completion.
+                // https://github.com/oven-sh/bun/issues/14644
+                return;
+            }
             buntest.add_result(current_state_data);
             // `report_unhandled` reports the uncaught exception, with a guard
             // for `Terminated` (which carries no pending exception to take).

--- a/test/js/bun/test/test-error-code-done-callback.test.ts
+++ b/test/js/bun/test/test-error-code-done-callback.test.ts
@@ -80,7 +80,6 @@ test("verify we print error messages passed to done callbacks", () => {
     ^
     error: you should see this(async)
     at <anonymous> (<dir>/test-error-done-callback-fixture.ts:42:14)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:37:3)
     (fail) error done callback (async)
     43 |   });
     44 | });

--- a/test/regression/issue/14624.test.ts
+++ b/test/regression/issue/14624.test.ts
@@ -39,7 +39,7 @@ test("uncaught promise rejection in async test should not hang", async () => {
 
   expect(timeout).toBeFalse();
   expect(output).toContain("test start");
-  // expect(output).toContain("test end"); // the process exits before this executes
+  expect(output).toContain("test end");
   expect(output).toContain("uncaught error");
   expect(exitCode).not.toBe(0);
   expect(output).toMatch(/✗|\(fail\)/);

--- a/test/regression/issue/14644.test.ts
+++ b/test/regression/issue/14644.test.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/14644
+// An unhandled promise rejection inside an async test must mark the test as
+// failed but still await the returned promise before running afterEach and the
+// next test.
+
+test("unhandled rejection in async test does not advance past the test body", async () => {
+  using dir = tempDir("issue-14644", {
+    "order.test.js": `
+      import { beforeEach, afterEach, test } from "bun:test";
+
+      beforeEach(() => { console.log("beforeEach"); });
+      afterEach(() => { console.log("afterEach"); });
+
+      test("a", async () => {
+        console.log("test a start");
+        ;(async () => { throw 123; })();
+        await Bun.sleep(1);
+        console.log("test a end");
+      });
+
+      test("b", async () => {
+        console.log("test b");
+        await Bun.sleep(1);
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "order.test.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const combined = stdout + stderr;
+
+  const pick = (s: string) =>
+    s
+      .split("\n")
+      .map(l => l.trim())
+      .filter(l => l.startsWith("beforeEach") || l.startsWith("afterEach") || l.startsWith("test "));
+
+  expect(pick(stdout)).toEqual([
+    "beforeEach",
+    "test a start",
+    "test a end",
+    "afterEach",
+    "beforeEach",
+    "test b",
+    "afterEach",
+  ]);
+
+  expect(combined).toContain("123");
+  expect(combined).toMatch(/\n 1 pass/);
+  expect(combined).toMatch(/\n 1 fail/);
+  expect(exitCode).toBe(1);
+});
+
+test("unhandled rejection from a macrotask while awaiting does not advance past the test body", async () => {
+  using dir = tempDir("issue-14644-timer", {
+    "order.test.js": `
+      import { afterEach, test } from "bun:test";
+
+      afterEach(() => { console.log("afterEach"); });
+
+      test("a", async () => {
+        console.log("test a start");
+        setTimeout(() => {
+          ;(async () => { throw 123; })();
+        }, 1);
+        await Bun.sleep(10);
+        console.log("test a end");
+      });
+
+      test("b", () => {
+        console.log("test b");
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "order.test.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const combined = stdout + stderr;
+
+  const pick = (s: string) =>
+    s
+      .split("\n")
+      .map(l => l.trim())
+      .filter(l => l.startsWith("afterEach") || l.startsWith("test "));
+
+  expect(pick(stdout)).toEqual(["test a start", "test a end", "afterEach", "test b", "afterEach"]);
+
+  expect(combined).toContain("123");
+  expect(combined).toMatch(/\n 1 pass/);
+  expect(combined).toMatch(/\n 1 fail/);
+  expect(exitCode).toBe(1);
+});


### PR DESCRIPTION
Fixes #14644.

## Repro

```js
import { beforeEach, afterEach, test } from "bun:test";
beforeEach(() => console.log("beforeEach"));
afterEach(() => console.log("afterEach"));
test("a", async () => {
  console.log("test a start");
  ;(async () => { throw 123; })();
  await Bun.sleep(1);
  console.log("test a end");
});
test("b", async () => { console.log("test b"); await Bun.sleep(1); });
```

Before: `test a start` / `afterEach` / `beforeEach` / `test b` / `test a end` (test a's body finishes while test b is already running).
After: `test a start` / `test a end` / `afterEach` / `beforeEach` / `test b`.

## Cause

`jest::on_unhandled_rejection` called `add_result(current_state_data)` with the currently-executing test entry's identity. `BunTest::run` then dequeued that token and `Execution::step` unconditionally called `advance_sequence` for it, moving on to `afterEach` and the next test while the test body's returned promise was still pending. When the promise later settled, its completion was rejected by `get_current_and_valid_execution_sequence` as stale.

## Fix

Track `has_pending_promise` on `ExecutionSequence`. `run_test_callback` sets it when the callback returns a promise that is still `Pending` (before draining rejections, so it is already set when the drain fires); `advance_sequence` clears it. `on_unhandled_rejection` still records the failure via `on_uncaught_exception` but, when the flag is set, does not enqueue a completion token: the body's own promise settling (or a timeout) advances execution.

Tests that only wait on a `done()` callback (no returned promise) keep the existing behavior of advancing on an uncaught exception (`done-infinity.fixture.ts`).

## Tests

- `test/regression/issue/14644.test.ts` covers the microtask-drain path and the macrotask path (rejection from a `setTimeout` while awaiting).
- `test/regression/issue/14624.test.ts` now also asserts `test end` is printed.
- `test-error-code-done-callback.test.ts` snapshot drops one frame: an `async done => { await Bun.sleep(0); done(err) }` test's `done()` no longer synchronously starts the next test inline, so that next test's async stack no longer carries a frame pointing into the previous test's body.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/test-error-code-done-callback.test.ts "test/regression/issue/14624.test.ts" "test/regression/issue/14644.test.ts"
bun test v1.4.0 (e90ca3317)

test/regression/issue/14624.test.ts:
37 | 
38 |   const output = stdout + stderr;
39 | 
40 |   expect(timeout).toBeFalse();
41 |   expect(output).toContain("test start");
42 |   expect(output).toContain("test end");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "test end"
Received: "bun test v1.4.0 (e90ca3317)\ntest start\n\nhang.test.js:\n2 |       import { test } from 'bun:test'\n3 | \n4 |       test('async test with uncaught rejection', async () => {\n5 |         console.log('test start');\n6 |         // This creates an unhandled promise rejection\n7 |         (async () => { throw new Error('uncaught error'); })();\n                                     ^\nerror: uncaught error\n      at <anonymous> (/tmp/issue-14624_Sqzx7B/hang.test.js:7:34)\n      at <anonymous> (/tmp/issue-14624_Sqzx7B/hang.test.js:7:56)\n      at <anonymous> (/t
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/regression/issue/14624.test.ts:
37 | 
38 |   const output = stdout + stderr;
39 | 
40 |   expect(timeout).toBeFalse();
41 |   expect(output).toContain("test start");
42 |   expect(output).toContain("test end");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "test end"
Received: "bun test v1.4.0-canary.1 (1498d7b77)\ntest start\n\nhang.test.js:\n2 |       import { test } from 'bun:test'\n3 | \n4 |       test('async test with uncaught rejection', async () = {\n5 |         console.log('test start');\n6 |         // This creates an unhandled promise rejection\n7 |         (async () => { throw new Error('uncaught error'); })();\n                                     ^\nerror: uncaught error\n      at  (/tmp/issue-14624_mrvsBk/hang.test.js:7:34)\n      at  (/tmp/issue-14624_mrvsBk/hang.test.js:7:56)\n(fail) async test with uncaught rejection [0.67ms]\n\n 0 pass\n 1 fail\nRan 1 test across 1 file. [15.00ms]\n"

      at <anonymous> (/workspace/bun/test/regression/issue/14624.test.ts:42:18)
(fail) uncaught promise rejection in async test should not hang [20.82ms]

test/regression/issue/1464
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/test-error-code-done-callback.test.ts "test/regression/issue/14624.test.ts" "test/regression/issue/14644.test.ts"
bun test v1.4.0 (e90ca3317)

test/regression/issue/14624.test.ts:
(pass) uncaught promise rejection in async test should not hang [579.10ms]

test/regression/issue/14644.test.ts:
(pass) unhandled rejection in async test does not advance past the test body [652.26ms]
(pass) unhandled rejection from a macrotask while awaiting does not advance past the test body [737.15ms]

test/js/bun/test/test-error-code-done-callback.test.ts:
(pass) verify we print error messages passed to done callbacks [3265.72ms]

 4 pass
 0 fail
 2 snapshots, 19 expect() calls
Ran 4 tests across 3 files. [10.28s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e90ca3317a
  features     baseline

22 deps, 108 codegen, 1171 objects in 1689ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen bindgenv2
[2/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[3/1234] gen .bind.ts → GeneratedBindings.cpp
[4/1234] gen ErrorCode+*.h
[5/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [438.00ms]
[6/1234] fetch picohttpparser
[picohttpparser] up to date
[7/1234] fetch tinycc
[tinycc] up to date
[8/1234] fetch zlib
[zlib] up to date
[9/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 i
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/Execution.rs               |   8 ++
 src/runtime/test_runner/bun_test.rs                |  18 ++++
 src/runtime/test_runner/jest.rs                    |  10 ++
 .../bun/test/test-error-code-done-callback.test.ts |   1 -
 test/regression/issue/14624.test.ts                |   2 +-
 test/regression/issue/14644.test.ts                | 109 +++++++++++++++++++++
 6 files changed, 146 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/runtime/test_runner/Execution.rs                        4      1      0
src/runtime/test_runner/bun_test.rs                         4      3      0
src/runtime/test_runner/jest.rs                             3      4      0
test/js/bun/test/test-error-code-done-callback.test.ts      1      0      0
test/regression/issue/14624.test.ts                         1      1      0
test/regression/issue/14644.test.ts                         0      2      0
```

</details>

<!-- robobun:evidence:end -->