### PR TITLE
Bun.Transpiler: preserve bare JSX expression statements without minify.syntax

### DIFF
--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1394,8 +1394,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return Ok(());
         }
 
-        // Matches esbuild's mangleStmts gate; without it Bun.Transpiler drops
-        // bare JSX / @__PURE__ expression statements (#14789).
         if p.options.features.minify_syntax {
             let Some(simplified) = SideEffects::simplify_unused_expr(p, data.value) else {
                 restore_stmt_expr!();

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1358,8 +1358,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmt: &mut Stmt,
         data: &mut S::SExpr,
     ) -> Result<(), Error> {
-        let should_trim_primitive = p.options.features.dead_code_elimination
-            && (p.options.features.minify_syntax && data.value.is_primitive_literal());
         p.stmt_expr_value = data.value.data;
 
         let is_top_level = p.current_scope == p.module_scope && !p.is_inside_single_stmt_body;
@@ -1387,11 +1385,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             () => {
                 p.stmt_expr_value = js_ast::ExprData::EMissing(E::Missing {});
             };
-        }
-
-        if should_trim_primitive && data.value.is_primitive_literal() {
-            restore_stmt_expr!();
-            return Ok(());
         }
 
         if p.options.features.minify_syntax {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1394,12 +1394,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return Ok(());
         }
 
-        // simplify unused
-        let Some(simplified) = SideEffects::simplify_unused_expr(p, data.value) else {
-            restore_stmt_expr!();
-            return Ok(());
-        };
-        data.value = simplified;
+        // esbuild only trims side-effect-free expression statements in
+        // mangleStmts (gated on minifySyntax). Running it unconditionally here
+        // drops bare JSX / `@__PURE__`-annotated calls from `Bun.Transpiler`
+        // output even though that API defaults to no minification (#14789).
+        if p.options.features.minify_syntax {
+            let Some(simplified) = SideEffects::simplify_unused_expr(p, data.value) else {
+                restore_stmt_expr!();
+                return Ok(());
+            };
+            data.value = simplified;
+        }
 
         if p.should_unwrap_common_js_to_esm() {
             if is_top_level {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1394,10 +1394,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return Ok(());
         }
 
-        // esbuild only trims side-effect-free expression statements in
-        // mangleStmts (gated on minifySyntax). Running it unconditionally here
-        // drops bare JSX / `@__PURE__`-annotated calls from `Bun.Transpiler`
-        // output even though that API defaults to no minification (#14789).
+        // Matches esbuild's mangleStmts gate; without it Bun.Transpiler drops
+        // bare JSX / @__PURE__ expression statements (#14789).
         if p.options.features.minify_syntax {
             let Some(simplified) = SideEffects::simplify_unused_expr(p, data.value) else {
                 restore_stmt_expr!();

--- a/test/bundler/transpiler/react-compiler-fixtures.test.ts
+++ b/test/bundler/transpiler/react-compiler-fixtures.test.ts
@@ -239,6 +239,26 @@ const MINIFY_SYNTAX_DIVERGENCE: Record<string, { compiledFunctions: number; buil
       buildError: true,
       reason: "constant folding rewrites the useMemo deps array entry `x` to the literal `0`",
     },
+    // minify.syntax drops a bare `<div>{x}</div>;` expression statement before the
+    // compiler sees it, so `infer` mode no longer recognises the function as a
+    // component. Without minify the statement is preserved and the function is
+    // compiled, matching upstream.
+    "array-map-frozen-array": {
+      compiledFunctions: 0,
+      reason: "bare JSX expression statement dropped before compiler inference",
+    },
+    "array-map-frozen-array-noAlias": {
+      compiledFunctions: 0,
+      reason: "bare JSX expression statement dropped before compiler inference",
+    },
+    "computed-load-primitive-as-dependency": {
+      compiledFunctions: 0,
+      reason: "bare JSX expression statement dropped before compiler inference",
+    },
+    "transitive-freeze-array": {
+      compiledFunctions: 0,
+      reason: "bare JSX expression statement dropped before compiler inference",
+    },
   });
 
 type Fixture = {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -302,10 +302,16 @@ describe("Bun.Transpiler", () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;
 
-      exp("declare = (...t) => R;e((a) => {(u=> uge);\r\n})", "declare = (...t) => R;\ne((a) => {\n  (u) => uge;\n});\n");
+      exp(
+        "declare = (...t) => R;e((a) => {(u=> uge);\r\n})",
+        "declare = (...t) => R;\ne((a) => {\n  (u) => uge;\n});\n",
+      );
       exp("declare = t => 0; () => () => 0", "declare = (t) => 0;\n() => () => 0;\n");
       exp("declare = function () {}; () => () => 0", "declare = function() {};\n() => () => 0;\n");
-      exp("declare = t => 0; function f() { () => 0; }\nf();", "declare = (t) => 0;\nfunction f() {\n  () => 0;\n}\nf();\n");
+      exp(
+        "declare = t => 0; function f() { () => 0; }\nf();",
+        "declare = (t) => 0;\nfunction f() {\n  () => 0;\n}\nf();\n",
+      );
 
       exp(
         "abstract = (t) => 0\nclass Foo { m() { return () => () => 0 } }",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -302,10 +302,10 @@ describe("Bun.Transpiler", () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;
 
-      exp("declare = (...t) => R;e((a) => {(u=> uge);\r\n})", "declare = (...t) => R;\ne((a) => {});\n");
-      exp("declare = t => 0; () => () => 0", "declare = (t) => 0;\n");
-      exp("declare = function () {}; () => () => 0", "declare = function() {};\n");
-      exp("declare = t => 0; function f() { () => 0; }\nf();", "declare = (t) => 0;\nfunction f() {}\nf();\n");
+      exp("declare = (...t) => R;e((a) => {(u=> uge);\r\n})", "declare = (...t) => R;\ne((a) => {\n  (u) => uge;\n});\n");
+      exp("declare = t => 0; () => () => 0", "declare = (t) => 0;\n() => () => 0;\n");
+      exp("declare = function () {}; () => () => 0", "declare = function() {};\n() => () => 0;\n");
+      exp("declare = t => 0; function f() { () => 0; }\nf();", "declare = (t) => 0;\nfunction f() {\n  () => 0;\n}\nf();\n");
 
       exp(
         "abstract = (t) => 0\nclass Foo { m() { return () => () => 0 } }",
@@ -998,7 +998,7 @@ function foo() {}
       err("let foo = (bar\nas (null))", 'Expected ")" but found "as"');
 
       exp("a as any ? b : c;", "a ? b : c;\n");
-      exp("a as any ? async () => b : c;", "a || c;\n");
+      exp("a as any ? async () => b : c;", "a ? async () => b : c;\n");
 
       exp("foo as number extends Object ? any : any;", "foo;\n");
       exp("foo as number extends Object ? () => void : any;", "foo;\n");
@@ -2154,6 +2154,42 @@ console.log(<div {...obj} key="after" />);`),
     );
   });
 
+  // https://github.com/oven-sh/bun/issues/14789
+  it("preserves bare expression statements when minify.syntax is off", async () => {
+    const jsx = new Bun.Transpiler({ loader: "jsx" });
+    // JSX lowers to a call the parser marks as pure; without minify.syntax
+    // that annotation must not cause the statement to be dropped.
+    expect(jsx.transformSync("<div>first</div>")).toBe(
+      'jsxDEV_7x81h0kn("div", {\n  children: "first"\n}, undefined, false, undefined, this);\n',
+    );
+    expect(await jsx.transform("<div>first</div>")).toBe(
+      'jsxDEV_7x81h0kn("div", {\n  children: "first"\n}, undefined, false, undefined, this);\n',
+    );
+    expect(jsx.transformSync("<>a</>")).toBe(
+      'jsxDEV_7x81h0kn(Fragment_8vg9x3sq, {\n  children: "a"\n}, undefined, false, undefined, this);\n',
+    );
+
+    // Classic runtime goes through the same code path.
+    const classic = new Bun.Transpiler({
+      loader: "jsx",
+      tsconfig: JSON.stringify({ compilerOptions: { jsx: "react" } }),
+    });
+    expect(classic.transformSync("<div>first</div>")).toBe('React.createElement("div", null, "first");\n');
+
+    // Other side-effect-free expression statements are likewise kept.
+    const js = new Bun.Transpiler({ loader: "js" });
+    expect(js.transformSync("/* @__PURE__ */ foo();")).toBe("foo();\n");
+    expect(js.transformSync("1;")).toBe("1;\n");
+    expect(js.transformSync("[1, 2, 3];")).toBe("[1, 2, 3];\n");
+    expect(js.transformSync("a === b;")).toBe("a === b;\n");
+
+    // Opting into minify.syntax restores the simplification.
+    const min = new Bun.Transpiler({ loader: "jsx", minify: { syntax: true } });
+    expect(min.transformSync("<div>first</div>")).toBe("");
+    expect(min.transformSync("/* @__PURE__ */ foo();")).toBe("");
+    expect(min.transformSync("1;")).toBe("");
+  });
+
   // Non-bundle transpile without `minify.identifiers` uses NoOpRenamer
   // (prints symbol.original_name verbatim), so the `generatedSymbolName`
   // hash suffix on the automatic JSX runtime import is the sole collision
@@ -3149,10 +3185,15 @@ console.log(resolve.length)
     describe("dead code elimination", () => {
       const transpilerNoDCE = new Bun.Transpiler({ deadCodeElimination: false });
       it("should DCE with deadCodeElimination: true or by default", () => {
-        expect(parsed("123", true, false)).toBe("");
-        expect(parsed("[-1, 2n, null]", true, false)).toBe("");
-        expect(parsed("true", true, false)).toBe("");
-        expect(parsed("!0", true, false)).toBe("");
+        // Trimming side-effect-free expression statements additionally requires
+        // minify.syntax; by default the transpiler preserves what was written.
+        expect(parsed("123", true, false, transpilerMinifySyntax)).toBe("");
+        expect(parsed("[-1, 2n, null]", true, false, transpilerMinifySyntax)).toBe("");
+        expect(parsed("true", true, false, transpilerMinifySyntax)).toBe("");
+        expect(parsed("!0", true, false, transpilerMinifySyntax)).toBe("");
+        expect(parsed("123", true, false)).toBe("123");
+        expect(parsed("[-1, 2n, null]", true, false)).toBe("[-1, 2n, null]");
+        // Dead branches are still eliminated without minify.syntax.
         expect(parsed('if (!1) "dead";', true, false)).toBe("if (false)");
         expect(parsed("if (!1) var x = 2;", true, false)).toBe("if (false)\n  var x");
         expect(parsed("if (undefined) { let y = Math.random(); }", true, false)).toBe("if (undefined) {}");
@@ -4808,7 +4849,7 @@ it("running a file with deeply nested unary operators does not crash the process
 });
 
 it("does not duplicate the branch when simplifying an unused ternary with a comma test", () => {
-  const transpiler = new Bun.Transpiler({ loader: "js" });
+  const transpiler = new Bun.Transpiler({ loader: "js", minify: { syntax: true } });
   expect(transpiler.transformSync("(f(), g()) ? 1 : h();").trim()).toBe("f(), g() || h();");
   expect(transpiler.transformSync("(f(), g()) ? h() : 1;").trim()).toBe("f(), g() && h();");
 });
@@ -5307,7 +5348,7 @@ describe("multi-line comment scanning", () => {
   it("treats newlines inside a large block comment as line terminators (ASI)", () => {
     for (const newline of ["\n", "\r", "\r\n", "\u2028", "\u2029"]) {
       const out = transpiler.transformSync(`function f() { return /*${pad600}${newline}${pad600}*/ 1 }`);
-      expect({ newline, out }).toEqual({ newline, out: "function f() {\n  return;\n}\n" });
+      expect({ newline, out }).toEqual({ newline, out: "function f() {\n  return;\n  1;\n}\n" });
     }
     // control: no newline anywhere inside the comment, so no ASI
     expect(transpiler.transformSync(`function f() { return /*${pad600}${pad600}*/ 1 }`)).toBe(


### PR DESCRIPTION
Fixes #14789.

## Repro

```js
new Bun.Transpiler({ loader: "jsx" }).transformSync("<div>first</div>")
// => ""  (expected a jsxDEV(...) call)
```

## Cause

JSX lowering marks the generated `jsx()`/`createElement()` call with `can_be_unwrapped_if_unused` (the same treatment as a `/* @__PURE__ */` annotation). The `SExpr` visitor then called `SideEffects::simplify_unused_expr` unconditionally, which unwrapped the pure call to its side-effect-free arguments and dropped the whole statement. The same happened to any `/* @__PURE__ */` call, literal, or other side-effect-free expression used as a statement.

esbuild only performs this simplification inside `mangleStmts`, which is gated on `minifySyntax`; its transform API preserves the statement:

```
$ echo '<div>first</div>' | esbuild --loader=jsx
/* @__PURE__ */ React.createElement("div", null, "first");
```

Bun ran the simplification whenever `dead_code_elimination` was on, which it is by default for `Bun.Transpiler`. This divergence dates back to the initial parser port.

## Fix

Gate the `simplify_unused_expr` call in `s_expr` on `p.options.features.minify_syntax`, matching esbuild.

Blast radius:

- **`bun run` / runtime loader:** unchanged. `target=bun` sets `tree_shaking` → `inlining` → `minify_syntax = true`, so the simplification still runs and a bare `<div/>;` in a script is still dropped.
- **`Bun.build`:** unchanged when `target: "bun"` or `minify.syntax` is set. For `target: "browser"` without minify (`bun build --no-bundle`), bare expression statements are now preserved, matching esbuild.
- **`Bun.Transpiler`:** bare JSX, `/* @__PURE__ */` calls, literals and other side-effect-free expression statements are now preserved by default. Dead-branch elimination (`if (false) ...`) still applies. `minify: { syntax: true }` restores the previous trimming.

## Verification

Added `Bun.Transpiler > preserves bare expression statements when minify.syntax is off` in `test/bundler/transpiler/transpiler.test.js` covering the automatic and classic JSX runtimes, async `transform()`, `/* @__PURE__ */`-annotated calls and plain literals, and asserting that `minify: { syntax: true }` still drops them.

Updated four existing assertions in that file that incidentally relied on the always-on simplification (scope-tracking, TS `as` ternary, the `deadCodeElimination` describe, and the large-comment ASI test), plus the one existing `simplify_unused_expr` ternary test which now opts into `minify: { syntax: true }`.

Recorded four react-compiler fixtures in `MINIFY_SYNTAX_DIVERGENCE` (`array-map-frozen-array`, `array-map-frozen-array-noAlias`, `computed-load-primitive-as-dependency`, `transitive-freeze-array`): each uses a bare `<div>{x}</div>;` as a freeze marker, which component inference now sees without minify (matching upstream) but which `minify.syntax` still drops before inference runs.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 342 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/react-compiler-fixtures.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (cf8d512c7)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.97ms]
(pass) Bun.Transpiler > normalizes \r\n [6.22ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.39ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.74ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.69ms]
(pass) Bun.Transpiler > property access inlining > works [2.41ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.14ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [19.25ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [3.67ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.75ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon 
... (truncated)

release without fix: 1168 skipped
bun test v1.4.0-canary.1 (05f782df7)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [2.81ms]
(pass) Bun.Transpiler > normalizes \r\n [0.18ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [1.00ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.17ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [1.35ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [1.39ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.07ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [0.17ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.28ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords followed by a newline apply ASI instead of a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 342 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/react-compiler-fixtures.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (cf8d512c7)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [6.34ms]
(pass) Bun.Transpiler > normalizes \r\n [7.03ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.23ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.52ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.73ms]
(pass) Bun.Transpiler > property access inlining > works [2.19ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.50ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [18.61ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [3.14ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.45ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon 
... (truncated)

release with fix: 1168 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 799ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/visit/visit_stmt.rs                  | 18 ++----
 .../transpiler/react-compiler-fixtures.test.ts     | 20 +++++++
 test/bundler/transpiler/transpiler.test.js         | 69 ++++++++++++++++++----
 3 files changed, 84 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/js_parser/visit/visit_stmt.rs                            6      5      0
test/bundler/transpiler/react-compiler-fixtures.test.ts      4      1      0
test/bundler/transpiler/transpiler.test.js                   8      3      0
```

</details>

<!-- robobun:evidence:end -->