### PR TITLE
shell: set BUN_BE_BUN=1 when $`bun` falls back to self in a compiled binary

### DIFF
--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -526,12 +526,9 @@ impl Cmd {
         resolved.push(0);
         interp.as_cmd_mut(this).args[0] = resolved;
 
-        // When `bun` was not on PATH and we fell back to our own executable,
-        // a `bun build --compile` binary would otherwise re-enter its bundled
-        // entrypoint instead of behaving as the `bun` CLI (#14459). Setting
-        // BUN_BE_BUN=1 makes the child skip the standalone-module-graph boot
-        // path. The entry is appended after `fill_env`, so an explicit
-        // `BUN_BE_BUN` from the user's env (earlier in the array) still wins.
+        // #14459: inside a `bun build --compile` binary, re-spawning ourselves
+        // without BUN_BE_BUN=1 re-enters the bundled entrypoint instead of the
+        // bun CLI.
         if fell_back_to_self_exe && bun_standalone_graph::Graph::get().is_some() {
             spawn_args
                 .env_array

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -473,11 +473,13 @@ impl Cmd {
         }
 
         // Resolve argv[0] via PATH (`bun_which::which`).
+        let mut fell_back_to_self_exe = false;
         let resolved: Option<Vec<u8>> = {
             let mut path_buf = bun_paths::path_buffer_pool::get();
             match bun_which::which(&mut *path_buf, spawn_args.path, spawn_args.cwd, &first_arg) {
                 Some(z) => Some(z.as_bytes().to_vec()),
                 None if &first_arg[..] == b"bun" || &first_arg[..] == b"bun-debug" => {
+                    fell_back_to_self_exe = true;
                     bun_core::self_exe_path()
                         .ok()
                         .map(|z| z.as_bytes().to_vec())
@@ -523,6 +525,18 @@ impl Cmd {
         // `execve`).
         resolved.push(0);
         interp.as_cmd_mut(this).args[0] = resolved;
+
+        // When `bun` was not on PATH and we fell back to our own executable,
+        // a `bun build --compile` binary would otherwise re-enter its bundled
+        // entrypoint instead of behaving as the `bun` CLI (#14459). Setting
+        // BUN_BE_BUN=1 makes the child skip the standalone-module-graph boot
+        // path. The entry is appended after `fill_env`, so an explicit
+        // `BUN_BE_BUN` from the user's env (earlier in the array) still wins.
+        if fell_back_to_self_exe && bun_standalone_graph::Graph::get().is_some() {
+            spawn_args
+                .env_array
+                .push(b"BUN_BE_BUN=1\0".as_ptr().cast::<core::ffi::c_char>());
+        }
 
         // Convert shell IO → subprocess stdio.
         let mut shellio = ShellIO::default();

--- a/test/regression/issue/14459.test.ts
+++ b/test/regression/issue/14459.test.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/14459
+// In a `bun build --compile` binary, Bun Shell's `bun` command fell back to
+// process.execPath (the compiled app itself) when no `bun` was on PATH,
+// re-running the app's entrypoint instead of behaving as the bun CLI.
+//
+// `bun build --compile` is slow under debug/ASAN; allow extra time.
+test("Bun.$`bun ...` inside a compiled executable runs bun, not the entrypoint", async () => {
+  using dir = tempDir("issue-14459", {
+    "entry.ts": `
+      import { $ } from "bun";
+      console.log("entrypoint pid=" + process.pid);
+      if (process.env.ISSUE_14459_CHILD === "1") {
+        // Guard against infinite recursion on unfixed builds: if we get here,
+        // $\`bun\` re-ran the entrypoint instead of behaving as the bun CLI.
+        console.log("ERROR: entrypoint re-entered");
+        process.exit(7);
+      }
+      const { stdout, exitCode } = await $\`bun --revision\`.env({ ISSUE_14459_CHILD: "1" }).nothrow().quiet();
+      console.log("child revision=" + stdout.toString().trim());
+      process.exit(exitCode);
+    `,
+  });
+
+  const outfile = join(String(dir), isWindows ? "app.exe" : "app");
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "./entry.ts", "--outfile", outfile],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) console.error(stdout, stderr);
+    expect(exitCode).toBe(0);
+  }
+
+  // Run with a PATH that does not contain `bun`, so the shell's fallback to
+  // self_exe_path() is the only way `bun` can resolve. Point PATH at the empty
+  // temp dir so no system-installed `bun` (e.g. /usr/bin/bun) is picked up.
+  await using proc = Bun.spawn({
+    cmd: [outfile],
+    env: { ...bunEnv, PATH: String(dir), Path: String(dir), BUN_BE_BUN: undefined },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Before the fix the child re-ran the entrypoint (hitting the guard above)
+  // instead of printing `bun --revision` output, so the revision line carried
+  // the child's "entrypoint pid=" text and the process exited 7.
+  const expectedRevision = `${Bun.version}+${Bun.revision.slice(0, 9)}`;
+  expect(stdout).not.toContain("ERROR: entrypoint re-entered");
+  expect(stdout).toContain("child revision=" + expectedRevision);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+}, 60_000);

--- a/test/regression/issue/14459.test.ts
+++ b/test/regression/issue/14459.test.ts
@@ -54,7 +54,11 @@ test("Bun.$`bun ...` inside a compiled executable runs bun, not the entrypoint",
   // Before the fix the child re-ran the entrypoint (hitting the guard above)
   // instead of printing `bun --revision` output, so the revision line carried
   // the child's "entrypoint pid=" text and the process exited 7.
-  const expectedRevision = `${Bun.version}+${Bun.revision.slice(0, 9)}`;
+  //
+  // Compare against the literal `--revision` output of the binary that built
+  // the executable; `Bun.version` lacks the `-canary.N` tag so reconstructing
+  // the string from it would break on release canary lanes.
+  const expectedRevision = (await Bun.$`${bunExe()} --revision`.env(bunEnv).text()).trim();
   expect(stdout).not.toContain("ERROR: entrypoint re-entered");
   expect(stdout).toContain("child revision=" + expectedRevision);
   expect(stderr).toBe("");

--- a/test/regression/issue/14459.test.ts
+++ b/test/regression/issue/14459.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 


### PR DESCRIPTION
## What does this PR do?

Fixes #14459.

### Repro

```ts
// entry.ts
import { $ } from "bun";
console.log("entrypoint pid=" + process.pid);
await $`bun --revision`;
```

```sh
bun build --compile entry.ts --outfile app
env PATH=/tmp ./app
```

Before this PR the `$\`bun ...\`` call resolved `bun` to `process.execPath` (the compiled app), which re-ran `entry.ts` in the child instead of behaving as the `bun` CLI, recursing until the user killed it (or, with the issue's original repro, exiting with "Unknown subcommand" and a `ShellError`).

### Cause

`src/runtime/shell/states/Cmd.rs` falls back to `bun_core::self_exe_path()` when `which("bun")` finds nothing on `PATH`. In a `bun build --compile` binary that path is the compiled app, and without `BUN_BE_BUN=1` the child boots the bundled standalone module graph instead of the CLI.

### Fix

When that fallback is taken and `StandaloneModuleGraph::get().is_some()` (i.e. we are a compiled binary), append `BUN_BE_BUN=1` to the spawn env so the child skips the standalone boot path and acts as plain `bun`. The entry is appended after `fill_env`, so an explicit `BUN_BE_BUN` from the caller's environment (earlier in the envp array) still wins.

If a real `bun` is found on `PATH`, behaviour is unchanged: the fallback is not taken and that binary is used.

### Verification

`test/regression/issue/14459.test.ts` compiles a binary that runs `$\`bun --revision\`` with `PATH` pointed at an empty temp dir. Without the fix the child re-enters the entrypoint (guarded to exit 7); with the fix the child prints the same revision as the test runner.

```
# without src/ change
(fail) Bun.$`bun ...` inside a compiled executable runs bun, not the entrypoint
  Expected to not contain: "ERROR: entrypoint re-entered"
  Received: "entrypoint pid=30364\nchild revision=entrypoint pid=30374\nERROR: entrypoint re-entered\n"

# with src/ change
(pass) Bun.$`bun ...` inside a compiled executable runs bun, not the entrypoint
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/regression/issue/14459.test.ts

<!-- robobun:evidence:end -->