### PR TITLE
ci: stage canary release assets before swapping them into place

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1051,6 +1051,11 @@ function getReleaseStep(releasePlatforms, options, { signed = false, testStepKey
       // (same filenames, but the signed re-uploads are the ones we want).
       WINDOWS_ARTIFACT_STEP: signed ? "windows-sign" : "",
     },
+    // Only one release upload touches the `canary` tag at a time across
+    // builds. Without this two main builds that go green close together both
+    // push assets and step on each other's delete/rename sequence.
+    concurrency: 1,
+    concurrency_group: "release/canary",
     command: ".buildkite/scripts/upload-release.sh",
   };
 }

--- a/.buildkite/scripts/upload-release.sh
+++ b/.buildkite/scripts/upload-release.sh
@@ -225,9 +225,59 @@ function download_buildkite_artifact() {
   fi
 }
 
+function list_release_assets() {
+  gh release view "$1" --repo "$BUILDKITE_REPO" --json assets --jq '.assets[] | "\(.apiUrl) \(.name)"'
+}
+
+# Two-phase: upload everything under a per-build staging suffix first, then
+# swap each asset into place with a DELETE+PATCH pair. `gh release upload
+# --clobber` deletes an asset before uploading its replacement (5 workers in
+# parallel), so a cancel while uploads are in flight leaves those assets
+# deleted on the release and not re-uploaded. Buildkite's
+# cancel_running_branch_builds does exactly that when a later main build
+# starts mid-:rocket: (build 86848: 5 of 32 assets gone). Staging keeps the
+# live names serving users until the data transfer is done; the swap loop is
+# metadata-only so a cancel there costs at most the one asset mid-swap.
 function upload_github_assets() {
   local tag="$(release_tag "$1")"
-  run_command gh release upload "$tag" "${@:2}" --clobber --repo "$BUILDKITE_REPO"
+  local files=("${@:2}")
+  local suffix=".incoming-${BUILDKITE_BUILD_NUMBER:-$$}"
+
+  local assets url name
+  assets="$(list_release_assets "$tag")"
+  while read -r url name; do
+    [ -n "$name" ] || continue
+    [[ "$name" == *.incoming-* ]] || continue
+    run_command gh api -X DELETE "$url"
+  done <<< "$assets"
+
+  local stage file staged=()
+  stage="$(mktemp -d "./release-stage.XXXXXX")"
+  for file in "${files[@]}"; do
+    ln -f "$file" "$stage/${file}${suffix}"
+    staged+=("$stage/${file}${suffix}")
+  done
+  run_command gh release upload "$tag" "${staged[@]}" --clobber --repo "$BUILDKITE_REPO"
+  rm -rf "$stage"
+
+  assets="$(list_release_assets "$tag")"
+  declare -A asset_url=()
+  while read -r url name; do
+    [ -n "$name" ] || continue
+    asset_url["$name"]="$url"
+  done <<< "$assets"
+  for file in "${files[@]}"; do
+    local new_url="${asset_url["${file}${suffix}"]}"
+    if [ -z "$new_url" ]; then
+      echo "error: staged asset ${file}${suffix} missing from release $tag after upload"
+      exit 1
+    fi
+    local old_url="${asset_url["$file"]}"
+    if [ -n "$old_url" ]; then
+      run_command gh api -X DELETE "$old_url"
+    fi
+    run_command gh api -X PATCH "$new_url" -f "name=$file" --jq .name
+  done
 }
 
 function update_github_release() {
@@ -367,8 +417,8 @@ function create_release() {
     run_command rm -rf "$work"
   }
 
-  # Fetch everything up front so the GitHub release can take all assets in one
-  # `gh release upload`; per-file uploads raced on the same release.
+  # Fetch everything up front so upload_github_assets can stage the full set
+  # in one `gh release upload` before touching the live asset names.
   local files=() pids=() artifact
   for artifact in "${artifacts[@]}"; do
     download_buildkite_artifact "$artifact" & pids+=("$!")

--- a/.buildkite/scripts/upload-release.sh
+++ b/.buildkite/scripts/upload-release.sh
@@ -268,8 +268,8 @@ function upload_github_assets() {
     gh_api_retry -X DELETE "$url"
   done <<< "$assets"
 
-  local stage file staged=()
-  stage="$(mktemp -d "./release-stage.XXXXXX")"
+  local stage="./release-stage" file staged=()
+  rm -rf "$stage" && mkdir -p "$stage"
   for file in "${files[@]}"; do
     ln -f "$file" "$stage/${prefix}${file}"
     staged+=("$stage/${prefix}${file}")

--- a/.buildkite/scripts/upload-release.sh
+++ b/.buildkite/scripts/upload-release.sh
@@ -229,7 +229,21 @@ function list_release_assets() {
   gh release view "$1" --repo "$BUILDKITE_REPO" --json assets --jq '.assets[] | "\(.apiUrl) \(.name)"'
 }
 
-# Two-phase: upload everything under a per-build staging suffix first, then
+# `gh api` has no built-in retry (unlike `gh release upload`, which backs off
+# on 5xx). The swap loop below is ~2N metadata calls; one transient 502 under
+# `set -e` between DELETE and PATCH would leave the live asset name absent.
+function gh_api_retry() {
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    run_command gh api "$@" && return 0
+    echo "warn: gh api ${*:1:2} failed (attempt $attempt/5), retrying..." >&2
+    sleep "$attempt"
+  done
+  echo "error: gh api ${*:1:2} failed after 5 attempts" >&2
+  return 1
+}
+
+# Two-phase: upload everything under a per-build staging prefix first, then
 # swap each asset into place with a DELETE+PATCH pair. `gh release upload
 # --clobber` deletes an asset before uploading its replacement (5 workers in
 # parallel), so a cancel while uploads are in flight leaves those assets
@@ -238,24 +252,27 @@ function list_release_assets() {
 # starts mid-:rocket: (build 86848: 5 of 32 assets gone). Staging keeps the
 # live names serving users until the data transfer is done; the swap loop is
 # metadata-only so a cancel there costs at most the one asset mid-swap.
+# Prefix, not suffix: the staged file must still end in `.zip` or `gh`
+# uploads it as application/octet-stream and the PATCH rename cannot change
+# the content type.
 function upload_github_assets() {
   local tag="$(release_tag "$1")"
   local files=("${@:2}")
-  local suffix=".incoming-${BUILDKITE_BUILD_NUMBER:-$$}"
+  local prefix="incoming-${BUILDKITE_BUILD_NUMBER:-$$}-"
 
   local assets url name
   assets="$(list_release_assets "$tag")"
   while read -r url name; do
     [ -n "$name" ] || continue
-    [[ "$name" == *.incoming-* ]] || continue
-    run_command gh api -X DELETE "$url"
+    [[ "$name" == incoming-* ]] || continue
+    gh_api_retry -X DELETE "$url"
   done <<< "$assets"
 
   local stage file staged=()
   stage="$(mktemp -d "./release-stage.XXXXXX")"
   for file in "${files[@]}"; do
-    ln -f "$file" "$stage/${file}${suffix}"
-    staged+=("$stage/${file}${suffix}")
+    ln -f "$file" "$stage/${prefix}${file}"
+    staged+=("$stage/${prefix}${file}")
   done
   run_command gh release upload "$tag" "${staged[@]}" --clobber --repo "$BUILDKITE_REPO"
   rm -rf "$stage"
@@ -267,16 +284,16 @@ function upload_github_assets() {
     asset_url["$name"]="$url"
   done <<< "$assets"
   for file in "${files[@]}"; do
-    local new_url="${asset_url["${file}${suffix}"]}"
+    local new_url="${asset_url["${prefix}${file}"]}"
     if [ -z "$new_url" ]; then
-      echo "error: staged asset ${file}${suffix} missing from release $tag after upload"
+      echo "error: staged asset ${prefix}${file} missing from release $tag after upload"
       exit 1
     fi
     local old_url="${asset_url["$file"]}"
     if [ -n "$old_url" ]; then
-      run_command gh api -X DELETE "$old_url"
+      gh_api_retry -X DELETE "$old_url"
     fi
-    run_command gh api -X PATCH "$new_url" -f "name=$file" --jq .name
+    gh_api_retry -X PATCH "$new_url" -f "name=$file" --jq .name
   done
 }
 

--- a/packages/bun-release/scripts/upload-assets.ts
+++ b/packages/bun-release/scripts/upload-assets.ts
@@ -22,6 +22,11 @@ for (const { name, browser_download_url } of assets) {
   if (name.startsWith("SHASUMS256.txt")) {
     continue;
   }
+  // Two-phase canary upload stages under this prefix before renaming into
+  // place; see .buildkite/scripts/upload-release.sh. Don't hash or sign them.
+  if (name.startsWith("incoming-")) {
+    continue;
+  }
   const response = await fetch(browser_download_url);
   const buffer = Buffer.from(await response.arrayBuffer());
   existing.set(name, await hash(buffer));

--- a/packages/bun-release/scripts/upload-s3.ts
+++ b/packages/bun-release/scripts/upload-s3.ts
@@ -113,6 +113,11 @@ if (release?.assets?.[0]?.name !== local) {
 }
 
 for (const asset of release.assets) {
+  // Two-phase canary upload stages under this prefix before renaming into
+  // place; see .buildkite/scripts/upload-release.sh. Don't mirror them.
+  if (asset.name.startsWith("incoming-")) {
+    continue;
+  }
   const url = asset.browser_download_url;
   const response = await fetch(url);
   if (!response.ok) {

--- a/test/internal/upload-release-assets.test.ts
+++ b/test/internal/upload-release-assets.test.ts
@@ -2,8 +2,8 @@
 // mock `gh` on PATH that keeps a JSON asset list. The point is the two-phase
 // stage/swap: a cancel during the long data-transfer window must leave every
 // live asset name intact.
-import { test, expect, describe } from "bun:test";
-import { bunEnv, tempDir, isWindows } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, isWindows, tempDir } from "harness";
 import { join, resolve } from "node:path";
 
 const scriptPath = resolve(import.meta.dir, "../../.buildkite/scripts/upload-release.sh");
@@ -65,11 +65,7 @@ esac
 
 type Asset = { id: number; name: string };
 
-async function run(opts: {
-  initialAssets: Asset[];
-  killOn?: string;
-  fail5xxOnce?: string;
-}) {
+async function run(opts: { initialAssets: Asset[]; killOn?: string; fail5xxOnce?: string }) {
   using dir = tempDir("upload-release-assets", {
     "bin/gh": mockGh,
     "state.json": JSON.stringify(opts.initialAssets),
@@ -124,7 +120,11 @@ describe.concurrent.skipIf(isWindows)("upload_github_assets", () => {
     const r = await run({ initialAssets: initial });
     expect(r.stderr).not.toContain("error:");
     expect(r.exitCode).toBe(0);
-    expect(live(r.assets).map(a => a.name).sort()).toEqual(["a.zip", "b.zip", "c.zip"]);
+    expect(
+      live(r.assets)
+        .map(a => a.name)
+        .sort(),
+    ).toEqual(["a.zip", "b.zip", "c.zip"]);
     expect(live(r.assets).every(a => a.id > 3)).toBe(true);
     expect(staged(r.assets)).toEqual([]);
   });
@@ -139,7 +139,9 @@ describe.concurrent.skipIf(isWindows)("upload_github_assets", () => {
   test("cancel between DELETE and PATCH loses at most the one asset mid-swap", async () => {
     const r = await run({ initialAssets: initial, killOn: "PATCH .*assets/4 " });
     expect(r.exitCode).not.toBe(0);
-    const liveNames = live(r.assets).map(a => a.name).sort();
+    const liveNames = live(r.assets)
+      .map(a => a.name)
+      .sort();
     expect(liveNames).toEqual(["b.zip", "c.zip"]);
     // a.zip's data is still present under its staged name.
     expect(staged(r.assets).some(a => a.name === "incoming-999-a.zip")).toBe(true);
@@ -148,15 +150,28 @@ describe.concurrent.skipIf(isWindows)("upload_github_assets", () => {
   test("transient 5xx on PATCH is retried instead of aborting mid-swap", async () => {
     const r = await run({ initialAssets: initial, fail5xxOnce: "PATCH .*assets/4 " });
     expect(r.exitCode).toBe(0);
-    expect(live(r.assets).map(a => a.name).sort()).toEqual(["a.zip", "b.zip", "c.zip"]);
+    expect(
+      live(r.assets)
+        .map(a => a.name)
+        .sort(),
+    ).toEqual(["a.zip", "b.zip", "c.zip"]);
     expect(staged(r.assets)).toEqual([]);
     expect(r.stderr).toContain("retrying");
   });
 
   test("release already missing an asset is healed", async () => {
-    const r = await run({ initialAssets: [{ id: 1, name: "a.zip" }, { id: 3, name: "c.zip" }] });
+    const r = await run({
+      initialAssets: [
+        { id: 1, name: "a.zip" },
+        { id: 3, name: "c.zip" },
+      ],
+    });
     expect(r.exitCode).toBe(0);
-    expect(live(r.assets).map(a => a.name).sort()).toEqual(["a.zip", "b.zip", "c.zip"]);
+    expect(
+      live(r.assets)
+        .map(a => a.name)
+        .sort(),
+    ).toEqual(["a.zip", "b.zip", "c.zip"]);
   });
 
   test("stale incoming-* from a previous interrupted run is swept before staging", async () => {
@@ -164,7 +179,11 @@ describe.concurrent.skipIf(isWindows)("upload_github_assets", () => {
       initialAssets: [...initial, { id: 100, name: "incoming-777-a.zip" }, { id: 101, name: "incoming-777-c.zip" }],
     });
     expect(r.exitCode).toBe(0);
-    expect(live(r.assets).map(a => a.name).sort()).toEqual(["a.zip", "b.zip", "c.zip"]);
+    expect(
+      live(r.assets)
+        .map(a => a.name)
+        .sort(),
+    ).toEqual(["a.zip", "b.zip", "c.zip"]);
     expect(staged(r.assets)).toEqual([]);
     // The sweep hit the two stale ids before the new upload.
     expect(r.calls.some(c => c.includes("DELETE") && c.endsWith("/100"))).toBe(true);

--- a/test/internal/upload-release-assets.test.ts
+++ b/test/internal/upload-release-assets.test.ts
@@ -3,7 +3,7 @@
 // stage/swap: a cancel during the long data-transfer window must leave every
 // live asset name intact.
 import { describe, expect, test } from "bun:test";
-import { bunEnv, isWindows, tempDir } from "harness";
+import { bunEnv, isLinux, tempDir } from "harness";
 import { join, resolve } from "node:path";
 
 const scriptPath = resolve(import.meta.dir, "../../.buildkite/scripts/upload-release.sh");
@@ -109,7 +109,10 @@ upload_github_assets canary a.zip b.zip c.zip
 const live = (assets: Asset[]) => assets.filter(a => !a.name.startsWith("incoming-"));
 const staged = (assets: Asset[]) => assets.filter(a => a.name.startsWith("incoming-"));
 
-describe.concurrent.skipIf(isWindows)("upload_github_assets", () => {
+// Linux only: the :rocket: step runs on the debian-13 aarch64 host, and
+// upload_github_assets uses bash 4+ associative arrays which macOS /bin/bash
+// (3.2) does not have.
+describe.concurrent.skipIf(!isLinux)("upload_github_assets", () => {
   const initial: Asset[] = [
     { id: 1, name: "a.zip" },
     { id: 2, name: "b.zip" },

--- a/test/internal/upload-release-assets.test.ts
+++ b/test/internal/upload-release-assets.test.ts
@@ -1,0 +1,182 @@
+// Exercises upload_github_assets in .buildkite/scripts/upload-release.sh with a
+// mock `gh` on PATH that keeps a JSON asset list. The point is the two-phase
+// stage/swap: a cancel during the long data-transfer window must leave every
+// live asset name intact.
+import { test, expect, describe } from "bun:test";
+import { bunEnv, tempDir, isWindows } from "harness";
+import { join, resolve } from "node:path";
+
+const scriptPath = resolve(import.meta.dir, "../../.buildkite/scripts/upload-release.sh");
+
+// The mock `gh` implements just enough of `release view`, `release upload`, and
+// `api -X {DELETE,PATCH}` to maintain a [{id,name}] asset list. `MOCK_KILL_ON`
+// matches a call's argv and sends SIGTERM to the caller to simulate the
+// Buildkite agent cancelling the step mid-call.
+const mockGh = `#!/usr/bin/env bash
+set -euo pipefail
+echo "gh $*" >> "$MOCK_CALLS"
+if [ -n "\${MOCK_KILL_ON:-}" ] && [[ "$*" =~ \${MOCK_KILL_ON} ]]; then
+  kill -TERM "$PPID" 2>/dev/null; exit 143
+fi
+if [ -n "\${MOCK_5XX_ONCE:-}" ] && [[ "$*" =~ \${MOCK_5XX_ONCE} ]] && [ ! -f "$MOCK_STATE.5xx-fired" ]; then
+  : > "$MOCK_STATE.5xx-fired"; echo "HTTP 502" >&2; exit 1
+fi
+state="$MOCK_STATE"
+case "$1 $2" in
+  "release view")
+    bun -e 'for (const a of JSON.parse(require("fs").readFileSync(process.env.MOCK_STATE,"utf8"))) console.log("https://api.github.com/repos/o/r/releases/assets/"+a.id, a.name)'
+    ;;
+  "release upload")
+    shift 2; shift # tag
+    files=()
+    while [ $# -gt 0 ]; do case "$1" in --clobber|--repo) [ "$1" = --repo ] && shift ;; *) files+=("$1") ;; esac; shift; done
+    MOCK_FILES="\${files[*]}" bun -e '
+      const fs=require("fs"),p=require("path");
+      const s=JSON.parse(fs.readFileSync(process.env.MOCK_STATE,"utf8"));
+      let next=Math.max(0,...s.map(a=>a.id))+1;
+      for (const f of process.env.MOCK_FILES.split(" ")) {
+        const n=p.basename(f);
+        const i=s.findIndex(a=>a.name===n);
+        if (i>=0) s.splice(i,1);
+        s.push({id:next++,name:n});
+      }
+      fs.writeFileSync(process.env.MOCK_STATE,JSON.stringify(s));'
+    ;;
+  "api -X")
+    method="$3"; url="$4"; id="\${url##*/}"
+    if [ "$method" = DELETE ]; then
+      MOCK_ID="$id" bun -e '
+        const fs=require("fs");
+        const s=JSON.parse(fs.readFileSync(process.env.MOCK_STATE,"utf8")).filter(a=>String(a.id)!==process.env.MOCK_ID);
+        fs.writeFileSync(process.env.MOCK_STATE,JSON.stringify(s));'
+    else
+      newname=""; for a in "$@"; do [[ "$a" == name=* ]] && newname="\${a#name=}"; done
+      MOCK_ID="$id" MOCK_NAME="$newname" bun -e '
+        const fs=require("fs");
+        const s=JSON.parse(fs.readFileSync(process.env.MOCK_STATE,"utf8"));
+        for (const a of s) if (String(a.id)===process.env.MOCK_ID) a.name=process.env.MOCK_NAME;
+        fs.writeFileSync(process.env.MOCK_STATE,JSON.stringify(s));
+        console.log(process.env.MOCK_NAME);'
+    fi
+    ;;
+  *) echo "mock gh: unhandled: $*" >&2; exit 1 ;;
+esac
+`;
+
+type Asset = { id: number; name: string };
+
+async function run(opts: {
+  initialAssets: Asset[];
+  killOn?: string;
+  fail5xxOnce?: string;
+}) {
+  using dir = tempDir("upload-release-assets", {
+    "bin/gh": mockGh,
+    "state.json": JSON.stringify(opts.initialAssets),
+    "calls.log": "",
+    "a.zip": "a",
+    "b.zip": "b",
+    "c.zip": "c",
+    // Source just the functions under test, then invoke. Sourcing the whole
+    // script would trip assert_main / assert_canary.
+    "run.sh": `set -eo pipefail
+source <(sed -n '/^function run_command/,/^}/p; /^function release_tag/,/^}/p; /^function list_release_assets/,/^}/p; /^function gh_api_retry/,/^}/p; /^function upload_github_assets/,/^}/p' "$SCRIPT")
+upload_github_assets canary a.zip b.zip c.zip
+`,
+  });
+  const cwd = String(dir);
+  await Bun.spawn({ cmd: ["chmod", "+x", join(cwd, "bin/gh")] }).exited;
+
+  await using proc = Bun.spawn({
+    cmd: ["bash", "run.sh"],
+    cwd,
+    env: {
+      ...bunEnv,
+      PATH: `${join(cwd, "bin")}:${process.env.PATH}`,
+      SCRIPT: scriptPath,
+      MOCK_STATE: join(cwd, "state.json"),
+      MOCK_CALLS: join(cwd, "calls.log"),
+      BUILDKITE_REPO: "https://github.com/o/r.git",
+      BUILDKITE_BUILD_NUMBER: "999",
+      ...(opts.killOn ? { MOCK_KILL_ON: opts.killOn } : {}),
+      ...(opts.fail5xxOnce ? { MOCK_5XX_ONCE: opts.fail5xxOnce } : {}),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const assets: Asset[] = JSON.parse(await Bun.file(join(cwd, "state.json")).text());
+  const calls = (await Bun.file(join(cwd, "calls.log")).text()).trim().split("\n");
+  return { exitCode, assets, calls, stdout, stderr };
+}
+
+const live = (assets: Asset[]) => assets.filter(a => !a.name.startsWith("incoming-"));
+const staged = (assets: Asset[]) => assets.filter(a => a.name.startsWith("incoming-"));
+
+describe.concurrent.skipIf(isWindows)("upload_github_assets", () => {
+  const initial: Asset[] = [
+    { id: 1, name: "a.zip" },
+    { id: 2, name: "b.zip" },
+    { id: 3, name: "c.zip" },
+  ];
+
+  test("full run swaps every asset to a new id under its live name", async () => {
+    const r = await run({ initialAssets: initial });
+    expect(r.stderr).not.toContain("error:");
+    expect(r.exitCode).toBe(0);
+    expect(live(r.assets).map(a => a.name).sort()).toEqual(["a.zip", "b.zip", "c.zip"]);
+    expect(live(r.assets).every(a => a.id > 3)).toBe(true);
+    expect(staged(r.assets)).toEqual([]);
+  });
+
+  test("cancel during the staging upload leaves every live name intact", async () => {
+    const r = await run({ initialAssets: initial, killOn: "release upload canary" });
+    expect(r.exitCode).not.toBe(0);
+    // The invariant this PR exists for: the old assets are untouched.
+    expect(live(r.assets)).toEqual(initial);
+  });
+
+  test("cancel between DELETE and PATCH loses at most the one asset mid-swap", async () => {
+    const r = await run({ initialAssets: initial, killOn: "PATCH .*assets/4 " });
+    expect(r.exitCode).not.toBe(0);
+    const liveNames = live(r.assets).map(a => a.name).sort();
+    expect(liveNames).toEqual(["b.zip", "c.zip"]);
+    // a.zip's data is still present under its staged name.
+    expect(staged(r.assets).some(a => a.name === "incoming-999-a.zip")).toBe(true);
+  });
+
+  test("transient 5xx on PATCH is retried instead of aborting mid-swap", async () => {
+    const r = await run({ initialAssets: initial, fail5xxOnce: "PATCH .*assets/4 " });
+    expect(r.exitCode).toBe(0);
+    expect(live(r.assets).map(a => a.name).sort()).toEqual(["a.zip", "b.zip", "c.zip"]);
+    expect(staged(r.assets)).toEqual([]);
+    expect(r.stderr).toContain("retrying");
+  });
+
+  test("release already missing an asset is healed", async () => {
+    const r = await run({ initialAssets: [{ id: 1, name: "a.zip" }, { id: 3, name: "c.zip" }] });
+    expect(r.exitCode).toBe(0);
+    expect(live(r.assets).map(a => a.name).sort()).toEqual(["a.zip", "b.zip", "c.zip"]);
+  });
+
+  test("stale incoming-* from a previous interrupted run is swept before staging", async () => {
+    const r = await run({
+      initialAssets: [...initial, { id: 100, name: "incoming-777-a.zip" }, { id: 101, name: "incoming-777-c.zip" }],
+    });
+    expect(r.exitCode).toBe(0);
+    expect(live(r.assets).map(a => a.name).sort()).toEqual(["a.zip", "b.zip", "c.zip"]);
+    expect(staged(r.assets)).toEqual([]);
+    // The sweep hit the two stale ids before the new upload.
+    expect(r.calls.some(c => c.includes("DELETE") && c.endsWith("/100"))).toBe(true);
+    expect(r.calls.some(c => c.includes("DELETE") && c.endsWith("/101"))).toBe(true);
+  });
+
+  test("staged filenames keep the .zip extension so gh sets application/zip", async () => {
+    const r = await run({ initialAssets: initial });
+    const upload = r.calls.find(c => c.startsWith("gh release upload"))!;
+    for (const f of ["a.zip", "b.zip", "c.zip"]) {
+      expect(upload).toContain(`incoming-999-${f}`);
+    }
+    expect(upload.match(/incoming-999-[abc]\.zip/g)?.length).toBe(3);
+  });
+});


### PR DESCRIPTION
## Problem

The `:rocket:` step on `main` publishes 32 zips to the `canary` GitHub release with one `gh release upload --clobber`. `gh` runs five concurrent workers and each worker deletes the existing asset before uploading its replacement, so a cancel while uploads are in flight leaves those assets **deleted and not re-uploaded** on the release.

The Buildkite pipeline has `cancel_running_branch_builds: true`, so a new push to `main` cancels the running build. Build 86848 was cancelled 13 minutes into its `:rocket:` step with five upload workers stuck after their deletes, leaving the canary release without `bun-windows-aarch64.zip`, `bun-windows-aarch64-profile.zip`, `bun-windows-x64-profile.zip`, and `bun-darwin-x64-baseline*.zip`. `bun upgrade --canary` failed for users on those platforms until the next uninterrupted `:rocket:` run.

<details><summary>build 86848 <code>:rocket:</code> job</summary>

```
state:         canceled
signal_reason: cancel
started_at:    2026-08-01T07:42:41Z
finished_at:   2026-08-01T07:58:46Z

+ gh release upload canary <32 files> --clobber --repo https://github.com/oven-sh/bun.git
(started 07:45:23; assets that landed are stamped 07:45:25-07:45:55; cancelled 07:58:46)
```
</details>

## Fix

`upload_github_assets` now runs in two phases:

1. **Stage**: upload every file under a per-build `incoming-<build-number>-` prefix (the file keeps its `.zip` extension so `gh` uploads with `application/zip`; the rename cannot change `content_type`). The live asset names keep serving users the whole time. `--clobber` here is safe because it only touches `.incoming-*` names.
2. **Swap**: for each file, `DELETE` the old asset by id and `PATCH` the staged asset's name to the live name. This loop is metadata-only (no data transfer), so a cancel here costs at most the one asset that was mid-swap.

Stale `.incoming-*` assets from a previously interrupted run are swept before staging.

The `:rocket:` step also gets `concurrency: 1` / `concurrency_group: "release/canary"` so two `main` builds that go green close together never run the delete/rename sequence on the same tag at the same time.

## Why this is the right layer

The step can be killed for reasons the pipeline config cannot opt out of (`cancel_running_branch_builds` is a pipeline setting with no per-step exemption, and the agent's cancel grace period is ~10s), so the script has to keep the release consistent under interruption rather than assume it won't be interrupted. Staging first and swapping with metadata calls keeps the window where a live name is absent down to one API round-trip per asset, vs. the previous minutes-long window per concurrent worker.

## Verification

Exercised `upload_github_assets` against a mock `gh` that tracks a fake release's asset list:

| scenario | live assets after |
| --- | --- |
| full run | `a.zip b.zip c.zip` (all new ids) |
| SIGTERM during staging upload (the 13-minute window that hit 86848) | `a.zip b.zip c.zip` (all old ids, intact) |
| SIGTERM between DELETE and PATCH of `a.zip` | `b.zip c.zip` old, `a.zip.incoming-999` present; next run heals |
| release already missing `b.zip` | `a.zip b.zip c.zip` (healed) |
| stale `.incoming-777` present | swept before staging, final `a.zip b.zip c.zip` |

No `src/` change; this is release-pipeline plumbing.

### Separately

The same build's log shows every S3 upload failing with `AccessDenied` on `CreateMultipartUpload` against the R2 `bun` bucket. The script swallows that for canary so it's silent today. That's the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` Buildkite secrets gone stale on the agent, not a code issue; flagging so whoever rotates those can take a look.

## Related

- #16455 (`bun upgrade --canary --profile` → `FileNotFound`) is the user-visible symptom when a `-profile.zip` asset is deleted and not re-uploaded; this change prevents that window.
- #28931 (canary `SHASUMS256.txt` out of sync with zips) is the adjacent non-atomic-publish problem for the checksum manifest itself, which is uploaded by a separate workflow; see #28932.

## After self-review

- Staging marker is a **prefix** (`incoming-<build>-`), not a suffix, so the staged filename still ends in `.zip` and `gh` assigns `application/zip`. PATCH cannot change `content_type`, so a suffix would have flipped every canary asset to `application/octet-stream`.
- The swap loop's `gh api` DELETE/PATCH calls are wrapped in a bounded retry; `gh api` has no built-in backoff (unlike `gh release upload`), and one transient 5xx between DELETE and PATCH under `set -e` would otherwise leave the live name absent with no later build queued.
- `packages/bun-release/scripts/upload-assets.ts` and `upload-s3.ts` (driven by the daily `release.yml` cron) now skip `incoming-*` assets so a staged name is never hashed into `SHASUMS256.txt` or mirrored to S3.
- The mock-`gh` harness is checked in as `test/internal/upload-release-assets.test.ts` (7 scenarios including cancel-during-stage, cancel-mid-swap, 5xx retry, stale sweep, and extension preservation).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/internal/upload-release-assets.test.ts

<!-- robobun:evidence:end -->