### PR TITLE
error: don't double source-map rethrown frames after reading .stack

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5507,7 +5507,7 @@ impl VirtualMachine {
 
         if frames.len() > 1 {
             for i in 0..frames.len() {
-                if i == top || frames[i].position.is_invalid() {
+                if i == top || frames[i].position.is_invalid() || frames[i].remapped {
                     continue;
                 }
                 let source_url = frames[i].source_url.to_utf8();

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -308,9 +308,8 @@ public:
                 return true;
             }
 
-            // V8/Node format for frames without a function name:
-            //     at /path/to/file.js:1:2
-            //     at async /path/to/file.js:1:2
+            // /path/to/file.js:1:2
+            // async /path/to/file.js:1:2
             lineInner = line;
             if (lineInner.startsWith("async "_s)) {
                 frame.isAsync = true;

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -296,6 +296,9 @@ public:
         if (openingParentheses > closingParentheses)
             openingParentheses = WTF::notFound;
 
+        StringView lineInner;
+        StringView functionName;
+
         if (openingParentheses == WTF::notFound || closingParentheses == WTF::notFound) {
             // Special case: "unknown" frames don't have parentheses but are valid
             // These appear in stack traces from certain error paths
@@ -305,12 +308,19 @@ public:
                 return true;
             }
 
-            // For any other frame without parentheses, terminate parsing as before
-            offset = stack.length();
-            return false;
+            // V8/Node format for frames without a function name:
+            //     at /path/to/file.js:1:2
+            //     at async /path/to/file.js:1:2
+            lineInner = line;
+            if (lineInner.startsWith("async "_s)) {
+                frame.isAsync = true;
+                lineInner = lineInner.substring(6);
+            }
+            functionName = StringView();
+        } else {
+            lineInner = StringView_slice(line, openingParentheses + 1, closingParentheses);
+            functionName = line.substring(0, openingParentheses - 1);
         }
-
-        auto lineInner = StringView_slice(line, openingParentheses + 1, closingParentheses);
 
         {
             auto marker1 = 0;
@@ -382,8 +392,6 @@ public:
             }
         }
     done_block:
-
-        StringView functionName = line.substring(0, openingParentheses - 1);
 
         if (functionName == "global code"_s) {
             functionName = StringView();

--- a/test/regression/issue/15859.test.ts
+++ b/test/regression/issue/15859.test.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/15859
+//
+// Reading `error.stack` before rethrowing caused the uncaught-exception printer
+// to show wrong line numbers for non-top frames (double source-mapped) and to
+// drop frames without a function name.
+
+const fixture = `import * as i1 from "util";
+import * as i2 from "util";
+import * as i3 from "util";
+function err() {
+    throw new Error()
+};
+function f1(){
+    err()
+}
+function f2(){
+
+}
+try {
+    f1();
+} catch (error: any) {
+    let x = error.stack
+    throw error
+}
+`;
+
+test("uncaught exception frames are not double source-mapped after reading error.stack", async () => {
+  using dir = tempDir("issue-15859", {
+    "test.ts": fixture,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("");
+  // f1's body calls err() on line 8. Before the fix this printed line 13
+  // (source-mapped twice).
+  expect(stderr).toContain("at f1 ");
+  expect(stderr).toMatch(/at f1 \(.*test\.ts:8:5\)/);
+  expect(stderr).not.toMatch(/at f1 \(.*test\.ts:13:/);
+  // err() throws on line 5; this frame was already correct (top frame).
+  expect(stderr).toMatch(/at err \(.*test\.ts:5:/);
+  expect(exitCode).toBe(1);
+});
+
+test("uncaught exception printer keeps the anonymous top-level frame after reading error.stack", async () => {
+  using dir = tempDir("issue-15859-anon", {
+    "test.ts": fixture,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("");
+  // The try block calls f1() on line 14 from module scope (no function name).
+  // Before the fix this frame was dropped entirely because the .stack string
+  // parser could not handle "at <url>:<line>:<col>" frames.
+  expect(stderr).toMatch(/at .*test\.ts:14:5/);
+  expect(exitCode).toBe(1);
+});
+
+test("uncaught exception frames match error.stack after reading it", async () => {
+  using dir = tempDir("issue-15859-match", {
+    "test.ts": `import * as i1 from "util";
+import * as i2 from "util";
+import * as i3 from "util";
+function err() {
+    throw new Error()
+};
+function f1(){
+    err()
+}
+function f2(){
+
+}
+try {
+    f1();
+} catch (error: any) {
+    console.log(error.stack)
+    throw error
+}
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const extract = (s: string) =>
+    [...s.matchAll(/test\.ts:(\d+):(\d+)/g)].map(m => `${m[1]}:${m[2]}`);
+
+  const stackPositions = extract(stdout);
+  const printedPositions = extract(stderr);
+
+  expect(stackPositions.length).toBeGreaterThanOrEqual(3);
+  expect(printedPositions).toEqual(stackPositions);
+  expect(exitCode).toBe(1);
+});

--- a/test/regression/issue/15859.test.ts
+++ b/test/regression/issue/15859.test.ts
@@ -109,8 +109,7 @@ try {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const extract = (s: string) =>
-    [...s.matchAll(/test\.ts:(\d+):(\d+)/g)].map(m => `${m[1]}:${m[2]}`);
+  const extract = (s: string) => [...s.matchAll(/test\.ts:(\d+):(\d+)/g)].map(m => `${m[1]}:${m[2]}`);
 
   const stackPositions = extract(stdout);
   const printedPositions = extract(stderr);


### PR DESCRIPTION
Fixes #15859.

## Repro

```ts
import * as i1 from "util";
import * as i2 from "util";
import * as i3 from "util";
function err() {
    throw new Error()
};
function f1(){
    err()
}
function f2(){

}
try {
    f1();
} catch (error: any) {
    let x = error.stack
    throw error
}
```

Before:
```
Error:
      at err (test.ts:5:15)
      at f1 (test.ts:13:5)
```

After (matches `error.stack`):
```
Error:
      at err (test.ts:5:15)
      at f1 (test.ts:8:5)
      at test.ts:14:5
```

## Cause

Reading `error.stack` causes JSC to clear `m_stackTrace` after materializing the string. On the rethrow, `fromErrorInstance` has no live `StackFrame` vector and falls back to parsing the `.stack` string with `V8StackTraceIterator`, which sets `remapped = true` on every parsed frame (the positions are already source-mapped).

`remap_zig_exception` checked that flag for the top frame but not in the loop over the remaining frames, so each non-top frame was fed back through `resolve_source_mapping` and remapped a second time. With three unused imports stripped by the transpiler, source line 8 is generated line 5; remapping source 8 as if it were generated yields source 13.

Separately, `V8StackTraceIterator` treated a line of the form `at /path:line:col` (no function name, no parentheses) as end-of-stack, dropping the anonymous top-level frame.

## Fix

- `remap_zig_exception`: skip frames with `remapped == true` in the non-top loop (matching the top-frame check and `remap_stack_frame_positions`).
- `V8StackTraceIterator::parseFrame`: when no parentheses are present, parse the whole line as `sourceURL:line:col` with an empty function name (handles `at <url>:<l>:<c>` and `at async <url>:<l>:<c>`).

## Verification

`test/regression/issue/15859.test.ts` has three cases (wrong-line, dropped frame, printed-frames-match-`error.stack`). All three fail on 1.4.0-canary.1+1498d7b77 and pass with this change.