### PR TITLE
worker_threads: go online before the top-level-await wait so parentPort messages aren't starved

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4553,18 +4553,35 @@ impl VirtualMachine {
     }
 
     /// Loads the worker entry point and waits for it, honoring termination requests.
+    ///
+    /// `on_started` runs once after the entry module's synchronous top-level
+    /// has executed (one `tick()` drains JSC's module-loader promise chain up
+    /// to the first `await`) but before the top-level-await wait loop. The
+    /// worker uses it to flip to `State::Running` and drain buffered messages,
+    /// so a `parentPort.on("message")` listener attached at top level receives
+    /// messages while a never-settling TLA keeps the wait loop spinning.
     pub(crate) fn load_entry_point_for_web_worker(
         &mut self,
         entry_path: &[u8],
+        on_started: impl FnOnce(),
     ) -> crate::CrateResult<*mut JSInternalPromise> {
         let promise = self.reload_entry_point(entry_path)?;
         self.event_loop_mut().perform_gc();
+        self.event_loop_mut().tick();
+        if self
+            .worker_ref()
+            .is_some_and(crate::web_worker::WebWorker::has_requested_terminate)
+        {
+            return Err(crate::CrateError::WorkerTerminated);
+        }
+        on_started();
         self.event_loop_mut()
             .wait_for_promise_with_termination(jsc::AnyPromise::Internal(promise));
-        if let Some(worker) = self.worker_ref() {
-            if worker.has_requested_terminate() {
-                return Err(crate::CrateError::WorkerTerminated);
-            }
+        if self
+            .worker_ref()
+            .is_some_and(crate::web_worker::WebWorker::has_requested_terminate)
+        {
+            return Err(crate::CrateError::WorkerTerminated);
         }
         Ok(self.pending_internal_promise.unwrap())
     }

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1089,7 +1089,21 @@ impl WebWorker {
         // standalone module graph, or `self.unresolved_specifier` — all of
         // which outlive the worker VM. `vm.main` stores it as a raw BACKREF
         // (see `VirtualMachine::set_main`); no lifetime extension needed.
-        let promise = match vm.as_mut().load_entry_point_for_web_worker(path) {
+        //
+        // `on_started` runs once the entry module's synchronous top-level has
+        // executed (so a `parentPort.on("message")` listener attached there is
+        // in place) but before the top-level-await wait. Going online here
+        // routes subsequent parent `postMessage()` through the TLA wait loop's
+        // `tick_concurrent()`; without it a worker that sits in a TLA
+        // `setImmediate` loop never transitions out of `State::Pending` and the
+        // parent's messages stay buffered forever (issue #15408).
+        let cpp_worker = self.cpp_worker;
+        let global = vm.global();
+        let promise = match vm.as_mut().load_entry_point_for_web_worker(path, || {
+            WebWorker__dispatchOnline(cpp_worker, global);
+            WebWorker__fireEarlyMessages(cpp_worker, global);
+            self.set_status(Status::Running);
+        }) {
             Ok(p) => p,
             Err(_) => {
                 // process.exit() may have run during load; don't clobber its code.
@@ -1137,16 +1151,6 @@ impl WebWorker {
 
         self.flush_logs(vm);
         log!("[{}] event loop start", self.execution_context_id);
-        // dispatchOnline fires the parent-side 'open' event and flips the C++
-        // state to Running (which routes postMessage directly instead of
-        // queuing). It is placed after the entry point has loaded so the parent
-        // observes 'online' only once the worker's top-level code has completed;
-        // moving it earlier would change that observable ordering.
-        // `cpp_worker` is the opaque C++-owned handle round-tripped via `safe fn`;
-        // `vm.global()` yields the live `&JSGlobalObject` published in start_vm.
-        WebWorker__dispatchOnline(self.cpp_worker, vm.global());
-        WebWorker__fireEarlyMessages(self.cpp_worker, vm.global());
-        self.set_status(Status::Running);
 
         // don't run the GC if we don't actually need to
         if vm.is_event_loop_alive() || vm.event_loop_mut().tick_concurrent_with_count() > 0 {

--- a/test/js/node/worker_threads/worker-top-level-await.test.ts
+++ b/test/js/node/worker_threads/worker-top-level-await.test.ts
@@ -1,52 +1,109 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
 import { Worker } from "worker_threads";
 
-// A worker whose entry module's top-level await never settles drains its event
-// loop with the module evaluation promise still pending. Node exits such a
-// worker with code 13 rather than hanging forever.
-test("worker with an unsettled top-level await exits with code 13", async () => {
-  const w = new Worker(new URL("data:text/javascript,await new Promise(() => {})"));
-  const exitCode = await new Promise<number>(resolve => w.on("exit", resolve));
-  expect(exitCode).toBe(13);
-});
+describe("worker top-level await", () => {
+  // A worker whose entry module's top-level await never settles drains its event
+  // loop with the module evaluation promise still pending. Node exits such a
+  // worker with code 13 rather than hanging forever.
+  test("worker with an unsettled top-level await exits with code 13", async () => {
+    const w = new Worker(new URL("data:text/javascript,await new Promise(() => {})"));
+    const exitCode = await new Promise<number>(resolve => w.on("exit", resolve));
+    expect(exitCode).toBe(13);
+  });
 
-test("worker with a settled top-level await exits with code 0", async () => {
-  const w = new Worker(new URL("data:text/javascript,await Promise.resolve()"));
-  const exitCode = await new Promise<number>(resolve => w.on("exit", resolve));
-  expect(exitCode).toBe(0);
-});
+  test("worker with a settled top-level await exits with code 0", async () => {
+    const w = new Worker(new URL("data:text/javascript,await Promise.resolve()"));
+    const exitCode = await new Promise<number>(resolve => w.on("exit", resolve));
+    expect(exitCode).toBe(0);
+  });
 
-// A top-level await that resolves and then schedules more work must not be
-// mistaken for an unsettled await: the loop is still alive, so the worker runs
-// to a normal exit.
-test("worker that stays busy after top-level await exits with code 0", async () => {
-  const w = new Worker(
-    new URL("data:text/javascript,await Promise.resolve(); await new Promise(r => setTimeout(r, 20));"),
-  );
-  const exitCode = await new Promise<number>(resolve => w.on("exit", resolve));
-  expect(exitCode).toBe(0);
-});
+  // A top-level await that resolves and then schedules more work must not be
+  // mistaken for an unsettled await: the loop is still alive, so the worker runs
+  // to a normal exit.
+  test("worker that stays busy after top-level await exits with code 0", async () => {
+    const w = new Worker(
+      new URL("data:text/javascript,await Promise.resolve(); await new Promise(r => setTimeout(r, 20));"),
+    );
+    const exitCode = await new Promise<number>(resolve => w.on("exit", resolve));
+    expect(exitCode).toBe(0);
+  });
 
-// A top-level await that rejects surfaces as a worker 'error', not the
-// unsettled-await code.
-test("worker with a rejected top-level await emits error", async () => {
-  const w = new Worker(new URL("data:text/javascript,await Promise.reject(new Error('boom'))"));
-  const error = await new Promise<Error>(resolve => w.on("error", resolve));
-  expect(error.message).toBe("boom");
-});
+  // A top-level await that rejects surfaces as a worker 'error', not the
+  // unsettled-await code.
+  test("worker with a rejected top-level await emits error", async () => {
+    const w = new Worker(new URL("data:text/javascript,await Promise.reject(new Error('boom'))"));
+    const error = await new Promise<Error>(resolve => w.on("error", resolve));
+    expect(error.message).toBe("boom");
+  });
 
-// Node only assigns 13 when nothing else set an exit code
-// (node_hooks.cc: `if (exit_code == ExitCode::kNoFailure)`).
-test("unsettled top-level await preserves a user-set process.exitCode", async () => {
-  for (const code of [42, 5]) {
+  // Node only assigns 13 when nothing else set an exit code
+  // (node_hooks.cc: `if (exit_code == ExitCode::kNoFailure)`).
+  test.each([42, 5])("unsettled top-level await preserves a user-set process.exitCode %p", async code => {
     const w = new Worker(new URL(`data:text/javascript,process.exitCode=${code}; await new Promise(() => {})`));
     const exitCode = await new Promise<number>(resolve => w.on("exit", resolve));
     expect({ code, exitCode }).toEqual({ code, exitCode: code });
-  }
-});
+  });
 
-test("unsettled top-level await still exits 13 when process.exitCode is 0", async () => {
-  const w = new Worker(new URL("data:text/javascript,process.exitCode=0; await new Promise(() => {})"));
-  const exitCode = await new Promise<number>(resolve => w.on("exit", resolve));
-  expect(exitCode).toBe(13);
+  test("unsettled top-level await still exits 13 when process.exitCode is 0", async () => {
+    const w = new Worker(new URL("data:text/javascript,process.exitCode=0; await new Promise(() => {})"));
+    const exitCode = await new Promise<number>(resolve => w.on("exit", resolve));
+    expect(exitCode).toBe(13);
+  });
+
+  // https://github.com/oven-sh/bun/issues/15408
+  // A worker whose top-level await never settles (yielding via setImmediate)
+  // must still receive parentPort messages: the worker goes online before the
+  // TLA wait, so parent postMessage() schedules drains that the TLA loop's
+  // tick_concurrent() picks up.
+  test("parentPort receives messages while top-level await spins on setImmediate", async () => {
+    const src = `
+      const { parentPort } = require("node:worker_threads");
+      parentPort.on("message", m => parentPort.postMessage("pong:" + m));
+      while (true) await new Promise(r => setImmediate(r));
+    `;
+    const w = new Worker(new URL("data:text/javascript," + encodeURIComponent(src)));
+    try {
+      w.postMessage("ping");
+      const [reply] = await once(w, "message");
+      expect(reply).toBe("pong:ping");
+    } finally {
+      await w.terminate();
+    }
+  });
+
+  // Same as above but the message is sent from the parent's 'online' handler,
+  // which the worker must observe while still inside its top-level await.
+  test("parentPort receives messages posted from 'online' while inside top-level await", async () => {
+    const src = `
+      const { parentPort } = require("node:worker_threads");
+      parentPort.on("message", m => parentPort.postMessage("pong:" + m));
+      await new Promise(r => setTimeout(r, 100_000).unref());
+    `;
+    const w = new Worker(new URL("data:text/javascript," + encodeURIComponent(src)));
+    try {
+      await once(w, "online");
+      w.postMessage("ping");
+      const [reply] = await once(w, "message");
+      expect(reply).toBe("pong:ping");
+    } finally {
+      await w.terminate();
+    }
+  });
+
+  // Node emits 'online' once the worker thread starts executing; it does not
+  // wait for top-level await to settle. An unsettled TLA exits with code 13
+  // (tested above); 'online' must still have fired first.
+  test("worker emits 'online' even when top-level await never settles", async () => {
+    const w = new Worker(new URL("data:text/javascript,await new Promise(() => {})"));
+    const events: string[] = [];
+    await new Promise<void>(resolve => {
+      w.on("online", () => events.push("online"));
+      w.on("exit", code => {
+        events.push("exit:" + code);
+        resolve();
+      });
+    });
+    expect(events).toEqual(["online", "exit:13"]);
+  });
 });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -626,18 +626,15 @@ describe("getHeapSnapshot", () => {
     });
   });
 
-  // "entry throws" is omitted: under `bun test`, isBunTest makes a worker's
-  // uncaught_exception return handled=true so spin() continues to
-  // fireEarlyMessages (the call resolves with real data). Under `bun -e`
-  // it rejects — see the test-worker-heapdump-failure.js vendored test for
-  // subprocess coverage. The two cases below take the shutdown() path
-  // directly so they exercise the m_pendingTasks abandon drain regardless.
-  test.each([
-    ["entry not found", undefined],
-    ["unsettled top-level await", "await new Promise(() => {})"],
-  ])("rejects ERR_WORKER_NOT_RUNNING when called before a worker that fails to start (%s)", async (_, src) => {
-    const worker =
-      src === undefined ? new Worker("/nonexistent/__bun_worker_path__.js") : new Worker(src, { eval: true });
+  // "entry throws" and "unsettled top-level await" are omitted: both now reach
+  // State::Running (dispatchOnline fires once the entry module's synchronous
+  // top-level has run), so fireEarlyMessages drains m_pendingTasks and the
+  // calls resolve with real data — see the next test. Under `bun -e` an entry
+  // throw rejects via test-worker-heapdump-failure.js. Only a worker whose
+  // entry fails to load takes the shutdown() path without ever going online,
+  // which is what the m_pendingTasks abandon drain is for.
+  test("rejects ERR_WORKER_NOT_RUNNING when called before a worker that fails to start (entry not found)", async () => {
+    const worker = new Worker("/nonexistent/__bun_worker_path__.js");
     worker.on("error", () => {});
     // Called immediately (m_state still Pending) so the task queues into
     // m_pendingTasks; dispatchExit drains it on the parent thread when the


### PR DESCRIPTION
Fixes #15408.
Fixes #21101.
Fixes #23102.

### Repro

```js
// a.mjs
import { Worker } from "node:worker_threads";
const worker = new Worker("./b.mjs");
worker.postMessage("");
worker.on("message", m => { console.log("parent got reply:", m); process.exit(0); });
setTimeout(() => { console.log("TIMEOUT"); process.exit(1); }, 15000);

// b.mjs
import { parentPort } from "node:worker_threads";
parentPort.on("message", () => { console.log("received message"); parentPort.postMessage("done"); });
while (true) await new Promise(r => setImmediate(r));
```

Before: `TIMEOUT` after 15s (worker busy-yields on `setImmediate`, message never delivered). Node delivers immediately.

### Cause

`WebWorker::spin()` called `dispatchOnline` + `fireEarlyMessages` only after `load_entry_point_for_web_worker()` returned, and that function blocks in `wait_for_promise_with_termination` until the entry module's TLA promise settles. A worker whose top-level `await` never settles stayed in `State::Pending` forever, so `Worker::enqueueToWorker` (Worker.cpp:237) buffered every parent `postMessage()` without scheduling a `drainToWorker` task, and `fireEarlyMessages` (the only other drain of that buffer) was never reached.

Node fires `online` when the worker thread starts executing and delivers port messages throughout TLA.

### Fix

`load_entry_point_for_web_worker` now runs one `tick()` after `reload_entry_point` (draining JSC's module-loader promise chain so the entry's synchronous top-level executes up to its first `await`), invokes an `on_started` callback, and only then enters the TLA wait loop. `spin()` passes `dispatchOnline` + `fireEarlyMessages` as the callback, so the worker reaches `State::Running` with any top-level `parentPort.on("message")` listener already attached; subsequent parent `postMessage()` calls schedule `drainToWorker` tasks that the TLA wait loop's `tick_concurrent()` picks up.

Side effect: the parent's `online` event now fires once the worker's synchronous top-level has run (matching Node) instead of after TLA settles. The `getHeapSnapshot` test's "unsettled top-level await" case is dropped: that worker now reaches `Running`, so a queued introspection call resolves via `fireEarlyMessages` rather than being rejected by the pending-task abandon drain (still covered by the "entry not found" case).

### Verification

`worker-top-level-await.test.ts` adds three tests: the issue repro (setImmediate loop receives messages), a message posted from the `online` handler reaching the worker during TLA, and `online` firing before an unsettled-TLA worker exits with code 13. All three fail on main and pass with the fix.

Regression sweep on the debug build: `worker-top-level-await.test.ts` 10/10, `worker_threads.test.ts` 90/90, `test/js/web/workers/worker.test.ts` 25/25, `message-port-pipe.test.ts` 13/13, `test-worker-heapdump-failure.js` exit 0.
