### PR TITLE
jsx: let bunfig.toml / --jsx-* override tsconfig.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
  "bun_wyhash",
  "const_format",
  "enum-map",
+ "enumset",
  "strum",
  "thiserror",
 ]
@@ -1230,7 +1231,6 @@ dependencies = [
  "bun_wyhash",
  "bun_zstd",
  "const_format",
- "enumset",
  "libc",
  "scopeguard",
  "strum",

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -43,6 +43,8 @@ jsxFragment = "Fragment"
 jsxImportSource = "react"
 ```
 
+When both `bunfig.toml` and `tsconfig.json` set a JSX field, the value from `bunfig.toml` wins. `--jsx-*` CLI flags likewise override both. Fields you don't set in `bunfig.toml` still fall through to `tsconfig.json`.
+
 Refer to the tsconfig docs for more information on these fields.
 
 - [`jsx`](https://www.typescriptlang.org/tsconfig#jsx)

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -720,10 +720,8 @@ impl<'a> Transpiler<'a> {
             let top_level_dir = self.fs().top_level_dir;
             if let Ok(Some(root_dir)) = self.resolver.read_dir_info(top_level_dir) {
                 if let Some(tsconfig) = root_dir.tsconfig_json() {
-                    // If we don't explicitly pass JSX, try to get it from the root tsconfig
-                    if self.options.transform_options.jsx.is_none() {
-                        self.options.jsx = jsx_pragma_from_resolver(&tsconfig.jsx);
-                    }
+                    // Skips fields in `set_fields` so explicit bunfig/CLI/Bun.build config wins.
+                    merge_tsconfig_jsx_into(tsconfig, &mut self.options.jsx);
                     self.options.emit_decorator_metadata = tsconfig.emit_decorator_metadata;
                     self.options.experimental_decorators = tsconfig.experimental_decorators;
                     if let Some(v) = tsconfig.use_define_for_class_fields {

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -944,24 +944,30 @@ impl<'a> Parser<'a> {
         }
 
         // ── jsx ──────────────────────────────────────────────────────────────
+        use bun_options_types::jsx::{JsxField, JsxFieldSet};
         let mut jsx_factory: Box<[u8]> = Box::default();
         let mut jsx_fragment: Box<[u8]> = Box::default();
         let mut jsx_import_source: Box<[u8]> = Box::default();
         let mut jsx_runtime = api::JsxRuntime::Automatic;
         let mut jsx_dev = true;
+        let mut jsx_set = JsxFieldSet::empty();
 
         if let Some(expr) = json.get(b"jsx") {
             if let Some(value) = expr.as_string(self.bump) {
                 if value == b"react" {
                     jsx_runtime = api::JsxRuntime::Classic;
+                    jsx_set |= JsxField::Runtime;
                 } else if value == b"solid" {
                     jsx_runtime = api::JsxRuntime::Solid;
+                    jsx_set |= JsxField::Runtime;
                 } else if value == b"react-jsx" {
                     jsx_runtime = api::JsxRuntime::Automatic;
                     jsx_dev = false;
+                    jsx_set |= JsxField::Runtime | JsxField::Development;
                 } else if value == b"react-jsxDEV" {
                     jsx_runtime = api::JsxRuntime::Automatic;
                     jsx_dev = true;
+                    jsx_set |= JsxField::Runtime | JsxField::Development;
                 } else {
                     self.add_error(
                         expr.loc,
@@ -973,19 +979,22 @@ impl<'a> Parser<'a> {
         if let Some(expr) = json.get(b"jsxImportSource") {
             if let Some(value) = expr.as_string(self.bump) {
                 jsx_import_source = Box::<[u8]>::from(value);
+                jsx_set |= JsxField::ImportSource;
             }
         }
         if let Some(expr) = json.get(b"jsxFragment") {
             if let Some(value) = expr.as_string(self.bump) {
                 jsx_fragment = Box::<[u8]>::from(value);
+                jsx_set |= JsxField::Fragment;
             }
         }
         if let Some(expr) = json.get(b"jsxFactory") {
             if let Some(value) = expr.as_string(self.bump) {
                 jsx_factory = Box::<[u8]>::from(value);
+                jsx_set |= JsxField::Factory;
             }
         }
-        {
+        if !jsx_set.is_empty() {
             if let Some(jsx) = self.ctx.args.jsx.as_mut() {
                 if !jsx_factory.is_empty() {
                     jsx.factory = jsx_factory;
@@ -996,8 +1005,13 @@ impl<'a> Parser<'a> {
                 if !jsx_import_source.is_empty() {
                     jsx.import_source = jsx_import_source;
                 }
-                jsx.runtime = jsx_runtime;
-                jsx.development = jsx_dev;
+                if jsx_set.contains(JsxField::Runtime) {
+                    jsx.runtime = jsx_runtime;
+                }
+                if jsx_set.contains(JsxField::Development) {
+                    jsx.development = jsx_dev;
+                }
+                jsx.set_fields |= jsx_set;
             } else {
                 self.ctx.args.jsx = Some(api::Jsx {
                     factory: jsx_factory,
@@ -1005,6 +1019,7 @@ impl<'a> Parser<'a> {
                     import_source: jsx_import_source,
                     runtime: jsx_runtime,
                     development: jsx_dev,
+                    set_fields: jsx_set,
                     ..Default::default()
                 });
             }

--- a/src/options_types/Cargo.toml
+++ b/src/options_types/Cargo.toml
@@ -15,6 +15,7 @@ strum.workspace = true
 bstr.workspace = true
 const_format.workspace = true
 enum-map.workspace = true
+enumset.workspace = true
 bun_core.workspace = true
 bun_collections.workspace = true
 bun_dotenv.workspace = true

--- a/src/options_types/jsx.rs
+++ b/src/options_types/jsx.rs
@@ -10,7 +10,20 @@
 
 use crate::schema::api;
 use bun_core::strings;
+use enumset::{EnumSet, EnumSetType};
 use std::borrow::Cow;
+
+/// [`Pragma`] fields a user can set explicitly; see [`Pragma::set_fields`].
+#[derive(EnumSetType, Debug)]
+pub enum JsxField {
+    Factory,
+    Fragment,
+    ImportSource,
+    Runtime,
+    Development,
+}
+
+pub type JsxFieldSet = EnumSet<JsxField>;
 
 /// 4-state including `_None` so `Pragma.runtime` preserves the zero value
 /// when an `api.Jsx` arrives with `runtime == _none`. `#[default]` is
@@ -174,6 +187,9 @@ pub struct Pragma {
     pub development: bool,
     pub parse: bool,
     pub side_effects: bool,
+
+    /// Fields set explicitly by bunfig / `--jsx-*` / `Bun.build({jsx})`; tsconfig won't overwrite these.
+    pub set_fields: JsxFieldSet,
 }
 
 impl Default for Pragma {
@@ -189,6 +205,7 @@ impl Default for Pragma {
             development: true,
             parse: true,
             side_effects: false,
+            set_fields: JsxFieldSet::empty(),
         }
     }
 }
@@ -294,6 +311,7 @@ impl Pragma {
 
         pragma.development = jsx.development;
         pragma.parse = true;
+        pragma.set_fields = jsx.set_fields;
         pragma
     }
 }

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -373,6 +373,8 @@ pub mod api {
         pub development: bool,
         pub import_source: Box<[u8]>,
         pub side_effects: bool,
+        /// Which of the above the user set explicitly; see [`crate::jsx::JsxField`].
+        pub set_fields: crate::jsx::JsxFieldSet,
     }
 
     /// Parallel-array string→string map as transmitted on the wire.

--- a/src/resolver/Cargo.toml
+++ b/src/resolver/Cargo.toml
@@ -14,7 +14,6 @@ strum.workspace = true
 bstr.workspace = true
 scopeguard.workspace = true
 const_format.workspace = true
-enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
 thiserror.workspace = true

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -2,7 +2,6 @@ use bun_collections::ArrayHashMap;
 use bun_core::strings;
 use bun_js_parser::lexer as js_lexer;
 use bun_parsers::json_parser;
-use enumset::{EnumSet, EnumSetType};
 
 // D042: `options::jsx::{Pragma, Runtime, ImportSource, RUNTIME_MAP, ...}` is
 // the canonical `bun_options_types::jsx` module. `merge_jsx` uses
@@ -10,6 +9,7 @@ use enumset::{EnumSet, EnumSetType};
 pub mod options {
     pub use bun_options_types::jsx;
 }
+pub(crate) use options::jsx::{JsxField, JsxFieldSet};
 
 /// Selects strict JSON vs JSONC (comments + trailing commas) parsing in
 /// `JsonCache::parse_json`.
@@ -120,18 +120,6 @@ impl JsonCache {
 // Both keys and values are owned (`Box`/`Vec`) and freed when the map drops.
 pub(crate) type PathsMap = ArrayHashMap<Box<[u8]>, Vec<Box<[u8]>>>;
 
-// Hand-listed Pragma fields actually used below.
-#[derive(EnumSetType, Debug)]
-pub(crate) enum JsxField {
-    Factory,
-    Fragment,
-    ImportSource,
-    Runtime,
-    Development,
-}
-
-pub(crate) type JsxFieldSet = EnumSet<JsxField>;
-
 pub struct TSConfigJSON {
     pub(crate) abs_path: Box<[u8]>,
 
@@ -226,26 +214,31 @@ impl TSConfigJSON {
         !self.base_url.is_empty()
     }
 
+    /// Apply this tsconfig's JSX settings on top of `current`, skipping fields in `current.set_fields`.
     pub fn merge_jsx(&self, current: options::jsx::Pragma) -> options::jsx::Pragma {
         let mut out = current;
+        let apply = self.jsx_flags.difference(out.set_fields);
 
-        if self.jsx_flags.contains(JsxField::Factory) {
+        if apply.contains(JsxField::Factory) {
             out.factory = self.jsx.factory.clone();
         }
 
-        if self.jsx_flags.contains(JsxField::Fragment) {
+        if apply.contains(JsxField::Fragment) {
             out.fragment = self.jsx.fragment.clone();
         }
 
-        if self.jsx_flags.contains(JsxField::ImportSource) {
+        if apply.contains(JsxField::ImportSource) {
             out.import_source = self.jsx.import_source.clone();
+            out.package_name.clone_from(&self.jsx.package_name);
+            out.classic_import_source
+                .clone_from(&self.jsx.classic_import_source);
         }
 
-        if self.jsx_flags.contains(JsxField::Runtime) {
+        if apply.contains(JsxField::Runtime) {
             out.runtime = self.jsx.runtime;
         }
 
-        if self.jsx_flags.contains(JsxField::Development) {
+        if apply.contains(JsxField::Development) {
             out.development = self.jsx.development;
         }
 

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -726,8 +726,10 @@ pub mod js_bundler {
                         bun_core::copy_lowercase(&slice.slice()[0..len], &mut str_lower[0..len]);
                     if let Some(runtime) = options::JSX::RUNTIME_MAP.get(&str_lower[0..len]) {
                         this.jsx.runtime = jsx_runtime_to_api(runtime.runtime);
+                        this.jsx.set_fields |= options::JSX::JsxField::Runtime;
                         if let Some(dev) = runtime.development {
                             this.jsx.development = dev;
+                            this.jsx.set_fields |= options::JSX::JsxField::Development;
                         }
                     } else {
                         return Err(global_this.throw_invalid_arguments(format_args!(
@@ -740,21 +742,25 @@ pub mod js_bundler {
 
                 if let Some(slice) = jsx_value.get_optional_slice(global_this, b"factory")? {
                     this.jsx.factory = Box::<[u8]>::from(slice.slice());
+                    this.jsx.set_fields |= options::JSX::JsxField::Factory;
                     drop(slice);
                 }
 
                 if let Some(slice) = jsx_value.get_optional_slice(global_this, b"fragment")? {
                     this.jsx.fragment = Box::<[u8]>::from(slice.slice());
+                    this.jsx.set_fields |= options::JSX::JsxField::Fragment;
                     drop(slice);
                 }
 
                 if let Some(slice) = jsx_value.get_optional_slice(global_this, b"importSource")? {
                     this.jsx.import_source = Box::<[u8]>::from(slice.slice());
+                    this.jsx.set_fields |= options::JSX::JsxField::ImportSource;
                     drop(slice);
                 }
 
                 if let Some(dev) = jsx_value.get_boolean_loose(global_this, "development")? {
                     this.jsx.development = dev;
+                    this.jsx.set_fields |= options::JSX::JsxField::Development;
                 }
 
                 if let Some(val) = jsx_value.get_boolean_loose(global_this, "sideEffects")? {

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -964,6 +964,7 @@ impl CompletionStruct for JSBundleCompletionTask {
                 std::borrow::Cow::Borrowed(b"react".as_slice())
             },
             side_effects: config.jsx.side_effects,
+            set_fields: config.jsx.set_fields,
             parse: true,
             import_source: options::jsx::ImportSource {
                 development: if !jsx_import.is_empty() {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1598,6 +1598,20 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         || jsx_import_source.is_some()
         || jsx_runtime.is_some()
     {
+        use bun_options_types::jsx::{JsxField, JsxFieldSet};
+        let mut set = JsxFieldSet::empty();
+        if jsx_factory.is_some() {
+            set |= JsxField::Factory;
+        }
+        if jsx_fragment.is_some() {
+            set |= JsxField::Fragment;
+        }
+        if jsx_import_source.is_some() {
+            set |= JsxField::ImportSource;
+        }
+        if jsx_runtime.is_some() {
+            set |= JsxField::Runtime;
+        }
         let default_factory: &[u8] = b"";
         let default_fragment: &[u8] = b"";
         let default_import_source: &[u8] = b"";
@@ -1613,6 +1627,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
                 },
                 development: false,
                 side_effects: jsx_side_effects,
+                set_fields: set,
             });
         } else {
             let prev = opts.jsx.take().unwrap();
@@ -1627,8 +1642,9 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
                 } else {
                     prev.runtime
                 },
-                development: false,
-                side_effects: jsx_side_effects,
+                development: prev.development,
+                side_effects: jsx_side_effects || prev.side_effects,
+                set_fields: prev.set_fields | set,
             });
         }
     }

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -10,6 +10,7 @@ use std::io::Write as _;
 use bun_core::{Global, Output};
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_options_types::context::MacroOptions;
+use bun_options_types::jsx::JsxField;
 use bun_ptr::Interned;
 use bun_resolver::fs::FileSystem;
 use bun_sys::Fd;
@@ -395,28 +396,31 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
         argv.push(lit(b"--no-env-file\0"));
     }
     if let Some(jsx) = &ctx.args.jsx {
-        if !jsx.factory.is_empty() {
+        // Each --jsx-* flag marks its field user-set in the worker, so only forward user-set fields.
+        if jsx.set_fields.contains(JsxField::Factory) {
             argv.push(print_z(format_args!(
                 "--jsx-factory={}",
                 bstr::BStr::new(&jsx.factory)
             ))?);
         }
-        if !jsx.fragment.is_empty() {
+        if jsx.set_fields.contains(JsxField::Fragment) {
             argv.push(print_z(format_args!(
                 "--jsx-fragment={}",
                 bstr::BStr::new(&jsx.fragment)
             ))?);
         }
-        if !jsx.import_source.is_empty() {
+        if jsx.set_fields.contains(JsxField::ImportSource) {
             argv.push(print_z(format_args!(
                 "--jsx-import-source={}",
                 bstr::BStr::new(&jsx.import_source)
             ))?);
         }
-        argv.push(print_z(format_args!(
-            "--jsx-runtime={}",
-            jsx_runtime_tag_name(jsx.runtime)
-        ))?);
+        if jsx.set_fields.contains(JsxField::Runtime) {
+            argv.push(print_z(format_args!(
+                "--jsx-runtime={}",
+                jsx_runtime_tag_name(jsx.runtime)
+            ))?);
+        }
         if jsx.side_effects {
             argv.push(lit(b"--jsx-side-effects\0"));
         }

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1071,23 +1071,21 @@ describe("bundler", () => {
         expect(file).not.toContain("/* @__PURE__ */");
         expect(normalizeBunSnapshot(file)).toMatchInlineSnapshot(`
           "// @bun
-          // node_modules/react/jsx-dev-runtime.js
-          var $$typeof = Symbol.for("jsxdev");
-          function jsxDEV(type, props, key, source, self) {
+          // node_modules/react/jsx-runtime.js
+          var $$typeof = Symbol.for("jsx");
+          function jsx(type, props, key) {
             return {
               $$typeof,
               type,
               props,
-              key,
-              source,
-              self
+              key
             };
           }
-          var Fragment = Symbol.for("jsxdev.fragment");
+          var Fragment = Symbol.for("jsx.fragment");
 
           // index.jsx
-          console.log(jsxDEV("a", {}, undefined, false, undefined, this));
-          console.log(jsxDEV(Fragment, {}, undefined, false, undefined, this));"
+          console.log(jsx("a", {}));
+          console.log(jsx(Fragment, {}));"
         `);
       },
     });

--- a/test/regression/issue/15844.test.ts
+++ b/test/regression/issue/15844.test.ts
@@ -1,0 +1,153 @@
+// https://github.com/oven-sh/bun/issues/15844
+// bunfig.toml jsx* fields must override tsconfig.json compilerOptions.jsx*.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+const indexTsx = `export const App = () => <div className="app">hello</div>;\n`;
+
+async function build(cwd: string, extra: string[] = []) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./index.tsx", "--external", "react", "--external", "preact", ...extra],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("bunfig jsx overrides tsconfig jsx (#15844)", () => {
+  test.concurrent("bunfig jsx = 'react' wins over tsconfig jsx: 'react-jsx'", async () => {
+    using dir = tempDir("bunfig-jsx-runtime", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react-jsx" } }),
+      "bunfig.toml": `jsx = "react"\njsxFactory = "React.createElement"\n`,
+      "index.tsx": indexTsx,
+    });
+    const { stdout, stderr, exitCode } = await build(String(dir));
+    expect(stderr).toBe("");
+    expect(stdout).toContain("React.createElement");
+    expect(stdout).not.toContain("jsx-dev-runtime");
+    expect(stdout).not.toContain("jsx-runtime");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("bunfig jsxImportSource wins over tsconfig jsxImportSource", async () => {
+    using dir = tempDir("bunfig-jsx-import-source", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react-jsx", jsxImportSource: "react" } }),
+      "bunfig.toml": `jsxImportSource = "preact"\n`,
+      "index.tsx": indexTsx,
+    });
+    const { stdout, stderr, exitCode } = await build(String(dir));
+    expect(stderr).toBe("");
+    // runtime is automatic (from tsconfig, bunfig did not set it), importSource preact (from bunfig)
+    expect(stdout).toContain(`"preact/jsx-runtime"`);
+    expect(stdout).not.toContain(`"react/jsx-`);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("--jsx-runtime wins over tsconfig jsx", async () => {
+    using dir = tempDir("cli-jsx-runtime", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react-jsx" } }),
+      "index.tsx": indexTsx,
+    });
+    const { stdout, stderr, exitCode } = await build(String(dir), ["--jsx-runtime", "classic"]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("React.createElement");
+    expect(stdout).not.toContain("jsx-runtime");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("bunfig jsxFactory wins over tsconfig jsxFactory", async () => {
+    using dir = tempDir("bunfig-jsx-factory", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react", jsxFactory: "React.createElement" } }),
+      "bunfig.toml": `jsx = "react"\njsxFactory = "h"\n`,
+      "index.tsx": indexTsx,
+    });
+    const { stdout, stderr, exitCode } = await build(String(dir));
+    expect(stderr).toBe("");
+    expect(stdout).toMatch(/\bh\(/);
+    expect(stdout).not.toContain("React.createElement");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("tsconfig jsx still applies when bunfig has no jsx keys", async () => {
+    using dir = tempDir("bunfig-no-jsx", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react", jsxFactory: "h" } }),
+      "bunfig.toml": `logLevel = "error"\n`,
+      "index.tsx": indexTsx,
+    });
+    const { stdout, stderr, exitCode } = await build(String(dir));
+    expect(stderr).toBe("");
+    expect(stdout).toMatch(/\bh\(/);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("tsconfig jsxImportSource reaches the key-after-spread createElement fallback", async () => {
+    using dir = tempDir("tsconfig-import-source-pkgname", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react-jsx", jsxImportSource: "preact" } }),
+      "index.tsx": `export const A = (p: any) => <div {...p} key="k" />;\n`,
+    });
+    const { stdout, stderr, exitCode } = await build(String(dir));
+    // key-after-spread is the one automatic-runtime shape that falls back to createElement,
+    // so this is the only warning expected on stderr.
+    expect(stderr).toContain('"key" prop after a {...spread} is deprecated in JSX');
+    expect(stderr).not.toContain("error:");
+    expect(stdout).toContain(`from "preact"`);
+    expect(stdout).not.toContain(`from "react"`);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("bunfig jsx = 'react-jsxDEV' survives an unrelated --jsx-* flag", async () => {
+    using dir = tempDir("bunfig-jsxdev-with-cli-flag", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react-jsx" } }),
+      "bunfig.toml": `jsx = "react-jsxDEV"\n`,
+      "index.tsx": indexTsx,
+    });
+    const { stdout, stderr, exitCode } = await build(String(dir), ["--jsx-import-source", "react"]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("jsx-dev-runtime");
+    expect(stdout).not.toContain(`"react/jsx-runtime"`);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("bun test --parallel workers apply the same precedence as a serial run", async () => {
+    // bunfig sets only jsxImportSource, so tsconfig's classic runtime must still
+    // apply. The parallel coordinator forwards the jsx config to each worker as
+    // --jsx-* flags; forwarding a field the user did not set would lock it in the
+    // worker and make the two modes transpile the same file differently.
+    const runtimeStub = `export const jsx = () => "automatic"; export const jsxs = jsx; export const jsxDEV = jsx; export const Fragment = "F";\n`;
+    const testFile = (name: string) =>
+      `import { test } from "bun:test";\n` +
+      `globalThis.React = { createElement: () => "classic" };\n` +
+      `test(${JSON.stringify(name)}, () => { console.log("RUNTIME_${name}=" + (<div />)); });\n`;
+    using dir = tempDir("bunfig-jsx-parallel-parity", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react" } }),
+      "bunfig.toml": `jsxImportSource = "preact"\n`,
+      "node_modules/preact/package.json": JSON.stringify({ name: "preact", version: "0.0.0" }),
+      "node_modules/preact/jsx-runtime.js": runtimeStub,
+      "node_modules/preact/jsx-dev-runtime.js": runtimeStub,
+      // Two files so --parallel=2 actually spawns workers instead of falling back to serial.
+      "a.test.tsx": testFile("a"),
+      "b.test.tsx": testFile("b"),
+    });
+
+    async function run(extraArgs: string[]) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", ...extraArgs],
+        env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const runtimes = [...(stdout + stderr).matchAll(/RUNTIME_([ab])=(\w+)/g)].map(m => `${m[1]}=${m[2]}`).sort();
+      // A failed run carries its stderr into the compared object so the diff says why.
+      return { runtimes, exitCode, ...(exitCode === 0 ? {} : { stderr }) };
+    }
+
+    const expected = { runtimes: ["a=classic", "b=classic"], exitCode: 0 };
+    expect(await run([])).toEqual(expected);
+    expect(await run(["--parallel=2"])).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Fixes #15844.

## Repro

```sh
printf '{ "compilerOptions": { "jsx": "react-jsx" } }' > tsconfig.json
printf 'jsx = "react"\njsxFactory = "React.createElement"\n' > bunfig.toml
printf 'export const App = () => <div className="app">hello</div>;\n' > index.tsx

bun build ./index.tsx --external react
# before: jsxDEV from react/jsx-dev-runtime  (bunfig ignored)
# after:  React.createElement                (bunfig wins)
```

## Cause

`TSConfigJSON::merge_jsx` applied every field tsconfig set, regardless of whether the incoming `Pragma` already carried a user-set value. The user-set side (`api::Jsx` / `Pragma`) had no per-field was-set tracking, so nothing could gate that overwrite. `configure_linker_with_auto_jsx` likewise did a wholesale `options.jsx = tsconfig.jsx` copy (or skipped tsconfig entirely) instead of merging.

## Fix

- `options_types::jsx`: add `JsxField` / `JsxFieldSet` (moved from the resolver) and `Pragma.set_fields`; carry it through `api::Jsx` and `Pragma::from_api`.
- `bunfig.rs`: populate `set_fields` for each `jsx*` key actually present, and stop materialising an `api::Jsx` when no `jsx*` keys are present (previously every bunfig load created one with default values, which itself masked tsconfig).
- `Arguments.rs` / `JSBundler.rs`: populate `set_fields` for each `--jsx-*` flag / `Bun.build({jsx})` option passed.
- `tsconfig_json.rs`: `merge_jsx` now computes `jsx_flags.difference(current.set_fields)` and only applies those. The tsconfig `extends` chain still merges child-over-parent because the base config's `set_fields` is empty.
- `transpiler.rs` `configure_linker_with_auto_jsx`: always merge the root tsconfig instead of the wholesale copy, so explicit user config survives and non-tracked fields like `side_effects` are preserved.
- `test/parallel/runner.rs`: the `bun test --parallel` coordinator re-emits the jsx config to each worker as `--jsx-*` flags. It forwarded `--jsx-runtime` whenever any jsx config existed, which under the new rule would mark the runtime user-set in the worker and block its tsconfig. It now forwards only the fields in `set_fields`, so a parallel run transpiles the same as a serial one.
- `docs/runtime/bunfig.mdx`: document the precedence.

## Precedence

`--jsx-*` / `bunfig.toml` `jsx*` / `Bun.build({jsx})` > `tsconfig.json` `compilerOptions.jsx*` > defaults, per field. A field not set in the higher tier still falls through to tsconfig.

## Behavior change

`Bun.build({jsx: {runtime: "automatic"}})` with a `tsconfig.json` that sets `"jsx": "react-jsx"` now emits the production `jsx` runtime (tsconfig's `development: false` fills the gap the user did not set) instead of `jsxDEV`. Previously `Bun.build({jsx})` caused tsconfig JSX to be skipped entirely. One `jsxSideEffects` snapshot in `bundler_jsx.test.ts` updated to reflect this; its `sideEffects` assertion is unchanged.

## Verification

`test/regression/issue/15844.test.ts` covers bunfig `jsx`/`jsxFactory`/`jsxImportSource` overriding tsconfig, `--jsx-runtime` overriding tsconfig, tsconfig still applying when bunfig has no jsx keys, the `jsxImportSource` key-after-spread fallback, a bunfig `react-jsxDEV` surviving an unrelated `--jsx-*` flag, and `bun test` versus `bun test --parallel=2` producing the same runtime on one fixture (the bunfig/CLI override cases fail on the released binary and pass here).

`bundler_jsx.test.ts`, `esbuild/tsconfig.test.ts`, `jsx-tsconfig-react-jsx.test.ts`, `transpiler-tsconfig-uaf.test.ts`, and `test/config/bunfig/` all pass.

## Overlap

This PR originally also carried the one-line `--tsconfig-override` fd fix for #22023; that is the same change as #34980, which is now the PR for it, so the resolver hunk and its tests were dropped from this branch (b97aa8c7e7) and the two no longer touch the same files. #36269 addresses the `--jsx-*` vs tsconfig dev/prod interaction from the bundler side with a different mechanism and will need reconciling with the `set_fields` approach here. #36209 changes the `development` default in `Arguments.rs` and is orthogonal.

## Rebase notes

The branch is squashed to one commit and rebased onto main. Two rebases needed manual resolution:

- #39631 (`jsx: keep the default factory when a tsconfig or pragma factory has no members`) changed `Pragma::from_api` to return `Pragma` instead of `Result<Pragma>`; this PR adds `pragma.set_fields = jsx.set_fields` before that return. Resolved by keeping both. An explicit but invalid factory such as `--jsx-factory=.` still marks `Factory` as user-set, so it yields the built-in default rather than the tsconfig value; valid flags and tsconfig-only configs behave as before. The `factoryMemberList` tests from #39631 pass on this branch.
- #39732 (dead code removal across Cargo manifests) removed `enum-map` from `src/resolver/Cargo.toml` and `enumset` from `src/options_types/Cargo.toml`, while this PR removes `enumset` from the resolver and starts using it in `options_types`. Resolved so the resolver keeps neither and `options_types` gets `enumset` back. The net `Cargo.lock` change is that one dependency edge moving from `bun_resolver` to `bun_options_types`, which is where `JsxField` now lives.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 15 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts "test/regression/issue/15844.test.ts"
ninja: Entering directory `/workspace/bun/build/debug'
[1/4] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[1/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_rust.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEG
... (truncated)

release without fix: 14 failed, 4 skipped
bun test v1.4.0-canary.1 (6e906e468)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [22.06ms]
(pass) bundler > jsx/AutomaticProd [12.11ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [12.63ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [11.95ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [12.51ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [14.73ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [7.41ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [5.39ms]
(pass) bundler > jsx/ClassicDev [12.10ms]
(pass) bundler > jsx/ClassicProd [12.98ms]
(pass) bundler > jsx/ClassicPragmaDev [11.35ms]
(pass) bundler > jsx/ClassicPragmaProd [14.49ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [13.08ms]
(pass) bundler > jsx/FactoryProd [13.25ms]
(pass) bundler > jsx/FactoryImportDev [12.67ms]
(pass) bundler > jsx/FactoryImportProd [13.06ms]
(pass) bundler > jsx/FactoryImportExplicitReactDefaultDev [7.25ms]
(pass) bundler > jsx/FactoryImportExplicitReact
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts "test/regression/issue/15844.test.ts"
bun test v1.4.0 (6e906e468)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1034.77ms]
(pass) bundler > jsx/AutomaticProd [664.03ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [633.79ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [623.48ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [675.23ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [655.63ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [347.75ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [319.09ms]
(pass) bundler > jsx/ClassicDev [691.13ms]
(pass) bundler > jsx/ClassicProd [722.17ms]
(pass) bundler > jsx/ClassicPragmaDev [669.17ms]
(pass) bundler > jsx/ClassicPragmaProd [660.26ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [655.32ms]
(pass) bundler > jsx/FactoryProd [683.29ms]
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2b315348f9
  features     baseline

23 deps, 129 codegen, 1172 objects in 726ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (6e906e468)

Checked 26 installs across 63 packages (no changes) [4.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (6e906e468)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (6e906e468)

Checked 111 installs across 104 packages (no changes) [11.00ms]
[5/1244] gen bindgenv2
[6/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 10ms

  react-refresh.js  4.81 KB  (entry point)

[7/1244] fetch tinycc
[tinycc] up to date
[8/1243] fetch zlib
[zlib] up to date
[9/1243] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConsta
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
Cargo.lock                                   |   2 +-
 docs/runtime/bunfig.mdx                      |   2 +
 src/bundler/transpiler.rs                    |   6 +-
 src/bunfig/bunfig.rs                         |  21 +++-
 src/options_types/Cargo.toml                 |   1 +
 src/options_types/jsx.rs                     |  18 ++++
 src/options_types/schema.rs                  |   2 +
 src/resolver/Cargo.toml                      |   1 -
 src/resolver/tsconfig_json.rs                |  29 ++---
 src/runtime/api/JSBundler.rs                 |   6 ++
 src/runtime/api/js_bundle_completion_task.rs |   1 +
 src/runtime/cli/Arguments.rs                 |  20 +++-
 src/runtime/cli/test/parallel/runner.rs      |  18 ++--
 test/bundler/bundler_jsx.test.ts             |  16 ++-
 test/regression/issue/15844.test.ts          | 153 +++++++++++++++++++++++++++
 15 files changed, 251 insertions(+), 45 deletions(-)
```

</details>

**gate history** · 9 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
Cargo.lock                                        0      0      0
docs/runtime/bunfig.mdx                           1      1      0
src/bundler/transpiler.rs                        10      6      0
src/bunfig/bunfig.rs                              1      1      0
src/options_types/Cargo.toml                      1      1      0
src/options_types/jsx.rs                          3      5      0
src/options_types/schema.rs                       1      1      0
src/resolver/Cargo.toml                           1      1      0
src/resolver/tsconfig_json.rs                     7      8      0
src/runtime/api/JSBundler.rs                      2      1      0
src/runtime/api/js_bundle_completion_task.rs      5      1      0
src/runtime/cli/Arguments.rs                      2      2      0
src/runtime/cli/test/parallel/runner.rs           3      3      0
test/bundler/bundler_jsx.test.ts                  0      0      0
test/regression/issue/15844.test.ts               5      6      0
```

</details>

<!-- robobun:evidence:end -->



