### PR TITLE
js_parser: stop the [x][0] / {f:x}.f folds from changing optional-chain / this / assignment semantics

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -56,12 +56,8 @@ impl Expr {
             // https://github.com/oven-sh/bun/issues/2594
             Data::ESpread(_) => false,
             Data::EMissing(_) => false,
-            // Inlining `a?.b` as the target of a surrounding member/call
-            // expression can splice two unrelated optional chains together:
-            // `[[a?.b]][0]?.[0].c` would become `a?.b.c`, which short-circuits
-            // past `.c` instead of throwing. The printer can only insert the
-            // `(a?.b)` wrapper when the parent's own optional_chain is None,
-            // which we cannot observe here, so bail out conservatively.
+            // `[[a?.b]][0]?.[0].c` must not become `a?.b.c`: inlining would
+            // splice this chain onto the parent's `?.` continuation.
             Data::EDot(e) => e.optional_chain.is_none(),
             Data::EIndex(e) => e.optional_chain.is_none(),
             Data::ECall(e) => e.optional_chain.is_none(),

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -56,6 +56,15 @@ impl Expr {
             // https://github.com/oven-sh/bun/issues/2594
             Data::ESpread(_) => false,
             Data::EMissing(_) => false,
+            // Inlining `a?.b` as the target of a surrounding member/call
+            // expression can splice two unrelated optional chains together:
+            // `[[a?.b]][0]?.[0].c` would become `a?.b.c`, which short-circuits
+            // past `.c` instead of throwing. The printer can only insert the
+            // `(a?.b)` wrapper when the parent's own optional_chain is None,
+            // which we cannot observe here, so bail out conservatively.
+            Data::EDot(e) => e.optional_chain.is_none(),
+            Data::EIndex(e) => e.optional_chain.is_none(),
+            Data::ECall(e) => e.optional_chain.is_none(),
             _ => true,
         }
     }

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -483,6 +483,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                             name,
                                         )
                                         && name != b"__proto__"
+                                        && value.can_be_inlined_from_property_access()
                                     {
                                         return Some(value);
                                     }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1057,9 +1057,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let target = e_.target.unwrap_inlined();
         let index = e_.index.unwrap_inlined();
 
-        // `delete [x][0]` and `[x][0] = v` act on the temporary, not on `x`.
+        // `[x][0] = v` writes into the temporary, not `x`.
         if p.options.features.minify_syntax
-            && !is_delete_target
             && in_.assign_target == js_ast::AssignTarget::None
         {
             if let Some(number) = index.data.as_e_number() {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1105,9 +1105,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 *e = p.new_expr(E::Undefined {}, inlined.loc);
                                 return;
                             }
-                            debug_assert!(inlined.can_be_inlined_from_property_access());
-                            *e = inlined;
-                            return;
+                            if inlined.can_be_inlined_from_property_access() {
+                                *e = inlined;
+                                return;
+                            }
                         }
                     }
                 }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1057,10 +1057,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let target = e_.target.unwrap_inlined();
         let index = e_.index.unwrap_inlined();
 
-        // These folds replace an index expression (a Reference into a temporary
-        // string/array) with a plain value. That is only sound when the parent
-        // uses the value, not the Reference: `delete [x][0]` and `[x][0] = v`
-        // act on the temporary, and inlining would redirect them at `x`.
+        // `delete [x][0]` and `[x][0] = v` act on the temporary, not on `x`.
         if p.options.features.minify_syntax
             && !is_delete_target
             && in_.assign_target == js_ast::AssignTarget::None

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1057,7 +1057,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let target = e_.target.unwrap_inlined();
         let index = e_.index.unwrap_inlined();
 
-        if p.options.features.minify_syntax {
+        // These folds replace an index expression (a Reference into a temporary
+        // string/array) with a plain value. That is only sound when the parent
+        // uses the value, not the Reference: `delete [x][0]` and `[x][0] = v`
+        // act on the temporary, and inlining would redirect them at `x`.
+        if p.options.features.minify_syntax
+            && !is_delete_target
+            && in_.assign_target == js_ast::AssignTarget::None
+        {
             if let Some(number) = index.data.as_e_number() {
                 if number.value() >= 0.0
                     && number.value() < (usize::MAX as f64)
@@ -1085,28 +1092,32 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
                         }
                     } else if let Some(array) = target.data.as_e_array() {
-                        // [x][0] -> x
-                        if array.items.len_u32() == 1 && number.value() == 0.0 {
-                            let inlined = *array.items.at(0);
-                            if inlined.can_be_inlined_from_property_access() {
-                                *e = inlined;
-                                return;
-                            }
-                        }
-
-                        // ['a', 'b', 'c'][1] -> 'b'
                         let int: usize = number.value() as usize;
-                        if int < array.items.len_u32() as usize
+                        // [x][0] -> x
+                        // ['a', 'b', 'c'][1] -> 'b'
+                        let inlined = if array.items.len_u32() == 1 && int == 0 {
+                            Some(*array.items.at(0))
+                        } else if int < array.items.len_u32() as usize
                             && p.expr_can_be_removed_if_unused(&target)
                         {
-                            let inlined = *array.items.at(int);
+                            Some(*array.items.at(int))
+                        } else {
+                            None
+                        };
+                        if let Some(inlined) = inlined {
                             // ['a', , 'c'][1] -> undefined
                             if matches!(inlined.data, Data::EMissing(..)) {
                                 *e = p.new_expr(E::Undefined {}, inlined.loc);
                                 return;
                             }
                             if inlined.can_be_inlined_from_property_access() {
-                                *e = inlined;
+                                // "[obj.m][0]()" => "(0, obj.m)()"
+                                *e = if is_call_target && inlined.has_value_for_this_in_call() {
+                                    p.new_expr(E::Number::new(0.0), expr.loc)
+                                        .join_with_comma(inlined)
+                                } else {
+                                    inlined
+                                };
                                 return;
                             }
                         }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1058,9 +1058,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let index = e_.index.unwrap_inlined();
 
         // `[x][0] = v` writes into the temporary, not `x`.
-        if p.options.features.minify_syntax
-            && in_.assign_target == js_ast::AssignTarget::None
-        {
+        if p.options.features.minify_syntax && in_.assign_target == js_ast::AssignTarget::None {
             if let Some(number) = index.data.as_e_number() {
                 if number.value() >= 0.0
                     && number.value() < (usize::MAX as f64)

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -177,10 +177,20 @@ describe("Bun.Transpiler", () => {
       ts.expectPrintedMin_("x = new [a?.b][0]()", "x = new [a?.b][0]");
       ts.expectPrintedMin_("[a?.b][0]`x`", "[a?.b][0]`x`");
 
+      // Same predicate on the sibling `{f: x}.f -> x` fold: `new a?.b` /
+      // `a?.b`x`` are syntax errors, so bail there too.
+      ts.expectPrintedMin_("x = new ({f: a?.b}).f()", "x = new { f: a?.b }.f");
+      ts.expectPrintedMin_("x = new ({f: a?.[b]}).f()", "x = new { f: a?.[b] }.f");
+      ts.expectPrintedMin_("x = new ({f: a?.b.c}).f()", "x = new { f: a?.b.c }.f");
+      ts.expectPrintedMin_("({f: a?.b}).f`x`", "({ f: a?.b }).f`x`");
+      ts.expectPrintedMin_("x = ({f: a?.b}).f", "x = { f: a?.b }.f");
+
       // Non-chain items are still inlined.
       ts.expectPrintedMin_("x = [[y]][0]?.[0].c", "x = y.c");
       ts.expectPrintedMin_("x = [a.b][0].c", "x = a.b.c");
       ts.expectPrintedMin_("x = [(a?.b)][0]", "x = [a?.b][0]");
+      ts.expectPrintedMin_("x = ({f: y}).f", "x = y");
+      ts.expectPrintedMin_("x = new ({f: C}).f()", "x = new C");
     });
     it("bails out or strips `this` when the index is a call/assignment target", () => {
       // `[obj.m][0]()` calls through a Reference into the temporary array,
@@ -222,6 +232,8 @@ describe("Bun.Transpiler", () => {
         check("this",       () => [obj.m][0](), "=> false");
         var o2 = { p: 1 };
         check("assign",     () => ([o2.p][0] = 5, o2.p), "=> 1");
+        var ab = { b: class {} };
+        check("new obj",    () => new ({ f: ab?.b }).f() instanceof ab.b, "=> true");
       `;
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", src],
@@ -241,6 +253,7 @@ describe("Bun.Transpiler", () => {
         "chain pure: ok",
         "this: ok",
         "assign: ok",
+        "new obj: ok",
       ]);
       expect(exitCode).toBe(0);
     });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -139,6 +139,56 @@ describe("Bun.Transpiler", () => {
     it("works nested", () => {
       ts.expectPrintedMin_('const a = ["hey"][0][0];', 'const a = "h"');
     });
+    it("bails out when the array item is an optional chain", () => {
+      // Folding `[a?.b][0]` to `a?.b` is unsafe when the result lands as the
+      // target of a surrounding optional-chain continuation: the two chains
+      // would be spliced into one. `[[a?.b]][0]?.[0].c` must not become
+      // `a?.b.c`, which short-circuits to `undefined` for `a == null` instead
+      // of throwing on the trailing `.c`.
+      ts.expectPrintedMin_("x = [[a?.b]][0]?.[0].c", "x = [a?.b]?.[0].c");
+      ts.expectPrintedMin_("x = [[a?.b]][0]?.[0]()", "x = [a?.b]?.[0]()");
+      ts.expectPrintedMin_("x = [[a?.b]][0]?.[0][c]", "x = [a?.b]?.[0][c]");
+      ts.expectPrintedMin_("x = ({ f: [a?.b] }).f?.[0].c", "x = [a?.b]?.[0].c");
+      ts.expectPrintedMin_("x = [[a?.[b]]][0]?.[0].c", "x = [a?.[b]]?.[0].c");
+      ts.expectPrintedMin_("x = [[a?.()]][0]?.[0].c", "x = [a?.()]?.[0].c");
+
+      // The outer `?.` on an array literal is dropped at parse time, so these
+      // reach the fold with `optional_chain == None` on the index and the
+      // printer adds the `(a?.b)` wrapper itself. Keep bailing on the fold so
+      // the wrapper isn't load-bearing.
+      ts.expectPrintedMin_("x = [a?.b][0]", "x = [a?.b][0]");
+      ts.expectPrintedMin_("x = [a?.b]?.[0]", "x = [a?.b][0]");
+      ts.expectPrintedMin_("x = [a?.b][0].c", "x = [a?.b][0].c");
+      ts.expectPrintedMin_("x = [a?.b]?.[0].c", "x = [a?.b][0].c");
+      ts.expectPrintedMin_("x = [a?.b][0]()", "x = [a?.b][0]()");
+
+      // Non-chain items are still inlined.
+      ts.expectPrintedMin_("x = [[y]][0]?.[0].c", "x = y.c");
+      ts.expectPrintedMin_("x = [a.b][0].c", "x = a.b.c");
+      ts.expectPrintedMin_("x = [(a?.b)][0]", "x = [a?.b][0]");
+    });
+    it("preserves the TypeError when an inlined optional chain is followed by a non-optional access", async () => {
+      const cases = [
+        "[[a?.b]][0]?.[0].c",
+        "[[a?.b]][0]?.[0]()",
+        "[[a?.b]][0]?.[0][0]",
+        "({ f: [a?.b] }).f?.[0].c",
+        "[a?.b][0].c",
+        "[a?.b]?.[0].c",
+      ];
+      const src = cases
+        .map(e => `try { void (${e}); console.log("no throw"); } catch (e) { console.log(e.constructor.name); }`)
+        .join("\n");
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", `var a = null;\n${src}`],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim().split("\n")).toEqual(cases.map(() => "TypeError"));
+      expect(exitCode).toBe(0);
+    });
     it("bails out on optional-chain index into enum", () => {
       const pre = "enum Foo { A }\nenum Bar { 'a-b' = 1 }\n";
       const lastLine = out => out.trimEnd().split("\n").at(-1);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -151,6 +151,14 @@ describe("Bun.Transpiler", () => {
       ts.expectPrintedMin_("x = ({ f: [a?.b] }).f?.[0].c", "x = [a?.b]?.[0].c");
       ts.expectPrintedMin_("x = [[a?.[b]]][0]?.[0].c", "x = [a?.[b]]?.[0].c");
       ts.expectPrintedMin_("x = [[a?.()]][0]?.[0].c", "x = [a?.()]?.[0].c");
+      // Continuation (not Start) on the inlined item's outermost node:
+      ts.expectPrintedMin_("x = [[a?.b.c]][0]?.[0].d", "x = [a?.b.c]?.[0].d");
+      ts.expectPrintedMin_("x = [[a?.b[c]]][0]?.[0].d", "x = [a?.b[c]]?.[0].d");
+      ts.expectPrintedMin_("x = [[a?.b()]][0]?.[0].d", "x = [a?.b()]?.[0].d");
+      // Multi-item path (expr_can_be_removed_if_unused): a @__PURE__ optional
+      // call is removable, so the second fold arm sees it.
+      ts.expectPrintedMin_("x = [[0, /* @__PURE__ */ a?.()]][0]?.[1].c", "x = [0, a?.()]?.[1].c");
+      ts.expectPrintedMin_("x = [0, /* @__PURE__ */ a?.()][1]", "x = [0, a?.()][1]");
 
       // The outer `?.` on an array literal is dropped at parse time, so these
       // reach the fold with `optional_chain == None` on the index and the
@@ -162,31 +170,78 @@ describe("Bun.Transpiler", () => {
       ts.expectPrintedMin_("x = [a?.b]?.[0].c", "x = [a?.b][0].c");
       ts.expectPrintedMin_("x = [a?.b][0]()", "x = [a?.b][0]()");
 
+      // Same bailout protects LHS / delete / new / tagged-template positions
+      // from becoming `a?.b = v` / `delete a?.b` / `new a?.b()`.
+      ts.expectPrintedMin_("[a?.b][0] = v", "[a?.b][0] = v");
+      ts.expectPrintedMin_("delete [a?.b][0]", "delete [a?.b][0]");
+      ts.expectPrintedMin_("x = new [a?.b][0]()", "x = new [a?.b][0]");
+      ts.expectPrintedMin_("[a?.b][0]`x`", "[a?.b][0]`x`");
+
       // Non-chain items are still inlined.
       ts.expectPrintedMin_("x = [[y]][0]?.[0].c", "x = y.c");
       ts.expectPrintedMin_("x = [a.b][0].c", "x = a.b.c");
       ts.expectPrintedMin_("x = [(a?.b)][0]", "x = [a?.b][0]");
     });
-    it("preserves the TypeError when an inlined optional chain is followed by a non-optional access", async () => {
-      const cases = [
-        "[[a?.b]][0]?.[0].c",
-        "[[a?.b]][0]?.[0]()",
-        "[[a?.b]][0]?.[0][0]",
-        "({ f: [a?.b] }).f?.[0].c",
-        "[a?.b][0].c",
-        "[a?.b]?.[0].c",
-      ];
-      const src = cases
-        .map(e => `try { void (${e}); console.log("no throw"); } catch (e) { console.log(e.constructor.name); }`)
-        .join("\n");
+    it("bails out or strips `this` when the index is a call/assignment target", () => {
+      // `[obj.m][0]()` calls through a Reference into the temporary array,
+      // so `this` is the array; inlining to `obj.m()` would bind `this` to
+      // `obj`. Match the sibling folds and emit `(0, obj.m)()`.
+      ts.expectPrintedMin_("x = [obj.m][0]()", "x = (0, obj.m)()");
+      ts.expectPrintedMin_("x = [obj[m]][0]()", "x = (0, obj[m])()");
+      ts.expectPrintedMin_("x = [obj.m][0]", "x = obj.m");
+      ts.expectPrintedMin_("x = [y][0]()", "x = y()");
+      ts.expectPrintedMin_("x = [() => y][0]()", "x = (() => y)()");
+
+      // `[x][0] = v` writes into the temporary, not `x`. Same for `"s"[n]`.
+      ts.expectPrintedMin_("[obj.p][0] = 5", "[obj.p][0] = 5");
+      ts.expectPrintedMin_("[obj.p][0] += 5", "[obj.p][0] += 5");
+      ts.expectPrintedMin_("[obj.p][0]++", "[obj.p][0]++");
+      ts.expectPrintedMin_("[x][0] = 1", "[x][0] = 1");
+      ts.expectPrintedMin_("[,][0] = 1", "[,][0] = 1");
+      ts.expectPrintedMin_('"foo"[2] = 1', '"foo"[2] = 1');
+      ts.expectPrintedMin_('["a", "b"][1] = 1', '["a", "b"][1] = 1');
+      ts.expectPrintedMin_("({ a: [obj.p][0] } = {})", "({ a: [obj.p][0] } = {})");
+    });
+    it("preserves runtime semantics when inlining from a literal index", async () => {
+      const src = `
+        var a = null;
+        function check(label, fn, expected) {
+          var got;
+          try { got = "=> " + fn(); } catch (e) { got = e.constructor.name; }
+          console.log(label + ": " + (got === expected ? "ok" : got + " (want " + expected + ")"));
+        }
+        check("chain .c",   () => [[a?.b]][0]?.[0].c, "TypeError");
+        check("chain ()",   () => [[a?.b]][0]?.[0](), "TypeError");
+        check("chain [0]",  () => [[a?.b]][0]?.[0][0], "TypeError");
+        check("chain obj",  () => ({ f: [a?.b] }).f?.[0].c, "TypeError");
+        check("chain flat", () => [a?.b][0].c, "TypeError");
+        check("chain ?.[", () => [a?.b]?.[0].c, "TypeError");
+        check("chain cont", () => [[a?.b.c]][0]?.[0].d, "TypeError");
+        check("chain pure", () => [[0, /* @__PURE__ */ a?.()]][0]?.[1].c, "TypeError");
+        var obj = { n: "obj", m() { return this === obj; } };
+        check("this",       () => [obj.m][0](), "=> false");
+        var o2 = { p: 1 };
+        check("assign",     () => ([o2.p][0] = 5, o2.p), "=> 1");
+      `;
       await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", `var a = null;\n${src}`],
+        cmd: [bunExe(), "-e", src],
         env: bunEnv,
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
-      expect(stdout.trim().split("\n")).toEqual(cases.map(() => "TypeError"));
+      expect(stdout.trim().split("\n")).toEqual([
+        "chain .c: ok",
+        "chain (): ok",
+        "chain [0]: ok",
+        "chain obj: ok",
+        "chain flat: ok",
+        "chain ?.[: ok",
+        "chain cont: ok",
+        "chain pure: ok",
+        "this: ok",
+        "assign: ok",
+      ]);
       expect(exitCode).toBe(0);
     });
     it("bails out on optional-chain index into enum", () => {


### PR DESCRIPTION
## Problem

With `minify_syntax` on (the default for `bun run`), the `[x][0] -> x` and `{f: x}.f -> x` folds were replacing an index/property Reference with a bare value without fully checking the parent context. All of these reproduce against Node on current main:

```js
var a = null;
[[a?.b]][0]?.[0].c;         // Node: TypeError   Bun: undefined    (output: a?.b.c)
new ({f: a?.b}).f();        // Node: runs        Bun: SyntaxError  (output: new a?.b)

var obj = { m() { return this === obj } };
[obj.m][0]();               // Node: false       Bun: true         (output: obj.m())

var o = { p: 1 };
[o.p][0] = 5; o.p;          // Node: 1           Bun: 5            (output: o.p = 5)
"foo"[2] = 1;               // Node: no-op       Bun: SyntaxError  (output: "o" = 1)
```

The direct form `[a?.b]?.[0].c` is hidden on main because the parse-time "drop `?.` on a non-nullable literal" simplification clears the outer chain first and the printer inserts `(a?.b)`; one level of indirection (`[[a?.b]][0]?.[0].c`, `({f:[a?.b]}).f?.[0].c`) bypasses that.

## Fix

- `can_be_inlined_from_property_access` now rejects `EDot`/`EIndex`/`ECall` whose `optional_chain` is set, so an optional chain is never spliced onto a surrounding `?.` continuation and never lands as a bare `new` / template-tag target.
- Both folds now route through that predicate (the `{f: x}.f` fold previously did not).
- The `e_index` fold bails when `in_.assign_target != None`, so `[x][0] = v`, `"s"[n] = v` and `[,][0] = v` are left as written instead of producing `x = v` / `"s" = v` / `void 0 = v`.
- When the `e_index` fold is a call target and the inlined item is an `EDot`/`EIndex`, it emits `(0, x)()` instead of `x()`, matching the sibling comma/`??`/`||`/`&&`/ternary folds so `this` is not rebound.
- The multi-item path's `debug_assert!` on the predicate becomes a real guard (reachable via a `/* @__PURE__ */ a?.()` array item).

The folds still fire for plain targets: `[a.b][0].c -> a.b.c`, `[[y]][0]?.[0].c -> y.c`, `[y][0]() -> y()`, `({f: y}).f -> y`, `new ({f: C}).f() -> new C`. esbuild does not perform these folds at all, so the remaining bailouts bring Bun in line with its output.

## Out of scope (tracked separately)

Two pieces of parser-context tracking were never wired up in the Rust port, so the corresponding parent positions are not yet covered here for plain (non-chain) items:

- `p.delete_target` is never set by the `UnDelete` arm, so `delete [obj.p][0]` still folds to `delete obj.p`. Wiring it up turns on every dormant `is_delete_target` guard in the visitor (bundler "cannot assign to import", CJS-named-export deopt, enum/namespace inlining under `delete`).
- `is_template_tag` is commented out, so `[obj.m][0]`x`` still rebinds `this`. Wiring it up touches every sibling fold (comma/`??`/`||`/`&&`/ternary).

Both are pre-existing and have a blast radius beyond this fold; the optional-chain bailout already keeps `delete [a?.b][0]` and `[a?.b][0]`x`` unfolded in the meantime.

## Verification

- `bun bd test test/bundler/transpiler/transpiler.test.js -t "property access inlining"` passes (8 tests); the three new tests fail with `src/` reverted to main.
- Full `transpiler.test.js` (186 pass / 0 fail) and `bundler_minify.test.ts` (42 pass / 0 fail) are green.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (aa68cffb9)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.64ms]
(pass) Bun.Transpiler > normalizes \r\n [5.92ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [3.87ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.99ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.54ms]
(pass) Bun.Transpiler > property access inlining > works [2.17ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.49ms]
76 |     transpiledOutput: code => {
77 |       return ts.parsed(code, false, false);
78 |     },
79 | 
80 |     expectPrintedMin_: (code, out) => {
81 |       expect(ts.parsedMin(code, !out.endsWith(";\n"), false)).toBe(out);
                                                                   ^
error: expect(received).toBe(expected)

Expected: "x = [a?.b]?.[0].c"
Received: "x = a?.b.c"

      at expectPrintedMin_ (/workspace/bun/test/bu
... (truncated)

release without fix: 2 failed, 22 skipped
bun test v1.4.0-canary.1 (8786d337f)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [2.42ms]
(pass) Bun.Transpiler > normalizes \r\n [0.15ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.08ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.14ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
76 |     transpiledOutput: code => {
77 |       return ts.parsed(code, false, false);
78 |     },
79 | 
80 |     expectPrintedMin_: (code, out) => {
81 |       expect(ts.parsedMin(code, !out.endsWith(";\n"), false)).toBe(out);
                                                                   ^
error: expect(received).toBe(expected)

Expected: "x = new { f: a?.b }.f"
Received: "x = new a?.b"

      at expectPrintedMin_ (/workspace/bun/test/bundler/transpiler/transpiler.test.js:81:63)
      at <anonymous> (/workspace/bun/test/bundler/transpiler/transpiler.test.js:182:10)
(fail) Bun.Transpiler > proper
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (aa68cffb9)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.75ms]
(pass) Bun.Transpiler > normalizes \r\n [6.06ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.03ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.03ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.56ms]
(pass) Bun.Transpiler > property access inlining > works [2.25ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.63ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [45.16ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [21.39ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [324.61ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 730ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/expr.rs                            |   5 ++
 src/js_parser/fold.rs                      |   1 +
 src/js_parser/visit/visit_expr.rs          |  36 +++++----
 test/bundler/transpiler/transpiler.test.js | 118 +++++++++++++++++++++++++++++
 4 files changed, 145 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/ast/expr.rs                                 3      3      0
src/js_parser/fold.rs                           2      1      0
src/js_parser/visit/visit_expr.rs               8      4      0
test/bundler/transpiler/transpiler.test.js      5     14      0
```

</details>

<!-- robobun:evidence:end -->