### PR TITLE
Intl.Locale: apply CLDR alias mappings during canonicalization

### DIFF
--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -306,6 +306,10 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
   // force-include would lock those in before the source can speak.
   const noPchSources = new Set<string>();
 
+  // Needs the ICU C++ API (icu::Locale::createCanonical) which the PCH hides
+  // via wtf/Platform.h's U_SHOW_CPLUSPLUS_API=0. Also in unified.ts noUnify.
+  noPchSources.add(resolve(cfg.cwd, "src/jsc/bindings/IntlCanonicalize.cpp"));
+
   // highway_json.cpp is compiled -O2 even in debug profiles (see its
   // fileOverrides entry in flags.ts); a TU at a different -O level than the
   // PCH cannot use the PCH ("__OPTIMIZE__ ... was disabled in precompiled

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "34c01d13391e00c06862a3d2c5b7fff350ac87e0";
+export const WEBKIT_VERSION = "autobuild-preview-pr-381-edc9ed33";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -803,6 +803,29 @@ export const defines: Flag[] = [
 // ═══════════════════════════════════════════════════════════════════════════
 
 export const linkerFlags: Flag[] = [
+  // ─── Force-include weakly-referenced archive members ───
+  // IntlCanonicalize.o defines Bun__canonicalizeLocaleID, which only
+  // libJavaScriptCore.a references and only weakly. In CI's split link the
+  // bun C++ objects are archived, and a weak ref never pulls an archive
+  // member, so without this the symbol stays null and JSC falls back to
+  // uloc_canonicalize. Local full builds pass the .o directly and don't
+  // need it, but it's harmless there.
+  {
+    flag: "-Wl,-u,_Bun__canonicalizeLocaleID",
+    when: c => c.darwin,
+    desc: "Pull IntlCanonicalize.o from the C++ archive (Mach-O underscore prefix)",
+  },
+  {
+    flag: "-Wl,-u,Bun__canonicalizeLocaleID",
+    when: c => c.unix && !c.darwin,
+    desc: "Pull IntlCanonicalize.o from the C++ archive",
+  },
+  {
+    flag: "/include:Bun__canonicalizeLocaleID",
+    when: c => c.windows,
+    desc: "Pull IntlCanonicalize.o from the C++ archive",
+  },
+
   // ─── Sanitizers ───
   {
     flag: "-fsanitize=address",

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -140,6 +140,10 @@ const noUnify: readonly string[] = [
   // Fifth highway TU (JSON structural indexer) — same foreach_target.h
   // include-guard reason.
   "src/jsc/bindings/highway_json.cpp",
+  // Needs the ICU C++ API (icu::Locale) which wtf/Platform.h hides via
+  // U_SHOW_CPLUSPLUS_API=0. Bundled siblings would include ICU C headers
+  // first and lock out locid.h's C++-only dependencies. Also noPchSources.
+  "src/jsc/bindings/IntlCanonicalize.cpp",
   // Declares its own minimal CGRect/kCFStringEncodingUTF8/kCFNumberDoubleType
   // so it doesn't pull a CoreGraphics load command; bundled with files that
   // include the real CF headers those names become ambiguous.

--- a/src/jsc/bindings/IntlCanonicalize.cpp
+++ b/src/jsc/bindings/IntlCanonicalize.cpp
@@ -13,6 +13,13 @@ extern "C" int32_t ualoc_canonicalForm(const char*, char*, int32_t, UErrorCode*)
 
 extern "C" int32_t Bun__canonicalizeLocaleID(const char* localeID, char* name, int32_t nameCapacity, UErrorCode* err)
 {
+    // uloc_forLanguageTag("und") yields "", and on macOS 13/14 libicucore
+    // canonicalizes "" to the process default locale; keep the root locale as-is.
+    if (localeID != nullptr && localeID[0] == '\0') {
+        if (nameCapacity > 0)
+            name[0] = '\0';
+        return 0;
+    }
     return ualoc_canonicalForm(localeID, name, nameCapacity, err);
 }
 

--- a/src/jsc/bindings/IntlCanonicalize.cpp
+++ b/src/jsc/bindings/IntlCanonicalize.cpp
@@ -1,26 +1,14 @@
-// C wrapper around ICU's CLDR-aware locale canonicalization, called from
-// JSC's canonicalizeLocaleIDWithoutNullTerminator (IntlObject.cpp). ICU's
-// uloc_canonicalize is documented as "does NOT map aliased names in any way",
-// so without this Intl.Locale("fre") stays "fre" instead of "fr", "en-UK"
-// stays "en-UK" instead of "en-GB", etc. (ICU-21506).
-//
-// WebKit compiles with U_SHOW_CPLUSPLUS_API=0 (wtf/Platform.h), and the ICU C
-// headers JSC already pulls in lock out the C++-only dependencies locid.h
-// needs, so this cannot live in WebKit. It is compiled standalone (noUnify)
-// and without the PCH so that root.h never sets U_SHOW_CPLUSPLUS_API before
-// the ICU headers are seen.
-//
-// Signature matches uloc_canonicalize so JSC's callBufferProducingFunction
-// can drive buffer growth.
+// CLDR-aware locale canonicalization for JSC (IntlObject.cpp, ICU-21506).
+// uloc_canonicalize skips alias mappings (fre->fr, en-UK->en-GB); this wraps
+// the ICU paths that don't. Built no-PCH/no-unify so wtf/Platform.h's
+// U_SHOW_CPLUSPLUS_API=0 never reaches <unicode/locid.h>. Signature matches
+// uloc_canonicalize for callBufferProducingFunction.
 
 #if defined(__APPLE__)
 
 #include <unicode/utypes.h>
 
-// Apple's libicucore exports this on every macOS version Bun supports (the
-// symbol is present in the MacOSX 12.3/13.3/15.4/26.4 SDK .tbd files; Bun's
-// minimum is 13.0). The declaration lives in Apple's internal ICU headers
-// (rdar://74314220); it wraps icu::Locale::createCanonical.
+// Apple libicucore SPI (rdar://74314220); present on macOS 13+ per SDK .tbd.
 extern "C" int32_t ualoc_canonicalForm(const char*, char*, int32_t, UErrorCode*);
 
 extern "C" int32_t Bun__canonicalizeLocaleID(const char* localeID, char* name, int32_t nameCapacity, UErrorCode* err)
@@ -33,13 +21,11 @@ extern "C" int32_t Bun__canonicalizeLocaleID(const char* localeID, char* name, i
 #include <unicode/locid.h>
 #include <cstring>
 
-// icu::Locale::createCanonical runs ICU's CLDR AliasReplacer since ICU 68.
-// ICU is statically linked on every non-Darwin target, so the C++ ABI is
-// fixed at build time.
 extern "C" int32_t Bun__canonicalizeLocaleID(const char* localeID, char* name, int32_t nameCapacity, UErrorCode* err)
 {
     if (err == nullptr || U_FAILURE(*err))
         return 0;
+    // Runs ICU's CLDR AliasReplacer since ICU 68; static link, so C++ ABI is fixed.
     icu::Locale locale = icu::Locale::createCanonical(localeID);
     if (locale.isBogus()) {
         *err = U_ILLEGAL_ARGUMENT_ERROR;

--- a/src/jsc/bindings/IntlCanonicalize.cpp
+++ b/src/jsc/bindings/IntlCanonicalize.cpp
@@ -1,0 +1,61 @@
+// C wrapper around ICU's CLDR-aware locale canonicalization, called from
+// JSC's canonicalizeLocaleIDWithoutNullTerminator (IntlObject.cpp). ICU's
+// uloc_canonicalize is documented as "does NOT map aliased names in any way",
+// so without this Intl.Locale("fre") stays "fre" instead of "fr", "en-UK"
+// stays "en-UK" instead of "en-GB", etc. (ICU-21506).
+//
+// WebKit compiles with U_SHOW_CPLUSPLUS_API=0 (wtf/Platform.h), and the ICU C
+// headers JSC already pulls in lock out the C++-only dependencies locid.h
+// needs, so this cannot live in WebKit. It is compiled standalone (noUnify)
+// and without the PCH so that root.h never sets U_SHOW_CPLUSPLUS_API before
+// the ICU headers are seen.
+//
+// Signature matches uloc_canonicalize so JSC's callBufferProducingFunction
+// can drive buffer growth.
+
+#if defined(__APPLE__)
+
+#include <unicode/utypes.h>
+
+// Apple's libicucore exports this on every macOS version Bun supports (the
+// symbol is present in the MacOSX 12.3/13.3/15.4/26.4 SDK .tbd files; Bun's
+// minimum is 13.0). The declaration lives in Apple's internal ICU headers
+// (rdar://74314220); it wraps icu::Locale::createCanonical.
+extern "C" int32_t ualoc_canonicalForm(const char*, char*, int32_t, UErrorCode*);
+
+extern "C" int32_t Bun__canonicalizeLocaleID(const char* localeID, char* name, int32_t nameCapacity, UErrorCode* err)
+{
+    return ualoc_canonicalForm(localeID, name, nameCapacity, err);
+}
+
+#else
+
+#include <unicode/locid.h>
+#include <cstring>
+
+// icu::Locale::createCanonical runs ICU's CLDR AliasReplacer since ICU 68.
+// ICU is statically linked on every non-Darwin target, so the C++ ABI is
+// fixed at build time.
+extern "C" int32_t Bun__canonicalizeLocaleID(const char* localeID, char* name, int32_t nameCapacity, UErrorCode* err)
+{
+    if (err == nullptr || U_FAILURE(*err))
+        return 0;
+    icu::Locale locale = icu::Locale::createCanonical(localeID);
+    if (locale.isBogus()) {
+        *err = U_ILLEGAL_ARGUMENT_ERROR;
+        return 0;
+    }
+    const char* canonical = locale.getName();
+    int32_t length = static_cast<int32_t>(std::strlen(canonical));
+    if (length < nameCapacity) {
+        std::memcpy(name, canonical, static_cast<size_t>(length));
+        name[length] = 0;
+    } else {
+        if (nameCapacity > 0)
+            std::memcpy(name, canonical, static_cast<size_t>(nameCapacity));
+        *err = length == nameCapacity ? U_STRING_NOT_TERMINATED_WARNING : U_BUFFER_OVERFLOW_ERROR;
+    }
+    return length;
+}
+
+#endif

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -279,6 +279,10 @@ describe("Intl.Locale canonicalization", () => {
     // And again after, so deprecated option values are also replaced.
     expect(new Intl.Locale("en", { region: "uk" }).toString()).toBe("en-GB");
     expect(new Intl.Locale("fre", { region: "uk" }).toString()).toBe("fr-GB");
+    // `und` round-trips through an empty ICU locale ID; on macOS 13/14
+    // libicucore canonicalizes "" to the process default locale, which would
+    // leak into the result as e.g. "sr-Latn-US-u-va-posix".
+    expect(new Intl.Locale("und").toString()).toBe("und");
     expect(new Intl.Locale("und", { language: "sh" }).toString()).toBe("sr-Latn");
   });
 

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -233,8 +233,77 @@ describe("Intl.getCanonicalLocales", () => {
       mo: Intl.getCanonicalLocales("mo")[0],
       ji: Intl.getCanonicalLocales("ji")[0],
     }).toEqual({ in: "id", iw: "he", mo: "ro", ji: "yi" });
-    // sh/tl/no are kept as-is (ICU ships bundles under both names)
-    expect(Intl.getCanonicalLocales(["sh", "tl", "no"])).toEqual(["sh", "tl", "no"]);
+    // `no` is the CLDR macrolanguage and stays as-is; `sh`/`tl` map to their
+    // CLDR replacements via the languageAlias table.
+    expect(Intl.getCanonicalLocales(["sh", "tl", "no"])).toEqual(["sr-Latn", "fil", "no"]);
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/14713
+// ICU's uloc_canonicalize does not apply CLDR alias mappings; JSC must route
+// through icu::Locale::createCanonical / ualoc_canonicalForm to get the
+// UTS #35 canonical form that ECMA-402 requires.
+describe("Intl.Locale canonicalization", () => {
+  test("deprecated language subtags", () => {
+    expect({
+      fre: new Intl.Locale("fre").baseName,
+      cmn: new Intl.Locale("cmn").baseName,
+      sh: new Intl.Locale("sh").baseName,
+      tl: new Intl.Locale("tl").baseName,
+      aam: new Intl.Locale("aam").baseName,
+    }).toEqual({ fre: "fr", cmn: "zh", sh: "sr-Latn", tl: "fil", aam: "aas" });
+  });
+
+  test("deprecated region subtags", () => {
+    expect({
+      "en-uk": new Intl.Locale("en-uk").baseName,
+      "en-DD": new Intl.Locale("en-DD").baseName,
+      "en-BU": new Intl.Locale("en-BU").baseName,
+      "ru-SU": new Intl.Locale("ru-SU").baseName,
+      "hy-SU": new Intl.Locale("hy-SU").baseName,
+      "und-Armn-SU": new Intl.Locale("und-Armn-SU").baseName,
+    }).toEqual({
+      "en-uk": "en-GB",
+      "en-DD": "en-DE",
+      "en-BU": "en-MM",
+      "ru-SU": "ru-RU",
+      "hy-SU": "hy-AM",
+      "und-Armn-SU": "und-Armn-AM",
+    });
+  });
+
+  test("canonicalization runs before and after option overrides", () => {
+    // CanonicalizeUnicodeLocaleId is applied to the input tag before options
+    // are merged, so SU resolves against und-Armn (-> AM) rather than ru (-> RU).
+    expect(new Intl.Locale("und-Armn-SU", { language: "ru" }).toString()).toBe("ru-Armn-AM");
+    // And again after, so deprecated option values are also replaced.
+    expect(new Intl.Locale("en", { region: "uk" }).toString()).toBe("en-GB");
+    expect(new Intl.Locale("fre", { region: "uk" }).toString()).toBe("fr-GB");
+    expect(new Intl.Locale("und", { language: "sh" }).toString()).toBe("sr-Latn");
+  });
+
+  test("derived getters reflect the canonical form", () => {
+    const uk = new Intl.Locale("en-uk");
+    const sh = new Intl.Locale("sh");
+    expect({ region: uk.region, language: sh.language, script: sh.script }).toEqual({
+      region: "GB",
+      language: "sr",
+      script: "Latn",
+    });
+  });
+
+  test("unicode extension keywords survive alias replacement", () => {
+    expect(new Intl.Locale("fre-u-ca-gregory").toString()).toBe("fr-u-ca-gregory");
+    expect(new Intl.Locale("en-uk-u-ca-gregory").toString()).toBe("en-GB-u-ca-gregory");
+  });
+
+  test("Intl.getCanonicalLocales applies the same alias mappings", () => {
+    expect(Intl.getCanonicalLocales(["fre", "en-uk", "und-Armn-SU", "cmn"])).toEqual([
+      "fr",
+      "en-GB",
+      "und-Armn-AM",
+      "zh",
+    ]);
   });
 });
 

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -283,6 +283,8 @@ describe("Intl.Locale canonicalization", () => {
     // libicucore canonicalizes "" to the process default locale, which would
     // leak into the result as e.g. "sr-Latn-US-u-va-posix".
     expect(new Intl.Locale("und").toString()).toBe("und");
+    expect(new Intl.Locale("und-u-ca-gregory").toString()).toBe("und-u-ca-gregory");
+    expect(new Intl.Locale("und-x-private").toString()).toBe("und-x-private");
     expect(new Intl.Locale("und", { language: "sh" }).toString()).toBe("sr-Latn");
   });
 


### PR DESCRIPTION
Fixes #14713.

> [!NOTE]
> `WEBKIT_VERSION` currently points at `autobuild-preview-pr-381-edc9ed33`, a preview build of oven-sh/WebKit#381. That PR must land first, and this line must be bumped to the resulting merge-commit sha before this Bun PR is merged.

### Reproduction

```js
new Intl.Locale("und-Armn-SU", { language: "ru" }).toString(); // "ru-Armn-SU", expected "ru-Armn-AM"
new Intl.Locale("fre").baseName;                               // "fre",        expected "fr"
new Intl.Locale("en-uk").baseName;                             // "en-UK",      expected "en-GB"
Intl.getCanonicalLocales("sh");                                // ["sh"],       expected ["sr-Latn"]
```

### Cause

JSC's `canonicalizeLocaleIDWithoutNullTerminator` calls ICU's `uloc_canonicalize`, which is documented as "does NOT map aliased names in any way" (ICU-21506). Safari avoids this via Apple's `ualoc_canonicalForm` SPI, gated behind `USE(APPLE_INTERNAL_SDK)` which Bun does not set. The CLDR-aware path in open-source ICU is `icu::Locale::createCanonical` (runs ICU's `AliasReplacer` since ICU 68), but WebKit compiles with `U_SHOW_CPLUSPLUS_API=0` (`wtf/Platform.h`), so the ICU C++ API is unreachable from JSC, and undoing that define from inside a unified-source TU breaks on ICU's header include guards.

### Fix

WebKit now forward-declares a weak `Bun__canonicalizeLocaleID` with the `uloc_canonicalize` signature and calls it from `canonicalizeLocaleIDWithoutNullTerminator` when present (oven-sh/WebKit#381; the `jsc` shell links without the symbol and keeps the old behavior).

`src/jsc/bindings/IntlCanonicalize.cpp` provides the implementation:
- **macOS:** forwards to `ualoc_canonicalForm`. The symbol is exported from `libicucore` on every macOS version Bun supports (present in the MacOSX 12.3 / 13.3 / 15.4 / 26.4 SDK `.tbd` files; Bun's minimum is 13.0), and as a plain C function it avoids the C++ ABI hazard of calling `icu::Locale` against the system ICU.
- **Everything else:** calls `icu::Locale::createCanonical`. ICU is statically linked on these targets, so the C++ ABI is fixed at build time.

The file is compiled standalone (`noUnify`) and without the PCH (`noPchSources`) so `wtf/Platform.h` never sets `U_SHOW_CPLUSPLUS_API=0` before `<unicode/locid.h>` is seen.

### Verification

`bun bd test test/js/web/intl/intl.test.ts` passes all 37 tests; the seven new `Intl.Locale canonicalization` tests plus the updated `Intl.getCanonicalLocales` assertion fail on a build without `IntlCanonicalize.cpp`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/intl/intl.test.ts

<!-- robobun:evidence:end -->