### PR TITLE
HTMLRewriter: stream through SinkHandle/SourceHandle; suspend async handlers instead of wait_for_promise

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -55,7 +55,7 @@ The workflow runs all three formatters simultaneously:
 
 1. Bump `channel` in `rust-toolchain.toml` (and `Dockerfile`/`bootstrap.sh` to match).
 2. Bump `RUSTUP_TOOLCHAIN` in the `Format Code` step's `env:` block in `format.yml` to the same value.
-3. Bump `RUSTUP_TOOLCHAIN` in the workflow-level `env:` block in `clippy.yml` and `miri.yml` to the same value.
+3. Bump `RUSTUP_TOOLCHAIN` in the workflow-level `env:` block in `clippy.yml`, `miri.yml`, and `lolhtml.yml` to the same value.
 4. `cargo fmt` formatting can change between nightlies; run `cargo fmt --all` locally on the new toolchain and include the resulting diff in the same PR.
 
 #### To update clang-format version:

--- a/.github/workflows/lolhtml.yml
+++ b/.github/workflows/lolhtml.yml
@@ -1,0 +1,72 @@
+name: lol-html
+
+permissions:
+  contents: read
+
+# The vendored lol-html is a fork (oven-sh/lol-html, `bun` branch) carrying
+# content-handler suspension, and its own test suite is the only thing that
+# guards the fork's invariants: nothing in the Bun test suite reaches, for
+# example, the parser's suspension bookkeeping or `Arena::compact()`. Run it
+# whenever the pinned commit or this workflow changes.
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "scripts/build/deps/lolhtml.ts"
+      - ".github/workflows/lolhtml.yml"
+  merge_group:
+
+env:
+  BUN_VERSION: "1.3.2"
+  LLVM_VERSION_MAJOR: "21"
+  # Keep in sync with `channel` in rust-toolchain.toml.
+  RUSTUP_TOOLCHAIN: nightly-2026-07-20
+
+jobs:
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Setup system deps
+        # cmake/ninja/clang for `--configure-only`, which is what generates the
+        # ninja edge that fetches + patches the vendored source.
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+          echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{ env.LLVM_VERSION_MAJOR }} main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends cmake ninja-build clang-${{ env.LLVM_VERSION_MAJOR }} lld-${{ env.LLVM_VERSION_MAJOR }} llvm-${{ env.LLVM_VERSION_MAJOR }}
+
+      - name: Setup Rust
+        run: |
+          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
+          rustup override set "$RUSTUP_TOOLCHAIN"
+          echo "::add-matcher::.github/rust-matcher.json"
+
+      - name: Fetch lol-html
+        # `clone-lolhtml` extracts the pinned fork archive into
+        # `vendor/lolhtml/` through the same ninja edge the real build uses.
+        run: |
+          bun install --frozen-lockfile
+          bun scripts/build.ts --configure-only
+          ninja -C build/debug clone-lolhtml
+
+      - name: cargo test
+        # `lol_html` is a path dependency, not a workspace member (it carries
+        # dev-dependencies the Bun workspace does not), so run it in place.
+        working-directory: vendor/lolhtml
+        run: cargo test

--- a/bench/snippets/html-rewriter-suspend.mjs
+++ b/bench/snippets/html-rewriter-suspend.mjs
@@ -1,0 +1,97 @@
+// Cost of async content-handler suspension in HTMLRewriter.
+//
+// Three handler shapes over the same input:
+//   sync:       element(el) { el.setAttribute(...) }                     — no suspension
+//   microtask:  async element(el) { await 0; el.setAttribute(...) }      — settles in the
+//               microtask checkpoint, so lol-html is NOT suspended
+//   suspend:    async element(el) { await immediate; el.setAttribute() } — forces lol-html to
+//               deep-copy the token, return Suspended, and resume() from a promise reaction
+//
+// Reports per-rewrite time (mitata) and steady-state RSS.
+//
+//   bun bd bench/snippets/html-rewriter-suspend.mjs
+//   ELEMENTS=2000 bun bd bench/snippets/html-rewriter-suspend.mjs
+
+import { bench, group, run } from "../runner.mjs";
+
+const ELEMENTS = Number(process.env.ELEMENTS ?? 500);
+const ATTR_COUNT = 4;
+
+// Build one realistic-ish element and repeat it N times so the token lol-html
+// parks on suspend is not degenerate (has attributes to copy).
+let element = "<p";
+for (let i = 0; i < ATTR_COUNT; i++) element += ` data-k${i}="vvvvvvvvvvvvvvvv"`;
+element += ">hello</p>";
+const htmlInput =
+  "<!doctype html><body>" +
+  Array.from({ length: ELEMENTS }, () => element).join("") +
+  "</body>";
+const inputBytes = Buffer.byteLength(htmlInput);
+
+const rw = () => new HTMLRewriter();
+const immediate = () => new Promise(r => setImmediate(r));
+
+const handlers = {
+  sync: {
+    element(el) {
+      el.setAttribute("x", "1");
+    },
+  },
+  microtask: {
+    async element(el) {
+      await 0;
+      el.setAttribute("x", "1");
+    },
+  },
+  suspend: {
+    async element(el) {
+      await immediate();
+      el.setAttribute("x", "1");
+    },
+  },
+};
+
+async function once(kind) {
+  await rw().on("p", handlers[kind]).transform(new Response(htmlInput)).text();
+}
+
+// ── throughput ───────────────────────────────────────────────────────────
+group(`transform ${ELEMENTS} <p> elements (${(inputBytes / 1024).toFixed(1)} KB)`, () => {
+  for (const kind of Object.keys(handlers)) {
+    bench(kind, async () => {
+      await once(kind);
+    });
+  }
+});
+
+await run();
+
+// ── RSS at steady state ──────────────────────────────────────────────────
+// mitata doesn't track RSS; measure it separately after a warmup so allocator
+// footprint is established. Reported as peak-after-pass minus baseline.
+const rss = process.memoryUsage.rss;
+async function rssPass(kind, n) {
+  for (let i = 0; i < n; i++) await once(kind);
+  Bun.gc(true);
+  return rss();
+}
+
+console.log("\nsteady-state RSS (after 200-iteration warmup, 200-iteration pass):");
+for (const kind of Object.keys(handlers)) {
+  await rssPass(kind, 200);
+  const before = await rssPass(kind, 0);
+  const after = await rssPass(kind, 200);
+  console.log(
+    `  ${kind.padEnd(10)} baseline ${(before / 1024 / 1024).toFixed(1)} MB, ` +
+      `after ${(after / 1024 / 1024).toFixed(1)} MB, ` +
+      `delta ${((after - before) / 1024 / 1024).toFixed(2)} MB`,
+  );
+}
+
+// ── per-suspension cost ──────────────────────────────────────────────────
+// Derived from the mitata run above (suspend - sync) / ELEMENTS, printed for
+// convenience; the mitata table is the authoritative measurement.
+console.log(
+  `\nper-element suspension overhead is (suspend_time - sync_time) / ${ELEMENTS}; ` +
+    `read it from the mitata table above.`,
+);

--- a/docs/runtime/html-rewriter.mdx
+++ b/docs/runtime/html-rewriter.mdx
@@ -113,16 +113,55 @@ rewriter.on("div.content", {
 });
 ```
 
-Handlers can be asynchronous and return a Promise. Async operations block the transformation until they complete:
+Handlers can be asynchronous and return a Promise. The transformation pauses on
+that element until the Promise settles, so handlers still run one at a time, in
+document order:
 
 ```ts
 rewriter.on("div", {
   async element(element) {
-    await Bun.sleep(1000);
-    element.setInnerContent("<span>replace</span>", { html: true });
+    const fragment = await fetch("https://example.com/fragment").then(r => r.text());
+    element.setInnerContent(fragment, { html: true });
   },
 });
 ```
+
+`transform(response)` returns immediately; the rewrite continues in the
+background and you read the result off the returned `Response`. Because the
+rewrite outlives `transform()`, an error thrown by an async handler (or a
+Promise it returns that rejects) rejects the response body instead of throwing
+from `transform()`:
+
+```ts
+try {
+  const output = await rewriter.transform(new Response(html)).text();
+} catch (error) {
+  console.error("a handler failed:", error);
+}
+```
+
+`transform()` on a `string` or `ArrayBuffer` has to return its result
+synchronously, so it cannot wait for a handler that needs the event loop to turn
+(a timer, I/O, a `fetch`). Such a handler makes `transform()` throw a
+`TypeError`, and the rewrite fails without running any further handlers:
+
+```ts
+new HTMLRewriter()
+  .on("div", {
+    async element(element) {
+      await Bun.sleep(1000); // needs a timer
+    },
+  })
+  .transform("<div></div>");
+// TypeError: HTMLRewriter.transform() cannot synchronously return a string
+// because a content handler returned a Promise that did not resolve within a
+// microtask. Pass a Response instead and await its body
+```
+
+A handler whose Promise settles within a microtask checkpoint (anything that
+does not need the event loop, including `process.nextTick` and already-resolved
+Promises) still works with `transform(string)`. Pass a `Response` whenever a
+handler might await real work.
 
 ### CSS Selector Support
 
@@ -306,25 +345,44 @@ When transforming a Response:
 
 ## Error Handling
 
-HTMLRewriter operations can throw errors in several cases:
+Which channel an error takes is decided by the overload you called, never by
+timing. `transform()` itself throws for:
 
-- Invalid selector syntax in `on()` method
-- Invalid HTML content in transformation methods
-- Stream errors when processing Response bodies
-- Memory allocation failures
+- Invalid selector syntax in the `on()` method
 - Invalid input types (for example, passing a Symbol)
-- Body already used errors
-
-Catch and handle these errors:
+- Body already used errors, and input bodies that have already failed or aborted
+- Anything a content handler raises on a `string` / `ArrayBuffer` input, since
+  those have to produce their result before `transform()` returns — including a
+  handler that needs the event loop (see [Element Handlers](#element-handlers))
 
 ```ts
 try {
-  const result = rewriter.transform(input);
-  // Process result
+  const result = rewriter.transform("<div></div>");
 } catch (error) {
   console.error("HTMLRewriter error:", error);
 }
 ```
+
+For a `Response` input, `transform()` returns before the rewrite finishes, so
+everything the rewrite discovers surfaces on the output body instead:
+
+- An error thrown by a content handler, or a rejected Promise one returned
+- Malformed or truncated input
+- Stream errors reading the input body
+- Memory allocation failures
+
+```ts
+try {
+  const output = await rewriter.transform(new Response(html)).text();
+} catch (error) {
+  console.error("the rewrite failed:", error);
+}
+```
+
+A rejection from a Promise a handler creates but neither returns nor awaits
+reaches neither channel: like any detached rejection, it goes to the
+process-global `unhandledRejection` path. Earlier versions of Bun could surface
+it from `transform()` itself.
 
 ---
 

--- a/packages/bun-types/html-rewriter.d.ts
+++ b/packages/bun-types/html-rewriter.d.ts
@@ -163,20 +163,35 @@ declare class HTMLRewriter {
 
   /**
    * Transform HTML content
+   *
+   * Returns immediately; the rewrite continues in the background. An error
+   * thrown by a content handler (or a Promise it returns that rejects) rejects
+   * the returned response's body rather than throwing from `transform()`.
+   *
    * @param input - The HTML to transform
    * @returns A new {@link Response} with the transformed HTML
    */
-  transform(input: Response | Blob | Bun.BufferSource): Response;
+  transform(input: Response): Response;
   /**
    * Transform HTML content
+   *
    * @param input - The HTML string to transform
    * @returns The transformed HTML as a string
+   * @throws {TypeError} If a content handler returns a Promise that needs the
+   * event loop to turn (a timer, I/O, a `fetch`). The result has to be produced
+   * synchronously, so pass a {@link Response} and await its body instead.
    */
   transform(input: string): string;
   /**
    * Transform HTML content
-   * @param input - The HTML to transform as a {@link ArrayBuffer}
+   *
+   * Every {@link Bun.BufferSource} (a TypedArray, DataView, or ArrayBuffer)
+   * produces an `ArrayBuffer`, not a `Response`.
+   *
+   * @param input - The HTML to transform as bytes
    * @returns A new {@link ArrayBuffer} with the transformed HTML
+   * @throws {TypeError} If a content handler returns a Promise that needs the
+   * event loop to turn. See {@link transform} for `string` inputs.
    */
-  transform(input: ArrayBuffer): ArrayBuffer;
+  transform(input: Bun.BufferSource): ArrayBuffer;
 }

--- a/scripts/build/deps/lolhtml.ts
+++ b/scripts/build/deps/lolhtml.ts
@@ -21,7 +21,13 @@
 
 import type { Dependency } from "../source.ts";
 
-const LOLHTML_COMMIT = "77127cd2b8545998756e8d64e36ee2313c4bb312";
+// oven-sh/lol-html is cloudflare/lol-html plus content-handler suspension
+// (`HtmlRewriter::resume()`), maintained on the `bun` branch. The upstream
+// base commit is recorded here so a rebase onto a new upstream tag is
+// `git rebase --onto <new-tag> <LOLHTML_UPSTREAM_BASE> bun` in the fork.
+const LOLHTML_UPSTREAM_BASE = "77127cd2b8545998756e8d64e36ee2313c4bb312"; // v2.7.2
+const LOLHTML_COMMIT = "725ce499aa9b71e38b7a2d0a9fbb6d7294a4079e";
+void LOLHTML_UPSTREAM_BASE;
 
 export const lolhtml: Dependency = {
   name: "lolhtml",
@@ -29,7 +35,7 @@ export const lolhtml: Dependency = {
 
   source: () => ({
     kind: "github-archive",
-    repo: "cloudflare/lol-html",
+    repo: "oven-sh/lol-html",
     commit: LOLHTML_COMMIT,
   }),
 

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -8,6 +8,7 @@ const classes = [
   "H3ResponseSink",
   "NetworkSink",
   "FetchRequestBodySink",
+  "HTMLRewriterSink",
 ];
 
 function names(name) {
@@ -1061,6 +1062,7 @@ function rustSink() {
     H3ResponseSink: "crate::webcore::streams::H3ResponseSink",
     NetworkSink: "crate::webcore::streams::NetworkSink",
     FetchRequestBodySink: "crate::webcore::fetch::fetch_request_body_sink::FetchRequestBodySink",
+    HTMLRewriterSink: "crate::api::html_rewriter::RewriterPipe",
   };
 
   const symbols: string[] = [];

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -183,6 +183,17 @@ pub struct VirtualMachine {
     pub pending_unref_counter: core::sync::atomic::AtomicI32,
     pub preload: Vec<Box<[u8]>>,
     pub unhandled_pending_rejection_to_capture: Option<*mut JSValue>,
+    /// LAYERING: the real type is `bun_runtime`'s
+    /// `html_rewriter::RewriterPipe` (a forward dep), stored type-erased.
+    ///
+    /// The HTMLRewriter sink whose lol-html `write()`/`end()`/`resume()` call
+    /// is currently on this VM's native stack, if any. Content handlers reach
+    /// their sink through it (to record a thrown exception, and to park the JS
+    /// wrapper + pending promise when an async handler suspends the rewrite).
+    /// Saved and restored LIFO around every lol-html call, so a handler body
+    /// that synchronously starts a nested `transform()` nests correctly.
+    /// All-zero bytes decode as `None` (null niche).
+    pub html_rewriter_active_sink: Option<core::ptr::NonNull<c_void>>,
     // Note: layering — the concrete `bun_standalone_graph::Graph` lives
     // in a higher-tier crate. The resolver already broke that cycle with the
     // `bun_resolver::StandaloneModuleGraph` trait; we hold the same trait

--- a/src/jsc/bindings/NativePromiseContext.cpp
+++ b/src/jsc/bindings/NativePromiseContext.cpp
@@ -18,14 +18,27 @@ const JSC::ClassInfo NativePromiseContext::s_info = {
     CREATE_METHOD_TABLE(NativePromiseContext)
 };
 
-NativePromiseContext* NativePromiseContext::create(JSC::VM& vm, JSC::Structure* structure, void* ctx, Tag tag)
+NativePromiseContext* NativePromiseContext::create(JSC::VM& vm, JSC::Structure* structure, void* ctx, Tag tag, JSC::JSValue held)
 {
     ASSERT(ctx);
     NativePromiseContext* cell = new (NotNull, JSC::allocateCell<NativePromiseContext>(vm))
         NativePromiseContext(vm, structure, ctx, tag);
     cell->finishCreation(vm);
+    if (held)
+        cell->m_held.set(vm, cell, held);
     return cell;
 }
+
+template<typename Visitor>
+void NativePromiseContext::visitChildrenImpl(JSC::JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = static_cast<NativePromiseContext*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+    visitor.append(thisObject->m_held);
+}
+
+DEFINE_VISIT_CHILDREN(NativePromiseContext);
 
 NativePromiseContext::~NativePromiseContext()
 {
@@ -41,14 +54,15 @@ void NativePromiseContext::destroy(JSC::JSCell* cell)
 
 } // namespace Bun
 
-extern "C" JSC::EncodedJSValue Bun__NativePromiseContext__create(Zig::GlobalObject* globalObject, void* ctx, uint8_t tag)
+extern "C" JSC::EncodedJSValue Bun__NativePromiseContext__create(Zig::GlobalObject* globalObject, void* ctx, uint8_t tag, JSC::EncodedJSValue held)
 {
     auto& vm = JSC::getVM(globalObject);
     auto* cell = Bun::NativePromiseContext::create(
         vm,
         globalObject->NativePromiseContextStructure(),
         ctx,
-        static_cast<Bun::NativePromiseContext::Tag>(tag));
+        static_cast<Bun::NativePromiseContext::Tag>(tag),
+        JSC::JSValue::decode(held));
     return JSC::JSValue::encode(cell);
 }
 

--- a/src/jsc/bindings/NativePromiseContext.h
+++ b/src/jsc/bindings/NativePromiseContext.h
@@ -42,12 +42,15 @@ public:
         HTTPSServerRequestContext,
         DebugHTTPServerRequestContext,
         DebugHTTPSServerRequestContext,
-        BodyValueBufferer,
         HTTPSServerH3RequestContext,
         DebugHTTPSServerH3RequestContext,
+        HTMLRewriterSuspension,
     };
 
-    static NativePromiseContext* create(JSC::VM& vm, JSC::Structure* structure, void* ctx, Tag tag);
+    // `held` is visited, so the reaction keeps it alive for as long as the
+    // Promise can settle (the HTMLRewriter suspension stores its Transform
+    // cell here). Pass the empty JSValue when nothing needs rooting.
+    static NativePromiseContext* create(JSC::VM& vm, JSC::Structure* structure, void* ctx, Tag tag, JSC::JSValue held);
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
     {
@@ -69,6 +72,7 @@ public:
     }
 
     DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
 
     static constexpr JSC::DestructionMode needsDestruction = JSC::DestructionMode::NeedsDestruction;
     static void destroy(JSC::JSCell* cell);
@@ -95,6 +99,7 @@ private:
     ~NativePromiseContext();
 
     WTF::CompactPointerTuple<NativePromiseContextPointee*, Tag> m_data;
+    JSC::WriteBarrier<JSC::Unknown> m_held;
 };
 
 } // namespace Bun

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2691,6 +2691,16 @@ void GlobalObject::finishCreation(VM& vm)
             init.setConstructor(constructor);
         });
 
+    m_JSHTMLRewriterSinkClassStructure.initLater(
+        [](LazyClassStructure::Initializer& init) {
+            auto* prototype = createJSSinkPrototype(init.vm, init.global, WebCore::SinkID::HTMLRewriterSink);
+            auto* structure = JSHTMLRewriterSink::createStructure(init.vm, init.global, prototype);
+            auto* constructor = JSHTMLRewriterSinkConstructor::create(init.vm, init.global, JSHTMLRewriterSinkConstructor::createStructure(init.vm, init.global, init.global->functionPrototype()), prototype);
+            init.setPrototype(prototype);
+            init.setStructure(structure);
+            init.setConstructor(constructor);
+        });
+
     m_JSBufferClassStructure.initLater(
         [](LazyClassStructure::Initializer& init) {
             auto* prototype = WebCore::createBufferPrototype(init.vm, init.global);
@@ -4057,10 +4067,10 @@ GlobalObject::PromiseFunctions GlobalObject::promiseHandlerID(Zig::FFIFunction h
         return GlobalObject::PromiseFunctions::Bun__TestScope__Describe2__bunTestThen;
     } else if (handler == Bun__TestScope__Describe2__bunTestCatch) {
         return GlobalObject::PromiseFunctions::Bun__TestScope__Describe2__bunTestCatch;
-    } else if (handler == Bun__BodyValueBufferer__onResolveStream) {
-        return GlobalObject::PromiseFunctions::Bun__BodyValueBufferer__onResolveStream;
-    } else if (handler == Bun__BodyValueBufferer__onRejectStream) {
-        return GlobalObject::PromiseFunctions::Bun__BodyValueBufferer__onRejectStream;
+    } else if (handler == Bun__HTMLRewriter__onHandlerResolve) {
+        return GlobalObject::PromiseFunctions::Bun__HTMLRewriter__onHandlerResolve;
+    } else if (handler == Bun__HTMLRewriter__onHandlerReject) {
+        return GlobalObject::PromiseFunctions::Bun__HTMLRewriter__onHandlerReject;
     } else if (handler == Bun__onResolveEntryPointResult) {
         return GlobalObject::PromiseFunctions::Bun__onResolveEntryPointResult;
     } else if (handler == Bun__onRejectEntryPointResult) {
@@ -4105,6 +4115,10 @@ GlobalObject::PromiseFunctions GlobalObject::promiseHandlerID(Zig::FFIFunction h
         return GlobalObject::PromiseFunctions::Bun__S3UploadStream__onResolveStream;
     } else if (handler == Bun__S3UploadStream__onRejectStream) {
         return GlobalObject::PromiseFunctions::Bun__S3UploadStream__onRejectStream;
+    } else if (handler == Bun__HTMLRewriter__onResolveInputStream) {
+        return GlobalObject::PromiseFunctions::Bun__HTMLRewriter__onResolveInputStream;
+    } else if (handler == Bun__HTMLRewriter__onRejectInputStream) {
+        return GlobalObject::PromiseFunctions::Bun__HTMLRewriter__onRejectInputStream;
     } else {
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -257,6 +257,10 @@ public:
     JSC::JSValue FetchRequestBodySinkPrototype() const { return m_JSFetchRequestBodySinkClassStructure.prototypeInitializedOnMainThread(this); }
     JSC::JSValue JSReadableNetworkSinkControllerPrototype() const { return m_JSFetchTaskletChunkedRequestControllerPrototype.getInitializedOnMainThread(this); }
 
+    JSC::Structure* HTMLRewriterSinkStructure() const { return m_JSHTMLRewriterSinkClassStructure.getInitializedOnMainThread(this); }
+    JSC::JSObject* HTMLRewriterSink() { return m_JSHTMLRewriterSinkClassStructure.constructorInitializedOnMainThread(this); }
+    JSC::JSValue HTMLRewriterSinkPrototype() const { return m_JSHTMLRewriterSinkClassStructure.prototypeInitializedOnMainThread(this); }
+
     JSC::Structure* JSBufferListStructure() const { return m_JSBufferListClassStructure.getInitializedOnMainThread(this); }
     JSC::JSObject* JSBufferList() { return m_JSBufferListClassStructure.constructorInitializedOnMainThread(this); }
     JSC::JSValue JSBufferListPrototype() const { return m_JSBufferListClassStructure.prototypeInitializedOnMainThread(this); }
@@ -398,8 +402,8 @@ public:
         jsFunctionOnLoadObjectResultReject,
         Bun__TestScope__Describe2__bunTestThen,
         Bun__TestScope__Describe2__bunTestCatch,
-        Bun__BodyValueBufferer__onRejectStream,
-        Bun__BodyValueBufferer__onResolveStream,
+        Bun__HTMLRewriter__onHandlerResolve,
+        Bun__HTMLRewriter__onHandlerReject,
         Bun__onResolveEntryPointResult,
         Bun__onRejectEntryPointResult,
         Bun__NodeHTTPRequest__onResolve,
@@ -422,8 +426,10 @@ public:
         Bun__FetchTasklet__onRejectRequestStream,
         Bun__S3UploadStream__onResolveStream,
         Bun__S3UploadStream__onRejectStream,
+        Bun__HTMLRewriter__onResolveInputStream,
+        Bun__HTMLRewriter__onRejectInputStream,
     };
-    static constexpr size_t promiseFunctionsSize = 46;
+    static constexpr size_t promiseFunctionsSize = 48;
 
     static PromiseFunctions promiseHandlerID(SYSV_ABI EncodedJSValue (*handler)(JSC::JSGlobalObject* arg0, JSC::CallFrame* arg1));
 
@@ -568,6 +574,7 @@ public:
     V(private, LazyClassStructure, m_JSNetworkSinkClassStructure)                                            \
     V(private, LazyClassStructure, m_JSH3ResponseSinkClassStructure)                                         \
     V(private, LazyClassStructure, m_JSFetchRequestBodySinkClassStructure)                                   \
+    V(private, LazyClassStructure, m_JSHTMLRewriterSinkClassStructure)                                       \
                                                                                                              \
     V(private, LazyClassStructure, m_JSStringDecoderClassStructure)                                          \
     V(private, LazyPropertyOfGlobalObject<JSObject>, m_JSFFICStringConstructor)                              \

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -589,6 +589,23 @@ ZIG_DECL void FetchRequestBodySink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(FetchRequestBodySink__write);
 #endif
 
+CPP_DECL JSC::EncodedJSValue HTMLRewriterSink__assignToStream(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, void* arg2, void** arg3);
+CPP_DECL JSC::EncodedJSValue HTMLRewriterSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
+CPP_DECL void* HTMLRewriterSink__fromJS(JSC::EncodedJSValue JSValue1);
+
+#ifdef __cplusplus
+
+ZIG_DECL JSC::EncodedJSValue HTMLRewriterSink__close(JSC::JSGlobalObject* arg0, void* arg1);
+BUN_DECLARE_HOST_FUNCTION(HTMLRewriterSink__construct);
+BUN_DECLARE_HOST_FUNCTION(HTMLRewriterSink__end);
+ZIG_DECL JSC::EncodedJSValue SYSV_ABI HTMLRewriterSink__endWithSink(void* arg0, JSC::JSGlobalObject* arg1);
+ZIG_DECL void HTMLRewriterSink__finalize(void* arg0);
+BUN_DECLARE_HOST_FUNCTION(HTMLRewriterSink__flush);
+BUN_DECLARE_HOST_FUNCTION(HTMLRewriterSink__start);
+ZIG_DECL void HTMLRewriterSink__updateRef(void* arg0, bool arg1);
+BUN_DECLARE_HOST_FUNCTION(HTMLRewriterSink__write);
+#endif
+
 #ifdef __cplusplus
 
 ZIG_DECL void Bun__WebSocketHTTPClient__cancel(WebSocketHTTPClient* arg0);
@@ -763,13 +780,13 @@ BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugTLS__onResolveStream);
 
 #endif
 
-#pragma mark - Bun__BodyValueBufferer
+#pragma mark - Bun__HTMLRewriter
 
 
 #ifdef __cplusplus
 
-BUN_DECLARE_HOST_FUNCTION(Bun__BodyValueBufferer__onRejectStream);
-BUN_DECLARE_HOST_FUNCTION(Bun__BodyValueBufferer__onResolveStream);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTMLRewriter__onHandlerResolve);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTMLRewriter__onHandlerReject);
 
 #endif
 
@@ -808,6 +825,9 @@ BUN_DECLARE_HOST_FUNCTION(Bun__FetchTasklet__onRejectRequestStream);
 
 BUN_DECLARE_HOST_FUNCTION(Bun__S3UploadStream__onResolveStream);
 BUN_DECLARE_HOST_FUNCTION(Bun__S3UploadStream__onRejectStream);
+
+BUN_DECLARE_HOST_FUNCTION(Bun__HTMLRewriter__onResolveInputStream);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTMLRewriter__onRejectInputStream);
 
 
 #endif

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -286,6 +286,7 @@ static void startJSSinkController(JSC::VM& vm, JSGlobalObject* globalObject, JSO
     BUN_START_JSSINK_CONTROLLER(JSReadableH3ResponseSinkController)
     BUN_START_JSSINK_CONTROLLER(JSReadableNetworkSinkController)
     BUN_START_JSSINK_CONTROLLER(JSReadableFetchRequestBodySinkController)
+    BUN_START_JSSINK_CONTROLLER(JSReadableHTMLRewriterSinkController)
 #undef BUN_START_JSSINK_CONTROLLER
     throwTypeError(globalObject, scope, "Unknown direct controller. This is a bug in Bun."_s);
 }

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -148,6 +148,22 @@ unsafe extern "C" {
     safe fn JSC__JSGlobalObject__drainMicrotasks(global: &JSGlobalObject) -> u8;
 }
 
+impl JSGlobalObject {
+    /// Run one microtask checkpoint: `process.nextTick` callbacks, then the
+    /// JSC microtask queue, and nothing else. No timers, no I/O, no deferred
+    /// tasks, so this cannot re-enter the event loop.
+    ///
+    /// `Err` means JS was terminated; a termination exception is left pending.
+    pub fn drain_microtasks_and_next_ticks(&self) -> Result<(), JsTerminated> {
+        jsc::mark_binding();
+        match JSC__JSGlobalObject__drainMicrotasks(self) {
+            drain_result::SUCCESS => Ok(()),
+            drain_result::JS_TERMINATED => Err(JsTerminated::JSTerminated),
+            _ => unreachable!(),
+        }
+    }
+}
+
 #[derive(thiserror::Error, strum::IntoStaticStr, Debug)]
 pub enum JsTerminated {
     #[error("JSTerminated")]

--- a/src/jsc/host_fn.rs
+++ b/src/jsc/host_fn.rs
@@ -70,6 +70,63 @@ macro_rules! jsc_host_abi {
     };
 }
 
+/// Re-exported for [`jsc_promise_handler!`] expansions so callers need no
+/// direct `bun_opaque` dep. Not public API.
+#[doc(hidden)]
+pub use bun_opaque::opaque_deref as __opaque_deref;
+
+/// Define a `JsHostFn`-shaped promise-reaction shim that forwards to a safe
+/// `fn(&JSGlobalObject, &CallFrame) -> JsResult<JSValue>` body.
+///
+/// Expands to a [`jsc_host_abi!`] `extern fn` whose signature matches
+/// [`JsHostFn`] (so the fn item coerces to the `JSValue::then`/`then2`
+/// callback slot and to `Zig::GlobalObject::promiseHandlerID`'s address
+/// comparison). The `*mut → &` derefs and `JsResult → JSValue` mapping are
+/// centralised here so the caller spells zero `unsafe`.
+///
+/// Two forms:
+///
+/// ```ignore
+/// // `#[unsafe(export_name = "Link__Symbol")]` on a locally-named shim:
+/// bun_jsc::jsc_promise_handler!(
+///     pub(crate) fn on_resolve_shim = "Link__Symbol" => on_resolve
+/// );
+///
+/// // `#[unsafe(no_mangle)]` — the shim ident IS the link symbol:
+/// bun_jsc::jsc_promise_handler!(
+///     pub fn Link__Symbol => on_resolve
+/// );
+/// ```
+#[macro_export]
+macro_rules! jsc_promise_handler {
+    ($vis:vis fn $shim:ident = $link:literal => $body:path) => {
+        $crate::jsc_host_abi! {
+            #[unsafe(export_name = $link)]
+            $vis unsafe fn $shim(
+                g: *mut $crate::JSGlobalObject,
+                cf: *mut $crate::CallFrame,
+            ) -> $crate::JSValue {
+                let g = $crate::host_fn::__opaque_deref(g);
+                let cf = $crate::host_fn::__opaque_deref(cf);
+                $crate::host_fn::to_js_host_fn_result(g, $body(g, cf))
+            }
+        }
+    };
+    ($vis:vis fn $shim:ident => $body:path) => {
+        $crate::jsc_host_abi! {
+            #[unsafe(no_mangle)]
+            $vis unsafe fn $shim(
+                g: *mut $crate::JSGlobalObject,
+                cf: *mut $crate::CallFrame,
+            ) -> $crate::JSValue {
+                let g = $crate::host_fn::__opaque_deref(g);
+                let cf = $crate::host_fn::__opaque_deref(cf);
+                $crate::host_fn::to_js_host_fn_result(g, $body(g, cf))
+            }
+        }
+    };
+}
+
 // Capitalized re-exports — enough call sites (and the crate-root re-export in
 // lib.rs) use the acronym-caps `JSHostFn*` spelling that both must resolve.
 pub use {JsHostFn as JSHostFn, JsHostFnZig as JSHostFnZig};

--- a/src/jsc_macros/lib.rs
+++ b/src/jsc_macros/lib.rs
@@ -698,6 +698,20 @@ fn js_class_hooks(args: &JsClassArgs, rust_ty: &Ident) -> TokenStream2 {
                     __create(global.as_mut_ptr(), ptr)
                 }
 
+                /// Safe sibling of [`to_js_ptr`] for `NonNull<Self>` handles.
+                /// The underlying `__create` extern is `safe fn`; `to_js_ptr`
+                /// is only marked `unsafe` to document the ownership-transfer
+                /// contract, which intrusive-refcounted callers uphold by
+                /// construction (the GC wrapper's `+1` is released in
+                /// `${T}Class__finalize`).
+                #[inline]
+                pub fn to_js_nonnull(
+                    ptr: ::core::ptr::NonNull<Self>,
+                    global: &::bun_jsc::JSGlobalObject,
+                ) -> ::bun_jsc::JSValue {
+                    __create(global.as_mut_ptr(), ptr.as_ptr())
+                }
+
                 /// Wrap an owned `Box<Self>` in a JS object. Typed sibling of
                 /// [`to_js_ptr`] — the boxed payload is leaked here and
                 /// reclaimed by `${T}Class__finalize`.

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -40,7 +40,7 @@ pub use tagged_pointer::TaggedPtr;
 pub mod ref_count;
 pub use ref_count::{
     AnyRefCounted, CellRefCounted, RefCount, RefCounted, RefPtr, ScopedRef, ThreadSafeRefCount,
-    ThreadSafeRefCounted, finalize_js_box, finalize_js_box_noop,
+    ThreadSafeRefCounted, destroy_box_with, finalize_js_box, finalize_js_box_noop,
 };
 // Derive macros — same names as the traits (separate namespace). The derives
 // expand to `::bun_ptr::…` paths, so this crate is the canonical re-export
@@ -218,6 +218,13 @@ impl<T: ?Sized> From<core::ptr::NonNull<T>> for BackRef<T, Shared> {
     #[inline]
     fn from(p: core::ptr::NonNull<T>) -> Self {
         BackRef(p, core::marker::PhantomData)
+    }
+}
+
+impl<T: ?Sized, P> From<BackRef<T, P>> for core::ptr::NonNull<T> {
+    #[inline]
+    fn from(b: BackRef<T, P>) -> Self {
+        b.0
     }
 }
 
@@ -632,6 +639,107 @@ unsafe impl<T: ?Sized + Sync, P> Send for BackRef<T, P> {}
 // holds exactly when `T: Sync`, so sharing the back-reference across threads is
 // sound.
 unsafe impl<T: ?Sized + Sync, P> Sync for BackRef<T, P> {}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DetachablePtr<T> — scoped `&mut T` parked behind `&self` for re-entrant reads.
+//
+// Pattern: a Rust/C library hands a handler closure `&mut X` for the duration
+// of one synchronous call; the handler needs to expose `X` to re-entrant code
+// (JS host-fns) that can only reach it through `&self` on a long-lived wrapper.
+// The handler erases the lifetime and parks the pointer with [`set`]; host-fns
+// read it via [`get_mut`]; a scopeguard calls [`detach`] before the closure
+// returns the borrow to the library. A detached slot reads as `None`, so a
+// wrapper retained past its handler scope never reaches a dangling pointer.
+//
+// This is the `&mut`-yielding sibling of [`BackRef`]. Like `BackRef`, the
+// safety obligation is a TYPE invariant discharged at the *set* site (not a
+// per-`get` `unsafe` block): whoever parks a pointer must arrange the paired
+// `detach()` before the original `&mut T` borrow ends, and every `get_mut()`
+// caller consumes the result within its own synchronous frame without holding
+// it across a call that could reach the same slot. Under that protocol the
+// single `unsafe` in [`get_mut`] is sound; keeping it here (rather than at
+// each host-fn call site) is the same centralisation trade-off `BackRef::get`
+// / `LaunderedSelf::r` already make in this crate.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A nullable slot for a lifetime-erased `&mut T` borrowed from an outer scope.
+/// See the module comment above for the full protocol.
+///
+/// # Type invariant
+/// Whenever the slot is non-null, the pointee is a live, exclusively-borrowed
+/// `T` whose originating `&mut T` scope has not yet ended (the setter has
+/// arranged a [`detach`](Self::detach) that runs before it does). Each
+/// [`get_mut`](Self::get_mut) borrow is the sole live `&mut T` for its use —
+/// callers take it once per host-fn body and never hold it across a re-entry
+/// that could reach the same slot.
+#[repr(transparent)]
+pub struct DetachablePtr<T>(core::cell::Cell<*mut T>);
+
+impl<T> DetachablePtr<T> {
+    /// A detached (null) slot.
+    #[inline]
+    pub const fn null() -> Self {
+        DetachablePtr(core::cell::Cell::new(core::ptr::null_mut()))
+    }
+
+    /// Construct with an initial parked pointer. Establishes the type
+    /// invariant: `ptr` (if non-null) must satisfy the contract on [`set`].
+    #[inline]
+    pub const fn new(ptr: *mut T) -> Self {
+        DetachablePtr(core::cell::Cell::new(ptr))
+    }
+
+    /// Park / retarget the slot. Safe: no reference is forged here. The type
+    /// invariant is the caller's structural guarantee — `ptr` is the
+    /// lifetime-erased address of a live `&mut T`, and a paired [`detach`]
+    /// will run before that borrow ends.
+    #[inline]
+    pub fn set(&self, ptr: *mut T) {
+        self.0.set(ptr);
+    }
+
+    /// Null the slot. After this, [`get_mut`] returns `None` and the wrapper's
+    /// host-fns become harmless no-ops.
+    #[inline]
+    pub fn detach(&self) {
+        self.0.set(core::ptr::null_mut());
+    }
+
+    /// `true` once [`detach`] has run (or the slot was never set).
+    #[inline]
+    pub fn is_detached(&self) -> bool {
+        self.0.get().is_null()
+    }
+
+    /// Recover the raw pointer (for forwarding / identity checks).
+    #[inline]
+    pub fn as_ptr(&self) -> *mut T {
+        self.0.get()
+    }
+
+    /// Load the parked `&mut T`, or `None` if detached.
+    ///
+    /// # Safety (encapsulated)
+    /// Sound under the `DetachablePtr` type invariant: a non-null load means
+    /// the pointee is still inside the setter's live exclusive borrow — valid,
+    /// aligned, and lent to nobody else. The unbounded `'a` is the caller's
+    /// obligation per the invariant: consume within the current synchronous
+    /// frame, never across a re-entry that could reach this slot.
+    #[inline]
+    pub fn get_mut<'a>(&self) -> Option<&'a mut T> {
+        // SAFETY: `DetachablePtr` type invariant — non-null ⇒ pointee is a
+        // live `&mut T` whose originating borrow has not ended; the paired
+        // `detach()` nulls the slot before it does. Sole live `&mut` per call.
+        unsafe { self.0.get().as_mut() }
+    }
+}
+
+impl<T> Default for DetachablePtr<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::null()
+    }
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // AsCtxPtr — `&self` → `*mut Self` for FFI / C-callback ctx slots.

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -616,6 +616,52 @@ pub unsafe trait CellRefCounted: Sized {
             unsafe { Self::destroy(this) };
         }
     }
+
+    /// Safe [`ref_`](Self::ref_) for a `NonNull<Self>` handle.
+    ///
+    /// The `unsafe trait` contract guarantees `this` points to a live
+    /// intrusively-refcounted `Self`; [`BackRef`](crate::BackRef) turns that
+    /// into a shared borrow without the caller spelling `unsafe`.
+    #[inline]
+    fn ref_nn(this: NonNull<Self>) {
+        crate::BackRef::from(this).ref_();
+    }
+
+    /// Safe [`deref`](Self::deref) for a `NonNull<Self>` handle.
+    ///
+    /// The single audited `unsafe` lives here in `bun_ptr`, beside the trait
+    /// contract that makes it sound, so callers holding a `NonNull` never
+    /// re-derive the raw-pointer provenance themselves.
+    #[inline]
+    fn deref_nn(this: NonNull<Self>) {
+        // SAFETY: `CellRefCounted` impl contract — `this` is a live,
+        // heap-allocated `Self` whose allocation `destroy` knows how to free;
+        // `NonNull` guarantees non-null. The caller owns one ref.
+        unsafe { Self::deref(this.as_ptr()) };
+    }
+}
+
+/// Run `before(&*this)` then reclaim `this` as a `Box<T>` and drop it.
+///
+/// Intended as the body of a `#[ref_count(destroy = …)]` target, where the
+/// wrapper needs to detach/invalidate itself before field `Drop` impls run.
+/// The raw-pointer deref is audited here once so per-type `destroy` bodies in
+/// callers stay `unsafe`-free.
+///
+/// Callers must only pass a pointer that originated from
+/// `Box::into_raw` / `heap::into_raw` and is the sole remaining owner — the
+/// same precondition as [`CellRefCounted::destroy`], which is the only
+/// sanctioned call site.
+#[inline]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub fn destroy_box_with<T>(this: *mut T, before: impl FnOnce(&T)) {
+    debug_assert!(!this.is_null());
+    // SAFETY: `CellRefCounted::destroy` contract — `this` is the sole live
+    // owner of a `Box`-allocated `T`; `before` only observes it shared.
+    unsafe {
+        before(&*this);
+        drop(Box::from_raw(this));
+    }
 }
 
 /// No-op [`DebugDataOps`] for [`CellRefCounted`] types — they carry no

--- a/src/runtime/api/NativePromiseContext.rs
+++ b/src/runtime/api/NativePromiseContext.rs
@@ -28,7 +28,6 @@ use bun_jsc::{JSGlobalObject, JSValue};
 
 use crate::api::html_rewriter;
 use crate::api::server;
-use crate::webcore::body;
 
 // Request contexts are a single generic
 // `NewRequestContext<ThisServer, SSL, DEBUG, HTTP3>`; alias the six
@@ -55,9 +54,9 @@ pub enum Tag {
     HTTPSServerRequestContext,
     DebugHTTPServerRequestContext,
     DebugHTTPSServerRequestContext,
-    BodyValueBufferer,
     HTTPSServerH3RequestContext,
     DebugHTTPSServerH3RequestContext,
+    HTMLRewriterSuspension,
 }
 
 impl Tag {
@@ -70,9 +69,9 @@ impl Tag {
             1 => Tag::HTTPSServerRequestContext,
             2 => Tag::DebugHTTPServerRequestContext,
             3 => Tag::DebugHTTPSServerRequestContext,
-            4 => Tag::BodyValueBufferer,
-            5 => Tag::HTTPSServerH3RequestContext,
-            6 => Tag::DebugHTTPSServerH3RequestContext,
+            4 => Tag::HTTPSServerH3RequestContext,
+            5 => Tag::DebugHTTPSServerH3RequestContext,
+            6 => Tag::HTMLRewriterSuspension,
             _ => unreachable!(),
         }
     }
@@ -105,8 +104,8 @@ impl<ThisServer, const SSL: bool, const DBG: bool, const H3: bool> NativePromise
 {
     const TAG: Tag = npc_tag_for(SSL, DBG, H3);
 }
-impl NativePromiseContextType for body::ValueBufferer<'_> {
-    const TAG: Tag = Tag::BodyValueBufferer;
+impl NativePromiseContextType for html_rewriter::RewriterPipe {
+    const TAG: Tag = Tag::HTMLRewriterSuspension;
 }
 
 // `&JSGlobalObject` is ABI-identical to a non-null pointer. `ctx` is stored
@@ -118,14 +117,22 @@ unsafe extern "C" {
         global: &JSGlobalObject,
         ctx: *mut c_void,
         tag: u8,
+        held: JSValue,
     ) -> JSValue;
     safe fn Bun__NativePromiseContext__take(value: JSValue) -> *mut c_void;
 }
 
-/// The caller must have already taken a ref on `ctx`. The returned cell owns
-/// that ref until `take()` transfers it back or GC runs the destructor.
-pub(crate) fn create<T: NativePromiseContextType>(global: &JSGlobalObject, ctx: *mut T) -> JSValue {
-    Bun__NativePromiseContext__create(global, ctx.cast::<c_void>(), T::TAG as u8)
+/// The cell owns the caller's claim on `ctx` until `take()` transfers it back
+/// or GC runs the destructor (which defers to [`DeferredDerefTask`]). `held`
+/// is visited by the cell, so whatever GC object keeps `ctx` alive can ride
+/// along for as long as the promise can settle; pass `JSValue::ZERO` when
+/// nothing needs rooting.
+pub(crate) fn create<T: NativePromiseContextType>(
+    global: &JSGlobalObject,
+    ctx: *mut T,
+    held: JSValue,
+) -> JSValue {
+    Bun__NativePromiseContext__create(global, ctx.cast::<c_void>(), T::TAG as u8, held)
 }
 
 /// Transfers the ref back to the caller and nulls the cell so the destructor
@@ -218,21 +225,19 @@ impl DeferredDerefTask {
                 Tag::DebugHTTPSServerRequestContext => {
                     (*ctx.cast::<DebugHTTPSServerRequestContext>()).deref()
                 }
-                Tag::BodyValueBufferer => {
-                    // ValueBufferer is embedded by value inside HTMLRewriter's
-                    // BufferOutputSink, with the owner pointer stored in .ctx.
-                    // The pending-promise ref was taken on the owner, so we
-                    // release it there.
-                    let bufferer = &*ctx.cast::<body::ValueBufferer<'_>>();
-                    html_rewriter::BufferOutputSink::deref(
-                        bufferer.ctx.cast::<html_rewriter::BufferOutputSink>(),
-                    );
-                }
                 Tag::HTTPSServerH3RequestContext => {
                     (*ctx.cast::<HTTPSServerH3RequestContext>()).deref()
                 }
                 Tag::DebugHTTPSServerH3RequestContext => {
                     (*ctx.cast::<DebugHTTPSServerH3RequestContext>()).deref()
+                }
+                Tag::HTMLRewriterSuspension => {
+                    let back = bun_ptr::BackRef::from(NonNull::new_unchecked(
+                        ctx.cast::<html_rewriter::RewriterPipe>(),
+                    ));
+                    if html_rewriter::RewriterPipe::abandon_suspension(back) {
+                        drop(Box::from_raw(ctx.cast::<html_rewriter::RewriterPipe>()));
+                    }
                 }
             }
         }
@@ -251,4 +256,4 @@ const _: () =
 const _: () =
     assert!(core::mem::align_of::<DebugHTTPSServerRequestContext>() > DeferredDerefTask::TAG_MASK);
 const _: () =
-    assert!(core::mem::align_of::<body::ValueBufferer<'_>>() > DeferredDerefTask::TAG_MASK);
+    assert!(core::mem::align_of::<html_rewriter::RewriterPipe>() > DeferredDerefTask::TAG_MASK);

--- a/src/runtime/api/html_rewriter.classes.ts
+++ b/src/runtime/api/html_rewriter.classes.ts
@@ -289,4 +289,19 @@ export default [
       },
     },
   }),
+  // Not user-visible. One per `transform()` call; the output Response roots it
+  // via its `values: [..., "transform"]` slot, and it is the `.then()` context
+  // for a suspended handler's promise. Its finalizer owns the native
+  // `RewriterPipe` box and the boxed lol-html rewriter.
+  define({
+    name: "HTMLRewriterTransform",
+    construct: false,
+    noConstructor: true,
+    finalize: true,
+    klass: {},
+    proto: {},
+    // WriteBarrier slots: everything the pipe must keep reachable and that
+    // would otherwise need a StrongOptional root.
+    values: ["response", "inputStream", "outputStream", "pendingPromise", "handlerError", "suspensionPromise"],
+  }),
 ];

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1,23 +1,32 @@
 //! HTMLRewriter API — wraps lol-html for JS.
 
 use core::cell::{Cell, RefCell};
+use core::ffi::c_void;
 use core::ptr::NonNull;
 use std::rc::Rc;
 
-use bun_core::MutableString;
 use bun_jsc::{
-    self as jsc, CallFrame, GlobalRef, JSGlobalObject, JSValue, JsCell, JsResult, ProtectedJSValue,
-    StrongOptional, SystemError, bun_string_jsc,
+    self as jsc, CallFrame, GlobalRef, JSGlobalObject, JSPromise, JSValue, JsCell, JsResult,
+    ProtectedJSValue, SystemError, bun_string_jsc,
 };
 // Note: `bun_jsc::VirtualMachine` is a *module* re-export
 // (`pub use self::virtual_machine as VirtualMachine;`). The struct lives at
 // `bun_jsc::virtual_machine::VirtualMachine` — import that directly so the
-// name resolves as a type at `&mut VirtualMachine` annotations and as the
-// owner of the `on_quiet_unhandled_rejection_handler_capture_value` assoc fn.
+// name resolves as a type.
 use bun_jsc::virtual_machine::VirtualMachine;
 
-use crate::webcore::response::HeadersRef;
-use crate::webcore::{self, Response};
+use bun_collections::ByteVecExt;
+use bun_ptr::{BackRef, CellRefCounted, DetachablePtr, RawSlice};
+use bun_sys::Error as SysError;
+
+use crate::api::native_promise_context;
+use crate::generated_classes::{js_HTMLRewriterTransform, js_Response};
+use crate::webcore::blob::SizeType as BlobSizeType;
+use crate::webcore::sink::JSSink;
+use crate::webcore::streams::{
+    self, SourceHandle, Start, StartTag, StreamError, StreamResult, Writable, WritablePending,
+};
+use crate::webcore::{self, ByteStream, DrainResult, ReadableStream, Response, SinkHandle};
 use bun_core::String as BunString;
 // `ZigString` re-exports `bun_core::ZigString`; JSC-side methods
 // (`to_js`, `with_encoding`, …) come from the `ZigStringJsc` extension trait.
@@ -26,8 +35,14 @@ use bun_jsc::call_frame::ArgumentsSlice;
 use bun_jsc::zig_string::ZigString;
 
 // lol-html rewritable units, lifetime-erased to `'static` so a `*mut RawX`
-// can be parked in a JsClass `Cell` for the duration of the synchronous
-// handler call (the Cell is nulled again before the handler returns).
+// can be parked in a JsClass `DetachablePtr` for the duration of the
+// synchronous handler call (the slot is nulled again before the handler
+// returns). The `DetachablePtr` type invariant is discharged by
+// `handler_callback`: it parks the `&mut X` lol-html lends the closure
+// (`build_settings`, `EndTag::on_end_tag`), runs the JS callback, and its
+// scopeguard `detach()`s the slot before the closure returns to lol-html — so
+// a non-null load means the pointee is still inside lol-html's exclusive
+// borrow, and a JS object retained past its handler reads `None`.
 type RawElement = lol_html::html_content::Element<'static, 'static>;
 type RawTextChunk = lol_html::html_content::TextChunk<'static>;
 type RawComment = lol_html::html_content::Comment<'static>;
@@ -36,26 +51,6 @@ type RawDocumentEnd = lol_html::html_content::DocumentEnd<'static>;
 type RawEndTag = lol_html::html_content::EndTag<'static>;
 
 // ───────────────────── local helpers ─────────────────────────────────────
-
-/// Load the lol-html unit out of a wrapper's `Cell<*mut RawX>` field for the
-/// body of one host-fn. This is the ONE sanctioned lifetime-erasure `unsafe`
-/// in this module. Returns `None` once the wrapper has been detached (the
-/// Cell nulled), so a JS object retained past its handler can never reach a
-/// dangling pointer.
-fn cell_get<'a, T>(cell: &Cell<*mut T>) -> Option<&'a mut T> {
-    // SAFETY: every non-null pointer in these Cells was erased with
-    // `ptr::from_mut(x).cast()` from the `&mut X` lol-html lends a handler
-    // closure for the duration of that synchronous call (`build_settings`,
-    // `EndTag::on_end_tag`). `handler_callback` parks it in the wrapper only
-    // while it runs the JS callback, and its scopeguard (`clear_field` /
-    // `invalidate`) nulls the Cell before that closure returns to lol-html —
-    // so a non-null load means the pointee is still inside lol-html's
-    // exclusive `&mut` borrow: live, aligned, and lent to nobody else. The
-    // unbounded `'a` is the caller's obligation: consume the returned `&mut`
-    // within the current host-fn body and never hold it across a re-entry
-    // into JS, which could reach this fn again on the same wrapper.
-    unsafe { cell.get().as_mut() }
-}
 
 /// Construct a `SystemError` with code+message and remaining fields defaulted.
 fn system_error(code: &'static str, message: &'static str) -> SystemError {
@@ -140,7 +135,7 @@ fn content_type(opts: Option<ContentOptions>) -> lol_html::html_content::Content
 /// - `$Raw`      — the `Raw*` type alias of the backing lol-html unit, e.g.
 ///                 `RawElement` (also paths the raw op as `$Raw::$name`,
 ///                 which holds for all 16 ops).
-/// - `$field`    — the `Cell<*mut $Raw>` field on `self`.
+/// - `$field`    — the `DetachablePtr<$Raw>` field on `self`.
 /// - `$null_ret` — sentinel when the raw ptr is null. **Differs per wrapper**:
 ///                 `JSValue::UNDEFINED` for TextChunk/Element,
 ///                 `JSValue::NULL` for DocEnd/Comment/EndTag.
@@ -160,7 +155,7 @@ macro_rules! lol_content_ops {
             content: ZigString,
             content_options: Option<ContentOptions>,
         ) -> JsResult<JSValue> {
-            let Some(raw) = cell_get(&self.$field) else {
+            let Some(raw) = self.$field.get_mut() else {
                 return Ok($null_ret);
             };
             let content_slice = content.to_slice();
@@ -222,14 +217,28 @@ pub struct LOLHTMLContext {
     pub(crate) document_handlers: Vec<Box<DocumentHandler>>,
 }
 
-/// `true` = the STOP directive from an `ElementHandler`/`DocumentHandler`/
-/// `EndTagHandler` callback. The message is load-bearing: lol-html's C API
-/// produced exactly this string for a stopped rewriter; it reaches JS as-is.
-fn directive_result(stop: bool) -> lol_html::HandlerResult {
-    if stop {
-        Err("The rewriter has been stopped.".into())
-    } else {
-        Ok(())
+/// What a JS content handler decided.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum HandlerOutcome {
+    /// The handler completed; keep rewriting.
+    Continue,
+    /// The handler threw / rejected / returned an Error: abort the rewrite.
+    Stop,
+    /// The handler returned a promise that is still pending after one
+    /// microtask drain: make lol-html park the current rewritable unit and
+    /// return from `write()`/`end()`/`resume()` so the event loop can run.
+    /// See [`RewriterPipe::begin_suspension`].
+    Suspend,
+}
+
+/// Map the outcome onto lol-html's `HandlerResult`. The `Stop` message is
+/// load-bearing: lol-html's C API produced exactly this string for a stopped
+/// rewriter; it reaches JS as-is.
+fn handler_result(outcome: HandlerOutcome) -> lol_html::HandlerResult {
+    match outcome {
+        HandlerOutcome::Continue => Ok(()),
+        HandlerOutcome::Stop => Err("The rewriter has been stopped.".into()),
+        HandlerOutcome::Suspend => Err(Box::new(lol_html::SuspensionRequest)),
     }
 }
 
@@ -261,21 +270,21 @@ fn build_settings(
             handlers = handlers.element(move |el: &mut lol_html::html_content::Element| {
                 let raw: *mut lol_html::html_content::Element<'static, 'static> =
                     core::ptr::from_mut(el).cast();
-                directive_result(ElementHandler::on_element(h.as_ptr(), raw))
+                handler_result(ElementHandler::on_element(h, raw))
             });
         }
         if has_comment {
             handlers = handlers.comments(move |c: &mut lol_html::html_content::Comment| {
                 let raw: *mut lol_html::html_content::Comment<'static> =
                     core::ptr::from_mut(c).cast();
-                directive_result(ElementHandler::on_comment(h.as_ptr(), raw))
+                handler_result(ElementHandler::on_comment(h, raw))
             });
         }
         if has_text {
             handlers = handlers.text(move |t: &mut lol_html::html_content::TextChunk| {
                 let raw: *mut lol_html::html_content::TextChunk<'static> =
                     core::ptr::from_mut(t).cast();
-                directive_result(ElementHandler::on_text(h.as_ptr(), raw))
+                handler_result(ElementHandler::on_text(h, raw))
             });
         }
         element_content_handlers.push((std::borrow::Cow::Owned(selector.clone()), handlers));
@@ -296,28 +305,28 @@ fn build_settings(
             handlers = handlers.doctype(move |d: &mut lol_html::html_content::Doctype| {
                 let raw: *mut lol_html::html_content::Doctype<'static> =
                     core::ptr::from_mut(d).cast();
-                directive_result(DocumentHandler::on_doc_type(h.as_ptr(), raw))
+                handler_result(DocumentHandler::on_doc_type(h, raw))
             });
         }
         if has_comment {
             handlers = handlers.comments(move |c: &mut lol_html::html_content::Comment| {
                 let raw: *mut lol_html::html_content::Comment<'static> =
                     core::ptr::from_mut(c).cast();
-                directive_result(DocumentHandler::on_comment(h.as_ptr(), raw))
+                handler_result(DocumentHandler::on_comment(h, raw))
             });
         }
         if has_text {
             handlers = handlers.text(move |t: &mut lol_html::html_content::TextChunk| {
                 let raw: *mut lol_html::html_content::TextChunk<'static> =
                     core::ptr::from_mut(t).cast();
-                directive_result(DocumentHandler::on_text(h.as_ptr(), raw))
+                handler_result(DocumentHandler::on_text(h, raw))
             });
         }
         if has_end {
             handlers = handlers.end(move |e: &mut lol_html::html_content::DocumentEnd| {
                 let raw: *mut lol_html::html_content::DocumentEnd<'static> =
                     core::ptr::from_mut(e).cast();
-                directive_result(DocumentHandler::on_end(h.as_ptr(), raw))
+                handler_result(DocumentHandler::on_end(h, raw))
             });
         }
         document_content_handlers.push(handlers);
@@ -389,15 +398,17 @@ impl HTMLRewriter {
     #[expect(clippy::boxed_local)]
     pub fn finalize(self: Box<Self>) {}
 
+    /// `sync_only_noun` is `Some("a string" | "an ArrayBuffer")` when the
+    /// caller needs the rewrite to finish before `transform()` returns; a
+    /// handler that would suspend then fails the rewrite instead.
     pub(crate) fn begin_transform(
         &self,
         global: &JSGlobalObject,
-        response: &mut Response,
+        response: &Response,
+        sync_only_noun: Option<&'static str>,
     ) -> JsResult<JSValue> {
         let new_context = Rc::clone(&self.context);
-        // SAFETY: `response` is a live `Response` whose JS wrapper is on
-        // the caller's stack (see `transform_`).
-        unsafe { BufferOutputSink::init(new_context, global, response) }
+        RewriterPipe::init(new_context, global, response, sync_only_noun)
     }
 
     pub(crate) fn transform_(
@@ -405,22 +416,26 @@ impl HTMLRewriter {
         global: &JSGlobalObject,
         response_value: JSValue,
     ) -> JsResult<JSValue> {
-        // Note: `Response` doesn't yet impl `JsClass`, so use the
-        // codegen `from_js` directly instead of `JSValue::as_::<Response>()`.
-        if let Some(response) =
-            webcore::response::js::from_js(response_value).map(|p| p.cast::<Response>())
+        // `js_Response::from_js` returns the `m_ctx` as `NonNull<Response>`;
+        // wrap it in a `BackRef` for a safe `&Response` — `response_value` is
+        // on the stack (conservatively scanned), so the native payload outlives
+        // this host-fn body.
+        if let Some(response) = js_Response::from_js(response_value).map(BackRef::<Response>::from)
         {
-            // SAFETY: response is the m_ctx of a live JS Response (response_value
-            // is on the stack, conservatively scanned).
-            let body_value = unsafe { (*response).get_body_value() };
+            // An already-failed body surfaces its stored upstream error (abort
+            // reason, connection error) instead of a generic "body already used"
+            // — the error is the useful bit, and `wire_input` would otherwise
+            // treat `Value::Error` as an empty blob and emit an empty document.
+            let body_value = response.get_body_value();
+            if let webcore::body::Value::Error(err) = body_value {
+                return Err(global.throw_value(err.to_js(global)));
+            }
             if matches!(*body_value, webcore::body::Value::Used) {
                 return Err(
                     global.throw_invalid_arguments(format_args!("Response body already used"))
                 );
             }
-            // SAFETY: `response` is the live m_ctx of `response_value` (kept
-            // alive on the caller's stack), never null.
-            let out = self.begin_transform(global, unsafe { &mut *response })?;
+            let out = self.begin_transform(global, &response, None)?;
             // Check if the returned value is an error and throw it properly
             if let Some(err) = out.to_error() {
                 return Err(global.throw_value(err));
@@ -436,7 +451,7 @@ impl HTMLRewriter {
         }
         let kind = if response_value.is_string() {
             ResponseKind::String
-        } else if response_value.js_type().is_typed_array_or_array_buffer() {
+        } else if response_value.js_type().is_array_buffer_like() {
             ResponseKind::ArrayBuffer
         } else {
             ResponseKind::Other
@@ -444,58 +459,53 @@ impl HTMLRewriter {
 
         if kind != ResponseKind::Other {
             let body_value = webcore::body::extract(global, response_value)?;
-            let resp = bun_core::heap::into_raw(Box::new(Response::init(
-                webcore::response::Init {
-                    status_code: 200,
-                    ..Default::default()
-                },
-                body_value,
-                BunString::empty(),
-                false,
-            )));
-            let _resp_guard = scopeguard::guard(resp, |r| {
-                // SAFETY: `r` is the `heap::into_raw` allocation from just
-                // above; finalize takes ownership and frees it exactly once.
-                Response::finalize(unsafe { Box::from_raw(r) })
-            });
+            // The guard owns the `Box<Response>` for the whole scope and hands
+            // it to `Response::finalize` on drop (unwind or return) — no raw
+            // pointer round-trip.
+            let resp = scopeguard::guard(
+                Box::new(Response::init(
+                    webcore::response::Init {
+                        status_code: 200,
+                        ..Default::default()
+                    },
+                    body_value,
+                    BunString::empty(),
+                    false,
+                )),
+                Response::finalize,
+            );
 
-            // SAFETY: `resp` is a live `heap::into_raw` allocation, never null.
-            let out_response_value = self.begin_transform(global, unsafe { &mut *resp })?;
+            // Carries its own article: "an ArrayBuffer", not "a ArrayBuffer".
+            let noun = if kind == ResponseKind::String {
+                "a string"
+            } else {
+                "an ArrayBuffer"
+            };
+            let out_response_value = self.begin_transform(global, &resp, Some(noun))?;
             // Check if the returned value is an error and throw it properly
             if let Some(err) = out_response_value.to_error() {
                 return Err(global.throw_value(err));
             }
             out_response_value.ensure_still_alive();
             let Some(out_response) =
-                webcore::response::js::from_js(out_response_value).map(|p| p.cast::<Response>())
+                js_Response::from_js(out_response_value).map(BackRef::<Response>::from)
             else {
                 return Ok(out_response_value);
             };
-            // SAFETY: out_response is the m_ctx of out_response_value (kept alive
-            // on the stack via ensure_still_alive above).
-            let mut blob = unsafe {
-                (*out_response)
-                    .get_body_value()
-                    .use_as_any_blob_allow_non_utf8_string()
-            };
 
-            let _out_guard = scopeguard::guard((out_response_value, out_response), |(v, r)| {
-                // `Response.js.dangerouslySetPtr(v, null)` — null out the JS
-                // wrapper's `m_ctx` so its GC finalize is a no-op, then finalize
-                // the native side ourselves.
-                // SAFETY: `v` is the live JS wrapper (kept on stack via
-                // ensure_still_alive); `r` is its `m_ctx` pointer, detached here
-                // and finalized exactly once.
-                unsafe {
-                    let _ = bun_jsc::generated::JSResponse::dangerously_set_ptr(
-                        v,
-                        core::ptr::null_mut(),
-                    );
-                    // Manually invoke the finalizer to ensure it does what we want.
-                    // SAFETY: `r` is the detached `m_ctx` pointer, sole owner here.
-                    Response::finalize(Box::from_raw(r));
-                }
-            });
+            // The body is never still `Locked` here: `sync_only_noun` makes a
+            // handler that would suspend fail the rewrite instead, and `init`
+            // rethrows that as the synchronous TypeError above.
+            let mut blob = out_response
+                .get_body_value()
+                .use_as_any_blob_allow_non_utf8_string();
+
+            // Null out the JS wrapper's `m_ctx` so its GC finalize is a no-op,
+            // then release the wrapper's +1 ourselves. The pipe still holds its
+            // own +1 (from `Response::ref_` in `init()`); `Drop for RewriterPipe`
+            // reclaims the allocation when the Transform cell is collected.
+            js_Response::detach_ptr(out_response_value);
+            Response::unref(out_response.as_const_ptr().cast_mut());
 
             return match kind {
                 ResponseKind::String => blob.to_string(global, webcore::Lifetime::Transfer),
@@ -540,134 +550,389 @@ impl HTMLRewriter {
     }
 }
 
-// ───────────────────────── BufferOutputSink ──────────────────────────────
+// ─────────────────────────── RewriterPipe ────────────────────────────────
 
-#[derive(bun_ptr::CellRefCounted)]
-pub struct BufferOutputSink {
-    // Intrusive RefCount; *Self is the `SinkRef` carried inside `rewriter`.
-    ref_count: Cell<u32>,
-    pub global: GlobalRef, // JSC_BORROW
-    pub(crate) bytes: MutableString,
-    // Heap-allocated (never held by value): `run_output_sink` must reach the
-    // rewriter through a raw pointer, never a `&mut` of `*sink`, because the
-    // output sink re-enters `&mut *sink` while the rewriter runs.
-    pub(crate) rewriter: *mut lol_html::HtmlRewriter<'static, SinkRef>, // null when unset
-    pub(crate) context: Rc<RefCell<LOLHTMLContext>>,
-    pub(crate) response: *mut Response, // BORROW_FIELD: kept alive by response_value Strong
-    pub(crate) response_value: StrongOptional,
-    pub(crate) body_value_bufferer: Option<webcore::body::ValueBufferer<'static>>,
-    // Points at the `sink_error` stack local in `init()`;
-    // only written while `init()` is on the stack.
-    // See `write_tmp_sync_error` for the full liveness/provenance argument.
-    pub(crate) tmp_sync_error: Option<NonNull<JSValue>>,
+/// The concrete lol-html rewriter type backing one `transform()`.
+pub(crate) type LolRewriter = lol_html::HtmlRewriter<'static, PipeOutput>;
+
+/// Which lol-html call the pipe still has to run (or finish). Advanced by
+/// [`RewriterPipe::feed`] / [`RewriterPipe::end_rewrite`] /
+/// [`RewriterPipe::resume_rewrite`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RewritePhase {
+    /// `write(input)` has not completed (not started, or a handler suspended it).
+    WritePending,
+    /// `write` completed; `end()` has not (not started, or suspended).
+    EndPending,
+    /// The rewrite ran to completion or failed; nothing left to drive.
+    Done,
 }
 
-impl BufferOutputSink {
-    // `ref_()`/`deref()` provided by `#[derive(CellRefCounted)]`.
+/// The JS wrapper a suspended handler is still using. Typed so the retarget/
+/// release dispatch is a match, not a `c_void` + fn-ptr pair.
+#[derive(Clone, Copy)]
+pub enum SuspendedWrapper {
+    Element(NonNull<Element>),
+    Comment(NonNull<Comment>),
+    TextChunk(NonNull<TextChunk>),
+    EndTag(NonNull<EndTag>),
+    DocType(NonNull<DocType>),
+    DocEnd(NonNull<DocEnd>),
+}
 
-    /// Single unsafe deref site for the set-once
-    /// `tmp_sync_error: Option<NonNull<JSValue>>` field, so the two callers in
-    /// `on_finished_buffering` stay safe. `tmp_sync_error` points at the
-    /// `sink_error: Cell<JSValue>` stack local in [`init`]; it is only written
-    /// through on the synchronous (`is_async == false`) path while `init` is
-    /// still on the stack, so the pointee is live and the `Cell`-derived
-    /// pointer carries `SharedReadWrite` provenance.
-    #[inline]
-    fn write_tmp_sync_error(sink: *mut Self, err: JSValue) {
-        // SAFETY: `sink` is a live heap allocation (refcount > 0, caller
-        // invariant); `tmp_sync_error` was set in `init()` and the synchronous
-        // caller is reached only while `init()` is still on the stack.
-        unsafe { *(*sink).tmp_sync_error.unwrap().as_ptr() = err };
+impl SuspendedWrapper {
+    /// Point the wrapper at the heap copy lol-html parked on suspend.
+    fn retarget(&self, rewriter: &mut LolRewriter) {
+        match *self {
+            Self::Element(p) => BackRef::from(p).retarget(Element::suspended_raw(rewriter)),
+            Self::Comment(p) => BackRef::from(p).retarget(Comment::suspended_raw(rewriter)),
+            Self::TextChunk(p) => BackRef::from(p).retarget(TextChunk::suspended_raw(rewriter)),
+            Self::EndTag(p) => BackRef::from(p).retarget(EndTag::suspended_raw(rewriter)),
+            Self::DocType(p) => BackRef::from(p).retarget(DocType::suspended_raw(rewriter)),
+            Self::DocEnd(p) => BackRef::from(p).retarget(DocEnd::suspended_raw(rewriter)),
+        }
+    }
+    /// Detach the wrapper and drop the ref `handler_callback` took.
+    fn release(self) {
+        match self {
+            Self::Element(p) => {
+                BackRef::from(p).detach();
+                <Element as CellRefCounted>::deref_nn(p);
+            }
+            Self::Comment(p) => {
+                BackRef::from(p).detach();
+                <Comment as CellRefCounted>::deref_nn(p);
+            }
+            Self::TextChunk(p) => {
+                BackRef::from(p).detach();
+                <TextChunk as CellRefCounted>::deref_nn(p);
+            }
+            Self::EndTag(p) => {
+                BackRef::from(p).detach();
+                <EndTag as CellRefCounted>::deref_nn(p);
+            }
+            Self::DocType(p) => {
+                BackRef::from(p).detach();
+                <DocType as CellRefCounted>::deref_nn(p);
+            }
+            Self::DocEnd(p) => {
+                BackRef::from(p).detach();
+                <DocEnd as CellRefCounted>::deref_nn(p);
+            }
+        }
+    }
+}
+
+/// Recorded by [`handler_callback`] when a handler returned a still-pending
+/// promise, consumed by [`RewriterPipe::begin_suspension`] immediately after
+/// the lol-html call returns `Err(Suspended)`. The promise itself is rooted in
+/// the cell's `suspensionPromise` WriteBarrier slot, not here.
+struct PendingSuspension {
+    wrapper: SuspendedWrapper,
+}
+
+impl PendingSuspension {
+    /// Hand the wrapper to a caller that adopts its ref, disarming [`Drop`].
+    fn take_wrapper(self) -> SuspendedWrapper {
+        core::mem::ManuallyDrop::new(self).wrapper
+    }
+}
+
+impl Drop for PendingSuspension {
+    fn drop(&mut self) {
+        self.wrapper.release();
+    }
+}
+
+/// Installs `pipe` as the VM's active HTMLRewriter sink for the duration of
+/// one lol-html `write()`/`end()`/`resume()` call, restoring the previous one
+/// on drop. LIFO so a handler body that synchronously runs a nested
+/// `transform()` nests correctly.
+struct ActiveSinkGuard {
+    prev: Option<NonNull<c_void>>,
+}
+
+impl ActiveSinkGuard {
+    fn enter(pipe: &RewriterPipe) -> Self {
+        let vm: &mut VirtualMachine = pipe.global.bun_vm().as_mut();
+        Self {
+            prev: core::mem::replace(
+                &mut vm.html_rewriter_active_sink,
+                NonNull::new(core::ptr::from_ref(pipe).cast_mut().cast()),
+            ),
+        }
+    }
+}
+
+impl Drop for ActiveSinkGuard {
+    fn drop(&mut self) {
+        // SAFETY: the JS thread's VM outlives this synchronous frame.
+        VirtualMachine::get().as_mut().html_rewriter_active_sink = self.prev;
+    }
+}
+
+/// The `RewriterPipe` whose lol-html call is on this VM's native stack, if
+/// any. Content handlers can only run inside such a call.
+fn active_sink(global: &JSGlobalObject) -> Option<BackRef<RewriterPipe>> {
+    global
+        .bun_vm_ref()
+        .html_rewriter_active_sink
+        .map(|p| BackRef::from(p.cast::<RewriterPipe>()))
+}
+
+/// Codegen alias: the generated `JSHTMLRewriterTransform` cell's `m_ctx` is a
+/// `*mut RewriterPipe`. The cell is created per `transform()` call, stashed in
+/// the output Response's `m_transform` slot, and used as the `.then()` context
+/// for a suspended handler's promise. Its six `values:` WriteBarrier slots
+/// root the output Response, input/output ReadableStreams, the JS-pump
+/// `WritablePending` promise, a captured handler error, and the suspension
+/// promise.
+pub type HTMLRewriterTransform = RewriterPipe;
+
+/// Streaming pipe for one `HTMLRewriter::transform()`: receives input bytes
+/// via [`SinkHandle::HTMLRewriter`], feeds them through lol-html (suspending
+/// when a content handler returns a pending Promise), and emits output either
+/// into a pre-stream buffer or — once JS reads `.body` — a [`ByteStream`]
+/// whose `producer` is [`SourceHandle::HTMLRewriter`].
+pub struct RewriterPipe {
+    pub(crate) global: GlobalRef,
+    /// The owning `JSHTMLRewriterTransform` wrapper cell (whose `m_ctx` is this
+    /// pipe). Its WriteBarrier slots root the response, input/output streams,
+    /// pending promise, and handler error.
+    cell: Cell<JSValue>,
+    /// Boxed (never held by value): lol-html's `write/end/resume` re-enter
+    /// `PipeOutput::handle_chunk` which reads fields off `*self`. `JsCell`
+    /// because those calls (and `suspended_*`) need `&mut LolRewriter` from
+    /// `&self`.
+    rewriter: JsCell<Option<Box<LolRewriter>>>,
+    context: Rc<RefCell<LOLHTMLContext>>,
+
+    // ── input side ───────────────────────────────────────────────────────
+    /// Upstream to resume (`ready()`) once output drains, or `close()` once
+    /// the output reader cancels.
+    input_source: Cell<SourceHandle>,
+    /// Input EOF arrived while a suspension or output backpressure kept us
+    /// from calling `end_rewrite()`; run it once unblocked.
+    input_ended: Cell<bool>,
+    /// `true` while a JS-pump `.then()` reaction (attached in
+    /// [`Self::wire_input`]) is still owed. The generated `${controller}__close`
+    /// drops its error argument, so `end_from_stream` defers terminal work to
+    /// the reaction (which carries the real error) while this is set.
+    js_pump_reaction_pending: Cell<bool>,
+    /// Bytes accepted from the input while suspended or output-backpressured.
+    pending_input: JsCell<Vec<u8>>,
+    high_water_mark: Cell<BlobSizeType>,
+
+    // ── output side ──────────────────────────────────────────────────────
+    /// Set by [`Self::on_readable_stream_available`]; `None` until JS reads
+    /// `.body` on the output Response. Kept alive by the cell's `outputStream`
+    /// slot.
+    output: Cell<Option<bun_ptr::BackRef<ByteStream>>>,
+    /// lol-html output buffered before the output ByteStream exists.
+    output_buffer: JsCell<Vec<u8>>,
+    /// Output Response. The pipe holds a native `+1` (released in `Drop`) so
+    /// the body stays reachable on the abandon-suspension path after the
+    /// Response JS wrapper has been swept alongside the Transform cell.
+    response: Cell<Option<bun_ptr::BackRef<Response>>>,
+
+    // ── suspension (from #33243) ─────────────────────────────────────────
+    phase: Cell<RewritePhase>,
+    /// Set for `transform(string)` / `transform(ArrayBuffer)`. Holds the noun
+    /// for the error message, article included. A handler that would suspend
+    /// fails the whole rewrite instead.
+    sync_only_noun: Cell<Option<&'static str>>,
+    /// Handed from the suspending [`handler_callback`] to
+    /// [`Self::begin_suspension`] across the lol-html unwind.
+    pending_suspension: Cell<Option<PendingSuspension>>,
+    suspended_wrapper: Cell<Option<SuspendedWrapper>>,
+    /// `true` while a lol-html `write`/`end_mut`/`resume` call on this pipe's
+    /// `rewriter` is on the stack. The output sink may re-enter the pipe via
+    /// `on_ready`/`write`/`end_from_stream` during that call; those entry
+    /// points defer instead of re-driving the (still-running) rewriter.
+    driving: Cell<bool>,
+
+    // ── JS-pump path ─────────────────────────────────────────────────────
+    /// Shared pending drain promise for the JS-pump `write()`/`flush(true)`.
+    pending: JsCell<WritablePending>,
+    done: Cell<bool>,
+}
+
+impl RewriterPipe {
+    /// `JSHTMLRewriterTransform` finalizer: the cell was collected, so
+    /// nothing that could dispatch into the pipe is left alive — a wired
+    /// native input source roots the cell through its `sinkOwner` slot, the
+    /// pipe's own output source through its `owner` slot, the output
+    /// ByteStream through the Response's `transform` slot, and a pending
+    /// handler promise through its reaction — so there is nothing to detach
+    /// and nothing here may touch other GC cells (sweep order across cells in
+    /// the same cycle is unspecified).
+    ///
+    /// If the pipe is still suspended, the handler promise was collected
+    /// without settling, and that promise's `NativePromiseContext` destructor
+    /// has already queued [`Self::abandon_suspension`] (promise dead implies
+    /// context cell dead: the promise's reaction was its only root). Hand the
+    /// Box to that task instead of dropping, signalled by the zeroed `cell`.
+    pub fn finalize(this: Box<Self>) {
+        this.cell.set(JSValue::ZERO);
+        if this.is_suspended() && !VirtualMachine::get().is_shutting_down() {
+            let _ = Box::into_raw(this);
+            return;
+        }
+        drop(this);
     }
 
-    /// # Safety
-    /// `original` must point to a live `Response` whose JS wrapper is kept
-    /// alive for the duration of this call.
-    unsafe fn init(
+    /// Queued by the `NativePromiseContext` destructor (via
+    /// `DeferredDerefTask`) when the handler's promise was collected without
+    /// settling: it will never resume this pipe. Runs on the JS thread,
+    /// outside GC sweep.
+    ///
+    /// Two states are possible. If the Transform cell is still alive (its
+    /// `cell` backref is set) — a reader or the output Response keeps the
+    /// rewrite reachable — fail the body normally, which errors the live
+    /// output stream and clears the `owner`/`sinkOwner` edges so the cell becomes
+    /// ordinary garbage. If the cell was swept with the promise (`cell` is
+    /// zeroed), `finalize` relinquished the Box to this task: every source
+    /// that could have held a backref died with the cell, so clear the
+    /// handles raw, fail the body through the Response native `+1`, and free.
+    ///
+    /// `pipe` is live either way: the context cell's held Transform rooted it
+    /// until the destructor ran, and `finalize` defers the free to this task.
+    /// Returns `true` when the cell was already swept (`finalize` handed the
+    /// Box to this task) and the caller must `Box::from_raw`-drop it.
+    pub(crate) fn abandon_suspension(pipe: bun_ptr::BackRef<Self>) -> bool {
+        let this = &*pipe;
+        let cell_alive = this.cell.get().is_cell();
+        this.release_suspended_wrapper();
+        if !cell_alive {
+            this.input_source.set(SourceHandle::None);
+            this.output.set(None);
+        }
+        this.fail(webcore::body::ValueError::Message(BunString::static_(
+            "HTMLRewriter content handler returned a Promise that will never settle",
+        )));
+        !cell_alive
+    }
+
+    /// Record a handler's exception for the enclosing lol-html call to pick
+    /// up once it returns. Rooted by the cell's `handlerError` WriteBarrier
+    /// slot until it is taken.
+    pub(crate) fn set_handler_error(&self, err: JSValue) {
+        js_HTMLRewriterTransform::handler_error_set_cached(self.cell.get(), &self.global, err);
+    }
+
+    /// Take (and clear) the handler error recorded during the lol-html call
+    /// that just returned.
+    fn take_handler_error(&self) -> Option<JSValue> {
+        let cell = self.cell.get();
+        let err = js_HTMLRewriterTransform::handler_error_get_cached(cell);
+        match err {
+            Some(v) if !v.is_empty_or_undefined_or_null() => {
+                js_HTMLRewriterTransform::handler_error_set_cached(
+                    cell,
+                    &self.global,
+                    JSValue::UNDEFINED,
+                );
+                Some(v)
+            }
+            _ => None,
+        }
+    }
+
+    /// Sever the wired input source: null the upstream's raw `sink` backref
+    /// so it can no longer dispatch into this pipe, and clear its `sinkOwner`
+    /// slot so I/O no longer roots the Transform cell through it. With
+    /// `cancel_upstream`, also close a native producer afterwards, so a
+    /// failed or cancelled rewrite stops a fetch mid-download and closes a
+    /// file fd instead of draining to upstream EOF; EOF paths pass `false`.
+    /// Only called from terminal paths on the JS thread, where the source is
+    /// still alive (it is rooted by the cell's `inputStream` slot until the
+    /// handle is dropped here). Idempotent: the handle is `None` after the
+    /// first call.
+    fn detach_input_source(&self, cancel_upstream: bool) {
+        let mut src = self.input_source.replace(SourceHandle::None);
+        match &src {
+            SourceHandle::ByteStream(bs) => bs.parent_const().set_sink_owner(JSValue::UNDEFINED),
+            SourceHandle::FileReader(fr) => fr.parent_const().set_sink_owner(JSValue::UNDEFINED),
+            _ => {}
+        }
+        let mut upstream = src;
+        JSSink::<RewriterPipe>::detach(&mut src, &self.global);
+        if cancel_upstream {
+            match upstream {
+                SourceHandle::ByteStream(_) | SourceHandle::FileReader(_) => {
+                    upstream.close(None);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Sever the output `ByteStream`'s `SourceHandle::HTMLRewriter` backref
+    /// (installed via `PendingValue.producer` in [`Self::init`]) so a later
+    /// `signal_drained()` can't reach a freed pipe, and clear its `owner`
+    /// slot. Only called from terminal paths on the JS thread. Idempotent.
+    fn detach_output(&self) {
+        if let Some(out) = self.output.take() {
+            out.parent_const().set_owner(JSValue::UNDEFINED);
+            out.parent_const().producer.set(SourceHandle::None);
+        }
+    }
+
+    #[inline]
+    fn is_suspended(&self) -> bool {
+        self.suspended_wrapper.get().is_some() || self.pending_suspension.take_peek().is_some()
+    }
+
+    #[inline]
+    fn output_backpressured(&self) -> bool {
+        if let Some(out) = self.output.get() {
+            return out.sink_paused.get()
+                || out.buffer.get().len() as BlobSizeType > self.high_water_mark.get();
+        }
+        // No output ByteStream yet: the pre-stream buffer has no drain signal
+        // (only `on_start_streaming`/`finish` consume it), so backpressuring
+        // the input here would deadlock the body-mixin (`.text()` etc.) path.
+        false
+    }
+
+    fn init(
         context: Rc<RefCell<LOLHTMLContext>>,
         global: &JSGlobalObject,
-        original: *mut Response,
+        original: &Response,
+        sync_only_noun: Option<&'static str>,
     ) -> JsResult<JSValue> {
-        let sink = bun_core::heap::into_raw(Box::new(BufferOutputSink {
-            ref_count: Cell::new(1),
+        let pipe = bun_core::heap::alloc_nn(RewriterPipe {
             global: GlobalRef::from(global),
-            bytes: MutableString::init_empty(),
-            rewriter: core::ptr::null_mut(),
+            cell: Cell::new(JSValue::ZERO),
+            rewriter: JsCell::new(None),
             context,
-            response: core::ptr::null_mut(),
-            response_value: StrongOptional::empty(),
-            body_value_bufferer: None,
-            tmp_sync_error: None,
-        }));
-        // SAFETY: `sink` is the `heap::into_raw` allocation above; refcount >= 1.
-        let _sink_guard = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
-        // Note: do not hold a long-lived `&mut *sink` here — the same
-        // allocation is also written through the raw pointer by the lol-html
-        // output-sink callback during `bufferer.run()` and by `deref(sink)`
-        // below. Access fields via raw-pointer place expressions instead.
+            input_source: Cell::new(SourceHandle::None),
+            input_ended: Cell::new(false),
+            js_pump_reaction_pending: Cell::new(false),
+            pending_input: JsCell::new(Vec::new()),
+            high_water_mark: Cell::new(16384),
+            output: Cell::new(None),
+            output_buffer: JsCell::new(Vec::new()),
+            response: Cell::new(None),
+            phase: Cell::new(RewritePhase::WritePending),
+            sync_only_noun: Cell::new(sync_only_noun),
+            pending_suspension: Cell::new(None),
+            suspended_wrapper: Cell::new(None),
+            driving: Cell::new(false),
+            pending: JsCell::new(WritablePending::default()),
+            done: Cell::new(false),
+        });
+        // Every field is `Cell`/`JsCell`, so a shared `&RewriterPipe` via
+        // `BackRef` is sound across the re-entrant lol-html calls below.
+        let this = BackRef::from(pipe);
 
-        let result = bun_core::heap::into_raw(Box::new(Response::init(
-            webcore::response::Init {
-                status_code: 200,
-                ..Default::default()
-            },
-            webcore::Body::new({
-                let mut pv = webcore::body::PendingValue::new(global);
-                pv.task = Some(sink.cast::<core::ffi::c_void>());
-                webcore::body::Value::Locked(pv)
-            }),
-            BunString::empty(),
-            false,
-        )));
+        let input_size = original.get_body_len();
 
-        // SAFETY: sink was just allocated via heap::alloc above; refcount==1.
-        unsafe { (*sink).response = result };
-        // Note (Stacked Borrows): `sink_error` is written via raw pointer
-        // by the unhandled-rejection handler during `bufferer.run()` and via
-        // `tmp_sync_error` from `on_finished_buffering`. Use a `Cell` so the
-        // exported `*mut` (via `Cell::as_ptr`, i.e. `UnsafeCell::get`) carries
-        // SharedReadWrite provenance — local `.get()` reads do NOT invalidate
-        // the stored raw pointer the way a `&`/`&mut` reborrow of a plain
-        // `mut` local would.
-        let sink_error: core::cell::Cell<JSValue> = core::cell::Cell::new(JSValue::ZERO);
-        let sink_error_ptr: *mut JSValue = sink_error.as_ptr();
-        // SAFETY: original is a live *Response passed from begin_transform; its
-        // JS wrapper is on the caller's stack.
-        let input_size = unsafe { (*original).get_body_len() };
-        // SAFETY: bun_vm() returns the live VM raw ptr; VM outlives this fn.
-        let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-
-        // Since we're still using vm.waitForPromise, we have to also override
-        // the error rejection handler. That way, we can propagate errors to the
-        // caller.
-        let scope = vm.unhandled_rejection_scope();
-        let prev_unhandled_pending_rejection_to_capture = vm.unhandled_pending_rejection_to_capture;
-        vm.unhandled_pending_rejection_to_capture = Some(sink_error_ptr);
-        // SAFETY: sink is a live heap allocation (refcount >= 1); sink_error_ptr
-        // is non-null (addr of stack local).
-        unsafe { (*sink).tmp_sync_error = Some(NonNull::new_unchecked(sink_error_ptr)) };
-        vm.on_unhandled_rejection =
-            VirtualMachine::on_quiet_unhandled_rejection_handler_capture_value;
-        // Read the *live* slot at scope exit (Cell shares provenance with the
-        // raw-pointer writers).
-        scopeguard::defer! {
-            sink_error.get().ensure_still_alive();
-            // SAFETY: VM outlives this guard (sync stack frame).
-            let vm = VirtualMachine::get().as_mut();
-            vm.unhandled_pending_rejection_to_capture = prev_unhandled_pending_rejection_to_capture;
-            scope.apply(vm);
-        }
-
-        // The handler closures point into `Box`es owned by `(*sink).context`,
-        // which `sink` keeps alive for the rewriter's whole lifetime.
-        // SAFETY: sink is a live heap allocation (refcount >= 1); the `RefMut`
-        // of `(*sink).context` is released at the end of this statement.
+        // The handler closures point into `Box`es owned by `(*pipe).context`,
+        // which `pipe` keeps alive for the rewriter's whole lifetime.
         let (element_content_handlers, document_content_handlers) =
-            unsafe { build_settings(&mut (*sink).context.borrow_mut()) };
-        // `SinkRef` carries the raw `sink` (`heap::into_raw` root) so every
-        // `(*sink).field` access shares its provenance; `run_output_sink`
-        // reaches the rewriter through a raw pointer, never `&mut *sink`.
-        let rewriter = bun_core::heap::into_raw(Box::new(lol_html::HtmlRewriter::new(
+            build_settings(&mut this.context.borrow_mut());
+        this.rewriter.set(Some(Box::new(lol_html::HtmlRewriter::new(
             lol_html::Settings {
                 element_content_handlers,
                 document_content_handlers,
@@ -686,98 +951,80 @@ impl BufferOutputSink {
                 enable_esi_tags: false,
                 adjust_charset_on_meta_tag: false,
             },
-            SinkRef(sink),
-        )));
-        // SAFETY: sink is a live heap allocation (refcount >= 1).
-        unsafe { (*sink).rewriter = rewriter };
+            PipeOutput(this),
+        ))));
 
-        // SAFETY: result and original are both live *Response (result allocated
-        // above, original kept alive by caller); no aliasing &mut exists.
-        unsafe {
-            (*result).set_init(
-                (*original).get_method(),
-                (*original).get_init_status_code(),
-                (*original).get_init_status_text().clone(),
-            );
+        // ── output Response: body starts Locked(PendingValue{...}) ──────────
+        // A consumer reading `.body` creates the ByteStream lazily; until then
+        // `PipeOutput` buffers into `output_buffer`, and `on_start_streaming`
+        // hands that over as `DrainResult::Owned`.
+        let result = bun_core::heap::alloc_nn(Response::init(
+            webcore::response::Init {
+                status_code: 200,
+                ..Default::default()
+            },
+            webcore::Body::new({
+                let mut pv = webcore::body::PendingValue::new(global);
+                pv.task = Some(pipe.cast::<c_void>());
+                pv.on_start_streaming = Some(RewriterPipe::on_start_streaming);
+                pv.on_readable_stream_available = Some(RewriterPipe::on_readable_stream_available);
+                pv.producer = SourceHandle::HTMLRewriter(this);
+                webcore::body::Value::Locked(pv)
+            }),
+            BunString::empty(),
+            false,
+        ));
+        let result_ref = BackRef::from(result);
+        this.response.set(Some(result_ref));
+        // Pipe owns a `+1` on the Response native so `fail()` can still reach
+        // the body after the Response JS wrapper has been swept (the
+        // abandon-suspension path runs from a deferred task after the
+        // Transform cell and Response wrapper were collected together).
+        Response::ref_(result.as_ptr());
 
-            // https://github.com/oven-sh/bun/issues/3334
-            // Note: `clone_this` takes `&mut self`, so use the `_mut`
-            // accessor (original is `*mut Response`). `clone_this` only reads
-            // `self` (FFI mutates a freshly-allocated clone, not the receiver).
-            if let Some(headers) = (*original).get_init_headers_mut() {
-                let cloned = headers.clone_this(global)?;
-                (*result).set_init_headers(cloned.map(|p| HeadersRef::adopt(p)));
-            }
+        result_ref.set_init(
+            original.get_method(),
+            original.get_init_status_code(),
+            original.get_init_status_text().clone(),
+        );
+
+        // https://github.com/oven-sh/bun/issues/3334
+        result_ref.set_init_headers(original.clone_init_headers(global)?);
+
+        let response_js_value = result_ref.to_js(&this.global);
+
+        // Hand ownership of `pipe` to its `JSHTMLRewriterTransform` wrapper cell.
+        // The cell's WriteBarrier slots root the Response and (later) the
+        // input/output streams; the Response's `transform` slot roots the cell
+        // so it survives as long as user code can reach the output.
+        let cell = js_HTMLRewriterTransform::to_js(pipe.as_ptr(), global);
+        if !cell.is_cell() {
+            // Ownership was not transferred (allocation of the wrapper failed);
+            // reclaim and drop the Box allocation.
+            bun_ptr::destroy_box_with(pipe.as_ptr(), |_| {});
+            return Err(global.throw_out_of_memory());
         }
+        this.cell.set(cell);
+        js_HTMLRewriterTransform::response_set_cached(cell, global, response_js_value);
+        js_Response::transform_set_cached(response_js_value, global, cell);
 
-        // Hold off on cloning until we're actually done.
-        // SAFETY: (*sink).response == result (set above), live heap allocation.
-        let response_js_value = unsafe { (*(*sink).response).to_js(&(*sink).global) };
-        // SAFETY: sink is a live heap allocation (refcount >= 1).
-        unsafe { (*sink).response_value.set(global, response_js_value) };
+        result_ref.set_url(original.url().clone());
 
-        // SAFETY: result/original are live *Response (see SAFETY note above).
-        // `url()` is +0 borrowed-bits; `set_url` takes +1 — `.clone()` to bump.
-        unsafe { (*result).set_url((*original).url().clone()) };
+        // ── wire input ──────────────────────────────────────────────────────
+        let value = original.get_body_value();
+        let owned_readable_stream = original.get_body_readable_stream(&this.global);
 
-        // SAFETY: original is a live *Response kept alive by caller.
-        let value = unsafe { (*original).get_body_value() };
-        // SAFETY: original is a live *Response kept alive by caller; sink live.
-        let owned_readable_stream =
-            unsafe { (*original).get_body_readable_stream(&(*sink).global) };
-        // SAFETY: sink is a live heap allocation (refcount >= 1).
-        unsafe {
-            (*sink).ref_();
-            (*sink).body_value_bufferer = Some(webcore::body::ValueBufferer::init(
-                sink.cast::<core::ffi::c_void>(),
-                // Note: `ValueBuffererCallback` takes `*mut c_void` for ctx;
-                // `on_finished_buffering` takes `*mut BufferOutputSink`. The
-                // wrapper trampoline restores the concrete type.
-                Self::on_finished_buffering_trampoline,
-                &(*sink).global,
-            ));
-        }
-        response_js_value.ensure_still_alive();
+        Self::wire_input(this, global, value, owned_readable_stream);
 
-        // SAFETY: sink is a live heap allocation; body_value_bufferer was just
-        // set to Some above. `run()` may synchronously invoke
-        // `on_finished_buffering`, which (via the rewriter's output sink)
-        // re-enters `SinkRef::handle_chunk` and forms a fresh
-        // `&mut *sink`. Hoist the bufferer through a raw pointer so no `&mut`
-        // derived from `*sink` is live across that callback.
-        let buffering_result: crate::Result<()> = unsafe {
-            let bufferer: *mut webcore::body::ValueBufferer =
-                (*sink).body_value_bufferer.as_mut().unwrap();
-            (*bufferer).run(value, owned_readable_stream)
-        };
-        if let Err(buffering_error) = buffering_result {
-            // SAFETY: `sink` is a live `heap::into_raw` allocation; release the
-            // ref taken for the in-flight bufferer.
-            unsafe { BufferOutputSink::deref(sink) };
-            return Ok(match buffering_error {
-                crate::Error::StreamAlreadyUsed => {
-                    let err = system_error(
-                        "ERR_STREAM_ALREADY_FINISHED",
-                        "Stream already used, please create a new one",
-                    );
-                    err.to_error_instance(global)
-                }
-                _ => {
-                    let err = system_error("ERR_STREAM_CANNOT_PIPE", "Failed to pipe stream");
-                    err.to_error_instance(global)
-                }
-            });
-        }
-
-        // sync error occurs — read via the Cell (shares SharedReadWrite
-        // provenance with the raw-pointer writers; see Note above).
-        let captured = sink_error.get();
-        if !captured.is_empty() {
+        // A handler that failed synchronously (the input was materialized, so
+        // the whole rewrite ran inline above) surfaces as a synchronous throw
+        // from `transform()`. Mark the pipe terminal so nothing tries to
+        // drive it again; the cell and its slots are ordinary garbage now.
+        if let Some(captured) = this.take_handler_error() {
             captured.ensure_still_alive();
-            captured.unprotect();
-            // Throw directly: the callers gate on `JSValue::to_error()`, which
-            // only recognises `ErrorInstance`/`Exception`, so an abort reason
-            // (a DOMException or any user value) would be returned instead.
+            this.phase.set(RewritePhase::Done);
+            this.done.set(true);
+            this.detach_output();
             return Err(global.throw_value(captured));
         }
 
@@ -785,198 +1032,724 @@ impl BufferOutputSink {
         Ok(response_js_value)
     }
 
-    fn on_finished_buffering_trampoline(
-        ctx: *mut core::ffi::c_void,
-        bytes: &[u8],
-        js_err: Option<webcore::body::ValueError>,
-        is_async: bool,
+    fn wire_input(
+        pipe: bun_ptr::BackRef<Self>,
+        global: &JSGlobalObject,
+        value: &mut webcore::body::Value,
+        stream: Option<ReadableStream>,
     ) {
-        // SAFETY: `ctx` is the `sink` heap allocation registered with the
-        // bufferer in `init()`; it was `ref_()`'d there so refcount > 0.
-        unsafe {
-            Self::on_finished_buffering(ctx.cast::<BufferOutputSink>(), bytes, js_err, is_async)
-        }
-    }
+        // `pipe` is the `heap::alloc_nn` allocation from `init()`; every field
+        // is `Cell`/`JsCell`, so the shared `BackRef` borrow is sound across
+        // the re-entrant lol-html calls below.
+        let this = pipe;
 
-    /// # Safety
-    /// `sink` must be a live `BufferOutputSink` heap allocation with
-    /// refcount > 0 (the +1 taken in `init()` is consumed here).
-    unsafe fn on_finished_buffering(
-        sink: *mut BufferOutputSink,
-        bytes: &[u8],
-        js_err: Option<webcore::body::ValueError>,
-        is_async: bool,
-    ) {
-        // SAFETY: `sink` was ref'd in `init()` before scheduling this callback;
-        // refcount > 0 so the allocation is live. `adopt` consumes that +1 on Drop.
-        let _g = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
-        // Note: do not materialise `&mut *sink` here — the rewriter
-        // write/end calls below re-enter `SinkRef::handle_chunk`
-        // through the stored raw pointer, which forms
-        // its own `&mut *sink`. Holding an outer `&mut` across that re-entry
-        // is aliased-&mut UB. Access fields via raw-pointer place expressions
-        // instead (mirroring `init()`).
-        //
-        // SAFETY: sink was ref'd in init() before scheduling this callback;
-        // refcount > 0 so the allocation is live.
-        let global = unsafe { (*sink).global };
-
-        if let Some(mut err) = js_err {
-            // SAFETY: (*sink).response is the heap Response allocated in init()
-            // and kept alive by (*sink).response_value (Strong root).
-            let sink_body_value = unsafe { (*(*sink).response).get_body_value() };
-            let sink_ptr_usize = sink as usize;
-            // If a `.body` readable is already attached, stay `Locked` so
-            // `to_error_instance` delivers the error to its ByteStream; clearing
-            // to `Empty` here would strand any pending `reader.read()` forever.
-            let has_readable = match sink_body_value {
-                webcore::body::Value::Locked(l) => l.readable.has(),
+        // A Locked body with no realised stream (fresh `fetch()` Response), or
+        // a file/S3-backed Blob, must be turned into a ReadableStream first so
+        // the ByteStream/FileReader wiring below can drive it.
+        let mut stream = stream;
+        if stream.is_none() {
+            let needs_stream = match value {
+                webcore::body::Value::Locked(_) => true,
+                webcore::body::Value::Blob(b) => b.needs_to_read_file() || b.is_s3(),
                 _ => false,
             };
-            if !has_readable
-                && matches!(sink_body_value, webcore::body::Value::Locked(l)
-                    if l.task.map_or(0, |p| p as usize) == sink_ptr_usize && l.promise.is_none())
-            {
-                // No reader and no pending read: normalize to `Empty` so
-                // `to_error_instance` takes the simple (non-`Locked`) path.
-                *sink_body_value = webcore::body::Value::Empty;
-            } else if matches!(sink_body_value, webcore::body::Value::Locked(l)
-                if l.task.map_or(0, |p| p as usize) == sink_ptr_usize && l.promise.is_some())
-            {
-                if let webcore::body::Value::Locked(l) = sink_body_value {
-                    l.on_receive_value = None;
-                    l.task = None;
+            if needs_stream {
+                match value
+                    .to_readable_stream(global)
+                    .and_then(|v| ReadableStream::from_js(v, global))
+                {
+                    Ok(s) => stream = s,
+                    Err(e) => {
+                        let err = global.take_exception(e);
+                        this.set_handler_error(err);
+                        return;
+                    }
                 }
             }
-            if is_async {
-                let _ = sink_body_value.to_error_instance(err.dupe(&global), &global);
-                // TODO: properly propagate exception upwards
-            } else {
-                let ret_err = err.to_js(&global);
-                ret_err.ensure_still_alive();
-                ret_err.protect();
-                Self::write_tmp_sync_error(sink, ret_err);
+        }
+
+        // Materialized-body fast path: feed synchronously, end, return. No
+        // stream wiring; this covers InternalBlob/WTFStringImpl/Empty/Used and
+        // Blob-with-bytes (the `sync_only_noun` path always lands here).
+        let Some(stream) = stream else {
+            // lol-html consumes UTF-8; `use_as_any_blob()` encodes a non-ASCII
+            // WTFStringImpl into an InternalBlob so `.slice()` is always UTF-8.
+            let mut any_blob = value.use_as_any_blob();
+            let bytes = any_blob.slice();
+            // Mark EOF first so a handler that suspends mid-feed resumes into
+            // `end_rewrite` once its promise settles.
+            this.input_ended.set(true);
+            if this.feed(bytes) {
+                this.end_rewrite();
             }
-            // Do not `end()` the rewriter: that would run `done()`, replacing
-            // the error just stored on the body with the truncated output.
-            // `Drop` destroys the rewriter once the sink's refcount hits zero.
+            // `blob::Any` has no `Drop`; release the WTFStringImpl/Blob `+1`
+            // transferred by `use_as_any_blob`. A suspended lol-html has
+            // already copied the unconsumed tail into its arena.
+            any_blob.detach();
+            return;
+        };
+
+        if stream.is_locked(global) || stream.is_disturbed(global) {
+            let err = system_error(
+                "ERR_STREAM_ALREADY_FINISHED",
+                "Stream already used, please create a new one",
+            );
+            this.set_handler_error(err.to_error_instance(global));
             return;
         }
 
-        // SAFETY: `sink` is live (refcount > 0, see fn safety contract).
-        if let Some(ret_err) = unsafe { Self::run_output_sink(sink, bytes, is_async) } {
-            ret_err.ensure_still_alive();
-            ret_err.protect();
-            Self::write_tmp_sync_error(sink, ret_err);
+        // Root the stream on the pipe and mark the input body consumed, so a
+        // second `transform()` / `.text()` on the same input throws "Body
+        // already used" instead of quietly yielding an empty document.
+        js_HTMLRewriterTransform::input_stream_set_cached(this.cell.get(), global, stream.value);
+        *value = webcore::body::Value::Used;
+
+        let sink_handle = SinkHandle::HTMLRewriter(this);
+
+        // Native ByteStream/FileReader fast-path: wire the SinkHandle directly,
+        // skipping the JS pump.
+        match stream.wire_native_sink(global, sink_handle, this.cell.get(), |src| {
+            this.input_source.set(src)
+        }) {
+            webcore::readable_stream::NativeWireResult::Wired => return,
+            webcore::readable_stream::NativeWireResult::EndedInline(err) => {
+                this.end_from_stream(err);
+                return;
+            }
+            webcore::readable_stream::NativeWireResult::NotNative => {}
+        }
+
+        // JS-pump fallback: `assign_to_stream` installs a JS sink wrapper that
+        // forwards to `JsSinkType for RewriterPipe`.
+        let assignment_result =
+            JSSink::<RewriterPipe>::assign_to_stream(global, stream.value, pipe.into());
+        assignment_result.ensure_still_alive();
+
+        if let Some(err) = assignment_result.to_error() {
+            this.end_from_stream(Some(StreamError::JSValue(jsc::strong::Optional::create(
+                err, global,
+            ))));
+            return;
+        }
+
+        if !assignment_result.is_empty_or_undefined_or_null() {
+            if let Some(promise) = assignment_result.as_any_promise() {
+                match promise.status() {
+                    jsc::js_promise::Status::Pending => {
+                        this.js_pump_reaction_pending.set(true);
+                        assignment_result.then_with_value(
+                            global,
+                            this.cell.get(),
+                            on_resolve_input_stream_shim,
+                            on_reject_input_stream_shim,
+                        );
+                        return;
+                    }
+                    jsc::js_promise::Status::Fulfilled => {
+                        this.end_from_stream(None);
+                        return;
+                    }
+                    jsc::js_promise::Status::Rejected => {
+                        promise.set_handled(global.vm());
+                        let result = promise.result(global.vm());
+                        this.end_from_stream(Some(StreamError::JSValue(
+                            jsc::strong::Optional::create(result, global),
+                        )));
+                        return;
+                    }
+                }
+            }
+        }
+
+        // undefined/null: the stream drained synchronously inside
+        // assignToStream.
+        this.end_from_stream(None);
+    }
+
+    /// `PendingValue::on_start_streaming` — the output Response's body is
+    /// being realised as a ByteStream: hand over everything lol-html has
+    /// already emitted.
+    fn on_start_streaming(ctx: NonNull<c_void>) -> DrainResult {
+        // `ctx` is the `pipe` heap allocation registered on the PendingValue
+        // in `init()`; the owning `JSHTMLRewriterTransform` cell (rooted by
+        // the output Response's `transform` slot) keeps it live.
+        let this = bun_ptr::BackRef::from(ctx.cast::<RewriterPipe>());
+        let list = this.output_buffer.replace(Vec::new());
+        if list.is_empty() {
+            return DrainResult::EstimatedSize(0);
+        }
+        let len = list.len();
+        DrainResult::Owned {
+            list,
+            size_hint: len,
         }
     }
 
-    /// Note: takes `*mut Self` (not `&mut self`) because
-    /// `HtmlRewriter::write/end` re-enter
-    /// `SinkRef::handle_chunk(&mut self)` through the
-    /// raw `*mut BufferOutputSink` captured at build time. A `&mut self`
-    /// receiver here would alias that inner `&mut` (Stacked Borrows UB).
-    ///
-    /// # Safety
-    /// `sink` must be a live `BufferOutputSink` heap allocation with
-    /// refcount > 0; `(*sink).rewriter` and `(*sink).response` must be set.
-    unsafe fn run_output_sink(sink: *mut Self, bytes: &[u8], is_async: bool) -> Option<JSValue> {
-        // SAFETY: sink is a live heap allocation (refcount > 0, caller
-        // invariant). Read fields into locals before the rewriter calls so no
-        // borrow of `*sink` is live across the re-entrant output sink.
-        let (global, response, rewriter) = unsafe {
-            let _ = (*sink).bytes.grow_by(bytes.len()); // OOM/capacity: fire-and-forget
-            ((*sink).global, (*sink).response, (*sink).rewriter)
+    /// `PendingValue::on_readable_stream_available` — the output ByteStream
+    /// now exists: stash its backref so `PipeOutput::handle_chunk` pushes
+    /// there instead of buffering.
+    fn on_readable_stream_available(
+        ctx: NonNull<c_void>,
+        global_this: &JSGlobalObject,
+        readable: ReadableStream,
+    ) {
+        let this = bun_ptr::BackRef::from(ctx.cast::<RewriterPipe>());
+        if let Some(bytes) = readable.ptr.bytes() {
+            // A reader rooting the output stream now roots the Transform cell
+            // too, so the `producer` backref cannot outlive the pipe. Cleared
+            // in `detach_output`.
+            bytes.parent_const().set_owner(this.cell.get());
+            this.output.set(Some(bytes));
+        }
+        js_HTMLRewriterTransform::output_stream_set_cached(
+            this.cell.get(),
+            global_this,
+            readable.value,
+        );
+        // If the rewrite already completed before a reader attached, deliver
+        // the terminal `Done` now so the first `read()` resolves.
+        if this.phase.get() == RewritePhase::Done
+            && !this.done.get()
+            && js_HTMLRewriterTransform::handler_error_get_cached(this.cell.get())
+                .is_none_or(|v| v.is_empty_or_undefined_or_null())
+        {
+            if let Some(out) = this.output.get() {
+                let _ = out.on_data(StreamResult::Done);
+            }
+            this.detach_output();
+        }
+    }
+
+    /// `SinkHandle::write` entry — input bytes arrived.
+    pub fn write(&self, data: &StreamResult) -> Writable {
+        let bytes = data.slice();
+        let len = bytes.len() as BlobSizeType;
+        if self.done.get() || self.phase.get() == RewritePhase::Done {
+            return Writable::Done;
+        }
+        if self.driving.get() || self.is_suspended() || self.output_backpressured() {
+            self.pending_input.with_mut(|v| v.extend_from_slice(bytes));
+            return Writable::Backpressure(len);
+        }
+        let fed = self.feed(bytes);
+        // `feed` ran user JS; a handler may have cancelled the output reader
+        // (`cancel_from_output`). Return `Done` so the native caller detaches
+        // its sink snapshot, even if the handler also suspended.
+        if self.done.get() || self.phase.get() == RewritePhase::Done {
+            return Writable::Done;
+        }
+        if !fed {
+            // `feed` returns false for both a handler suspension and a fatal
+            // error. Only the latter should detach the upstream sink.
+            if self.is_suspended() {
+                return Writable::Backpressure(len);
+            }
+            return Writable::Done;
+        }
+        if self.is_suspended() || self.output_backpressured() {
+            return Writable::Backpressure(len);
+        }
+        Writable::Owned(len)
+    }
+
+    /// `SinkHandle::end` entry — input EOF or terminal upstream error.
+    pub fn end_from_stream(&self, err: Option<StreamError>) {
+        // Detach via `detach_input_source` (not a bare `.set(None)`) so a
+        // `JSController`'s `m_sinkPtr` is nulled before any path can free the
+        // pipe; otherwise the controller's destructor would later dispatch
+        // `__controllerDetached`/`__finalize` on freed memory. The upstream
+        // already ended, so there is nothing to cancel.
+        self.detach_input_source(false);
+
+        if self.js_pump_reaction_pending.get() {
+            // The pump-promise `.then()` reaction is the single terminal
+            // authority on the JS-pump path: `rsisAbrupt` calls
+            // `controller.close(error)` synchronously (the generated `__close`
+            // drops the argument) before rejecting the pump promise, so running
+            // `end_rewrite` here would resolve the body with truncated output
+            // and pre-empt the reject reaction.
+            return;
+        }
+
+        js_HTMLRewriterTransform::input_stream_set_cached(
+            self.cell.get(),
+            &self.global,
+            JSValue::UNDEFINED,
+        );
+        if self.done.get() || self.phase.get() == RewritePhase::Done {
+            return;
+        }
+        if let Some(err) = err {
+            let value_error = match err {
+                StreamError::JSValue(v) => webcore::body::ValueError::JSValue(v),
+                StreamError::Error(e) => {
+                    webcore::body::ValueError::SystemError(e.to_system_error().into())
+                }
+                StreamError::AbortReason(r) => webcore::body::ValueError::AbortReason(r),
+            };
+            self.fail(value_error);
+            return;
+        }
+        if self.driving.get() || self.is_suspended() || !self.pending_input.get().is_empty() {
+            self.input_ended.set(true);
+            return;
+        }
+        self.end_rewrite();
+    }
+
+    /// `SourceHandle::on_ready` entry — the output ByteStream drained.
+    pub fn resume(&self) {
+        if self.done.get()
+            || self.phase.get() == RewritePhase::Done
+            || self.driving.get()
+            || self.is_suspended()
+            || self.output_backpressured()
+        {
+            return;
+        }
+        self.drain_pending_input();
+    }
+
+    /// `SourceHandle::on_close` entry — the output reader cancelled.
+    pub fn cancel_from_output(&self, _err: Option<SysError>) {
+        self.detach_output();
+        self.detach_input_source(true);
+        js_HTMLRewriterTransform::input_stream_set_cached(
+            self.cell.get(),
+            &self.global,
+            JSValue::UNDEFINED,
+        );
+        self.phase.set(RewritePhase::Done);
+        self.done.set(true);
+        self.pending.with_mut(|p| {
+            p.result = Writable::Done;
+            p.run();
+        });
+    }
+
+    /// Run one lol-html `write`/`end_mut`/`resume` call under the
+    /// [`ActiveSinkGuard`] and `driving` flag. Re-entrant `SinkHandle`/
+    /// `SourceHandle` calls into this pipe check `driving` and defer, so the
+    /// `with_mut` borrow on `rewriter` is never aliased. Returns `None` when
+    /// the rewriter is unset.
+    fn drive_rewriter<R>(&self, f: impl FnOnce(&mut LolRewriter) -> R) -> Option<R> {
+        if self.rewriter.get().is_none() {
+            return None;
+        }
+        let _active = ActiveSinkGuard::enter(self);
+        self.driving.set(true);
+        let res = self.rewriter.with_mut(|r| r.as_deref_mut().map(f));
+        self.driving.set(false);
+        res
+    }
+
+    /// Feed `bytes` through lol-html once. Returns `true` if the write
+    /// completed (`Ok` — possibly buffering output), `false` if the rewrite
+    /// failed or suspended.
+    fn feed(&self, bytes: &[u8]) -> bool {
+        match self.drive_rewriter(|r| r.write(bytes)) {
+            None => false,
+            Some(Ok(())) => true,
+            Some(Err(e)) => {
+                self.on_rewriting_error(&e);
+                false
+            }
+        }
+    }
+
+    /// `write` completed (no more input owed): run `end()`. Installs its own
+    /// [`ActiveSinkGuard`].
+    fn end_rewrite(&self) {
+        self.phase.set(RewritePhase::EndPending);
+        // `end_mut` (unlike the consuming `end`) keeps the rewriter alive: a
+        // document-end handler can suspend it, and `Drop` is what frees it.
+        match self.drive_rewriter(|r| r.end_mut()) {
+            None => self.phase.set(RewritePhase::Done),
+            Some(Err(e)) => self.on_rewriting_error(&e),
+            Some(Ok(())) => self.finish(),
+        }
+    }
+
+    fn finish(&self) {
+        self.phase.set(RewritePhase::Done);
+        // The rewrite completed: free the boxed lol-html state machine now
+        // instead of at cell collection, so a long-lived output Response does
+        // not retain the parser arena. Safe here: every driver null-checks
+        // `rewriter` or gates on `phase == Done` first, and no wrapper is
+        // parked in the rewriter (a suspension is resolved before `finish`
+        // is reachable). Error/cancel paths leave it for `Drop` — a wrapper
+        // retargeted at a heap-parked unit may still be attached there.
+        debug_assert!(!self.is_suspended());
+        self.rewriter.set(None);
+        if let Some(out) = self.output.get() {
+            let _ = out.on_data(StreamResult::Done);
+            self.detach_output();
+            return;
+        }
+        // No stream attached yet: resolve the output body with the buffered
+        // output so `.text()`/`Bun.serve` sees the final bytes.
+        let Some(response) = self.response.get() else {
+            return;
         };
-
-        // SAFETY: rewriter heap-allocated by init(), not yet freed.
-        if let Err(e) = unsafe { (*rewriter).write(bytes) } {
-            // Poisoned: never call `end()` after a failed `write()`. The
-            // field stays non-null so `Drop` frees the rewriter.
-            if is_async {
-                // SAFETY: response kept alive by response_value Strong.
-                let _ = unsafe { (*response).get_body_value() }.to_error_instance(
-                    webcore::body::ValueError::Message(lol_err_string(&e)),
-                    &global,
-                );
-                // TODO: properly propagate exception upwards
-                return None;
-            } else {
-                return Some(create_lolhtml_error(&global, &e));
-            }
-        }
-
-        // `HtmlRewriter::end(self)` consumes the rewriter: null the field
-        // first so `Drop` does not free it a second time.
-        // SAFETY: sink is a live heap allocation (refcount > 0).
-        unsafe { (*sink).rewriter = core::ptr::null_mut() };
-        // SAFETY: `rewriter` was heap-allocated by init(); sole owner now.
-        if let Err(e) = unsafe { bun_core::heap::take(rewriter) }.end() {
-            if is_async {
-                // SAFETY: response kept alive by response_value Strong.
-                let _ = unsafe { (*response).get_body_value() }.to_error_instance(
-                    webcore::body::ValueError::Message(lol_err_string(&e)),
-                    &global,
-                );
-                // TODO: properly propagate exception upwards
-                return None;
-            } else {
-                return Some(create_lolhtml_error(&global, &e));
-            }
-        }
-
-        None
-    }
-
-    pub(crate) fn done(&mut self) {
-        // SAFETY: self.response is kept alive by self.response_value (Strong
-        // root) for the lifetime of this sink.
-        let body_value = unsafe { (*self.response).get_body_value() };
+        let body_value = response.get_body_value();
+        let bytes = self.output_buffer.replace(Vec::new());
         let mut prev_value = core::mem::replace(
             body_value,
             webcore::body::Value::InternalBlob(webcore::InternalBlob {
-                bytes: core::mem::replace(&mut self.bytes, MutableString::init_empty()).list,
+                bytes,
                 was_string: false,
             }),
         );
-
         let _ = webcore::body::Value::resolve(&mut prev_value, body_value, &self.global, None);
-        // TODO: properly propagate exception upwards
     }
 
-    pub fn write(&mut self, bytes: &[u8]) {
-        let _ = self.bytes.append(bytes); // OOM/capacity: fire-and-forget
+    /// Feed the accumulated `pending_input` once unblocked, then maybe end,
+    /// then signal the upstream source to resume.
+    fn drain_pending_input(&self) {
+        let pending = self.pending_input.replace(Vec::new());
+        if !pending.is_empty() && !self.feed(&pending) {
+            return;
+        }
+        // `feed` ran user JS; re-check the terminal state before `end_rewrite`
+        // would overwrite `phase = Done` set by `cancel_from_output`/`fail`.
+        if self.done.get() || self.phase.get() == RewritePhase::Done {
+            return;
+        }
+        if self.is_suspended() || self.output_backpressured() {
+            return;
+        }
+        if self.input_ended.get() {
+            self.end_rewrite();
+            return;
+        }
+        // `ready()` may re-enter and write `input_source` (sink → feed →
+        // fail/end_from_stream), so copy the handle out instead of holding a
+        // `with_mut` borrow across the call.
+        let mut src = self.input_source.get();
+        src.ready(None, None);
+        // Wake a JS pump's pending `write()`/`flush(true)` promise.
+        self.pending.with_mut(|p| p.run());
+    }
+
+    /// A content handler's promise resolved: continue the rewrite from
+    /// wherever lol-html parked it, then drain any `pending_input` that
+    /// arrived while suspended.
+    fn resume_rewrite(&self) {
+        if self.phase.get() == RewritePhase::Done {
+            // Output reader cancelled (or the rewrite failed) while suspended.
+            return;
+        }
+        if let Some(Err(e)) = self.drive_rewriter(|r| r.resume()) {
+            return self.on_rewriting_error(&e);
+        }
+        match self.phase.get() {
+            RewritePhase::WritePending => self.drain_pending_input(),
+            RewritePhase::EndPending => self.finish(),
+            RewritePhase::Done => {}
+        }
+    }
+
+    /// A lol-html call returned an error: either the (non-fatal) handler
+    /// suspension escape, or a real failure to surface.
+    fn on_rewriting_error(&self, e: &lol_html::errors::RewritingError) {
+        if matches!(e, lol_html::errors::RewritingError::Suspended) {
+            return self.begin_suspension();
+        }
+        let leftover = self.pending_suspension.take();
+        debug_assert!(
+            leftover.is_none(),
+            "lol-html returned a non-suspension error with a suspension armed"
+        );
+        drop(leftover);
+
+        self.phase.set(RewritePhase::Done);
+        let captured = self.take_handler_error();
+
+        if self.sync_only_noun.get().is_some() {
+            // `init()` is still on the stack; make `transform()` throw.
+            return self.set_handler_error(
+                captured.unwrap_or_else(|| create_lolhtml_error(&self.global, e)),
+            );
+        }
+
+        let value_error = match captured {
+            Some(js_err) => {
+                js_err.ensure_still_alive();
+                webcore::body::ValueError::JSValue(jsc::strong::Optional::create(
+                    js_err,
+                    &self.global,
+                ))
+            }
+            None => webcore::body::ValueError::Message(lol_err_string(e)),
+        };
+        self.fail(value_error);
+    }
+
+    fn begin_suspension(&self) {
+        let wrapper = self
+            .pending_suspension
+            .take()
+            .expect("lol-html suspended without a pending HTMLRewriter handler promise")
+            .take_wrapper();
+
+        self.rewriter.with_mut(|r| {
+            if let Some(r) = r.as_deref_mut() {
+                wrapper.retarget(r);
+            }
+        });
+        self.suspended_wrapper.set(Some(wrapper));
+
+        // The `.then()` context is a `NativePromiseContext` holding the
+        // Transform cell: while the promise can settle, the reaction roots
+        // the context, the context roots the cell, and the cell keeps `pipe`
+        // alive. If the promise is collected without settling, the context's
+        // destructor queues `abandon_suspension` — independent of whether
+        // anything else still reaches the cell — so a rewrite parked on a
+        // dead promise always fails its body instead of leaking.
+        let cell = self.cell.get();
+        let promise = js_HTMLRewriterTransform::suspension_promise_get_cached(cell)
+            .expect("suspension promise slot empty");
+        let pipe = core::ptr::from_ref(self).cast_mut();
+        let context = native_promise_context::create(&self.global, pipe, cell);
+        promise.then_with_value(
+            &self.global,
+            context,
+            Bun__HTMLRewriter__onHandlerResolve,
+            Bun__HTMLRewriter__onHandlerReject,
+        );
+        // The slot only roots the promise across the lol-html unwind; once the
+        // reaction is wired the promise must be independently collectible so
+        // the NativePromiseContext destructor can fire `abandon_suspension`.
+        js_HTMLRewriterTransform::suspension_promise_set_cached(
+            cell,
+            &self.global,
+            JSValue::UNDEFINED,
+        );
+    }
+
+    fn release_suspended_wrapper(&self) {
+        if let Some(wrapper) = self.suspended_wrapper.take() {
+            wrapper.release();
+        }
+    }
+
+    /// Put `err` on the output `Response`'s body / ByteStream.
+    fn fail(&self, err: webcore::body::ValueError) {
+        self.phase.set(RewritePhase::Done);
+        self.done.set(true);
+        self.detach_input_source(true);
+        let cell = self.cell.get();
+        if cell.is_cell() {
+            js_HTMLRewriterTransform::input_stream_set_cached(
+                cell,
+                &self.global,
+                JSValue::UNDEFINED,
+            );
+        }
+        // Settle any `flush(true)`/`write()` promise a direct-stream `pull()`
+        // is parked on so the pump promise can settle (mirrors
+        // `cancel_from_output`).
+        self.pending.with_mut(|p| {
+            p.result = Writable::Done;
+            p.run();
+        });
+
+        if let Some(out) = self.output.get() {
+            let mut err = err;
+            let _ = out.on_data(StreamResult::Err(err.to_stream_error(&self.global)));
+            self.detach_output();
+            return;
+        }
+        let Some(response) = self.response.get() else {
+            return;
+        };
+        let body_value = response.get_body_value();
+        let has_readable = match body_value {
+            webcore::body::Value::Locked(l) => l.readable.has(),
+            _ => false,
+        };
+        if !has_readable
+            && matches!(body_value, webcore::body::Value::Locked(l)
+                if l.promise.is_none() && l.on_receive_value.is_none())
+        {
+            *body_value = webcore::body::Value::Empty;
+        }
+        let _ = body_value.to_error_instance(err, &self.global);
     }
 }
 
-/// `lol_html::OutputSink` for the rewriter built in [`BufferOutputSink::init`].
-/// Carries a raw `*mut BufferOutputSink` (never a reference) so the rewriter
-/// stored on the sink does not self-borrow.
-pub struct SinkRef(*mut BufferOutputSink);
+/// `lol_html::OutputSink` for the rewriter built in [`RewriterPipe::init`].
+/// The pipe owns the `Box<LolRewriter>` that owns this `PipeOutput`, so the
+/// back-reference invariant (pointee outlives holder) is structurally upheld.
+pub struct PipeOutput(BackRef<RewriterPipe>);
 
-impl lol_html::OutputSink for SinkRef {
+impl lol_html::OutputSink for PipeOutput {
     fn handle_chunk(&mut self, chunk: &[u8]) {
-        // SAFETY: `self.0` is the sink that owns this rewriter (refcount > 0
-        // inside `run_output_sink`), and no other `&mut *sink` is live —
-        // `run_output_sink` reads its fields into locals before the call.
-        let sink = unsafe { &mut *self.0 };
-        // lol-html signals end-of-output with a zero-length final chunk.
         if chunk.is_empty() {
-            sink.done();
+            return;
+        }
+        let pipe = &*self.0;
+        if let Some(out) = pipe.output.get() {
+            let _ = out.on_data(StreamResult::Temporary(RawSlice::new(chunk)));
         } else {
-            sink.write(chunk);
+            pipe.output_buffer.with_mut(|v| v.extend_from_slice(chunk));
         }
     }
 }
 
-impl Drop for BufferOutputSink {
+impl Drop for RewriterPipe {
     fn drop(&mut self) {
-        // bytes, body_value_bufferer, context (Rc), response_value (Strong) drop automatically.
-        if !self.rewriter.is_null() {
-            // SAFETY: rewriter heap-allocated by init() and not yet freed
-            // (`run_output_sink` nulls the field before consuming it in `end`).
-            unsafe { bun_core::heap::destroy(self.rewriter) };
+        // A pipe cancelled or failed while suspended keeps its parked wrapper
+        // until the handler promise settles; if that promise is collected
+        // instead, this is the wrapper's last owner. Releasing it here (it
+        // only nulls the wrapper's unit Cell and drops its Box, no GC access)
+        // detaches any JS-retained Element/TextChunk before the rewriter it
+        // points into is destroyed below.
+        if let Some(w) = self.suspended_wrapper.take() {
+            w.release();
         }
+        if let Some(response) = self.response.take() {
+            // Balances the `Response::ref_()` in `init()`.
+            Response::unref(response.as_const_ptr().cast_mut());
+        }
+    }
+}
+
+// ───────────────── RewriterPipe: JsSinkType (JS-pump fallback) ───────────
+
+crate::impl_js_sink_abi!(RewriterPipe, "HTMLRewriterSink");
+
+impl crate::webcore::sink::JsSinkType for RewriterPipe {
+    const NAME: &'static str = "HTMLRewriterSink";
+    const HAS_FLUSH_FROM_JS: bool = true;
+    const START_TAG: Option<StartTag> = Some(StartTag::HTMLRewriterSink);
+
+    fn memory_cost(&self) -> usize {
+        self.pending_input.get().capacity() + self.output_buffer.get().capacity()
+    }
+    fn finalize(&mut self) {}
+    fn write_bytes(&mut self, data: &StreamResult) -> Writable {
+        RewriterPipe::write(self, data)
+    }
+    fn write_utf16(&mut self, data: &StreamResult) -> Writable {
+        let mut buf = Vec::new();
+        let _ = buf.write_utf16(data.slice16());
+        RewriterPipe::write(self, &StreamResult::Temporary(RawSlice::new(&buf)))
+    }
+    fn write_latin1(&mut self, data: &StreamResult) -> Writable {
+        let bytes = data.slice();
+        if bun_core::strings::is_all_ascii(bytes) {
+            return RewriterPipe::write(self, data);
+        }
+        let mut buf = Vec::new();
+        let _ = buf.write_latin1(bytes);
+        RewriterPipe::write(self, &StreamResult::Temporary(RawSlice::new(&buf)))
+    }
+    fn end(&mut self, err: Option<SysError>) -> bun_sys::Result<()> {
+        self.end_from_stream(err.map(StreamError::Error));
+        bun_sys::Result::Ok(())
+    }
+    fn end_from_js(&mut self, _global: &JSGlobalObject) -> bun_sys::Result<JSValue> {
+        self.end_from_stream(None);
+        bun_sys::Result::Ok(JSValue::js_number(0.0))
+    }
+    fn flush(&mut self) -> bun_sys::Result<()> {
+        bun_sys::Result::Ok(())
+    }
+    fn flush_from_js(&mut self, global: &JSGlobalObject, wait: bool) -> bun_sys::Result<JSValue> {
+        use streams::PendingState;
+        if self.pending.get().state == PendingState::Pending {
+            let prom = self.pending.with_mut(|p| p.promise(global));
+            let prom_js = JSPromise::opaque_ref(prom).to_js();
+            js_HTMLRewriterTransform::pending_promise_set_cached(self.cell.get(), global, prom_js);
+            return bun_sys::Result::Ok(prom_js);
+        }
+        if self.done.get() || self.phase.get() == RewritePhase::Done {
+            return bun_sys::Result::Ok(JSPromise::resolved_promise_value(
+                global,
+                JSValue::js_number(0.0),
+            ));
+        }
+        if wait && (self.driving.get() || self.is_suspended() || self.output_backpressured()) {
+            let prom = self.pending.with_mut(|p| {
+                p.result = Writable::Owned(0);
+                p.promise(global)
+            });
+            let prom_js = JSPromise::opaque_ref(prom).to_js();
+            js_HTMLRewriterTransform::pending_promise_set_cached(self.cell.get(), global, prom_js);
+            return bun_sys::Result::Ok(prom_js);
+        }
+        bun_sys::Result::Ok(JSPromise::resolved_promise_value(
+            global,
+            JSValue::js_number(0.0),
+        ))
+    }
+    fn start(&mut self, config: Start) -> bun_sys::Result<()> {
+        if let Start::ChunkSize(chunk_size) = config {
+            if chunk_size > 0 {
+                self.high_water_mark.set(chunk_size);
+            }
+        }
+        bun_sys::Result::Ok(())
+    }
+    fn source(&mut self) -> Option<&mut SourceHandle> {
+        Some(self.input_source.get_mut())
+    }
+    fn done(&self) -> bool {
+        self.done.get()
+    }
+}
+
+// ───────── .then() reactions for a content handler's promise ─────────────
+
+bun_jsc::jsc_promise_handler!(
+    pub fn Bun__HTMLRewriter__onHandlerResolve => on_handler_resolve
+);
+bun_jsc::jsc_promise_handler!(
+    pub fn Bun__HTMLRewriter__onHandlerReject => on_handler_reject
+);
+
+fn on_handler_resolve(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    let _ = global;
+    let args = frame.arguments();
+    // `take` nulls the context so its destructor is a no-op; `None` means the
+    // suspension was already abandoned.
+    let Some(pipe) = native_promise_context::take::<RewriterPipe>(args[args.len() - 1]) else {
+        return Ok(JSValue::UNDEFINED);
+    };
+    let pipe = BackRef::from(pipe);
+    let pipe = &*pipe;
+    pipe.release_suspended_wrapper();
+    pipe.resume_rewrite();
+    Ok(JSValue::UNDEFINED)
+}
+
+fn on_handler_reject(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    let args = frame.arguments();
+    let reason = args[0];
+    let Some(pipe) = native_promise_context::take::<RewriterPipe>(args[args.len() - 1]) else {
+        return Ok(JSValue::UNDEFINED);
+    };
+    let pipe = BackRef::from(pipe);
+    let pipe = &*pipe;
+    pipe.release_suspended_wrapper();
+    pipe.fail(webcore::body::ValueError::JSValue(
+        jsc::strong::Optional::create(reason, global),
+    ));
+    Ok(JSValue::UNDEFINED)
+}
+
+/// Peek helper for `Cell<Option<T>>` where `T` is not `Copy`.
+trait CellOptionPeek<T> {
+    fn take_peek(&self) -> Option<()>;
+}
+impl<T> CellOptionPeek<T> for Cell<Option<T>> {
+    #[inline]
+    fn take_peek(&self) -> Option<()> {
+        let v = self.take();
+        let some = v.is_some().then_some(());
+        self.set(v);
+        some
     }
 }
 
@@ -998,49 +1771,25 @@ pub struct DocumentHandler {
 }
 
 impl DocumentHandler {
-    pub(crate) fn on_doc_type(
-        this: *mut Self,
-        value: *mut lol_html::html_content::Doctype<'static>,
-    ) -> bool {
-        handler_callback::<Self, DocType, lol_html::html_content::Doctype<'static>>(
-            this,
-            value,
-            |w| w.doctype.set(core::ptr::null_mut()),
-            |h| h.on_doc_type_callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub(crate) fn on_doc_type(this: NonNull<Self>, value: *mut RawDoctype) -> HandlerOutcome {
+        handler_callback::<Self, DocType, RawDoctype>(this, value, |h| {
+            h.on_doc_type_callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
-    pub(crate) fn on_comment(
-        this: *mut Self,
-        value: *mut lol_html::html_content::Comment<'static>,
-    ) -> bool {
-        handler_callback::<Self, Comment, lol_html::html_content::Comment<'static>>(
-            this,
-            value,
-            |w| w.comment.set(core::ptr::null_mut()),
-            |h| h.on_comment_callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub(crate) fn on_comment(this: NonNull<Self>, value: *mut RawComment) -> HandlerOutcome {
+        handler_callback::<Self, Comment, RawComment>(this, value, |h| {
+            h.on_comment_callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
-    pub(crate) fn on_text(
-        this: *mut Self,
-        value: *mut lol_html::html_content::TextChunk<'static>,
-    ) -> bool {
-        handler_callback::<Self, TextChunk, lol_html::html_content::TextChunk<'static>>(
-            this,
-            value,
-            |w| w.text_chunk.set(core::ptr::null_mut()),
-            |h| h.on_text_callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub(crate) fn on_text(this: NonNull<Self>, value: *mut RawTextChunk) -> HandlerOutcome {
+        handler_callback::<Self, TextChunk, RawTextChunk>(this, value, |h| {
+            h.on_text_callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
-    pub(crate) fn on_end(
-        this: *mut Self,
-        value: *mut lol_html::html_content::DocumentEnd<'static>,
-    ) -> bool {
-        handler_callback::<Self, DocEnd, lol_html::html_content::DocumentEnd<'static>>(
-            this,
-            value,
-            |w| w.doc_end.set(core::ptr::null_mut()),
-            |h| h.on_end_callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub(crate) fn on_end(this: NonNull<Self>, value: *mut RawDocumentEnd) -> HandlerOutcome {
+        handler_callback::<Self, DocEnd, RawDocumentEnd>(this, value, |h| {
+            h.on_end_callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
 
     pub(crate) fn init(global: &JSGlobalObject, this_object: JSValue) -> JsResult<DocumentHandler> {
@@ -1130,109 +1879,133 @@ impl HandlerLike for EndTagHandler {
     }
 }
 
-/// Trait abstracting the wrapper-type bits `HandlerCallback` needs.
+/// Trait abstracting the wrapper-type bits [`handler_callback`] and the
+/// suspension plumbing need.
 pub trait WrapperLike {
     type Raw;
-    fn init(value: *mut Self::Raw) -> *mut Self;
+    fn init(value: *mut Self::Raw) -> NonNull<Self>;
     fn ref_(&self);
-    /// # Safety
-    /// `this` must be a live `heap::alloc` allocation with refcount >= 1.
-    unsafe fn deref(this: *mut Self);
+    /// Release one intrusive ref on the live `heap::alloc` allocation `this`.
+    fn deref_nn(this: NonNull<Self>);
     /// `jsc.Codegen.JS${T}.toJS` — wraps the *existing* heap allocation `this`
-    /// in a JS wrapper (the codegen `${T}__create`). Takes `*mut Self` (not
+    /// in a JS wrapper (the codegen `${T}__create`). Takes `NonNull<Self>` (not
     /// `&self`) because the C++ side stores the raw heap pointer in `m_ctx`;
     /// deriving it from a `&self` would launder shared-borrow provenance into
     /// the GC's exclusive-owner pointer.
-    ///
-    /// # Safety
-    /// `this` must be a live `heap::alloc` allocation with refcount >= 1.
-    unsafe fn to_js(this: *mut Self, global: &JSGlobalObject) -> JSValue;
-    /// Some wrapper types (Element) hand out sub-objects that borrow from the
-    /// underlying lol-html value and must be detached along with the wrapper
-    /// itself. Default: no-op (caller passes a `clear_field` closure instead).
-    fn invalidate(&self) {}
-    const HAS_INVALIDATE: bool = false;
+    fn to_js(this: NonNull<Self>, global: &JSGlobalObject) -> JSValue;
+    /// Null out the wrapper's lol-html pointer and detach any sub-objects it
+    /// handed to JS (Element's AttributeIterators). Every host-fn on the
+    /// wrapper is a harmless no-op afterwards.
+    fn detach(&self);
+    /// Re-point the wrapper at a different lol-html unit: the heap copy
+    /// lol-html parks when one of the unit's handlers suspends on it.
+    fn retarget(&self, raw: *mut Self::Raw);
+    /// The lol-html unit of this type the rewriter is suspended on, as the
+    /// lifetime-erased raw pointer the wrapper stores. Null if the rewriter
+    /// is not suspended on a `Self::Raw`.
+    fn suspended_raw(rewriter: &mut LolRewriter) -> *mut Self::Raw;
+    /// Wrap a ref'd `NonNull<Self>` as the matching [`SuspendedWrapper`] variant.
+    fn into_suspended(wrapper: NonNull<Self>) -> SuspendedWrapper;
 }
 
 /// Forwarding `WrapperLike` impl — every wrapper type's trait impl is a pure
 /// pass-through to inherent / `CellRefCounted`-derived / `JsClass`-codegen
-/// methods. The optional `, invalidate`
-/// tail wires up types (Element) that hand out sub-objects which must be
-/// detached alongside the lol-html value.
+/// methods. `$field` is the wrapper's `DetachablePtr<$raw>`; `$suspended` is the
+/// `lol_html::HtmlRewriter` accessor for the parked unit of that type.
+/// `Element` implements the trait by hand: its `detach` also has to
+/// invalidate the `AttributeIterator`s it handed out.
 macro_rules! impl_wrapper_like {
-    ($ty:ty, $raw:ty $(, $invalidate:ident)?) => {
+    ($ty:ident, $raw:ty, $field:ident, $suspended:ident) => {
         impl WrapperLike for $ty {
             type Raw = $raw;
-            fn init(v: *mut Self::Raw) -> *mut Self { Self::init(v) }
-            fn ref_(&self) { self.ref_() }
-            unsafe fn deref(this: *mut Self) {
-                // SAFETY: `WrapperLike::deref` contract — `this` is a live
-                // `heap::alloc` allocation with refcount >= 1.
-                unsafe { Self::deref(this) }
+            fn init(v: *mut Self::Raw) -> NonNull<Self> {
+                Self::init(v)
             }
-            unsafe fn to_js(this: *mut Self, g: &JSGlobalObject) -> JSValue {
-                // SAFETY: `this` is a live `heap::alloc` allocation
-                // (refcount >= 1); ownership is shared with the GC wrapper via
-                // the intrusive refcount (`${T}Class__finalize` →
-                // `Self::finalize` → `deref`).
-                unsafe { Self::to_js_ptr(this, g) }
+            fn ref_(&self) {
+                self.ref_()
             }
-            $(
-                fn invalidate(&self) { Self::$invalidate(self) }
-                const HAS_INVALIDATE: bool = true;
-            )?
+            fn deref_nn(this: NonNull<Self>) {
+                <Self as CellRefCounted>::deref_nn(this)
+            }
+            fn to_js(this: NonNull<Self>, g: &JSGlobalObject) -> JSValue {
+                Self::to_js_nonnull(this, g)
+            }
+            fn detach(&self) {
+                self.$field.detach();
+            }
+            fn retarget(&self, raw: *mut Self::Raw) {
+                self.$field.set(raw);
+            }
+            fn suspended_raw(rewriter: &mut LolRewriter) -> *mut Self::Raw {
+                rewriter.$suspended().map_or(core::ptr::null_mut(), |unit| {
+                    core::ptr::from_mut(unit).cast()
+                })
+            }
+            fn into_suspended(wrapper: NonNull<Self>) -> SuspendedWrapper {
+                SuspendedWrapper::$ty(wrapper)
+            }
         }
     };
 }
 
+/// The value an `Exception` cell wraps. Handing the cell itself to
+/// `JSPromise::reject` asserts, and a `Locked` body can now reject with any
+/// handler error, so unwrap at the point of capture. `to_error` falls back to
+/// the cell for a non-`Exception` (it cannot happen here).
+fn exception_value(exc: NonNull<jsc::Exception>) -> JSValue {
+    let cell = JSValue::from_cell(exc.as_ptr());
+    cell.to_error().unwrap_or(cell)
+}
+
+/// Record a content handler's exception / rejection on the sink whose lol-html
+/// call is on the stack, so `transform()` (sync) or the output body (async)
+/// surfaces it instead of lol-html's generic "stopped" message.
+///
+/// Takes the sink explicitly rather than re-deriving it from `global`: a caller
+/// that has already established there is none would otherwise silently drop the
+/// error.
+fn record_handler_error(sink: &RewriterPipe, err: JSValue) {
+    err.ensure_still_alive();
+    sink.set_handler_error(err);
+}
+
 fn handler_callback<H, Z, L>(
-    this: *mut H,
+    this: NonNull<H>,
     value: *mut L,
-    clear_field: impl FnOnce(&Z),
     get_callback: impl FnOnce(&H) -> Option<JSValue>,
-) -> bool
+) -> HandlerOutcome
 where
     H: HandlerLike,
     Z: WrapperLike<Raw = L>,
 {
     jsc::mark_binding();
 
-    let wrapper = Z::init(value);
-    // SAFETY: Z::init returns a fresh heap allocation.
-    unsafe { (*wrapper).ref_() };
+    let wrapper: NonNull<Z> = Z::init(value);
+    BackRef::from(wrapper).ref_();
 
-    // When using RefCount, we don't check the count value directly as it's an
-    // opaque type now. The init values are handled by Box::new with Cell::new(1).
-
-    // SAFETY: wrapper is a live heap allocation (ref'd above) for the entire
-    // scope of this guard; deref runs at most once on this path.
-    let _guard = scopeguard::guard(wrapper, |w| unsafe {
-        if Z::HAS_INVALIDATE {
-            // Some wrapper types (Element) hand out sub-objects that borrow
-            // from the underlying lol-html value and must be detached along
-            // with the wrapper itself.
-            (*w).invalidate();
-        } else {
-            clear_field(&*w);
-        }
-        Z::deref(w);
+    // The detach+deref runs at most once on this path. On the SUSPEND path the
+    // guard is disarmed and `SuspendedWrapper::release` runs the same
+    // detach+deref once the handler's promise settles instead.
+    let guard = scopeguard::guard(wrapper, |w| {
+        BackRef::from(w).detach();
+        Z::deref_nn(w);
     });
 
-    // SAFETY: `this` is the Box<ElementHandler>/Box<DocumentHandler> userdata
-    // pointer we registered with lol-html; it lives in LOLHTMLContext for the
-    // duration of the rewriter. `&` (not `&mut`) — `cb.call()` below re-enters
-    // JS, which may re-enter another `handler_callback` on the same handler
-    // (R-2); aliased `&H` is sound, aliased `&mut H` is not.
-    let this = unsafe { &*this };
+    // `this` is the Box<ElementHandler>/Box<DocumentHandler> userdata pointer we
+    // registered with lol-html; it lives in LOLHTMLContext for the duration of
+    // the rewriter. `&` (not `&mut`) — `cb.call()` below re-enters JS, which
+    // may re-enter another `handler_callback` on the same handler (R-2);
+    // aliased `&H` is sound, aliased `&mut H` is not.
+    let this = BackRef::from(this);
     let global = this.global();
-    // Note: re-derive the VM at each use site rather than caching a `&mut`.
-    // `cb.call(...)` and `wait_for_promise(...)` re-enter JS / the event loop,
-    // which mutate the same VirtualMachine through `global.bun_vm()` (and a
-    // nested handler_callback would form its own `&mut VirtualMachine`).
-    // Holding a long-lived `&mut` across those calls is two-live-&mut UB under
-    // Stacked Borrows, so re-acquire a short-lived borrow at each touch.
-    // SAFETY: bun_vm() returns the live VM raw ptr; VM outlives this call.
-    let vm = || -> &mut VirtualMachine { global.bun_vm().as_mut() };
+
+    // Content handlers only ever run from inside a pipe's lol-html call, which
+    // installs the guard. Read it once here so every error path below has a
+    // sink to record onto.
+    let Some(sink) = active_sink(global) else {
+        debug_assert!(false, "HTMLRewriter handler ran outside a rewrite");
+        return HandlerOutcome::Stop;
+    };
 
     // Use a TopExceptionScope to properly handle exceptions from the JavaScript
     // callback. A post-hoc `try_take_exception()`
@@ -1245,68 +2018,88 @@ where
     // the pending exception through it, and clear it explicitly.
     bun_jsc::top_scope!(scope, global);
 
-    let cb = get_callback(this).expect("callback must be set if handler registered");
-    let result = match cb.call(
-        global,
-        this.this_object(),
-        // SAFETY: `wrapper` is a live heap allocation (ref'd above; guard deref
-        // runs after this call). `to_js` hands the raw pointer to the C++
-        // wrapper.
-        &[unsafe { Z::to_js(wrapper, global) }],
-    ) {
+    let cb = get_callback(&this).expect("callback must be set if handler registered");
+    let result = match cb.call(global, this.this_object(), &[Z::to_js(wrapper, global)]) {
         Ok(v) => v,
         Err(_) => {
-            // If there's an exception in the scope, capture it for later retrieval
             if let Some(exc) = scope.exception() {
-                let exc_value = JSValue::from_cell(exc.as_ptr());
-                // Store the exception in the VM's unhandled rejection capture
-                // mechanism if it's available (this is the same mechanism used
-                // by BufferOutputSink)
-                if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
-                    // SAFETY: VM-owned pointer set by BufferOutputSink::init.
-                    unsafe { *err_ptr = exc_value };
-                }
+                record_handler_error(&sink, exception_value(exc));
             }
-            // Clear the exception from the scope to prevent assertion failures
             scope.clear_exception();
-            // Return true to indicate failure to LOLHTML, which will cause the
-            // write operation to fail and the error handling logic to take over.
-            return true;
+            return HandlerOutcome::Stop;
         }
     };
 
-    // Check if there's an exception that was thrown but not caught by the error union
     if let Some(exc) = scope.exception() {
-        let exc_value = JSValue::from_cell(exc.as_ptr());
-        // Store the exception in the VM's unhandled rejection capture mechanism
-        if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
-            // SAFETY: VM-owned pointer set by BufferOutputSink::init.
-            unsafe { *err_ptr = exc_value };
-        }
-        // Clear the exception to prevent assertion failures
+        record_handler_error(&sink, exception_value(exc));
         scope.clear_exception();
-        return true;
+        return HandlerOutcome::Stop;
     }
 
-    if !result.is_undefined_or_null() {
-        // Note: `is_error() || is_aggregate_error(global)` —
-        // NOT `isAnyError`, which has different
-        // coverage (Exception cells / `Symbol.error` vs cross-realm
-        // AggregateError).
-        if result.is_error() || result.is_aggregate_error(global) {
-            return true;
-        }
+    if result.is_undefined_or_null() {
+        return HandlerOutcome::Continue;
+    }
 
-        if let Some(promise) = result.as_any_promise() {
-            vm().wait_for_promise(promise);
-            let fail = promise.status() == jsc::js_promise::Status::Rejected;
-            if fail {
-                vm().unhandled_rejection(global, promise.result(global.vm()), promise.as_value());
+    // Note: `is_error() || is_aggregate_error(global)` —
+    // NOT `isAnyError`, which has different
+    // coverage (Exception cells / `Symbol.error` vs cross-realm
+    // AggregateError).
+    if result.is_error() || result.is_aggregate_error(global) {
+        record_handler_error(&sink, result);
+        return HandlerOutcome::Stop;
+    }
+
+    let Some(promise) = result.as_any_promise() else {
+        return HandlerOutcome::Continue;
+    };
+
+    // An `async` handler's promise settles through a microtask checkpoint even
+    // when its body never truly awaits; run ONE checkpoint before deciding. A
+    // promise still pending afterwards is waiting on I/O or a timer and must
+    // suspend the rewrite instead of nesting the whole event loop inside
+    // lol-html's `write()`.
+    if promise.status() == jsc::js_promise::Status::Pending {
+        if global.drain_microtasks_and_next_ticks().is_err()
+            || !global.clear_exception_except_termination()
+        {
+            return HandlerOutcome::Stop;
+        }
+    }
+
+    match promise.status() {
+        jsc::js_promise::Status::Fulfilled => HandlerOutcome::Continue,
+        jsc::js_promise::Status::Rejected => {
+            promise.set_handled(global.vm());
+            record_handler_error(&sink, promise.result(global.vm()));
+            HandlerOutcome::Stop
+        }
+        jsc::js_promise::Status::Pending => {
+            // `transform(string)` / `transform(ArrayBuffer)` must hand back the
+            // result before `transform()` returns.
+            if let Some(noun) = sink.sync_only_noun.get() {
+                let err = global.create_type_error_instance(format_args!(
+                    "HTMLRewriter.transform() cannot synchronously return {noun} because a \
+                     content handler returned a Promise that did not resolve within a microtask. \
+                     Pass a Response instead and await its body"
+                ));
+                record_handler_error(&sink, err);
+                return HandlerOutcome::Stop;
             }
-            return fail;
+
+            // Hand the wrapper to the suspension: it has to stay valid across
+            // the handler's `await`, so disarm the guard here.
+            let wrapper = scopeguard::ScopeGuard::into_inner(guard);
+            js_HTMLRewriterTransform::suspension_promise_set_cached(
+                sink.cell.get(),
+                global,
+                result,
+            );
+            sink.pending_suspension.set(Some(PendingSuspension {
+                wrapper: Z::into_suspended(wrapper),
+            }));
+            HandlerOutcome::Suspend
         }
     }
-    false
 }
 
 // ───────────────────────── ElementHandler ────────────────────────────────
@@ -1363,40 +2156,22 @@ impl ElementHandler {
         Ok(handler)
     }
 
-    pub(crate) fn on_element(
-        this: *mut Self,
-        value: *mut lol_html::html_content::Element<'static, 'static>,
-    ) -> bool {
-        handler_callback::<Self, Element, lol_html::html_content::Element<'static, 'static>>(
-            this,
-            value,
-            |_| {}, // Element uses HAS_INVALIDATE
-            |h| h.on_element_callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub(crate) fn on_element(this: NonNull<Self>, value: *mut RawElement) -> HandlerOutcome {
+        handler_callback::<Self, Element, RawElement>(this, value, |h| {
+            h.on_element_callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
 
-    pub(crate) fn on_comment(
-        this: *mut Self,
-        value: *mut lol_html::html_content::Comment<'static>,
-    ) -> bool {
-        handler_callback::<Self, Comment, lol_html::html_content::Comment<'static>>(
-            this,
-            value,
-            |w| w.comment.set(core::ptr::null_mut()),
-            |h| h.on_comment_callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub(crate) fn on_comment(this: NonNull<Self>, value: *mut RawComment) -> HandlerOutcome {
+        handler_callback::<Self, Comment, RawComment>(this, value, |h| {
+            h.on_comment_callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
 
-    pub(crate) fn on_text(
-        this: *mut Self,
-        value: *mut lol_html::html_content::TextChunk<'static>,
-    ) -> bool {
-        handler_callback::<Self, TextChunk, lol_html::html_content::TextChunk<'static>>(
-            this,
-            value,
-            |w| w.text_chunk.set(core::ptr::null_mut()),
-            |h| h.on_text_callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub(crate) fn on_text(this: NonNull<Self>, value: *mut RawTextChunk) -> HandlerOutcome {
+        handler_callback::<Self, TextChunk, RawTextChunk>(this, value, |h| {
+            h.on_text_callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
 }
 
@@ -1415,18 +2190,10 @@ fn create_lolhtml_error(global: &JSGlobalObject, message: &dyn core::fmt::Displa
         // it's a synchronous error
         return err;
     }
-    // SAFETY: bun_vm() returns the live VM raw ptr; VM outlives this call.
-    let vm: &VirtualMachine = global.bun_vm();
-    if let Some(err_ptr) = vm.unhandled_pending_rejection_to_capture {
-        // SAFETY: VM-owned pointer; valid while VM lives.
-        let slot = unsafe { &mut *err_ptr };
-        if !slot.is_empty() {
-            let result = *slot;
-            *slot = JSValue::ZERO;
-            return result;
-        }
-    }
-
+    // The handler's own exception / rejection, if any, is recorded on the
+    // active `RewriterPipe` (`record_handler_error`) and `on_rewriting_error`
+    // prefers it over the generic message, so only lol-html-internal
+    // parse/encoding errors reach here.
     let err = lol_err_string(message);
     let value = bun_string_jsc::to_error_instance(&err, global);
     value.put(
@@ -1452,7 +2219,8 @@ fn utf8_or_throw<'a>(global: &JSGlobalObject, bytes: &'a [u8]) -> JsResult<&'a s
 
 /// Decode a raw-`JSValue` setter argument to owned UTF-8. `to_slice` runs
 /// ToString (user `toString()`/`[Symbol.toPrimitive]`), so callers MUST do
-/// this BEFORE `cell_get`: the re-entered JS would alias its exclusive `&mut`.
+/// this BEFORE `DetachablePtr::get_mut`: the re-entered JS would alias its
+/// exclusive `&mut`.
 fn setter_utf8_arg(global: &JSGlobalObject, value: JSValue) -> JsResult<String> {
     let slice = value.to_slice(global)?;
     Ok(utf8_or_throw(global, slice.slice())?.to_owned())
@@ -1480,17 +2248,17 @@ pub struct TextChunk {
     // Intrusive RefCount; *Self is the JS wrapper m_ctx.
     ref_count: Cell<u32>,
     // R-2: `Cell` so host-fns take `&self` (re-entry-safe).
-    pub(crate) text_chunk: Cell<*mut RawTextChunk>,
+    pub(crate) text_chunk: DetachablePtr<RawTextChunk>,
 }
 
 impl TextChunk {
     // `ref_()`/`deref()` provided by `#[derive(CellRefCounted)]`.
 
-    pub(crate) fn init(text_chunk: *mut RawTextChunk) -> *mut TextChunk {
-        bun_core::heap::into_raw(Box::new(TextChunk {
+    pub(crate) fn init(text_chunk: *mut RawTextChunk) -> NonNull<TextChunk> {
+        bun_core::heap::alloc_nn(TextChunk {
             ref_count: Cell::new(1),
-            text_chunk: Cell::new(text_chunk),
-        }))
+            text_chunk: DetachablePtr::new(text_chunk),
+        })
     }
 
     lol_content_ops! { RawTextChunk, text_chunk, JSValue::UNDEFINED;
@@ -1505,7 +2273,7 @@ impl TextChunk {
         _global: &JSGlobalObject,
         call_frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let Some(chunk) = cell_get(&self.text_chunk) else {
+        let Some(chunk) = self.text_chunk.get_mut() else {
             return Ok(JSValue::UNDEFINED);
         };
         chunk.remove();
@@ -1514,7 +2282,7 @@ impl TextChunk {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_text(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
-        let Some(chunk) = cell_get(&self.text_chunk) else {
+        let Some(chunk) = self.text_chunk.get_mut() else {
             return Ok(JSValue::UNDEFINED);
         };
         string_to_js(chunk.as_str(), global)
@@ -1522,7 +2290,7 @@ impl TextChunk {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn removed(&self, _global: &JSGlobalObject) -> JSValue {
-        match cell_get(&self.text_chunk) {
+        match self.text_chunk.get_mut() {
             Some(chunk) => JSValue::from(chunk.removed()),
             None => JSValue::UNDEFINED,
         }
@@ -1530,7 +2298,7 @@ impl TextChunk {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn last_in_text_node(&self, _global: &JSGlobalObject) -> JSValue {
-        match cell_get(&self.text_chunk) {
+        match self.text_chunk.get_mut() {
             Some(chunk) => JSValue::from(chunk.last_in_text_node()),
             None => JSValue::UNDEFINED,
         }
@@ -1541,7 +2309,7 @@ impl TextChunk {
     }
 }
 
-impl_wrapper_like!(TextChunk, RawTextChunk);
+impl_wrapper_like!(TextChunk, RawTextChunk, text_chunk, suspended_text_chunk);
 
 // ──────────────────────────── DocType ────────────────────────────────────
 
@@ -1551,7 +2319,7 @@ pub struct DocType {
     // Intrusive RefCount; *Self is the JS wrapper m_ctx.
     ref_count: Cell<u32>,
     // R-2: `Cell` so host-fns take `&self` (re-entry-safe).
-    pub(crate) doctype: Cell<*mut RawDoctype>,
+    pub(crate) doctype: DetachablePtr<RawDoctype>,
 }
 
 impl DocType {
@@ -1561,17 +2329,17 @@ impl DocType {
         bun_ptr::finalize_js_box_noop(self);
     }
 
-    pub(crate) fn init(doctype: *mut RawDoctype) -> *mut DocType {
-        bun_core::heap::into_raw(Box::new(DocType {
+    pub(crate) fn init(doctype: *mut RawDoctype) -> NonNull<DocType> {
+        bun_core::heap::alloc_nn(DocType {
             ref_count: Cell::new(1),
-            doctype: Cell::new(doctype),
-        }))
+            doctype: DetachablePtr::new(doctype),
+        })
     }
 
     /// The doctype name.
     #[bun_jsc::host_fn(getter)]
     pub fn name(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
-        let Some(dt) = cell_get(&self.doctype) else {
+        let Some(dt) = self.doctype.get_mut() else {
             return Ok(JSValue::UNDEFINED);
         };
         opt_string_to_js_or_null(dt.name(), global_object)
@@ -1579,7 +2347,7 @@ impl DocType {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn system_id(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
-        let Some(dt) = cell_get(&self.doctype) else {
+        let Some(dt) = self.doctype.get_mut() else {
             return Ok(JSValue::UNDEFINED);
         };
         opt_string_to_js_or_null(dt.system_id(), global_object)
@@ -1587,7 +2355,7 @@ impl DocType {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn public_id(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
-        let Some(dt) = cell_get(&self.doctype) else {
+        let Some(dt) = self.doctype.get_mut() else {
             return Ok(JSValue::UNDEFINED);
         };
         opt_string_to_js_or_null(dt.public_id(), global_object)
@@ -1599,7 +2367,7 @@ impl DocType {
         _global: &JSGlobalObject,
         call_frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let Some(dt) = cell_get(&self.doctype) else {
+        let Some(dt) = self.doctype.get_mut() else {
             return Ok(JSValue::UNDEFINED);
         };
         dt.remove();
@@ -1608,14 +2376,14 @@ impl DocType {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn removed(&self, _global: &JSGlobalObject) -> JSValue {
-        match cell_get(&self.doctype) {
+        match self.doctype.get_mut() {
             Some(dt) => JSValue::from(dt.removed()),
             None => JSValue::UNDEFINED,
         }
     }
 }
 
-impl_wrapper_like!(DocType, RawDoctype);
+impl_wrapper_like!(DocType, RawDoctype, doctype, suspended_doctype);
 
 // ──────────────────────────── DocEnd ─────────────────────────────────────
 
@@ -1625,17 +2393,17 @@ pub struct DocEnd {
     // Intrusive RefCount; *Self is the JS wrapper m_ctx.
     ref_count: Cell<u32>,
     // R-2: `Cell` so host-fns take `&self` (re-entry-safe).
-    pub(crate) doc_end: Cell<*mut RawDocumentEnd>,
+    pub(crate) doc_end: DetachablePtr<RawDocumentEnd>,
 }
 
 impl DocEnd {
     // `ref_()`/`deref()` provided by `#[derive(CellRefCounted)]`.
 
-    pub(crate) fn init(doc_end: *mut RawDocumentEnd) -> *mut DocEnd {
-        bun_core::heap::into_raw(Box::new(DocEnd {
+    pub(crate) fn init(doc_end: *mut RawDocumentEnd) -> NonNull<DocEnd> {
+        bun_core::heap::alloc_nn(DocEnd {
             ref_count: Cell::new(1),
-            doc_end: Cell::new(doc_end),
-        }))
+            doc_end: DetachablePtr::new(doc_end),
+        })
     }
 
     lol_content_ops! { RawDocumentEnd, doc_end, JSValue::NULL;
@@ -1647,7 +2415,7 @@ impl DocEnd {
     }
 }
 
-impl_wrapper_like!(DocEnd, RawDocumentEnd);
+impl_wrapper_like!(DocEnd, RawDocumentEnd, doc_end, suspended_document_end);
 
 // ──────────────────────────── Comment ────────────────────────────────────
 
@@ -1657,17 +2425,17 @@ pub struct Comment {
     // Intrusive RefCount; *Self is the JS wrapper m_ctx.
     ref_count: Cell<u32>,
     // R-2: `Cell` so host-fns take `&self` (re-entry-safe).
-    pub(crate) comment: Cell<*mut RawComment>,
+    pub(crate) comment: DetachablePtr<RawComment>,
 }
 
 impl Comment {
     // `ref_()`/`deref()` provided by `#[derive(CellRefCounted)]`.
 
-    pub(crate) fn init(comment: *mut RawComment) -> *mut Comment {
-        bun_core::heap::into_raw(Box::new(Comment {
+    pub(crate) fn init(comment: *mut RawComment) -> NonNull<Comment> {
+        bun_core::heap::alloc_nn(Comment {
             ref_count: Cell::new(1),
-            comment: Cell::new(comment),
-        }))
+            comment: DetachablePtr::new(comment),
+        })
     }
 
     lol_content_ops! { RawComment, comment, JSValue::NULL;
@@ -1682,7 +2450,7 @@ impl Comment {
         _global: &JSGlobalObject,
         call_frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let Some(comment) = cell_get(&self.comment) else {
+        let Some(comment) = self.comment.get_mut() else {
             return Ok(JSValue::NULL);
         };
         comment.remove();
@@ -1691,7 +2459,7 @@ impl Comment {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_text(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
-        let Some(comment) = cell_get(&self.comment) else {
+        let Some(comment) = self.comment.get_mut() else {
             return Ok(JSValue::NULL);
         };
         string_to_js(&comment.text(), global_object)
@@ -1702,11 +2470,11 @@ impl Comment {
     // `JsResult<()>`); the proc-macro shim would emit a second, conflicting
     // `JsResult<bool>` wrapper.
     pub(crate) fn set_text(&self, global: &JSGlobalObject, value: JSValue) -> JsResult<()> {
-        if self.comment.get().is_null() {
+        if self.comment.is_detached() {
             return Ok(());
         }
         let text = setter_utf8_arg(global, value)?;
-        let Some(comment) = cell_get(&self.comment) else {
+        let Some(comment) = self.comment.get_mut() else {
             return Ok(());
         };
         if let Err(e) = comment.set_text(&text) {
@@ -1717,7 +2485,7 @@ impl Comment {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn removed(&self, _global: &JSGlobalObject) -> JSValue {
-        match cell_get(&self.comment) {
+        match self.comment.get_mut() {
             Some(comment) => JSValue::from(comment.removed()),
             None => JSValue::UNDEFINED,
         }
@@ -1728,7 +2496,7 @@ impl Comment {
     }
 }
 
-impl_wrapper_like!(Comment, RawComment);
+impl_wrapper_like!(Comment, RawComment, comment, suspended_comment);
 
 // ──────────────────────────── EndTag ─────────────────────────────────────
 
@@ -1738,7 +2506,7 @@ pub struct EndTag {
     // Intrusive RefCount; *Self is the JS wrapper m_ctx.
     ref_count: Cell<u32>,
     // R-2: `Cell` so host-fns take `&self` (re-entry-safe).
-    pub(crate) end_tag: Cell<*mut RawEndTag>,
+    pub(crate) end_tag: DetachablePtr<RawEndTag>,
 }
 
 pub struct EndTagHandler {
@@ -1749,24 +2517,21 @@ pub struct EndTagHandler {
 }
 
 impl EndTagHandler {
-    pub(crate) fn on_end_tag(this: *mut Self, value: *mut RawEndTag) -> bool {
-        handler_callback::<Self, EndTag, RawEndTag>(
-            this,
-            value,
-            |w| w.end_tag.set(core::ptr::null_mut()),
-            |h| h.callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub(crate) fn on_end_tag(this: NonNull<Self>, value: *mut RawEndTag) -> HandlerOutcome {
+        handler_callback::<Self, EndTag, RawEndTag>(this, value, |h| {
+            h.callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
 }
 
 impl EndTag {
     // `ref_()`/`deref()` provided by `#[derive(CellRefCounted)]`.
 
-    pub(crate) fn init(end_tag: *mut RawEndTag) -> *mut EndTag {
-        bun_core::heap::into_raw(Box::new(EndTag {
+    pub(crate) fn init(end_tag: *mut RawEndTag) -> NonNull<EndTag> {
+        bun_core::heap::alloc_nn(EndTag {
             ref_count: Cell::new(1),
-            end_tag: Cell::new(end_tag),
-        }))
+            end_tag: DetachablePtr::new(end_tag),
+        })
     }
 
     pub fn finalize(self: Box<Self>) {
@@ -1785,7 +2550,7 @@ impl EndTag {
         _global: &JSGlobalObject,
         call_frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let Some(end_tag) = cell_get(&self.end_tag) else {
+        let Some(end_tag) = self.end_tag.get_mut() else {
             return Ok(JSValue::UNDEFINED);
         };
         end_tag.remove();
@@ -1794,7 +2559,7 @@ impl EndTag {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_name(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
-        let Some(end_tag) = cell_get(&self.end_tag) else {
+        let Some(end_tag) = self.end_tag.get_mut() else {
             return Ok(JSValue::UNDEFINED);
         };
         string_to_js(&end_tag.name(), global_object)
@@ -1803,11 +2568,11 @@ impl EndTag {
     // Note: no `#[bun_jsc::host_fn(setter)]` — generated_classes.rs already
     // emits `EndTagPrototype__setName` via `host_setter_result`.
     pub(crate) fn set_name(&self, global: &JSGlobalObject, value: JSValue) -> JsResult<()> {
-        if self.end_tag.get().is_null() {
+        if self.end_tag.is_detached() {
             return Ok(());
         }
         let name = setter_utf8_arg(global, value)?;
-        let Some(end_tag) = cell_get(&self.end_tag) else {
+        let Some(end_tag) = self.end_tag.get_mut() else {
             return Ok(());
         };
         end_tag.set_name_str(name);
@@ -1815,60 +2580,47 @@ impl EndTag {
     }
 }
 
-impl_wrapper_like!(EndTag, RawEndTag);
+impl_wrapper_like!(EndTag, RawEndTag, end_tag, suspended_end_tag);
 
 // ───────────────────────── AttributeIterator ─────────────────────────────
 
 /// The JS `AttributeIterator` heap-boxes one of these over `Element::attributes`
-/// (the Rust crate exposes a slice, not a boxed iterator like the C API did).
-/// Lifetimes are erased; `Element` detaches every iterator before invalidation.
-type RawAttributeIterator = core::slice::Iter<'static, lol_html::html_content::Attribute<'static>>;
-
 #[bun_jsc::JsClass(no_construct, no_finalize, no_constructor)]
 #[derive(bun_ptr::CellRefCounted)]
 #[ref_count(destroy = AttributeIterator::destroy_on_zero)]
 pub struct AttributeIterator {
     // Intrusive RefCount; *Self is the JS wrapper m_ctx.
     ref_count: Cell<u32>,
-    // R-2: `Cell` so host-fns take `&self` (re-entry-safe).
-    pub(crate) iterator: Cell<*mut RawAttributeIterator>,
+    /// Non-owning backref to the `Element` wrapper that handed this iterator
+    /// out. Reading the attributes through it (rather than caching a
+    /// `slice::Iter` into the attribute buffer) means a suspension, which
+    /// re-points the element at lol-html's heap-parked copy, re-points this
+    /// iterator too. The element keeps a `+1` on us and nulls this in
+    /// `detach()`, so it never dangles. R-2: `Cell` so host-fns take `&self`.
+    element: Cell<Option<BackRef<Element>>>,
+    /// Index of the next attribute to yield.
+    index: Cell<usize>,
 }
 
 impl AttributeIterator {
     // `ref_()`/`deref()` provided by `#[derive(CellRefCounted)]`.
 
-    /// `CellRefCounted::destroy` target — detach the lol-html iterator before
-    /// freeing the Box.
+    /// `CellRefCounted::destroy` target.
     ///
     /// Safe fn: only reachable via the `#[ref_count(destroy = …)]` derive,
     /// whose generated trait `destroy` upholds the sole-owner contract.
     fn destroy_on_zero(this: *mut Self) {
-        // SAFETY: refcount hit zero; sole owner of a `heap::alloc`'d `Self`.
-        unsafe {
-            (*this).detach();
-            drop(bun_core::heap::take(this));
-        }
+        bun_ptr::destroy_box_with(this, |t| t.detach());
     }
 
+    /// Drop the backref. The element owns our `+1` and clears it here, so the
+    /// raw pointer is never read after the element stops tracking us.
     fn detach(&self) {
-        let iterator = self.iterator.replace(core::ptr::null_mut());
-        if !iterator.is_null() {
-            // SAFETY: `iterator` was `heap::into_raw`'d in
-            // `Element::get_attributes`; the Cell is its sole owner and was
-            // nulled above, so this runs at most once.
-            unsafe { bun_core::heap::destroy(iterator) };
-        }
+        self.element.set(None);
     }
 
     pub fn finalize(self: Box<Self>) {
-        // Refcounted: release the JS wrapper's +1. Hand ownership back to the
-        // raw refcount FIRST so a panic in detach() leaks instead of UAF-ing
-        // siblings.
-        let this = bun_core::heap::release(self);
-        this.detach();
-        // SAFETY: `this` is the Box-allocated m_ctx payload; the JS wrapper
-        // held one ref, which this call releases.
-        unsafe { Self::deref(this) };
+        bun_ptr::finalize_js_box(self, |t| t.detach());
     }
 
     #[bun_jsc::host_fn(method)]
@@ -1880,9 +2632,14 @@ impl AttributeIterator {
         let done_label = bun_core::ZigString::init(b"done");
         let value_label = bun_core::ZigString::init(b"value");
 
-        let Some(attribute) = cell_get(&self.iterator).and_then(|it| it.next()) else {
-            // Exhausted or already detached: free the boxed iterator eagerly
-            // (a no-op once the Cell is null), matching the c-api path.
+        // Detached (the handler returned, or an attribute was mutated), the
+        // element itself is gone, or we ran off the end of the buffer.
+        let attribute = self
+            .element
+            .get()
+            .and_then(|el| el.element.get_mut())
+            .and_then(|raw| raw.attributes().get(self.index.get()));
+        let Some(attribute) = attribute else {
             self.detach();
             return JSValue::create_object2(
                 global_object,
@@ -1892,6 +2649,7 @@ impl AttributeIterator {
                 JSValue::UNDEFINED,
             );
         };
+        self.index.set(self.index.get() + 1);
 
         let value = attribute.value();
         let name = attribute.name();
@@ -1930,16 +2688,15 @@ pub struct Element {
     // Intrusive RefCount; *Self is the JS wrapper m_ctx.
     ref_count: Cell<u32>,
     // R-2: `Cell` so host-fns take `&self` (re-entry-safe).
-    pub(crate) element: Cell<*mut RawElement>,
-    /// AttributeIterator instances created by `getAttributes()` that borrow
-    /// from `element`. They must be detached in `invalidate()` when the
-    /// handler returns so that JS cannot dereference the freed lol-html
-    /// attribute buffer.
+    pub(crate) element: DetachablePtr<RawElement>,
+    /// AttributeIterator instances handed out by `getAttributes()`. Each holds
+    /// a non-owning backref to this `Element` plus a `+1` we own; `invalidate()`
+    /// nulls those backrefs when the handler returns, so none can outlive us.
     /// R-2: `JsCell` (non-Copy `Vec`) — pushed/drained from `&self` host-fns
     /// (`get_attributes`, `set_attribute`, `remove_attribute`). The `with_mut`
     /// closures do not call into JS, so the short `&mut Vec` borrow cannot
     /// overlap a re-entrant access.
-    pub(crate) attribute_iterators: JsCell<Vec<*mut AttributeIterator>>,
+    pub(crate) attribute_iterators: JsCell<Vec<NonNull<AttributeIterator>>>,
 }
 
 impl Element {
@@ -1951,50 +2708,41 @@ impl Element {
     /// Safe fn: only reachable via the `#[ref_count(destroy = …)]` derive,
     /// whose generated trait `destroy` upholds the sole-owner contract.
     fn destroy_on_zero(this: *mut Self) {
-        // SAFETY: refcount hit zero; sole owner of a `heap::alloc`'d `Self`.
-        unsafe {
-            (*this).invalidate();
-            drop(bun_core::heap::take(this));
-        }
+        bun_ptr::destroy_box_with(this, |t| t.invalidate());
     }
 
-    pub(crate) fn init(element: *mut RawElement) -> *mut Element {
-        bun_core::heap::into_raw(Box::new(Element {
+    pub(crate) fn init(element: *mut RawElement) -> NonNull<Element> {
+        bun_core::heap::alloc_nn(Element {
             ref_count: Cell::new(1),
-            element: Cell::new(element),
+            element: DetachablePtr::new(element),
             attribute_iterators: JsCell::new(Vec::new()),
-        }))
+        })
     }
 
     pub fn finalize(self: Box<Self>) {
         bun_ptr::finalize_js_box_noop(self);
     }
 
-    /// Detach every `AttributeIterator` we handed to JS. Called when the
-    /// underlying attribute buffer is about to become invalid — either because
-    /// the handler is returning, or because `setAttribute` / `removeAttribute`
-    /// is about to mutate the `Vec<Attribute>` the iterators borrow from.
+    /// End every `AttributeIterator` we handed to JS: null its backref to us
+    /// and release our `+1`. Called when the handler is returning (we are about
+    /// to stop being a valid target) or when `setAttribute` / `removeAttribute`
+    /// is about to renumber the attributes their index refers into.
     fn detach_attribute_iterators(&self) {
         // R-2: take the Vec out of the cell, drain on the stack — no `&mut`
         // projection of `self` is held across `detach()`/`deref()` (which do
         // not re-enter JS, but defence-in-depth keeps the JsCell borrow zero-len).
         let iters = self.attribute_iterators.replace(Vec::new());
         for iter in iters {
-            // SAFETY: iter is a live AttributeIterator we ref'd in get_attributes();
-            // ref_count >= 1 so the allocation is valid here.
-            unsafe { (*iter).detach() };
-            // SAFETY: `iter` is a live AttributeIterator we ref'd in
-            // `get_attributes()`; release that ref.
-            unsafe { AttributeIterator::deref(iter) };
+            BackRef::from(iter).detach();
+            <AttributeIterator as CellRefCounted>::deref_nn(iter);
         }
     }
 
     /// Called by `handler_callback` when the handler returns. The underlying
-    /// `*LOLHTML.Element` (and the attribute buffer any `AttributeIterator`
-    /// borrows from) is only valid during handler execution, so we must null
-    /// it out here along with any iterators we handed to JS.
+    /// `*LOLHTML.Element` is only valid during handler execution, so null it
+    /// out here, and end the iterators that read through it.
     pub(crate) fn invalidate(&self) {
-        self.element.set(core::ptr::null_mut());
+        self.element.detach();
         self.detach_attribute_iterators();
         self.attribute_iterators.set(Vec::new());
     }
@@ -2005,7 +2753,7 @@ impl Element {
         function: JSValue,
         call_frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let Some(el) = cell_get(&self.element) else {
+        let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::NULL);
         };
         if function.is_undefined_or_null() || !function.is_callable() {
@@ -2031,12 +2779,13 @@ impl Element {
         };
         handlers.push(Box::new(move |end_tag| {
             // SAFETY: lifetime erasure. `end_tag` only lives for this
-            // synchronous call; `handler_callback`'s `clear_field` nulls the
-            // `EndTag` JsClass `Cell` before this closure returns, so JS can
-            // never reach the erased pointer afterwards.
+            // synchronous call; `handler_callback`'s guard detaches the
+            // `EndTag` JsClass slot before this closure returns (or, on a
+            // suspension, re-points it at the heap copy lol-html parks), so
+            // JS can never reach a dangling pointer.
             let raw: *mut RawEndTag = core::ptr::from_mut(end_tag).cast();
-            directive_result(EndTagHandler::on_end_tag(
-                core::ptr::from_mut(&mut end_tag_handler),
+            handler_result(EndTagHandler::on_end_tag(
+                NonNull::from(&mut end_tag_handler),
                 raw,
             ))
         }));
@@ -2050,7 +2799,7 @@ impl Element {
         global_object: &JSGlobalObject,
         name: ZigString,
     ) -> JsResult<JSValue> {
-        let Some(el) = cell_get(&self.element) else {
+        let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::NULL);
         };
         let slice = name.to_slice();
@@ -2068,7 +2817,7 @@ impl Element {
         global: &JSGlobalObject,
         name: ZigString,
     ) -> JsResult<JSValue> {
-        let Some(el) = cell_get(&self.element) else {
+        let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::FALSE);
         };
         let slice = name.to_slice();
@@ -2084,12 +2833,12 @@ impl Element {
         name_: ZigString,
         value_: ZigString,
     ) -> JsResult<JSValue> {
-        let Some(el) = cell_get(&self.element) else {
+        let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::UNDEFINED);
         };
 
-        // Mutating the attribute Vec (push → possible realloc) invalidates the
-        // slice::Iter any live AttributeIterator borrows from.
+        // A push shifts what the index any live AttributeIterator holds refers
+        // to, so end their iteration rather than let them repeat or skip one.
         self.detach_attribute_iterators();
 
         let name_slice = name_.to_slice();
@@ -2110,12 +2859,12 @@ impl Element {
         global_object: &JSGlobalObject,
         name: ZigString,
     ) -> JsResult<JSValue> {
-        let Some(el) = cell_get(&self.element) else {
+        let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::UNDEFINED);
         };
 
-        // Vec::remove shifts trailing elements and shrinks len, leaving any
-        // live slice::Iter's end pointer past the new end.
+        // `Vec::remove` shifts the trailing attributes down, so a live
+        // AttributeIterator's index would skip the one that took this slot.
         self.detach_attribute_iterators();
 
         let name_slice = name.to_slice();
@@ -2199,7 +2948,7 @@ impl Element {
         _global: &JSGlobalObject,
         call_frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let Some(el) = cell_get(&self.element) else {
+        let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::UNDEFINED);
         };
         el.remove();
@@ -2213,7 +2962,7 @@ impl Element {
         _global: &JSGlobalObject,
         call_frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let Some(el) = cell_get(&self.element) else {
+        let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::UNDEFINED);
         };
         el.remove_and_keep_content();
@@ -2222,7 +2971,7 @@ impl Element {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_tag_name(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
-        let Some(el) = cell_get(&self.element) else {
+        let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::UNDEFINED);
         };
         string_to_js(&el.tag_name(), global_object)
@@ -2231,11 +2980,11 @@ impl Element {
     // Note: no `#[bun_jsc::host_fn(setter)]` — generated_classes.rs already
     // emits `ElementPrototype__setTagName` via `host_setter_result`.
     pub(crate) fn set_tag_name(&self, global: &JSGlobalObject, value: JSValue) -> JsResult<()> {
-        if self.element.get().is_null() {
+        if self.element.is_detached() {
             return Ok(());
         }
         let name = setter_utf8_arg(global, value)?;
-        let Some(el) = cell_get(&self.element) else {
+        let Some(el) = self.element.get_mut() else {
             return Ok(());
         };
         if let Err(e) = el.set_tag_name(&name) {
@@ -2246,7 +2995,7 @@ impl Element {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_removed(&self, _global: &JSGlobalObject) -> JSValue {
-        match cell_get(&self.element) {
+        match self.element.get_mut() {
             Some(el) => JSValue::from(el.removed()),
             None => JSValue::UNDEFINED,
         }
@@ -2254,7 +3003,7 @@ impl Element {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_self_closing(&self, _global: &JSGlobalObject) -> JSValue {
-        match cell_get(&self.element) {
+        match self.element.get_mut() {
             Some(el) => JSValue::from(el.is_self_closing()),
             None => JSValue::UNDEFINED,
         }
@@ -2262,7 +3011,7 @@ impl Element {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_can_have_content(&self, _global: &JSGlobalObject) -> JSValue {
-        match cell_get(&self.element) {
+        match self.element.get_mut() {
             Some(el) => JSValue::from(el.can_have_content()),
             None => JSValue::UNDEFINED,
         }
@@ -2270,7 +3019,7 @@ impl Element {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_namespace_uri(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
-        let Some(el) = cell_get(&self.element) else {
+        let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::UNDEFINED);
         };
         string_to_js(el.namespace_uri(), global_object)
@@ -2278,32 +3027,117 @@ impl Element {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_attributes(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
-        let Some(el) = cell_get(&self.element) else {
+        if self.element.is_detached() {
             return Ok(JSValue::UNDEFINED);
-        };
+        }
 
-        // `cell_get`'s erased `'static` carries through `attributes()`. The
-        // boxed iterator never outlives the real attribute buffer: it is
-        // tracked below and detached in `invalidate()` (when the handler
-        // returns) and before any attribute mutation.
-        let attrs: &'static [lol_html::html_content::Attribute<'static>] = el.attributes();
-        let iter = bun_core::heap::into_raw(Box::new(attrs.iter()));
-        let attr_iter = bun_core::heap::into_raw(Box::new(AttributeIterator {
+        // The iterator reads attributes back through `self` on every `next()`,
+        // so it follows a retarget (suspension) and never caches a borrow into
+        // the attribute buffer.
+        let attr_iter = bun_core::heap::alloc_nn(AttributeIterator {
             ref_count: Cell::new(1),
-            iterator: Cell::new(iter),
-        }));
-        // Track this iterator so we can detach it when the handler returns.
-        // lol-html's attribute slice borrows from the element's token buffer
-        // which is freed after the callback; leaking the iterator to JS
-        // without detaching it would be a use-after-free.
-        // SAFETY: attr_iter is a fresh heap::alloc allocation (refcount==1).
-        unsafe { (*attr_iter).ref_() };
+            element: Cell::new(Some(BackRef::new(self))),
+            index: Cell::new(0),
+        });
+        // Track this iterator so we can detach it when the handler returns or
+        // an attribute mutation invalidates it.
+        <AttributeIterator as CellRefCounted>::ref_nn(attr_iter);
         // R-2: `with_mut` — closure does not call into JS (push only).
         self.attribute_iterators.with_mut(|v| v.push(attr_iter));
-        // SAFETY: attr_iter is live (refcount==2 now); ownership is shared with
-        // the GC wrapper via the intrusive refcount (`finalize` → `deref`).
-        Ok(unsafe { AttributeIterator::to_js_ptr(attr_iter, global_object) })
+        Ok(AttributeIterator::to_js_nonnull(attr_iter, global_object))
     }
 }
 
-impl_wrapper_like!(Element, RawElement, invalidate);
+// `Element` is the one wrapper whose `detach` has to do more than null out the
+// raw pointer: it also ends the `AttributeIterator`s it handed to JS, which
+// hold a backref to it and read through it (see `invalidate`).
+impl WrapperLike for Element {
+    type Raw = RawElement;
+    fn init(v: *mut Self::Raw) -> NonNull<Self> {
+        Self::init(v)
+    }
+    fn ref_(&self) {
+        self.ref_()
+    }
+    fn deref_nn(this: NonNull<Self>) {
+        <Self as CellRefCounted>::deref_nn(this)
+    }
+    fn to_js(this: NonNull<Self>, g: &JSGlobalObject) -> JSValue {
+        Self::to_js_nonnull(this, g)
+    }
+    fn detach(&self) {
+        self.invalidate();
+    }
+    fn retarget(&self, raw: *mut Self::Raw) {
+        // The element's lol-html backing (including the attribute buffer) was
+        // replaced by the owned copy `into_suspended` parked on the heap.
+        // `AttributeIterator` reads through this same cell on every `next()`,
+        // so iterators handed out before the handler's `await` keep working,
+        // resuming at the same index into the copied buffer.
+        self.element.set(raw);
+    }
+    fn suspended_raw(rewriter: &mut LolRewriter) -> *mut Self::Raw {
+        rewriter
+            .suspended_element()
+            .map_or(core::ptr::null_mut(), |unit| {
+                core::ptr::from_mut(unit).cast()
+            })
+    }
+    fn into_suspended(wrapper: NonNull<Self>) -> SuspendedWrapper {
+        SuspendedWrapper::Element(wrapper)
+    }
+}
+
+// ───────────────── input-stream JS-pump .then() reactions ────────────────
+// `JSSink::<RewriterPipe>::assign_to_stream` returns a promise on the
+// JS-readable fallback path (no native ByteStream/FileReader). These are its
+// resolve/reject reactions, mirroring `Bun__FetchTasklet__on*RequestStream`
+// (src/runtime/webcore/fetch/FetchTasklet.rs) and `Bun__FileSink__on*Stream`.
+// The context is the `JSHTMLRewriterTransform` cell passed by
+// `RewriterPipe::wire_input`'s `.then_with_value()`; the cell (and thus the
+// pipe) stays alive as long as the pump promise's reaction is rooted.
+
+fn on_resolve_input_stream(
+    _global_this: &JSGlobalObject,
+    callframe: &CallFrame,
+) -> JsResult<JSValue> {
+    let args = callframe.arguments();
+    let Some(this) = js_HTMLRewriterTransform::from_js(args[args.len() - 1]) else {
+        return Ok(JSValue::UNDEFINED);
+    };
+    let this = BackRef::from(this);
+    let this = &*this;
+    this.js_pump_reaction_pending.set(false);
+    this.end_from_stream(None);
+    Ok(JSValue::UNDEFINED)
+}
+
+fn on_reject_input_stream(
+    global_this: &JSGlobalObject,
+    callframe: &CallFrame,
+) -> JsResult<JSValue> {
+    let args = callframe.arguments();
+    let Some(this) = js_HTMLRewriterTransform::from_js(args[args.len() - 1]) else {
+        return Ok(JSValue::UNDEFINED);
+    };
+    let err = args[0];
+    let this = BackRef::from(this);
+    let this = &*this;
+    this.js_pump_reaction_pending.set(false);
+    this.end_from_stream(Some(crate::webcore::streams::StreamError::JSValue(
+        jsc::strong::Optional::create(err, global_this),
+    )));
+    Ok(JSValue::UNDEFINED)
+}
+
+// Exported as *function* symbols so `Zig::GlobalObject::promiseHandlerID`'s
+// address comparison matches; a `static` fn-ptr export would export the data
+// slot's address, not the code address (see `Bun__FileSink__onResolveStream`).
+bun_jsc::jsc_promise_handler!(
+    pub(crate) fn on_resolve_input_stream_shim = "Bun__HTMLRewriter__onResolveInputStream"
+        => on_resolve_input_stream
+);
+bun_jsc::jsc_promise_handler!(
+    pub(crate) fn on_reject_input_stream_shim = "Bun__HTMLRewriter__onRejectInputStream"
+        => on_reject_input_stream
+);

--- a/src/runtime/api/streams.classes.ts
+++ b/src/runtime/api/streams.classes.ts
@@ -92,7 +92,10 @@ function source(name) {
         : {}),
     },
     klass: {},
-    values: ["pendingPromise", "onCloseCallback", "onDrainCallback"],
+    // `owner` roots the GC cell of the peer producing into this source
+    // (`producer` backref); `sinkOwner` roots the peer it pipes into
+    // (`sink` backref). A chained transform needs both.
+    values: ["pendingPromise", "onCloseCallback", "onDrainCallback", "owner", "sinkOwner"],
   });
 }
 

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -26,12 +26,6 @@ pub enum Error {
     SyntaxError,
     #[error("FmtError")]
     FmtError,
-    #[error("StreamAlreadyUsed")]
-    StreamAlreadyUsed,
-    #[error("InvalidStream")]
-    InvalidStream,
-    #[error("UnsupportedStreamType")]
-    UnsupportedStreamType,
     #[error("JSError")]
     JSError,
     #[error("ERR_TLS_CERT_ALTNAME_INVALID")]
@@ -598,9 +592,6 @@ impl Error {
             Self::SnapshotInConcurrentGroup => "SnapshotInConcurrentGroup",
             Self::SyntaxError => "SyntaxError",
             Self::FmtError => "FmtError",
-            Self::StreamAlreadyUsed => "StreamAlreadyUsed",
-            Self::InvalidStream => "InvalidStream",
-            Self::UnsupportedStreamType => "UnsupportedStreamType",
             Self::JSError => "JSError",
             Self::ERR_TLS_CERT_ALTNAME_INVALID => "ERR_TLS_CERT_ALTNAME_INVALID",
             Self::RequestBodyNotReusable => "RequestBodyNotReusable",

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1968,7 +1968,8 @@ where
     }
 
     fn do_render_with_body_locked(this: NonNull<c_void>, value: &mut Body::Value) {
-        let pinned = RequestContextRef::pin(this.cast::<Self>().as_ptr());
+        // Consumes the +1 taken at the `on_receive_value` registration site.
+        let pinned = RequestContextRef::adopt(this.cast::<Self>().as_ptr());
         pinned
             .ctx()
             .do_render_with_body(std::ptr::from_mut(value), None);

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3294,9 +3294,24 @@ where
                                     Self::drain_response_buffer_and_metadata_corked,
                                     this.as_ctx_ptr(),
                                 );
+                            } else if matches!(
+                                byte_stream.parent_const().producer.get(),
+                                WebCore::streams::SourceHandle::HTMLRewriter(_)
+                            ) {
+                                // An HTMLRewriter producer can fail before its
+                                // first byte (an async handler rejecting);
+                                // defer status/headers to the first chunk/end
+                                // so that failure can still reach `error()`.
+                                // Headers never preceded the first byte on
+                                // this path before either: the old
+                                // implementation buffered the whole rewrite.
+                            } else {
+                                // if we only have metadata to send, send it now
+                                resp.run_corked_with_type(
+                                    Self::render_metadata_corked,
+                                    this.as_ctx_ptr(),
+                                );
                             }
-                            // Otherwise defer metadata to the first chunk/end so
-                            // a pre-first-byte failure can still reach `error()`.
                             return;
                         }
                     }
@@ -3341,9 +3356,9 @@ where
         }
         let resp = this.resp.get().expect("infallible: resp bound");
 
-        // The `Source::Bytes` path defers metadata until the first body
-        // chunk so an upstream failure that arrives before any bytes can
-        // still reach the server's `error()` hook. Flush it now, corked.
+        // A rewriter-produced `Source::Bytes` body defers metadata until the
+        // first chunk so a pre-first-byte failure can still reach the
+        // server's `error()` hook. Flush it now, corked.
         if !this.flags.has_written_status() {
             resp.run_corked_with_type(Self::render_metadata_corked, this.as_ctx_ptr());
         }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3298,13 +3298,9 @@ where
                                 byte_stream.parent_const().producer.get(),
                                 WebCore::streams::SourceHandle::HTMLRewriter(_)
                             ) {
-                                // An HTMLRewriter producer can fail before its
-                                // first byte (an async handler rejecting);
-                                // defer status/headers to the first chunk/end
-                                // so that failure can still reach `error()`.
-                                // Headers never preceded the first byte on
-                                // this path before either: the old
-                                // implementation buffered the whole rewrite.
+                                // Defer status/headers to the first chunk/end
+                                // so a pre-first-byte handler failure can
+                                // still reach `error()`.
                             } else {
                                 // if we only have metadata to send, send it now
                                 resp.run_corked_with_type(

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -238,7 +238,7 @@ mod NativePromiseContext {
         global: &JSGlobalObject,
         ctx: *mut T,
     ) -> JSValue {
-        npc::create(global, ctx)
+        npc::create(global, ctx, JSValue::ZERO)
     }
     #[inline]
     pub(super) fn take<T>(cell: JSValue) -> Option<NonNull<T>> {
@@ -792,8 +792,13 @@ where
         if self.reject_unsendable_response(unsafe { (*response).status_code() }) {
             return;
         }
+        // An async error() Response may replace a still-protected streaming
+        // Response; release the original before overwriting.
+        if self.flags.response_protected() {
+            self.response_jsvalue.get().unprotect();
+            self.flags.set_response_protected(false);
+        }
         self.response_jsvalue.set(value);
-        debug_assert!(!self.flags.response_protected());
         self.flags.set_response_protected(true);
         value.protect();
 
@@ -1962,8 +1967,8 @@ where
         });
     }
 
-    fn do_render_with_body_locked(this: *mut c_void, value: &mut Body::Value) {
-        let pinned = RequestContextRef::pin(this.cast::<Self>());
+    fn do_render_with_body_locked(this: NonNull<c_void>, value: &mut Body::Value) {
+        let pinned = RequestContextRef::pin(this.cast::<Self>().as_ptr());
         pinned
             .ctx()
             .do_render_with_body(std::ptr::from_mut(value), None);
@@ -2068,7 +2073,7 @@ where
             ResponseStreamJSSink::<SSL_ENABLED, HTTP3>::assign_to_stream(
                 global_this,
                 stream.value,
-                &mut response_stream.sink,
+                NonNull::from(&mut response_stream.sink),
             );
 
         assignment_result.ensure_still_alive();
@@ -3288,13 +3293,9 @@ where
                                     Self::drain_response_buffer_and_metadata_corked,
                                     this.as_ctx_ptr(),
                                 );
-                            } else {
-                                // if we only have metadata to send, send it now
-                                resp.run_corked_with_type(
-                                    Self::render_metadata_corked,
-                                    this.as_ctx_ptr(),
-                                );
                             }
+                            // Otherwise defer metadata to the first chunk/end so
+                            // a pre-first-byte failure can still reach `error()`.
                             return;
                         }
                     }
@@ -3310,10 +3311,14 @@ where
                     return;
                 }
 
-                // when there's no stream, we need to
+                // No stream and no other consumer: wait for `Value::resolve`.
+                // The registered callback owns a +1 on `this`, released by
+                // `do_render_with_body_locked`.
+                this.ref_();
+                this.flags.set_has_marked_pending(true);
                 lock.on_receive_value =
                     Some(|ctx, value| Self::do_render_with_body_locked(ctx, value));
-                lock.task = Some(this.as_ctx_ptr().cast::<c_void>());
+                lock.task = Some(NonNull::new(this.as_ctx_ptr().cast::<c_void>()).unwrap());
 
                 return;
             }
@@ -3334,6 +3339,13 @@ where
             return WebCore::streams::Writable::Done;
         }
         let resp = this.resp.get().expect("infallible: resp bound");
+
+        // The `Source::Bytes` path defers metadata until the first body
+        // chunk so an upstream failure that arrives before any bytes can
+        // still reach the server's `error()` hook. Flush it now, corked.
+        if !this.flags.has_written_status() {
+            resp.run_corked_with_type(Self::render_metadata_corked, this.as_ctx_ptr());
+        }
 
         let chunk = stream.slice();
         // on failure, it will continue to allocate
@@ -3365,13 +3377,33 @@ where
         if this.is_aborted_or_ended() {
             return;
         }
-        if err.is_some()
-            && let Some(resp) = this.resp.get()
-        {
-            let state = resp.state();
-            if state.is_http_write_called() && state.is_response_pending() {
-                this.force_close();
+        if let Some(err) = err {
+            // No status committed yet: the upstream producer (e.g. a
+            // suspended `HTMLRewriter` transform whose async handler
+            // rejected) failed before any bytes were emitted. Detach the
+            // ByteStream state and hand the error to the server's
+            // `error()` hook so it can supply the response.
+            if !this.flags.has_written_status() {
+                let global_this = this.server().global_this();
+                let js_err = err.to_js(global_this);
+                this.byte_stream.set(None);
+                this.response_body_readable_stream_ref
+                    .with_mut(|s| s.deinit());
+                this.run_error_handler(js_err);
                 return;
+            }
+            if let Some(resp) = this.resp.get() {
+                let state = resp.state();
+                if state.is_http_write_called() && state.is_response_pending() {
+                    this.force_close();
+                    return;
+                }
+            }
+        } else if !this.flags.has_written_status() {
+            // Upstream ended cleanly before any chunk: flush the deferred
+            // status/headers so the client sees them before the terminator.
+            if let Some(resp) = this.resp.get() {
+                resp.run_corked_with_type(Self::render_metadata_corked, this.as_ctx_ptr());
             }
         }
         this.end_stream(this.should_close_connection());
@@ -3646,6 +3678,34 @@ where
                         // falls through to the default error page below.
                         // SAFETY: `response` is the live, rooted cell pointer.
                         if HTTPStatusText::is_sendable(unsafe { (*response).status_code() }) {
+                            // A file or streaming body defers `render_metadata`
+                            // past this frame, where `_keep` is the only root,
+                            // so root the Response the way the async error
+                            // path does or the deferred flush can read a
+                            // collected weakref.
+                            if self.flags.response_protected() {
+                                self.response_jsvalue.get().unprotect();
+                            }
+                            self.response_jsvalue.set(result);
+                            self.flags.set_response_protected(false);
+                            // SAFETY: sole `&mut Response` borrow for this
+                            // cell; it ends before `render` reborrows the
+                            // same pointer.
+                            let body_value = unsafe { (*response).get_body_value() };
+                            body_value.to_blob_if_possible();
+                            match body_value {
+                                Body::Value::Blob(blob) => {
+                                    if shim::blob_needs_to_read_file(blob) {
+                                        result.protect();
+                                        self.flags.set_response_protected(true);
+                                    }
+                                }
+                                Body::Value::Locked(_) => {
+                                    result.protect();
+                                    self.flags.set_response_protected(true);
+                                }
+                                _ => {}
+                            }
                             // SAFETY: as above.
                             unsafe { self.render(response) };
                             return;
@@ -3704,6 +3764,10 @@ where
                     return;
                 }
 
+                // Same as handle_resolve: release a still-protected original.
+                if ctx.flags.response_protected() {
+                    ctx.response_jsvalue.get().unprotect();
+                }
                 ctx.response_jsvalue.set(fulfilled_value);
                 fulfilled_value.ensure_still_alive();
                 ctx.flags.set_response_protected(false);
@@ -4366,27 +4430,27 @@ where
     }
 
     pub(crate) fn on_request_body_readable_stream_available(
-        ptr: *mut c_void,
+        ptr: NonNull<c_void>,
         global_this: &JSGlobalObject,
         readable: WebCore::ReadableStream,
     ) {
         // SAFETY: `ptr` is the registered live body-callback context.
-        let this = unsafe { &*ptr.cast::<Self>() };
+        let this = unsafe { ptr.cast::<Self>().as_ref() };
         debug_assert!(!this.request_body_readable_stream_ref.with_mut(|s| s.has()));
         this.request_body_readable_stream_ref
             .set(readable_stream::Strong::init(readable, global_this));
     }
 
-    pub(crate) fn on_start_buffering_callback(this: *mut c_void) {
+    pub(crate) fn on_start_buffering_callback(this: NonNull<c_void>) {
         // SAFETY: `this` is the registered live body-callback context.
-        unsafe { &*this.cast::<Self>() }.on_start_buffering();
+        unsafe { this.cast::<Self>().as_ref() }.on_start_buffering();
     }
 
     pub(crate) fn on_start_streaming_request_body_callback(
-        this: *mut c_void,
+        this: NonNull<c_void>,
     ) -> WebCore::DrainResult {
         // SAFETY: `this` is the registered live body-callback context.
-        unsafe { &*this.cast::<Self>() }.on_start_streaming_request_body()
+        unsafe { this.cast::<Self>().as_ref() }.on_start_streaming_request_body()
     }
 
     pub(crate) fn get_remote_socket_info(&self) -> Option<uws::SocketAddress> {

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -822,7 +822,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 unsafe {
                     *body_value =
                         crate::webcore::body::Value::Locked(crate::webcore::body::PendingValue {
-                            task: Some(ctx.cast::<c_void>()),
+                            task: Some(core::ptr::NonNull::new(ctx).unwrap().cast::<c_void>()),
                             global: std::ptr::from_ref(global),
                             on_start_buffering: Some(
                                 ServerRequestContext::<SSL, DEBUG>::on_start_buffering_callback,

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -128,10 +128,10 @@ trait RequestCtxOps: RequestCtx {
     fn arm_on_data(&self, resp: &mut Self::Resp);
     // body-streaming callback hooks (type-erased, stored on `Body::PendingValue`).
     // `this` must be a live `*mut Self::RequestCtx` cast to `*mut c_void`.
-    fn on_start_buffering_callback(this: *mut c_void);
-    fn on_start_streaming_request_body_callback(this: *mut c_void) -> WebCore::DrainResult;
+    fn on_start_buffering_callback(this: NonNull<c_void>);
+    fn on_start_streaming_request_body_callback(this: NonNull<c_void>) -> WebCore::DrainResult;
     fn on_request_body_readable_stream_available(
-        this: *mut c_void,
+        this: NonNull<c_void>,
         global_this: &JSGlobalObject,
         readable: WebCore::ReadableStream,
     );
@@ -258,16 +258,16 @@ where
             .on_data(handler::<ThisServer, SSL, DBG, H3>, self.as_ctx_ptr());
     }
     #[inline]
-    fn on_start_buffering_callback(this: *mut c_void) {
+    fn on_start_buffering_callback(this: NonNull<c_void>) {
         Self::on_start_buffering_callback(this)
     }
     #[inline]
-    fn on_start_streaming_request_body_callback(this: *mut c_void) -> WebCore::DrainResult {
+    fn on_start_streaming_request_body_callback(this: NonNull<c_void>) -> WebCore::DrainResult {
         Self::on_start_streaming_request_body_callback(this)
     }
     #[inline]
     fn on_request_body_readable_stream_available(
-        this: *mut c_void,
+        this: NonNull<c_void>,
         global_this: &JSGlobalObject,
         readable: WebCore::ReadableStream,
     ) {
@@ -3313,7 +3313,7 @@ where
                 // we don't waste memory
                 if let Some(body) = ctx.request_body_mut() {
                     *body = BodyValue::Locked(crate::webcore::body::PendingValue {
-                        task: Some(ctx_slot.cast::<c_void>()),
+                        task: Some(NonNull::new(ctx_slot).unwrap().cast::<c_void>()),
                         global: server.global_this,
                         on_start_buffering: Some(Ctx::on_start_buffering_callback),
                         on_start_streaming: Some(Ctx::on_start_streaming_request_body_callback),

--- a/src/runtime/webcore.rs
+++ b/src/runtime/webcore.rs
@@ -355,8 +355,6 @@ pub enum PathOrFileDescriptor {
 // ─── SinkHandle ──────────────────────────────────────────────────────────────
 // Held by ByteStream; dispatches write()/end() to the native sink.
 
-pub type SinkWriteFn = fn(ctx: *mut core::ffi::c_void, data: &streams::Result) -> streams::Writable;
-
 #[derive(Copy, Clone, Default)]
 pub enum SinkHandle {
     #[default]
@@ -365,7 +363,7 @@ pub enum SinkHandle {
     FetchRequestBody(bun_ptr::BackRef<fetch::FetchRequestBodySink, bun_ptr::Mut>),
     S3Upload(bun_ptr::BackRef<streams::NetworkSink, bun_ptr::Mut>),
     FileSink(bun_ptr::BackRef<file_sink::FileSink>),
-    ValueBufferer(*mut core::ffi::c_void, SinkWriteFn),
+    HTMLRewriter(bun_ptr::BackRef<crate::api::html_rewriter::RewriterPipe>),
 }
 
 impl SinkHandle {
@@ -390,7 +388,7 @@ impl SinkHandle {
             // SAFETY: live backref; ByteStream clears sink before free.
             SinkHandle::S3Upload(mut p) => unsafe { p.get_mut() }.write(data),
             SinkHandle::FileSink(p) => p.write(data),
-            SinkHandle::ValueBufferer(ctx, write) => write(ctx, data),
+            SinkHandle::HTMLRewriter(p) => p.write(data),
         }
     }
 
@@ -406,11 +404,7 @@ impl SinkHandle {
             // Raw-ptr dispatch: may re-borrow and free the sink (see its doc).
             SinkHandle::S3Upload(p) => streams::NetworkSink::end_from_stream(p.as_ptr(), err),
             SinkHandle::FileSink(p) => p.end_from_stream(err),
-            SinkHandle::ValueBufferer(ctx, write) => {
-                if let Some(e) = err {
-                    let _ = write(ctx, &streams::Result::Err(e));
-                }
-            }
+            SinkHandle::HTMLRewriter(p) => p.end_from_stream(err),
         }
     }
 }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1605,7 +1605,7 @@ impl BlobExt for Blob {
             global_this,
             readable_stream.value,
             // SAFETY: file_sink is a live +1 *mut FileSink.
-            unsafe { &mut *file_sink },
+            unsafe { NonNull::new_unchecked(file_sink) },
         );
 
         assignment_result.ensure_still_alive();
@@ -5257,7 +5257,7 @@ pub(crate) fn write_file_internal(
                         {
                             on_start_buffering(orig_task);
                         }
-                        locked.task = Some(task.cast::<c_void>());
+                        locked.task = Some(NonNull::new(task).unwrap().cast::<c_void>());
                         locked.on_receive_value = Some(WriteFileWaitFromLockedValueTask::then_wrap);
                         // SAFETY: `task` was just heap-allocated; consumed in `then_wrap`.
                         Ok(ControlFlow::Break(unsafe { (*task).promise.value() }))

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -856,7 +856,12 @@ impl Value {
         let Value::Locked(locked) = self else {
             unreachable!("locked_to_native_stream on non-Locked Value");
         };
-        if locked.promise.is_some() || !locked.action.is_none() {
+        // A registered `on_receive_value` means a native consumer (Bun.write,
+        // the server's render-wait) owns this body and has retargeted `task`
+        // to its own context; materializing a stream here would dispatch the
+        // producer's remaining callbacks with that foreign context.
+        if locked.promise.is_some() || !locked.action.is_none() || locked.on_receive_value.is_some()
+        {
             return ReadableStream::used(global_this);
         }
         let mut drain_result = DrainResult::EstimatedSize(0);

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1498,7 +1498,13 @@ impl Value {
             }));
         }
 
-        if locked.promise.is_some() || !locked.action.is_none() || locked.readable.has() {
+        // `on_receive_value`: same consumer-owned-task guard as
+        // `locked_to_native_stream`.
+        if locked.promise.is_some()
+            || !locked.action.is_none()
+            || locked.readable.has()
+            || locked.on_receive_value.is_some()
+        {
             return Ok(Value::Used);
         }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1,6 +1,5 @@
 //! https://developer.mozilla.org/en-US/docs/Web/API/Body
 
-use bun_collections::VecExt;
 use core::ffi::c_void;
 use core::ptr::NonNull;
 
@@ -18,8 +17,7 @@ use bun_http_types::MimeType::MimeType;
 use crate::jsc::HTTPHeaderName;
 pub use crate::webcore::InternalBlob;
 use crate::webcore::form_data::AsyncFormDataExt as _;
-use crate::webcore::sink::{self, ArrayBufferSink};
-use bun_core::{MutableString, String as BunString, ZigString};
+use bun_core::{String as BunString, ZigString};
 use bun_core::{WTFStringImpl, WTFStringImplExt as _, WTFStringImplStruct};
 use bun_jsc::ZigStringJsc as _;
 use bun_jsc::{JsCell, StringJsc as _};
@@ -88,7 +86,6 @@ fn as_url_search_params(value: JSValue) -> Option<*mut URLSearchParams> {
 
 bun_core::declare_scope!(BodyValue, visible);
 bun_core::declare_scope!(BodyMixin, visible);
-bun_core::declare_scope!(BodyValueBufferer, visible);
 
 type JsTerminated<T> = jsc::JsResult<T>;
 
@@ -226,17 +223,17 @@ pub struct PendingValue {
     // lifetime per PORTING.md §Type map (no lifetime params on structs);
     // raw ptr until we pick `&'static` vs a JSC handle.
     pub global: *const JSGlobalObject,
-    pub task: Option<*mut c_void>,
+    pub task: Option<NonNull<c_void>>,
 
     /// runs after the data is available.
-    pub(crate) on_receive_value: Option<fn(ctx: *mut c_void, value: &mut Value)>,
+    pub(crate) on_receive_value: Option<fn(ctx: NonNull<c_void>, value: &mut Value)>,
 
     /// conditionally runs when requesting data
     /// used in HTTP server to ignore request bodies unless asked for it
-    pub(crate) on_start_buffering: Option<fn(ctx: *mut c_void)>,
-    pub(crate) on_start_streaming: Option<fn(ctx: *mut c_void) -> DrainResult>,
+    pub(crate) on_start_buffering: Option<fn(ctx: NonNull<c_void>)>,
+    pub(crate) on_start_streaming: Option<fn(ctx: NonNull<c_void>) -> DrainResult>,
     pub(crate) on_readable_stream_available:
-        Option<fn(ctx: *mut c_void, global_this: &JSGlobalObject, readable: ReadableStream)>,
+        Option<fn(ctx: NonNull<c_void>, global_this: &JSGlobalObject, readable: ReadableStream)>,
     /// Upstream producer to notify on cancel/drain/consumer-attach; forwarded
     /// to the `NewSource` when the locked body is realised as a native stream.
     pub producer: streams::SourceHandle,
@@ -1089,7 +1086,29 @@ impl Value {
         bun_core::scoped_log!(BodyValue, "resolve");
         if let Value::Locked(locked) = self {
             if let Some(readable) = locked.readable.get(global) {
-                readable.done(global);
+                // Feed the already-created stream (instead of closing it empty)
+                // only when it is the sole consumer of this pending body.
+                let sole_consumer = locked.promise.is_none() && locked.on_receive_value.is_none();
+                let fed = sole_consumer
+                    .then(|| readable.ptr.bytes())
+                    .flatten()
+                    .map(|bytes| {
+                        // BACKREF: `Source::bytes()` payload is live for the
+                        // ReadableStream JS wrapper's lifetime.
+                        let mut blob = new.use_as_any_blob_allow_non_utf8_string();
+                        let res = bytes.on_data(streams::Result::TemporaryAndDone(
+                            bun_ptr::RawSlice::new(blob.slice()),
+                        ));
+                        blob.detach();
+                        res
+                    })
+                    .transpose()?;
+
+                if fed.is_some() {
+                    *new = Value::Used;
+                } else {
+                    readable.done(global);
+                }
                 locked.readable.deinit();
             }
 
@@ -1601,11 +1620,8 @@ impl Value {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// JSC-integration: extract / BodyMixin (host-fn methods) / ValueBufferer.
+// JSC-integration: extract / BodyMixin (host-fn methods).
 // ────────────────────────────────────────────────────────────────────────────
-
-// `sink::JSSink<T>` is a free generic (inherent associated types are unstable).
-type ArrayBufferJSSink = sink::JSSink<ArrayBufferSink>;
 
 // https://github.com/WebKit/webkit/blob/main/Source/WebCore/Modules/fetch/FetchBody.cpp#L45
 pub(crate) fn extract(global_this: &JSGlobalObject, value: JSValue) -> JsResult<Body> {
@@ -2227,422 +2243,4 @@ fn handle_body_error(value: &mut Value, global_object: &JSGlobalObject) -> Optio
     let js = err.to_js(global_object);
     *value = Value::Used;
     Some(JSPromise::rejected_promise(global_object, js).to_js())
-}
-
-// ────────────────────────────────────────────────────────────────────────────
-// ValueBufferer
-// ────────────────────────────────────────────────────────────────────────────
-
-pub(crate) type ValueBuffererCallback =
-    fn(ctx: *mut c_void, bytes: &[u8], err: Option<ValueError>, is_async: bool);
-
-pub struct ValueBufferer<'a> {
-    pub ctx: *mut c_void,
-    pub(crate) on_finished_buffering: ValueBuffererCallback,
-
-    pub(crate) js_sink: Option<Box<ArrayBufferJSSink>>,
-    pub(crate) byte_stream: Option<NonNull<ByteStream>>,
-    // readable stream strong ref to keep byte stream alive
-    pub(crate) readable_stream_ref: webcore::readable_stream::Strong,
-    pub(crate) stream_buffer: MutableString,
-    // allocator dropped — global mimalloc
-    pub global: &'a JSGlobalObject,
-}
-
-impl<'a> Drop for ValueBufferer<'a> {
-    fn drop(&mut self) {
-        // stream_buffer dropped automatically
-        if let Some(byte_stream) = self.byte_stream {
-            // Kept alive by `readable_stream_ref` while set — satisfies the
-            // `BackRef` outlives-holder invariant. R-2: `unpipe_without_deref`
-            // takes `&self` (interior-mutable).
-            bun_ptr::BackRef::from(byte_stream).unpipe_without_deref();
-        }
-        self.readable_stream_ref.deinit();
-
-        if let Some(mut buffer_stream) = self.js_sink.take() {
-            buffer_stream.detach_self(self.global);
-            // The wrapper is a `Box<JSSink<ArrayBufferSink>>`; dropping it
-            // frees the box and runs `Vec<u8>`'s Drop.
-            drop(buffer_stream);
-        }
-    }
-}
-
-impl<'a> ValueBufferer<'a> {
-    pub(crate) fn init(
-        ctx: *mut c_void,
-        on_finish: ValueBuffererCallback,
-        global: &'a JSGlobalObject,
-    ) -> Self {
-        Self {
-            ctx,
-            on_finished_buffering: on_finish,
-            js_sink: None,
-            byte_stream: None,
-            readable_stream_ref: Default::default(),
-            global,
-            stream_buffer: MutableString::default(),
-        }
-    }
-
-    pub(crate) fn run(
-        &mut self,
-        value: &mut Value,
-        owned_readable_stream: Option<ReadableStream>,
-    ) -> crate::Result<()> {
-        value.to_blob_if_possible();
-
-        match value {
-            Value::Used => {
-                bun_core::scoped_log!(BodyValueBufferer, "Used");
-                return Err(crate::Error::StreamAlreadyUsed);
-            }
-            Value::Empty | Value::Null => {
-                bun_core::scoped_log!(BodyValueBufferer, "Empty");
-                (self.on_finished_buffering)(self.ctx, b"", None, false);
-                return Ok(());
-            }
-            Value::Error(err) => {
-                bun_core::scoped_log!(BodyValueBufferer, "Error");
-                // The payload (BunString / Strong) owns refs and has Drop, so a `ptr::read`
-                // bitwise copy would manufacture a second owner → double-deref when both
-                // sides drop. Produce a properly ref-bumped duplicate instead.
-                let err_copy = err.dupe(self.global);
-                (self.on_finished_buffering)(self.ctx, b"", Some(err_copy), false);
-                return Ok(());
-            }
-            Value::WTFStringImpl(_) | Value::InternalBlob(_) | Value::Blob(_) => {
-                // toBlobIfPossible checks for WTFString needing a conversion.
-                let mut input = value.use_as_any_blob_allow_non_utf8_string();
-                let is_pending = input.needs_to_read_file();
-
-                if is_pending {
-                    if let AnyBlob::Blob(blob) = &mut input {
-                        // The ZST `InternalReadFileFn<C>` impl lets `do_read_file_internal`
-                        // monomorphize a `fn(*mut c_void, ReadFileResultType)` thunk.
-                        struct LoadFileAdapter;
-                        impl<'b> blob::InternalReadFileFn<ValueBufferer<'b>> for LoadFileAdapter {
-                            fn call(
-                                sink: *mut ValueBufferer<'b>,
-                                bytes: blob::read_file::ReadFileResultType,
-                            ) {
-                                // SAFETY: `sink` was set from `self as *mut Self` below and
-                                // outlives the read (ValueBufferer is heap-pinned by caller).
-                                unsafe { &mut *sink }.on_finished_loading_file(bytes);
-                            }
-                        }
-                        let global = self.global;
-                        blob.do_read_file_internal::<Self, LoadFileAdapter>(
-                            std::ptr::from_mut::<Self>(self),
-                            global,
-                        );
-                    }
-                } else {
-                    let bytes = input.slice();
-                    bun_core::scoped_log!(BodyValueBufferer, "Blob {}", bytes.len());
-                    (self.on_finished_buffering)(self.ctx, bytes, None, false);
-                    input.detach();
-                }
-                return Ok(());
-            }
-            Value::Locked(_) => {
-                self.buffer_locked_body_value(value, owned_readable_stream)?;
-            }
-        }
-        Ok(())
-    }
-
-    fn on_finished_loading_file(&mut self, bytes: blob::read_file::ReadFileResultType) {
-        match bytes {
-            blob::read_file::ReadFileResultType::Err(err) => {
-                bun_core::scoped_log!(BodyValueBufferer, "onFinishedLoadingFile Error");
-                (self.on_finished_buffering)(
-                    self.ctx,
-                    b"",
-                    Some(ValueError::SystemError(err)),
-                    true,
-                );
-            }
-            blob::read_file::ReadFileResultType::Result(data) => {
-                // SAFETY: every producer sets `buf = heap::alloc(v.into_boxed_slice())`
-                // (read_file.rs); reclaim ownership here. Dropped at end of scope.
-                let buf = unsafe { Box::<[u8]>::from_raw(data.buf) };
-                bun_core::scoped_log!(
-                    BodyValueBufferer,
-                    "onFinishedLoadingFile Data {}",
-                    buf.len()
-                );
-                (self.on_finished_buffering)(self.ctx, &buf, None, true);
-            }
-        }
-    }
-
-    fn write_chunk(&mut self, stream: &streams::Result) -> streams::Writable {
-        if let streams::Result::Err(err) = stream {
-            bun_core::scoped_log!(BodyValueBufferer, "onStreamPipe error");
-            let js_err = err.to_js(self.global);
-            let ref_ = jsc::strong::Optional::create(js_err, self.global);
-            (self.on_finished_buffering)(self.ctx, b"", Some(ValueError::JSValue(ref_)), true);
-            return streams::Writable::Done;
-        }
-        let chunk = stream.slice();
-        let len = chunk.len();
-        bun_core::scoped_log!(BodyValueBufferer, "onStreamPipe chunk {}", len);
-        let _ = self.stream_buffer.write(chunk);
-        if stream.is_done() {
-            let bytes = self.stream_buffer.list.as_slice();
-            bun_core::scoped_log!(BodyValueBufferer, "onStreamPipe done {}", bytes.len());
-            (self.on_finished_buffering)(self.ctx, bytes, None, true);
-            return streams::Writable::Done;
-        }
-        streams::Writable::Owned(len as u64)
-    }
-
-    /// Reclaim the `*mut Self` smuggled through a `NativePromiseContext` cell
-    /// as an exclusive borrow. Centralises the `Option<NonNull<Self>>` deref
-    /// for the two host-fn entry points below (one accessor, N safe callers).
-    ///
-    /// # Safety (encapsulated)
-    /// `NativePromiseContext::take` returns the live ctx pointer set in
-    /// `create()` (caller stashed `&mut Self` and held a +1 ref); the cell is
-    /// nulled on take so this is the sole owner. `ValueBufferer` is heap-
-    /// pinned by its caller for the stream's duration.
-    #[inline]
-    fn take_ctx<'r>(cell: JSValue) -> Option<&'r mut Self> {
-        // SAFETY: see fn doc — +1 ref transferred back; sole live `&mut`.
-        crate::api::NativePromiseContext::take::<Self>(cell).map(|mut p| unsafe { p.as_mut() })
-    }
-
-    fn on_resolve_stream(_global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        let args = callframe.arguments();
-        let Some(sink) = Self::take_ctx(args[args.len() - 1]) else {
-            return Ok(JSValue::UNDEFINED);
-        };
-        sink.handle_resolve_stream(true);
-        Ok(JSValue::UNDEFINED)
-    }
-
-    fn on_reject_stream(_global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        let args = callframe.arguments();
-        let Some(sink) = Self::take_ctx(args[args.len() - 1]) else {
-            return Ok(JSValue::UNDEFINED);
-        };
-        let err = args[0];
-        sink.handle_reject_stream(err, true);
-        Ok(JSValue::UNDEFINED)
-    }
-
-    fn handle_reject_stream(&mut self, err: JSValue, is_async: bool) {
-        if let Some(mut wrapper) = self.js_sink.take() {
-            wrapper.detach_self(self.global);
-            // see `Drop` impl — dropping the Box frees the wrapper
-            // and runs `Vec<u8>`'s Drop.
-            drop(wrapper);
-        }
-        // `jsc::strong::Optional` owns a GC root; `ptr::read`-duplicating it would
-        // double-deinit. Transfer the single owner directly to the callback; the callback
-        // (or its returned `ValueError`'s Drop) is responsible for releasing it.
-        let ref_ = jsc::strong::Optional::create(err, self.global);
-        (self.on_finished_buffering)(self.ctx, b"", Some(ValueError::JSValue(ref_)), is_async);
-    }
-
-    fn handle_resolve_stream(&mut self, is_async: bool) {
-        if let Some(wrapper) = &self.js_sink {
-            let bytes = wrapper.sink.bytes.slice();
-            bun_core::scoped_log!(BodyValueBufferer, "handleResolveStream {}", bytes.len());
-            (self.on_finished_buffering)(self.ctx, bytes, None, is_async);
-        } else {
-            bun_core::scoped_log!(BodyValueBufferer, "handleResolveStream no sink");
-            (self.on_finished_buffering)(self.ctx, b"", None, is_async);
-        }
-    }
-
-    fn buffer_locked_body_value(
-        &mut self,
-        value: &mut Value,
-        owned_readable_stream: Option<ReadableStream>,
-    ) -> crate::Result<()> {
-        debug_assert!(matches!(value, Value::Locked(_)));
-        let Value::Locked(locked) = value else {
-            unreachable!()
-        };
-        let readable_stream = 'brk: {
-            if let Some(stream) = locked.readable.get(self.global) {
-                // keep the stream alive until we're done with it.
-                // Transfer ownership: `*value = .Used` below would otherwise
-                // drop `locked.readable` anyway, so moving the existing GC
-                // root preserves the refcount balance.
-                self.readable_stream_ref = core::mem::take(&mut locked.readable);
-                break 'brk Some(stream);
-            }
-            if let Some(stream) = owned_readable_stream {
-                // response owns the stream, so we hold a strong reference to it
-                self.readable_stream_ref =
-                    webcore::readable_stream::Strong::init(stream, self.global);
-                break 'brk Some(stream);
-            }
-            None
-        };
-        if let Some(stream) = readable_stream {
-            *value = Value::Used;
-
-            if stream.is_locked(self.global) {
-                return Err(crate::Error::StreamAlreadyUsed);
-            }
-
-            match stream.ptr {
-                webcore::readable_stream::Source::Invalid => {
-                    return Err(crate::Error::InvalidStream);
-                }
-                // toBlobIfPossible should've caught this
-                webcore::readable_stream::Source::Blob(_)
-                | webcore::readable_stream::Source::File(_) => unreachable!(),
-                webcore::readable_stream::Source::JavaScript
-                | webcore::readable_stream::Source::Direct => {
-                    // this is broken right now
-                    // return self.create_js_sink(stream);
-                    return Err(crate::Error::UnsupportedStreamType);
-                }
-                webcore::readable_stream::Source::Bytes(byte_stream_ptr) => {
-                    // BACKREF: see `Source::bytes()` — payload owned by the
-                    // readable stream, kept alive via `self.readable_stream_ref`
-                    // above. R-2: all touched fields are interior-mutable.
-                    let byte_stream = stream.ptr.bytes().expect("matched Bytes");
-                    debug_assert!(byte_stream.sink.get().is_none());
-                    debug_assert!(self.byte_stream.is_none());
-
-                    let bytes = byte_stream.buffer.get().as_slice();
-                    // If we've received the complete body by the time this function is called
-                    // we can avoid streaming it and just send it all at once.
-                    if byte_stream.has_received_last_chunk.get() {
-                        if let streams::Result::Err(err) = &byte_stream.pending.get().result {
-                            bun_core::scoped_log!(
-                                BodyValueBufferer,
-                                "byte stream has_received_last_chunk error"
-                            );
-                            let js_err = err.to_js(self.global);
-                            let ref_ = jsc::strong::Optional::create(js_err, self.global);
-                            (self.on_finished_buffering)(
-                                self.ctx,
-                                b"",
-                                Some(ValueError::JSValue(ref_)),
-                                false,
-                            );
-                            stream.done(self.global);
-                            return Ok(());
-                        }
-                        bun_core::scoped_log!(
-                            BodyValueBufferer,
-                            "byte stream has_received_last_chunk {}",
-                            bytes.len()
-                        );
-                        (self.on_finished_buffering)(self.ctx, bytes, None, false);
-                        // is safe to detach here because we're not going to receive any more data
-                        stream.done(self.global);
-                        return Ok(());
-                    }
-
-                    byte_stream.sink.set(webcore::SinkHandle::ValueBufferer(
-                        std::ptr::from_mut::<Self>(self).cast::<c_void>(),
-                        |ctx, stream| {
-                            // SAFETY: `ctx` is the `*mut Self` stored at hook-in time;
-                            // `ValueBufferer` is heap-pinned by its owner (BufferOutputSink).
-                            // `ValueBufferer::Drop` clears `byte_stream.sink` before releasing
-                            // `readable_stream_ref`, so this handle never outlives the pointee.
-                            unsafe { &mut *ctx.cast::<Self>() }.write_chunk(stream)
-                        },
-                    ));
-                    self.byte_stream = NonNull::new(byte_stream_ptr);
-                    bun_core::scoped_log!(
-                        BodyValueBufferer,
-                        "byte stream pre-buffered {}",
-                        bytes.len()
-                    );
-
-                    let _ = self.stream_buffer.write(bytes);
-                    return Ok(());
-                }
-            }
-        }
-
-        // reshaped for borrowck — re-borrow locked after possible *value = Used above.
-        let Value::Locked(locked) = value else {
-            unreachable!()
-        };
-
-        if locked.on_receive_value.is_some() || locked.task.is_some() {
-            // ValueBufferer wants the whole body; tell the producer to never
-            // pause for JS backpressure before the stream is materialised.
-            if let (Some(on_start_buffering), Some(task)) =
-                (locked.on_start_buffering.take(), locked.task)
-            {
-                on_start_buffering(task);
-            }
-            // someone else is waiting for the stream or waiting for `onStartStreaming`
-            let readable = value
-                .to_readable_stream(self.global)
-                .map_err(|_| crate::Error::JSError)?;
-            // The JS exception value is
-            // flattened to a string-coded error because `run`'s callers consume
-            // `crate::Error` (the exception itself stays pending on the VM).
-            readable.ensure_still_alive();
-            readable.protect();
-            return self.buffer_locked_body_value(value, None);
-        }
-        // is safe to wait it buffer
-        locked.task = Some(std::ptr::from_mut::<Self>(self).cast::<c_void>());
-        locked.on_receive_value = Some(Self::on_receive_value);
-        Ok(())
-    }
-
-    fn on_receive_value(ctx: *mut c_void, value: &mut Value) {
-        // SAFETY: ctx was set from `self as *mut Self` in buffer_locked_body_value.
-        let sink = unsafe { bun_ptr::callback_ctx::<Self>(ctx) };
-        match value {
-            Value::Error(err) => {
-                bun_core::scoped_log!(BodyValueBufferer, "onReceiveValue Error");
-                // See run(): produce a ref-bumped duplicate instead of `ptr::read`ing a
-                // non-Copy owned value (would double-deref on drop).
-                let err_copy = err.dupe(sink.global);
-                (sink.on_finished_buffering)(sink.ctx, b"", Some(err_copy), true);
-            }
-            _ => {
-                value.to_blob_if_possible();
-                let input = value.use_as_any_blob_allow_non_utf8_string();
-                let bytes = input.slice();
-                bun_core::scoped_log!(BodyValueBufferer, "onReceiveValue {}", bytes.len());
-                (sink.on_finished_buffering)(sink.ctx, bytes, None, true);
-            }
-        }
-    }
-}
-
-// `#[bun_jsc::host_fn]` on on_resolve_stream/on_reject_stream emits the JSC ABI shim;
-// these no_mangle re-exports point at those shims under the C names the C++ side expects.
-bun_jsc::jsc_host_abi! {
-    #[unsafe(no_mangle)]
-    pub(crate) unsafe fn Bun__BodyValueBufferer__onResolveStream(
-        global: *mut JSGlobalObject,
-        callframe: *mut CallFrame,
-    ) -> JSValue {
-        // S008: `JSGlobalObject`/`CallFrame` are `opaque_ffi!` ZST handles —
-        // safe `*mut → &` via `opaque_deref` (JSC guarantees non-null/live).
-        let (global, callframe) =
-            (bun_opaque::opaque_deref(global), bun_opaque::opaque_deref(callframe));
-        jsc::to_js_host_fn_result(global, ValueBufferer::on_resolve_stream(global, callframe))
-    }
-}
-bun_jsc::jsc_host_abi! {
-    #[unsafe(no_mangle)]
-    pub(crate) unsafe fn Bun__BodyValueBufferer__onRejectStream(
-        global: *mut JSGlobalObject,
-        callframe: *mut CallFrame,
-    ) -> JSValue {
-        // S008: `JSGlobalObject`/`CallFrame` are `opaque_ffi!` ZST handles —
-        // safe `*mut → &` via `opaque_deref` (JSC guarantees non-null/live).
-        let (global, callframe) =
-            (bun_opaque::opaque_deref(global), bun_opaque::opaque_deref(callframe));
-        jsc::to_js_host_fn_result(global, ValueBufferer::on_reject_stream(global, callframe))
-    }
 }

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -1269,6 +1269,7 @@ pub type Source = readable_stream::NewSource<FileReader>;
 // `unsafe { (*ptr).method() }` scope and never hold `&mut Source` across other
 // `self.*` accesses.
 bun_core::impl_field_parent! { FileReader => Source.context; pub fn raw parent; }
+bun_core::impl_field_parent! { FileReader => Source.context; pub fn parent_const; }
 
 impl readable_stream::SourceContext for FileReader {
     const NAME: &'static str = "File";

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1606,7 +1606,11 @@ impl FileSink {
         // above): the JS builtins always call `controller.end()`/`.close()`
         // (`${controller}__end/close` → `controller->detach()` → m_sinkPtr=null)
         // before GC, so the controller's dtor never reaches `finalize`.
-        let promise_result = JSSink::assign_to_stream(global_this, stream.value, self);
+        let promise_result = JSSink::assign_to_stream(
+            global_this,
+            stream.value,
+            core::ptr::NonNull::from(&mut *self),
+        );
 
         if let Some(err) = promise_result.to_error() {
             self.readable_stream.set(readable_stream::Strong::default());

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1548,58 +1548,34 @@ impl FileSink {
         self.readable_stream
             .set(readable_stream::Strong::init(*stream, global_this));
 
-        // Native ByteStream fast-path: wire SinkHandle directly, skip the JS pump.
-        if let Some(byte_stream) = stream.ptr.bytes() {
-            if byte_stream.sink.get().is_none() {
-                self.source
-                    .set(streams::SourceHandle::ByteStream(byte_stream));
-                byte_stream
-                    .sink
-                    .set(webcore::SinkHandle::FileSink(bun_ptr::BackRef::new(&*self)));
-                byte_stream.sink_paused.set(false);
-                stream.lock_native(global_this);
-                byte_stream.signal_consumer_attached();
-
-                if let Some(err) = byte_stream.take_pending_error() {
-                    byte_stream.sink.set(webcore::SinkHandle::None);
-                    self.end_from_stream(Some(err));
-                    return JSValue::UNDEFINED;
+        // Native ByteStream/FileReader fast-path: wire the SinkHandle
+        // directly, skipping the JS pump.
+        match stream.wire_native_sink(
+            global_this,
+            webcore::SinkHandle::FileSink(bun_ptr::BackRef::new(&*self)),
+            JSValue::UNDEFINED,
+            |src| self.source.set(src),
+        ) {
+            readable_stream::NativeWireResult::Wired => {
+                self.writer
+                    .with_mut(|w| w.enable_keeping_process_alive(self.io_evtloop()));
+                if !self.must_be_kept_alive_until_eof.get() {
+                    self.must_be_kept_alive_until_eof.set(true);
+                    self.ref_();
                 }
-
-                let buffered = byte_stream.drain();
-                let has_last = byte_stream.has_received_last_chunk.get();
-                if !buffered.is_empty() {
-                    let chunk = if has_last {
-                        streams::Result::OwnedAndDone(buffered)
-                    } else {
-                        streams::Result::Owned(buffered)
-                    };
-                    match self.write(&chunk) {
-                        streams::Writable::Backpressure(_) => byte_stream.sink_paused.set(true),
-                        streams::Writable::Done | streams::Writable::Err(_) => {
-                            byte_stream.sink.set(webcore::SinkHandle::None);
-                            self.source.set(streams::SourceHandle::None);
-                            let _ = self.end(None);
-                            return JSValue::UNDEFINED;
-                        }
-                        _ => {}
-                    }
-                }
-                if has_last {
-                    byte_stream.sink.set(webcore::SinkHandle::None);
-                    self.source.set(streams::SourceHandle::None);
-                    let _ = self.end(None);
-                } else {
-                    self.writer
-                        .with_mut(|w| w.enable_keeping_process_alive(self.io_evtloop()));
-                    if !self.must_be_kept_alive_until_eof.get() {
-                        self.must_be_kept_alive_until_eof.set(true);
-                        self.ref_();
+                return JSValue::UNDEFINED;
+            }
+            readable_stream::NativeWireResult::EndedInline(err) => {
+                self.source.set(streams::SourceHandle::None);
+                match err {
+                    Some(err) => self.end_from_stream(Some(err)),
+                    None => {
+                        let _ = self.end(None);
                     }
                 }
                 return JSValue::UNDEFINED;
             }
-            // sink already attached: fall through to the JS pump.
+            readable_stream::NativeWireResult::NotNative => {}
         }
 
         // No per-wrapper +1 for the controller (only the transient `_guard`

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -18,6 +18,19 @@ pub struct ReadableStream {
     pub ptr: Source,
 }
 
+/// Outcome of [`ReadableStream::wire_native_sink`].
+pub enum NativeWireResult {
+    /// The sink was installed on the native source; the source will call
+    /// `SinkHandle::end` itself when it's done.
+    Wired,
+    /// Not a native source (no `Bytes`/`File` backing, or it already has a
+    /// sink). Fall through to the JS-pump path.
+    NotNative,
+    /// The source was already done or errored. The sink was not left
+    /// installed; the caller runs its own end-of-stream handling.
+    EndedInline(Option<streams::StreamError>),
+}
+
 // ─── ReadableStream::Strong ──────────────────────────────────────────────────
 
 /// A `ReadableStream` handle for [`crate::webcore::body::PendingValue`] and the
@@ -292,6 +305,91 @@ impl ReadableStream {
     /// after `readStreamIntoSink` acquires a reader.
     pub fn lock_native(&self, global_object: &JSGlobalObject) {
         ReadableStream__lockNative(self.value, global_object);
+    }
+
+    /// Wire `sink` directly to this stream's native `ByteStream`/`FileReader`
+    /// source, skipping the JS pump. `set_source` is called with the matching
+    /// [`SourceHandle`](streams::SourceHandle) before the source is driven;
+    /// the source's `sinkOwner` slot is pointed at `owner_cell` (`owner`
+    /// belongs to the producer side). See [`NativeWireResult`] for caller
+    /// obligations.
+    pub fn wire_native_sink(
+        &self,
+        global: &JSGlobalObject,
+        sink: webcore::SinkHandle,
+        owner_cell: JSValue,
+        set_source: impl FnOnce(streams::SourceHandle),
+    ) -> NativeWireResult {
+        use streams::{SourceHandle, Start, StreamError, StreamResult, Writable};
+        use webcore::SinkHandle;
+
+        if let Some(byte_stream) = self.ptr.bytes() {
+            if byte_stream.sink.get().is_none() {
+                set_source(SourceHandle::ByteStream(byte_stream));
+                byte_stream.parent_const().set_sink_owner(owner_cell);
+                byte_stream.sink.set(sink);
+                byte_stream.sink_paused.set(false);
+                self.lock_native(global);
+                byte_stream.signal_consumer_attached();
+
+                if let Some(err) = byte_stream.take_pending_error() {
+                    byte_stream.sink.set(SinkHandle::None);
+                    return NativeWireResult::EndedInline(Some(err));
+                }
+
+                let buffered = byte_stream.drain();
+                let has_last = byte_stream.has_received_last_chunk.get();
+                if !buffered.is_empty() {
+                    let chunk = if has_last {
+                        StreamResult::OwnedAndDone(buffered)
+                    } else {
+                        StreamResult::Owned(buffered)
+                    };
+                    match sink.write(&chunk) {
+                        Writable::Backpressure(_) => byte_stream.sink_paused.set(true),
+                        Writable::Done | Writable::Err(_) => {
+                            byte_stream.sink.set(SinkHandle::None);
+                            return NativeWireResult::EndedInline(None);
+                        }
+                        _ => {}
+                    }
+                }
+                if has_last {
+                    byte_stream.sink.set(SinkHandle::None);
+                    return NativeWireResult::EndedInline(None);
+                }
+                return NativeWireResult::Wired;
+            }
+        }
+
+        if let Some(file_reader) = self.ptr.file() {
+            if !file_reader.done.get() && file_reader.sink.get().is_none() {
+                match file_reader.start_for_sink(global) {
+                    Some(Start::Err(e)) => {
+                        use bun_sys_jsc::SystemErrorJsc;
+                        let err_js = e.to_system_error().to_error_instance(global);
+                        err_js.ensure_still_alive();
+                        return NativeWireResult::EndedInline(Some(StreamError::JSValue(
+                            jsc::strong::Optional::create(err_js, global),
+                        )));
+                    }
+                    Some(Start::OwnedAndDone(bytes)) => {
+                        let _ = sink.write(&StreamResult::OwnedAndDone(bytes));
+                        return NativeWireResult::EndedInline(None);
+                    }
+                    Some(_) | None => {}
+                }
+                set_source(SourceHandle::FileReader(file_reader));
+                file_reader.parent_const().set_sink_owner(owner_cell);
+                file_reader.sink.set(sink);
+                file_reader.sink_paused.set(true);
+                self.lock_native(global);
+                file_reader.pull_into_sink();
+                return NativeWireResult::Wired;
+            }
+        }
+
+        NativeWireResult::NotNative
     }
 
     /// Decrement Source ref count and detach the underlying stream if ref count is zero
@@ -654,6 +752,10 @@ pub trait SourceContext: Sized {
     fn js_on_close_callback_set_cached(this: JSValue, global: &JSGlobalObject, value: JSValue);
     /// `js_${NAME}InternalReadableStreamSource::on_close_callback_get_cached`
     fn js_on_close_callback_get_cached(this: JSValue) -> Option<JSValue>;
+    /// `js_${NAME}InternalReadableStreamSource::owner_set_cached`
+    fn js_owner_set_cached(this: JSValue, global: &JSGlobalObject, value: JSValue);
+    /// `js_${NAME}InternalReadableStreamSource::sink_owner_set_cached`
+    fn js_sink_owner_set_cached(this: JSValue, global: &JSGlobalObject, value: JSValue);
 
     fn on_start(&mut self) -> streams::Start;
     fn on_pull(&mut self, buf: &mut [u8], view: JSValue) -> streams::Result;
@@ -773,6 +875,8 @@ pub(crate) trait NewSourceCodegen {
     fn on_drain_callback_get_cached(this: JSValue) -> Option<JSValue>;
     fn on_close_callback_set_cached(this: JSValue, global: &JSGlobalObject, value: JSValue);
     fn on_close_callback_get_cached(this: JSValue) -> Option<JSValue>;
+    fn owner_set_cached(this: JSValue, global: &JSGlobalObject, value: JSValue);
+    fn sink_owner_set_cached(this: JSValue, global: &JSGlobalObject, value: JSValue);
 }
 
 /// Binds the `SourceContext::js_*` accessors to the codegen'd
@@ -827,6 +931,22 @@ macro_rules! source_context_codegen {
         ) -> Option<$crate::webcore::jsc::JSValue> {
             $crate::generated_classes::$gen::on_close_callback_get_cached(this)
         }
+        #[inline]
+        fn js_owner_set_cached(
+            this: $crate::webcore::jsc::JSValue,
+            global: &$crate::webcore::jsc::JSGlobalObject,
+            value: $crate::webcore::jsc::JSValue,
+        ) {
+            $crate::generated_classes::$gen::owner_set_cached(this, global, value)
+        }
+        #[inline]
+        fn js_sink_owner_set_cached(
+            this: $crate::webcore::jsc::JSValue,
+            global: &$crate::webcore::jsc::JSGlobalObject,
+            value: $crate::webcore::jsc::JSValue,
+        ) {
+            $crate::generated_classes::$gen::sink_owner_set_cached(this, global, value)
+        }
     };
 }
 
@@ -855,6 +975,12 @@ impl<C: SourceContext> NewSourceCodegen for NewSource<C> {
     fn on_close_callback_get_cached(this: JSValue) -> Option<JSValue> {
         C::js_on_close_callback_get_cached(this)
     }
+    fn owner_set_cached(this: JSValue, global: &JSGlobalObject, value: JSValue) {
+        C::js_owner_set_cached(this, global, value)
+    }
+    fn sink_owner_set_cached(this: JSValue, global: &JSGlobalObject, value: JSValue) {
+        C::js_sink_owner_set_cached(this, global, value)
+    }
 }
 
 // Enforce the layout invariant `from_js`/`Source` rely on.
@@ -863,6 +989,23 @@ const _: () = assert!(core::mem::offset_of!(NewSource<ByteStream>, context) == 0
 const _: () = assert!(core::mem::offset_of!(NewSource<FileReader>, context) == 0);
 
 impl<C: SourceContext> NewSource<C> {
+    /// Point the `owner` slot at the GC cell of the peer producing into this
+    /// source (its `producer` backref), so rooting the source roots the
+    /// producer. `JSValue::UNDEFINED` clears; no-op without a JS wrapper.
+    pub fn set_owner(&self, value: JSValue) {
+        if let Some(this) = self.this_jsvalue.try_get() {
+            <Self as NewSourceCodegen>::owner_set_cached(this, self.global_this(), value);
+        }
+    }
+
+    /// Same as [`Self::set_owner`] for the `sinkOwner` slot: roots the peer
+    /// this source pipes into (its `sink` backref).
+    pub fn set_sink_owner(&self, value: JSValue) {
+        if let Some(this) = self.this_jsvalue.try_get() {
+            <Self as NewSourceCodegen>::sink_owner_set_cached(this, self.global_this(), value);
+        }
+    }
+
     /// Safe `&JSGlobalObject` accessor for the JSC_BORROW `global_this`
     /// back-pointer. `global_this` is stored from a live `&JSGlobalObject` at
     /// construction (or reassigned in `start()` from a fresh live one); the

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -407,6 +407,20 @@ impl Response {
         self.init_mut().headers.as_deref_mut()
     }
 
+    /// Deep-copy this response's init headers (if any) into a fresh
+    /// `HeadersRef`. Centralises the `FetchHeaders::clone_this` +
+    /// `HeadersRef::adopt` pair so callers stay `unsafe`-free.
+    #[inline]
+    pub(crate) fn clone_init_headers(
+        &self,
+        global: &JSGlobalObject,
+    ) -> JsResult<Option<HeadersRef>> {
+        match self.init_mut().headers.as_ref() {
+            Some(headers) => headers.clone_this(global),
+            None => Ok(None),
+        }
+    }
+
     #[inline]
     pub(crate) fn swap_init_headers(&self) -> Option<HeadersRef> {
         self.init.with_mut(|init| init.headers.take())

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -1,4 +1,5 @@
 use core::ffi::c_void;
+use core::ptr::NonNull;
 
 use crate::api::bun_subprocess::Subprocess;
 use crate::webcore::streams::{self, SourceHandle};
@@ -11,19 +12,6 @@ use bun_sys::{self as sys, Error as SysError};
 pub use crate::webcore::array_buffer_sink::ArrayBufferSink;
 
 crate::impl_js_sink_abi!(ArrayBufferSink, "ArrayBufferSink");
-
-impl JSSink<ArrayBufferSink> {
-    /// Unprotects the controller cell stashed in `source` as `JSController`
-    /// and tells C++ to drop its back-pointer. Called from
-    /// `Body::ValueBufferer` Drop / reject paths.
-    // Renamed from `detach` to avoid colliding with the generic
-    // `JSSink<T: JsSinkAbi>::detach(source, global)` associated fn — Rust
-    // forbids same-name items across impl blocks for the same type even with
-    // different signatures (E0592).
-    pub(crate) fn detach_self(&mut self, global: &JSGlobalObject) {
-        JSSink::<ArrayBufferSink>::detach(&mut self.sink.source, global);
-    }
-}
 
 // ──────────────────────────────────────────────────────────────────────────
 // JSSink
@@ -191,12 +179,16 @@ impl<T: JsSinkAbi> JSSink<T> {
     pub fn assign_to_stream(
         global: &crate::webcore::jsc::JSGlobalObject,
         stream: crate::webcore::jsc::JSValue,
-        ptr: &mut T,
+        mut ptr: NonNull<T>,
     ) -> crate::webcore::jsc::JSValue
     where
         T: JsSinkType,
     {
         use crate::webcore::jsc::JSValue;
+        // SAFETY: `ptr` is a live sink owned by the caller for this synchronous
+        // call; the pointer is only stashed in C++ `m_sinkPtr` and `source()` is
+        // read here synchronously.
+        let ptr = unsafe { ptr.as_mut() };
         // Pre-seed JSController(ZERO) so a sync drain's __controllerDetached can match-and-clear;
         // only install the real controller value if the placeholder survived.
         if let Some(src) = ptr.source() {

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -1,4 +1,5 @@
 use core::ffi::c_void;
+use core::ptr::NonNull;
 use core::sync::atomic::AtomicU8;
 #[cfg(not(windows))]
 use core::sync::atomic::Ordering;
@@ -1336,10 +1337,12 @@ pub struct WriteFileWaitFromLockedValueTask {
 }
 
 impl WriteFileWaitFromLockedValueTask {
-    pub(crate) fn then_wrap(this: *mut c_void, value: &mut body::Value) {
+    pub(crate) fn then_wrap(this: NonNull<c_void>, value: &mut body::Value) {
         // SAFETY: `this` is the Box-allocated task registered as `locked.task` below;
         // ownership is reclaimed here (the `Locked` arm re-leaks it).
-        let this = unsafe { bun_core::heap::take(this.cast::<WriteFileWaitFromLockedValueTask>()) };
+        let this = unsafe {
+            bun_core::heap::take(this.cast::<WriteFileWaitFromLockedValueTask>().as_ptr())
+        };
         let _ = Self::then(this, value);
         // TODO: properly propagate exception upwards
     }
@@ -1424,7 +1427,11 @@ impl WriteFileWaitFromLockedValueTask {
                 // Restore the moved-out blob so the next `then()` has its store.
                 this.file_blob = file_blob;
                 locked.on_receive_value = Some(Self::then_wrap);
-                locked.task = Some(bun_core::heap::into_raw(this).cast::<c_void>());
+                locked.task = Some(
+                    NonNull::new(bun_core::heap::into_raw(this))
+                        .unwrap()
+                        .cast::<c_void>(),
+                );
             }
         }
         Ok(())

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -661,85 +661,23 @@ impl FetchTasklet {
         let sink_handle = SinkHandle::FetchRequestBody(bun_ptr::BackRef::new_mut(sink));
         self.sink = Some(core::ptr::NonNull::from(&mut *sink));
 
-        // Native ByteStream fast-path: wire SinkHandle directly, skip the JS pump.
-        if let Some(byte_stream) = stream.ptr.bytes() {
-            if byte_stream.sink.get().is_none() {
-                sink.source = SourceHandle::ByteStream(byte_stream);
-                byte_stream.sink.set(sink_handle);
-                byte_stream.sink_paused.set(false);
-                stream.lock_native(&global_this);
-                byte_stream.signal_consumer_attached();
-
-                if let Some(err) = byte_stream.take_pending_error() {
-                    byte_stream.sink.set(SinkHandle::None);
-                    sink.task = None;
+        // Native ByteStream/FileReader fast-path: wire the SinkHandle
+        // directly, skipping the JS pump.
+        match stream.wire_native_sink(&global_this, sink_handle, JSValue::UNDEFINED, |src| {
+            sink.source = src;
+        }) {
+            crate::webcore::readable_stream::NativeWireResult::Wired => return,
+            crate::webcore::readable_stream::NativeWireResult::EndedInline(err) => {
+                sink.task = None;
+                let err_js = err.map(|err| {
                     let err_js = err.to_js(&global_this);
                     err_js.ensure_still_alive();
-                    self.write_end_request(Some(err_js));
-                    return;
-                }
-
-                let buffered = byte_stream.drain();
-                let has_last = byte_stream.has_received_last_chunk.get();
-                if !buffered.is_empty() {
-                    let chunk = if has_last {
-                        StreamResult::OwnedAndDone(buffered)
-                    } else {
-                        StreamResult::Owned(buffered)
-                    };
-                    match sink.write(&chunk) {
-                        Writable::Backpressure(_) => byte_stream.sink_paused.set(true),
-                        Writable::Done | Writable::Err(_) => {
-                            byte_stream.sink.set(SinkHandle::None);
-                            sink.task = None;
-                            self.write_end_request(None);
-                            return;
-                        }
-                        _ => {}
-                    }
-                }
-                if has_last {
-                    byte_stream.sink.set(SinkHandle::None);
-                    sink.task = None;
-                    self.write_end_request(None);
-                }
+                    err_js
+                });
+                self.write_end_request(err_js);
                 return;
             }
-            // sink already attached: fall through to the JS pump.
-        }
-
-        // Native FileReader fast-path: same wiring as ByteStream, but the
-        // reader is pull-driven so kick it with `pull_into_sink` instead of
-        // draining a pre-buffered chunk. Bun's file streams defer `start()`
-        // to the first read, so drive it here; an error or synchronous
-        // completion is delivered immediately.
-        if let Some(file_reader) = stream.ptr.file() {
-            if !file_reader.done.get() && file_reader.sink.get().is_none() {
-                match file_reader.start_for_sink(&global_this) {
-                    Some(crate::webcore::streams::Start::Err(e)) => {
-                        use bun_sys_jsc::SystemErrorJsc;
-                        let err_js = e.to_system_error().to_error_instance(&global_this);
-                        err_js.ensure_still_alive();
-                        sink.task = None;
-                        self.write_end_request(Some(err_js));
-                        return;
-                    }
-                    Some(crate::webcore::streams::Start::OwnedAndDone(bytes)) => {
-                        let _ = sink.write(&StreamResult::OwnedAndDone(bytes));
-                        sink.task = None;
-                        self.write_end_request(None);
-                        return;
-                    }
-                    Some(_) => {}
-                    None => {}
-                }
-                sink.source = SourceHandle::FileReader(file_reader);
-                file_reader.sink.set(sink_handle);
-                file_reader.sink_paused.set(true);
-                stream.lock_native(&global_this);
-                file_reader.pull_into_sink();
-                return;
-            }
+            crate::webcore::readable_stream::NativeWireResult::NotNative => {}
         }
 
         let assignment_result = JSSink::<FetchRequestBodySink>::assign_to_stream(

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1,4 +1,5 @@
 use core::ffi::c_void;
+use core::ptr::NonNull;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use bun_boringssl as boringssl;
@@ -271,9 +272,9 @@ impl FetchTasklet {
     /// of the registration, and fires only on the JS thread — so the returned
     /// `&mut` is the sole live borrow.
     #[inline]
-    fn from_ctx<'a>(ctx: *mut c_void) -> &'a mut Self {
+    fn from_ctx<'a>(ctx: NonNull<c_void>) -> &'a mut Self {
         // SAFETY: see INVARIANT above.
-        unsafe { bun_ptr::callback_ctx::<FetchTasklet>(ctx) }
+        unsafe { bun_ptr::callback_ctx::<FetchTasklet>(ctx.as_ptr()) }
     }
 
     /// Recover `&mut Self` from a `*mut FetchTasklet` callback arg.
@@ -741,8 +742,11 @@ impl FetchTasklet {
             }
         }
 
-        let assignment_result =
-            JSSink::<FetchRequestBodySink>::assign_to_stream(&global_this, stream.value, sink);
+        let assignment_result = JSSink::<FetchRequestBodySink>::assign_to_stream(
+            &global_this,
+            stream.value,
+            core::ptr::NonNull::from(&mut *sink),
+        );
         assignment_result.ensure_still_alive();
 
         if let Some(err) = assignment_result.to_error() {
@@ -1653,7 +1657,7 @@ impl FetchTasklet {
     }
 
     fn on_readable_stream_available(
-        ctx: *mut c_void,
+        ctx: NonNull<c_void>,
         global_this: &JSGlobalObject,
         readable: ReadableStream,
     ) {
@@ -1664,7 +1668,7 @@ impl FetchTasklet {
         this.is_buffering_body.store(false, Ordering::Release);
     }
 
-    fn on_start_streaming_http_response_body_callback(ctx: *mut c_void) -> DrainResult {
+    fn on_start_streaming_http_response_body_callback(ctx: NonNull<c_void>) -> DrainResult {
         let this = Self::from_ctx(ctx);
         if this.signal_store.aborted.load(Ordering::Relaxed) {
             return DrainResult::Aborted;
@@ -1765,7 +1769,7 @@ impl FetchTasklet {
             .try_transition_receive_mode(BodyReceiveMode::BufferAll, BodyReceiveMode::Paused);
     }
 
-    fn on_start_buffering_callback(ctx: *mut c_void) {
+    fn on_start_buffering_callback(ctx: NonNull<c_void>) {
         let this = Self::from_ctx(ctx);
         this.poll_ref.ref_(bun_io::js_vm_ctx());
         this.is_buffering_body.store(true, Ordering::Release);
@@ -1820,7 +1824,7 @@ impl FetchTasklet {
         if self.is_waiting_body {
             let mut pending = body::PendingValue::new(&self.global_this);
             pending.size_hint = self.get_size_hint();
-            pending.task = Some(std::ptr::from_mut(self).cast::<c_void>());
+            pending.task = Some(NonNull::from(&mut *self).cast::<c_void>());
             pending.on_start_streaming =
                 Some(FetchTasklet::on_start_streaming_http_response_body_callback);
             pending.on_readable_stream_available = Some(FetchTasklet::on_readable_stream_available);

--- a/src/runtime/webcore/response.classes.ts
+++ b/src/runtime/webcore/response.classes.ts
@@ -93,7 +93,7 @@ export default [
         fn: "constructError",
       },
     },
-    values: ["stream"],
+    values: ["stream", "transform"],
     proto: {
       url: {
         getter: "getURL",

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -1079,8 +1079,11 @@ pub(crate) fn upload_stream(
     }
 
     // The controller cell is installed into `sink.source` by `assign_to_stream`.
-    let assignment_result: JSValue =
-        NetworkSinkJSSink::assign_to_stream(global_this, readable_stream.value, sink);
+    let assignment_result: JSValue = NetworkSinkJSSink::assign_to_stream(
+        global_this,
+        readable_stream.value,
+        NonNull::from(sink),
+    );
     assignment_result.ensure_still_alive();
 
     if let Some(err_value) = assignment_result.to_error() {

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -89,6 +89,7 @@ pub enum StartTag {
     H3ResponseSink,
     NetworkSink,
     FetchRequestBodySink,
+    HTMLRewriterSink,
     Ready,
     OwnedAndDone,
     Done,
@@ -156,6 +157,9 @@ impl Start {
             }
             StartTag::FetchRequestBodySink => {
                 Self::from_js_with_tag::<{ StartTag::FetchRequestBodySink }>(global_this, value)
+            }
+            StartTag::HTMLRewriterSink => {
+                Self::from_js_with_tag::<{ StartTag::HTMLRewriterSink }>(global_this, value)
             }
             // No `Start` variant carries these tags from JS.
             _ => Self::from_js(global_this, value),
@@ -259,7 +263,8 @@ impl Start {
             | StartTag::HTTPSResponseSink
             | StartTag::HTTPResponseSink
             | StartTag::H3ResponseSink
-            | StartTag::FetchRequestBodySink => {
+            | StartTag::FetchRequestBodySink
+            | StartTag::HTMLRewriterSink => {
                 let mut empty = true;
                 let mut chunk_size: BlobSizeType = 2048;
 
@@ -876,6 +881,17 @@ impl UpstreamSource for crate::webcore::fetch::fetch_tasklet::FetchTasklet {
     }
 }
 
+impl UpstreamSource for crate::api::html_rewriter::RewriterPipe {
+    #[inline]
+    fn on_ready(&self) {
+        self.resume();
+    }
+    #[inline]
+    fn on_close(&self, err: Option<SysError>) {
+        self.cancel_from_output(err);
+    }
+}
+
 /// Tagged handle a sink holds to its upstream source — a closed set of
 /// variants so native source↔sink pairs can pump without a JS round-trip.
 #[derive(Copy, Clone, Default)]
@@ -895,6 +911,7 @@ pub enum SourceHandle {
     FetchResponseBody(BackRef<crate::webcore::fetch::fetch_tasklet::FetchTasklet, bun_ptr::Mut>),
     ServerRequestBody(crate::server::AnyRequestContext),
     S3DownloadBody(BackRef<crate::webcore::s3::client::S3DownloadStreamWrapper, bun_ptr::Mut>),
+    HTMLRewriter(BackRef<crate::api::html_rewriter::RewriterPipe>),
 }
 
 impl SourceHandle {
@@ -936,6 +953,7 @@ impl SourceHandle {
             // SAFETY: live backref; cleared before the pointee is freed.
             SourceHandle::S3DownloadBody(mut p) => unsafe { p.get_mut() }.on_stream_cancelled(),
             SourceHandle::ServerRequestBody(_) => {}
+            SourceHandle::HTMLRewriter(p) => p.on_close(err),
         }
     }
 
@@ -958,6 +976,7 @@ impl SourceHandle {
             SourceHandle::FileReader(p) => p.on_ready(),
             SourceHandle::FetchResponseBody(p) => p.on_ready(),
             SourceHandle::ServerRequestBody(any) => any.on_request_body_stream_drained(),
+            SourceHandle::HTMLRewriter(p) => p.on_ready(),
             // Remaining variants leave `on_ready` at the trait default (no-op).
             SourceHandle::Subprocess(_)
             | SourceHandle::ShellWritable(_)
@@ -976,7 +995,8 @@ impl SourceHandle {
             | SourceHandle::FileReader(_)
             | SourceHandle::Subprocess(_)
             | SourceHandle::ShellWritable(_)
-            | SourceHandle::S3DownloadBody(_) => {}
+            | SourceHandle::S3DownloadBody(_)
+            | SourceHandle::HTMLRewriter(_) => {}
         }
     }
 }

--- a/test/integration/bun-types/fixture/index.ts
+++ b/test/integration/bun-types/fixture/index.ts
@@ -346,7 +346,7 @@ new HTMLRewriter()
       console.log(element.getAttribute("src"));
     },
   })
-  .transform(new Blob(['<script src="/main.js"></script>']));
+  .transform(new Response('<script src="/main.js"></script>'));
 
 Buffer.from("foo").equals(Buffer.from("bar"));
 

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -813,6 +813,32 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     expect(await Bun.file(dest).text()).toBe("<html><body><p>hi</p></body></html>");
   });
 
+  // Bun.write owns the Locked body (on_receive_value + retargeted task);
+  // clone()'s tee must see that and yield a used body instead of dispatching
+  // the producer callbacks with Bun.write's task as ctx.
+  it("Bun.write(path, HTMLRewriter.transform(resp)) survives clone() while a handler is suspended", async () => {
+    using dir = tempDir("bun-write-htmlrewriter-clone", {});
+    const dest = join(String(dir), "out.html");
+    const { promise: suspended, resolve: onSuspend } = Promise.withResolvers();
+    const { promise: gate, resolve: openGate } = Promise.withResolvers();
+    const out = new HTMLRewriter()
+      .on("p", {
+        async element(el) {
+          onSuspend();
+          await gate;
+          el.setInnerContent("x");
+        },
+      })
+      .transform(new Response("<p>y</p>"));
+    const write = Bun.write(dest, out);
+    await suspended;
+    const clone = out.clone();
+    expect(clone).toBeInstanceOf(Response);
+    openGate();
+    await write;
+    expect(await Bun.file(dest).text()).toBe("<p>x</p>");
+  });
+
   it("BunFile.name survives concurrent write() calls + GC", async () => {
     using dir = tempDir("bun-file-name-concurrent-write-gc", {});
     const filePath = join(String(dir), "out.txt");

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -337,7 +337,7 @@ it("process.versions", () => {
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "05f0fafaa3be31e31d7b4b5c17dc60f62c991171",
-    lolhtml: "77127cd2b8545998756e8d64e36ee2313c4bb312",
+    lolhtml: "725ce499aa9b71e38b7a2d0a9fbb6d7294a4079e",
     ares: "3ac47ee46edd8ea40370222f91613fc16c434853",
     libdeflate: "c8c56a20f8f621e6a966b716b31f1dedab6a41e3",
     zstd: "f8745da6ff1ad1e7bab384bd1f9d742439278e99",

--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -1,15 +1,63 @@
 import { heapStats } from "bun:jsc";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug } from "harness";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 
-// When a handler throws, handler_callback() parks the JSC Exception cell in the
-// VM's rejection-capture slot (a stack local in BufferOutputSink::init(),
-// conservatively scanned) so create_lolhtml_error() can hand it to the caller.
-// handler_callback() used to .protect() the stored cell, but nothing on the
-// consuming path dropped that protection, so every caught handler exception
-// leaked one protected Exception (and the Error it wraps) for the life of the
-// process.
-//
+// `wire_input`'s materialized-body path transfers the body's `+1` (a
+// `WTFStringImpl` for an all-ASCII `new Response("...")`) into an `AnyBlob`
+// that it must `.detach()` after feeding. `WTFStringImpl` is native-heap, so
+// the Response-count tests below would not catch this.
+test("transform(new Response(ascii)) releases the input WTFStringImpl", async () => {
+  const code = /* js */ `
+    const rss = process.memoryUsage.rss;
+    // ~64 KB of ASCII so the leak dominates allocator noise.
+    const html = "<!doctype html>" + Buffer.alloc(64 * 1024, "x").toString() + "<p>.</p>";
+    const rw = new HTMLRewriter().on("p", { element() {} });
+
+    async function pass(n) {
+      for (let i = 0; i < n; i++) await rw.transform(new Response(html)).text();
+      Bun.gc(true);
+      return rss();
+    }
+
+    await pass(200); // warmup
+    const before = await pass(200);
+    await pass(200); await pass(200);
+    const after = await pass(200);
+    process.stdout.write(JSON.stringify({ deltaMB: (after - before) / 1024 / 1024 }) + "\\n");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", "-e", code],
+    env: {
+      ...bunEnv,
+      BUN_GARBAGE_COLLECTOR_LEVEL: "0",
+      // ASAN's quarantine pins freed blocks and keeps RSS at peak.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0", "thread_local_quarantine_size_kb=0"]
+        .filter(Boolean)
+        .join(":"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(
+    stderr
+      .split("\n")
+      .filter(l => !l.startsWith("WARNING: ASAN"))
+      .join("\n")
+      .trim(),
+  ).toBe("");
+  // A crash leaves stdout empty; surface it (and the exit code) instead of a
+  // generic JSON.parse SyntaxError.
+  expect({ stdout: stdout.trim(), exitCode }).toEqual({
+    stdout: expect.stringMatching(/^\{"deltaMB":/),
+    exitCode: 0,
+  });
+  const { deltaMB } = JSON.parse(stdout.trim());
+  // Unfixed: ~38 MB (3 × 200 × 64 KB). Fixed: ~0.
+  expect(deltaMB).toBeLessThan(15);
+}, 30_000);
+
 // https://github.com/oven-sh/bun/issues/31804
 test("exceptions thrown from handlers do not leak protected Exception roots", async () => {
   const code = /* js */ `
@@ -148,7 +196,7 @@ test.skipIf(isDebug)(
         return rss();
       }
 
-      pass(); pass();
+      pass(); pass(); pass();
       const before = pass();
       pass(); pass();
       const after = pass();
@@ -185,10 +233,432 @@ test.skipIf(isDebug)(
 
     const { deltaMB } = JSON.parse(stdout.trim());
 
-    // Unfixed: ~50 MB over 3 measured passes. Fixed: ±1 MB plateau.
-    // Threshold sits at ~half the unfixed signal.
-    expect(deltaMB).toBeLessThan(25);
+    // Unfixed: ~50 MB over 3 measured passes. Fixed: a plateau, but RSS is a
+    // high-water mark and allocator jitter has been observed to reach ~30 MB
+    // on release lanes, so the bound sits between that and the unfixed signal.
+    expect(deltaMB).toBeLessThan(35);
     expect(exitCode).toBe(0);
   },
   15_000,
 );
+
+// `fail()` / `cancel_from_output()` on a native ByteStream/FileReader input
+// must detach the source's sink backref and let the Transform cell become
+// unreachable, or every rewrite pins its output Response. Covers the
+// suspend-then-reject, suspend-then-resume-throw, and output-cancel paths;
+// the materialized-body test above never wires a native source.
+test("async handler reject/cancel on native-stream input releases the pipe", async () => {
+  using dir = tempDir("hr-native-leak", { "in.html": "<p>a</p><p>b</p><div>x</div>" });
+  const file = `${dir}/in.html`;
+
+  const rewrites = async (count: number) => {
+    for (let i = 0; i < count; i++) {
+      // suspend-then-reject (on_handler_reject → fail)
+      await new HTMLRewriter()
+        .on("p", {
+          async element() {
+            await new Promise(r => setTimeout(r, 0));
+            throw new Error("x");
+          },
+        })
+        .transform(new Response(Bun.file(file)))
+        .text()
+        .catch(e => e.message);
+
+      // output-reader cancel while suspended (cancel_from_output). The handler
+      // promise is resolved explicitly after the cancel so the suspension ref
+      // is released through `on_handler_resolve`'s early-Done exit rather than
+      // depending on GC-driven abandon (covered by the never-settling test).
+      const { promise, resolve } = Promise.withResolvers<void>();
+      const out = new HTMLRewriter().on("p", { element: () => promise }).transform(new Response(Bun.file(file)));
+      const reader = out.body!.getReader();
+      const first = reader.read();
+      await reader.cancel();
+      resolve();
+      await first.catch(() => {});
+
+      // suspend-then-resume-then-sync-throw (resume_rewrite → fail)
+      await new HTMLRewriter()
+        .on("p", { async element() {} })
+        .on("div", {
+          element() {
+            throw new Error("y");
+          },
+        })
+        .transform(new Response(Bun.file(file)))
+        .text()
+        .catch(e => e.message);
+    }
+  };
+
+  const responses = () => {
+    Bun.gc(true);
+    return heapStats().objectTypeCounts.Response ?? 0;
+  };
+
+  await rewrites(20);
+  const before = responses();
+  await rewrites(60);
+  const after = responses();
+
+  // Unfixed: ~180 leaked Responses (one input + one output per rewrite that
+  // detached a native source without releasing the input ref).
+  expect(after - before).toBeLessThan(30);
+});
+
+// A handler that cancels the output reader synchronously does so while
+// `feed()` is still on the stack. `write()` must re-check `done` after
+// `feed()` and return `Done` so the native caller's snapshot `sink.end()`
+// detaches the upstream; otherwise it keeps dispatching into a terminal pipe
+// and the output Response stays pinned.
+test("cancelling the output reader from inside a handler releases the pipe", async () => {
+  // The server emits the second chunk only after the client signals the handler
+  // has run on the first (so `has_received_last_chunk` is false at cancel time),
+  // and the client awaits the server's close before moving on. No timing guesses.
+  let sawFirst = Promise.withResolvers<void>();
+  let serverClosed = Promise.withResolvers<void>();
+  await using server = Bun.serve({
+    port: 0,
+    async fetch() {
+      return new Response(
+        new ReadableStream({
+          async start(c) {
+            c.enqueue(new TextEncoder().encode("<p>a</p>"));
+            await sawFirst.promise;
+            c.enqueue(new TextEncoder().encode("<p>b</p>"));
+            c.close();
+            serverClosed.resolve();
+          },
+        }),
+      );
+    },
+  });
+  const url = `http://localhost:${server.port}/`;
+
+  const rewrites = async (count: number) => {
+    for (let i = 0; i < count; i++) {
+      // Alternate sync vs async handler: the async variant cancels and THEN
+      // suspends, covering `write()`'s `feed() == false` branch.
+      const async = i % 2 === 1;
+      sawFirst = Promise.withResolvers();
+      serverClosed = Promise.withResolvers();
+      let reader: ReadableStreamDefaultReader | null;
+      const upstream = await fetch(url);
+      const out = new HTMLRewriter()
+        .on("p", {
+          element: async
+            ? async () => {
+                reader?.cancel();
+                reader = null;
+                await new Promise(r => setTimeout(r, 0));
+              }
+            : () => {
+                reader?.cancel();
+                reader = null;
+              },
+        })
+        .transform(upstream);
+      reader = out.body!.getReader();
+      await reader.read().catch(() => {});
+      sawFirst.resolve();
+      await serverClosed.promise;
+    }
+  };
+
+  // The pipe's own release is synchronous; the upstream fetch's Response can
+  // lag a few turns after the server closes.
+  const responses = async () => {
+    let last = Infinity;
+    for (let i = 0; i < 20; i++) {
+      Bun.gc(true);
+      const now = heapStats().objectTypeCounts.Response ?? 0;
+      if (now === last) return now;
+      last = now;
+      await new Promise(r => setImmediate(r));
+    }
+    return last;
+  };
+
+  await rewrites(10);
+  const before = await responses();
+  await rewrites(40);
+  const after = await responses();
+
+  // Unfixed: ~40 leaked Responses (one output per rewrite).
+  expect(after - before).toBeLessThan(15);
+});
+
+// A suspension parks the rewritable unit's JS wrapper and the boxed lol-html
+// rewriter, and the handler promise's reaction roots the Transform cell, so
+// everything is released only once that promise settles. A general canary for
+// the settle path.
+test("suspended rewrites release their parked state once the handler settles", async () => {
+  const suspendingRewrites = async (count: number) => {
+    for (let i = 0; i < count; i++) {
+      await new HTMLRewriter()
+        .on("p", {
+          async element(element) {
+            await new Promise(r => setTimeout(r, 0));
+            element.setInnerContent("x");
+          },
+        })
+        .transform(new Response("<p>y</p>"))
+        .text();
+    }
+  };
+
+  const counts = () => {
+    Bun.gc(true);
+    const { objectTypeCounts, protectedObjectTypeCounts } = heapStats();
+    return {
+      responses: objectTypeCounts.Response ?? 0,
+      functions: protectedObjectTypeCounts.Function ?? 0,
+    };
+  };
+
+  await suspendingRewrites(40);
+  const before = counts();
+  await suspendingRewrites(120);
+  const after = counts();
+
+  expect(after.responses - before.responses).toBeLessThan(30);
+  expect(after.functions - before.functions).toBeLessThan(30);
+});
+
+// The abandon path: a handler awaiting a promise nothing will ever resolve.
+// The promise is collected unsettled, the reaction rooting the Transform cell
+// goes with it, and the cell's finalizer defers to
+// `RewriterPipe::abandon_suspension`, which rejects the body and releases the
+// parked wrapper.
+//
+// This is the only guard for that mechanism, so it has to assert the release,
+// not just the rejection. Poll for the rejections rather than forcing exactly N
+// GCs, so a slow ASAN lane doesn't turn a pass into a 5s hang.
+test("never-settling handler promises are abandoned and release their parked state", async () => {
+  const N = 60;
+
+  const abandonAll = async (count: number) => {
+    const bodies = [];
+    for (let i = 0; i < count; i++) {
+      bodies.push(
+        new HTMLRewriter()
+          .on("p", {
+            async element() {
+              await new Promise(() => {});
+            },
+          })
+          .transform(new Response("<p>x</p>"))
+          .text()
+          .then(
+            () => "resolved",
+            e => e.message,
+          ),
+      );
+    }
+    // The handler promises are unreachable now; collect until every body has
+    // been abandoned, rather than guessing a GC count.
+    const settled: string[] = [];
+    for (let i = 0; i < 100 && settled.length < count; i++) {
+      Bun.gc(true);
+      await new Promise(r => setTimeout(r, 1));
+      settled.length = 0;
+      settled.push(
+        ...(await Promise.all(bodies.map(b => Promise.race([b, Promise.resolve(undefined)])))).filter(Boolean),
+      );
+    }
+    // Every body must have settled by now; assert it so a regression that
+    // strands one fails with a count instead of hanging on the await below.
+    expect(settled.length).toBe(count);
+    return await Promise.all(bodies);
+  };
+
+  const counts = () => {
+    Bun.gc(true);
+    const { objectTypeCounts, protectedObjectTypeCounts } = heapStats();
+    return {
+      responses: objectTypeCounts.Response ?? 0,
+      functions: protectedObjectTypeCounts.Function ?? 0,
+    };
+  };
+
+  // Warm up so one-time allocations don't land in the measured delta.
+  const warm = await abandonAll(10);
+  expect(warm.every(m => m.includes("will never settle"))).toBe(true);
+
+  const before = counts();
+  const results = await abandonAll(N);
+  const after = counts();
+
+  // Every one was abandoned with the real reason...
+  expect(results.every(m => m.includes("will never settle"))).toBe(true);
+  // ...and nothing it parked is still pinned. A regression that keeps rejecting
+  // the body but stops releasing would show up as ~N leaked Responses.
+  expect(after.responses - before.responses).toBeLessThan(N / 4);
+  expect(after.functions - before.functions).toBeLessThan(N / 4);
+});
+
+// Same abandon path, but with a NATIVE (FileReader) input wired through a raw
+// SinkHandle. The Transform cell and the input NewSource can be swept in the
+// same GC cycle here, so the pipe's finalizer must not write into the source:
+// the source's `sinkOwner` slot roots the cell while the source is alive, and
+// the abandon task clears the stale handle raw instead of unpiping through it.
+// The materialized bodies in the test above never wire a native source, so
+// only this exercises that ordering under ASAN.
+test("never-settling handler promises on a file-backed input are abandoned", async () => {
+  using dir = tempDir("hr-abandon-file", { "in.html": "<p>a</p><p>b</p>" });
+  const file = `${dir}/in.html`;
+  const N = 20;
+
+  const bodies = [];
+  for (let i = 0; i < N; i++) {
+    bodies.push(
+      new HTMLRewriter()
+        .on("p", {
+          async element() {
+            await new Promise(() => {});
+          },
+        })
+        .transform(new Response(Bun.file(file)))
+        .text()
+        .then(
+          () => "resolved",
+          e => e.message,
+        ),
+    );
+  }
+  const settled: string[] = [];
+  for (let i = 0; i < 100 && settled.length < N; i++) {
+    Bun.gc(true);
+    await new Promise(r => setTimeout(r, 1));
+    settled.length = 0;
+    settled.push(
+      ...(await Promise.all(bodies.map(b => Promise.race([b, Promise.resolve(undefined)])))).filter(Boolean),
+    );
+  }
+  expect(settled.length).toBe(N);
+  const results = await Promise.all(bodies);
+  expect(results.every(m => m.includes("will never settle"))).toBe(true);
+});
+
+// The abandon path with a realized output stream. Holding the reader keeps
+// the Transform cell reachable (reader -> stream -> NewSource `owner` slot),
+// so collecting the cell cannot be what detects the dead handler promise:
+// the promise context's destructor is, and it must error the live stream.
+test("a held reader's read() rejects when the handler promise is collected", async () => {
+  const out = new HTMLRewriter()
+    .on("p", {
+      async element() {
+        await new Promise(() => {});
+      },
+    })
+    .transform(new Response("<p>x</p>"));
+  const reader = out.body!.getReader();
+  const read = reader.read().then(
+    () => "resolved",
+    e => e.message,
+  );
+
+  let msg: string | undefined;
+  for (let i = 0; i < 100 && msg === undefined; i++) {
+    Bun.gc(true);
+    await new Promise(r => setTimeout(r, 1));
+    msg = await Promise.race([read, Promise.resolve(undefined)]);
+  }
+  expect(msg).toContain("will never settle");
+});
+
+// Same, but nothing is held: realizing `.body` installs the body's `readable`
+// Strong inside the Response native, which the pipe's own `+1` used to keep
+// alive, closing a Strong-rooted loop through the output source's `owner`
+// slot that GC could never break. The promise-context abandon makes the
+// rewrite terminal (clearing the `owner` edges), so everything collapses.
+test("never-settling handler promises with a realized body release their parked state", async () => {
+  const N = 30;
+
+  const abandonAll = async (count: number) => {
+    const reads = [];
+    for (let i = 0; i < count; i++) {
+      reads.push(
+        new HTMLRewriter()
+          .on("p", {
+            async element() {
+              await new Promise(() => {});
+            },
+          })
+          .transform(new Response("<p>x</p>"))
+          .body!.getReader()
+          .read()
+          .then(
+            () => "resolved",
+            e => e.message,
+          ),
+      );
+    }
+    const settled: string[] = [];
+    for (let i = 0; i < 100 && settled.length < count; i++) {
+      Bun.gc(true);
+      await new Promise(r => setTimeout(r, 1));
+      settled.length = 0;
+      settled.push(
+        ...(await Promise.all(reads.map(b => Promise.race([b, Promise.resolve(undefined)])))).filter(Boolean),
+      );
+    }
+    expect(settled.length).toBe(count);
+    return await Promise.all(reads);
+  };
+
+  const responses = () => {
+    Bun.gc(true);
+    return heapStats().objectTypeCounts.Response ?? 0;
+  };
+
+  const warm = await abandonAll(10);
+  expect(warm.every(m => m.includes("will never settle"))).toBe(true);
+
+  const before = responses();
+  const results = await abandonAll(N);
+  const after = responses();
+
+  expect(results.every(m => m.includes("will never settle"))).toBe(true);
+  expect(after - before).toBeLessThan(N / 3);
+});
+
+// Input-side sibling of the realized-body case: a `type: 'direct'` pull
+// parked on `await controller.flush(true)` holds a pending-flush promise
+// whose reactions reach back to the Transform cell through the pump promise.
+// Abandon must not depend on the cell becoming unreachable: the dead handler
+// promise's context destructor fires it, and `fail()` settles the parked
+// flush so the whole graph collapses.
+test("a direct-stream pull parked on flush(true) is released when the handler promise is collected", async () => {
+  const text = new HTMLRewriter()
+    .on("p", {
+      async element() {
+        await new Promise(() => {});
+      },
+    })
+    .transform(
+      new Response(
+        new ReadableStream({
+          type: "direct",
+          async pull(controller) {
+            controller.write(new TextEncoder().encode("<p>x</p>"));
+            await controller.flush(true);
+            controller.close();
+          },
+        }),
+      ),
+    )
+    .text()
+    .then(
+      () => "resolved",
+      e => e.message,
+    );
+
+  let msg: string | undefined;
+  for (let i = 0; i < 100 && msg === undefined; i++) {
+    Bun.gc(true);
+    await new Promise(r => setTimeout(r, 1));
+    msg = await Promise.race([text, Promise.resolve(undefined)]);
+  }
+  expect(msg).toContain("will never settle");
+});

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { once } from "events";
 import fs from "fs";
-import { gcTick, tls, tmpdirSync } from "harness";
+import { bunEnv, bunExe, gcTick, tempDir, tls, tmpdirSync } from "harness";
 import { createServer as createTcpServer } from "net";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
@@ -22,16 +22,18 @@ describe("HTMLRewriter", () => {
     expect(() => new HTMLRewriter().transform(Symbol("ok"))).toThrow();
   });
 
-  it("error inside element handler", () => {
-    expect(() =>
-      new HTMLRewriter()
-        .on("div", {
-          element(element) {
-            throw new Error("test");
-          },
-        })
-        .transform(new Response("<div>hello</div>")),
-    ).toThrow("test");
+  // Which channel a handler error takes is decided by the overload, not by
+  // whether the input body happened to be buffered: every `Response` input
+  // rejects its output body.
+  it("error inside element handler rejects the body", async () => {
+    const res = new HTMLRewriter()
+      .on("div", {
+        element(element) {
+          throw new Error("test");
+        },
+      })
+      .transform(new Response("<div>hello</div>"));
+    await expect(res.text()).rejects.toThrow("test");
   });
 
   it("error inside element handler (string)", () => {
@@ -46,44 +48,46 @@ describe("HTMLRewriter", () => {
     ).toThrow("test");
   });
 
-  it("fast async error inside element handler", () => {
-    let caught = false;
-    try {
-      new HTMLRewriter()
-        .on("div", {
-          async element(element) {
-            await setImmediatePromise();
-            throw new Error("test");
-          },
-        })
-        .transform(new Response("<div>hello</div>"));
-      expect.unreachable();
-    } catch (e) {
-      caught = true;
-      expect(e.message).toBe("test");
-    } finally {
-      expect(caught).toBeTrue();
-    }
+  it("async error without a real await inside element handler rejects the body", async () => {
+    const res = new HTMLRewriter()
+      .on("div", {
+        async element(element) {
+          throw new Error("test");
+        },
+      })
+      .transform(new Response("<div>hello</div>"));
+    await expect(res.text()).rejects.toThrow("test");
   });
 
-  it("slow async error inside element handler", () => {
-    let caught = false;
-    try {
-      new HTMLRewriter()
-        .on("div", {
-          async element(element) {
-            await Bun.sleep(1);
-            throw new Error("test");
-          },
-        })
-        .transform(new Response("<div>hello</div>"));
-      expect.unreachable();
-    } catch (e) {
-      caught = true;
-      expect(e.message).toBe("test");
-    } finally {
-      expect(caught).toBeTrue();
-    }
+  // A handler that only settles once the event loop turns (setImmediate /
+  // setTimeout / I/O) suspends the rewrite: `transform()` returns the
+  // Response immediately and the failure surfaces on its body, exactly like
+  // Cloudflare's HTMLRewriter. It can no longer throw synchronously, because
+  // HTMLRewriter no longer nests the event loop inside `transform()`.
+  it("fast async error inside element handler rejects the body", async () => {
+    const res = new HTMLRewriter()
+      .on("div", {
+        async element(element) {
+          await setImmediatePromise();
+          throw new Error("test");
+        },
+      })
+      .transform(new Response("<div>hello</div>"));
+    expect(res).toBeInstanceOf(Response);
+    await expect(res.text()).rejects.toThrow("test");
+  });
+
+  it("slow async error inside element handler rejects the body", async () => {
+    const res = new HTMLRewriter()
+      .on("div", {
+        async element(element) {
+          await Bun.sleep(1);
+          throw new Error("test");
+        },
+      })
+      .transform(new Response("<div>hello</div>"));
+    expect(res).toBeInstanceOf(Response);
+    await expect(res.text()).rejects.toThrow("test");
   });
 
   it("HTMLRewriter: async replacement", async () => {
@@ -100,6 +104,751 @@ describe("HTMLRewriter", () => {
     await gcTick();
     expect(await res.text()).toBe("<div><span>replace</span></div>");
     await gcTick();
+  });
+
+  // Async content handlers suspend the lol-html rewrite until their promise
+  // settles, instead of spinning a nested event loop inside `transform()`.
+  // The rewritable unit is moved onto the heap for the duration of the
+  // `await`, so post-`await` mutations still land on the element that gets
+  // serialized, and handlers stay strictly one-at-a-time.
+  describe("async handlers suspend the rewrite", () => {
+    it("runs async element handlers strictly in document order", async () => {
+      const count = 8;
+      const order = [];
+      const html = Array.from({ length: count }, (_, i) => `<i id="${i}"></i>`).join("");
+      const res = new HTMLRewriter()
+        .on("i", {
+          async element(element) {
+            const id = element.getAttribute("id");
+            await setImmediatePromise();
+            order.push(id);
+            element.setInnerContent(id);
+          },
+        })
+        .transform(new Response(html));
+      expect(await res.text()).toBe(Array.from({ length: count }, (_, i) => `<i id="${i}">${i}</i>`).join(""));
+      // Each handler must finish (including its awaited half) before the
+      // parser reaches the next element.
+      expect(order).toEqual(Array.from({ length: count }, (_, i) => String(i)));
+    });
+
+    it("mutations made before and after the await both land", async () => {
+      const res = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            element.setAttribute("before", "1");
+            await setImmediatePromise();
+            element.setAttribute("after", "2");
+            element.setAttribute("id", "x");
+          },
+        })
+        .transform(new Response('<div id="a">inner</div>'));
+      expect(await res.text()).toBe('<div id="x" before="1" after="2">inner</div>');
+    });
+
+    it("an attribute iterator from before the await keeps working", async () => {
+      // The suspension deep-copies the element (and its attribute buffer) onto
+      // the heap. The iterator reads attributes back through the element on
+      // every next(), so it follows the copy and resumes at the same index
+      // instead of silently reporting done.
+      let partial, rest, fresh;
+      const res = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            const it = element.attributes;
+            partial = it.next().value;
+            await setImmediatePromise();
+            rest = [...it];
+            fresh = [...element.attributes];
+            element.setAttribute("c", "3");
+          },
+        })
+        .transform(new Response('<div a="1" b="2">x</div>'));
+      expect(await res.text()).toBe('<div a="1" b="2" c="3">x</div>');
+      expect(partial).toEqual(["a", "1"]);
+      // Resumes mid-iteration against the parked copy.
+      expect(rest).toEqual([["b", "2"]]);
+      expect(fresh).toEqual([
+        ["a", "1"],
+        ["b", "2"],
+      ]);
+    });
+
+    it("a for..of over attributes with an await in the body visits all of them", async () => {
+      const seen = [];
+      const res = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            for (const [name, value] of element.attributes) {
+              await setImmediatePromise();
+              seen.push(`${name}=${value}`);
+            }
+          },
+        })
+        .transform(new Response('<div a="1" b="2" c="3">x</div>'));
+      expect(await res.text()).toBe('<div a="1" b="2" c="3">x</div>');
+      expect(seen).toEqual(["a=1", "b=2", "c=3"]);
+    });
+
+    it("runs the next handler for the same element after the previous one's await", async () => {
+      const order = [];
+      const res = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            await setImmediatePromise();
+            order.push("a");
+            element.setAttribute("a", "");
+          },
+        })
+        .on("div", {
+          async element(element) {
+            await setImmediatePromise();
+            order.push("b");
+            element.setAttribute("b", "");
+          },
+        })
+        .transform(new Response("<div></div>"));
+      expect(await res.text()).toBe('<div a="" b=""></div>');
+      expect(order).toEqual(["a", "b"]);
+    });
+
+    it("element removed after the await suppresses its content", async () => {
+      const res = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            await setImmediatePromise();
+            element.remove();
+          },
+        })
+        .transform(new Response("a<div>gone<span>too</span></div>b"));
+      expect(await res.text()).toBe("ab");
+    });
+
+    it("async text handler", async () => {
+      const res = new HTMLRewriter()
+        .on("div", {
+          async text(chunk) {
+            if (chunk.lastInTextNode) return;
+            const original = chunk.text;
+            await setImmediatePromise();
+            chunk.replace(original.toUpperCase());
+          },
+        })
+        .transform(new Response("<div>hello</div>world"));
+      expect(await res.text()).toBe("<div>HELLO</div>world");
+    });
+
+    // The canonical "append once the text node ends" idiom, suspended on the
+    // lastInTextNode chunk itself and mutated after the resume.
+    it("async text handler suspending on lastInTextNode and mutating it", async () => {
+      const res = new HTMLRewriter()
+        .on("div", {
+          async text(chunk) {
+            if (!chunk.lastInTextNode) return;
+            await setImmediatePromise();
+            chunk.after("|", { html: false });
+          },
+        })
+        .transform(new Response("<div>hello</div>"));
+      expect(await res.text()).toBe("<div>hello|</div>");
+    });
+
+    // The `is_async` arm of `on_rewriting_error`: a handler throwing while the
+    // input is still streaming must surface the real error, not lol-html's
+    // generic "The rewriter has been stopped."
+    it("a throwing handler on a streaming input surfaces the real error", async () => {
+      const encoder = new TextEncoder();
+      // The body must still be incomplete when `transform()` runs, or the
+      // rewrite finishes inline and the handler throws synchronously instead
+      // (also correct, but a different code path). Hold the tail back until
+      // `transform()` has returned rather than racing the loopback.
+      const transformCalled = Promise.withResolvers();
+      await using server = Bun.serve({
+        port: 0,
+        fetch: () =>
+          new Response(
+            new ReadableStream({
+              async start(controller) {
+                controller.enqueue(encoder.encode("<div>"));
+                await transformCalled.promise;
+                controller.enqueue(encoder.encode("x</div>"));
+                controller.close();
+              },
+            }),
+          ),
+      });
+      const upstream = await fetch(`http://localhost:${server.port}/`);
+      const res = new HTMLRewriter()
+        .on("div", {
+          element() {
+            throw new Error("boom");
+          },
+        })
+        .transform(upstream);
+      transformCalled.resolve();
+      await expect(res.text()).rejects.toThrow("boom");
+    });
+
+    // `new Response(new ReadableStream({...}))` — the JS-source input path
+    // (#11758/#14216): the rewrite must pump the JS stream through the sink
+    // and an async handler can suspend mid-stream.
+    it("a JS ReadableStream input with an async handler", async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        async start(controller) {
+          controller.enqueue(encoder.encode("<html><body>"));
+          await setImmediatePromise();
+          controller.enqueue(encoder.encode("<p>old</p>"));
+          await setImmediatePromise();
+          controller.enqueue(encoder.encode("</body></html>"));
+          controller.close();
+        },
+      });
+      const res = new HTMLRewriter()
+        .on("p", {
+          async element(element) {
+            await setImmediatePromise();
+            element.setInnerContent("new");
+          },
+        })
+        .transform(new Response(stream));
+      expect(await res.text()).toBe("<html><body><p>new</p></body></html>");
+    });
+
+    // `rsisAbrupt` calls `controller.close(error)` synchronously before
+    // rejecting the pump promise, and the generated `__close` drops its error
+    // argument. The pipe must defer its terminal step to the reject reaction
+    // so the real error reaches the output body instead of resolving with
+    // truncated HTML.
+    it.each(["default", "pull"])(
+      "a JS ReadableStream (%s) input that errors mid-stream rejects the body",
+      async kind => {
+        const encoder = new TextEncoder();
+        const stream = new ReadableStream(
+          kind === "pull"
+            ? {
+                pulls: 0,
+                pull(controller) {
+                  if (this.pulls++ === 0) return controller.enqueue(encoder.encode("<p>partial"));
+                  controller.error(new Error("upstream boom"));
+                },
+              }
+            : {
+                async start(controller) {
+                  controller.enqueue(encoder.encode("<p>partial"));
+                  await setImmediatePromise();
+                  controller.error(new Error("upstream boom"));
+                },
+              },
+        );
+        const res = new HTMLRewriter().on("p", { element() {} }).transform(new Response(stream));
+        await expect(res.text()).rejects.toThrow("upstream boom");
+      },
+    );
+
+    // A `type: 'direct'` source whose `pull()` throws synchronously leaves the
+    // JS controller's `m_sinkPtr` set after `readDirectStream` returns with an
+    // exception; `end_from_stream` must null it (via `JSSink::detach`) before
+    // the pipe can be freed so the controller's destructor doesn't dispatch
+    // into freed memory.
+    it("a direct ReadableStream whose pull() throws synchronously rejects the body", async () => {
+      for (let i = 0; i < 4; i++) {
+        const stream = new ReadableStream({
+          type: "direct",
+          pull() {
+            throw new Error("pull threw");
+          },
+        });
+        const res = new HTMLRewriter().on("p", { element() {} }).transform(new Response(stream));
+        await expect(res.text()).rejects.toThrow("pull threw");
+        Bun.gc(true);
+      }
+    });
+
+    // `fail()` must settle the `WritablePending` slot so a direct `pull()`
+    // parked on `await controller.flush(true)` resumes, letting the pump
+    // promise settle and release the input `+1` (`cancel_from_output`
+    // already did this; `fail()` didn't).
+    it("a direct ReadableStream parked on flush(true) is released when the handler rejects", async () => {
+      let afterFlush = 0;
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        type: "direct",
+        async pull(controller) {
+          controller.write(encoder.encode("<p>x</p>"));
+          await controller.flush(true);
+          afterFlush++;
+          controller.close();
+        },
+      });
+      const res = new HTMLRewriter()
+        .on("p", {
+          async element() {
+            await setImmediatePromise();
+            throw new Error("handler rejected");
+          },
+        })
+        .transform(new Response(stream));
+      await expect(res.text()).rejects.toThrow("handler rejected");
+      await setImmediatePromise();
+      expect(afterFlush).toBe(1);
+    });
+
+    // Two rewriters chained, both suspending: `init()`'s own comment names
+    // "another transform()" as a supported consumer of a pending body.
+    it("chained suspending transforms", async () => {
+      const first = new HTMLRewriter()
+        .on("p", {
+          async element(element) {
+            await setImmediatePromise();
+            element.setAttribute("one", "");
+          },
+        })
+        .transform(new Response("<p>x</p>"));
+      const second = new HTMLRewriter()
+        .on("p", {
+          async element(element) {
+            await setImmediatePromise();
+            element.setAttribute("two", "");
+          },
+        })
+        .transform(first);
+      expect(await second.text()).toBe('<p one="" two="">x</p>');
+    });
+
+    it("a rejection in the first of two chained transforms rejects the last body", async () => {
+      const first = new HTMLRewriter()
+        .on("p", {
+          async element() {
+            await setImmediatePromise();
+            throw new Error("inner boom");
+          },
+        })
+        .transform(new Response("<p>x</p>"));
+      const second = new HTMLRewriter().on("p", { element() {} }).transform(first);
+      await expect(second.text()).rejects.toThrow("inner boom");
+    });
+
+    // The resume path's own `handler_callback` sees a Fulfilled promise only
+    // when a microtask-only handler follows a real-await one.
+    it("a microtask-only handler after a suspending one", async () => {
+      const order = [];
+      const res = new HTMLRewriter()
+        .on("p", {
+          async element(element) {
+            await setImmediatePromise();
+            order.push("slow");
+            element.setAttribute("slow", "");
+          },
+        })
+        .on("p", {
+          async element(element) {
+            await Promise.resolve();
+            order.push("fast");
+            element.setAttribute("fast", "");
+          },
+        })
+        .transform(new Response("<p>x</p>"));
+      expect(await res.text()).toBe('<p slow="" fast="">x</p>');
+      expect(order).toEqual(["slow", "fast"]);
+    });
+
+    it("async comments, doctype, and document end handlers", async () => {
+      const res = new HTMLRewriter()
+        .onDocument({
+          async doctype(doctype) {
+            await setImmediatePromise();
+            doctype.remove();
+          },
+          async comments(comment) {
+            const text = comment.text;
+            await setImmediatePromise();
+            comment.text = `${text}${text}`;
+          },
+          async end(end) {
+            await setImmediatePromise();
+            end.append("<tail>", { html: true });
+          },
+        })
+        .transform(new Response("<!DOCTYPE html><p><!--x--></p>"));
+      expect(await res.text()).toBe("<p><!--xx--></p><tail>");
+    });
+
+    it("async onEndTag handler", async () => {
+      const res = new HTMLRewriter()
+        .on("div", {
+          element(element) {
+            element.onEndTag(async endTag => {
+              await setImmediatePromise();
+              endTag.before("!");
+            });
+          },
+        })
+        .transform(new Response("<div>x</div>y"));
+      expect(await res.text()).toBe("<div>x!</div>y");
+    });
+
+    it("the element survives a GC during the await", async () => {
+      const res = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            element.setAttribute("pre", "1");
+            await gcTick();
+            await setImmediatePromise();
+            await gcTick();
+            element.setAttribute("post", "2");
+            element.setInnerContent("<b>ok</b>", { html: true });
+          },
+        })
+        .transform(new Response("<div>old</div>"));
+      // One more collection while the transform is suspended and `transform()`
+      // has already returned.
+      await gcTick();
+      expect(await res.text()).toBe('<div pre="1" post="2"><b>ok</b></div>');
+    });
+
+    it("a nested transform inside a suspended handler", async () => {
+      const res = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            const inner = await new HTMLRewriter()
+              .on("b", {
+                async element(b) {
+                  await setImmediatePromise();
+                  b.setInnerContent("inner");
+                },
+              })
+              .transform(new Response("<b>x</b>"))
+              .text();
+            element.setInnerContent(inner, { html: true });
+          },
+        })
+        .transform(new Response("<div>outer</div>"));
+      expect(await res.text()).toBe("<div><b>inner</b></div>");
+    });
+
+    it("transform(string) throws if a handler needs the event loop to settle", () => {
+      expect(() =>
+        new HTMLRewriter()
+          .on("div", {
+            async element(element) {
+              await setImmediatePromise();
+            },
+          })
+          .transform("<div></div>"),
+      ).toThrow(
+        "HTMLRewriter.transform() cannot synchronously return a string because a content " +
+          "handler returned a Promise that did not resolve within a microtask. Pass a " +
+          "Response instead and await its body",
+      );
+    });
+
+    it("transform(string) stays synchronous for microtask-only async handlers", () => {
+      const out = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            await Promise.resolve();
+            await null;
+            element.setInnerContent("sync enough");
+          },
+        })
+        .transform("<div>old</div>");
+      expect(out).toBe("<div>sync enough</div>");
+    });
+
+    // The suspend decision runs one microtask checkpoint, which drains
+    // process.nextTick before the promise jobs (Node ordering), so a handler
+    // that completes via nextTick is still "synchronous enough".
+    for (const [label, schedule] of [
+      ["process.nextTick", r => process.nextTick(r)],
+      ["queueMicrotask", r => queueMicrotask(r)],
+    ]) {
+      it(`transform(string) stays synchronous for a handler awaiting ${label}`, () => {
+        const out = new HTMLRewriter()
+          .on("div", {
+            async element(element) {
+              await new Promise(schedule);
+              element.setInnerContent("ok");
+            },
+          })
+          .transform("<div>old</div>");
+        expect(out).toBe("<div>ok</div>");
+      });
+    }
+
+    // transform(string) must fail atomically: the throw means the whole
+    // rewrite failed, so no later handler may run against the orphaned output
+    // and no post-throw rejection may be swallowed.
+    it("transform(string) throwing runs no later handlers", async () => {
+      let later = 0;
+      expect(() =>
+        new HTMLRewriter()
+          .on("a", {
+            async element() {
+              await setImmediatePromise();
+            },
+          })
+          .on("b", {
+            element() {
+              later++;
+            },
+          })
+          .transform("<a></a><b></b>"),
+      ).toThrow("cannot synchronously return a string");
+      // Give the orphaned rewrite every chance to resume and run `b`.
+      await setImmediatePromise();
+      await setImmediatePromise();
+      expect(later).toBe(0);
+    });
+
+    // A suspended transform hands back a Response whose body is still pending.
+    // Every consumer of that body has to get the bytes once the rewrite
+    // finishes, not just `.text()`.
+    describe("consumers of a still-pending output body", () => {
+      const suspending = () =>
+        new HTMLRewriter()
+          .on("p", {
+            async element(element) {
+              await setImmediatePromise();
+              element.setInnerContent("new");
+            },
+          })
+          .transform(new Response("<p>old</p>"));
+
+      it(".text()", async () => {
+        expect(await suspending().text()).toBe("<p>new</p>");
+      });
+
+      it(".blob()", async () => {
+        expect(await (await suspending().blob()).text()).toBe("<p>new</p>");
+      });
+
+      it(".arrayBuffer()", async () => {
+        const buf = await suspending().arrayBuffer();
+        expect(new TextDecoder().decode(buf)).toBe("<p>new</p>");
+      });
+
+      it(".body reader drains the bytes", async () => {
+        const reader = suspending().body.getReader();
+        const chunks = [];
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          chunks.push(value);
+        }
+        expect(new TextDecoder().decode(Buffer.concat(chunks))).toBe("<p>new</p>");
+      });
+
+      it("new Response(res.body).text()", async () => {
+        expect(await new Response(suspending().body).text()).toBe("<p>new</p>");
+      });
+
+      // `Value::tee` realises the pending body as a ByteStream via
+      // on_start_streaming/on_readable_stream_available, then tees it; the
+      // rewrite keeps feeding that ByteStream, so both branches drain.
+      it(".clone() delivers the transformed bytes to both branches", async () => {
+        const res = suspending();
+        const clone = res.clone();
+        const [cloneText, originalText] = await Promise.all([clone.text(), res.text()]);
+        expect(cloneText).toBe("<p>new</p>");
+        expect(originalText).toBe("<p>new</p>");
+      });
+
+      it("Bun.write(file, res)", async () => {
+        using dir = tempDir("hr-pending-body", {});
+        const out = path.join(String(dir), "out.html");
+        await Bun.write(out, suspending());
+        expect(await Bun.file(out).text()).toBe("<p>new</p>");
+      });
+    });
+
+    it("transform(ArrayBuffer) throws the ArrayBuffer wording", () => {
+      expect(() =>
+        new HTMLRewriter()
+          .on("div", {
+            async element() {
+              await setImmediatePromise();
+            },
+          })
+          .transform(new TextEncoder().encode("<div></div>")),
+      ).toThrow("cannot synchronously return an ArrayBuffer");
+    });
+
+    // A rejection from a Promise a handler creates but neither returns nor
+    // awaits is the user's to handle. Main's nested event loop hijacked it into
+    // `transform()`'s synchronous throw (swallowing unrelated rejections with
+    // exit 0); now it reaches the process-global unhandledRejection path.
+    //
+    // Fixture note: it has to be a real-await handler on a Response. A sync
+    // handler on a string input behaves the same pre- and post-PR, so that
+    // shape pins nothing.
+    it("a detached rejection inside a handler reaches unhandledRejection", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const r = new HTMLRewriter()
+             .on("p", { async element(e) {
+               (async () => { throw new Error("detached"); })();
+               await Bun.sleep(5);
+               e.setInnerContent("ok");
+             } })
+             .transform(new Response("<p>x</p>"));
+           console.log("BODY:" + (await r.text()));`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // The rewrite itself succeeds; the detached rejection is reported and
+      // takes the process down, rather than being captured by transform().
+      expect({ stdout: stdout.trim(), reported: stderr.includes("detached"), exitCode }).toEqual({
+        stdout: "BODY:<p>ok</p>",
+        reported: true,
+        exitCode: 1,
+      });
+    });
+
+    // The headline production shape: returning a suspended transform straight
+    // out of a Bun.serve handler, with a live client waiting.
+    it("Bun.serve delivers a suspended transform to a live client", async () => {
+      await using server = Bun.serve({
+        port: 0,
+        fetch: () =>
+          new HTMLRewriter()
+            .on("p", {
+              async element(element) {
+                await setImmediatePromise();
+                element.setInnerContent("served");
+              },
+            })
+            .transform(new Response("<p>x</p>")),
+      });
+      const res = await fetch(`http://localhost:${server.port}/`);
+      expect(await res.text()).toBe("<p>served</p>");
+      expect(res.status).toBe(200);
+    });
+
+    it("Bun.serve routes a rejecting async handler to the error() hook", async () => {
+      const seen = Promise.withResolvers();
+      await using server = Bun.serve({
+        port: 0,
+        error(e) {
+          seen.resolve(e.message);
+          return new Response("handled", { status: 500 });
+        },
+        fetch: () =>
+          new HTMLRewriter()
+            .on("p", {
+              async element() {
+                await setImmediatePromise();
+                throw new Error("handler blew up");
+              },
+            })
+            .transform(new Response("<p>x</p>")),
+      });
+      const res = await fetch(`http://localhost:${server.port}/`);
+      expect(await seen.promise).toBe("handler blew up");
+      expect({ body: await res.text(), status: res.status }).toEqual({ body: "handled", status: 500 });
+
+      // The server keeps serving afterwards.
+      const after = await fetch(`http://localhost:${server.port}/`);
+      expect(after.status).toBe(500);
+    });
+
+    // Same shape through the two async error() arms: the original streaming
+    // Response is still protected when its producer fails before the first
+    // byte, and each arm must release it before installing the replacement.
+    it.concurrent.each(["settled", "awaiting"])(
+      "Bun.serve routes a rejecting async handler to an async error() hook (%s)",
+      async kind => {
+        const seen = Promise.withResolvers();
+        await using server = Bun.serve({
+          port: 0,
+          async error(e) {
+            seen.resolve(e.message);
+            if (kind === "awaiting") await setImmediatePromise();
+            return new Response("handled", { status: 500 });
+          },
+          fetch: () =>
+            new HTMLRewriter()
+              .on("p", {
+                async element() {
+                  await setImmediatePromise();
+                  throw new Error("handler blew up");
+                },
+              })
+              .transform(new Response("<p>x</p>")),
+        });
+        const res = await fetch(`http://localhost:${server.port}/`);
+        expect(await seen.promise).toBe("handler blew up");
+        expect({ body: await res.text(), status: res.status }).toEqual({ body: "handled", status: 500 });
+      },
+    );
+
+    // The response body is still a pending/locked value when the client goes
+    // away; the rewrite must still be allowed to finish (or fail) afterwards
+    // without corrupting the RequestContext it was registered against, and the
+    // server must keep working.
+    it.concurrent.each(["resolves", "rejects"])(
+      "client aborts while the handler is suspended, then the handler %s",
+      async settle => {
+        const suspended = Promise.withResolvers();
+        const serverSawAbort = Promise.withResolvers();
+        const gate = Promise.withResolvers();
+        const handlerDone = Promise.withResolvers();
+        let handlerFinished = 0;
+
+        await using server = Bun.serve({
+          port: 0,
+          async fetch(req) {
+            if (new URL(req.url).pathname === "/after") return new Response("still alive");
+            req.signal.addEventListener("abort", () => serverSawAbort.resolve());
+            return new HTMLRewriter()
+              .on("p", {
+                async element(element) {
+                  suspended.resolve();
+                  await gate.promise;
+                  element.setInnerContent("too late");
+                  handlerFinished++;
+                  handlerDone.resolve();
+                },
+              })
+              .transform(new Response("<p>original</p>"));
+          },
+        });
+
+        const controller = new AbortController();
+        const clientResult = fetch(`http://localhost:${server.port}/`, {
+          signal: controller.signal,
+        }).then(
+          r => r.text(),
+          e => e,
+        );
+
+        // Only abort once the handler has actually suspended the rewrite,
+        // and only resume it once the server has observed the abort.
+        await suspended.promise;
+        controller.abort();
+        const abortError = await clientResult;
+        expect(abortError).toBeInstanceOf(DOMException);
+        expect(abortError.name).toBe("AbortError");
+        await serverSawAbort.promise;
+
+        if (settle === "resolves") {
+          gate.resolve();
+          await handlerDone.promise;
+        } else {
+          gate.reject(new Error("handler failed after the client left"));
+        }
+
+        // The aborted request is gone; the server must still answer.
+        const after = await fetch(`http://localhost:${server.port}/after`);
+        expect(await after.text()).toBe("still alive");
+        expect(handlerFinished).toBe(settle === "resolves" ? 1 : 0);
+      },
+    );
   });
 
   it("HTMLRewriter handles Symbol invalid type error", async () => {
@@ -222,12 +971,19 @@ describe("HTMLRewriter", () => {
       await withPartialBodyServer(async (url, release) => {
         const res = await fetch(url);
         const transformed = rewriter().transform(res);
-        // Start the read BEFORE the upstream fails. This is the one shape
+        // Start reading BEFORE the upstream fails. This is the one shape
         // (readable attached, no pending promise) where the error must reach
-        // the attached stream; discarding it would strand this read forever.
-        const read = settle(transformed.body.getReader().read());
+        // the attached stream; discarding it would strand a read forever.
+        // Streaming may deliver the partial rewritten output before the
+        // upstream error arrives — drain any such chunks; the error must then
+        // reach this reader (not close cleanly, not hang).
+        const reader = transformed.body.getReader();
         release();
-        expect(await read).toEqual(rejectedWithConnectionError);
+        let result;
+        do {
+          result = await settle(reader.read());
+        } while (!result.rejected && !result.value.done);
+        expect(result).toEqual(rejectedWithConnectionError);
       });
     });
 
@@ -956,12 +1712,12 @@ const payloads = [
   {
     name: "direct",
     data: getStream("direct", "none"),
-    test: it.todo,
+    test: it,
   },
   {
     name: "default",
     data: getStream("default", "none"),
-    test: it.todo,
+    test: it,
   },
   {
     name: "file",
@@ -1003,6 +1759,39 @@ payloads.forEach(type => {
     expect(trimmed).toStartWith("<!DOCTYPE html>");
     expect(calls).toBeGreaterThan(0);
   });
+});
+
+it("transform(DataView) returns an ArrayBuffer", () => {
+  // Sentinel bytes before and after the HTML so a reader that ignores
+  // byteOffset/byteLength and feeds the whole buffer would fail the match.
+  const html = new TextEncoder().encode("<p>x</p>");
+  const buf = new ArrayBuffer(4 + html.length + 4);
+  new Uint8Array(buf).fill("<".charCodeAt(0));
+  new Uint8Array(buf, 4, html.length).set(html);
+  const out = new HTMLRewriter()
+    .on("p", { element: e => e.setInnerContent("y") })
+    .transform(new DataView(buf, 4, html.length));
+  expect(out).toBeInstanceOf(ArrayBuffer);
+  expect(new TextDecoder().decode(out)).toBe("<p>y</p>");
+});
+
+it("a handler that returns (not throws) an Error rejects with that Error", async () => {
+  const err = new Error("returned, not thrown");
+  const res = new HTMLRewriter().on("p", { element: () => err }).transform(new Response("<p>x</p>"));
+  await expect(res.text()).rejects.toThrow("returned, not thrown");
+});
+
+it.each([
+  ["direct ReadableStream", () => getStream("direct", "none")],
+  ["default ReadableStream", () => getStream("default", "none")],
+  ["blob", () => new Blob([fixture_html_content])],
+])("transform() marks the input body used (%s)", async (_, data) => {
+  const res = new Response(data());
+  const rw = new HTMLRewriter().on("h1", { element() {} });
+  await rw.transform(res).text();
+  expect(res.bodyUsed).toBe(true);
+  expect(() => rw.transform(res)).toThrow("Response body already used");
+  await expect(res.text()).rejects.toThrow("Body already used");
 });
 
 // lol-html reports an absent attribute with a NULL pointer and a
@@ -1122,28 +1911,26 @@ describe("doctype publicId/systemId distinguish empty from absent", () => {
 });
 
 describe("invalid arguments throw instead of returning an error value", () => {
-  it("setAttribute with a forbidden character in the name throws", () => {
-    expect(() =>
-      new HTMLRewriter()
-        .on("div", {
-          element(el) {
-            el.setAttribute("a b", "1");
-          },
-        })
-        .transform(new Response("<div>t</div>")),
-    ).toThrow("character is forbidden in the attribute name");
+  it("setAttribute with a forbidden character in the name rejects the body", async () => {
+    const res = new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          el.setAttribute("a b", "1");
+        },
+      })
+      .transform(new Response("<div>t</div>"));
+    await expect(res.text()).rejects.toThrow("character is forbidden in the attribute name");
   });
 
-  it("setAttribute with an empty name throws", () => {
-    expect(() =>
-      new HTMLRewriter()
-        .on("div", {
-          element(el) {
-            el.setAttribute("", "1");
-          },
-        })
-        .transform(new Response("<div>t</div>")),
-    ).toThrow("Attribute name can't be empty.");
+  it("setAttribute with an empty name rejects the body", async () => {
+    const res = new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          el.setAttribute("", "1");
+        },
+      })
+      .transform(new Response("<div>t</div>"));
+    await expect(res.text()).rejects.toThrow("Attribute name can't be empty.");
   });
 
   it("setAttribute failure leaves the element unchanged", async () => {
@@ -1175,19 +1962,18 @@ describe("invalid arguments throw instead of returning an error value", () => {
     ).toThrow("character is forbidden in the attribute name");
   });
 
-  it("onEndTag with a non-function throws a TypeError", () => {
-    let err;
-    try {
-      new HTMLRewriter()
-        .on("div", {
-          element(el) {
-            el.onEndTag("nope");
-          },
-        })
-        .transform(new Response("<div>t</div>"));
-    } catch (e) {
-      err = e;
-    }
+  it("onEndTag with a non-function rejects the body with a TypeError", async () => {
+    const res = new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          el.onEndTag("nope");
+        },
+      })
+      .transform(new Response("<div>t</div>"));
+    const err = await res.text().then(
+      () => null,
+      e => e,
+    );
     expect(err).toBeInstanceOf(TypeError);
     expect(err.message).toBe("Expected a function");
   });
@@ -1269,5 +2055,111 @@ describe("tagName, endTag.name, and comment.text setters", () => {
     expect(savedElement.tagName).toBeUndefined();
     expect(savedEndTag.name).toBeUndefined();
     expect(savedComment.text).toBeNull();
+  });
+});
+
+// `transform(await fetch(url)).text()` never stores the output Response, and
+// the upstream ByteStream dispatches in via a SinkHandle raw pointer between
+// event-loop turns, so the input source's `sinkOwner` slot is what keeps the
+// Transform cell (and so the pipe) alive across a GC between chunks; without
+// it the pipe is freed mid-rewrite and the body promise is stranded forever.
+describe("GC pressure mid-rewrite", () => {
+  it("a native-input rewrite survives GC when nothing references the output Response", async () => {
+    const sawFirst = Promise.withResolvers();
+    const gcDone = Promise.withResolvers();
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(
+          new ReadableStream({
+            async start(c) {
+              c.enqueue(new TextEncoder().encode("<p>one</p>"));
+              // Hold the second chunk until the test has GC'd, so the
+              // collection window between chunks is deterministic.
+              await gcDone.promise;
+              c.enqueue(new TextEncoder().encode("<p>two</p>"));
+              c.close();
+            },
+          }),
+        );
+      },
+    });
+
+    const rewritten = new HTMLRewriter()
+      .on("p", {
+        element(el) {
+          el.setInnerContent("x");
+          sawFirst.resolve();
+        },
+      })
+      .transform(await fetch(`http://localhost:${server.port}/`))
+      .text();
+
+    await sawFirst.promise;
+    Bun.gc(true);
+    await Bun.sleep(0);
+    Bun.gc(true);
+    gcDone.resolve();
+
+    expect(await rewritten).toBe("<p>x</p><p>x</p>");
+  });
+
+  // Cancel while suspended, then let the never-settling handler promise be
+  // collected: the pipe is freed via plain drop (done is already true, so no
+  // abandon task runs), which must release the parked wrapper. A JS-retained
+  // Element is then detached, not left pointing into the freed rewriter.
+  it("a wrapper stashed across a cancelled suspension is detached, not dangling", async () => {
+    let stash = null;
+    let out = new HTMLRewriter()
+      .on("p", {
+        element(el) {
+          stash = el;
+          return new Promise(() => {});
+        },
+      })
+      .transform(new Response("<p>x</p>"));
+    let reader = out.body.getReader();
+    let first = reader.read();
+    await reader.cancel();
+    await first.catch(() => {});
+    out = null;
+    reader = null;
+    first = null;
+
+    // The handler promise and the Transform cell are unreachable now; collect
+    // until the wrapper is detached (its tagName getter reads through the
+    // unit Cell, undefined once detached).
+    for (let i = 0; i < 100 && stash.tagName !== undefined; i++) {
+      Bun.gc(true);
+      await Bun.sleep(1);
+    }
+    expect(stash.tagName).toBeUndefined();
+  });
+
+  // Chained transform where the intermediate Response is a temporary: while
+  // the second pipe's handler is suspended, the first pipe is parked on the
+  // shared ByteStream's backpressure with its producer backref installed.
+  // GC in that window must not collect the first pipe; only the stream's GC
+  // edges keep it alive.
+  it("a chained transform survives GC when nothing references the intermediate Response", async () => {
+    const rw1 = new HTMLRewriter().on("p", {
+      async element(el) {
+        await setImmediatePromise();
+        el.setAttribute("one", "");
+      },
+    });
+    const rw2 = new HTMLRewriter().on("p", {
+      async element(el) {
+        for (let i = 0; i < 8; i++) {
+          Bun.gc(true);
+          await Bun.sleep(1);
+        }
+        el.setAttribute("two", "");
+      },
+    });
+    // A separate frame so the intermediate Response temporary is off the
+    // stack before the GC loop in rw2's handler runs.
+    const start = () => rw2.transform(rw1.transform(new Response("<p>x</p>"))).text();
+    expect(await start()).toBe('<p one="" two="">x</p>');
   });
 });

--- a/test/regression/issue/19219.test.ts
+++ b/test/regression/issue/19219.test.ts
@@ -52,7 +52,8 @@ test("HTMLRewriter should handle errors in async handlers", async () => {
   const html = "<div>test</div>";
   const response = new Response(html);
 
-  expect(() => {
-    rewriter.transform(response);
-  }).toThrow("Async handler error");
+  // A `Response` input surfaces handler errors on the output body, so the
+  // descriptive error this issue is about arrives there rather than from
+  // `transform()`. The `string` inputs above still throw.
+  await expect(rewriter.transform(response).text()).rejects.toThrow("Async handler error");
 });

--- a/test/regression/issue/21680.test.ts
+++ b/test/regression/issue/21680.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { tempDir } from "harness";
 
-test("HTMLRewriter should not crash when element handler throws an exception - issue #21680", () => {
+test("HTMLRewriter should not crash when element handler throws an exception - issue #21680", async () => {
   // The most important test: ensure the original crashing case from the GitHub issue doesn't crash
   // This was the exact case from the issue that caused "ASSERTION FAILED: Unexpected exception observed"
 
@@ -11,24 +11,26 @@ test("HTMLRewriter should not crash when element handler throws an exception - i
   });
 
   // Original failing case: this should not crash the process
-  expect(() => {
-    const rewriter = new HTMLRewriter().on("script", {
-      element(a) {
-        throw new Error("abc");
-      },
-    });
-    rewriter.transform(new Response(Bun.file(`${dir}/min.html`)));
-  }).not.toThrow(); // The important thing is it doesn't crash, we're ok with it silently failing
+  const rewriter = new HTMLRewriter().on("script", {
+    element(a) {
+      throw new Error("abc");
+    },
+  });
+  const res = rewriter.transform(new Response(Bun.file(`${dir}/min.html`)));
+  // The important thing is it doesn't crash; the handler's error surfaces on
+  // the output body. Await it so the file read completes before `dir` is
+  // disposed.
+  await expect(res.text()).rejects.toThrow("abc");
 
-  // Test with Response containing string content
-  expect(() => {
-    const rewriter = new HTMLRewriter().on("script", {
-      element(a) {
-        throw new Error("response test");
-      },
-    });
-    rewriter.transform(new Response("<script></script>"));
-  }).toThrow("response test");
+  // Test with Response containing string content. A `Response` input surfaces
+  // the handler's error on the output body rather than throwing from
+  // `transform()`; the point of this test is that neither crashes.
+  const rewriter2 = new HTMLRewriter().on("script", {
+    element(a) {
+      throw new Error("response test");
+    },
+  });
+  await expect(rewriter2.transform(new Response("<script></script>")).text()).rejects.toThrow("response test");
 });
 
 test("HTMLRewriter exception handling should not break normal operation", () => {


### PR DESCRIPTION
### What

`HTMLRewriter.transform()` now streams: input body chunks flow through `lol-html` into an output `ByteStream` as they arrive, with backpressure propagated end-to-end via the `SinkHandle`/`SourceHandle` pattern from #36087. Async content handlers no longer nest the event loop.

```
input body ──► SinkHandle::HTMLRewriter ──► lol_html::HtmlRewriter ──► output ByteStream
     ▲                                                                       │
     └─────────── SourceHandle::HTMLRewriter (producer) ◄────────────────────┘
```

### Why

`BufferOutputSink` fully buffered the source body via `ValueBufferer` before a single `rewriter.write()` + `end()`, and `handler_callback` spun `vm.wait_for_promise()` six native frames deep inside lol-html for any handler that returned a Promise. That meant handlers fired only at source-end (TTFB = full download), `.body` / `Bun.serve` saw an empty stream (#6068, #19305), JS-backed `ReadableStream` inputs were rejected outright (#11758, #14216), and the nested loop was a known hazard class (deadlocks, ready-poll clobbering, pending-exception leaks).

lol-html could not be suspended before because its tokens are stack locals borrowing a stack-local lexeme; returning from `write()` destroys them, and an async handler must be able to mutate the element after its `await`.

### lol-html fork (`oven-sh/lol-html`, branch `bun`)

A handler returns `Err(SuspensionRequest)` to suspend. The in-flight unit is deep-copied onto the heap, `write()`/`end()` return the non-poisoning `RewritingError::Suspended`, and `HtmlRewriter::resume()` continues from a `StateMachineBookmark`. The pending captured-text flush is hoisted from `Dispatcher::handle_tag` into the lexer actions so every suspension point has a uniform shape. `Arena::shift` advances a start offset instead of memmoving the tail (a suspended rewrite re-feeds its unconsumed tail on every resume). 23 in-crate tests added; the new `.github/workflows/lolhtml.yml` runs the fork's own `cargo test` at the pinned commit, gated on `scripts/build/deps/lolhtml.ts`. The fork is a `github-archive` source (no patch file), so rebasing onto a new upstream tag is a `git rebase --onto` in the fork plus a commit bump here.

### Bun side (`RewriterPipe` replaces `BufferOutputSink`)

- **Ownership**: a generated `HTMLRewriterTransform` JS cell (not user-visible) owns the pipe; its GC finalizer frees it, and nothing pins anything. Liveness is plain GC edges: the output Response's `transform` WriteBarrier slot and the `.then()` context of a suspended handler's (or the JS pump's) promise reach the cell, the cell's five slots root the Response, the input/output streams, the pending flush promise, and a captured handler error, and a wired native source's `owner` WriteBarrier slot (new on the generated NewSource cells) points back at the cell, so I/O that roots the source (a FetchTasklet, a FileReader's read refs, a reader on the output stream) roots the rewrite for exactly the window the raw `SinkHandle`/producer backrefs are wired. A handler promise collected without settling lets `finalize` defer to an event-loop task (`abandon_suspension`) that rejects the body before freeing; the pipe holds one native `+1` on the Response (released in `Drop`) so that task can still reach the body. No intrusive refcount, no `Strong` fields on the pipe; `finish()` frees the boxed lol-html state machine eagerly, and `fail()`/output-cancel close the upstream producer instead of draining it to EOF.
- **Output**: the returned `Response`'s body is `Locked(PendingValue { task: pipe, on_start_streaming, on_readable_stream_available, producer: SourceHandle::HTMLRewriter })`, the `FetchTasklet::to_body_value` shape. The `ByteStream` is created lazily when a consumer reads `.body` or a body-mixin method; until then, rewriter output buffers in a `Vec<u8>` handed over as `DrainResult::Owned`.
- **Input**: mirrors `FetchTasklet::start_request_stream`. Native `ByteStream`/`FileReader` sources wire `byte_stream.sink = SinkHandle::HTMLRewriter` + `lock_native` + `drain()`; other stream kinds go through `JSSink::<RewriterPipe>::assign_to_stream` (new `HTMLRewriterSink` codegen entry). Materialized bodies (`InternalBlob`/bytes `Blob`/`WTFStringImpl`) feed synchronously.
- **Backpressure**: `RewriterPipe::write` feeds one chunk through `rewriter.write()` (output chunks push via `ByteStream::on_data`). If the output is paused or a handler suspended, `write` returns `Writable::Backpressure`; `ByteStream::resume` → `SourceHandle::HTMLRewriter::on_ready` → `pipe.resume()` drains `pending_input` then `input_source.ready()`.
- **Async handlers**: `handler_callback` returns `HandlerOutcome::{Continue, Stop, Suspend}`. On a pending Promise it runs one microtask checkpoint (`process.nextTick` then promise jobs, never the loop); a genuinely pending Promise suspends. The JS wrapper is retargeted at the heap-parked token so post-`await` mutations land where they should. The `.then()` context is the Transform cell itself (the reactions recover the pipe via `from_js`), so a handler promise collected without settling abandons the parked rewrite instead of leaking it.
- **Error handling**: `handler_error` on the pipe replaces the stack `Cell` + `unhandled_pending_rejection_to_capture` override. A handler error on a streaming input now rejects the body with the real error instead of `The rewriter has been stopped.`.
- `AttributeIterator` holds a backref to the `Element` plus an index instead of a boxed `slice::Iter`, so `for (const [k, v] of el.attributes) { await ... }` keeps working across a suspension.

### Deletions

`ValueBufferer` (~430 lines of `Body.rs`) and its host-fn exports; `SinkHandle::ValueBufferer` + `SinkWriteFn`; `JSSink<ArrayBufferSink>::detach_self`; `crate::Error::{StreamAlreadyUsed, InvalidStream, UnsupportedStreamType}`; `NativePromiseContext::Tag::BodyValueBufferer` (ordinal 4 reused for `HTMLRewriterSuspension`); the two `Bun__BodyValueBufferer__*` `PromiseFunctions` (slots reused for `Bun__HTMLRewriter__onHandler{Resolve,Reject}`).

### Behavior changes

1. **Error channel is decided by the overload, not by timing.** `transform(string)` / `transform(ArrayBuffer)` throw from `transform()`. Every `Response` input rejects its output body instead. Five existing tests that pinned the old timing-dependent split are updated. Input-body errors (already-failed or aborted body) still throw synchronously from `transform()`.
2. A handler whose Promise needs the event loop to turn makes `transform(string)` / `transform(ArrayBuffer)` throw a `TypeError` (`pass a Response and await its body`) instead of spinning. A Promise that settles within a microtask checkpoint still works.
3. A rejection a handler neither awaits nor returns reaches `unhandledRejection` instead of being captured and thrown from `transform()`.
4. `transform()` types corrected: `Bun.BufferSource` returns `ArrayBuffer` (it always has at runtime); `Blob` removed from the overload (it threw at runtime).
5. `Bun.serve` with an HTMLRewriter-produced response body defers status/headers until the first body byte or clean end, so a handler that fails before emitting any bytes is routed to the server'''s `error()` hook instead of committing `200 OK` then force-closing the connection. Headers never preceded the first byte on this path before either (the old implementation buffered the whole rewrite). All other native-ByteStream bodies (proxied `fetch()`, S3, spawn stdout) keep sending status/headers immediately, and JS `ReadableStream` bodies (`do_render_stream`) are unchanged.

`docs/runtime/html-rewriter.mdx` and `packages/bun-types/html-rewriter.d.ts` cover 1-4.

### Verification

- `test/js/workerd/html-rewriter.test.js`: 107 pass, 0 fail under ASAN debug and under `BUN_JSC_validateExceptionChecks=1`. New coverage: async element/text/comment/doctype/onEndTag/document-end handlers, `Bun.gc(true)` while an element is heap-parked across an `await`, re-suspension by a second handler on the same element, nested `transform()` inside a suspended handler, strict document-order across 8 awaiting handlers, `Bun.serve` with a live client, client abort mid-suspension, the consumer matrix for a pending output body, JS-backed and `type:'direct'` `ReadableStream` inputs.
- `test/js/workerd/html-rewriter-leak.test.ts`: protected-object + `Response` count regression over 120 suspending rewrites; a never-settling handler rejects the body instead of leaking.
- Fail-before: `works with payload of type direct` → `ERR_STREAM_CANNOT_PIPE` on the released bun.
- `bun-types` green, `cargo clippy -p bun_runtime` clean.
- `vendor/lolhtml/.ref` re-fetch of the fork verified through the real ninja edge.


Fixes #11758
Fixes #14216
Fixes #6068
Fixes #19305

Closes #33243 (same lol-html fork, different input layer), Closes #35324 (ResumableSink, deleted in #36087), Closes #32988 (per-chunk ValueBufferer callback).


<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 20 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js test/js/node/process/process.test.js test/js/workerd/html-rewriter-leak.test.ts

<!-- robobun:evidence:end -->






