### PR TITLE
feat(node): implement process.initgroups

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3095,9 +3095,9 @@ static JSValue maybe_uid_by_name(JSC::ThrowScope& throwScope, JSGlobalObject* gl
     return {};
 }
 
-static JSValue maybe_gid_by_name(JSC::ThrowScope& throwScope, JSGlobalObject* globalObject, JSValue value)
+static JSValue maybe_gid_by_name(JSC::ThrowScope& throwScope, JSGlobalObject* globalObject, JSValue value, WTF::StringView argName = "id"_s)
 {
-    if (!value.isNumber() && !value.isString()) return JSValue::decode(Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "id"_s, "number or string"_s, value));
+    if (!value.isNumber() && !value.isString()) return JSValue::decode(Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, argName, "number or string"_s, value));
     if (!value.isString()) return value;
 
     auto str = value.getString(globalObject);
@@ -3277,7 +3277,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functioninitgroups, (JSGlobalObject * globalObj
     auto username = usernameUtf8.data();
 
     auto is_number = extraGroupValue.isNumber();
-    extraGroupValue = maybe_gid_by_name(scope, globalObject, extraGroupValue);
+    extraGroupValue = maybe_gid_by_name(scope, globalObject, extraGroupValue, "extraGroup"_s);
     RETURN_IF_EXCEPTION(scope, {});
     uint32_t extraGroup = 0;
     if (is_number) Bun::V::validateInteger(scope, globalObject, extraGroupValue, "extraGroup"_s, jsNumber(0), jsNumber(std::numeric_limits<int32_t>::max()), &extraGroup);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3242,6 +3242,59 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionsetgroups, (JSGlobalObject * globalObje
     return JSValue::encode(jsNumber(result));
 }
 
+JSC_DEFINE_HOST_FUNCTION(Process_functioninitgroups, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto userValue = callFrame->argument(0);
+    auto extraGroupValue = callFrame->argument(1);
+
+    if (!userValue.isNumber() && !userValue.isString()) {
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "user"_s, "number or string"_s, userValue);
+    }
+
+    String usernameStr;
+    if (userValue.isString()) {
+        usernameStr = userValue.getString(globalObject);
+    } else {
+        uint32_t uid = 0;
+        Bun::V::validateInteger(scope, globalObject, userValue, "user"_s, jsNumber(0), jsNumber(std::numeric_limits<int32_t>::max()), &uid);
+        RETURN_IF_EXCEPTION(scope, {});
+        
+        struct passwd pwd;
+        struct passwd* pp = nullptr;
+        char buf[8192];
+        if (getpwuid_r(uid, &pwd, buf, sizeof(buf), &pp) == 0 && pp != nullptr) {
+            usernameStr = String::fromUTF8(pp->pw_name);
+        } else {
+            auto message = makeString("User identifier does not exist: "_s, userValue.toUInt32(globalObject));
+            scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_UNKNOWN_CREDENTIAL, message));
+            return {};
+        }
+    }
+    RETURN_IF_EXCEPTION(scope, {});
+    auto usernameUtf8 = usernameStr.utf8();
+    auto username = usernameUtf8.data();
+
+    auto is_number = extraGroupValue.isNumber();
+    extraGroupValue = maybe_gid_by_name(scope, globalObject, extraGroupValue);
+    RETURN_IF_EXCEPTION(scope, {});
+    uint32_t extraGroup = 0;
+    if (is_number) Bun::V::validateInteger(scope, globalObject, extraGroupValue, "extraGroup"_s, jsNumber(0), jsNumber(std::numeric_limits<int32_t>::max()), &extraGroup);
+    if (!is_number) extraGroup = extraGroupValue.toUInt32(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    int err = 0;
+    auto result = callWithoutThreadSuspension([&] { 
+        int res = initgroups(username, extraGroup);
+        if (res != 0) err = errno;
+        return res;
+    });
+    if (result != 0) throwSystemError(scope, globalObject, "initgroups"_s, err);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(jsUndefined());
+}
+
 #endif
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionAssert, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -4532,6 +4585,7 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   getgid                           Process_functiongetgid                              Function 0
   getgroups                        Process_functiongetgroups                           Function 0
   getuid                           Process_functiongetuid                              Function 0
+  initgroups                       Process_functioninitgroups                          Function 2
 
   setegid                          Process_functionsetegid                             Function 1
   seteuid                          Process_functionseteuid                             Function 1

--- a/test/js/node/process/process-initgroups.test.ts
+++ b/test/js/node/process/process-initgroups.test.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "bun:test";
+
+test("process.initgroups exists", () => {
+  if (process.platform === "win32") {
+    expect(process.initgroups).toBeUndefined();
+    return;
+  }
+  expect(typeof process.initgroups).toBe("function");
+  expect(process.initgroups.length).toBe(2);
+});
+
+test("process.initgroups argument validation", () => {
+  if (process.platform === "win32") return;
+
+  expect(() => {
+    // @ts-ignore
+    process.initgroups();
+  }).toThrow(TypeError);
+
+  expect(() => {
+    // @ts-ignore
+    process.initgroups({}, "staff");
+  }).toThrow(TypeError);
+
+  expect(() => {
+    // @ts-ignore
+    process.initgroups("root", {});
+  }).toThrow(TypeError);
+});
+
+test("process.initgroups system error or EPERM", () => {
+  if (process.platform === "win32") return;
+
+  if (process.getuid && process.getuid() !== 0) {
+    expect(() => {
+      process.initgroups("root", 0);
+    }).toThrow(/EPERM/);
+    
+    expect(() => {
+      process.initgroups(0, "wheel");
+    }).toThrow(/EPERM/);
+  } else {
+    expect(() => {
+      process.initgroups("root", 0);
+    }).not.toThrow();
+  }
+});
+
+test("process.initgroups unknown credential", () => {
+  if (process.platform === "win32") return;
+
+  expect(() => {
+    process.initgroups("does-not-exist-user-123456", 0);
+  }).toThrow(/does not exist/);
+
+  expect(() => {
+    process.initgroups(999999, 0);
+  }).toThrow(/does not exist/);
+
+  expect(() => {
+    process.initgroups("root", "does-not-exist-group-123456");
+  }).toThrow(/does not exist/);
+});

--- a/test/js/node/process/process-initgroups.test.ts
+++ b/test/js/node/process/process-initgroups.test.ts
@@ -31,18 +31,22 @@ test("process.initgroups argument validation", () => {
 test("process.initgroups system error or EPERM", () => {
   if (process.platform === "win32") return;
 
+  const existingGroup = process.getgroups ? (process.getgroups()[0] ?? process.getgid?.() ?? 0) : 0;
+
   if (process.getuid && process.getuid() !== 0) {
     expect(() => {
       process.initgroups("root", 0);
     }).toThrow(/EPERM/);
     
     expect(() => {
-      process.initgroups(0, "wheel");
+      process.initgroups(0, existingGroup);
     }).toThrow(/EPERM/);
   } else {
-    expect(() => {
-      process.initgroups("root", 0);
-    }).not.toThrow();
+    const { exitCode, stderr } = Bun.spawnSync({
+      cmd: [process.execPath, "-e", "process.initgroups('root', 0);"],
+    });
+    expect(stderr.toString()).toBe("");
+    expect(exitCode).toBe(0);
   }
 });
 


### PR DESCRIPTION
Resolves #23891

Implements process.initgroups() for Node.js compatibility by wrapping the platform initgroups(3) API and following Bun's existing process credential API patterns.

- Supports both numeric (UID/GID) and string (username/groupname) resolution.
- Captures and throws appropriate SystemErrors (e.g., EPERM) for non-root invocations.
- Throws credential errors for unresolvable users/groups.
- Includes exhaustive test coverage in process-initgroups.test.ts.
- Gracefully disabled on Windows, matching Node.js behavior.
