### PR TITLE
build: link native darwin ASAN with ld64.lld (Apple's ld_new rejects rustc ASAN relocations)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ Bun requires LLVM 21.1.8 (`clang` is part of LLVM). This version is enforced by 
 {% codetabs group="os" %}
 
 ```bash#macOS (Homebrew)
-$ brew install llvm@21
+$ brew install llvm@21 lld@21
 ```
 
 ```bash#Ubuntu/Debian

--- a/docs/project/contributing.mdx
+++ b/docs/project/contributing.mdx
@@ -101,7 +101,7 @@ Bun requires LLVM 21.1.8 (`clang` is part of LLVM). The build system enforces th
 <CodeGroup>
 
 ```bash macOS (Homebrew)
-brew install llvm@21
+brew install llvm@21 lld@21
 ```
 
 ```bash Ubuntu/Debian

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1203,7 +1203,9 @@ install_llvm() {
 		append_to_path "/usr/lib/llvm-$(llvm_version)/bin"
 		;;
 	brew)
-		install_packages "llvm@$(llvm_version)"
+		# lld is a separate keg-only formula (ld64.lld is needed for native
+		# ASAN links — Apple's ld rejects rustc's ASAN relocations).
+		install_packages "llvm@$(llvm_version)" "lld@$(llvm_version)"
 		;;
 	apk)
 		install_packages \

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -723,10 +723,10 @@ function linkNdkRuntimesIntoClang(cc: string, ndk: string, host: Host, triple: s
  * concrete values. After this runs, everything downstream sees plain booleans.
  *
  * `host` defaults to the real process host; tests pass a fake to exercise
- * native-vs-cross branches on any machine.
+ * native-vs-cross branches on any machine. The input is never mutated.
  */
-export function resolveConfig(partial: PartialConfig, toolchain: Toolchain, host: Host = detectHost()): Config {
-  host.rustTriple = toolchain.rustHostTriple;
+export function resolveConfig(partial: PartialConfig, toolchain: Toolchain, hostIn: Host = detectHost()): Config {
+  const host: Host = { ...hostIn, rustTriple: toolchain.rustHostTriple };
 
   // ─── Target platform ───
   const os = partial.os ?? host.os;

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -139,6 +139,15 @@ export interface Config {
   /** IR PGO: .profdata file path (optimized build). Mutually exclusive with pgoGenerate. */
   pgoUse: string | undefined;
   asan: boolean;
+  /**
+   * The darwin link uses lld's Mach-O port (`ld64.lld`) instead of Apple's
+   * ld. True for darwin cross-compiles (always) and for native darwin ASAN
+   * builds (Apple's `-ld_new` rejects rustc's `-Zsanitizer=address`
+   * relocations; see workarounds.ts "darwin-asan-ld-new"). Link flags that
+   * key on linker behavior (segment ordering, the macho-postlink stack-size
+   * patch) check this, not `crossTarget`.
+   */
+  darwinLld: boolean;
   assertions: boolean;
   logs: boolean;
   /** x64-only: target nehalem (no AVX). Default true on x64 — the only x64 build we ship. */
@@ -1166,6 +1175,34 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     }
   }
 
+  // ─── Native darwin ASAN → ld64.lld ───
+  // rustc's `-Zsanitizer=address` emits objects whose ASAN sections
+  // (`__asan_globals`, `__asan_liveness`, the `asan.module_ctor/dtor` in
+  // `__mod_init_func`) carry relocations Apple's new linker (`-ld_new` /
+  // ld-prime) rejects as `invalid r_symbolnum=<N>`. The cross-compile path
+  // already links with ld64.lld and is unaffected, so route native darwin
+  // ASAN links through it too. Tracked in workarounds.ts
+  // ("darwin-asan-ld-new") so this self-obsoletes once Apple's linker (or
+  // rustc's codegen) stops tripping on these objects.
+  let darwinNativeLld: string | undefined;
+  if (darwin && !darwinCross && asan) {
+    if (toolchain.ld64Lld === undefined) {
+      throw new BuildError(
+        "Native darwin ASAN builds link with ld64.lld (Apple's ld rejects rustc's ASAN relocations)",
+        {
+          hint:
+            "ld64.lld ships with the same Homebrew llvm install as clang. " +
+            "Reinstall `brew install llvm@21` (or set --asan=off to link with Apple's ld).",
+        },
+      );
+    }
+    darwinNativeLld = toolchain.ld64Lld;
+  }
+  // True whenever a darwin link goes through ld64.lld instead of Apple's ld
+  // (cross-compile, or the native-ASAN swap above). rust-only cross builds
+  // skip the link entirely, so leaving them false is harmless.
+  const darwinLld = ld64StripSwap !== undefined || darwinNativeLld !== undefined;
+
   return {
     os,
     arch,
@@ -1193,6 +1230,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     pgoGenerate,
     pgoUse,
     asan,
+    darwinLld,
     assertions,
     logs,
     baseline,
@@ -1223,7 +1261,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     clangResourceDir: toolchain.clangResourceDir,
     ar: toolchain.ar,
     ranlib: toolchain.ranlib,
-    ld: ld64StripSwap?.ld ?? ld,
+    ld: ld64StripSwap?.ld ?? darwinNativeLld ?? ld,
     rustLld: toolchain.rustLld,
     rustLlvmVersion: toolchain.rustLlvmVersion,
     rustSysroot: toolchain.rustSysroot,

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -1184,9 +1184,11 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   // already links with ld64.lld and is unaffected, so route native darwin
   // ASAN links through it too. Tracked in workarounds.ts
   // ("darwin-asan-ld-new") so this self-obsoletes once Apple's linker (or
-  // rustc's codegen) stops tripping on these objects.
+  // rustc's codegen) stops tripping on these objects. rust-only mode never
+  // links, so skip the ld64.lld requirement (same gate as the darwinCross
+  // block above).
   let darwinNativeLld: string | undefined;
-  if (darwin && !darwinCross && asan) {
+  if (darwin && !darwinCross && asan && (partial.mode ?? "full") !== "rust-only") {
     if (toolchain.ld64Lld === undefined) {
       throw new BuildError(
         "Native darwin ASAN builds link with ld64.lld (Apple's ld rejects rustc's ASAN relocations)",
@@ -1200,8 +1202,8 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     darwinNativeLld = toolchain.ld64Lld;
   }
   // True whenever a darwin link goes through ld64.lld instead of Apple's ld
-  // (cross-compile, or the native-ASAN swap above). rust-only cross builds
-  // skip the link entirely, so leaving them false is harmless.
+  // (cross-compile, or the native-ASAN swap above). rust-only builds skip
+  // the link entirely, so leaving them false is harmless.
   const darwinLld = ld64StripSwap !== undefined || darwinNativeLld !== undefined;
 
   return {

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -721,9 +721,11 @@ function linkNdkRuntimesIntoClang(cc: string, ndk: string, host: Host, triple: s
  *
  * This is where all the "X defaults to Y unless Z" chains get resolved into
  * concrete values. After this runs, everything downstream sees plain booleans.
+ *
+ * `host` defaults to the real process host; tests pass a fake to exercise
+ * native-vs-cross branches on any machine.
  */
-export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Config {
-  const host = detectHost();
+export function resolveConfig(partial: PartialConfig, toolchain: Toolchain, host: Host = detectHost()): Config {
   host.rustTriple = toolchain.rustHostTriple;
 
   // ─── Target platform ───

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -224,9 +224,9 @@ export interface Config {
   /** llvm-ranlib. undefined on windows (llvm-lib indexes itself). */
   ranlib: string | undefined;
   /**
-   * ld.lld on linux, lld-link on windows, ld64.lld when cross-compiling for
-   * darwin from a non-darwin host. May be empty on native darwin (clang
-   * invokes the system linker).
+   * ld.lld on linux, lld-link on windows, ld64.lld for darwin cross-compiles
+   * and native darwin ASAN builds (see `darwinLld`). Empty on native darwin
+   * non-ASAN (clang invokes the system linker).
    */
   ld: string;
   /**
@@ -426,9 +426,10 @@ export interface Toolchain {
   ranlib: string | undefined;
   ld: string;
   /**
-   * lld's Mach-O port (`ld64.lld`), resolved on non-darwin unix hosts.
-   * Swapped in as `cfg.ld` when the target is darwin and the host isn't —
-   * there's no Apple `ld` to drive, and ld.lld only emits ELF.
+   * lld's Mach-O port (`ld64.lld`), resolved on every unix host. Swapped in
+   * as `cfg.ld` for darwin cross-compiles (no Apple `ld` to drive, and
+   * ld.lld only emits ELF) and for native darwin ASAN builds (see
+   * workarounds.ts "darwin-asan-ld-new").
    */
   ld64Lld: string | undefined;
   /**

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -1192,8 +1192,8 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
         "Native darwin ASAN builds link with ld64.lld (Apple's ld rejects rustc's ASAN relocations)",
         {
           hint:
-            "ld64.lld ships with the same Homebrew llvm install as clang. " +
-            "Reinstall `brew install llvm@21` (or set --asan=off to link with Apple's ld).",
+            "Homebrew ships lld as a separate keg-only formula: `brew install lld@21`. " +
+            "Or set --asan=off to link with Apple's ld instead.",
         },
       );
     }

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -998,8 +998,8 @@ export const linkerFlags: Flag[] = [
     // unsigned binaries fine, an ad-hoc signature buys nothing there, and
     // the CodeDirectory costs 32 bytes per 4 KB page ≈ 0.8% of the binary).
     flag: "-Wl,-adhoc_codesign",
-    when: c => c.darwin && c.crossTarget !== undefined && c.arm64,
-    desc: "macOS arm64 cross-link: emit an ad-hoc LC_CODE_SIGNATURE for macho-postlink to replace",
+    when: c => c.darwinLld && c.arm64,
+    desc: "macOS arm64 ld64.lld link: emit an ad-hoc LC_CODE_SIGNATURE for macho-postlink to replace",
   },
   {
     // `bun build --compile` grows the __BUN placeholder segment in place and
@@ -1014,8 +1014,8 @@ export const linkerFlags: Flag[] = [
     // holds a single 8-byte JSC::SourceProfiler hook and is only meaningful
     // as a dyld-shared-cache page-grouping hint, which executables don't use.
     flag: "-Wl,-rename_segment,__DATA_DIRTY,__DATA",
-    when: c => c.darwin && c.crossTarget !== undefined,
-    desc: "macOS cross-link: keep __BUN as the last content segment so `bun build --compile` can grow it",
+    when: c => c.darwinLld,
+    desc: "macOS ld64.lld link: keep __BUN as the last content segment so `bun build --compile` can grow it",
   },
   {
     // Identical-code folding, on top of -dead_strip: dead_strip removes
@@ -1035,10 +1035,21 @@ export const linkerFlags: Flag[] = [
   {
     // -ld_new selects Apple's new linker — only meaningful (and only
     // understood) when Apple's ld driver does the link. ld64.lld (the
-    // cross-link path) parses it as `-l d_new` and fails.
+    // cross-link path, and native ASAN below) parses it as `-l d_new` and
+    // fails.
     flag: "-Wl,-ld_new",
-    when: c => c.darwin && c.crossTarget === undefined,
-    desc: "Use new Apple linker (native darwin links only)",
+    when: c => c.darwin && !c.darwinLld,
+    desc: "Use new Apple linker (native darwin non-ASAN links only)",
+  },
+  {
+    // Native darwin ASAN: Apple's -ld_new rejects rustc's
+    // `-Zsanitizer=address` relocations as `invalid r_symbolnum=<N>`, so
+    // link with ld64.lld instead (cfg.ld is swapped in resolveConfig). The
+    // cross-link entry below already passes --ld-path for non-native hosts.
+    // Tracked in workarounds.ts ("darwin-asan-ld-new").
+    flag: c => `--ld-path=${c.ld}`,
+    when: c => c.darwinLld && c.crossTarget === undefined,
+    desc: "Native darwin ASAN link: ld64.lld (Apple's ld_new rejects rustc's ASAN relocations)",
   },
   {
     // Cross-link from a non-darwin host: same pattern as Android/FreeBSD —

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -1074,8 +1074,8 @@ export const linkerFlags: Flag[] = [
     // `bun build --compile` rewrites the segment at 16 KB alignment anyway
     // (exe_format/macho.rs). arm64 uses 16 KB pages, so it's unaffected.
     flag: ["-Wl,-sectalign,__BUN,__bun,0x1000"],
-    when: c => c.darwin && c.crossTarget !== undefined && c.x64,
-    desc: "macOS x64 cross-link: keep the __BUN segment's filesize ≤ vmsize under ld64.lld",
+    when: c => c.darwinLld && c.x64,
+    desc: "macOS x64 ld64.lld link: keep the __BUN segment's filesize ≤ vmsize",
   },
   {
     // Must also be passed at link: ld64 reads this to write LC_BUILD_VERSION.minos.

--- a/scripts/build/shims.ts
+++ b/scripts/build/shims.ts
@@ -28,9 +28,10 @@ export interface ShimLinkOpts {
 const ASAN_DYLD_SHIM = "asan-dyld-shim.dylib";
 
 /**
- * macOS-from-Linux cross links need a post-link fixup pass over every
- * Mach-O executable they produce (the linked bun-profile/bun-debug AND the
- * stripped bun):
+ * darwin links that go through ld64.lld (cross-compiles, and native ASAN
+ * builds per workarounds.ts "darwin-asan-ld-new") need a post-link fixup
+ * pass over every Mach-O executable they produce (the linked
+ * bun-profile/bun-debug AND the stripped bun):
  *
  *   - ld64.lld parses `-stack_size` but doesn't implement it (LLVM 21 prints
  *     "not yet implemented"), so LC_MAIN.stacksize stays 0 → the 8 MB
@@ -51,7 +52,7 @@ const ASAN_DYLD_SHIM = "asan-dyld-shim.dylib";
  * postlink $out ...`.
  */
 export function needsMachoPostlink(cfg: Config): boolean {
-  return cfg.darwin && cfg.crossTarget !== undefined;
+  return cfg.darwinLld;
 }
 
 /** Host-compiled fixup tool. Lives next to the executables it patches. */

--- a/scripts/build/tools.ts
+++ b/scripts/build/tools.ts
@@ -296,6 +296,11 @@ function llvmSearchPaths(os: OS, arch: Arch): string[] {
     }
     paths.push(`${brewPrefix}/opt/llvm@${LLVM_MAJOR}/bin`);
     paths.push(`${brewPrefix}/opt/llvm/bin`);
+    // Homebrew ships lld (ld64.lld / ld.lld) as a separate keg-only formula,
+    // NOT inside the llvm keg. Needed for native darwin ASAN links (see
+    // workarounds.ts "darwin-asan-ld-new").
+    paths.push(`${brewPrefix}/opt/lld@${LLVM_MAJOR}/bin`);
+    paths.push(`${brewPrefix}/opt/lld/bin`);
   }
 
   if (os === "windows") {
@@ -491,9 +496,10 @@ export function resolveLlvmToolchain(
   // ld64.lld: lld's Mach-O port. Swapped in as cfg.ld when a non-darwin
   // host cross-compiles FOR darwin, and for native darwin ASAN builds
   // (Apple's ld_new rejects rustc's ASAN relocations — see workarounds.ts
-  // "darwin-asan-ld-new"). Ships in the same LLVM install as clang, so the
-  // lookup is a handful of stats; resolved opportunistically on every unix
-  // host since the target isn't known yet.
+  // "darwin-asan-ld-new"). On Linux it ships alongside ld.lld; on darwin
+  // Homebrew puts it in a separate keg-only `lld@<ver>` formula, which
+  // llvmSearchPaths() covers. Resolved opportunistically on every unix host
+  // since the target isn't known yet.
   let ld64Lld: string | undefined;
   if (os !== "windows") {
     ld64Lld = findLlvmTool("ld64.lld", paths, os, { checkVersion: false, required: false })?.path;

--- a/scripts/build/tools.ts
+++ b/scripts/build/tools.ts
@@ -488,12 +488,14 @@ export function resolveLlvmToolchain(
     ld = ""; // darwin: unused
   }
 
-  // ld64.lld: lld's Mach-O port. Only used when a non-darwin host
-  // cross-compiles FOR darwin (resolveConfig swaps it in as cfg.ld); the
-  // target isn't known here, so resolve it opportunistically — it ships in
-  // the same LLVM install as ld.lld, and the lookup is a handful of stats.
+  // ld64.lld: lld's Mach-O port. Swapped in as cfg.ld when a non-darwin
+  // host cross-compiles FOR darwin, and for native darwin ASAN builds
+  // (Apple's ld_new rejects rustc's ASAN relocations — see workarounds.ts
+  // "darwin-asan-ld-new"). Ships in the same LLVM install as clang, so the
+  // lookup is a handful of stats; resolved opportunistically on every unix
+  // host since the target isn't known yet.
   let ld64Lld: string | undefined;
-  if (os !== "darwin" && os !== "windows") {
+  if (os !== "windows") {
     ld64Lld = findLlvmTool("ld64.lld", paths, os, { checkVersion: false, required: false })?.path;
   }
 

--- a/scripts/build/workarounds.ts
+++ b/scripts/build/workarounds.ts
@@ -172,10 +172,11 @@ export const workarounds: Workaround[] = [
       return cfg.rustLlvmVersion !== undefined && satisfiesRange(cfg.rustLlvmVersion, `>=${RECHECK_AT_RUST_LLVM}`);
     },
     cleanup:
-      `In scripts/build/config.ts drop the native-darwin-ASAN ld64.lld swap and the darwinLld field; ` +
-      `in flags.ts restore the plain \`-Wl,-ld_new\` entry and revert the darwinLld predicates to ` +
-      `crossTarget checks; in tools.ts re-gate ld64.lld resolution to non-darwin hosts; in shims.ts ` +
-      `restore needsMachoPostlink to the crossTarget check; and delete this entry.`,
+      `In scripts/build/config.ts drop the native-darwin-ASAN \`darwinNativeLld\` swap (darwinLld ` +
+      `then reduces to \`ld64StripSwap !== undefined\`); in flags.ts delete the native \`--ld-path\` ` +
+      `entry and drop \`!c.darwinLld\` from the -Wl,-ld_new predicate; and delete this entry. Keep ` +
+      `cfg.darwinLld itself and the predicates that read it (flags.ts, shims.ts, workarounds.ts): ` +
+      `they key on "which Mach-O linker", not on this workaround.`,
   },
   {
     id: "darwin-cross-stack-size",

--- a/scripts/build/workarounds.ts
+++ b/scripts/build/workarounds.ts
@@ -155,14 +155,37 @@ export const workarounds: Workaround[] = [
       `scripts/build/shims.ts, and this entry.`,
   },
   {
+    id: "darwin-asan-ld-new",
+    issue: "Apple ld-prime vs rustc -Zsanitizer=address (no upstream tracker yet)",
+    description:
+      "Apple's new linker (`-ld_new` / ld-prime) rejects relocations in rustc's ASAN sections " +
+      "(`__asan_globals`, `__asan_liveness`, `asan.module_ctor/dtor`) as `invalid r_symbolnum=<N>`, " +
+      "so the native darwin debug link fails. Native darwin ASAN links go through ld64.lld instead " +
+      "(cfg.darwinLld) — the same linker the cross-compile path already uses.",
+    applies: cfg => cfg.darwin && cfg.asan && cfg.crossTarget === undefined,
+    expectedToBeFixed: cfg => {
+      // The offending relocation comes from rustc's LLVM codegen; re-test
+      // when the pinned rustc moves to its next LLVM major. If `bun bd`
+      // (default asan on arm64 macOS) links cleanly with `-Wl,-ld_new`
+      // restored, delete the workaround; otherwise bump the threshold.
+      const RECHECK_AT_RUST_LLVM = "23.0.0";
+      return cfg.rustLlvmVersion !== undefined && satisfiesRange(cfg.rustLlvmVersion, `>=${RECHECK_AT_RUST_LLVM}`);
+    },
+    cleanup:
+      `In scripts/build/config.ts drop the native-darwin-ASAN ld64.lld swap and the darwinLld field; ` +
+      `in flags.ts restore the plain \`-Wl,-ld_new\` entry and revert the darwinLld predicates to ` +
+      `crossTarget checks; in tools.ts re-gate ld64.lld resolution to non-darwin hosts; in shims.ts ` +
+      `restore needsMachoPostlink to the crossTarget check; and delete this entry.`,
+  },
+  {
     id: "darwin-cross-stack-size",
     issue:
       "https://github.com/llvm/llvm-project/blob/main/lld/MachO/Driver.cpp (OPT_stack_size in unimplemented warnings)",
     description:
       "ld64.lld parses `-stack_size` but doesn't implement it (\"is not yet implemented. Stay " +
-      'tuned..."), so darwin cross links keep the 8 MB default main-thread stack instead of the ' +
+      'tuned..."), so darwin ld64.lld links keep the 8 MB default main-thread stack instead of the ' +
       "18 MB JSC needs. shims/macho-postlink.c patches LC_MAIN.stacksize after the link instead.",
-    applies: cfg => cfg.darwin && cfg.crossTarget !== undefined,
+    applies: cfg => cfg.darwinLld,
     expectedToBeFixed: cfg => {
       // Not implemented as of LLVM 21 (lld/MachO/Driver.cpp keeps
       // OPT_stack_size in the "unimplemented, warn and ignore" list).

--- a/scripts/build/workarounds.ts
+++ b/scripts/build/workarounds.ts
@@ -174,9 +174,9 @@ export const workarounds: Workaround[] = [
     cleanup:
       `In scripts/build/config.ts drop the native-darwin-ASAN \`darwinNativeLld\` swap (darwinLld ` +
       `then reduces to \`ld64StripSwap !== undefined\`); in flags.ts delete the native \`--ld-path\` ` +
-      `entry and drop \`!c.darwinLld\` from the -Wl,-ld_new predicate; and delete this entry. Keep ` +
-      `cfg.darwinLld itself and the predicates that read it (flags.ts, shims.ts, workarounds.ts): ` +
-      `they key on "which Mach-O linker", not on this workaround.`,
+      `entry (its predicate is now unreachable); and delete this entry. Keep cfg.darwinLld and ` +
+      `every predicate that reads it, including \`-Wl,-ld_new\`'s \`!c.darwinLld\`: they key on ` +
+      `"which Mach-O linker", not on this workaround.`,
   },
   {
     id: "darwin-cross-stack-size",

--- a/test/internal/macos-cross-config.test.ts
+++ b/test/internal/macos-cross-config.test.ts
@@ -12,7 +12,13 @@ import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
 import { existsSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { resolveConfig, type Config, type Host, type PartialConfig, type Toolchain } from "../../scripts/build/config.ts";
+import {
+  resolveConfig,
+  type Config,
+  type Host,
+  type PartialConfig,
+  type Toolchain,
+} from "../../scripts/build/config.ts";
 import { webkit } from "../../scripts/build/deps/webkit.ts";
 import { parsePackedFeaturesList } from "../../scripts/build/features-json.ts";
 import { computeFlags, DARWIN_STACK_SIZE } from "../../scripts/build/flags.ts";

--- a/test/internal/macos-cross-config.test.ts
+++ b/test/internal/macos-cross-config.test.ts
@@ -259,7 +259,11 @@ describe.skipIf(isMacOS)("macOS cross-compile config (non-darwin host)", () => {
   });
 });
 
-describe("native darwin ASAN → ld64.lld (workarounds.ts 'darwin-asan-ld-new')", () => {
+// Skipped on macOS for the same reason as the block above: resolveDarwin() on
+// a darwin host enters the native branch and spawns xcode-select/xcrun against
+// the real SDK. The tests only exercise computeFlags/needsMachoPostlink over a
+// hand-overridden Config record, so running them on a real mac gains nothing.
+describe.skipIf(isMacOS)("native darwin ASAN → ld64.lld (workarounds.ts 'darwin-asan-ld-new')", () => {
   // resolveConfig() detects the real host, so a Linux machine can't resolve a
   // "native darwin" config directly. Build one by taking the darwin cross
   // resolution (which populates every darwin field) and overriding just the

--- a/test/internal/macos-cross-config.test.ts
+++ b/test/internal/macos-cross-config.test.ts
@@ -7,12 +7,12 @@
  * cover the "darwin target on a non-darwin host" path are skipped on macOS,
  * where the same inputs intentionally resolve to the native toolchain instead.
  */
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { resolveConfig, type Config, type PartialConfig, type Toolchain } from "../../scripts/build/config.ts";
+import { resolveConfig, type Config, type Host, type PartialConfig, type Toolchain } from "../../scripts/build/config.ts";
 import { webkit } from "../../scripts/build/deps/webkit.ts";
 import { parsePackedFeaturesList } from "../../scripts/build/features-json.ts";
 import { computeFlags, DARWIN_STACK_SIZE } from "../../scripts/build/flags.ts";
@@ -259,37 +259,60 @@ describe.skipIf(isMacOS)("macOS cross-compile config (non-darwin host)", () => {
   });
 });
 
-// Skipped on macOS for the same reason as the block above: resolveDarwin() on
-// a darwin host enters the native branch and spawns xcode-select/xcrun against
-// the real SDK. The tests only exercise computeFlags/needsMachoPostlink over a
-// hand-overridden Config record, so running them on a real mac gains nothing.
+// Skipped on macOS so the fake DEVELOPER_DIR doesn't shadow the real host SDK
+// for any other test in this file; on a real mac these inputs resolve without
+// the injected host anyway.
 describe.skipIf(isMacOS)("native darwin ASAN → ld64.lld (workarounds.ts 'darwin-asan-ld-new')", () => {
-  // resolveConfig() detects the real host, so a Linux machine can't resolve a
-  // "native darwin" config directly. Build one by taking the darwin cross
-  // resolution (which populates every darwin field) and overriding just the
-  // linker-selection fields — computeFlags/needsMachoPostlink read Config as
-  // a plain record, so the rest is inert.
-  function nativeDarwinAsan(): Config {
-    return {
-      ...resolveDarwin({ buildType: "Debug", assertions: true }),
+  // resolveConfig() takes an optional Host so tests can exercise the native
+  // darwin branch on any machine. detectMacosSdk() respects DEVELOPER_DIR, so
+  // point it at a CLT-shaped fake SDK and no xcode-select/xcrun is spawned.
+  const darwinHost: Host = { os: "darwin", arch: "aarch64", exeSuffix: "", rustTriple: undefined };
+  function resolveNativeDarwin(partial: PartialConfig, toolchain = mockToolchain()): Config {
+    return resolveConfig({ os: "darwin", arch: "aarch64", ...partial }, toolchain, { ...darwinHost });
+  }
+
+  let fakeClt: ReturnType<typeof tempDir>;
+  let prevDevDir: string | undefined;
+  beforeAll(() => {
+    fakeClt = tempDir("fake-clt", {});
+    const versioned = join(String(fakeClt), "SDKs", "MacOSX15.0.sdk");
+    mkdirSync(versioned, { recursive: true });
+    symlinkSync(versioned, join(String(fakeClt), "SDKs", "MacOSX.sdk"));
+    prevDevDir = process.env.DEVELOPER_DIR;
+    process.env.DEVELOPER_DIR = String(fakeClt);
+  });
+  afterAll(() => {
+    if (prevDevDir === undefined) delete process.env.DEVELOPER_DIR;
+    else process.env.DEVELOPER_DIR = prevDevDir;
+    fakeClt[Symbol.dispose]();
+  });
+
+  test("resolveConfig selects ld64.lld for native debug (asan default) and throws without it", () => {
+    // Debug on arm64 macOS defaults asan on → the native-ASAN swap fires.
+    const cfg = resolveNativeDarwin({ buildType: "Debug" });
+    expect({
+      crossTarget: cfg.crossTarget,
+      asan: cfg.asan,
+      darwinLld: cfg.darwinLld,
+      ld: cfg.ld,
+    }).toEqual({
       crossTarget: undefined,
       asan: true,
       darwinLld: true,
       ld: "/fake/llvm/bin/ld64.lld",
-    };
-  }
-  function nativeDarwinNoAsan(): Config {
-    return {
-      ...resolveDarwin({ buildType: "Debug", assertions: true }),
-      crossTarget: undefined,
-      asan: false,
-      darwinLld: false,
-      ld: "",
-    };
-  }
+    });
+    // Missing ld64.lld is a configure-time error, not a late link failure;
+    // rust-only mode never links so it's exempt.
+    expect(() => resolveNativeDarwin({ buildType: "Debug" }, mockToolchain({ ld64Lld: undefined }))).toThrow(
+      /ld64\.lld/,
+    );
+    expect(() =>
+      resolveNativeDarwin({ buildType: "Debug", mode: "rust-only" }, mockToolchain({ ld64Lld: undefined })),
+    ).not.toThrow();
+  });
 
   test("native ASAN links through --ld-path=ld64.lld instead of Apple's -ld_new", () => {
-    const flags = computeFlags(nativeDarwinAsan());
+    const flags = computeFlags(resolveNativeDarwin({ buildType: "Debug" }));
     // The whole point: -ld_new is the Apple linker that rejects rustc's ASAN
     // relocations with `invalid r_symbolnum`; ld64.lld handles them.
     expect(flags.ldflags).not.toContain("-Wl,-ld_new");
@@ -300,7 +323,7 @@ describe.skipIf(isMacOS)("native darwin ASAN → ld64.lld (workarounds.ts 'darwi
   });
 
   test("native ASAN picks up the ld64.lld-specific link flags", () => {
-    const flags = computeFlags(nativeDarwinAsan());
+    const flags = computeFlags(resolveNativeDarwin({ buildType: "Debug" }));
     // Segment ordering quirk is about ld64.lld, not about cross-compiling.
     expect(flags.ldflags).toContain("-Wl,-rename_segment,__DATA_DIRTY,__DATA");
     // arm64 needs a signature for macho-postlink to regenerate after the
@@ -314,12 +337,12 @@ describe.skipIf(isMacOS)("native darwin ASAN → ld64.lld (workarounds.ts 'darwi
     // x64's __BUN sectalign cap is an ld64.lld quirk too (not cross-specific);
     // arm64 doesn't need it (16 KB pages).
     expect(flags.ldflags).not.toContain("-Wl,-sectalign,__BUN,__bun,0x1000");
-    const x64 = computeFlags({ ...nativeDarwinAsan(), x64: true, arm64: false });
+    const x64 = computeFlags(resolveNativeDarwin({ buildType: "Debug", arch: "x64", asan: true }));
     expect(x64.ldflags).toContain("-Wl,-sectalign,__BUN,__bun,0x1000");
   });
 
   test("native ASAN runs macho-postlink (ld64.lld ignores -stack_size)", () => {
-    const cfg = nativeDarwinAsan();
+    const cfg = resolveNativeDarwin({ buildType: "Debug" });
     expect(needsMachoPostlink(cfg)).toBe(true);
     const cmd = machoPostlinkCommand(cfg);
     expect(cmd).toContain(`macho-postlink $out --stack-size=${DARWIN_STACK_SIZE}`);
@@ -329,7 +352,15 @@ describe.skipIf(isMacOS)("native darwin ASAN → ld64.lld (workarounds.ts 'darwi
   });
 
   test("native non-ASAN keeps Apple's -ld_new and skips every ld64.lld extra", () => {
-    const cfg = nativeDarwinNoAsan();
+    // Release on native darwin defaults asan off → Apple's ld stays. On a real
+    // darwin host resolveLlvmToolchain leaves toolchain.ld = "" (clang invokes
+    // the system linker), so mirror that here.
+    const cfg = resolveNativeDarwin({ buildType: "Release" }, mockToolchain({ ld: "" }));
+    expect({ asan: cfg.asan, darwinLld: cfg.darwinLld, ld: cfg.ld }).toEqual({
+      asan: false,
+      darwinLld: false,
+      ld: "",
+    });
     const flags = computeFlags(cfg);
     expect(flags.ldflags).toContain("-Wl,-ld_new");
     expect(flags.ldflags.some(f => f.startsWith("--ld-path="))).toBe(false);

--- a/test/internal/macos-cross-config.test.ts
+++ b/test/internal/macos-cross-config.test.ts
@@ -307,6 +307,11 @@ describe("native darwin ASAN → ld64.lld (workarounds.ts 'darwin-asan-ld-new')"
     // driver into the modern -platform_version argument on a non-Apple host.
     expect(flags.ldflags).not.toContain("-mlinker-version=705");
     expect(flags.ldflags.some(f => f.startsWith("--target="))).toBe(false);
+    // x64's __BUN sectalign cap is an ld64.lld quirk too (not cross-specific);
+    // arm64 doesn't need it (16 KB pages).
+    expect(flags.ldflags).not.toContain("-Wl,-sectalign,__BUN,__bun,0x1000");
+    const x64 = computeFlags({ ...nativeDarwinAsan(), x64: true, arm64: false });
+    expect(x64.ldflags).toContain("-Wl,-sectalign,__BUN,__bun,0x1000");
   });
 
   test("native ASAN runs macho-postlink (ld64.lld ignores -stack_size)", () => {

--- a/test/internal/macos-cross-config.test.ts
+++ b/test/internal/macos-cross-config.test.ts
@@ -22,6 +22,7 @@ import {
   elfDebugCompressPostlinkCommand,
   machoEntitlementsPlist,
   machoPostlinkCommand,
+  needsMachoPostlink,
 } from "../../scripts/build/shims.ts";
 
 /** A fully-populated fake toolchain — resolveConfig never spawns any of these. */
@@ -71,6 +72,7 @@ describe.skipIf(isMacOS)("macOS cross-compile config (non-darwin host)", () => {
     expect(cfg.osxDeploymentTarget).toBe("13.0");
     expect(cfg.osxSysroot).toBeDefined();
     expect(cfg.ld).toBe("/fake/llvm/bin/ld64.lld");
+    expect(cfg.darwinLld).toBe(true);
     expect(cfg.strip).toBe("/fake/llvm/bin/llvm-strip");
 
     const x64 = resolveDarwin({ arch: "x64" });
@@ -254,6 +256,87 @@ describe.skipIf(isMacOS)("macOS cross-compile config (non-darwin host)", () => {
     expect(flags.cxxflags.some(f => f.includes("apple-macosx"))).toBe(false);
     expect(flags.cxxflags).not.toContain("-isysroot");
     expect(flags.cxxflags).not.toContain("-nostdinc");
+  });
+});
+
+describe("native darwin ASAN → ld64.lld (workarounds.ts 'darwin-asan-ld-new')", () => {
+  // resolveConfig() detects the real host, so a Linux machine can't resolve a
+  // "native darwin" config directly. Build one by taking the darwin cross
+  // resolution (which populates every darwin field) and overriding just the
+  // linker-selection fields — computeFlags/needsMachoPostlink read Config as
+  // a plain record, so the rest is inert.
+  function nativeDarwinAsan(): Config {
+    return {
+      ...resolveDarwin({ buildType: "Debug", assertions: true }),
+      crossTarget: undefined,
+      asan: true,
+      darwinLld: true,
+      ld: "/fake/llvm/bin/ld64.lld",
+    };
+  }
+  function nativeDarwinNoAsan(): Config {
+    return {
+      ...resolveDarwin({ buildType: "Debug", assertions: true }),
+      crossTarget: undefined,
+      asan: false,
+      darwinLld: false,
+      ld: "",
+    };
+  }
+
+  test("native ASAN links through --ld-path=ld64.lld instead of Apple's -ld_new", () => {
+    const flags = computeFlags(nativeDarwinAsan());
+    // The whole point: -ld_new is the Apple linker that rejects rustc's ASAN
+    // relocations with `invalid r_symbolnum`; ld64.lld handles them.
+    expect(flags.ldflags).not.toContain("-Wl,-ld_new");
+    expect(flags.ldflags).toContain("--ld-path=/fake/llvm/bin/ld64.lld");
+    // --ld-path is emitted exactly once (the cross-link entry is gated on
+    // crossTarget, so it doesn't double up).
+    expect(flags.ldflags.filter(f => f.startsWith("--ld-path="))).toHaveLength(1);
+  });
+
+  test("native ASAN picks up the ld64.lld-specific link flags", () => {
+    const flags = computeFlags(nativeDarwinAsan());
+    // Segment ordering quirk is about ld64.lld, not about cross-compiling.
+    expect(flags.ldflags).toContain("-Wl,-rename_segment,__DATA_DIRTY,__DATA");
+    // arm64 needs a signature for macho-postlink to regenerate after the
+    // stack-size patch.
+    expect(flags.ldflags).toContain("-Wl,-adhoc_codesign");
+    // Cross-only machinery must NOT leak into the native link: clang already
+    // knows its host target, and -mlinker-version is only needed to coax the
+    // driver into the modern -platform_version argument on a non-Apple host.
+    expect(flags.ldflags).not.toContain("-mlinker-version=705");
+    expect(flags.ldflags.some(f => f.startsWith("--target="))).toBe(false);
+  });
+
+  test("native ASAN runs macho-postlink (ld64.lld ignores -stack_size)", () => {
+    const cfg = nativeDarwinAsan();
+    expect(needsMachoPostlink(cfg)).toBe(true);
+    const cmd = machoPostlinkCommand(cfg);
+    expect(cmd).toContain(`macho-postlink $out --stack-size=${DARWIN_STACK_SIZE}`);
+    // arm64: the stack-size patch invalidates the ad-hoc signature, so it's
+    // re-signed with the debug entitlements (get-task-allow for lldb).
+    expect(cmd).toContain("entitlements.debug.plist");
+  });
+
+  test("native non-ASAN keeps Apple's -ld_new and skips every ld64.lld extra", () => {
+    const cfg = nativeDarwinNoAsan();
+    const flags = computeFlags(cfg);
+    expect(flags.ldflags).toContain("-Wl,-ld_new");
+    expect(flags.ldflags.some(f => f.startsWith("--ld-path="))).toBe(false);
+    expect(flags.ldflags).not.toContain("-Wl,-rename_segment,__DATA_DIRTY,__DATA");
+    expect(flags.ldflags).not.toContain("-Wl,-adhoc_codesign");
+    expect(needsMachoPostlink(cfg)).toBe(false);
+    expect(machoPostlinkCommand(cfg)).toBe("");
+  });
+
+  test("non-darwin configs never set darwinLld", () => {
+    const linux = resolveConfig(
+      { os: "linux", arch: "x64", abi: "gnu", buildType: "Debug", asan: true, linuxSysroot: "/fake" },
+      mockToolchain({ ld64Lld: undefined, llvmStrip: undefined, dsymutil: undefined }),
+    );
+    expect(linux.darwinLld).toBe(false);
+    expect(needsMachoPostlink(linux)).toBe(false);
   });
 });
 

--- a/test/internal/macos-cross-config.test.ts
+++ b/test/internal/macos-cross-config.test.ts
@@ -274,7 +274,7 @@ describe.skipIf(isMacOS)("native darwin ASAN → ld64.lld (workarounds.ts 'darwi
   // point it at a CLT-shaped fake SDK and no xcode-select/xcrun is spawned.
   const darwinHost: Host = { os: "darwin", arch: "aarch64", exeSuffix: "", rustTriple: undefined };
   function resolveNativeDarwin(partial: PartialConfig, toolchain = mockToolchain()): Config {
-    return resolveConfig({ os: "darwin", arch: "aarch64", ...partial }, toolchain, { ...darwinHost });
+    return resolveConfig({ os: "darwin", arch: "aarch64", ...partial }, toolchain, darwinHost);
   }
 
   let fakeClt: ReturnType<typeof tempDir>;
@@ -315,6 +315,9 @@ describe.skipIf(isMacOS)("native darwin ASAN → ld64.lld (workarounds.ts 'darwi
     expect(() =>
       resolveNativeDarwin({ buildType: "Debug", mode: "rust-only" }, mockToolchain({ ld64Lld: undefined })),
     ).not.toThrow();
+    // resolveConfig never mutates the caller's Host (rustTriple is stamped on
+    // an internal copy).
+    expect(darwinHost).toEqual({ os: "darwin", arch: "aarch64", exeSuffix: "", rustTriple: undefined });
   });
 
   test("native ASAN links through --ld-path=ld64.lld instead of Apple's -ld_new", () => {


### PR DESCRIPTION
## Repro

On an arm64 mac (Sequoia 15.1, Homebrew `llvm@21`, rustup `nightly-2026-07-20`), the default `bun bd` (debug + ASAN) fails at the final link:

```
ld: invalid r_symbolnum=16 in 'rust-target/aarch64-apple-darwin/debug/libbun_rust.a[7169](bun_ptr-*.rcgu.o)'
clang++: error: linker command failed with exit code 1
```

The offending object carries rustc's `-Zsanitizer=address` sections (`__asan_globals`, `__asan_liveness`, the `asan.module_ctor/dtor` in `__mod_init_func`). Apple's new linker (`-Wl,-ld_new` / ld-prime, selected by `scripts/build/flags.ts` for native darwin links) rejects a relocation in one of them. Reproduces with and without `-Cllvm-args=-addrsig`, so it is not the address-significance section.

The cross-compile path already links with `ld64.lld` (lld's Mach-O port) and is unaffected.

## Cause

`flags.ts` unconditionally passed `-Wl,-ld_new` for native darwin links. rustc's LLVM codegen for `-Zsanitizer=address` emits a relocation form that ld-prime does not accept; `ld64.lld` handles it.

## Fix

Route native darwin ASAN links through `ld64.lld`, the same linker the cross-compile path already uses, and carry the ld64.lld-specific adjustments that the cross path already applies:

- **`config.ts`**: new `cfg.darwinLld`, true whenever a darwin link uses `ld64.lld` (cross-compile, or native ASAN). `cfg.ld` is swapped to Homebrew's `ld64.lld` for the native-ASAN case, with a clear configure-time error if it's missing.
- **`tools.ts`**: resolve `ld64.lld` on darwin hosts too, and search Homebrew's separate keg-only `lld@<ver>` formula (lld is not inside the `llvm@<ver>` keg).
- **`flags.ts`**: `-Wl,-ld_new` is now gated on `!darwinLld`; a new entry passes `--ld-path=${c.ld}` for native ASAN. `-Wl,-rename_segment,__DATA_DIRTY,__DATA`, `-Wl,-adhoc_codesign`, and `-Wl,-sectalign,__BUN,__bun,0x1000` are re-keyed on `darwinLld` since they compensate for `ld64.lld` behavior, not for cross-compiling.
- **`shims.ts`**: `needsMachoPostlink` now keys on `darwinLld`, so the LC_MAIN stack-size patch and ad-hoc re-sign also run for native ASAN links (`ld64.lld` still ignores `-stack_size`).
- **`workarounds.ts`**: self-obsoleting `darwin-asan-ld-new` entry so the swap is re-tested when the pinned rustc's LLVM major moves.
- **`bootstrap.sh` / `CONTRIBUTING.md` / `docs/project/contributing.mdx`**: install `lld@<ver>` alongside `llvm@<ver>` on macOS.

Native non-ASAN darwin builds, Linux, Windows, and every cross path are untouched: the Linux debug `build.ninja` regenerates byte-identical before and after this change.

## Why this is correct

Switching the native ASAN link to `ld64.lld` is not a new linker path for bun: it is exactly how the shipped macOS binaries are already linked (CI cross-compiles macOS from Linux with `ld64.lld`). `cfg.darwinLld` captures "the darwin link uses `ld64.lld`" so the adjustments that the cross path already carries (segment rename for `bun build --compile`, stack-size postlink, ad-hoc re-sign, x64 sectalign) follow the linker, not the host. The field is kept as a permanent abstraction; the workaround cleanup only removes the native-ASAN swap.

## Verification

`test/internal/macos-cross-config.test.ts` gains a describe block that pins the native-ASAN link flags:

- native ASAN emits `--ld-path=<ld64.lld>` and **not** `-Wl,-ld_new`
- native ASAN picks up `-Wl,-rename_segment,__DATA_DIRTY,__DATA`, `-Wl,-adhoc_codesign`, and (on x64) `-Wl,-sectalign,__BUN,__bun,0x1000`, but not the cross-only `--target=` / `-mlinker-version`
- `needsMachoPostlink` is true for native ASAN and the postlink command carries `--stack-size` + debug entitlements
- native non-ASAN keeps `-Wl,-ld_new` and none of the ld64.lld extras
- linux configs keep `darwinLld: false`

25 tests pass under `bun bd test`. Reverting `scripts/build/**` makes 4 of the new cases fail (first failure shows the native ASAN ldflags containing `-Wl,-ld_new`, which is exactly the bug).

> Build-script-only change (`scripts/build/**` + bootstrap/docs): no `src/**` or `packages/**` diff. The regression coverage lives alongside the other build-config tests in `test/internal/`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->