### PR TITLE
react_compiler: preserve E::UnaryFlags through codegen (delete/typeof Reference semantics)

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -135,7 +135,7 @@ pub struct Unary {
 }
 
 bitflags::bitflags! {
-    #[derive(Clone, Copy, Default, PartialEq, Eq)]
+    #[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
     #[repr(transparent)]
     pub struct UnaryFlags: u8 {
         /// The expression "typeof (0, x)" must not become "typeof x" if "x"

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -135,7 +135,7 @@ pub struct Unary {
 }
 
 bitflags::bitflags! {
-    #[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+    #[derive(Clone, Copy, Default, PartialEq, Eq)]
     #[repr(transparent)]
     pub struct UnaryFlags: u8 {
         /// The expression "typeof (0, x)" must not become "typeof x" if "x"

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -1853,14 +1853,17 @@ fn codegen_base_instruction_value(
             ))
         }
         InstructionValue::UnaryExpression {
-            operator, value, ..
+            operator,
+            value,
+            bun_flags,
+            ..
         } => {
             let arg = codegen_place_to_expression(cx, value)?;
             Ok(Expr::init(
                 E::Unary {
                     op: convert_unary_operator(*operator),
                     value: arg,
-                    flags: E::UnaryFlags::empty(),
+                    flags: *bun_flags,
                 },
                 loc,
             ))
@@ -1995,7 +1998,8 @@ fn codegen_base_instruction_value(
                 E::Unary {
                     op: OpCode::UnDelete,
                     value: property_access_expr(obj, property, loc, None),
-                    flags: E::UnaryFlags::empty(),
+                    // `lower_unary` only creates PropertyDelete when this flag was set.
+                    flags: E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
                 },
                 loc,
             ))
@@ -2055,7 +2059,7 @@ fn codegen_base_instruction_value(
                         },
                         loc,
                     ),
-                    flags: E::UnaryFlags::empty(),
+                    flags: E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
                 },
                 loc,
             ))

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -1863,9 +1863,6 @@ fn codegen_base_instruction_value(
                 E::Unary {
                     op: convert_unary_operator(*operator),
                     value: arg,
-                    // Threaded from the visited `E::Unary` so the printer's
-                    // `typeof (0, x)` re-wrap sees the same flag it would
-                    // without the react-compiler pass.
                     flags: *bun_flags,
                 },
                 loc,
@@ -2001,10 +1998,7 @@ fn codegen_base_instruction_value(
                 E::Unary {
                     op: OpCode::UnDelete,
                     value: property_access_expr(obj, property, loc, None),
-                    // `lower_unary` only creates PropertyDelete when this flag was set on
-                    // the visited `delete` node. Without it the printer wraps the operand
-                    // as `delete (0, obj.prop)`, which evaluates the property to a value
-                    // and returns true without deleting.
+                    // `lower_unary` only creates PropertyDelete when this flag was set.
                     flags: E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
                 },
                 loc,
@@ -2065,8 +2059,6 @@ fn codegen_base_instruction_value(
                         },
                         loc,
                     ),
-                    // See PropertyDelete above; lowering only creates
-                    // ComputedDelete from `delete <EIndex>`.
                     flags: E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
                 },
                 loc,

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -1853,14 +1853,20 @@ fn codegen_base_instruction_value(
             ))
         }
         InstructionValue::UnaryExpression {
-            operator, value, ..
+            operator,
+            value,
+            bun_flags,
+            ..
         } => {
             let arg = codegen_place_to_expression(cx, value)?;
             Ok(Expr::init(
                 E::Unary {
                     op: convert_unary_operator(*operator),
                     value: arg,
-                    flags: E::UnaryFlags::empty(),
+                    // Threaded from the visited `E::Unary` so the printer's
+                    // `typeof (0, x)` re-wrap sees the same flag it would
+                    // without the react-compiler pass.
+                    flags: *bun_flags,
                 },
                 loc,
             ))
@@ -1995,11 +2001,10 @@ fn codegen_base_instruction_value(
                 E::Unary {
                     op: OpCode::UnDelete,
                     value: property_access_expr(obj, property, loc, None),
-                    // The parser only sets this flag for `delete <ident|dot|index>`;
-                    // lowering only creates PropertyDelete from `delete <EDot>`, so
-                    // the source form always had it set. Without it the printer
-                    // wraps the operand as `delete (0, obj.prop)`, which evaluates
-                    // the property to a value and returns true without deleting.
+                    // `lower_unary` only creates PropertyDelete when this flag was set on
+                    // the visited `delete` node. Without it the printer wraps the operand
+                    // as `delete (0, obj.prop)`, which evaluates the property to a value
+                    // and returns true without deleting.
                     flags: E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
                 },
                 loc,

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -1853,17 +1853,14 @@ fn codegen_base_instruction_value(
             ))
         }
         InstructionValue::UnaryExpression {
-            operator,
-            value,
-            bun_flags,
-            ..
+            operator, value, ..
         } => {
             let arg = codegen_place_to_expression(cx, value)?;
             Ok(Expr::init(
                 E::Unary {
                     op: convert_unary_operator(*operator),
                     value: arg,
-                    flags: *bun_flags,
+                    flags: E::UnaryFlags::empty(),
                 },
                 loc,
             ))
@@ -1998,8 +1995,7 @@ fn codegen_base_instruction_value(
                 E::Unary {
                     op: OpCode::UnDelete,
                     value: property_access_expr(obj, property, loc, None),
-                    // `lower_unary` only creates PropertyDelete when this flag was set.
-                    flags: E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
+                    flags: E::UnaryFlags::empty(),
                 },
                 loc,
             ))
@@ -2059,7 +2055,7 @@ fn codegen_base_instruction_value(
                         },
                         loc,
                     ),
-                    flags: E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
+                    flags: E::UnaryFlags::empty(),
                 },
                 loc,
             ))

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -1995,7 +1995,12 @@ fn codegen_base_instruction_value(
                 E::Unary {
                     op: OpCode::UnDelete,
                     value: property_access_expr(obj, property, loc, None),
-                    flags: E::UnaryFlags::empty(),
+                    // The parser only sets this flag for `delete <ident|dot|index>`;
+                    // lowering only creates PropertyDelete from `delete <EDot>`, so
+                    // the source form always had it set. Without it the printer
+                    // wraps the operand as `delete (0, obj.prop)`, which evaluates
+                    // the property to a value and returns true without deleting.
+                    flags: E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
                 },
                 loc,
             ))
@@ -2055,7 +2060,9 @@ fn codegen_base_instruction_value(
                         },
                         loc,
                     ),
-                    flags: E::UnaryFlags::empty(),
+                    // See PropertyDelete above; lowering only creates
+                    // ComputedDelete from `delete <EIndex>`.
+                    flags: E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
                 },
                 loc,
             ))

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -752,6 +752,8 @@ pub enum InstructionValue {
     UnaryExpression {
         operator: UnaryOperator,
         value: Place,
+        /// Parse-time flags from the visited `E::Unary`, restored at codegen.
+        bun_flags: bun_ast::E::UnaryFlags,
         loc: Option<SourceLocation>,
     },
     TypeCastExpression {

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -752,8 +752,7 @@ pub enum InstructionValue {
     UnaryExpression {
         operator: UnaryOperator,
         value: Place,
-        /// Bun's parse-time `E::UnaryFlags` (carries WAS_ORIGINALLY_TYPEOF_IDENTIFIER),
-        /// threaded through so codegen can restore it on the rebuilt `E::Unary`.
+        /// Parse-time flags from the visited `E::Unary`, restored at codegen.
         bun_flags: bun_ast::E::UnaryFlags,
         loc: Option<SourceLocation>,
     },

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -752,6 +752,9 @@ pub enum InstructionValue {
     UnaryExpression {
         operator: UnaryOperator,
         value: Place,
+        /// Bun's parse-time `E::UnaryFlags` (carries WAS_ORIGINALLY_TYPEOF_IDENTIFIER),
+        /// threaded through so codegen can restore it on the rebuilt `E::Unary`.
+        bun_flags: bun_ast::E::UnaryFlags,
         loc: Option<SourceLocation>,
     },
     TypeCastExpression {

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -752,8 +752,6 @@ pub enum InstructionValue {
     UnaryExpression {
         operator: UnaryOperator,
         value: Place,
-        /// Parse-time flags from the visited `E::Unary`, restored at codegen.
-        bun_flags: bun_ast::E::UnaryFlags,
         loc: Option<SourceLocation>,
     },
     TypeCastExpression {

--- a/src/react_compiler/lowering/build_hir/expr.rs
+++ b/src/react_compiler/lowering/build_hir/expr.rs
@@ -984,13 +984,9 @@ fn lower_unary(
     let loc = convert_loc(bun_loc);
     match unary.op {
         UnDelete => match &unary.value.data {
-            // The parser sets WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS
-            // only when the source operand is syntactically an identifier or member
-            // expression. The visitor can fold `delete (true ? a.b : c.d)` to an EDot
-            // operand with the flag unset; that form has no-op semantics (operand is a
-            // value, not a Reference) and must not become a PropertyDelete. Gating on
-            // the flag matches upstream, which sees the unfolded ConditionalExpression
-            // and takes the "Only object properties can be deleted" bailout.
+            // The visitor can fold `delete (true ? a.b : c.d)` to an EDot operand
+            // with this flag unset; that form is a spec no-op and must fall through
+            // to the bailout (matching upstream on the unfolded conditional).
             Data::EDot(d)
                 if d.optional_chain.is_none()
                     && unary.flags.contains(

--- a/src/react_compiler/lowering/build_hir/expr.rs
+++ b/src/react_compiler/lowering/build_hir/expr.rs
@@ -984,13 +984,7 @@ fn lower_unary(
     let loc = convert_loc(bun_loc);
     match unary.op {
         UnDelete => match &unary.value.data {
-            // A flagless EDot here is a visitor-folded no-op `delete`; bail like upstream.
-            Data::EDot(d)
-                if d.optional_chain.is_none()
-                    && unary.flags.contains(
-                        E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
-                    ) =>
-            {
+            Data::EDot(d) if d.optional_chain.is_none() => {
                 let object = lower_expression_to_temporary(builder, &d.target)?;
                 Ok(InstructionValue::PropertyDelete {
                     object,
@@ -998,12 +992,7 @@ fn lower_unary(
                     loc,
                 })
             }
-            Data::EIndex(i)
-                if i.optional_chain.is_none()
-                    && unary.flags.contains(
-                        E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
-                    ) =>
-            {
+            Data::EIndex(i) if i.optional_chain.is_none() => {
                 let object = lower_expression_to_temporary(builder, &i.target)?;
                 let property = lower_expression_to_temporary(builder, &i.index)?;
                 Ok(InstructionValue::ComputedDelete {
@@ -1032,7 +1021,6 @@ fn lower_unary(
             Ok(InstructionValue::UnaryExpression {
                 operator,
                 value,
-                bun_flags: unary.flags,
                 loc,
             })
         }

--- a/src/react_compiler/lowering/build_hir/expr.rs
+++ b/src/react_compiler/lowering/build_hir/expr.rs
@@ -984,9 +984,7 @@ fn lower_unary(
     let loc = convert_loc(bun_loc);
     match unary.op {
         UnDelete => match &unary.value.data {
-            // The visitor can fold `delete (true ? a.b : c.d)` to an EDot operand
-            // with this flag unset; that form is a spec no-op and must fall through
-            // to the bailout (matching upstream on the unfolded conditional).
+            // A flagless EDot here is a visitor-folded no-op `delete`; bail like upstream.
             Data::EDot(d)
                 if d.optional_chain.is_none()
                     && unary.flags.contains(

--- a/src/react_compiler/lowering/build_hir/expr.rs
+++ b/src/react_compiler/lowering/build_hir/expr.rs
@@ -984,7 +984,13 @@ fn lower_unary(
     let loc = convert_loc(bun_loc);
     match unary.op {
         UnDelete => match &unary.value.data {
-            Data::EDot(d) if d.optional_chain.is_none() => {
+            // A flagless EDot here is a visitor-folded no-op `delete`; bail like upstream.
+            Data::EDot(d)
+                if d.optional_chain.is_none()
+                    && unary.flags.contains(
+                        E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
+                    ) =>
+            {
                 let object = lower_expression_to_temporary(builder, &d.target)?;
                 Ok(InstructionValue::PropertyDelete {
                     object,
@@ -992,7 +998,12 @@ fn lower_unary(
                     loc,
                 })
             }
-            Data::EIndex(i) if i.optional_chain.is_none() => {
+            Data::EIndex(i)
+                if i.optional_chain.is_none()
+                    && unary.flags.contains(
+                        E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
+                    ) =>
+            {
                 let object = lower_expression_to_temporary(builder, &i.target)?;
                 let property = lower_expression_to_temporary(builder, &i.index)?;
                 Ok(InstructionValue::ComputedDelete {
@@ -1021,6 +1032,7 @@ fn lower_unary(
             Ok(InstructionValue::UnaryExpression {
                 operator,
                 value,
+                bun_flags: unary.flags,
                 loc,
             })
         }

--- a/src/react_compiler/lowering/build_hir/expr.rs
+++ b/src/react_compiler/lowering/build_hir/expr.rs
@@ -984,7 +984,19 @@ fn lower_unary(
     let loc = convert_loc(bun_loc);
     match unary.op {
         UnDelete => match &unary.value.data {
-            Data::EDot(d) if d.optional_chain.is_none() => {
+            // The parser sets WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS
+            // only when the source operand is syntactically an identifier or member
+            // expression. The visitor can fold `delete (true ? a.b : c.d)` to an EDot
+            // operand with the flag unset; that form has no-op semantics (operand is a
+            // value, not a Reference) and must not become a PropertyDelete. Gating on
+            // the flag matches upstream, which sees the unfolded ConditionalExpression
+            // and takes the "Only object properties can be deleted" bailout.
+            Data::EDot(d)
+                if d.optional_chain.is_none()
+                    && unary.flags.contains(
+                        E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
+                    ) =>
+            {
                 let object = lower_expression_to_temporary(builder, &d.target)?;
                 Ok(InstructionValue::PropertyDelete {
                     object,
@@ -992,7 +1004,12 @@ fn lower_unary(
                     loc,
                 })
             }
-            Data::EIndex(i) if i.optional_chain.is_none() => {
+            Data::EIndex(i)
+                if i.optional_chain.is_none()
+                    && unary.flags.contains(
+                        E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
+                    ) =>
+            {
                 let object = lower_expression_to_temporary(builder, &i.target)?;
                 let property = lower_expression_to_temporary(builder, &i.index)?;
                 Ok(InstructionValue::ComputedDelete {
@@ -1021,6 +1038,7 @@ fn lower_unary(
             Ok(InstructionValue::UnaryExpression {
                 operator,
                 value,
+                bun_flags: unary.flags,
                 loc,
             })
         }

--- a/src/react_compiler/optimization/constant_propagation.rs
+++ b/src/react_compiler/optimization/constant_propagation.rs
@@ -449,6 +449,7 @@ fn evaluate_instruction(
             operator,
             value,
             loc,
+            ..
         } => match operator {
             UnaryOperator::Not => {
                 let operand = read(constants, value);

--- a/src/react_compiler/optimization/constant_propagation.rs
+++ b/src/react_compiler/optimization/constant_propagation.rs
@@ -449,7 +449,6 @@ fn evaluate_instruction(
             operator,
             value,
             loc,
-            ..
         } => match operator {
             UnaryOperator::Not => {
                 let operand = read(constants, value);

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -557,6 +557,46 @@ describe("bundler", () => {
     },
   });
 
+  // Regression: codegen.rs PropertyDelete/ComputedDelete emitted `E::Unary` with
+  // `UnaryFlags::empty()`. The parser sets `WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS`
+  // for `delete <dot|index>`; the printer re-wraps any `delete <dot|index>`
+  // lacking that flag as `delete (0, obj.prop)`, which evaluates the property to
+  // a value and returns `true` without deleting anything.
+  itBundled("react-compiler/PropertyDeletePreservesReferenceSemantics", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useMemo } from "react";
+        export function useThing(a, b) {
+          return useMemo(() => {
+            const x = { a, b, c: 3 };
+            delete x.b;
+            const key = "c";
+            delete x[key];
+            return x;
+          }, [a, b]);
+        }
+        console.log(JSON.stringify(useThing(1, 2)));
+      `,
+      "/node_modules/react/index.js": `exports.useMemo = (f) => f();`,
+      "/node_modules/react/compiler-runtime.js": `exports.c = n => new Array(n).fill(Symbol.for("react.memo_cache_sentinel"));`,
+      "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    run: { stdout: '{"a":1}' },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // The hook must be compiled (sanity: codegen, not a bailout, is on trial).
+      // With react bundled the `_c` import is renamed, so assert on the
+      // compiler-runtime body being linked in instead.
+      expect(out).toContain("react.memo_cache_sentinel");
+      // `delete (0, x.b)` / `delete (0, x[...])` evaluates to a value, not a
+      // Reference — must not appear for either the dot or index form.
+      expect(out).not.toMatch(/delete\s*\(\s*0\s*,/);
+    },
+  });
+
   itBundled("react-compiler/NonComponentUntouched", {
     files: {
       "/entry.jsx": /* jsx */ `

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -557,11 +557,12 @@ describe("bundler", () => {
     },
   });
 
-  // Regression: codegen.rs PropertyDelete/ComputedDelete emitted `E::Unary` with
-  // `UnaryFlags::empty()`. The parser sets `WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS`
-  // for `delete <dot|index>`; the printer re-wraps any `delete <dot|index>`
-  // lacking that flag as `delete (0, obj.prop)`, which evaluates the property to
-  // a value and returns `true` without deleting anything.
+  // Regression: codegen.rs PropertyDelete/ComputedDelete/UnaryExpression emitted
+  // `E::Unary` with `UnaryFlags::empty()`. The parser sets
+  // `WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS` for `delete <dot|index>`;
+  // the printer re-wraps any `delete <dot|index>` lacking that flag as
+  // `delete (0, obj.prop)`, which evaluates the property to a value and returns
+  // `true` without deleting anything.
   itBundled("react-compiler/PropertyDeletePreservesReferenceSemantics", {
     files: {
       "/entry.jsx": /* jsx */ `
@@ -594,6 +595,84 @@ describe("bundler", () => {
       // `delete (0, x.b)` / `delete (0, x[...])` evaluates to a value, not a
       // Reference — must not appear for either the dot or index form.
       expect(out).not.toMatch(/delete\s*\(\s*0\s*,/);
+    },
+  });
+
+  // Sibling of the above: `WAS_ORIGINALLY_TYPEOF_IDENTIFIER` was also dropped,
+  // so the printer wrapped `typeof undeclared` as `typeof (0, undeclared)`,
+  // which throws ReferenceError instead of returning "undefined" — breaking
+  // the common `typeof window !== "undefined"` SSR check.
+  itBundled("react-compiler/TypeofUnboundIdentifierPreservesFlag", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useMemo } from "react";
+        export function useIsBrowser() {
+          return useMemo(() => typeof window !== "undefined", []);
+        }
+        // The folded-conditional form must keep throwing semantics: the visitor
+        // wraps it as a real (0, x) comma expression, and codegen must not set
+        // the flag just because the operand inlines to an identifier.
+        export function useTypeofFolded() {
+          return useMemo(() => {
+            try {
+              return typeof (true ? NotDeclaredAnywhere : Other);
+            } catch {
+              return "threw";
+            }
+          }, []);
+        }
+        console.log(useIsBrowser(), useTypeofFolded());
+      `,
+      "/node_modules/react/index.js": `exports.useMemo = (f) => f();`,
+      "/node_modules/react/compiler-runtime.js": `exports.c = n => new Array(n).fill(Symbol.for("react.memo_cache_sentinel"));`,
+      "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    run: { stdout: "false threw" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // Both hooks must be compiled (RC drops the `useMemo` wrapper); these
+      // particular bodies need 0 memo slots so compiler-runtime is tree-shaken.
+      expect(out).not.toContain("useMemo(");
+      // `typeof window` must survive as-is; `typeof (true ? ...)` must stay wrapped.
+      expect(out).toMatch(/\btypeof window\b(?!\s*\))/);
+      expect(out).toMatch(/\btypeof\s*\(\s*0\s*,\s*NotDeclaredAnywhere\s*\)/);
+    },
+  });
+
+  // `delete (true ? o.a : o.b)` is a no-op per spec (operand is a value, not a
+  // Reference). The visitor folds the conditional to a bare EDot with the
+  // delete-flag unset; lowering must not turn that into a real PropertyDelete.
+  // Upstream's Babel plugin sees the unfolded ConditionalExpression and bails
+  // with "Only object properties can be deleted", so bailing out here matches.
+  itBundled("react-compiler/DeleteFoldedConditionalKeepsNoOpSemantics", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        export function Comp({ a, b }) {
+          const o = { a, b };
+          const r = delete (true ? o.a : o.b);
+          return <div>{r}{JSON.stringify(o)}</div>;
+        }
+        const el = Comp({ a: 1, b: 2 });
+        console.log(el.props.children.join(""));
+      `,
+      "/node_modules/react/index.js": `module.exports = {};`,
+      "/node_modules/react/jsx-runtime.js": `exports.jsx = exports.jsxs = (t, p) => ({ t, props: p });`,
+      "/node_modules/react/jsx-dev-runtime.js": `exports.jsxDEV = (t, p) => ({ t, props: p });`,
+      "/node_modules/react/compiler-runtime.js": `exports.c = n => new Array(n).fill(Symbol.for("react.memo_cache_sentinel"));`,
+      "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    run: { stdout: 'true{"a":1,"b":2}' },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // The component bails out of compilation (Babel parity), so the delete
+      // stays in its post-visit `delete (0, o.a)` form.
+      expect(out).toMatch(/delete\s*\(\s*0\s*,\s*o\.a\s*\)/);
     },
   });
 


### PR DESCRIPTION
## Problem

`delete obj.prop` and `typeof undeclaredGlobal` inside a react-compiled function both lose their parse-time `E::UnaryFlags` on the round-trip through HIR, so the printer's `(0, ...)` guard (`src/js_printer/lib.rs:4003-4004`) re-wraps them:

```jsx
import { useMemo } from "react";
export function useThing(props) {
  return useMemo(() => {
    const x = { a: props.a, b: props.b };
    delete x.b;                                // prints `delete (0, x.b)` → no-op, returns true
    const k = "a";
    delete x[k];                               // prints `delete (0, x["a"])` → no-op
    return x;
  }, [props.a, props.b]);
}
export function useIsBrowser() {
  return useMemo(() => typeof window !== "undefined", []);  // prints `typeof (0, window)` → ReferenceError under SSR
}
```

```console
$ bun build entry.jsx --react-compiler --external='*' --target=browser
    ..., delete (0, x.b), delete (0, x["a"]), ...
    return typeof (0, window) !== "undefined";
```

## Cause

`src/react_compiler/codegen.rs` rebuilt every `E::Unary` with `flags: UnaryFlags::empty()`:

- `InstructionValue::PropertyDelete` / `InstructionValue::ComputedDelete` dropped `WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS`, so the printer wrapped every `delete <dot|index>` as `delete (0, ...)`, which evaluates the property to a value and returns `true` without deleting.
- `InstructionValue::UnaryExpression` dropped `WAS_ORIGINALLY_TYPEOF_IDENTIFIER`, so the printer wrapped `typeof undeclaredGlobal` as `typeof (0, undeclaredGlobal)`, which throws `ReferenceError` instead of returning `"undefined"`.

`lower_unary` (`src/react_compiler/lowering/build_hir/expr.rs`) discarded `unary.flags` at construction time, so codegen had nothing to restore.

## Fix

- **typeof**: thread `unary.flags` through HIR. `InstructionValue::UnaryExpression` gains a `bun_flags: E::UnaryFlags` field; lowering copies the visited node's flags in and codegen copies them back out. This preserves the visitor's own distinction between `typeof x` (flag set, no wrap) and `typeof (folded-to-x)` (flag unset, visitor already wrapped as a real `(0, x)` comma expression, stays throwing).
- **delete**: set the flag unconditionally at both codegen sites, and gate `lower_unary`'s `EDot`/`EIndex` arms on `unary.flags` so a flagless operand (the visitor folded `delete (true ? a.b : c.d)` to a bare `EDot`) falls through to the existing "Only object properties can be deleted" bailout. That matches upstream's Babel plugin, which sees the unfolded `ConditionalExpression` and bails the same way, and keeps the spec no-op semantics for that edge case.
- `E::UnaryFlags` gains `Debug` (the HIR enum derives `Debug`); the other `bitflags!` in `src/ast/` already do.

Babel's reference output for the upstream `delete-property` / `delete-computed-property` fixtures is plain `delete x.b` / `delete x["b"]`, which this now matches.

## Verification

```console
$ bun bd test test/bundler/transpiler/react-compiler.test.ts
```

New tests (`PropertyDeletePreservesReferenceSemantics`, `TypeofUnboundIdentifierPreservesFlag`) fail on main (`delete (0,` / `typeof (0, window)` in the output; runtime `{"a":1,"b":2,"c":3}` / `ReferenceError`) and pass with this change. `DeleteFoldedConditionalKeepsNoOpSemantics` guards the edge case that an earlier revision of this PR regressed.

Full `react-compiler.test.ts` (35 pass), `react-compiler-fixtures.test.ts` (3293 pass), `bundler_edgecase.test.ts` (117 pass), `transpiler.test.js` (183 pass).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.0 (24ba9a8d5)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [666.07ms]
(pass) bundler > react-compiler/ComponentWithHooks [318.58ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [310.09ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [167.71ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [99.67ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [98.31ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [92.83ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [88.96ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [328.38ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [408.04ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [308.97ms]
(pass) bundler > react-compiler/BranchBooleanFeatureFlagPreservesDCE [297.46ms]
(pass) bundler >
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [25.82ms]
(pass) bundler > react-compiler/ComponentWithHooks [7.97ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [6.81ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [5.18ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [3.72ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [3.44ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [3.27ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [2.90ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [7.82ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [17.67ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [6.30ms]
(pass) bundler > react-compiler/BranchBooleanFeatureFlagPreservesDCE [6.19ms]
(pass) bundler > react-compiler/ForwardRefSiblingFn [6.28ms]
(pass) bundler > react-compiler/SelfRefConstArrow [6.76ms]
(pass) bundler > react-compiler/OutlinedFunctionMinify-syntax=false-identifiers=true 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.0 (24ba9a8d5)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [653.40ms]
(pass) bundler > react-compiler/ComponentWithHooks [308.29ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [318.35ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [165.34ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [95.91ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [96.14ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [91.32ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [95.26ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [334.42ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [419.07ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [330.33ms]
(pass) bundler > react-compiler/BranchBooleanFeatureFlagPreservesDCE [290.63ms]
(pass) bundler >
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     24ba9a8d51
  features     baseline

22 deps, 108 codegen, 1171 objects in 810ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [17.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [7.00ms]
[3/1234] gen bindgenv2
[4/1234] gen ErrorCode+*.h
[5/1234] fetch picohttpparser
[picohttpparser] up to date
[6/1234] gen .bind.ts → GeneratedBindings.cpp
[7/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [7.00ms]
[8/1234] fetch tinycc
[tinycc] up to date
[9/1234] fetch zlib
[zlib] up to date
[10/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/e.rs                                       |   2 +-
 src/react_compiler/codegen.rs                      |  12 ++-
 src/react_compiler/hir/mod.rs                      |   2 +
 src/react_compiler/lowering/build_hir/expr.rs      |  16 ++-
 .../optimization/constant_propagation.rs           |   1 +
 test/bundler/transpiler/react-compiler.test.ts     | 119 +++++++++++++++++++++
 6 files changed, 145 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/ast/e.rs                                                 1      1      0
src/react_compiler/codegen.rs                                2      5      0
src/react_compiler/hir/mod.rs                                2      2      0
src/react_compiler/lowering/build_hir/expr.rs                3      4      0
src/react_compiler/optimization/constant_propagation.rs      1      1      0
test/bundler/transpiler/react-compiler.test.ts               1      4      0
```

</details>

<!-- robobun:evidence:end -->