### PR TITLE
react_compiler: preserve typeof unbound-global semantics in codegen

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -135,7 +135,7 @@ pub struct Unary {
 }
 
 bitflags::bitflags! {
-    #[derive(Clone, Copy, Default, PartialEq, Eq)]
+    #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
     #[repr(transparent)]
     pub struct UnaryFlags: u8 {
         /// The expression "typeof (0, x)" must not become "typeof x" if "x"

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -1853,14 +1853,17 @@ fn codegen_base_instruction_value(
             ))
         }
         InstructionValue::UnaryExpression {
-            operator, value, ..
+            operator,
+            value,
+            flags,
+            ..
         } => {
             let arg = codegen_place_to_expression(cx, value)?;
             Ok(Expr::init(
                 E::Unary {
                     op: convert_unary_operator(*operator),
                     value: arg,
-                    flags: E::UnaryFlags::empty(),
+                    flags: *flags,
                 },
                 loc,
             ))

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -752,10 +752,7 @@ pub enum InstructionValue {
     UnaryExpression {
         operator: UnaryOperator,
         value: Place,
-        /// Bun's printer re-wraps `typeof <unbound-identifier>` as `typeof (0, x)`
-        /// unless `WAS_ORIGINALLY_TYPEOF_IDENTIFIER` is set, so codegen must
-        /// restore the parse-time flag. Upstream has no equivalent because
-        /// Babel's generator never inserts the `(0, …)` guard.
+        /// Parse-time `E::UnaryFlags`, threaded back to codegen for the printer.
         flags: bun_ast::e::UnaryFlags,
         loc: Option<SourceLocation>,
     },

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -752,6 +752,11 @@ pub enum InstructionValue {
     UnaryExpression {
         operator: UnaryOperator,
         value: Place,
+        /// Bun's printer re-wraps `typeof <unbound-identifier>` as `typeof (0, x)`
+        /// unless `WAS_ORIGINALLY_TYPEOF_IDENTIFIER` is set, so codegen must
+        /// restore the parse-time flag. Upstream has no equivalent because
+        /// Babel's generator never inserts the `(0, …)` guard.
+        flags: bun_ast::e::UnaryFlags,
         loc: Option<SourceLocation>,
     },
     TypeCastExpression {

--- a/src/react_compiler/lowering/build_hir/expr.rs
+++ b/src/react_compiler/lowering/build_hir/expr.rs
@@ -1021,6 +1021,7 @@ fn lower_unary(
             Ok(InstructionValue::UnaryExpression {
                 operator,
                 value,
+                flags: unary.flags,
                 loc,
             })
         }

--- a/src/react_compiler/optimization/constant_propagation.rs
+++ b/src/react_compiler/optimization/constant_propagation.rs
@@ -449,6 +449,7 @@ fn evaluate_instruction(
             operator,
             value,
             loc,
+            ..
         } => match operator {
             UnaryOperator::Not => {
                 let operand = read(constants, value);

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -891,4 +891,71 @@ describe("bundler", () => {
       expect(out).toMatch(/__MEMO_CACHE_SENTINEL\)\s*\{[^}]*globalFn\(\)/);
     },
   });
+
+  // Regression: codegen.rs UnaryExpression emitted `E::Unary` with
+  // `UnaryFlags::empty()`. The parser sets `WAS_ORIGINALLY_TYPEOF_IDENTIFIER`
+  // for `typeof <identifier>`; without that flag the printer re-wraps an
+  // unbound operand as `typeof (0, x)`, which evaluates `x` and throws a
+  // ReferenceError instead of returning "undefined".
+  itBundled("react-compiler/TypeofUnboundGlobalReturnsUndefined", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useMemo } from "react";
+        export function useThing(a) {
+          return useMemo(() => [typeof SomeUnboundGlobal, a], [a]);
+        }
+        console.log(JSON.stringify(useThing(1)));
+      `,
+      "/node_modules/react/index.js": `exports.useMemo = (f) => f();`,
+      "/node_modules/react/compiler-runtime.js": `exports.c = n => new Array(n).fill(Symbol.for("react.memo_cache_sentinel"));`,
+      "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    run: { stdout: '["undefined",1]' },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // The hook must be compiled (codegen, not a bailout, is on trial).
+      // With react bundled the `_c` import is renamed, so assert on the
+      // compiler-runtime body being linked in instead.
+      expect(out).toContain("react.memo_cache_sentinel");
+      // `typeof (0, SomeUnboundGlobal)` evaluates the reference and throws.
+      expect(out).not.toMatch(/typeof\s*\(\s*0\s*,\s*SomeUnboundGlobal/);
+      expect(out).toMatch(/typeof\s+SomeUnboundGlobal\b/);
+    },
+  });
+
+  // Control: the parse-time flag is NOT set for `typeof (0, x)`. Lowering
+  // discards the side-effect-free `0`, so codegen sees a bare identifier
+  // again; the printer must still re-wrap because the source did not have
+  // `typeof <identifier>` semantics.
+  itBundled("react-compiler/TypeofSequenceUnboundGlobalStillThrows", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useMemo } from "react";
+        export function useThing(a) {
+          return useMemo(() => [typeof (0, SomeUnboundGlobal), a], [a]);
+        }
+        try {
+          useThing(1);
+          console.log("no throw");
+        } catch (e) {
+          console.log(e instanceof ReferenceError ? "ReferenceError" : "other");
+        }
+      `,
+      "/node_modules/react/index.js": `exports.useMemo = (f) => f();`,
+      "/node_modules/react/compiler-runtime.js": `exports.c = n => new Array(n).fill(Symbol.for("react.memo_cache_sentinel"));`,
+      "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    run: { stdout: "ReferenceError" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain("react.memo_cache_sentinel");
+      expect(out).toMatch(/typeof\s*\(\s*0\s*,\s*SomeUnboundGlobal/);
+    },
+  });
 });


### PR DESCRIPTION
## Problem

`typeof unboundGlobal` inside a react-compiled function prints as `typeof (0, unboundGlobal)`, which throws `ReferenceError` instead of returning `"undefined"`.

```jsx
import { useMemo } from "react";
export function useThing() {
  return useMemo(() => typeof SomeUnboundGlobal, []);
}
```

```console
$ bun build entry.jsx --react-compiler --external='*' --target=browser
...
function useThing() {
  return typeof (0, SomeUnboundGlobal);
}
```

This breaks the feature-detection idiom (`typeof WebSocket !== "undefined"` etc.) in any hook or component the compiler rewrites.

## Cause

`src/react_compiler/codegen.rs` at `InstructionValue::UnaryExpression` emits `E::Unary { op: UnTypeof, flags: E::UnaryFlags::empty() }`. The printer (`src/js_printer/lib.rs:4003`) re-wraps any `typeof <unbound EIdentifier>` that lacks `WAS_ORIGINALLY_TYPEOF_IDENTIFIER` as `typeof (0, ...)`, to preserve the throwing semantics of e.g. `typeof (a ?? b)` after folding.

The parser sets that flag for `typeof <EIdentifier>` (`src/js_parser/parse/parse_prefix.rs:369-371`), but `lower_unary` (`src/react_compiler/lowering/build_hir/expr.rs:1016-1026`) did not capture `unary.flags`, so the HIR had no way to distinguish `typeof x` from `typeof (0, x)` at codegen time. Both collapse to `UnaryExpression { TypeOf, <temp-for-LoadGlobal> }`, because sequence lowering discards the side-effect-free `0` and inlines the global load.

Upstream's HIR also drops the distinction, but `@babel/generator` never inserts a defensive `(0, ...)` wrap, so Babel emits `typeof x` for both forms.

## Fix

Thread the parse-time `E::UnaryFlags` through `InstructionValue::UnaryExpression` and emit them back in codegen. `typeof x` then keeps `WAS_ORIGINALLY_TYPEOF_IDENTIFIER` so the printer leaves it alone; `typeof (0, x)` has an empty flag set so the printer still re-wraps the inlined identifier. `typeof (sideEffect(), x)` is unaffected (the operand stays a sequence, which the printer never wraps).

This is stricter than Babel's reference output (which loses the throw for `typeof (0, x)`), but it matches the source semantics in every case. Sibling of #36741; that one can set the delete flag unconditionally because `PropertyDelete`/`ComputedDelete` are only lowered from `delete <EDot|EIndex>`, whereas `UnaryExpression { TypeOf }` is reached from both flagged and unflagged sources.

Also adds `Debug` to `E::UnaryFlags` so the HIR `#[derive(Debug)]` keeps compiling.

## Verification

```console
$ bun bd test test/bundler/transpiler/react-compiler.test.ts -t TypeofUnboundGlobal
# TypeofUnboundGlobalReturnsUndefined: fails on main (output contains `typeof (0, SomeUnboundGlobal)` and run throws)
# TypeofSequenceUnboundGlobalStillThrows: passes on both (control)
# both pass with this change
```

Full `react-compiler.test.ts` (34 pass) and `react-compiler-fixtures.test.ts` (3293 pass, 320 skip) pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.0 (eeac6ea72)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [672.22ms]
(pass) bundler > react-compiler/ComponentWithHooks [299.48ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [311.71ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [183.13ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [103.88ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [125.64ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [95.64ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [112.12ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [380.78ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [475.61ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [334.92ms]
(pass) bundler > react-compiler/BranchBooleanFeatureFlagPreservesDCE [349.05ms]
(pass) bundle
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (d75001695)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [18.57ms]
(pass) bundler > react-compiler/ComponentWithHooks [7.04ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [7.80ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [5.96ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [2.91ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [4.29ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [2.88ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [2.40ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [7.45ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [12.11ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [7.07ms]
(pass) bundler > react-compiler/BranchBooleanFeatureFlagPreservesDCE [6.29ms]
(pass) bundler > react-compiler/ForwardRefSiblingFn [6.11ms]
(pass) bundler > react-compiler/SelfRefConstArrow [5.89ms]
(pass) bundler > react-compiler/OutlinedFunctionMinify-syntax=false-identifiers=true 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.0 (eeac6ea72)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [686.47ms]
(pass) bundler > react-compiler/ComponentWithHooks [316.62ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [328.66ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [199.49ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [99.27ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [112.06ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [107.43ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [93.92ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [331.42ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [427.64ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [330.02ms]
(pass) bundler > react-compiler/BranchBooleanFeatureFlagPreservesDCE [293.72ms]
(pass) bundler
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 711ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/e.rs                                       |  2 +-
 src/react_compiler/codegen.rs                      |  7 ++-
 src/react_compiler/hir/mod.rs                      |  2 +
 src/react_compiler/lowering/build_hir/expr.rs      |  1 +
 .../optimization/constant_propagation.rs           |  1 +
 test/bundler/transpiler/react-compiler.test.ts     | 67 ++++++++++++++++++++++
 6 files changed, 77 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/ast/e.rs                                                 1      1      0
src/react_compiler/codegen.rs                                5      1      0
src/react_compiler/hir/mod.rs                                6      3      0
src/react_compiler/lowering/build_hir/expr.rs                3      1      0
src/react_compiler/optimization/constant_propagation.rs      1      1      0
test/bundler/transpiler/react-compiler.test.ts               2      2      0
```

</details>

<!-- robobun:evidence:end -->