### PR TITLE
js_printer: wrap cross-module enum inlined as a delete operand when non-finite

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1242,10 +1242,6 @@ pub enum ExprFlag {
     HasNonOptionalChainParent,
     ExprResultIsUnused,
     IsFollowedByOf,
-    /// The expression is the direct operand of a `delete` whose source form was
-    /// an identifier or property access. A print-time rewrite that would
-    /// surface a bare identifier here (e.g. cross-module enum inlining to
-    /// `NaN`/`Infinity`) must keep it a value, not a Reference.
     IsDeleteTarget,
 }
 
@@ -3313,8 +3309,6 @@ pub(crate) mod __gated_printer {
                 }
                 ExprData::EIndex(e) => {
                     let is_delete_target = flags.contains(ExprFlag::IsDeleteTarget);
-                    // The delete target is this index expression itself, never its target
-                    // or index subexpressions.
                     flags.remove(ExprFlag::IsDeleteTarget);
 
                     let mut wrap = false;
@@ -4030,14 +4024,8 @@ pub(crate) mod __gated_printer {
                                 E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
                             )
                         {
-                            // The operand was a property access / identifier in source, so
-                            // the `(0, ...)` re-wrap above is skipped. Cross-module enum
-                            // inlining in the EDot/EIndex print arms can still replace that
-                            // access with `NaN`/`Infinity` (a strict-mode `delete <id>`
-                            // SyntaxError). Tell the operand it is the delete target so the
-                            // inline path can wrap itself. Gating on the parse-time flag keeps
-                            // this from reaching compound operands (EIf/EBinary) that forward
-                            // `flags` to children which are not themselves delete targets.
+                            // Gate on the parse-time flag so this never reaches compound
+                            // operands (EIf/EBinary) that forward `flags` to non-target children.
                             value_flags.insert(ExprFlag::IsDeleteTarget);
                         }
                         self.print_expr(e.value, Level::Prefix.sub(1), value_flags);
@@ -6193,11 +6181,8 @@ pub(crate) mod __gated_printer {
             level: Level,
             is_delete_target: bool,
         ) {
-            // `delete E.N` sets WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS, so the
-            // EUnary arm does not re-wrap. Inlining a non-finite number here would then print
-            // `delete NaN` / `delete Infinity`: a strict-mode SyntaxError. Wrap in `(0, ...)`
-            // so the operand stays a value; `delete <value>` evaluates to `true`, matching the
-            // source semantics (enum members are configurable).
+            // `delete NaN` / `delete Infinity` is a strict-mode SyntaxError; wrap so the
+            // inlined value stays a value, not a Reference.
             let wrap = is_delete_target
                 && matches!(inlined, js_ast::InlinedEnumValueDecoded::Number(n) if !n.is_finite());
             let level = if wrap {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1242,7 +1242,6 @@ pub enum ExprFlag {
     HasNonOptionalChainParent,
     ExprResultIsUnused,
     IsFollowedByOf,
-    IsDeleteTarget,
 }
 
 pub(crate) type ExprFlagSet = enumset::EnumSet<ExprFlag>;
@@ -3256,7 +3255,6 @@ pub(crate) mod __gated_printer {
                 }
                 ExprData::EDot(e) => {
                     let is_optional_chain = e.optional_chain == Some(js_ast::OptionalChain::Start);
-                    let is_delete_target = flags.contains(ExprFlag::IsDeleteTarget);
 
                     let mut wrap = false;
                     if e.optional_chain.is_none() {
@@ -3266,7 +3264,7 @@ pub(crate) mod __gated_printer {
                         if let Some(inlined) =
                             self.try_to_get_imported_enum_value(e.target, &e.name)
                         {
-                            self.print_inlined_enum(inlined, &e.name, level, is_delete_target);
+                            self.print_inlined_enum(inlined, &e.name, level);
                             return;
                         }
                     } else {
@@ -3308,9 +3306,6 @@ pub(crate) mod __gated_printer {
                     }
                 }
                 ExprData::EIndex(e) => {
-                    let is_delete_target = flags.contains(ExprFlag::IsDeleteTarget);
-                    flags.remove(ExprFlag::IsDeleteTarget);
-
                     let mut wrap = false;
                     if e.optional_chain.is_none() {
                         flags.insert(ExprFlag::HasNonOptionalChainParent);
@@ -3321,12 +3316,7 @@ pub(crate) mod __gated_printer {
                                 if let Some(value) =
                                     self.try_to_get_imported_enum_value(e.target, str.slice8())
                                 {
-                                    self.print_inlined_enum(
-                                        value,
-                                        str.slice8(),
-                                        level,
-                                        is_delete_target,
-                                    );
+                                    self.print_inlined_enum(value, str.slice8(), level);
                                     return;
                                 }
                             }
@@ -4018,17 +4008,7 @@ pub(crate) mod __gated_printer {
                         self.print_expr(e.value, Level::Prefix.sub(1), ExprFlag::none());
                         self.print(b")");
                     } else {
-                        let mut value_flags = ExprFlag::none();
-                        if e.op == Op::Code::UnDelete
-                            && e.flags.contains(
-                                E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
-                            )
-                        {
-                            // Gate on the parse-time flag so this never reaches compound
-                            // operands (EIf/EBinary) that forward `flags` to non-target children.
-                            value_flags.insert(ExprFlag::IsDeleteTarget);
-                        }
-                        self.print_expr(e.value, Level::Prefix.sub(1), value_flags);
+                        self.print_expr(e.value, Level::Prefix.sub(1), ExprFlag::none());
                     }
                     }
 
@@ -6179,20 +6159,7 @@ pub(crate) mod __gated_printer {
             inlined: js_ast::InlinedEnumValueDecoded,
             comment: &[u8],
             level: Level,
-            is_delete_target: bool,
         ) {
-            // `delete NaN` / `delete Infinity` is a strict-mode SyntaxError; wrap so the
-            // inlined value stays a value, not a Reference.
-            let wrap = is_delete_target
-                && matches!(inlined, js_ast::InlinedEnumValueDecoded::Number(n) if !n.is_finite());
-            let level = if wrap {
-                self.print(b"(0,");
-                self.print_space();
-                Level::Comma
-            } else {
-                level
-            };
-
             match inlined {
                 js_ast::InlinedEnumValueDecoded::Number(num) => self.print_number(num, level),
                 // TODO: extract printString
@@ -6217,10 +6184,6 @@ pub(crate) mod __gated_printer {
                     self.print(comment);
                     self.print(b" */");
                 }
-            }
-
-            if wrap {
-                self.print(b")");
             }
         }
 

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1242,6 +1242,7 @@ pub enum ExprFlag {
     HasNonOptionalChainParent,
     ExprResultIsUnused,
     IsFollowedByOf,
+    IsDeleteTarget,
 }
 
 pub(crate) type ExprFlagSet = enumset::EnumSet<ExprFlag>;
@@ -3255,6 +3256,7 @@ pub(crate) mod __gated_printer {
                 }
                 ExprData::EDot(e) => {
                     let is_optional_chain = e.optional_chain == Some(js_ast::OptionalChain::Start);
+                    let is_delete_target = flags.contains(ExprFlag::IsDeleteTarget);
 
                     let mut wrap = false;
                     if e.optional_chain.is_none() {
@@ -3264,7 +3266,7 @@ pub(crate) mod __gated_printer {
                         if let Some(inlined) =
                             self.try_to_get_imported_enum_value(e.target, &e.name)
                         {
-                            self.print_inlined_enum(inlined, &e.name, level);
+                            self.print_inlined_enum(inlined, &e.name, level, is_delete_target);
                             return;
                         }
                     } else {
@@ -3306,6 +3308,9 @@ pub(crate) mod __gated_printer {
                     }
                 }
                 ExprData::EIndex(e) => {
+                    let is_delete_target = flags.contains(ExprFlag::IsDeleteTarget);
+                    flags.remove(ExprFlag::IsDeleteTarget);
+
                     let mut wrap = false;
                     if e.optional_chain.is_none() {
                         flags.insert(ExprFlag::HasNonOptionalChainParent);
@@ -3316,7 +3321,12 @@ pub(crate) mod __gated_printer {
                                 if let Some(value) =
                                     self.try_to_get_imported_enum_value(e.target, str.slice8())
                                 {
-                                    self.print_inlined_enum(value, str.slice8(), level);
+                                    self.print_inlined_enum(
+                                        value,
+                                        str.slice8(),
+                                        level,
+                                        is_delete_target,
+                                    );
                                     return;
                                 }
                             }
@@ -4008,7 +4018,15 @@ pub(crate) mod __gated_printer {
                         self.print_expr(e.value, Level::Prefix.sub(1), ExprFlag::none());
                         self.print(b")");
                     } else {
-                        self.print_expr(e.value, Level::Prefix.sub(1), ExprFlag::none());
+                        let mut value_flags = ExprFlag::none();
+                        if e.op == Op::Code::UnDelete
+                            && e.flags.contains(
+                                E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
+                            )
+                        {
+                            value_flags.insert(ExprFlag::IsDeleteTarget);
+                        }
+                        self.print_expr(e.value, Level::Prefix.sub(1), value_flags);
                     }
                     }
 
@@ -6159,7 +6177,19 @@ pub(crate) mod __gated_printer {
             inlined: js_ast::InlinedEnumValueDecoded,
             comment: &[u8],
             level: Level,
+            is_delete_target: bool,
         ) {
+            // "delete NaN" / "delete Infinity" is a strict-mode SyntaxError
+            let wrap = is_delete_target
+                && matches!(inlined, js_ast::InlinedEnumValueDecoded::Number(n) if !n.is_finite());
+            let level = if wrap {
+                self.print(b"(0,");
+                self.print_space();
+                Level::Comma
+            } else {
+                level
+            };
+
             match inlined {
                 js_ast::InlinedEnumValueDecoded::Number(num) => self.print_number(num, level),
                 // TODO: extract printString
@@ -6184,6 +6214,10 @@ pub(crate) mod __gated_printer {
                     self.print(comment);
                     self.print(b" */");
                 }
+            }
+
+            if wrap {
+                self.print(b")");
             }
         }
 

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1242,6 +1242,11 @@ pub enum ExprFlag {
     HasNonOptionalChainParent,
     ExprResultIsUnused,
     IsFollowedByOf,
+    /// The expression is the direct operand of a `delete` whose source form was
+    /// an identifier or property access. A print-time rewrite that would
+    /// surface a bare identifier here (e.g. cross-module enum inlining to
+    /// `NaN`/`Infinity`) must keep it a value, not a Reference.
+    IsDeleteTarget,
 }
 
 pub(crate) type ExprFlagSet = enumset::EnumSet<ExprFlag>;
@@ -3255,6 +3260,7 @@ pub(crate) mod __gated_printer {
                 }
                 ExprData::EDot(e) => {
                     let is_optional_chain = e.optional_chain == Some(js_ast::OptionalChain::Start);
+                    let is_delete_target = flags.contains(ExprFlag::IsDeleteTarget);
 
                     let mut wrap = false;
                     if e.optional_chain.is_none() {
@@ -3264,7 +3270,7 @@ pub(crate) mod __gated_printer {
                         if let Some(inlined) =
                             self.try_to_get_imported_enum_value(e.target, &e.name)
                         {
-                            self.print_inlined_enum(inlined, &e.name, level);
+                            self.print_inlined_enum(inlined, &e.name, level, is_delete_target);
                             return;
                         }
                     } else {
@@ -3306,6 +3312,11 @@ pub(crate) mod __gated_printer {
                     }
                 }
                 ExprData::EIndex(e) => {
+                    let is_delete_target = flags.contains(ExprFlag::IsDeleteTarget);
+                    // The delete target is this index expression itself, never its target
+                    // or index subexpressions.
+                    flags.remove(ExprFlag::IsDeleteTarget);
+
                     let mut wrap = false;
                     if e.optional_chain.is_none() {
                         flags.insert(ExprFlag::HasNonOptionalChainParent);
@@ -3316,7 +3327,12 @@ pub(crate) mod __gated_printer {
                                 if let Some(value) =
                                     self.try_to_get_imported_enum_value(e.target, str.slice8())
                                 {
-                                    self.print_inlined_enum(value, str.slice8(), level);
+                                    self.print_inlined_enum(
+                                        value,
+                                        str.slice8(),
+                                        level,
+                                        is_delete_target,
+                                    );
                                     return;
                                 }
                             }
@@ -4008,7 +4024,23 @@ pub(crate) mod __gated_printer {
                         self.print_expr(e.value, Level::Prefix.sub(1), ExprFlag::none());
                         self.print(b")");
                     } else {
-                        self.print_expr(e.value, Level::Prefix.sub(1), ExprFlag::none());
+                        let mut value_flags = ExprFlag::none();
+                        if e.op == Op::Code::UnDelete
+                            && e.flags.contains(
+                                E::UnaryFlags::WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS,
+                            )
+                        {
+                            // The operand was a property access / identifier in source, so
+                            // the `(0, ...)` re-wrap above is skipped. Cross-module enum
+                            // inlining in the EDot/EIndex print arms can still replace that
+                            // access with `NaN`/`Infinity` (a strict-mode `delete <id>`
+                            // SyntaxError). Tell the operand it is the delete target so the
+                            // inline path can wrap itself. Gating on the parse-time flag keeps
+                            // this from reaching compound operands (EIf/EBinary) that forward
+                            // `flags` to children which are not themselves delete targets.
+                            value_flags.insert(ExprFlag::IsDeleteTarget);
+                        }
+                        self.print_expr(e.value, Level::Prefix.sub(1), value_flags);
                     }
                     }
 
@@ -6159,7 +6191,23 @@ pub(crate) mod __gated_printer {
             inlined: js_ast::InlinedEnumValueDecoded,
             comment: &[u8],
             level: Level,
+            is_delete_target: bool,
         ) {
+            // `delete E.N` sets WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS, so the
+            // EUnary arm does not re-wrap. Inlining a non-finite number here would then print
+            // `delete NaN` / `delete Infinity`: a strict-mode SyntaxError. Wrap in `(0, ...)`
+            // so the operand stays a value; `delete <value>` evaluates to `true`, matching the
+            // source semantics (enum members are configurable).
+            let wrap = is_delete_target
+                && matches!(inlined, js_ast::InlinedEnumValueDecoded::Number(n) if !n.is_finite());
+            let level = if wrap {
+                self.print(b"(0,");
+                self.print_space();
+                Level::Comma
+            } else {
+                level
+            };
+
             match inlined {
                 js_ast::InlinedEnumValueDecoded::Number(num) => self.print_number(num, level),
                 // TODO: extract printString
@@ -6184,6 +6232,10 @@ pub(crate) mod __gated_printer {
                     self.print(comment);
                     self.print(b" */");
                 }
+            }
+
+            if wrap {
+                self.print(b")");
             }
         }
 

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -2236,11 +2236,6 @@ describe("bundler", () => {
       ]);
     },
   });
-  // Cross-module enum inlining happens at print time after
-  // WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS has already bypassed the
-  // `(0, ...)` re-wrap in the EUnary print arm. When the inlined value prints as `NaN`
-  // or `Infinity` that yields `delete NaN`, a strict-mode SyntaxError in the ESM bundle.
-  // Finite numbers and strings are fine (`delete 42` / `delete "s"` are valid and true).
   itBundled("ts/EnumCrossModuleInliningDeleteTarget", {
     files: {
       "/entry.ts": /* ts */ `

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -2236,6 +2236,69 @@ describe("bundler", () => {
       ]);
     },
   });
+  // Cross-module enum inlining happens at print time after
+  // WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS has already bypassed the
+  // `(0, ...)` re-wrap in the EUnary print arm. When the inlined value prints as `NaN`
+  // or `Infinity` that yields `delete NaN`, a strict-mode SyntaxError in the ESM bundle.
+  // Finite numbers and strings are fine (`delete 42` / `delete "s"` are valid and true).
+  itBundled("ts/EnumCrossModuleInliningDeleteTarget", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { E } from './enums'
+        console.log(JSON.stringify([
+          delete E.N,
+          delete E.I,
+          delete E.NI,
+          delete E.F,
+          delete E.S,
+          delete E["N"],
+          delete E["I"],
+        ]))
+      `,
+      "/enums.ts": /* ts */ `
+        export enum E {
+          N = 0 / 0,
+          I = 1 / 0,
+          NI = -1 / 0,
+          F = 42,
+          S = "s",
+        }
+      `,
+    },
+    minifySyntax: false, // intentionally disabled. enum inlining always happens
+    run: { stdout: "[true,true,true,true,true,true,true]" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // The bundle is an ES module: `delete NaN` / `delete Infinity` would be a
+      // SyntaxError. Non-finite values must be wrapped; finite/string values need not be.
+      expect(out).not.toContain("delete NaN");
+      expect(out).not.toContain("delete Infinity");
+      expect(out).toContain("delete (0, NaN /* N */)");
+      expect(out).toContain("delete (0, Infinity /* I */)");
+      expect(out).toContain("delete (0, -Infinity /* NI */)");
+      expect(out).toContain("delete 42 /* F */");
+      expect(out).toContain('delete "s" /* S */');
+    },
+  });
+  itBundled("ts/EnumCrossModuleInliningDeleteTargetMinified", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { E } from './enums'
+        console.log(JSON.stringify([delete E.N, delete E.I, delete E["N"]]))
+      `,
+      "/enums.ts": /* ts */ `
+        export enum E { N = 0 / 0, I = 1 / 0 }
+      `,
+    },
+    minifyWhitespace: true,
+    minifySyntax: true,
+    run: { stdout: "[true,true,true]" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).not.toContain("delete NaN");
+      expect(out).toContain("delete(0,NaN)");
+    },
+  });
   itBundled("ts/EnumExportClause", {
     files: {
       "/entry.ts": /* ts */ `


### PR DESCRIPTION
## Problem

```ts
// enums.ts
export enum E { N = 0/0, I = 1/0 }
// entry.ts
import { E } from './enums';
globalThis.r = delete E.N;
```

```console
$ bun build ./entry.ts
globalThis.r = delete NaN /* N */;
$ node <(bun build ./entry.ts)
SyntaxError: Delete of an unqualified identifier in strict mode.
```

Cross-module TS enum inlining happens at print time in the `EDot`/`EIndex` arms via `try_to_get_imported_enum_value`. The source is `delete E.N` (an `EDot`), so `WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS` is set and the `(0, ...)` re-wrap in the `EUnary` arm is skipped; the `EDot` arm then replaces the property access with `NaN` / `Infinity`, which are identifier references and therefore a strict-mode `delete <id>` SyntaxError in the emitted ESM bundle. esbuild has the same bug.

Related but distinct:

- #36740 handles the `(0, ...)` re-wrap when the parse-time flag is **unset** (operand was not a property access in source) by extending `is_identifier_or_numeric_constant_or_property_access`. That guard is short-circuited here because the flag is set.
- #36734 sets `p.delete_target` in the visitor so same-module enum references (which become `EInlinedEnum` at visit time) are not inlined when they are the delete target. That does not reach this path: `try_to_get_imported_enum_value` fires at print time after the visit pass, keyed on `EImportIdentifier`.

## Fix

Add `ExprFlag::IsDeleteTarget` and set it when printing the operand of `delete` whose parse-time flag is set (so it never reaches compound operands like `EIf`/`EBinary` that forward `flags` to children which are not themselves delete targets). `print_inlined_enum` wraps in `(0, ...)` when `is_delete_target` and the value is a non-finite number. Finite numbers and strings are left as-is (`delete 42` / `delete "s"` are valid strict-mode expressions that already evaluate to `true`).

`delete (0, NaN)` evaluates to `true`, matching the source semantics: enum members are own configurable data properties, so `delete E.N` returns `true`. Keeping the property access instead of inlining would require the linker to retain the enum object for this one use; the wrap preserves the return value without that coupling and is consistent with the existing semantic model for enum inlining.

```console
$ bun build ./entry.ts
globalThis.r = delete (0, NaN /* N */);
```

## Verification

```console
$ bun bd test test/bundler/esbuild/ts.test.ts -t EnumCrossModuleInliningDeleteTarget   # 2 new tests, fail on main
```

Full `esbuild/ts.test.ts` (59 pass), `bundler_edgecase.test.ts` (117 pass), `bundler_minify.test.ts` (42 pass), `transpiler.test.js` (183 pass), `esbuild/default.test.ts` (151 pass), `esbuild/dce.test.ts` (78 pass) unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 10 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/ts.test.ts
bun test v1.4.0 (a05e926a4)

test/bundler/esbuild/ts.test.ts:
(pass) bundler > ts/DeclareConst [539.55ms]
(pass) bundler > ts/DeclareLet [93.69ms]
(pass) bundler > ts/DeclareVar [91.67ms]
(pass) bundler > ts/DeclareClass [89.39ms]
(pass) bundler > ts/DeclareClassFields [441.93ms]
(pass) bundler > ts/DeclareFunction [92.88ms]
(pass) bundler > ts/DeclareNamespace [85.05ms]
(pass) bundler > ts/DeclareEnum [89.57ms]
(pass) bundler > ts/DeclareConstEnum [91.03ms]
(pass) bundler > ts/ConstEnumComments [390.49ms]
(pass) bundler > ts/ImportEmptyNamespace [372.60ms]
(pass) bundler > ts/ImportMissingES6 [96.77ms]
(pass) bundler > ts/ImportMissingUnusedES6 [86.96ms]
(todo) bundler > ts/ExportMissingES6
(pass) bundler > ts/ImportMissingFile [82.19ms]
(pass) bundler > ts/ImportTypeOnlyFile [368.64ms]
(pass) bundler > ts/ExportEquals [408.13ms]
(pass) bundler > ts/ExportNamespace [384.10ms]
(pass) bundler > ts/MinifyEnumExported [179.70ms]
(pass) bundler > ts/MinifyNestedEnum [134.23ms]
(pass) bundler > ts/MinifyNames
... (truncated)

release without fix: 10 skipped
bun test v1.4.0-canary.1 (6f75b3f95)

test/bundler/esbuild/ts.test.ts:
(pass) bundler > ts/DeclareConst [13.85ms]
(pass) bundler > ts/DeclareLet [3.60ms]
(pass) bundler > ts/DeclareVar [3.45ms]
(pass) bundler > ts/DeclareClass [3.21ms]
(pass) bundler > ts/DeclareClassFields [11.24ms]
(pass) bundler > ts/DeclareFunction [3.15ms]
(pass) bundler > ts/DeclareNamespace [2.92ms]
(pass) bundler > ts/DeclareEnum [3.18ms]
(pass) bundler > ts/DeclareConstEnum [3.41ms]
(pass) bundler > ts/ConstEnumComments [11.54ms]
(pass) bundler > ts/ImportEmptyNamespace [10.60ms]
(pass) bundler > ts/ImportMissingES6 [3.88ms]
(pass) bundler > ts/ImportMissingUnusedES6 [4.12ms]
(todo) bundler > ts/ExportMissingES6
(pass) bundler > ts/ImportMissingFile [3.11ms]
(pass) bundler > ts/ImportTypeOnlyFile [10.66ms]
(pass) bundler > ts/ExportEquals [12.56ms]
(pass) bundler > ts/ExportNamespace [11.28ms]
(pass) bundler > ts/MinifyEnumExported [3.78ms]
(pass) bundler > ts/MinifyNestedEnum [5.05ms]
(pass) bundler > ts/MinifyNamespace [3.73ms]
(pass) bundler > ts/MinifyDerivedClass [30.38ms]
(pass) bundler > ts/ImportVsLocalCollisionAllTypes [11.69ms]
(pass) bundler > ts/ImportVsLocalCollisionMixed [9.95
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 10 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/ts.test.ts
bun test v1.4.0 (a05e926a4)

test/bundler/esbuild/ts.test.ts:
(pass) bundler > ts/DeclareConst [531.72ms]
(pass) bundler > ts/DeclareLet [109.04ms]
(pass) bundler > ts/DeclareVar [89.93ms]
(pass) bundler > ts/DeclareClass [90.90ms]
(pass) bundler > ts/DeclareClassFields [444.48ms]
(pass) bundler > ts/DeclareFunction [98.77ms]
(pass) bundler > ts/DeclareNamespace [86.16ms]
(pass) bundler > ts/DeclareEnum [87.58ms]
(pass) bundler > ts/DeclareConstEnum [93.80ms]
(pass) bundler > ts/ConstEnumComments [391.13ms]
(pass) bundler > ts/ImportEmptyNamespace [373.64ms]
(pass) bundler > ts/ImportMissingES6 [96.42ms]
(pass) bundler > ts/ImportMissingUnusedES6 [84.47ms]
(todo) bundler > ts/ExportMissingES6
(pass) bundler > ts/ImportMissingFile [81.68ms]
(pass) bundler > ts/ImportTypeOnlyFile [375.97ms]
(pass) bundler > ts/ExportEquals [398.62ms]
(pass) bundler > ts/ExportNamespace [372.37ms]
(pass) bundler > ts/MinifyEnumExported [180.98ms]
(pass) bundler > ts/MinifyNestedEnum [132.42ms]
(pass) bundler > ts/MinifyName
... (truncated)

release with fix: 10 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 698ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_printer/lib.rs           | 40 +++++++++++++++++++++++++---
 test/bundler/esbuild/ts.test.ts | 58 +++++++++++++++++++++++++++++++++++++++++
 2 files changed, 95 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/js_printer/lib.rs               11     13      0
test/bundler/esbuild/ts.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->