### PR TITLE
fix(http): abort chunked responses after controller.error()

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3210,7 +3210,35 @@ where
                             // If we've received the complete body by the time this function is called
                             // we can avoid streaming it and just send it all at once.
                             if byte_stream.has_received_last_chunk.get() {
+                                let pending_error = byte_stream.take_pending_error();
                                 let mut byte_list = byte_stream.drain();
+                                if let Some(err) = pending_error {
+                                    let err_js = err.to_js(global_this);
+                                    err_js.ensure_still_alive();
+                                    this.response_body_readable_stream_ref.deinit();
+
+                                    if byte_list.is_empty() {
+                                        Self::handle_reject_stream(this, global_this, err_js);
+                                        return;
+                                    }
+
+                                    this.response_buf_owned = byte_list.move_to_list();
+                                    resp.run_corked_with_type(
+                                        Self::drain_response_buffer_and_metadata_corked,
+                                        this,
+                                    );
+                                    if let Some(resp) = this.resp {
+                                        let state = resp.state();
+                                        if state.is_http_write_called()
+                                            && state.is_response_pending()
+                                        {
+                                            this.force_close();
+                                            return;
+                                        }
+                                    }
+                                    Self::handle_reject_stream(this, global_this, err_js);
+                                    return;
+                                }
                                 this.blob = AnyBlob::from_array_list(
                                     byte_list.move_to_list_managed(),
                                 );

--- a/test/js/bun/http/serve-stream-body-error-fixture.ts
+++ b/test/js/bun/http/serve-stream-body-error-fixture.ts
@@ -73,6 +73,13 @@ const sources: Record<string, () => ReadableStream> = {
         throw new Error("boom");
       },
     }),
+  "mid-stream-controller-error": () =>
+    new ReadableStream({
+      start(c) {
+        c.enqueue("chunk-a");
+        midStreamResolve = () => c.error(new Error("boom"));
+      },
+    }),
   // The client aborts the download mid-stream, which makes Bun cancel the body
   // stream; the source's cancel() then throws. That rejection belongs to a
   // promise Bun created internally and must not surface as unhandledRejection.

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -83,20 +83,24 @@ test.concurrent("pull-throw in development mode: the rejection is handled", asyn
 // keeps handle_reject_stream quiet here, which the existing
 // serve-direct-readable-stream.test.ts and serve-stream-reject-flush-leak
 // tests rely on. The development-mode variant below asserts the report.
-test.concurrent("mid-stream error: the chunked body is not terminated as complete", async () => {
-  const { stdout, exitCode } = await runFixture("mid-stream-reject");
-  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
-    result: {
-      statusLine: "HTTP/1.1 200 OK",
-      cleanChunkedTerminator: false,
-      body: "7\r\nchunk-a\r\n",
-      errorCb: 0,
-      unhandled: 0,
-      secondStatusLine: "HTTP/1.1 200 OK",
-    },
-    exitCode: 0,
-  });
-});
+test.concurrent.each(["mid-stream-reject", "mid-stream-controller-error"])(
+  "%s: the chunked body is not terminated as complete",
+  async variant => {
+    // https://github.com/oven-sh/bun/issues/36477
+    const { stdout, exitCode } = await runFixture(variant);
+    expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+      result: {
+        statusLine: "HTTP/1.1 200 OK",
+        cleanChunkedTerminator: false,
+        body: "7\r\nchunk-a\r\n",
+        errorCb: 0,
+        unhandled: 0,
+        secondStatusLine: "HTTP/1.1 200 OK",
+      },
+      exitCode: 0,
+    });
+  },
+);
 
 // Under `development: true` (the default for a plain script) the mid-stream
 // error is reported by handle_reject_stream, and the connection must still be


### PR DESCRIPTION
### What does this PR do?

When a `ReadableStream` response body has already produced bytes and then ends with `controller.error()`, preserve the pending stream error instead of converting the buffered bytes into a complete Blob response.

This makes Bun flush the bytes already written and close the chunked response without the terminal `0\r\n\r\n` chunk, matching the existing rejected-pull mid-stream behavior so clients can detect the truncated body.

Fix #36477

### How did you verify your code works?

## Test verification (RED -> GREEN)

RED on the unfixed runtime:

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/http/serve-stream-body-error.test.ts -t "mid-stream-controller-error"
bun test v1.3.14 (0d9b296a)

(fail) mid-stream-controller-error: the chunked body is not terminated as complete
Expected cleanChunkedTerminator: false
Received cleanChunkedTerminator: true
Received body included:
7
chunk-a
0

0 pass
15 filtered out
1 fail
```

GREEN with the patched debug build:

```
$ BUN_DEBUG_QUIET_LOGS=1 bun bd test test/js/bun/http/serve-stream-body-error.test.ts -t "mid-stream-controller-error"
bun test v1.4.0 (f91d5c95c)

(pass) mid-stream-controller-error: the chunked body is not terminated as complete

1 pass
15 filtered out
0 fail
```

Full affected test file:

```
$ BUN_DEBUG_QUIET_LOGS=1 bun bd test test/js/bun/http/serve-stream-body-error.test.ts
16 pass
0 fail
```

Local source lints:

```
$ bun test test/internal/source-lints/
61 pass
0 fail
```
