### PR TITLE
fix(server): serialize async websocket messages

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4144,6 +4144,10 @@ GlobalObject::PromiseFunctions GlobalObject::promiseHandlerID(Zig::FFIFunction h
         return GlobalObject::PromiseFunctions::Bun__CronJob__onPromiseResolve;
     } else if (handler == Bun__CronJob__onPromiseReject) {
         return GlobalObject::PromiseFunctions::Bun__CronJob__onPromiseReject;
+    } else if (handler == Bun__ServerWebSocket__onMessagePromiseResolve) {
+        return GlobalObject::PromiseFunctions::Bun__ServerWebSocket__onMessagePromiseResolve;
+    } else if (handler == Bun__ServerWebSocket__onMessagePromiseReject) {
+        return GlobalObject::PromiseFunctions::Bun__ServerWebSocket__onMessagePromiseReject;
     } else if (handler == Bun__HTTPRequestContextH3__onReject) {
         return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextH3__onReject;
     } else if (handler == Bun__HTTPRequestContextH3__onRejectStream) {

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -438,7 +438,10 @@ public:
         Bun__HTMLRewriter__onResolveInputStream,
         Bun__HTMLRewriter__onRejectInputStream,
     };
-    static constexpr size_t promiseFunctionsSize = 48;
+    // Must equal the number of PromiseFunctions entries above; ThenablesArray is sized from it.
+    static constexpr size_t promiseFunctionsSize = 50;
+    static_assert(promiseFunctionsSize + 1 > static_cast<size_t>(PromiseFunctions::Bun__HTMLRewriter__onRejectInputStream),
+        "promiseFunctionsSize must cover every PromiseFunctions entry; bump it when adding enum entries");
 
     static PromiseFunctions promiseHandlerID(SYSV_ABI EncodedJSValue (*handler)(JSC::JSGlobalObject* arg0, JSC::CallFrame* arg1));
 

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -421,6 +421,8 @@ public:
         Bun__FileSink__onRejectStream,
         Bun__CronJob__onPromiseResolve,
         Bun__CronJob__onPromiseReject,
+        Bun__ServerWebSocket__onMessagePromiseResolve,
+        Bun__ServerWebSocket__onMessagePromiseReject,
         Bun__HTTPRequestContextH3__onReject,
         Bun__HTTPRequestContextH3__onRejectStream,
         Bun__HTTPRequestContextH3__onResolve,

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -787,6 +787,8 @@ BUN_DECLARE_HOST_FUNCTION(Bun__TestScope__Describe2__bunTestThen);
 BUN_DECLARE_HOST_FUNCTION(Bun__TestScope__Describe2__bunTestCatch);
 BUN_DECLARE_HOST_FUNCTION(Bun__CronJob__onPromiseResolve);
 BUN_DECLARE_HOST_FUNCTION(Bun__CronJob__onPromiseReject);
+BUN_DECLARE_HOST_FUNCTION(Bun__ServerWebSocket__onMessagePromiseResolve);
+BUN_DECLARE_HOST_FUNCTION(Bun__ServerWebSocket__onMessagePromiseReject);
 
 #endif
 

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -506,6 +506,11 @@ impl ServerWebSocket {
 
         let _loop_guard = vm.enter_event_loop_scope();
 
+        let js_this = self
+            .this_value
+            .get()
+            .try_get()
+            .unwrap_or(JSValue::UNDEFINED);
         let data = match opcode {
             Opcode::Text => jsc::bun_string_jsc::create_utf8_for_js(global_object, message),
             Opcode::Binary => self.binary_to_js(global_object, message),
@@ -514,13 +519,7 @@ impl ServerWebSocket {
         // Converting the payload threw (or the VM is terminating): there is
         // no message to deliver; the handler's landing frame folds it.
         let data = data?;
-        let arguments = [
-            self.this_value
-                .get()
-                .try_get()
-                .unwrap_or(JSValue::UNDEFINED),
-            data,
-        ];
+        let arguments = [js_this, data];
 
         let mut corker = Corker {
             args: &arguments,
@@ -545,6 +544,19 @@ impl ServerWebSocket {
 
         if let Some(promise) = result.as_any_promise() {
             match promise.status() {
+                jsc::js_promise::Status::Pending => {
+                    if js_this.is_empty_or_undefined_or_null() {
+                        return Ok(());
+                    }
+                    ws.pause();
+                    result.then_with_value(
+                        global_object,
+                        js_this,
+                        Bun__ServerWebSocket__onMessagePromiseResolve,
+                        Bun__ServerWebSocket__onMessagePromiseReject,
+                    );
+                    return Ok(());
+                }
                 jsc::js_promise::Status::Rejected => {
                     // Value discarded; the side
                     // effect (JSC__JSPromise__result) conditionally sets
@@ -1584,6 +1596,62 @@ impl WebSocketHandler for ServerWebSocket {
         // SAFETY: per trait contract.
         crate::dispatch::fold(unsafe { &*this }.on_close(ws, code, message));
     }
+}
+
+fn server_websocket_from_promise_context(frame: &CallFrame) -> Option<&'static ServerWebSocket> {
+    frame
+        .arguments()
+        .last()
+        .and_then(|js_this| js_this.as_class_ref::<ServerWebSocket>())
+}
+
+bun_jsc::jsc_host_abi! {
+    #[unsafe(no_mangle)]
+    pub unsafe fn Bun__ServerWebSocket__onMessagePromiseResolve(
+        global: *mut JSGlobalObject,
+        frame: *mut CallFrame,
+    ) -> JSValue {
+        // SAFETY: JSC passes valid non-null pointers for the host call's duration.
+        let (global, frame) = unsafe { (&*global, &*frame) };
+        jsc::host_fn::to_js_host_fn_result(global, on_message_promise_resolve(global, frame))
+    }
+}
+
+bun_jsc::jsc_host_abi! {
+    #[unsafe(no_mangle)]
+    pub unsafe fn Bun__ServerWebSocket__onMessagePromiseReject(
+        global: *mut JSGlobalObject,
+        frame: *mut CallFrame,
+    ) -> JSValue {
+        // SAFETY: JSC passes valid non-null pointers for the host call's duration.
+        let (global, frame) = unsafe { (&*global, &*frame) };
+        jsc::host_fn::to_js_host_fn_result(global, on_message_promise_reject(global, frame))
+    }
+}
+
+fn on_message_promise_resolve(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    if let Some(this) = server_websocket_from_promise_context(frame)
+        && !this.is_closed()
+    {
+        this.websocket().resume();
+    }
+    Ok(JSValue::UNDEFINED)
+}
+
+fn on_message_promise_reject(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    let args = frame.arguments();
+    let error_value = args.first().copied().unwrap_or(JSValue::UNDEFINED);
+    let Some(this) = server_websocket_from_promise_context(frame) else {
+        return Ok(JSValue::UNDEFINED);
+    };
+    if this.is_closed() {
+        return Ok(JSValue::UNDEFINED);
+    }
+
+    this.websocket().resume();
+    let handler = this.handler();
+    handler.run_error_callback(handler.on_error, global, error_value)?;
+    Ok(JSValue::UNDEFINED)
 }
 
 struct Corker<'a> {

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -548,7 +548,12 @@ impl ServerWebSocket {
                     if js_this.is_empty_or_undefined_or_null() {
                         return Ok(());
                     }
-                    ws.pause();
+                    // The handler can close (or terminate) the socket synchronously
+                    // before returning its pending promise; `pause()` would then
+                    // reach into a uWS socket that is already gone.
+                    if !self.is_closed() {
+                        ws.pause();
+                    }
                     result.then_with_value(
                         global_object,
                         js_this,

--- a/src/uws_sys/WebSocket.rs
+++ b/src/uws_sys/WebSocket.rs
@@ -86,6 +86,16 @@ impl AnyWebSocket {
         c::uws_ws_close(ssl, ws)
     }
 
+    pub fn pause(self) {
+        let (ssl, ws) = self.split();
+        c::uws_ws_pause(ssl, ws)
+    }
+
+    pub fn resume(self) {
+        let (ssl, ws) = self.split();
+        c::uws_ws_resume(ssl, ws)
+    }
+
     pub fn send(self, message: &[u8], opcode: Opcode, compress: bool, fin: bool) -> SendStatus {
         let (ssl, ws) = self.split();
         // SAFETY: `ws` is a live uWS-owned socket (S012 opaque); ptr+len from &[u8].
@@ -526,6 +536,8 @@ pub mod c {
         );
         pub(crate) safe fn uws_ws_get_user_data(ssl: i32, ws: &mut RawWebSocket) -> *mut c_void;
         pub(crate) safe fn uws_ws_close(ssl: i32, ws: &mut RawWebSocket);
+        pub(crate) safe fn uws_ws_pause(ssl: i32, ws: &mut RawWebSocket);
+        pub(crate) safe fn uws_ws_resume(ssl: i32, ws: &mut RawWebSocket);
         pub(crate) fn uws_ws_send_with_options(
             ssl: i32,
             ws: *mut RawWebSocket,

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -841,6 +841,38 @@ extern "C"
     }
   }
 
+  void uws_ws_pause(int ssl, uws_websocket_t *ws)
+  {
+    if (ssl)
+    {
+      TLSWebSocket *uws =
+          (TLSWebSocket *)ws;
+      uws->pause();
+    }
+    else
+    {
+      TCPWebSocket *uws =
+          (TCPWebSocket *)ws;
+      uws->pause();
+    }
+  }
+
+  void uws_ws_resume(int ssl, uws_websocket_t *ws)
+  {
+    if (ssl)
+    {
+      TLSWebSocket *uws =
+          (TLSWebSocket *)ws;
+      uws->resume();
+    }
+    else
+    {
+      TCPWebSocket *uws =
+          (TCPWebSocket *)ws;
+      uws->resume();
+    }
+  }
+
   uws_sendstatus_t uws_ws_send(int ssl, uws_websocket_t *ws, const char *message,
                                size_t length, uws_opcode_t opcode)
   {

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -19,28 +19,35 @@ const WEBSOCKET_ASYNC_DONE_PREFIX = "done:";
 const WEBSOCKET_ASYNC_POLL_TURNS = 20;
 const WEBSOCKET_ASYNC_NOT_FOUND_STATUS = 404;
 const WEBSOCKET_ASYNC_EXPECTED_MESSAGE_COUNT = 2;
+const WEBSOCKET_ASYNC_REJECT_MESSAGE = "reject";
+const WEBSOCKET_ASYNC_AFTER_REJECT_MESSAGE = "after-reject";
+const WEBSOCKET_ASYNC_REJECTION_MESSAGE = "async websocket handler rejected";
+const WEBSOCKET_ASYNC_REJECT_DEADLINE_MS = 20_000;
+const WEBSOCKET_ASYNC_SUBPROCESS_TIMEOUT_MS = 30_000;
 const HTTP_PROTOCOL_PREFIX = "http";
 const WS_PROTOCOL_PREFIX = "ws";
 
 async function didSettleWithinImmediateTurns<T>(promise: Promise<T>, turns: number): Promise<boolean> {
   let settled = false;
+  let rejected = false;
   let rejection: unknown;
   promise.then(
     () => {
       settled = true;
     },
     error => {
+      rejected = true;
       rejection = error;
     },
   );
 
   for (let turn = 0; turn < turns; turn++) {
-    if (rejection) throw rejection;
+    if (rejected) throw rejection;
     if (settled) return true;
     await new Promise<void>(resolve => setImmediate(resolve));
   }
 
-  if (rejection) throw rejection;
+  if (rejected) throw rejection;
   return settled;
 }
 
@@ -2076,6 +2083,93 @@ test("async websocket message handlers run serially per socket", async () => {
 
   ws.close();
 });
+
+// `websocket.error` is not in the public `WebSocketHandler` type, so this runs
+// in a subprocess like the other `websocket.error` coverage in this file.
+test(
+  "a rejected async websocket message handler reports the error and resumes the socket",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const REJECT = ${JSON.stringify(WEBSOCKET_ASYNC_REJECT_MESSAGE)};
+        const AFTER = ${JSON.stringify(WEBSOCKET_ASYNC_AFTER_REJECT_MESSAGE)};
+        const DONE_PREFIX = ${JSON.stringify(WEBSOCKET_ASYNC_DONE_PREFIX)};
+        const REJECTION_MESSAGE = ${JSON.stringify(WEBSOCKET_ASYNC_REJECTION_MESSAGE)};
+
+        const errorReported = Promise.withResolvers();
+        const echoReceived = Promise.withResolvers();
+
+        using server = Bun.serve({
+          port: 0,
+          hostname: "127.0.0.1",
+          fetch(req, s) {
+            if (s.upgrade(req)) return;
+            return new Response(null, { status: ${WEBSOCKET_ASYNC_NOT_FOUND_STATUS} });
+          },
+          websocket: {
+            async message(ws, message) {
+              const text = String(message);
+              if (text === REJECT) {
+                // Suspend first so the handler returns a *pending* promise: that
+                // is the path that pauses the socket.
+                await Promise.resolve();
+                throw new Error(REJECTION_MESSAGE);
+              }
+              ws.send(DONE_PREFIX + text);
+            },
+            error(error) {
+              errorReported.resolve(error?.message ?? String(error));
+            },
+          },
+        });
+
+        const ws = new WebSocket("ws://127.0.0.1:" + server.port);
+        const opened = Promise.withResolvers();
+        ws.onopen = () => opened.resolve();
+        ws.onerror = event => {
+          opened.reject(event);
+          errorReported.reject(event);
+          echoReceived.reject(event);
+        };
+        ws.onmessage = event => echoReceived.resolve(String(event.data));
+        await opened.promise;
+
+        // Deadline only: turns a broken resume into a printed null instead of a hang.
+        const deadline = Bun.sleep(${WEBSOCKET_ASYNC_REJECT_DEADLINE_MS}).then(() => null);
+
+        ws.send(REJECT);
+        const errorMessage = await Promise.race([errorReported.promise, deadline]);
+
+        // The socket was paused for the pending handler; this only arrives if
+        // the rejection resumed it.
+        ws.send(AFTER);
+        const echoed = await Promise.race([echoReceived.promise, deadline]);
+
+        console.log(JSON.stringify({ errorMessage, echoed }));
+        process.exit(0);
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ out: JSON.parse(stdout.trim() || "null"), stderr }).toEqual({
+      out: {
+        errorMessage: WEBSOCKET_ASYNC_REJECTION_MESSAGE,
+        echoed: WEBSOCKET_ASYNC_DONE_PREFIX + WEBSOCKET_ASYNC_AFTER_REJECT_MESSAGE,
+      },
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  },
+  WEBSOCKET_ASYNC_SUBPROCESS_TIMEOUT_MS,
+);
 
 test("should be able to abrubtly close a upload request", async () => {
   const { promise, resolve } = Promise.withResolvers();

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -13,6 +13,37 @@ import {
 } from "harness";
 import path from "path";
 
+const WEBSOCKET_ASYNC_FIRST_MESSAGE = "first";
+const WEBSOCKET_ASYNC_SECOND_MESSAGE = "second";
+const WEBSOCKET_ASYNC_DONE_PREFIX = "done:";
+const WEBSOCKET_ASYNC_POLL_TURNS = 20;
+const WEBSOCKET_ASYNC_NOT_FOUND_STATUS = 404;
+const WEBSOCKET_ASYNC_EXPECTED_MESSAGE_COUNT = 2;
+const HTTP_PROTOCOL_PREFIX = "http";
+const WS_PROTOCOL_PREFIX = "ws";
+
+async function didSettleWithinImmediateTurns<T>(promise: Promise<T>, turns: number): Promise<boolean> {
+  let settled = false;
+  let rejection: unknown;
+  promise.then(
+    () => {
+      settled = true;
+    },
+    error => {
+      rejection = error;
+    },
+  );
+
+  for (let turn = 0; turn < turns; turn++) {
+    if (rejection) throw rejection;
+    if (settled) return true;
+    await new Promise<void>(resolve => setImmediate(resolve));
+  }
+
+  if (rejection) throw rejection;
+  return settled;
+}
+
 describe.concurrent("Server", () => {
   test("should not use 100% CPU when websocket is idle", async () => {
     await using proc = Bun.spawn({
@@ -1961,6 +1992,89 @@ test("should be able to async upgrade using custom protocol", async () => {
   };
 
   expect(await promise).toBe(true);
+});
+
+test("async websocket message handlers run serially per socket", async () => {
+  const firstEntered = Promise.withResolvers<void>();
+  const secondEntered = Promise.withResolvers<void>();
+  const releaseFirst = Promise.withResolvers<void>();
+  const clientOpened = Promise.withResolvers<void>();
+  const clientMessagesReceived = Promise.withResolvers<void>();
+  const clientMessages: string[] = [];
+  const handlerEntries: string[] = [];
+  let inFlightHandlers = 0;
+  let maxInFlightHandlers = 0;
+
+  using server = Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      if (server.upgrade(req)) return;
+      return new Response(null, { status: WEBSOCKET_ASYNC_NOT_FOUND_STATUS });
+    },
+    websocket: {
+      async message(ws, message) {
+        inFlightHandlers++;
+        maxInFlightHandlers = Math.max(maxInFlightHandlers, inFlightHandlers);
+        const text = String(message);
+        handlerEntries.push(text);
+        if (text === WEBSOCKET_ASYNC_FIRST_MESSAGE) {
+          firstEntered.resolve();
+          await releaseFirst.promise;
+        } else if (text === WEBSOCKET_ASYNC_SECOND_MESSAGE) {
+          secondEntered.resolve();
+        }
+        ws.send(WEBSOCKET_ASYNC_DONE_PREFIX + text);
+        inFlightHandlers--;
+      },
+    },
+  });
+
+  const ws = new WebSocket(server.url.href.replace(HTTP_PROTOCOL_PREFIX, WS_PROTOCOL_PREFIX));
+  ws.onopen = () => clientOpened.resolve();
+  ws.onerror = event => {
+    clientOpened.reject(event);
+    clientMessagesReceived.reject(event);
+  };
+  ws.onmessage = event => {
+    clientMessages.push(String(event.data));
+    if (clientMessages.length === WEBSOCKET_ASYNC_EXPECTED_MESSAGE_COUNT) {
+      clientMessagesReceived.resolve();
+    }
+  };
+
+  await clientOpened.promise;
+  ws.send(WEBSOCKET_ASYNC_FIRST_MESSAGE);
+  await firstEntered.promise;
+
+  ws.send(WEBSOCKET_ASYNC_SECOND_MESSAGE);
+  const secondStartedBeforeFirstSettled = await didSettleWithinImmediateTurns(
+    secondEntered.promise,
+    WEBSOCKET_ASYNC_POLL_TURNS,
+  );
+
+  expect({
+    handlerEntries,
+    maxInFlightHandlers,
+    secondStartedBeforeFirstSettled,
+  }).toEqual({
+    handlerEntries: [WEBSOCKET_ASYNC_FIRST_MESSAGE],
+    maxInFlightHandlers: 1,
+    secondStartedBeforeFirstSettled: false,
+  });
+
+  releaseFirst.resolve();
+  await secondEntered.promise;
+  await clientMessagesReceived.promise;
+
+  expect({ clientMessages, maxInFlightHandlers }).toEqual({
+    clientMessages: [
+      WEBSOCKET_ASYNC_DONE_PREFIX + WEBSOCKET_ASYNC_FIRST_MESSAGE,
+      WEBSOCKET_ASYNC_DONE_PREFIX + WEBSOCKET_ASYNC_SECOND_MESSAGE,
+    ],
+    maxInFlightHandlers: 1,
+  });
+
+  ws.close();
 });
 
 test("should be able to abrubtly close a upload request", async () => {


### PR DESCRIPTION
Fix #32483

## Summary

- pause the underlying uWS websocket while an async `websocket.message` handler is pending, so two messages on the same socket cannot run their handlers concurrently
- resume reads when the handler promise settles — on rejection as well as resolution
- route rejected async message handlers through the existing `websocket.error` callback
- skip the `pause()` when the handler closed or terminated the socket synchronously before suspending (the socket is already gone; `AnyWebSocket::pause()` would deref it)
- bump `promiseFunctionsSize` to cover the two new `PromiseFunctions` entries, with a `static_assert` so the array can never again be sized below the highest enum index

## Testing

Serialization regression:

```sh
USE_SYSTEM_BUN=1 bun test test/js/bun/http/bun-server.test.ts -t "async websocket message handlers run serially per socket"
```

Fails on released Bun with `maxInFlightHandlers: 2` and `secondStartedBeforeFirstSettled: true`.

Reject-path regression:

```sh
USE_SYSTEM_BUN=1 bun test test/js/bun/http/bun-server.test.ts -t "rejected async websocket message handler"
```

Fails on released Bun — the rejection escapes to the uncaught path on stderr instead of reaching `websocket.error`, and the socket never resumes, so the follow-up message is never processed:

```
- "echoed": "done:after-reject",        + "echoed": null,
- "errorMessage": "async websocket ...  + "errorMessage": null,
+ stderr: "error: async websocket handler rejected"
 0 pass  1 fail
```

Both pass with the fix:

```sh
bun bd test test/js/bun/http/bun-server.test.ts -t "async websocket"
# 2 pass  0 fail  4 expect() calls
```

Full file plus `bun test test/internal/source-lints/` are green, with one pre-existing exception: `Server > normlizes incoming request URLs` (an HTTPS fetch test unrelated to this diff) takes 4.42s standalone against the 5s default timeout and tips over under suite load in a debug build. It passes in isolation on the same binary.

## Notes

The `is_closed()` guard on `pause()` has no dedicated test: the unguarded path does not fault deterministically in a non-ASAN build, and a "does not crash" test would never fail in CI. `close()` and `terminate()` both set `flags.closed` before touching uWS, so `is_closed()` is accurate at that point; the guard matches what `on_drain` and `on_message_promise_resolve` already do for their uWS calls.
