### PR TITLE
Bun.serve: free the NewServer Box synchronously when finalize() runs during VM shutdown

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1797,6 +1797,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // for the server's lifetime); single-threaded JS context, no aliasing `&mut`.
         let vm = unsafe { &mut *self.vm_mut() };
 
+        if vm.is_shutting_down() {
+            // No more ticks; `finalize()` frees via `DEINIT_SCHEDULED` instead.
+            return;
+        }
+
         if !self.flags.contains(ServerFlags::TERMINATED) {
             // App.close can cause finalizers to run.
             // scheduleDeinit can be called inside a finalizer.
@@ -1947,13 +1952,13 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
     // ─── deinit ──────────────────────────────────────────────────────────────
     /// Tear down the uws app handles and free the boxed server. Only called
-    /// from `schedule_deinit`'s task or synchronously on listen-failure.
+    /// from `schedule_deinit`'s task, on listen-failure, or from `finalize()` at VM shutdown.
     ///
     /// # Safety
     /// `this` must be the unique owning pointer to a heap-allocated `NewServer`
     /// produced by [`Self::init`]; no other reference may be live, and `this`
     /// must not be used after this returns.
-    fn deinit(this: *mut Self) {
+    pub(super) fn deinit(this: *mut Self) {
         httplog!("deinit");
         // SAFETY: `this` was heap-allocated in `init()` and is uniquely owned here.
         let this_ref = unsafe { &mut *this };

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2802,11 +2802,15 @@ where
         // unconditional. `Box::into_raw` (not `heap::release`) keeps raw-owner
         // provenance for the `deinit()` dealloc — a `&mut self`-derived tag
         // there would be Stacked-Borrows UB. JSC-handle Drops are no-ops past
-        // `is_shutting_down()`, so the synchronous free is safe then.
+        // `is_shutting_down()`; `TERMINATED` means `app.close()` already ran,
+        // so `NewApp::destroy` can't orphan a keep-alive socket.
         let this = unsafe { &mut *this_ptr };
         this.js_value.finalize();
         this.deinit_if_we_can();
-        if this.flags.contains(ServerFlags::DEINIT_SCHEDULED) && this.vm().is_shutting_down() {
+        if this.flags.contains(ServerFlags::DEINIT_SCHEDULED)
+            && this.flags.contains(ServerFlags::TERMINATED)
+            && this.vm().is_shutting_down()
+        {
             Self::deinit(this_ptr);
         }
     }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2795,11 +2795,20 @@ where
 
     pub fn finalize(self: Box<Self>) {
         httplog!("finalize");
-        // `deinit_if_we_can` may defer the actual free (pending requests still
-        // hold a ref), so hand ownership back to the raw teardown path.
-        let this = bun_core::heap::release(self);
+        let this_ptr = bun_core::heap::into_raw(self);
+        // SAFETY: just unboxed; uniquely owned here until either the inline
+        // `deinit()` below or `schedule_deinit()`'s enqueued task reclaims it.
+        // `deinit_if_we_can` may defer (pending requests), so the free is not
+        // unconditional. `Box::into_raw` (not `heap::release`) keeps raw-owner
+        // provenance for the `deinit()` dealloc — a `&mut self`-derived tag
+        // there would be Stacked-Borrows UB. JSC-handle Drops are no-ops past
+        // `is_shutting_down()`, so the synchronous free is safe then.
+        let this = unsafe { &mut *this_ptr };
         this.js_value.finalize();
         this.deinit_if_we_can();
+        if this.flags.contains(ServerFlags::DEINIT_SCHEDULED) && this.vm().is_shutting_down() {
+            Self::deinit(this_ptr);
+        }
     }
 
     pub(crate) fn get_all_closed_promise(&mut self, global: &JSGlobalObject) -> JSValue {

--- a/test/js/bun/http/bun-serve-html-405.test.ts
+++ b/test/js/bun/http/bun-serve-html-405.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 test("dev server html route: non-GET/HEAD requests complete without hanging", async () => {
@@ -43,3 +43,55 @@ test("dev server html route: non-GET/HEAD requests complete without hanging", as
     });
   }
 });
+
+// A server whose JS wrapper survives to lastChanceToFinalize used to leak its
+// NewServer Box: finalize() -> schedule_deinit() enqueued a ManagedTask that
+// the now-exiting event loop never ran. The html_bundle::Route.server
+// back-pointer makes the orphaned Box a pointer cycle, so LSan reports every
+// interior allocation as an indirect leak. Only observable via LeakSanitizer.
+test.skipIf(!isASAN || isWindows)(
+  "stopped Bun.serve with a static route is freed at VM teardown",
+  async () => {
+    await using dir = tempDir("serve-static-route-teardown-leak", {
+      "index.html": `<!DOCTYPE html><html><body>hi</body></html>`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { default: html } = await import(process.argv[1]);
+          const server = Bun.serve({
+            port: 0,
+            development: true,
+            routes: { "/": html },
+            fetch: () => new Response("no"),
+          });
+          await (await fetch(server.url)).text();
+          server.stop(true);
+        `,
+        join(dir, "index.html"),
+      ],
+      env: {
+        ...bunEnv,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The dev-server bundler prints "Bundled page in Nms: <path>" to stderr on
+    // first request; strip it so the assertion shows only LSan's report.
+    const filtered = stderr
+      .split("\n")
+      .filter(l => !l.includes("Bundled page in "))
+      .join("\n")
+      .trim();
+    expect({ stdout, stderr: filtered, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  },
+  // LSan symbolizes through llvm-symbolizer on failure, which is slow against
+  // the debug binary.
+  30_000,
+);

--- a/test/js/bun/http/bun-serve-html-405.test.ts
+++ b/test/js/bun/http/bun-serve-html-405.test.ts
@@ -95,3 +95,36 @@ test.skipIf(!isASAN || isWindows)(
   // the debug binary.
   30_000,
 );
+
+// Graceful stop() leaves the keep-alive socket in the uws app's socket group.
+// A NewApp::destroy at lastChanceToFinalize would unlink that group from the
+// loop and orphan the socket, so the synchronous deinit path above is gated
+// on TERMINATED (set only by an abrupt stop or an app.close() that already
+// drained the group).
+test.skipIf(!isASAN || isWindows)(
+  "gracefully-stopped Bun.serve does not orphan a keep-alive socket at VM teardown",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+          await (await fetch(server.url)).text();
+          server.stop();
+        `,
+      ],
+      env: {
+        ...bunEnv,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  },
+  30_000,
+);


### PR DESCRIPTION
Fixes `test/js/bun/http/bun-serve-html-405.test.ts` going red on x64-asan (build [87498](https://buildkite.com/bun/bun/builds/87498) and several unrelated PR builds since ~87000).

## Repro

```
BUN_DESTRUCT_VM_ON_EXIT=1 ASAN_OPTIONS=detect_leaks=1 \
LSAN_OPTIONS=suppressions=test/leaksan.supp \
bun-debug test test/js/bun/http/bun-serve-html-405.test.ts
```

```
Indirect leak of 2104 byte(s) in 1 object(s) allocated from:
    ...
    #11 new<bun_runtime::server::NewServer<false, true>>
    #12 init<false, true> src/runtime/server/mod.rs:2009:47
    #13 bun_runtime::api::bun_object::serve src/runtime/api/BunObject.rs:1564:26
    ...
    #21 BunObject_callback_serve src/runtime/api/BunObject.rs:230:25
SUMMARY: AddressSanitizer: 2942 byte(s) leaked in 7 allocation(s).
```

10/10 without this change, 0/10 with it (local debug+ASAN).

## Cause

`using server = Bun.serve({ development: true, routes: { "/": html } })` disposes via `stop(true)`, which makes `deinit_if_we_can()` downgrade `js_value` to `Weak` and return. The `NewServer` Box is only freed once the JS wrapper's `finalize()` fires and `schedule_deinit()` enqueues the actual `deinit()` as a `ManagedTask`.

When the wrapper survives to `lastChanceToFinalize` (`BUN_DESTRUCT_VM_ON_EXIT=1`, which the CI runner sets on ASAN lanes), `global_exit()` has already had its last event-loop tick. The enqueued task never runs, and `EventLoop::deinit()` drops the task box without a cleanup (`ManagedTask::new` sets `cleanup: None`). The 2104-byte `NewServer<false, true>` Box, its `config.static_routes` Vec, the `html_bundle::Route` it refcounts, and the route's path strings are all orphaned. `Route.server: Cell<Option<AnyServer>>` points back at the server so LSan sees a pointer cycle and reports every allocation as indirect.

The path has always existed, but before #35356 the per-tick GC sampler usually collected the wrapper during the handful of event-loop ticks between the test body and `global_exit()`, so `schedule_deinit()` ran while the loop was still live. With only the 1s idle-timer GC, a single fast test like this one reaches shutdown with the wrapper still alive more often (about half the PR builds since the merge).

## Fix

`schedule_deinit()` now sets `DEINIT_SCHEDULED` and returns without enqueueing when `is_shutting_down()`. `finalize()` then frees the Box synchronously when the server has been fully drained: it unboxes via `Box::into_raw` first so the dealloc goes through the raw owning pointer rather than a `&mut self` frame (whose FnEntry protector would make the dealloc Stacked-Borrows UB, same pattern as `Listener::finalize` / `UDPSocket::finalize`). Every JSC handle on the Drop chain (`JSPromiseStrong`, `JsRef`, `UserRouteBuilder.callback: Strong`) funnels through `Strong::Impl::destroy`, which is a no-op past `is_shutting_down()`, so freeing here is safe.

The inline free is gated on `TERMINATED`: `NewApp::destroy` runs `us_socket_group_deinit`, which unlinks the socket group from the loop's list without closing any sockets still in it. A graceful `stop()` only closes the listener and leaves keep-alive sockets open in the group; destroying the app there would orphan them (seen as a 280-byte `us_poll_t` direct leak on `vendor/elysia/test/core/before-handle-arrow.test.ts` with an earlier revision of this PR, and a `US_ASSERT(head_sockets==NULL)` abort on the debug build). `TERMINATED` is set only once `app.close()` has run, so the inline free is taken for abruptly-stopped servers (what `using server` does) and skipped for gracefully-stopped ones, which is identical to `main`'s behaviour for them.

Other callers that can reach `schedule_deinit()` past shutdown (a last request draining inside `close_all_socket_groups`, which runs before `lastChanceToFinalize`) only set the flag and leave the Box, since `NewApp::destroy` there would delete the uws socket group mid-iteration.

## Verification

Two ASAN-only subprocess tests added:
- abrupt `stop(true)` of a dev server with an HTML route under `BUN_DESTRUCT_VM_ON_EXIT=1` + `detect_leaks=1`: fails on `main` with the 7-allocation LSan report above; passes with this change.
- graceful `stop()` of a plain server with a keep-alive client connection: passes on both `main` and this change (asserts `us_socket_group_deinit`'s `head_sockets==NULL` precondition, which an earlier revision of this change violated).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-html-405.test.ts

<!-- robobun:evidence:end -->