### PR TITLE
test(upgrade): run bun-upgrade.test.ts entirely against a local server

### DIFF
--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -1,13 +1,167 @@
 import { spawn } from "bun";
 import { upgrade_test_helpers } from "bun:internal-for-testing";
-import { describe, expect, it, setDefaultTimeout } from "bun:test";
-import { bunExe, bunEnv as env, tempDir, tls, tmpdirSync } from "harness";
+import { describe, expect, it } from "bun:test";
+import { bunExe, bunEnv as env, isMusl, isWindows, tempDir, tls, tmpdirSync } from "harness";
 import { existsSync, statSync } from "node:fs";
-import { copyFile } from "node:fs/promises";
+import { copyFile, writeFile } from "node:fs/promises";
 import { basename, join } from "path";
 const { openTempDirWithoutSharingDelete, closeTempDirHandle } = upgrade_test_helpers;
 
-setDefaultTimeout(1000 * 60 * 5);
+// Cover every platform/arch/abi/cpu combination so the asset list matches
+// whichever target this test runs on. Non-matching names are ignored.
+function allAssetNames(profile = false) {
+  const names: string[] = [];
+  for (const os of ["windows", "linux", "darwin"]) {
+    for (const arch of ["x64", "aarch64"]) {
+      for (const abi of ["", "-musl"]) {
+        for (const cpu of ["", "-baseline"]) {
+          names.push(`bun-${os}-${arch}${abi}${cpu}${profile ? "-profile" : ""}.zip`);
+        }
+      }
+    }
+  }
+  return names;
+}
+
+// Build a minimal ZIP archive with a single stored (uncompressed) entry.
+// `unzip -o` on POSIX restores the mode from the Unix external-attrs field;
+// Expand-Archive on Windows ignores it.
+function makeZipStored(entryName: string, data: Buffer, unixMode: number): Buffer {
+  const nameBytes = Buffer.from(entryName, "utf8");
+  const crc = Bun.hash.crc32(data);
+  const size = data.length;
+
+  const lfhLen = 30 + nameBytes.length;
+  const cdhLen = 46 + nameBytes.length;
+  const cdOffset = lfhLen + size;
+
+  const buf = Buffer.alloc(lfhLen + size + cdhLen + 22);
+  let p = 0;
+  const u16 = (v: number) => {
+    buf.writeUInt16LE(v, p);
+    p += 2;
+  };
+  const u32 = (v: number) => {
+    buf.writeUInt32LE(v >>> 0, p);
+    p += 4;
+  };
+  const raw = (b: Buffer) => {
+    b.copy(buf, p);
+    p += b.length;
+  };
+
+  // Local file header
+  u32(0x04034b50);
+  u16(20); // version needed
+  u16(0); // flags
+  u16(0); // method: stored
+  u16(0); // mtime
+  u16(0); // mdate
+  u32(crc);
+  u32(size);
+  u32(size);
+  u16(nameBytes.length);
+  u16(0);
+  raw(nameBytes);
+  raw(data);
+
+  // Central directory header
+  u32(0x02014b50);
+  u16((3 << 8) | 20); // made by: Unix, spec 2.0
+  u16(20);
+  u16(0);
+  u16(0);
+  u16(0);
+  u16(0);
+  u32(crc);
+  u32(size);
+  u32(size);
+  u16(nameBytes.length);
+  u16(0);
+  u16(0);
+  u16(0);
+  u16(0);
+  u32((0o100000 | unixMode) << 16);
+  u32(0); // LFH offset
+  raw(nameBytes);
+
+  // End of central directory
+  u32(0x06054b50);
+  u16(0);
+  u16(0);
+  u16(1);
+  u16(1);
+  u32(cdhLen);
+  u32(cdOffset);
+  u16(0);
+
+  return buf;
+}
+
+// Write a release zip for the current target that, once unpacked, yields an
+// executable at the path `bun upgrade` verifies. On POSIX a shell script is
+// enough because `unzip` preserves the mode bits; on Windows the verify step
+// spawns `bun.exe` directly, so the archive has to carry a real PE image.
+async function writeFakeReleaseZip(outPath: string, version: string): Promise<void> {
+  const os = process.platform === "win32" ? "windows" : process.platform === "darwin" ? "darwin" : "linux";
+  const arch = process.arch === "arm64" ? "aarch64" : "x64";
+  const abi = isMusl ? "-musl" : "";
+  const folder = `bun-${os}-${arch}${abi}`;
+  if (isWindows) {
+    const exe = Buffer.from(await Bun.file(bunExe()).arrayBuffer());
+    await writeFile(outPath, makeZipStored(`${folder}/bun.exe`, exe, 0o755));
+  } else {
+    const script = Buffer.from(`#!/bin/sh\nprintf '%s\\n' '${version}'\n`);
+    await writeFile(outPath, makeZipStored(`${folder}/bun`, script, 0o755));
+  }
+}
+
+type ReleaseServer = Bun.Server & { env: Record<string, string> };
+
+function startReleaseServer(opts: {
+  tagName: string;
+  assetNames?: string[];
+  zipPath?: string;
+  zipBody?: string;
+  digest?: string;
+}): ReleaseServer {
+  const assetNames = opts.assetNames ?? allAssetNames();
+  const server = Bun.serve({
+    tls: tls,
+    port: 0,
+    async fetch(req) {
+      const { pathname } = new URL(req.url);
+      if (pathname.startsWith("/download/")) {
+        if (opts.zipPath) return new Response(Bun.file(opts.zipPath));
+        return new Response(opts.zipBody ?? "this is not a real zip archive");
+      }
+      return new Response(
+        JSON.stringify({
+          tag_name: opts.tagName,
+          assets: assetNames.map(name => ({
+            url: "foo",
+            content_type: "application/zip",
+            name,
+            ...(opts.digest ? { digest: opts.digest } : {}),
+            browser_download_url: `https://${server.hostname}:${server.port}/download/${name}`,
+          })),
+        }),
+      );
+    },
+  }) as ReleaseServer;
+  server.env = {
+    ...env,
+    NODE_TLS_REJECT_UNAUTHORIZED: "0",
+    GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+    // The upgrade-failure path exits via Global::exit(1) while the HTTP
+    // thread and the intentionally-leaked progress/download buffers are
+    // still live; LeakSanitizer reports those at exit and abort_on_error
+    // turns the clean exit(1) into SIGABRT on the ASAN lane. Leak
+    // detection is not what these tests assert.
+    ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+  };
+  return server;
+}
 
 describe.concurrent(() => {
   it("two invalid arguments, should display error message and suggest command", async () => {
@@ -77,7 +231,11 @@ describe.concurrent(() => {
     expect(err.split(/\r?\n/)).not.toContain("note: Use `bun update --help` instead.");
   });
 
-  it("two valid argument, should succeed", async () => {
+  it("two valid arguments, should succeed", async () => {
+    // `--stable --profile` are both recognised flags; argument validation must
+    // let them through. The release server returns a garbage archive so the
+    // upgrade fails later, after argument parsing has already accepted them.
+    using server = startReleaseServer({ tagName: "bun-v9.9.9", assetNames: allAssetNames(true) });
     const cwd = tmpdirSync();
     const execPath = join(cwd, basename(bunExe()));
     await copyFile(bunExe(), execPath);
@@ -87,7 +245,7 @@ describe.concurrent(() => {
       stdout: null,
       stdin: "pipe",
       stderr: "pipe",
-      env,
+      env: server.env,
     });
 
     const err = await proc.stderr.text();
@@ -96,107 +254,47 @@ describe.concurrent(() => {
       "error: This command updates Bun itself, and does not take package names.",
     );
     expect(err.split(/\r?\n/)).not.toContain("note: Use `bun update --stable --profile` instead.");
-  });
-
-  it("zero arguments, should succeed", async () => {
-    const tagName = bunExe().includes("-debug") ? "canary" : `bun-v${Bun.version}`;
-    using server = Bun.serve({
-      tls: tls,
-      port: 0,
-      async fetch() {
-        return new Response(
-          JSON.stringify({
-            "tag_name": tagName,
-            "assets": [
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-windows-x64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-windows-x64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-windows-x64-baseline.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-windows-x64-baseline.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-windows-aarch64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-windows-aarch64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-linux-x64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-linux-x64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-linux-x64-baseline.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-linux-x64-baseline.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-linux-aarch64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-linux-aarch64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-darwin-x64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-darwin-x64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-darwin-x64-baseline.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-darwin-x64-baseline.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-darwin-aarch64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-darwin-aarch64.zip`,
-              },
-            ],
-          }),
-        );
-      },
-    });
-
-    // On windows, open the temporary directory without FILE_SHARE_DELETE before spawning
-    // the upgrade process. This is to test for EBUSY errors
-    openTempDirWithoutSharingDelete();
-    const cwd = tmpdirSync();
-    const execPath = join(cwd, basename(bunExe()));
-    await copyFile(bunExe(), execPath);
-
-    await using proc = Bun.spawn({
-      cmd: [execPath, "upgrade"],
-      cwd,
-      stdout: null,
-      stdin: "pipe",
-      stderr: "pipe",
-      env: {
-        ...env,
-        NODE_TLS_REJECT_UNAUTHORIZED: "0",
-        GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
-      },
-    });
-
-    closeTempDirHandle();
-
-    // Should not contain error message
-    expect(await proc.stderr.text()).not.toContain("error:");
-    // Reap the subprocess: stderr can close before the child exits, and an
-    // unreaped child is force-killed by the test runner at test end without
-    // draining the Subprocess refcount — LSan then flags it as a leak.
     await proc.exited;
   });
+});
+
+it("completes against a locally-served release with the system temp dir held open without FILE_SHARE_DELETE", async () => {
+  // `--stable` routes through the GitHub releases API (overridable via
+  // GITHUB_API_DOMAIN) instead of the compiled-in canary URL, so the whole
+  // download/unpack/verify path runs against the local server. On non-canary
+  // builds the current-version check short-circuits before the download,
+  // which still produces no `error:` and is fine: canary covers the temp-dir
+  // path on Windows.
+  const version = Bun.version;
+  const cwd = tmpdirSync();
+  const execPath = join(cwd, basename(bunExe()));
+  const zipPath = join(cwd, "release.zip");
+  await Promise.all([copyFile(bunExe(), execPath), writeFakeReleaseZip(zipPath, version)]);
+
+  using server = startReleaseServer({ tagName: `bun-v${version}`, zipPath });
+
+  // On Windows, open the temporary directory without FILE_SHARE_DELETE before spawning
+  // the upgrade process. This is to test for EBUSY errors.
+  openTempDirWithoutSharingDelete();
+
+  await using proc = Bun.spawn({
+    cmd: [execPath, "upgrade", "--stable"],
+    cwd,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env: server.env,
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  closeTempDirHandle();
+
+  expect(stderr).not.toContain("error:");
+  // Canary builds always download (the current-version short-circuit is gated
+  // on !IS_CANARY); a non-canary build whose version matches the served tag
+  // takes the "already on the latest" exit instead.
+  expect(stderr).toMatch(/Upgraded\.|already on the latest/);
+  expect(exitCode).toBe(0);
 });
 
 it("recreates the staging directory in the temp dir instead of reusing a pre-existing one", async () => {
@@ -213,42 +311,7 @@ it("recreates the staging directory in the temp dir instead of reusing a pre-exi
   });
   const stagingRootPath = String(stagingRoot);
 
-  // Cover every platform/arch/abi/cpu combination so the asset list matches
-  // whichever target this test runs on. Non-matching names are ignored.
-  const assetNames: string[] = [];
-  for (const os of ["windows", "linux", "darwin"]) {
-    for (const arch of ["x64", "aarch64"]) {
-      for (const abi of ["", "-musl"]) {
-        for (const cpu of ["", "-baseline"]) {
-          assetNames.push(`bun-${os}-${arch}${abi}${cpu}.zip`);
-        }
-      }
-    }
-  }
-
-  using server = Bun.serve({
-    tls: tls,
-    port: 0,
-    async fetch(req) {
-      const { pathname } = new URL(req.url);
-      if (pathname.startsWith("/releases/")) {
-        // The downloaded artifact only needs to be non-empty so the upgrade
-        // reaches the staging step; it is expected to fail when unpacking.
-        return new Response("this is not a real zip archive");
-      }
-      return new Response(
-        JSON.stringify({
-          "tag_name": tagName,
-          "assets": assetNames.map(name => ({
-            "url": "foo",
-            "content_type": "application/zip",
-            "name": name,
-            "browser_download_url": `https://${server.hostname}:${server.port}/releases/${tagName}/${name}`,
-          })),
-        }),
-      );
-    },
-  });
+  using server = startReleaseServer({ tagName });
 
   const cwd = tmpdirSync();
   const execPath = join(cwd, basename(bunExe()));
@@ -263,16 +326,8 @@ it("recreates the staging directory in the temp dir instead of reusing a pre-exi
     stdin: "pipe",
     stderr: "pipe",
     env: {
-      ...env,
-      NODE_TLS_REJECT_UNAUTHORIZED: "0",
-      GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+      ...server.env,
       BUN_TMPDIR: stagingRootPath,
-      // The upgrade-failure path exits via Global::exit(1) while the HTTP
-      // thread and the intentionally-leaked progress/download buffers are
-      // still live; LeakSanitizer reports those at exit and abort_on_error
-      // turns the clean exit(1) into SIGABRT on the ASAN lane. Leak
-      // detection is not what this test asserts.
-      ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
     },
   });
 
@@ -300,40 +355,8 @@ it("verifies the downloaded release archive against the digest reported by the r
   const correctDigest = `sha256:${new Bun.CryptoHasher("sha256").update(archiveBody).digest("hex")}`;
   const wrongDigest = `sha256:${Buffer.alloc(32, 0xab).toString("hex")}`;
 
-  const assetNames: string[] = [];
-  for (const os of ["windows", "linux", "darwin"]) {
-    for (const arch of ["x64", "aarch64"]) {
-      for (const abi of ["", "-musl"]) {
-        for (const cpu of ["", "-baseline"]) {
-          assetNames.push(`bun-${os}-${arch}${abi}${cpu}.zip`);
-        }
-      }
-    }
-  }
-
   const runUpgrade = async (tagName: string, digest: string) => {
-    using server = Bun.serve({
-      tls: tls,
-      port: 0,
-      async fetch(req) {
-        const { pathname } = new URL(req.url);
-        if (pathname.startsWith("/releases/")) {
-          return new Response(archiveBody);
-        }
-        return new Response(
-          JSON.stringify({
-            "tag_name": tagName,
-            "assets": assetNames.map(name => ({
-              "url": "foo",
-              "content_type": "application/zip",
-              "name": name,
-              "digest": digest,
-              "browser_download_url": `https://${server.hostname}:${server.port}/releases/${tagName}/${name}`,
-            })),
-          }),
-        );
-      },
-    });
+    using server = startReleaseServer({ tagName, digest, zipBody: archiveBody });
 
     const cwd = tmpdirSync();
     const execPath = join(cwd, basename(bunExe()));
@@ -345,12 +368,7 @@ it("verifies the downloaded release archive against the digest reported by the r
       stdout: null,
       stdin: "pipe",
       stderr: "pipe",
-      env: {
-        ...env,
-        NODE_TLS_REJECT_UNAUTHORIZED: "0",
-        GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
-        ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
-      },
+      env: server.env,
     });
 
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);


### PR DESCRIPTION
## What

Reworks `test/cli/install/bun-upgrade.test.ts` so no test contacts `api.github.com`, `github.com`, or `r2.dev`. Every upgrade invocation now talks only to a local `Bun.serve` on `port: 0` via `GITHUB_API_DOMAIN`.

## Why the old tests hit GitHub

Two tests were reaching the public internet on every run:

- `two valid argument, should succeed` spawned `bun upgrade --stable --profile` with no `GITHUB_API_DOMAIN`, so the version lookup went straight to `https://api.github.com/repos/Jarred-Sumner/bun-releases-for-updater/releases/latest`.
- `zero arguments, should succeed` set `GITHUB_API_DOMAIN`, but every CI/debug binary is a canary build, and the canary path builds its download URL at compile time as `https://github.com/oven-sh/bun/releases/download/canary/<name>.zip` without consulting `GITHUB_API_DOMAIN`. The local server and its `r2.dev` asset URLs were never reached; the test was downloading the real ~30 MB canary archive on every lane.

## Change

- New `startReleaseServer()` helper serves both the release JSON and the archive body from one local TLS server and returns the env block (`GITHUB_API_DOMAIN`, `NODE_TLS_REJECT_UNAUTHORIZED`, `ASAN_OPTIONS`) every upgrade spawn needs. All server-backed tests share it.
- New `makeZipStored()` writes a minimal single-entry stored ZIP. On POSIX the fake release archive contains a shell script that echoes `Bun.version` (the `unzip -o` path preserves the mode bits from the Unix external-attrs field). On Windows the archive carries a copy of `bunExe()` because the verify step spawns `bun.exe` directly and needs a real PE image.
- The `zero arguments` test is now `completes against a locally-served release with the system temp dir held open without FILE_SHARE_DELETE`: it passes `--stable` so the version lookup goes through `GITHUB_API_DOMAIN`, downloads the locally-served zip, unpacks, verifies, and replaces the copied executable, all while the Windows `openTempDirWithoutSharingDelete` handle is held. It now asserts `stderr` matches `/Upgraded\.|already on the latest/` and `exitCode === 0` so a short-circuit or silent network failure would fail the test.
- The `two valid arguments` test now points at the local server; it only ever asserted the absence of the arg-validation error, so the upgrade is allowed to fail later on the garbage archive.
- The duplicated asset-name loop in the staging-directory and digest tests is folded into `allAssetNames()`; their behaviour is unchanged.
- Dropped the 5-minute `setDefaultTimeout`; nothing in the file waits on the network anymore.

## Verification

```
$ bun bd test test/cli/install/bun-upgrade.test.ts
 8 pass, 0 fail, 5.94s    # Linux x64 debug+ASAN

$ bun test test/cli/install/bun-upgrade.test.ts   # Windows x64, release canary
 8 pass, 0 fail, 11.41s
```

The happy-path test's stderr on Linux debug shows the full local flow:

```
Downgrading from Bun 1.4.0-debug-canary to Bun v1.4.0-debug
Downloading...
[280.00ms] Upgraded.
Welcome to Bun v1.4.0-debug!
```

## Relation to #36702

#36702 takes a different route: it changes the canary upgrade path in `upgrade_command.rs` to consult `GITHUB_API_DOMAIN` before falling back to the hardcoded URL, and updates the test to assert the download hit the local server (with a fake archive that stops at unzip). This PR is test-only and keeps the full unpack/verify/replace flow under test by serving a working archive. Either approach removes the GitHub dependency; they are not mutually exclusive.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->