### PR TITLE
Bun.write: don't over-copy or ftruncate a caller-supplied destination fd

### DIFF
--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -319,10 +319,8 @@ impl<'a> CopyFile<'a> {
             self.destination_file_store.pathlike,
             PathOrFileDescriptor::Path(_)
         );
-        let fallback_cap = if unknown_size {
-            MAX_SIZE
-        } else {
-            remain as SizeType
+        let fallback_cap = |remain: usize| -> SizeType {
+            if unknown_size { MAX_SIZE } else { remain as SizeType }
         };
 
         // defer { this.read_len = @truncate(total_written); }
@@ -343,7 +341,7 @@ impl<'a> CopyFile<'a> {
                 src_fd,
                 dest_fd,
                 bun_opened_dest,
-                fallback_cap,
+                fallback_cap(remain),
                 &mut total_written,
             ) {
                 bun_sys::Result::Err(err) => {
@@ -408,7 +406,7 @@ impl<'a> CopyFile<'a> {
                         src_fd,
                         dest_fd,
                         bun_opened_dest,
-                        fallback_cap,
+                        fallback_cap(remain),
                         &mut total_written,
                     ) {
                         bun_sys::Result::Err(err) => {
@@ -455,7 +453,7 @@ impl<'a> CopyFile<'a> {
                             src_fd,
                             dest_fd,
                             bun_opened_dest,
-                            fallback_cap,
+                            fallback_cap(remain),
                             &mut total_written,
                         ) {
                             bun_sys::Result::Err(err) => {

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -320,7 +320,11 @@ impl<'a> CopyFile<'a> {
             PathOrFileDescriptor::Path(_)
         );
         let fallback_cap = |remain: usize| -> SizeType {
-            if unknown_size { MAX_SIZE } else { remain as SizeType }
+            if unknown_size {
+                MAX_SIZE
+            } else {
+                remain as SizeType
+            }
         };
 
         // defer { this.read_len = @truncate(total_written); }

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -972,6 +972,11 @@ fn read_write_fallback(
     }
 }
 
+/// read() from `src_fd`, write() to `dest_fd`, stopping after `cap` bytes (or
+/// EOF). Never reads past `cap` and never touches the destination's length, so
+/// it is safe for a caller-supplied fd (Bun.stdout redirected to a file,
+/// Bun.file(fd)).
+#[inline(never)] // 64 KB stack buffer
 #[cfg(not(windows))]
 fn read_write_loop_capped(
     src_fd: Fd,

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -789,7 +789,9 @@ impl<'a> CopyFile<'a> {
                 return;
             }
 
-            if stat.st_size != 0 {
+            // BSD fstat on a pipe reports bytes currently buffered in st_size;
+            // only a regular-file st_size is a length.
+            if stat.st_size != 0 && bun_sys::S::ISREG(stat.st_mode as _) {
                 self.max_length = (SizeType::try_from(stat.st_size)
                     .expect("int cast")
                     .min(self.max_length))
@@ -801,7 +803,6 @@ impl<'a> CopyFile<'a> {
                 }
 
                 if PREALLOCATE_SUPPORTED
-                    && bun_sys::S::ISREG(stat.st_mode as _)
                     && self.max_length > PREALLOCATE_LENGTH
                     && self.max_length != MAX_SIZE
                 {

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -315,6 +315,15 @@ impl<'a> CopyFile<'a> {
         let mut total_written: u64 = 0;
         let src_fd = self.source_fd;
         let dest_fd = self.destination_fd;
+        let bun_opened_dest = matches!(
+            self.destination_file_store.pathlike,
+            PathOrFileDescriptor::Path(_)
+        );
+        let fallback_cap = if unknown_size {
+            MAX_SIZE
+        } else {
+            remain as SizeType
+        };
 
         // defer { this.read_len = @truncate(total_written); }
         let read_len_slot: *mut SizeType = &raw mut self.read_len;
@@ -330,28 +339,18 @@ impl<'a> CopyFile<'a> {
         // If they can't use copy_file_range, they probably also can't
         // use sendfile() or splice()
         if !bun_sys::copy_file::can_use_copy_file_range_syscall() {
-            match node_fs::NodeFS::copy_file_using_read_write_loop(
-                bun_core::ZStr::EMPTY,
-                bun_core::ZStr::EMPTY,
+            match read_write_fallback(
                 src_fd,
                 dest_fd,
-                if unknown_size { 0 } else { remain },
+                bun_opened_dest,
+                fallback_cap,
                 &mut total_written,
             ) {
                 bun_sys::Result::Err(err) => {
                     self.system_error = Some(err.to_system_error());
                     return Err(bun_errno::from_errno(err.errno as i32).into());
                 }
-                bun_sys::Result::Ok(()) => {
-                    // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
-                    let _ = unsafe {
-                        libc::ftruncate(
-                            dest_fd.native(),
-                            i64::try_from(total_written).expect("int cast"),
-                        )
-                    };
-                    return Ok(());
-                }
+                bun_sys::Result::Ok(()) => return Ok(()),
             }
         }
 
@@ -405,28 +404,18 @@ impl<'a> CopyFile<'a> {
                 // OPNOTSUPP: filesystem doesn't support this operation
                 bun_sys::E::ENOSYS | bun_sys::E::EXDEV | bun_sys::E::ENOTSUP => {
                     // TODO: this should use non-blocking I/O.
-                    match node_fs::NodeFS::copy_file_using_read_write_loop(
-                        bun_core::ZStr::EMPTY,
-                        bun_core::ZStr::EMPTY,
+                    match read_write_fallback(
                         src_fd,
                         dest_fd,
-                        if unknown_size { 0 } else { remain },
+                        bun_opened_dest,
+                        fallback_cap,
                         &mut total_written,
                     ) {
                         bun_sys::Result::Err(err) => {
                             self.system_error = Some(err.to_system_error());
                             return Err(bun_errno::from_errno(err.errno as i32).into());
                         }
-                        bun_sys::Result::Ok(()) => {
-                            // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
-                            let _ = unsafe {
-                                libc::ftruncate(
-                                    dest_fd.native(),
-                                    i64::try_from(total_written).expect("int cast"),
-                                )
-                            };
-                            return Ok(());
-                        }
+                        bun_sys::Result::Ok(()) => return Ok(()),
                     }
                 }
 
@@ -462,28 +451,18 @@ impl<'a> CopyFile<'a> {
                     // to a read/write loop
                     if total_written == 0 {
                         // TODO: this should use non-blocking I/O.
-                        match node_fs::NodeFS::copy_file_using_read_write_loop(
-                            bun_core::ZStr::EMPTY,
-                            bun_core::ZStr::EMPTY,
+                        match read_write_fallback(
                             src_fd,
                             dest_fd,
-                            if unknown_size { 0 } else { remain },
+                            bun_opened_dest,
+                            fallback_cap,
                             &mut total_written,
                         ) {
                             bun_sys::Result::Err(err) => {
                                 self.system_error = Some(err.to_system_error());
                                 return Err(bun_errno::from_errno(err.errno as i32).into());
                             }
-                            bun_sys::Result::Ok(()) => {
-                                // SAFETY: dest_fd is a valid open fd; raw ftruncate(2).
-                                let _ = unsafe {
-                                    libc::ftruncate(
-                                        dest_fd.native(),
-                                        i64::try_from(total_written).expect("int cast"),
-                                    )
-                                };
-                                return Ok(());
-                            }
+                            bun_sys::Result::Ok(()) => return Ok(()),
                         }
                     }
 
@@ -527,51 +506,20 @@ impl<'a> CopyFile<'a> {
         Ok(())
     }
 
-    /// read() from `source_fd`, write() to `destination_fd`, stopping after
-    /// `cap` bytes have been read (or EOF). Unlike
-    /// `copy_file_using_read_write_loop`, this never reads past `cap` and
-    /// never touches the destination's length, so it is safe for a
-    /// caller-supplied fd (Bun.stdout redirected to a file, Bun.file(fd)).
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     fn do_read_write_loop_capped(&mut self, cap: SizeType) -> Result<(), crate::Error> {
-        let mut buf = [0u8; 64 * 1024];
-        let mut remaining = cap;
         let mut total: u64 = 0;
-        while remaining > 0 {
-            let want = (buf.len() as SizeType).min(remaining) as usize;
-            let amt = match bun_sys::read(self.source_fd, &mut buf[..want]) {
-                bun_sys::Result::Ok(n) => n,
-                bun_sys::Result::Err(err) => {
-                    self.read_len = total as SizeType;
-                    self.system_error = Some(err.to_system_error());
-                    return Err(bun_errno::from_errno(err.errno as i32).into());
-                }
-            };
-            if amt == 0 {
-                break;
+        match read_write_loop_capped(self.source_fd, self.destination_fd, cap, &mut total) {
+            bun_sys::Result::Ok(()) => {
+                self.read_len = total as SizeType;
+                Ok(())
             }
-            remaining -= amt as SizeType;
-            let mut slice = &buf[..amt];
-            while !slice.is_empty() {
-                match bun_sys::write(self.destination_fd, slice) {
-                    bun_sys::Result::Ok(0) => {
-                        self.read_len = total as SizeType;
-                        return Ok(());
-                    }
-                    bun_sys::Result::Ok(n) => {
-                        total += n as u64;
-                        slice = &slice[n..];
-                    }
-                    bun_sys::Result::Err(err) => {
-                        self.read_len = total as SizeType;
-                        self.system_error = Some(err.to_system_error());
-                        return Err(bun_errno::from_errno(err.errno as i32).into());
-                    }
-                }
+            bun_sys::Result::Err(err) => {
+                self.read_len = total as SizeType;
+                self.system_error = Some(err.to_system_error());
+                Err(bun_errno::from_errno(err.errno as i32).into())
             }
         }
-        self.read_len = total as SizeType;
-        Ok(())
     }
 
     #[cfg(target_os = "macos")]
@@ -1000,6 +948,66 @@ impl<'a> CopyFile<'a> {
             }
         }
     }
+}
+
+/// The read/write fallback used when Linux's kernel copy syscalls are
+/// unavailable for this fd pair. For a destination Bun opened itself with
+/// `O_TRUNC`, copy the whole source and then `ftruncate` (cheap, matches the
+/// historical behaviour). For a caller-supplied fd, copy exactly `cap` bytes
+/// so nothing outside the requested window is touched.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn read_write_fallback(
+    src_fd: Fd,
+    dest_fd: Fd,
+    bun_opened_dest: bool,
+    cap: SizeType,
+    total: &mut u64,
+) -> bun_sys::Result<()> {
+    if bun_opened_dest {
+        let stat_size = if cap == MAX_SIZE { 0 } else { cap as usize };
+        node_fs::NodeFS::copy_file_using_read_write_loop(
+            bun_core::ZStr::EMPTY,
+            bun_core::ZStr::EMPTY,
+            src_fd,
+            dest_fd,
+            stat_size,
+            total,
+        )?;
+        let _ = bun_sys::ftruncate(dest_fd, i64::try_from(*total).expect("int cast"));
+        Ok(())
+    } else {
+        read_write_loop_capped(src_fd, dest_fd, cap, total)
+    }
+}
+
+#[cfg(not(windows))]
+fn read_write_loop_capped(
+    src_fd: Fd,
+    dest_fd: Fd,
+    cap: SizeType,
+    total: &mut u64,
+) -> bun_sys::Result<()> {
+    let mut buf = [0u8; 64 * 1024];
+    let mut remaining = cap;
+    while remaining > 0 {
+        let want = (buf.len() as SizeType).min(remaining) as usize;
+        let amt = bun_sys::read(src_fd, &mut buf[..want])?;
+        if amt == 0 {
+            break;
+        }
+        remaining -= amt as SizeType;
+        let mut slice = &buf[..amt];
+        while !slice.is_empty() {
+            match bun_sys::write(dest_fd, slice)? {
+                0 => return Ok(()),
+                n => {
+                    *total += n as u64;
+                    slice = &slice[n..];
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 // Ownership is encoded in the types, so cleanup is all field `Drop`:

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -972,10 +972,6 @@ fn read_write_fallback(
     }
 }
 
-/// read() from `src_fd`, write() to `dest_fd`, stopping after `cap` bytes (or
-/// EOF). Never reads past `cap` and never touches the destination's length, so
-/// it is safe for a caller-supplied fd (Bun.stdout redirected to a file,
-/// Bun.file(fd)).
 #[inline(never)] // 64 KB stack buffer
 #[cfg(not(windows))]
 fn read_write_loop_capped(

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -865,12 +865,8 @@ impl<'a> CopyFile<'a> {
 
             #[cfg(target_os = "macos")]
             {
-                // fcopyfile(COPYFILE_DATA) rewrites the destination from
-                // offset 0 and the slice-trim below is implemented as
-                // ftruncate(dest); both destroy bytes in a file the caller
-                // already had open (Bun.stdout redirected with `>>`,
-                // Bun.file(fd)). Only take the fcopyfile path for a
-                // destination this function opened itself.
+                // fcopyfile rewrites dest from offset 0 and the slice trim is
+                // ftruncate; both are only safe for a dest Bun opened O_TRUNC.
                 if matches!(
                     self.destination_file_store.pathlike,
                     PathOrFileDescriptor::Path(_)
@@ -950,11 +946,6 @@ impl<'a> CopyFile<'a> {
     }
 }
 
-/// The read/write fallback used when Linux's kernel copy syscalls are
-/// unavailable for this fd pair. For a destination Bun opened itself with
-/// `O_TRUNC`, copy the whole source and then `ftruncate` (cheap, matches the
-/// historical behaviour). For a caller-supplied fd, copy exactly `cap` bytes
-/// so nothing outside the requested window is touched.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn read_write_fallback(
     src_fd: Fd,

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -527,6 +527,53 @@ impl<'a> CopyFile<'a> {
         Ok(())
     }
 
+    /// read() from `source_fd`, write() to `destination_fd`, stopping after
+    /// `cap` bytes have been read (or EOF). Unlike
+    /// `copy_file_using_read_write_loop`, this never reads past `cap` and
+    /// never touches the destination's length, so it is safe for a
+    /// caller-supplied fd (Bun.stdout redirected to a file, Bun.file(fd)).
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    fn do_read_write_loop_capped(&mut self, cap: SizeType) -> Result<(), crate::Error> {
+        let mut buf = [0u8; 64 * 1024];
+        let mut remaining = cap;
+        let mut total: u64 = 0;
+        while remaining > 0 {
+            let want = (buf.len() as SizeType).min(remaining) as usize;
+            let amt = match bun_sys::read(self.source_fd, &mut buf[..want]) {
+                bun_sys::Result::Ok(n) => n,
+                bun_sys::Result::Err(err) => {
+                    self.read_len = total as SizeType;
+                    self.system_error = Some(err.to_system_error());
+                    return Err(bun_errno::from_errno(err.errno as i32).into());
+                }
+            };
+            if amt == 0 {
+                break;
+            }
+            remaining -= amt as SizeType;
+            let mut slice = &buf[..amt];
+            while !slice.is_empty() {
+                match bun_sys::write(self.destination_fd, slice) {
+                    bun_sys::Result::Ok(0) => {
+                        self.read_len = total as SizeType;
+                        return Ok(());
+                    }
+                    bun_sys::Result::Ok(n) => {
+                        total += n as u64;
+                        slice = &slice[n..];
+                    }
+                    bun_sys::Result::Err(err) => {
+                        self.read_len = total as SizeType;
+                        self.system_error = Some(err.to_system_error());
+                        return Err(bun_errno::from_errno(err.errno as i32).into());
+                    }
+                }
+            }
+        }
+        self.read_len = total as SizeType;
+        Ok(())
+    }
+
     #[cfg(target_os = "macos")]
     pub(crate) fn do_fcopy_file_with_read_write_loop_fallback(
         &mut self,
@@ -870,20 +917,31 @@ impl<'a> CopyFile<'a> {
 
             #[cfg(target_os = "macos")]
             {
-                if self.do_fcopy_file_with_read_write_loop_fallback().is_err() {
+                // fcopyfile(COPYFILE_DATA) rewrites the destination from
+                // offset 0 and the slice-trim below is implemented as
+                // ftruncate(dest); both destroy bytes in a file the caller
+                // already had open (Bun.stdout redirected with `>>`,
+                // Bun.file(fd)). Only take the fcopyfile path for a
+                // destination this function opened itself.
+                if matches!(
+                    self.destination_file_store.pathlike,
+                    PathOrFileDescriptor::Path(_)
+                ) {
+                    if self.do_fcopy_file_with_read_write_loop_fallback().is_err() {
+                        self.do_close();
+                        return;
+                    }
+                    if stat.st_size != 0
+                        && SizeType::try_from(stat.st_size).expect("int cast") > self.max_length
+                    {
+                        let _ = bun_sys::ftruncate(
+                            self.destination_fd,
+                            i64::try_from(self.max_length).expect("int cast"),
+                        );
+                    }
+                } else if self.do_read_write_loop_capped(self.max_length).is_err() {
                     self.do_close();
                     return;
-                }
-                if stat.st_size != 0
-                    && SizeType::try_from(stat.st_size).expect("int cast") > self.max_length
-                {
-                    // SAFETY: `destination_fd` is open; libc ftruncate(2).
-                    let _ = unsafe {
-                        bun_sys::darwin::ftruncate(
-                            self.destination_fd.native(),
-                            i64::try_from(self.max_length).expect("int cast"),
-                        )
-                    };
                 }
 
                 self.do_close();
@@ -892,32 +950,40 @@ impl<'a> CopyFile<'a> {
 
             #[cfg(target_os = "freebsd")]
             {
-                let mut total_written: u64 = 0;
-                match node_fs::NodeFS::copy_file_using_read_write_loop(
-                    bun_core::ZStr::EMPTY,
-                    bun_core::ZStr::EMPTY,
-                    self.source_fd,
-                    self.destination_fd,
-                    0,
-                    &mut total_written,
+                if matches!(
+                    self.destination_file_store.pathlike,
+                    PathOrFileDescriptor::Path(_)
                 ) {
-                    bun_sys::Result::Err(err) => {
-                        self.system_error = Some(err.to_system_error());
-                        self.do_close();
-                        return;
-                    }
-                    bun_sys::Result::Ok(()) => {}
-                }
-                if stat.st_size != 0
-                    && SizeType::try_from(stat.st_size).expect("int cast") > self.max_length
-                {
-                    let _ = bun_sys::ftruncate(
+                    let mut total_written: u64 = 0;
+                    match node_fs::NodeFS::copy_file_using_read_write_loop(
+                        bun_core::ZStr::EMPTY,
+                        bun_core::ZStr::EMPTY,
+                        self.source_fd,
                         self.destination_fd,
-                        i64::try_from(self.max_length).expect("int cast"),
-                    );
-                    self.read_len = total_written.min(self.max_length as u64) as SizeType;
-                } else {
-                    self.read_len = total_written as SizeType;
+                        0,
+                        &mut total_written,
+                    ) {
+                        bun_sys::Result::Err(err) => {
+                            self.system_error = Some(err.to_system_error());
+                            self.do_close();
+                            return;
+                        }
+                        bun_sys::Result::Ok(()) => {}
+                    }
+                    if stat.st_size != 0
+                        && SizeType::try_from(stat.st_size).expect("int cast") > self.max_length
+                    {
+                        let _ = bun_sys::ftruncate(
+                            self.destination_fd,
+                            i64::try_from(self.max_length).expect("int cast"),
+                        );
+                        self.read_len = total_written.min(self.max_length as u64) as SizeType;
+                    } else {
+                        self.read_len = total_written as SizeType;
+                    }
+                } else if self.do_read_write_loop_capped(self.max_length).is_err() {
+                    self.do_close();
+                    return;
                 }
                 self.do_close();
                 return;

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -805,6 +805,10 @@ impl<'a> CopyFile<'a> {
                 }
 
                 if PREALLOCATE_SUPPORTED
+                    && matches!(
+                        self.destination_file_store.pathlike,
+                        PathOrFileDescriptor::Path(_)
+                    )
                     && self.max_length > PREALLOCATE_LENGTH
                     && self.max_length != MAX_SIZE
                 {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -498,7 +498,12 @@ const IS_UV_FS_COPYFILE_DISABLED =
       await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: fallbackEnv, stdout: "pipe", stderr: "pipe" });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      expect({ stdout, resolved: stderr, head: fs.readFileSync(dst).subarray(0, 15).toString(), size: fs.statSync(dst).size }).toEqual({
+      expect({
+        stdout,
+        resolved: stderr,
+        head: fs.readFileSync(dst).subarray(0, 15).toString(),
+        size: fs.statSync(dst).size,
+      }).toEqual({
         stdout: "",
         resolved: String(size),
         head: "AAAAAAAAAASSSSS",

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -7,7 +7,6 @@ import {
   exampleSite,
   gcTick,
   isASAN,
-  isLinux,
   isWindows,
   tempDir,
   withoutAggressiveGC,

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -481,6 +481,31 @@ const IS_UV_FS_COPYFILE_DISABLED =
       });
       expect(exitCode).toBe(0);
     });
+
+    it("does not fallocate an O_APPEND fd for a source above the preallocate threshold", async () => {
+      const size = 3_000_000;
+      using dir = tempDir("bun-write-fd-preallocate", { "dst.bin": "AAAAAAAAAA" });
+      const src = join(String(dir), "src.bin");
+      const dst = join(String(dir), "dst.bin");
+      fs.writeFileSync(src, Buffer.alloc(size, "S"));
+      const script = `
+        const fs = require("fs");
+        const fd = fs.openSync(${JSON.stringify(dst)}, "a");
+        try {
+          process.stderr.write(String(await Bun.write(Bun.file(fd), Bun.file(${JSON.stringify(src)}))));
+        } finally { fs.closeSync(fd); }
+      `;
+      await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: fallbackEnv, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout, resolved: stderr, head: fs.readFileSync(dst).subarray(0, 15).toString(), size: fs.statSync(dst).size }).toEqual({
+        stdout: "",
+        resolved: String(size),
+        head: "AAAAAAAAAASSSSS",
+        size: 10 + size,
+      });
+      expect(exitCode).toBe(0);
+    });
   });
 
   // fstat on a FIFO reports st_size == 0, so the kernel-copy / bounded loop

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -425,28 +425,37 @@ const IS_UV_FS_COPYFILE_DISABLED =
     await Bun.write(Bun.stderr, Bun.file(path.join(import.meta.dir, "hello-world.txt")));
   });
 
-  // macOS fcopyfile(COPYFILE_DATA) rewrites dst from offset 0, and slice copies
-  // used to ftruncate(dst, N) afterwards on macOS/FreeBSD; both destroy bytes in
-  // a file the caller already had open. Linux is skipped: copy_file_range rejects
-  // O_APPEND with EBADF and the non-append case already preserves bytes, so the
-  // test cannot fail-before there.
-  describe.skipIf(isWindows || isLinux)("Bun.write(Bun.file(fd), Bun.file(path)) does not truncate the fd", () => {
+  // macOS fcopyfile(COPYFILE_DATA) rewrites dst from offset 0, and the
+  // slice trim on macOS/FreeBSD (and the Linux read/write fallback) was
+  // ftruncate(dst, N); both destroy bytes in a file the caller already had
+  // open. BUN_CONFIG_DISABLE_COPY_FILE_RANGE=1 routes Linux through the
+  // fallback so the assertion fail-befores on every POSIX lane.
+  describe.skipIf(isWindows)("Bun.write(Bun.file(fd), Bun.file(path)) does not truncate the fd", () => {
+    const fallbackEnv = { ...bunEnv, BUN_CONFIG_DISABLE_COPY_FILE_RANGE: "1" };
+
     it("preserves bytes past the slice window in an r+ fd", async () => {
       using dir = tempDir("bun-write-fd-slice", {
         "src.bin": Buffer.alloc(200_000, "S").toString(),
         "dst.bin": Buffer.alloc(30, "D").toString(),
       });
+      const src = join(String(dir), "src.bin");
       const dst = join(String(dir), "dst.bin");
-      const fd = fs.openSync(dst, "r+");
-      try {
-        const written = await Bun.write(Bun.file(fd).slice(0, 5), Bun.file(join(String(dir), "src.bin")));
-        expect({ written, content: fs.readFileSync(dst, "utf8") }).toEqual({
-          written: 5,
-          content: "SSSSS" + Buffer.alloc(25, "D").toString(),
-        });
-      } finally {
-        fs.closeSync(fd);
-      }
+      const script = `
+        const fs = require("fs");
+        const fd = fs.openSync(${JSON.stringify(dst)}, "r+");
+        try {
+          process.stderr.write(String(await Bun.write(Bun.file(fd).slice(0, 5), Bun.file(${JSON.stringify(src)}))));
+        } finally { fs.closeSync(fd); }
+      `;
+      await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: fallbackEnv, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout, resolved: stderr, content: fs.readFileSync(dst, "utf8") }).toEqual({
+        stdout: "",
+        resolved: "5",
+        content: "SSSSS" + Buffer.alloc(25, "D").toString(),
+      });
+      expect(exitCode).toBe(0);
     });
 
     it("preserves pre-existing bytes when stdout is redirected with >>", async () => {
@@ -460,7 +469,7 @@ const IS_UV_FS_COPYFILE_DISABLED =
 
       await using proc = Bun.spawn({
         cmd: ["sh", "-c", `"$BUN" -e ${JSON.stringify(script)} >> ${JSON.stringify(log)}`],
-        env: { ...bunEnv, BUN: bunExe() },
+        env: { ...fallbackEnv, BUN: bunExe() },
         stdout: "pipe",
         stderr: "pipe",
       });
@@ -475,12 +484,11 @@ const IS_UV_FS_COPYFILE_DISABLED =
     });
   });
 
-  // On Linux, FIFO -> FIFO goes through splice(2). fstat on a FIFO reports
-  // st_size == 0, and the copy loop used to treat its unknown-size probe as
-  // the total byte budget, silently dropping the rest of the stream.
+  // fstat on a FIFO reports st_size == 0, so the kernel-copy / bounded loop
+  // must terminate on EOF, not on the stat-derived budget.
   // Bun.spawn({stdin:"pipe"}) hands the child a socketpair, not a FIFO, so
   // run the pipeline under sh to get real kernel pipes on fd 0/1.
-  it.skipIf(!isLinux)("Bun.write(Bun.stdout, Bun.stdin) copies the whole pipe (> 4096 bytes)", async () => {
+  it.skipIf(isWindows)("Bun.write(Bun.stdout, Bun.stdin) copies the whole pipe (> 4096 bytes)", async () => {
     const size = 1024 * 1024;
     const script = `process.stderr.write(String(await Bun.write(Bun.stdout, Bun.stdin)))`;
 

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -425,6 +425,56 @@ const IS_UV_FS_COPYFILE_DISABLED =
     await Bun.write(Bun.stderr, Bun.file(path.join(import.meta.dir, "hello-world.txt")));
   });
 
+  // macOS fcopyfile(COPYFILE_DATA) rewrites dst from offset 0, and slice copies
+  // used to ftruncate(dst, N) afterwards on macOS/FreeBSD; both destroy bytes in
+  // a file the caller already had open. Linux is skipped: copy_file_range rejects
+  // O_APPEND with EBADF and the non-append case already preserves bytes, so the
+  // test cannot fail-before there.
+  describe.skipIf(isWindows || isLinux)("Bun.write(Bun.file(fd), Bun.file(path)) does not truncate the fd", () => {
+    it("preserves bytes past the slice window in an r+ fd", async () => {
+      using dir = tempDir("bun-write-fd-slice", {
+        "src.bin": Buffer.alloc(200_000, "S").toString(),
+        "dst.bin": Buffer.alloc(30, "D").toString(),
+      });
+      const dst = join(String(dir), "dst.bin");
+      const fd = fs.openSync(dst, "r+");
+      try {
+        const written = await Bun.write(Bun.file(fd).slice(0, 5), Bun.file(join(String(dir), "src.bin")));
+        expect({ written, content: fs.readFileSync(dst, "utf8") }).toEqual({
+          written: 5,
+          content: "SSSSS" + Buffer.alloc(25, "D").toString(),
+        });
+      } finally {
+        fs.closeSync(fd);
+      }
+    });
+
+    it("preserves pre-existing bytes when stdout is redirected with >>", async () => {
+      using dir = tempDir("bun-write-stdout-append", {
+        "src.bin": Buffer.alloc(1000, "S").toString(),
+        "log.txt": "AAAAAAAAAA",
+      });
+      const src = join(String(dir), "src.bin");
+      const log = join(String(dir), "log.txt");
+      const script = `process.stderr.write(String(await Bun.write(Bun.stdout.slice(0, 100), Bun.file(${JSON.stringify(src)}))))`;
+
+      await using proc = Bun.spawn({
+        cmd: ["sh", "-c", `"$BUN" -e ${JSON.stringify(script)} >> ${JSON.stringify(log)}`],
+        env: { ...bunEnv, BUN: bunExe() },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout, resolved: stderr, content: fs.readFileSync(log, "utf8") }).toEqual({
+        stdout: "",
+        resolved: "100",
+        content: "AAAAAAAAAA" + Buffer.alloc(100, "S").toString(),
+      });
+      expect(exitCode).toBe(0);
+    });
+  });
+
   // On Linux, FIFO -> FIFO goes through splice(2). fstat on a FIFO reports
   // st_size == 0, and the copy loop used to treat its unknown-size probe as
   // the total byte budget, silently dropping the rest of the stream.


### PR DESCRIPTION
## Repro

```sh
head -c 200000 /dev/zero | tr '\0' S > /tmp/src.bin
printf 'DDDDDDDDDDDDDDDDDDDDDDDDDDDDDD' > /tmp/dst.bin
BUN_CONFIG_DISABLE_COPY_FILE_RANGE=1 bun -e '
  const fs = require("fs");
  const fd = fs.openSync("/tmp/dst.bin", "r+");
  console.log(await Bun.write(Bun.file(fd).slice(0, 5), Bun.file("/tmp/src.bin")));
  fs.closeSync(fd);
'
wc -c /tmp/dst.bin
# Linux (fallback): 200000 (expected 30; whole source over-copied then ftruncated)
# macOS:            5      (expected 30; fcopyfile rewrote from 0 then ftruncate(5))
```

Same for `Bun.stdout` under `>>` redirection: the pre-existing bytes in the redirected file are gone after the write.

## Cause

`CopyFile::run_async` dispatched fd-backed destinations through the same path as path destinations.

- **macOS:** `fcopyfile(COPYFILE_DATA)` rewrites the destination from offset 0, and when `stat.st_size > max_length` Bun then calls `ftruncate(dest, max_length)` to trim the over-copied tail. Both are safe when Bun opened the destination with `O_CREAT|O_TRUNC`, but for a caller-supplied fd they discard whatever the file already contained.
- **FreeBSD** and the **Linux read/write fallback** (kernel < 4.5, `EXDEV`, `ENOTSUP`, `EINVAL`, or `BUN_CONFIG_DISABLE_COPY_FILE_RANGE`): `copy_file_using_read_write_loop` reads the source to EOF regardless of `max_length` and then `ftruncate(dest, total_written)` sets the file length, with the same effect.

The Linux `copy_file_range`/`sendfile`/`splice` happy path already copies exactly `max_length` bytes and does not truncate, so this only shows up there when the kernel syscall is unavailable for the fd pair.

## Fix

Add `read_write_loop_capped`, a bounded `read()`/`write()` loop that transfers exactly `cap` bytes (or to EOF) and never touches the destination's length. Route every fd-backed destination through it:

- macOS/FreeBSD `run_async`: take the `fcopyfile`/`ftruncate` branch only when `destination_file_store.pathlike` is a path.
- Linux `do_copy_file_range`: the three identical fallback sites are factored into `read_write_fallback`, which keeps the existing copy-to-EOF + `ftruncate` for path destinations and uses the bounded loop for fd destinations.

## Verification

Two tests in `test/js/bun/io/bun-write.test.js` under `Bun.write(Bun.file(fd), Bun.file(path)) does not truncate the fd` spawn a child with `BUN_CONFIG_DISABLE_COPY_FILE_RANGE=1` so they fail-before on every POSIX lane:

```
=== system bun ===
(fail) preserves bytes past the slice window in an r+ fd
  resolved: "200000", content: 200000 x "S"   (expected "5", "SSSSS" + 25 x "D")
(fail) preserves pre-existing bytes when stdout is redirected with >>
  resolved: "1000", content: 1000 bytes        (expected "100", 110 bytes)

=== this branch ===
(pass) preserves bytes past the slice window in an r+ fd
(pass) preserves pre-existing bytes when stdout is redirected with >>
```

The existing `Bun.write(Bun.stdout, Bun.stdin) copies the whole pipe` test is widened from Linux-only to every POSIX lane, covering the bounded loop's EOF-termination branch on macOS/FreeBSD. `cargo check -p bun_runtime --target {aarch64,x86_64}-apple-darwin` and `--target x86_64-unknown-freebsd` pass.

## Related

Found during review of #36692 (which routes a FIFO source through `splice` on Linux; the `bun_opened_dest` guard it adds to the same three fallback sites is subsumed by `read_write_fallback` here). #32859 reworks the same block to honour source slices and #33715 sets `read_len` after `fcopyfile`; both are complementary and will need a small rebase against whichever lands first.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->