### PR TITLE
refactor(resolver): collapse is_esm/is_user_require_resolve into ResolveMode

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1479,7 +1479,14 @@ unsafe extern "C" fn Zig__GlobalObject__resolve(
     let (global, specifier, source) = unsafe { (&*global, *specifier, *source) };
     // SAFETY: C++ passes valid non-null pointers.
     let (res, query) = unsafe { (&mut *res, &mut *query) };
-    match VirtualMachine::resolve(res, global, specifier, source, Some(query), true) {
+    match VirtualMachine::resolve(
+        res,
+        global,
+        specifier,
+        source,
+        Some(query),
+        crate::virtual_machine::ResolveMode::Esm,
+    ) {
         Ok(()) => {}
         Err(_) => {
             debug_assert!(!res.success);

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -211,8 +211,8 @@ pub struct LoaderHooks {
     pub resolve_embedded_node_file:
         unsafe fn(vm: *mut VirtualMachine, in_out_str: *mut bun_core::String) -> bool,
     /// `VirtualMachine.resolveMaybeNeedsTrailingSlash(res, global, specifier,
-    /// source, query_string?, is_esm, is_a_file_path, is_user_require_resolve)`
-    /// — the resolution path behind
+    /// source, query_string?, mode, is_a_file_path)` — the resolution path
+    /// behind
     /// `Bun__resolveSync` / `Zig__GlobalObject__resolve` / `import.meta.resolve`.
     /// Body reaches into `transpiler.resolver.resolveAndAutoInstall`, the
     /// `PluginRunner`, `ObjectURLRegistry`, and `ServerEntryPoint` (all
@@ -227,9 +227,8 @@ pub struct LoaderHooks {
         specifier: bun_core::String,
         source: bun_core::String,
         query_string: *mut bun_core::String,
-        is_esm: bool,
+        mode: crate::virtual_machine::ResolveMode,
         is_a_file_path: bool,
-        is_user_require_resolve: bool,
     ) -> bool,
     /// `Bun__transpileVirtualModule` body —
     /// transpiles plugin-provided source through the per-thread `BufferPrinter`

--- a/src/jsc/NodeModuleModule.rs
+++ b/src/jsc/NodeModuleModule.rs
@@ -101,8 +101,7 @@ fn find_path_inner(
         request,
         cur_path,
         None,
-        false,
-        true,
+        crate::virtual_machine::ResolveMode::RequireResolve,
     ) {
         Ok(()) => {}
         Err(JsError::Thrown) => {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2910,6 +2910,49 @@ impl crate::ipc::SendQueueOwner for IPCInstance {
     }
 }
 
+/// Caller intent for runtime module resolution. Replaces the
+/// `(is_esm, is_user_require_resolve)` bool pair so the nonsensical
+/// `(true, true)` combination is unrepresentable inside Rust.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ResolveMode {
+    /// ESM `import` / `import()` / `import.meta.resolve`.
+    Esm,
+    /// CommonJS `require()`.
+    Require,
+    /// `require.resolve()`. Node returns the bare specifier for builtins here
+    /// (`require.resolve("fs") === "fs"`), unlike `require("fs")`.
+    RequireResolve,
+}
+
+impl ResolveMode {
+    #[inline]
+    pub fn is_esm(self) -> bool {
+        matches!(self, Self::Esm)
+    }
+
+    #[inline]
+    pub fn import_kind(self) -> bun_ast::ImportKind {
+        match self {
+            Self::Esm => bun_ast::ImportKind::Stmt,
+            Self::Require => bun_ast::ImportKind::Require,
+            Self::RequireResolve => bun_ast::ImportKind::RequireResolve,
+        }
+    }
+
+    /// Fold the two-bool FFI encoding C++ passes. When both are set (no valid
+    /// meaning), `Esm` wins, matching the previous open-coded mapping.
+    #[inline]
+    pub fn from_ffi_bools(is_esm: bool, is_user_require_resolve: bool) -> Self {
+        if is_esm {
+            Self::Esm
+        } else if is_user_require_resolve {
+            Self::RequireResolve
+        } else {
+            Self::Require
+        }
+    }
+}
+
 /// Output slot for module resolution: the resolver result plus the resolved path and query string.
 #[derive(Default)]
 pub struct ResolveFunctionResult {
@@ -4184,7 +4227,7 @@ impl VirtualMachine {
         specifier: bun_core::String,
         source: bun_core::String,
         query_string: Option<&mut bun_core::String>,
-        is_esm: bool,
+        mode: ResolveMode,
     ) -> JsResult<()> {
         Self::resolve_maybe_needs_trailing_slash::<true>(
             res,
@@ -4192,8 +4235,7 @@ impl VirtualMachine {
             specifier,
             source,
             query_string,
-            is_esm,
-            false,
+            mode,
         )
     }
 
@@ -4204,20 +4246,13 @@ impl VirtualMachine {
         specifier: bun_core::String,
         source: bun_core::String,
         query_string: Option<&mut bun_core::String>,
-        is_esm: bool,
-        is_user_require_resolve: bool,
+        mode: ResolveMode,
     ) -> JsResult<()> {
         const MAX_LEN: usize = (bun_paths::MAX_PATH_BYTES as f64 * 1.5) as usize;
         if IS_A_FILE_PATH && specifier.length() > MAX_LEN {
             let specifier_utf8 = specifier.to_utf8();
             let source_utf8 = source.to_utf8();
-            let import_kind = if is_esm {
-                bun_ast::ImportKind::Stmt
-            } else if is_user_require_resolve {
-                bun_ast::ImportKind::RequireResolve
-            } else {
-                bun_ast::ImportKind::Require
-            };
+            let import_kind = mode.import_kind();
             let printed = crate::ResolveMessage::fmt(
                 specifier_utf8.slice(),
                 source_utf8.slice(),
@@ -4270,11 +4305,13 @@ impl VirtualMachine {
             bun_ast::Target::Bun,
             Default::default(),
         ) {
-            *res = ErrorableString::ok(if is_user_require_resolve && hardcoded.node_builtin {
-                specifier.dupe_ref()
-            } else {
-                bun_core::String::init(hardcoded.path.as_bytes())
-            });
+            *res = ErrorableString::ok(
+                if mode == ResolveMode::RequireResolve && hardcoded.node_builtin {
+                    specifier.dupe_ref()
+                } else {
+                    bun_core::String::init(hardcoded.path.as_bytes())
+                },
+            );
             return Ok(());
         }
 
@@ -4341,18 +4378,12 @@ impl VirtualMachine {
             &mut result,
             specifier_utf8.slice(),
             normalize_source(source_utf8.slice()),
-            is_esm,
+            mode.is_esm(),
             IS_A_FILE_PATH,
         );
         if let Err(err_) = resolve_result {
             let err = err_;
-            let import_kind = if is_esm {
-                bun_ast::ImportKind::Stmt
-            } else if is_user_require_resolve {
-                bun_ast::ImportKind::RequireResolve
-            } else {
-                bun_ast::ImportKind::Require
-            };
+            let import_kind = mode.import_kind();
             // Find a `.resolve`-metadata msg if the log has one.
             let msg = log
                 .msgs

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2910,17 +2910,12 @@ impl crate::ipc::SendQueueOwner for IPCInstance {
     }
 }
 
-/// Caller intent for runtime module resolution. Replaces the
-/// `(is_esm, is_user_require_resolve)` bool pair so the nonsensical
-/// `(true, true)` combination is unrepresentable inside Rust.
+/// Caller intent for runtime module resolution.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum ResolveMode {
-    /// ESM `import` / `import()` / `import.meta.resolve`.
     Esm,
-    /// CommonJS `require()`.
     Require,
-    /// `require.resolve()`. Node returns the bare specifier for builtins here
-    /// (`require.resolve("fs") === "fs"`), unlike `require("fs")`.
+    /// `require.resolve()`: returns the bare specifier for Node builtins.
     RequireResolve,
 }
 
@@ -2939,8 +2934,7 @@ impl ResolveMode {
         }
     }
 
-    /// Fold the two-bool FFI encoding C++ passes. When both are set (no valid
-    /// meaning), `Esm` wins, matching the previous open-coded mapping.
+    /// Fold the two-bool encoding the C++ FFI boundary passes.
     #[inline]
     pub fn from_ffi_bools(is_esm: bool, is_user_require_resolve: bool) -> Self {
         if is_esm {

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -81,7 +81,7 @@ use bun_jsc::{
 // `bun_jsc::VirtualMachine` is the *module* re-export; the struct lives one level deeper.
 use crate::cli::open::Editor;
 use bun_core::{String as BunString, ZigString, strings};
-use bun_jsc::virtual_machine::VirtualMachine;
+use bun_jsc::virtual_machine::{ResolveMode, VirtualMachine};
 use bun_paths::MAX_PATH_BYTES;
 #[cfg(not(windows))]
 use bun_paths::PathBuffer;
@@ -1116,10 +1116,14 @@ fn do_resolve(global_this: &JSGlobalObject, arguments: &[JSValue]) -> JsResult<J
         return Err(global_this.throw_invalid_arguments(format_args!("from must be a string")));
     }
 
-    let mut is_esm = true;
+    let mut mode = ResolveMode::Esm;
     if let Some(next) = args.next_eat() {
         if next.is_boolean() {
-            is_esm = next.to_boolean();
+            mode = if next.to_boolean() {
+                ResolveMode::Esm
+            } else {
+                ResolveMode::Require
+            };
         } else {
             return Err(global_this.throw_invalid_arguments(format_args!("esm must be a boolean")));
         }
@@ -1129,7 +1133,7 @@ fn do_resolve(global_this: &JSGlobalObject, arguments: &[JSValue]) -> JsResult<J
     let specifier_str = scopeguard::guard(specifier_str, |s| s.deref());
     let from_str = from.to_bun_string(global_this)?;
     let from_str = scopeguard::guard(from_str, |s| s.deref());
-    do_resolve_with_args::<false>(global_this, *specifier_str, *from_str, is_esm, false)
+    do_resolve_with_args::<false>(global_this, *specifier_str, *from_str, mode)
 }
 
 /// Single Drop point for the three `BunString`s `do_resolve_with_args` may own.
@@ -1159,8 +1163,7 @@ fn do_resolve_with_args<const IS_FILE_PATH: bool>(
     ctx: &JSGlobalObject,
     specifier: BunString,
     from: BunString,
-    is_esm: bool,
-    is_user_require_resolve: bool,
+    mode: ResolveMode,
 ) -> JsResult<JSValue> {
     let mut errorable: ErrorableString = ErrorableString::ok(BunString::empty());
     let mut owned = ResolveDerefOnDrop {
@@ -1185,8 +1188,7 @@ fn do_resolve_with_args<const IS_FILE_PATH: bool>(
         specifier_for_resolve,
         from,
         Some(&mut owned.query_string),
-        is_esm,
-        is_user_require_resolve,
+        mode,
     )?;
 
     if !errorable.success {
@@ -1250,16 +1252,20 @@ pub fn bun_resolve(
     };
     let source_str = scopeguard::guard(source_str, |s| s.deref());
 
-    let value =
-        match do_resolve_with_args::<true>(global, *specifier_str, *source_str, is_esm, false) {
-            Ok(v) => v,
-            Err(_) => {
-                let err = global.try_take_exception().unwrap();
-                return JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global, err,
-                );
-            }
-        };
+    let value = match do_resolve_with_args::<true>(
+        global,
+        *specifier_str,
+        *source_str,
+        ResolveMode::from_ffi_bools(is_esm, false),
+    ) {
+        Ok(v) => v,
+        Err(_) => {
+            let err = global.try_take_exception().unwrap();
+            return JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                global, err,
+            );
+        }
+    };
 
     JSPromise::resolved_promise_value(global, value)
 }
@@ -1297,8 +1303,7 @@ pub fn bun_resolve_sync(
             global,
             *specifier_str,
             *source_str,
-            is_esm,
-            is_user_require_resolve,
+            ResolveMode::from_ffi_bools(is_esm, is_user_require_resolve),
         )
     })
 }
@@ -1365,8 +1370,7 @@ pub fn bun_resolve_sync_with_paths(
             global,
             *specifier_str,
             *source_str,
-            is_esm,
-            is_user_require_resolve,
+            ResolveMode::from_ffi_bools(is_esm, is_user_require_resolve),
         )
     })
 }
@@ -1387,7 +1391,12 @@ pub fn bun_resolve_sync_with_strings(
         specifier
     );
     jsc::to_js_host_call(global, || {
-        do_resolve_with_args::<true>(global, *specifier, *source, is_esm, false)
+        do_resolve_with_args::<true>(
+            global,
+            *specifier,
+            *source,
+            ResolveMode::from_ffi_bools(is_esm, false),
+        )
     })
 }
 
@@ -1417,8 +1426,7 @@ pub fn bun_resolve_sync_with_source(
             global,
             *specifier_str,
             *source,
-            is_esm,
-            is_user_require_resolve,
+            ResolveMode::from_ffi_bools(is_esm, is_user_require_resolve),
         )
     })
 }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -32,7 +32,7 @@ use bun_jsc::module_loader::{
 };
 use bun_jsc::resolved_source::OwnedResolvedSource;
 use bun_jsc::virtual_machine::{
-    InitOptions, RuntimeHooks, RuntimeState as OpaqueRuntimeState, VirtualMachine,
+    InitOptions, ResolveMode, RuntimeHooks, RuntimeState as OpaqueRuntimeState, VirtualMachine,
 };
 use bun_jsc::{
     AnyPromise, ErrorCode, ErrorableResolvedSource, ErrorableString, JSGlobalObject,
@@ -5083,9 +5083,8 @@ unsafe fn resolve_hook(
     specifier: bun_core::String,
     source: bun_core::String,
     query_string: *mut bun_core::String,
-    is_esm: bool,
+    mode: ResolveMode,
     is_a_file_path: bool,
-    is_user_require_resolve: bool,
 ) -> bool {
     use bun_ast::Target;
     use bun_jsc::ResolveMessage;
@@ -5107,13 +5106,7 @@ unsafe fn resolve_hook(
     if is_a_file_path && specifier.length() > MAX_SPECIFIER_LEN {
         let specifier_utf8 = specifier.to_utf8();
         let source_utf8 = source.to_utf8();
-        let import_kind = if is_esm {
-            ImportKind::Stmt
-        } else if is_user_require_resolve {
-            ImportKind::RequireResolve
-        } else {
-            ImportKind::Require
-        };
+        let import_kind = mode.import_kind();
         let printed = ResolveMessage::fmt(
             specifier_utf8.slice(),
             source_utf8.slice(),
@@ -5168,10 +5161,10 @@ unsafe fn resolve_hook(
     }
 
     // Hardcoded builtin alias fast path. For
-    // `require.resolve("fs")` (`is_user_require_resolve && node_builtin`) Node
-    // returns the bare specifier as-is, not the canonical `node:fs`.
+    // `require.resolve("fs")` (`RequireResolve && node_builtin`) Node returns
+    // the bare specifier as-is, not the canonical `node:fs`.
     if let Some(hardcoded) = Alias::get(specifier_utf8.slice(), Target::Bun, AliasCfg::default()) {
-        let path = if is_user_require_resolve && hardcoded.node_builtin {
+        let path = if mode == ResolveMode::RequireResolve && hardcoded.node_builtin {
             specifier.dupe_ref()
         } else {
             bun_core::String::init(hardcoded.path.as_bytes())
@@ -5234,7 +5227,7 @@ unsafe fn resolve_hook(
             vm,
             specifier_utf8.slice(),
             normalize_source(source_utf8.slice()),
-            is_esm,
+            mode.is_esm(),
             is_a_file_path,
             &mut result_path,
             &mut result_query,
@@ -5249,13 +5242,7 @@ unsafe fn resolve_hook(
                 }
             }
 
-            let import_kind = if is_esm {
-                ImportKind::Stmt
-            } else if is_user_require_resolve {
-                ImportKind::RequireResolve
-            } else {
-                ImportKind::Require
-            };
+            let import_kind = mode.import_kind();
 
             let printed = ResolveMessage::fmt(
                 specifier_utf8.slice(),


### PR DESCRIPTION
## What

`VirtualMachine::resolve_maybe_needs_trailing_slash` took two `bool` params:

```rust
is_esm: bool,
is_user_require_resolve: bool,
```

and immediately folded them into an `ImportKind`:

```rust
let import_kind = if is_esm {
    ImportKind::Stmt
} else if is_user_require_resolve {
    ImportKind::RequireResolve
} else {
    ImportKind::Require
};
```

The `(true, true)` combination has no valid meaning and was silently treated as `Stmt`. The same two-bool pair was threaded through `do_resolve_with_args`, `find_path_inner`, `LoaderHooks::resolve` and `resolve_hook`, with the fold above open-coded at four separate sites.

This replaces the pair with a three-variant enum on the Rust side of the call chain:

```rust
pub enum ResolveMode { Esm, Require, RequireResolve }
```

and folds once at each FFI entry point via `ResolveMode::from_ffi_bools`. Call sites now read `ResolveMode::RequireResolve` instead of `false, true`.

## Why

Makes the nonsensical `(true, true)` state unrepresentable inside Rust, removes four copies of the same mapping, and makes call sites self-documenting. `bun_ast::ImportKind` was considered but has 12 variants, nine of which are invalid here.

## Scope

Rust-internal only. The C++ FFI boundary (`Bun__resolveSync`, `Bun__resolveSyncWithPaths`, `Bun__resolveSyncWithSource` in `ImportMetaObject.h`) keeps its two-bool ABI unchanged; conversion happens once per entry point. `_resolve` still receives `is_esm` as a plain bool, so the underlying resolver continues to see only `Stmt`/`Require`, never `RequireResolve`, exactly as before (this matters for the `prefer_module_field && kind != Require` branch at `resolver.rs:5545`).

## Verification

No behavior change; verified against the existing resolve suite:

```
bun bd test test/js/bun/resolve/resolve.test.ts \
  test/js/bun/resolve/import-meta.test.js \
  test/js/bun/resolve/require.test.ts \
  test/js/bun/resolve/import-meta-resolve.test.mjs \
  test/js/bun/resolve/resolve-error.test.ts
# 127 pass, 0 fail

bun bd test test/js/node/module/ test/js/bun/resolve/import-custom-condition.test.ts
# 99 pass, 0 fail
```

This is a type-system refactor with no JS-observable difference, so there is no fail-before test to write; correctness is established by the existing coverage staying green.