### PR TITLE
js_parser: collapse ParseStatementOptions scope bools and SideEffects::Result into enums

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4657,7 +4657,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         match &mut binding.data {
             js_ast::b::B::BMissing(_) => {}
             js_ast::b::B::BIdentifier(bind) => {
-                if !opts.is_typescript_declare || (opts.is_namespace_scope && opts.is_export) {
+                if !opts.is_typescript_declare || (opts.scope.is_namespace() && opts.is_export) {
                     bind.r#ref = self.declare_symbol(
                         kind,
                         binding.loc,

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -723,7 +723,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if Self::IS_TYPESCRIPT_ENABLED {
             if opts.is_typescript_declare {
                 p.pop_and_discard_scope(scope_index);
-                if opts.is_namespace_scope && opts.is_export {
+                if opts.scope.is_namespace() && opts.is_export {
                     p.has_non_local_export_declare_inside_namespace = true;
                 }
 

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -15,7 +15,8 @@ use crate::defines::Define;
 use crate::lexer as js_lexer;
 use crate::p::P;
 use crate::parser::{
-    Jest, ParseStatementOptions, RuntimeFeatures, RuntimeImports, ScanPassResult, WrapMode,
+    Jest, ParseStatementOptions, RuntimeFeatures, RuntimeImports, ScanPassResult, StatementScope,
+    WrapMode,
 };
 use bun_ast as js_ast;
 use bun_ast::DeclaredSymbol;
@@ -414,7 +415,7 @@ impl<'a> Parser<'a> {
 
         // Parse the file in the first pass, but do not bind symbols
         let mut opts = ParseStatementOptions {
-            is_module_scope: true,
+            scope: StatementScope::Module,
             ..Default::default()
         };
 
@@ -695,7 +696,7 @@ impl<'a> Parser<'a> {
 
         // Parse the file in the first pass, but do not bind symbols
         let mut opts = ParseStatementOptions {
-            is_module_scope: true,
+            scope: StatementScope::Module,
             ..Default::default()
         };
         let mut parse_tracer = bun_core::perf::trace("JSParser::parse");

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -117,7 +117,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     p.pop_and_discard_scope(if_stmt_scope_index);
                 }
 
-                if opts.is_typescript_declare && opts.is_namespace_scope && opts.is_export {
+                if opts.is_typescript_declare && opts.scope.is_namespace() && opts.is_export {
                     p.has_non_local_export_declare_inside_namespace = true;
                 }
 

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -1332,7 +1332,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let name = self.lexer.identifier;
         self.lexer.expect(T::TIdentifier)?;
 
-        if opts.is_module_scope {
+        if opts.scope.is_module() {
             self.local_type_names.put(name, true)?;
         }
 
@@ -1354,7 +1354,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let name = self.lexer.identifier;
         self.lexer.expect(T::TIdentifier)?;
 
-        if opts.is_module_scope {
+        if opts.scope.is_module() {
             self.local_type_names.put(name, true)?;
         }
 

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -14,8 +14,7 @@ use js_lexer::T;
 use crate::parser::fs;
 use crate::parser::{
     AwaitOrYield, DeferredTsDecorators, LexicalDecl, ParseStatementOptions, ParsedPath, Ref,
-    StatementScope,
-    StmtList,
+    StatementScope, StmtList,
 };
 use crate::typescript;
 use bun_ast::{ImportKind, ImportRecordFlags, ImportRecordTag};

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -14,6 +14,7 @@ use js_lexer::T;
 use crate::parser::fs;
 use crate::parser::{
     AwaitOrYield, DeferredTsDecorators, LexicalDecl, ParseStatementOptions, ParsedPath, Ref,
+    StatementScope,
     StmtList,
 };
 use crate::typescript;
@@ -828,11 +829,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         loc: bun_ast::Loc,
     ) -> Result<Stmt> {
         let previous_export_keyword = p.esm_export_keyword;
-        if opts.is_module_scope {
-            p.esm_export_keyword = p.lexer.range();
-        } else if !opts.is_namespace_scope {
-            p.lexer.unexpected()?;
-            return Err(crate::Error::SyntaxError);
+        match opts.scope {
+            StatementScope::Module => p.esm_export_keyword = p.lexer.range(),
+            StatementScope::Namespace => {}
+            StatementScope::Nested => {
+                p.lexer.unexpected()?;
+                return Err(crate::Error::SyntaxError);
+            }
         }
         p.lexer.next()?;
 
@@ -860,8 +863,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             T::TImport => {
                 // "export import foo = bar"
-                if Self::IS_TYPESCRIPT_ENABLED && (opts.is_module_scope || opts.is_namespace_scope)
-                {
+                if Self::IS_TYPESCRIPT_ENABLED && opts.scope != StatementScope::Nested {
                     opts.is_export = true;
                     return p.parse_stmt(opts);
                 }
@@ -931,7 +933,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     return Err(crate::Error::SyntaxError);
                                 }
                                 let mut skipper = ParseStatementOptions {
-                                    is_module_scope: opts.is_module_scope,
+                                    scope: opts.scope,
                                     is_export: true,
                                     ..Default::default()
                                 };
@@ -964,9 +966,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
 
             T::TDefault => {
-                if !opts.is_module_scope
-                    && (!opts.is_namespace_scope || !opts.is_typescript_declare)
-                {
+                if !opts.allows_esm_import_export() {
                     p.lexer.unexpected()?;
                     return Err(crate::Error::SyntaxError);
                 }
@@ -1193,9 +1193,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 ))
             }
             T::TAsterisk => {
-                if !opts.is_module_scope
-                    && (!opts.is_namespace_scope || !opts.is_typescript_declare)
-                {
+                if !opts.allows_esm_import_export() {
                     p.lexer.unexpected()?;
                     return Err(crate::Error::SyntaxError);
                 }
@@ -1275,9 +1273,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 ))
             }
             T::TOpenBrace => {
-                if !opts.is_module_scope
-                    && (!opts.is_namespace_scope || !opts.is_typescript_declare)
-                {
+                if !opts.allows_esm_import_export() {
                     p.lexer.unexpected()?;
                     return Err(crate::Error::SyntaxError);
                 }
@@ -1407,7 +1403,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut was_originally_bare_import = false;
 
         // "export import foo = bar"
-        if (opts.is_export || (opts.is_namespace_scope && !opts.is_typescript_declare))
+        if (opts.is_export || (opts.scope.is_namespace() && !opts.is_typescript_declare))
             && p.lexer.token != T::TIdentifier
         {
             p.lexer.expected(T::TIdentifier)?;
@@ -1431,9 +1427,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             T::TStringLiteral | T::TNoSubstitutionTemplateLiteral => {
                 // "import 'path'"
-                if !opts.is_module_scope
-                    && (!opts.is_namespace_scope || !opts.is_typescript_declare)
-                {
+                if !opts.allows_esm_import_export() {
                     p.lexer.unexpected()?;
                     return Err(crate::Error::SyntaxError);
                 }
@@ -1441,9 +1435,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             T::TAsterisk => {
                 // "import * as ns from 'path'"
-                if !opts.is_module_scope
-                    && (!opts.is_namespace_scope || !opts.is_typescript_declare)
-                {
+                if !opts.allows_esm_import_export() {
                     p.lexer.unexpected()?;
                     return Err(crate::Error::SyntaxError);
                 }
@@ -1461,9 +1453,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             T::TOpenBrace => {
                 // "import {item1, item2} from 'path'"
-                if !opts.is_module_scope
-                    && (!opts.is_namespace_scope || !opts.is_typescript_declare)
-                {
+                if !opts.allows_esm_import_export() {
                     p.lexer.unexpected()?;
                     return Err(crate::Error::SyntaxError);
                 }
@@ -1491,7 +1481,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             T::TIdentifier => {
                 // "import defaultItem from 'path'"
                 // "import foo = bar"
-                if !opts.is_module_scope && !opts.is_namespace_scope {
+                if opts.scope == StatementScope::Nested {
                     p.lexer.unexpected()?;
                     return Err(crate::Error::SyntaxError);
                 }
@@ -1528,9 +1518,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // Same scope restriction as `import * as ns from 'path'`:
                     // ESM import declarations are only valid at module scope
                     // (or inside a TypeScript `declare namespace`).
-                    if !opts.is_module_scope
-                        && (!opts.is_namespace_scope || !opts.is_typescript_declare)
-                    {
+                    if !opts.allows_esm_import_export() {
                         p.lexer.unexpected()?;
                         return Err(crate::Error::SyntaxError);
                     }
@@ -1606,7 +1594,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // Parse TypeScript import assignment statements
                     if p.lexer.token == T::TEquals
                         || opts.is_export
-                        || (opts.is_namespace_scope && !opts.is_typescript_declare)
+                        || (opts.scope.is_namespace() && !opts.is_typescript_declare)
                     {
                         p.esm_import_keyword = previous_import_keyword; // This wasn't an ESM import statement after all;
                         return p.parse_type_script_import_equals_stmt(
@@ -1778,7 +1766,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if p.lexer.token == T::TIdentifier && !p.lexer.has_newline_before {
                     // "type Foo = any"
                     let mut stmt_opts = ParseStatementOptions {
-                        is_module_scope: opts.is_module_scope,
+                        scope: opts.scope,
                         ..Default::default()
                     };
                     p.skip_type_script_type_stmt(&mut stmt_opts)?;
@@ -1792,7 +1780,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // "declare module 'fs' {}"
                 // "declare module 'fs';"
                 if !p.lexer.has_newline_before
-                    && (opts.is_module_scope || opts.is_namespace_scope)
+                    && opts.scope != StatementScope::Nested
                     && (p.lexer.token == T::TIdentifier
                         || (p.lexer.token == T::TStringLiteral && opts.is_typescript_declare))
                 {
@@ -1805,7 +1793,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // "export default interface \n Foo {}"
                 if !p.lexer.has_newline_before || opts.is_name_optional {
                     let mut stmt_opts = ParseStatementOptions {
-                        is_module_scope: opts.is_module_scope,
+                        scope: opts.scope,
                         ..Default::default()
                     };
 
@@ -1836,7 +1824,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             js_lexer::TypescriptStmtKeyword::TsStmtGlobal => {
                 // "declare module 'fs' { global { namespace NodeJS {} } }"
-                if opts.is_namespace_scope
+                if opts.scope.is_namespace()
                     && opts.is_typescript_declare
                     && p.lexer.token == T::TOpenBrace
                 {
@@ -1934,7 +1922,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // inside a namespace with an "export var" statement containing all
                 // of the declared bindings. That "export var" statement will later
                 // cause identifiers to be transformed into property accesses.
-                if opts.is_namespace_scope && opts.is_export {
+                if opts.scope.is_namespace() && opts.is_export {
                     let mut decls: G::DeclList = bun_alloc::AstAlloc::vec();
                     match &stmt.data {
                         js_ast::StmtData::SLocal(local) => {

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -130,9 +130,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Remove unnecessary optional chains
         if p.options.features.minify_syntax {
-            let result = SideEffects::to_null_or_undefined(p, &left.data);
-            if result.ok && !result.value {
-                optional_start = None;
+            if let Some(result) = SideEffects::to_null_or_undefined(p, &left.data) {
+                if !result.value {
+                    optional_start = None;
+                }
             }
         }
 

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -4,7 +4,7 @@ use bun_collections::VecExt;
 use crate::Error;
 use crate::lexer::{self as js_lexer, T};
 use crate::p::P;
-use crate::parser::{FnOrArrowDataParse, ParseStatementOptions, Ref, ScopeOrder};
+use crate::parser::{FnOrArrowDataParse, ParseStatementOptions, Ref, ScopeOrder, StatementScope};
 use bun_alloc::{ArenaVec as BumpVec, ArenaVecExt as _};
 use bun_ast::expr::EFlags;
 use bun_ast::flags;
@@ -250,7 +250,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             let mut _opts = ParseStatementOptions {
                 is_export: true,
-                is_namespace_scope: true,
+                scope: StatementScope::Namespace,
                 is_typescript_declare: opts.is_typescript_declare,
                 ..ParseStatementOptions::default()
             };
@@ -263,7 +263,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         } else {
             p.lexer.expect(T::TOpenBrace)?;
             let mut _opts = ParseStatementOptions {
-                is_namespace_scope: true,
+                scope: StatementScope::Namespace,
                 is_typescript_declare: opts.is_typescript_declare,
                 ..ParseStatementOptions::default()
             };
@@ -398,7 +398,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             || opts.is_typescript_declare
         {
             p.pop_and_discard_scope(scope_index);
-            if opts.is_module_scope {
+            if opts.scope.is_module() {
                 p.local_type_names.put(name_text, true)?;
             }
             return Ok(p.s(S::TypeScript {}, loc));
@@ -733,7 +733,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.lexer.expect(T::TCloseBrace)?;
 
         if opts.is_typescript_declare {
-            if opts.is_namespace_scope && opts.is_export {
+            if opts.scope.is_namespace() && opts.is_export {
                 p.has_non_local_export_declare_inside_namespace = true;
             }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1567,9 +1567,6 @@ pub struct ParseClassOptions<'a> {
     pub(crate) is_type_script_declare: bool,
 }
 
-/// Tracks which kind of statement list the parser is currently inside.
-/// `Module` and `Namespace` are mutually exclusive (a namespace body is never
-/// the module scope), so a single tri-state replaces the former pair of bools.
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum StatementScope {
@@ -1614,8 +1611,6 @@ impl<'a> ParseStatementOptions<'a> {
         !decs.values.is_empty()
     }
 
-    /// ESM import/export declarations are only legal at module scope or inside
-    /// a TypeScript `declare namespace` block.
     #[inline]
     pub(crate) fn allows_esm_import_export(&self) -> bool {
         match self.scope {

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1567,12 +1567,37 @@ pub struct ParseClassOptions<'a> {
     pub(crate) is_type_script_declare: bool,
 }
 
+/// Tracks which kind of statement list the parser is currently inside.
+/// `Module` and `Namespace` are mutually exclusive (a namespace body is never
+/// the module scope), so a single tri-state replaces the former pair of bools.
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub enum StatementScope {
+    /// Any nested block/function body. ESM import/export are disallowed here.
+    #[default]
+    Nested,
+    /// Top-level module statement list.
+    Module,
+    /// Inside a TypeScript `namespace`/`module` block.
+    Namespace,
+}
+
+impl StatementScope {
+    #[inline]
+    pub(crate) fn is_module(self) -> bool {
+        matches!(self, Self::Module)
+    }
+    #[inline]
+    pub(crate) fn is_namespace(self) -> bool {
+        matches!(self, Self::Namespace)
+    }
+}
+
 #[derive(Default, Clone, Copy)]
 pub struct ParseStatementOptions<'a> {
     pub(crate) ts_decorators: Option<DeferredTsDecorators<'a>>,
     pub(crate) lexical_decl: LexicalDecl,
-    pub(crate) is_module_scope: bool,
-    pub(crate) is_namespace_scope: bool,
+    pub(crate) scope: StatementScope,
     pub(crate) is_export: bool,
     pub(crate) is_using_statement: bool,
     /// For "export default" pseudo-statements,
@@ -1587,6 +1612,17 @@ impl<'a> ParseStatementOptions<'a> {
             return false;
         };
         !decs.values.is_empty()
+    }
+
+    /// ESM import/export declarations are only legal at module scope or inside
+    /// a TypeScript `declare namespace` block.
+    #[inline]
+    pub(crate) fn allows_esm_import_export(&self) -> bool {
+        match self.scope {
+            StatementScope::Module => true,
+            StatementScope::Namespace => self.is_typescript_declare,
+            StatementScope::Nested => false,
+        }
     }
 }
 

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -81,7 +81,8 @@ impl SideEffects {
                     }
                     Op::Code::BinLogicalOr => {
                         if let Some(effects) = SideEffects::to_boolean(p, &e.right.data) {
-                            if !effects.value && effects.side_effects == SideEffects::NoSideEffects {
+                            if !effects.value && effects.side_effects == SideEffects::NoSideEffects
+                            {
                                 // "if (anything || falsyNoSideEffects)" => "if (anything)"
                                 *expr = e.left;
                                 continue;

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -14,21 +14,14 @@ pub enum SideEffects {
     NoSideEffects,
 }
 
+/// A boolean value the parser was able to prove at compile time, together
+/// with whether evaluating the original expression could have observable
+/// side effects. Returned as `Option<Known>` from `to_boolean` /
+/// `to_null_or_undefined`; `None` means the value could not be determined.
 #[derive(Clone, Copy, Debug)]
-pub struct Result {
-    pub(crate) side_effects: SideEffects,
-    pub(crate) ok: bool,
+pub struct Known {
     pub(crate) value: bool,
-}
-
-impl Default for Result {
-    fn default() -> Self {
-        Self {
-            side_effects: SideEffects::CouldHaveSideEffects,
-            ok: false,
-            value: false,
-        }
-    }
+    pub(crate) side_effects: SideEffects,
 }
 
 #[derive(Clone, Copy)]
@@ -78,25 +71,21 @@ impl SideEffects {
                 }
                 ExprData::EBinary(e) => match e.op {
                     Op::Code::BinLogicalAnd => {
-                        let effects = SideEffects::to_boolean(p, &e.right.data);
-                        if effects.ok
-                            && effects.value
-                            && effects.side_effects == SideEffects::NoSideEffects
-                        {
-                            // "if (anything && truthyNoSideEffects)" => "if (anything)"
-                            *expr = e.left;
-                            continue;
+                        if let Some(effects) = SideEffects::to_boolean(p, &e.right.data) {
+                            if effects.value && effects.side_effects == SideEffects::NoSideEffects {
+                                // "if (anything && truthyNoSideEffects)" => "if (anything)"
+                                *expr = e.left;
+                                continue;
+                            }
                         }
                     }
                     Op::Code::BinLogicalOr => {
-                        let effects = SideEffects::to_boolean(p, &e.right.data);
-                        if effects.ok
-                            && !effects.value
-                            && effects.side_effects == SideEffects::NoSideEffects
-                        {
-                            // "if (anything || falsyNoSideEffects)" => "if (anything)"
-                            *expr = e.left;
-                            continue;
+                        if let Some(effects) = SideEffects::to_boolean(p, &e.right.data) {
+                            if !effects.value && effects.side_effects == SideEffects::NoSideEffects {
+                                // "if (anything || falsyNoSideEffects)" => "if (anything)"
+                                *expr = e.left;
+                                continue;
+                            }
                         }
                     }
                     _ => {}
@@ -796,14 +785,9 @@ impl SideEffects {
     pub(crate) fn to_null_or_undefined<'a, const TS: bool, const SCAN: bool>(
         p: &P<'a, TS, SCAN>,
         exp: &ExprData,
-    ) -> Result {
+    ) -> Option<Known> {
         if !p.options.features.dead_code_elimination {
-            // value should not be read if ok is false, all existing calls already adhere to this
-            return Result {
-                ok: false,
-                value: false,
-                side_effects: SideEffects::CouldHaveSideEffects,
-            };
+            return None;
         }
         match exp {
             // Never null or undefined
@@ -814,22 +798,19 @@ impl SideEffects {
             | ExprData::ERegExp(_)
             | ExprData::EFunction(_)
             | ExprData::EArrow(_)
-            | ExprData::EBigInt(_) => Result {
+            | ExprData::EBigInt(_) => Some(Known {
                 value: false,
                 side_effects: SideEffects::NoSideEffects,
-                ok: true,
-            },
-            ExprData::EObject(_) | ExprData::EArray(_) | ExprData::EClass(_) => Result {
+            }),
+            ExprData::EObject(_) | ExprData::EArray(_) | ExprData::EClass(_) => Some(Known {
                 value: false,
                 side_effects: SideEffects::CouldHaveSideEffects,
-                ok: true,
-            },
+            }),
             // Always null or undefined
-            ExprData::ENull(_) | ExprData::EUndefined(_) => Result {
+            ExprData::ENull(_) | ExprData::EUndefined(_) => Some(Known {
                 value: true,
                 side_effects: SideEffects::NoSideEffects,
-                ok: true,
-            },
+            }),
             ExprData::EUnary(e) => match e.op {
                 // Always number or bigint
                 Op::Code::UnPos | Op::Code::UnNeg | Op::Code::UnCpl
@@ -837,13 +818,13 @@ impl SideEffects {
                 | Op::Code::UnPostDec | Op::Code::UnPostInc
                 // Always boolean
                 | Op::Code::UnNot | Op::Code::UnTypeof | Op::Code::UnDelete => {
-                    Result { value: false, side_effects: SideEffects::CouldHaveSideEffects, ok: true }
+                    Some(Known { value: false, side_effects: SideEffects::CouldHaveSideEffects })
                 }
                 // Always undefined
                 Op::Code::UnVoid => {
-                    Result { value: true, side_effects: SideEffects::CouldHaveSideEffects, ok: true }
+                    Some(Known { value: true, side_effects: SideEffects::CouldHaveSideEffects })
                 }
-                _ => Result::default(),
+                _ => None,
             },
             ExprData::EBinary(e) => match e.op {
                 // always string or number or bigint
@@ -863,209 +844,163 @@ impl SideEffects {
                 | Op::Code::BinLooseNe | Op::Code::BinLt | Op::Code::BinGt
                 | Op::Code::BinLe | Op::Code::BinGe | Op::Code::BinInstanceof
                 | Op::Code::BinIn => {
-                    Result { ok: true, value: false, side_effects: SideEffects::CouldHaveSideEffects }
+                    Some(Known { value: false, side_effects: SideEffects::CouldHaveSideEffects })
                 }
                 Op::Code::BinComma => {
-                    let res = Self::to_null_or_undefined(p, &e.right.data);
-                    if res.ok {
-                        Result { value: res.value, side_effects: SideEffects::CouldHaveSideEffects, ok: true }
-                    } else {
-                        Result::default()
-                    }
+                    Self::to_null_or_undefined(p, &e.right.data).map(|res| Known {
+                        value: res.value,
+                        side_effects: SideEffects::CouldHaveSideEffects,
+                    })
                 }
-                _ => Result::default(),
+                _ => None,
             },
             ExprData::EInlinedEnum(e) => Self::to_null_or_undefined(p, &e.value.data),
-            _ => Result::default(),
+            _ => None,
         }
     }
 
     pub(crate) fn to_boolean<'a, const TS: bool, const SCAN: bool>(
         p: &P<'a, TS, SCAN>,
         exp: &ExprData,
-    ) -> Result {
+    ) -> Option<Known> {
         if !p.options.features.dead_code_elimination {
-            return Result::default();
+            return None;
         }
         if !p.stack_check.is_safe_to_recurse() {
             p.report_stack_overflow(bun_ast::Loc::EMPTY);
-            return Result::default();
+            return None;
         }
         match exp {
-            ExprData::ENull(_) | ExprData::EUndefined(_) => Result {
+            ExprData::ENull(_) | ExprData::EUndefined(_) => Some(Known {
                 value: false,
                 side_effects: SideEffects::NoSideEffects,
-                ok: true,
-            },
-            ExprData::EBoolean(e) | ExprData::EBranchBoolean(e) => Result {
+            }),
+            ExprData::EBoolean(e) | ExprData::EBranchBoolean(e) => Some(Known {
                 value: e.value,
                 side_effects: SideEffects::NoSideEffects,
-                ok: true,
-            },
-            ExprData::ENumber(e) => Result {
+            }),
+            ExprData::ENumber(e) => Some(Known {
                 value: e.value() != 0.0 && !e.value().is_nan(),
                 side_effects: SideEffects::NoSideEffects,
-                ok: true,
-            },
-            ExprData::EBigInt(e) => {
-                let equal = E::BigInt::check_equality(&e.value, b"0");
-                Result {
-                    value: equal == Some(false),
-                    side_effects: SideEffects::NoSideEffects,
-                    ok: equal.is_some(),
-                }
-            }
-            ExprData::EString(e) => Result {
+            }),
+            ExprData::EBigInt(e) => E::BigInt::check_equality(&e.value, b"0").map(|equal| Known {
+                value: !equal,
+                side_effects: SideEffects::NoSideEffects,
+            }),
+            ExprData::EString(e) => Some(Known {
                 // Open-coded `isPresent` to dodge an ambiguous inherent `len()`
                 // while E.rs's duplicate `impl EString` blocks are being merged.
                 value: e.rope_len > 0 || !e.data.is_empty(),
                 side_effects: SideEffects::NoSideEffects,
-                ok: true,
-            },
-            ExprData::EFunction(_) | ExprData::EArrow(_) | ExprData::ERegExp(_) => Result {
+            }),
+            ExprData::EFunction(_) | ExprData::EArrow(_) | ExprData::ERegExp(_) => Some(Known {
                 value: true,
                 side_effects: SideEffects::NoSideEffects,
-                ok: true,
-            },
-            ExprData::EObject(_) | ExprData::EArray(_) | ExprData::EClass(_) => Result {
+            }),
+            ExprData::EObject(_) | ExprData::EArray(_) | ExprData::EClass(_) => Some(Known {
                 value: true,
                 side_effects: SideEffects::CouldHaveSideEffects,
-                ok: true,
-            },
+            }),
             ExprData::EUnary(e) => match e.op {
-                Op::Code::UnVoid => Result {
+                Op::Code::UnVoid => Some(Known {
                     value: false,
                     side_effects: SideEffects::CouldHaveSideEffects,
-                    ok: true,
-                },
+                }),
                 Op::Code::UnTypeof => {
                     // Never an empty string
-                    Result {
+                    Some(Known {
                         value: true,
                         side_effects: SideEffects::CouldHaveSideEffects,
-                        ok: true,
-                    }
+                    })
                 }
-                Op::Code::UnNot => {
-                    let res = Self::to_boolean(p, &e.value.data);
-                    if res.ok {
-                        Result {
-                            value: !res.value,
-                            side_effects: res.side_effects,
-                            ok: true,
-                        }
-                    } else {
-                        Result::default()
-                    }
-                }
-                _ => Result::default(),
+                Op::Code::UnNot => Self::to_boolean(p, &e.value.data).map(|res| Known {
+                    value: !res.value,
+                    side_effects: res.side_effects,
+                }),
+                _ => None,
             },
             ExprData::EBinary(e) => match e.op {
-                Op::Code::BinLogicalOr => {
-                    let res = Self::to_boolean(p, &e.right.data);
-                    if res.ok && res.value {
-                        Result {
-                            value: true,
-                            side_effects: SideEffects::CouldHaveSideEffects,
-                            ok: true,
-                        }
-                    } else {
-                        Result::default()
-                    }
-                }
-                Op::Code::BinLogicalAnd => {
-                    let res = Self::to_boolean(p, &e.right.data);
-                    if res.ok && !res.value {
-                        Result {
-                            value: false,
-                            side_effects: SideEffects::CouldHaveSideEffects,
-                            ok: true,
-                        }
-                    } else {
-                        Result::default()
-                    }
-                }
-                Op::Code::BinComma => {
-                    let res = Self::to_boolean(p, &e.right.data);
-                    if res.ok {
-                        Result {
-                            value: res.value,
-                            side_effects: SideEffects::CouldHaveSideEffects,
-                            ok: true,
-                        }
-                    } else {
-                        Result::default()
-                    }
-                }
+                Op::Code::BinLogicalOr => match Self::to_boolean(p, &e.right.data) {
+                    Some(res) if res.value => Some(Known {
+                        value: true,
+                        side_effects: SideEffects::CouldHaveSideEffects,
+                    }),
+                    _ => None,
+                },
+                Op::Code::BinLogicalAnd => match Self::to_boolean(p, &e.right.data) {
+                    Some(res) if !res.value => Some(Known {
+                        value: false,
+                        side_effects: SideEffects::CouldHaveSideEffects,
+                    }),
+                    _ => None,
+                },
+                Op::Code::BinComma => Self::to_boolean(p, &e.right.data).map(|res| Known {
+                    value: res.value,
+                    side_effects: SideEffects::CouldHaveSideEffects,
+                }),
                 Op::Code::BinGt => {
                     if let Some(left_num) = e.left.data.to_finite_number() {
                         if let Some(right_num) = e.right.data.to_finite_number() {
-                            return Result {
-                                ok: true,
+                            return Some(Known {
                                 value: left_num > right_num,
                                 side_effects: SideEffects::NoSideEffects,
-                            };
+                            });
                         }
                     }
-                    Result::default()
+                    None
                 }
                 Op::Code::BinLt => {
                     if let Some(left_num) = e.left.data.to_finite_number() {
                         if let Some(right_num) = e.right.data.to_finite_number() {
-                            return Result {
-                                ok: true,
+                            return Some(Known {
                                 value: left_num < right_num,
                                 side_effects: SideEffects::NoSideEffects,
-                            };
+                            });
                         }
                     }
-                    Result::default()
+                    None
                 }
                 Op::Code::BinLe => {
                     if let Some(left_num) = e.left.data.to_finite_number() {
                         if let Some(right_num) = e.right.data.to_finite_number() {
-                            return Result {
-                                ok: true,
+                            return Some(Known {
                                 value: left_num <= right_num,
                                 side_effects: SideEffects::NoSideEffects,
-                            };
+                            });
                         }
                     }
-                    Result::default()
+                    None
                 }
                 Op::Code::BinGe => {
                     if let Some(left_num) = e.left.data.to_finite_number() {
                         if let Some(right_num) = e.right.data.to_finite_number() {
-                            return Result {
-                                ok: true,
+                            return Some(Known {
                                 value: left_num >= right_num,
                                 side_effects: SideEffects::NoSideEffects,
-                            };
+                            });
                         }
                     }
-                    Result::default()
+                    None
                 }
-                _ => Result::default(),
+                _ => None,
             },
             ExprData::EInlinedEnum(e) => Self::to_boolean(p, &e.value.data),
             ExprData::ESpecial(special) => match special {
                 E::Special::ModuleExports
                 | E::Special::ResolvedSpecifierString(_)
-                | E::Special::HotData => Result::default(),
+                | E::Special::HotData => None,
                 E::Special::HotAccept | E::Special::HotAcceptVisited | E::Special::HotEnabled => {
-                    Result {
-                        ok: true,
+                    Some(Known {
                         value: true,
                         side_effects: SideEffects::NoSideEffects,
-                    }
+                    })
                 }
-                E::Special::HotDisabled => Result {
-                    ok: true,
+                E::Special::HotDisabled => Some(Known {
                     value: false,
                     side_effects: SideEffects::NoSideEffects,
-                },
+                }),
             },
-            _ => Result::default(),
+            _ => None,
         }
     }
 }

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -14,10 +14,6 @@ pub enum SideEffects {
     NoSideEffects,
 }
 
-/// A boolean value the parser was able to prove at compile time, together
-/// with whether evaluating the original expression could have observable
-/// side effects. Returned as `Option<Known>` from `to_boolean` /
-/// `to_null_or_undefined`; `None` means the value could not be determined.
 #[derive(Clone, Copy, Debug)]
 pub struct Known {
     pub(crate) value: bool,

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -134,8 +134,7 @@ impl BinaryExpressionVisitor {
         // Mark the control flow as dead if the branch is never taken
         match e_.op {
             Op::Code::BinLogicalOr => {
-                let side_effects = SideEffects::to_boolean(p, &e_.left.data);
-                if side_effects.ok && side_effects.value {
+                if SideEffects::to_boolean(p, &e_.left.data).is_some_and(|k| k.value) {
                     // "true || dead"
                     let old = p.is_control_flow_dead;
                     p.is_control_flow_dead = true;
@@ -146,8 +145,7 @@ impl BinaryExpressionVisitor {
                 }
             }
             Op::Code::BinLogicalAnd => {
-                let side_effects = SideEffects::to_boolean(p, &e_.left.data);
-                if side_effects.ok && !side_effects.value {
+                if SideEffects::to_boolean(p, &e_.left.data).is_some_and(|k| !k.value) {
                     // "false && dead"
                     let old = p.is_control_flow_dead;
                     p.is_control_flow_dead = true;
@@ -158,8 +156,7 @@ impl BinaryExpressionVisitor {
                 }
             }
             Op::Code::BinNullishCoalescing => {
-                let side_effects = SideEffects::to_null_or_undefined(p, &e_.left.data);
-                if side_effects.ok && !side_effects.value {
+                if SideEffects::to_null_or_undefined(p, &e_.left.data).is_some_and(|k| !k.value) {
                     // "notNullOrUndefined ?? dead"
                     let old = p.is_control_flow_dead;
                     p.is_control_flow_dead = true;
@@ -361,8 +358,8 @@ impl BinaryExpressionVisitor {
                 }
             }
             Op::Code::BinNullishCoalescing => {
-                let null_or_undefined = SideEffects::to_null_or_undefined(p, &e_.left.data);
-                if null_or_undefined.ok {
+                if let Some(null_or_undefined) = SideEffects::to_null_or_undefined(p, &e_.left.data)
+                {
                     if !null_or_undefined.value {
                         return e_.left;
                     } else if null_or_undefined.side_effects == SideEffects::NoSideEffects {
@@ -384,30 +381,29 @@ impl BinaryExpressionVisitor {
                 }
             }
             Op::Code::BinLogicalOr => {
-                let side_effects = SideEffects::to_boolean(p, &e_.left.data);
-                if side_effects.ok && side_effects.value {
-                    return e_.left;
-                } else if side_effects.ok && side_effects.side_effects == SideEffects::NoSideEffects
-                {
-                    // "(0 || fn)()" => "fn()"
-                    // "(0 || this.fn)" => "this.fn"
-                    // "(0 || this.fn)()" => "(0, this.fn)()"
-                    if is_call_target && e_.right.has_value_for_this_in_call() {
-                        return Expr::join_with_comma(
-                            Expr {
-                                data: prefill::data::ZERO,
-                                loc: e_.left.loc,
-                            },
-                            e_.right,
-                        );
-                    }
+                if let Some(side_effects) = SideEffects::to_boolean(p, &e_.left.data) {
+                    if side_effects.value {
+                        return e_.left;
+                    } else if side_effects.side_effects == SideEffects::NoSideEffects {
+                        // "(0 || fn)()" => "fn()"
+                        // "(0 || this.fn)" => "this.fn"
+                        // "(0 || this.fn)()" => "(0, this.fn)()"
+                        if is_call_target && e_.right.has_value_for_this_in_call() {
+                            return Expr::join_with_comma(
+                                Expr {
+                                    data: prefill::data::ZERO,
+                                    loc: e_.left.loc,
+                                },
+                                e_.right,
+                            );
+                        }
 
-                    return e_.right;
+                        return e_.right;
+                    }
                 }
             }
             Op::Code::BinLogicalAnd => {
-                let side_effects = SideEffects::to_boolean(p, &e_.left.data);
-                if side_effects.ok {
+                if let Some(side_effects) = SideEffects::to_boolean(p, &e_.left.data) {
                     if !side_effects.value {
                         return e_.left;
                     } else if side_effects.side_effects == SideEffects::NoSideEffects {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1237,18 +1237,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             e_.value = SideEffects::simplify_boolean(p, e_.value);
                         }
 
-                        let side_effects = SideEffects::to_boolean(p, &e_.value.data);
-                        if side_effects.ok
-                            && (side_effects.side_effects == SideEffects::NoSideEffects
-                                || p.expr_can_be_removed_if_unused(&e_.value))
-                        {
-                            *e = p.new_expr(
-                                E::Boolean {
-                                    value: !side_effects.value,
-                                },
-                                expr.loc,
-                            );
-                            return;
+                        if let Some(side_effects) = SideEffects::to_boolean(p, &e_.value.data) {
+                            if side_effects.side_effects == SideEffects::NoSideEffects
+                                || p.expr_can_be_removed_if_unused(&e_.value)
+                            {
+                                *e = p.new_expr(
+                                    E::Boolean {
+                                        value: !side_effects.value,
+                                    },
+                                    expr.loc,
+                                );
+                                return;
+                            }
                         }
 
                         if p.options.features.minify_syntax {
@@ -1468,68 +1468,65 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         e_.test = SideEffects::simplify_boolean(p, e_.test);
 
-        let side_effects = SideEffects::to_boolean(p, &e_.test.data);
-
-        if !side_effects.ok {
+        let Some(side_effects) = SideEffects::to_boolean(p, &e_.test.data) else {
             p.visit_expr(&mut e_.yes);
             p.visit_expr(&mut e_.no);
-        } else {
-            // Mark the control flow as dead if the branch is never taken
-            if side_effects.value {
-                // "true ? live : dead"
-                p.visit_expr(&mut e_.yes);
-                let old = p.is_control_flow_dead;
-                p.is_control_flow_dead = true;
-                p.visit_expr(&mut e_.no);
-                p.is_control_flow_dead = old;
+            return;
+        };
 
-                if side_effects.side_effects == SideEffects::CouldHaveSideEffects {
-                    *e = SideEffects::simplify_unused_expr(p, e_.test)
-                        .unwrap_or_else(|| p.new_expr(E::Missing {}, e_.test.loc))
-                        .join_with_comma(e_.yes);
-                    return;
-                }
+        // Mark the control flow as dead if the branch is never taken
+        if side_effects.value {
+            // "true ? live : dead"
+            p.visit_expr(&mut e_.yes);
+            let old = p.is_control_flow_dead;
+            p.is_control_flow_dead = true;
+            p.visit_expr(&mut e_.no);
+            p.is_control_flow_dead = old;
 
-                // "(1 ? fn : 2)()" => "fn()"
-                // "(1 ? this.fn : 2)" => "this.fn"
-                // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
-                if is_call_target && e_.yes.has_value_for_this_in_call() {
-                    *e = p
-                        .new_expr(E::Number::new(0.0), e_.test.loc)
-                        .join_with_comma(e_.yes);
-                    return;
-                }
-
-                *e = e_.yes;
-                return;
-            } else {
-                // "false ? dead : live"
-                let old = p.is_control_flow_dead;
-                p.is_control_flow_dead = true;
-                p.visit_expr(&mut e_.yes);
-                p.is_control_flow_dead = old;
-                p.visit_expr(&mut e_.no);
-
-                // "(a, false) ? b : c" => "a, c"
-                if side_effects.side_effects == SideEffects::CouldHaveSideEffects {
-                    *e = SideEffects::simplify_unused_expr(p, e_.test)
-                        .unwrap_or_else(|| p.new_expr(E::Missing {}, e_.test.loc))
-                        .join_with_comma(e_.no);
-                    return;
-                }
-
-                // "(1 ? fn : 2)()" => "fn()"
-                // "(1 ? this.fn : 2)" => "this.fn"
-                // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
-                if is_call_target && e_.no.has_value_for_this_in_call() {
-                    *e = p
-                        .new_expr(E::Number::new(0.0), e_.test.loc)
-                        .join_with_comma(e_.no);
-                    return;
-                }
-                *e = e_.no;
+            if side_effects.side_effects == SideEffects::CouldHaveSideEffects {
+                *e = SideEffects::simplify_unused_expr(p, e_.test)
+                    .unwrap_or_else(|| p.new_expr(E::Missing {}, e_.test.loc))
+                    .join_with_comma(e_.yes);
                 return;
             }
+
+            // "(1 ? fn : 2)()" => "fn()"
+            // "(1 ? this.fn : 2)" => "this.fn"
+            // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
+            if is_call_target && e_.yes.has_value_for_this_in_call() {
+                *e = p
+                    .new_expr(E::Number::new(0.0), e_.test.loc)
+                    .join_with_comma(e_.yes);
+                return;
+            }
+
+            *e = e_.yes;
+        } else {
+            // "false ? dead : live"
+            let old = p.is_control_flow_dead;
+            p.is_control_flow_dead = true;
+            p.visit_expr(&mut e_.yes);
+            p.is_control_flow_dead = old;
+            p.visit_expr(&mut e_.no);
+
+            // "(a, false) ? b : c" => "a, c"
+            if side_effects.side_effects == SideEffects::CouldHaveSideEffects {
+                *e = SideEffects::simplify_unused_expr(p, e_.test)
+                    .unwrap_or_else(|| p.new_expr(E::Missing {}, e_.test.loc))
+                    .join_with_comma(e_.no);
+                return;
+            }
+
+            // "(1 ? fn : 2)()" => "fn()"
+            // "(1 ? this.fn : 2)" => "this.fn"
+            // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
+            if is_call_target && e_.no.has_value_for_this_in_call() {
+                *e = p
+                    .new_expr(E::Number::new(0.0), e_.test.loc)
+                    .join_with_comma(e_.no);
+                return;
+            }
+            *e = e_.no;
         }
     }
 

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1653,14 +1653,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         data.body = p.visit_loop_body(data.body);
 
         data.test = SideEffects::simplify_boolean(p, data.test);
-        let result = SideEffects::to_boolean(p, &data.test.data);
-        if result.ok && result.side_effects == SideEffects::NoSideEffects {
-            data.test = p.new_expr(
-                E::Boolean {
-                    value: result.value,
-                },
-                data.test.loc,
-            );
+        if let Some(result) = SideEffects::to_boolean(p, &data.test.data) {
+            if result.side_effects == SideEffects::NoSideEffects {
+                data.test = p.new_expr(
+                    E::Boolean {
+                        value: result.value,
+                    },
+                    data.test.loc,
+                );
+            }
         }
 
         stmts.push(*stmt);
@@ -1697,7 +1698,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         let effects = SideEffects::to_boolean(p, &data.test.data);
-        if effects.ok && !effects.value {
+        if effects.is_some_and(|k| !k.value) {
             let old = p.is_control_flow_dead;
             p.is_control_flow_dead = true;
             data.yes = p.visit_single_stmt(data.yes, StmtsKind::None);
@@ -1708,7 +1709,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // The "else" clause is optional
         if let Some(no) = data.no {
-            if effects.ok && effects.value {
+            if effects.is_some_and(|k| k.value) {
                 let old = p.is_control_flow_dead;
                 p.is_control_flow_dead = true;
                 data.no = Some(p.visit_single_stmt(no, StmtsKind::None));
@@ -1739,7 +1740,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         if p.options.features.minify_syntax {
-            if effects.ok {
+            if let Some(effects) = effects {
                 if effects.value {
                     if data.no.is_none()
                         || !SideEffects::should_keep_stmt_in_dead_control_flow(
@@ -1837,9 +1838,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.visit_expr(&mut test);
             data.test = Some(SideEffects::simplify_boolean(p, test));
 
-            let result = SideEffects::to_boolean(p, &data.test.unwrap().data);
-            if result.ok && result.value && result.side_effects == SideEffects::NoSideEffects {
-                data.test = None;
+            if let Some(result) = SideEffects::to_boolean(p, &data.test.unwrap().data) {
+                if result.value && result.side_effects == SideEffects::NoSideEffects {
+                    data.test = None;
+                }
             }
         }
 


### PR DESCRIPTION
Two dependent-bool pairs in the parser whose cross product included states that are never constructed and would be meaningless if they were.

## `ParseStatementOptions` scope

`is_module_scope` and `is_namespace_scope` are mutually exclusive: `is_module_scope` is only set at the two parse entry points (`parse_entry.rs`), `is_namespace_scope` only inside `parse_type_script_namespace_stmt`. Every consumer treats them as a three-way switch.

Replaced with `enum StatementScope { Nested, Module, Namespace }`. The seven copies of

```rust
if !opts.is_module_scope
    && (!opts.is_namespace_scope || !opts.is_typescript_declare)
```

fold into `if !opts.allows_esm_import_export()`, and the `if/else if` at the top of `t_export` becomes an exhaustive `match`.

## `scan_side_effects::Result`

`Result { ok, value, side_effects }` only carries a meaningful `value` / `side_effects` when `ok == true`; every caller guards on `.ok` before reading either field. `{ ok: false, value: true }` was never constructed.

Replaced with `Option<Known { value, side_effects }>` so `to_boolean` and `to_null_or_undefined` return `None` for the unknown case and callers use `if let Some(..)` / `is_some_and(..)` instead of a separate `.ok` read.

## Why

Making both states unrepresentable removes the possibility of a future change constructing `{ is_module_scope: true, is_namespace_scope: true }` or reading `.value` without checking `.ok`, both of which would silently miscompile. No behavior change.

## Verification

This is a type-level refactor with no semantic change, so there is no test that fails before and passes after. Existing coverage exercises every touched path and passes unchanged:

- `test/bundler/esbuild/dce.test.ts` (78 pass)
- `test/bundler/esbuild/ts.test.ts` (57 pass)
- `test/bundler/esbuild/default.test.ts` (151 pass)
- `test/bundler/esbuild/importstar_ts.test.ts` (23 pass)
- `test/bundler/bundler_minify.test.ts` (42 pass)
- `test/bundler/bundler_edgecase.test.ts` (117 pass)
- `test/bundler/bundler_regressions.test.ts` (9 pass, incl. NamespaceTracking#12337)
- `test/bundler/transpiler/transpiler.test.js` (183 pass, 12 snapshots)

Net: 13 files changed, +284 / -328.