### PR TITLE
sys/repl/shell: collapse dependent-bool pairs into enums (fixes ls -a -A ordering)

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1217,7 +1217,7 @@ pub mod package_manifest {
                                 cache_dir,
                                 outpath,
                                 bun_sys::Renameat2Flags {
-                                    exchange: true,
+                                    mode: bun_sys::RenameMode::Exchange,
                                     ..Default::default()
                                 },
                             )?;

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -781,6 +781,9 @@ fn cmd_save(repl: &mut Repl, args: &[u8]) -> ReplResult {
 }
 
 fn cmd_editor(repl: &mut Repl, _: &[u8]) -> ReplResult {
+    if repl.input_mode == InputMode::Multiline {
+        return ReplResult::SkipEval;
+    }
     repl.print(format_args!(
         "{}// Entering editor mode (Ctrl+D to finish, Ctrl+C to cancel){}\n",
         Color::DIM,
@@ -788,7 +791,6 @@ fn cmd_editor(repl: &mut Repl, _: &[u8]) -> ReplResult {
     ));
     repl.input_mode = InputMode::Editor;
     repl.editor_buffer.clear();
-    repl.multiline_buffer.clear();
     ReplResult::SkipEval
 }
 

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -788,6 +788,7 @@ fn cmd_editor(repl: &mut Repl, _: &[u8]) -> ReplResult {
     ));
     repl.input_mode = InputMode::Editor;
     repl.editor_buffer.clear();
+    repl.multiline_buffer.clear();
     ReplResult::SkipEval
 }
 

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -786,7 +786,7 @@ fn cmd_editor(repl: &mut Repl, _: &[u8]) -> ReplResult {
         Color::DIM,
         Color::RESET
     ));
-    repl.editor_mode = true;
+    repl.input_mode = InputMode::Editor;
     repl.editor_buffer.clear();
     ReplResult::SkipEval
 }
@@ -794,7 +794,7 @@ fn cmd_editor(repl: &mut Repl, _: &[u8]) -> ReplResult {
 fn cmd_break(repl: &mut Repl, _: &[u8]) -> ReplResult {
     repl.line_editor.clear();
     repl.multiline_buffer.clear();
-    repl.in_multiline = false;
+    repl.input_mode = InputMode::Normal;
     ReplResult::SkipEval
 }
 
@@ -827,6 +827,13 @@ fn cmd_history(repl: &mut Repl, _: &[u8]) -> ReplResult {
 // Main REPL Struct
 // ============================================================================
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum InputMode {
+    Normal,
+    Multiline,
+    Editor,
+}
+
 pub(super) struct Repl<'a> {
     line_editor: LineEditor,
     history: History,
@@ -834,8 +841,7 @@ pub(super) struct Repl<'a> {
     editor_buffer: Vec<u8>,
 
     // State
-    in_multiline: bool,
-    editor_mode: bool,
+    input_mode: InputMode,
     running: bool,
     is_tty: bool,
     use_colors: bool,
@@ -873,8 +879,7 @@ impl<'a> Repl<'a> {
             history: History::init(),
             multiline_buffer: Vec::new(),
             editor_buffer: Vec::new(),
-            in_multiline: false,
-            editor_mode: false,
+            input_mode: InputMode::Normal,
             running: false,
             is_tty: false,
             use_colors: false,
@@ -1170,7 +1175,7 @@ impl<'a> Repl<'a> {
     // ========================================================================
 
     fn get_prompt(&self) -> &'static [u8] {
-        if self.in_multiline || self.editor_mode {
+        if self.input_mode != InputMode::Normal {
             if self.use_colors {
                 return concat!("\x1b[2m", "... ", "\x1b[0m").as_bytes();
             } else {
@@ -1186,7 +1191,7 @@ impl<'a> Repl<'a> {
     }
 
     fn get_prompt_length(&self) -> usize {
-        if self.in_multiline || self.editor_mode {
+        if self.input_mode != InputMode::Normal {
             return 4; // "... "
         }
         2 // "> " or "\u{276f} "
@@ -2011,8 +2016,8 @@ impl<'a> Repl<'a> {
             match key {
                 Key::Enter => self.handle_enter()?,
                 Key::CtrlC => self.handle_ctrl_c(),
-                Key::CtrlD => {
-                    if self.editor_mode {
+                Key::CtrlD => match self.input_mode {
+                    InputMode::Editor => {
                         // Finish editor mode
                         self.print(format_args!("\n"));
                         // Note: reshaped for borrowck — clone editor_buffer slice before evaluate
@@ -2021,17 +2026,19 @@ impl<'a> Repl<'a> {
                             self.evaluate_and_print(&code);
                             self.editor_buffer = code;
                         }
-                        self.editor_mode = false;
+                        self.input_mode = InputMode::Normal;
                         self.editor_buffer.clear();
                         self.refresh_line();
-                    } else if self.line_editor.buffer.is_empty() && !self.in_multiline {
+                    }
+                    InputMode::Normal if self.line_editor.buffer.is_empty() => {
                         self.print(format_args!("\n"));
                         self.running = false;
-                    } else {
+                    }
+                    _ => {
                         self.line_editor.delete_char();
                         self.refresh_line();
                     }
-                }
+                },
                 Key::CtrlL => {
                     self.write(Cursor::CLEAR_SCREEN.as_bytes());
                     self.write(Cursor::HOME.as_bytes());
@@ -2139,7 +2146,7 @@ impl<'a> Repl<'a> {
         // Note: reshaped for borrowck — copy line out so we can call &mut self methods
         let line: Vec<u8> = self.line_editor.get_line().to_vec();
 
-        if self.editor_mode {
+        if self.input_mode == InputMode::Editor {
             if strings::trim(&line, b" \t").is_empty() {
                 self.editor_buffer.extend_from_slice(b"\n");
             } else {
@@ -2193,13 +2200,13 @@ impl<'a> Repl<'a> {
         }
 
         // Handle empty line
-        if line.is_empty() && !self.in_multiline {
+        if line.is_empty() && self.input_mode != InputMode::Multiline {
             self.refresh_line();
             return Ok(());
         }
 
         // Check for multi-line input
-        let full_code: &[u8] = if self.in_multiline {
+        let full_code: &[u8] = if self.input_mode == InputMode::Multiline {
             self.multiline_buffer.extend_from_slice(&line);
             self.multiline_buffer.push(b'\n');
             &self.multiline_buffer
@@ -2208,8 +2215,8 @@ impl<'a> Repl<'a> {
         };
 
         if is_incomplete_code(full_code) {
-            if !self.in_multiline {
-                self.in_multiline = true;
+            if self.input_mode != InputMode::Multiline {
+                self.input_mode = InputMode::Multiline;
                 self.multiline_buffer.extend_from_slice(&line);
                 self.multiline_buffer.push(b'\n');
             }
@@ -2219,7 +2226,7 @@ impl<'a> Repl<'a> {
         }
 
         // Complete code - evaluate it
-        let code_to_eval: Box<[u8]> = if self.in_multiline {
+        let code_to_eval: Box<[u8]> = if self.input_mode == InputMode::Multiline {
             Box::<[u8]>::from(self.multiline_buffer.as_slice())
         } else {
             Box::<[u8]>::from(line.as_slice())
@@ -2232,40 +2239,46 @@ impl<'a> Repl<'a> {
         // Reset state
         self.line_editor.clear();
         self.multiline_buffer.clear();
-        self.in_multiline = false;
+        self.input_mode = InputMode::Normal;
         self.history.reset_position();
         self.refresh_line();
         Ok(())
     }
 
     fn handle_ctrl_c(&mut self) {
-        if self.editor_mode {
-            self.print(format_args!(
-                "\n{}// Editor mode cancelled{}\n",
-                Color::DIM,
-                Color::RESET
-            ));
-            self.editor_mode = false;
-            self.editor_buffer.clear();
-        } else if self.in_multiline {
-            self.print(format_args!("\n"));
-            self.in_multiline = false;
-            self.multiline_buffer.clear();
-        } else if !self.line_editor.buffer.is_empty() {
-            self.print(format_args!("^C\n"));
-            self.line_editor.clear();
-        } else if self.ctrl_c_pressed {
-            // Second Ctrl+C on empty line - exit
-            self.print(format_args!("\n"));
-            self.running = false;
-            return;
-        } else {
-            self.ctrl_c_pressed = true;
-            self.print(format_args!(
-                "\n{}(press Ctrl+C again to exit, or Ctrl+D){}\n",
-                Color::DIM,
-                Color::RESET
-            ));
+        match self.input_mode {
+            InputMode::Editor => {
+                self.print(format_args!(
+                    "\n{}// Editor mode cancelled{}\n",
+                    Color::DIM,
+                    Color::RESET
+                ));
+                self.input_mode = InputMode::Normal;
+                self.editor_buffer.clear();
+            }
+            InputMode::Multiline => {
+                self.print(format_args!("\n"));
+                self.input_mode = InputMode::Normal;
+                self.multiline_buffer.clear();
+            }
+            InputMode::Normal if !self.line_editor.buffer.is_empty() => {
+                self.print(format_args!("^C\n"));
+                self.line_editor.clear();
+            }
+            InputMode::Normal if self.ctrl_c_pressed => {
+                // Second Ctrl+C on empty line - exit
+                self.print(format_args!("\n"));
+                self.running = false;
+                return;
+            }
+            InputMode::Normal => {
+                self.ctrl_c_pressed = true;
+                self.print(format_args!(
+                    "\n{}(press Ctrl+C again to exit, or Ctrl+D){}\n",
+                    Color::DIM,
+                    Color::RESET
+                ));
+            }
         }
         self.history.reset_position();
         self.refresh_line();

--- a/src/runtime/shell/builtin/ls.rs
+++ b/src/runtime/shell/builtin/ls.rs
@@ -249,8 +249,8 @@ impl Ls {
         }
         for &ch in &flag[1..] {
             match ch {
-                b'a' => opts.show_all = true,
-                b'A' => opts.show_almost_all = true,
+                b'a' => opts.dotfiles = DotfileMode::All,
+                b'A' => opts.dotfiles = DotfileMode::AlmostAll,
                 b'd' => opts.list_directories = true,
                 b'l' => opts.long_listing = true,
                 b'R' => opts.recursive = true,
@@ -513,19 +513,11 @@ impl ShellLsTask {
     }
 
     fn should_skip_entry(&self, name: &[u8]) -> bool {
-        if self.opts.show_all {
-            return false;
+        match self.opts.dotfiles {
+            DotfileMode::All => false,
+            DotfileMode::AlmostAll => name == b"." || name == b"..",
+            DotfileMode::Hide => name.first() == Some(&b'.'),
         }
-        // Show all directory entries whose name begin with a dot (`.`), EXCEPT
-        // `.` and `..`.
-        if self.opts.show_almost_all {
-            if name == b"." || name == b".." {
-                return true;
-            }
-        } else if name.first() == Some(&b'.') {
-            return true;
-        }
-        false
     }
 
     // TODO more complex output like multi-column
@@ -761,14 +753,23 @@ impl crate::shell::interpreter::ShellTaskCtx for ShellLsTask {
     }
 }
 
+/// `-a`/`-A` are alternatives of a single policy; the last flag on the
+/// command line wins (matches GNU coreutils).
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum DotfileMode {
+    #[default]
+    Hide,
+    /// `-A`, `--almost-all` — show dotfiles but skip `.` and `..`.
+    AlmostAll,
+    /// `-a`, `--all` — show everything including `.` and `..`.
+    All,
+}
+
 /// Only the fields actually consulted are kept; the rest are recognised by
 /// `parse_flag` but not stored.
 #[derive(Clone, Copy, Default)]
 pub struct Opts {
-    /// `-a`, `--all` — do not ignore entries starting with `.`
-    pub(crate) show_all: bool,
-    /// `-A`, `--almost-all` — like `-a` but skip `.` and `..`
-    pub(crate) show_almost_all: bool,
+    pub(crate) dotfiles: DotfileMode,
     /// `-d`, `--directory` — list directories themselves, not their contents
     pub(crate) list_directories: bool,
     /// `-l` — use a long listing format

--- a/src/runtime/shell/builtin/ls.rs
+++ b/src/runtime/shell/builtin/ls.rs
@@ -753,8 +753,7 @@ impl crate::shell::interpreter::ShellTaskCtx for ShellLsTask {
     }
 }
 
-/// `-a`/`-A` are alternatives of a single policy; the last flag on the
-/// command line wins (matches GNU coreutils).
+/// `-a` vs `-A`; the last one on the command line wins (GNU coreutils).
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) enum DotfileMode {
     #[default]

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1070,9 +1070,7 @@ impl error::IntoErrnoInt for bun_windows_sys::NTSTATUS {
     }
 }
 
-/// The exchange/no-replace axis of [`Renameat2Flags`]. `Exchange` and
-/// `NoReplace` are mutually exclusive: `renameat2(2)` on Linux and
-/// `renameatx_np` on macOS both reject the combination with `EINVAL`.
+/// `Exchange` and `NoReplace` are mutually exclusive at the kernel level.
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 pub enum RenameMode {
     #[default]

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1070,13 +1070,25 @@ impl error::IntoErrnoInt for bun_windows_sys::NTSTATUS {
     }
 }
 
+/// The exchange/no-replace axis of [`Renameat2Flags`]. `Exchange` and
+/// `NoReplace` are mutually exclusive: `renameat2(2)` on Linux and
+/// `renameatx_np` on macOS both reject the combination with `EINVAL`.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+pub enum RenameMode {
+    #[default]
+    Normal,
+    /// Linux `RENAME_EXCHANGE` / macOS `RENAME_SWAP`.
+    Exchange,
+    /// Linux `RENAME_NOREPLACE` / macOS `RENAME_EXCL`.
+    NoReplace,
+}
+
 /// Flags for [`renameat2`].
 /// On Linux maps to `RENAME_EXCHANGE`/`RENAME_NOREPLACE`; on macOS maps to
 /// `RENAME_SWAP`/`RENAME_EXCL`/`RENAME_NOFOLLOW_ANY`.
 #[derive(Clone, Copy, Default)]
 pub struct Renameat2Flags {
-    pub exchange: bool,
-    pub exclude: bool,
+    pub mode: RenameMode,
     pub nofollow: bool,
 }
 
@@ -1088,11 +1100,10 @@ impl Renameat2Flags {
         #[cfg(target_os = "macos")]
         {
             // <sys/stdio.h>: RENAME_SWAP=2, RENAME_EXCL=4, RENAME_NOFOLLOW_ANY=0x10
-            if self.exchange {
-                flags |= 2;
-            }
-            if self.exclude {
-                flags |= 4;
+            match self.mode {
+                RenameMode::Normal => {}
+                RenameMode::Exchange => flags |= 2,
+                RenameMode::NoReplace => flags |= 4,
             }
             if self.nofollow {
                 flags |= 0x10;
@@ -1100,20 +1111,19 @@ impl Renameat2Flags {
         }
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
-            if self.exchange {
-                flags |= libc::RENAME_EXCHANGE as u32;
+            match self.mode {
+                RenameMode::Normal => {}
+                RenameMode::Exchange => flags |= libc::RENAME_EXCHANGE as u32,
+                RenameMode::NoReplace => flags |= libc::RENAME_NOREPLACE as u32,
             }
-            if self.exclude {
-                flags |= libc::RENAME_NOREPLACE as u32;
-            }
+            let _ = self.nofollow;
         }
         #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
         {
-            if self.exchange {
-                flags |= 1;
-            }
-            if self.exclude {
-                flags |= 2;
+            match self.mode {
+                RenameMode::Normal => {}
+                RenameMode::Exchange => flags |= 1,
+                RenameMode::NoReplace => flags |= 2,
             }
             let _ = self.nofollow;
         }
@@ -9239,7 +9249,7 @@ pub(crate) fn renameat_concurrently_without_fallback(
                 to_dir_fd,
                 to,
                 Renameat2Flags {
-                    exclude: true,
+                    mode: RenameMode::NoReplace,
                     ..Default::default()
                 },
             ) {
@@ -9265,7 +9275,7 @@ pub(crate) fn renameat_concurrently_without_fallback(
                         to_dir_fd,
                         to,
                         Renameat2Flags {
-                            exchange: true,
+                            mode: RenameMode::Exchange,
                             ..Default::default()
                         },
                     ) {

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1067,20 +1067,19 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
     });
   });
 
-  test(".editor entered from a pending multiline abandons the pending input", async () => {
-    await withTerminalRepl(async ({ send, waitFor }) => {
-      send("function __stale() {\n");
+  test(".editor is ignored while a multiline input is pending", async () => {
+    await withTerminalRepl(async ({ send, waitFor, allOutput }) => {
+      send("function __pending() {\n");
       await waitFor("...");
       send(".editor\n");
-      await waitFor(/editor mode/i);
-      send("\x03"); // Ctrl+C to cancel editor
-      await waitFor(/cancelled/i);
-      // The pending `function __stale() {` must be gone: a fresh multiline
-      // should complete on its own closing bracket.
-      send("[1,\n");
       await waitFor("...");
-      send("2]\n");
-      await waitFor("[ 1, 2 ]");
+      // `.editor` must not switch modes here: the next line still feeds the
+      // pending function body, which then completes and is callable.
+      send("return 42 }\n");
+      await waitFor(/\u276f|> /);
+      send("__pending()\n");
+      await waitFor("42");
+      expect(allOutput()).not.toMatch(/editor mode/i);
     });
   });
 

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1067,6 +1067,23 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
     });
   });
 
+  test(".editor entered from a pending multiline abandons the pending input", async () => {
+    await withTerminalRepl(async ({ send, waitFor }) => {
+      send("function __stale() {\n");
+      await waitFor("...");
+      send(".editor\n");
+      await waitFor(/editor mode/i);
+      send("\x03"); // Ctrl+C to cancel editor
+      await waitFor(/cancelled/i);
+      // The pending `function __stale() {` must be gone: a fresh multiline
+      // should complete on its own closing bracket.
+      send("[1,\n");
+      await waitFor("...");
+      send("2]\n");
+      await waitFor("[ 1, 2 ]");
+    });
+  });
+
   test("multiline input with open brace", async () => {
     await withTerminalRepl(async ({ send, waitFor }) => {
       send("function test() {\n");

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -221,6 +221,36 @@ describe.concurrent("bunshell ls", () => {
         .run();
     });
 
+    test("-a and -A: last one wins (separate args)", async () => {
+      using tempdir = tempDir("ls-aA-order", {
+        ".hidden": "",
+        "visible": "",
+      });
+      await TestBuilder.command`ls -a -A`
+        .setTempdir(String(tempdir))
+        .stdout(s => expect(sortedLsOutput(s)).toEqual([".hidden", "visible"]))
+        .run();
+      await TestBuilder.command`ls -A -a`
+        .setTempdir(String(tempdir))
+        .stdout(s => expect(sortedLsOutput(s)).toEqual([".", "..", ".hidden", "visible"]))
+        .run();
+    });
+
+    test("-a and -A: last one wins (combined arg)", async () => {
+      using tempdir = tempDir("ls-aA-combined", {
+        ".hidden": "",
+        "visible": "",
+      });
+      await TestBuilder.command`ls -aA`
+        .setTempdir(String(tempdir))
+        .stdout(s => expect(sortedLsOutput(s)).toEqual([".hidden", "visible"]))
+        .run();
+      await TestBuilder.command`ls -Aa`
+        .setTempdir(String(tempdir))
+        .stdout(s => expect(sortedLsOutput(s)).toEqual([".", "..", ".hidden", "visible"]))
+        .run();
+    });
+
     test("-d with multiple directories", async () => {
       await using tempdir = tempDir("ls-d-multi", {});
       await $`mkdir dir1 dir2`.quiet().throws(true).cwd(tempdir);


### PR DESCRIPTION
## What

Replaces three pairs of mutually-exclusive bools with enums:

| Where | Before | After |
|---|---|---|
| `bun_sys::Renameat2Flags` | `exchange: bool`, `exclude: bool` | `mode: RenameMode { Normal, Exchange, NoReplace }` |
| `repl::Repl` | `in_multiline: bool`, `editor_mode: bool` | `input_mode: InputMode { Normal, Multiline, Editor }` |
| `shell::ls::Opts` | `show_all: bool`, `show_almost_all: bool` | `dotfiles: DotfileMode { Hide, AlmostAll, All }` |

## Why

Each pair encoded a 3-way choice as two bools whose `(true, true)` state was either rejected by the kernel, unreachable, or wrong:

- `renameat2(2)` on Linux and `renameatx_np` on macOS both return `EINVAL` for `RENAME_EXCHANGE | RENAME_NOREPLACE`, so `{ exchange: true, exclude: true }` could never succeed. `nofollow` is orthogonal and stays a separate bool.
- Every read site in the REPL dispatched on the two bools as a 3-way `if editor … else if multiline … else …`.
- `ls -a` and `-A` are ordered alternatives of one policy.

## Behavior change: `ls -a -A`

The `ls` change fixes flag ordering to match GNU coreutils. `-a`/`-A` are now last-one-wins:

```console
$ mkdir d && touch d/.hidden d/visible

# GNU coreutils 9.7
$ ls -a -A d    # -A wins -> no . / ..
.hidden  visible
$ ls -A -a d    # -a wins -> . / .. included
.  ..  .hidden  visible
```

Previously Bun set two independent bools and checked `show_all` first, so `-a` always won regardless of position:

```console
# Bun before this PR
$ bun -e 'await Bun.$`ls -a -A d`'
.
..
.hidden
visible
```

## Behavior change: REPL `.editor` from a pending multiline

Typing `.editor` while a multiline input is pending (`... ` prompt) is now a no-op: the command is ignored and the pending input stays intact. Previously the two independent bools let editor mode stack on top of multiline; with a single mode enum that stacking is not representable, and silently entering editor mode here would either abandon the pending input or leave a stale buffer. Ignoring the command keeps the user at the continuation prompt with nothing lost.

The `Renameat2Flags` refactor is behavior-preserving; no caller ever set both bools.

## Verification

- `bun bd test test/js/bun/shell/commands/ls.test.ts` (new `-a/-A` ordering tests; 27 pass, 2 pre-existing root-only failures)
- `bun bd test test/js/bun/repl/repl.test.ts` (148 pass, including the new `.editor`-from-multiline test)
- `cargo test -p bun_sys` (15 pass, including `renameat_concurrently_does_not_close_caller_fd`)
- `bun run rust:check-all` (10/10 targets)
