### PR TITLE
Bump WebKit: Windows GC conservative-scan hardening (preview)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "f0f60fd2324817dae9656d8bf2fcae25ceaccc37";
+export const WEBKIT_VERSION = "autobuild-preview-pr-382-f3912165";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
Bumps WebKit to oven-sh/WebKit#382 (`autobuild-preview-pr-382-f3912165`, rebased onto WebKit main `0cbb4a1946`) to exercise the Windows GC conservative-scan hardening in Bun's CI.

Changes picked up (four commits in the WebKit PR):

1. `Thread::getRegisters` (Windows): `RELEASE_ASSERT` on `GetThreadContext` failure (with `GetLastError()` in crash info) and return only the populated `CONTEXT_INTEGER | CONTEXT_CONTROL` prefix (256 bytes on x64 vs `sizeof(CONTEXT)` = 1232) so the conservative root scan does not copy uninitialized collector stack.
2. `MachineThreads::tryCopyOtherThreadStack`: value-initialize `PlatformRegisters` so unpopulated bytes scan as zero, not stale `SlotVisitor` frames. Platform-independent.
3. `Thread::suspend` (Windows): retry both `SuspendThread` and `GetThreadContext` with spin-then-`Sleep(1)` backoff (up to 100 attempts) for transient failures. `tryCopyOtherThreadStacks`: `RELEASE_ASSERT` if a live thread still cannot be suspended instead of silently skipping its roots. (A thread that has completed `didExit()` is already removed from the group under the lock we hold, so there is no exited-thread case to tolerate.)
4. `RegisterState.h`: gate the explicit callee-save inline-asm capture on `COMPILER(GCC_COMPATIBLE) || COMPILER(CLANG)` (clang-cl defines `__clang__` but not `__GNUC__`, and accepts GNU inline asm) and add a Win64 variant capturing `rbx, rbp, rdi, rsi, r12-r15`. Also adds `rbp` to the SysV x86_64 list. MSVC proper keeps the `setjmp` fallback.

This bump also carries WebKit main `f0f60fd2..0cbb4a1946` relative to what `main` pins today (URLParser speedup, `VM::addTerminationDeadline`, FFI i64/u64 modulo conversion, threadsafe JSFFICallback change and its revert).

Do not merge until oven-sh/WebKit#382 lands on `main`; then re-point `WEBKIT_VERSION` at the merged sha.

<details>
<summary>Rebase history</summary>

The branch was originally based on bun `b0a723ff` pinning a preview built on WebKit `9f8f24db`. `main` has since taken roughly ten WebKit bumps (now `f0f60fd2`) whose JSC API changes Bun's C++ depends on, so the old preview could not be rebased onto current `main`. The WebKit PR was rebased onto WebKit main `0cbb4a1946` (clean 3-way apply; upstream had added `Thread::barrierInstructionCache` and `processIsShuttingDown` to `ThreadingWin.cpp`, neither overlapping the changed functions), a fresh preview was built, and this branch was recreated on current bun `main` with a single commit pointing at it. The only conflict was the `WEBKIT_VERSION` line itself.

Earlier CI on the pre-rebase preview (`87d87c14`, bun build #87798): 194/196 jobs passed, all failures were retry-passing flakes also seen on `main`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->