### PR TITLE
test: make test-fs-read-stream-pos.js deterministic (90s worst case → <100ms)

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -97,12 +97,6 @@ function getNodeParallelTestTimeout(testPath) {
   if (testPath.includes("test-cluster-")) return 60_000; // cluster IPC + socket-handle passing is process-heavy under runner concurrency
   if (testPath.includes("-docker-")) return 60_000;
   if (testPath.includes("test-stdin-pipe-large")) return 60_000; // pipes 1MB stdin->stdout through an extra child process; slow under runner concurrency
-  // test-fs-read-stream-pos.js exit condition is a pure timing race (writer must append
-  // between two consecutive ReadStream preads) with a 90s upstream safety timer; solo
-  // runtimes are ~1s on linux-x64 but 1-40s on Windows since #34834 raised its timer
-  // resolution, and aarch64 CI retries running alone have exceeded 20s (builds 85866,
-  // 85400). 120s lets the safety timer fire.
-  if (testPath.includes("test-fs-read-stream-pos")) return 120_000;
   if (!isCI) return 60_000; // everything slower in debug mode
   if (options["step"]?.includes("-asan-")) return 60_000;
   return 20_000;
@@ -641,12 +635,6 @@ async function runTests() {
   const isParallelSafeTest = testPath => {
     const p = testPath.replaceAll("\\", "/");
     if (!p.includes("js/node/test/parallel/") && !p.includes("js/bun/test/parallel/")) return false;
-    // test-fs-read-stream-pos.js arms a common.mustCallAtLeast per stream; under
-    // I/O-heavy neighbours (e.g. test-fs-read-stream-fd-leak) the 1ms append
-    // interval is starved long enough for a stream to catch cur == EOF and get
-    // zero 'data' events, failing the mustCallAtLeast check on exit. Run it in
-    // the serial phase so the writer keeps its 1ms cadence.
-    if (p.endsWith("test-fs-read-stream-pos.js")) return false;
     return true;
   };
   console.log("parallel-safe width", parallelSafeWidth);

--- a/test/js/node/test/parallel/test-fs-read-stream-pos.js
+++ b/test/js/node/test/parallel/test-fs-read-stream-pos.js
@@ -15,21 +15,28 @@ fs.writeFileSync(file, '');
 
 let counter = 0;
 
-const writeInterval = setInterval(() => {
+const appendLine = () => {
   counter = counter + 1;
-  const line = `hello at ${counter}\n`;
-  fs.writeFileSync(file, line, { flag: 'a' });
-}, 1);
+  fs.writeFileSync(file, `hello at ${counter}\n`, { flag: 'a' });
+};
+
+// Seed a line so the first stream is guaranteed at least one 'data' event and a
+// short (< hwm) tail chunk even before the 1ms writer has had a chance to fire.
+appendLine();
+
+const writeInterval = setInterval(appendLine, 1);
 
 const hwm = 10;
 let bufs = [];
 let isLow = false;
 let cur = 0;
 let stream;
+let streamStart = 0;
 
 const readInterval = setInterval(common.mustCallAtLeast(() => {
   if (stream) return;
 
+  streamStart = cur;
   stream = fs.createReadStream(file, {
     highWaterMark: hwm,
     start: cur
@@ -38,7 +45,16 @@ const readInterval = setInterval(common.mustCallAtLeast(() => {
     cur += chunk.length;
     bufs.push(chunk);
     if (isLow) {
-      const brokenLines = Buffer.concat(bufs).toString()
+      const read = Buffer.concat(bufs);
+      const onDisk = fs.readFileSync(file);
+      assert.strictEqual(read.length, cur - streamStart);
+      assert.ok(cur <= onDisk.length, `cur ${cur} exceeds file size ${onDisk.length}`);
+      // nodejs/node#33940: after a short read the next pread was issued at the
+      // wrong position, so the bytes delivered here overlapped or skipped what
+      // earlier chunks had already returned. The concatenated chunks must be
+      // exactly the file's bytes at [streamStart, cur).
+      assert.deepStrictEqual(read, onDisk.subarray(streamStart, cur));
+      const brokenLines = read.toString()
         .split('\n')
         .filter((line) => {
           const s = 'hello at'.slice(0, line.length);
@@ -53,6 +69,13 @@ const readInterval = setInterval(common.mustCallAtLeast(() => {
     }
     if (chunk.length !== hwm) {
       isLow = true;
+      // Upstream relies on the 1ms writer landing between this short read and
+      // the stream's next pread, and carries a 90s safety timer for when that
+      // race never hits (reached routinely on Windows, where the test then
+      // exits without asserting anything). Appending here, before the next
+      // _read is scheduled, makes the follow-up chunk deterministic without
+      // changing the code path under test.
+      appendLine();
     }
   }));
   stream.on('end', () => {
@@ -62,15 +85,9 @@ const readInterval = setInterval(common.mustCallAtLeast(() => {
   });
 }), 10);
 
-// Time longer than 90 seconds to exit safely
-const endTimer = setTimeout(() => {
-  exitTest();
-}, 90000);
-
 const exitTest = () => {
   clearInterval(readInterval);
   clearInterval(writeInterval);
-  clearTimeout(endTimer);
   if (stream && !stream.destroyed) {
     stream.on('close', () => {
       process.exit();


### PR DESCRIPTION
### What

The exit path of the upstream test is a pure timing race: the 1 ms append interval must land between two consecutive `ReadStream` preads within one stream instance (a short chunk followed by another `'data'` before `'end'`). Upstream ships a 90 s safety timer for when the race doesn't hit. On that path the assertion block never runs, so the test exits 0 without checking anything.

This PR appends synchronously inside the `'data'` handler the moment a short chunk arrives. The stream's next `_read` is scheduled after the handler returns, so that pread is guaranteed to find the appended bytes. It is exactly the code path the race was trying to reach (short read, file grows, next pread from the same stream), just without the race. The 90 s safety timer and the two runner workarounds from #36478 are then dead and are removed.

The assertion block now also checks that the concatenated chunks are byte-for-byte the file's `[streamStart, cur)` range. nodejs/node#33940 was a wrong-position pread after a short read; this catches it directly (duplicated or skipped bytes fail the equality) instead of only via the broken-line heuristic.

The 1 ms background writer and the `common.mustCallAtLeast` wrappers are kept so the test still reads a growing file the way the original does.

### Why

Build #87550 spent 90 s on this file on Windows 2019 x64, and #36478 measured 1-40 s over 30 solo Windows runs. When it reaches 90 s the test has asserted nothing. `'data'` runs synchronously from the read callback's `push`, and `_read` is re-scheduled via `process.nextTick` after `push` returns, so a synchronous append inside the handler is ordered strictly before the next pread in both Bun's `readStreamPrototype._read` and Node's `ReadStream.prototype._read`. For `hwm = 10` and 11/12-byte lines, the running file size is never a multiple of 10 while `counter ≤ 105`, so the first stream always produces a short tail chunk and the test exits in that stream.

Orthogonal to #36548 / #36479: those address the event-loop ordering that made the race hard to hit; this makes the test independent of the race so neither the 120 s runner ceiling nor the serial scheduling is needed.

### Verification

Release (`USE_SYSTEM_BUN=1 bun test/js/node/test/parallel/test-fs-read-stream-pos.js`):

| platform | before | after |
| --- | --- | --- |
| linux x64, 10 runs | 129-5730 ms | 71-99 ms |
| windows x64, 5/20 runs | 275-10511 ms (90 s on #87550) | 67-75 ms |
| windows x64 under 3 concurrent `test-fs-read-stream-fd-leak.js` neighbours | (failed `mustCallAtLeast` per #36478) | 69-75 ms, exit 0 |

`bun bd test/js/node/test/parallel/test-fs-read-stream-pos.js` (linux x64 debug+ASAN): 3.5-3.9 s before, 3.3-4.1 s after. Both are dominated by debug startup and lazy `node:stream` load; the test body itself is a handful of preads either way.

Node passes the modified test in 60-111 ms on both platforms.

Assertion strength: an instrumented run confirms the `isLow` branch is reached in the first stream on every run on both platforms, and a `createReadStream` with a custom `options.fs.read` that rewinds the position by one byte after a short read (simulating nodejs/node#33940) fails the new `deepStrictEqual` in both Bun and Node.

`bun test test/internal/parallel-allowlist.test.ts`: 2/2 pass. `node --check scripts/runner.node.mjs`: ok.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->