### PR TITLE
install: make --prefer-offline resolve auto-installs from the disk cache

### DIFF
--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -100,7 +100,6 @@ impl PackageManager {
 
     pub(crate) fn get_installed_versions_from_disk_cache(
         &mut self,
-        tags_buf: &mut Vec<u8>,
         package_name: &[u8],
     ) -> crate::Result<Vec<semver::Version>> {
         let mut list: Vec<semver::Version> = Vec::new();
@@ -136,33 +135,21 @@ impl PackageManager {
                 continue;
             }
             let name: &[u8] = entry.name.slice_u8();
-            // Entries are named by `cached_npm_package_folder_name_print`
-            // minus the `<package>@` prefix: `<version>`, then `@@<registry
-            // host>` for non-default registries, then the `@@@<cache
-            // version>` suffix. Trim from the first `@@` so the version
-            // parses; `path_for_cached_npm_path` reconstructs the full name.
+            // Entry names carry `@@<registry host>` / `@@@<cache version>`
+            // suffixes after the version; trim them before parsing.
             let name = &name[..strings::index_of(name, b"@@").unwrap_or(name.len())];
             let sliced = SlicedString::init(name, name);
             let parsed = semver::Version::parse(sliced);
             if !parsed.valid || parsed.wildcard != semver::query::Wildcard::None {
                 continue;
             }
-            // not handling OOM
-            // TODO: wildcard
-            let mut version = parsed.version.min();
-            let total = (version.tag.build.len() + version.tag.pre.len()) as usize;
-            if total > 0 {
-                let len_before = tags_buf.len();
-                // `clone_into` writes exactly `total` bytes (build.len + pre.len)
-                // into `available` and advances it; zero-fill the tail first so
-                // we can hand it out as a safe `&mut [u8]` instead of slicing
-                // raw spare capacity.
-                tags_buf.resize(len_before + total, 0);
-                let mut available = &mut tags_buf[len_before..];
-                let new_version = version.clone_into(name, &mut available);
-                version = new_version;
+            let version = parsed.version.min();
+            // Pre/build tags are stored as wyhash hex in entry names and
+            // cannot be mapped back to a cache path, so only stable versions
+            // are resolvable offline.
+            if version.tag.has_pre() || version.tag.has_build() {
+                continue;
             }
-
             list.push(version);
         }
 
@@ -177,44 +164,37 @@ impl PackageManager {
     ) -> Option<PackageID> {
         match version.tag {
             dependency::Tag::Npm => {}
-            // Offline, "latest" means the newest stable version in the cache.
-            // Other dist tags stay ambiguous and go to the registry.
+            // Offline, "latest" means the newest stable cached version.
             dependency::Tag::DistTag if version.dist_tag().tag.slice(version_buf) == b"latest" => {}
             _ => return None,
         }
 
-        let mut tags_buf: Vec<u8> = Vec::new();
-        let mut installed_versions =
-            match self.get_installed_versions_from_disk_cache(&mut tags_buf, package_name) {
-                Ok(v) => v,
-                Err(err) => {
-                    bun_core::debug!(
-                        "error getting installed versions from disk cache: {}",
-                        err.name()
-                    );
-                    return None;
-                }
-            };
-
-        // TODO: make this fewer passes
+        let mut installed_versions = match self.get_installed_versions_from_disk_cache(package_name)
         {
-            let tags_slice: &[u8] = tags_buf.as_slice();
-            // Sort descending. Use the total-order helper with swapped args
-            // (`b.order(a)`) so equal keys yield `Equal`; a two-way Less/Greater
-            // closure is not antisymmetric and may panic since Rust 1.81.
-            installed_versions.sort_by(|a, b| semver::Version::order_fn(tags_slice, *b, *a));
-        }
+            Ok(v) => v,
+            Err(err) => {
+                bun_core::debug!(
+                    "error getting installed versions from disk cache: {}",
+                    err.name()
+                );
+                return None;
+            }
+        };
+
+        // Sort descending. The entries are tag-free (stable versions only),
+        // so no string buffer is needed. Use the total-order helper with
+        // swapped args (`b.order(a)`) so equal keys yield `Equal`; a two-way
+        // Less/Greater closure is not antisymmetric and may panic since
+        // Rust 1.81.
+        installed_versions.sort_by(|a, b| semver::Version::order_fn(&[], *b, *a));
         let npm_query = version.try_npm();
         for installed_version in installed_versions.iter().copied() {
             let matches = match npm_query {
-                Some(npm) => npm.version.satisfies(
-                    installed_version,
-                    self.lockfile.buffers.string_bytes.as_slice(),
-                    tags_buf.as_slice(),
-                ),
-                // "latest": the list is sorted descending, so the first
-                // non-prerelease version is the newest stable one.
-                None => !installed_version.tag.has_pre(),
+                // The query's pre/build tags were parsed against `version_buf`,
+                // not the lockfile's string bytes.
+                Some(npm) => npm.version.satisfies(installed_version, version_buf, &[]),
+                // Sorted descending: the first entry is the newest stable.
+                None => true,
             };
             if matches {
                 let mut buf = PathBuffer::uninit();
@@ -226,8 +206,10 @@ impl PackageManager {
                 ) {
                     Ok(p) => p,
                     Err(err) => {
+                        // Stale or foreign-registry index entries reconstruct
+                        // to a path that no longer exists; try the next one.
                         bun_core::debug!("error getting path for cached npm path: {}", err.name());
-                        return None;
+                        continue;
                     }
                 };
                 let dep_version = dependency::Version {
@@ -262,7 +244,7 @@ impl PackageManager {
                             "error getting or putting folder resolution: {}",
                             err.name()
                         );
-                        return None;
+                        continue;
                     }
                 }
             }

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -28,8 +28,9 @@ pub fn resolve_from_disk_cache(
     this: &mut PackageManager,
     package_name: &[u8],
     version: &dependency::Version,
+    version_buf: &[u8],
 ) -> Option<PackageID> {
-    this.resolve_from_disk_cache(package_name, version)
+    this.resolve_from_disk_cache(package_name, version, version_buf)
 }
 
 #[inline]
@@ -135,6 +136,12 @@ impl PackageManager {
                 continue;
             }
             let name: &[u8] = entry.name.slice_u8();
+            // Entries are named by `cached_npm_package_folder_name_print`
+            // minus the `<package>@` prefix: `<version>`, then `@@<registry
+            // host>` for non-default registries, then the `@@@<cache
+            // version>` suffix. Trim from the first `@@` so the version
+            // parses; `path_for_cached_npm_path` reconstructs the full name.
+            let name = &name[..strings::index_of(name, b"@@").unwrap_or(name.len())];
             let sliced = SlicedString::init(name, name);
             let parsed = semver::Version::parse(sliced);
             if !parsed.valid || parsed.wildcard != semver::query::Wildcard::None {
@@ -166,11 +173,15 @@ impl PackageManager {
         &mut self,
         package_name: &[u8],
         version: &dependency::Version,
+        version_buf: &[u8],
     ) -> Option<PackageID> {
-        if version.tag != dependency::Tag::Npm {
-            // only npm supported right now
-            // tags are more ambiguous
-            return None;
+        match version.tag {
+            dependency::Tag::Npm => {}
+            // Offline, "latest" means the newest stable version in the cache.
+            // Other dist tags stay ambiguous and go to the registry.
+            dependency::Tag::DistTag
+                if version.dist_tag().tag.slice(version_buf) == b"latest" => {}
+            _ => return None,
         }
 
         let mut tags_buf: Vec<u8> = Vec::new();
@@ -194,13 +205,19 @@ impl PackageManager {
             // closure is not antisymmetric and may panic since Rust 1.81.
             installed_versions.sort_by(|a, b| semver::Version::order_fn(tags_slice, *b, *a));
         }
-        let npm_query = version.npm();
+        let npm_query = version.try_npm();
         for installed_version in installed_versions.iter().copied() {
-            if npm_query.version.satisfies(
-                installed_version,
-                self.lockfile.buffers.string_bytes.as_slice(),
-                tags_buf.as_slice(),
-            ) {
+            let matches = match npm_query {
+                Some(npm) => npm.version.satisfies(
+                    installed_version,
+                    self.lockfile.buffers.string_bytes.as_slice(),
+                    tags_buf.as_slice(),
+                ),
+                // "latest": the list is sorted descending, so the first
+                // non-prerelease version is the newest stable one.
+                None => !installed_version.tag.has_pre(),
+            };
+            if matches {
                 let mut buf = PathBuffer::uninit();
                 let npm_package_path = match super::path_for_cached_npm_path(
                     self,

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -179,8 +179,7 @@ impl PackageManager {
             dependency::Tag::Npm => {}
             // Offline, "latest" means the newest stable version in the cache.
             // Other dist tags stay ambiguous and go to the registry.
-            dependency::Tag::DistTag
-                if version.dist_tag().tag.slice(version_buf) == b"latest" => {}
+            dependency::Tag::DistTag if version.dist_tag().tag.slice(version_buf) == b"latest" => {}
             _ => return None,
         }
 

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -181,11 +181,9 @@ impl PackageManager {
             }
         };
 
-        // Sort descending. The entries are tag-free (stable versions only),
-        // so no string buffer is needed. Use the total-order helper with
-        // swapped args (`b.order(a)`) so equal keys yield `Equal`; a two-way
-        // Less/Greater closure is not antisymmetric and may panic since
-        // Rust 1.81.
+        // Sort descending via the total-order helper (`b.order(a)`); a plain
+        // Less/Greater closure is not antisymmetric and may panic since 1.81.
+        // Entries are stable-only, so no string buffer is needed.
         installed_versions.sort_by(|a, b| semver::Version::order_fn(&[], *b, *a));
         let npm_query = version.try_npm();
         for installed_version in installed_versions.iter().copied() {

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -369,8 +369,9 @@ impl hooks::AutoInstaller for PackageManager {
         &mut self,
         name: &[u8],
         version: &hooks::DependencyVersion,
+        version_buf: &[u8],
     ) -> Option<PackageID> {
-        pm_resolution::resolve_from_disk_cache(self, name, version)
+        pm_resolution::resolve_from_disk_cache(self, name, version, version_buf)
     }
 
     fn enqueue_dependency_to_root(

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -186,7 +186,12 @@ fn normalize_package_json_path<'a>(
 
     // We consider it valid if there is a package.json in the folder
     let normalized: &[u8] = if non_normalized_path.len() == 1 && non_normalized_path[0] == b'.' {
-        non_normalized_path
+        match global_or_relative {
+            // "." means the cache folder itself; the dot-path branch below
+            // would resolve it against the project's top-level dir instead.
+            GlobalOrRelative::CacheFolder(_) => b"",
+            _ => non_normalized_path,
+        }
     } else if bun_paths::is_absolute(non_normalized_path) {
         strings::trim_right(non_normalized_path, SEP_STR.as_bytes())
     } else {

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -187,8 +187,7 @@ fn normalize_package_json_path<'a>(
     // We consider it valid if there is a package.json in the folder
     let normalized: &[u8] = if non_normalized_path.len() == 1 && non_normalized_path[0] == b'.' {
         match global_or_relative {
-            // "." means the cache folder itself; the dot-path branch below
-            // would resolve it against the project's top-level dir instead.
+            // "." is the cache folder itself, not the project's top-level dir.
             GlobalOrRelative::CacheFolder(_) => b"",
             _ => non_normalized_path,
         }

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1482,6 +1482,7 @@ pub trait AutoInstaller {
         &mut self,
         name: &[u8],
         version: &DependencyVersion,
+        version_buf: &[u8],
     ) -> Option<PackageID>;
     fn enqueue_dependency_to_root(
         &mut self,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3593,7 +3593,8 @@ impl<'a> Resolver<'a> {
         }
 
         if self.opts.install_preference == bun_options_types::offline_mode::OfflineMode::Offline {
-            if let Some(package_id) = pm!().resolve_from_disk_cache(esm.name, &version) {
+            if let Some(package_id) = pm!().resolve_from_disk_cache(esm.name, &version, version_buf)
+            {
                 *input_package_id_ = package_id;
                 return DependencyToResolve::Resolution(
                     pm!().lockfile_package_resolution(package_id),

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -233,7 +233,9 @@ test("--prefer-offline resolves latest to the newest stable cached version", asy
 
   // Keep only the extracted packages and their version index.
   online = false;
-  for (const entry of readdirSync(cacheDir).filter(e => e.endsWith(".npm"))) {
+  const manifests = readdirSync(cacheDir).filter(e => e.endsWith(".npm"));
+  expect(manifests.length).toBeGreaterThan(0);
+  for (const entry of manifests) {
     rmSync(join(cacheDir, entry), { force: true });
   }
   requests.length = 0;

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -153,7 +153,7 @@ test("--prefer-offline resolves auto-installed packages from the disk cache", as
   // Without --prefer-offline the resolver asks the registry and fails.
   {
     await using proc = run();
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(requests).toContain("/no-deps");
     expect(stderr).toContain("Cannot find package 'no-deps'");
     expect(exitCode).not.toBe(0);
@@ -166,11 +166,90 @@ test("--prefer-offline resolves auto-installed packages from the disk cache", as
   {
     await using proc = run("--prefer-offline");
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(requests).not.toContain("/no-deps");
+    expect(requests).toEqual([]);
     expect(stderr).not.toContain("Cannot find package");
     expect(stdout).toBe("2.0.0\n");
     expect(exitCode).toBe(0);
   }
+});
+
+// Offline, a bare specifier resolves as dist-tag "latest", which must pick the
+// newest stable cached version and skip prereleases that sort above it
+// (prereleases-2 caches 1.0.0-next.23 > 0.5.0, the only stable version).
+test("--prefer-offline resolves latest to the newest stable cached version", async () => {
+  const fixtures = join(import.meta.dir, "..", "install", "registry", "packages", "prereleases-2");
+  const requests: string[] = [];
+  let online = true;
+  using registry = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const pathname = new URL(req.url).pathname;
+      requests.push(pathname);
+      if (!online) return new Response("offline", { status: 404 });
+      if (pathname === "/prereleases-2") {
+        const manifest = await Bun.file(join(fixtures, "package.json")).text();
+        return Response.json(
+          JSON.parse(manifest.replaceAll("http://localhost:4873", `http://127.0.0.1:${registry.port}`)),
+        );
+      }
+      const tgz = pathname.match(/^\/prereleases-2\/-\/(prereleases-2-[^/]+\.tgz)$/);
+      if (tgz) return new Response(Bun.file(join(fixtures, tgz[1])));
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  const bunfig = `[install]\nregistry = "http://127.0.0.1:${registry.port}/"\n`;
+  using dir = tempDir("prefer-offline-latest", {
+    "package.json": JSON.stringify({ name: "myapp", version: "1.0.0" }),
+    "index.js": `console.log(require("prereleases-2/package.json").version);`,
+    "bunfig.toml": bunfig,
+    // Scratch projects that only exist to seed the shared cache.
+    "seed-pre/package.json": JSON.stringify({
+      name: "seed-pre",
+      dependencies: { "prereleases-2": "1.0.0-next.23" },
+    }),
+    "seed-pre/bunfig.toml": bunfig,
+    "seed-stable/package.json": JSON.stringify({
+      name: "seed-stable",
+      dependencies: { "prereleases-2": "0.5.0" },
+    }),
+    "seed-stable/bunfig.toml": bunfig,
+  });
+  const cacheDir = join(String(dir), ".bun-cache");
+  const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir };
+
+  for (const seed of ["seed-pre", "seed-stable"]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: join(String(dir), seed),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+
+  // Keep only the extracted packages and their version index.
+  online = false;
+  for (const entry of readdirSync(cacheDir).filter(e => e.endsWith(".npm"))) {
+    rmSync(join(cacheDir, entry), { force: true });
+  }
+  requests.length = 0;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--prefer-offline", "--install=force", "index.js"],
+    cwd: String(dir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(requests).toEqual([]);
+  expect(stderr).not.toContain("Cannot find package");
+  expect(stdout).toBe("0.5.0\n");
+  expect(exitCode).toBe(0);
 });
 
 test("--install=fallback to install missing packages", async () => {

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync } from "fs";
+import { mkdirSync, readdirSync, rmSync } from "fs";
 import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
@@ -83,6 +83,94 @@ test("auto-install in a project whose package.json has a name and version", asyn
   expect(requests).toContain("/pkg-that-does-not-exist-anywhere");
   expect(stderr).toContain("Cannot find package 'pkg-that-does-not-exist-anywhere'");
   expect(exitCode).toBe(1);
+});
+
+// `--prefer-offline` makes runtime auto-install resolve from the local disk
+// cache without asking the registry (the resolver's
+// `install_preference == Offline` path). One online run populates the cache,
+// then the registry starts returning 404: without the flag resolution
+// re-fetches the manifest and fails, with the flag the cached version
+// satisfies the range and the registry is never contacted.
+test("--prefer-offline resolves auto-installed packages from the disk cache", async () => {
+  const fixtures = join(import.meta.dir, "..", "install", "registry", "packages", "no-deps");
+  const requests: string[] = [];
+  let online = true;
+  using registry = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const pathname = new URL(req.url).pathname;
+      requests.push(pathname);
+      if (!online) return new Response("offline", { status: 404 });
+      if (pathname === "/no-deps") {
+        const manifest = await Bun.file(join(fixtures, "package.json")).text();
+        return Response.json(
+          JSON.parse(manifest.replaceAll("http://localhost:4873", `http://127.0.0.1:${registry.port}`)),
+        );
+      }
+      const tgz = pathname.match(/^\/no-deps\/-\/(no-deps-[\d.]+\.tgz)$/);
+      if (tgz) return new Response(Bun.file(join(fixtures, tgz[1])));
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  using dir = tempDir("prefer-offline", {
+    "package.json": JSON.stringify({
+      name: "myapp",
+      version: "1.0.0",
+      dependencies: { "no-deps": "^2.0.0" },
+    }),
+    "index.js": `console.log(require("no-deps").version);`,
+    "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${registry.port}/"\n`,
+  });
+  const cacheDir = join(String(dir), ".bun-cache");
+  const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir };
+  const run = (...flags: string[]) =>
+    Bun.spawn({
+      cmd: [bunExe(), ...flags, "--install=force", "index.js"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+  // Online run populates the disk cache (extracted package + version index).
+  {
+    await using proc = run();
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("Cannot find package");
+    expect(stdout).toBe("2.0.0\n");
+    expect(exitCode).toBe(0);
+  }
+
+  // Drop the cached manifests (keep the extracted packages) and take the
+  // registry offline so any manifest re-fetch fails.
+  online = false;
+  const manifests = readdirSync(cacheDir).filter(e => e.endsWith(".npm"));
+  expect(manifests.length).toBeGreaterThan(0);
+  for (const entry of manifests) rmSync(join(cacheDir, entry), { force: true });
+  requests.length = 0;
+
+  // Without --prefer-offline the resolver asks the registry and fails.
+  {
+    await using proc = run();
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(requests).toContain("/no-deps");
+    expect(stderr).toContain("Cannot find package 'no-deps'");
+    expect(exitCode).not.toBe(0);
+  }
+
+  requests.length = 0;
+
+  // With --prefer-offline the cached 2.0.0 satisfies ^2.0.0 and the registry
+  // is never contacted.
+  {
+    await using proc = run("--prefer-offline");
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(requests).not.toContain("/no-deps");
+    expect(stderr).not.toContain("Cannot find package");
+    expect(stdout).toBe("2.0.0\n");
+    expect(exitCode).toBe(0);
+  }
 });
 
 test("--install=fallback to install missing packages", async () => {


### PR DESCRIPTION
### Repro

```sh
# cache is warm (one prior online run), registry unreachable
bun --prefer-offline index.js
# error: Cannot find package 'no-deps' from '.../index.js'
```

`--prefer-offline` is supposed to let runtime auto-install resolve from `$BUN_INSTALL_CACHE_DIR` without asking the registry, but it always fell through to the network and failed whenever the registry did.

### Cause

The offline path (`Resolver::enqueue_dependency_to_resolve` -> `PackageManager::resolve_from_disk_cache`) was dead for three stacked reasons:

1. The per-package version index in the cache names its entries `<version>[@@<registry host>]@@@<cache version>` (for example `2.0.0@@127.0.0.1@@@1`). `get_installed_versions_from_disk_cache` parsed the whole entry name as an exact semver, the `@` made the parse invalid, and the scan always returned an empty list.
2. A bare `require("pkg")` resolves as dist-tag `latest` before the project package.json's dependency ranges are attached, and `resolve_from_disk_cache` rejected every non-`npm` version tag, so the common case bailed before even scanning the cache.
3. Once the scan found a version, the folder resolution passed `"."` to `normalize_package_json_path`, whose dot-path branch joins against the project's top-level dir. It read the project's own package.json instead of the cached package's, registering a lockfile package with the wrong name and failing downstream with `Unexpected while resolving package`.

### Fix

- Trim the entry name at the first `@@` before the semver parse; `path_for_cached_npm_path` reconstructs the full suffixed name when resolving the path.
- Skip prerelease/build entries in the scan: their tags are stored as wyhash hex in the entry name and cannot be mapped back to a cache path. This also removes the `tags_buf` plumbing (the surviving entries carry no tag strings).
- Accept dist-tag `latest` in `resolve_from_disk_cache`: offline, it picks the newest stable cached version. Other dist tags are still ambiguous and go to the registry. This is a policy choice worth a maintainer's sign-off: it matches what the online path does for the first resolution attempt (which also resolves `latest` before package.json ranges attach), but offline it is decided from the cache instead of the registry manifest.
- `satisfies` now reads the query's pre/build tags from `version_buf` (the buffer the range was parsed against) instead of the lockfile's string bytes.
- A stale or foreign-registry index entry that fails path reconstruction now falls through to the next candidate instead of aborting the whole scan.
- In `normalize_package_json_path`, `"."` with a `CacheFolder` base now means the cache folder itself rather than the project root. `CacheFolder` has exactly one caller, so no other resolution kind changes.

### Verification

Two tests in `test/cli/run/run-autoinstall.test.ts`, both against a local registry that is flipped to 404 after seeding the cache:

- Range resolution: an online run populates the cache, a run without the flag fails (and is seen asking the registry), `--prefer-offline` loads the cached `2.0.0` for `^2.0.0` with zero registry requests.
- `latest` selection: with no package.json entry for the package and both `0.5.0` and the higher-sorting prerelease `1.0.0-next.23` cached, `--prefer-offline` resolves `0.5.0` with zero registry requests.

Both fail on bun 1.4.0-canary (`Cannot find package`), pass with this change. `bun bd test test/cli/run/run-autoinstall.test.ts`: 14 pass.
