### PR TITLE
http: parse Connection/Transfer-Encoding/Content-Encoding/Upgrade as token lists

### DIFF
--- a/src/http/HeaderValueIterator.rs
+++ b/src/http/HeaderValueIterator.rs
@@ -1,8 +1,6 @@
 use bun_core::strings;
 
-// Stores the remaining input slice and inlines the tokenize-by-',' logic in
-// `next()` — the std iterator equivalent (`slice::Split` + `.filter(..)`) has
-// an unnameable closure type that can't be stored as a field.
+/// Iterates comma-separated HTTP header list tokens, trimming OWS and skipping empties.
 pub struct HeaderValueIterator<'a> {
     remaining: &'a [u8],
 }
@@ -13,28 +11,46 @@ impl<'a> HeaderValueIterator<'a> {
             remaining: strings::trim(input, b" \t"),
         }
     }
+}
 
-    pub fn next(&mut self) -> Option<&'a [u8]> {
-        // tokenizeScalar semantics: skip leading delimiters, take until next delimiter.
-        while let Some((&b',', rest)) = self.remaining.split_first() {
-            self.remaining = rest;
-        }
-        if self.remaining.is_empty() {
-            return None;
-        }
-        let end = self
-            .remaining
-            .iter()
-            .position(|&b| b == b',')
-            .unwrap_or(self.remaining.len());
-        let token = &self.remaining[..end];
-        self.remaining = &self.remaining[end..];
+impl<'a> Iterator for HeaderValueIterator<'a> {
+    type Item = &'a [u8];
 
-        let slice = strings::trim(token, b" \t");
-        if slice.is_empty() {
-            return self.next();
+    fn next(&mut self) -> Option<&'a [u8]> {
+        loop {
+            while let Some((&b',', rest)) = self.remaining.split_first() {
+                self.remaining = rest;
+            }
+            if self.remaining.is_empty() {
+                return None;
+            }
+            let end = strings::index_of_char(self.remaining, b',')
+                .map_or(self.remaining.len(), |i| i as usize);
+            let token = strings::trim(&self.remaining[..end], b" \t");
+            self.remaining = &self.remaining[end..];
+            if !token.is_empty() {
+                return Some(token);
+            }
         }
-
-        Some(slice)
     }
+}
+
+/// True if the request `Upgrade` header names any protocol other than `h2`/`h2c` (which we ignore).
+pub fn upgrade_header_is_not_h2(value: &[u8]) -> bool {
+    HeaderValueIterator::init(value)
+        .any(|token| !strings::eql_any_case_insensitive_ascii(token, &[b"h2", b"h2c"]))
+}
+
+/// `Some(false)` if any token is `close` (wins), `Some(true)` if `keep-alive`, else `None`.
+pub fn connection_header_keep_alive(value: &[u8]) -> Option<bool> {
+    let mut keep_alive = None;
+    for token in HeaderValueIterator::init(value) {
+        if strings::eql_case_insensitive_ascii_check_length(token, b"close") {
+            return Some(false);
+        }
+        if strings::eql_case_insensitive_ascii_check_length(token, b"keep-alive") {
+            keep_alive = Some(true);
+        }
+    }
+    keep_alive
 }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -105,7 +105,9 @@ pub enum Protocol {
 }
 
 pub use bun_http_types::Encoding::Encoding;
-pub use header_value_iterator::HeaderValueIterator;
+pub use header_value_iterator::{
+    HeaderValueIterator, connection_header_keep_alive, upgrade_header_is_not_h2,
+};
 pub use init_error::InitError;
 
 /// Cloned response metadata (headers + url + status). Ownership transfers to
@@ -2359,17 +2361,10 @@ impl<'a> HTTPClient<'a> {
                 h if h == hash_header_const(b"Connection") => {
                     if will_append {
                         override_connection_header = true;
-                        let connection_value = self.header_str(header_values[i]);
-                        if bun_core::strings::eql_case_insensitive_ascii_check_length(
-                            connection_value,
-                            b"close",
-                        ) {
-                            self.flags.disable_keepalive = true;
-                        } else if bun_core::strings::eql_case_insensitive_ascii_check_length(
-                            connection_value,
-                            b"keep-alive",
-                        ) {
-                            self.flags.disable_keepalive = false;
+                        if let Some(keep_alive) =
+                            connection_header_keep_alive(self.header_str(header_values[i]))
+                        {
+                            self.flags.disable_keepalive = !keep_alive;
                         }
                     }
                 }
@@ -2404,11 +2399,7 @@ impl<'a> HTTPClient<'a> {
                 }
                 h if h == hash_header_const(b"Upgrade") => {
                     if will_append {
-                        let value = self.header_str(header_values[i]);
-                        if !bun_core::strings::eql_any_case_insensitive_ascii(
-                            value,
-                            &[b"h2", b"h2c"],
-                        ) {
+                        if upgrade_header_is_not_h2(self.header_str(header_values[i])) {
                             self.flags.upgrade_state = HTTPUpgradeState::Pending;
                         }
                     }
@@ -4752,6 +4743,7 @@ impl<'a> HTTPClient<'a> {
         let mut location: &[u8] = b"";
         let mut pretend_304 = false;
         let mut is_server_sent_events = false;
+        let mut content_codings: u32 = 0;
         for (header_i, header) in response.headers.list.iter().enumerate() {
             match hash_header_name(header.name()) {
                 h if h == hash_header_const(b"Content-Length") => {
@@ -4800,25 +4792,21 @@ impl<'a> HTTPClient<'a> {
                 }
                 h if h == hash_header_const(b"Content-Encoding") => {
                     if !self.flags.disable_decompression {
-                        // RFC 9110 §8.4.1: content codings are case-insensitive.
-                        // `x-gzip` is a registered deprecated alias of `gzip`.
-                        let value = header.value();
-                        if strings::eql_case_insensitive_ascii_check_length(value, b"gzip")
-                            || strings::eql_case_insensitive_ascii_check_length(value, b"x-gzip")
-                        {
-                            self.state.encoding = Encoding::Gzip;
-                            self.state.content_encoding_i = header_i as u8;
-                        } else if strings::eql_case_insensitive_ascii_check_length(
-                            value, b"deflate",
-                        ) {
-                            self.state.encoding = Encoding::Deflate;
-                            self.state.content_encoding_i = header_i as u8;
-                        } else if strings::eql_case_insensitive_ascii_check_length(value, b"br") {
-                            self.state.encoding = Encoding::Brotli;
-                            self.state.content_encoding_i = header_i as u8;
-                        } else if strings::eql_case_insensitive_ascii_check_length(value, b"zstd") {
-                            self.state.encoding = Encoding::Zstd;
-                            self.state.content_encoding_i = header_i as u8;
+                        for token in HeaderValueIterator::init(header.value()) {
+                            match Encoding::from_token(token) {
+                                Some(Encoding::Identity) => {}
+                                Some(coding) if coding.is_compressed() && content_codings == 0 => {
+                                    self.state.encoding = coding;
+                                    self.state.content_encoding_i = header_i as u8;
+                                    content_codings = 1;
+                                }
+                                // Stacked or unknown codings: we can only strip one layer, so pass through raw.
+                                _ => {
+                                    self.state.encoding = Encoding::Identity;
+                                    self.state.content_encoding_i = u8::MAX;
+                                    content_codings = u32::MAX;
+                                }
+                            }
                         }
                     }
                 }
@@ -4832,52 +4820,31 @@ impl<'a> HTTPClient<'a> {
                     {
                         continue;
                     }
-                    // RFC 9112 §7: transfer-coding names are case-insensitive.
-                    let value = header.value();
-                    if strings::eql_case_insensitive_ascii_check_length(value, b"gzip")
-                        || strings::eql_case_insensitive_ascii_check_length(value, b"x-gzip")
-                    {
-                        if !self.flags.disable_decompression {
-                            self.state.transfer_encoding = Encoding::Gzip;
+                    // RFC 9112 §6.1: `chunked`, if present, must be the final coding.
+                    for token in HeaderValueIterator::init(header.value()) {
+                        if self.state.transfer_encoding == Encoding::Chunked {
+                            return Err(crate::Error::UnsupportedTransferEncoding);
                         }
-                    } else if strings::eql_case_insensitive_ascii_check_length(value, b"deflate") {
-                        if !self.flags.disable_decompression {
-                            self.state.transfer_encoding = Encoding::Deflate;
+                        match Encoding::from_token(token) {
+                            Some(Encoding::Chunked) => {
+                                self.state.transfer_encoding = Encoding::Chunked;
+                            }
+                            Some(_) => {}
+                            None => return Err(crate::Error::UnsupportedTransferEncoding),
                         }
-                    } else if strings::eql_case_insensitive_ascii_check_length(value, b"br") {
-                        if !self.flags.disable_decompression {
-                            self.state.transfer_encoding = Encoding::Brotli;
-                        }
-                    } else if strings::eql_case_insensitive_ascii_check_length(value, b"zstd") {
-                        if !self.flags.disable_decompression {
-                            self.state.transfer_encoding = Encoding::Zstd;
-                        }
-                    } else if strings::eql_case_insensitive_ascii_check_length(value, b"identity") {
-                        self.state.transfer_encoding = Encoding::Identity;
-                    } else if strings::eql_case_insensitive_ascii_check_length(value, b"chunked") {
-                        self.state.transfer_encoding = Encoding::Chunked;
-                    } else {
-                        return Err(crate::Error::UnsupportedTransferEncoding);
                     }
                 }
                 h if h == hash_header_const(b"Location") => {
                     location = header.value();
                 }
                 h if h == hash_header_const(b"Connection") => {
-                    // `close` applies on any status (RFC 9112 §9.6); only an
-                    // explicit `keep-alive` is gated on a 2xx success.
-                    if bun_core::strings::eql_case_insensitive_ascii_check_length(
-                        header.value(),
-                        b"close",
-                    ) {
-                        self.state.flags.allow_keepalive = false;
-                    } else if (200..=299).contains(&response.status_code)
-                        && bun_core::strings::eql_case_insensitive_ascii_check_length(
-                            header.value(),
-                            b"keep-alive",
-                        )
-                    {
-                        self.state.flags.allow_keepalive = true;
+                    // `close` applies on any status (RFC 9112 §9.6); `keep-alive` only on 2xx.
+                    match connection_header_keep_alive(header.value()) {
+                        Some(false) => self.state.flags.allow_keepalive = false,
+                        Some(true) if (200..=299).contains(&response.status_code) => {
+                            self.state.flags.allow_keepalive = true;
+                        }
+                        _ => {}
                     }
                 }
                 h if h == hash_header_const(b"Last-Modified") => {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2330,6 +2330,7 @@ impl<'a> HTTPClient<'a> {
         let mut override_accept_header = false;
         let mut override_host_header = false;
         let mut override_connection_header = false;
+        let mut connection_close_requested = false;
         let mut override_user_agent = false;
         let mut add_transfer_encoding = true;
         let mut original_content_length: Option<&[u8]> = None;
@@ -2361,10 +2362,15 @@ impl<'a> HTTPClient<'a> {
                 h if h == hash_header_const(b"Connection") => {
                     if will_append {
                         override_connection_header = true;
-                        if let Some(keep_alive) =
-                            connection_header_keep_alive(self.header_str(header_values[i]))
-                        {
-                            self.flags.disable_keepalive = !keep_alive;
+                        match connection_header_keep_alive(self.header_str(header_values[i])) {
+                            Some(false) => {
+                                connection_close_requested = true;
+                                self.flags.disable_keepalive = true;
+                            }
+                            Some(true) if !connection_close_requested => {
+                                self.flags.disable_keepalive = false;
+                            }
+                            _ => {}
                         }
                     }
                 }
@@ -4838,13 +4844,9 @@ impl<'a> HTTPClient<'a> {
                     location = header.value();
                 }
                 h if h == hash_header_const(b"Connection") => {
-                    // `close` applies on any status (RFC 9112 §9.6); `keep-alive` only on 2xx.
-                    match connection_header_keep_alive(header.value()) {
-                        Some(false) => self.state.flags.allow_keepalive = false,
-                        Some(true) if (200..=299).contains(&response.status_code) => {
-                            self.state.flags.allow_keepalive = true;
-                        }
-                        _ => {}
+                    // `close` on any field line, any status, is sticky (RFC 9110 §5.3, RFC 9112 §9.6).
+                    if connection_header_keep_alive(header.value()) == Some(false) {
+                        self.state.flags.allow_keepalive = false;
                     }
                 }
                 h if h == hash_header_const(b"Last-Modified") => {

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1307,7 +1307,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
         remain_buf: &[u8],
     ) {
         let mut upgrade_header = picohttp::Header::ZERO;
-        let mut connection_header = picohttp::Header::ZERO;
+        let mut connection_header_seen = false;
+        let mut connection_has_upgrade = false;
         let mut websocket_accept_header = picohttp::Header::ZERO;
         let mut protocol_header_seen = false;
 
@@ -1323,13 +1324,15 @@ impl<const SSL: bool> HTTPClient<SSL> {
         for header in response.headers.list {
             match header.name().len() {
                 len if len == b"Connection".len() => {
-                    if connection_header.name().is_empty()
-                        && strings::eql_case_insensitive_ascii_ignore_length(
-                            header.name(),
-                            b"Connection",
-                        )
-                    {
-                        connection_header = *header;
+                    if strings::eql_case_insensitive_ascii_ignore_length(
+                        header.name(),
+                        b"Connection",
+                    ) {
+                        connection_header_seen = true;
+                        connection_has_upgrade |=
+                            HeaderValueIterator::init(header.value()).any(|t| {
+                                strings::eql_case_insensitive_ascii_check_length(t, b"upgrade")
+                            });
                     }
                 }
                 len if len == b"Upgrade".len() => {
@@ -1524,12 +1527,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
             return;
         }
 
-        if connection_header
-            .name()
-            .len()
-            .min(connection_header.value().len())
-            == 0
-        {
+        if !connection_header_seen {
             // SAFETY: no `&mut Self` is live across this call.
             unsafe { Self::terminate(this, ErrorCode::MissingConnectionHeader) };
             return;
@@ -1553,7 +1551,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
             return;
         }
 
-        if !strings::eql_case_insensitive_ascii(connection_header.value(), b"Upgrade", true) {
+        if !connection_has_upgrade {
             // SAFETY: no `&mut Self` is live across this call.
             unsafe { Self::terminate(this, ErrorCode::InvalidConnectionHeader) };
             return;

--- a/src/http_types/Encoding.rs
+++ b/src/http_types/Encoding.rs
@@ -9,6 +9,26 @@ pub enum Encoding {
 }
 
 impl Encoding {
+    /// Parses one case-insensitive coding token (RFC 9110 §8.4.1 / RFC 9112 §7); `None` if unrecognized.
+    pub fn from_token(token: &[u8]) -> Option<Encoding> {
+        use bun_core::strings::eql_case_insensitive_ascii_check_length as eql;
+        if eql(token, b"gzip") || eql(token, b"x-gzip") {
+            Some(Encoding::Gzip)
+        } else if eql(token, b"deflate") {
+            Some(Encoding::Deflate)
+        } else if eql(token, b"br") {
+            Some(Encoding::Brotli)
+        } else if eql(token, b"zstd") {
+            Some(Encoding::Zstd)
+        } else if eql(token, b"identity") {
+            Some(Encoding::Identity)
+        } else if eql(token, b"chunked") {
+            Some(Encoding::Chunked)
+        } else {
+            None
+        }
+    }
+
     pub fn can_use_lib_deflate(self) -> bool {
         matches!(self, Encoding::Gzip | Encoding::Deflate)
     }

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1388,10 +1388,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             }
 
             if let Some(upgrade_) = headers_ref.fast_get(HTTPHeaderName::Upgrade) {
-                let upgrade = upgrade_.to_slice();
-                // `defer upgrade.deinit()` → Drop.
-                let slice = upgrade.slice();
-                if slice != b"h2" && slice != b"h2c" {
+                if http::upgrade_header_is_not_h2(upgrade_.to_slice().slice()) {
                     upgraded_connection = true;
                 }
             }

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -153,6 +153,9 @@ describe("fetch() decodes Content-Encoding case-insensitively", () => {
     ["zstd", "zstd"],
     ["ZSTD", "zstd"],
     ["Zstd", "zstd"],
+    ["identity, gzip", "gzip"],
+    ["gzip , identity", "gzip"],
+    ["identity,br,identity", "br"],
   ];
 
   it.each(cases)("Content-Encoding: %s", async (enc, kind) => {
@@ -252,6 +255,58 @@ describe("fetch() decodes Content-Encoding case-insensitively", () => {
       const res = await fetch(`http://127.0.0.1:${port}/`);
       expect(res.status).toBe(200);
       expect(await res.text()).toBe("plain-text-body");
+    } finally {
+      server.close();
+    }
+  });
+
+  // We can only strip one coding; a stacked Content-Encoding is passed through raw with the header intact.
+  it.each(["gzip, br", "deflate, gzip"])("stacked Content-Encoding: %s passes through untouched", async enc => {
+    const body = brotliCompressSync(gzipSync(payload));
+    const server = createServer((req, res) => {
+      res.setHeader("Content-Encoding", enc);
+      res.end(body);
+    });
+    await once(server.listen(0), "listening");
+    try {
+      const { port } = server.address() as import("node:net").AddressInfo;
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      expect(res.headers.get("content-encoding")).toBe(enc);
+      expect(Buffer.from(await res.arrayBuffer())).toEqual(body);
+    } finally {
+      server.close();
+    }
+  });
+
+  // RFC 9112 §6.1: `Transfer-Encoding: gzip, chunked` is chunked framing.
+  it.each(["gzip, chunked", "identity,chunked", "Chunked"])("Transfer-Encoding: %s is chunked framing", async te => {
+    const server = createNetServer(socket => {
+      socket.on("error", () => {});
+      socket.once("data", () => {
+        socket.write(`HTTP/1.1 200 OK\r\nTransfer-Encoding: ${te}\r\n\r\n5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n`);
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const { port } = server.address() as import("node:net").AddressInfo;
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      expect(await res.text()).toBe("hello world");
+    } finally {
+      server.close();
+    }
+  });
+
+  it.each(["chunked, gzip", "foobar"])("Transfer-Encoding: %s is rejected", async te => {
+    const server = createNetServer(socket => {
+      socket.on("error", () => {});
+      socket.once("data", () => {
+        socket.end(`HTTP/1.1 200 OK\r\nTransfer-Encoding: ${te}\r\nConnection: close\r\n\r\n0\r\n\r\n`);
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const { port } = server.address() as import("node:net").AddressInfo;
+      expect(async () => await fetch(`http://127.0.0.1:${port}/`)).toThrow("UnsupportedTransferEncoding");
     } finally {
       server.close();
     }

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -80,7 +80,15 @@ test("fetch does not reuse a pooled TLS connection for a request with a differen
 // so the pool can't leak into other tests. The server here keeps the socket
 // open and answers every request on it, so the connection count is exactly
 // how many times bun dialed (pooled reuse => 1, correct => 4).
-test.concurrent.each([200, 400, 413, 500])("a %d response with Connection: close is not pooled", async status => {
+test.concurrent.each([
+  [200, "close"],
+  [400, "close"],
+  [413, "close"],
+  [500, "close"],
+  [200, "close, keep-alive"],
+  [200, "Keep-Alive ,\tClose"],
+  [200, "upgrade, close"],
+] as const)("a %d response with Connection: %s is not pooled", async (status, connection) => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -96,7 +104,7 @@ test.concurrent.each([200, 400, 413, 500])("a %d response with Connection: close
             buf += d.toString("latin1");
             while (buf.includes("\\r\\n\\r\\n")) {
               buf = buf.slice(buf.indexOf("\\r\\n\\r\\n") + 4);
-              sock.write("HTTP/1.1 ${status} X\\r\\nContent-Length: 2\\r\\nConnection: close\\r\\n\\r\\nok");
+              sock.write("HTTP/1.1 ${status} X\\r\\nContent-Length: 2\\r\\nConnection: ${connection}\\r\\n\\r\\nok");
             }
           });
         });

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -88,6 +88,7 @@ test.concurrent.each([
   [200, "close, keep-alive"],
   [200, "Keep-Alive ,\tClose"],
   [200, "upgrade, close"],
+  [200, "close\\r\\nConnection: keep-alive"],
 ] as const)("a %d response with Connection: %s is not pooled", async (status, connection) => {
   await using proc = Bun.spawn({
     cmd: [

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -619,6 +619,50 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
   });
 });
 
+// RFC 6455 §4.1: the 101's Connection header must *contain* an `Upgrade` token, not equal it.
+describe("WebSocket handshake Connection header token list", () => {
+  it.each([
+    ["Connection: keep-alive, Upgrade"],
+    ["Connection: upgrade,keep-alive"],
+    ["Connection: keep-alive", "Connection: Upgrade"],
+  ])("%s", async (...connectionHeaders) => {
+    const server = createServer(sock => {
+      sock.on("error", () => {});
+      let buf = "";
+      sock.on("data", chunk => {
+        buf += chunk.toString("latin1");
+        if (!buf.includes("\r\n\r\n")) return;
+        const key = /sec-websocket-key: *([^\r\n]+)/i.exec(buf)![1];
+        const accept = createHash("sha1")
+          .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+          .digest("base64");
+        sock.write(
+          [
+            "HTTP/1.1 101 Switching Protocols",
+            "Upgrade: websocket",
+            ...connectionHeaders,
+            `Sec-WebSocket-Accept: ${accept}`,
+            "",
+            "",
+          ].join("\r\n"),
+        );
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const port = (server.address() as import("node:net").AddressInfo).port;
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      ws.onopen = () => resolve();
+      ws.onclose = e => reject(new Error(`closed ${e.code} ${e.reason}`));
+      await promise;
+      ws.terminate();
+    } finally {
+      server.close();
+    }
+  });
+});
+
 async function listen(): Promise<URL> {
   const pathname = path.join(import.meta.dir, "./websocket-server-echo.mjs");
   const { promise, resolve, reject } = Promise.withResolvers();


### PR DESCRIPTION
`fetch()` compared several list-valued headers as whole strings. The user-visible one: a response with `Connection: close, keep-alive` was returned to the keep-alive pool, and the next request on that socket failed with *"The socket connection was closed unexpectedly"* / `ECONNRESET`.

All sites now go through the existing `HeaderValueIterator` (which now `impl Iterator`).

| Header | Before | After |
|---|---|---|
| `Connection` (fetch req + resp) | exact `close` / `keep-alive` only | any `close` token disables pooling; `close` wins over `keep-alive` |
| `Connection` (WebSocket 101) | must equal `Upgrade`; only first header read | must *contain* `upgrade`, across multiple `Connection` headers |
| `Transfer-Encoding` (resp) | `gzip, chunked` → `UnsupportedTransferEncoding` | chunked framing; `chunked` not-last or unknown coding rejected |
| `Content-Encoding` (resp) | `identity, gzip` / `gzip, identity` not decoded | `identity` ignored; stacked codings (`gzip, br`) pass through raw with header intact |
| `Upgrade` (fetch req) | case-sensitive in one of two call sites | shared, case-insensitive |

Tests extend the existing matrices in `fetch-keepalive.test.ts`, `fetch-gzip.test.ts`, `websocket-client.test.ts`; the new rows fail on current canary.

Fixes #31463
Closes #31464
Closes #33727
