### PR TITLE
streams: direct controller methods no-op (not throw) once closed

### DIFF
--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -36,8 +36,6 @@ namespace WebCore {
 using namespace JSC;
 using namespace Bun::WebStreams;
 
-static constexpr auto directControllerClosedMessage = "ReadableStreamDirectController is now closed"_s;
-
 const ClassInfo JSDirectStreamController::s_info = { "DirectStreamController"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDirectStreamController) };
 
 JSDirectStreamController::JSDirectStreamController(VM& vm, Structure* structure, DirectSinkKind sinkKind)
@@ -886,6 +884,8 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectEndOfTickFlush, (JSGlobalOb
 }
 
 // The FIVE public own methods are JSBoundFunctions over these [bound-convention] targets.
+// Once m_closed is set (end/close, error, or consumer cancel) they no-op: a producer's
+// in-flight pull() calling any of them after the controller is closed must not throw.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectWrite, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
@@ -894,7 +894,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectWrite, (JSGlobalObject *
     if (!controller) [[unlikely]]
         return JSValue::encode(jsUndefined());
     if (controller->m_closed)
-        return throwVMTypeError(globalObject, scope, directControllerClosedMessage);
+        return JSValue::encode(jsNumber(0));
     JSValue wrote = writeToDirectSink(globalObject, controller, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, {});
     controller->armEndOfTickFlush(globalObject);
@@ -907,10 +907,8 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectClose, (JSGlobalObject *
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* controller = dynamicDowncast<JSDirectStreamController>(callFrame->argument(0));
-    if (!controller) [[unlikely]]
+    if (!controller || controller->m_closed) [[unlikely]]
         return JSValue::encode(jsUndefined());
-    if (controller->m_closed)
-        return throwVMTypeError(globalObject, scope, directControllerClosedMessage);
     controller->onClose(globalObject, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
@@ -921,10 +919,8 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectFlush, (JSGlobalObject *
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* controller = dynamicDowncast<JSDirectStreamController>(callFrame->argument(0));
-    if (!controller) [[unlikely]]
+    if (!controller || controller->m_closed) [[unlikely]]
         return JSValue::encode(jsUndefined());
-    if (controller->m_closed)
-        return throwVMTypeError(globalObject, scope, directControllerClosedMessage);
     controller->onFlush(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
@@ -935,10 +931,8 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectError, (JSGlobalObject *
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* controller = dynamicDowncast<JSDirectStreamController>(callFrame->argument(0));
-    if (!controller) [[unlikely]]
+    if (!controller || controller->m_closed) [[unlikely]]
         return JSValue::encode(jsUndefined());
-    if (controller->m_closed)
-        return throwVMTypeError(globalObject, scope, directControllerClosedMessage);
     controller->handleError(globalObject, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -884,8 +884,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectEndOfTickFlush, (JSGlobalOb
 }
 
 // The FIVE public own methods are JSBoundFunctions over these [bound-convention] targets.
-// Once m_closed is set (end/close, error, or consumer cancel) they no-op: a producer's
-// in-flight pull() calling any of them after the controller is closed must not throw.
+// Once m_closed is set they no-op: a late call from an in-flight pull() must not throw.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectWrite, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -447,7 +447,9 @@ JSPromise* readableStreamCancel(JSGlobalObject* globalObject, JSReadableStream* 
             pendingRead->fulfill(vm, doneResult);
             RETURN_IF_EXCEPTION(scope, nullptr);
         }
-        controller->m_closed = true;
+        // m_closed is NOT set here: a write()/end() captured by an in-flight pull() must not
+        // throw after a consumer-side cancel (Bun v1.3.x behavior). onClose early-returns on
+        // stream state, and handleError's callees all tolerate the cleared source below.
         directStreamControllerClearSource(controller);
         sourceCancelPromise = promiseFulfilledWith(globalObject, JSC::jsUndefined());
         break;

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -447,7 +447,7 @@ JSPromise* readableStreamCancel(JSGlobalObject* globalObject, JSReadableStream* 
             pendingRead->fulfill(vm, doneResult);
             RETURN_IF_EXCEPTION(scope, nullptr);
         }
-        // m_closed stays false: a late write()/end() from an in-flight pull() must not throw.
+        controller->m_closed = true;
         directStreamControllerClearSource(controller);
         sourceCancelPromise = promiseFulfilledWith(globalObject, JSC::jsUndefined());
         break;

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -447,9 +447,7 @@ JSPromise* readableStreamCancel(JSGlobalObject* globalObject, JSReadableStream* 
             pendingRead->fulfill(vm, doneResult);
             RETURN_IF_EXCEPTION(scope, nullptr);
         }
-        // m_closed is NOT set here: a write()/end() captured by an in-flight pull() must not
-        // throw after a consumer-side cancel (Bun v1.3.x behavior). onClose early-returns on
-        // stream state, and handleError's callees all tolerate the cleared source below.
+        // m_closed stays false: a late write()/end() from an in-flight pull() must not throw.
         directStreamControllerClearSource(controller);
         sourceCancelPromise = promiseFulfilledWith(globalObject, JSC::jsUndefined());
         break;

--- a/test/js/web/streams/readable-stream-terminal-barrier-release.test.ts
+++ b/test/js/web/streams/readable-stream-terminal-barrier-release.test.ts
@@ -96,10 +96,11 @@ test("ReadableStream releases source-only WriteBarriers once terminal", async ()
   expect(exitCode).toBe(0);
 });
 
-// readableStreamCancel's Direct arm used to leave m_closed false (onClose early-returned
-// because the stream was already Closed), so a captured controller could still reach
-// writeToDirectSink after cancel. With m_closed set, the bound methods throw.
-test("direct controller write() after reader.cancel() throws closed", async () => {
+// readableStreamCancel's Direct arm must not set m_closed: a producer whose async pull()
+// outlives a consumer-side cancel() still holds the bound controller, and its late
+// write()/end() are no-ops that do not throw (Bun v1.3.x behavior). #36703 briefly made
+// this throw; this test pins the non-throwing contract.
+test("direct controller write() after reader.cancel() does not throw", async () => {
   let ctrl: any;
   let pullStarted = Promise.withResolvers<void>();
   const rs = new ReadableStream({
@@ -115,5 +116,6 @@ test("direct controller write() after reader.cancel() throws closed", async () =
   reader.read().catch(() => {});
   await pullStarted.promise;
   await reader.cancel();
-  expect(() => ctrl.write("after-cancel")).toThrow(/closed/);
+  expect(ctrl.write("after-cancel")).toBe("after-cancel".length);
+  expect(() => ctrl.end()).not.toThrow();
 });

--- a/test/js/web/streams/readable-stream-terminal-barrier-release.test.ts
+++ b/test/js/web/streams/readable-stream-terminal-barrier-release.test.ts
@@ -96,11 +96,10 @@ test("ReadableStream releases source-only WriteBarriers once terminal", async ()
   expect(exitCode).toBe(0);
 });
 
-// readableStreamCancel's Direct arm must not set m_closed: a producer whose async pull()
-// outlives a consumer-side cancel() still holds the bound controller, and its late
-// write()/end() are no-ops that do not throw (Bun v1.3.x behavior). #36703 briefly made
-// this throw; this test pins the non-throwing contract.
-test("direct controller write() after reader.cancel() does not throw", async () => {
+// The bound direct-controller methods no-op (rather than throw) once m_closed is set.
+// A producer whose async pull() outlives a consumer-side cancel() — or keeps calling
+// after its own end()/error() — must not see a TypeError.
+test("direct controller methods no-op once closed", async () => {
   let ctrl: any;
   let pullStarted = Promise.withResolvers<void>();
   const rs = new ReadableStream({
@@ -116,7 +115,25 @@ test("direct controller write() after reader.cancel() does not throw", async () 
   reader.read().catch(() => {});
   await pullStarted.promise;
   await reader.cancel();
-  expect(ctrl.write("after-cancel")).toBe("after-cancel".length);
-  expect(() => ctrl.end()).not.toThrow();
-  expect(() => ctrl.flush()).not.toThrow();
+  expect(ctrl.write("after-cancel")).toBe(0);
+  expect(ctrl.end()).toBeUndefined();
+  expect(ctrl.flush()).toBeUndefined();
+  expect(ctrl.error(new Error("after-cancel"))).toBeUndefined();
+
+  // Same contract when m_closed is reached via end() instead of cancel().
+  let ctrl2: any;
+  const rs2 = new ReadableStream({
+    type: "direct",
+    pull(c: any) {
+      ctrl2 = c;
+      c.write("x");
+      c.end();
+    },
+  });
+  for await (const _ of rs2) {
+  }
+  expect(ctrl2.write("after-end")).toBe(0);
+  expect(ctrl2.end()).toBeUndefined();
+  expect(ctrl2.flush()).toBeUndefined();
+  expect(ctrl2.error(new Error("after-end"))).toBeUndefined();
 });

--- a/test/js/web/streams/readable-stream-terminal-barrier-release.test.ts
+++ b/test/js/web/streams/readable-stream-terminal-barrier-release.test.ts
@@ -118,4 +118,6 @@ test("direct controller write() after reader.cancel() does not throw", async () 
   await reader.cancel();
   expect(ctrl.write("after-cancel")).toBe("after-cancel".length);
   expect(() => ctrl.end()).not.toThrow();
+  expect(() => ctrl.flush()).not.toThrow();
+  expect(() => ctrl.error(new Error("after-cancel"))).not.toThrow();
 });

--- a/test/js/web/streams/readable-stream-terminal-barrier-release.test.ts
+++ b/test/js/web/streams/readable-stream-terminal-barrier-release.test.ts
@@ -119,5 +119,4 @@ test("direct controller write() after reader.cancel() does not throw", async () 
   expect(ctrl.write("after-cancel")).toBe("after-cancel".length);
   expect(() => ctrl.end()).not.toThrow();
   expect(() => ctrl.flush()).not.toThrow();
-  expect(() => ctrl.error(new Error("after-cancel"))).not.toThrow();
 });


### PR DESCRIPTION
#36703 set `m_closed = true` in `readableStreamCancel`'s `ControllerKind::Direct` arm, and the bound `write`/`end`/`close`/`flush`/`error` handlers throw `TypeError: ReadableStreamDirectController is now closed` whenever `m_closed` is set. That is a user-visible change from v1.3.x for a producer whose in-flight `pull()` keeps calling the controller after the consumer has cancelled (or after its own `end()`/`error()`).

```js
const rs = new ReadableStream({
  type: "direct",
  async pull(c) {
    ctrl = c;
    c.write("first");
    await new Promise(() => {});
  },
});
const r = rs.getReader();
r.read().catch(() => {});
// ...after pull has started...
await r.cancel();
ctrl.write("after-cancel");
// v1.3.x: byte count
// after #36703: TypeError: ReadableStreamDirectController is now closed
```

## Fix

Keep `m_closed = true` on cancel (the state is accurate) and change the bound handlers to no-op instead of throw once `m_closed` is set: `write()` returns `0`, `end()`/`close()`/`flush()`/`error()` return `undefined`. `ReadableStreamOperations.cpp` is unchanged from main; the now-unused `directControllerClosedMessage` constant is removed.

## Verification

```
# without src/ change
TypeError: ReadableStreamDirectController is now closed
(fail) direct controller methods no-op once closed

# with src/ change (incl. BUN_DESTRUCT_VM_ON_EXIT=1 + detect_leaks=1)
(pass) ReadableStream releases source-only WriteBarriers once terminal
(pass) direct controller methods no-op once closed
```

The test covers both the `reader.cancel()` path and the `controller.end()` path. Open PR #34854 also throws on `m_closed` after cancel and would need the same treatment if it lands.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/streams/readable-stream-terminal-barrier-release.test.ts
bun test v1.4.0 (c8be033d3)

test/js/web/streams/readable-stream-terminal-barrier-release.test.ts:
(pass) ReadableStream releases source-only WriteBarriers once terminal [2645.80ms]
113 |   });
114 |   const reader = rs.getReader();
115 |   reader.read().catch(() => {});
116 |   await pullStarted.promise;
117 |   await reader.cancel();
118 |   expect(ctrl.write("after-cancel")).toBe(0);
                    ^
TypeError: ReadableStreamDirectController is now closed
      at <anonymous> (/workspace/bun/test/js/web/streams/readable-stream-terminal-barrier-release.test.ts:118:15)
(fail) direct controller methods no-op once closed [47.15ms]

 1 pass
 1 fail
 3 expect() calls
Ran 2 tests across 1 file. [4.73s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (a6fb7a624)

test/js/web/streams/readable-stream-terminal-barrier-release.test.ts:
(pass) ReadableStream releases source-only WriteBarriers once terminal [28.31ms]
113 |   });
114 |   const reader = rs.getReader();
115 |   reader.read().catch(() => {});
116 |   await pullStarted.promise;
117 |   await reader.cancel();
118 |   expect(ctrl.write("after-cancel")).toBe(0);
                                           ^
error: expect(received).toBe(expected)

Expected: 0
Received: 12

      at <anonymous> (/workspace/bun/test/js/web/streams/readable-stream-terminal-barrier-release.test.ts:118:38)
(fail) direct controller methods no-op once closed [1.54ms]

 1 pass
 1 fail
 4 expect() calls
Ran 2 tests across 1 file. [175.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/streams/readable-stream-terminal-barrier-release.test.ts
bun test v1.4.0 (c8be033d3)

test/js/web/streams/readable-stream-terminal-barrier-release.test.ts:
(pass) ReadableStream releases source-only WriteBarriers once terminal [2656.43ms]
(pass) direct controller methods no-op once closed [51.20ms]

 2 pass
 0 fail
 11 expect() calls
Ran 2 tests across 1 file. [4.74s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 677ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/41] gen cpp.rs (cppbind)
[2/41] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/41] gen JS modules (bundle-modules)
Preprocess modules (8808ms)
Bundle modules (32ms)
Postprocesss modules (250ms)
Bundle Functions (698ms)
Generate Code (29ms)

[9.83s] Bundled "src/js" for production
  2559 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[3/30] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../webcore/streams/JSDirectStreamController.cpp   | 17 ++++--------
 ...eadable-stream-terminal-barrier-release.test.ts | 30 ++++++++++++++++++----
 2 files changed, 30 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…c/bindings/webcore/streams/JSDirectStreamController.cpp     10      2      0
…treams/readable-stream-terminal-barrier-release.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->