### PR TITLE
test(spawn-maxbuf): widen 'yes is killed' wall-clock budget on debug, unquarantine

### DIFF
--- a/test/expectations.txt
+++ b/test/expectations.txt
@@ -62,9 +62,6 @@ test/js/node/test/parallel/test-stream-wrap-encoding.js [ FAIL ] # needs interna
 # test-http-max-http-headers.js is vendored.
 test/js/node/test/parallel/test-set-http-max-http-headers.js [ FAIL ] # spawns test-http-max-http-headers.js which is not vendored
 
-# Tests that are flaky
-test/js/bun/spawn/spawn-maxbuf.test.ts [ FLAKY ]
-
 # Tests failed due to ASAN: attempting free on address which was not malloc()-ed
 [ ASAN ] test/integration/next-pages/test/dev-server-ssr-100.test.ts [ CRASH ]
 [ ASAN ] test/integration/next-pages/test/next-build.test.ts [ CRASH ]

--- a/test/js/bun/spawn/spawn-maxbuf.test.ts
+++ b/test/js/bun/spawn/spawn-maxbuf.test.ts
@@ -1,4 +1,4 @@
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isDebug } from "harness";
 
 const { isWindows } = require("../../node/test/common");
 
@@ -13,7 +13,13 @@ async function toUtf8(out: ReadableStream<Uint8Array>): Promise<string> {
 }
 
 describe("yes is killed", () => {
-  // TODO
+  // The wall-clock window below includes the child's startup (bunExe() has to
+  // boot before `yes` writes its first byte). On a debug+ASAN build that startup
+  // alone is ~150-250ms, so the release 100ms budget is spent before maxBuffer
+  // has anything to measure. Byte-level promptness is asserted by the "caps the
+  // buffer" tests below; this is the coarse "didn't wait a full tick" sanity check.
+  const killWindow = isDebug ? 1000 : 100;
+
   test("Bun.spawn", async () => {
     const timeStart = Date.now();
     const proc = Bun.spawn([bunExe(), "exec", "yes"], {
@@ -25,7 +31,7 @@ describe("yes is killed", () => {
     expect(proc.exitCode).toBe(null);
     expect(proc.signalCode).toBe(isWindows ? "SIGKILL" : "SIGHUP");
     const timeEnd = Date.now();
-    expect(timeEnd - timeStart).toBeLessThan(100); // make sure it's not waiting a full tick
+    expect(timeEnd - timeStart).toBeLessThan(killWindow);
     const result = await toUtf8(proc.stdout);
     expect(result).toStartWith("y\n".repeat(128));
     const stderr = await toUtf8(proc.stderr);
@@ -43,7 +49,7 @@ describe("yes is killed", () => {
     expect(proc.exitCode).toBe(null);
     expect(proc.signalCode).toBe(isWindows ? "SIGKILL" : "SIGHUP");
     const timeEnd = Date.now();
-    expect(timeEnd - timeStart).toBeLessThan(100); // make sure it's not waiting a full tick
+    expect(timeEnd - timeStart).toBeLessThan(killWindow);
     const result = proc.stdout.toString("utf-8");
     expect(result).toStartWith("y\n".repeat(128));
     const stderr = proc.stderr.toString("utf-8");


### PR DESCRIPTION
`test/js/bun/spawn/spawn-maxbuf.test.ts` has been whole-file `[ FLAKY ]` in `test/expectations.txt`, hiding all 16 maxBuffer/timeout cases on every CI lane. Probed in build [87834](https://buildkite.com/bun/bun/builds/87834) it passes every release and release-asan lane cleanly, so the quarantine is stale for CI. What it was hiding is a debug-only false positive: under `bun bd` the two `yes is killed` cases fail deterministically.

## Repro

```
$ bun bd test test/js/bun/spawn/spawn-maxbuf.test.ts -t "yes is killed"
(fail) yes is killed > Bun.spawn
  error: expect(received).toBeLessThan(expected)
  Expected: < 100
  Received: 170
(fail) yes is killed > Bun.spawnSync
  error: expect(received).toBeLessThan(expected)
  Expected: < 100
  Received: 162
```

## Cause

Both tests assert `Date.now()` from before `spawn()` to after `exited` is under 100ms, with the comment "make sure it's not waiting a full tick". The child is `[bunExe(), "exec", "yes"]`, so the measured window includes the child `bun` process reaching `main()` before `yes` can write its first byte. On a debug+ASAN build that startup alone is ~150-250ms:

```
$ bun bd -e 'const t=Date.now(); Bun.spawnSync([process.execPath,"-e",""]); console.log(Date.now()-t)'
185
```

so the 100ms budget is exhausted before maxBuffer has anything to react to. Release and release-asan start in <15ms and stay well inside the bound.

## Fix

Widen the wall-clock window to `isDebug ? 1000 : 100`, matching the pattern used elsewhere for timing budgets that include a debug-build spawn (e.g. `fetch-tls-abortsignal-timeout.test.ts`, `buffer-indexof-worstcase.test.ts`). Release keeps the original 100ms bound unchanged. Promptness of the kill itself is already asserted byte-precisely by the "caps the buffer while the child is still writing" tests (`stdout.length <= maxBuffer + 64*1024` against an 8MB firehose), so this assertion is only the coarse "not deferred by seconds" sanity check.

Drop the whole-file quarantine line.

## Verification

```
$ bun bd test test/js/bun/spawn/spawn-maxbuf.test.ts
 16 pass
 0 fail
```

Five consecutive `bun bd` runs: `yes is killed` at 128-157ms (< 1000). Release: 2-11ms (< 100).

Test-only change; no runtime behaviour is touched.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · test-only change (timing threshold + unquarantine), no src/ change to stash

<!-- robobun:evidence:end -->