### PR TITLE
sink: detach JSSink controller when assignToStream throws

### DIFF
--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -209,6 +209,22 @@ impl<T: JsSinkAbi> JSSink<T> {
             std::ptr::from_mut::<T>(ptr).cast::<c_void>(),
             (&raw mut bits).cast::<*mut c_void>(),
         );
+        // `${name}__assignToStream` creates the JSReadable*SinkController with
+        // m_sinkPtr=ptr before calling into the stream pump. If the pump setup
+        // throws (e.g. a direct stream's `pull` getter), nothing ever calls
+        // end()/close() on the controller, so its destructor would run
+        // `${name}__finalize(m_sinkPtr)` after the caller has freed the sink.
+        // Detach it now while `ptr` is still live; the controller's later GC
+        // then sees m_sinkPtr==null and skips the native finalize.
+        if bits != 0 && result.to_error().is_some() {
+            if let Some(src) = ptr.source() {
+                *src = streams::SourceHandle::None;
+            }
+            let _ = ::bun_jsc::call_check_slow(global, || {
+                streams::controller_abi::detach_ptr(JSValue::from_encoded(bits))
+            });
+            return result;
+        }
         if let Some(src) = ptr.source() {
             if matches!(*src, streams::SourceHandle::JSController(_)) {
                 *src = if bits != 0 {

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1252,6 +1252,7 @@ it.skipIf(isWindows)("leaves a caller-supplied stdout fd open when stdin stream 
     fstatSync(fd);
     writeSync(fd, "still-open");
     closeSync(fd);
+    Bun.gc(true);
     console.log(message);
     process.exit(0);
   `;
@@ -1261,6 +1262,7 @@ it.skipIf(isWindows)("leaves a caller-supplied stdout fd open when stdin stream 
     stdio: ["ignore", "pipe", "pipe"],
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
   expect(stdout.trim()).toBe("pull unavailable");
   expect(readFileSync(file, "utf8")).toContain("still-open");
   expect(exitCode).toBe(0);
@@ -1293,6 +1295,7 @@ it.skipIf(isWindows)("leaves a Bun.file(fd) stdout open when stdin stream setup 
     fstatSync(fd);
     writeSync(fd, "still-open");
     closeSync(fd);
+    Bun.gc(true);
     console.log(message);
     process.exit(0);
   `;


### PR DESCRIPTION
## What

`JSSink::assign_to_stream` now detaches the freshly created `JSReadable*SinkController` (nulling its `m_sinkPtr`) when the C++ stream-pump setup returns an error, before returning to the caller.

## Why

The generated `${name}__assignToStream` functions create the controller with `m_sinkPtr = sinkPtr` and then call into `GlobalObject::assignToStream` → `readDirectStream` / `readStreamIntoSink`. If that setup throws (for example a direct `ReadableStream` whose `pull` getter throws), the controller is never started, so nothing ever calls `end()`/`close()` to null `m_sinkPtr`. The caller's error path (`Writable::init` for `Bun.spawn`) then releases and frees the native sink. When the controller is later swept, its destructor runs `${name}__controllerDetached` / `${name}__finalize` on freed memory.

ASAN report:

```
heap-use-after-free on address 0x799feed81c78
READ of size 1
  #0 JSSink<FileSink>::js_controller_detached  Sink.rs:567
  #1 FileSink__controllerDetached              generated_jssink.rs:179
  #2 JSReadableFileSinkController::~JSReadableFileSinkController()

freed by:
  #12 FileSink::deinit                         FileSink.rs:1142
  #16 Writable::pipe_release                   Writable.rs:70
  #17 Writable::init                           Writable.rs:339
  #18 spawn_maybe_sync                         js_bun_spawn_bindings.rs:1379
```

The fix is at the generic `JSSink::assign_to_stream` layer so it covers every sink type (`FileSink`, `NetworkSink`, `FetchRequestBodySink`, ...), not just the spawn path.

## Repro

```js
const { openSync, closeSync } = require("node:fs");
const fd = openSync("/tmp/out.txt", "w");
let armed = false;
const stream = new ReadableStream({
  type: "direct",
  get pull() { if (armed) throw new Error("pull unavailable"); return () => {}; },
});
armed = true;
try {
  Bun.spawn({ cmd: [process.execPath, "-e", "0"], stdio: [stream, fd, "ignore"] });
} catch {}
closeSync(fd);
Bun.gc(true);   // sweep -> controller dtor -> UAF
```

## Tests

The two existing `spawn.test.ts` cases that cover the stdin-stream-setup-throws path now force a full GC in the child fixture so the controller destructor runs deterministically under debug+ASAN as well. Previously they were only failing on the release-asan lane (where the whole file has been quarantined as `[ASAN] [TIMEOUT]`), which is why this went unnoticed.

```
bun bd test test/js/bun/spawn/spawn.test.ts -t "stdin stream setup fails"
```

fails on `main` (ASAN heap-use-after-free in the child's stderr) and passes with this change. `spawn-stdin-readable-stream-edge-cases.test.ts` and `body-stream.test.ts` continue to pass.