### PR TITLE
Bun.serve: fix use-after-free when a retained ServerWebSocket outlives a stopped server

### DIFF
--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -703,7 +703,6 @@ impl ServerWebSocket {
             .try_get()
             .unwrap_or(JSValue::UNDEFINED);
         let this_value_cell: &JsCell<JsRef> = &self.this_value;
-        let global_object_ref = handler.global_object;
         let _cleanup = scopeguard::guard(signal, move |sig| {
             if let Some(sig) = sig {
                 // `sig` was stored with a +1 ref by the upgrade caller; it
@@ -714,9 +713,11 @@ impl ServerWebSocket {
                 sig.unref();
             }
             if was_not_empty {
-                // Drop the server-wrapper traced edge: once closed, this socket
-                // no longer needs to pin the server (and its handler slots).
-                js::server_set_cached(cached_this, global_object_ref.get(), JSValue::ZERO);
+                // Keep the `server` traced edge (set in `init`) even after
+                // close: `self.handler` points into the server's allocation,
+                // and JS can still call publish()/send() on a retained closed
+                // socket. Clearing the edge here let the server free while
+                // this wrapper was alive, a use-after-free (#36788).
                 // R-2: closure-scoped `&mut JsRef` via `JsCell::with_mut` —
                 // no raw `*mut` projection needed.
                 this_value_cell.with_mut(|v| v.downgrade());

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -713,11 +713,9 @@ impl ServerWebSocket {
                 sig.unref();
             }
             if was_not_empty {
-                // Keep the `server` traced edge (set in `init`) even after
-                // close: `self.handler` points into the server's allocation,
-                // and JS can still call publish()/send() on a retained closed
-                // socket. Clearing the edge here let the server free while
-                // this wrapper was alive, a use-after-free (#36788).
+                // The `server` traced edge set in `init` must outlive this
+                // wrapper: `self.handler` points into the server's allocation
+                // and publish()/send() still work on closed sockets (#36788).
                 // R-2: closure-scoped `&mut JsRef` via `JsCell::with_mut` —
                 // no raw `*mut` projection needed.
                 this_value_cell.with_mut(|v| v.downgrade());

--- a/test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts
+++ b/test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/36788
+// A ServerWebSocket retained in JS after its connection closed holds a raw
+// pointer into the server's native allocation. Once the server was stopped
+// and its JS wrapper collected, the native server was freed while the
+// retained socket wrapper was still alive, so ws.publish()/ws.send() read
+// freed memory (heap-use-after-free under ASAN).
+test("retained ServerWebSocket stays usable after server.stop() and GC", async () => {
+  using dir = tempDir("ws-stop-retained", {
+    "repro.js": `
+      globalThis.retained = null;
+
+      async function connectAndClose() {
+        let server = Bun.serve({
+          port: 0,
+          fetch(req, srv) {
+            if (srv.upgrade(req)) return;
+            return new Response("no");
+          },
+          websocket: {
+            open(ws) {
+              globalThis.retained = ws;
+            },
+            message() {},
+            close() {},
+          },
+        });
+        const client = new WebSocket("ws://127.0.0.1:" + server.port + "/");
+        await new Promise((resolve, reject) => {
+          client.onopen = resolve;
+          client.onerror = reject;
+        });
+        const closed = new Promise(resolve => (client.onclose = resolve));
+        client.close();
+        await closed;
+        await Bun.sleep(50);
+        server.stop(true);
+      }
+
+      await connectAndClose();
+
+      // Collect the Server wrapper: clean macrotask stacks plus allocation
+      // pressure so JSC actually sweeps the wrapper and the deferred native
+      // teardown tasks run.
+      for (let i = 0; i < 50; i++) {
+        await new Promise(resolve => setTimeout(resolve, 1));
+        let garbage = [];
+        for (let j = 0; j < 1000; j++) garbage.push({ x: j, s: "s" + j });
+        garbage = null;
+        Bun.gc(true);
+      }
+      await Bun.sleep(50);
+
+      const ws = globalThis.retained;
+      console.log(JSON.stringify([ws.readyState, ws.publish("t", "m"), ws.send("m"), ws.subscribe("t")]));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "repro.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).not.toContain("AddressSanitizer");
+  expect(stdout.trim()).toBe("[3,0,0,false]");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts
+++ b/test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts
@@ -36,7 +36,7 @@ test("retained ServerWebSocket stays usable after server.stop() and GC", async (
         client.close();
         await closed;
         await serverClosed.promise;
-        server.stop(true);
+        await server.stop(true);
       }
 
       await connectAndClose();

--- a/test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts
+++ b/test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts
@@ -13,6 +13,7 @@ test("retained ServerWebSocket stays usable after server.stop() and GC", async (
       globalThis.retained = null;
 
       async function connectAndClose() {
+        const serverClosed = Promise.withResolvers();
         let server = Bun.serve({
           port: 0,
           fetch(req, srv) {
@@ -24,7 +25,9 @@ test("retained ServerWebSocket stays usable after server.stop() and GC", async (
               globalThis.retained = ws;
             },
             message() {},
-            close() {},
+            close() {
+              serverClosed.resolve();
+            },
           },
         });
         const client = new WebSocket("ws://127.0.0.1:" + server.port + "/");
@@ -35,15 +38,16 @@ test("retained ServerWebSocket stays usable after server.stop() and GC", async (
         const closed = new Promise(resolve => (client.onclose = resolve));
         client.close();
         await closed;
-        await Bun.sleep(50);
+        await serverClosed.promise;
         server.stop(true);
       }
 
       await connectAndClose();
 
       // Collect the Server wrapper: clean macrotask stacks plus allocation
-      // pressure so JSC actually sweeps the wrapper and the deferred native
-      // teardown tasks run.
+      // pressure so JSC actually sweeps the wrapper. The server's native
+      // teardown then runs on deferred event-loop tasks with no JS-observable
+      // signal; the setTimeout ticks in this loop are what drain them.
       for (let i = 0; i < 50; i++) {
         await new Promise(resolve => setTimeout(resolve, 1));
         let garbage = [];
@@ -51,7 +55,9 @@ test("retained ServerWebSocket stays usable after server.stop() and GC", async (
         garbage = null;
         Bun.gc(true);
       }
-      await Bun.sleep(50);
+      // Drain the deferred teardown tasks enqueued by the final GC iteration.
+      await new Promise(resolve => setTimeout(resolve, 1));
+      await new Promise(resolve => setTimeout(resolve, 1));
 
       const ws = globalThis.retained;
       console.log(JSON.stringify([ws.readyState, ws.publish("t", "m"), ws.send("m"), ws.subscribe("t")]));
@@ -67,7 +73,6 @@ test("retained ServerWebSocket stays usable after server.stop() and GC", async (
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).not.toContain("AddressSanitizer");
   expect(stdout.trim()).toBe("[3,0,0,false]");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts
+++ b/test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts
@@ -65,11 +65,7 @@ test("retained ServerWebSocket stays usable after server.stop() and GC", async (
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("AddressSanitizer");
   expect(stdout.trim()).toBe("[3,0,0,false]");

--- a/test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts
+++ b/test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts
@@ -1,12 +1,9 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-// https://github.com/oven-sh/bun/issues/36788
-// A ServerWebSocket retained in JS after its connection closed holds a raw
-// pointer into the server's native allocation. Once the server was stopped
-// and its JS wrapper collected, the native server was freed while the
-// retained socket wrapper was still alive, so ws.publish()/ws.send() read
-// freed memory (heap-use-after-free under ASAN).
+// A closed ServerWebSocket retained in JS points into the server's native
+// allocation; stopping and collecting the server freed it, so ws.publish()
+// and ws.send() read freed memory. Found investigating #36788.
 test("retained ServerWebSocket stays usable after server.stop() and GC", async () => {
   using dir = tempDir("ws-stop-retained", {
     "repro.js": `
@@ -73,6 +70,7 @@ test("retained ServerWebSocket stays usable after server.stop() and GC", async (
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(stderr).toBe("");
   expect(stdout.trim()).toBe("[3,0,0,false]");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Repro

```js
let server = Bun.serve({
  port: 0,
  fetch(req, srv) { if (srv.upgrade(req)) return; return new Response("no"); },
  websocket: { open(ws) { globalThis.retained = ws; }, message() {}, close() {} },
});
// connect a WebSocket client, close it, then:
server.stop(true);
server = null;
// run GC until the Server wrapper is collected, then:
globalThis.retained.publish("topic", "hello"); // heap-use-after-free
```

Under an ASAN build this crashes deterministically:

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 8 in ServerWebSocket::publish_ctx src/runtime/server/ServerWebSocket.rs:263
freed by: NewServer::deinit src/runtime/server/mod.rs (schedule_deinit task)
```

### Cause

A `ServerWebSocket` holds a raw `BackRef` into the server's native allocation (the websocket handler lives in `ServerConfig.websocket` inside the `NewServer` box). The wrapper pins the server's JS wrapper through the traced `server` cached value, set in `ServerWebSocket::init`, which is what makes that raw pointer sound.

`on_close` cleared that edge ("once closed, this socket no longer needs to pin the server"). That is wrong: `publish()`, `send()`, and the rest of the methods still dereference the handler on a closed socket (publishing via a closed socket is supported and broadcasts app-wide). Once the server was stopped and its JS wrapper collected, the deferred teardown freed the `NewServer` box while retained closed sockets still pointed into it.

### Fix

Keep the traced `server` edge for the wrapper's whole lifetime (only the strong `this_value` ref is downgraded on close, so the socket wrapper itself stays collectible). The server's native allocation now strictly outlives every `ServerWebSocket` wrapper; once user code drops both, the whole group is collected as usual.

### Verification

- New test `test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts` crashes with ASAN heap-use-after-free before the fix, passes after (`[3,0,0,false]`: closed readyState, publish/send return 0, subscribe returns false, same as calling them on a stopped-but-alive server).
- `bun bd test test/js/bun/websocket/` passes (the pre-existing `send() (benchmark)` test sits at the edge of its 30s timeout under debug+ASAN, unrelated to this change).

Found while investigating #36788 (a 1.3.14 field crash showing wild-pointer corruption during `Bun.serve` shutdown: `panic(main thread): Segmentation fault at address 0x632D656475616C63`). That crash is not reproducible locally and cannot be confirmed to be this exact bug, but it is the same family: server teardown freeing state that retained objects still reference.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts
bun test v1.4.0 (0ad709165)

test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts:
killed 1 dangling process
(fail) retained ServerWebSocket stays usable after server.stop() and GC [5004.81ms]
  ^ this test timed out after 5000ms.

 0 pass
 1 fail
Ran 1 test across 1 file. [7.03s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (ce6288166)

test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts:
(pass) retained ServerWebSocket stays usable after server.stop() and GC [99.56ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [250.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts
bun test v1.4.0 (0ad709165)

test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts:
(pass) retained ServerWebSocket stays usable after server.stop() and GC [1829.86ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [3.83s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 646ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp.o
[2/8] gen cpp.rs (cppbind)
[3/8] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 238 extern-C blocks audited
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/ServerWebSocket.rs              |  7 +-
 .../websocket-server-stop-retained-ws.test.ts      | 76 ++++++++++++++++++++++
 2 files changed, 79 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/server/ServerWebSocket.rs                         6      3      0
…bun/websocket/websocket-server-stop-retained-ws.test.ts      1      6      0
```

</details>

**root cause** · written by the author bot

The crash was a use-after-free in the ServerWebSocket close path, where the traced server reference was released during close cleanup even though a still-retained ServerWebSocket object could later reach it, causing teardown after server.stop() to dereference freed memory that had since been reused by unrelated string data. The fix keeps the traced server reference alive for closed sockets, releasing only the abort signal and downgrading the cached this reference, so retained sockets remain safe to touch after shutdown. A regression test covers retaining a socket, stopping the server, forci…

<!-- robobun:evidence:end -->