### PR TITLE
test(spawn-maxbuf): use >= for Date.now()-measured lower bound on spawnSync timeout

### DIFF
--- a/test/js/bun/spawn/spawn-maxbuf.test.ts
+++ b/test/js/bun/spawn/spawn-maxbuf.test.ts
@@ -237,7 +237,10 @@ describe("timeout kills the process", () => {
     expect(proc.exitCode).toBe(null);
     expect(proc.signalCode).toBe(isWindows ? "SIGKILL" : "SIGHUP");
     const timeEnd = Date.now();
-    expect(timeEnd - timeStart).toBeGreaterThan(100); // make sure it actually waits
+    // The timeout deadline is CLOCK_MONOTONIC at nanosecond precision, so by the
+    // time spawnSync returns at least 100ms have elapsed. Date.now() truncates to
+    // whole milliseconds, so floor(end) - floor(start) can equal exactly 100.
+    expect(timeEnd - timeStart).toBeGreaterThanOrEqual(100); // make sure it actually waits
     expect(timeEnd - timeStart).toBeLessThan(200); // make sure it's terminating early
     const result = proc.stdout.toString("utf-8");
     expect(result).toBe("");


### PR DESCRIPTION
Follow-up to #36782, which unquarantined `spawn-maxbuf.test.ts` and exposed a latent boundary flake in a different subtest.

## Failure

```
240 |     expect(timeEnd - timeStart).toBeGreaterThan(100); // make sure it actually waits
error: expect(received).toBeGreaterThan(expected)
Expected: > 100
Received: 100
✗ timeout kills the process > Bun.spawnSync [101.64ms]
```

Seen on main [build 87859](https://buildkite.com/bun/bun/builds/87859) (alpine 3.23 x64, retry passed) and [build 87890](https://buildkite.com/bun/bun/builds/87890) (debian 13 aarch64, red on every retry). The assertion has been in the file since #18293; it was hidden by the whole-file `[ FLAKY ]` quarantine until #36782 removed it.

## Cause

The `spawnSync` timeout deadline is computed as `CLOCK_MONOTONIC + 100ms` at nanosecond precision (`js_bun_spawn_bindings.rs`: `now.add_ms(timeout_ms)`), and the timeout fires when `CLOCK_MONOTONIC >= deadline` (`SpawnSyncEventLoop::tick_with_timeout`). So by the time `spawnSync` returns, at least 100ms of monotonic time has elapsed.

The test measures with `Date.now()`, which truncates the wall clock to whole milliseconds. For a real elapsed interval of 100.x ms, `floor(end) - floor(start)` can be exactly 100 (e.g. start at T+0.1ms → `Date.now()=T`, end at T+100.2ms → `Date.now()=T+100`). The test duration `[101.64ms]` in the CI output confirms the wait itself was not short.

Local 500-iteration probe on release:

```
{"min":100,"hit100":7,"under100":0,"iterations":500}
```

The delta lands on exactly 100 in ~1.4% of runs and never goes below 100, so `>=` is the tight bound.

## Fix

Change `toBeGreaterThan(100)` to `toBeGreaterThanOrEqual(100)`. The lower bound is kept because it is the only thing in this test that would catch `timeout: 100` being misread as `timeout: 0` (the `exitedDueToTimeout`/`signalCode` checks would still pass if the kill fired immediately). Node's own `test-child-process-spawnsync-timeout.js` only asserts the upper bound and relies on `error.code === 'ETIMEDOUT'`; Bun's `exitedDueToTimeout` is equivalent, but the `>= 100` here is cheap extra coverage.

The sibling `toBeGreaterThan(1000)` assertions in the `timeout Infinity` block measure a child `sleep 1` plus `bunExe()` startup, which is always comfortably above 1000ms, so they are left as-is.

## Verification

```
$ bun bd test test/js/bun/spawn/spawn-maxbuf.test.ts
 16 pass
 0 fail
```

Five consecutive full-file debug runs pass.

Test-only change; no runtime behaviour is touched.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->