### PR TITLE
bun:sqlite: keep close(false) graceful for prepare() statements, make query() cache LRU

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -133,8 +133,10 @@ db.close(true);
 Using a statement that was finalized by `close()` throws `Database has closed`, except `toString()`, which returns an empty string, and `finalize()`, which stays safe to call.
 
 <Note>
-  `close(false)` is called automatically when the database is garbage collected. It is safe to call multiple times but
-  has no effect after the first. The `using` statement calls `close(true)`.
+  `close()` is safe to call multiple times but has no effect after the first (except that `close(true)` after
+  `close(false)` still finalizes any remaining `.prepare()` statements). If a `Database` is garbage collected without
+  being closed, the connection is released once every statement created from it has also been finalized or collected.
+  The `using` statement calls `close(true)`.
 </Note>
 
 ### `using` statement

--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -112,15 +112,17 @@ const db = new Database("./mydb.sqlite");
 
 ### `.close(throwOnError: boolean = false)`
 
-To close a database connection, call `.close()`:
+To close a database connection but let statements created with `.prepare()` keep working until they are finalized or garbage collected, call `.close(false)`:
 
 ```ts db.ts icon="/icons/typescript.svg" highlight={3}
 const db = new Database();
 // ... do stuff
-db.close();
+db.close(false);
 ```
 
-Any prepared statements that were not finalized are finalized as part of closing, so the connection (and the database file) is released immediately. Using a statement after its database was closed throws an error, except `toString()`, which returns an empty string, and `finalize()`, which stays safe to call. Pass `true` to throw if the connection fails to close:
+Statements created with `.query()` are owned by the `Database` and are finalized immediately either way. The underlying connection (and the database file handle) is released once the last outstanding `.prepare()` statement is finalized.
+
+To finalize **every** outstanding statement, release the connection immediately, and throw if SQLite reports an error while closing, call `.close(true)`:
 
 ```ts db.ts icon="/icons/typescript.svg" highlight={3}
 const db = new Database();
@@ -128,9 +130,11 @@ const db = new Database();
 db.close(true);
 ```
 
+Using a statement that was finalized by `close()` throws `Database has closed`, except `toString()`, which returns an empty string, and `finalize()`, which stays safe to call.
+
 <Note>
-  `close()` is called automatically when the database is garbage collected. It is safe to call multiple times but has no
-  effect after the first.
+  `close(false)` is called automatically when the database is garbage collected. It is safe to call multiple times but
+  has no effect after the first. The `using` statement calls `close(true)`.
 </Note>
 
 ### `using` statement
@@ -174,7 +178,7 @@ const query = db.query(`select "Hello world" as message`);
 <Note>
 **What does "cached" mean?**
 
-The caching refers to the **compiled prepared statement** (the SQL bytecode), not the query results. When you call `db.query()` with the same SQL string multiple times, Bun returns the same cached `Statement` object instead of recompiling the SQL.
+The caching refers to the **compiled prepared statement** (the SQL bytecode), not the query results. When you call `db.query()` with the same SQL string multiple times, Bun returns the same cached `Statement` object instead of recompiling the SQL. The cache holds the `Database.MAX_QUERY_CACHE_SIZE` (default 20) most recently used SQL strings; evicted statements keep working but a later `db.query()` with the same string compiles a new one.
 
 It is safe to reuse a cached statement with different parameter values:
 

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -136,6 +136,13 @@ declare module "bun:sqlite" {
     static open(filename: string, options?: number | DatabaseOptions): Database;
 
     /**
+     * Maximum number of distinct SQL strings {@link Database.query} keeps
+     * cached per `Database`. Least-recently-used entries are evicted first.
+     * @default 20
+     */
+    static MAX_QUERY_CACHE_SIZE: number;
+
+    /**
      * Execute a SQL query **without returning any results**.
      *
      * This does not cache the query. To run a query multiple times, use {@link prepare} instead.
@@ -264,24 +271,31 @@ declare module "bun:sqlite" {
     /**
      * Close the database connection.
      *
-     * Prepared statements that were not finalized are finalized as part of
-     * closing, so the connection is released immediately. It is safe to call
-     * this method multiple times. If the database is already closed, this is
-     * a no-op. Running queries or using statements after the database has
-     * been closed throws an error, except statement `toString()`, which
-     * returns an empty string, and `finalize()`, which stays safe to call.
+     * Statements created with {@link Database.query} are finalized
+     * immediately. With `throwOnError` unset or `false`, statements created
+     * with {@link Database.prepare} keep working until they are finalized or
+     * garbage collected, and the underlying connection is released after the
+     * last one (`sqlite3_close_v2`). With `throwOnError: true`, every
+     * outstanding statement is finalized, the connection is released
+     * immediately (`sqlite3_close`), and an error is thrown if SQLite fails
+     * to close it.
+     *
+     * It is safe to call this method multiple times. If the database is
+     * already closed, this is a no-op. Creating new statements after close
+     * throws; using a statement that close finalized throws
+     * `Database has closed`, except `toString()`, which returns an empty
+     * string, and `finalize()`, which stays safe to call.
      *
      * @example
      * ```ts
      * db.close();
      * ```
-     * This is called automatically when the database instance is garbage collected.
-     *
-     * Internally, this calls `sqlite3_close`.
+     * `close(false)` is called automatically when the database instance is
+     * garbage collected; `using db = ...` calls `close(true)`.
      */
     close(
       /**
-       * If `true`, throw an error if the connection fails to close
+       * If `true`, finalize every outstanding statement and throw if the connection fails to close
        * @default false
        *
        * Learn more in the [sqlite3 documentation](https://www.sqlite.org/c3ref/close.html).

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -290,8 +290,9 @@ declare module "bun:sqlite" {
      * ```ts
      * db.close();
      * ```
-     * `close(false)` is called automatically when the database instance is
-     * garbage collected; `using db = ...` calls `close(true)`.
+     * If a `Database` is garbage collected without being closed, the
+     * connection is released once every statement created from it has also
+     * been finalized or collected. `using db = ...` calls `close(true)`.
      */
     close(
       /**

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -529,7 +529,9 @@ class Database implements SqliteTypes.Database {
   }
 
   [kPrepareOwned](query: string, flags: number) {
-    return new Statement(SQL.prepare(this.#handle, query, undefined, flags, this.#internalFlags | kOwnedByDatabaseFlag));
+    return new Statement(
+      SQL.prepare(this.#handle, query, undefined, flags, this.#internalFlags | kOwnedByDatabaseFlag),
+    );
   }
 
   static MAX_QUERY_CACHE_SIZE = 20;

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -107,6 +107,7 @@ interface CppSQLStatement {
   raw: (...args: TODO[]) => TODO;
   finalize: (...args: TODO[]) => TODO;
   toString: (...args: TODO[]) => TODO;
+  isFinalized: boolean;
   columns: string[];
   columnsCount: number;
   paramsCount: number;
@@ -163,7 +164,9 @@ class Statement {
   values: SqliteTypes.Statement["values"];
   raw: SqliteTypes.Statement["raw"];
   run: SqliteTypes.Statement["run"];
-  isFinalized = false;
+  get isFinalized() {
+    return this.#raw.isFinalized;
+  }
 
   toJSON() {
     return {
@@ -327,7 +330,6 @@ class Statement {
   }
 
   finalize(...args) {
-    this.isFinalized = true;
     return this.#raw.finalize(...args);
   }
 
@@ -496,16 +498,13 @@ class Database implements SqliteTypes.Database {
 
   close(throwOnError = false) {
     // native close finalizes every kOwnedByDatabaseFlag statement (query cache + transaction controller)
-    for (const stmt of this.#queryCache.values()) stmt.isFinalized = true;
-    this.#queryCache.clear();
+    this.#queryCache.$clear();
     controllers?.delete(this);
     return SQL.close(this.#handle, throwOnError);
   }
   clearQueryCache() {
-    for (const stmt of this.#queryCache.values()) {
-      stmt?.finalize?.();
-    }
-    this.#queryCache.clear();
+    this.#queryCache.$forEach(stmt => stmt.finalize());
+    this.#queryCache.$clear();
   }
 
   run(query, ...params) {
@@ -537,7 +536,7 @@ class Database implements SqliteTypes.Database {
   static MAX_QUERY_CACHE_SIZE = 20;
 
   get [cachedCount]() {
-    return this.#queryCache.size;
+    return this.#queryCache.$size;
   }
 
   query(query) {
@@ -550,12 +549,12 @@ class Database implements SqliteTypes.Database {
     }
 
     const cache = this.#queryCache;
-    let stmt = cache.get(query);
+    let stmt = cache.$get(query);
     if (stmt !== undefined) {
       // LRU: re-insert so the most recently used key is last
-      cache.delete(query);
+      cache.$delete(query);
       if (stmt.isFinalized) stmt = this[kPrepareOwned](query, constants.SQLITE_PREPARE_PERSISTENT);
-      cache.set(query, stmt);
+      cache.$set(query, stmt);
       return stmt;
     }
 
@@ -563,8 +562,14 @@ class Database implements SqliteTypes.Database {
     const max = Database.MAX_QUERY_CACHE_SIZE;
     if (max > 0) {
       // evicted statements stay usable; close() still finalizes them via kOwnedByDatabaseFlag
-      if (cache.size >= max) cache.delete(cache.keys().next().value);
-      cache.set(query, stmt);
+      if (cache.$size >= max) {
+        let oldest;
+        cache.$forEach((_, key) => {
+          if (oldest === undefined) oldest = key;
+        });
+        cache.$delete(oldest);
+      }
+      cache.$set(query, stmt);
     }
     return stmt;
   }

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -4,6 +4,7 @@ import type * as SqliteTypes from "bun:sqlite";
 const kSafeIntegersFlag = 1 << 1;
 const kStrictFlag = 1 << 2;
 const kOwnedByDatabaseFlag = 1 << 3;
+const kPrepareOwned = Symbol("prepareOwned");
 
 const defineProperties = Object.defineProperties;
 const toStringTag = Symbol.toStringTag;
@@ -429,7 +430,6 @@ class Database implements SqliteTypes.Database {
   #handle;
   #queryCache: Map<string, Statement> = new Map();
   filename;
-  #hasClosed = false;
   get handle() {
     return this.#handle;
   }
@@ -473,9 +473,7 @@ class Database implements SqliteTypes.Database {
   }
 
   [Symbol.dispose]() {
-    if (!this.#hasClosed) {
-      this.close(true);
-    }
+    this.close(true);
   }
 
   static setCustomSQLite(path) {
@@ -497,25 +495,10 @@ class Database implements SqliteTypes.Database {
   }
 
   close(throwOnError = false) {
-    this.clearQueryCache();
-    // Finalize any prepared statements created by db.transaction()
-    if (controllers) {
-      const controller = controllers.get(this);
-      if (controller) {
-        controllers.delete(this);
-        const seen = new Set();
-        for (const ctrl of [controller.default, controller.deferred, controller.immediate, controller.exclusive]) {
-          if (!ctrl) continue;
-          for (const stmt of [ctrl.begin, ctrl.commit, ctrl.rollback, ctrl.savepoint, ctrl.release, ctrl.rollbackTo]) {
-            if (stmt && !seen.has(stmt)) {
-              seen.add(stmt);
-              stmt.finalize?.();
-            }
-          }
-        }
-      }
-    }
-    this.#hasClosed = true;
+    // native close finalizes every kOwnedByDatabaseFlag statement (query cache + transaction controller)
+    for (const stmt of this.#queryCache.values()) stmt.isFinalized = true;
+    this.#queryCache.clear();
+    controllers?.delete(this);
     return SQL.close(this.#handle, throwOnError);
   }
   clearQueryCache() {
@@ -545,16 +528,8 @@ class Database implements SqliteTypes.Database {
     return new Statement(SQL.prepare(this.#handle, query, params, flags || 0, this.#internalFlags));
   }
 
-  #prepareOwned(query: string) {
-    return new Statement(
-      SQL.prepare(
-        this.#handle,
-        query,
-        undefined,
-        constants.SQLITE_PREPARE_PERSISTENT,
-        this.#internalFlags | kOwnedByDatabaseFlag,
-      ),
-    );
+  [kPrepareOwned](query: string, flags: number) {
+    return new Statement(SQL.prepare(this.#handle, query, undefined, flags, this.#internalFlags | kOwnedByDatabaseFlag));
   }
 
   static MAX_QUERY_CACHE_SIZE = 20;
@@ -577,12 +552,12 @@ class Database implements SqliteTypes.Database {
     if (stmt !== undefined) {
       // LRU: re-insert so the most recently used key is last
       cache.delete(query);
-      if (stmt.isFinalized) stmt = this.#prepareOwned(query);
+      if (stmt.isFinalized) stmt = this[kPrepareOwned](query, constants.SQLITE_PREPARE_PERSISTENT);
       cache.set(query, stmt);
       return stmt;
     }
 
-    stmt = this.#prepareOwned(query);
+    stmt = this[kPrepareOwned](query, constants.SQLITE_PREPARE_PERSISTENT);
     const max = Database.MAX_QUERY_CACHE_SIZE;
     if (max > 0) {
       // evicted statements stay usable; close() still finalizes them via kOwnedByDatabaseFlag
@@ -632,20 +607,20 @@ const getController = (db, _self) => {
   let controller = (controllers ||= new WeakMap()).get(db);
   if (!controller) {
     const shared = {
-      commit: db.prepare("COMMIT", undefined, 0),
-      rollback: db.prepare("ROLLBACK", undefined, 0),
-      savepoint: db.prepare("SAVEPOINT `\t_bs3.\t`", undefined, 0),
-      release: db.prepare("RELEASE `\t_bs3.\t`", undefined, 0),
-      rollbackTo: db.prepare("ROLLBACK TO `\t_bs3.\t`", undefined, 0),
+      commit: db[kPrepareOwned]("COMMIT", 0),
+      rollback: db[kPrepareOwned]("ROLLBACK", 0),
+      savepoint: db[kPrepareOwned]("SAVEPOINT `\t_bs3.\t`", 0),
+      release: db[kPrepareOwned]("RELEASE `\t_bs3.\t`", 0),
+      rollbackTo: db[kPrepareOwned]("ROLLBACK TO `\t_bs3.\t`", 0),
     };
 
     controllers.set(
       db,
       (controller = {
-        default: Object.assign({ begin: db.prepare("BEGIN", undefined, 0) }, shared),
-        deferred: Object.assign({ begin: db.prepare("BEGIN DEFERRED", undefined, 0) }, shared),
-        immediate: Object.assign({ begin: db.prepare("BEGIN IMMEDIATE", undefined, 0) }, shared),
-        exclusive: Object.assign({ begin: db.prepare("BEGIN EXCLUSIVE", undefined, 0) }, shared),
+        default: Object.assign({ begin: db[kPrepareOwned]("BEGIN", 0) }, shared),
+        deferred: Object.assign({ begin: db[kPrepareOwned]("BEGIN DEFERRED", 0) }, shared),
+        immediate: Object.assign({ begin: db[kPrepareOwned]("BEGIN IMMEDIATE", 0) }, shared),
+        exclusive: Object.assign({ begin: db[kPrepareOwned]("BEGIN EXCLUSIVE", 0) }, shared),
       }),
     );
   }

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -3,6 +3,7 @@ import type * as SqliteTypes from "bun:sqlite";
 
 const kSafeIntegersFlag = 1 << 1;
 const kStrictFlag = 1 << 2;
+const kOwnedByDatabaseFlag = 1 << 3;
 
 const defineProperties = Object.defineProperties;
 const toStringTag = Symbol.toStringTag;
@@ -426,9 +427,7 @@ class Database implements SqliteTypes.Database {
 
   #internalFlags = 0;
   #handle;
-  #cachedQueriesKeys: string[] = [];
-  #cachedQueriesLengths: number[] = [];
-  #cachedQueriesValues: Statement[] = [];
+  #queryCache: Map<string, Statement> = new Map();
   filename;
   #hasClosed = false;
   get handle() {
@@ -520,12 +519,10 @@ class Database implements SqliteTypes.Database {
     return SQL.close(this.#handle, throwOnError);
   }
   clearQueryCache() {
-    for (let item of this.#cachedQueriesValues) {
-      item?.finalize?.();
+    for (const stmt of this.#queryCache.values()) {
+      stmt?.finalize?.();
     }
-    this.#cachedQueriesKeys.length = 0;
-    this.#cachedQueriesValues.length = 0;
-    this.#cachedQueriesLengths.length = 0;
+    this.#queryCache.clear();
   }
 
   run(query, ...params) {
@@ -548,10 +545,22 @@ class Database implements SqliteTypes.Database {
     return new Statement(SQL.prepare(this.#handle, query, params, flags || 0, this.#internalFlags));
   }
 
+  #prepareOwned(query: string) {
+    return new Statement(
+      SQL.prepare(
+        this.#handle,
+        query,
+        undefined,
+        constants.SQLITE_PREPARE_PERSISTENT,
+        this.#internalFlags | kOwnedByDatabaseFlag,
+      ),
+    );
+  }
+
   static MAX_QUERY_CACHE_SIZE = 20;
 
   get [cachedCount]() {
-    return this.#cachedQueriesKeys.length;
+    return this.#queryCache.size;
   }
 
   query(query) {
@@ -563,35 +572,23 @@ class Database implements SqliteTypes.Database {
       throw new Error("SQL query cannot be empty.");
     }
 
-    const willCache = this.#cachedQueriesKeys.length < Database.MAX_QUERY_CACHE_SIZE;
-
-    // this list should be pretty small
-    let index = this.#cachedQueriesLengths.indexOf(query.length);
-    while (index !== -1) {
-      if (this.#cachedQueriesKeys[index] !== query) {
-        index = this.#cachedQueriesLengths.indexOf(query.length, index + 1);
-        continue;
-      }
-
-      const stmt = this.#cachedQueriesValues[index];
-      if (stmt.isFinalized) {
-        return (this.#cachedQueriesValues[index] = this.prepare(
-          query,
-          undefined,
-          willCache ? constants.SQLITE_PREPARE_PERSISTENT : 0,
-        ));
-      }
+    const cache = this.#queryCache;
+    let stmt = cache.get(query);
+    if (stmt !== undefined) {
+      // LRU: re-insert so the most recently used key is last
+      cache.delete(query);
+      if (stmt.isFinalized) stmt = this.#prepareOwned(query);
+      cache.set(query, stmt);
       return stmt;
     }
 
-    var stmt = this.prepare(query, undefined, willCache ? constants.SQLITE_PREPARE_PERSISTENT : 0);
-
-    if (willCache) {
-      this.#cachedQueriesKeys.push(query);
-      this.#cachedQueriesLengths.push(query.length);
-      this.#cachedQueriesValues.push(stmt);
+    stmt = this.#prepareOwned(query);
+    const max = Database.MAX_QUERY_CACHE_SIZE;
+    if (max > 0) {
+      // evicted statements stay usable; close() still finalizes them via kOwnedByDatabaseFlag
+      if (cache.size >= max) cache.delete(cache.keys().next().value);
+      cache.set(query, stmt);
     }
-
     return stmt;
   }
 

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -562,13 +562,7 @@ class Database implements SqliteTypes.Database {
     const max = Database.MAX_QUERY_CACHE_SIZE;
     if (max > 0) {
       // evicted statements stay usable; close() still finalizes them via kOwnedByDatabaseFlag
-      if (cache.$size >= max) {
-        let oldest;
-        cache.$forEach((_, key) => {
-          if (oldest === undefined) oldest = key;
-        });
-        cache.$delete(oldest);
-      }
+      if (cache.$size >= max) cache.$delete(cache.$keys().next().value);
       cache.$set(query, stmt);
     }
     return stmt;

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -221,6 +221,18 @@ public:
     std::atomic<uint64_t> version;
     size_t reference_count;
     WTF::HashSet<WebCore::JSSQLStatement*> statements;
+    // close(false) with live db.prepare() statements: JS-visible closed, sqlite3_close deferred until they drain.
+    bool closed = false;
+
+    sqlite3* handle() const { return closed ? nullptr : db; }
+
+    void closeIfDrained()
+    {
+        if (closed && db && !sqlite3_next_stmt(db, nullptr)) {
+            sqlite3_close_v2(db);
+            db = nullptr;
+        }
+    }
 
     void release()
     {
@@ -240,7 +252,7 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VersionSqlite3);
 
 static ASCIILiteral finalizedMessage(VersionSqlite3* versionDB)
 {
-    return versionDB && !versionDB->db ? "Database has closed"_s : "Statement has finalized"_s;
+    return versionDB && !versionDB->handle() ? "Database has closed"_s : "Statement has finalized"_s;
 }
 
 class SQLiteSingleton {
@@ -954,7 +966,7 @@ static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindin
 
     // Property reads on `target` can run JS that finalizes `stmt` (statement.finalize() / db.close()); re-validate after each.
     const auto& statementStillAlive = [&]() -> bool {
-        if (statement ? statement->stmt != stmt : versionDB->db != db) [[unlikely]] {
+        if (statement ? statement->stmt != stmt : versionDB->handle() != db) [[unlikely]] {
             if (!scope.exception())
                 throwException(globalObject, scope, createError(globalObject, statement ? finalizedMessage(versionDB) : "Database has closed"_s));
             return false;
@@ -1163,7 +1175,7 @@ static JSC::JSValue rebindStatement(JSC::JSGlobalObject* lexicalGlobalObject, JS
         } else {
             value = array->getDirectIndex(lexicalGlobalObject, i);
             RETURN_IF_EXCEPTION(scope, {});
-            if (statement ? statement->stmt != stmt : versionDB->db != db) [[unlikely]] {
+            if (statement ? statement->stmt != stmt : versionDB->handle() != db) [[unlikely]] {
                 throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, statement ? finalizedMessage(versionDB) : "Database has closed"_s));
                 return {};
             }
@@ -1360,7 +1372,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementSerialize, (JSC::JSGlobalObject * lexical
     }
 
     // Read after toWTFString: a user toString() may have closed the database.
-    sqlite3* db = versionDB->db;
+    sqlite3* db = versionDB->handle();
     if (!db) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Can't do this on a closed database"_s));
         return {};
@@ -1404,7 +1416,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementLoadExtensionFunction, (JSC::JSGlobalObje
     auto extensionString = extension.toWTFString(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    sqlite3* db = versionDB->db;
+    sqlite3* db = versionDB->handle();
     if (!db) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Can't do this on a closed database"_s));
         return {};
@@ -1463,7 +1475,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Invalid database handle"_s));
         return {};
     }
-    sqlite3* db = versionDB->db;
+    sqlite3* db = versionDB->handle();
 
     if (!db) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
@@ -1544,7 +1556,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
 
                 SQLiteBindingsMap bindings { static_cast<uint16_t>(count > -1 ? count : 0), strict };
                 JSC::JSValue reb = rebindStatement(lexicalGlobalObject, bindingsAliveScope.value(), scope, db, versionDB, sql.stmt, bindings, safeIntegers, nullptr);
-                if (versionDB->db != db) [[unlikely]] {
+                if (versionDB->handle() != db) [[unlikely]] {
                     sql.stmt = nullptr; // close() during binding already finalized it via the sqlite3_next_stmt() sweep
                     if (!scope.exception())
                         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
@@ -1623,7 +1635,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementIsInTransactionFunction, (JSC::JSGlobalOb
         return {};
     }
 
-    sqlite3* db = versionDB->db;
+    sqlite3* db = versionDB->handle();
 
     if (!db) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
@@ -1663,7 +1675,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementPrepareStatementFunction, (JSC::JSGlobalO
         return {};
     }
 
-    sqlite3* db = versionDB->db;
+    sqlite3* db = versionDB->handle();
     if (!db) {
         throwException(lexicalGlobalObject, scope, createRangeError(lexicalGlobalObject, "Cannot use a closed database"_s));
         return {};
@@ -1847,12 +1859,12 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
     bool force = (throwOnError.isEmpty() || throwOnError.isUndefined()) ? false : throwOnError.toBoolean(lexicalGlobalObject);
 
     sqlite3* db = versionDB->db;
-    // no-op if already closed
-    if (!db) {
+    // no-op if already closed; close(true) after close(false) still force-finalizes whatever was kept
+    if (!db || (versionDB->closed && !force)) {
         return JSValue::encode(jsUndefined());
     }
 
-    // close(false) keeps db.prepare() statements usable and lets sqlite3_close_v2() defer; everything else is finalized now.
+    // close(false) keeps db.prepare() statements usable and defers sqlite3_close until they drain; everything else is finalized now.
     WTF::HashSet<sqlite3_stmt*> kept;
     for (auto* statement : versionDB->statements) {
         if (!statement->stmt)
@@ -1869,6 +1881,11 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
         if (!kept.contains(stmt))
             sqlite3_finalize(stmt);
         stmt = next;
+    }
+
+    versionDB->closed = true;
+    if (!kept.isEmpty()) {
+        return JSValue::encode(jsUndefined());
     }
 
     int statusCode = force ? sqlite3_close(db) : sqlite3_close_v2(db);
@@ -1920,7 +1937,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFcntlFunction, (JSC::JSGlobalObject * lex
         return {};
     }
 
-    sqlite3* db = versionDB->db;
+    sqlite3* db = versionDB->handle();
     // no-op if already closed
     if (!db) {
         return JSValue::encode(jsUndefined());
@@ -2849,6 +2866,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFunctionFinalize, (JSC::JSGlobalObject * 
     if (castedThis->stmt) {
         sqlite3_finalize(castedThis->stmt);
         castedThis->stmt = nullptr;
+        if (castedThis->version_db)
+            castedThis->version_db->closeIfDrained();
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
@@ -2873,6 +2892,8 @@ JSSQLStatement::~JSSQLStatement()
     }
     if (this->stmt) {
         sqlite3_finalize(this->stmt);
+        if (this->version_db)
+            this->version_db->closeIfDrained();
     }
 
     if (auto* columnNames = this->columnNames.get()) {

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -224,25 +224,23 @@ public:
 
     sqlite3* handle() const { return closed ? nullptr : db; }
 
+    void closeHandle()
+    {
+        if (db)
+            sqlite3_close_v2(std::exchange(db, nullptr));
+    }
+
     void closeIfDrained()
     {
-        if (closed && db && !sqlite3_next_stmt(db, nullptr)) {
-            sqlite3_close_v2(db);
-            db = nullptr;
-        }
+        if (closed && db && !sqlite3_next_stmt(db, nullptr))
+            closeHandle();
     }
 
     void release()
     {
         ASSERT(reference_count > 0);
-        --reference_count;
-        if (reference_count == 0) {
-            if (!db) {
-                return;
-            }
-            sqlite3_close_v2(db);
-            db = nullptr;
-        }
+        if (--reference_count == 0)
+            closeHandle();
     };
 };
 
@@ -353,6 +351,7 @@ JSC_DECLARE_HOST_FUNCTION(jsSQLStatementToStringFunction);
 JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetColumnNames);
 JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetColumnCount);
 JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetParamCount);
+JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetIsFinalized);
 JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetHasMultipleStatements);
 
 JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetColumnTypes);
@@ -686,6 +685,7 @@ static const HashTableValue JSSQLStatementPrototypeTableValues[] = {
     { "columns"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetColumnNames, 0 } },
     { "columnsCount"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetColumnCount, 0 } },
     { "paramsCount"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetParamCount, 0 } },
+    { "isFinalized"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetIsFinalized, 0 } },
     { "columnTypes"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetColumnTypes, 0 } },
     { "declaredTypes"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetColumnDeclaredTypes, 0 } },
     { "safeIntegers"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetSafeIntegers, jsSqlStatementSetSafeIntegers } },
@@ -2702,6 +2702,15 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetParamCount, (JSGlobalObject * lexicalG
     CHECK_PREPARED
 
     RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSC::jsNumber(sqlite3_bind_parameter_count(castedThis->stmt))));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetIsFinalized, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    JSSQLStatement* castedThis = dynamicDowncast<JSSQLStatement>(JSValue::decode(thisValue));
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    CHECK_THIS
+    RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSC::jsBoolean(!castedThis->stmt)));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnTypes, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -192,10 +192,10 @@ static inline JSC::JSValue jsBigIntFromSQLite(JSC::JSGlobalObject* globalObject,
         return {};                                                                                                      \
     }
 
-#define CHECK_PREPARED                                                                                                          \
-    if (castedThis->stmt == nullptr || castedThis->version_db == nullptr) [[unlikely]] {                                        \
+#define CHECK_PREPARED                                                                                              \
+    if (castedThis->stmt == nullptr || castedThis->version_db == nullptr) [[unlikely]] {                            \
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis))); \
-        return {};                                                                                                              \
+        return {};                                                                                                  \
     }
 
 namespace WebCore {

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -194,16 +194,14 @@ static inline JSC::JSValue jsBigIntFromSQLite(JSC::JSGlobalObject* globalObject,
 
 #define CHECK_PREPARED                                                                                                          \
     if (castedThis->stmt == nullptr || castedThis->version_db == nullptr) [[unlikely]] {                                        \
-        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis->version_db))); \
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis))); \
         return {};                                                                                                              \
     }
 
 namespace WebCore {
 class JSSQLStatement;
+static ASCIILiteral finalizedMessage(const JSSQLStatement* statement);
 }
-
-class VersionSqlite3;
-static ASCIILiteral finalizedMessage(VersionSqlite3* versionDB);
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VersionSqlite3);
 
@@ -249,11 +247,6 @@ public:
 };
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VersionSqlite3);
-
-static ASCIILiteral finalizedMessage(VersionSqlite3* versionDB)
-{
-    return versionDB && !versionDB->handle() ? "Database has closed"_s : "Statement has finalized"_s;
-}
 
 class SQLiteSingleton {
 public:
@@ -546,6 +539,7 @@ public:
     bool useBigInt64 : 1 = false;
     // Created by db.query(); close(false) finalizes these but leaves db.prepare() statements usable.
     bool ownedByDatabase : 1 = false;
+    bool finalizedByClose : 1 = false;
 
 protected:
     JSSQLStatement(JSC::Structure* structure, JSDOMGlobalObject& globalObject, sqlite3_stmt* stmt, VersionSqlite3* version_db, int64_t memorySizeChange = 0)
@@ -559,6 +553,11 @@ protected:
 
     void finishCreation(JSC::VM& vm);
 };
+
+static ASCIILiteral finalizedMessage(const JSSQLStatement* statement)
+{
+    return statement->finalizedByClose ? "Database has closed"_s : "Statement has finalized"_s;
+}
 
 static JSValue toJSAsBuffer(JSC::VM& vm, JSC::JSGlobalObject* globalObject, sqlite3_stmt* stmt, int i)
 {
@@ -968,7 +967,7 @@ static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindin
     const auto& statementStillAlive = [&]() -> bool {
         if (statement ? statement->stmt != stmt : versionDB->handle() != db) [[unlikely]] {
             if (!scope.exception())
-                throwException(globalObject, scope, createError(globalObject, statement ? finalizedMessage(versionDB) : "Database has closed"_s));
+                throwException(globalObject, scope, createError(globalObject, statement ? finalizedMessage(statement) : "Database has closed"_s));
             return false;
         }
         return true;
@@ -1176,7 +1175,7 @@ static JSC::JSValue rebindStatement(JSC::JSGlobalObject* lexicalGlobalObject, JS
             value = array->getDirectIndex(lexicalGlobalObject, i);
             RETURN_IF_EXCEPTION(scope, {});
             if (statement ? statement->stmt != stmt : versionDB->handle() != db) [[unlikely]] {
-                throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, statement ? finalizedMessage(versionDB) : "Database has closed"_s));
+                throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, statement ? finalizedMessage(statement) : "Database has closed"_s));
                 return {};
             }
             if (!value)
@@ -1875,6 +1874,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
         }
         sqlite3_finalize(statement->stmt);
         statement->stmt = nullptr;
+        statement->finalizedByClose = true;
     }
     for (sqlite3_stmt* stmt = sqlite3_next_stmt(db, nullptr); stmt;) {
         sqlite3_stmt* next = sqlite3_next_stmt(db, stmt);
@@ -2300,7 +2300,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
                     resultArray->push(lexicalGlobalObject, result);
                     RETURN_IF_EXCEPTION(scope, {});
                     if (castedThis->stmt != stmt) [[unlikely]] {
-                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis->version_db)));
+                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis)));
                         return {};
                     }
                     status = sqlite3_step(stmt);
@@ -2312,7 +2312,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
                     resultArray->push(lexicalGlobalObject, result);
                     RETURN_IF_EXCEPTION(scope, {});
                     if (castedThis->stmt != stmt) [[unlikely]] {
-                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis->version_db)));
+                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis)));
                         return {};
                     }
                     status = sqlite3_step(stmt);
@@ -2458,7 +2458,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows, (JSC::JSGlo
                     resultArray->push(lexicalGlobalObject, row);
                     RETURN_IF_EXCEPTION(scope, {});
                     if (castedThis->stmt != stmt) [[unlikely]] {
-                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis->version_db)));
+                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis)));
                         return {};
                     }
                     status = sqlite3_step(stmt);
@@ -2547,7 +2547,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRawRows, (JSC::JS
                     RETURN_IF_EXCEPTION(scope, {});
 
                     if (castedThis->stmt != stmt) [[unlikely]] {
-                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis->version_db)));
+                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis)));
                         return {};
                     }
 
@@ -2927,7 +2927,7 @@ JSC::JSValue JSSQLStatement::rebind(JSC::JSGlobalObject* lexicalGlobalObject, JS
     // A getter invoked while binding can finalize this statement; the callers
     // cache `stmt` before binding and call sqlite3_step() on it afterwards.
     if (this->stmt != stmt) [[unlikely]] {
-        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(this->version_db)));
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(this)));
         return {};
     }
 

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -54,6 +54,7 @@
 #include "BunString.h"
 static constexpr int32_t kSafeIntegersFlag = 1 << 1;
 static constexpr int32_t kStrictFlag = 1 << 2;
+static constexpr int32_t kOwnedByDatabaseFlag = 1 << 3;
 
 #ifndef BREAKING_CHANGES_BUN_1_2
 #define BREAKING_CHANGES_BUN_1_2 0
@@ -181,7 +182,7 @@ static inline JSC::JSValue jsBigIntFromSQLite(JSC::JSGlobalObject* globalObject,
 
 #define DO_REBIND(param)                                                                                                \
     if (param.isObject()) {                                                                                             \
-        JSC::JSValue reb = castedThis->rebind(lexicalGlobalObject, param, castedThis->version_db->db);                  \
+        JSC::JSValue reb = castedThis->rebind(lexicalGlobalObject, param);                                              \
         RETURN_IF_EXCEPTION(scope, {});                                                                                 \
         if (!reb.isNumber()) [[unlikely]] {                                                                             \
             return JSValue::encode(reb); /* this means an error */                                                      \
@@ -191,15 +192,18 @@ static inline JSC::JSValue jsBigIntFromSQLite(JSC::JSGlobalObject* globalObject,
         return {};                                                                                                      \
     }
 
-#define CHECK_PREPARED                                                                                             \
-    if (castedThis->stmt == nullptr || castedThis->version_db == nullptr) [[unlikely]] {                           \
-        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s)); \
-        return {};                                                                                                 \
+#define CHECK_PREPARED                                                                                                          \
+    if (castedThis->stmt == nullptr || castedThis->version_db == nullptr) [[unlikely]] {                                        \
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis->version_db))); \
+        return {};                                                                                                              \
     }
 
 namespace WebCore {
 class JSSQLStatement;
 }
+
+class VersionSqlite3;
+static ASCIILiteral finalizedMessage(VersionSqlite3* versionDB);
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VersionSqlite3);
 
@@ -216,9 +220,6 @@ public:
     sqlite3* db;
     std::atomic<uint64_t> version;
     size_t reference_count;
-    // Live statement wrappers on this connection. close() finalizes each one
-    // and nulls its stmt pointer, like better-sqlite3's CloseHandles() and
-    // node:sqlite's FinalizeStatements().
     WTF::HashSet<WebCore::JSSQLStatement*> statements;
 
     void release()
@@ -236,6 +237,11 @@ public:
 };
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VersionSqlite3);
+
+static ASCIILiteral finalizedMessage(VersionSqlite3* versionDB)
+{
+    return versionDB && !versionDB->db ? "Database has closed"_s : "Statement has finalized"_s;
+}
 
 class SQLiteSingleton {
 public:
@@ -505,7 +511,7 @@ public:
 
     static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
-    JSC::JSValue rebind(JSGlobalObject* globalObject, JSC::JSValue values, sqlite3* db);
+    JSC::JSValue rebind(JSGlobalObject* globalObject, JSC::JSValue values);
 
     bool need_update() { return version_db->version.load() != version; }
     void update_version() { version = version_db->version.load(); }
@@ -526,6 +532,8 @@ public:
     SQLiteBindingsMap m_bindingNames = { 0, false };
     bool hasExecuted : 1 = false;
     bool useBigInt64 : 1 = false;
+    // Created by db.query(); close(false) finalizes these but leaves db.prepare() statements usable.
+    bool ownedByDatabase : 1 = false;
 
 protected:
     JSSQLStatement(JSC::Structure* structure, JSDOMGlobalObject& globalObject, sqlite3_stmt* stmt, VersionSqlite3* version_db, int64_t memorySizeChange = 0)
@@ -944,19 +952,11 @@ static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindin
 {
     int count = 0;
 
-    // Reading a property off `target` can run arbitrary JS (getters, Proxy
-    // traps), which can call statement.finalize() or db.close() and free
-    // `stmt`. Re-validate before touching `stmt` again after any callback
-    // into JS.
+    // Property reads on `target` can run JS that finalizes `stmt` (statement.finalize() / db.close()); re-validate after each.
     const auto& statementStillAlive = [&]() -> bool {
-        if (versionDB->db != db) [[unlikely]] {
+        if (statement ? statement->stmt != stmt : versionDB->db != db) [[unlikely]] {
             if (!scope.exception())
-                throwException(globalObject, scope, createError(globalObject, "Database has closed"_s));
-            return false;
-        }
-        if (statement && statement->stmt != stmt) [[unlikely]] {
-            if (!scope.exception())
-                throwException(globalObject, scope, createError(globalObject, "Statement has finalized"_s));
+                throwException(globalObject, scope, createError(globalObject, statement ? finalizedMessage(versionDB) : "Database has closed"_s));
             return false;
         }
         return true;
@@ -1163,12 +1163,8 @@ static JSC::JSValue rebindStatement(JSC::JSGlobalObject* lexicalGlobalObject, JS
         } else {
             value = array->getDirectIndex(lexicalGlobalObject, i);
             RETURN_IF_EXCEPTION(scope, {});
-            if (versionDB->db != db) [[unlikely]] {
-                throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
-                return {};
-            }
-            if (statement && statement->stmt != stmt) [[unlikely]] {
-                throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
+            if (statement ? statement->stmt != stmt : versionDB->db != db) [[unlikely]] {
+                throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, statement ? finalizedMessage(versionDB) : "Database has closed"_s));
                 return {};
             }
             if (!value)
@@ -1549,10 +1545,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
                 SQLiteBindingsMap bindings { static_cast<uint16_t>(count > -1 ? count : 0), strict };
                 JSC::JSValue reb = rebindStatement(lexicalGlobalObject, bindingsAliveScope.value(), scope, db, versionDB, sql.stmt, bindings, safeIntegers, nullptr);
                 if (versionDB->db != db) [[unlikely]] {
-                    // A close() during binding finalized sql.stmt via its
-                    // sqlite3_next_stmt() sweep; keep the auto-destructor
-                    // from finalizing it again.
-                    sql.stmt = nullptr;
+                    sql.stmt = nullptr; // close() during binding already finalized it via the sqlite3_next_stmt() sweep
                     if (!scope.exception())
                         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
                     return {};
@@ -1720,6 +1713,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementPrepareStatementFunction, (JSC::JSGlobalO
         const int32_t internalFlags = internalFlagsValue.asInt32();
         sqlStatement->m_bindingNames.trimLeadingPrefix = (internalFlags & kStrictFlag) != 0;
         sqlStatement->useBigInt64 = (internalFlags & kSafeIntegersFlag) != 0;
+        sqlStatement->ownedByDatabase = (internalFlags & kOwnedByDatabaseFlag) != 0;
     }
 
     if (bindings.isObject()) {
@@ -1850,7 +1844,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
         return {};
     }
 
-    bool shouldThrowOnError = (throwOnError.isEmpty() || throwOnError.isUndefined()) ? false : throwOnError.toBoolean(lexicalGlobalObject);
+    bool force = (throwOnError.isEmpty() || throwOnError.isUndefined()) ? false : throwOnError.toBoolean(lexicalGlobalObject);
 
     sqlite3* db = versionDB->db;
     // no-op if already closed
@@ -1858,32 +1852,32 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
         return JSValue::encode(jsUndefined());
     }
 
-    // Finalize every outstanding statement so sqlite3_close() cannot fail
-    // with SQLITE_BUSY, nulling each wrapper's handle so it never touches
-    // freed memory.
+    // close(false) keeps db.prepare() statements usable and lets sqlite3_close_v2() defer; everything else is finalized now.
+    WTF::HashSet<sqlite3_stmt*> kept;
     for (auto* statement : versionDB->statements) {
-        if (statement->stmt) {
-            sqlite3_finalize(statement->stmt);
-            statement->stmt = nullptr;
+        if (!statement->stmt)
+            continue;
+        if (!force && !statement->ownedByDatabase) {
+            kept.add(statement->stmt);
+            continue;
         }
+        sqlite3_finalize(statement->stmt);
+        statement->stmt = nullptr;
     }
-    versionDB->statements.clear();
-
-    // Backstop for statements not owned by a wrapper, e.g. the transient one
-    // in jsSQLStatementExecuteFunction when a bound getter calls close().
-    while (sqlite3_stmt* stmt = sqlite3_next_stmt(db, nullptr)) {
-        sqlite3_finalize(stmt);
+    for (sqlite3_stmt* stmt = sqlite3_next_stmt(db, nullptr); stmt;) {
+        sqlite3_stmt* next = sqlite3_next_stmt(db, stmt);
+        if (!kept.contains(stmt))
+            sqlite3_finalize(stmt);
+        stmt = next;
     }
 
-    int statusCode = sqlite3_close(db);
-    if (statusCode != SQLITE_OK) {
-        // The statements are already gone, so the connection is unusable
-        // either way: defer the close and retire the handle.
+    int statusCode = force ? sqlite3_close(db) : sqlite3_close_v2(db);
+    if (statusCode != SQLITE_OK && force) {
         sqlite3_close_v2(db);
     }
     versionDB->db = nullptr;
 
-    if (statusCode != SQLITE_OK && shouldThrowOnError) {
+    if (statusCode != SQLITE_OK && force) {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, WTF::String::fromUTF8(sqlite3_errstr(statusCode))));
         return {};
     }
@@ -2196,7 +2190,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionIterate, (JSC::JS
     if (!busy) {
         int statusCode = sqlite3_reset(stmt);
         if (statusCode != SQLITE_OK) [[unlikely]] {
-            throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
+            throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
             return {};
         }
     }
@@ -2228,7 +2222,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionIterate, (JSC::JS
     if (status == SQLITE_DONE || status == SQLITE_OK || status == SQLITE_ROW) {
         RELEASE_AND_RETURN(scope, JSValue::encode(result));
     } else {
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
+        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
         sqlite3_reset(stmt);
         return {};
     }
@@ -2247,7 +2241,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
     int statusCode = sqlite3_reset(stmt);
 
     if (statusCode != SQLITE_OK) [[unlikely]] {
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
+        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
         return {};
     }
 
@@ -2273,7 +2267,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
     if (status == SQLITE_ROW) {
         // this is a count from UPDATE or another query like that
         if (columnCount == 0) {
-            result = jsNumber(sqlite3_changes(castedThis->version_db->db));
+            result = jsNumber(sqlite3_changes(sqlite3_db_handle(stmt)));
 
             while (status == SQLITE_ROW) {
                 status = sqlite3_step(stmt);
@@ -2289,7 +2283,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
                     resultArray->push(lexicalGlobalObject, result);
                     RETURN_IF_EXCEPTION(scope, {});
                     if (castedThis->stmt != stmt) [[unlikely]] {
-                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
+                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis->version_db)));
                         return {};
                     }
                     status = sqlite3_step(stmt);
@@ -2301,7 +2295,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
                     resultArray->push(lexicalGlobalObject, result);
                     RETURN_IF_EXCEPTION(scope, {});
                     if (castedThis->stmt != stmt) [[unlikely]] {
-                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
+                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis->version_db)));
                         return {};
                     }
                     status = sqlite3_step(stmt);
@@ -2315,7 +2309,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
     }
 
     if (status != SQLITE_DONE && status != SQLITE_OK) [[unlikely]] {
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
+        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
         sqlite3_reset(stmt);
         return {};
     }
@@ -2342,7 +2336,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionGet, (JSC::JSGlob
 
     int statusCode = sqlite3_reset(stmt);
     if (statusCode != SQLITE_OK) [[unlikely]] {
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
+        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
         return {};
     }
 
@@ -2376,7 +2370,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionGet, (JSC::JSGlob
     if (status == SQLITE_DONE || status == SQLITE_OK) {
         RELEASE_AND_RETURN(scope, JSValue::encode(result));
     } else {
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
+        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
         sqlite3_reset(stmt);
         return {};
     }
@@ -2396,7 +2390,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows, (JSC::JSGlo
 
     int statusCode = sqlite3_reset(stmt);
     if (statusCode != SQLITE_OK) [[unlikely]] {
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
+        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
         sqlite3_reset(stmt);
         return {};
     }
@@ -2447,7 +2441,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows, (JSC::JSGlo
                     resultArray->push(lexicalGlobalObject, row);
                     RETURN_IF_EXCEPTION(scope, {});
                     if (castedThis->stmt != stmt) [[unlikely]] {
-                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
+                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis->version_db)));
                         return {};
                     }
                     status = sqlite3_step(stmt);
@@ -2463,7 +2457,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows, (JSC::JSGlo
     }
 
     if (status != SQLITE_DONE && status != SQLITE_OK) [[unlikely]] {
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
+        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
         sqlite3_reset(stmt);
         return {};
     }
@@ -2485,7 +2479,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRawRows, (JSC::JS
 
     int statusCode = sqlite3_reset(stmt);
     if (statusCode != SQLITE_OK) [[unlikely]] {
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
+        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
         sqlite3_reset(stmt);
         return {};
     }
@@ -2532,12 +2526,11 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRawRows, (JSC::JS
                         RELEASE_AND_RETURN(scope, {});
                     }
                     resultArray->push(lexicalGlobalObject, row);
-                    // No sqlite3_reset here: push() can run user code that
-                    // finalizes `stmt` (statement.finalize() or db.close()).
+                    // no sqlite3_reset: push() can run user code that finalizes `stmt`
                     RETURN_IF_EXCEPTION(scope, {});
 
                     if (castedThis->stmt != stmt) [[unlikely]] {
-                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
+                        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(castedThis->version_db)));
                         return {};
                     }
 
@@ -2554,7 +2547,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRawRows, (JSC::JS
     }
 
     if (status != SQLITE_DONE && status != SQLITE_OK) [[unlikely]] {
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
+        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
         sqlite3_reset(stmt);
         return {};
     }
@@ -2577,7 +2570,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRun, (JSC::JSGlob
 
     int statusCode = sqlite3_reset(stmt);
     if (statusCode != SQLITE_OK) [[unlikely]] {
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
+        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
         return {};
     }
 
@@ -2588,12 +2581,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRun, (JSC::JSGlob
         DO_REBIND(arg0);
     }
 
-    if (!castedThis->version_db->db) [[unlikely]] {
-        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
-        return {};
-    }
-
-    int total_changes_before = sqlite3_total_changes(castedThis->version_db->db);
+    auto* db = sqlite3_db_handle(stmt);
+    int total_changes_before = sqlite3_total_changes(db);
 
     int status = sqlite3_step(stmt);
     if (!sqlite3_stmt_readonly(stmt)) {
@@ -2613,13 +2602,12 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRun, (JSC::JSGlob
     }
 
     if (status != SQLITE_DONE && status != SQLITE_OK) [[unlikely]] {
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
+        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
         sqlite3_reset(stmt);
         return {};
     }
 
     if (auto* diff = dynamicDowncast<JSC::InternalFieldTuple>(diffValue)) {
-        auto* db = castedThis->version_db->db;
         const int total_changes_after = sqlite3_total_changes(db);
         int64_t last_insert_rowid = sqlite3_last_insert_rowid(db);
         diff->putInternalField(vm, 0, JSC::jsNumber(total_changes_after - total_changes_before));
@@ -2722,7 +2710,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnTypes, (JSGlobalObject * lexical
     // Reset the statement (safe for read-only statements)
     int resetStatus = sqlite3_reset(castedThis->stmt);
     if (resetStatus != SQLITE_OK) {
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
+        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(castedThis->stmt)));
         return {};
     }
 
@@ -2770,7 +2758,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnTypes, (JSGlobalObject * lexical
         }
     } else {
         // If there was an error stepping, throw it
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
+        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(castedThis->stmt)));
         sqlite3_reset(castedThis->stmt);
         return {};
     }
@@ -2906,19 +2894,19 @@ void JSSQLStatement::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-JSC::JSValue JSSQLStatement::rebind(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue values, sqlite3* db)
+JSC::JSValue JSSQLStatement::rebind(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue values)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* stmt = this->stmt;
 
-    auto val = rebindStatement(lexicalGlobalObject, values, scope, this->version_db->db, this->version_db, stmt, this->m_bindingNames, this->useBigInt64, this);
+    auto val = rebindStatement(lexicalGlobalObject, values, scope, sqlite3_db_handle(stmt), this->version_db, stmt, this->m_bindingNames, this->useBigInt64, this);
     RETURN_IF_EXCEPTION(scope, {});
 
     // A getter invoked while binding can finalize this statement; the callers
     // cache `stmt` before binding and call sqlite3_step() on it afterwards.
     if (this->stmt != stmt) [[unlikely]] {
-        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s));
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, finalizedMessage(this->version_db)));
         return {};
     }
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1549,7 +1549,55 @@ it("close(true) finalizes outstanding prepared statements instead of throwing", 
   db.exec("INSERT INTO foo (name) VALUES ('foo')");
   const prepared = db.prepare("SELECT * FROM foo");
   expect(() => db.close(true)).not.toThrow();
-  expect(() => prepared.all()).toThrow("Statement has finalized");
+  expect(() => prepared.all()).toThrow("Database has closed");
+});
+
+it("close(false) leaves prepare() statements usable but finalizes query() statements", () => {
+  const db = new Database(":memory:");
+  db.exec("CREATE TABLE foo (a INTEGER)");
+  db.exec("INSERT INTO foo VALUES (1), (2), (3)");
+  const select = db.prepare("SELECT a FROM foo ORDER BY a");
+  const insert = db.prepare("INSERT INTO foo VALUES (?)");
+  const iter = select.iterate();
+  expect(iter.next().value).toEqual({ a: 1 });
+  const owned = [];
+  for (let i = 0; i <= Database.MAX_QUERY_CACHE_SIZE + 2; i++) {
+    owned.push(db.query(`SELECT a + ${i} AS v FROM foo`));
+  }
+
+  db.close(false);
+
+  expect([...iter]).toEqual([{ a: 2 }, { a: 3 }]);
+  expect(() => insert.run(4)).not.toThrow();
+  expect(select.all()).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }]);
+  for (const stmt of owned) {
+    expect(() => stmt.all()).toThrow("Database has closed");
+  }
+  expect(() => db.prepare("SELECT 1")).toThrow("Cannot use a closed database");
+  expect(() => db.query("SELECT 1")).toThrow("Cannot use a closed database");
+  select.finalize();
+  insert.finalize();
+});
+
+it("query() cache evicts least-recently-used statements past MAX_QUERY_CACHE_SIZE", () => {
+  const db = new Database(":memory:");
+  db.exec("CREATE TABLE foo (a INTEGER)");
+  const cachedCount = Symbol.for("Bun.Database.cache.count");
+  const first = db.query("SELECT a + 0 FROM foo");
+  const second = db.query("SELECT a + 1 FROM foo");
+  for (let i = 2; i < Database.MAX_QUERY_CACHE_SIZE; i++) db.query(`SELECT a + ${i} FROM foo`);
+  expect(db[cachedCount]).toBe(Database.MAX_QUERY_CACHE_SIZE);
+  // touch `first` so `second` becomes the LRU entry
+  expect(db.query("SELECT a + 0 FROM foo")).toBe(first);
+  const overflow = db.query(`SELECT a + ${Database.MAX_QUERY_CACHE_SIZE} FROM foo`);
+  expect(db[cachedCount]).toBe(Database.MAX_QUERY_CACHE_SIZE);
+  expect(db.query("SELECT a + 0 FROM foo")).toBe(first);
+  expect(db.query(`SELECT a + ${Database.MAX_QUERY_CACHE_SIZE} FROM foo`)).toBe(overflow);
+  expect(db.query("SELECT a + 1 FROM foo")).not.toBe(second);
+  // the evicted statement still works until close()
+  expect(second.all()).toEqual([]);
+  db.close();
+  expect(() => second.all()).toThrow("Database has closed");
 });
 
 it("close(true) finalizes query() statements created after the cache filled up (#36572)", () => {
@@ -1572,7 +1620,7 @@ it("close(true) finalizes query() statements past the cache limit that are still
   }
   expect(() => db.close(true)).not.toThrow();
   for (const stmt of statements) {
-    expect(() => stmt.all()).toThrow("Statement has finalized");
+    expect(() => stmt.all()).toThrow("Database has closed");
   }
 });
 
@@ -1609,15 +1657,25 @@ it("close() should NOT throw an error if the database is in use", () => {
   expect(() => db.close()).not.toThrow("database is locked");
 });
 
-it("close() releases the database file so it can be deleted immediately (#36572)", () => {
+it("close(true) releases the database file so it can be deleted immediately (#36572)", () => {
   using dir = tempDir("sqlite-close-unlink", {});
   const file = path.join(String(dir), "x.sqlite");
   const db = new Database(file);
   db.exec("CREATE TABLE t (a INTEGER)");
   db.prepare("SELECT a FROM t").all();
+  db.close(true);
+  // On Windows rmSync throws EBUSY if the statement kept the file handle open past close(true).
+  rmSync(file);
+  expect(existsSync(file)).toBe(false);
+});
+
+it("close() releases the database file when only query() statements are outstanding (#36572)", () => {
+  using dir = tempDir("sqlite-close-unlink-query", {});
+  const file = path.join(String(dir), "x.sqlite");
+  const db = new Database(file);
+  db.exec("CREATE TABLE t (a INTEGER)");
+  for (let i = 0; i <= Database.MAX_QUERY_CACHE_SIZE; i++) db.query(`SELECT a + ${i} FROM t`).all();
   db.close();
-  // On Windows this throws EBUSY if the statement above kept the
-  // connection (and the file handle) open past close().
   rmSync(file);
   expect(existsSync(file)).toBe(false);
 });
@@ -1632,7 +1690,7 @@ it("should dispose even if a prepared statement is still live", () => {
       prepared = db.prepare("SELECT * FROM foo");
     }
   }).not.toThrow();
-  expect(() => prepared.get()).toThrow("Statement has finalized");
+  expect(() => prepared.get()).toThrow("Database has closed");
 });
 
 it("should dispose", () => {
@@ -1738,11 +1796,8 @@ it("#13082", async () => {
     runs[i] = run(ops[i % ops.length]);
   }
 
-  const results = await Promise.allSettled(runs);
-  for (const result of results) {
-    expect(result.status).toBe("rejected");
-    expect(result.reason.message).toBe("Statement has finalized");
-  }
+  // close(false) leaves prepare() statements usable even after the Database wrapper is collected
+  await Promise.all(runs);
 });
 
 // The internal SQL.run / SQL.prepare / SQL.isInTransaction helpers used to

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1626,15 +1626,38 @@ it("WAL is checkpointed at exit for a database closed with close(false) while a 
        const db = new Database(process.argv[1]);
        db.exec("PRAGMA journal_mode=WAL; CREATE TABLE t (a); INSERT INTO t VALUES (1)");
        const sel = db.prepare("SELECT * FROM t");
-       sel.get();
-       db.close();`,
+       console.log(JSON.stringify(sel.get()));
+       db.close();
+       console.log(JSON.stringify(sel.get()));`,
       file,
     ],
     env: bunEnv,
-    stderr: "inherit",
+    stderr: "pipe",
   });
-  expect(await proc.exited).toBe(0);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: '{"a":1}\n{"a":1}\n', stderr: "", exitCode: 0 });
   expect(existsSync(file + "-wal") ? statSync(file + "-wal").size : 0).toBe(0);
+  {
+    using db = new Database(file, { readonly: true });
+    expect(db.query("SELECT * FROM t").all()).toEqual([{ a: 1 }]);
+  }
+});
+
+it("Statement.isFinalized reflects native state, including statements finalized by close()", () => {
+  const db = new Database(":memory:");
+  const prev = Database.MAX_QUERY_CACHE_SIZE;
+  Database.MAX_QUERY_CACHE_SIZE = 0;
+  try {
+    const uncached = db.query("SELECT 1");
+    const prepared = db.prepare("SELECT 2");
+    expect([uncached.isFinalized, prepared.isFinalized]).toEqual([false, false]);
+    db.close();
+    expect([uncached.isFinalized, prepared.isFinalized]).toEqual([true, false]);
+    prepared.finalize();
+    expect(prepared.isFinalized).toBe(true);
+  } finally {
+    Database.MAX_QUERY_CACHE_SIZE = prev;
+  }
 });
 
 it("`using` releases the connection even after an explicit close(false) left a prepare() statement live", () => {

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1579,6 +1579,64 @@ it("close(false) leaves prepare() statements usable but finalizes query() statem
   insert.finalize();
 });
 
+it("prepare() statements kept past close(false) report changes and real errors, and survive schema changes", () => {
+  using dir = tempDir("sqlite-close-deferred", {});
+  const file = path.join(String(dir), "x.sqlite");
+  const db = new Database(file);
+  db.exec("CREATE TABLE t (b UNIQUE)");
+  const insert = db.prepare("INSERT INTO t VALUES (?)");
+  db.close(false);
+  expect(insert.run(1)).toEqual({ changes: 1, lastInsertRowid: 1 });
+  expect(() => insert.run(1)).toThrow("UNIQUE constraint failed: t.b");
+  {
+    using other = new Database(file);
+    other.exec("CREATE TABLE u (x)");
+  }
+  expect(insert.run(2)).toEqual({ changes: 1, lastInsertRowid: 2 });
+  // close(true) after close(false) force-finalizes what was kept and releases the file
+  db.close(true);
+  expect(() => insert.run(3)).toThrow("Database has closed");
+  rmSync(file);
+  expect(existsSync(file)).toBe(false);
+});
+
+it("close(false) releases the file once the last prepare() statement is finalized", () => {
+  using dir = tempDir("sqlite-close-drain", {});
+  const file = path.join(String(dir), "x.sqlite");
+  const db = new Database(file);
+  db.exec("CREATE TABLE t (a)");
+  const a = db.prepare("SELECT a FROM t");
+  const b = db.prepare("SELECT a + 1 FROM t");
+  db.close(false);
+  a.finalize();
+  expect(b.all()).toEqual([]);
+  b.finalize();
+  rmSync(file);
+  expect(existsSync(file)).toBe(false);
+});
+
+it("WAL is checkpointed at exit for a database closed with close(false) while a prepare() statement is live", async () => {
+  using dir = tempDir("sqlite-close-wal", {});
+  const file = path.join(String(dir), "x.sqlite");
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { Database } = require("bun:sqlite");
+       const db = new Database(process.argv[1]);
+       db.exec("PRAGMA journal_mode=WAL; CREATE TABLE t (a); INSERT INTO t VALUES (1)");
+       const sel = db.prepare("SELECT * FROM t");
+       sel.get();
+       db.close();`,
+      file,
+    ],
+    env: bunEnv,
+    stderr: "inherit",
+  });
+  expect(await proc.exited).toBe(0);
+  expect(existsSync(file + "-wal") ? statSync(file + "-wal").size : 0).toBe(0);
+});
+
 it("query() cache evicts least-recently-used statements past MAX_QUERY_CACHE_SIZE", () => {
   const db = new Database(":memory:");
   db.exec("CREATE TABLE foo (a INTEGER)");

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1637,6 +1637,34 @@ it("WAL is checkpointed at exit for a database closed with close(false) while a 
   expect(existsSync(file + "-wal") ? statSync(file + "-wal").size : 0).toBe(0);
 });
 
+it("`using` releases the connection even after an explicit close(false) left a prepare() statement live", () => {
+  using dir = tempDir("sqlite-using-after-close", {});
+  const file = path.join(String(dir), "x.sqlite");
+  let stmt;
+  {
+    using db = new Database(file);
+    db.exec("CREATE TABLE t (a)");
+    stmt = db.prepare("SELECT a FROM t");
+    stmt.get();
+    db.close();
+    expect(stmt.all()).toEqual([]);
+  }
+  expect(() => stmt.all()).toThrow("Database has closed");
+  rmSync(file);
+  expect(existsSync(file)).toBe(false);
+});
+
+it("a statement the user finalized still reports 'Statement has finalized' after close()", () => {
+  const db = new Database(":memory:");
+  const a = db.prepare("SELECT 1");
+  const b = db.prepare("SELECT 2");
+  a.finalize();
+  db.close();
+  expect(() => a.get()).toThrow("Statement has finalized");
+  b.finalize();
+  expect(() => b.get()).toThrow("Statement has finalized");
+});
+
 it("query() cache evicts least-recently-used statements past MAX_QUERY_CACHE_SIZE", () => {
   const db = new Database(":memory:");
   db.exec("CREATE TABLE foo (a INTEGER)");


### PR DESCRIPTION
Follow-up to #36573, which made both `close()` modes force-finalize every statement. That was a behavior change for `db.prepare()` statements held across `close(false)` (reads/iterators used to keep working via `sqlite3_close_v2`). This restores a coherent graceful mode and gives `throwOnError` real meaning.

| after… | `close()` / `close(false)` | `close(true)` / `using` |
|---|---|---|
| `db.query()` statements (cached or evicted) | finalized | finalized |
| `db.prepare()` statements | **keep working** (reads *and* writes) until finalized/GC'd | finalized |
| connection / file handle | released when last `prepare()` stmt is finalized (`sqlite3_close_v2`) | released immediately (`sqlite3_close`), throws on failure |
| using a finalized stmt | `Database has closed` | `Database has closed` |
| `db.query()` / `db.prepare()` new | throws | throws |

Also:

| | before | after |
|---|---|---|
| `db.query()` cache | first 20 distinct strings cached forever; everything after uncached and non-`PERSISTENT` | LRU of `MAX_QUERY_CACHE_SIZE`; every `query()` stmt is `PERSISTENT` and tracked as Database-owned so `close()` finalizes it even after eviction |
| `prepare()` stmt `.run()` after `close(false)` | `Database has closed` (while `.all()` worked) | works (statement paths use `sqlite3_db_handle(stmt)`) |
| post-close error | `Statement has finalized` | `Database has closed` |

#36572 / #35604 / #11418 stay fixed (`close(true)` never hits `SQLITE_BUSY`; `close()` releases the file when only `query()` statements are outstanding). Docs and types updated.