### PR TITLE
Upgrade WebKit to 3722912ff800

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "34c01d13391e00c06862a3d2c5b7fff350ac87e0";
+export const WEBKIT_VERSION = "autobuild-preview-pr-383-b9ea4dc5";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-383-b9ea4dc5";
+export const WEBKIT_VERSION = "e6e37cda216c0292ae68c30c84a9dc8601d0fba5";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/bundler/analyze_transpiled_module.rs
+++ b/src/bundler/analyze_transpiled_module.rs
@@ -84,12 +84,18 @@ impl RecordKind {
             Self::IMPORT_INFO_SINGLE_TYPE_SCRIPT => Ok(4),
             Self::IMPORT_INFO_NAMESPACE => Ok(4),
             Self::IMPORT_INFO_NAMESPACE_DEFER => Ok(4),
-            Self::EXPORT_INFO_INDIRECT => Ok(3),
-            Self::EXPORT_INFO_LOCAL => Ok(3),
-            Self::EXPORT_INFO_NAMESPACE => Ok(2),
-            Self::EXPORT_INFO_STAR => Ok(1),
+            Self::EXPORT_INFO_INDIRECT => Ok(4),
+            Self::EXPORT_INFO_LOCAL => Ok(4),
+            Self::EXPORT_INFO_NAMESPACE => Ok(3),
+            Self::EXPORT_INFO_STAR => Ok(2),
             _ => Err(crate::Error::InvalidRecordKind),
         }
+    }
+
+    /// Number of trailing slots holding a bitcast `FetchParameters` rather
+    /// than a `StringID`. Every record kind has exactly one trailing FP slot.
+    pub fn trailing_fetch_parameters_slots(self) -> usize {
+        1
     }
 }
 

--- a/src/bundler/analyze_transpiled_module.rs
+++ b/src/bundler/analyze_transpiled_module.rs
@@ -80,10 +80,10 @@ impl RecordKind {
 
     pub fn len(self) -> crate::Result<usize> {
         match self {
-            Self::IMPORT_INFO_SINGLE => Ok(3),
-            Self::IMPORT_INFO_SINGLE_TYPE_SCRIPT => Ok(3),
-            Self::IMPORT_INFO_NAMESPACE => Ok(3),
-            Self::IMPORT_INFO_NAMESPACE_DEFER => Ok(3),
+            Self::IMPORT_INFO_SINGLE => Ok(4),
+            Self::IMPORT_INFO_SINGLE_TYPE_SCRIPT => Ok(4),
+            Self::IMPORT_INFO_NAMESPACE => Ok(4),
+            Self::IMPORT_INFO_NAMESPACE_DEFER => Ok(4),
             Self::EXPORT_INFO_INDIRECT => Ok(3),
             Self::EXPORT_INFO_LOCAL => Ok(3),
             Self::EXPORT_INFO_NAMESPACE => Ok(2),

--- a/src/bundler/analyze_transpiled_module.rs
+++ b/src/bundler/analyze_transpiled_module.rs
@@ -50,21 +50,21 @@ unsafe impl bytemuck::Zeroable for RecordKind {}
 unsafe impl bytemuck::Pod for RecordKind {}
 
 impl RecordKind {
-    /// module_name, import_name, local_name
+    /// module_name, import_name, local_name, fetch_parameters
     pub(crate) const IMPORT_INFO_SINGLE: Self = Self(0);
-    /// module_name, import_name, local_name
+    /// module_name, import_name, local_name, fetch_parameters
     pub(crate) const IMPORT_INFO_SINGLE_TYPE_SCRIPT: Self = Self(1);
-    /// module_name, import_name = '*', local_name
+    /// module_name, import_name = '*', local_name, fetch_parameters
     pub(crate) const IMPORT_INFO_NAMESPACE: Self = Self(2);
-    /// export_name, import_name, module_name
+    /// export_name, import_name, module_name, fetch_parameters
     pub(crate) const EXPORT_INFO_INDIRECT: Self = Self(3);
-    /// export_name, local_name, padding (for local => indirect conversion)
+    /// export_name, local_name, padding, fetch_parameters (for local => indirect conversion)
     pub(crate) const EXPORT_INFO_LOCAL: Self = Self(4);
-    /// export_name, module_name
+    /// export_name, module_name, fetch_parameters
     pub(crate) const EXPORT_INFO_NAMESPACE: Self = Self(5);
-    /// module_name
+    /// module_name, fetch_parameters
     pub(crate) const EXPORT_INFO_STAR: Self = Self(6);
-    /// module_name, import_name = '*', local_name (ModulePhase::Defer)
+    /// module_name, import_name = '*', local_name, fetch_parameters (ModulePhase::Defer)
     pub(crate) const IMPORT_INFO_NAMESPACE_DEFER: Self = Self(7);
 
     // PascalCase aliases — `bundler_jsc::analyze_jsc` pattern-matches on these

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -324,6 +324,7 @@ pub(crate) fn post_process_js_chunk(
                                         irp_id,
                                         default_id,
                                         local_name_id,
+                                        analyze_transpiled_module::ImportAttributes::None,
                                         false,
                                     );
                                 }
@@ -342,6 +343,7 @@ pub(crate) fn post_process_js_chunk(
                                         irp_id,
                                         alias_id,
                                         local_name_id,
+                                        analyze_transpiled_module::ImportAttributes::None,
                                         false,
                                     );
                                 }
@@ -355,7 +357,11 @@ pub(crate) fn post_process_js_chunk(
                                     let local_name = chunk.renamer.name_for_symbol(s.namespace_ref);
                                     mi.str(local_name)
                                 };
-                                mi.add_import_info_namespace(irp_id, local_name_id);
+                                mi.add_import_info_namespace(
+                                    irp_id,
+                                    local_name_id,
+                                    analyze_transpiled_module::ImportAttributes::None,
+                                );
                             }
                         }
                         _ => {}

--- a/src/bundler_jsc/analyze_jsc.rs
+++ b/src/bundler_jsc/analyze_jsc.rs
@@ -93,17 +93,6 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
             {
                 return core::ptr::null_mut();
             }
-            match k {
-                RecordKind::ImportInfoSingle
-                | RecordKind::ImportInfoSingleTypeScript
-                | RecordKind::ImportInfoNamespace
-                | RecordKind::ImportInfoNamespaceDefer
-                | RecordKind::ExportInfoIndirect
-                | RecordKind::ExportInfoLocal
-                | RecordKind::ExportInfoNamespace
-                | RecordKind::ExportInfoStar => {}
-                _ => return core::ptr::null_mut(),
-            }
             i += len;
         }
     }

--- a/src/bundler_jsc/analyze_jsc.rs
+++ b/src/bundler_jsc/analyze_jsc.rs
@@ -199,8 +199,8 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
                         analyze::FetchParameters(buffer[i + 3].0).to_script_fetch_parameters_type(),
                     ),
                 RecordKind::ExportInfoIndirect => {
-                    let ty = analyze::FetchParameters(buffer[i + 3].0)
-                        .to_script_fetch_parameters_type();
+                    let ty =
+                        analyze::FetchParameters(buffer[i + 3].0).to_script_fetch_parameters_type();
                     if buffer[i + 1] == StringID::STAR_NAMESPACE {
                         module_record.add_namespace_export(
                             identifiers,

--- a/src/bundler_jsc/analyze_jsc.rs
+++ b/src/bundler_jsc/analyze_jsc.rs
@@ -40,11 +40,8 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
     let identifier_count = strings_lens.len();
     let is_valid_string_id =
         |id: StringID| (id.0 as usize) < identifier_count || id.0 >= StringID::STAR_NAMESPACE.0;
-    // The 4th slot of each ImportInfo* record is a bitcast FetchParameters
-    // (None/Javascript/Webassembly/Json sentinels at u32::MAX-3..=u32::MAX, or
-    // a real StringID for HostDefined), so the buffer check accepts that wider
-    // sentinel range. The per-slot usage below never indexes those slots into
-    // the identifiers array.
+    // ImportInfo* slot [i+3] is a bitcast FetchParameters, so the buffer check
+    // accepts the wider sentinel range (>= Json = u32::MAX-3).
     let is_valid_buffer_slot =
         |id: StringID| (id.0 as usize) < identifier_count || id.0 >= RequestedModuleValue::Json.0;
     if !buffer.iter().copied().all(is_valid_buffer_slot)

--- a/src/bundler_jsc/analyze_jsc.rs
+++ b/src/bundler_jsc/analyze_jsc.rs
@@ -40,18 +40,15 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
     let identifier_count = strings_lens.len();
     let is_valid_string_id =
         |id: StringID| (id.0 as usize) < identifier_count || id.0 >= StringID::STAR_NAMESPACE.0;
-    // ImportInfo* slot [i+3] is a bitcast FetchParameters, so the buffer check
-    // accepts the wider sentinel range (>= Json = u32::MAX-3).
-    let is_valid_buffer_slot =
-        |id: StringID| (id.0 as usize) < identifier_count || id.0 >= RequestedModuleValue::Json.0;
-    if !buffer.iter().copied().all(is_valid_buffer_slot)
-        || !requested_modules_keys
-            .iter()
-            .copied()
-            .all(is_valid_string_id)
+    let is_valid_fetch_parameters =
+        |v: u32| (v as usize) < identifier_count || v >= RequestedModuleValue::Json.0;
+    if !requested_modules_keys
+        .iter()
+        .copied()
+        .all(is_valid_string_id)
         || !requested_modules_values
             .iter()
-            .all(|&v| (v.0 as usize) < identifier_count || v.0 >= RequestedModuleValue::Json.0)
+            .all(|&v| is_valid_fetch_parameters(v.0))
     {
         return core::ptr::null_mut();
     }
@@ -79,7 +76,21 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
     {
         let mut i: usize = 0;
         for &k in record_kinds.iter() {
-            if i + k.len().unwrap_or(0) > buffer.len() {
+            let Ok(len) = k.len() else {
+                return core::ptr::null_mut();
+            };
+            if i + len > buffer.len() {
+                return core::ptr::null_mut();
+            }
+            let fp_slots = k.trailing_fetch_parameters_slots();
+            if !buffer[i..i + len - fp_slots]
+                .iter()
+                .copied()
+                .all(is_valid_string_id)
+                || !buffer[i + len - fp_slots..i + len]
+                    .iter()
+                    .all(|s| is_valid_fetch_parameters(s.0))
+            {
                 return core::ptr::null_mut();
             }
             match k {
@@ -93,7 +104,7 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
                 | RecordKind::ExportInfoStar => {}
                 _ => return core::ptr::null_mut(),
             }
-            i += k.len().expect("unreachable"); // handled above
+            i += len;
         }
     }
 
@@ -188,24 +199,39 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
                         analyze::FetchParameters(buffer[i + 3].0).to_script_fetch_parameters_type(),
                     ),
                 RecordKind::ExportInfoIndirect => {
+                    let ty = analyze::FetchParameters(buffer[i + 3].0)
+                        .to_script_fetch_parameters_type();
                     if buffer[i + 1] == StringID::STAR_NAMESPACE {
-                        module_record.add_namespace_export(identifiers, buffer[i], buffer[i + 2])
+                        module_record.add_namespace_export(
+                            identifiers,
+                            buffer[i],
+                            buffer[i + 2],
+                            ty,
+                        )
                     } else {
                         module_record.add_indirect_export(
                             identifiers,
                             buffer[i],
                             buffer[i + 1],
                             buffer[i + 2],
+                            ty,
                         )
                     }
                 }
                 RecordKind::ExportInfoLocal => {
                     module_record.add_local_export(identifiers, buffer[i], buffer[i + 1])
                 }
-                RecordKind::ExportInfoNamespace => {
-                    module_record.add_namespace_export(identifiers, buffer[i], buffer[i + 1])
-                }
-                RecordKind::ExportInfoStar => module_record.add_star_export(identifiers, buffer[i]),
+                RecordKind::ExportInfoNamespace => module_record.add_namespace_export(
+                    identifiers,
+                    buffer[i],
+                    buffer[i + 1],
+                    analyze::FetchParameters(buffer[i + 2].0).to_script_fetch_parameters_type(),
+                ),
+                RecordKind::ExportInfoStar => module_record.add_star_export(
+                    identifiers,
+                    buffer[i],
+                    analyze::FetchParameters(buffer[i + 1].0).to_script_fetch_parameters_type(),
+                ),
                 _ => unreachable!(), // handled above
             }
             i += k.len().expect("unreachable"); // handled above
@@ -272,6 +298,7 @@ unsafe extern "C" {
         export_name: StringID,
         import_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     );
     fn JSC_JSModuleRecord__addLocalExport(
         module_record: *mut JSModuleRecord,
@@ -284,11 +311,13 @@ unsafe extern "C" {
         identifier_array: *mut IdentifierArray,
         export_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     );
     fn JSC_JSModuleRecord__addStarExport(
         module_record: *mut JSModuleRecord,
         identifier_array: *mut IdentifierArray,
         module_name: StringID,
+        module_request_type: u8,
     );
 
     fn JSC_JSModuleRecord__addRequestedModuleNullAttributesPtr(
@@ -391,6 +420,7 @@ trait JSModuleRecordExt {
         export_name: StringID,
         import_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     );
     fn add_local_export(
         self,
@@ -403,8 +433,14 @@ trait JSModuleRecordExt {
         ia: *mut IdentifierArray,
         export_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     );
-    fn add_star_export(self, ia: *mut IdentifierArray, module_name: StringID);
+    fn add_star_export(
+        self,
+        ia: *mut IdentifierArray,
+        module_name: StringID,
+        module_request_type: u8,
+    );
     fn add_requested_module_null_attributes_ptr(
         self,
         ia: *mut IdentifierArray,
@@ -479,10 +515,18 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         export_name: StringID,
         import_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     ) {
         // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
         unsafe {
-            JSC_JSModuleRecord__addIndirectExport(self, ia, export_name, import_name, module_name)
+            JSC_JSModuleRecord__addIndirectExport(
+                self,
+                ia,
+                export_name,
+                import_name,
+                module_name,
+                module_request_type,
+            )
         }
     }
     #[inline]
@@ -501,14 +545,28 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         ia: *mut IdentifierArray,
         export_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     ) {
         // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
-        unsafe { JSC_JSModuleRecord__addNamespaceExport(self, ia, export_name, module_name) }
+        unsafe {
+            JSC_JSModuleRecord__addNamespaceExport(
+                self,
+                ia,
+                export_name,
+                module_name,
+                module_request_type,
+            )
+        }
     }
     #[inline]
-    fn add_star_export(self, ia: *mut IdentifierArray, module_name: StringID) {
+    fn add_star_export(
+        self,
+        ia: *mut IdentifierArray,
+        module_name: StringID,
+        module_request_type: u8,
+    ) {
         // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
-        unsafe { JSC_JSModuleRecord__addStarExport(self, ia, module_name) }
+        unsafe { JSC_JSModuleRecord__addStarExport(self, ia, module_name, module_request_type) }
     }
     #[inline]
     fn add_requested_module_null_attributes_ptr(

--- a/src/bundler_jsc/analyze_jsc.rs
+++ b/src/bundler_jsc/analyze_jsc.rs
@@ -40,7 +40,14 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
     let identifier_count = strings_lens.len();
     let is_valid_string_id =
         |id: StringID| (id.0 as usize) < identifier_count || id.0 >= StringID::STAR_NAMESPACE.0;
-    if !buffer.iter().copied().all(is_valid_string_id)
+    // The 4th slot of each ImportInfo* record is a bitcast FetchParameters
+    // (None/Javascript/Webassembly/Json sentinels at u32::MAX-3..=u32::MAX, or
+    // a real StringID for HostDefined), so the buffer check accepts that wider
+    // sentinel range. The per-slot usage below never indexes those slots into
+    // the identifiers array.
+    let is_valid_buffer_slot =
+        |id: StringID| (id.0 as usize) < identifier_count || id.0 >= RequestedModuleValue::Json.0;
+    if !buffer.iter().copied().all(is_valid_buffer_slot)
         || !requested_modules_keys
             .iter()
             .copied()
@@ -158,6 +165,7 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
                     buffer[i + 1],
                     buffer[i + 2],
                     buffer[i],
+                    analyze::FetchParameters(buffer[i + 3].0).to_script_fetch_parameters_type(),
                 ),
                 RecordKind::ImportInfoSingleTypeScript => module_record
                     .add_import_entry_single_type_script(
@@ -165,12 +173,14 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
                         buffer[i + 1],
                         buffer[i + 2],
                         buffer[i],
+                        analyze::FetchParameters(buffer[i + 3].0).to_script_fetch_parameters_type(),
                     ),
                 RecordKind::ImportInfoNamespace => module_record.add_import_entry_namespace(
                     identifiers,
                     buffer[i + 1],
                     buffer[i + 2],
                     buffer[i],
+                    analyze::FetchParameters(buffer[i + 3].0).to_script_fetch_parameters_type(),
                 ),
                 RecordKind::ImportInfoNamespaceDefer => module_record
                     .add_import_entry_namespace_defer(
@@ -178,6 +188,7 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
                         buffer[i + 1],
                         buffer[i + 2],
                         buffer[i],
+                        analyze::FetchParameters(buffer[i + 3].0).to_script_fetch_parameters_type(),
                     ),
                 RecordKind::ExportInfoIndirect => {
                     if buffer[i + 1] == StringID::STAR_NAMESPACE {
@@ -321,6 +332,7 @@ unsafe extern "C" {
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     );
     fn JSC_JSModuleRecord__addImportEntrySingleTypeScript(
         module_record: *mut JSModuleRecord,
@@ -328,6 +340,7 @@ unsafe extern "C" {
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     );
     fn JSC_JSModuleRecord__addImportEntryNamespace(
         module_record: *mut JSModuleRecord,
@@ -335,6 +348,7 @@ unsafe extern "C" {
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     );
     fn JSC_JSModuleRecord__addImportEntryNamespaceDefer(
         module_record: *mut JSModuleRecord,
@@ -342,6 +356,7 @@ unsafe extern "C" {
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     );
 }
 impl JSModuleRecord {
@@ -430,6 +445,7 @@ trait JSModuleRecordExt {
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     );
     fn add_import_entry_single_type_script(
         self,
@@ -437,6 +453,7 @@ trait JSModuleRecordExt {
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     );
     fn add_import_entry_namespace(
         self,
@@ -444,6 +461,7 @@ trait JSModuleRecordExt {
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     );
     fn add_import_entry_namespace_defer(
         self,
@@ -451,6 +469,7 @@ trait JSModuleRecordExt {
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     );
 }
 impl JSModuleRecordExt for *mut JSModuleRecord {
@@ -571,10 +590,18 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     ) {
         // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
         unsafe {
-            JSC_JSModuleRecord__addImportEntrySingle(self, ia, import_name, local_name, module_name)
+            JSC_JSModuleRecord__addImportEntrySingle(
+                self,
+                ia,
+                import_name,
+                local_name,
+                module_name,
+                module_request_type,
+            )
         }
     }
     #[inline]
@@ -584,6 +611,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     ) {
         // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
         unsafe {
@@ -593,6 +621,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
                 import_name,
                 local_name,
                 module_name,
+                module_request_type,
             )
         }
     }
@@ -603,6 +632,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     ) {
         // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
         unsafe {
@@ -612,6 +642,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
                 import_name,
                 local_name,
                 module_name,
+                module_request_type,
             )
         }
     }
@@ -622,6 +653,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
+        module_request_type: u8,
     ) {
         // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
         unsafe {
@@ -631,6 +663,7 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
                 import_name,
                 local_name,
                 module_name,
+                module_request_type,
             )
         }
     }

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -75,24 +75,26 @@ pub mod analyze_transpiled_module {
     use bun_collections::HashMap;
     use bun_core::slice_as_bytes;
 
+    /// Every record kind carries one trailing bitcast-`FetchParameters` slot
+    /// after its `StringID` payload.
     #[repr(u8)]
     #[derive(Clone, Copy, PartialEq, Eq)]
     pub enum RecordKind {
-        /// module_name, import_name, local_name
+        /// module_name, import_name, local_name, fetch_parameters
         ImportInfoSingle,
-        /// module_name, import_name, local_name
+        /// module_name, import_name, local_name, fetch_parameters
         ImportInfoSingleTypeScript,
-        /// module_name, import_name = '*', local_name
+        /// module_name, import_name = '*', local_name, fetch_parameters
         ImportInfoNamespace,
-        /// export_name, import_name, module_name
+        /// export_name, import_name, module_name, fetch_parameters
         ExportInfoIndirect,
-        /// export_name, local_name, padding (for local => indirect conversion)
+        /// export_name, local_name, padding, fetch_parameters (for local => indirect conversion)
         ExportInfoLocal,
-        /// export_name, module_name
+        /// export_name, module_name, fetch_parameters
         ExportInfoNamespace,
-        /// module_name
+        /// module_name, fetch_parameters
         ExportInfoStar,
-        /// module_name, import_name = '*', local_name
+        /// module_name, import_name = '*', local_name, fetch_parameters
         ///
         /// `import defer * as ns from "mod"` — same payload as
         /// `ImportInfoNamespace` but the resulting `ImportEntry` carries
@@ -106,10 +108,10 @@ pub mod analyze_transpiled_module {
                 Self::ImportInfoSingleTypeScript => 4,
                 Self::ImportInfoNamespace => 4,
                 Self::ImportInfoNamespaceDefer => 4,
-                Self::ExportInfoIndirect => 3,
-                Self::ExportInfoLocal => 3,
-                Self::ExportInfoNamespace => 2,
-                Self::ExportInfoStar => 1,
+                Self::ExportInfoIndirect => 4,
+                Self::ExportInfoLocal => 4,
+                Self::ExportInfoNamespace => 3,
+                Self::ExportInfoStar => 2,
             }
         }
     }
@@ -426,13 +428,19 @@ pub mod analyze_transpiled_module {
             export_name: StringID,
             import_name: StringID,
             module_name: StringID,
+            fetch_parameters: FetchParameters,
         ) {
             if self.has_or_add_exported_name(export_name) {
                 return;
             } // a syntax error will be emitted later in this case
             self.add_record(
                 RecordKind::ExportInfoIndirect,
-                &[export_name, import_name, module_name],
+                &[
+                    export_name,
+                    import_name,
+                    module_name,
+                    StringID(fetch_parameters.0),
+                ],
             );
         }
         pub(crate) fn add_export_info_local(
@@ -445,21 +453,37 @@ pub mod analyze_transpiled_module {
             } // a syntax error will be emitted later in this case
             self.add_record(
                 RecordKind::ExportInfoLocal,
-                &[export_name, local_name, StringID(u32::MAX)],
+                &[
+                    export_name,
+                    local_name,
+                    StringID(u32::MAX),
+                    StringID(FetchParameters::None.0),
+                ],
             );
         }
         pub(crate) fn add_export_info_namespace(
             &mut self,
             export_name: StringID,
             module_name: StringID,
+            fetch_parameters: FetchParameters,
         ) {
             if self.has_or_add_exported_name(export_name) {
                 return;
             } // a syntax error will be emitted later in this case
-            self.add_record(RecordKind::ExportInfoNamespace, &[export_name, module_name]);
+            self.add_record(
+                RecordKind::ExportInfoNamespace,
+                &[export_name, module_name, StringID(fetch_parameters.0)],
+            );
         }
-        pub(crate) fn add_export_info_star(&mut self, module_name: StringID) {
-            self.add_record(RecordKind::ExportInfoStar, &[module_name]);
+        pub(crate) fn add_export_info_star(
+            &mut self,
+            module_name: StringID,
+            fetch_parameters: FetchParameters,
+        ) {
+            self.add_record(
+                RecordKind::ExportInfoStar,
+                &[module_name, StringID(fetch_parameters.0)],
+            );
         }
 
         fn has_or_add_exported_name(&mut self, name: StringID) -> bool {
@@ -532,6 +556,7 @@ pub mod analyze_transpiled_module {
             struct LocalImport {
                 module_name: StringID,
                 import_name: StringID,
+                fetch_parameters: StringID,
                 record_kinds_idx: usize,
                 is_namespace: bool,
             }
@@ -548,6 +573,7 @@ pub mod analyze_transpiled_module {
                             LocalImport {
                                 module_name: self.buffer[i],
                                 import_name: self.buffer[i + 1],
+                                fetch_parameters: self.buffer[i + 3],
                                 record_kinds_idx: idx,
                                 is_namespace: false,
                             },
@@ -558,6 +584,7 @@ pub mod analyze_transpiled_module {
                             LocalImport {
                                 module_name: self.buffer[i],
                                 import_name: StringID::STAR_NAMESPACE,
+                                fetch_parameters: self.buffer[i + 3],
                                 record_kinds_idx: idx,
                                 is_namespace: true,
                             },
@@ -583,6 +610,7 @@ pub mod analyze_transpiled_module {
                             *k = RecordKind::ExportInfoIndirect;
                             self.buffer[i + 1] = ip.import_name;
                             self.buffer[i + 2] = ip.module_name;
+                            self.buffer[i + 3] = ip.fetch_parameters;
                             // In TypeScript, the re-exported import may target a type-only
                             // export that was elided. Convert the import to SingleTypeScript
                             // so JSC tolerates it being NotFound during linking.
@@ -5157,9 +5185,16 @@ pub(crate) mod __gated_printer {
                             );
                             if let Some(alias) = &s.alias {
                                 let alias_id = mi.str(alias.original_name.slice());
-                                mi.add_export_info_namespace(alias_id, irp_id);
+                                mi.add_export_info_namespace(
+                                    alias_id,
+                                    irp_id,
+                                    analyze_transpiled_module::FetchParameters::None,
+                                );
                             } else {
-                                mi.add_export_info_star(irp_id);
+                                mi.add_export_info_star(
+                                    irp_id,
+                                    analyze_transpiled_module::FetchParameters::None,
+                                );
                             }
                         }
                     }
@@ -5337,7 +5372,12 @@ pub(crate) mod __gated_printer {
                             let mi = self.module_info().expect("infallible: module_info enabled");
                             let alias_id = mi.str(item.alias.slice());
                             let name_id = mi.str(name);
-                            mi.add_export_info_indirect(alias_id, name_id, irp_id);
+                            mi.add_export_info_indirect(
+                                alias_id,
+                                name_id,
+                                irp_id,
+                                analyze_transpiled_module::FetchParameters::None,
+                            );
                         }
                     }
                 }

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -102,10 +102,10 @@ pub mod analyze_transpiled_module {
     impl RecordKind {
         pub(crate) fn len(self) -> usize {
             match self {
-                Self::ImportInfoSingle => 3,
-                Self::ImportInfoSingleTypeScript => 3,
-                Self::ImportInfoNamespace => 3,
-                Self::ImportInfoNamespaceDefer => 3,
+                Self::ImportInfoSingle => 4,
+                Self::ImportInfoSingleTypeScript => 4,
+                Self::ImportInfoNamespace => 4,
+                Self::ImportInfoNamespaceDefer => 4,
                 Self::ExportInfoIndirect => 3,
                 Self::ExportInfoLocal => 3,
                 Self::ExportInfoNamespace => 2,
@@ -164,6 +164,18 @@ pub mod analyze_transpiled_module {
         #[inline]
         pub(crate) fn host_defined(value: StringID) -> Self {
             Self(value.0)
+        }
+        /// Map to JSC's `ScriptFetchParameters::Type` enum (None=0, JavaScript=1,
+        /// WebAssembly=2, JSON=3, HostDefined=4). `None` becomes `JavaScript`
+        /// to match `NodesAnalyzeModule.cpp`'s no-attributes default.
+        #[inline]
+        pub fn to_script_fetch_parameters_type(self) -> u8 {
+            match self {
+                Self::None | Self::Javascript => 1,
+                Self::Webassembly => 2,
+                Self::Json => 3,
+                _ => 4,
+            }
         }
     }
 
@@ -243,7 +255,12 @@ pub mod analyze_transpiled_module {
         keys: Vec<StringID>,
         values: Vec<FetchParameters>,
         phases: Vec<ModulePhase>,
-        index: HashMap<(StringID, ModulePhase), usize>,
+        /// Dedup key: `(specifier, ScriptFetchParameters::Type, phase)` —
+        /// matches JSC's `ModuleAnalyzer::appendRequestedModule`, which keys
+        /// on `ModuleMapKey { specifier, attributes->type() }` per phase
+        /// (WebKit 90b2ecf79ae3). Two HostDefined attributes with different
+        /// strings collapse to one entry, same as JSC.
+        index: HashMap<(StringID, u8, ModulePhase), usize>,
     }
     impl RequestedModules {
         fn keys(&self) -> &[StringID] {
@@ -255,17 +272,18 @@ pub mod analyze_transpiled_module {
         fn phases(&self) -> &[ModulePhase] {
             &self.phases
         }
-        /// Returns `true` if `(key, phase)` was already present.
+        /// Returns `true` if `(key, type-of-value, phase)` was already present.
         fn insert_if_absent(
             &mut self,
             key: StringID,
             value: FetchParameters,
             phase: ModulePhase,
         ) -> bool {
-            if self.index.contains_key(&(key, phase)) {
+            let type_key = value.to_script_fetch_parameters_type();
+            if self.index.contains_key(&(key, type_key, phase)) {
                 return true;
             }
-            self.index.insert((key, phase), self.keys.len());
+            self.index.insert((key, type_key, phase), self.keys.len());
             self.keys.push(key);
             self.values.push(value);
             self.phases.push(phase);
@@ -283,8 +301,15 @@ pub mod analyze_transpiled_module {
             }
             if touched {
                 self.index.clear();
-                for (i, (&k, &p)) in self.keys.iter().zip(self.phases.iter()).enumerate() {
-                    self.index.insert((k, p), i);
+                for (i, ((&k, &v), &p)) in self
+                    .keys
+                    .iter()
+                    .zip(self.values.iter())
+                    .zip(self.phases.iter())
+                    .enumerate()
+                {
+                    self.index
+                        .insert((k, v.to_script_fetch_parameters_type(), p), i);
                 }
             }
         }
@@ -351,6 +376,7 @@ pub mod analyze_transpiled_module {
             module_name: StringID,
             import_name: StringID,
             local_name: StringID,
+            fetch_parameters: FetchParameters,
             only_used_as_type: bool,
         ) {
             self.add_record(
@@ -359,23 +385,44 @@ pub mod analyze_transpiled_module {
                 } else {
                     RecordKind::ImportInfoSingle
                 },
-                &[module_name, import_name, local_name],
+                &[
+                    module_name,
+                    import_name,
+                    local_name,
+                    StringID(fetch_parameters.0),
+                ],
             );
         }
-        pub fn add_import_info_namespace(&mut self, module_name: StringID, local_name: StringID) {
+        pub fn add_import_info_namespace(
+            &mut self,
+            module_name: StringID,
+            local_name: StringID,
+            fetch_parameters: FetchParameters,
+        ) {
             self.add_record(
                 RecordKind::ImportInfoNamespace,
-                &[module_name, StringID::STAR_NAMESPACE, local_name],
+                &[
+                    module_name,
+                    StringID::STAR_NAMESPACE,
+                    local_name,
+                    StringID(fetch_parameters.0),
+                ],
             );
         }
         pub(crate) fn add_import_info_namespace_defer(
             &mut self,
             module_name: StringID,
             local_name: StringID,
+            fetch_parameters: FetchParameters,
         ) {
             self.add_record(
                 RecordKind::ImportInfoNamespaceDefer,
-                &[module_name, StringID::STAR_NAMESPACE, local_name],
+                &[
+                    module_name,
+                    StringID::STAR_NAMESPACE,
+                    local_name,
+                    StringID(fetch_parameters.0),
+                ],
             );
         }
         pub(crate) fn add_export_info_indirect(
@@ -449,7 +496,8 @@ pub mod analyze_transpiled_module {
             import_record_path: StringID,
             fetch_parameters: FetchParameters,
         ) {
-            // jsc only records the attributes of the first import with the given import_record_path. so only put if not exists.
+            // JSC dedupes by (specifier, ScriptFetchParameters::Type) per phase;
+            // insert_if_absent mirrors that.
             self.requested_modules.insert_if_absent(
                 import_record_path,
                 fetch_parameters,
@@ -5790,10 +5838,10 @@ pub(crate) mod __gated_printer {
                         // so we re-borrow it between `name_for_symbol` calls instead of holding
                         // a single long-lived `mi` across the whole block. `irp_id` is Copy.
                         let import_record_path = &record.path.text;
-                        let irp_id = {
+                        use analyze_transpiled_module::FetchParameters as FP;
+                        let (irp_id, fetch_parameters) = {
                             let mi = self.module_info().expect("infallible: module_info enabled");
                             let irp_id = mi.str(import_record_path);
-                            use analyze_transpiled_module::FetchParameters as FP;
                             let fetch_parameters: FP = if IS_BUN_PLATFORM {
                                 if let Some(loader) = record.loader {
                                     use bun_ast::Loader;
@@ -5833,7 +5881,7 @@ pub(crate) mod __gated_printer {
                                 analyze_transpiled_module::ModulePhase::Evaluation
                             };
                             mi.request_module_with_phase(irp_id, fetch_parameters, phase);
-                            irp_id
+                            (irp_id, fetch_parameters)
                         };
 
                         if let Some(name) = &s.default_name {
@@ -5841,7 +5889,13 @@ pub(crate) mod __gated_printer {
                             let mi = self.module_info().expect("infallible: module_info enabled");
                             let local_name_id = mi.str(local_name);
                             let default_id = mi.str(b"default");
-                            mi.add_import_info_single(irp_id, default_id, local_name_id, false);
+                            mi.add_import_info_single(
+                                irp_id,
+                                default_id,
+                                local_name_id,
+                                fetch_parameters,
+                                false,
+                            );
                         }
 
                         for item in slice_of(s.items).iter() {
@@ -5849,7 +5903,13 @@ pub(crate) mod __gated_printer {
                             let mi = self.module_info().expect("infallible: module_info enabled");
                             let local_name_id = mi.str(local_name);
                             let alias_id = mi.str(item.alias.slice());
-                            mi.add_import_info_single(irp_id, alias_id, local_name_id, false);
+                            mi.add_import_info_single(
+                                irp_id,
+                                alias_id,
+                                local_name_id,
+                                fetch_parameters,
+                                false,
+                            );
                         }
 
                         if record
@@ -5860,9 +5920,17 @@ pub(crate) mod __gated_printer {
                             let mi = self.module_info().expect("infallible: module_info enabled");
                             let local_name_id = mi.str(local_name);
                             if phase_defer {
-                                mi.add_import_info_namespace_defer(irp_id, local_name_id);
+                                mi.add_import_info_namespace_defer(
+                                    irp_id,
+                                    local_name_id,
+                                    fetch_parameters,
+                                );
                             } else {
-                                mi.add_import_info_namespace(irp_id, local_name_id);
+                                mi.add_import_info_namespace(
+                                    irp_id,
+                                    local_name_id,
+                                    fetch_parameters,
+                                );
                             }
                         }
                     }

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -165,9 +165,8 @@ pub mod analyze_transpiled_module {
         pub(crate) fn host_defined(value: StringID) -> Self {
             Self(value.0)
         }
-        /// Map to JSC's `ScriptFetchParameters::Type` enum (None=0, JavaScript=1,
-        /// WebAssembly=2, JSON=3, HostDefined=4). `None` becomes `JavaScript`
-        /// to match `NodesAnalyzeModule.cpp`'s no-attributes default.
+        /// JSC `ScriptFetchParameters::Type` value. `None` maps to `JavaScript`
+        /// (NodesAnalyzeModule's no-attribute default).
         #[inline]
         pub fn to_script_fetch_parameters_type(self) -> u8 {
             match self {
@@ -255,11 +254,8 @@ pub mod analyze_transpiled_module {
         keys: Vec<StringID>,
         values: Vec<FetchParameters>,
         phases: Vec<ModulePhase>,
-        /// Dedup key: `(specifier, ScriptFetchParameters::Type, phase)` —
-        /// matches JSC's `ModuleAnalyzer::appendRequestedModule`, which keys
-        /// on `ModuleMapKey { specifier, attributes->type() }` per phase
-        /// (WebKit 90b2ecf79ae3). Two HostDefined attributes with different
-        /// strings collapse to one entry, same as JSC.
+        /// Keyed on `(specifier, ScriptFetchParameters::Type, phase)` per
+        /// JSC's `ModuleAnalyzer::appendRequestedModule` (WebKit 90b2ecf79ae3).
         index: HashMap<(StringID, u8, ModulePhase), usize>,
     }
     impl RequestedModules {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -247,17 +247,14 @@ pub mod analyze_transpiled_module {
     }
 
     /// Insertion-ordered list of requested modules. Dedup key is
-    /// `(specifier, phase)` to match JSC's `ModuleAnalyzer::appendRequestedModule`,
-    /// which appends one entry per unique pair — so the same specifier can be
-    /// requested at both Evaluation and Defer phase.
+    /// `(specifier, ScriptFetchParameters::Type, phase)` per JSC's
+    /// `ModuleAnalyzer::appendRequestedModule` (WebKit 90b2ecf79ae3).
     // PERF: three allocations + a side HashMap; revisit with a real IndexMap.
     #[derive(Default)]
     struct RequestedModules {
         keys: Vec<StringID>,
         values: Vec<FetchParameters>,
         phases: Vec<ModulePhase>,
-        /// Keyed on `(specifier, ScriptFetchParameters::Type, phase)` per
-        /// JSC's `ModuleAnalyzer::appendRequestedModule` (WebKit 90b2ecf79ae3).
         index: HashMap<(StringID, u8, ModulePhase), usize>,
     }
     impl RequestedModules {

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -48,7 +48,10 @@ bun_core::declare_scope!(cache, visible);
 /// bindings from the compiled bytecode after the module-loader rewrite, so the
 /// record no longer carries them; blobs written in the old numbering must not
 /// be read back.
-const EXPECTED_VERSION: u32 = 24;
+/// Version 25: ImportInfo* records carry a 4th FetchParameters slot so the
+/// ImportEntry's moduleRequestType matches JSC's after WebKit 90b2ecf79ae3
+/// keyed m_loadedModules on (specifier, type).
+const EXPECTED_VERSION: u32 = 25;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -48,9 +48,9 @@ bun_core::declare_scope!(cache, visible);
 /// bindings from the compiled bytecode after the module-loader rewrite, so the
 /// record no longer carries them; blobs written in the old numbering must not
 /// be read back.
-/// Version 25: ImportInfo* records carry a 4th FetchParameters slot so the
-/// ImportEntry's moduleRequestType matches JSC's after WebKit 90b2ecf79ae3
-/// keyed m_loadedModules on (specifier, type).
+/// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
+/// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
+/// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
 const EXPECTED_VERSION: u32 = 25;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
+++ b/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
@@ -110,6 +110,11 @@ extern "C" void JSC_JSModuleRecord__addRequestedModuleHostDefined(JSModuleRecord
     moduleRecord->appendRequestedModule(getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName), std::move(attributes), toModulePhase(phaseDefer));
 }
 
+static_assert(static_cast<uint8_t>(JSC::ScriptFetchParameters::Type::JavaScript) == 1, "ScriptFetchParameters::Type tag drift vs to_script_fetch_parameters_type()");
+static_assert(static_cast<uint8_t>(JSC::ScriptFetchParameters::Type::WebAssembly) == 2, "ScriptFetchParameters::Type tag drift vs to_script_fetch_parameters_type()");
+static_assert(static_cast<uint8_t>(JSC::ScriptFetchParameters::Type::JSON) == 3, "ScriptFetchParameters::Type tag drift vs to_script_fetch_parameters_type()");
+static_assert(static_cast<uint8_t>(JSC::ScriptFetchParameters::Type::HostDefined) == 4, "ScriptFetchParameters::Type tag drift vs to_script_fetch_parameters_type()");
+
 extern "C" void JSC_JSModuleRecord__addImportEntrySingle(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t importName, uint32_t localName, uint32_t moduleName, uint8_t moduleRequestType)
 {
     moduleRecord->addImportEntry(JSModuleRecord::ImportEntry {

--- a/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
+++ b/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
@@ -63,21 +63,21 @@ extern "C" JSModuleRecord* JSC_JSModuleRecord__create(JSGlobalObject* globalObje
     return result;
 }
 
-extern "C" void JSC_JSModuleRecord__addIndirectExport(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t exportName, uint32_t importName, uint32_t moduleName)
+extern "C" void JSC_JSModuleRecord__addIndirectExport(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t exportName, uint32_t importName, uint32_t moduleName, uint8_t moduleRequestType)
 {
-    moduleRecord->addExportEntry(JSModuleRecord::ExportEntry::createIndirect(getFromIdentifierArray(moduleRecord->vm(), identifierArray, exportName), getFromIdentifierArray(moduleRecord->vm(), identifierArray, importName), getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName), JSC::ScriptFetchParameters::Type::JavaScript));
+    moduleRecord->addExportEntry(JSModuleRecord::ExportEntry::createIndirect(getFromIdentifierArray(moduleRecord->vm(), identifierArray, exportName), getFromIdentifierArray(moduleRecord->vm(), identifierArray, importName), getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName), static_cast<JSC::ScriptFetchParameters::Type>(moduleRequestType)));
 }
 extern "C" void JSC_JSModuleRecord__addLocalExport(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t exportName, uint32_t localName)
 {
     moduleRecord->addExportEntry(JSModuleRecord::ExportEntry::createLocal(getFromIdentifierArray(moduleRecord->vm(), identifierArray, exportName), getFromIdentifierArray(moduleRecord->vm(), identifierArray, localName)));
 }
-extern "C" void JSC_JSModuleRecord__addNamespaceExport(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t exportName, uint32_t moduleName)
+extern "C" void JSC_JSModuleRecord__addNamespaceExport(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t exportName, uint32_t moduleName, uint8_t moduleRequestType)
 {
-    moduleRecord->addExportEntry(JSModuleRecord::ExportEntry::createNamespace(getFromIdentifierArray(moduleRecord->vm(), identifierArray, exportName), getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName), JSC::ScriptFetchParameters::Type::JavaScript));
+    moduleRecord->addExportEntry(JSModuleRecord::ExportEntry::createNamespace(getFromIdentifierArray(moduleRecord->vm(), identifierArray, exportName), getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName), static_cast<JSC::ScriptFetchParameters::Type>(moduleRequestType)));
 }
-extern "C" void JSC_JSModuleRecord__addStarExport(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t moduleName)
+extern "C" void JSC_JSModuleRecord__addStarExport(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t moduleName, uint8_t moduleRequestType)
 {
-    moduleRecord->addStarExportEntry(getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName), JSC::ScriptFetchParameters::Type::JavaScript);
+    moduleRecord->addStarExportEntry(getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName), static_cast<JSC::ScriptFetchParameters::Type>(moduleRequestType));
 }
 static inline AbstractModuleRecord::ModulePhase toModulePhase(bool phaseDefer)
 {

--- a/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
+++ b/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
@@ -268,7 +268,7 @@ String dumpRecordInfo(JSModuleRecord* moduleRecord)
         for (const auto& pair : moduleRecord->importEntries()) {
             WTF::StringPrintStream line;
             auto& importEntry = pair.value;
-            line.print("      import(", importEntry.importName, "), local(", importEntry.localName, "), module(", importEntry.moduleRequest, ")");
+            line.print("      import(", importEntry.importName, "), local(", importEntry.localName, "), module(", importEntry.moduleRequest, "), type(", (uint8_t)importEntry.moduleRequestType, ")");
             if (importEntry.phase == AbstractModuleRecord::ModulePhase::Defer)
                 line.print(", phase(defer)");
             line.print("\n");
@@ -292,11 +292,11 @@ String dumpRecordInfo(JSModuleRecord* moduleRecord)
             break;
 
         case AbstractModuleRecord::ExportEntry::Type::Indirect:
-            line.print("      [Indirect] ", "export(", exportEntry.exportName, "), import(", exportEntry.importName, "), module(", exportEntry.moduleName, ")\n");
+            line.print("      [Indirect] ", "export(", exportEntry.exportName, "), import(", exportEntry.importName, "), module(", exportEntry.moduleName, "), type(", (uint8_t)exportEntry.moduleRequestType, ")\n");
             break;
 
         case AbstractModuleRecord::ExportEntry::Type::Namespace:
-            line.print("      [Namespace] ", "export(", exportEntry.exportName, "), module(", exportEntry.moduleName, ")\n");
+            line.print("      [Namespace] ", "export(", exportEntry.exportName, "), module(", exportEntry.moduleName, "), type(", (uint8_t)exportEntry.moduleRequestType, ")\n");
             break;
         }
         sortedEntries.append(line.toString());
@@ -311,7 +311,7 @@ String dumpRecordInfo(JSModuleRecord* moduleRecord)
         Vector<String> sortedStarExports;
         for (const auto& [moduleName, moduleRequestType] : moduleRecord->starExportEntries()) {
             WTF::StringPrintStream line;
-            line.print("      [Star] module(", moduleName.get(), ")\n");
+            line.print("      [Star] module(", moduleName.get(), "), type(", (uint8_t)moduleRequestType, ")\n");
             sortedStarExports.append(line.toString());
         }
         std::sort(sortedStarExports.begin(), sortedStarExports.end(), [](const String& a, const String& b) {

--- a/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
+++ b/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
@@ -110,38 +110,42 @@ extern "C" void JSC_JSModuleRecord__addRequestedModuleHostDefined(JSModuleRecord
     moduleRecord->appendRequestedModule(getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName), std::move(attributes), toModulePhase(phaseDefer));
 }
 
-extern "C" void JSC_JSModuleRecord__addImportEntrySingle(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t importName, uint32_t localName, uint32_t moduleName)
+extern "C" void JSC_JSModuleRecord__addImportEntrySingle(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t importName, uint32_t localName, uint32_t moduleName, uint8_t moduleRequestType)
 {
     moduleRecord->addImportEntry(JSModuleRecord::ImportEntry {
         .type = JSModuleRecord::ImportEntryType::Single,
+        .moduleRequestType = static_cast<JSC::ScriptFetchParameters::Type>(moduleRequestType),
         .moduleRequest = getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName),
         .importName = getFromIdentifierArray(moduleRecord->vm(), identifierArray, importName),
         .localName = getFromIdentifierArray(moduleRecord->vm(), identifierArray, localName),
     });
 }
-extern "C" void JSC_JSModuleRecord__addImportEntrySingleTypeScript(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t importName, uint32_t localName, uint32_t moduleName)
+extern "C" void JSC_JSModuleRecord__addImportEntrySingleTypeScript(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t importName, uint32_t localName, uint32_t moduleName, uint8_t moduleRequestType)
 {
     moduleRecord->addImportEntry(JSModuleRecord::ImportEntry {
         .type = JSModuleRecord::ImportEntryType::SingleTypeScript,
+        .moduleRequestType = static_cast<JSC::ScriptFetchParameters::Type>(moduleRequestType),
         .moduleRequest = getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName),
         .importName = getFromIdentifierArray(moduleRecord->vm(), identifierArray, importName),
         .localName = getFromIdentifierArray(moduleRecord->vm(), identifierArray, localName),
     });
 }
-extern "C" void JSC_JSModuleRecord__addImportEntryNamespace(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t importName, uint32_t localName, uint32_t moduleName)
+extern "C" void JSC_JSModuleRecord__addImportEntryNamespace(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t importName, uint32_t localName, uint32_t moduleName, uint8_t moduleRequestType)
 {
     moduleRecord->addImportEntry(JSModuleRecord::ImportEntry {
         .type = JSModuleRecord::ImportEntryType::Namespace,
+        .moduleRequestType = static_cast<JSC::ScriptFetchParameters::Type>(moduleRequestType),
         .moduleRequest = getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName),
         .importName = getFromIdentifierArray(moduleRecord->vm(), identifierArray, importName),
         .localName = getFromIdentifierArray(moduleRecord->vm(), identifierArray, localName),
     });
 }
-extern "C" void JSC_JSModuleRecord__addImportEntryNamespaceDefer(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t importName, uint32_t localName, uint32_t moduleName)
+extern "C" void JSC_JSModuleRecord__addImportEntryNamespaceDefer(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t importName, uint32_t localName, uint32_t moduleName, uint8_t moduleRequestType)
 {
     moduleRecord->addImportEntry(JSModuleRecord::ImportEntry {
         .type = JSModuleRecord::ImportEntryType::Namespace,
         .phase = AbstractModuleRecord::ModulePhase::Defer,
+        .moduleRequestType = static_cast<JSC::ScriptFetchParameters::Type>(moduleRequestType),
         .moduleRequest = getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName),
         .importName = getFromIdentifierArray(moduleRecord->vm(), identifierArray, importName),
         .localName = getFromIdentifierArray(moduleRecord->vm(), identifierArray, localName),

--- a/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
+++ b/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
@@ -65,7 +65,7 @@ extern "C" JSModuleRecord* JSC_JSModuleRecord__create(JSGlobalObject* globalObje
 
 extern "C" void JSC_JSModuleRecord__addIndirectExport(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t exportName, uint32_t importName, uint32_t moduleName)
 {
-    moduleRecord->addExportEntry(JSModuleRecord::ExportEntry::createIndirect(getFromIdentifierArray(moduleRecord->vm(), identifierArray, exportName), getFromIdentifierArray(moduleRecord->vm(), identifierArray, importName), getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName)));
+    moduleRecord->addExportEntry(JSModuleRecord::ExportEntry::createIndirect(getFromIdentifierArray(moduleRecord->vm(), identifierArray, exportName), getFromIdentifierArray(moduleRecord->vm(), identifierArray, importName), getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName), JSC::ScriptFetchParameters::Type::JavaScript));
 }
 extern "C" void JSC_JSModuleRecord__addLocalExport(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t exportName, uint32_t localName)
 {
@@ -73,11 +73,11 @@ extern "C" void JSC_JSModuleRecord__addLocalExport(JSModuleRecord* moduleRecord,
 }
 extern "C" void JSC_JSModuleRecord__addNamespaceExport(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t exportName, uint32_t moduleName)
 {
-    moduleRecord->addExportEntry(JSModuleRecord::ExportEntry::createNamespace(getFromIdentifierArray(moduleRecord->vm(), identifierArray, exportName), getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName)));
+    moduleRecord->addExportEntry(JSModuleRecord::ExportEntry::createNamespace(getFromIdentifierArray(moduleRecord->vm(), identifierArray, exportName), getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName), JSC::ScriptFetchParameters::Type::JavaScript));
 }
 extern "C" void JSC_JSModuleRecord__addStarExport(JSModuleRecord* moduleRecord, Identifier* identifierArray, uint32_t moduleName)
 {
-    moduleRecord->addStarExportEntry(getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName));
+    moduleRecord->addStarExportEntry(getFromIdentifierArray(moduleRecord->vm(), identifierArray, moduleName), JSC::ScriptFetchParameters::Type::JavaScript);
 }
 static inline AbstractModuleRecord::ModulePhase toModulePhase(bool phaseDefer)
 {
@@ -309,7 +309,7 @@ String dumpRecordInfo(JSModuleRecord* moduleRecord)
 
     {
         Vector<String> sortedStarExports;
-        for (const auto& moduleName : moduleRecord->starExportEntries()) {
+        for (const auto& [moduleName, moduleRequestType] : moduleRecord->starExportEntries()) {
             WTF::StringPrintStream line;
             line.print("      [Star] module(", moduleName.get(), ")\n");
             sortedStarExports.append(line.toString());

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -327,6 +327,10 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
             // the remaining integration work lands. BUN_JSC_useTemporal=1
             // re-enables it for opt-in testing.
             JSC::Options::useTemporal() = false;
+            // Upstream enabled Wasm Memory64 by default (0d0080ea539d); keep
+            // it off in Bun while upstream stabilises it.
+            // BUN_JSC_useWasmMemory64=1 re-enables it for opt-in testing.
+            JSC::Options::useWasmMemory64() = false;
             JSC::dangerouslyOverrideJSCBytecodeCacheVersion(getWebKitBytecodeCacheVersion());
 
 #ifdef BUN_DEBUG

--- a/test/js/bun/jsc/webkit-upgrade-3722912f.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-3722912f.test.ts
@@ -32,11 +32,11 @@ describe.concurrent("WebKit 3722912ff800 upgrade", () => {
     expect(typeof desc?.get).toBe("function");
   });
 
-  test("indirect, namespace and star re-exports link (BunAnalyzeTranspiledModule + 90b2ecf79ae3)", async () => {
+  test("indirect, namespace and star re-exports link on the JSC ModuleAnalyzer path (90b2ecf79ae3)", async () => {
     // Upstream now threads ScriptFetchParameters::Type through createIndirect /
-    // createNamespace / addStarExportEntry and starExportEntries(). Bun's
-    // analyze-module bindings supply Type::JavaScript for each; this verifies
-    // the three shapes still link and resolve.
+    // createNamespace / addStarExportEntry and starExportEntries(). This runs
+    // under plain `bun run` so JSC's own ModuleAnalyzer builds the record; the
+    // BunTranspiledModule path is covered by the --isolate test below.
     using dir = tempDir("wk-reexport", {
       "leaf.mjs": `export const a = 1; export const b = 2; export const c = 3;`,
       "mid.mjs": `

--- a/test/js/bun/jsc/webkit-upgrade-3722912f.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-3722912f.test.ts
@@ -71,15 +71,23 @@ describe.concurrent("WebKit 3722912ff800 upgrade", () => {
     // in release.
     using dir = tempDir("wk-typed-import", {
       "d.json": `{"ok":true}`,
+      "mid.ts": `
+        import j from "./d.json" with { type: "json" };
+        import * as ns from "./d.json" with { type: "json" };
+        export { j, ns };
+      `,
       "typed.test.ts": `
         import j from "./d.json" with { type: "json" };
         import t from "./d.json" with { type: "text" };
         import * as ns from "./d.json" with { type: "json" };
+        import { j as rj, ns as rns } from "./mid.ts";
         import { test, expect } from "bun:test";
         test("typed", () => {
           expect(j).toEqual({ ok: true });
           expect(JSON.parse(t as string)).toEqual({ ok: true });
           expect(ns.default).toEqual({ ok: true });
+          expect(rj).toEqual({ ok: true });
+          expect(rns.default).toEqual({ ok: true });
         });
       `,
     });
@@ -90,10 +98,9 @@ describe.concurrent("WebKit 3722912ff800 upgrade", () => {
       stderr: "pipe",
       stdout: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("1 pass");
     expect(stderr).not.toContain("Imports different");
-    expect(stdout).toBeDefined();
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/jsc/webkit-upgrade-3722912f.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-3722912f.test.ts
@@ -60,4 +60,40 @@ describe.concurrent("WebKit 3722912ff800 upgrade", () => {
     expect(JSON.parse(stdout)).toEqual({ a: 1, b: 2, c: 3, ns: { a: 1, b: 2, c: 3 } });
     expect(exitCode).toBe(0);
   });
+
+  test("typed import attributes resolve through BunTranspiledModule (--isolate) (90b2ecf79ae3)", async () => {
+    // Upstream 90b2ecf79ae3 keys m_loadedModules on (specifier, type) and
+    // ModuleAnalyzer::appendRequestedModule dedupes on that pair. Bun only
+    // takes the BunTranspiledModule path under `bun test --isolate`, so
+    // exercise it explicitly: without the ImportEntry/RequestedModules type
+    // threading this rejects with "Imports different between
+    // parseFromSourceCode and fallbackParse" in debug and null-derefs
+    // in release.
+    using dir = tempDir("wk-typed-import", {
+      "d.json": `{"ok":true}`,
+      "typed.test.ts": `
+        import j from "./d.json" with { type: "json" };
+        import t from "./d.json" with { type: "text" };
+        import * as ns from "./d.json" with { type: "json" };
+        import { test, expect } from "bun:test";
+        test("typed", () => {
+          expect(j).toEqual({ ok: true });
+          expect(JSON.parse(t as string)).toEqual({ ok: true });
+          expect(ns.default).toEqual({ ok: true });
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--isolate", "typed.test.ts"],
+      env: { ...bunEnv, BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0" },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("1 pass");
+    expect(stderr).not.toContain("Imports different");
+    expect(stdout).toBeDefined();
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/jsc/webkit-upgrade-3722912f.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-3722912f.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Coverage for the WebKit 3722912ff800 sync (oven-sh/WebKit#383). Each case
+// pins an observable behavior difference so the gate can distinguish the old
+// JSC from the new one, and the re-export cases exercise the
+// ScriptFetchParameters::Type threading added to BunAnalyzeTranspiledModule.
+
+describe.concurrent("WebKit 3722912ff800 upgrade", () => {
+  test("Iterator.prototype.includes is enabled by default (319f94b3db4a)", () => {
+    expect(typeof Iterator.prototype.includes).toBe("function");
+    function* g() {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
+    expect(g().includes(2)).toBe(true);
+    expect(g().includes(5)).toBe(false);
+  });
+
+  test("cyclic Array.prototype.join throws RangeError (f2f2c2ddf637)", () => {
+    // StringRecursionChecker was removed; cyclic join now recurses until the
+    // stack check throws instead of short-circuiting to the empty string.
+    const a: unknown[] = [];
+    a.push(a);
+    expect(() => a.join()).toThrow(RangeError);
+  });
+
+  test("WebAssembly.Exception gains options.traceStack and stack getter (bf6512f84f7d)", () => {
+    expect(WebAssembly.Exception.length).toBe(2);
+    const desc = Object.getOwnPropertyDescriptor(WebAssembly.Exception.prototype, "stack");
+    expect(typeof desc?.get).toBe("function");
+  });
+
+  test("indirect, namespace and star re-exports link (BunAnalyzeTranspiledModule + 90b2ecf79ae3)", async () => {
+    // Upstream now threads ScriptFetchParameters::Type through createIndirect /
+    // createNamespace / addStarExportEntry and starExportEntries(). Bun's
+    // analyze-module bindings supply Type::JavaScript for each; this verifies
+    // the three shapes still link and resolve.
+    using dir = tempDir("wk-reexport", {
+      "leaf.mjs": `export const a = 1; export const b = 2; export const c = 3;`,
+      "mid.mjs": `
+        export { a } from "./leaf.mjs";
+        export * as ns from "./leaf.mjs";
+        export * from "./leaf.mjs";
+      `,
+      "entry.mjs": `
+        import { a, b, c, ns } from "./mid.mjs";
+        process.stdout.write(JSON.stringify({ a, b, c, ns: { a: ns.a, b: ns.b, c: ns.c } }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ a: 1, b: 2, c: 3, ns: { a: 1, b: 2, c: 3 } });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Upgrades the WebKit fork to upstream WebKit/WebKit@3722912ff800 (2026-08-02) via oven-sh/WebKit#383.

oven-sh/WebKit#383 is merged; `WEBKIT_VERSION` points at the merge commit `e6e37cda216c0292ae68c30c84a9dc8601d0fba5`.

## Bun-side changes

Upstream `90b2ecf79ae3` keys `m_loadedModules` on `(specifier, ScriptFetchParameters::Type)` and threads the type through `ImportEntry`, `ExportEntry`, `StarExportEntry`, and `ModuleAnalyzer::appendRequestedModule`. Under `bun test --isolate` (the `BunTranspiledModule` path), Bun'''s synthesized record must agree with what JSC'''s own `ModuleAnalyzer` would produce from the printed source; a mismatch fails the BUN_DEBUG record diff in debug and null-derefs `hostResolveImportedModule` in release.

- `analyze_transpiled_module` / `js_printer`: every `RecordKind` now carries one trailing `FetchParameters` slot. `add_import_info_*` and `add_export_info_*` accept it; `finalize()` propagates the source import'''s slot through the Local->Indirect conversion. `RequestedModules` dedupes on `(specifier, Type, phase)`.
- `analyze_jsc.rs`: decodes the trailing slot to the JSC `Type` enum and passes it to every `addImportEntry*` / `addIndirectExport` / `addNamespaceExport` / `addStarExport`; buffer validation is per-slot so only the trailing slot accepts the wider `FetchParameters` sentinel range.
- `BunAnalyzeTranspiledModule.cpp`: all seven `addImportEntry*` / `add*Export` functions take `uint8_t moduleRequestType` and set `.moduleRequestType` explicitly; `dumpRecordInfo()` prints `type(N)` for import/export/star entries; `static_assert` pins the ordinal values `to_script_fetch_parameters_type()` hardcodes.
- `RuntimeTranspilerCache` `EXPECTED_VERSION` -> 25 (esm_record layout change).

## WebKit-side changes (oven-sh/WebKit#383)

- 17 merge conflicts resolved in JSC/WTF; fork's `USE(BUN_JSC_ADDITIONS)` hunks preserved.
- Fork `ffi/` code adapted to upstream's 32-bit removal (`USE_JSVALUE64` macro deleted, `is64Bit()` removed, `payloadFor` -> `lowWordFor`).
- `InspectorDebuggerAgent.cpp`: handle `BunTranspiledModule`/`Synthetic` in new `scriptTypeForScript` switch.
- Recorded `01aaa3e0be0c` as ancestor via `-s ours` (oven-sh/WebKit#352 was a squash merge).

## How did you verify your code works?

- `bun run jsc:build:debug` builds and the `jsc` shell runs (`-e 'print(42)'` -> `42`).
- `bun run build:local -p '42'` links and runs against the local merged WebKit.
- oven-sh/WebKit#383 preview build green on all 38 platform variants.
- `bun bd -p 'process.versions.webkit'` -> `preview-pr-383-b9ea4dc5`.
- New test `test/js/bun/jsc/webkit-upgrade-3722912f.test.ts`: 4/4 pass with `bun bd test`, 3/4 fail with `USE_SYSTEM_BUN=1 bun test` (old JSC lacks `Iterator.prototype.includes`, returns `""` for cyclic join, `WebAssembly.Exception.length === 1`).

## JavaScriptCore/WTF/bmalloc changes since 01aaa3e0be0c (Jul 25)

Upstream range: WebKit/WebKit@01aaa3e0be0c...3722912ff800 (474 commits total, 110 touching JSC/WTF/bmalloc, Jul 25 → Aug 2 2026).

### Highlights

- `29ceb3c03de3` Remove 32-bit JSValues (JSVALUE32_64 and `CPU(NEEDS_ALIGNED_ACCESS)` deleted).
- `857bd4334690` Remove ARMv7 JIT support (ARMv7 is CLoop-only now; drops remaining 32-bit/x86 JIT refs).
- `232cebabc1f3` Remove big-endian support and platforms without unaligned loads/stores (WTF + JSC).
- `6eaa5ac1f65d` Remove 32-bit libpas support.
- `bfb1b1183bc2` Remove the B3/Air graph-coloring register allocator (greedy is the only allocator now).
- `0d0080ea539d` Enable WebAssembly Memory64 by default (+ Table64/SIMD follow-ups).
- `f2f2c2ddf637` Remove `StringRecursionChecker`; cyclic `toString`/`join` now throws RangeError via stack check (spec-correct).
- `319f94b3db4a` Enable `Iterator.prototype.includes()` by default.
- `90b2ecf79ae3` `hostResolveImportedModule` now honors import-attribute `type` (module loader behavior change).
- `f5716f6401ed` Add `preserve_most` calling convention to fastMalloc APIs on ARM64 (perf + ABI of WTF alloc entry points).

### JavaScriptCore

**Runtime / builtins**
- `f2f2c2ddf637` Remove StringRecursionChecker; rely on stack-overflow checks.
- `cd91e7f128dd` Add fast flag for `ToPrimitive(Object)` calls in runtime.
- `173a0bd6d937` Use `defaultToPrimitiveFastAndNonObservable` in `JSObject::toString`.
- `960adeccefcd` Fast operation for `Array#shift`.
- `92c6650c7947` Add `JSArrayIterator::next` C++ helper.
- `cb1c48b3e95f` Extend `Array.from()` Set fast path to `set.keys()/.values()`.
- `4a2e724d6789` Fix: `Array.from(set.keys()/.values())` fast path ignored `Symbol.iterator` overrides.
- `73e4c589c1e6` Extend `StringSplitCache` to RegExp separators.
- `656d3c36830f` / `1d355c27ea88` 8-byte SWAR fast paths in `JSON.stringify` string copy (same-type & upconvert).
- `9f9370cc729f` Fix JSON.stringify regression around `toJSON` check.
- `2eb77e9c9473` BigInt: implement Crandall reduction.
- `39b1bb9cfc85` BigInt: deploy Comba multiplication more broadly.
- `319f94b3db4a` Enable `Iterator.prototype.includes()`.
- `0731b27c1b60` `Iterator.zip`: use null-prototype objects for options/underlying iterator.
- `90b2ecf79ae3` `hostResolveImportedModule` respects module request import-attribute `type`.
- `4f54300b848a` Collect diagnostics when `getDirect` returns zero JSValue in `llint_slow_path_get_by_id`.

**Parser / bytecompiler**
- `c2beca7a439f` Lexer: scan integer tokens in a single pass.
- `72ea806faa21` Use overflow-safe range when choosing a switch jump table.

**LLInt / DFG / FTL / B3**
- `29ceb3c03de3` Remove 32-bit JSValues.
- `857bd4334690` Remove ARMv7 JIT support.
- `bfb1b1183bc2` Remove B3/Air graph-coloring register allocator.
- `68cde6ba2ad3` Make IRO (Air register allocation) faster.
- `83540481435f` DFG: allocate `BasicBlock::intersectionOfPastValuesAtHead` only for OSR-entry targets.
- `1566615170ec` DFG fix: `EnumeratorNextUpdateIndexAndMode` must require original array structure for `InBoundsSaneChain`.
- `e759fa9dd063` LLInt: inline hot path of `op_enter`.
- `9610c2113b45` offlineasm: emit ARM64 register-offset addressing for BaseIndex operands.
- `4ebed2479144` Speed up `addSortedRange` via binary search.
- `1c006b0b0f62` Fix regex `setLastIndex` on 32-bit.

**WebAssembly**
- `0d0080ea539d` Enable Memory64 feature flag.
- `15aa6fad53e3` Memory64: SIMD support.
- `bf0425598904` Memory64: expand declared memory limits.
- `862994e2cc37` Memory64: validate table import address-type match.
- `184ee4c654bd` Memory64: Table64 in OMG tier.
- `d202bedc5ff6` Memory64: Table64 in BBQ tier.
- `bf6512f84f7d` Support `WebAssembly.Exception` `options.traceStack` (+ `stack` getter, ctor length = 2).
- `24527bbb9ac8` Optimize Wasm JITCallee publication (lock splitting, icache barrier rework).
- `1803d6109d98` Speed up `WebAssembly.Table` construction.
- `d434a41411a3` BBQ: optimize `br_table` for consecutive same-target runs.
- `51d3dbaa278e` IPInt: add `DEFINE_IPINT_THUNK_FOR_ENTRY`.
- `244cd98f7986` Fix `generateWasmOpsHeader.py` under non-UTF-8 locales.

**Yarr / RegExp**
- `581f1d958329` Start end-anchored fixed-size regexps at the only possible position.
- `a458a6c1f0a7` v-mode class-set op loop: stop early when no more output possible.
- `7c5dbbcba110` Extend `ParenthesesSubpatternTerminal`.
- `e1def8f4e5fd` Don't save sibling/ancestor-sibling frame slots for `ParenContext`.
- `1e43057f135a` Extend first-character filter further.
- `54916608d7d6` Fix non-BMP advance latch; simplify `tryReadUnicodeCharImpl`.
- `46a4b17efbe9` `optimizeBOL`: don't filter contents of negative lookaheads.
- `b128ddd863ab` Fix dot-star-wrapped optimization for sticky patterns.
- `98d0367d2247` Fix: `^` inside a paren that can match empty does not anchor the pattern.

**Intl / Temporal**
- `09917ef55b0f` Add missing `U_FAILURE(status)` check in `actualLunisolarMonthLength`.

**Inspector**
- `3722912ff800` / `7be5445e4a22` / `e8c97076834e` / `f3e34dde7c9d` Canvas: instrument & record WebGPU devices/pipelines.
- `301d6b2b21f7` Associate WebAssembly module scripts with the fetching resource.
- `28b979b1659b` / `479edb2e4395` Site Isolation: implement `Network.loadResource` / `Network.getSerializedCertificate`.

### WTF

- `232cebabc1f3` Remove big-endian support and `CPU(NEEDS_ALIGNED_ACCESS)`.
- `e5fa5c604438` Upgrade fast_float to 8.2.10.
- `a288a8ec809b` Widen `find16`/`find32` SIMD threshold; faster ASCII case-conversion prefix copy.
- `6cb1077d85c8` `makeStringByReplacingAll()` now uses SIMD-accelerated `find()`.
- `5590f2e70615` Fix `AdaptiveStringSearcher` good-suffix shift table off-by-one.
- `f5716f6401ed` Add `preserve_most` to most fastMalloc APIs on ARM64.
- `f7a9d16e1531` Add `removeIf()` to `WeakHashSet` / `WeakListHashSet`.
- `e1fc460b8f1d` Add `removeIf()` to `RobinHoodHashTable`.
- `ff1f31c83dc7` Treat creating/destroying a `CheckedPtr` as no-delete.
- `bf15f00ebe95` Remove 12 unused internal-linkage templates (TypeTraits/HashTable/Vector/etc.).
- `5b84cf3719fa` Use `__builtin_trap` instead of inline asm under clang static analyzer.
- `158f737725b7` Add helpers for Darwin temp/cache directories.
- `04e3d47960f3` Limit URL size at IPC boundary (Chrome/Blink parity).
- `5daad377031c` / `a7ea27dd3bb6` Enable `-Wthread-safety` on GTK/WPE and fix findings.
- `7eb640d408f8` CMake: merge Mac and iOS ports into "Cocoa".
- `cfb222f3c4d1` CMake: run `cleandead` at end of configuration.

### bmalloc

- `6eaa5ac1f65d` Remove 32-bit libpas support.
- `f5716f6401ed` `preserve_most` on fastMalloc APIs (ARM64).
- `8b8b3e5ee16c` Fix inverted `MADV_ZERO` support latch in `VMAllocate.cpp`.
- `ead6285911f6` libpas: `pas_thread_local_cache_for_all` clobbered its should-go-again result.
- `90cbe5e85528` libpas: fix benign read from a deallocated TLC.
- `e388877954d1` PGM allocator: fix uninitialized `free_status` misclassifying OOB as UAF.
- `05c83a6550b7` libpas: fix `MTE_overrideEnablementForJavaScriptCore=true` incorrectly disabling MTE.
- `f01297663d40` / `86fb5e3a4eef` / `d18773ec666e` libpas test coverage (scavenging / zeroing / paged-out pages).

### Breaking/notable for Bun

- **32-bit purge**: `29ceb3c03de3` (JSVALUE32_64 removed), `857bd4334690` (ARMv7 JIT removed), `6eaa5ac1f65d` (32-bit libpas removed), `232cebabc1f3` (big-endian + `CPU(NEEDS_ALIGNED_ACCESS)` removed). Any `#if USE(JSVALUE64)` / `CPU(ADDRESS32)` guards in Bun patches are now dead.
- **`VM` layout**: `f2f2c2ddf637` deletes `StringRecursionChecker.{h,cpp}` and the `stringRecursionCheck*` fields from `VM.h`. Cyclic `Array.prototype.join`/`toString` now throws `RangeError` instead of returning `""`.
- **Module loader**: `90b2ecf79ae3` changes `hostResolveImportedModule` to propagate the import-attribute `type` — check Bun's module loader hook signatures.
- **Register allocator**: `bfb1b1183bc2` removes the B3/Air graph-coloring allocator and its `Options::` toggle.
- **fastMalloc ABI (ARM64)**: `f5716f6401ed` adds `__attribute__((preserve_most))` to `fastMalloc`/`fastFree` etc. — affects anything calling these across the WTF boundary on arm64.
- **BuiltinNames**: `bf6512f84f7d` registers `stackPrivateName` as private-only; `WebAssembly.Exception` constructor `length` becomes 2 and gains a `stack` prototype getter.
- **Feature defaults**: `0d0080ea539d` Wasm Memory64 on by default; `319f94b3db4a` `Iterator.prototype.includes` on by default.
- **Wasm threading**: `24527bbb9ac8` reworks icache barrier / callee publication and adds `Thread::barrierInstructionCache()` in WTF.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 2 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/jsc/webkit-upgrade-3722912f.test.ts"
ninja: Entering directory `/workspace/bun/build/debug'
[1/182] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 238 extern-C blocks audited
[2/182] gen cpp.rs (cppbind)
[3/182] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 7 sinks, 84 exported symbols
Generating /workspace/bun/build/debug/codegen/JSSink.lut.h from /workspace/bun/build/debug/codegen/JSSink.lut.txt
[4/182] gen JS modules (bundle-modules)
Preprocess modules (8715ms)
Bundle modules (63ms)
Postprocesss modules (24ms)
Bundle Functions (746ms)
Generate Code (12ms)

[9.57s] Bundled "src/js" for development
  2749 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[4/181] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[177/181] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
FAILED: obj/unified/UnifiedSou
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (385f52890)

test/js/bun/jsc/webkit-upgrade-3722912f.test.ts:
(pass) WebKit 3722912ff800 upgrade > Iterator.prototype.includes is enabled by default (319f94b3db4a) [0.19ms]
(pass) WebKit 3722912ff800 upgrade > cyclic Array.prototype.join throws RangeError (f2f2c2ddf637) [2.51ms]
(pass) WebKit 3722912ff800 upgrade > WebAssembly.Exception gains options.traceStack and stack getter (bf6512f84f7d) [0.48ms]
(pass) WebKit 3722912ff800 upgrade > typed import attributes resolve through BunTranspiledModule (--isolate) (90b2ecf79ae3) [8.49ms]
(pass) WebKit 3722912ff800 upgrade > indirect, namespace and star re-exports link on the JSC ModuleAnalyzer path (90b2ecf79ae3) [22.09ms]

 5 pass
 0 fail
 12 expect() calls
Ran 5 tests across 1 file. [152.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/jsc/webkit-upgrade-3722912f.test.ts"
bun test v1.4.0 (59b0de097)

test/js/bun/jsc/webkit-upgrade-3722912f.test.ts:
(pass) WebKit 3722912ff800 upgrade > Iterator.prototype.includes is enabled by default (319f94b3db4a) [13.19ms]
(pass) WebKit 3722912ff800 upgrade > cyclic Array.prototype.join throws RangeError (f2f2c2ddf637) [10.75ms]
(pass) WebKit 3722912ff800 upgrade > WebAssembly.Exception gains options.traceStack and stack getter (bf6512f84f7d) [3.66ms]
(pass) WebKit 3722912ff800 upgrade > typed import attributes resolve through BunTranspiledModule (--isolate) (90b2ecf79ae3) [317.28ms]
(pass) WebKit 3722912ff800 upgrade > indirect, namespace and star re-exports link on the JSC ModuleAnalyzer path (90b2ecf79ae3) [1138.48ms]

 5 pass
 0 fail
 12 expect() calls
Ran 5 tests across 1 file. [3.17s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 676ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/140] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 238 extern-C blocks audited
[2/140] gen cpp.rs (cppbind)
[3/140] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 7 sinks, 84 exported symbols
Generating /workspace/bun/build/release/codegen/JSSink.lut.h from /workspace/bun/build/release/codegen/JSSink.lut.txt
[4/140] gen JS modules (bundle-modules)
Preprocess modules (8727ms)
Bundle modules (51ms)
Postprocesss modules (106ms)
Bundle Functions (687ms)
Generate Code (20ms)

[9.61s] Bundled "src/js" for production
  2559 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[4/139] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
^[[1m^[[92m   Compilin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                     |   2 +-
 src/bundler/analyze_transpiled_module.rs         |  38 +++--
 src/bundler/linker_context/postProcessJSChunk.rs |   8 +-
 src/bundler_jsc/analyze_jsc.rs                   | 135 ++++++++++++----
 src/js_printer/lib.rs                            | 191 +++++++++++++++++------
 src/jsc/RuntimeTranspilerCache.rs                |   5 +-
 src/jsc/bindings/BunAnalyzeTranspiledModule.cpp  |  39 +++--
 test/js/bun/jsc/webkit-upgrade-3722912f.test.ts  | 106 +++++++++++++
 8 files changed, 416 insertions(+), 108 deletions(-)
```

</details>

**gate history** · 5 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
scripts/build/deps/webkit.ts                          1      1      0
src/bundler/analyze_transpiled_module.rs              3      3      0
src/bundler/linker_context/postProcessJSChunk.rs      1      1      0
src/bundler_jsc/analyze_jsc.rs                       13     15      0
src/js_printer/lib.rs                                 9     16      0
src/jsc/RuntimeTranspilerCache.rs                     2      3      0
src/jsc/bindings/BunAnalyzeTranspiledModule.cpp       8     12      0
test/js/bun/jsc/webkit-upgrade-3722912f.test.ts       2      5      0
```

</details>

<!-- robobun:evidence:end -->

