### PR TITLE
fetch: hold Body.Locked.readable as a real JSC::Weak so on_abort doesn't deref a freed NewSource box

### DIFF
--- a/src/jsc/Weak.rs
+++ b/src/jsc/Weak.rs
@@ -91,6 +91,19 @@ impl<T> Default for Weak<T> {
 }
 
 impl<T> Weak<T> {
+    /// A weak handle with no finalize callback (`WeakRefType::None`). `get()`
+    /// returns `None` once GC reaps weak handles for the collected referent,
+    /// which happens before any sweep (precise or lazy) runs cell destructors.
+    pub fn create_passive(value: JSValue, global_this: &JSGlobalObject) -> Self {
+        if value.is_empty() {
+            return Self::default();
+        }
+        Self {
+            r#ref: Some(WeakImpl::init(global_this, value, WeakRefType::None, None)),
+            _ctx: PhantomData,
+        }
+    }
+
     pub fn create(
         value: JSValue,
         global_this: &JSGlobalObject,

--- a/src/jsc/Weak.rs
+++ b/src/jsc/Weak.rs
@@ -91,9 +91,8 @@ impl<T> Default for Weak<T> {
 }
 
 impl<T> Weak<T> {
-    /// A weak handle with no finalize callback (`WeakRefType::None`). `get()`
-    /// returns `None` once GC reaps weak handles for the collected referent,
-    /// which happens before any sweep (precise or lazy) runs cell destructors.
+    /// A weak handle with no finalize callback. `get()` reads `None` from the
+    /// moment GC reaps the referent, before any sweep runs cell destructors.
     pub fn create_passive(value: JSValue, global_this: &JSGlobalObject) -> Self {
         if value.is_empty() {
             return Self::default();

--- a/src/jsc/bindings/Weak.cpp
+++ b/src/jsc/bindings/Weak.cpp
@@ -56,6 +56,9 @@ static JSC::WeakHandleOwner* getWeakRefOwner()
 static JSC::WeakHandleOwner* getWeakRefOwner(WeakRefType type)
 {
     switch (type) {
+    case WeakRefType::None:
+        // Passive weak: no finalize callback. JSC::Weak accepts a null owner.
+        return nullptr;
     case WeakRefType::FetchResponse: {
         return getWeakRefOwner<WeakRefType::FetchResponse>();
     }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1694,7 +1694,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 if let Some(stream) = locked.readable.get(global_object) {
                     stream.value.ensure_still_alive();
                     Self::stream_set_cached(js_value, global_object, stream.value);
-                    locked.readable.downgrade();
+                    locked.readable.downgrade(global_object);
                 }
             }
         }

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -21,14 +21,16 @@ pub struct ReadableStream {
 // ─── ReadableStream::Strong ──────────────────────────────────────────────────
 
 /// A `ReadableStream` handle for [`crate::webcore::body::PendingValue`] and the
-/// producers that feed it. `held` roots the stream as a GC root; `weak` stores
-/// the same JSValue after the owning wrapper's traced `m_stream` slot has taken
-/// ownership, so readers of `Locked.readable` keep working without the handle
-/// pinning the stream (and its captured async context) past the wrapper's
-/// lifetime.
+/// producers that feed it. `held` roots the stream as a GC root; after
+/// [`Self::downgrade`] the stream is owned by the wrapper's traced `m_stream`
+/// slot instead and `weak` observes it via a real `JSC::Weak`, so readers of
+/// `Locked.readable` keep working without the handle pinning the stream (and
+/// its captured async context) past the wrapper's lifetime, and see `None` the
+/// moment GC reaps the stream rather than a dangling `Source` pointer into a
+/// freed `Box<NewSource<_>>`.
 pub struct Strong {
     held: bun_jsc::strong::Optional, // jsc.Strong.Optional = .empty
-    weak: JSValue,
+    weak: bun_jsc::Weak<()>,
 }
 
 /// Re-export under the qualified name callers expect.
@@ -38,24 +40,18 @@ impl Default for Strong {
     fn default() -> Self {
         Self {
             held: bun_jsc::strong::Optional::empty(),
-            weak: JSValue::ZERO,
+            weak: bun_jsc::Weak::default(),
         }
     }
 }
 
 impl Strong {
     fn value(&self) -> Option<JSValue> {
-        self.held.get().or_else(|| {
-            if self.weak.is_empty() {
-                None
-            } else {
-                Some(self.weak)
-            }
-        })
+        self.held.get().or_else(|| self.weak.get())
     }
 
     pub(crate) fn has(&mut self) -> bool {
-        self.held.has() || !self.weak.is_empty()
+        self.held.has() || self.weak.get().is_some()
     }
 
     pub(crate) fn is_disturbed(&self, global: &JSGlobalObject) -> bool {
@@ -68,23 +64,25 @@ impl Strong {
     pub(crate) fn init(this: ReadableStream, global: &JSGlobalObject) -> Strong {
         Strong {
             held: bun_jsc::strong::Optional::create(this.value, global),
-            weak: JSValue::ZERO,
+            weak: bun_jsc::Weak::default(),
         }
     }
 
-    /// Release the GC root while keeping the JSValue readable for native
-    /// consumers. Caller must keep the stream alive elsewhere (the owning
-    /// `Request`/`Response` wrapper's `m_stream` `WriteBarrier` slot).
-    pub(crate) fn downgrade(&mut self) {
+    /// Release the GC root while keeping the stream readable for native
+    /// consumers. The owning `Request`/`Response` wrapper's `m_stream`
+    /// `WriteBarrier` keeps the stream alive from here; `weak` tracks it as a
+    /// real `JSC::Weak` so `get()` returns `None` once the wrapper (and with it
+    /// the stream's native `NewSource` box) is collected.
+    pub(crate) fn downgrade(&mut self, global: &JSGlobalObject) {
         if let Some(value) = self.held.get() {
-            self.weak = value;
+            self.weak = bun_jsc::Weak::create_passive(value, global);
             self.held.deinit();
         }
     }
 
     pub(crate) fn deinit(&mut self) {
         self.held.deinit();
-        self.weak = JSValue::ZERO;
+        self.weak = bun_jsc::Weak::default();
     }
 
     pub(crate) fn get(&self, global: &JSGlobalObject) -> Option<ReadableStream> {
@@ -105,7 +103,7 @@ impl Strong {
             if self.held.has() {
                 self.held.set(global, first.value);
             } else {
-                self.weak = first.value;
+                self.weak = bun_jsc::Weak::create_passive(first.value, global);
             }
             return Ok(Some(second));
         }

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -21,33 +21,33 @@ pub struct ReadableStream {
 // ─── ReadableStream::Strong ──────────────────────────────────────────────────
 
 /// A `ReadableStream` handle for [`crate::webcore::body::PendingValue`] and the
-/// producers that feed it. `held` roots the stream; after [`Self::downgrade`]
-/// `weak` observes it via a real `JSC::Weak` so readers see `None` once the
-/// stream (and its `Box<NewSource<_>>`) is collected, not a dangling `Source`.
-pub struct Strong {
-    held: bun_jsc::strong::Optional, // jsc.Strong.Optional = .empty
-    weak: bun_jsc::Weak<()>,
+/// producers that feed it.
+#[derive(Default)]
+pub enum Strong {
+    #[default]
+    Empty,
+    /// GC-roots the stream.
+    Held(bun_jsc::Strong),
+    /// After [`Self::downgrade`]: the owning wrapper's `m_stream` `WriteBarrier`
+    /// roots the stream; observed through a real `JSC::Weak` so readers see
+    /// `None` once the stream (and its `Box<NewSource<_>>`) is collected.
+    Weak(bun_jsc::Weak<()>),
 }
 
 /// Re-export under the qualified name callers expect.
 pub type ReadableStreamStrong = Strong;
 
-impl Default for Strong {
-    fn default() -> Self {
-        Self {
-            held: bun_jsc::strong::Optional::empty(),
-            weak: bun_jsc::Weak::default(),
-        }
-    }
-}
-
 impl Strong {
     fn value(&self) -> Option<JSValue> {
-        self.held.get().or_else(|| self.weak.get())
+        match self {
+            Self::Empty => None,
+            Self::Held(s) => Some(s.get()),
+            Self::Weak(w) => w.get(),
+        }
     }
 
     pub(crate) fn has(&mut self) -> bool {
-        self.held.has() || self.weak.get().is_some()
+        self.value().is_some()
     }
 
     pub(crate) fn is_disturbed(&self, global: &JSGlobalObject) -> bool {
@@ -58,25 +58,20 @@ impl Strong {
     }
 
     pub(crate) fn init(this: ReadableStream, global: &JSGlobalObject) -> Strong {
-        Strong {
-            held: bun_jsc::strong::Optional::create(this.value, global),
-            weak: bun_jsc::Weak::default(),
-        }
+        Self::Held(bun_jsc::Strong::create(this.value, global))
     }
 
-    /// Release the GC root while keeping the stream readable via `weak` (a
-    /// real `JSC::Weak`). The owning wrapper's `m_stream` `WriteBarrier` keeps
-    /// the stream alive from here.
+    /// Release the GC root while keeping the stream readable via `Weak`. The
+    /// owning wrapper's `m_stream` `WriteBarrier` keeps the stream alive from
+    /// here.
     pub(crate) fn downgrade(&mut self, global: &JSGlobalObject) {
-        if let Some(value) = self.held.get() {
-            self.weak = bun_jsc::Weak::create_passive(value, global);
-            self.held.deinit();
+        if let Self::Held(s) = self {
+            *self = Self::Weak(bun_jsc::Weak::create_passive(s.get(), global));
         }
     }
 
     pub(crate) fn deinit(&mut self) {
-        self.held.deinit();
-        self.weak = bun_jsc::Weak::default();
+        *self = Self::Empty;
     }
 
     pub(crate) fn get(&self, global: &JSGlobalObject) -> Option<ReadableStream> {
@@ -87,17 +82,16 @@ impl Strong {
         None
     }
 
-    // deinit: body only calls held.deinit() → handled by Drop on bun_jsc::Strong.
-
     pub(crate) fn tee(&mut self, global: &JSGlobalObject) -> JsResult<Option<ReadableStream>> {
         if let Some(stream) = self.get(global) {
             let Some((first, second)) = stream.tee(global)? else {
                 return Ok(None);
             };
-            if self.held.has() {
-                self.held.set(global, first.value);
-            } else {
-                self.weak = bun_jsc::Weak::create_passive(first.value, global);
+            match self {
+                Self::Held(s) => s.set(global, first.value),
+                Self::Weak(_) | Self::Empty => {
+                    *self = Self::Weak(bun_jsc::Weak::create_passive(first.value, global))
+                }
             }
             return Ok(Some(second));
         }

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -21,13 +21,9 @@ pub struct ReadableStream {
 // ─── ReadableStream::Strong ──────────────────────────────────────────────────
 
 /// A `ReadableStream` handle for [`crate::webcore::body::PendingValue`] and the
-/// producers that feed it. `held` roots the stream as a GC root; after
-/// [`Self::downgrade`] the stream is owned by the wrapper's traced `m_stream`
-/// slot instead and `weak` observes it via a real `JSC::Weak`, so readers of
-/// `Locked.readable` keep working without the handle pinning the stream (and
-/// its captured async context) past the wrapper's lifetime, and see `None` the
-/// moment GC reaps the stream rather than a dangling `Source` pointer into a
-/// freed `Box<NewSource<_>>`.
+/// producers that feed it. `held` roots the stream; after [`Self::downgrade`]
+/// `weak` observes it via a real `JSC::Weak` so readers see `None` once the
+/// stream (and its `Box<NewSource<_>>`) is collected, not a dangling `Source`.
 pub struct Strong {
     held: bun_jsc::strong::Optional, // jsc.Strong.Optional = .empty
     weak: bun_jsc::Weak<()>,
@@ -68,11 +64,9 @@ impl Strong {
         }
     }
 
-    /// Release the GC root while keeping the stream readable for native
-    /// consumers. The owning `Request`/`Response` wrapper's `m_stream`
-    /// `WriteBarrier` keeps the stream alive from here; `weak` tracks it as a
-    /// real `JSC::Weak` so `get()` returns `None` once the wrapper (and with it
-    /// the stream's native `NewSource` box) is collected.
+    /// Release the GC root while keeping the stream readable via `weak` (a
+    /// real `JSC::Weak`). The owning wrapper's `m_stream` `WriteBarrier` keeps
+    /// the stream alive from here.
     pub(crate) fn downgrade(&mut self, global: &JSGlobalObject) {
         if let Some(value) = self.held.get() {
             self.weak = bun_jsc::Weak::create_passive(value, global);

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -137,15 +137,11 @@ impl BodyAbortListener {
             response.get_body_value(),
             BodyValue::Used | BodyValue::Error(_) | BodyValue::Null | BodyValue::Empty
         ) {
-            // `get_body_readable_stream`'s `js_ref()` path reads `m_stream` off
-            // a raw `JsRef::Weak(JSValue)` to the wrapper; when the wrapper is
-            // unmarked but its MarkedBlock destructor has not yet run (lazy
-            // sweep), that chain reaches the stream's `m_nativePtr` source
-            // cell, a PreciseAllocation whose destructor has already freed the
-            // `NewSource` box. `Locked.readable` is a real `JSC::Weak` on the
-            // stream and is cleared at weak-reap time, so it returns `None`
-            // exactly when the stream (and with it the box) is collected, and
-            // the live stream when a reader still roots it without the wrapper.
+            // Not `get_body_readable_stream`: its `js_ref()` path reads a raw
+            // JSValue to a wrapper that may be unmarked but not yet swept,
+            // reaching a `NewSource` box the source cell's (PreciseAllocation)
+            // destructor already freed. `Locked.readable` is a real `JSC::Weak`
+            // on the stream and reads `None` exactly when the box is gone.
             if let BodyValue::Locked(locked) = response.get_body_value() {
                 if let Some(readable) = locked.readable.get(&global) {
                     readable.value.ensure_still_alive();

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -118,13 +118,6 @@ pub(crate) struct BodyAbortListener {
     signal: AbortSignalRef,
     /// `Response` owns `Box<Self>`, so a ref-counted pointer here would cycle.
     response: bun_ptr::ParentRef<Response>,
-    /// GC-cleared handle to the `JSResponse` wrapper. `on_abort` dereferences the
-    /// body stream's native `NewSource` box (via `ReadableStream::done`), whose
-    /// lifetime is bounded by the wrapper's traced `m_stream` slot; once the
-    /// wrapper is unmarked this box may already be freed (its source cell is a
-    /// PreciseAllocation swept in `sweepInFinalize`) even though the native
-    /// `Response` outlives its wrapper's lazily-swept destructor.
-    wrapper: bun_jsc::Weak<()>,
     global: GlobalRef,
 }
 
@@ -136,24 +129,25 @@ impl BodyAbortListener {
         // box is dropped, so it is live here. Copy out up front: erroring a
         // still-streaming body can re-enter `Response::unref` via
         // `FetchTasklet::ignore_remaining_response_body` and destroy this box.
-        let (response, global, wrapper_live) = unsafe {
-            let this = &*ctx.cast::<Self>();
-            (this.response, this.global, this.wrapper.get().is_some())
-        };
+        let (response, global) =
+            unsafe { ((*ctx.cast::<Self>()).response, (*ctx.cast::<Self>()).global) };
         Response::ref_(response.as_mut_ptr());
         let _keepalive = scopeguard::guard((), move |()| Response::unref(response.as_mut_ptr()));
         if !matches!(
             response.get_body_value(),
             BodyValue::Used | BodyValue::Error(_) | BodyValue::Null | BodyValue::Empty
         ) {
-            // `get_body_readable_stream`'s `js_ref()` path reads the stream
-            // from a raw JSValue to the dead-but-unswept wrapper's `m_stream`
-            // slot, then the stream's `m_nativePtr` source cell (a
-            // PreciseAllocation whose destructor already freed the native
-            // box). With the wrapper collected there is no reader to observe
-            // the error anyway, so skip straight to poisoning the body value.
-            if wrapper_live {
-                if let Some(readable) = response.get_body_readable_stream(&global) {
+            // `get_body_readable_stream`'s `js_ref()` path reads `m_stream` off
+            // a raw `JsRef::Weak(JSValue)` to the wrapper; when the wrapper is
+            // unmarked but its MarkedBlock destructor has not yet run (lazy
+            // sweep), that chain reaches the stream's `m_nativePtr` source
+            // cell, a PreciseAllocation whose destructor has already freed the
+            // `NewSource` box. `Locked.readable` is a real `JSC::Weak` on the
+            // stream and is cleared at weak-reap time, so it returns `None`
+            // exactly when the stream (and with it the box) is collected, and
+            // the live stream when a reader still roots it without the wrapper.
+            if let BodyValue::Locked(locked) = response.get_body_value() {
+                if let Some(readable) = locked.readable.get(&global) {
                     readable.value.ensure_still_alive();
                     readable.error(&global, reason);
                 }
@@ -512,7 +506,6 @@ impl Response {
     /// SAFETY: `this` must be a live heap `Response` (stored as the listener's [`ParentRef`]).
     pub(crate) unsafe fn attach_abort_signal(
         this: *mut Response,
-        wrapper: JSValue,
         global: &JSGlobalObject,
         signal: &AbortSignal,
     ) {
@@ -523,7 +516,6 @@ impl Response {
             signal: signal_ref,
             // SAFETY: caller contract; `this` is live and owns the box.
             response: unsafe { bun_ptr::ParentRef::from_raw_mut(this) },
-            wrapper: bun_jsc::Weak::create_passive(wrapper, global),
             global: GlobalRef::new(global),
         });
         signal.add_listener(

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -118,6 +118,13 @@ pub(crate) struct BodyAbortListener {
     signal: AbortSignalRef,
     /// `Response` owns `Box<Self>`, so a ref-counted pointer here would cycle.
     response: bun_ptr::ParentRef<Response>,
+    /// GC-cleared handle to the `JSResponse` wrapper. `on_abort` dereferences the
+    /// body stream's native `NewSource` box (via `ReadableStream::done`), whose
+    /// lifetime is bounded by the wrapper's traced `m_stream` slot; once the
+    /// wrapper is unmarked this box may already be freed (its source cell is a
+    /// PreciseAllocation swept in `sweepInFinalize`) even though the native
+    /// `Response` outlives its wrapper's lazily-swept destructor.
+    wrapper: bun_jsc::Weak<()>,
     global: GlobalRef,
 }
 
@@ -129,17 +136,27 @@ impl BodyAbortListener {
         // box is dropped, so it is live here. Copy out up front: erroring a
         // still-streaming body can re-enter `Response::unref` via
         // `FetchTasklet::ignore_remaining_response_body` and destroy this box.
-        let (response, global) =
-            unsafe { ((*ctx.cast::<Self>()).response, (*ctx.cast::<Self>()).global) };
+        let (response, global, wrapper_live) = unsafe {
+            let this = &*ctx.cast::<Self>();
+            (this.response, this.global, this.wrapper.get().is_some())
+        };
         Response::ref_(response.as_mut_ptr());
         let _keepalive = scopeguard::guard((), move |()| Response::unref(response.as_mut_ptr()));
         if !matches!(
             response.get_body_value(),
             BodyValue::Used | BodyValue::Error(_) | BodyValue::Null | BodyValue::Empty
         ) {
-            if let Some(readable) = response.get_body_readable_stream(&global) {
-                readable.value.ensure_still_alive();
-                readable.error(&global, reason);
+            // `get_body_readable_stream`'s `js_ref()` path reads the stream
+            // from a raw JSValue to the dead-but-unswept wrapper's `m_stream`
+            // slot, then the stream's `m_nativePtr` source cell (a
+            // PreciseAllocation whose destructor already freed the native
+            // box). With the wrapper collected there is no reader to observe
+            // the error anyway, so skip straight to poisoning the body value.
+            if wrapper_live {
+                if let Some(readable) = response.get_body_readable_stream(&global) {
+                    readable.value.ensure_still_alive();
+                    readable.error(&global, reason);
+                }
             }
             let err = BodyValueError::JSValue(bun_jsc::strong::Optional::create(reason, &global));
             // R-2: re-derive after `error()` ran JS.
@@ -495,6 +512,7 @@ impl Response {
     /// SAFETY: `this` must be a live heap `Response` (stored as the listener's [`ParentRef`]).
     pub(crate) unsafe fn attach_abort_signal(
         this: *mut Response,
+        wrapper: JSValue,
         global: &JSGlobalObject,
         signal: &AbortSignal,
     ) {
@@ -505,6 +523,7 @@ impl Response {
             signal: signal_ref,
             // SAFETY: caller contract; `this` is live and owns the box.
             response: unsafe { bun_ptr::ParentRef::from_raw_mut(this) },
+            wrapper: bun_jsc::Weak::create_passive(wrapper, global),
             global: GlobalRef::new(global),
         });
         signal.add_listener(

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2006,7 +2006,7 @@ impl FetchTasklet {
         // Response-owned listener so abort still errors the body after this tasklet detaches its own.
         if let Some(signal) = self.abort_signal() {
             // SAFETY: `response` is the live heap allocation owned by JSC.
-            unsafe { Response::attach_abort_signal(response, response_js, &global_this, signal) };
+            unsafe { Response::attach_abort_signal(response, &global_this, signal) };
         }
         response_js
     }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2006,7 +2006,7 @@ impl FetchTasklet {
         // Response-owned listener so abort still errors the body after this tasklet detaches its own.
         if let Some(signal) = self.abort_signal() {
             // SAFETY: `response` is the live heap allocation owned by JSC.
-            unsafe { Response::attach_abort_signal(response, &global_this, signal) };
+            unsafe { Response::attach_abort_signal(response, response_js, &global_this, signal) };
         }
         response_js
     }

--- a/test/js/web/fetch/fetch-abort-after-cancel-gc-fixture.ts
+++ b/test/js/web/fetch/fetch-abort-after-cancel-gc-fixture.ts
@@ -1,0 +1,36 @@
+// #36624 downgraded `Body.Locked.readable` from a `bun_jsc::Strong` to a raw
+// JSValue once the Response wrapper's traced `m_stream` slot owns the stream.
+// After reader.cancel() drops every other root and the wrapper becomes
+// unreachable, an eden GC (Bun.gc(false)) reaps weak handles and sweeps
+// PreciseAllocations synchronously (freeing the `Box<NewSource<_>>` via the
+// source cell's destructor) but leaves the MarkedBlock Response wrapper for
+// lazy sweep, so the BodyAbortListener is still registered when abort fires.
+// on_abort then dereferences the freed box through that raw JSValue.
+//
+// Bun.gc(true) does NOT reproduce: the full synchronous sweep runs the
+// wrapper's destructor first, which drops the listener.
+
+using server = Bun.serve({
+  port: 0,
+  fetch: () => new Response(Buffer.alloc(20000, "x")),
+});
+const url = `http://127.0.0.1:${server.port}/`;
+
+async function one(signal: AbortSignal) {
+  const resp = await fetch(url, { signal });
+  const rd = resp.body!.getReader();
+  await rd.read();
+  await rd.cancel();
+  // resp + rd are garbage once this returns
+}
+
+const ITER = Number(process.env.ITER ?? 60);
+for (let i = 0; i < ITER; i++) {
+  const ac = new AbortController();
+  await Promise.all([one(ac.signal), one(ac.signal), one(ac.signal)]);
+  Bun.gc(false);
+  await Bun.sleep(5);
+  ac.abort();
+  await Bun.sleep(5);
+}
+process.stdout.write(`done ${ITER}\n`);

--- a/test/js/web/fetch/fetch-abort-stream-body.test.ts
+++ b/test/js/web/fetch/fetch-abort-stream-body.test.ts
@@ -34,9 +34,9 @@ test.concurrent(
 // stream through the downgraded `Locked.readable` handle. The fix stores that
 // handle as a real JSC::Weak so it reads as empty once reaped. Full details in
 // the fixture.
-test.skipIf(!isASAN).concurrent(
-  "abort after reader.cancel() + eden GC does not use a freed response-body source",
-  async () => {
+test
+  .skipIf(!isASAN)
+  .concurrent("abort after reader.cancel() + eden GC does not use a freed response-body source", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), join(import.meta.dir, "fetch-abort-after-cancel-gc-fixture.ts")],
       env: { ...bunEnv, ITER: "20", ASAN_OPTIONS: "fast_unwind_on_fatal=1" },
@@ -49,8 +49,7 @@ test.skipIf(!isASAN).concurrent(
     expect(stderr).not.toContain("AddressSanitizer");
     expect(stdout).toBe("done 20\n");
     expect(exitCode).toBe(0);
-  },
-);
+  });
 
 test("aborting fetch with a ReadableStream request body does not double-cancel the sink", async () => {
   await using proc = Bun.spawn({

--- a/test/js/web/fetch/fetch-abort-stream-body.test.ts
+++ b/test/js/web/fetch/fetch-abort-stream-body.test.ts
@@ -39,7 +39,7 @@ test.skipIf(!isASAN).concurrent(
   async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), join(import.meta.dir, "fetch-abort-after-cancel-gc-fixture.ts")],
-      env: { ...bunEnv, ITER: "60", ASAN_OPTIONS: "fast_unwind_on_fatal=1" },
+      env: { ...bunEnv, ITER: "20", ASAN_OPTIONS: "fast_unwind_on_fatal=1" },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -47,10 +47,9 @@ test.skipIf(!isASAN).concurrent(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).not.toContain("AddressSanitizer");
-    expect(stdout).toBe("done 60\n");
+    expect(stdout).toBe("done 20\n");
     expect(exitCode).toBe(0);
   },
-  30_000,
 );
 
 test("aborting fetch with a ReadableStream request body does not double-cancel the sink", async () => {

--- a/test/js/web/fetch/fetch-abort-stream-body.test.ts
+++ b/test/js/web/fetch/fetch-abort-stream-body.test.ts
@@ -32,8 +32,8 @@ test.concurrent(
 // that GC sweeps synchronously; the Response wrapper (MarkedBlock) is swept
 // lazily, so its BodyAbortListener can fire between the two and read the body
 // stream through the downgraded `Locked.readable` handle. The fix stores that
-// handle (and the listener's wrapper handle) as a real JSC::Weak so they read
-// as empty once reaped. Full details in the fixture.
+// handle as a real JSC::Weak so it reads as empty once reaped. Full details in
+// the fixture.
 test.skipIf(!isASAN).concurrent(
   "abort after reader.cancel() + eden GC does not use a freed response-body source",
   async () => {

--- a/test/js/web/fetch/fetch-abort-stream-body.test.ts
+++ b/test/js/web/fetch/fetch-abort-stream-body.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isMacOS } from "harness";
+import { bunEnv, bunExe, isASAN, isMacOS } from "harness";
 import { once } from "node:events";
 import net from "node:net";
 import { join } from "node:path";
@@ -26,6 +26,31 @@ test.concurrent(
     expect(stdout).toBe("arrayBuffer rejected AbortError\ntext rejected AbortError\n");
     expect(exitCode).toBe(0);
   },
+);
+
+// The stream's native NewSource box is owned by a PreciseAllocation source cell
+// that GC sweeps synchronously; the Response wrapper (MarkedBlock) is swept
+// lazily, so its BodyAbortListener can fire between the two and read the body
+// stream through the downgraded `Locked.readable` handle. The fix stores that
+// handle (and the listener's wrapper handle) as a real JSC::Weak so they read
+// as empty once reaped. Full details in the fixture.
+test.skipIf(!isASAN).concurrent(
+  "abort after reader.cancel() + eden GC does not use a freed response-body source",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "fetch-abort-after-cancel-gc-fixture.ts")],
+      env: { ...bunEnv, ITER: "60", ASAN_OPTIONS: "fast_unwind_on_fatal=1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("AddressSanitizer");
+    expect(stdout).toBe("done 60\n");
+    expect(exitCode).toBe(0);
+  },
+  30_000,
 );
 
 test("aborting fetch with a ReadableStream request body does not double-cancel the sink", async () => {

--- a/test/js/web/fetch/fetch-abort-stream-body.test.ts
+++ b/test/js/web/fetch/fetch-abort-stream-body.test.ts
@@ -39,7 +39,11 @@ test
   .concurrent("abort after reader.cancel() + eden GC does not use a freed response-body source", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), join(import.meta.dir, "fetch-abort-after-cancel-gc-fixture.ts")],
-      env: { ...bunEnv, ITER: "20", ASAN_OPTIONS: "fast_unwind_on_fatal=1" },
+      env: {
+        ...bunEnv,
+        ITER: "20",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "fast_unwind_on_fatal=1"].filter(Boolean).join(":"),
+      },
       stdout: "pipe",
       stderr: "pipe",
     });


### PR DESCRIPTION
## What

`fetch(url, { signal })` + `resp.body.getReader()` + `reader.cancel()`, drop the Response, then abort the signal: heap-use-after-free on the response body stream's native `Box<NewSource<_>>`. Reproduces 5/5 under ASAN on `main`, clean on `5b7c3cacbe63` (before #36624).

```
READ of size 1 in NewSource<ByteBlobLoader>::cancel (ReadableStream.rs:936)
  <- ReadableStream::done <- ReadableStream::error
  <- BodyAbortListener::on_abort (Response.rs:142)
  <- AbortSignal::runAbortSteps <- Timeout::run <- __bun_fire_timer
freed by: JSDestructibleObjectDestroyFunc <- PreciseAllocation::sweep
  <- sweepPreciseAllocations <- Heap::sweepInFinalize
allocated by: Box::new(NewSource<..>) <- Value::to_readable_stream <- Response.body getter
```

Minimal repro (crashes at iteration 0 on debug and release ASAN):

```js
const server = Bun.serve({ port: 0, fetch: () => new Response(Buffer.alloc(20000, "x")) });
async function one(signal) {
  const resp = await fetch(server.url, { signal });
  const rd = resp.body.getReader();
  await rd.read();
  await rd.cancel();
}
for (;;) {
  const ac = new AbortController();
  await Promise.all([one(ac.signal), one(ac.signal), one(ac.signal)]);
  Bun.gc(false);            // must NOT be gc(true)
  await Bun.sleep(5);
  ac.abort();
  await Bun.sleep(5);
}
```

## Cause

#36624 changed `readable_stream::Strong` so that `check_body_stream_ref` downgrades `Body.Locked.readable` from a `bun_jsc::Strong` to a raw `weak: JSValue` once the Response wrapper's traced `m_stream` WriteBarrier slot owns the stream. That raw JSValue is never cleared when the stream is collected.

After `reader.cancel()` (ByteStream path) or once the body is fully buffered (ByteBlobLoader path), nothing but the Response wrapper's `m_stream` roots the stream. When the user drops the Response, one eden GC:

1. reaps weak handles (so a real `JSC::Weak` would already read `None`),
2. runs `sweepInFinalize` -> `sweepPreciseAllocations`, which sweeps the `JS{Bytes,Blob}InternalReadableStreamSource` cell **synchronously**; its destructor runs `NewSource::finalize` -> `decrement_count` -> `drop(Box<NewSource<_>>)`,
3. leaves the `JSResponse` wrapper's MarkedBlock cell for lazy sweep.

`Response::finalize` (the wrapper cell destructor) is what sets `js_ref` to `Finalized` and drops `abort_listener`, so in that window the native `Response` is still alive, `Locked.readable` still holds the stream's raw JSValue, and `BodyAbortListener` is still registered. `AbortSignal.timeout` / `ac.abort()` then fires:

* `on_abort` -> `get_body_readable_stream` reaches the dead stream through either `js_ref()` (raw JSValue to the dead-but-unswept wrapper) or `Locked.readable`'s raw JSValue -> `ReadableStreamTag__tagged` -> `m_nativePtr` -> the destructed source cell's `m_ctx` -> the freed `Box<NewSource<_>>`, and
* `Value::to_error_instance` reads the same handle via `strong_readable.get()` -> `bytes.on_data()`.

`Bun.gc(true)` does not reproduce: a full synchronous sweep runs the wrapper destructor in the same pass, which drops the listener before abort can fire.

## Fix

* `readable_stream::Strong::weak` is now `bun_jsc::Weak<()>` instead of a raw `JSValue`. `downgrade()` creates it with the new `WeakRefType::None` (no finalize owner; `JSC::Weak` accepts a null owner). `get()` / `has()` / `is_disturbed()` / `tee()` all see `None` once the stream is reaped, so `Value::to_error_instance` and every other `Locked.readable` reader skip the freed `NewSource` deref.
* `BodyAbortListener::on_abort` reads the stream via `Locked.readable` directly instead of `get_body_readable_stream`, whose `js_ref()` path would still read a raw `JsRef::Weak(JSValue)` to the dead-but-unswept wrapper. `Locked.readable.get()` returns the live stream when a reader roots it without the wrapper, and `None` exactly when the stream (and its `NewSource` box) is collected.
* `bun_jsc::Weak::create_passive` and a `WeakRefType::None` arm in `Bun__WeakRef__new` support an ownerless `JSC::Weak`.

No user-visible behaviour changes: when the stream is collected `readable.error()` was already a no-op (`webStreamControllerError` early-returns on a non-Readable stream; `NewSource::cancel` early-returns on `cancelled`); when the stream is alive `readable.error()` runs exactly as before.

## Verification

* `test/js/web/fetch/fetch-abort-after-cancel-gc-fixture.ts` + test: crashes at iteration 0 on `main` under debug+ASAN (`bun bd test`), passes with this PR.
* release+ASAN: 5/5 clean on both the fixture (100 iters) and the original fuzzer repro (300 iters); `main` crashes 5/5 and 4/4 respectively.
* `test/js/bun/http/serve-http3.test.ts` "client abort during streaming response" passes 3/3 on release+ASAN (regressed on the first commit of this PR; fixed in c5da841).
* #36624's leak regression test `test/regression/issue/29267` still passes (the downgrade is preserved; only the storage is now a real Weak).
* `test/js/web/fetch/{fetch-abort-stream-body,body,body-stream,body-clone,fetch-abort-queued,fetch-stream-cancel-leak}.test.ts` and `test/js/web/streams/readable-stream-terminal-barrier-release.test.ts` unchanged vs `main`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch-abort-stream-body.test.ts

<!-- robobun:evidence:end -->