### PR TITLE
napi: align symbol/buffer/coercion/reference/tsfn semantics with Node.js

### DIFF
--- a/src/jsc/bindings/NapiRef.cpp
+++ b/src/jsc/bindings/NapiRef.cpp
@@ -8,6 +8,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NapiRef);
 
 void NapiRef::ref()
 {
+    // Node's Reference::Ref(): once the weak referent has been collected the
+    // persistent is empty, so ref() returns 0 without incrementing. Callers of
+    // napi_reference_ref read back refCount, so leaving it unchanged yields 0.
+    if (!value()) {
+        NAPI_LOG("ref %p (referent collected)", this);
+        return;
+    }
     NAPI_LOG("ref %p %u -> %u", this, refCount, refCount + 1);
     ++refCount;
     if (refCount == 1 && !weakValueRef.isClear()) {

--- a/src/jsc/bindings/NapiRef.cpp
+++ b/src/jsc/bindings/NapiRef.cpp
@@ -9,9 +9,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NapiRef);
 void NapiRef::ref()
 {
     // Node's Reference::Ref(): once the weak referent has been collected the
-    // persistent is empty, so ref() returns 0 without incrementing. Callers of
-    // napi_reference_ref read back refCount, so leaving it unchanged yields 0.
-    if (!value()) {
+    // persistent is empty, so ref() returns 0 without incrementing. We held a
+    // weak handle iff weakValueRef has a tag; when that handle has since been
+    // cleared by GC, get() is empty. Callers of napi_reference_ref read back
+    // refCount, so leaving it unchanged yields 0.
+    if (refCount == 0 && !weakValueRef.isClear() && !weakValueRef.get()) {
         NAPI_LOG("ref %p (referent collected)", this);
         return;
     }

--- a/src/jsc/bindings/NapiRef.cpp
+++ b/src/jsc/bindings/NapiRef.cpp
@@ -8,11 +8,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NapiRef);
 
 void NapiRef::ref()
 {
-    // Node's Reference::Ref(): once the weak referent has been collected the
-    // persistent is empty, so ref() returns 0 without incrementing. We held a
-    // weak handle iff weakValueRef has a tag; when that handle has since been
-    // cleared by GC, get() is empty. Callers of napi_reference_ref read back
-    // refCount, so leaving it unchanged yields 0.
+    // Node's Reference::Ref(): once the weak referent is collected, return 0
+    // without incrementing.
     if (refCount == 0 && !weakValueRef.isClear() && !weakValueRef.get()) {
         NAPI_LOG("ref %p (referent collected)", this);
         return;

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1471,7 +1471,9 @@ node_api_create_external_string_latin1(napi_env env,
     if (length == 0) {
         *result = toNapi(JSC::jsEmptyString(JSC::getVM(globalObject)), globalObject);
         env->doFinalizer(finalize_callback, str, finalize_hint);
-        NAPI_RETURN_SUCCESS_UNLESS_EXCEPTION(env);
+        // Ownership transferred; return ok even if doFinalizer promoted a
+        // pre-existing napi_throw to the VM, so the caller doesn't double-free.
+        return napi_set_last_error(env, napi_ok);
     }
 
     Ref<WTF::ExternalStringImpl> impl = WTF::ExternalStringImpl::create({ reinterpret_cast<const Latin1Character*>(str), static_cast<unsigned int>(length) }, finalize_hint, [finalize_callback, env](void* hint, void* str, unsigned length) {
@@ -1515,7 +1517,9 @@ node_api_create_external_string_utf16(napi_env env,
     if (length == 0) {
         *result = toNapi(JSC::jsEmptyString(JSC::getVM(globalObject)), globalObject);
         env->doFinalizer(finalize_callback, str, finalize_hint);
-        NAPI_RETURN_SUCCESS_UNLESS_EXCEPTION(env);
+        // Ownership transferred; return ok even if doFinalizer promoted a
+        // pre-existing napi_throw to the VM, so the caller doesn't double-free.
+        return napi_set_last_error(env, napi_ok);
     }
 
     Ref<WTF::ExternalStringImpl> impl = WTF::ExternalStringImpl::create({ reinterpret_cast<const char16_t*>(str), static_cast<unsigned int>(length) }, finalize_hint, [finalize_callback, env](void* hint, void* str, unsigned length) {

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -582,8 +582,6 @@ extern "C" napi_status napi_set_named_property(napi_env env, napi_value object,
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, object);
     NAPI_CHECK_ARG(env, utf8name);
-    // TODO find a way to permit empty strings
-    NAPI_RETURN_EARLY_IF_FALSE(env, *utf8name, napi_invalid_arg);
     NAPI_CHECK_ARG(env, value);
 
     auto globalObject = toJS(env);
@@ -669,8 +667,10 @@ extern "C" napi_status napi_has_named_property(napi_env env, napi_value object,
     JSC::Identifier propertyName = identifierFromUtf8(vm, utf8Name);
 
     PropertySlot slot(target, PropertySlot::InternalMethodType::HasProperty);
-    *result = target->getPropertySlot(globalObject, propertyName, slot);
-    NAPI_RETURN_SUCCESS_UNLESS_EXCEPTION(env);
+    bool has_property = target->getPropertySlot(globalObject, propertyName, slot);
+    NAPI_RETURN_IF_EXCEPTION(env);
+    *result = has_property;
+    NAPI_RETURN_SUCCESS(env);
 }
 extern "C" napi_status napi_get_named_property(napi_env env, napi_value object,
     const char* utf8Name,
@@ -688,8 +688,10 @@ extern "C" napi_status napi_get_named_property(napi_env env, napi_value object,
 
     JSC::Identifier propertyName = identifierFromUtf8(vm, utf8Name);
 
-    *result = toNapi(target->get(globalObject, propertyName), globalObject);
-    NAPI_RETURN_SUCCESS_UNLESS_EXCEPTION(env);
+    JSValue got = target->get(globalObject, propertyName);
+    NAPI_RETURN_IF_EXCEPTION(env);
+    *result = toNapi(got, globalObject);
+    NAPI_RETURN_SUCCESS(env);
 }
 
 extern "C" size_t Bun__napi_module_register_count;
@@ -987,8 +989,8 @@ napi_define_properties(napi_env env, napi_value object, size_t property_count,
     NAPI_RETURN_EARLY_IF_FALSE(env, properties || property_count == 0, napi_invalid_arg);
 
     JSValue objectValue = toJS(object);
-    JSC::JSObject* objectObject = objectValue.getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, objectObject, napi_object_expected);
+    JSC::JSObject* objectObject = objectValue.toObject(globalObject);
+    RETURN_IF_EXCEPTION(throwScope, napi_set_last_error(env, napi_object_expected));
 
     for (size_t i = 0; i < property_count; i++) {
         napi_status status = Napi::defineProperty(env, objectObject, properties[i], throwScope);
@@ -1452,11 +1454,10 @@ node_api_create_external_string_latin1(napi_env env,
 {
     // https://nodejs.org/api/n-api.html#node_api_create_external_string_latin1
     NAPI_PREAMBLE_NO_PENDING_CHECK(env);
-    NAPI_CHECK_ARG(env, str);
+    // Node's CHECK_NEW_STRING_ARGS: str may be null when length is 0.
+    NAPI_RETURN_EARLY_IF_FALSE(env, length == 0 || str != nullptr, napi_invalid_arg);
     NAPI_CHECK_ARG(env, result);
-    // Reject while a napi exception is pending before adopting str, so the caller
-    // cleanly retains ownership (matches napi_create_external_buffer/_arraybuffer).
-    NAPI_RETURN_EARLY_IF_FALSE(env, !env->hasPendingException(), napi_pending_exception);
+    NAPI_RETURN_EARLY_IF_FALSE(env, length == NAPI_AUTO_LENGTH || length <= INT_MAX, napi_invalid_arg);
 
     length = length == NAPI_AUTO_LENGTH ? strlen(str) : length;
     Zig::GlobalObject* globalObject = toJS(env);
@@ -1497,11 +1498,10 @@ node_api_create_external_string_utf16(napi_env env,
 {
     // https://nodejs.org/api/n-api.html#node_api_create_external_string_utf16
     NAPI_PREAMBLE_NO_PENDING_CHECK(env);
-    NAPI_CHECK_ARG(env, str);
+    // Node's CHECK_NEW_STRING_ARGS: str may be null when length is 0.
+    NAPI_RETURN_EARLY_IF_FALSE(env, length == 0 || str != nullptr, napi_invalid_arg);
     NAPI_CHECK_ARG(env, result);
-    // Reject while a napi exception is pending before adopting str, so the caller
-    // cleanly retains ownership (matches napi_create_external_buffer/_arraybuffer).
-    NAPI_RETURN_EARLY_IF_FALSE(env, !env->hasPendingException(), napi_pending_exception);
+    NAPI_RETURN_EARLY_IF_FALSE(env, length == NAPI_AUTO_LENGTH || length <= INT_MAX, napi_invalid_arg);
 
     length = length == NAPI_AUTO_LENGTH ? std::char_traits<char16_t>::length(str) : length;
     Zig::GlobalObject* globalObject = toJS(env);
@@ -1598,7 +1598,7 @@ extern "C" JS_EXPORT napi_status node_api_get_module_file_name(napi_env env,
 {
     NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ARG(env, result);
-    *result = env->filename;
+    *result = env->filename ? env->filename : "";
     NAPI_RETURN_SUCCESS(env);
 }
 
@@ -1613,8 +1613,7 @@ extern "C" JS_EXPORT napi_status node_api_set_prototype(napi_env env,
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = JSC::getVM(globalObject);
 
-    JSObject* obj = toJS(object).getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, obj, napi_object_expected);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, obj, toJS(object));
 
     // JSC's setPrototypeDirect asserts prototype.isObject() || prototype.isNull();
     // reject primitives here rather than reaching the engine assertion.
@@ -1783,12 +1782,10 @@ extern "C" napi_status napi_object_freeze(napi_env env, napi_value object_value)
 {
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, object_value);
-    JSC::JSValue value = toJS(object_value);
-    NAPI_RETURN_EARLY_IF_FALSE(env, value.isObject(), napi_object_expected);
 
     Zig::GlobalObject* globalObject = toJS(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, object, toJS(object_value));
 
-    JSC::JSObject* object = uncheckedDowncast<JSC::JSObject>(value);
     objectConstructorFreeze(globalObject, object);
     NAPI_RETURN_IF_EXCEPTION(env);
 
@@ -1798,12 +1795,10 @@ extern "C" napi_status napi_object_seal(napi_env env, napi_value object_value)
 {
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, object_value);
-    JSC::JSValue value = toJS(object_value);
-    NAPI_RETURN_EARLY_IF_FALSE(env, value.isObject(), napi_object_expected);
 
     Zig::GlobalObject* globalObject = toJS(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, object, toJS(object_value));
 
-    JSC::JSObject* object = uncheckedDowncast<JSC::JSObject>(value);
     objectConstructorSeal(globalObject, object);
     NAPI_RETURN_IF_EXCEPTION(env);
 
@@ -3042,18 +3037,14 @@ extern "C" napi_status napi_create_symbol(napi_env env, napi_value description,
     JSC::VM& vm = JSC::getVM(globalObject);
 
     JSC::JSValue descriptionValue = toJS(description);
-    if (descriptionValue && !descriptionValue.isUndefinedOrNull()) {
+    if (descriptionValue) {
         NAPI_RETURN_EARLY_IF_FALSE(env, descriptionValue.isString(), napi_string_expected);
 
         WTF::String descriptionString = descriptionValue.getString(globalObject);
         NAPI_RETURN_IF_VM_EXCEPTION(env);
 
-        if (descriptionString.length() > 0) {
-            *result = toNapi(JSC::Symbol::createWithDescription(vm, descriptionString),
-                globalObject);
-            NAPI_RETURN_SUCCESS(env);
-        }
-        // TODO handle empty string?
+        *result = toNapi(JSC::Symbol::createWithDescription(vm, descriptionString), globalObject);
+        NAPI_RETURN_SUCCESS(env);
     }
 
     auto* symbol = JSC::Symbol::create(vm);
@@ -3094,9 +3085,10 @@ extern "C" napi_status napi_new_instance(napi_env env, napi_value constructor,
     });
 
     auto value = construct(globalObject, constructorValue, constructData, args);
+    NAPI_RETURN_IF_EXCEPTION(env);
     *result = toNapi(value, globalObject);
 
-    NAPI_RETURN_SUCCESS_UNLESS_EXCEPTION(env);
+    NAPI_RETURN_SUCCESS(env);
 }
 
 extern "C" napi_status napi_instanceof(napi_env env, napi_value object, napi_value constructor, bool* result)
@@ -3183,8 +3175,8 @@ extern "C" napi_status napi_type_tag_object(napi_env env, napi_value value, cons
     NAPI_CHECK_ARG(env, value);
     NAPI_CHECK_ARG(env, type_tag);
     Zig::GlobalObject* globalObject = toJS(env);
-    JSObject* js_object = toJS(value).getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, js_object, napi_object_expected);
+    JSObject* js_object = toJS(value).toObject(globalObject);
+    NAPI_RETURN_IF_VM_EXCEPTION(env);
     JSValue napiTypeTagValue = globalObject->napiTypeTags()->get(js_object);
 
     auto* existing_tag = dynamicDowncast<Bun::NapiTypeTag>(napiTypeTagValue);
@@ -3203,8 +3195,8 @@ extern "C" napi_status napi_check_object_type_tag(napi_env env, napi_value value
     NAPI_CHECK_ARG(env, value);
     NAPI_CHECK_ARG(env, type_tag);
     Zig::GlobalObject* globalObject = toJS(env);
-    JSObject* js_object = toJS(value).getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, js_object, napi_object_expected);
+    JSObject* js_object = toJS(value).toObject(globalObject);
+    NAPI_RETURN_IF_VM_EXCEPTION(env);
 
     bool match = false;
     auto* found_tag = dynamicDowncast<Bun::NapiTypeTag>(globalObject->napiTypeTags()->get(js_object));

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2045,8 +2045,7 @@ extern "C" fn napi_get_buffer_info(
     let Some(array_buf) = value.as_array_buffer(env.to_js()) else {
         return NapiEnv::set_last_error(Some(env), NapiStatus::invalid_arg);
     };
-    // Node's node::Buffer::HasInstance accepts any ArrayBufferView (typed
-    // arrays and DataView) but rejects a bare ArrayBuffer.
+    // node::Buffer::HasInstance is IsArrayBufferView: reject a bare ArrayBuffer.
     if array_buf.typed_array_type == jsc::JSType::ArrayBuffer {
         return NapiEnv::set_last_error(Some(env), NapiStatus::invalid_arg);
     }
@@ -2525,8 +2524,7 @@ impl ThreadSafeFunction {
             return;
         }
 
-        // Node's kMaxIterationCount: cap per tick so a producer that enqueues
-        // faster than we drain cannot starve the rest of the event loop.
+        // Node's kMaxIterationCount: yield after this many callbacks per tick.
         const MAX_ITERATION_COUNT: u32 = 1000;
         let mut is_first = true;
         let mut iterations: u32 = 0;
@@ -2543,8 +2541,13 @@ impl ThreadSafeFunction {
                     .store(DispatchState::Pending as u8, Ordering::SeqCst);
                 iterations += 1;
                 if iterations >= MAX_ITERATION_COUNT {
-                    // Yield: flip Pending -> Idle so schedule_dispatch
-                    // re-enqueues a fresh tick for the remainder.
+                    // dispatch_one() may have drained the final item and already
+                    // enqueued the finalizer task (closing == Closed); a second
+                    // dispatch on that pointer would run on freed memory.
+                    if self_.closing.load(Ordering::SeqCst) == ClosingState::Closed as u8 {
+                        return;
+                    }
+                    // Flip to Idle so schedule_dispatch re-enqueues the remainder.
                     self_
                         .dispatch_state
                         .store(DispatchState::Idle as u8, Ordering::SeqCst);
@@ -2708,9 +2711,7 @@ impl ThreadSafeFunction {
                 // SAFETY: `env` is held alive by `self.env` (`NapiEnvRef`) for the TSF's lifetime.
                 let env_ref = unsafe { &*env };
                 let _hs = NapiHandleScope::open_scoped(env_ref);
-                // Node passes a null napi_value for js_callback when no func was
-                // supplied at creation. Addons gate on `js_callback != NULL`, so
-                // an encoded `undefined` (a non-zero napi_value) would be wrong.
+                // No func at creation => null js_callback (Node), not encoded undefined.
                 let js = match cb_js.get() {
                     Some(v) => napi_value::create(env_ref, v),
                     None => napi_value(0),

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2045,6 +2045,11 @@ extern "C" fn napi_get_buffer_info(
     let Some(array_buf) = value.as_array_buffer(env.to_js()) else {
         return NapiEnv::set_last_error(Some(env), NapiStatus::invalid_arg);
     };
+    // Node's node::Buffer::HasInstance accepts any ArrayBufferView (typed
+    // arrays and DataView) but rejects a bare ArrayBuffer.
+    if array_buf.typed_array_type == jsc::JSType::ArrayBuffer {
+        return NapiEnv::set_last_error(Some(env), NapiStatus::invalid_arg);
+    }
 
     write_out(data, array_buf.ptr);
     write_out(length, array_buf.byte_len);
@@ -2520,7 +2525,11 @@ impl ThreadSafeFunction {
             return;
         }
 
+        // Node's kMaxIterationCount: cap per tick so a producer that enqueues
+        // faster than we drain cannot starve the rest of the event loop.
+        const MAX_ITERATION_COUNT: u32 = 1000;
         let mut is_first = true;
+        let mut iterations: u32 = 0;
 
         // Run the tasks.
         loop {
@@ -2532,6 +2541,16 @@ impl ThreadSafeFunction {
                 self_
                     .dispatch_state
                     .store(DispatchState::Pending as u8, Ordering::SeqCst);
+                iterations += 1;
+                if iterations >= MAX_ITERATION_COUNT {
+                    // Yield: flip Pending -> Idle so schedule_dispatch
+                    // re-enqueues a fresh tick for the remainder.
+                    self_
+                        .dispatch_state
+                        .store(DispatchState::Idle as u8, Ordering::SeqCst);
+                    self_.schedule_dispatch();
+                    return;
+                }
             } else {
                 // We're done running tasks, for now. Transition Running → Idle
                 // via CAS instead of an unconditional store: between
@@ -2558,11 +2577,6 @@ impl ThreadSafeFunction {
                 // state was bumped to Pending by enqueue()/release(); re-dispatch.
             }
         }
-
-        // Node sets a maximum number of runs per ThreadSafeFunction to 1,000.
-        // We don't set a max. I would like to see an issue caused by not
-        // setting a max before we do set a max. It is better for performance to
-        // not add unnecessary event loop ticks.
     }
 
     pub(crate) fn is_closing(&self) -> bool {
@@ -2691,17 +2705,17 @@ impl ThreadSafeFunction {
                 js: cb_js,
                 napi_threadsafe_function_call_js,
             } => {
-                let js: JSValue = cb_js.get().unwrap_or(JSValue::UNDEFINED);
-
                 // SAFETY: `env` is held alive by `self.env` (`NapiEnvRef`) for the TSF's lifetime.
                 let env_ref = unsafe { &*env };
                 let _hs = NapiHandleScope::open_scoped(env_ref);
-                napi_threadsafe_function_call_js(
-                    env,
-                    napi_value::create(env_ref, js),
-                    self.ctx,
-                    task,
-                );
+                // Node passes a null napi_value for js_callback when no func was
+                // supplied at creation. Addons gate on `js_callback != NULL`, so
+                // an encoded `undefined` (a non-zero napi_value) would be wrong.
+                let js = match cb_js.get() {
+                    Some(v) => napi_value::create(env_ref, v),
+                    None => napi_value(0),
+                };
+                napi_threadsafe_function_call_js(env, js, self.ctx, task);
             }
         }
         Ok(())

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2782,9 +2782,10 @@ impl ThreadSafeFunction {
         (NapiStatus::ok as napi_status, false)
     }
 
-    /// Caller must hold `lock`. Reached from addon threads (`enqueue`,
-    /// `release_locked`), so it may only take a shared `&EventLoop`: the JS
-    /// thread can be inside `tick()` with its own `&mut` at the same time.
+    /// Addon-thread callers must hold `lock` (they race `env_teardown` for
+    /// `event_loop`); JS-thread callers (on_dispatch yield, env_teardown) need
+    /// not. Takes only a shared `&EventLoop` because the JS thread may be
+    /// inside `tick()` with its own `&mut`.
     fn schedule_dispatch(&mut self) {
         let prev = self
             .dispatch_state

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1392,6 +1392,24 @@ nativeTests.test_threadsafe_function_orphan_leak = async () => {
   }
 };
 
+// napi_reference_ref on a reference whose referent has been collected must
+// return 0 (and leave the count at 0) instead of incrementing.
+nativeTests.test_reference_ref_after_collect_driver = async gc => {
+  const ext = nativeTests.test_create_weak_ref_for_gc();
+  await gcUntil(() => true);
+  nativeTests.test_reference_ref_after_collect(gc, ext);
+};
+
+// When napi_create_threadsafe_function is given no JS func, the call_js
+// callback receives a null js_callback (addons test `if (js_callback != NULL)`).
+nativeTests.test_tsfn_null_js_callback_driver = async () => {
+  nativeTests.test_tsfn_null_js_callback();
+  for (let i = 0; i < 10; i++) {
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  nativeTests.test_tsfn_null_js_callback_result();
+};
+
 // Microtasks queued by one threadsafe-function callback must be drained before
 // the next callback in the same dispatch, and not before the first one.
 nativeTests.test_threadsafe_function_microtask_order = async () => {

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1415,7 +1415,7 @@ nativeTests.test_tsfn_null_js_callback_driver = async () => {
 nativeTests.test_tsfn_many_items_driver = async () => {
   nativeTests.test_tsfn_many_items();
   for (let i = 0; i < 1000; i++) {
-    if (nativeTests.test_tsfn_many_items_count() >= 1200) break;
+    if (nativeTests.test_tsfn_many_items_count() >= 2000) break;
     await new Promise(resolve => setImmediate(resolve));
   }
   nativeTests.test_tsfn_many_items_result();

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1396,7 +1396,7 @@ nativeTests.test_threadsafe_function_orphan_leak = async () => {
 // return 0 (and leave the count at 0) instead of incrementing.
 nativeTests.test_reference_ref_after_collect_driver = async gc => {
   const ext = nativeTests.test_create_weak_ref_for_gc();
-  await gcUntil(() => true);
+  await gcUntil(() => nativeTests.test_weak_ref_is_collected(gc, ext));
   nativeTests.test_reference_ref_after_collect(gc, ext);
 };
 
@@ -1404,7 +1404,8 @@ nativeTests.test_reference_ref_after_collect_driver = async gc => {
 // callback receives a null js_callback (addons test `if (js_callback != NULL)`).
 nativeTests.test_tsfn_null_js_callback_driver = async () => {
   nativeTests.test_tsfn_null_js_callback();
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < 1000; i++) {
+    if (nativeTests.test_tsfn_null_js_callback_ran()) break;
     await new Promise(resolve => setImmediate(resolve));
   }
   nativeTests.test_tsfn_null_js_callback_result();

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1411,6 +1411,16 @@ nativeTests.test_tsfn_null_js_callback_driver = async () => {
   nativeTests.test_tsfn_null_js_callback_result();
 };
 
+// Crosses the 1000-iteration dispatch cap so the TSFN yields and re-schedules.
+nativeTests.test_tsfn_many_items_driver = async () => {
+  nativeTests.test_tsfn_many_items();
+  for (let i = 0; i < 1000; i++) {
+    if (nativeTests.test_tsfn_many_items_count() >= 1200) break;
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  nativeTests.test_tsfn_many_items_result();
+};
+
 // Microtasks queued by one threadsafe-function callback must be drained before
 // the next callback in the same dispatch, and not before the first one.
 nativeTests.test_threadsafe_function_microtask_order = async () => {

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -4007,6 +4007,49 @@ test_tsfn_null_js_callback_result(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+static std::atomic<int> tsfn_many_count(0);
+
+static void tsfn_many_call_js(napi_env env, napi_value js_callback,
+                              void *context, void *data) {
+  tsfn_many_count.fetch_add(1);
+}
+
+// Enqueues enough items to cross Node's kMaxIterationCount so the dispatch
+// loop yields mid-drain and re-schedules. Asserts every callback fired and
+// (under ASAN) that the yield did not double-schedule a freed pointer.
+static napi_value test_tsfn_many_items(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  tsfn_many_count.store(0);
+  napi_value name;
+  NODE_API_CALL(
+      env, napi_create_string_utf8(env, "tsfn-many", NAPI_AUTO_LENGTH, &name));
+  napi_threadsafe_function tsfn;
+  NODE_API_CALL(env, napi_create_threadsafe_function(
+                         env, NULL, NULL, name, 0, 1, NULL,
+                         tsfn_nullcb_finalize, NULL, tsfn_many_call_js, &tsfn));
+  for (int i = 0; i < 1200; i++) {
+    NODE_API_CALL(
+        env, napi_call_threadsafe_function(tsfn, NULL, napi_tsfn_nonblocking));
+  }
+  NODE_API_CALL(env,
+                napi_release_threadsafe_function(tsfn, napi_tsfn_release));
+  return ok(env);
+}
+
+static napi_value test_tsfn_many_items_count(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value r;
+  NODE_API_CALL(env, napi_create_int32(env, tsfn_many_count.load(), &r));
+  return r;
+}
+
+static napi_value
+test_tsfn_many_items_result(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  printf("tsfn callbacks fired: %d\n", tsfn_many_count.load());
+  return ok(env);
+}
+
 void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_typedarray_info_byte_offset);
   REGISTER_FUNCTION(env, exports, test_dataview_info_byte_offset);
@@ -4092,6 +4135,9 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback);
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_ran);
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_result);
+  REGISTER_FUNCTION(env, exports, test_tsfn_many_items);
+  REGISTER_FUNCTION(env, exports, test_tsfn_many_items_count);
+  REGISTER_FUNCTION(env, exports, test_tsfn_many_items_result);
 }
 
 } // namespace napitests

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -3710,6 +3710,283 @@ static napi_value test_napi_status_codes_node26(const Napi::CallbackInfo &info) 
   return ok(env);
 }
 
+// Verifies behavioral parity with Node.js for a grab-bag of N-API functions
+// whose observable result (not just status code) differed from Node:
+// empty-key named set, symbol description handling, external-string argument
+// validation, buffer-info type gate, ToObject coercion for define/freeze/
+// seal/type-tag/set-prototype, result write-on-exception ordering, and
+// module_file_name non-null. Output is compared byte-for-byte against Node
+// by checkSameOutput.
+static napi_value
+test_napi_node26_semantic_parity(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+#ifndef _WIN32
+  BlockingStdoutScope blocking_stdout;
+#endif
+
+  napi_value v_null, v_undef, v_num, v_str, v_str_empty, v_true, v_one, v_obj;
+  NODE_API_CALL(env, napi_get_null(env, &v_null));
+  NODE_API_CALL(env, napi_get_undefined(env, &v_undef));
+  NODE_API_CALL(env, napi_create_double(env, 42.5, &v_num));
+  NODE_API_CALL(env,
+                napi_create_string_utf8(env, "abc", NAPI_AUTO_LENGTH, &v_str));
+  NODE_API_CALL(env, napi_create_string_utf8(env, "", 0, &v_str_empty));
+  NODE_API_CALL(env, napi_get_boolean(env, true, &v_true));
+  NODE_API_CALL(env, napi_create_int32(env, 1, &v_one));
+  NODE_API_CALL(env, napi_create_object(env, &v_obj));
+
+  // napi_set_named_property with "" key
+  report_status(env, "set_named_property(\"\")",
+                napi_set_named_property(env, v_obj, "", v_one));
+  {
+    napi_value key, got;
+    NODE_API_CALL(env, napi_create_string_utf8(env, "", 0, &key));
+    NODE_API_CALL(env, napi_get_property(env, v_obj, key, &got));
+    int32_t n = 0;
+    napi_get_value_int32(env, got, &n);
+    printf("obj[\"\"]=%d\n", n);
+  }
+
+  // napi_create_symbol
+  {
+    napi_value sym;
+    report_status(env, "create_symbol(undefined)",
+                  napi_create_symbol(env, v_undef, &sym));
+    report_status(env, "create_symbol(null)",
+                  napi_create_symbol(env, v_null, &sym));
+    report_status(env, "create_symbol(number)",
+                  napi_create_symbol(env, v_num, &sym));
+    napi_status s = napi_create_symbol(env, v_str_empty, &sym);
+    report_status(env, "create_symbol(\"\")", s);
+    if (s == napi_ok) {
+      napi_value global, sym_ctor, proto, desc_key, desc;
+      NODE_API_CALL(env, napi_get_global(env, &global));
+      NODE_API_CALL(env,
+                    napi_get_named_property(env, global, "Symbol", &sym_ctor));
+      NODE_API_CALL(
+          env, napi_get_named_property(env, sym_ctor, "prototype", &proto));
+      NODE_API_CALL(env, napi_create_string_utf8(env, "description",
+                                                 NAPI_AUTO_LENGTH, &desc_key));
+      NODE_API_CALL(env, napi_get_property(env, sym, desc_key, &desc));
+      napi_valuetype t;
+      NODE_API_CALL(env, napi_typeof(env, desc, &t));
+      char buf[8] = {0};
+      size_t len = 0;
+      if (t == napi_string)
+        napi_get_value_string_utf8(env, desc, buf, sizeof(buf), &len);
+      printf("create_symbol(\"\") description: type=%d len=%zu\n", (int)t, len);
+    }
+  }
+
+  // node_api_create_external_string_latin1 argument validation
+  {
+    napi_value out;
+    bool copied;
+    report_status(env, "ext_string_latin1(NULL,0)",
+                  node_api_create_external_string_latin1(
+                      env, NULL, 0, NULL, NULL, &out, &copied));
+    static char sbuf[1] = {0};
+    report_status(env, "ext_string_latin1(ptr,INT_MAX+1)",
+                  node_api_create_external_string_latin1(
+                      env, sbuf, ((size_t)INT_MAX) + 1u, NULL, NULL, &out,
+                      &copied));
+    static char16_t sbuf16[1] = {0};
+    report_status(env, "ext_string_utf16(ptr,INT_MAX+1)",
+                  node_api_create_external_string_utf16(
+                      env, sbuf16, ((size_t)INT_MAX) + 1u, NULL, NULL, &out,
+                      &copied));
+  }
+
+  // napi_get_buffer_info type gate
+  {
+    napi_value ab;
+    void *d;
+    size_t sz;
+    NODE_API_CALL(env, napi_create_arraybuffer(env, 8, &d, &ab));
+    report_status(env, "get_buffer_info(ArrayBuffer)",
+                  napi_get_buffer_info(env, ab, &d, &sz));
+    napi_value ta;
+    NODE_API_CALL(env,
+                  napi_create_typedarray(env, napi_uint8_array, 8, ab, 0, &ta));
+    report_status(env, "get_buffer_info(Uint8Array)",
+                  napi_get_buffer_info(env, ta, &d, &sz));
+    napi_value dv;
+    NODE_API_CALL(env, napi_create_dataview(env, 8, ab, 0, &dv));
+    report_status(env, "get_buffer_info(DataView)",
+                  napi_get_buffer_info(env, dv, &d, &sz));
+  }
+
+  // ToObject coercion: define_properties / freeze / seal / type_tag /
+  // set_prototype accept primitives, throw+object_expected for null/undefined
+  {
+    napi_value v;
+    NODE_API_CALL(env, napi_create_int32(env, 7, &v));
+    napi_property_descriptor desc = {"x",  NULL, NULL,         NULL,
+                                     NULL, v,    napi_default, NULL};
+    report_status(env, "define_properties(number)",
+                  napi_define_properties(env, v_num, 1, &desc));
+    report_status(env, "define_properties(null)",
+                  napi_define_properties(env, v_null, 1, &desc));
+    report_status(env, "object_freeze(number)",
+                  napi_object_freeze(env, v_num));
+    report_status(env, "object_freeze(null)", napi_object_freeze(env, v_null));
+    report_status(env, "object_seal(number)", napi_object_seal(env, v_num));
+    report_status(env, "object_seal(undefined)",
+                  napi_object_seal(env, v_undef));
+    napi_type_tag tag = {1, 2};
+    report_status(env, "type_tag_object(number)",
+                  napi_type_tag_object(env, v_num, &tag));
+    report_status(env, "type_tag_object(null)",
+                  napi_type_tag_object(env, v_null, &tag));
+    bool match;
+    report_status(env, "check_object_type_tag(number)",
+                  napi_check_object_type_tag(env, v_num, &tag, &match));
+    report_status(env, "check_object_type_tag(null)",
+                  napi_check_object_type_tag(env, v_null, &tag, &match));
+    napi_value proto;
+    NODE_API_CALL(env, napi_create_object(env, &proto));
+    report_status(env, "node_api_set_prototype(number)",
+                  node_api_set_prototype(env, v_num, proto));
+    report_status(env, "node_api_set_prototype(null)",
+                  node_api_set_prototype(env, v_null, proto));
+  }
+
+  // napi_new_instance / napi_get_named_property / napi_has_named_property do
+  // not touch *result when the call fails with an exception.
+  {
+    napi_value thrower;
+    NODE_API_CALL(
+        env, napi_create_function(
+                 env, "Throws", NAPI_AUTO_LENGTH,
+                 [](napi_env e, napi_callback_info) -> napi_value {
+                   napi_throw_error(e, NULL, "ctor");
+                   return NULL;
+                 },
+                 NULL, &thrower));
+    napi_value sentinel = reinterpret_cast<napi_value>(0xdeadbeef);
+    napi_value r = sentinel;
+    napi_status s = napi_new_instance(env, thrower, 0, NULL, &r);
+    bool pending;
+    napi_is_exception_pending(env, &pending);
+    if (pending) {
+      napi_value e;
+      napi_get_and_clear_last_exception(env, &e);
+    }
+    printf("new_instance(throws): status=%d result_written=%d\n", (int)s,
+           r != sentinel);
+
+    // Proxy whose has/get traps throw
+    napi_value script, proxy;
+    NODE_API_CALL(
+        env, napi_create_string_utf8(
+                 env,
+                 "new Proxy({}, {has: () => { throw new Error('h'); }, "
+                 "get: () => { throw new Error('g'); }})",
+                 NAPI_AUTO_LENGTH, &script));
+    NODE_API_CALL(env, napi_run_script(env, script, &proxy));
+    r = sentinel;
+    s = napi_get_named_property(env, proxy, "k", &r);
+    napi_is_exception_pending(env, &pending);
+    if (pending) {
+      napi_value e;
+      napi_get_and_clear_last_exception(env, &e);
+    }
+    printf("get_named_property(throws): status=%d result_written=%d\n", (int)s,
+           r != sentinel);
+    bool br = true;
+    s = napi_has_named_property(env, proxy, "k", &br);
+    napi_is_exception_pending(env, &pending);
+    if (pending) {
+      napi_value e;
+      napi_get_and_clear_last_exception(env, &e);
+    }
+    printf("has_named_property(throws): status=%d result_written=%d\n", (int)s,
+           br != true);
+  }
+
+  // node_api_get_module_file_name never writes NULL
+  {
+    const char *fn = reinterpret_cast<const char *>(0x1);
+    napi_status s = node_api_get_module_file_name(env, &fn);
+    printf("module_file_name: status=%d is_null=%d\n", (int)s, fn == NULL);
+  }
+
+  return ok(env);
+}
+
+// Returns a weak napi_ref to a fresh object so the JS side can GC and then
+// inspect napi_reference_ref behaviour after the referent is collected.
+static napi_value
+test_create_weak_ref_for_gc(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value obj;
+  NODE_API_CALL(env, napi_create_object(env, &obj));
+  napi_ref ref;
+  NODE_API_CALL(env, napi_create_reference(env, obj, 0, &ref));
+  napi_value ext;
+  NODE_API_CALL(env,
+                napi_create_external(env, reinterpret_cast<void *>(ref), NULL,
+                                     NULL, &ext));
+  return ext;
+}
+
+static napi_value
+test_reference_ref_after_collect(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  void *p;
+  NODE_API_CALL(env, napi_get_value_external(env, info[1], &p));
+  napi_ref ref = reinterpret_cast<napi_ref>(p);
+
+  napi_value v = NULL;
+  NODE_API_CALL(env, napi_get_reference_value(env, ref, &v));
+  napi_valuetype t = napi_undefined;
+  if (v) napi_typeof(env, v, &t);
+  uint32_t count = 999;
+  NODE_API_CALL(env, napi_reference_ref(env, ref, &count));
+  printf("get_reference_value is undefined=%d reference_ref count=%u\n",
+         (v == NULL || t == napi_undefined), count);
+  uint32_t count2 = 999;
+  NODE_API_CALL(env, napi_reference_ref(env, ref, &count2));
+  printf("second reference_ref count=%u\n", count2);
+  NODE_API_CALL(env, napi_delete_reference(env, ref));
+  return ok(env);
+}
+
+static std::atomic<int> tsfn_nullcb_was_null(-1);
+
+static void tsfn_nullcb_call_js(napi_env env, napi_value js_callback,
+                                void *context, void *data) {
+  tsfn_nullcb_was_null.store(js_callback == NULL ? 1 : 0);
+}
+
+static void tsfn_nullcb_finalize(napi_env env, void *data, void *hint) {}
+
+static napi_value
+test_tsfn_null_js_callback(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  tsfn_nullcb_was_null.store(-1);
+  napi_value name;
+  NODE_API_CALL(env, napi_create_string_utf8(env, "tsfn-nullcb",
+                                             NAPI_AUTO_LENGTH, &name));
+  napi_threadsafe_function tsfn;
+  NODE_API_CALL(env, napi_create_threadsafe_function(
+                         env, NULL, NULL, name, 0, 1, NULL,
+                         tsfn_nullcb_finalize, NULL, tsfn_nullcb_call_js,
+                         &tsfn));
+  NODE_API_CALL(
+      env, napi_call_threadsafe_function(tsfn, NULL, napi_tsfn_nonblocking));
+  NODE_API_CALL(env,
+                napi_release_threadsafe_function(tsfn, napi_tsfn_release));
+  return ok(env);
+}
+
+static napi_value
+test_tsfn_null_js_callback_result(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  printf("js_callback == NULL: %d\n", tsfn_nullcb_was_null.load());
+  return ok(env);
+}
+
 void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_typedarray_info_byte_offset);
   REGISTER_FUNCTION(env, exports, test_dataview_info_byte_offset);
@@ -3788,6 +4065,11 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_node_api_create_object_with_properties);
   REGISTER_FUNCTION(env, exports, test_node_api_sharedarraybuffer);
   REGISTER_FUNCTION(env, exports, test_napi_status_codes_node26);
+  REGISTER_FUNCTION(env, exports, test_napi_node26_semantic_parity);
+  REGISTER_FUNCTION(env, exports, test_create_weak_ref_for_gc);
+  REGISTER_FUNCTION(env, exports, test_reference_ref_after_collect);
+  REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback);
+  REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_result);
 }
 
 } // namespace napitests

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -4015,8 +4015,10 @@ static void tsfn_many_call_js(napi_env env, napi_value js_callback,
 }
 
 // Enqueues enough items to cross Node's kMaxIterationCount so the dispatch
-// loop yields mid-drain and re-schedules. Asserts every callback fired and
-// (under ASAN) that the yield did not double-schedule a freed pointer.
+// loop yields mid-drain and re-schedules. 2000 is a multiple of the cap so the
+// second tick's 1000th dispatch is the final item: that path queues the
+// finalizer inside dispatch_one() and then hits the closing == Closed guard on
+// the yield, so ASAN would catch a double-schedule on the freed TSFN.
 static napi_value test_tsfn_many_items(const Napi::CallbackInfo &info) {
   napi_env env = info.Env();
   tsfn_many_count.store(0);
@@ -4027,7 +4029,7 @@ static napi_value test_tsfn_many_items(const Napi::CallbackInfo &info) {
   NODE_API_CALL(env, napi_create_threadsafe_function(
                          env, NULL, NULL, name, 0, 1, NULL,
                          tsfn_nullcb_finalize, NULL, tsfn_many_call_js, &tsfn));
-  for (int i = 0; i < 1200; i++) {
+  for (int i = 0; i < 2000; i++) {
     NODE_API_CALL(
         env, napi_call_threadsafe_function(tsfn, NULL, napi_tsfn_nonblocking));
   }

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -3724,14 +3724,11 @@ test_napi_node26_semantic_parity(const Napi::CallbackInfo &info) {
   BlockingStdoutScope blocking_stdout;
 #endif
 
-  napi_value v_null, v_undef, v_num, v_str, v_str_empty, v_true, v_one, v_obj;
+  napi_value v_null, v_undef, v_num, v_str_empty, v_one, v_obj;
   NODE_API_CALL(env, napi_get_null(env, &v_null));
   NODE_API_CALL(env, napi_get_undefined(env, &v_undef));
   NODE_API_CALL(env, napi_create_double(env, 42.5, &v_num));
-  NODE_API_CALL(env,
-                napi_create_string_utf8(env, "abc", NAPI_AUTO_LENGTH, &v_str));
   NODE_API_CALL(env, napi_create_string_utf8(env, "", 0, &v_str_empty));
-  NODE_API_CALL(env, napi_get_boolean(env, true, &v_true));
   NODE_API_CALL(env, napi_create_int32(env, 1, &v_one));
   NODE_API_CALL(env, napi_create_object(env, &v_obj));
 
@@ -3759,12 +3756,7 @@ test_napi_node26_semantic_parity(const Napi::CallbackInfo &info) {
     napi_status s = napi_create_symbol(env, v_str_empty, &sym);
     report_status(env, "create_symbol(\"\")", s);
     if (s == napi_ok) {
-      napi_value global, sym_ctor, proto, desc_key, desc;
-      NODE_API_CALL(env, napi_get_global(env, &global));
-      NODE_API_CALL(env,
-                    napi_get_named_property(env, global, "Symbol", &sym_ctor));
-      NODE_API_CALL(
-          env, napi_get_named_property(env, sym_ctor, "prototype", &proto));
+      napi_value desc_key, desc;
       NODE_API_CALL(env, napi_create_string_utf8(env, "description",
                                                  NAPI_AUTO_LENGTH, &desc_key));
       NODE_API_CALL(env, napi_get_property(env, sym, desc_key, &desc));

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -3930,6 +3930,23 @@ test_create_weak_ref_for_gc(const Napi::CallbackInfo &info) {
   return ext;
 }
 
+// Predicate for gcUntil: true once the weak ref's value is undefined.
+static napi_value
+test_weak_ref_is_collected(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  void *p;
+  NODE_API_CALL(env, napi_get_value_external(env, info[1], &p));
+  napi_ref ref = reinterpret_cast<napi_ref>(p);
+  napi_value v = NULL;
+  NODE_API_CALL(env, napi_get_reference_value(env, ref, &v));
+  napi_valuetype t = napi_undefined;
+  if (v) napi_typeof(env, v, &t);
+  napi_value r;
+  NODE_API_CALL(env,
+                napi_get_boolean(env, v == NULL || t == napi_undefined, &r));
+  return r;
+}
+
 static napi_value
 test_reference_ref_after_collect(const Napi::CallbackInfo &info) {
   napi_env env = info.Env();
@@ -3978,6 +3995,17 @@ test_tsfn_null_js_callback(const Napi::CallbackInfo &info) {
   NODE_API_CALL(env,
                 napi_release_threadsafe_function(tsfn, napi_tsfn_release));
   return ok(env);
+}
+
+// Predicate for the driver's bounded poll; no printf so checkSameOutput stays
+// clean.
+static napi_value
+test_tsfn_null_js_callback_ran(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value r;
+  NODE_API_CALL(env,
+                napi_get_boolean(env, tsfn_nullcb_was_null.load() != -1, &r));
+  return r;
 }
 
 static napi_value
@@ -4067,8 +4095,10 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_napi_status_codes_node26);
   REGISTER_FUNCTION(env, exports, test_napi_node26_semantic_parity);
   REGISTER_FUNCTION(env, exports, test_create_weak_ref_for_gc);
+  REGISTER_FUNCTION(env, exports, test_weak_ref_is_collected);
   REGISTER_FUNCTION(env, exports, test_reference_ref_after_collect);
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback);
+  REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_ran);
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_result);
 }
 

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1636,7 +1636,9 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
       expect(output).toContain("check_object_type_tag(number): status=0 pending=0");
       expect(output).toContain("node_api_set_prototype(number): status=0 pending=0");
       expect(output).toContain("node_api_set_prototype(null): status=2 pending=1");
-      expect(output).toContain("result_written=0");
+      expect(output).toContain("new_instance(throws): status=10 result_written=0");
+      expect(output).toContain("get_named_property(throws): status=10 result_written=0");
+      expect(output).toContain("has_named_property(throws): status=10 result_written=0");
       expect(output).toContain("module_file_name: status=0 is_null=0");
     });
 

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1655,7 +1655,7 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
 
     it("threadsafe function drains >1000 queued items across the kMaxIterationCount yield", async () => {
       const output = await checkSameOutput("test_tsfn_many_items_driver", []);
-      expect(output).toContain("tsfn callbacks fired: 1200");
+      expect(output).toContain("tsfn callbacks fired: 2000");
     });
   });
 

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1611,6 +1611,47 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
     });
   });
 
+  describe("semantic parity with Node.js", () => {
+    it("matches Node for symbol description, ToObject coercion, external-string args, buffer-info gate, result-on-exception, empty named key, and module filename", async () => {
+      const output = await checkSameOutput("test_napi_node26_semantic_parity", []);
+      expect(output).toContain('set_named_property(""): status=0 pending=0');
+      expect(output).toContain('obj[""]=1');
+      expect(output).toContain("create_symbol(undefined): status=3 pending=0");
+      expect(output).toContain("create_symbol(null): status=3 pending=0");
+      expect(output).toContain('create_symbol(""): status=0 pending=0');
+      expect(output).toContain('create_symbol("") description: type=4 len=0');
+      expect(output).toContain("ext_string_latin1(NULL,0): status=0 pending=0");
+      expect(output).toContain("ext_string_latin1(ptr,INT_MAX+1): status=1 pending=0");
+      expect(output).toContain("ext_string_utf16(ptr,INT_MAX+1): status=1 pending=0");
+      expect(output).toContain("get_buffer_info(ArrayBuffer): status=1 pending=0");
+      expect(output).toContain("get_buffer_info(Uint8Array): status=0 pending=0");
+      expect(output).toContain("get_buffer_info(DataView): status=0 pending=0");
+      expect(output).toContain("define_properties(number): status=0 pending=0");
+      expect(output).toContain("define_properties(null): status=2 pending=1");
+      expect(output).toContain("object_freeze(number): status=0 pending=0");
+      expect(output).toContain("object_freeze(null): status=2 pending=1");
+      expect(output).toContain("object_seal(number): status=0 pending=0");
+      expect(output).toContain("type_tag_object(number): status=0 pending=0");
+      expect(output).toContain("type_tag_object(null): status=10 pending=1");
+      expect(output).toContain("check_object_type_tag(number): status=0 pending=0");
+      expect(output).toContain("node_api_set_prototype(number): status=0 pending=0");
+      expect(output).toContain("node_api_set_prototype(null): status=2 pending=1");
+      expect(output).toContain("result_written=0");
+      expect(output).toContain("module_file_name: status=0 is_null=0");
+    });
+
+    it("napi_reference_ref returns 0 after the referent is collected", async () => {
+      const output = await checkSameOutput("test_reference_ref_after_collect_driver", []);
+      expect(output).toContain("reference_ref count=0");
+      expect(output).toContain("second reference_ref count=0");
+    });
+
+    it("threadsafe function call_js receives NULL js_callback when created without a func", async () => {
+      const output = await checkSameOutput("test_tsfn_null_js_callback_driver", []);
+      expect(output).toContain("js_callback == NULL: 1");
+    });
+  });
+
   describe("napi_is_arraybuffer", () => {
     it("distinguishes ArrayBuffer from SharedArrayBuffer and typed arrays", async () => {
       // https://github.com/oven-sh/bun/issues/32624

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1652,6 +1652,11 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
       const output = await checkSameOutput("test_tsfn_null_js_callback_driver", []);
       expect(output).toContain("js_callback == NULL: 1");
     });
+
+    it("threadsafe function drains >1000 queued items across the kMaxIterationCount yield", async () => {
+      const output = await checkSameOutput("test_tsfn_many_items_driver", []);
+      expect(output).toContain("tsfn callbacks fired: 1200");
+    });
   });
 
   describe("napi_is_arraybuffer", () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1644,7 +1644,7 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
 
     it("napi_reference_ref returns 0 after the referent is collected", async () => {
       const output = await checkSameOutput("test_reference_ref_after_collect_driver", []);
-      expect(output).toContain("reference_ref count=0");
+      expect(output).toContain("get_reference_value is undefined=1 reference_ref count=0");
       expect(output).toContain("second reference_ref count=0");
     });
 


### PR DESCRIPTION
> **Superseded.** Kept open as a draft, at a maintainer's request, as the reference for the full audit. It will not be rebased; the content landed via the split PRs below and the remaining diff is tracked in #36850.
>
> - #36845 (merged) TSFN: NULL `js_callback`
> - #36846 (merged) ToObject coercion
> - #36847 (merged) external-string arg validation
> - #36849 (merged) symbol description, empty key, result ordering, module_file_name
> - #36850 (open) `napi_reference_ref` after collection, `napi_get_buffer_info` gate
>
> Dropped after review: the TSFN `kMaxIterationCount` cap (no issue motivating it).

---

## What

A set of N-API functions whose observable behaviour (not just return status) differed from Node.js. Each was verified by running the same native addon under both `node` v26 and `bun`; the new tests use `checkSameOutput` so Bun's stdout is compared byte-for-byte with Node's.

| Function | Before (Bun) | Node.js / after |
|---|---|---|
| `napi_set_named_property(env, obj, "", v)` | `napi_invalid_arg` | `napi_ok` (sets `obj[""]`) |
| `napi_create_symbol(env, <js undefined/null>, &r)` | `napi_ok`, `Symbol()` | `napi_string_expected` |
| `napi_create_symbol(env, <js "">, &r)` | `.description === undefined` | `.description === ""` |
| `node_api_create_external_string_latin1(env, NULL, 0, ...)` | `napi_invalid_arg` | `napi_ok` (empty string) |
| `node_api_create_external_string_{latin1,utf16}(env, p, INT_MAX+1, ...)` | **crash** (truncated `static_cast<unsigned>` span) | `napi_invalid_arg` |
| `napi_get_buffer_info(env, <ArrayBuffer>, ...)` | `napi_ok` | `napi_invalid_arg` (`HasInstance` = `IsArrayBufferView`) |
| `napi_define_properties` / `napi_object_freeze` / `napi_object_seal` / `node_api_set_prototype` on a number | `napi_object_expected`, no exception | `napi_ok` (ToObject-coerced) |
| ... on `null` / `undefined` | `napi_object_expected`, no exception | `napi_object_expected`, pending `TypeError` |
| `napi_type_tag_object` / `napi_check_object_type_tag` on a number | `napi_object_expected`, no exception | `napi_ok` |
| ... on `null` | `napi_object_expected`, no exception | `napi_pending_exception` |
| `napi_new_instance` / `napi_get_named_property` / `napi_has_named_property` when the underlying JS throws | writes `*result`, then `napi_pending_exception` | `napi_pending_exception`, `*result` untouched |
| `node_api_get_module_file_name` on the `napi_module_register` path | writes `NULL` | writes `""` |
| `napi_reference_ref` after the weak referent is collected | increments (returns 1, 2, ...) | returns 0, does not increment |
| TSFN `call_js_cb` when created with `func == NULL` | `js_callback` is encoded `undefined` (non-null) | `js_callback == NULL` |
| TSFN dispatch loop | unbounded | 1000-iteration cap then re-schedule (`kMaxIterationCount`) |

## Why

These are the cases where a correct N-API addon observes a different answer under Bun than under Node.js, for the same sequence of calls. The external-string length overflow is a crash in practice (the truncated `unsigned` is used as a span length over the caller's buffer). The `js_callback != NULL` check is how napi-rs and similar decide whether to invoke the JS function inside `call_js_cb`; the encoded `undefined` value is a non-zero pointer, so addons were calling `napi_call_function` on it and panicking with "expect Function, got: Undefined".

Fixes #13771
Closes #30543 (subsumed; same TSFN `js_callback` fix)

Two items from the originating audit were dropped after empirical verification: `napi_set_property` / `_element` do not need a put-return check (V8's `Object::Set` never returns `Just(false)`, so Node's `napi_generic_failure` branch is unreachable and Bun already matches), and `napi_get_prototype` already avoids the Proxy `getPrototypeOf` trap in Bun.

The `napi_get_typedarray_info` / `napi_get_dataview_info` type gate and the `napi_add_finalizer` teardown guarantee are already covered by #34132 and #32912 respectively.

## Verification

New `checkSameOutput` tests in `test/napi/napi.test.ts` (`-t "semantic parity with Node"`) compare Bun against Node.js and fail under the released Bun:

```
$ USE_SYSTEM_BUN=1 bun test test/napi/napi.test.ts -t "semantic parity"
(fail) ... matches Node for symbol description, ToObject coercion, ...
(fail) ... napi_reference_ref returns 0 after the referent is collected
(fail) ... threadsafe function call_js receives NULL js_callback ...

$ bun bd test test/napi/napi.test.ts -t "semantic parity"
(pass) ... (all three)
```

The vendored Node.js `js-native-api/test_symbol`, `test_object`, `test_properties`, `test_reference`, and `node-api/test_threadsafe_function` suites continue to pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->
