### PR TITLE
bundler: propagate worker termination from plugin setup() wait instead of panicking

### DIFF
--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -552,10 +552,7 @@ pub mod js_bundler {
                             match promise
                                 .unwrap(global_this.vm(), jsc::PromiseUnwrapMode::MarkHandled)
                             {
-                                // wait_for_promise returns early once the VM's
-                                // TerminationException has fired (execution_forbidden),
-                                // leaving the promise Pending. Propagate instead of
-                                // panicking so the terminating worker unwinds cleanly.
+                                // wait_for_promise returns early on VM termination; propagate.
                                 jsc::PromiseResult::Pending => {
                                     return Err(JsError::Terminated);
                                 }

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -552,7 +552,13 @@ pub mod js_bundler {
                             match promise
                                 .unwrap(global_this.vm(), jsc::PromiseUnwrapMode::MarkHandled)
                             {
-                                jsc::PromiseResult::Pending => unreachable!(),
+                                // wait_for_promise returns early once the VM's
+                                // TerminationException has fired (execution_forbidden),
+                                // leaving the promise Pending. Propagate instead of
+                                // panicking so the terminating worker unwinds cleanly.
+                                jsc::PromiseResult::Pending => {
+                                    return Err(JsError::Terminated);
+                                }
                                 jsc::PromiseResult::Fulfilled(val) => {
                                     plugin_result = val;
                                 }

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -377,7 +377,8 @@ impl SplitBundlerOptions {
                 // live for the lifetime of the global object.
                 global.bun_vm().as_mut().wait_for_promise(promise);
                 match promise.unwrap(global.vm(), bun_jsc::PromiseUnwrapMode::MarkHandled) {
-                    bun_jsc::PromiseResult::Pending => unreachable!(),
+                    // wait_for_promise returns early on VM termination; propagate.
+                    bun_jsc::PromiseResult::Pending => return Err(JsError::Terminated),
                     bun_jsc::PromiseResult::Fulfilled(_val) => {}
                     bun_jsc::PromiseResult::Rejected(err) => {
                         return Err(global.throw_value(err));

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -526,7 +526,8 @@ impl Expect {
                             }
                             Promise::None => unreachable!(),
                         },
-                        js_promise::Status::Pending => unreachable!(),
+                        // wait_for_promise returns early on VM termination; propagate.
+                        js_promise::Status::Pending => return Err(JsError::Terminated),
                     }
 
                     new_value.ensure_still_alive();
@@ -903,7 +904,8 @@ impl Expect {
                     // since we know for sure it rejected, we should always return the error
                     return Ok((Some(rejected.to_error().unwrap_or(rejected)), return_value_from_function));
                 }
-                js_promise::Unwrapped::Pending => unreachable!(),
+                // wait_for_promise returns early on VM termination; propagate.
+                js_promise::Unwrapped::Pending => return Err(JsError::Terminated),
             }
         }
 
@@ -1492,9 +1494,9 @@ impl Expect {
 
             result = promise.result(vm);
             result.ensure_still_alive();
-            debug_assert!(!result.is_empty());
             match promise.status() {
-                js_promise::Status::Pending => unreachable!(),
+                // wait_for_promise returns early on VM termination; propagate.
+                js_promise::Status::Pending => return Err(JsError::Terminated),
                 js_promise::Status::Fulfilled => {}
                 js_promise::Status::Rejected => {
                     // TODO: rewrite this code to use .then() instead of blocking the event loop

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1567,9 +1567,7 @@ test("Bun.build in a Worker: terminate() while plugin async setup() is pending d
         for (let r = 0; r < ${rounds}; r++) {
           const ws = [];
           for (let i = 0; i < 3; i++) {
-            const w = new Worker(wfile, { workerData: { entry } });
-            w.on("error", () => {});
-            ws.push(w);
+            ws.push(new Worker(wfile, { workerData: { entry } }));
           }
           // Each worker posts "up" from inside its plugin setup() body, so by
           // the time we see it the worker is parked in wait_for_promise.

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1525,3 +1525,72 @@ test("Bun.build can be called thousands of times in one process without crashing
   expect(stdout.trim()).toBe("OK 400");
   expect(exitCode).toBe(0);
 }, 180_000);
+
+// Terminating a Worker while a Bun.build() plugin's async setup() promise is
+// still pending makes wait_for_promise return early (execution forbidden) with
+// the promise still Pending. Previously the Pending arm in Config::from_js was
+// an unreachable!() and the whole process (parent included) aborted with
+// "panic: internal error: entered unreachable code".
+test("Bun.build in a Worker: terminate() while plugin async setup() is pending does not crash the process", async () => {
+  // Debug/ASAN worker VM startup is slow; a handful of rounds is enough since
+  // the setup promise never resolves, so every terminate() lands mid-wait.
+  const rounds = isDebug || isASAN ? 4 : 12;
+  using dir = tempDir("bun-build-worker-terminate-setup", {
+    "entry.js": "export default 1;\n",
+    "w.cjs": `
+      const { parentPort, workerData } = require("node:worker_threads");
+      const entry = workerData.entry;
+      // Keep the event loop live so wait_for_promise's auto_tick wakes promptly
+      // on notifyNeedTermination.
+      setInterval(() => {}, 5);
+      Bun.build({
+        entrypoints: [entry],
+        plugins: [{
+          name: "never-resolves",
+          async setup(b) {
+            // We are now inside Config::from_js -> wait_for_promise. Tell the
+            // parent to terminate us, then keep this promise Pending forever.
+            parentPort.postMessage("up");
+            await new Promise(() => {});
+            b.onLoad({ filter: /never/ }, () => undefined);
+          },
+        }],
+      }).catch(() => {});
+    `,
+    "run.cjs": `
+      const { Worker } = require("node:worker_threads");
+      const path = require("node:path");
+      const wfile = path.join(__dirname, "w.cjs");
+      const entry = path.join(__dirname, "entry.js");
+
+      (async () => {
+        for (let r = 0; r < ${rounds}; r++) {
+          const ws = [];
+          for (let i = 0; i < 3; i++) {
+            const w = new Worker(wfile, { workerData: { entry } });
+            w.on("error", () => {});
+            ws.push(w);
+          }
+          // Each worker posts "up" from inside its plugin setup() body, so by
+          // the time we see it the worker is parked in wait_for_promise.
+          await Promise.all(ws.map(w => new Promise(res => w.once("message", res))));
+          await Promise.all(ws.map(w => w.terminate()));
+        }
+        console.log("PASS " + ${rounds});
+        process.exit(0);
+      })();
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe(`PASS ${rounds}`);
+  expect(exitCode).toBe(0);
+}, 60_000);

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1570,8 +1570,14 @@ test("Bun.build in a Worker: terminate() while plugin async setup() is pending d
             ws.push(new Worker(wfile, { workerData: { entry } }));
           }
           // Each worker posts "up" from inside its plugin setup() body, so by
-          // the time we see it the worker is parked in wait_for_promise.
-          await Promise.all(ws.map(w => new Promise(res => w.once("message", res))));
+          // the time we see it the worker is parked in wait_for_promise. Wire
+          // error/exit to reject so a pre-"up" failure surfaces immediately
+          // instead of hanging until the outer test timeout.
+          await Promise.all(ws.map(w => new Promise((res, rej) => {
+            w.once("message", res);
+            w.once("error", rej);
+            w.once("exit", code => rej(new Error("worker exited before 'up': " + code)));
+          })));
           await Promise.all(ws.map(w => w.terminate()));
         }
         console.log("PASS " + ${rounds});


### PR DESCRIPTION
## Problem

Calling `Bun.build()` inside a Worker with a plugin whose `async setup()` returns a promise, then terminating that worker while the setup promise is still pending, aborts the entire process:

```
panic: internal error: entered unreachable code
  bun_runtime::api::js_bundler::Config::from_js   src/runtime/api/JSBundler.rs:555
```

Repro (crashes stock 1.4.0 at round 0):
```js
import { Worker } from "node:worker_threads";
// worker body: Bun.build({ plugins: [{ async setup(b) { postMessage("up"); await new Promise(() => {}); } }] })
const w = new Worker(wfile, { workerData });
await new Promise(r => w.once("message", r));
await w.terminate();   // => whole-process abort
```

## Cause

`Config::from_js` awaits the plugin setup promise via `EventLoop::wait_for_promise`, which breaks out of its tick loop as soon as `jsc_vm.execution_forbidden()` is true:

```rust
while promise.status() == PromiseStatus::Pending {
    if jsc_vm.execution_forbidden() { break; }
    self.tick();
    ...
}
```

`execution_forbidden()` is only set from `VM::throwTerminationException()` (and `DeferredWorkTimer::doWork` after observing a pending TerminationException), so when the loop breaks the promise is still `Pending` and a TerminationException is already on the VM. The caller's `Pending` match arm was `unreachable!()`, and the panic handler aborts, taking the parent process down with the worker.

## Fix

Return `Err(JsError::Terminated)` from the `Pending` arm so the host-fn wrapper returns `JSValue::ZERO` and the pending TerminationException unwinds the worker normally. Applied to every `wait_for_promise` caller with this pattern that is reachable from a worker VM:

- `src/runtime/api/JSBundler.rs` (`Bun.build` plugin setup)
- `src/runtime/bake/bake_body.rs` (bake plugin setup)
- `src/runtime/test_runner/expect.rs` (`.resolves`/`.rejects`, `toThrow` on an async fn, async custom matcher result)

The three sibling sites in `src/runtime/bake/production.rs` are intentionally left as-is: they run on the main VM from the `bun build --app` CLI, and `forbidExecutionOnTermination()` is only set for worker VMs (ZigGlobalObject.cpp), so `wait_for_promise` cannot return `Pending` there today.

## Verification

New test in `test/bundler/bun-build-api.test.ts` spawns workers that call `Bun.build()` with a plugin whose `setup()` posts `"up"` from inside the setup body and then awaits a never-resolving promise; the parent terminates each worker once it sees `"up"`. On stock 1.4.0 the subprocess aborts at round 0 with the panic above; with this change it completes all rounds and exits 0.

```
(pass) Bun.build in a Worker: terminate() while plugin async setup() is pending does not crash the process
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->