### PR TITLE
napi: align return status codes with Node.js for validation and failure paths

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -151,6 +151,12 @@ using namespace Zig;
 // Return an error code if an exception was thrown after NAPI_PREAMBLE
 #define NAPI_RETURN_IF_VM_EXCEPTION(_env) RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error((_env), napi_pending_exception))
 
+// Like NAPI_RETURN_IF_VM_EXCEPTION but returns a caller-chosen status.
+// Used where Node.js reports a specific code (e.g. napi_string_expected,
+// napi_generic_failure) while leaving the thrown exception pending.
+#define NAPI_RETURN_STATUS_IF_EXCEPTION(_env, _status) \
+    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error((_env), (_status)))
+
 #define NAPI_RETURN_IF_EXCEPTION_WITH_SCOPE(_env, _scope)                                   \
     do {                                                                                    \
         RETURN_IF_EXCEPTION((_scope), napi_set_last_error((_env), napi_pending_exception)); \
@@ -2187,7 +2193,7 @@ extern "C" napi_status napi_coerce_to_string(napi_env env, napi_value value,
 
     // .toString() can throw
     JSValue resultValue = JSValue(jsValue.toString(globalObject));
-    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_string_expected));
+    NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_string_expected);
 
     JSC::EnsureStillAliveScope ensureStillAlive1(resultValue);
     *result = toNapi(resultValue, globalObject);
@@ -2222,7 +2228,7 @@ extern "C" napi_status napi_coerce_to_number(napi_env env, napi_value value, nap
     JSValue jsValue = toJS(value);
     // might throw
     double nativeNumber = jsValue.toNumber(globalObject);
-    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_number_expected));
+    NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_number_expected);
 
     *result = toNapi(JSC::jsNumber(nativeNumber), globalObject);
     NAPI_RETURN_SUCCESS(env);
@@ -2239,7 +2245,7 @@ extern "C" napi_status napi_coerce_to_object(napi_env env, napi_value value, nap
     JSValue jsValue = toJS(value);
     // might throw
     JSObject* obj = jsValue.toObject(globalObject);
-    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_object_expected));
+    NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_object_expected);
 
     *result = toNapi(obj, globalObject);
     NAPI_RETURN_SUCCESS(env);
@@ -2276,7 +2282,7 @@ extern "C" napi_status napi_create_buffer(napi_env env, size_t length,
 
     // In Node.js, napi_create_buffer is uninitialized memory.
     auto* uint8Array = JSC::JSUint8Array::createUninitialized(globalObject, subclassStructure, length);
-    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_generic_failure));
+    NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_generic_failure);
 
     if (data != nullptr) {
         // Node.js' code looks like this:
@@ -2337,7 +2343,7 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
         // TODO: is there a way to create a detached uint8 array?
         auto arrayBuffer = JSC::ArrayBuffer::createUninitialized(0, 1);
         auto* buffer = JSC::JSUint8Array::create(globalObject, subclassStructure, WTF::move(arrayBuffer), 0, 0);
-        RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_generic_failure));
+        NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_generic_failure);
         buffer->existingBuffer()->detach(vm);
 
         vm.heap.addFinalizer(buffer, [env = WTF::Ref<NapiEnv>(*env), finalize_cb, data, finalize_hint](JSCell* cell) -> void {
@@ -2357,7 +2363,7 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
     auto arrayBuffer = ArrayBuffer::createFromBytes({ reinterpret_cast<const uint8_t*>(data), length }, WTF::move(destructor));
 
     auto* buffer = JSC::JSUint8Array::create(globalObject, subclassStructure, WTF::move(arrayBuffer), 0, length);
-    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_generic_failure));
+    NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_generic_failure);
 
     // Arm only after successful creation: if create threw, the destructor
     // runs disarmed and skips finalize_cb (caller retains ownership).
@@ -3119,7 +3125,7 @@ extern "C" napi_status napi_instanceof(napi_env env, napi_value object, napi_val
     JSValue objectValue = toJS(object);
     JSValue constructorValue = toJS(constructor);
     JSC::JSObject* constructorObject = constructorValue.toObject(globalObject);
-    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_object_expected));
+    NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_object_expected);
 
     if (!constructorObject->isCallable()) {
         napi_throw_type_error(env, "ERR_NAPI_CONS_FUNCTION", "Constructor must be a function");
@@ -3127,7 +3133,7 @@ extern "C" napi_status napi_instanceof(napi_env env, napi_value object, napi_val
     }
 
     *result = constructorObject->hasInstance(globalObject, objectValue);
-    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_generic_failure));
+    NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_generic_failure);
 
     return napi_set_last_error(env, napi_ok);
 }

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -151,9 +151,7 @@ using namespace Zig;
 // Return an error code if an exception was thrown after NAPI_PREAMBLE
 #define NAPI_RETURN_IF_VM_EXCEPTION(_env) RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error((_env), napi_pending_exception))
 
-// Like NAPI_RETURN_IF_VM_EXCEPTION but returns a caller-chosen status.
-// Used where Node.js reports a specific code (e.g. napi_string_expected,
-// napi_generic_failure) while leaving the thrown exception pending.
+// Like NAPI_RETURN_IF_VM_EXCEPTION but returns a caller-chosen status while leaving the exception pending.
 #define NAPI_RETURN_STATUS_IF_EXCEPTION(_env, _status) \
     RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error((_env), (_status)))
 
@@ -1023,8 +1021,6 @@ static napi_status throwErrorWithCStrings(napi_env env, const char* code_utf8, c
     auto* globalObject = toJS(env);
     auto& vm = JSC::getVM(globalObject);
 
-    // Node.js uses NAPI_PREAMBLE for napi_throw_*error: if an exception is
-    // already pending, return napi_pending_exception and leave it untouched.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     if (scope.exception() || env->hasPendingException()) {
         return napi_set_last_error(env, napi_pending_exception);
@@ -1175,8 +1171,6 @@ extern "C" JS_EXPORT napi_status node_api_post_finalizer(napi_env env,
     void* finalize_data,
     void* finalize_hint)
 {
-    // Node.js uses only CHECK_ENV here (basic-env function) and does not
-    // null-check finalize_cb; a NULL cb is enqueued and no-ops on run.
     NAPI_PREAMBLE_NO_THROW_SCOPE(env);
     napi_internal_enqueue_finalizer(env, finalize_cb, finalize_data, finalize_hint);
     return napi_set_last_error(env, napi_ok);
@@ -3014,15 +3008,10 @@ extern "C" napi_status napi_create_bigint_words(napi_env env,
     NAPI_RETURN_IF_EXCEPTION_WITH_SCOPE(env, scope);
     NAPI_CHECK_ARG(env, result);
     NAPI_CHECK_ARG(env, words);
-    // Node.js: RETURN_STATUS_IF_FALSE(env, word_count <= INT_MAX, napi_invalid_arg).
     NAPI_RETURN_EARLY_IF_FALSE(env, word_count <= INT_MAX, napi_invalid_arg);
 
-    // V8 checks its kMaxLength before reading the words array, so Node's
-    // test_bigint passes INT_MAX with a 10-element buffer and expects a throw.
-    // JSC::tryCreateFromWords trims trailing zeroes first (reads words[n-1]),
-    // so throw here to avoid reading past the caller's buffer.
-    // JSBigInt::maxLength is private; JSBigInt.h defines it as
-    // maxLengthBits (1 << 20) / digitBits (CHAR_BIT * sizeof(uint64_t)).
+    // JSC::tryCreateFromWords reads words[n-1] before its length check, so throw
+    // here first. Value mirrors JSBigInt::maxLength (maxLengthBits / digitBits).
     constexpr size_t jscBigIntMaxWords = (1 << 20) / (CHAR_BIT * sizeof(uint64_t));
     if (word_count > jscBigIntMaxWords) {
         JSC::throwOutOfMemoryError(globalObject, scope);

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -831,7 +831,7 @@ extern "C" napi_status napi_wrap(napi_env env,
     auto& vm = JSC::getVM(globalObject);
     JSValue jsc_value = toJS(js_object);
     JSObject* jsc_object = jsc_value.getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, jsc_object, napi_object_expected);
+    NAPI_RETURN_EARLY_IF_FALSE(env, jsc_object, napi_invalid_arg);
 
     // NapiPrototype has an inline field to store a napi_ref, so we use that if we can
     auto* napi_instance = dynamicDowncast<NapiPrototype>(jsc_object);
@@ -875,7 +875,7 @@ extern "C" napi_status napi_remove_wrap(napi_env env, napi_value js_object,
 
     JSValue jsc_value = toJS(js_object);
     JSObject* jsc_object = jsc_value.getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, jsc_object, napi_object_expected);
+    NAPI_RETURN_EARLY_IF_FALSE(env, jsc_object, napi_invalid_arg);
     // may be null
     auto* napi_instance = dynamicDowncast<NapiPrototype>(jsc_object);
 
@@ -912,7 +912,7 @@ extern "C" napi_status napi_unwrap(napi_env env, napi_value js_object,
 
     JSValue jsc_value = toJS(js_object);
     JSObject* jsc_object = jsc_value.getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, jsc_object, napi_object_expected);
+    NAPI_RETURN_EARLY_IF_FALSE(env, jsc_object, napi_invalid_arg);
 
     Zig::GlobalObject* globalObject = toJS(env);
     auto& vm = JSC::getVM(globalObject);
@@ -1016,6 +1016,13 @@ static napi_status throwErrorWithCStrings(napi_env env, const char* code_utf8, c
 {
     auto* globalObject = toJS(env);
     auto& vm = JSC::getVM(globalObject);
+
+    // Node.js uses NAPI_PREAMBLE for napi_throw_*error: if an exception is
+    // already pending, return napi_pending_exception and leave it untouched.
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    if (scope.exception() || env->hasPendingException()) {
+        return napi_set_last_error(env, napi_pending_exception);
+    }
 
     if (!msg_utf8) {
         return napi_set_last_error(env, napi_invalid_arg);
@@ -1137,7 +1144,7 @@ extern "C" napi_status napi_add_finalizer(napi_env env, napi_value js_object,
 
     JSC::JSValue objectValue = toJS(js_object);
     JSC::JSObject* object = objectValue.getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, object, napi_object_expected);
+    NAPI_RETURN_EARLY_IF_FALSE(env, object, napi_invalid_arg);
 
     if (result) {
         // If they're expecting a Ref, use the ref.
@@ -1162,10 +1169,11 @@ extern "C" JS_EXPORT napi_status node_api_post_finalizer(napi_env env,
     void* finalize_data,
     void* finalize_hint)
 {
-    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
-    NAPI_CHECK_ARG(env, finalize_cb);
+    // Node.js uses only CHECK_ENV here (basic-env function) and does not
+    // null-check finalize_cb; a NULL cb is enqueued and no-ops on run.
+    NAPI_PREAMBLE_NO_THROW_SCOPE(env);
     napi_internal_enqueue_finalizer(env, finalize_cb, finalize_data, finalize_hint);
-    NAPI_RETURN_SUCCESS(env);
+    return napi_set_last_error(env, napi_ok);
 }
 
 extern "C" napi_status napi_reference_unref(napi_env env, napi_ref ref,
@@ -2179,7 +2187,7 @@ extern "C" napi_status napi_coerce_to_string(napi_env env, napi_value value,
 
     // .toString() can throw
     JSValue resultValue = JSValue(jsValue.toString(globalObject));
-    NAPI_RETURN_IF_EXCEPTION(env);
+    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_string_expected));
 
     JSC::EnsureStillAliveScope ensureStillAlive1(resultValue);
     *result = toNapi(resultValue, globalObject);
@@ -2214,7 +2222,7 @@ extern "C" napi_status napi_coerce_to_number(napi_env env, napi_value value, nap
     JSValue jsValue = toJS(value);
     // might throw
     double nativeNumber = jsValue.toNumber(globalObject);
-    NAPI_RETURN_IF_EXCEPTION(env);
+    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_number_expected));
 
     *result = toNapi(JSC::jsNumber(nativeNumber), globalObject);
     NAPI_RETURN_SUCCESS(env);
@@ -2231,7 +2239,7 @@ extern "C" napi_status napi_coerce_to_object(napi_env env, napi_value value, nap
     JSValue jsValue = toJS(value);
     // might throw
     JSObject* obj = jsValue.toObject(globalObject);
-    NAPI_RETURN_IF_EXCEPTION(env);
+    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_object_expected));
 
     *result = toNapi(obj, globalObject);
     NAPI_RETURN_SUCCESS(env);
@@ -2268,7 +2276,7 @@ extern "C" napi_status napi_create_buffer(napi_env env, size_t length,
 
     // In Node.js, napi_create_buffer is uninitialized memory.
     auto* uint8Array = JSC::JSUint8Array::createUninitialized(globalObject, subclassStructure, length);
-    NAPI_RETURN_IF_EXCEPTION(env);
+    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_generic_failure));
 
     if (data != nullptr) {
         // Node.js' code looks like this:
@@ -2329,7 +2337,7 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
         // TODO: is there a way to create a detached uint8 array?
         auto arrayBuffer = JSC::ArrayBuffer::createUninitialized(0, 1);
         auto* buffer = JSC::JSUint8Array::create(globalObject, subclassStructure, WTF::move(arrayBuffer), 0, 0);
-        NAPI_RETURN_IF_EXCEPTION(env);
+        RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_generic_failure));
         buffer->existingBuffer()->detach(vm);
 
         vm.heap.addFinalizer(buffer, [env = WTF::Ref<NapiEnv>(*env), finalize_cb, data, finalize_hint](JSCell* cell) -> void {
@@ -2349,7 +2357,7 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
     auto arrayBuffer = ArrayBuffer::createFromBytes({ reinterpret_cast<const uint8_t*>(data), length }, WTF::move(destructor));
 
     auto* buffer = JSC::JSUint8Array::create(globalObject, subclassStructure, WTF::move(arrayBuffer), 0, length);
-    NAPI_RETURN_IF_EXCEPTION(env);
+    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_generic_failure));
 
     // Arm only after successful creation: if create threw, the destructor
     // runs disarmed and skips finalize_cb (caller retains ownership).
@@ -2932,7 +2940,7 @@ extern "C" napi_status napi_run_script(napi_env env, napi_value script,
     NAPI_RETURN_EARLY_IF_FALSE(env, scriptValue.isString(), napi_string_expected);
 
     WTF::String code = scriptValue.getString(globalObject);
-    RETURN_IF_EXCEPTION(throwScope, napi_set_last_error(env, napi_pending_exception));
+    RETURN_IF_EXCEPTION(throwScope, napi_set_last_error(env, napi_generic_failure));
 
     JSC::SourceCode sourceCode = makeSource(code, SourceOrigin(), SourceTaintedOrigin::Untainted);
 
@@ -2941,7 +2949,7 @@ extern "C" napi_status napi_run_script(napi_env env, napi_value script,
 
     if (returnedException) {
         env->scheduleException(returnedException.get());
-        return napi_set_last_error(env, napi_pending_exception);
+        return napi_set_last_error(env, napi_generic_failure);
     }
 
     ASSERT(!value.isEmpty());
@@ -3000,15 +3008,17 @@ extern "C" napi_status napi_create_bigint_words(napi_env env,
     NAPI_RETURN_IF_EXCEPTION_WITH_SCOPE(env, scope);
     NAPI_CHECK_ARG(env, result);
     NAPI_CHECK_ARG(env, words);
-    // JSBigInt::createWithLength's size argument is unsigned int.
-    NAPI_RETURN_EARLY_IF_FALSE(env, word_count <= UINT_MAX, napi_invalid_arg);
+    // Node.js: RETURN_STATUS_IF_FALSE(env, word_count <= INT_MAX, napi_invalid_arg).
+    NAPI_RETURN_EARLY_IF_FALSE(env, word_count <= INT_MAX, napi_invalid_arg);
 
-    // we check INT_MAX here because it won't reject any bigints that should be able to be created
-    // (as the true limit is much lower), and one Node.js test expects an exception instead of
-    // napi_invalid_arg in case the length is INT_MAX
-    if (word_count >= INT_MAX) {
-        // we use this error as the error from creating a massive bigint literal is simply
-        // "RangeError: Out of memory"
+    // V8 checks its kMaxLength before reading the words array, so Node's
+    // test_bigint passes INT_MAX with a 10-element buffer and expects a throw.
+    // JSC::tryCreateFromWords trims trailing zeroes first (reads words[n-1]),
+    // so throw here to avoid reading past the caller's buffer.
+    // JSBigInt::maxLength is private; JSBigInt.h defines it as
+    // maxLengthBits (1 << 20) / digitBits (CHAR_BIT * sizeof(uint64_t)).
+    constexpr size_t jscBigIntMaxWords = (1 << 20) / (CHAR_BIT * sizeof(uint64_t));
+    if (word_count > jscBigIntMaxWords) {
         JSC::throwOutOfMemoryError(globalObject, scope);
         RETURN_IF_EXCEPTION(scope, napi_set_last_error(env, napi_pending_exception));
     }

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -1177,9 +1177,10 @@ extern "C" fn napi_make_callback(
     }
 
     let this_value = recv;
-    let args_slice: &[JSValue] = if arg_count > 0 && !args.is_null() {
-        // SAFETY: napi_value is repr(transparent) over i64, same as JSValue; caller guarantees
-        // [args, args+arg_count) is valid.
+    let args_slice: &[JSValue] = if arg_count > 0 {
+        // SAFETY: napi_value is repr(transparent) over i64, same as JSValue; the
+        // arg_count > 0 && args.is_null() case returned napi_invalid_arg above,
+        // and caller guarantees [args, args+arg_count) is valid.
         unsafe { bun_core::ffi::slice(args.cast::<JSValue>(), arg_count) }
     } else {
         &[]

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -701,7 +701,7 @@ extern "C" fn napi_create_string_utf8(
     let global_object = env.to_js();
     let string = match jsc::bun_string_jsc::create_utf8_for_js(global_object, slice) {
         Ok(v) => v,
-        Err(_) => return NapiEnv::set_last_error(Some(env), NapiStatus::pending_exception),
+        Err(_) => return env.generic_failure(),
     };
     result.set(env, string);
     env.ok()
@@ -1162,17 +1162,21 @@ extern "C" fn napi_make_callback(
     bun_output::scoped_log!(napi, "napi_make_callback");
     let env = preamble!(env_);
     let (recv, func) = (recv_.get(), func_.get());
+    // Node.js: CHECK_ARG(env, recv); if (argc > 0) CHECK_ARG(env, argv);
+    // then CHECK_TO_FUNCTION (napi_invalid_arg on non-function).
+    if recv.is_empty() {
+        return env.invalid_arg();
+    }
+    if arg_count > 0 && args.is_null() {
+        return env.invalid_arg();
+    }
     if func.is_empty_or_undefined_or_null()
         || (!func.is_callable() && !func.is_async_context_frame())
     {
-        return NapiEnv::set_last_error(Some(env), NapiStatus::function_expected);
+        return env.invalid_arg();
     }
 
-    let this_value = if !recv.is_empty() {
-        recv
-    } else {
-        JSValue::UNDEFINED
-    };
+    let this_value = recv;
     let args_slice: &[JSValue] = if arg_count > 0 && !args.is_null() {
         // SAFETY: napi_value is repr(transparent) over i64, same as JSValue; caller guarantees
         // [args, args+arg_count) is valid.
@@ -1549,7 +1553,7 @@ extern "C" fn napi_resolve_deferred(
     let resolution = resolution_.get();
     let prom = deferred_box.get();
     if prom.resolve(env.to_js(), resolution).is_err() {
-        return NapiEnv::set_last_error(Some(env), NapiStatus::pending_exception);
+        return env.generic_failure();
     }
     env.ok()
 }
@@ -1567,7 +1571,7 @@ extern "C" fn napi_reject_deferred(
     let rejection = rejection_.get();
     let prom = deferred_box.get();
     if prom.reject(env.to_js(), Ok(rejection)).is_err() {
-        return NapiEnv::set_last_error(Some(env), NapiStatus::pending_exception);
+        return env.generic_failure();
     }
     env.ok()
 }
@@ -2002,7 +2006,7 @@ extern "C" fn napi_create_buffer_copy(
     let result = get_out!(env, result_);
     let buffer: JSValue = match JSValue::create_buffer_from_length(env.to_js(), length) {
         Ok(b) => b,
-        Err(_) => return NapiEnv::set_last_error(Some(env), NapiStatus::pending_exception),
+        Err(_) => return env.generic_failure(),
     };
     if let Some(mut array_buf) = buffer.as_array_buffer(env.to_js()) {
         if length > 0 {
@@ -3153,14 +3157,21 @@ extern "C" fn napi_unref_threadsafe_function(
     func: napi_threadsafe_function,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_unref_threadsafe_function");
-    let env = get_env!(env_);
-    // SAFETY: func is non-null per N-API contract.
-    let func = unsafe { &mut *func };
-    if let Some(loop_) = func.event_loop.as_ref() {
+    // Node.js ignores env entirely (basic-env function) and returns raw
+    // napi_ok without touching last_error.
+    // SAFETY: caller passes a pointer from napi_create_threadsafe_function.
+    let Some(func) = (unsafe { func.as_mut() }) else {
+        return NapiStatus::invalid_arg as napi_status;
+    };
+    #[cfg(debug_assertions)]
+    // SAFETY: env_ is either null or a valid napi_env per N-API contract.
+    if let (Some(loop_), Some(env)) = (func.event_loop.as_ref(), unsafe { env_.as_ref() }) {
         debug_assert!(core::ptr::eq(loop_.global.unwrap().as_ptr(), env.to_js()));
     }
+    #[cfg(not(debug_assertions))]
+    let _ = env_;
     func.unref();
-    env.ok()
+    NapiStatus::ok as napi_status
 }
 
 #[unsafe(no_mangle)]
@@ -3169,14 +3180,21 @@ extern "C" fn napi_ref_threadsafe_function(
     func: napi_threadsafe_function,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_ref_threadsafe_function");
-    let env = get_env!(env_);
-    // SAFETY: func is non-null per N-API contract.
-    let func = unsafe { &mut *func };
-    if let Some(loop_) = func.event_loop.as_ref() {
+    // Node.js ignores env entirely (basic-env function) and returns raw
+    // napi_ok without touching last_error.
+    // SAFETY: caller passes a pointer from napi_create_threadsafe_function.
+    let Some(func) = (unsafe { func.as_mut() }) else {
+        return NapiStatus::invalid_arg as napi_status;
+    };
+    #[cfg(debug_assertions)]
+    // SAFETY: env_ is either null or a valid napi_env per N-API contract.
+    if let (Some(loop_), Some(env)) = (func.event_loop.as_ref(), unsafe { env_.as_ref() }) {
         debug_assert!(core::ptr::eq(loop_.global.unwrap().as_ptr(), env.to_js()));
     }
+    #[cfg(not(debug_assertions))]
+    let _ = env_;
     func.ref_();
-    env.ok()
+    NapiStatus::ok as napi_status
 }
 
 const NAPI_AUTO_LENGTH: usize = usize::MAX;

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -1162,8 +1162,6 @@ extern "C" fn napi_make_callback(
     bun_output::scoped_log!(napi, "napi_make_callback");
     let env = preamble!(env_);
     let (recv, func) = (recv_.get(), func_.get());
-    // Node.js: CHECK_ARG(env, recv); if (argc > 0) CHECK_ARG(env, argv);
-    // then CHECK_TO_FUNCTION (napi_invalid_arg on non-function).
     if recv.is_empty() {
         return env.invalid_arg();
     }
@@ -3158,8 +3156,6 @@ extern "C" fn napi_unref_threadsafe_function(
     func: napi_threadsafe_function,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_unref_threadsafe_function");
-    // Node.js ignores env entirely (basic-env function) and returns raw
-    // napi_ok without touching last_error.
     // SAFETY: caller passes a pointer from napi_create_threadsafe_function.
     let Some(func) = (unsafe { func.as_mut() }) else {
         return NapiStatus::invalid_arg as napi_status;
@@ -3181,8 +3177,6 @@ extern "C" fn napi_ref_threadsafe_function(
     func: napi_threadsafe_function,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_ref_threadsafe_function");
-    // Node.js ignores env entirely (basic-env function) and returns raw
-    // napi_ok without touching last_error.
     // SAFETY: caller passes a pointer from napi_create_threadsafe_function.
     let Some(func) = (unsafe { func.as_mut() }) else {
         return NapiStatus::invalid_arg as napi_status;

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -3595,6 +3595,21 @@ static napi_value test_napi_status_codes_node26(const Napi::CallbackInfo &info) 
         true);
   }
 
+  // napi_create_buffer / napi_create_buffer_copy: allocation failure returns
+  // napi_generic_failure. Both engines reject SIZE_MAX before allocating or
+  // reading data.
+  {
+    napi_value out;
+    void *data;
+    print_status("napi_create_buffer(SIZE_MAX)",
+                 napi_create_buffer(env, SIZE_MAX, &data, &out), true);
+    static const char one_byte = 0;
+    print_status(
+        "napi_create_buffer_copy(SIZE_MAX)",
+        napi_create_buffer_copy(env, SIZE_MAX, &one_byte, nullptr, &out),
+        true);
+  }
+
   // napi_throw_error while an exception is already pending: Node returns
   // napi_pending_exception and keeps the first exception.
   {
@@ -3653,14 +3668,12 @@ static napi_value test_napi_status_codes_node26(const Napi::CallbackInfo &info) 
            (int)napi_unref_threadsafe_function(nullptr, tsfn));
 
     // last_error should be untouched: arm it, call ref, then read it back.
-    napi_value dummy;
     napi_get_value_int32(env, undefinedv, nullptr); // sets napi_invalid_arg
     napi_ref_threadsafe_function(env, tsfn);
     const napi_extended_error_info *err;
     napi_get_last_error_info(env, &err);
     printf("napi_ref_threadsafe_function: last_error_preserved=%d\n",
            (int)err->error_code);
-    (void)dummy;
 
     NODE_API_CALL(env,
                   napi_release_threadsafe_function(tsfn, napi_tsfn_release));

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -3494,6 +3494,181 @@ test_node_api_sharedarraybuffer(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+static void noop_tsfn_cb(napi_env, napi_value, void *, void *) {}
+
+// Each case below returns a different napi_status in Bun than in Node.js 26
+// prior to the fix; see the PR body for the per-function Node.js references.
+// This test prints status codes and pending-exception state so checkSameOutput
+// can diff Bun against Node byte-for-byte.
+static napi_value test_napi_status_codes_node26(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+#ifndef _WIN32
+  BlockingStdoutScope stdout_scope;
+#endif
+
+  napi_value number, sym, nullv, undefinedv, obj, fn;
+  NODE_API_CALL(env, napi_create_int32(env, 7, &number));
+  {
+    napi_value desc;
+    NODE_API_CALL(env,
+                  napi_create_string_utf8(env, "s", NAPI_AUTO_LENGTH, &desc));
+    NODE_API_CALL(env, napi_create_symbol(env, desc, &sym));
+  }
+  NODE_API_CALL(env, napi_get_null(env, &nullv));
+  NODE_API_CALL(env, napi_get_undefined(env, &undefinedv));
+  NODE_API_CALL(env, napi_create_object(env, &obj));
+  NODE_API_CALL(env, napi_create_function(
+                         env, "noop", NAPI_AUTO_LENGTH,
+                         [](napi_env e, napi_callback_info) -> napi_value {
+                           napi_value u;
+                           napi_get_undefined(e, &u);
+                           return u;
+                         },
+                         nullptr, &fn));
+
+  auto print_status = [&](const char *label, napi_status st,
+                          bool drain_exception) {
+    bool pending = false;
+    napi_is_exception_pending(env, &pending);
+    printf("%s: status=%d pending=%d\n", label, (int)st, (int)pending);
+    if (drain_exception && pending) {
+      napi_value exc;
+      napi_get_and_clear_last_exception(env, &exc);
+    }
+  };
+
+  // napi_wrap / napi_unwrap / napi_remove_wrap / napi_add_finalizer on a
+  // primitive: Node returns napi_invalid_arg, not napi_object_expected.
+  {
+    void *out;
+    napi_ref ref_out;
+    print_status(
+        "napi_wrap(number)",
+        napi_wrap(env, number, nullptr, nullptr, nullptr, nullptr), true);
+    print_status("napi_unwrap(number)", napi_unwrap(env, number, &out), true);
+    print_status("napi_remove_wrap(number)",
+                 napi_remove_wrap(env, number, &out), true);
+    print_status(
+        "napi_add_finalizer(number)",
+        napi_add_finalizer(
+            env, number, nullptr,
+            [](napi_env, void *, void *) {}, nullptr, &ref_out),
+        true);
+  }
+
+  // napi_coerce_to_*: when coercion throws, Node returns napi_<type>_expected
+  // and leaves the exception pending.
+  {
+    napi_value out;
+    print_status("napi_coerce_to_number(Symbol)",
+                 napi_coerce_to_number(env, sym, &out), true);
+    print_status("napi_coerce_to_string(Symbol)",
+                 napi_coerce_to_string(env, sym, &out), true);
+    print_status("napi_coerce_to_object(null)",
+                 napi_coerce_to_object(env, nullv, &out), true);
+  }
+
+  // napi_run_script: on compile or eval error Node returns
+  // napi_generic_failure, not napi_pending_exception.
+  {
+    napi_value script_throw, script_syntax, out;
+    NODE_API_CALL(env, napi_create_string_utf8(env, "throw new Error('E')",
+                                               NAPI_AUTO_LENGTH,
+                                               &script_throw));
+    NODE_API_CALL(env, napi_create_string_utf8(env, "?!?", NAPI_AUTO_LENGTH,
+                                               &script_syntax));
+    print_status("napi_run_script(throw)",
+                 napi_run_script(env, script_throw, &out), true);
+    print_status("napi_run_script(syntax)",
+                 napi_run_script(env, script_syntax, &out), true);
+  }
+
+  // napi_create_bigint_words: for INT_MAX < word_count Node returns
+  // napi_invalid_arg with no throw.
+  {
+    napi_value out;
+    uint64_t one = 1;
+    print_status(
+        "napi_create_bigint_words(INT_MAX+1)",
+        napi_create_bigint_words(env, 0, (size_t)INT_MAX + 1, &one, &out),
+        true);
+  }
+
+  // napi_throw_error while an exception is already pending: Node returns
+  // napi_pending_exception and keeps the first exception.
+  {
+    NODE_API_CALL(env, napi_throw_error(env, nullptr, "first"));
+    napi_status s = napi_throw_error(env, nullptr, "second");
+    printf("napi_throw_error(2nd): status=%d\n", (int)s);
+    napi_value exc;
+    NODE_API_CALL(env, napi_get_and_clear_last_exception(env, &exc));
+    napi_value msg_key, msg;
+    NODE_API_CALL(env, napi_create_string_utf8(env, "message",
+                                               NAPI_AUTO_LENGTH, &msg_key));
+    NODE_API_CALL(env, napi_get_property(env, exc, msg_key, &msg));
+    char buf[64] = {0};
+    size_t len = 0;
+    NODE_API_CALL(env,
+                  napi_get_value_string_utf8(env, msg, buf, sizeof(buf), &len));
+    printf("napi_throw_error(2nd): kept=%s\n", buf);
+  }
+
+  // node_api_post_finalizer: Node accepts a NULL finalize_cb.
+  {
+    print_status("node_api_post_finalizer(NULL)",
+                 node_api_post_finalizer(env, nullptr, nullptr, nullptr),
+                 true);
+  }
+
+  // napi_make_callback argument validation: Node returns napi_invalid_arg for
+  // a NULL recv, for argc>0 with argv==NULL, and for a non-function func.
+  {
+    napi_value out;
+    print_status(
+        "napi_make_callback(recv=NULL)",
+        napi_make_callback(env, nullptr, nullptr, fn, 0, nullptr, &out), true);
+    print_status(
+        "napi_make_callback(argc>0,argv=NULL)",
+        napi_make_callback(env, nullptr, obj, fn, 1, nullptr, &out), true);
+    print_status(
+        "napi_make_callback(func=number)",
+        napi_make_callback(env, nullptr, obj, number, 0, nullptr, &out),
+        true);
+  }
+
+  // napi_ref/unref_threadsafe_function: Node ignores env (basic-env function)
+  // and does not touch last_error.
+  {
+    napi_value name;
+    NODE_API_CALL(env, napi_create_string_utf8(env, "tsfn_status_codes",
+                                               NAPI_AUTO_LENGTH, &name));
+    napi_threadsafe_function tsfn = nullptr;
+    NODE_API_CALL(env, napi_create_threadsafe_function(
+                           env, nullptr, nullptr, name, 0, 1, nullptr,
+                           nullptr, nullptr, noop_tsfn_cb, &tsfn));
+    printf("napi_ref_threadsafe_function(env=NULL): status=%d\n",
+           (int)napi_ref_threadsafe_function(nullptr, tsfn));
+    printf("napi_unref_threadsafe_function(env=NULL): status=%d\n",
+           (int)napi_unref_threadsafe_function(nullptr, tsfn));
+
+    // last_error should be untouched: arm it, call ref, then read it back.
+    napi_value dummy;
+    napi_get_value_int32(env, undefinedv, nullptr); // sets napi_invalid_arg
+    napi_ref_threadsafe_function(env, tsfn);
+    const napi_extended_error_info *err;
+    napi_get_last_error_info(env, &err);
+    printf("napi_ref_threadsafe_function: last_error_preserved=%d\n",
+           (int)err->error_code);
+    (void)dummy;
+
+    NODE_API_CALL(env,
+                  napi_release_threadsafe_function(tsfn, napi_tsfn_release));
+  }
+
+  return ok(env);
+}
+
 void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_typedarray_info_byte_offset);
   REGISTER_FUNCTION(env, exports, test_dataview_info_byte_offset);
@@ -3570,6 +3745,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_node_api_set_prototype);
   REGISTER_FUNCTION(env, exports, test_node_api_create_object_with_properties);
   REGISTER_FUNCTION(env, exports, test_node_api_sharedarraybuffer);
+  REGISTER_FUNCTION(env, exports, test_napi_status_codes_node26);
 }
 
 } // namespace napitests

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -456,6 +456,10 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       // napi_create_bigint_words > INT_MAX: napi_invalid_arg, no throw
       expect(result).toContain("napi_create_bigint_words(INT_MAX+1): status=1 pending=0");
 
+      // napi_create_buffer / napi_create_buffer_copy: napi_generic_failure (9) on alloc failure
+      expect(result).toContain("napi_create_buffer(SIZE_MAX): status=9 pending=1");
+      expect(result).toContain("napi_create_buffer_copy(SIZE_MAX): status=9 pending=1");
+
       // second napi_throw_error: napi_pending_exception, first message kept
       expect(result).toContain("napi_throw_error(2nd): status=10");
       expect(result).toContain("napi_throw_error(2nd): kept=first");

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -435,6 +435,46 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     });
   });
 
+  describe("status code alignment with Node.js", () => {
+    it("returns the same napi_status as Node.js for invalid inputs", async () => {
+      const result = await checkSameOutput("test_napi_status_codes_node26", []);
+
+      // napi_wrap/unwrap/remove_wrap/add_finalizer on primitive -> napi_invalid_arg (1)
+      for (const fn of ["napi_wrap", "napi_unwrap", "napi_remove_wrap", "napi_add_finalizer"]) {
+        expect(result).toContain(`${fn}(number): status=1 pending=0`);
+      }
+
+      // napi_coerce_to_*: type-specific status, exception stays pending
+      expect(result).toContain("napi_coerce_to_number(Symbol): status=6 pending=1");
+      expect(result).toContain("napi_coerce_to_string(Symbol): status=3 pending=1");
+      expect(result).toContain("napi_coerce_to_object(null): status=2 pending=1");
+
+      // napi_run_script: napi_generic_failure (9), exception stays pending
+      expect(result).toContain("napi_run_script(throw): status=9 pending=1");
+      expect(result).toContain("napi_run_script(syntax): status=9 pending=1");
+
+      // napi_create_bigint_words > INT_MAX: napi_invalid_arg, no throw
+      expect(result).toContain("napi_create_bigint_words(INT_MAX+1): status=1 pending=0");
+
+      // second napi_throw_error: napi_pending_exception, first message kept
+      expect(result).toContain("napi_throw_error(2nd): status=10");
+      expect(result).toContain("napi_throw_error(2nd): kept=first");
+
+      // node_api_post_finalizer(NULL): napi_ok
+      expect(result).toContain("node_api_post_finalizer(NULL): status=0 pending=0");
+
+      // napi_make_callback validation -> napi_invalid_arg
+      for (const which of ["recv=NULL", "argc>0,argv=NULL", "func=number"]) {
+        expect(result).toContain(`napi_make_callback(${which}): status=1 pending=0`);
+      }
+
+      // napi_ref/unref_threadsafe_function: env ignored, last_error untouched
+      expect(result).toContain("napi_ref_threadsafe_function(env=NULL): status=0");
+      expect(result).toContain("napi_unref_threadsafe_function(env=NULL): status=0");
+      expect(result).toContain("napi_ref_threadsafe_function: last_error_preserved=1");
+    });
+  });
+
   describe("napi_async_work", () => {
     it("null checks execute callbacks", async () => {
       const output = await checkSameOutput("test_napi_async_work_execute_null_check", []);


### PR DESCRIPTION
## What

A set of N-API entry points return a different `napi_status` than Node.js 26 for specific inputs. None of these crash; they break addons that branch on `status == X`. This aligns each to Node.js, verified against `js_native_api_v8.cc` / `node_api.cc` on `v26.x`.

## Before / after

`test_napi_status_codes_node26` (diffed byte-for-byte against Node via `checkSameOutput`):

```
                                          bun (before)   node / bun (after)
napi_wrap(number)                         status=2       status=1
napi_unwrap(number)                       status=2       status=1
napi_remove_wrap(number)                  status=2       status=1
napi_add_finalizer(number)                status=2       status=1
napi_coerce_to_number(Symbol)             status=10      status=6  pending=1
napi_coerce_to_string(Symbol)             status=10      status=3  pending=1
napi_coerce_to_object(null)               status=10      status=2  pending=1
napi_run_script(throw)                    status=10      status=9  pending=1
napi_run_script(syntax)                   status=10      status=9  pending=1
napi_create_bigint_words(INT_MAX+1)       status=10 p=1  status=1  pending=0
napi_create_buffer(SIZE_MAX)              status=10      status=9  pending=1
napi_create_buffer_copy(SIZE_MAX)         status=10      status=9  pending=1
napi_throw_error while one is pending     status=0       status=10 (first kept)
node_api_post_finalizer(NULL)             status=1       status=0
napi_make_callback(recv=NULL)             status=0       status=1
napi_make_callback(argc>0,argv=NULL)      status=0       status=1
napi_make_callback(func=number)           status=5       status=1
napi_ref_threadsafe_function(env=NULL)    status=1       status=0
napi_unref_threadsafe_function(env=NULL)  status=1       status=0
napi_ref_threadsafe_function last_error   cleared        preserved
```

## Changes

**`src/jsc/bindings/napi.cpp`**

- New `NAPI_RETURN_STATUS_IF_EXCEPTION(env, status)` macro alongside `NAPI_RETURN_IF_VM_EXCEPTION`, for call sites where Node.js reports a specific code while leaving the thrown exception pending. Used by the coerce-to-\*/create-buffer paths below and by the two pre-existing `napi_instanceof` call sites (no behavior change there).
- `napi_wrap` / `napi_unwrap` / `napi_remove_wrap` / `napi_add_finalizer`: non-object `js_object` returns `napi_invalid_arg` (was `napi_object_expected`). Node: `RETURN_STATUS_IF_FALSE(env, value->IsObject(), napi_invalid_arg)` in `v8impl::Wrap/Unwrap`.
- `napi_coerce_to_number` / `_string` / `_object`: when the coercion throws, return `napi_{number,string,object}_expected` (was `napi_pending_exception`). The thrown exception stays pending. Node: `GEN_COERCE_FUNCTION` -> `CHECK_MAYBE_EMPTY(..., napi_X_expected)`.
- `napi_run_script`: compile/eval error returns `napi_generic_failure` (was `napi_pending_exception`). Exception stays pending on the env. Node: `CHECK_MAYBE_EMPTY(env, maybe_script, napi_generic_failure)` / same for `Run()`.
- `napi_create_buffer` / `napi_create_external_buffer`: allocation failure returns `napi_generic_failure` (was `napi_pending_exception`). Node: `CHECK_MAYBE_EMPTY(env, maybe, napi_generic_failure)`.
- `napi_create_bigint_words`: `word_count > INT_MAX` returns `napi_invalid_arg` with no throw (was a thrown `RangeError` + `napi_pending_exception` for `INT_MAX < word_count <= UINT_MAX`). Node: `RETURN_STATUS_IF_FALSE(env, word_count <= INT_MAX, napi_invalid_arg)`. Counts between JSC's bigint limit and `INT_MAX` still throw, guarded before `createFromWords` so we never read past the caller's buffer (V8 checks its limit before reading; JSC trims trailing zeroes first).
- `napi_throw_error` / `napi_throw_type_error` / `napi_throw_range_error` / `node_api_throw_syntax_error`: if an exception is already pending, return `napi_pending_exception` and leave it untouched (was `napi_ok`, overwriting the first exception). Node uses `NAPI_PREAMBLE` for all four. The internal call sites in `napi_instanceof` / `napi_create_dataview` sit behind a preamble that has already rejected a pending exception, so they are unaffected.
- `node_api_post_finalizer`: accept a NULL `finalize_cb` (was `napi_invalid_arg`). Node uses only `CHECK_ENV` and enqueues unconditionally; `napi_internal_enqueue_finalizer` early-returns on a null callback.

**`src/runtime/napi/napi_body.rs`**

- `napi_create_string_utf8`: creation failure returns `napi_generic_failure` (was `napi_pending_exception`), consistent with Bun's own latin1/utf16 variants and Node's `CHECK_MAYBE_EMPTY`.
- `napi_make_callback`: NULL `recv` / `argc > 0 && argv == NULL` / non-function `func` all return `napi_invalid_arg` (was: accepted / accepted / `napi_function_expected`). Node: `CHECK_ARG(env, recv)`, `if (argc > 0) CHECK_ARG(env, argv)`, `CHECK_TO_FUNCTION` (-> `napi_invalid_arg`).
- `napi_resolve_deferred` / `napi_reject_deferred`: resolve/reject failure returns `napi_generic_failure` (was `napi_pending_exception`). Node: `RETURN_STATUS_IF_FALSE(env, success.FromMaybe(false), napi_generic_failure)` in `ConcludeDeferred`.
- `napi_create_buffer_copy`: allocation failure returns `napi_generic_failure` (was `napi_pending_exception`).
- `napi_ref_threadsafe_function` / `napi_unref_threadsafe_function`: ignore `env` (basic-env functions) and return `napi_ok` without touching `last_error`. Node: `CHECK_NOT_NULL(func); return ...->Ref();` with no env check and no `napi_set_last_error`.

## Not in this PR

`napi_create_typedarray` / `napi_create_dataview` non-ArrayBuffer -> `napi_invalid_arg` and the coded-RangeError alignment for typedarray bounds are covered by #34132.

## Coverage

`test_napi_status_codes_node26` pins every change that is reachable without engine OOM. The remaining `pending_exception -> generic_failure` edits are alignment-by-inspection only:

- `napi_create_string_utf8` creation failure: `length > INT_MAX` is rejected with `napi_invalid_arg` first, so the failure arm needs a true JSC string-allocation OOM.
- `napi_create_external_buffer` allocation failure: the empty-buffer and external-bytes paths do not have a size pre-check that can be tripped deterministically.
- `napi_resolve_deferred` / `napi_reject_deferred` failure: the underlying `JSPromise::resolve/reject` only `Err`s on VM termination; the deferred handle is freed on first use, so a second call is UB rather than a testable failure.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/napi/napi.test.ts -t 'returns the same napi_status'
  -> fail (21/21 lines differ from Node)

bun bd test test/napi/napi.test.ts -t 'returns the same napi_status'
  -> pass (Bun output == Node output)
```

The vendored Node test suites for `test_bigint`, `test_conversions`, `test_error`, `test_exception`, `6_object_wrap`, `8_passing_wrapped`, `test_promise`, `test_function`, `test_general`, `test_object` all pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->