### PR TITLE
worker: re-throw TerminationException from Bun__reportUnhandledError so terminate() breaks a microtask-bound ReadableStream loop

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4899,6 +4899,21 @@ bool JSC__VM__hasTerminationRequest(JSC::VM* vm)
     return vm->hasTerminationRequest();
 }
 
+// InternalMicrotask::BunPerformMicrotaskJob catches any exception from the
+// job callback with an unconditional clearException() and then calls
+// Bun__reportUnhandledError with the Exception*. When the caught exception
+// is the TerminationException that clear spends the one shot the
+// NeedTermination trap fired, so the microtask drain never observes
+// termination and a worker in a microtask-bound loop can spin forever.
+// Re-establishing the TerminationException here lets MicrotaskQueue's
+// runMicrotask see it on return and break out of the drain.
+[[ZIG_EXPORT(nothrow)]]
+void JSC__VM__rethrowTerminationException(JSC::VM* vm)
+{
+    if (vm->hasTerminationRequest() && !vm->hasPendingTerminationException())
+        vm->throwTerminationException();
+}
+
 void JSC__VM__setExecutionForbidden(JSC::VM* arg0, bool arg1)
 {
     (*arg0).setExecutionForbidden();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4899,14 +4899,8 @@ bool JSC__VM__hasTerminationRequest(JSC::VM* vm)
     return vm->hasTerminationRequest();
 }
 
-// InternalMicrotask::BunPerformMicrotaskJob catches any exception from the
-// job callback with an unconditional clearException() and then calls
-// Bun__reportUnhandledError with the Exception*. When the caught exception
-// is the TerminationException that clear spends the one shot the
-// NeedTermination trap fired, so the microtask drain never observes
-// termination and a worker in a microtask-bound loop can spin forever.
-// Re-establishing the TerminationException here lets MicrotaskQueue's
-// runMicrotask see it on return and break out of the drain.
+// Re-establish a TerminationException that was spent by an unconditional
+// clearException() (BunPerformMicrotaskJob) so the microtask drain observes it.
 [[ZIG_EXPORT(nothrow)]]
 void JSC__VM__rethrowTerminationException(JSC::VM* vm)
 {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4899,8 +4899,6 @@ bool JSC__VM__hasTerminationRequest(JSC::VM* vm)
     return vm->hasTerminationRequest();
 }
 
-// Re-establish a TerminationException that was spent by an unconditional
-// clearException() (BunPerformMicrotaskJob) so the microtask drain observes it.
 [[ZIG_EXPORT(nothrow)]]
 void JSC__VM__rethrowTerminationException(JSC::VM* vm)
 {

--- a/src/jsc/bindings/webcore/EventEmitter.cpp
+++ b/src/jsc/bindings/webcore/EventEmitter.cpp
@@ -252,11 +252,6 @@ bool EventEmitter::innerInvokeEventListeners(const Identifier& eventType, Simple
         auto* exception = exceptionPtr.get();
 
         if (exception) [[unlikely]] {
-            // The NakedPtr<Exception>& call() overload has already cleared the
-            // exception. Running more listeners (or error listeners) after
-            // termination would re-enter JS with the TerminationException
-            // re-thrown by Bun__reportUnhandledError and trip
-            // executeCallImpl's assertNoException().
             if (vm.isTerminationException(exception)) [[unlikely]]
                 break;
             auto errorIdentifier = vm.propertyNames->error;

--- a/src/jsc/bindings/webcore/EventEmitter.cpp
+++ b/src/jsc/bindings/webcore/EventEmitter.cpp
@@ -252,6 +252,13 @@ bool EventEmitter::innerInvokeEventListeners(const Identifier& eventType, Simple
         auto* exception = exceptionPtr.get();
 
         if (exception) [[unlikely]] {
+            // The NakedPtr<Exception>& call() overload has already cleared the
+            // exception. Running more listeners (or error listeners) after
+            // termination would re-enter JS with the TerminationException
+            // re-thrown by Bun__reportUnhandledError and trip
+            // executeCallImpl's assertNoException().
+            if (vm.isTerminationException(exception)) [[unlikely]]
+                break;
             auto errorIdentifier = vm.propertyNames->error;
             auto hasErrorListener = this->hasActiveEventListeners(errorIdentifier);
             if (!hasErrorListener || eventType == errorIdentifier) {

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -117,12 +117,14 @@ pub fn queue_task(global: &JSGlobalObject, task: *mut crate::cpp_task::CppTask) 
 pub fn report_unhandled_error(global: &JSGlobalObject, value: JSValue) -> JSValue {
     crate::mark_binding!();
 
-    if !value.is_termination_exception() {
-        let _ = global
-            .bun_vm()
-            .as_mut()
-            .uncaught_exception(global, value, false);
+    if value.is_termination_exception() {
+        crate::cpp::JSC__VM__rethrowTerminationException(global.vm());
+        return JSValue::UNDEFINED;
     }
+    let _ = global
+        .bun_vm()
+        .as_mut()
+        .uncaught_exception(global, value, false);
     JSValue::UNDEFINED
 }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1689,12 +1689,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
     /// into the GC-traced `js.gc.stream` slot to break the cycle (the JS
     /// wrapper owns the stream; native side must not hold it strongly).
     ///
-    /// Called from constructors after the native object has been heap-allocated,
-    /// so it must not reach a VMTraps safepoint (a TerminationException thrown
-    /// here would leave the generated `construct` holding a non-null ptr with
-    /// an exception pending, tripping its leak assertion). `Strong::value()`
-    /// is a pure slot read; `Strong::get()` would re-tag through `from_js`,
-    /// which is a safepoint.
+    /// Runs after the native object is heap-allocated, so it must not hit a
+    /// VMTraps safepoint: `Strong::value()` is a pure read, `Strong::get()`
+    /// would re-tag via `from_js` and is one.
     fn check_body_stream_ref(&self, global_object: &JSGlobalObject) {
         if let Some(js_value) = self.js_ref() {
             if let Value::Locked(locked) = self.get_body_value() {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1688,13 +1688,10 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
     /// Migrate any `Locked.readable` strong ref
     /// into the GC-traced `js.gc.stream` slot to break the cycle (the JS
     /// wrapper owns the stream; native side must not hold it strongly).
-    ///
-    /// Runs after the native object is heap-allocated, so it must not hit a
-    /// VMTraps safepoint: `Strong::value()` is a pure read, `Strong::get()`
-    /// would re-tag via `from_js` and is one.
     fn check_body_stream_ref(&self, global_object: &JSGlobalObject) {
         if let Some(js_value) = self.js_ref() {
             if let Value::Locked(locked) = self.get_body_value() {
+                // `Strong::get()` is a VMTraps safepoint; this runs post-alloc.
                 if let Some(stream_value) = locked.readable.value() {
                     stream_value.ensure_still_alive();
                     Self::stream_set_cached(js_value, global_object, stream_value);

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1688,12 +1688,19 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
     /// Migrate any `Locked.readable` strong ref
     /// into the GC-traced `js.gc.stream` slot to break the cycle (the JS
     /// wrapper owns the stream; native side must not hold it strongly).
+    ///
+    /// Called from constructors after the native object has been heap-allocated,
+    /// so it must not reach a VMTraps safepoint (a TerminationException thrown
+    /// here would leave the generated `construct` holding a non-null ptr with
+    /// an exception pending, tripping its leak assertion). `Strong::value()`
+    /// is a pure slot read; `Strong::get()` would re-tag through `from_js`,
+    /// which is a safepoint.
     fn check_body_stream_ref(&self, global_object: &JSGlobalObject) {
         if let Some(js_value) = self.js_ref() {
             if let Value::Locked(locked) = self.get_body_value() {
-                if let Some(stream) = locked.readable.get(global_object) {
-                    stream.value.ensure_still_alive();
-                    Self::stream_set_cached(js_value, global_object, stream.value);
+                if let Some(stream_value) = locked.readable.value() {
+                    stream_value.ensure_still_alive();
+                    Self::stream_set_cached(js_value, global_object, stream_value);
                     locked.readable.downgrade();
                 }
             }

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -44,7 +44,7 @@ impl Default for Strong {
 }
 
 impl Strong {
-    fn value(&self) -> Option<JSValue> {
+    pub(crate) fn value(&self) -> Option<JSValue> {
         self.held.get().or_else(|| {
             if self.weak.is_empty() {
                 None

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -228,6 +228,7 @@ describe("terminate() resolves for a worker in a microtask-bound ReadableStream 
               }
             }
             console.log("PASS");
+            process.exit(0);
           `,
           ],
           env: bunEnv,

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -215,8 +215,12 @@ describe("terminate() resolves for a worker in a microtask-bound ReadableStream 
               '(async () => { for (;;) { ' + ${JSON.stringify(expr)} + '; await 0; } })();';
             for (let r = 0; r < ${localRounds}; r++) {
               const w = new Worker(src, { eval: true });
+              await new Promise((res, rej) => {
+                w.once("message", res);
+                w.once("error", rej);
+                w.once("exit", (c) => rej(new Error("worker exited " + c + " before ready")));
+              });
               w.on("error", () => {});
-              await new Promise((res) => w.once("message", res));
               await Bun.sleep((r * 23) % 80);
               const winner = await Promise.race([
                 w.terminate().then(() => "ok"),

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -177,6 +177,73 @@ test.skipIf(!isASAN)(
   timeout,
 );
 
+// Regression: InternalMicrotask::BunPerformMicrotaskJob (used by
+// queueMicrotask and by the C++ stream start/pull reaction jobs) catches any
+// exception from the job callback with an unconditional clearException(), so
+// when the caught exception is the TerminationException the microtask drain
+// never observes termination. A worker in a microtask-bound loop that
+// constructs a JS-source ReadableStream (or calls queueMicrotask) each turn
+// would spin forever with terminate() never resolving.
+// The Response / Request variants additionally cover a trap safepoint inside
+// check_body_stream_ref that fired the TerminationException after the native
+// Response/Request had been heap-allocated, tripping the generated
+// constructor's "Memory leak detected: new Response()" assertion.
+describe("terminate() resolves for a worker in a microtask-bound ReadableStream loop", () => {
+  const variants: Record<string, string> = {
+    "new ReadableStream({pull})": `new ReadableStream({ pull(c) { c.enqueue(1); c.close(); } })`,
+    "new ReadableStream({start})": `new ReadableStream({ start(c) { c.close(); } })`,
+    "new Response(new ReadableStream)": `new Response(new ReadableStream({ async pull() {} }))`,
+    "new Request(new ReadableStream)": `new Request("http://x", { method: "POST", body: new ReadableStream({ pull(c) { c.close(); } }), duplex: "half" })`,
+    "queueMicrotask": `queueMicrotask(() => {})`,
+  };
+  // A single hang is deterministic on an unfixed build (the loop is purely
+  // microtask-bound), so a small sweep of offsets is plenty.
+  const localRounds = slow ? 3 : 6;
+  const deadline = slow ? 10_000 : 4_000;
+
+  for (const [name, expr] of Object.entries(variants)) {
+    test.concurrent(
+      name,
+      async () => {
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `
+            const { Worker } = require("node:worker_threads");
+            const src = 'require("node:worker_threads").parentPort.postMessage("up");' +
+              '(async () => { for (;;) { ' + ${JSON.stringify(expr)} + '; await 0; } })();';
+            for (let r = 0; r < ${localRounds}; r++) {
+              const w = new Worker(src, { eval: true });
+              w.on("error", () => {});
+              await new Promise((res) => w.once("message", res));
+              await Bun.sleep((r * 23) % 80);
+              const winner = await Promise.race([
+                w.terminate().then(() => "ok"),
+                Bun.sleep(${deadline}).then(() => "hung"),
+              ]);
+              if (winner !== "ok") {
+                console.log("HUNG round " + r);
+                process.exit(1);
+              }
+            }
+            console.log("PASS");
+          `,
+          ],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(stdout).toBe("PASS\n");
+        expect(exitCode).toBe(0);
+      },
+      timeout,
+    );
+  }
+});
+
 // Regression: Bun.serve() inside a worker, streaming a JS ReadableStream body,
 // then worker.terminate() mid-stream. Worker shutdown stops the server which
 // tears down the in-flight HTTP(S)ResponseSink and fires its JS onClose hook


### PR DESCRIPTION
## Problem

`worker.terminate()` never resolves when the worker is in a microtask-bound loop that constructs a JS-source `ReadableStream` (or calls `queueMicrotask`) each turn. The worker thread keeps spinning at ~0.5-0.7 core forever, no `exit` event fires, and a second `terminate()` also never resolves.

```js
import { Worker } from "node:worker_threads";
const src = `require("worker_threads").parentPort.postMessage("up");
(async () => { for (;;) { new ReadableStream({ pull(c) { c.enqueue(new Uint8Array(8)); c.close(); } }); await 0; } })();`;
const w = new Worker(src, { eval: true });
await new Promise(r => w.once("message", r));
await Bun.sleep(30);
await w.terminate(); // never resolves
```

Reproduces on main since the C++ streams rewrite (#33193); Node terminates the identical worker in a few ms.

## Cause

`InternalMicrotask::BunPerformMicrotaskJob` (the runner for `queueMicrotask` and the C++ stream start/pull reaction jobs added in #33193) catches any exception from the job callback with an unconditional `clearException()` and then calls `Bun__reportUnhandledError` with the `Exception*`:

```cpp
if (auto* exception = catchScope.exception()) {
    catchScope.clearException();
    if (Bun__reportUnhandledError)
        Bun__reportUnhandledError(globalObject, JSValue::encode(exception));
}
```

When the caught exception is the `TerminationException`, that clear consumes the one shot the `NeedTermination` trap fired (the trap bit was already cleared by `VMTraps::handleTraps`), so `MicrotaskQueue::runMicrotask`'s `clearExceptionExceptTermination()` check never trips and the drain keeps processing microtasks forever.

A plain `for(;;){ await 0 }` loop terminates because the promise-reaction microtask path goes through `runMicrotask`'s termination-aware clear; it's only `BunPerformMicrotaskJob` with its own catch scope that swallows it.

Separately, under debug/ASAN the `new Response(new ReadableStream({...}))` shape aborts with:

```
ASSERTION FAILED: Memory leak detected: new Response() allocated memory without checking for exceptions.
!ptr
codegen/ZigGeneratedClasses.cpp : JSResponseConstructor::construct
```

because `check_body_stream_ref` (called from `Response::constructor` / `Request::construct_into` after the native object has been heap-allocated) re-tagged the stored stream via `ReadableStream::from_js`, whose Rust-side post-call exception check is a VMTraps safepoint. A `TerminationException` thrown there left the generated `construct` holding a non-null `ptr` with an exception pending.

## Fix

`Bun__reportUnhandledError` already skipped reporting a `TerminationException`; it now re-throws it via `VM::throwTerminationException` (guarded on `hasTerminationRequest() && !hasPendingTerminationException()`) so `MicrotaskQueue::runMicrotask` sees it on return and breaks out of the drain. This covers every `BunPerformMicrotaskJob` caller (streams reactions, `queueMicrotask`, promise-reject deferrals).

`check_body_stream_ref` now reads the stored `JSValue` directly from the `Strong`'s slot instead of going through `ReadableStream::from_js`; it only needed the value, never the source tag.

The `BunPerformMicrotaskJob` handler itself lives in JavaScriptCore's prebuilt `JSMicrotask.cpp` and should eventually use `clearExceptionExceptTermination()`; this change makes `terminate()` work correctly regardless.

## Verification

New `describe` block in `test/js/web/workers/worker-terminate-lifetime.test.ts` spawns a worker in each of five microtask-bound loop shapes (`ReadableStream` pull/start, `Response`/`Request` wrapping a stream, `queueMicrotask`), sweeps a few `terminate()` timing offsets, and asserts `terminate()` resolves. On main the ReadableStream/Request shapes print `HUNG round 0` and fail; with this change all five pass (144/144 terminations across 3 local stress runs).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->