### PR TITLE
body: clear producer hooks on PendingValue once the body is realised as a ByteStream

### DIFF
--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -283,7 +283,11 @@ impl PendingValue {
         self.on_start_buffering = None;
         self.on_start_streaming = None;
         self.on_readable_stream_available = None;
-        self.task = None;
+        if self.on_receive_value.is_none() {
+            // A registered `on_receive_value` means `task` is the consumer's
+            // ctx (overwriting the producer), read by `resolve()`.
+            self.task = None;
+        }
         self.producer = streams::SourceHandle::None;
     }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -277,10 +277,8 @@ impl Default for PendingValue {
 }
 
 impl PendingValue {
-    /// Called once `readable` is set and the producer hooks have fired: the
-    /// ByteStream's `NewSource.producer` owns delivery from here, and the
-    /// producer these point at (e.g. a `FetchTasklet`) may be freed before a
-    /// later consumer (`Bun.write`, `ValueBufferer`) looks at them.
+    /// Once `readable` is set the live handle is `NewSource.producer`; these
+    /// hooks go stale when the producer (e.g. `FetchTasklet`) is freed.
     fn detach_producer(&mut self) {
         self.on_start_buffering = None;
         self.on_start_streaming = None;

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -909,9 +909,16 @@ impl Value {
         };
         locked.readable = webcore::readable_stream::Strong::init(readable, global_this);
 
-        if let Some(on_readable_stream_available) = locked.on_readable_stream_available {
+        if let Some(on_readable_stream_available) = locked.on_readable_stream_available.take() {
             on_readable_stream_available(locked.task.unwrap(), global_this, readable);
         }
+        // Delivery is now owned by the ByteStream's `NewSource.producer`; the
+        // producer hooks and `task` here point at (e.g.) a `FetchTasklet` that
+        // can be freed once the transfer completes, so a later consumer
+        // (`Bun.write`, `ValueBufferer`) must not call them.
+        locked.on_start_buffering = None;
+        locked.task = None;
+        locked.producer = streams::SourceHandle::None;
 
         // In text mode the returned stream emits strings, so it must not be
         // cached as the body's byte stream (consulted by `.body`, `bodyUsed`,
@@ -1538,13 +1545,17 @@ impl Value {
             global_this,
         );
 
-        if let Some(on_readable_stream_available) = locked.on_readable_stream_available {
+        if let Some(on_readable_stream_available) = locked.on_readable_stream_available.take() {
             on_readable_stream_available(
                 locked.task.unwrap(),
                 global_this,
                 locked.readable.get(global_this).unwrap(),
             );
         }
+        // See `locked_to_native_stream`: the ByteStream now owns delivery.
+        locked.on_start_buffering = None;
+        locked.task = None;
+        locked.producer = streams::SourceHandle::None;
 
         let teed = match locked.readable.tee(global_this)? {
             Some(t) => t,

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -277,6 +277,18 @@ impl Default for PendingValue {
 }
 
 impl PendingValue {
+    /// Called once `readable` is set and the producer hooks have fired: the
+    /// ByteStream's `NewSource.producer` owns delivery from here, and the
+    /// producer these point at (e.g. a `FetchTasklet`) may be freed before a
+    /// later consumer (`Bun.write`, `ValueBufferer`) looks at them.
+    fn detach_producer(&mut self) {
+        self.on_start_buffering = None;
+        self.on_start_streaming = None;
+        self.on_readable_stream_available = None;
+        self.task = None;
+        self.producer = streams::SourceHandle::None;
+    }
+
     /// Safe `&JSGlobalObject` accessor for the JSC_BORROW `global` back-pointer.
     #[inline]
     pub(crate) fn global(&self) -> &JSGlobalObject {
@@ -912,13 +924,7 @@ impl Value {
         if let Some(on_readable_stream_available) = locked.on_readable_stream_available.take() {
             on_readable_stream_available(locked.task.unwrap(), global_this, readable);
         }
-        // Delivery is now owned by the ByteStream's `NewSource.producer`; the
-        // producer hooks and `task` here point at (e.g.) a `FetchTasklet` that
-        // can be freed once the transfer completes, so a later consumer
-        // (`Bun.write`, `ValueBufferer`) must not call them.
-        locked.on_start_buffering = None;
-        locked.task = None;
-        locked.producer = streams::SourceHandle::None;
+        locked.detach_producer();
 
         // In text mode the returned stream emits strings, so it must not be
         // cached as the body's byte stream (consulted by `.body`, `bodyUsed`,
@@ -1552,10 +1558,7 @@ impl Value {
                 locked.readable.get(global_this).unwrap(),
             );
         }
-        // See `locked_to_native_stream`: the ByteStream now owns delivery.
-        locked.on_start_buffering = None;
-        locked.task = None;
-        locked.producer = streams::SourceHandle::None;
+        locked.detach_producer();
 
         let teed = match locked.readable.tee(global_this)? {
             Some(t) => t,

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -6,6 +6,7 @@ import {
   exampleHtml,
   exampleSite,
   gcTick,
+  isASAN,
   isLinux,
   isWindows,
   tempDir,
@@ -744,6 +745,44 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     expect(f.name).toBe(filePath);
     expect(await f.text()).toBe("d");
   });
+
+  // `resp.body` materialises the body as a native ByteStream; once the
+  // transfer finishes the FetchTasklet is freed, but the body's PendingValue
+  // kept `task` / `on_start_buffering` pointing at the freed tasklet, and
+  // `Bun.write(path, resp)` then called `on_start_buffering(task)`.
+  it.skipIf(!isASAN).each([
+    [
+      "getReader().read() then releaseLock()",
+      "const rd = resp.body.getReader(); await rd.read(); rd.releaseLock();",
+    ],
+    ["resp.body getter", "resp.body;"],
+    ["resp.clone()", "resp.clone();"],
+  ])(
+    "Bun.write(path, fetch()) after the body was exposed as a stream does not use a freed FetchTasklet (%s)",
+    async (_name, expose) => {
+      using dir = tempDir("bun-write-fetch-freed-tasklet", {});
+      const out = JSON.stringify(join(String(dir), "out.bin"));
+      const fixture = `
+        const server = Bun.serve({ port: 0, fetch: () => new Response(Buffer.alloc(200000, "x")) });
+        for (let i = 0; i < 8; i++) {
+          const resp = await fetch(\`http://127.0.0.1:\${server.port}/\`);
+          ${expose}
+          await Bun.sleep(5);
+          await Promise.race([Bun.write(${out}, resp).catch(() => {}), Bun.sleep(100)]);
+        }
+        console.log("done");
+        server.stop(true);
+        process.exit(0);
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: { ...bunEnv, ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":") },
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "done", stderr: "", exitCode: 0 });
+    },
+  );
 
   it("BunFile.name survives concurrent write() calls + GC", async () => {
     using dir = tempDir("bun-file-name-concurrent-write-gc", {});

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -751,10 +751,7 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
   // kept `task` / `on_start_buffering` pointing at the freed tasklet, and
   // `Bun.write(path, resp)` then called `on_start_buffering(task)`.
   it.skipIf(!isASAN).each([
-    [
-      "getReader().read() then releaseLock()",
-      "const rd = resp.body.getReader(); await rd.read(); rd.releaseLock();",
-    ],
+    ["getReader().read() then releaseLock()", "const rd = resp.body.getReader(); await rd.read(); rd.releaseLock();"],
     ["resp.body getter", "resp.body;"],
     ["resp.clone()", "resp.clone();"],
   ])(

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -776,7 +776,10 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
         // detect_leaks=0: the write promise never settles on a stream-backed
         // body (#13237), so WriteFileWaitFromLockedValueTask is still live at
         // process.exit; this test is about the heap-use-after-free only.
-        env: { ...bunEnv, ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0", "detect_leaks=0"].filter(Boolean).join(":") },
+        env: {
+          ...bunEnv,
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0", "detect_leaks=0"].filter(Boolean).join(":"),
+        },
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -787,6 +787,32 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     },
   );
 
+  it("Bun.write(path, HTMLRewriter.transform(resp)) still resolves after out.body is touched", async () => {
+    using dir = tempDir("bun-write-htmlrewriter-body", {});
+    const dest = join(String(dir), "out.html");
+    const { promise: gate, resolve: openGate } = Promise.withResolvers();
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () =>
+        new Response(
+          async function* () {
+            yield "<html><body>";
+            await gate;
+            yield "<p>hi</p></body></html>";
+          },
+          { headers: { "content-type": "text/html" } },
+        ),
+    });
+    const resp = await fetch(server.url);
+    const out = new HTMLRewriter().on("*", {}).transform(resp);
+    const write = Bun.write(dest, out);
+    expect(out.body).toBeInstanceOf(ReadableStream);
+    openGate();
+    const written = await write;
+    expect(written).toBe(35);
+    expect(await Bun.file(dest).text()).toBe("<html><body><p>hi</p></body></html>");
+  });
+
   it("BunFile.name survives concurrent write() calls + GC", async () => {
     using dir = tempDir("bun-file-name-concurrent-write-gc", {});
     const filePath = join(String(dir), "out.txt");

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -773,7 +773,10 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       `;
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", fixture],
-        env: { ...bunEnv, ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":") },
+        // detect_leaks=0: the write promise never settles on a stream-backed
+        // body (#13237), so WriteFileWaitFromLockedValueTask is still live at
+        // process.exit; this test is about the heap-use-after-free only.
+        env: { ...bunEnv, ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0", "detect_leaks=0"].filter(Boolean).join(":") },
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);


### PR DESCRIPTION
### Repro

```js
const server = Bun.serve({ port: 0, fetch: () => new Response("x".repeat(20000)) });
const resp = await fetch(`http://127.0.0.1:${server.port}/`);
const rd = resp.body.getReader();
await rd.read();
rd.releaseLock();
await Bun.sleep(5);                 // fetch completes, FetchTasklet freed
await Bun.write("/tmp/out.bin", resp);  // heap-use-after-free under ASAN
```

ASAN (debug build, origin/main 54bbd5dd9660 and 5b7c3cacbe63):

```
READ of size 1 in bun_io::keep_alive::KeepAlive::ref_ (keep_alive.rs:78)
  FetchTasklet::on_start_buffering_callback (FetchTasklet.rs:1825)
  blob::write_file_internal::{closure} (Blob.rs:5236)
freed by:
  drop<Box<FetchTasklet>> <- FetchTasklet::deinit (:509)
  <- on_progress_update cleanup deref (:1006)
```

`resp.body;` alone (no reader) before the sleep also triggers it, as does `resp.clone()`.

### Cause

`FetchTasklet::to_body_value` stores `pending.task = self` and `pending.on_start_buffering` / `on_start_streaming` / `on_readable_stream_available` / `producer` on the Response's `Locked` body.

Touching `.body` runs `locked_to_native_stream`, which `.take()`s `on_start_streaming`, copies `producer` onto the new `NewSource<ByteStream>`, stores `locked.readable`, and calls `on_readable_stream_available`, but leaves `on_start_buffering` / `on_readable_stream_available` / `task` / `producer` on the PendingValue pointing at the tasklet. The clone/tee materialisation path does the same.

Once the transfer completes, `on_progress_update`'s `is_done` cleanup derefs the tasklet to zero and frees it (`clear_stream_handlers` clears the ByteStream's `producer`, not the PendingValue's). The body stays `Locked{readable}` with the stale hooks.

`write_file_internal`'s non-S3 `Locked` arm doesn't look at `locked.readable`; it calls `on_start_buffering(orig_task)` with the freed pointer, then parks on `on_receive_value`. `BodyValueBufferer` at `Body.rs:2593` has the same call for any body where `task.is_some()`.

### Fix

Add `PendingValue::detach_producer()` and call it at both materialisation points after the ByteStream is wired up and `on_readable_stream_available` has fired. It clears `on_start_buffering` / `on_start_streaming` / `on_readable_stream_available` / `producer`, and clears `task` only when `on_receive_value` is unset: once a consumer has registered `on_receive_value`, `task` holds the consumer's ctx (read by `Value::resolve` / `Value::to_error_instance` via `.unwrap()`), not the producer being detached; every `on_receive_value` setter writes `task` alongside it so the stale producer pointer cannot be in `task` in that state. Delivery is then owned by the ByteStream's `NewSource.producer`, the single live back-reference already cleared by `clear_stream_handlers` on teardown.

The `Bun.write` hang on a stream-backed body (`on_receive_value` never fires) is unchanged here; #32906 and #35531 cover it. Both of those still call `on_start_buffering(producer_task)` before checking for a readable, so neither removes this UAF on its own.

### Verification

`test/js/bun/io/bun-write.test.js` gains:

- an ASAN-gated `it.each` covering the three exposure shapes (`getReader().read()` then `releaseLock()`; bare `resp.body`; `resp.clone()`). Each spawns a subprocess that runs 8 iterations against a 200 KB loopback body and asserts `{stdout: "done", stderr: "", exitCode: 0}`. `ASAN_OPTIONS=symbolize=0:detect_leaks=0` keeps the crashing child's exit prompt (symbolize) and suppresses the known `WriteFileWaitFromLockedValueTask` leak from the #13237 hang (detect_leaks).
- a test that drives `Bun.write(path, HTMLRewriter.transform(resp))` then `out.body` through an async input body and asserts the write resolves with the rewritten bytes, guarding the `on_receive_value` case.

Without the `src/` change the three ASAN cases fail on the heap-use-after-free; with it all four pass. `body.test.ts` (448 pass), `body-stream.test.ts` (9086 pass), `html-rewriter.test.js` (69 pass) and `fetch-response-finalizer-sweep.test.ts` are unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->