### PR TITLE
bake: release SavedRequest ctx ref when a deferred framework request is aborted

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2660,7 +2660,7 @@ impl DevServer {
         // SAFETY: `self` is live; `framework_bundle` points into
         // `self.route_bundles[route_bundle_index].data`. Raw-ptr receiver — see
         // Note on `compute_arguments_for_framework_request`.
-        let args = unsafe {
+        let args = match unsafe {
             Self::compute_arguments_for_framework_request(
                 self,
                 route_bundle_index,
@@ -2668,7 +2668,16 @@ impl DevServer {
                 params_js_value,
                 true,
             )
-        }?;
+        } {
+            Ok(a) => a,
+            Err(e) => {
+                // `Saved.ctx` is `Copy`; explicit deinit so the pool slot releases.
+                if let SavedRequestUnion::Saved(mut saved) = req {
+                    saved.deinit();
+                }
+                return Err(e);
+            }
+        };
 
         self.server
             .as_ref()

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3116,12 +3116,7 @@ impl DeferredRequest {
                 saved
                     .ctx
                     .set_signal_aborted(jsc::CommonAbortReason::ConnectionClosed);
-                // `AnyRequestContext` is `Copy`: `drop(saved)` alone releases
-                // only `js_request`. Balance the `prepare_and_save_...` +1 so
-                // `RequestContext::on_abort`'s own `RequestContextRef` drop (on
-                // the client-disconnect path) reaches zero and runs
-                // `on_request_complete` — otherwise the pool slot and
-                // `pending_requests` both stick.
+                // `ctx` is `Copy`; explicit deinit so `on_abort`'s deref reaches 0.
                 saved.deinit();
             }
             Handler::BundledHtmlPage(r) => {

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3107,7 +3107,7 @@ impl DeferredRequest {
         );
         let handler = ::core::mem::replace(&mut self.handler, Handler::Aborted);
         match handler {
-            Handler::ServerHandler(saved) => {
+            Handler::ServerHandler(mut saved) => {
                 deferred_request::debug_log_dr!(
                     "  request url: {}",
                     // SAFETY: saved.request is a live *mut webcore::Request (held strong by ctx)
@@ -3116,8 +3116,13 @@ impl DeferredRequest {
                 saved
                     .ctx
                     .set_signal_aborted(jsc::CommonAbortReason::ConnectionClosed);
-                // Note: saved.js_request (jsc::Strong) drops at end of arm
-                drop(saved);
+                // `AnyRequestContext` is `Copy`: `drop(saved)` alone releases
+                // only `js_request`. Balance the `prepare_and_save_...` +1 so
+                // `RequestContext::on_abort`'s own `RequestContextRef` drop (on
+                // the client-disconnect path) reaches zero and runs
+                // `on_request_complete` — otherwise the pool slot and
+                // `pending_requests` both stick.
+                saved.deinit();
             }
             Handler::BundledHtmlPage(r) => {
                 // Reached from JS event-loop tasks (on_plugins_rejected, the

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -892,6 +892,13 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // SAFETY: `this` is the live server backref for this request.
         let Some(server_js) = unsafe { &*this }.js_value_for_dispatch() else {
             server_body::respond_stopped_503(bun_opaque::opaque_deref_mut(resp));
+            // A `Saved` payload owns the initial `RequestContext` ref (+1 from
+            // `prepare_and_save_js_request_context`); `AnyRequestContext` is
+            // `Copy`, so dropping `req` alone leaks the pool slot and the
+            // matching `pending_requests` decrement.
+            if let SavedRequestUnion::Saved(mut saved) = req {
+                saved.deinit();
+            }
             return;
         };
         let prepared: PreparedRequest<SSL, DEBUG> = match &req {

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -892,10 +892,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // SAFETY: `this` is the live server backref for this request.
         let Some(server_js) = unsafe { &*this }.js_value_for_dispatch() else {
             server_body::respond_stopped_503(bun_opaque::opaque_deref_mut(resp));
-            // A `Saved` payload owns the initial `RequestContext` ref (+1 from
-            // `prepare_and_save_js_request_context`); `AnyRequestContext` is
-            // `Copy`, so dropping `req` alone leaks the pool slot and the
-            // matching `pending_requests` decrement.
+            // `Saved.ctx` is `Copy`; explicit deinit so the pool slot releases.
             if let SavedRequestUnion::Saved(mut saved) = req {
                 saved.deinit();
             }

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -1,5 +1,6 @@
 // Bundle tests are tests concerning bundling bugs that only occur in DevServer.
 import { expect } from "bun:test";
+import { once } from "node:events";
 import fs from "node:fs";
 import net from "node:net";
 import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
@@ -928,6 +929,12 @@ devTest("client disconnect on a deferred framework route releases the RequestCon
     // Client goes away mid-bundle → RequestContext::on_abort runs the
     // DeferredRequest abort callback and drops the SavedRequest.
     sock.destroy();
+    await once(sock, "close");
+    // Force the server's event loop to turn so the FIN is processed (and
+    // DeferredRequest::abort has run) before the plugin gate is released.
+    // /_dev_server_test_set is a plain route added by the harness bootstrap,
+    // so it returns without touching the bundler.
+    await dev.fetch("/_dev_server_test_set");
 
     // Let bundling finish so the deferred list is drained (Handler is now
     // Aborted; the drain loop skips it).

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -1,5 +1,7 @@
 // Bundle tests are tests concerning bundling bugs that only occur in DevServer.
 import { expect } from "bun:test";
+import fs from "node:fs";
+import net from "node:net";
 import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
 devTest("import identifier doesnt get renamed", {
@@ -863,5 +865,77 @@ devTest("barrel optimization: namespace re-export cycle through a star-exported 
   async test(dev) {
     await using c = await dev.client("/");
     await c.expectMessage("result: object Y KEEP DEEP OTHER");
+  },
+});
+// A framework-route request that is deferred (SavedRequest in
+// DeferredRequest::ServerHandler) and then aborted by the client must release
+// its RequestContext refcount so `pending_requests` reaches zero and the
+// server can deinit. The harness's gracefulExit() asserts deinit fires.
+devTest("client disconnect on a deferred framework route releases the RequestContext", {
+  framework: minimalFramework,
+  // The plugin makes bundling observable: it writes `.entered` once the
+  // route's bundle has started (i.e. the request has been deferred) and then
+  // blocks until `.unblock` appears, giving the test a deterministic window to
+  // close the socket mid-bundle.
+  pluginFile: `
+    import * as fs from 'node:fs';
+    import * as path from 'node:path';
+    export default [
+      {
+        name: 'gate',
+        setup(build) {
+          build.onLoad({ filter: /gate\\.ts$/ }, async (args) => {
+            const dir = path.dirname(args.path);
+            fs.writeFileSync(path.join(dir, 'gate.entered'), '');
+            while (!fs.existsSync(path.join(dir, 'gate.unblock'))) {
+              await new Promise(r => setTimeout(r, 5));
+            }
+            return { contents: 'export const gate = 1;', loader: 'ts' };
+          });
+        },
+      },
+    ];
+  `,
+  files: {
+    "gate.ts": `throw new Error('plugin should have replaced this');`,
+    "routes/index.ts": `
+      import { gate } from '../gate.ts';
+      export default function () {
+        return new Response('gate: ' + gate);
+      }
+    `,
+  },
+  async test(dev) {
+    const entered = dev.join("gate.entered");
+    const unblock = dev.join("gate.unblock");
+
+    // Raw TCP so closing the socket is an unambiguous client abort.
+    const sock = net.connect(dev.port, "127.0.0.1");
+    await new Promise<void>((resolve, reject) => {
+      sock.once("connect", resolve);
+      sock.once("error", reject);
+    });
+    sock.write(`GET / HTTP/1.1\r\nHost: 127.0.0.1:${dev.port}\r\nConnection: keep-alive\r\n\r\n`);
+
+    // Wait until the bundler has actually picked up gate.ts: the request has
+    // reached the server and is parked in the deferred list.
+    const deadline = Date.now() + 30_000;
+    while (!fs.existsSync(entered)) {
+      if (Date.now() > deadline) throw new Error("plugin gate never entered");
+      await new Promise(r => setTimeout(r, 5));
+    }
+
+    // Client goes away mid-bundle → RequestContext::on_abort runs the
+    // DeferredRequest abort callback and drops the SavedRequest.
+    sock.destroy();
+
+    // Let bundling finish so the deferred list is drained (Handler is now
+    // Aborted; the drain loop skips it).
+    fs.writeFileSync(unblock, "");
+    await dev.fetch("/").equals("gate: 1");
+
+    // gracefulExit() at the end of this test sends `stop(true)` and polls
+    // getDevServerDeinitCount(); if pending_requests is stuck at 1 the
+    // server never deinits and the harness throws.
   },
 });

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -3,7 +3,7 @@ import { expect } from "bun:test";
 import { once } from "node:events";
 import fs from "node:fs";
 import net from "node:net";
-import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
+import { devTest, emptyHtmlFile, minimalFramework, WAIT_MULTIPLIER } from "../bake-harness";
 
 devTest("import identifier doesnt get renamed", {
   framework: minimalFramework,
@@ -920,7 +920,7 @@ devTest("client disconnect on a deferred framework route releases the RequestCon
 
     // Wait until the bundler has actually picked up gate.ts: the request has
     // reached the server and is parked in the deferred list.
-    const deadline = Date.now() + 30_000;
+    const deadline = Date.now() + 5_000 * WAIT_MULTIPLIER;
     while (!fs.existsSync(entered)) {
       if (Date.now() > deadline) throw new Error("plugin gate never entered");
       await new Promise(r => setTimeout(r, 5));

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -912,24 +912,28 @@ devTest("client disconnect on a deferred framework route releases the RequestCon
 
     // Raw TCP so closing the socket is an unambiguous client abort.
     const sock = net.connect(dev.port, "127.0.0.1");
-    await new Promise<void>((resolve, reject) => {
-      sock.once("connect", resolve);
-      sock.once("error", reject);
-    });
-    sock.write(`GET / HTTP/1.1\r\nHost: 127.0.0.1:${dev.port}\r\nConnection: keep-alive\r\n\r\n`);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        sock.once("connect", resolve);
+        sock.once("error", reject);
+      });
+      sock.write(`GET / HTTP/1.1\r\nHost: 127.0.0.1:${dev.port}\r\nConnection: keep-alive\r\n\r\n`);
 
-    // Wait until the bundler has actually picked up gate.ts: the request has
-    // reached the server and is parked in the deferred list.
-    const deadline = Date.now() + 5_000 * WAIT_MULTIPLIER;
-    while (!fs.existsSync(entered)) {
-      if (Date.now() > deadline) throw new Error("plugin gate never entered");
-      await new Promise(r => setTimeout(r, 5));
+      // Wait until the bundler has actually picked up gate.ts: the request has
+      // reached the server and is parked in the deferred list.
+      const deadline = Date.now() + 5_000 * WAIT_MULTIPLIER;
+      while (!fs.existsSync(entered)) {
+        if (Date.now() > deadline) throw new Error("plugin gate never entered");
+        await new Promise(r => setTimeout(r, 5));
+      }
+
+      // Client goes away mid-bundle → RequestContext::on_abort runs the
+      // DeferredRequest abort callback and drops the SavedRequest.
+      sock.destroy();
+      await once(sock, "close");
+    } finally {
+      sock.destroy();
     }
-
-    // Client goes away mid-bundle → RequestContext::on_abort runs the
-    // DeferredRequest abort callback and drops the SavedRequest.
-    sock.destroy();
-    await once(sock, "close");
     // Force the server's event loop to turn so the FIN is processed (and
     // DeferredRequest::abort has run) before the plugin gate is released.
     // /_dev_server_test_set is a plain route added by the harness bootstrap,


### PR DESCRIPTION
## Problem

A framework-route request that is deferred while its bundle is building (stored as a `SavedRequest` inside `DeferredRequest::ServerHandler`) leaks its `RequestContext` when the client disconnects mid-bundle. The server's `pending_requests` never returns to zero, so `deinit_if_we_can()` never frees the `NewServer` and the bake harness graceful-exit check fails with:

```
error: Failed to trigger deinit. Check with BUN_DEBUG_Server=1 and see why it does not free itself.
```

### Repro

```ts
// framework route with a plugin that blocks bundling
// 1. GET / over raw TCP           -> request is deferred (SavedRequest created, ref_count=2)
// 2. client closes the socket     -> RequestContext::on_abort runs the DeferredRequest abort cb
// 3. unblock + GET / again        -> bundle drains; aborted entry is skipped
// 4. server.stop(true)            -> pending_requests stuck at 1, deinit never fires
```

## Cause

`SavedRequest` carries an `AnyRequestContext` (a `Copy` tagged pointer), so Rust `Drop` does nothing for the ref it owns; `SavedRequest::deinit()` exists to release it but three sites dropped the struct without calling it:

- `DeferredRequest::abort()` just did `drop(saved)` after `set_signal_aborted`. On client disconnect `RequestContext::on_abort` runs this callback and then drops one ref via its own `RequestContextRef` guard, leaving the count at 1; the drain loop later sees `Handler::Aborted` and skips the entry.
- `on_saved_request`'s defensive `respond_stopped_503` early-return for `SavedRequestUnion::Saved` (documented-unreachable today but would leak if it ever fires).
- `on_framework_request_with_bundle`'s `?` on `compute_arguments_for_framework_request` drops `req` on error before reaching `on_saved_request`; the drain-loop scopeguard only balances the `defer_request` +1.

## Fix

Call `saved.deinit()` at all three sites. `SavedRequest::deinit()` releases the `js_request` strong (idempotent with `StrongOptional::Drop`) and `ctx.deref()`; with `RequestContext::on_abort`'s existing `RequestContextRef` drop the count reaches zero on the client-disconnect path, `on_request_complete()` runs, and `pending_requests` decrements.

## Why not `impl Drop for SavedRequest`?

A `Drop` that calls `self.ctx.deref()` is the structurally right shape and would make future early-returns safe by construction. I kept this PR to targeted `deinit()` calls because the existing bundle-failure drain (DevServer.rs:4636-4643) and `DeferredRequest::__deinit()` rely on double-`deinit()` to balance both the initial and `defer_request` refs; moving to `Drop` changes that pattern and the `on_plugins_rejected` / finalize_bundle OOM paths (which still leave the `defer_request` +1 unbalanced and never write a response, tracked separately) belong in the same refactor. Happy to follow up with the `Drop` + `take_ctx()` change across all sites.

## Test

`test/bake/dev/bundle.test.ts` gains a test that uses an `onLoad` plugin to hold bundling open deterministically, opens a raw TCP request to `/`, waits for the plugin to signal it has been entered (request is deferred), destroys the socket, round-trips a plain harness route so the server has processed the FIN, then unblocks bundling and fetches again. The bake harness `gracefulExit()` asserts `getDevServerDeinitCount()` increments after `stop(true)`; without the fix that check throws.

Also re-ran `test/bake/deinitialization.test.ts` and `test/bake/dev/plugins.test.ts` with the change.
