### PR TITLE
bake: respond 500 and release both RequestContext refs when on_plugins_rejected / OOM drains a deferred framework request

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3845,7 +3845,7 @@ fn drain_current_bundle_requests(current_bundle: &mut CurrentBundle) {
     if !current_bundle.requests.first.is_null() {
         // cannot be an assertion because in the case of OOM, the request list was not drained.
         bun_core::debug!(
-            "current_bundle.requests.first != null. this leaves pending requests without an error page!",
+            "current_bundle.requests.first != null. failing pending requests with 500 (bundle-completion OOM defer).",
         );
     }
     while let Some(node) = current_bundle.requests.pop_first() {

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3143,7 +3143,8 @@ impl DeferredRequest {
         }
     }
 
-    /// Deinitializes state by aborting the connection.
+    /// Client-disconnect path (uWS `onAborted` / `RequestContext::on_abort`);
+    /// the response is already dead. Server-side abandonment uses [`fail()`].
     fn abort(&mut self) {
         deferred_request::debug_log_dr!(
             "DeferredRequest(0x{:x}) abort",
@@ -3163,11 +3164,27 @@ impl DeferredRequest {
                 // Note: saved.js_request (jsc::Strong) drops at end of arm
                 drop(saved);
             }
+            Handler::BundledHtmlPage(_) | Handler::Aborted => {}
+        }
+    }
+
+    /// Server-side abandonment (plugin load failure, bundle-completion OOM
+    /// defer): respond 500 and release both `RequestContext` refs. Callers
+    /// follow with `deref_()`.
+    fn fail(&mut self) {
+        match ::core::mem::replace(&mut self.handler, Handler::Aborted) {
+            Handler::ServerHandler(mut saved) => {
+                let resp = saved.response;
+                let ctx = saved.ctx;
+                // Deref both (prepare_and_save +1, defer_request +1) first so
+                // `detach_response` clears the uWS callbacks before the 500.
+                saved.deinit();
+                ctx.deref();
+                resp.write_status(b"500 Internal Server Error");
+                resp.write_header_int(b"Content-Length", 0);
+                resp.end_without_body(true);
+            }
             Handler::BundledHtmlPage(r) => {
-                // Reached from JS event-loop tasks (on_plugins_rejected, the
-                // bundle-completion OOM cleanup defer), so end_without_body
-                // alone cannot close the socket; write Content-Length so the
-                // client has framing.
                 r.response.write_status(b"500 Internal Server Error");
                 r.response.write_header_int(b"Content-Length", 0);
                 r.response.end_without_body(true);
@@ -3838,7 +3855,7 @@ fn drain_current_bundle_requests(current_bundle: &mut CurrentBundle) {
         // SAFETY: pop_first returns a live `*mut Node<T>`; `data` was
         // initialized by `defer_request`.
         let req = unsafe { (*node).data.assume_init_mut() };
-        req.abort();
+        req.fail();
         req.deref_();
     }
 }
@@ -6219,16 +6236,26 @@ impl DevServer {
 
     pub(crate) fn on_plugins_rejected(&mut self) -> crate::Result<()> {
         self.plugin_state = PluginState::Err;
+        // Keep `pending_requests > 0` for the drain: `fail()`'s ctx deref
+        // reaches `deinit_if_we_can()`, which would drop `Box<DevServer>`
+        // (i.e. `*self`) mid-loop if `stop()` had already taken the listener.
+        let server = self.server;
+        if let Some(mut s) = server {
+            s.on_pending_request();
+        }
         while let Some(item) = self.next_bundle.requests.pop_first() {
             // SAFETY: `pop_first` returns a valid `*mut Node<DeferredRequest>`;
             // `data` was initialized by `defer_request`.
             unsafe {
                 let d = (*item).data.assume_init_mut();
-                d.abort();
+                d.fail();
                 d.deref_();
             }
         }
         self.next_bundle.route_queue.clear_retaining_capacity();
+        if let Some(mut s) = server {
+            s.on_static_request_complete();
+        }
         // TODO: allow recovery from this state
         Ok(())
     }

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3176,13 +3176,14 @@ impl DeferredRequest {
             Handler::ServerHandler(mut saved) => {
                 let resp = saved.response;
                 let ctx = saved.ctx;
-                // Deref both (prepare_and_save +1, defer_request +1) first so
-                // `detach_response` clears the uWS callbacks before the 500.
+                // Write while ctx is still ref'd so the final `deref`'s
+                // `deinit()` (microtask drain, `detach_response`) cannot
+                // outrun the raw response handle.
                 saved.deinit();
-                ctx.deref();
                 resp.write_status(b"500 Internal Server Error");
                 resp.write_header_int(b"Content-Length", 0);
                 resp.end_without_body(true);
+                ctx.deref();
             }
             Handler::BundledHtmlPage(r) => {
                 r.response.write_status(b"500 Internal Server Error");

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3174,16 +3174,12 @@ impl DeferredRequest {
     fn fail(&mut self) {
         match ::core::mem::replace(&mut self.handler, Handler::Aborted) {
             Handler::ServerHandler(mut saved) => {
-                let resp = saved.response;
-                let ctx = saved.ctx;
-                // Write while ctx is still ref'd so the final `deref`'s
-                // `deinit()` (microtask drain, `detach_response`) cannot
-                // outrun the raw response handle.
+                saved.response.write_status(b"500 Internal Server Error");
+                saved.response.write_header_int(b"Content-Length", 0);
+                // `end_without_body` derefs the prepare_and_save +1;
+                // `saved.deinit` derefs `defer_request`'s +1.
+                saved.ctx.end_without_body(true);
                 saved.deinit();
-                resp.write_status(b"500 Internal Server Error");
-                resp.write_header_int(b"Content-Length", 0);
-                resp.end_without_body(true);
-                ctx.deref();
             }
             Handler::BundledHtmlPage(r) => {
                 r.response.write_status(b"500 Internal Server Error");

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -250,6 +250,10 @@ impl AnyRequestContext {
         dispatch!(self, (), |_T, ctx| ctx.deref())
     }
 
+    pub(crate) fn end_without_body(self, close_connection: bool) {
+        dispatch!(self, (), |_T, ctx| ctx.end_without_body(close_connection))
+    }
+
     pub fn on_request_body_stream_drained(self) {
         dispatch!(
             self,

--- a/test/bake/serve-plugins-dev-server.test.ts
+++ b/test/bake/serve-plugins-dev-server.test.ts
@@ -283,7 +283,10 @@ test.concurrent(
       `,
       "server.ts": `
         import * as fs from "node:fs";
+        import * as path from "node:path";
         import { getDevServerDeinitCount } from "bun:internal-for-testing";
+        const entered = path.join(import.meta.dir, "entered");
+        const stopped = path.join(import.meta.dir, "stopped");
         const server = Bun.serve({
           port: 0,
           development: true,
@@ -309,7 +312,7 @@ test.concurrent(
           .catch(e => (e as Error).name);
         // Wait until the plugin has actually been entered: that only happens
         // after the request was deferred, so the DeferredRequest is in place.
-        while (!fs.existsSync("entered")) {
+        while (!fs.existsSync(entered)) {
           await new Promise(r => setTimeout(r, 5));
         }
 
@@ -319,7 +322,7 @@ test.concurrent(
         server.stop();
         // Now let the plugin throw so on_plugins_rejected drains the list with
         // the listener already gone.
-        fs.writeFileSync("stopped", "");
+        fs.writeFileSync(stopped, "");
 
         const result = await pending;
         let deinit = false;

--- a/test/bake/serve-plugins-dev-server.test.ts
+++ b/test/bake/serve-plugins-dev-server.test.ts
@@ -137,3 +137,216 @@ test.concurrent("DevServer is notified when [serve.static] plugin setup resolves
   expect(out).toEqual({ status: 200, fromPlugin: true });
   expect(exitCode).toBe(0);
 });
+
+// Same reject path but the deferred request is a *framework* route
+// (DeferredRequest::Handler::ServerHandler) rather than a BundledHtmlPage.
+// on_plugins_rejected drains the deferred list; the ServerHandler arm must
+// write a response and release both RequestContext refs (the
+// prepare_and_save +1 and defer_request's ctx.ref_() +1) so the server's
+// pending_requests reaches zero and DevServer::drop runs after stop(true).
+test.concurrent(
+  "on_plugins_rejected responds and releases a deferred framework-route RequestContext",
+  async () => {
+    using dir = tempDir("serve-plugins-devserver-reject-framework", {
+      "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+      "plugin.ts": `
+        export default {
+          name: "boom-plugin",
+          async setup() {
+            await Promise.resolve();
+            throw new Error("plugin setup failed on purpose");
+          },
+        };
+      `,
+      "minimal.server.ts": `
+        export function render(req, meta) {
+          return meta.pageModule.default(req, meta);
+        }
+        export function registerClientReference(value, file, uid) {
+          return { value, file, uid };
+        }
+      `,
+      "routes/index.ts": `
+        export default function () {
+          return new Response("unreachable: plugin load fails first");
+        }
+      `,
+      "server.ts": `
+        import { getDevServerDeinitCount } from "bun:internal-for-testing";
+        const server = Bun.serve({
+          port: 0,
+          development: true,
+          app: {
+            framework: {
+              fileSystemRouterTypes: [
+                { root: "./routes", style: "nextjs-pages", serverEntryPoint: "./minimal.server.ts" },
+              ],
+              serverComponents: {
+                separateSSRGraph: false,
+                serverRuntimeImportSource: "./minimal.server.ts",
+                serverRegisterClientReferenceExport: "registerClientReference",
+              },
+            },
+          },
+          fetch() { return new Response("fallback"); },
+        } as any);
+
+        // First request defers into next_bundle.requests as Handler::ServerHandler
+        // while [serve.static] plugins are Pending; the plugin then rejects and
+        // on_plugins_rejected drains the list. The deferred entry must be answered
+        // (500) and its RequestContext fully released so stop(true) can deinit.
+        // The reject runs on the next microtask after the request is deferred, so
+        // the fixed path answers well under a second.
+        let result;
+        try {
+          const res = await fetch(server.url, { signal: AbortSignal.timeout(3_000) });
+          result = String(res.status);
+        } catch (e) {
+          result = (e as Error).name;
+        }
+
+        const before = getDevServerDeinitCount();
+        server.stop(true);
+        let deinit = false;
+        for (let i = 0; i < 250; i++) {
+          Bun.gc(true);
+          await new Promise(r => setTimeout(r, 1));
+          if (getDevServerDeinitCount() > before) { deinit = true; break; }
+        }
+        console.log(JSON.stringify({ result, deinit }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "server.ts"],
+      env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("plugin setup failed on purpose");
+
+    const line = stdout.split("\n").find(l => l.startsWith("{"));
+    expect(line).toBeDefined();
+    // Without the fix the ServerHandler arm wrote nothing and dropped only the
+    // js_request Strong, so the fetch hit the AbortSignal timeout
+    // ("TimeoutError") and the stranded RequestContext ref kept
+    // pending_requests > 0 (deinit: false).
+    expect(JSON.parse(line!)).toEqual({ result: "500", deinit: true });
+    expect(exitCode).toBe(0);
+  },
+  20_000,
+);
+
+// Same as above but server.stop() takes the listener *before* the plugin
+// promise rejects. on_plugins_rejected now drives pending_requests to zero
+// inside its drain, so without a keep-alive that would re-enter
+// deinit_if_we_can() and drop Box<DevServer> mid-loop (UAF on the deferred
+// request pool and next_bundle list head).
+test.concurrent(
+  "on_plugins_rejected after server.stop(): deferred framework request is released without tearing down the DevServer mid-drain",
+  async () => {
+    using dir = tempDir("serve-plugins-devserver-reject-framework-stopped", {
+      "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+      "plugin.ts": `
+        import * as fs from "node:fs";
+        import * as path from "node:path";
+        export default {
+          name: "boom-plugin",
+          async setup() {
+            // setup() is only reached after the first request has triggered
+            // get_or_load_plugins and been deferred into next_bundle.requests,
+            // so by the time this marker lands the DeferredRequest exists.
+            fs.writeFileSync(path.join(import.meta.dir, "entered"), "");
+            const stopped = path.join(import.meta.dir, "stopped");
+            while (!fs.existsSync(stopped)) {
+              await new Promise(r => setTimeout(r, 5));
+            }
+            throw new Error("plugin setup failed on purpose");
+          },
+        };
+      `,
+      "minimal.server.ts": `
+        export function render(req, meta) {
+          return meta.pageModule.default(req, meta);
+        }
+        export function registerClientReference(value, file, uid) {
+          return { value, file, uid };
+        }
+      `,
+      "routes/index.ts": `
+        export default function () {
+          return new Response("unreachable: plugin load fails first");
+        }
+      `,
+      "server.ts": `
+        import * as fs from "node:fs";
+        import { getDevServerDeinitCount } from "bun:internal-for-testing";
+        const server = Bun.serve({
+          port: 0,
+          development: true,
+          app: {
+            framework: {
+              fileSystemRouterTypes: [
+                { root: "./routes", style: "nextjs-pages", serverEntryPoint: "./minimal.server.ts" },
+              ],
+              serverComponents: {
+                separateSSRGraph: false,
+                serverRuntimeImportSource: "./minimal.server.ts",
+                serverRegisterClientReferenceExport: "registerClientReference",
+              },
+            },
+          },
+          fetch() { return new Response("fallback"); },
+        } as any);
+
+        // Issue the request (defers as Handler::ServerHandler while plugin setup
+        // is spinning), then take the listener away before letting setup throw.
+        const pending = fetch(server.url, { signal: AbortSignal.timeout(5_000) })
+          .then(r => String(r.status))
+          .catch(e => (e as Error).name);
+        // Wait until the plugin has actually been entered: that only happens
+        // after the request was deferred, so the DeferredRequest is in place.
+        while (!fs.existsSync("entered")) {
+          await new Promise(r => setTimeout(r, 5));
+        }
+
+        const before = getDevServerDeinitCount();
+        // Graceful: closes the listen socket only; the deferred request's
+        // connection stays open and pending_requests stays > 0.
+        server.stop();
+        // Now let the plugin throw so on_plugins_rejected drains the list with
+        // the listener already gone.
+        fs.writeFileSync("stopped", "");
+
+        const result = await pending;
+        let deinit = false;
+        for (let i = 0; i < 250; i++) {
+          Bun.gc(true);
+          await new Promise(r => setTimeout(r, 1));
+          if (getDevServerDeinitCount() > before) { deinit = true; break; }
+        }
+        console.log(JSON.stringify({ result, deinit }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "server.ts"],
+      env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("plugin setup failed on purpose");
+
+    const line = stdout.split("\n").find(l => l.startsWith("{"));
+    expect(line).toBeDefined();
+    expect(JSON.parse(line!)).toEqual({ result: "500", deinit: true });
+    expect(exitCode).toBe(0);
+  },
+  20_000,
+);


### PR DESCRIPTION
## Problem

When a bake dev server drains its deferred-request list because plugin loading failed (`on_plugins_rejected`) or because `finalize_bundle` hits the OOM cleanup defer, it calls `DeferredRequest::abort()` on each entry. For a `Handler::BundledHtmlPage` entry that writes a framed 500 (since #35008); for a `Handler::ServerHandler` entry (a framework route) it only fires the request's abort signal and drops the `SavedRequest`:

```rust
Handler::ServerHandler(saved) => {
    saved.ctx.set_signal_aborted(jsc::CommonAbortReason::ConnectionClosed);
    drop(saved);
}
```

Two observable effects:

1. **Client hangs.** Nothing is written to `saved.response`, so the HTTP client waits until its own timeout.
2. **`RequestContext` slot and `pending_requests` leak.** The context starts at `ref_count=1` from `prepare_and_save_js_request_context`; `defer_request` bumps it to 2 via `ctx.ref_()`. `drop(saved)` releases neither (`AnyRequestContext` is `Copy`), and on this path `RequestContext::on_abort` never runs (the client did not disconnect), so its `RequestContextRef` drop does not contribute either. `__deinit` in the follow-up `deref_()` sees `Handler::Aborted` and no-ops. `on_request_complete()` is never reached and `pending_requests` stays positive, so `server.stop(true)` cannot trigger `DevServer::drop`.

`abort()` is the right behaviour for its other caller (`RequestContext::on_abort`, i.e. client disconnect, where the response is dead and `on_abort`'s own guard balances the second ref), but not here.

## Fix

Add `DeferredRequest::fail()` for the server-side abandonment case and switch both non-network callers to it. For `ServerHandler` it releases both refs (`saved.deinit()` for the `prepare_and_save` +1, `ctx.deref()` for `defer_request`'s +1) so `detach_response` clears the uWS abort/timeout callbacks, then writes a framed 500 to the still-valid `AnyResponse`. `BundledHtmlPage` keeps the existing 500 write (moved here from `abort()`). `abort()` is now exclusively the client-disconnect path.

Bracket `on_plugins_rejected`'s drain with an `on_pending_request()` / `on_static_request_complete()` keep-alive: `fail()`'s final ctx deref reaches `on_request_complete()` → `deinit_if_we_can()`, and if `server.stop()` had already taken the listener that would drop `Box<DevServer>` (which holds the `deferred_request_pool`) mid-loop. Under the debug/ASAN build that produced a `heap-use-after-free` in `DeferredRequest::deref_`. The `finalize_bundle` OOM defer was already guarded by `start_async_bundle`'s `pending_requests` +1 (released only in the outer-defer that runs after the OOM drain).

This is complementary to #36811, which fixes the missing deref on the client-disconnect path inside `abort()`; neither depends on the other.

## Tests

`test/bake/serve-plugins-dev-server.test.ts` gains two framework-route variants of the existing `[serve.static]`-plugin-rejects test:

- **`on_plugins_rejected` responds and releases a deferred framework-route `RequestContext`.** A child process configures a minimal framework router, hits `/` while plugin setup is pending, lets the plugin reject, and asserts `{ result: "500", deinit: true }` (fetch answered + `getDevServerDeinitCount()` incremented after `stop(true)`). On `main` the child reports `{ result: "TimeoutError", deinit: false }`.
- **`on_plugins_rejected` after `server.stop()`.** Same shape but the plugin gates its throw on a file written after `server.stop()` has run, so `on_plugins_rejected` drains with the listener already gone. Without the keep-alive this produces the ASAN `heap-use-after-free` stack at `DeferredRequest::deref_` → `on_plugins_rejected` → `handle_on_reject`.

Also re-ran `test/bake/dev/plugins.test.ts`, `test/bake/dev/bundle.test.ts`, `test/bake/deinitialization.test.ts`, and `test/js/bun/http/bun-serve-html-405.test.ts` with the change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/serve-plugins-dev-server.test.ts
bun test v1.4.0 (820e2e7cf)

test/bake/serve-plugins-dev-server.test.ts:
(pass) DevServer is notified when [serve.static] plugin setup rejects [414.21ms]
(pass) DevServer is notified when [serve.static] plugin setup resolves [566.71ms]
232 |     expect(line).toBeDefined();
233 |     // Without the fix the ServerHandler arm wrote nothing and dropped only the
234 |     // js_request Strong, so the fetch hit the AbortSignal timeout
235 |     // ("TimeoutError") and the stranded RequestContext ref kept
236 |     // pending_requests > 0 (deinit: false).
237 |     expect(JSON.parse(line!)).toEqual({ result: "500", deinit: true });
                                    ^
error: expect(received).toEqual(expected)

  {
-   "deinit": true,
-   "result": "500",
+   "deinit": false,
+   "result": "TimeoutError",
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/bake/serve-plugins-dev-server.test.ts:237:31)
(fail) on_plugins_rejected responds and releases a deferred framework-ro
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (e108562c1)

test/bake/serve-plugins-dev-server.test.ts:
(pass) DevServer is notified when [serve.static] plugin setup rejects [12.26ms]
(pass) DevServer is notified when [serve.static] plugin setup resolves [18.25ms]
(pass) on_plugins_rejected responds and releases a deferred framework-route RequestContext [25.86ms]
(pass) on_plugins_rejected after server.stop(): deferred framework request is released without tearing down the DevServer mid-drain [33.50ms]

 4 pass
 0 fail
 15 expect() calls
Ran 4 tests across 1 file. [175.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/serve-plugins-dev-server.test.ts
bun test v1.4.0 (820e2e7cf)

test/bake/serve-plugins-dev-server.test.ts:
(pass) DevServer is notified when [serve.static] plugin setup rejects [586.08ms]
(pass) DevServer is notified when [serve.static] plugin setup resolves [706.28ms]
(pass) on_plugins_rejected responds and releases a deferred framework-route RequestContext [1581.28ms]
(pass) on_plugins_rejected after server.stop(): deferred framework request is released without tearing down the DevServer mid-drain [1828.46ms]

 4 pass
 0 fail
 15 expect() calls
Ran 4 tests across 1 file. [4.30s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 707ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 238 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/DevServer.rs              |  40 ++++--
 src/runtime/server/AnyRequestContext.rs    |   4 +
 test/bake/serve-plugins-dev-server.test.ts | 216 +++++++++++++++++++++++++++++
 3 files changed, 252 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/bake/DevServer.rs                  12     13      0
src/runtime/server/AnyRequestContext.rs         3      1      0
test/bake/serve-plugins-dev-server.test.ts      5     10      0
```

</details>

<!-- robobun:evidence:end -->