### PR TITLE
HTMLRewriter: throw 'Response body already used' for a disturbed body

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -435,6 +435,14 @@ impl HTMLRewriter {
                     global.throw_invalid_arguments(format_args!("Response body already used"))
                 );
             }
+            if matches!(*body_value, webcore::body::Value::Locked(_)) {
+                if let Some(readable) = response.get_body_readable_stream(global) {
+                    if readable.is_disturbed(global) {
+                        return Err(global
+                            .throw_invalid_arguments(format_args!("Response body already used")));
+                    }
+                }
+            }
             let out = self.begin_transform(global, &response, None)?;
             // Check if the returned value is an error and throw it properly
             if let Some(err) = out.to_error() {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1129,6 +1129,43 @@ describe("HTMLRewriter", () => {
     expect(await output.text()).toBe("<div><blink>it worked!</blink></div>");
   });
 
+  it("(from Bun.file().stream()) supports element handlers", async () => {
+    const filePath = join(tmpdirSync(), "html-rewriter-file-stream.html");
+    await Bun.write(filePath, "<p>a</p><p>b</p>");
+    const src = `
+      const out = new HTMLRewriter()
+        .on("p", { element(el) { el.setAttribute("v", "1"); } })
+        .transform(new Response(Bun.file(${JSON.stringify(filePath)}).stream()));
+      process.stdout.write(await out.text());
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe('<p v="1">a</p><p v="1">b</p>');
+    expect(exitCode).toBe(0);
+  });
+
+  it.each([
+    ["Blob", () => new Blob(["<p>a</p><p>b</p>"])],
+    ["Bun.file", () => Bun.file(join(tmpdirSync(), "html-rewriter-disturbed.html"))],
+  ])("throws on a disturbed Response body (%s)", async (name, body) => {
+    const data = body();
+    if (name === "Bun.file") await Bun.write(data, "<p>a</p><p>b</p>");
+    const resp = new Response(data);
+    const rd = resp.body.getReader();
+    await rd.read();
+    rd.releaseLock();
+    expect(resp.bodyUsed).toBe(true);
+    expect(() => new HTMLRewriter().on("p", { element() {} }).transform(resp)).toThrow(
+      expect.objectContaining({ name: "TypeError", message: "Response body already used" }),
+    );
+  });
+
   it("supports attribute iterator", async () => {
     var rewriter = new HTMLRewriter();
     var expected = [


### PR DESCRIPTION
`HTMLRewriter.transform()` on a `Response` whose body stream has been partially read (`getReader()` + `read()` + `releaseLock()`) used to abort the process with `internal error: entered unreachable code` in `ValueBufferer::buffer_locked_body_value`. #36733 replaced that code path and it now throws `ERR_STREAM_ALREADY_FINISHED` from `wire_input`'s `is_disturbed` guard, so the crash is gone; this PR is the residual consistency fix plus coverage.

```js
const resp = new Response(new Blob(["<p>a</p><p>b</p>"]));
const rd = resp.body.getReader();
await rd.read();
rd.releaseLock();
// resp.bodyUsed === true
new HTMLRewriter().on("p", { element() {} }).transform(resp);
// before: Error "Stream already used, please create a new one" (ERR_STREAM_ALREADY_FINISHED)
// after:  TypeError "Response body already used" (ERR_INVALID_ARG_TYPE)
```

### Fix

`transform_` checks `is_disturbed` on a `Locked` body's stream alongside the existing `Value::Used` check, so a disturbed body throws the same `Response body already used` TypeError as `.text()`/`.json()`/`.clone()` and as a body consumed by a previous `transform()` (the latter is already asserted by the `transform() marks the input body used` test at the bottom of the file).

### Tests

- `(from Bun.file().stream())`: subprocess coverage for the originally reported shape (transform rewrites a `Response(Bun.file(path).stream())` body).
- `throws on a disturbed Response body`: partially reads a Blob body and a Bun.file body before `transform()` and asserts `TypeError: Response body already used`. Fails on main without the `transform_` check (throws `Error`/`ERR_STREAM_ALREADY_FINISHED` instead), passes with it.

Full `html-rewriter.test.js` suite: 124 pass, 0 fail.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/workerd/html-rewriter.test.js
bun test v1.4.0 (519cef19e)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [16.68ms]
(pass) HTMLRewriter > error inside element handler rejects the body [12.81ms]
(pass) HTMLRewriter > error inside element handler (string) [7.87ms]
(pass) HTMLRewriter > async error without a real await inside element handler rejects the body [12.00ms]
(pass) HTMLRewriter > fast async error inside element handler rejects the body [23.72ms]
(pass) HTMLRewriter > slow async error inside element handler rejects the body [11.02ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [113.76ms]
(pass) HTMLRewriter > async handlers suspend the rewrite > runs async element handlers strictly in document order [611.88ms]
(pass) HTMLRewriter > async handlers suspend the rewrite > mutations made before and after the await both land [20.61ms]
(pass) HTMLRewriter > async handlers suspend the rewrite > an attribute iterator from before the await keeps working [17.90ms]
(pass) HTMLRewriter > async ha
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [0.12ms]
27 |   // rejects its output body.
28 |   it("error inside element handler rejects the body", async () => {
29 |     const res = new HTMLRewriter()
30 |       .on("div", {
31 |         element(element) {
32 |           throw new Error("test");
                         ^
error: test
      at element (/workspace/bun/test/js/workerd/html-rewriter.test.js:32:21)
      at <anonymous> (/workspace/bun/test/js/workerd/html-rewriter.test.js:35:8)
(fail) HTMLRewriter > error inside element handler rejects the body [0.46ms]
(pass) HTMLRewriter > error inside element handler (string) [0.09ms]
50 | 
51 |   it("async error without a real await inside element handler rejects the body", async () => {
52 |     const res = new HTMLRewriter()
53 |       .on("div", {
54 |         async element(element) {
55 |           throw new Error("test");
                         ^
error: test
      at element (/workspace/bun/test/js/workerd/html-rewriter.test.js:55:21)
      at <anonymous> (/workspace/bun/test/js/workerd/html-rewriter.test.js:58:8)
50 | 
51 |   it("async erro
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/workerd/html-rewriter.test.js
bun test v1.4.0 (519cef19e)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [12.94ms]
(pass) HTMLRewriter > error inside element handler rejects the body [7.72ms]
(pass) HTMLRewriter > error inside element handler (string) [4.73ms]
(pass) HTMLRewriter > async error without a real await inside element handler rejects the body [7.37ms]
(pass) HTMLRewriter > fast async error inside element handler rejects the body [21.76ms]
(pass) HTMLRewriter > slow async error inside element handler rejects the body [10.34ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [114.47ms]
(pass) HTMLRewriter > async handlers suspend the rewrite > runs async element handlers strictly in document order [634.00ms]
(pass) HTMLRewriter > async handlers suspend the rewrite > mutations made before and after the await both land [20.71ms]
(pass) HTMLRewriter > async handlers suspend the rewrite > an attribute iterator from before the await keeps working [17.21ms]
(pass) HTMLRewriter > async hand
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     519cef19e3
  features     baseline

22 deps, 108 codegen, 1171 objects in 839ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [9.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [5.00ms]
[4/1234] gen ErrorCode+*.h
[5/1234] gen bindgenv2
[6/1234] fetch tinycc
[tinycc] up to date
[7/1234] fetch picohttpparser
[picohttpparser] up to date
[8/1234] fetch zlib
[zlib] up to date
[9/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConst
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/html_rewriter.rs      |  8 ++++++++
 test/js/workerd/html-rewriter.test.js | 37 +++++++++++++++++++++++++++++++++++
 2 files changed, 45 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/runtime/api/html_rewriter.rs           6      2      0
test/js/workerd/html-rewriter.test.js      7     14      0
```

</details>

<!-- robobun:evidence:end -->