### PR TITLE
worker: fence in-flight AnyTaskJob work against terminate() freeing the VM

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -273,9 +273,8 @@ pub struct VirtualMachine {
     pub(crate) macro_event_loop: EventLoop,
     pub regular_event_loop: EventLoop,
     pub event_loop: *mut EventLoop, // BORROW_FIELD — points at sibling regular_event_loop/macro_event_loop
-    /// See [`crate::any_task_job::AnyTaskGate`]. `Option` only so the field is
-    /// zero-valid for `init()`'s `alloc_zeroed`; written there, always `Some`
-    /// until `destroy()`.
+    /// See [`crate::any_task_job::AnyTaskGate`]. `Option` only for
+    /// `alloc_zeroed` validity; always `Some` between `init()` and `destroy()`.
     pub any_task_gate: Option<std::sync::Arc<crate::any_task_job::AnyTaskGate>>,
 
     pub(crate) ref_strings: crate::ref_string::Map,
@@ -756,12 +755,10 @@ impl VirtualMachine {
         unsafe { &*self.event_loop }
     }
 
-    /// See [`crate::any_task_job::AnyTaskGate`]. Always `Some` between
-    /// `init()` and `destroy()`.
     #[inline]
     pub fn any_task_gate(&self) -> &std::sync::Arc<crate::any_task_job::AnyTaskGate> {
         debug_assert!(self.any_task_gate.is_some());
-        // SAFETY: written in `init()`, taken in `destroy()`; every caller is
+        // SAFETY: `Some` between `init()` and `destroy()`; every caller is
         // between the two.
         unsafe { self.any_task_gate.as_ref().unwrap_unchecked() }
     }
@@ -1569,10 +1566,7 @@ impl VirtualMachine {
             // drain below) or observes the flag under m_lock and drops.
             // destructOnExit sets it again (idempotently).
             Bun__JSCTaskScheduler__markShuttingDown(self.global());
-            // Same mirror for work-pool `AnyTaskJob`s (see web_worker.rs
-            // shutdown()): wait out any in-flight `ctx.run()` (which may be
-            // reading/writing a JSC `ArrayBuffer`) before `destructOnExit`
-            // frees the JSC heap.
+            // Same fence for work-pool `AnyTaskJob`s; see `AnyTaskGate`.
             self.any_task_gate().close();
 
             // Every worker has now posted its close task to our concurrent
@@ -4495,9 +4489,6 @@ impl VirtualMachine {
         // so reclaim it here or every Worker leaks it.
         drop(core::mem::take(&mut self.preload));
 
-        // Release this VM's `AnyTaskGate` ref; the gate itself is freed once
-        // every in-flight pool-thread job that observed the close has dropped
-        // its clone.
         drop(self.any_task_gate.take());
 
         // SAFETY: this VM is raw-`dealloc`'d (no field `Drop` runs), so

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -273,6 +273,10 @@ pub struct VirtualMachine {
     pub(crate) macro_event_loop: EventLoop,
     pub regular_event_loop: EventLoop,
     pub event_loop: *mut EventLoop, // BORROW_FIELD — points at sibling regular_event_loop/macro_event_loop
+    /// See [`crate::any_task_job::AnyTaskGate`]. `Option` only so the field is
+    /// zero-valid for `init()`'s `alloc_zeroed`; written there, always `Some`
+    /// until `destroy()`.
+    pub any_task_gate: Option<std::sync::Arc<crate::any_task_job::AnyTaskGate>>,
 
     pub(crate) ref_strings: crate::ref_string::Map,
     pub(crate) ref_strings_mutex: bun_threading::Mutex,
@@ -750,6 +754,16 @@ impl VirtualMachine {
     pub fn event_loop_shared(&self) -> &EventLoop {
         // SAFETY: see `event_loop_mut`.
         unsafe { &*self.event_loop }
+    }
+
+    /// See [`crate::any_task_job::AnyTaskGate`]. Always `Some` between
+    /// `init()` and `destroy()`.
+    #[inline]
+    pub fn any_task_gate(&self) -> &std::sync::Arc<crate::any_task_job::AnyTaskGate> {
+        debug_assert!(self.any_task_gate.is_some());
+        // SAFETY: written in `init()`, taken in `destroy()`; every caller is
+        // between the two.
+        unsafe { self.any_task_gate.as_ref().unwrap_unchecked() }
     }
 
     /// Alias for [`Self::event_loop_mut`]. Kept for callers migrated on the
@@ -1555,6 +1569,11 @@ impl VirtualMachine {
             // drain below) or observes the flag under m_lock and drops.
             // destructOnExit sets it again (idempotently).
             Bun__JSCTaskScheduler__markShuttingDown(self.global());
+            // Same mirror for work-pool `AnyTaskJob`s (see web_worker.rs
+            // shutdown()): wait out any in-flight `ctx.run()` (which may be
+            // reading/writing a JSC `ArrayBuffer`) before `destructOnExit`
+            // frees the JSC heap.
+            self.any_task_gate().close();
 
             // Every worker has now posted its close task to our concurrent
             // queue (OUTSTANDING is decremented after dispatchExit). Drop
@@ -2136,6 +2155,7 @@ impl VirtualMachine {
             (*regular).virtual_machine = NonNull::new(vm);
             let _ = (*regular).tasks.ensure_unused_capacity(64);
             addr_of_mut!((*vm).event_loop).write(regular);
+            addr_of_mut!((*vm).any_task_gate).write(Some(crate::any_task_job::AnyTaskGate::new()));
 
             // `source_mappings.map` is a sibling-field backref onto
             // `saved_source_map_table`.
@@ -4474,6 +4494,11 @@ impl VirtualMachine {
         // time and `load_preloads` clears the boxes but keeps the Vec buffer,
         // so reclaim it here or every Worker leaks it.
         drop(core::mem::take(&mut self.preload));
+
+        // Release this VM's `AnyTaskGate` ref; the gate itself is freed once
+        // every in-flight pool-thread job that observed the close has dropped
+        // its clone.
+        drop(self.any_task_gate.take());
 
         // SAFETY: this VM is raw-`dealloc`'d (no field `Drop` runs), so
         // `transpiler` is never auto-dropped after `deinit` clears its fields.

--- a/src/jsc/any_task_job.rs
+++ b/src/jsc/any_task_job.rs
@@ -9,13 +9,65 @@
 
 use core::ffi::c_void;
 use core::ptr::NonNull;
+use std::sync::Arc;
 
 use bun_event_loop::AnyTask::AnyTask;
 use bun_io::KeepAlive;
+use bun_threading::RwLock;
 use bun_threading::work_pool::{IntrusiveWorkTask as _, Task as WorkPoolTask, WorkPool};
 
 use crate::event_loop::ConcurrentTask;
 use crate::{JSGlobalObject, JsResult, VirtualMachineRef as VirtualMachine};
+
+/// Close-once fence between a VM and every [`AnyTaskJob`] it schedules, so the
+/// pool-thread work body and completion either run entirely before
+/// `worker.terminate()` tears the VM down, or not at all.
+///
+/// Each VM owns one `Arc` clone; each in-flight job holds another (so the gate
+/// itself outlives both). The pool thread runs `ctx.run()` and the
+/// `enqueue_task_concurrent` push under a read lock: several ctxs read inputs
+/// from (and `Scrypt` writes its output into) JSC-heap-backed `ArrayBuffer`s
+/// that `Heap::lastChanceToFinalize` frees regardless of `protect()`, and the
+/// enqueue itself dereferences the embedded `EventLoop`, so both must be
+/// ordered before JSC-heap teardown and the VM free.
+///
+/// [`crate::web_worker::WebWorker`]'s shutdown calls [`Self::close`] before
+/// draining the concurrent queue, before JSC teardown, and before deallocating
+/// the VM. Taking the write lock waits out every in-flight reader (so the KDF
+/// finishes and its push is visible to the drain), and once `closed` is set
+/// any later pool task skips its body entirely. Same fence-then-drain shape as
+/// `ScriptExecutionContext::markTerminating` for the C++ `postTaskTo` path.
+/// Matches Node's behaviour of draining in-flight libuv work on env teardown.
+pub struct AnyTaskGate {
+    closed: RwLock<bool>,
+}
+
+impl AnyTaskGate {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            closed: RwLock::new(false),
+        })
+    }
+
+    /// Mark the owning VM as going away. Takes the write lock, so it returns
+    /// only after every concurrent [`Self::run_gated`] reader has released.
+    pub fn close(&self) {
+        *self.closed.write() = true;
+    }
+
+    /// Run `body` under a read lock if the gate is open, else skip it. The
+    /// lock held across `body` orders it entirely before [`Self::close`]
+    /// returns. Returns `false` when closed (body not run).
+    fn run_gated(&self, body: impl FnOnce()) -> bool {
+        let guard = self.closed.read();
+        if *guard {
+            return false;
+        }
+        body();
+        drop(guard);
+        true
+    }
+}
 
 /// Per-job payload trait. Implementors own the off-thread work body and the
 /// JS-thread completion; the surrounding heap/queue/keep-alive plumbing is
@@ -49,6 +101,10 @@ pub trait AnyTaskJobCtx: Sized {
 /// e.g. a `JSPromiseStrong` field after scheduling.
 pub struct AnyTaskJob<C> {
     vm: bun_ptr::BackRef<VirtualMachine>,
+    /// The pool-thread [`Self::run_task`] only dereferences `vm` (and the
+    /// JSC-heap buffers `ctx` borrows) under this gate's read lock, so a
+    /// worker VM freed by terminate() is never touched. See [`AnyTaskGate`].
+    gate: Arc<AnyTaskGate>,
     task: WorkPoolTask,
     any_task: AnyTask,
     poll: KeepAlive,
@@ -72,9 +128,11 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
     /// (running `Drop for C`). The returned pointer is owned by the caller
     /// until handed to [`Self::schedule`].
     pub fn create(global: &JSGlobalObject, ctx: C) -> JsResult<*mut Self> {
-        let vm = bun_ptr::BackRef::new(global.bun_vm());
+        let vm_ref = global.bun_vm();
+        let vm = bun_ptr::BackRef::new(vm_ref);
         let job = bun_core::heap::into_raw(Box::new(Self {
             vm,
+            gate: Arc::clone(vm_ref.any_task_gate()),
             task: WorkPoolTask {
                 node: Default::default(),
                 callback: Self::run_task,
@@ -137,14 +195,39 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
     fn run_task(task: *mut WorkPoolTask) {
         // SAFETY: only reachable via the `WorkPoolTask::callback` slot wired
         // in `create`; `task` points to `Self.task` and the job is live until
-        // `run_from_js` reclaims it.
-        let job = unsafe { &mut *Self::from_task_ptr(task) };
-        let vm = job.vm;
-        job.ctx.run(vm.global);
-        // `ConcurrentTask::create` heap-allocates a fresh task; the queue takes
-        // ownership of it.
-        vm.event_loop_shared()
-            .enqueue_task_concurrent(ConcurrentTask::create(job.any_task.task()));
+        // `run_from_js` reclaims it (or is leaked below).
+        let this = unsafe { Self::from_task_ptr(task) };
+        // SAFETY: `gate` was written in `create`; this thread exclusively owns
+        // `*this` until the enqueue below hands it to the JS thread. Cloned so
+        // the read lock can be held while `this` is reborrowed `&mut` inside.
+        let gate = Arc::clone(unsafe { &(*this).gate });
+        let ran = gate.run_gated(|| {
+            // SAFETY: gate open ⇒ worker shutdown hasn't passed `close()` ⇒
+            // the owning VM, its JSC heap (which `ctx.run` may read/write via
+            // `ArrayBuffer`-backed inputs/outputs), and its embedded event
+            // loop are all still live.
+            let job = unsafe { &mut *this };
+            let vm = job.vm;
+            job.ctx.run(vm.global);
+            // `ConcurrentTask::create` heap-allocates; the queue takes
+            // ownership.
+            vm.event_loop_shared()
+                .enqueue_task_concurrent(ConcurrentTask::create(job.any_task.task()));
+        });
+        drop(gate);
+        if ran {
+            return;
+        }
+        // Gate closed (worker terminated before this task was picked up).
+        // SAFETY: `this` is the sole owner (`run_gated` did not touch it);
+        // `gate` was written in `create` and is never read again past this
+        // point (the box is leaked below).
+        unsafe { core::ptr::drop_in_place(core::ptr::addr_of_mut!((*this).gate)) };
+        // The remainder of the box (`poll`, `ctx`) is intentionally leaked:
+        // `ctx` holds `Strong` JSC handles into the dead VM's heap and
+        // `poll.unref` would touch the freed event loop. This matches the fate
+        // of tasks already queued on a terminated worker's never-drained
+        // concurrent queue.
     }
 
     /// `AnyTask` callback — runs ON the JS thread. Reclaims the heap

--- a/src/jsc/any_task_job.rs
+++ b/src/jsc/any_task_job.rs
@@ -19,25 +19,13 @@ use bun_threading::work_pool::{IntrusiveWorkTask as _, Task as WorkPoolTask, Wor
 use crate::event_loop::ConcurrentTask;
 use crate::{JSGlobalObject, JsResult, VirtualMachineRef as VirtualMachine};
 
-/// Close-once fence between a VM and every [`AnyTaskJob`] it schedules, so the
-/// pool-thread work body and completion either run entirely before
-/// `worker.terminate()` tears the VM down, or not at all.
-///
-/// Each VM owns one `Arc` clone; each in-flight job holds another (so the gate
-/// itself outlives both). The pool thread runs `ctx.run()` and the
-/// `enqueue_task_concurrent` push under a read lock: several ctxs read inputs
-/// from (and `Scrypt` writes its output into) JSC-heap-backed `ArrayBuffer`s
-/// that `Heap::lastChanceToFinalize` frees regardless of `protect()`, and the
-/// enqueue itself dereferences the embedded `EventLoop`, so both must be
-/// ordered before JSC-heap teardown and the VM free.
-///
-/// [`crate::web_worker::WebWorker`]'s shutdown calls [`Self::close`] before
-/// draining the concurrent queue, before JSC teardown, and before deallocating
-/// the VM. Taking the write lock waits out every in-flight reader (so the KDF
-/// finishes and its push is visible to the drain), and once `closed` is set
-/// any later pool task skips its body entirely. Same fence-then-drain shape as
-/// `ScriptExecutionContext::markTerminating` for the C++ `postTaskTo` path.
-/// Matches Node's behaviour of draining in-flight libuv work on env teardown.
+/// Close-once fence between a VM and every [`AnyTaskJob`] it schedules.
+/// [`AnyTaskJob::run_task`] runs `ctx.run()` and the completion enqueue under
+/// a read lock (both touch the JSC heap / VM box; `Heap::lastChanceToFinalize`
+/// frees `ArrayBuffer` inputs regardless of `protect()`). Worker shutdown and
+/// `global_exit` call [`Self::close`] (write lock, waits out readers) before
+/// JSC teardown and the VM free. Same fence-then-drain shape as
+/// `ScriptExecutionContext::markTerminating`.
 pub struct AnyTaskGate {
     closed: RwLock<bool>,
 }
@@ -101,9 +89,8 @@ pub trait AnyTaskJobCtx: Sized {
 /// e.g. a `JSPromiseStrong` field after scheduling.
 pub struct AnyTaskJob<C> {
     vm: bun_ptr::BackRef<VirtualMachine>,
-    /// The pool-thread [`Self::run_task`] only dereferences `vm` (and the
-    /// JSC-heap buffers `ctx` borrows) under this gate's read lock, so a
-    /// worker VM freed by terminate() is never touched. See [`AnyTaskGate`].
+    /// [`Self::run_task`] only dereferences `vm`/JSC-heap buffers under this
+    /// gate's read lock. See [`AnyTaskGate`].
     gate: Arc<AnyTaskGate>,
     task: WorkPoolTask,
     any_task: AnyTask,
@@ -219,15 +206,12 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
             return;
         }
         // Gate closed (worker terminated before this task was picked up).
-        // SAFETY: `this` is the sole owner (`run_gated` did not touch it);
-        // `gate` was written in `create` and is never read again past this
-        // point (the box is leaked below).
+        // SAFETY: sole owner of `*this` (`run_gated` did not touch it); `gate`
+        // is never read again (the box is leaked below).
         unsafe { core::ptr::drop_in_place(core::ptr::addr_of_mut!((*this).gate)) };
-        // The remainder of the box (`poll`, `ctx`) is intentionally leaked:
-        // `ctx` holds `Strong` JSC handles into the dead VM's heap and
-        // `poll.unref` would touch the freed event loop. This matches the fate
-        // of tasks already queued on a terminated worker's never-drained
-        // concurrent queue.
+        // `poll`/`ctx` are intentionally leaked: both would touch the freed
+        // VM/JSC heap on Drop. Same fate as tasks stranded on a terminated
+        // worker's never-drained concurrent queue.
     }
 
     /// `AnyTask` callback — runs ON the JS thread. Reclaims the heap

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1302,6 +1302,13 @@ impl WebWorker {
             // or observes m_isShuttingDown under m_lock and drops. Idempotent;
             // teardownJSCVM sets it again.
             Bun__JSCTaskScheduler__markShuttingDown(vm.global());
+            // Same fence for work-pool jobs (`AnyTaskJob`: node:crypto KDFs/
+            // HKDF/primes/keypairs/sign, Bun.secrets, Bun.zstd*). `close()`'s
+            // write lock waits out every pool thread that is inside
+            // `ctx.run()` or the enqueue (both touch the JSC heap / `vm`), so
+            // they finish before teardownJSCVM and step 5's free; a job the
+            // pool picks up after this observes `closed` and skips its body.
+            vm.any_task_gate().close();
             // Reclaim queued CppTasks (the per-worker stdio/messaging
             // MessagePort drain tasks that can be in self.tasks mid-tick when
             // terminate() lands, and any Worker dispatchExit close task from a

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1302,12 +1302,7 @@ impl WebWorker {
             // or observes m_isShuttingDown under m_lock and drops. Idempotent;
             // teardownJSCVM sets it again.
             Bun__JSCTaskScheduler__markShuttingDown(vm.global());
-            // Same fence for work-pool jobs (`AnyTaskJob`: node:crypto KDFs/
-            // HKDF/primes/keypairs/sign, Bun.secrets, Bun.zstd*). `close()`'s
-            // write lock waits out every pool thread that is inside
-            // `ctx.run()` or the enqueue (both touch the JSC heap / `vm`), so
-            // they finish before teardownJSCVM and step 5's free; a job the
-            // pool picks up after this observes `closed` and skips its body.
+            // Same fence for work-pool `AnyTaskJob`s; see `AnyTaskGate`.
             vm.any_task_gate().close();
             // Reclaim queued CppTasks (the per-worker stdio/messaging
             // MessagePort drain tasks that can be in self.tasks mid-tick when

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -490,8 +490,12 @@ test(
           'parentPort.postMessage("up");';
         for (let r = 0; r < ${rounds}; r++) {
           const w = new Worker(src, { eval: true });
+          await new Promise((res, rej) => {
+            w.once("message", res);
+            w.once("error", rej);
+            w.once("exit", (c) => rej(new Error("worker exited " + c + " before ready")));
+          });
           w.on("error", () => {});
-          await new Promise((res) => w.once("message", res));
           await w.terminate();
         }
         console.log("ok");

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -455,3 +455,60 @@ test.skipIf(!isDebug)(
   },
   120_000,
 );
+
+// Regression: worker.terminate() while an async crypto.pbkdf2()/scrypt() was
+// running on the shared work pool freed the worker VM (and its JSC heap) out
+// from under the pool thread. AnyTaskJob::run_task both (a) handed the
+// caller's ArrayBuffer-backed password/salt to BoringSSL (freed by
+// Heap::lastChanceToFinalize) and (b) dereferenced the VM box to post the
+// completion (freed by the worker's dealloc). Release builds segfaulted the
+// whole process; ASAN reported the UAF on a "Bun Pool" thread inside
+// PKCS5_PBKDF2_HMAC / EVP_PBE_scrypt or VirtualMachine::event_loop_shared.
+test(
+  "terminate() while async crypto.pbkdf2()/scrypt() with Buffer inputs is running on the work pool does not UAF",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const src =
+          'const { parentPort } = require("node:worker_threads");' +
+          'const crypto = require("node:crypto");' +
+          // Salt length NOT a multiple of 64: SHA-256's block function is
+          // uninstrumented assembly, only the <64-byte tail goes through
+          // memcpy where ASAN can observe the freed read.
+          'const salt = Buffer.alloc((4 << 20) - 17, 0xaa);' +
+          'const pw = salt.subarray(0, 1 << 20);' +
+          // Heavy enough params that each job is still inside BoringSSL on a
+          // pool thread when terminate() lands (so the worker event loop never
+          // reaches the JS-thread completion), but bounded so the fix's
+          // close() wait stays well under the test timeout.
+          'for (let k = 0; k < 2; k++) crypto.pbkdf2(pw, salt, 200000, 64, "sha256", () => {});' +
+          'for (let k = 0; k < 2; k++) crypto.scrypt(salt, pw, 32, { N: 1 << 14, r: 8, p: 1, maxmem: 128 << 20 }, () => {});' +
+          'parentPort.postMessage("up");';
+        for (let r = 0; r < ${rounds}; r++) {
+          const w = new Worker(src, { eval: true });
+          w.on("error", () => {});
+          await new Promise((res) => w.once("message", res));
+          await w.terminate();
+        }
+        console.log("ok");
+      `,
+      ],
+      // A job still on the pool when the gate closes is leaked by design (its
+      // ctx holds Strong/JSPromiseStrong handles into the dead VM's JSC heap,
+      // and poll.unref would touch the freed event loop). Bounded per
+      // terminated worker; opt this subprocess out of LSan so that stranded
+      // accounting is not asserted as a regression.
+      env: { ...bunEnv, ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
+  },
+  timeout,
+);


### PR DESCRIPTION
## Problem

`worker.terminate()` while an async `crypto.pbkdf2()`/`crypto.scrypt()` (or any other `AnyTaskJob`: HKDF, prime/keypair gen, sign, DH, `Bun.secrets`, `Bun.zstd*`) is running on the shared work pool frees the worker VM and its JSC heap out from under the pool thread. `AnyTaskJob::run_task` both

- hands the caller's ArrayBuffer-backed password/salt to BoringSSL, whose backing store `Heap::lastChanceToFinalize` frees regardless of `protect()`, and
- dereferences the VM box to post the completion (`vm.event_loop_shared()` on the raw `BackRef<VirtualMachine>`).

Release builds segfault the whole process; debug+ASAN reports the UAF on a "Bun Pool" thread:

```
heap-use-after-free  READ of size 8  thread T4 (Bun Pool 0)
  #0 VirtualMachine::event_loop_shared   src/jsc/VirtualMachine.rs:752
  #1 AnyTaskJob<Pbkdf2Ctx>::run_task     src/jsc/any_task_job.rs:146
freed by thread (Worker):
  WebWorker::shutdown                    src/jsc/web_worker.rs:1383
```

The ArrayBuffer-read face shows as `PKCS5_PBKDF2_HMAC` / `EVP_PBE_scrypt` reading freed bytes inside BoringSSL, but only when the salt length is not a multiple of the SHA-256 block size: the block function is uninstrumented assembly, so ASAN only observes the <64-byte memcpy tail. Worker `process.exit()` and an uncaught throw take the same shutdown path.

## Fix

A per-VM `Arc<RwLock<bool>>` gate. `AnyTaskJob::create` clones it; `run_task` runs `ctx.run()` and the `enqueue_task_concurrent` push under a read lock. `WebWorker::shutdown` (and `global_exit` for the destruct-on-exit path) close the gate right next to the existing `markTerminating`/`markShuttingDown` fences, before the concurrent-queue drain, before JSC teardown, and before deallocating the VM. The write lock waits out every in-flight reader so the work body finishes and its push is visible to the drain; a job the pool picks up after `close()` observes it and skips its body.

Skipped jobs intentionally leak their `ctx` (it holds `Strong`/`JSPromiseStrong` handles into the dead VM's heap, and `poll.unref` would touch the freed event loop); bounded per terminated worker, same fate as tasks already queued on a terminated worker's never-drained concurrent queue. The gate `Arc` itself is released on both paths so it does not accumulate.

`close()` blocking on the longest in-flight KDF matches Node's behaviour of draining in-flight libuv work on env teardown.

## Scope

This is #35154 rebased onto current main with a Buffer-input test for the ArrayBuffer-read face. The other cross-thread producers (`FetchTasklet`, `WorkTask`, `ConcurrentPromiseTask`, `AsyncFSTask`, `PasswordJob`, napi, watchers) still have the analogous defect and stay with #35767 / #34154; the `AnyTaskGate` here is reusable by those call sites.

## Verification

New test in `test/js/web/workers/worker-terminate-lifetime.test.ts`: a subprocess arms 2x pbkdf2 + 2x scrypt with a 4 MiB Buffer salt in each of `rounds` workers and terminates once armed.

- `USE_SYSTEM_BUN=1`: child segfaults at `0xFFFFFFFF00000000` (rc 139, round 6-7)
- `bun bd` without the src/ change: ASAN heap-use-after-free at `AnyTaskJob<Pbkdf2Ctx>::run_task` (round 0)
- `bun bd` with the fix: 4/4 rounds clean, ~10s under ASAN
- `test/js/node/crypto/{pbkdf2,scrypt}.test.ts`, `node-crypto.test.js` (203), `zstd.test.ts` (83) all pass
- `bun run rust:check-all`: 10/10 targets ok

The pre-existing `dns.lookup()` test in the same file fails on current main (4104-byte leak) with or without this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->

Towards #32073
