### PR TITLE
JSBuffer: allow TerminationException in bufferFromPointerAndLengthAndDeinit's no-exception assert

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -405,8 +405,7 @@ JSC::EncodedJSValue JSBuffer__bufferFromPointerAndLengthAndDeinit(JSC::JSGlobalO
         uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, 0);
     }
 
-    // only JSC::JSUint8Array::create can throw and we control the ArrayBuffer passed in,
-    // but we may be entered with a worker's TerminationException already pending.
+    // only JSC::JSUint8Array::create can throw and we control the ArrayBuffer passed in.
     scope.assertNoExceptionExceptTermination();
     ASSERT(uint8Array);
 

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -405,8 +405,9 @@ JSC::EncodedJSValue JSBuffer__bufferFromPointerAndLengthAndDeinit(JSC::JSGlobalO
         uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, 0);
     }
 
-    // only JSC::JSUint8Array::create can throw and we control the ArrayBuffer passed in.
-    scope.assertNoException();
+    // only JSC::JSUint8Array::create can throw and we control the ArrayBuffer passed in,
+    // but its allocation may service VMTraps and observe a pending TerminationException.
+    scope.assertNoExceptionExceptTermination();
     ASSERT(uint8Array);
 
     return JSC::JSValue::encode(uint8Array);

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -406,7 +406,7 @@ JSC::EncodedJSValue JSBuffer__bufferFromPointerAndLengthAndDeinit(JSC::JSGlobalO
     }
 
     // only JSC::JSUint8Array::create can throw and we control the ArrayBuffer passed in,
-    // but its allocation may service VMTraps and observe a pending TerminationException.
+    // but we may be entered with a worker's TerminationException already pending.
     scope.assertNoExceptionExceptTermination();
     ASSERT(uint8Array);
 

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -464,8 +464,10 @@ test.skipIf(!isDebug)(
 // JSBuffer__bufferFromPointerAndLengthAndDeinit with that exception still
 // pending and the assert SIGABRTs the whole process. The assert is under
 // ENABLE(EXCEPTION_SCOPE_VERIFICATION) = ASSERT_ENABLED || ASAN_ENABLED, so
-// it is compiled in for both debug and release+ASAN.
-test.skipIf(!isDebug && !isASAN)(
+// it is compiled in for both debug and release+ASAN; this stays debug-only
+// for now because release+ASAN hits the orthogonal AnyTaskJob pool-thread
+// UAF (#36817) that this assert was masking.
+test.skipIf(!isDebug)(
   "terminate() while a worker's async crypto.pbkdf2() completion is creating its result Buffer does not trip assertNoException()",
   async () => {
     await using proc = Bun.spawn({

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -482,9 +482,9 @@ test.skipIf(!isDebug && !isASAN)(
           // and overlaps the parent's terminate(). The async completion then
           // allocates a 64-byte Buffer via JSBuffer__bufferFromPointerAndLengthAndDeinit.
           'const salt = Buffer.alloc(3 << 20, 0xaa);' +
-          'parentPort.postMessage("up");' +
           'function lane() { crypto.pbkdf2(salt, salt, 1, 64, "sha256", lane); }' +
-          'for (let i = 0; i < 8; i++) lane();';
+          'for (let i = 0; i < 8; i++) lane();' +
+          'parentPort.postMessage("up");';
         function ready(w) {
           return new Promise((res, rej) => {
             w.once("message", res);

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -457,13 +457,15 @@ test.skipIf(!isDebug)(
 );
 
 // Regression: JSBuffer__bufferFromPointerAndLengthAndDeinit finished with a
-// plain scope.assertNoException(). JSUint8Array::create allocates, which
-// services VMTraps; a concurrent worker.terminate() installs the sticky
-// TerminationException there, and the assert SIGABRTs the whole process.
-// Hit from async crypto.pbkdf2()'s completion (Pbkdf2Ctx::then ->
-// JSValue::create_buffer) running on a worker that has just been terminated.
-// Release WebKit compiles that ASSERT out, so debug-only.
-test.skipIf(!isDebug)(
+// plain scope.assertNoException(). With several pbkdf2 lanes in flight, one
+// lane's JS callback hits a bytecode trap checkpoint where a concurrent
+// worker.terminate() installs the sticky TerminationException; the next
+// lane's completion (Pbkdf2Ctx::then -> JSValue::create_buffer) then enters
+// JSBuffer__bufferFromPointerAndLengthAndDeinit with that exception still
+// pending and the assert SIGABRTs the whole process. The assert is under
+// ENABLE(EXCEPTION_SCOPE_VERIFICATION) = ASSERT_ENABLED || ASAN_ENABLED, so
+// it is compiled in for both debug and release+ASAN.
+test.skipIf(!isDebug && !isASAN)(
   "terminate() while a worker's async crypto.pbkdf2() completion is creating its result Buffer does not trip assertNoException()",
   async () => {
     await using proc = Bun.spawn({

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -455,3 +455,64 @@ test.skipIf(!isDebug)(
   },
   120_000,
 );
+
+// Regression: JSBuffer__bufferFromPointerAndLengthAndDeinit finished with a
+// plain scope.assertNoException(). JSUint8Array::create allocates, which
+// services VMTraps; a concurrent worker.terminate() installs the sticky
+// TerminationException there, and the assert SIGABRTs the whole process.
+// Hit from async crypto.pbkdf2()'s completion (Pbkdf2Ctx::then ->
+// JSValue::create_buffer) running on a worker that has just been terminated.
+// Release WebKit compiles that ASSERT out, so debug-only.
+test.skipIf(!isDebug)(
+  "terminate() while a worker's async crypto.pbkdf2() completion is creating its result Buffer does not trip assertNoException()",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const src =
+          'const { parentPort } = require("node:worker_threads");' +
+          'const crypto = require("node:crypto");' +
+          // One iteration, large salt: EVP_PBKDF2_HMAC is dominated by the
+          // HMAC over the salt, so the threadpool job is short but nonzero
+          // and overlaps the parent's terminate(). The async completion then
+          // allocates a 64-byte Buffer via JSBuffer__bufferFromPointerAndLengthAndDeinit.
+          'const salt = Buffer.alloc(3 << 20, 0xaa);' +
+          'parentPort.postMessage("up");' +
+          'function lane() { crypto.pbkdf2(salt, salt, 1, 64, "sha256", lane); }' +
+          'for (let i = 0; i < 8; i++) lane();';
+        function ready(w) {
+          return new Promise((res, rej) => {
+            w.once("message", res);
+            w.once("error", rej);
+            w.once("exit", (c) => rej(new Error("worker exited " + c + " before ready")));
+          });
+        }
+        for (let r = 0; r < 15; r++) {
+          const ws = [];
+          for (let i = 0; i < 4; i++) {
+            const w = new Worker(src, { eval: true });
+            ws.push(w);
+          }
+          await Promise.all(ws.map(ready));
+          for (const w of ws) w.on("error", () => {});
+          await Bun.sleep(r % 7);
+          await Promise.all(ws.map((w) => w.terminate()));
+        }
+        console.log("PASS");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("PASS\n");
+    expect(exitCode).toBe(0);
+  },
+  120_000,
+);


### PR DESCRIPTION
`JSBuffer__bufferFromPointerAndLengthAndDeinit` ends with `scope.assertNoException()` on the grounds that the only thing inside that can throw is `JSC::JSUint8Array::create` and we control the `ArrayBuffer` it wraps. That holds for ordinary exceptions, but a concurrent `worker.terminate()` can install the sticky `TerminationException` at a bytecode trap checkpoint on the worker thread before this function is entered, and nothing between the scope declaration and the assert clears it. The assert then SIGABRTs the whole process.

Hit from async `crypto.pbkdf2()`'s JS-thread completion with several lanes in flight: one lane's JS callback takes the termination trap, the next lane's completion enters `JSBuffer__bufferFromPointerAndLengthAndDeinit` with the exception still pending.

```
ASSERTION FAILED: !exception()
ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
  JSBuffer__bufferFromPointerAndLengthAndDeinit (src/jsc/bindings/JSBuffer.cpp:409)
  JSValue::create_buffer (src/jsc/JSValue.rs)
  Pbkdf2Ctx::then (src/runtime/crypto/PBKDF2.rs)
  AnyTaskJob<Pbkdf2Ctx>::run_from_js
  ... EventLoop::tick ... WebWorker::spin
```

`JSValue::create_buffer` / `create_buffer_from_box` (the Rust wrappers of this C++ function) are also reached from the shell interpreter's stdout/stderr resolve, `Bun.gunzipSync`/`zstdDecompress`/`inflateSync`, `TextEncoder`, and FFI `toBuffer`, so any of those on a terminating worker trips it the same way.

Use `assertNoExceptionExceptTermination()`, matching the other allocation-adjacent assert sites in the bindings (ModuleLoader, ZigGlobalObject, JSDOMExceptionHandling, JSCommonJSModule, bindings.cpp, ObjectBindings) and the `ASSERT_NO_PENDING_EXCEPTION` helper in `headers-handwritten.h`.

### Verification

New `skipIf(!isDebug)` test in `worker-terminate-lifetime.test.ts`: 4 workers each keep 8 lanes of 1-iteration `pbkdf2()` hot, parent terminates mid-stream, 15 rounds. On a debug build without the src/ change:

```
(fail) terminate() while a worker's async crypto.pbkdf2() completion is creating its result Buffer does not trip assertNoException() [3229.08ms]
  "ASSERTION FAILED: !exception() ... ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()"
```

With the change it passes (~31s under debug+ASAN, 3/3 clean).

The assert is also compiled in for release+ASAN (`ENABLE(EXCEPTION_SCOPE_VERIFICATION) = ASSERT_ENABLED || ASAN_ENABLED`), but that lane hits the orthogonal `AnyTaskJob` pool-thread UAF (#36817) that this assert was masking. The gate stays debug-only, matching the sibling tests in this file, and can widen to `!isDebug && !isASAN` once #36817 lands.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->