### PR TITLE
test(install): make config-version.test.ts offline and concurrent

### DIFF
--- a/test/cli/install/config-version.test.ts
+++ b/test/cli/install/config-version.test.ts
@@ -1,68 +1,59 @@
-import { file } from "bun";
-import { afterAll, describe, expect, test } from "bun:test";
+import { file, spawn } from "bun";
+import { describe, expect, test } from "bun:test";
 import { exists } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunEnv as env, runBunInstall } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, stderrForInstall, tempDir } from "harness";
 import { join } from "path";
 
-var registry = new VerdaccioRegistry();
+// These tests cover the `configVersion` field in bun.lock and the linker
+// selection it gates. They run fully offline using file:/workspace: deps so no
+// registry process is spawned; see lockfile-version-2.test.ts for the same
+// pattern. All three spawn into independent tempdirs and run concurrently.
 
-// Two tests below resolve a real package (`no-deps`) from Verdaccio. The
-// registry runs as a forked child and, in some sandboxed CI environments, can
-// fail to actually serve packages even after `start()` returns. Gate those two
-// on whether the registry can serve the `no-deps` manifest — the exact thing
-// they install — so they run wherever the registry works and skip (rather than
-// fail with `ConnectionRefused`) where it doesn't. The third test is offline
-// (workspace-only) and always runs.
-// Start fire-and-forget: `start()` only settles on its IPC "ready" message (or
-// a spawn error), so a child that exits without signalling — the sandbox case
-// this gating handles — would leave an awaited `start()` hanging forever and
-// drop every test in this file. The bounded poll below is the sole readiness
-// signal.
-let registryCanServe = false;
-registry.start().catch(() => {});
-const registryDeadline = Date.now() + 30_000;
-while (Date.now() < registryDeadline) {
-  try {
-    const res = await fetch(`${registry.registryUrl()}no-deps`, { signal: AbortSignal.timeout(2_000) });
-    await res.arrayBuffer();
-    if (res.ok) {
-      registryCanServe = true;
-      break;
-    }
-  } catch {}
-  await Bun.sleep(250);
+async function install(cwd: string) {
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { out, err: stderrForInstall(err), exitCode };
 }
 
-afterAll(() => {
-  registry.stop();
-});
-
-describe("configVersion", () => {
-  test.skipIf(!registryCanServe)("new projects use current config version", async () => {
-    const { packageDir } = await registry.createTestDir({
-      files: {
-        "package.json": JSON.stringify({
-          name: "new-proj",
-          dependencies: {
-            "no-deps": "1.0.0",
-          },
-        }),
-      },
+describe.concurrent("configVersion", () => {
+  test("new projects use current config version", async () => {
+    using dir = tempDir("config-version-new-proj", {
+      "package.json": JSON.stringify({
+        name: "new-proj",
+        dependencies: { dep: "file:./dep" },
+      }),
+      "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
     });
+    const packageDir = String(dir);
 
-    await runBunInstall(env, packageDir);
+    const { out, err, exitCode } = await install(packageDir);
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(err).not.toContain("warn:");
+    expect(normalizeBunSnapshot(out, packageDir)).toMatchInlineSnapshot(`
+      "bun install <version> (<revision>)
 
+      + dep@dep
+
+      1 package installed"
+    `);
+    expect(exitCode).toBe(0);
+
+    // non-monorepo: hoisted linker, no .bun store
     expect(
       await Promise.all([
         exists(join(packageDir, "node_modules/.bun")),
-        file(join(packageDir, "node_modules/no-deps/package.json")).json(),
+        file(join(packageDir, "node_modules/dep/package.json")).json(),
       ]),
-    ).toEqual([false, { name: "no-deps", version: "1.0.0" }]);
+    ).toEqual([false, { name: "dep", version: "1.0.0" }]);
 
-    const lockfile = await (
-      await file(join(packageDir, "bun.lock")).text()
-    ).replaceAll(/localhost:\d+/g, "localhost:1234");
-    expect(lockfile).toMatchInlineSnapshot(`
+    expect(await file(join(packageDir, "bun.lock")).text()).toMatchInlineSnapshot(`
       "{
         "lockfileVersion": 2,
         "configVersion": 1,
@@ -70,47 +61,52 @@ describe("configVersion", () => {
           "": {
             "name": "new-proj",
             "dependencies": {
-              "no-deps": "1.0.0",
+              "dep": "file:./dep",
             },
           },
         },
         "packages": {
-          "no-deps": ["no-deps@1.0.0", "http://localhost:1234/no-deps/-/no-deps-1.0.0.tgz", {}, "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw=="],
+          "dep": ["dep@file:dep", {}],
         }
       }
       "
     `);
   });
 
-  test.skipIf(!registryCanServe)("new monorepos use isolated linker", async () => {
-    const { packageDir } = await registry.createTestDir({
-      files: {
-        "package.json": JSON.stringify({
-          name: "new-proj",
-          workspaces: ["packages/*"],
-        }),
-        "packages/pkg1/package.json": JSON.stringify({
-          name: "pkg1",
-          dependencies: {
-            "no-deps": "1.0.0",
-          },
-        }),
-      },
+  test("new monorepos use isolated linker", async () => {
+    using dir = tempDir("config-version-new-monorepo", {
+      "package.json": JSON.stringify({
+        name: "new-proj",
+        workspaces: ["packages/*"],
+      }),
+      "packages/pkg1/package.json": JSON.stringify({
+        name: "pkg1",
+        dependencies: { dep: "file:../../dep" },
+      }),
+      "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
     });
+    const packageDir = String(dir);
 
-    await runBunInstall(env, packageDir);
+    const { out, err, exitCode } = await install(packageDir);
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(err).not.toContain("warn:");
+    expect(normalizeBunSnapshot(out, packageDir)).toMatchInlineSnapshot(`
+      "bun install <version> (<revision>)
 
+      2 packages installed"
+    `);
+    expect(exitCode).toBe(0);
+
+    // monorepo: isolated linker, dep lives in the .bun store and is linked into pkg1
     expect(
       await Promise.all([
-        exists(join(packageDir, "packages/pkg1/node_modules/no-deps")),
-        file(join(packageDir, "node_modules/.bun/no-deps@1.0.0/node_modules/no-deps/package.json")).json(),
+        exists(join(packageDir, "packages/pkg1/node_modules/dep")),
+        file(join(packageDir, "node_modules/.bun/dep@file+dep/node_modules/dep/package.json")).json(),
       ]),
-    ).toEqual([true, { name: "no-deps", version: "1.0.0" }]);
+    ).toEqual([true, { name: "dep", version: "1.0.0" }]);
 
-    const lockfile = await (
-      await file(join(packageDir, "bun.lock")).text()
-    ).replaceAll(/localhost:\d+/g, "localhost:1234");
-    expect(lockfile).toMatchInlineSnapshot(`
+    expect(await file(join(packageDir, "bun.lock")).text()).toMatchInlineSnapshot(`
       "{
         "lockfileVersion": 2,
         "configVersion": 1,
@@ -121,14 +117,14 @@ describe("configVersion", () => {
           "packages/pkg1": {
             "name": "pkg1",
             "dependencies": {
-              "no-deps": "1.0.0",
+              "dep": "file:../../dep",
             },
           },
         },
         "packages": {
-          "no-deps": ["no-deps@1.0.0", "http://localhost:1234/no-deps/-/no-deps-1.0.0.tgz", {}, "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw=="],
-
           "pkg1": ["pkg1@workspace:packages/pkg1"],
+
+          "pkg1/dep": ["dep@file:dep", {}],
         }
       }
       "
@@ -136,39 +132,41 @@ describe("configVersion", () => {
   });
 
   test("should add configVersion@v0 to an existing lockfile", async () => {
-    const { packageDir } = await registry.createTestDir({
-      files: {
-        "package.json": JSON.stringify({
-          name: "root-1",
-          workspaces: ["packages/*"],
-          dependencies: {
-            "pkg1": "workspace:*",
+    using dir = tempDir("config-version-existing-lockfile", {
+      "package.json": JSON.stringify({
+        name: "root-1",
+        workspaces: ["packages/*"],
+        dependencies: { pkg1: "workspace:*" },
+      }),
+      "packages/pkg1/package.json": JSON.stringify({ name: "pkg1" }),
+      "bun.lock": JSON.stringify({
+        lockfileVersion: 1,
+        workspaces: {
+          "": {
+            name: "new-proj",
+            dependencies: { pkg1: "workspace:*" },
           },
-        }),
-        "packages/pkg1/package.json": JSON.stringify({
-          "name": "pkg1",
-        }),
-        "bun.lock": JSON.stringify({
-          "lockfileVersion": 1,
-          "workspaces": {
-            "": {
-              "name": "new-proj",
-              "dependencies": {
-                "pkg1": "workspace:*",
-              },
-            },
-            "packages/pkg1": {
-              "name": "pkg1",
-            },
-          },
-          "packages": {
-            "pkg1": ["pkg1@workspace:packages/pkg1"],
-          },
-        }),
-      },
+          "packages/pkg1": { name: "pkg1" },
+        },
+        packages: {
+          pkg1: ["pkg1@workspace:packages/pkg1"],
+        },
+      }),
     });
+    const packageDir = String(dir);
 
-    await runBunInstall(bunEnv, packageDir);
+    const { out, err, exitCode } = await install(packageDir);
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(err).not.toContain("warn:");
+    expect(normalizeBunSnapshot(out, packageDir)).toMatchInlineSnapshot(`
+      "bun install <version> (<revision>)
+
+      + pkg1@workspace:packages/pkg1
+
+      1 package installed"
+    `);
+    expect(exitCode).toBe(0);
 
     // should be hoisted install
     expect(
@@ -178,12 +176,9 @@ describe("configVersion", () => {
       ]),
     ).toEqual([false, { name: "pkg1" }]);
 
-    const lockfile = await (
-      await file(join(packageDir, "bun.lock")).text()
-    ).replaceAll(/localhost:\d+/g, "localhost:1234");
     // lockfileVersion stays 1 — an existing lockfile is never bumped on re-save.
     // configVersion is backfilled (0) because the loaded lockfile had none.
-    expect(lockfile).toMatchInlineSnapshot(`
+    expect(await file(join(packageDir, "bun.lock")).text()).toMatchInlineSnapshot(`
       "{
         "lockfileVersion": 1,
         "configVersion": 0,


### PR DESCRIPTION
### What

`test/cli/install/config-version.test.ts` took ~10s on alpine 3.23 x64 in CI (build 88024). Most of that time was forking a verdaccio child process and polling it for up to 30 seconds before any test could run, with two of the three tests gated behind `test.skipIf(!registryCanServe)`, which silently reports them as passed when the poll loop gives up.

### Change

All three tests cover the `configVersion` field in `bun.lock` and the linker selection it gates; neither depends on where packages come from. Replace the registry dependency with a local `file:` dependency (same pattern as `lockfile-version-2.test.ts` in the same directory), drop the verdaccio process and the 30s readiness poll entirely, and run the three independent installs under `describe.concurrent`.

Assertions are tightened along the way:
- The two previously skippable tests now always run.
- `bun install` stdout is asserted via `normalizeBunSnapshot` inline snapshots before the exit code.
- The indirect `.not.toContain("panic:")` check inherited from `runBunInstall` is gone.

No tests are deleted or skipped; the lockfile inline snapshots and the `node_modules` layout checks are preserved.

### Why this is correct

The `configVersion` field and the default linker decision are computed from whether the project is a workspace root and whether a lockfile already existed, independent of the dependency protocol. Running the same three scenarios with a `file:` dependency exercises the same code path in `src/install/` that writes `configVersion` and picks the linker; the only thing that changes in the lockfile snapshot is the `packages` entry shape (`["dep@file:dep", {}]` instead of the registry URL/sha line), which is not what these tests cover. Registry resolution itself is covered extensively elsewhere in `test/cli/install/`.

### Timing

`bun bd test test/cli/install/config-version.test.ts`, best of three:

| | before | after |
| --- | --- | --- |
| debug | 3.48s | 2.24s |
| release | 970ms | 155ms |

On alpine the verdaccio fork is considerably slower than locally (the file reports ~10s there), so the CI-side improvement should be larger than the local release ratio suggests.

#33115 replaces verdaccio across the whole install suite with an in-process registry and also touches this file; this change is independent of that (the file no longer uses any registry at all) and can land on its own.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/install/config-version.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/install/config-version.test.ts
bun test v1.4.0 (784a26460)

test/cli/install/config-version.test.ts:
(pass) configVersion > new projects use current config version [228.75ms]
(pass) configVersion > should add configVersion@v0 to an existing lockfile [189.45ms]
(pass) configVersion > new monorepos use isolated linker [238.33ms]

 3 pass
 0 fail
 6 snapshots, 21 expect() calls
Ran 3 tests across 1 file. [2.42s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/install/config-version.test.ts | 221 ++++++++++++++++----------------
 1 file changed, 108 insertions(+), 113 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
test/cli/install/config-version.test.ts      1      1      0
```

</details>

**self-review** · no surviving concerns

28 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->