### PR TITLE
test(vm): replace network-dependent happy-dom #16277 repro with deterministic tail-call repro

### DIFF
--- a/test/js/node/vm/happy-dom-vm-16277.test.ts
+++ b/test/js/node/vm/happy-dom-vm-16277.test.ts
@@ -103,10 +103,12 @@ test("happy-dom Window (vm.createContext on the Window object) works", async () 
     url: "http://localhost/",
     settings: { disableJavaScriptFileLoading: true },
   });
-  expect(vm.isContext(window)).toBe(true);
-  const { document, localStorage } = window;
-  localStorage.clear();
-  document.body.innerHTML = `<div id="x">ok</div>`;
-  expect(document.getElementById("x")?.textContent).toBe("ok");
-  await window.happyDOM.close();
+  try {
+    expect(vm.isContext(window)).toBe(true);
+    const { document } = window;
+    document.body.innerHTML = `<div id="x">ok</div>`;
+    expect(document.getElementById("x")?.textContent).toBe("ok");
+  } finally {
+    await window.happyDOM.close();
+  }
 });

--- a/test/js/node/vm/happy-dom-vm-16277.test.ts
+++ b/test/js/node/vm/happy-dom-vm-16277.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { Window } from "happy-dom";
 import { bunEnv, bunExe } from "harness";
 import vm from "node:vm";
 
@@ -92,4 +93,20 @@ test("stack materialized in ErrorInstance::finalizeUnconditionally does not cras
   expect(stdout).toBe("64 string\n");
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
+});
+
+test("happy-dom Window (vm.createContext on the Window object) works", async () => {
+  // happy-dom's `new Window()` is the only place in the test suite that calls
+  // vm.createContext on a large real-world object and runs a Script in it.
+  // Kept here (without the external fetch) so that integration path stays covered.
+  const window = new Window({
+    url: "http://localhost/",
+    settings: { disableJavaScriptFileLoading: true },
+  });
+  expect(vm.isContext(window)).toBe(true);
+  const { document, localStorage } = window;
+  localStorage.clear();
+  document.body.innerHTML = `<div id="x">ok</div>`;
+  expect(document.getElementById("x")?.textContent).toBe("ok");
+  await window.happyDOM.close();
 });

--- a/test/js/node/vm/happy-dom-vm-16277.test.ts
+++ b/test/js/node/vm/happy-dom-vm-16277.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import vm from "node:vm";
+import { bunEnv, bunExe } from "harness";
 
 // Regression tests for https://github.com/oven-sh/bun/issues/16277
 //
@@ -38,7 +39,7 @@ test("error stack includes the reconstructed tail-call frame", () => {
   // The reconstructed frame has codeBlock=inner's but callee=null; the fix is
   // that Bun's stack formatter null-checks the callee before `->getObject()`.
   const stack = String(err.stack);
-  expect(stack.includes("is not a function") || stack.includes("not callable")).toBe(true);
+  expect(stack).toContain("is not a function");
   expect(stack).toContain("inner");
   // `outer` was the tail caller of `inner`; its own frame is legitimately gone
   // (tail-call semantics), but `inner` must be present.
@@ -61,13 +62,34 @@ test("same path through a node:vm context", () => {
   expect(stack).toContain("is not a function");
 });
 
-test("error whose stack is materialized lazily during GC does not crash", () => {
-  // Create Errors with tail-call frames and drop them without touching `.stack`
-  // so JSC materializes the stack string in the ErrorInstance finalizer, which
-  // runs under Heap::runEndPhase.
-  for (let i = 0; i < 64; i++) makeTailCallError();
-  Bun.gc(true);
-  // If we got here the finalizer did not crash; finish with a positive check.
-  const stack = String((makeTailCallError() as Error).stack);
-  expect(stack).toContain("inner");
+test("stack materialized in ErrorInstance::finalizeUnconditionally does not crash", async () => {
+  // ErrorInstance::finalizeUnconditionally runs on ErrorInstances that survive
+  // a collection, and calls computeErrorInfo only when one of the captured
+  // frames' callee or codeBlock is unmarked. So: retain the Error, but let the
+  // per-iteration Function (and thus its CodeBlock) become unreachable, so the
+  // reconstructed frame's codeBlock is unmarked at Bun.gc(true). On Bun 1.1.43
+  // the child segfaults at address 0x5 inside Bun.gc(true); that crash trace is
+  // the one in the original report.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `"use strict";
+       const errs = [];
+       for (let i = 0; i < 64; i++) {
+         const inner = new Function("fn", "'use strict'; return fn();");
+         const outer = new Function("inner", "fn", "'use strict'; return inner(fn);");
+         try { outer(inner, null); } catch (e) { errs.push(e); }
+       }
+       Bun.gc(true);
+       process.stdout.write(String(errs.length) + " " + typeof errs[0].stack + "\\n");`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("64 string\n");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
 });

--- a/test/js/node/vm/happy-dom-vm-16277.test.ts
+++ b/test/js/node/vm/happy-dom-vm-16277.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import vm from "node:vm";
 import { bunEnv, bunExe } from "harness";
+import vm from "node:vm";
 
 // Regression tests for https://github.com/oven-sh/bun/issues/16277
 //

--- a/test/js/node/vm/happy-dom-vm-16277.test.ts
+++ b/test/js/node/vm/happy-dom-vm-16277.test.ts
@@ -1,27 +1,73 @@
 import { expect, test } from "bun:test";
-import { Window } from "happy-dom";
-test("reproduction", async (): Promise<undefined> => {
-  expect.assertions(1);
-  for (let i: number = 0; i < 2; ++i) {
-    // TODO: have a reproduction of this that doesn't depend on a 10 MB file.
-    const response: Response = new Response(`<!DOCTYPE html>
-<html>
-  <head>
-    <script
-    id="base-js"
-    src="https://www.youtube.com/s/desktop/6ed1dd74/jsbin/desktop_polymer_legacy_browsers.vflset/desktop_polymer_legacy_browsers.js"
-    nonce="4oKS2biXokC0utrX4MKrsQ"></script>
-  </head>
-  </body>
-</html>`);
-    const window: Window = new Window({ url: "http://youtube.com" });
-    const localStorage = window.localStorage;
-    global.window = window;
-    global.document = window.document;
-    localStorage.clear();
-    document.body.innerHTML = await response.text();
-  }
+import vm from "node:vm";
 
-  // This test passes by simply not crashing.
-  expect().pass();
+// Regression tests for https://github.com/oven-sh/bun/issues/16277
+//
+// The original report hit this via happy-dom loading a large external script
+// that happened to tail-call a non-function. The root cause is that when a
+// strict-mode tail call site invokes a value that is not callable, JSC
+// reconstructs the elided tail-call frame from CallLinkInfo with a null
+// `callee` and a non-null `codeBlock`. Bun's stack formatter dereferenced
+// `frame.callee()` unconditionally, which segfaulted at address 0x5.
+//
+// The original test shelled out to YouTube via happy-dom's synchronous fetch
+// (child_process.execFileSync) to obtain such a script, which made the test
+// both network-dependent and very slow. These tests reproduce the exact crash
+// deterministically and locally.
+
+function makeTailCallError(): unknown {
+  "use strict";
+  function inner(fn: () => void): void {
+    "use strict";
+    return fn();
+  }
+  function outer(fn: () => void): void {
+    "use strict";
+    return inner(fn);
+  }
+  try {
+    outer(null as any);
+  } catch (e) {
+    return e;
+  }
+  throw new Error("unreachable: outer(null) did not throw");
+}
+
+test("error stack includes the reconstructed tail-call frame", () => {
+  const err = makeTailCallError() as Error;
+  // The reconstructed frame has codeBlock=inner's but callee=null; the fix is
+  // that Bun's stack formatter null-checks the callee before `->getObject()`.
+  const stack = String(err.stack);
+  expect(stack.includes("is not a function") || stack.includes("not callable")).toBe(true);
+  expect(stack).toContain("inner");
+  // `outer` was the tail caller of `inner`; its own frame is legitimately gone
+  // (tail-call semantics), but `inner` must be present.
+});
+
+test("same path through a node:vm context", () => {
+  const ctx = vm.createContext({});
+  const err = vm.runInContext(
+    `"use strict";
+     function inner(fn) { "use strict"; return fn(); }
+     function outer(fn) { "use strict"; return inner(fn); }
+     var caught;
+     try { outer(null); } catch (e) { caught = e; }
+     caught;`,
+    ctx,
+  );
+  expect(err).toBeTruthy();
+  const stack = String((err as Error).stack);
+  expect(stack).toContain("inner");
+  expect(stack).toContain("is not a function");
+});
+
+test("error whose stack is materialized lazily during GC does not crash", () => {
+  // Create Errors with tail-call frames and drop them without touching `.stack`
+  // so JSC materializes the stack string in the ErrorInstance finalizer, which
+  // runs under Heap::runEndPhase.
+  for (let i = 0; i < 64; i++) makeTailCallError();
+  Bun.gc(true);
+  // If we got here the finalizer did not crash; finish with a positive check.
+  const stack = String((makeTailCallError() as Error).stack);
+  expect(stack).toContain("inner");
 });


### PR DESCRIPTION
## What

`test/js/node/vm/happy-dom-vm-16277.test.ts` was taking ~11s on the `debian 13 x64-asan` lane (build 88024) and had a `TODO: have a reproduction of this that doesn't depend on a 10 MB file`. This PR resolves that TODO.

## Why the old test was slow and unreliable

The old test set `document.body.innerHTML` to HTML containing `<script src="https://www.youtube.com/.../desktop_polymer_legacy_browsers.js">`. happy-dom's synchronous script loader then spawned `ChildProcess.execFileSync(process.argv[0], ['-e', <http-request>])` twice to fetch that 10 MB bundle from YouTube and evaluated it in the vm context. Under a debug+ASAN build each child process spawn costs several seconds regardless of outcome.

It also meant coverage depended on external network reachability: in sandboxed runners where `youtube.com` does not resolve, the fetch throws early and the test **passes on Bun 1.1.43** (the broken version), so it was not guarding the regression there.

## Root cause of #16277

When a strict-mode tail call site invokes a value that is not callable, JSC reconstructs the elided caller frame from `CallLinkInfo` via `Interpreter::getStackTrace`, emitting a `StackFrame` with `codeBlock` set and `callee == nullptr` (the `StackFrame(VM&, owner, CodeBlock*, BytecodeIndex)` constructor). Bun's `formatStackTrace` dereferenced `frame.callee()->getObject()` without a null check, which segfaulted at address `0x5`. PR #16280 added the null check.

## New tests

1. Strict-mode `return fn()` where `fn` is `null`, then assert the resulting `.stack` contains the reconstructed `inner` frame and `"is not a function"`.
2. The same pattern run inside a `node:vm` context.
3. In a spawned child: create such errors repeatedly via per-iteration `new Function` and retain them, then `Bun.gc(true)`, so the captured frame's `codeBlock` is unmarked and `ErrorInstance::finalizeUnconditionally` materializes the stack under `Heap::runEndPhase` (the path in the original crash trace). Asserts `stderr === ""`, `stdout === "64 string\n"`, `signalCode === null`, `exitCode === 0`.
4. A network-free happy-dom smoke test (`new Window()` with `disableJavaScriptFileLoading`, set `innerHTML`, assert `vm.isContext(window)` and the parsed DOM) so `vm.createContext` on a happy-dom `Window` stays covered in Bun. The other happy-dom references in the suite either run under Node.js, are commented out, or use `GlobalWindow` which skips the vm context.

## Verification

| Bun version | Result |
| --- | --- |
| **1.1.43 (regression)** | **`panic(main thread): Segmentation fault at address 0x5`** in test 1; the child in test 3 segfaults inside `Bun.gc(true)` |
| current debug+ASAN | 4 pass |
| current debug+ASAN, `BUN_JSC_useJIT=0` | 4 pass |
| current release | 4 pass |

Local timing (`bun bd test test/js/node/vm/happy-dom-vm-16277.test.ts`, debug+ASAN):

| | wall-clock |
| --- | --- |
| before | 16.5s (test body 8.5s; timed out at the default 5s limit without `--timeout`) |
| after | 9.5s (happy-dom import dominates under debug+ASAN; 0.3s on release) |

Assertions: 1 × `expect().pass()` before → 11 real `expect()` calls now. No external network access.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/vm/happy-dom-vm-16277.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/js/node/vm/happy-dom-vm-16277.test.ts"
bun test v1.4.0 (a930a2579)

test/js/node/vm/happy-dom-vm-16277.test.ts:
(pass) error stack includes the reconstructed tail-call frame [16.92ms]
(pass) same path through a node:vm context [27.00ms]
(pass) stack materialized in ErrorInstance::finalizeUnconditionally does not crash [1223.50ms]
(pass) happy-dom Window (vm.createContext on the Window object) works [583.74ms]

 4 pass
 0 fail
 11 expect() calls
Ran 4 tests across 1 file. [9.23s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/vm/happy-dom-vm-16277.test.ts | 131 ++++++++++++++++++++++++-----
 1 file changed, 109 insertions(+), 22 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
test/js/node/vm/happy-dom-vm-16277.test.ts      2      5      0
```

</details>

<!-- robobun:evidence:end -->