### PR TITLE
redis: reject NaN/undefined seconds in expire() instead of sending EXPIRE key 0

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -657,8 +657,6 @@ impl JSValkeyClient {
             return Err(global.throw_invalid_argument_type("expire", "key", "string or buffer"));
         };
 
-        // validate_integer_range maps undefined/NaN to the default (0), which
-        // would send `EXPIRE key 0` and delete the key. Reject both explicitly.
         let seconds_value = frame.argument(1);
         if seconds_value.is_undefined() {
             return Err(global.throw_invalid_property_type_value(

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -657,8 +657,18 @@ impl JSValkeyClient {
             return Err(global.throw_invalid_argument_type("expire", "key", "string or buffer"));
         };
 
+        // validate_integer_range maps undefined/NaN to the default (0), which
+        // would send `EXPIRE key 0` and delete the key. Reject both explicitly.
+        let seconds_value = frame.argument(1);
+        if seconds_value.is_undefined() {
+            return Err(global.throw_invalid_property_type_value(b"seconds", b"number", seconds_value));
+        }
+        if seconds_value.is_number() && seconds_value.as_number().is_nan() {
+            return Err(global.throw_invalid_property_type_value(b"seconds", b"integer", seconds_value));
+        }
+
         let seconds = global.validate_integer_range::<i32>(
-            frame.argument(1),
+            seconds_value,
             0,
             jsc::IntegerRange {
                 min: 0,

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -661,10 +661,18 @@ impl JSValkeyClient {
         // would send `EXPIRE key 0` and delete the key. Reject both explicitly.
         let seconds_value = frame.argument(1);
         if seconds_value.is_undefined() {
-            return Err(global.throw_invalid_property_type_value(b"seconds", b"number", seconds_value));
+            return Err(global.throw_invalid_property_type_value(
+                b"seconds",
+                b"number",
+                seconds_value,
+            ));
         }
         if seconds_value.is_number() && seconds_value.as_number().is_nan() {
-            return Err(global.throw_invalid_property_type_value(b"seconds", b"integer", seconds_value));
+            return Err(global.throw_invalid_property_type_value(
+                b"seconds",
+                b"integer",
+                seconds_value,
+            ));
         }
 
         let seconds = global.validate_integer_range::<i32>(

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -7008,3 +7008,55 @@ describe("RedisClient URL parsing", () => {
     }
   });
 });
+
+describe("RedisClient argument validation", () => {
+  function syncThrow(fn: () => unknown): unknown {
+    try {
+      const p = fn();
+      // Swallow the eventual rejection so a failing assertion below isn't
+      // followed by an unhandled-rejection crash.
+      (p as Promise<unknown>)?.catch?.(() => {});
+    } catch (e) {
+      return e;
+    }
+    return undefined;
+  }
+
+  // Argument validation runs before any network I/O, so no server is needed.
+  test("expire() rejects NaN/undefined seconds instead of sending `EXPIRE key 0`", () => {
+    const client = new RedisClient("redis://127.0.0.1:1", { autoReconnect: false });
+    try {
+      expect(syncThrow(() => client.expire("k", NaN))).toMatchObject({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: expect.stringContaining('"seconds"'),
+      });
+      // @ts-expect-error: testing runtime behavior with a missing argument
+      expect(syncThrow(() => client.expire("k"))).toMatchObject({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: expect.stringContaining('"seconds"'),
+      });
+      // @ts-expect-error: testing runtime behavior with an explicit undefined
+      expect(syncThrow(() => client.expire("k", undefined))).toMatchObject({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: expect.stringContaining('"seconds"'),
+      });
+    } finally {
+      client.close();
+    }
+  });
+
+  test("expire() still rejects other bad seconds values", () => {
+    const client = new RedisClient("redis://127.0.0.1:1", { autoReconnect: false });
+    try {
+      expect(syncThrow(() => client.expire("k", -5))).toMatchObject({ code: "ERR_OUT_OF_RANGE" });
+      expect(syncThrow(() => client.expire("k", 1.9))).toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
+      // @ts-expect-error: testing runtime behavior with invalid types
+      expect(syncThrow(() => client.expire("k", "10"))).toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
+      // @ts-expect-error: testing runtime behavior with invalid types
+      expect(syncThrow(() => client.expire("k", null))).toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
+      expect(syncThrow(() => client.expire("k", Infinity))).toMatchObject({ code: "ERR_OUT_OF_RANGE" });
+    } finally {
+      client.close();
+    }
+  });
+});


### PR DESCRIPTION
## Repro

```js
const wire = [];
const HELLO = "%1\r\n+proto\r\n:3\r\n";
const server = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: {
  open(s) { s.buf = ""; s.hello = false; },
  data(s, d) {
    s.buf += d.toString("latin1"); let out = "";
    for (;;) { const m = /^\*(\d+)\r\n/.exec(s.buf); if (!m) break;
      let i = m[0].length; const argv = []; let ok = true;
      for (let k = 0; k < +m[1]; k++) {
        const mm = /^\$(\d+)\r\n/.exec(s.buf.slice(i)); if (!mm) { ok = false; break; }
        const L = +mm[1]; if (s.buf.length < i + mm[0].length + L + 2) { ok = false; break; }
        argv.push(s.buf.substr(i + mm[0].length, L)); i += mm[0].length + L + 2; }
      if (!ok) break; s.buf = s.buf.slice(i);
      if (!s.hello) { s.hello = true; out += HELLO; continue; }
      wire.push(argv.join(" ")); out += argv[0] === "EXPIRE" ? ":1\r\n" : "+OK\r\n"; }
    if (out) s.write(out); }, close() {}, error() {} } });
const c = new Bun.RedisClient(`redis://127.0.0.1:${server.port}`, { autoReconnect: false });
await c.connect();
console.log("expire(k,NaN):", await c.expire("k", NaN).catch(e => e.code));
console.log("expire(k):    ", await c.expire("k").catch(e => e.code));
c.close(); server.stop(true);
console.log("wire:", JSON.stringify(wire));
```

Before:
```
expire(k,NaN): 1
expire(k):     1
wire: ["EXPIRE k 0","EXPIRE k 0"]
```

Against a real server that `EXPIRE k 0` deletes the key immediately, so a forgotten argument or a `parseInt(cfg.ttl)` that produced `NaN` turns "set a TTL" into "delete now" with a success result.

## Cause

`expire()` passes `seconds` through `validate_integer_range::<i32>` with a default of `0`. That helper intentionally maps both `undefined` and `NaN` to the default (it is used elsewhere for optional integer properties), so both values came out as `0` and were serialized onto the wire. Every other bad value is already rejected loudly: `-5`/`2**62`/`Infinity` throw `ERR_OUT_OF_RANGE`, `1.9`/`"10"`/`null` throw `ERR_INVALID_ARG_TYPE`. Only `NaN` and `undefined` fell through silently.

`expire` is the only typed helper that does this client-side coercion; `pexpire`/`expireat`/`setex`/`getex`/`incrby`/... stringify their argument and pass the literal `"NaN"`/`"undefined"` to the server, which rejects it.

## Fix

Reject `undefined` and `NaN` in `expire()` before the range check, using the same `ERR_INVALID_ARG_TYPE` the validator already uses for non-integer and non-number inputs.

After:
```
expire(k,NaN): ERR_INVALID_ARG_TYPE
expire(k):     ERR_INVALID_ARG_TYPE
wire: []
```

## Verification

```
bun bd test test/js/valkey/valkey.test.ts -t "RedisClient argument validation"
```

The new test is client-side only (validation happens before any network I/O), so it runs without a docker redis. It fails on `main` (`toMatchObject` receives `undefined` because `expire('k', NaN)` did not throw) and passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 916 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey.test.ts
bun test v1.4.0 (fa3a70fe8)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specified amount with DECRBY
(skip) Valkey Redis Clie
... (truncated)

release without fix: 7 failed, 916 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specified amount with DECRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should rename a key with RENAME
(skip) Valkey Redis Client (tls) > Basic Operations > should rename a key with RENAME overwr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 916 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey.test.ts
bun test v1.4.0 (fa3a70fe8)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specified amount with DECRBY
(skip) Valkey Redis Clie
... (truncated)

release with fix: 916 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 683ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/120] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 238 extern-C blocks audited
[1/120] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m core v0.0.0 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m darling_core v0.21.3
[1m[92m   Compiling[0m strum_macros v0.26.4
[1m[92m   Compiling[0m enum-map-derive v0.17.0
[1m[92m   Compiling[0m thiserror-impl v2.0.18
[1m[92m   Compiling[0m bun_dispatch v0.0.0 (/workspace/bun/src/dispatch)
[1m[92m   Compiling[0m bun_core_macros v0.0.0 (/workspace/bun/src/bun_core_macros)
[1m[92m   Compiling[0m bun_jsc_macros v0.0.0 (/workspace/bun/src/jsc_macros)
[1m[92m   Compiling[0m phf_macros v0.13.1
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/valkey_jsc/js_valkey_functions.rs | 18 +++++++++-
 test/js/valkey/valkey.test.ts                 | 52 +++++++++++++++++++++++++++
 2 files changed, 69 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/runtime/valkey_jsc/js_valkey_functions.rs      2      2      0
test/js/valkey/valkey.test.ts                      2      1      0
```

</details>

<!-- robobun:evidence:end -->