### PR TITLE
redis: reject file-backed Blob arguments instead of sending the empty string

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -74,10 +74,8 @@ fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<JSArgumen
     }
 
     let arg = JSArgument::from_js_maybe_file(global, value, false)?;
-    // A file- or S3-backed Blob has an empty `shared_view()` (bytes live
-    // off-heap), so letting it through would serialize as the empty string
-    // on the wire. Reject it up front like ServerWebSocket / MySQL do.
     if let Some(JSArgument::Blob(ref blob)) = arg {
+        // `shared_view()` is empty for file/S3 stores, which would serialize as "".
         if blob.needs_to_read_file() || blob.is_s3() {
             return Err(global.throw_invalid_arguments(format_args!(
                 "RedisClient cannot serialize a file- or S3-backed Blob; pass await blob.bytes() instead"

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -73,7 +73,18 @@ fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<JSArgumen
         return JSArgument::from_js_maybe_file(global, str.to_js(), true);
     }
 
-    JSArgument::from_js_maybe_file(global, value, false)
+    let arg = JSArgument::from_js_maybe_file(global, value, false)?;
+    // A file- or S3-backed Blob has an empty `shared_view()` (bytes live
+    // off-heap), so letting it through would serialize as the empty string
+    // on the wire. Reject it up front like ServerWebSocket / MySQL do.
+    if let Some(JSArgument::Blob(ref blob)) = arg {
+        if blob.needs_to_read_file() || blob.is_s3() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "RedisClient cannot serialize a file- or S3-backed Blob; pass await blob.bytes() instead"
+            )));
+        }
+    }
+    Ok(arg)
 }
 
 /// Shim around `protocol::valkey_error_to_js` that:

--- a/test/js/valkey/unit/buffer-operations.test.ts
+++ b/test/js/valkey/unit/buffer-operations.test.ts
@@ -1,4 +1,7 @@
+import { RedisClient, type TCPSocketListener } from "bun";
 import { beforeEach, describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "node:path";
 import { ConnectionType, createClient, ctx, isEnabled } from "../test-utils";
 
 describe.skipIf(!isEnabled)("Valkey: Buffer Operations", () => {
@@ -113,3 +116,119 @@ describe.skipIf(!isEnabled)("Valkey: Buffer Operations", () => {
 function expectAssert(value: unknown): asserts value {
   expect(value).toBeTruthy();
 }
+
+// Argument-serialization tests that run without a real server. A Blob whose
+// bytes live off-heap (Bun.file / S3) has an empty in-memory view; before the
+// fix, that view was silently written to the wire as a zero-length bulk string.
+describe("Valkey: Blob argument serialization", () => {
+  const CRLF = "\r\n";
+  const HELLO = `%1${CRLF}$5${CRLF}proto${CRLF}:3${CRLF}`;
+
+  type PerSocket = { buf: string; hello: boolean };
+
+  function createRecorder(): { server: TCPSocketListener<PerSocket>; wire: string[][] } {
+    const wire: string[][] = [];
+    const server = Bun.listen<PerSocket>({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(s) {
+          s.data = { buf: "", hello: false };
+        },
+        data(s, d) {
+          const st = s.data;
+          st.buf += d.toString("latin1");
+          let out = "";
+          for (;;) {
+            const m = /^\*(\d+)\r\n/.exec(st.buf);
+            if (!m) break;
+            let i = m[0].length;
+            const argv: string[] = [];
+            let ok = true;
+            for (let k = 0; k < +m[1]; k++) {
+              const mm = /^\$(\d+)\r\n/.exec(st.buf.slice(i));
+              if (!mm) {
+                ok = false;
+                break;
+              }
+              const L = +mm[1];
+              if (st.buf.length < i + mm[0].length + L + 2) {
+                ok = false;
+                break;
+              }
+              argv.push(st.buf.substr(i + mm[0].length, L));
+              i += mm[0].length + L + 2;
+            }
+            if (!ok) break;
+            st.buf = st.buf.slice(i);
+            if (!st.hello) {
+              st.hello = true;
+              out += HELLO;
+              continue;
+            }
+            wire.push(argv);
+            out += `+OK${CRLF}`;
+          }
+          if (out) s.write(out);
+        },
+        close() {},
+        error() {},
+      },
+    });
+    return { server, wire };
+  }
+
+  test("in-memory Blob arguments reach the wire with their bytes intact", async () => {
+    const { server, wire } = createRecorder();
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`, { autoReconnect: false });
+    try {
+      await client.connect();
+      await client.set("mem", new Blob(["blobdata"]));
+      await client.set("sliced", new Blob(["0123456789"]).slice(2, 5));
+      await client.set(new Blob(["keyblob"]), "v");
+    } finally {
+      client.close();
+      server.stop(true);
+    }
+    expect(wire).toEqual([
+      ["SET", "mem", "blobdata"],
+      ["SET", "sliced", "234"],
+      ["SET", "keyblob", "v"],
+    ]);
+  });
+
+  test("file-backed Blob arguments are rejected instead of serialized as empty", async () => {
+    using dir = tempDir("valkey-file-blob", { "src.txt": "FILEDATA123" });
+    const fpath = join(String(dir), "src.txt");
+
+    const { server, wire } = createRecorder();
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`, { autoReconnect: false });
+    try {
+      await client.connect();
+
+      const msg = /file- or S3-backed Blob/;
+      // value position
+      expect(() => client.set("file", Bun.file(fpath))).toThrow(msg);
+      // key position
+      expect(() => client.set(Bun.file(fpath), "as-key")).toThrow(msg);
+      // single-part Blob around a file-backed Blob shares the file store
+      expect(() => client.set("wrapped", new Blob([Bun.file(fpath)]))).toThrow(msg);
+      // reading the file once does not make the Blob itself in-memory
+      const bf = Bun.file(fpath);
+      await bf.text();
+      expect(() => client.set("fileRead", bf)).toThrow(msg);
+      // nonexistent path is still a file-backed Blob
+      expect(() => client.set("missing", Bun.file(join(String(dir), "no.txt")))).toThrow(msg);
+      // other prototype methods route through the same converter
+      expect(() => client.getBuffer(Bun.file(fpath))).toThrow(msg);
+      expect(() => client.append("k", Bun.file(fpath))).toThrow(msg);
+
+      // nothing above should have produced a frame
+      await client.set("after", "ok");
+    } finally {
+      client.close();
+      server.stop(true);
+    }
+    expect(wire).toEqual([["SET", "after", "ok"]]);
+  });
+});

--- a/test/js/valkey/unit/buffer-operations.test.ts
+++ b/test/js/valkey/unit/buffer-operations.test.ts
@@ -206,22 +206,28 @@ describe("Valkey: Blob argument serialization", () => {
     try {
       await client.connect();
 
-      const msg = /file- or S3-backed Blob/;
+      const expected = expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: expect.stringMatching(/file- or S3-backed Blob/),
+      });
       // value position
-      expect(() => client.set("file", Bun.file(fpath))).toThrow(msg);
+      expect(() => client.set("file", Bun.file(fpath))).toThrow(expected);
       // key position
-      expect(() => client.set(Bun.file(fpath), "as-key")).toThrow(msg);
+      expect(() => client.set(Bun.file(fpath), "as-key")).toThrow(expected);
       // single-part Blob around a file-backed Blob shares the file store
-      expect(() => client.set("wrapped", new Blob([Bun.file(fpath)]))).toThrow(msg);
+      expect(() => client.set("wrapped", new Blob([Bun.file(fpath)]))).toThrow(expected);
       // reading the file once does not make the Blob itself in-memory
       const bf = Bun.file(fpath);
       await bf.text();
-      expect(() => client.set("fileRead", bf)).toThrow(msg);
+      expect(() => client.set("fileRead", bf)).toThrow(expected);
       // nonexistent path is still a file-backed Blob
-      expect(() => client.set("missing", Bun.file(join(String(dir), "no.txt")))).toThrow(msg);
+      expect(() => client.set("missing", Bun.file(join(String(dir), "no.txt")))).toThrow(expected);
+      // S3-backed Blob (no network: the throw happens in argument conversion)
+      const s3 = new Bun.S3Client({ accessKeyId: "x", secretAccessKey: "y", bucket: "b", endpoint: "http://127.0.0.1:1" });
+      expect(() => client.set("s3", s3.file("some-key"))).toThrow(expected);
       // other prototype methods route through the same converter
-      expect(() => client.getBuffer(Bun.file(fpath))).toThrow(msg);
-      expect(() => client.append("k", Bun.file(fpath))).toThrow(msg);
+      expect(() => client.getBuffer(Bun.file(fpath))).toThrow(expected);
+      expect(() => client.append("k", Bun.file(fpath))).toThrow(expected);
 
       // nothing above should have produced a frame
       await client.set("after", "ok");

--- a/test/js/valkey/unit/buffer-operations.test.ts
+++ b/test/js/valkey/unit/buffer-operations.test.ts
@@ -223,7 +223,12 @@ describe("Valkey: Blob argument serialization", () => {
       // nonexistent path is still a file-backed Blob
       expect(() => client.set("missing", Bun.file(join(String(dir), "no.txt")))).toThrow(expected);
       // S3-backed Blob (no network: the throw happens in argument conversion)
-      const s3 = new Bun.S3Client({ accessKeyId: "x", secretAccessKey: "y", bucket: "b", endpoint: "http://127.0.0.1:1" });
+      const s3 = new Bun.S3Client({
+        accessKeyId: "x",
+        secretAccessKey: "y",
+        bucket: "b",
+        endpoint: "http://127.0.0.1:1",
+      });
       expect(() => client.set("s3", s3.file("some-key"))).toThrow(expected);
       // other prototype methods route through the same converter
       expect(() => client.getBuffer(Bun.file(fpath))).toThrow(expected);


### PR DESCRIPTION
## What does this PR do?

`RedisClient` accepts `Blob` for any `KeyLike` parameter (key or value). The argument converter read the Blob's bytes via `shared_view()`, which is empty for a file- or S3-backed store. So:

```js
await redis.set("tpl", Bun.file("page.html"));
```

sent `SET "tpl" ""` on the wire, resolved `"OK"`, and silently dropped the file contents. The same applied to:

- a `Bun.file()` as a key (became the empty key `""`)
- a single-part `new Blob([Bun.file(p)])` (shares the file store)
- a nonexistent path (no `ENOENT`, just `""`)

Wire-verified on stock 1.4.0-canary and release-asan main; deterministic.

### Cause

`js_valkey_functions.rs::from_js` calls `BlobOrStringOrBuffer::from_js_maybe_file(global, value, false)`. The `false` skips the file-blob guard in `from_js_maybe_file_maybe_async`, so a file-backed Blob falls through to `Self::Blob(blob.dupe())` and `slice()` returns its empty `shared_view()`. (The `allow_file` parameter there is named the opposite of its effect; left alone to keep the diff small.)

### Fix

After conversion, check `needs_to_read_file() || is_s3()` on the Blob arm and throw `ERR_INVALID_ARG_TYPE` with "pass await blob.bytes() instead", matching `ServerWebSocket.send` and the MySQL parameter binder. All ~50 prototype methods and `.send()` route through this one helper, so the check covers every argument position.

### Not changed

A `Uint8Array` over a detached `ArrayBuffer` still serializes as `""`. Per spec a detached view has `byteLength === 0`, and Node treats it as empty in comparable APIs, so sending zero bytes is arguably correct; happy to reject it too if preferred.

### How did you verify your code works?

Added two dockerless tests to `test/js/valkey/unit/buffer-operations.test.ts` that stand up a minimal RESP3 recorder:

- in-memory / sliced Blobs reach the wire with their bytes intact (regression guard)
- `Bun.file()` as value, as key, wrapped, after `.text()`, nonexistent path, and via `getBuffer`/`append` all throw and produce no wire frame

```
USE_SYSTEM_BUN=1 bun test buffer-operations.test.ts -t "Blob argument"   # 1 pass, 1 fail
bun bd test buffer-operations.test.ts -t "Blob argument"                 # 2 pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 9 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/unit/buffer-operations.test.ts
bun test v1.4.0 (23619b79a)

test/js/valkey/unit/buffer-operations.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey: Buffer Operations > getBuffer returns binary data as Uint8Array
(skip) Valkey: Buffer Operations > getBuffer for non-existent key returns null
(skip) Valkey: Buffer Operations > Really long buffer
(skip) Valkey: Buffer Operations > Buffer with no bytes
(skip) Valkey: Buffer Operations > Buffer with null bytes
(skip) Valkey: Buffer Operations > concurrent getBuffer against large blob
(skip) Valkey: Buffer Operations > set and getBuffer with ArrayBufferView key
(skip) Valkey: Buffer Operations > set and getBuffer with ArrayBuffer key
(skip) Valkey: Buffer Operations > set and getBuffer with Blob key
(pass) Valkey: Blob argument serialization > in-memory Blob arguments reach th
... (truncated)

release without fix: 1 failed, 9 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/valkey/unit/buffer-operations.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey: Buffer Operations > getBuffer returns binary data as Uint8Array
(skip) Valkey: Buffer Operations > getBuffer for non-existent key returns null
(skip) Valkey: Buffer Operations > Really long buffer
(skip) Valkey: Buffer Operations > Buffer with no bytes
(skip) Valkey: Buffer Operations > Buffer with null bytes
(skip) Valkey: Buffer Operations > concurrent getBuffer against large blob
(skip) Valkey: Buffer Operations > set and getBuffer with ArrayBufferView key
(skip) Valkey: Buffer Operations > set and getBuffer with ArrayBuffer key
(skip) Valkey: Buffer Operations > set and getBuffer with Blob key
(pass) Valkey: Blob argument serialization > in-memory Blob arguments reach the wire with their bytes intact [1.76ms]
209 |       const expected = expect.objectContaining({
210 |         code: "ERR_INVALID_ARG_TYPE",
211 |         message: expect.s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 9 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/unit/buffer-operations.test.ts
bun test v1.4.0 (23619b79a)

test/js/valkey/unit/buffer-operations.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey: Buffer Operations > getBuffer returns binary data as Uint8Array
(skip) Valkey: Buffer Operations > getBuffer for non-existent key returns null
(skip) Valkey: Buffer Operations > Really long buffer
(skip) Valkey: Buffer Operations > Buffer with no bytes
(skip) Valkey: Buffer Operations > Buffer with null bytes
(skip) Valkey: Buffer Operations > concurrent getBuffer against large blob
(skip) Valkey: Buffer Operations > set and getBuffer with ArrayBufferView key
(skip) Valkey: Buffer Operations > set and getBuffer with ArrayBuffer key
(skip) Valkey: Buffer Operations > set and getBuffer with Blob key
(pass) Valkey: Blob argument serialization > in-memory Blob arguments reach th
... (truncated)

release with fix: 9 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 665ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/124] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[2/124] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 238 extern-C blocks audited
[2/124] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m lol_html v2.7.2 (/workspace/bun/vendor/lolhtml)
[1m[92m   Compiling[0m subtle v2.6.1
[1m[92m   Compiling[0m arrayvec v0.7.6
[1m[92m   Compiling[0m base64 v0.22.1
[1m[92m   Compiling[0m constant_time_eq v0.4.2
[1m[92m   Compiling[0m generic-array v0.14.7
[1m[92m   Compiling[0m arrayref v0.3.9
[1m[92m   Compiling[0m byteorder v1.5.0
[1m[92m   Compiling[0m blake2b_simd v1.0.4
[1m[92m   Compiling[0m crypto-common v0.1.7
[1m[92m   Compiling[0m block-buffer v0.10.4
[1m[92m   Compiling[0m inout v0.1.4
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/valkey_jsc/js_valkey_functions.rs |  11 ++-
 test/js/valkey/unit/buffer-operations.test.ts | 130 ++++++++++++++++++++++++++
 2 files changed, 140 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/runtime/valkey_jsc/js_valkey_functions.rs      4      3      0
test/js/valkey/unit/buffer-operations.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->