### PR TITLE
inspector: handle BigInt/Symbol in returnByValue instead of asserting

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "f0f60fd2324817dae9656d8bf2fcae25ceaccc37";
+export const WEBKIT_VERSION = "autobuild-preview-pr-384-739b330d";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -377,6 +377,93 @@ describe("http metadata endpoint", () => {
   });
 });
 
+// Runtime.evaluate with returnByValue:true on a value holding a BigInt or
+// Symbol used to hit ASSERT_NOT_REACHED in Inspector::jsToInspectorValue
+// (aborting an assertions build) and return the misleading "Object has too
+// long reference chain" error on release. It should now report the value as
+// unserializable with V8's wording and leave the debuggee running.
+describe("Runtime.evaluate returnByValue with BigInt/Symbol", () => {
+  let child: Subprocess | undefined;
+
+  afterEach(() => {
+    child?.kill();
+    child = undefined;
+  });
+
+  async function evaluateByValue(expression: string) {
+    child = spawn({
+      cwd: import.meta.dir,
+      cmd: [bunExe(), "--inspect=127.0.0.1:0", "inspectee.js"],
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+
+    let url: URL | undefined;
+    let stderr = "";
+    const decoder = new TextDecoder();
+    for await (const chunk of child.stderr as ReadableStream) {
+      stderr += decoder.decode(chunk);
+      for (const line of stderr.split("\n")) {
+        const trimmed = stripAnsi(line).trim();
+        try {
+          url = new URL(trimmed);
+        } catch {}
+        if (url?.protocol.includes("ws")) break;
+      }
+      if (url?.protocol.includes("ws")) break;
+      if (stderr.includes("Listening:")) break;
+    }
+    if (!url) {
+      process.stderr.write(stderr);
+      throw new Error("Unable to find listening URL");
+    }
+
+    const ws = new WebSocket(url);
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener("open", () => resolve());
+      ws.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
+    });
+    const reply = new Promise<any>((resolve, reject) => {
+      ws.addEventListener("message", ({ data }) => resolve(JSON.parse(data.toString())));
+      ws.addEventListener("close", () => reject(new Error("WebSocket closed before reply")));
+    });
+    ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression, returnByValue: true } }));
+    const result = await reply;
+    ws.close();
+    return result;
+  }
+
+  for (const expression of ["[1n]", "({a: 1n})", 'Symbol("s")', "({b: Symbol()})"]) {
+    test(expression, async () => {
+      const reply = await evaluateByValue(expression);
+      expect(reply).toEqual({
+        id: 1,
+        error: {
+          code: -32000,
+          message: "Object couldn't be returned by value",
+          data: expect.anything(),
+        },
+      });
+      // The debuggee must survive the request (an assertions build used to
+      // SIGABRT here before the reply arrived).
+      expect(child!.exitCode).toBeNull();
+      expect(child!.signalCode).toBeNull();
+    });
+  }
+
+  test("bare 1n", async () => {
+    // A bare top-level BigInt is represented via description without a JSON
+    // value and has always worked; keep it covered so the unserializable path
+    // above does not regress it.
+    const reply = await evaluateByValue("1n");
+    expect(reply).toEqual({
+      id: 1,
+      result: { result: { type: "bigint", description: "1n" }, wasThrown: false },
+    });
+  });
+});
+
 describe("unix domain socket without websocket", () => {
   let tempdir: string;
   let randomSocketPath: () => string;

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -329,6 +329,7 @@ async function spawnInspectee(): Promise<{ child: Subprocess; url: URL }> {
 
   if (!url) {
     process.stderr.write(stderr);
+    child.kill();
     throw new Error("Unable to find listening URL");
   }
   return { child, url };

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -421,12 +421,24 @@ describe("Runtime.evaluate returnByValue with BigInt/Symbol", () => {
 
     const ws = new WebSocket(url);
     await new Promise<void>((resolve, reject) => {
-      ws.addEventListener("open", () => resolve());
-      ws.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
+      ws.addEventListener("open", () => resolve(), { once: true });
+      ws.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })), { once: true });
+      ws.addEventListener("close", () => reject(new Error("WebSocket closed before open")), { once: true });
     });
     const reply = new Promise<any>((resolve, reject) => {
-      ws.addEventListener("message", ({ data }) => resolve(JSON.parse(data.toString())));
-      ws.addEventListener("close", () => reject(new Error("WebSocket closed before reply")));
+      ws.addEventListener(
+        "message",
+        ({ data }) => {
+          try {
+            resolve(JSON.parse(data.toString()));
+          } catch (cause) {
+            reject(new Error(`non-JSON inspector reply: ${data}`, { cause }));
+          }
+        },
+        { once: true },
+      );
+      ws.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })), { once: true });
+      ws.addEventListener("close", () => reject(new Error("WebSocket closed before reply")), { once: true });
     });
     ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression, returnByValue: true } }));
     const result = await reply;

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -300,49 +300,51 @@ describe("websocket", () => {
   });
 });
 
-describe("http metadata endpoint", () => {
-  let metadataInspectee: Subprocess | undefined;
+async function spawnInspectee(): Promise<{ child: Subprocess; url: URL }> {
+  const child = spawn({
+    cwd: import.meta.dir,
+    cmd: [bunExe(), "--inspect=127.0.0.1:0", "inspectee.js"],
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
 
-  async function spawnInspectee(): Promise<URL> {
-    metadataInspectee = spawn({
-      cwd: import.meta.dir,
-      cmd: [bunExe(), "--inspect=127.0.0.1:0", "inspectee.js"],
-      env: bunEnv,
-      stdout: "ignore",
-      stderr: "pipe",
-    });
-
-    let url: URL | undefined;
-    let stderr = "";
-    const decoder = new TextDecoder();
-    for await (const chunk of metadataInspectee.stderr as ReadableStream) {
-      stderr += decoder.decode(chunk);
-      for (const line of stderr.split("\n")) {
-        try {
-          url = new URL(line);
-        } catch {}
-        if (url?.protocol.includes("ws")) {
-          break;
-        }
-      }
-      if (stderr.includes("Listening:")) {
+  let url: URL | undefined;
+  let stderr = "";
+  const decoder = new TextDecoder();
+  for await (const chunk of child.stderr as ReadableStream) {
+    stderr += decoder.decode(chunk);
+    for (const line of stderr.split("\n")) {
+      try {
+        url = new URL(line);
+      } catch {}
+      if (url?.protocol.includes("ws")) {
         break;
       }
     }
-
-    if (!url) {
-      process.stderr.write(stderr);
-      throw new Error("Unable to find listening URL");
+    if (stderr.includes("Listening:")) {
+      break;
     }
-    return url;
   }
+
+  if (!url) {
+    process.stderr.write(stderr);
+    throw new Error("Unable to find listening URL");
+  }
+  return { child, url };
+}
+
+describe("http metadata endpoint", () => {
+  let metadataInspectee: Subprocess | undefined;
 
   afterEach(() => {
     metadataInspectee?.kill();
   });
 
   test("serves /json/version only for a Host of the bound hostname, localhost, or an IP literal", async () => {
-    const { port } = await spawnInspectee();
+    const { child, url } = await spawnInspectee();
+    metadataInspectee = child;
+    const { port } = url;
     const endpoint = `http://127.0.0.1:${port}/json/version`;
 
     const allowed = await fetch(endpoint);
@@ -365,7 +367,9 @@ describe("http metadata endpoint", () => {
   });
 
   test("serves /json/version only to allowed web origins", async () => {
-    const { port } = await spawnInspectee();
+    const { child, url } = await spawnInspectee();
+    metadataInspectee = child;
+    const { port } = url;
     const endpoint = `http://127.0.0.1:${port}/json/version`;
 
     const loopback = await fetch(endpoint, { headers: { "Origin": "http://127.0.0.1:8080" } });
@@ -391,35 +395,10 @@ describe("Runtime.evaluate returnByValue with BigInt/Symbol", () => {
   });
 
   async function evaluateByValue(expression: string) {
-    child = spawn({
-      cwd: import.meta.dir,
-      cmd: [bunExe(), "--inspect=127.0.0.1:0", "inspectee.js"],
-      env: bunEnv,
-      stdout: "ignore",
-      stderr: "pipe",
-    });
+    const spawned = await spawnInspectee();
+    child = spawned.child;
 
-    let url: URL | undefined;
-    let stderr = "";
-    const decoder = new TextDecoder();
-    for await (const chunk of child.stderr as ReadableStream) {
-      stderr += decoder.decode(chunk);
-      for (const line of stderr.split("\n")) {
-        const trimmed = stripAnsi(line).trim();
-        try {
-          url = new URL(trimmed);
-        } catch {}
-        if (url?.protocol.includes("ws")) break;
-      }
-      if (url?.protocol.includes("ws")) break;
-      if (stderr.includes("Listening:")) break;
-    }
-    if (!url) {
-      process.stderr.write(stderr);
-      throw new Error("Unable to find listening URL");
-    }
-
-    const ws = new WebSocket(url);
+    const ws = new WebSocket(spawned.url);
     await new Promise<void>((resolve, reject) => {
       ws.addEventListener("open", () => resolve(), { once: true });
       ws.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })), { once: true });


### PR DESCRIPTION
### What does this PR do?

`Runtime.evaluate` / `Runtime.callFunctionOn` / `Debugger.evaluateOnCallFrame` with `returnByValue: true` on a result that holds a BigInt or Symbol reached `ASSERT_NOT_REACHED` in `Inspector::jsToInspectorValue` (InjectedScriptBase.cpp:96), aborting an assertions build of the debuggee. Release builds fell through to `nullptr` and the caller reported the unrelated "Object has too long reference chain (must not be longer than 1000)" error.

### Repro

```js
// bun --inspect=127.0.0.1:<port>/tok -e "setInterval(()=>{},1000)" &
// connect WebSocket to ws://127.0.0.1:<port>/tok, send:
{"id":1,"method":"Runtime.evaluate","params":{"expression":"[1n]","returnByValue":true}}
```

Before (assertions build):
```
SHOULD NEVER BE REACHED
vendor/WebKit/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp(96) : RefPtr<JSON::Value> Inspector::jsToInspectorValue(JSC::JSGlobalObject *, JSC::JSValue, int)
```
debuggee exits SIGABRT.

Before (release): `{"error":{"code":-32000,"message":"Object has too long reference chain (must not be longer than 1000)"}}`, debuggee alive.

Also reproduces with `({a:1n})`, `Symbol("s")`, `({b:Symbol()})`, and over `Debugger.evaluateOnCallFrame` while paused. A bare `1n` is fine because `InjectedScriptSource.js` never stores it on `RemoteObject.value`.

### Cause

`jsToInspectorValue` has arms for null/undefined, boolean, number, string, and object, then `ASSERT_NOT_REACHED()`. BigInt and Symbol (introduced after this code was written) fall through. When `returnByValue` is set, `InjectedScriptSource.js` stores the raw value on `RemoteObject.value` and the C++ side recurses into it.

### Fix

The fix is in oven-sh/WebKit#384:
- Add an explicit `isBigInt() || isSymbol()` arm returning `nullptr` (unserializable), avoiding the assert.
- Replace the "reference chain" error string with "Object couldn't be returned by value", matching V8's inspector wording (`node -e '...'` returns the same for `[1n]`) and accurate for both the depth-limit and unserializable-primitive cases.

This PR bumps `WEBKIT_VERSION` to the preview build of that change and adds a `--inspect` regression test covering `[1n]`, `{a:1n}`, `Symbol()`, `{b:Symbol()}`, plus the already-working bare `1n`.

### Verification

```
$ USE_SYSTEM_BUN=1 bun test test/cli/inspect/inspect.test.ts -t "Runtime.evaluate returnByValue"
 4 fail ("Object has too long reference chain" instead of "Object couldn't be returned by value")
 1 pass (bare 1n)
```

After: all 5 pass; the debuggee stays alive on an assertions build.

Note: `WEBKIT_VERSION` currently points at the `autobuild-preview-pr-384-*` tag and will be switched to the merged oven-sh/WebKit main sha before this PR merges.