### PR TITLE
inspector: reject reserved HashMap keys as Debugger scriptId

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "34c01d13391e00c06862a3d2c5b7fff350ac87e0";
+export const WEBKIT_VERSION = "autobuild-preview-pr-386-71c8e36d";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -457,6 +457,125 @@ describe("unix domain socket without websocket", () => {
   }
 });
 
+// WTF::HashMap<unsigned, ...> reserves 0 as the empty-bucket key and UINT32_MAX as
+// the deleted-bucket key. InspectorDebuggerAgent parses the protocol scriptId string
+// to a uint32_t and calls m_scripts.find() with it; without an isValidKey() guard,
+// scriptId "0" asserts on ASSERT_ENABLED builds and on release returns a phantom
+// default-constructed Script (empty scriptSource) because the lookup matches the
+// first empty bucket. Unparseable scriptIds collapse to 0 via value_or(0) as well.
+describe("Debugger scriptId validation", () => {
+  async function openSession() {
+    const child = spawn({
+      cmd: [bunExe(), "--inspect=127.0.0.1:0/tok", "-e", "setInterval(()=>{},1e3)"],
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+
+    let url: URL | undefined;
+    let stderr = "";
+    const decoder = new TextDecoder();
+    for await (const chunk of child.stderr as ReadableStream) {
+      stderr += decoder.decode(chunk);
+      for (const line of stderr.split("\n")) {
+        try {
+          const candidate = new URL(line);
+          if (candidate.protocol.includes("ws")) url = candidate;
+        } catch {}
+      }
+      if (url || stderr.includes("Listening:")) break;
+    }
+    if (!url) {
+      process.stderr.write(stderr);
+      child.kill("SIGKILL");
+      throw new Error("inspector did not print a ws:// URL");
+    }
+
+    const ws = new WebSocket(url);
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener("open", () => resolve());
+      ws.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
+    });
+
+    const pending = new Map<number, (reply: any) => void>();
+    let closed = false;
+    ws.addEventListener("message", ({ data }) => {
+      const msg = JSON.parse(String(data));
+      if (typeof msg.id === "number") pending.get(msg.id)?.(msg);
+    });
+    ws.addEventListener("close", ev => {
+      closed = true;
+      for (const [, resolve] of pending) resolve({ __closed: { code: ev.code, reason: ev.reason } });
+      pending.clear();
+    });
+
+    let nextId = 1;
+    const send = (method: string, params: Record<string, unknown>) => {
+      const id = nextId++;
+      const reply = new Promise<any>(resolve => pending.set(id, resolve));
+      ws.send(JSON.stringify({ id, method, params }));
+      return reply;
+    };
+
+    expect(await send("Debugger.enable", {})).toMatchObject({ result: {} });
+
+    return {
+      child,
+      send,
+      get closed() {
+        return closed;
+      },
+      [Symbol.dispose]() {
+        try {
+          ws.close();
+        } catch {}
+        child.kill("SIGKILL");
+      },
+    };
+  }
+
+  const invalidScriptIds = ["0", "4294967295", "-1", "99999999999999999999", "not-a-number"];
+  const missingScript = { error: { message: expect.stringContaining("Missing script") } };
+
+  test("Debugger.getScriptSource returns an error for the reserved hash keys", async () => {
+    using session = await openSession();
+    for (const scriptId of invalidScriptIds) {
+      const reply = await session.send("Debugger.getScriptSource", { scriptId });
+      expect({ scriptId, reply }).toMatchObject({ scriptId, reply: missingScript });
+      expect(reply.result).toBeUndefined();
+    }
+    expect(session.closed).toBe(false);
+    expect(session.child.exitCode).toBeNull();
+    expect(session.child.signalCode).toBeNull();
+  });
+
+  test("Debugger.searchInContent returns an error for the reserved hash keys", async () => {
+    using session = await openSession();
+    for (const scriptId of invalidScriptIds) {
+      const reply = await session.send("Debugger.searchInContent", { scriptId, query: "x" });
+      expect({ scriptId, reply }).toMatchObject({ scriptId, reply: missingScript });
+      expect(reply.result).toBeUndefined();
+    }
+    expect(session.closed).toBe(false);
+    expect(session.child.exitCode).toBeNull();
+    expect(session.child.signalCode).toBeNull();
+  });
+
+  test("Debugger.setBreakpoint / getBreakpointLocations reject scriptId 0 in location", async () => {
+    using session = await openSession();
+    for (const scriptId of invalidScriptIds) {
+      const location = { scriptId, lineNumber: 0, columnNumber: 0 };
+      const setReply = await session.send("Debugger.setBreakpoint", { location });
+      expect({ scriptId, setReply }).toMatchObject({ scriptId, setReply: missingScript });
+      const locReply = await session.send("Debugger.getBreakpointLocations", { start: location, end: location });
+      expect({ scriptId, locReply }).toMatchObject({ scriptId, locReply: missingScript });
+    }
+    expect(session.closed).toBe(false);
+    expect(session.child.exitCode).toBeNull();
+    expect(session.child.signalCode).toBeNull();
+  });
+});
+
 /// TODO: this test is flaky because the inspect may not send all messages before the process exit
 /// we need to implement a way/option so we wait every message from the inspector before exiting
 test.todo("junit reporter", async () => {


### PR DESCRIPTION
Depends on oven-sh/WebKit#386. `WEBKIT_VERSION` currently points at that PR's preview build and must be updated to the merged sha once it lands.

## Problem

`InspectorDebuggerAgent::m_scripts` is an `UncheckedKeyHashMap<JSC::SourceID, Script>`. WTF's default integer hash traits reserve `0` as the empty-bucket key and `UINT32_MAX` as the deleted-bucket key. Several `Debugger.*` protocol handlers parse the client-supplied `scriptId` string with `parseIntegerAllowingTrailingJunk<uint32_t>(...).value_or(0)` and pass the result directly to `m_scripts.find()`.

When an inspector client sends `scriptId: "0"` (or `"-1"`, `"not-a-number"`, or an overflow string, all of which `value_or(0)` collapses to `0`):

* `ASSERT_ENABLED` builds hit `ASSERTION FAILED: isValidKey(*entry)` at `wtf/HashTable.h:692` and SIGABRT.
* release builds match the first empty bucket and return a phantom default-constructed `Script`: `Debugger.getScriptSource` replies `{"scriptSource":""}` for a script that does not exist, and `Debugger.setBreakpoint` then dereferences the phantom's null `sourceProvider` and **SIGSEGVs the debuggee**.

## Repro

```js
// against bun --inspect=127.0.0.1:<port>/tok
ws.send(JSON.stringify({id:1, method:"Debugger.enable", params:{}}));
ws.send(JSON.stringify({id:2, method:"Debugger.getScriptSource", params:{scriptId:"0"}}));
// release: {"result":{"scriptSource":""},"id":2}
// debug-asan: ASSERTION FAILED: isValidKey(*entry) ... SIGABRT

ws.send(JSON.stringify({id:3, method:"Debugger.setBreakpoint", params:{location:{scriptId:"0",lineNumber:0}}}));
// release: debuggee dies, signal=SIGSEGV (Segmentation fault at address 0x70)
```

`Debugger.searchInContent`, `Debugger.continueToLocation` and `Debugger.getBreakpointLocations` take the same path.

## Fix

oven-sh/WebKit#386 guards each protocol-supplied `m_scripts.find()` with `m_scripts.isValidKey(sourceID)` so the reserved keys take the same "Missing script ..." error path as any other unknown id (same pattern as `InspectorDOMAgent::nodeForId`). This PR carries the `WEBKIT_VERSION` bump and the regression tests.

## Verification

With the current prebuilt WebKit (fail-before, `bun bd`):
```
(fail) Debugger.getScriptSource returns an error for the reserved hash keys
(fail) Debugger.searchInContent returns an error for the reserved hash keys
(fail) Debugger.setBreakpoint / getBreakpointLocations reject scriptId 0 in location
```

With oven-sh/WebKit#386 applied (pass-after, `bun run build:local`):
```
(pass) Debugger.getScriptSource returns an error for the reserved hash keys [563.02ms]
(pass) Debugger.searchInContent returns an error for the reserved hash keys [490.78ms]
(pass) Debugger.setBreakpoint / getBreakpointLocations reject scriptId 0 in location [512.08ms]
3 pass, 42 expect() calls
```

The fix lives in the WebKit prebuilt (bumped via `scripts/build/deps/webkit.ts`), so the src-stash gate cannot observe fail-before; the proof above is the manual equivalent.

Requires `--inspect` + the inspector token; loopback-bound by default.