### PR TITLE
napi: pass NULL js_callback to call_js when no func supplied

### DIFF
--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2520,10 +2520,7 @@ impl ThreadSafeFunction {
             return;
         }
 
-        // Node's kMaxIterationCount: yield after this many callbacks per tick.
-        const MAX_ITERATION_COUNT: u32 = 1000;
         let mut is_first = true;
-        let mut iterations: u32 = 0;
 
         // Run the tasks.
         loop {
@@ -2535,21 +2532,6 @@ impl ThreadSafeFunction {
                 self_
                     .dispatch_state
                     .store(DispatchState::Pending as u8, Ordering::SeqCst);
-                iterations += 1;
-                if iterations >= MAX_ITERATION_COUNT {
-                    // dispatch_one() may have drained the final item and already
-                    // enqueued the finalizer task (closing == Closed); a second
-                    // dispatch on that pointer would run on freed memory.
-                    if self_.closing.load(Ordering::SeqCst) == ClosingState::Closed as u8 {
-                        return;
-                    }
-                    // Flip to Idle so schedule_dispatch re-enqueues the remainder.
-                    self_
-                        .dispatch_state
-                        .store(DispatchState::Idle as u8, Ordering::SeqCst);
-                    self_.schedule_dispatch();
-                    return;
-                }
             } else {
                 // We're done running tasks, for now. Transition Running → Idle
                 // via CAS instead of an unconditional store: between
@@ -2576,6 +2558,11 @@ impl ThreadSafeFunction {
                 // state was bumped to Pending by enqueue()/release(); re-dispatch.
             }
         }
+
+        // Node sets a maximum number of runs per ThreadSafeFunction to 1,000.
+        // We don't set a max. I would like to see an issue caused by not
+        // setting a max before we do set a max. It is better for performance to
+        // not add unnecessary event loop ticks.
     }
 
     pub(crate) fn is_closing(&self) -> bool {
@@ -2779,10 +2766,9 @@ impl ThreadSafeFunction {
         (NapiStatus::ok as napi_status, false)
     }
 
-    /// Addon-thread callers must hold `lock` (they race `env_teardown` for
-    /// `event_loop`); JS-thread callers (on_dispatch yield, env_teardown) need
-    /// not. Takes only a shared `&EventLoop` because the JS thread may be
-    /// inside `tick()` with its own `&mut`.
+    /// Caller must hold `lock`. Reached from addon threads (`enqueue`,
+    /// `release_locked`), so it may only take a shared `&EventLoop`: the JS
+    /// thread can be inside `tick()` with its own `&mut` at the same time.
     fn schedule_dispatch(&mut self) {
         let prev = self
             .dispatch_state

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2520,7 +2520,10 @@ impl ThreadSafeFunction {
             return;
         }
 
+        // Node's kMaxIterationCount: yield after this many callbacks per tick.
+        const MAX_ITERATION_COUNT: u32 = 1000;
         let mut is_first = true;
+        let mut iterations: u32 = 0;
 
         // Run the tasks.
         loop {
@@ -2532,6 +2535,21 @@ impl ThreadSafeFunction {
                 self_
                     .dispatch_state
                     .store(DispatchState::Pending as u8, Ordering::SeqCst);
+                iterations += 1;
+                if iterations >= MAX_ITERATION_COUNT {
+                    // dispatch_one() may have drained the final item and already
+                    // enqueued the finalizer task (closing == Closed); a second
+                    // dispatch on that pointer would run on freed memory.
+                    if self_.closing.load(Ordering::SeqCst) == ClosingState::Closed as u8 {
+                        return;
+                    }
+                    // Flip to Idle so schedule_dispatch re-enqueues the remainder.
+                    self_
+                        .dispatch_state
+                        .store(DispatchState::Idle as u8, Ordering::SeqCst);
+                    self_.schedule_dispatch();
+                    return;
+                }
             } else {
                 // We're done running tasks, for now. Transition Running → Idle
                 // via CAS instead of an unconditional store: between
@@ -2558,11 +2576,6 @@ impl ThreadSafeFunction {
                 // state was bumped to Pending by enqueue()/release(); re-dispatch.
             }
         }
-
-        // Node sets a maximum number of runs per ThreadSafeFunction to 1,000.
-        // We don't set a max. I would like to see an issue caused by not
-        // setting a max before we do set a max. It is better for performance to
-        // not add unnecessary event loop ticks.
     }
 
     pub(crate) fn is_closing(&self) -> bool {
@@ -2691,17 +2704,15 @@ impl ThreadSafeFunction {
                 js: cb_js,
                 napi_threadsafe_function_call_js,
             } => {
-                let js: JSValue = cb_js.get().unwrap_or(JSValue::UNDEFINED);
-
                 // SAFETY: `env` is held alive by `self.env` (`NapiEnvRef`) for the TSF's lifetime.
                 let env_ref = unsafe { &*env };
                 let _hs = NapiHandleScope::open_scoped(env_ref);
-                napi_threadsafe_function_call_js(
-                    env,
-                    napi_value::create(env_ref, js),
-                    self.ctx,
-                    task,
-                );
+                // No func at creation => null js_callback (Node), not encoded undefined.
+                let js = match cb_js.get() {
+                    Some(v) => napi_value::create(env_ref, v),
+                    None => napi_value(0),
+                };
+                napi_threadsafe_function_call_js(env, js, self.ctx, task);
             }
         }
         Ok(())
@@ -2768,9 +2779,10 @@ impl ThreadSafeFunction {
         (NapiStatus::ok as napi_status, false)
     }
 
-    /// Caller must hold `lock`. Reached from addon threads (`enqueue`,
-    /// `release_locked`), so it may only take a shared `&EventLoop`: the JS
-    /// thread can be inside `tick()` with its own `&mut` at the same time.
+    /// Addon-thread callers must hold `lock` (they race `env_teardown` for
+    /// `event_loop`); JS-thread callers (on_dispatch yield, env_teardown) need
+    /// not. Takes only a shared `&EventLoop` because the JS thread may be
+    /// inside `tick()` with its own `&mut`.
     fn schedule_dispatch(&mut self) {
         let prev = self
             .dispatch_state

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1403,16 +1403,6 @@ nativeTests.test_tsfn_null_js_callback_driver = async () => {
   nativeTests.test_tsfn_null_js_callback_result();
 };
 
-// Crosses the 1000-iteration dispatch cap so the TSFN yields and re-schedules.
-nativeTests.test_tsfn_many_items_driver = async () => {
-  nativeTests.test_tsfn_many_items();
-  for (let i = 0; i < 1000; i++) {
-    if (nativeTests.test_tsfn_many_items_count() >= 2000) break;
-    await new Promise(resolve => setImmediate(resolve));
-  }
-  nativeTests.test_tsfn_many_items_result();
-};
-
 // Microtasks queued by one threadsafe-function callback must be drained before
 // the next callback in the same dispatch, and not before the first one.
 nativeTests.test_threadsafe_function_microtask_order = async () => {

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1392,6 +1392,27 @@ nativeTests.test_threadsafe_function_orphan_leak = async () => {
   }
 };
 
+// When napi_create_threadsafe_function is given no JS func, the call_js
+// callback receives a null js_callback (addons test `if (js_callback != NULL)`).
+nativeTests.test_tsfn_null_js_callback_driver = async () => {
+  nativeTests.test_tsfn_null_js_callback();
+  for (let i = 0; i < 1000; i++) {
+    if (nativeTests.test_tsfn_null_js_callback_ran()) break;
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  nativeTests.test_tsfn_null_js_callback_result();
+};
+
+// Crosses the 1000-iteration dispatch cap so the TSFN yields and re-schedules.
+nativeTests.test_tsfn_many_items_driver = async () => {
+  nativeTests.test_tsfn_many_items();
+  for (let i = 0; i < 1000; i++) {
+    if (nativeTests.test_tsfn_many_items_count() >= 2000) break;
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  nativeTests.test_tsfn_many_items_result();
+};
+
 // Microtasks queued by one threadsafe-function callback must be drained before
 // the next callback in the same dispatch, and not before the first one.
 nativeTests.test_threadsafe_function_microtask_order = async () => {

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -3710,6 +3710,97 @@ static napi_value test_napi_status_codes_node26(const Napi::CallbackInfo &info) 
   return ok(env);
 }
 
+static std::atomic<int> tsfn_nullcb_was_null(-1);
+
+static void tsfn_nullcb_call_js(napi_env env, napi_value js_callback,
+                                void *context, void *data) {
+  tsfn_nullcb_was_null.store(js_callback == NULL ? 1 : 0);
+}
+
+static void tsfn_nullcb_finalize(napi_env env, void *data, void *hint) {}
+
+static napi_value
+test_tsfn_null_js_callback(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  tsfn_nullcb_was_null.store(-1);
+  napi_value name;
+  NODE_API_CALL(env, napi_create_string_utf8(env, "tsfn-nullcb",
+                                             NAPI_AUTO_LENGTH, &name));
+  napi_threadsafe_function tsfn;
+  NODE_API_CALL(env, napi_create_threadsafe_function(
+                         env, NULL, NULL, name, 0, 1, NULL,
+                         tsfn_nullcb_finalize, NULL, tsfn_nullcb_call_js,
+                         &tsfn));
+  NODE_API_CALL(
+      env, napi_call_threadsafe_function(tsfn, NULL, napi_tsfn_nonblocking));
+  NODE_API_CALL(env,
+                napi_release_threadsafe_function(tsfn, napi_tsfn_release));
+  return ok(env);
+}
+
+// Predicate for the driver's bounded poll; no printf so checkSameOutput stays
+// clean.
+static napi_value
+test_tsfn_null_js_callback_ran(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value r;
+  NODE_API_CALL(env,
+                napi_get_boolean(env, tsfn_nullcb_was_null.load() != -1, &r));
+  return r;
+}
+
+static napi_value
+test_tsfn_null_js_callback_result(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  printf("js_callback == NULL: %d\n", tsfn_nullcb_was_null.load());
+  return ok(env);
+}
+
+static std::atomic<int> tsfn_many_count(0);
+
+static void tsfn_many_call_js(napi_env env, napi_value js_callback,
+                              void *context, void *data) {
+  tsfn_many_count.fetch_add(1);
+}
+
+// Enqueues enough items to cross Node's kMaxIterationCount so the dispatch
+// loop yields mid-drain and re-schedules. 2000 is a multiple of the cap so the
+// second tick's 1000th dispatch is the final item: that path queues the
+// finalizer inside dispatch_one() and then hits the closing == Closed guard on
+// the yield, so ASAN would catch a double-schedule on the freed TSFN.
+static napi_value test_tsfn_many_items(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  tsfn_many_count.store(0);
+  napi_value name;
+  NODE_API_CALL(
+      env, napi_create_string_utf8(env, "tsfn-many", NAPI_AUTO_LENGTH, &name));
+  napi_threadsafe_function tsfn;
+  NODE_API_CALL(env, napi_create_threadsafe_function(
+                         env, NULL, NULL, name, 0, 1, NULL,
+                         tsfn_nullcb_finalize, NULL, tsfn_many_call_js, &tsfn));
+  for (int i = 0; i < 2000; i++) {
+    NODE_API_CALL(
+        env, napi_call_threadsafe_function(tsfn, NULL, napi_tsfn_nonblocking));
+  }
+  NODE_API_CALL(env,
+                napi_release_threadsafe_function(tsfn, napi_tsfn_release));
+  return ok(env);
+}
+
+static napi_value test_tsfn_many_items_count(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value r;
+  NODE_API_CALL(env, napi_create_int32(env, tsfn_many_count.load(), &r));
+  return r;
+}
+
+static napi_value
+test_tsfn_many_items_result(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  printf("tsfn callbacks fired: %d\n", tsfn_many_count.load());
+  return ok(env);
+}
+
 void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_typedarray_info_byte_offset);
   REGISTER_FUNCTION(env, exports, test_dataview_info_byte_offset);
@@ -3788,6 +3879,12 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_node_api_create_object_with_properties);
   REGISTER_FUNCTION(env, exports, test_node_api_sharedarraybuffer);
   REGISTER_FUNCTION(env, exports, test_napi_status_codes_node26);
+  REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback);
+  REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_ran);
+  REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_result);
+  REGISTER_FUNCTION(env, exports, test_tsfn_many_items);
+  REGISTER_FUNCTION(env, exports, test_tsfn_many_items_count);
+  REGISTER_FUNCTION(env, exports, test_tsfn_many_items_result);
 }
 
 } // namespace napitests

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -3756,51 +3756,6 @@ test_tsfn_null_js_callback_result(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
-static std::atomic<int> tsfn_many_count(0);
-
-static void tsfn_many_call_js(napi_env env, napi_value js_callback,
-                              void *context, void *data) {
-  tsfn_many_count.fetch_add(1);
-}
-
-// Enqueues enough items to cross Node's kMaxIterationCount so the dispatch
-// loop yields mid-drain and re-schedules. 2000 is a multiple of the cap so the
-// second tick's 1000th dispatch is the final item: that path queues the
-// finalizer inside dispatch_one() and then hits the closing == Closed guard on
-// the yield, so ASAN would catch a double-schedule on the freed TSFN.
-static napi_value test_tsfn_many_items(const Napi::CallbackInfo &info) {
-  napi_env env = info.Env();
-  tsfn_many_count.store(0);
-  napi_value name;
-  NODE_API_CALL(
-      env, napi_create_string_utf8(env, "tsfn-many", NAPI_AUTO_LENGTH, &name));
-  napi_threadsafe_function tsfn;
-  NODE_API_CALL(env, napi_create_threadsafe_function(
-                         env, NULL, NULL, name, 0, 1, NULL,
-                         tsfn_nullcb_finalize, NULL, tsfn_many_call_js, &tsfn));
-  for (int i = 0; i < 2000; i++) {
-    NODE_API_CALL(
-        env, napi_call_threadsafe_function(tsfn, NULL, napi_tsfn_nonblocking));
-  }
-  NODE_API_CALL(env,
-                napi_release_threadsafe_function(tsfn, napi_tsfn_release));
-  return ok(env);
-}
-
-static napi_value test_tsfn_many_items_count(const Napi::CallbackInfo &info) {
-  napi_env env = info.Env();
-  napi_value r;
-  NODE_API_CALL(env, napi_create_int32(env, tsfn_many_count.load(), &r));
-  return r;
-}
-
-static napi_value
-test_tsfn_many_items_result(const Napi::CallbackInfo &info) {
-  napi_env env = info.Env();
-  printf("tsfn callbacks fired: %d\n", tsfn_many_count.load());
-  return ok(env);
-}
-
 void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_typedarray_info_byte_offset);
   REGISTER_FUNCTION(env, exports, test_dataview_info_byte_offset);
@@ -3882,9 +3837,6 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback);
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_ran);
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_result);
-  REGISTER_FUNCTION(env, exports, test_tsfn_many_items);
-  REGISTER_FUNCTION(env, exports, test_tsfn_many_items_count);
-  REGISTER_FUNCTION(env, exports, test_tsfn_many_items_result);
 }
 
 } // namespace napitests

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -526,11 +526,6 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(output).toContain("js_callback == NULL: 1");
     });
 
-    it("drains >1000 queued items across the kMaxIterationCount yield", async () => {
-      const output = await checkSameOutput("test_tsfn_many_items_driver", []);
-      expect(output).toContain("tsfn callbacks fired: 2000");
-    });
-
     it("keeps the event loop alive without async_work", async () => {
       const result = await checkSameOutput("test_promise_with_threadsafe_function", []);
       expect(result).toContain("tsfn_callback");

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -521,6 +521,16 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
   });
 
   describe("napi_threadsafe_function", () => {
+    it("passes NULL js_callback to call_js when created without a func", async () => {
+      const output = await checkSameOutput("test_tsfn_null_js_callback_driver", []);
+      expect(output).toContain("js_callback == NULL: 1");
+    });
+
+    it("drains >1000 queued items across the kMaxIterationCount yield", async () => {
+      const output = await checkSameOutput("test_tsfn_many_items_driver", []);
+      expect(output).toContain("tsfn callbacks fired: 2000");
+    });
+
     it("keeps the event loop alive without async_work", async () => {
       const result = await checkSameOutput("test_promise_with_threadsafe_function", []);
       expect(result).toContain("tsfn_callback");


### PR DESCRIPTION
Split from #36801 (1/5).

## What

When the threadsafe function was created with `func == NULL`, pass `js_callback = NULL` to `call_js_cb` instead of an encoded `undefined`.

## Why (fixes #13771, closes #30543)

Node's `DispatchOne` ([src/node_api.cc#L452-L462](https://github.com/nodejs/node/blob/v26.x/src/node_api.cc#L452-L462)):

```cpp
napi_value js_callback = nullptr;
if (!ref.IsEmpty()) {
  v8::Local<v8::Function> js_cb = v8::Local<v8::Function>::New(env->isolate, ref);
  js_callback = v8impl::JsValueFromV8LocalValue(js_cb);
}
env->CallbackIntoModule<false>(
    [&](napi_env env) { call_js_cb(env, js_callback, context, data); });
```

When `ref` is empty (the caller passed `func = NULL` to `napi_create_threadsafe_function`), `js_callback` stays `nullptr`. Bun was passing `napi_value::create(env, cb_js.get().unwrap_or(JSValue::UNDEFINED))`, which is the encoded `undefined` value (a non-zero pointer). Addons such as napi-rs and lightningcss test `if (js_callback != NULL)` and, seeing a non-null value, try to `napi_call_function` it:

```
thread '<unnamed>' panicked at napi/src/threadsafe_function.rs:235:57:
called `Result::unwrap()` on an `Err` value: Error { status: InvalidArg, reason: "expect Function, got: Undefined" }
```

## Verification

New `checkSameOutput` test fails under the released Bun:

```
$ USE_SYSTEM_BUN=1 bun test test/napi/napi.test.ts -t "passes NULL js_callback"
- "js_callback == NULL: 1
+ "js_callback == NULL: 0
```

The `kMaxIterationCount` cap that was in the first revision of this PR has been dropped: no issue has been filed about the unbounded dispatch loop, and the cap as written did not yield to setImmediate/timers anyway (`enqueue_task_concurrent` is drained inside the same `tick()`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->