### PR TITLE
napi: ToObject-coerce primitives in define_properties/freeze/seal/type_tag/set_prototype

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -987,8 +987,8 @@ napi_define_properties(napi_env env, napi_value object, size_t property_count,
     NAPI_RETURN_EARLY_IF_FALSE(env, properties || property_count == 0, napi_invalid_arg);
 
     JSValue objectValue = toJS(object);
-    JSC::JSObject* objectObject = objectValue.getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, objectObject, napi_object_expected);
+    JSC::JSObject* objectObject = objectValue.toObject(globalObject);
+    RETURN_IF_EXCEPTION(throwScope, napi_set_last_error(env, napi_object_expected));
 
     for (size_t i = 0; i < property_count; i++) {
         napi_status status = Napi::defineProperty(env, objectObject, properties[i], throwScope);
@@ -1613,8 +1613,7 @@ extern "C" JS_EXPORT napi_status node_api_set_prototype(napi_env env,
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = JSC::getVM(globalObject);
 
-    JSObject* obj = toJS(object).getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, obj, napi_object_expected);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, obj, toJS(object));
 
     // JSC's setPrototypeDirect asserts prototype.isObject() || prototype.isNull();
     // reject primitives here rather than reaching the engine assertion.
@@ -1783,12 +1782,10 @@ extern "C" napi_status napi_object_freeze(napi_env env, napi_value object_value)
 {
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, object_value);
-    JSC::JSValue value = toJS(object_value);
-    NAPI_RETURN_EARLY_IF_FALSE(env, value.isObject(), napi_object_expected);
 
     Zig::GlobalObject* globalObject = toJS(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, object, toJS(object_value));
 
-    JSC::JSObject* object = uncheckedDowncast<JSC::JSObject>(value);
     objectConstructorFreeze(globalObject, object);
     NAPI_RETURN_IF_EXCEPTION(env);
 
@@ -1798,12 +1795,10 @@ extern "C" napi_status napi_object_seal(napi_env env, napi_value object_value)
 {
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, object_value);
-    JSC::JSValue value = toJS(object_value);
-    NAPI_RETURN_EARLY_IF_FALSE(env, value.isObject(), napi_object_expected);
 
     Zig::GlobalObject* globalObject = toJS(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, object, toJS(object_value));
 
-    JSC::JSObject* object = uncheckedDowncast<JSC::JSObject>(value);
     objectConstructorSeal(globalObject, object);
     NAPI_RETURN_IF_EXCEPTION(env);
 
@@ -3183,8 +3178,8 @@ extern "C" napi_status napi_type_tag_object(napi_env env, napi_value value, cons
     NAPI_CHECK_ARG(env, value);
     NAPI_CHECK_ARG(env, type_tag);
     Zig::GlobalObject* globalObject = toJS(env);
-    JSObject* js_object = toJS(value).getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, js_object, napi_object_expected);
+    JSObject* js_object = toJS(value).toObject(globalObject);
+    NAPI_RETURN_IF_VM_EXCEPTION(env);
     JSValue napiTypeTagValue = globalObject->napiTypeTags()->get(js_object);
 
     auto* existing_tag = dynamicDowncast<Bun::NapiTypeTag>(napiTypeTagValue);
@@ -3203,8 +3198,8 @@ extern "C" napi_status napi_check_object_type_tag(napi_env env, napi_value value
     NAPI_CHECK_ARG(env, value);
     NAPI_CHECK_ARG(env, type_tag);
     Zig::GlobalObject* globalObject = toJS(env);
-    JSObject* js_object = toJS(value).getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, js_object, napi_object_expected);
+    JSObject* js_object = toJS(value).toObject(globalObject);
+    NAPI_RETURN_IF_VM_EXCEPTION(env);
 
     bool match = false;
     auto* found_tag = dynamicDowncast<Bun::NapiTypeTag>(globalObject->napiTypeTags()->get(js_object));

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -3756,6 +3756,53 @@ test_tsfn_null_js_callback_result(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// napi_define_properties / napi_object_freeze / napi_object_seal /
+// napi_type_tag_object / napi_check_object_type_tag / node_api_set_prototype
+// must ToObject-coerce primitives like Node's CHECK_TO_OBJECT[_WITH_PREAMBLE].
+static napi_value
+test_napi_toobject_coercion_node26(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+#ifndef _WIN32
+  BlockingStdoutScope blocking_stdout;
+#endif
+
+  napi_value v_null, v_undef, v_num;
+  NODE_API_CALL(env, napi_get_null(env, &v_null));
+  NODE_API_CALL(env, napi_get_undefined(env, &v_undef));
+  NODE_API_CALL(env, napi_create_double(env, 42.5, &v_num));
+
+  napi_value v;
+  NODE_API_CALL(env, napi_create_int32(env, 7, &v));
+  napi_property_descriptor desc = {"x",  NULL, NULL,         NULL,
+                                   NULL, v,    napi_default, NULL};
+  report_status(env, "define_properties(number)",
+                napi_define_properties(env, v_num, 1, &desc));
+  report_status(env, "define_properties(null)",
+                napi_define_properties(env, v_null, 1, &desc));
+  report_status(env, "object_freeze(number)", napi_object_freeze(env, v_num));
+  report_status(env, "object_freeze(null)", napi_object_freeze(env, v_null));
+  report_status(env, "object_seal(number)", napi_object_seal(env, v_num));
+  report_status(env, "object_seal(undefined)", napi_object_seal(env, v_undef));
+  napi_type_tag tag = {1, 2};
+  report_status(env, "type_tag_object(number)",
+                napi_type_tag_object(env, v_num, &tag));
+  report_status(env, "type_tag_object(null)",
+                napi_type_tag_object(env, v_null, &tag));
+  bool match;
+  report_status(env, "check_object_type_tag(number)",
+                napi_check_object_type_tag(env, v_num, &tag, &match));
+  report_status(env, "check_object_type_tag(null)",
+                napi_check_object_type_tag(env, v_null, &tag, &match));
+  napi_value proto;
+  NODE_API_CALL(env, napi_create_object(env, &proto));
+  report_status(env, "node_api_set_prototype(number)",
+                node_api_set_prototype(env, v_num, proto));
+  report_status(env, "node_api_set_prototype(null)",
+                node_api_set_prototype(env, v_null, proto));
+
+  return ok(env);
+}
+
 void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_typedarray_info_byte_offset);
   REGISTER_FUNCTION(env, exports, test_dataview_info_byte_offset);
@@ -3837,6 +3884,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback);
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_ran);
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_result);
+  REGISTER_FUNCTION(env, exports, test_napi_toobject_coercion_node26);
 }
 
 } // namespace napitests

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1605,6 +1605,22 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
       expect(output).toContain("keep_numbers key0 typeof=number");
       expect(output).toContain("numbers_to_strings key0 typeof=string");
     });
+
+    it("coerces primitives for define_properties/freeze/seal/type_tag/set_prototype", async () => {
+      const output = await checkSameOutput("test_napi_toobject_coercion_node26", []);
+      expect(output).toContain("define_properties(number): status=0 pending=0");
+      expect(output).toContain("define_properties(null): status=2 pending=1");
+      expect(output).toContain("object_freeze(number): status=0 pending=0");
+      expect(output).toContain("object_freeze(null): status=2 pending=1");
+      expect(output).toContain("object_seal(number): status=0 pending=0");
+      expect(output).toContain("object_seal(undefined): status=2 pending=1");
+      expect(output).toContain("type_tag_object(number): status=0 pending=0");
+      expect(output).toContain("type_tag_object(null): status=10 pending=1");
+      expect(output).toContain("check_object_type_tag(number): status=0 pending=0");
+      expect(output).toContain("check_object_type_tag(null): status=10 pending=1");
+      expect(output).toContain("node_api_set_prototype(number): status=0 pending=0");
+      expect(output).toContain("node_api_set_prototype(null): status=2 pending=1");
+    });
   });
 
   describe("napi_object_freeze and napi_object_seal", () => {


### PR DESCRIPTION
Split from #36801 (2/5).

## What

`napi_define_properties`, `napi_object_freeze`, `napi_object_seal`, `napi_type_tag_object`, `napi_check_object_type_tag`, and `node_api_set_prototype` now ToObject-coerce a primitive `object` argument (succeeding) and leave a `TypeError` pending for `null`/`undefined`, instead of returning `napi_object_expected` with no exception for any non-object.

| Input | Before (Bun) | Node.js / after |
|---|---|---|
| number/string/bool | `napi_object_expected`, no exception | `napi_ok` (ToObject-coerced) |
| `null`/`undefined` (define_properties/freeze/seal/set_prototype) | `napi_object_expected`, no exception | `napi_object_expected`, pending `TypeError` |
| `null`/`undefined` (type_tag_object/check_object_type_tag) | `napi_object_expected`, no exception | `napi_pending_exception` |

## Node.js source

All six use `CHECK_TO_OBJECT` or `CHECK_TO_OBJECT_WITH_PREAMBLE`, which is `ToObject()` coercion ([src/js_native_api_v8.h#L245-L274](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.h#L245-L274)):

- `napi_define_properties`: [src/js_native_api_v8.cc#L1426](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.cc#L1426)
- `napi_object_freeze` / `napi_object_seal`: [src/js_native_api_v8.cc#L1502](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.cc#L1502), [#L1519](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.cc#L1519)
- `napi_type_tag_object` / `napi_check_object_type_tag`: [src/js_native_api_v8.cc#L2728](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.cc#L2728), [#L2767](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.cc#L2767) (`_WITH_PREAMBLE` → `napi_pending_exception`)
- `node_api_set_prototype`: [src/js_native_api_v8.cc#L1584](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.cc#L1584)

`CHECK_TO_TYPE` returns the supplied status (`napi_object_expected`) on failure; `CHECK_TO_TYPE_WITH_PREAMBLE` returns `napi_pending_exception` when an exception was caught, which is why the two `type_tag` functions report a different status on `null`.

## Verification

New `checkSameOutput` test compares Bun against Node byte-for-byte. Fails under the released Bun (e.g. `define_properties(number): status=2 pending=0` vs Node's `status=0 pending=0`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->