### PR TITLE
napi: validate node_api_create_external_string args like Node's CHECK_NEW_STRING_ARGS

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1454,11 +1454,10 @@ node_api_create_external_string_latin1(napi_env env,
 {
     // https://nodejs.org/api/n-api.html#node_api_create_external_string_latin1
     NAPI_PREAMBLE_NO_PENDING_CHECK(env);
-    NAPI_CHECK_ARG(env, str);
+    // Node's CHECK_NEW_STRING_ARGS: str may be null when length is 0.
+    NAPI_RETURN_EARLY_IF_FALSE(env, length == 0 || str != nullptr, napi_invalid_arg);
     NAPI_CHECK_ARG(env, result);
-    // Reject while a napi exception is pending before adopting str, so the caller
-    // cleanly retains ownership (matches napi_create_external_buffer/_arraybuffer).
-    NAPI_RETURN_EARLY_IF_FALSE(env, !env->hasPendingException(), napi_pending_exception);
+    NAPI_RETURN_EARLY_IF_FALSE(env, length == NAPI_AUTO_LENGTH || length <= INT_MAX, napi_invalid_arg);
 
     length = length == NAPI_AUTO_LENGTH ? strlen(str) : length;
     Zig::GlobalObject* globalObject = toJS(env);
@@ -1472,7 +1471,9 @@ node_api_create_external_string_latin1(napi_env env,
     if (length == 0) {
         *result = toNapi(JSC::jsEmptyString(JSC::getVM(globalObject)), globalObject);
         env->doFinalizer(finalize_callback, str, finalize_hint);
-        NAPI_RETURN_SUCCESS_UNLESS_EXCEPTION(env);
+        // Ownership transferred; return ok even if doFinalizer promoted a
+        // pre-existing napi_throw to the VM, so the caller doesn't double-free.
+        return napi_set_last_error(env, napi_ok);
     }
 
     Ref<WTF::ExternalStringImpl> impl = WTF::ExternalStringImpl::create({ reinterpret_cast<const Latin1Character*>(str), static_cast<unsigned int>(length) }, finalize_hint, [finalize_callback, env](void* hint, void* str, unsigned length) {
@@ -1499,11 +1500,10 @@ node_api_create_external_string_utf16(napi_env env,
 {
     // https://nodejs.org/api/n-api.html#node_api_create_external_string_utf16
     NAPI_PREAMBLE_NO_PENDING_CHECK(env);
-    NAPI_CHECK_ARG(env, str);
+    // Node's CHECK_NEW_STRING_ARGS: str may be null when length is 0.
+    NAPI_RETURN_EARLY_IF_FALSE(env, length == 0 || str != nullptr, napi_invalid_arg);
     NAPI_CHECK_ARG(env, result);
-    // Reject while a napi exception is pending before adopting str, so the caller
-    // cleanly retains ownership (matches napi_create_external_buffer/_arraybuffer).
-    NAPI_RETURN_EARLY_IF_FALSE(env, !env->hasPendingException(), napi_pending_exception);
+    NAPI_RETURN_EARLY_IF_FALSE(env, length == NAPI_AUTO_LENGTH || length <= INT_MAX, napi_invalid_arg);
 
     length = length == NAPI_AUTO_LENGTH ? std::char_traits<char16_t>::length(str) : length;
     Zig::GlobalObject* globalObject = toJS(env);
@@ -1517,7 +1517,9 @@ node_api_create_external_string_utf16(napi_env env,
     if (length == 0) {
         *result = toNapi(JSC::jsEmptyString(JSC::getVM(globalObject)), globalObject);
         env->doFinalizer(finalize_callback, str, finalize_hint);
-        NAPI_RETURN_SUCCESS_UNLESS_EXCEPTION(env);
+        // Ownership transferred; return ok even if doFinalizer promoted a
+        // pre-existing napi_throw to the VM, so the caller doesn't double-free.
+        return napi_set_last_error(env, napi_ok);
     }
 
     Ref<WTF::ExternalStringImpl> impl = WTF::ExternalStringImpl::create({ reinterpret_cast<const char16_t*>(str), static_cast<unsigned int>(length) }, finalize_hint, [finalize_callback, env](void* hint, void* str, unsigned length) {

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -3915,6 +3915,32 @@ test_napi_symbol_key_result_ordering(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// node_api_create_external_string_{latin1,utf16}: Node's CHECK_NEW_STRING_ARGS
+// accepts (NULL, 0) and rejects length > INT_MAX.
+static napi_value
+test_napi_external_string_args(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+#ifndef _WIN32
+  BlockingStdoutScope blocking_stdout;
+#endif
+  napi_value out;
+  bool copied;
+  report_status(env, "ext_string_latin1(NULL,0)",
+                node_api_create_external_string_latin1(env, NULL, 0, NULL, NULL,
+                                                       &out, &copied));
+  static char sbuf[1] = {0};
+  report_status(
+      env, "ext_string_latin1(ptr,INT_MAX+1)",
+      node_api_create_external_string_latin1(
+          env, sbuf, ((size_t)INT_MAX) + 1u, NULL, NULL, &out, &copied));
+  static char16_t sbuf16[1] = {0};
+  report_status(
+      env, "ext_string_utf16(ptr,INT_MAX+1)",
+      node_api_create_external_string_utf16(
+          env, sbuf16, ((size_t)INT_MAX) + 1u, NULL, NULL, &out, &copied));
+  return ok(env);
+}
+
 void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_typedarray_info_byte_offset);
   REGISTER_FUNCTION(env, exports, test_dataview_info_byte_offset);
@@ -3998,6 +4024,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_result);
   REGISTER_FUNCTION(env, exports, test_napi_toobject_coercion_node26);
   REGISTER_FUNCTION(env, exports, test_napi_symbol_key_result_ordering);
+  REGISTER_FUNCTION(env, exports, test_napi_external_string_args);
 }
 
 } // namespace napitests

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -337,6 +337,13 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(result).toContain("external utf16 empty: length=0");
       expect(result).toContain("external utf16 nonempty: copied=0");
     });
+
+    it("accepts (NULL, 0) and rejects length > INT_MAX", async () => {
+      const output = await checkSameOutput("test_napi_external_string_args", []);
+      expect(output).toContain("ext_string_latin1(NULL,0): status=0 pending=0");
+      expect(output).toContain("ext_string_latin1(ptr,INT_MAX+1): status=1 pending=0");
+      expect(output).toContain("ext_string_utf16(ptr,INT_MAX+1): status=1 pending=0");
+    });
   });
 
   describe("napi_create_external_buffer", () => {


### PR DESCRIPTION
Split from #36801 (3/5).

## What

`node_api_create_external_string_latin1` / `_utf16`:

- Accept `(str = NULL, length = 0)` and return the empty string
- Reject `length > INT_MAX` with `napi_invalid_arg` (previously the `static_cast<unsigned int>(length)` truncated into a wild span over the caller's buffer and **crashed**)
- Zero-length branch returns `napi_ok` directly after running the finalizer, so a pre-existing `napi_throw_*` that `doFinalizer` promotes to the VM cannot cause a non-ok status after the buffer has already been freed

| Input | Before (Bun) | Node.js / after |
|---|---|---|
| `(NULL, 0)` | `napi_invalid_arg` | `napi_ok` (empty string) |
| `(ptr, INT_MAX+1)` | **crash** | `napi_invalid_arg` |

## Node.js source

`CHECK_NEW_STRING_ARGS` ([src/js_native_api_v8.cc#L43-L52](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.cc#L43-L52)):

```cpp
#define CHECK_NEW_STRING_ARGS(env, str, length, result)                        \
  do {                                                                         \
    CHECK_ENV_NOT_IN_GC((env));                                                \
    if ((length) > 0) CHECK_ARG((env), (str));                                 \
    CHECK_ARG((env), (result));                                                \
    RETURN_STATUS_IF_FALSE(                                                    \
        (env),                                                                 \
        ((length) == NAPI_AUTO_LENGTH) || (length) <= INT_MAX,                 \
        napi_invalid_arg);                                                     \
  } while (0)
```

Used by `NewExternalString` at [src/js_native_api_v8.cc#L107-L137](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.cc#L107-L137). No pending-exception gate.

## Verification

New `checkSameOutput` test in `test/napi/napi.test.ts`. The released Bun returns `status=1` for `(NULL,0)` and crashes on `(ptr, INT_MAX+1)`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->