### PR TITLE
napi: symbol description, empty named key, result-on-exception ordering, module_file_name

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -582,8 +582,6 @@ extern "C" napi_status napi_set_named_property(napi_env env, napi_value object,
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, object);
     NAPI_CHECK_ARG(env, utf8name);
-    // TODO find a way to permit empty strings
-    NAPI_RETURN_EARLY_IF_FALSE(env, *utf8name, napi_invalid_arg);
     NAPI_CHECK_ARG(env, value);
 
     auto globalObject = toJS(env);
@@ -669,8 +667,10 @@ extern "C" napi_status napi_has_named_property(napi_env env, napi_value object,
     JSC::Identifier propertyName = identifierFromUtf8(vm, utf8Name);
 
     PropertySlot slot(target, PropertySlot::InternalMethodType::HasProperty);
-    *result = target->getPropertySlot(globalObject, propertyName, slot);
-    NAPI_RETURN_SUCCESS_UNLESS_EXCEPTION(env);
+    bool has_property = target->getPropertySlot(globalObject, propertyName, slot);
+    NAPI_RETURN_IF_EXCEPTION(env);
+    *result = has_property;
+    NAPI_RETURN_SUCCESS(env);
 }
 extern "C" napi_status napi_get_named_property(napi_env env, napi_value object,
     const char* utf8Name,
@@ -688,8 +688,10 @@ extern "C" napi_status napi_get_named_property(napi_env env, napi_value object,
 
     JSC::Identifier propertyName = identifierFromUtf8(vm, utf8Name);
 
-    *result = toNapi(target->get(globalObject, propertyName), globalObject);
-    NAPI_RETURN_SUCCESS_UNLESS_EXCEPTION(env);
+    JSValue got = target->get(globalObject, propertyName);
+    NAPI_RETURN_IF_EXCEPTION(env);
+    *result = toNapi(got, globalObject);
+    NAPI_RETURN_SUCCESS(env);
 }
 
 extern "C" size_t Bun__napi_module_register_count;
@@ -1598,7 +1600,7 @@ extern "C" JS_EXPORT napi_status node_api_get_module_file_name(napi_env env,
 {
     NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ARG(env, result);
-    *result = env->filename;
+    *result = env->filename ? env->filename : "";
     NAPI_RETURN_SUCCESS(env);
 }
 
@@ -3037,18 +3039,14 @@ extern "C" napi_status napi_create_symbol(napi_env env, napi_value description,
     JSC::VM& vm = JSC::getVM(globalObject);
 
     JSC::JSValue descriptionValue = toJS(description);
-    if (descriptionValue && !descriptionValue.isUndefinedOrNull()) {
+    if (descriptionValue) {
         NAPI_RETURN_EARLY_IF_FALSE(env, descriptionValue.isString(), napi_string_expected);
 
         WTF::String descriptionString = descriptionValue.getString(globalObject);
         NAPI_RETURN_IF_VM_EXCEPTION(env);
 
-        if (descriptionString.length() > 0) {
-            *result = toNapi(JSC::Symbol::createWithDescription(vm, descriptionString),
-                globalObject);
-            NAPI_RETURN_SUCCESS(env);
-        }
-        // TODO handle empty string?
+        *result = toNapi(JSC::Symbol::createWithDescription(vm, descriptionString), globalObject);
+        NAPI_RETURN_SUCCESS(env);
     }
 
     auto* symbol = JSC::Symbol::create(vm);
@@ -3089,9 +3087,10 @@ extern "C" napi_status napi_new_instance(napi_env env, napi_value constructor,
     });
 
     auto value = construct(globalObject, constructorValue, constructData, args);
+    NAPI_RETURN_IF_EXCEPTION(env);
     *result = toNapi(value, globalObject);
 
-    NAPI_RETURN_SUCCESS_UNLESS_EXCEPTION(env);
+    NAPI_RETURN_SUCCESS(env);
 }
 
 extern "C" napi_status napi_instanceof(napi_env env, napi_value object, napi_value constructor, bool* result)

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -3803,6 +3803,118 @@ test_napi_toobject_coercion_node26(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// Empty-key set, symbol description handling, result-on-exception ordering,
+// and module_file_name non-null: byte-for-byte vs Node via checkSameOutput.
+static napi_value
+test_napi_symbol_key_result_ordering(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+#ifndef _WIN32
+  BlockingStdoutScope blocking_stdout;
+#endif
+
+  napi_value v_null, v_undef, v_num, v_str_empty, v_one, v_obj;
+  NODE_API_CALL(env, napi_get_null(env, &v_null));
+  NODE_API_CALL(env, napi_get_undefined(env, &v_undef));
+  NODE_API_CALL(env, napi_create_double(env, 42.5, &v_num));
+  NODE_API_CALL(env, napi_create_string_utf8(env, "", 0, &v_str_empty));
+  NODE_API_CALL(env, napi_create_int32(env, 1, &v_one));
+  NODE_API_CALL(env, napi_create_object(env, &v_obj));
+
+  report_status(env, "set_named_property(\"\")",
+                napi_set_named_property(env, v_obj, "", v_one));
+  {
+    napi_value key, got;
+    NODE_API_CALL(env, napi_create_string_utf8(env, "", 0, &key));
+    NODE_API_CALL(env, napi_get_property(env, v_obj, key, &got));
+    int32_t n = 0;
+    napi_get_value_int32(env, got, &n);
+    printf("obj[\"\"]=%d\n", n);
+  }
+
+  {
+    napi_value sym;
+    report_status(env, "create_symbol(undefined)",
+                  napi_create_symbol(env, v_undef, &sym));
+    report_status(env, "create_symbol(null)",
+                  napi_create_symbol(env, v_null, &sym));
+    report_status(env, "create_symbol(number)",
+                  napi_create_symbol(env, v_num, &sym));
+    napi_status s = napi_create_symbol(env, v_str_empty, &sym);
+    report_status(env, "create_symbol(\"\")", s);
+    if (s == napi_ok) {
+      napi_value desc_key, desc;
+      NODE_API_CALL(env, napi_create_string_utf8(env, "description",
+                                                 NAPI_AUTO_LENGTH, &desc_key));
+      NODE_API_CALL(env, napi_get_property(env, sym, desc_key, &desc));
+      napi_valuetype t;
+      NODE_API_CALL(env, napi_typeof(env, desc, &t));
+      char buf[8] = {0};
+      size_t len = 0;
+      if (t == napi_string)
+        napi_get_value_string_utf8(env, desc, buf, sizeof(buf), &len);
+      printf("create_symbol(\"\") description: type=%d len=%zu\n", (int)t, len);
+    }
+  }
+
+  {
+    napi_value thrower;
+    NODE_API_CALL(
+        env, napi_create_function(
+                 env, "Throws", NAPI_AUTO_LENGTH,
+                 [](napi_env e, napi_callback_info) -> napi_value {
+                   napi_throw_error(e, NULL, "ctor");
+                   return NULL;
+                 },
+                 NULL, &thrower));
+    napi_value sentinel = reinterpret_cast<napi_value>(0xdeadbeef);
+    napi_value r = sentinel;
+    napi_status s = napi_new_instance(env, thrower, 0, NULL, &r);
+    bool pending;
+    napi_is_exception_pending(env, &pending);
+    if (pending) {
+      napi_value e;
+      napi_get_and_clear_last_exception(env, &e);
+    }
+    printf("new_instance(throws): status=%d result_written=%d\n", (int)s,
+           r != sentinel);
+
+    napi_value script, proxy;
+    NODE_API_CALL(
+        env, napi_create_string_utf8(
+                 env,
+                 "new Proxy({}, {has: () => { throw new Error('h'); }, "
+                 "get: () => { throw new Error('g'); }})",
+                 NAPI_AUTO_LENGTH, &script));
+    NODE_API_CALL(env, napi_run_script(env, script, &proxy));
+    r = sentinel;
+    s = napi_get_named_property(env, proxy, "k", &r);
+    napi_is_exception_pending(env, &pending);
+    if (pending) {
+      napi_value e;
+      napi_get_and_clear_last_exception(env, &e);
+    }
+    printf("get_named_property(throws): status=%d result_written=%d\n", (int)s,
+           r != sentinel);
+    bool br = true;
+    s = napi_has_named_property(env, proxy, "k", &br);
+    napi_is_exception_pending(env, &pending);
+    if (pending) {
+      napi_value e;
+      napi_get_and_clear_last_exception(env, &e);
+    }
+    printf("has_named_property(throws): status=%d result_written=%d\n", (int)s,
+           br != true);
+  }
+
+  {
+    const char *fn = reinterpret_cast<const char *>(0x1);
+    napi_status s = node_api_get_module_file_name(env, &fn);
+    printf("module_file_name: status=%d is_null=%d\n", (int)s, fn == NULL);
+  }
+
+  return ok(env);
+}
+
 void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_typedarray_info_byte_offset);
   REGISTER_FUNCTION(env, exports, test_dataview_info_byte_offset);
@@ -3885,6 +3997,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_ran);
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_result);
   REGISTER_FUNCTION(env, exports, test_napi_toobject_coercion_node26);
+  REGISTER_FUNCTION(env, exports, test_napi_symbol_key_result_ordering);
 }
 
 } // namespace napitests

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -436,6 +436,20 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
   });
 
   describe("status code alignment with Node.js", () => {
+    it("matches Node for symbol description, empty named key, result-on-exception ordering, and module filename", async () => {
+      const output = await checkSameOutput("test_napi_symbol_key_result_ordering", []);
+      expect(output).toContain('set_named_property(""): status=0 pending=0');
+      expect(output).toContain('obj[""]=1');
+      expect(output).toContain("create_symbol(undefined): status=3 pending=0");
+      expect(output).toContain("create_symbol(null): status=3 pending=0");
+      expect(output).toContain('create_symbol(""): status=0 pending=0');
+      expect(output).toContain('create_symbol("") description: type=4 len=0');
+      expect(output).toContain("new_instance(throws): status=10 result_written=0");
+      expect(output).toContain("get_named_property(throws): status=10 result_written=0");
+      expect(output).toContain("has_named_property(throws): status=10 result_written=0");
+      expect(output).toContain("module_file_name: status=0 is_null=0");
+    });
+
     it("returns the same napi_status as Node.js for invalid inputs", async () => {
       const result = await checkSameOutput("test_napi_status_codes_node26", []);
 


### PR DESCRIPTION
Split from #36801 (4/5).

## What

| Function | Before (Bun) | Node.js / after |
|---|---|---|
| `napi_set_named_property(env, obj, "", v)` | `napi_invalid_arg` | `napi_ok` (sets `obj[""]`) |
| `napi_create_symbol(env, <js undefined/null>, &r)` | `napi_ok`, `Symbol()` | `napi_string_expected` |
| `napi_create_symbol(env, <js "">, &r)` | `.description === undefined` | `.description === ""` |
| `napi_new_instance` / `napi_get_named_property` / `napi_has_named_property` when underlying JS throws | writes `*result`, then `napi_pending_exception` | `napi_pending_exception`, `*result` untouched |
| `node_api_get_module_file_name` on the `napi_module_register` path | writes `NULL` | writes `""` |

## Node.js source

- `napi_set_named_property` uses `CHECK_NEW_FROM_UTF8`, which only rejects `nullptr`: [src/js_native_api_v8.cc#L25-L41, #L1262-L1283](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.cc#L25-L41)
- `napi_create_symbol` special-cases only `description == nullptr`; any non-null non-string is `napi_string_expected`: [src/js_native_api_v8.cc#L1925-L1944](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.cc#L1925-L1944)
- `napi_new_instance` / `napi_get_named_property` / `napi_has_named_property` check the `Maybe` before writing `*result`: [src/js_native_api_v8.cc#L3026-L3029](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.cc#L3026-L3029), [#L1327-L1331](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.cc#L1327-L1331), [#L1303-L1306](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.cc#L1303-L1306)
- `node_api_get_module_file_name` returns `filename.c_str()` from a `std::string`, which is never `NULL`: [src/node_api.cc#L1456-L1464](https://github.com/nodejs/node/blob/v26.x/src/node_api.cc#L1456-L1464), [src/node_api_internals.h#L39-L41](https://github.com/nodejs/node/blob/v26.x/src/node_api_internals.h#L39-L41)

## Verification

New `checkSameOutput` test compares Bun against Node byte-for-byte; fails under the released Bun.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->