### PR TITLE
napi: napi_reference_ref returns 0 after the referent is collected; napi_get_buffer_info rejects bare ArrayBuffer

### DIFF
--- a/src/jsc/bindings/NapiRef.cpp
+++ b/src/jsc/bindings/NapiRef.cpp
@@ -8,6 +8,12 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NapiRef);
 
 void NapiRef::ref()
 {
+    // Node's Reference::Ref(): once the weak referent is collected, return 0
+    // without incrementing.
+    if (refCount == 0 && !weakValueRef.isClear() && !weakValueRef.get()) {
+        NAPI_LOG("ref %p (referent collected)", this);
+        return;
+    }
     NAPI_LOG("ref %p %u -> %u", this, refCount, refCount + 1);
     ++refCount;
     if (refCount == 1 && !weakValueRef.isClear()) {

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2044,6 +2044,10 @@ extern "C" fn napi_get_buffer_info(
     let Some(array_buf) = value.as_array_buffer(env.to_js()) else {
         return NapiEnv::set_last_error(Some(env), NapiStatus::invalid_arg);
     };
+    // node::Buffer::HasInstance is IsArrayBufferView: reject a bare ArrayBuffer.
+    if array_buf.typed_array_type == jsc::JSType::ArrayBuffer {
+        return NapiEnv::set_last_error(Some(env), NapiStatus::invalid_arg);
+    }
 
     write_out(data, array_buf.ptr);
     write_out(length, array_buf.byte_len);

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1403,6 +1403,14 @@ nativeTests.test_tsfn_null_js_callback_driver = async () => {
   nativeTests.test_tsfn_null_js_callback_result();
 };
 
+// napi_reference_ref on a reference whose referent has been collected must
+// return 0 (and leave the count at 0) instead of incrementing.
+nativeTests.test_reference_ref_after_collect_driver = async gc => {
+  const ext = nativeTests.test_create_weak_ref_for_gc();
+  await gcUntil(() => nativeTests.test_weak_ref_is_collected(gc, ext));
+  nativeTests.test_reference_ref_after_collect(gc, ext);
+};
+
 // Microtasks queued by one threadsafe-function callback must be drained before
 // the next callback in the same dispatch, and not before the first one.
 nativeTests.test_threadsafe_function_microtask_order = async () => {

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -3941,6 +3941,87 @@ test_napi_external_string_args(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// napi_get_buffer_info must reject a bare ArrayBuffer/SharedArrayBuffer like
+// Node's node::Buffer::HasInstance (IsArrayBufferView).
+static napi_value
+test_napi_get_buffer_info_gate(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+#ifndef _WIN32
+  BlockingStdoutScope blocking_stdout;
+#endif
+  napi_value ab;
+  void *d;
+  size_t sz;
+  NODE_API_CALL(env, napi_create_arraybuffer(env, 8, &d, &ab));
+  report_status(env, "get_buffer_info(ArrayBuffer)",
+                napi_get_buffer_info(env, ab, &d, &sz));
+  napi_value ta;
+  NODE_API_CALL(env,
+                napi_create_typedarray(env, napi_uint8_array, 8, ab, 0, &ta));
+  report_status(env, "get_buffer_info(Uint8Array)",
+                napi_get_buffer_info(env, ta, &d, &sz));
+  napi_value dv;
+  NODE_API_CALL(env, napi_create_dataview(env, 8, ab, 0, &dv));
+  report_status(env, "get_buffer_info(DataView)",
+                napi_get_buffer_info(env, dv, &d, &sz));
+  return ok(env);
+}
+
+// Returns a weak napi_ref to a fresh object so the JS side can GC and then
+// inspect napi_reference_ref behaviour after the referent is collected.
+static napi_value
+test_create_weak_ref_for_gc(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value obj;
+  NODE_API_CALL(env, napi_create_object(env, &obj));
+  napi_ref ref;
+  NODE_API_CALL(env, napi_create_reference(env, obj, 0, &ref));
+  napi_value ext;
+  NODE_API_CALL(env,
+                napi_create_external(env, reinterpret_cast<void *>(ref), NULL,
+                                     NULL, &ext));
+  return ext;
+}
+
+// Predicate for gcUntil: true once the weak ref's value is undefined.
+static napi_value
+test_weak_ref_is_collected(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  void *p;
+  NODE_API_CALL(env, napi_get_value_external(env, info[1], &p));
+  napi_ref ref = reinterpret_cast<napi_ref>(p);
+  napi_value v = NULL;
+  NODE_API_CALL(env, napi_get_reference_value(env, ref, &v));
+  napi_valuetype t = napi_undefined;
+  if (v) napi_typeof(env, v, &t);
+  napi_value r;
+  NODE_API_CALL(env,
+                napi_get_boolean(env, v == NULL || t == napi_undefined, &r));
+  return r;
+}
+
+static napi_value
+test_reference_ref_after_collect(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  void *p;
+  NODE_API_CALL(env, napi_get_value_external(env, info[1], &p));
+  napi_ref ref = reinterpret_cast<napi_ref>(p);
+
+  napi_value v = NULL;
+  NODE_API_CALL(env, napi_get_reference_value(env, ref, &v));
+  napi_valuetype t = napi_undefined;
+  if (v) napi_typeof(env, v, &t);
+  uint32_t count = 999;
+  NODE_API_CALL(env, napi_reference_ref(env, ref, &count));
+  printf("get_reference_value is undefined=%d reference_ref count=%u\n",
+         (v == NULL || t == napi_undefined), count);
+  uint32_t count2 = 999;
+  NODE_API_CALL(env, napi_reference_ref(env, ref, &count2));
+  printf("second reference_ref count=%u\n", count2);
+  NODE_API_CALL(env, napi_delete_reference(env, ref));
+  return ok(env);
+}
+
 void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_typedarray_info_byte_offset);
   REGISTER_FUNCTION(env, exports, test_dataview_info_byte_offset);
@@ -4025,6 +4106,10 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_napi_toobject_coercion_node26);
   REGISTER_FUNCTION(env, exports, test_napi_symbol_key_result_ordering);
   REGISTER_FUNCTION(env, exports, test_napi_external_string_args);
+  REGISTER_FUNCTION(env, exports, test_napi_get_buffer_info_gate);
+  REGISTER_FUNCTION(env, exports, test_create_weak_ref_for_gc);
+  REGISTER_FUNCTION(env, exports, test_weak_ref_is_collected);
+  REGISTER_FUNCTION(env, exports, test_reference_ref_after_collect);
 }
 
 } // namespace napitests

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -318,6 +318,17 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     it("can recover the value from a weak ref", async () => {
       await checkSameOutput("test_napi_ref", []);
     });
+    it("napi_reference_ref returns 0 after the referent is collected", async () => {
+      const output = await checkSameOutput("test_reference_ref_after_collect_driver", []);
+      expect(output).toContain("get_reference_value is undefined=1 reference_ref count=0");
+      expect(output).toContain("second reference_ref count=0");
+    });
+    it("napi_get_buffer_info rejects a bare ArrayBuffer", async () => {
+      const output = await checkSameOutput("test_napi_get_buffer_info_gate", []);
+      expect(output).toContain("get_buffer_info(ArrayBuffer): status=1 pending=0");
+      expect(output).toContain("get_buffer_info(Uint8Array): status=0 pending=0");
+      expect(output).toContain("get_buffer_info(DataView): status=0 pending=0");
+    });
     it("allows creating a handle scope in the finalizer", async () => {
       await checkSameOutput("test_napi_handle_scope_finalizer", []);
     });


### PR DESCRIPTION
Split from #36801 (5/5).

## What

| Function | Before (Bun) | Node.js / after |
|---|---|---|
| `napi_reference_ref` after the weak referent is collected | increments (returns 1, 2, ...) | returns 0, does not increment |
| `napi_get_buffer_info(env, <ArrayBuffer>, ...)` | `napi_ok` | `napi_invalid_arg` |

## Node.js source

- `Reference::Ref()` returns 0 without incrementing once the persistent is empty: [src/js_native_api_v8.cc#L690-L700](https://github.com/nodejs/node/blob/v26.x/src/js_native_api_v8.cc#L690-L700)

  ```cpp
  uint32_t Reference::Ref() {
    if (persistent_.IsEmpty()) {
      return 0;
    }
    if (++refcount_ == 1 && can_be_weak_) {
      persistent_.ClearWeak();
    }
    return refcount_;
  }
  ```

  The check in `NapiRef::ref()` is `refCount == 0 && !weakValueRef.isClear() && !weakValueRef.get()` so it only fires when a weak handle was set and has since been cleared by GC; strongly-held or never-weak references keep their existing behaviour.

- `napi_get_buffer_info` gates on `node::Buffer::HasInstance`: [src/node_api.cc#L1150-L1169](https://github.com/nodejs/node/blob/v26.x/src/node_api.cc#L1150-L1169), which is `IsArrayBufferView()` ([src/node_buffer.cc](https://github.com/nodejs/node/blob/v26.x/src/node_buffer.cc)). Typed arrays and DataView pass; a bare `ArrayBuffer` / `SharedArrayBuffer` does not.

## Verification

Two new `checkSameOutput` tests. The `reference_ref` driver polls `napi_get_reference_value` via `gcUntil` so it waits for collection instead of assuming a single GC pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->