### PR TITLE
inspector: bump WebKit so Debugger.disable is idempotent on asserts builds

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,9 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "e6e37cda216c0292ae68c30c84a9dc8601d0fba5";
+// Preview of oven-sh/WebKit#385: guard InspectorDebuggerAgent::disable() so a redundant
+// Debugger.disable does not trip ASSERT(!!m_client != !!client) in JSC::Debugger::setClient.
+export const WEBKIT_VERSION = "autobuild-preview-pr-385-10e1ab9b";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/cli/inspect/inspect-debugger-disable.test.ts
+++ b/test/cli/inspect/inspect-debugger-disable.test.ts
@@ -1,0 +1,92 @@
+import { spawn } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+
+// InspectorDebuggerAgent::disable() used to call internalDisable() unconditionally, so a
+// Debugger.disable on an already-disabled agent (or before any enable) re-ran
+// m_debugger.setClient(nullptr) and tripped ASSERT(!!m_client != !!client) in
+// JSC::Debugger::setClient. Frontends send Debugger.disable liberally on teardown, so this is
+// an ordinary sequence. The assert is ASSERT_ENABLED-only, hence the skipIf.
+test.skipIf(!isDebug && !isASAN)("Debugger.disable is idempotent and does not abort on asserts builds", async () => {
+  await using child = spawn({
+    cmd: [bunExe(), "--inspect=127.0.0.1:0", "-e", "setInterval(()=>{},1000)"],
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+
+  let stderr = "";
+  const decoder = new TextDecoder();
+  const { promise: urlPromise, resolve: resolveUrl, reject: rejectUrl } = Promise.withResolvers<URL>();
+  const stderrDrained = (async () => {
+    for await (const chunk of child.stderr) {
+      stderr += decoder.decode(chunk);
+      const m = stderr.match(/ws:\/\/[^\s]+/);
+      if (m) resolveUrl(new URL(m[0]));
+    }
+    rejectUrl(new Error("inspectee exited before printing inspector URL:\n" + stderr));
+  })();
+
+  const url = await urlPromise;
+  const ws = new WebSocket(url);
+  const replies: Record<number, unknown> = {};
+  try {
+    let nextId = 1;
+    let failed: unknown;
+    const pending = new Map<number, (x: unknown) => void>();
+    const send = (method: string, params: object = {}) =>
+      new Promise<unknown>(resolve => {
+        if (failed) return resolve(failed);
+        const id = nextId++;
+        pending.set(id, resolve);
+        ws.send(JSON.stringify({ id, method, params }));
+      });
+    const fail = (r: unknown) => {
+      failed ??= r;
+      for (const p of pending.values()) p(r);
+      pending.clear();
+    };
+    ws.addEventListener("message", ev => {
+      const msg = JSON.parse(String(ev.data));
+      if (typeof msg.id === "number" && pending.has(msg.id)) {
+        replies[msg.id] = msg;
+        pending.get(msg.id)!(msg);
+        pending.delete(msg.id);
+      }
+    });
+    ws.addEventListener("close", ({ code, reason }) => fail({ closed: { code, reason } }));
+    ws.addEventListener("error", cause => fail({ error: String(cause) }));
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener("open", () => resolve());
+      ws.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
+    });
+
+    // Disable before any enable: m_enabled is false at startup, so the agent must early-return.
+    await send("Debugger.disable");
+    // Enable, disable, disable: the second disable must be a no-op, not a second setClient(nullptr).
+    await send("Debugger.enable");
+    await send("Debugger.disable");
+    await send("Debugger.disable");
+    // The agent must still be usable afterwards.
+    await send("Debugger.enable");
+    await send("Debugger.disable");
+  } finally {
+    ws.close();
+    child.kill();
+  }
+
+  await Promise.all([child.exited, stderrDrained.catch(() => {})]);
+  if (child.signalCode === "SIGABRT") {
+    throw new Error(
+      `inspectee aborted on Debugger.disable (replies=${JSON.stringify(replies)}):\n${stderr.slice(-2000)}`,
+    );
+  }
+  expect(replies).toEqual({
+    1: { id: 1, result: {} },
+    2: { id: 2, result: {} },
+    3: { id: 3, result: {} },
+    4: { id: 4, result: {} },
+    5: { id: 5, result: {} },
+    6: { id: 6, result: {} },
+  });
+});


### PR DESCRIPTION
A `Debugger.disable` sent to `bun --inspect` on an already-disabled Debugger agent (or before any `Debugger.enable`) aborts an asserts build:

```
ASSERTION FAILED: !!m_client != !!client
vendor/WebKit/Source/JavaScriptCore/debugger/Debugger.cpp(331) : void JSC::Debugger::setClient(Client *)
```

Release just answers `{}` and continues. Reproduces over both the WebSocket and `--inspect=unix:` transports; the `--inspect` server forwards messages straight to JSC's backend dispatcher, so the crash is in WebKit. Frontends send `Debugger.disable` liberally on teardown (detach + close, or two attached tools each disabling), so this is an ordinary sequence rather than an exotic one.

## Cause

`InspectorDebuggerAgent::disable()` calls `internalDisable(false)` unconditionally. `internalDisable()` runs `m_debugger.setClient(nullptr)`, and `JSC::Debugger::setClient` asserts the client is transitioning (`!!m_client != !!client`). When `m_client` is already null, either because the agent was never enabled or because `disable()` already ran, the assert fails.

`enable()` guards with `if (enabled()) return makeUnexpected(...)`; `willDestroyFrontendAndBackend()` guards `internalDisable()` with `if (enabled())`; `InspectorHeapAgent::disable()` and `InspectorConsoleAgent::disable()` both early-return when already disabled. `InspectorDebuggerAgent::disable()` is the odd one out.

## Fix

[oven-sh/WebKit#385](https://github.com/oven-sh/WebKit/pull/385) adds `if (!enabled()) return { };` to `InspectorDebuggerAgent::disable()`, mirroring the other agents. Branched off `e6e37cda21` (current `WEBKIT_VERSION`) so the preview bump is minimal.

This PR bumps `WEBKIT_VERSION` to the preview build and adds `test/cli/inspect/inspect-debugger-disable.test.ts` which drives `disable → enable → disable → disable → enable → disable` over the `--inspect` WebSocket and asserts all six replies arrive and the inspectee does not SIGABRT. The test is `test.skipIf(!isDebug && !isASAN)` since the assert is `ASSERT_ENABLED`-only.

## Verification

```
$ bun bd test test/cli/inspect/inspect-debugger-disable.test.ts
# with WEBKIT_VERSION = e6e37cda21 (main):
(fail) Debugger.disable is idempotent and does not abort on asserts builds
  error: inspectee aborted on Debugger.disable (replies={}):
  ASSERTION FAILED: !!m_client != !!client
# with WEBKIT_VERSION = autobuild-preview-pr-385-10e1ab9b:
(pass) Debugger.disable is idempotent and does not abort on asserts builds [538.69ms]
```

`test/js/node/inspector/inspector.test.ts` 23/23 and `test/js/bun/jsc/webkit-upgrade-3722912f.test.ts` 5/5 with the bump.

Once oven-sh/WebKit#385 merges, `WEBKIT_VERSION` should be repointed at the merged main sha (preview releases are deleted at that point).

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 2 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/inspect/inspect-debugger-disable.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/inspect/inspect-debugger-disable.test.ts
bun test v1.4.0 (5561f3f75)

test/cli/inspect/inspect-debugger-disable.test.ts:
(pass) Debugger.disable is idempotent and does not abort on asserts builds [541.04ms]

 1 pass
 0 fail
 1 expect() calls
Ran 1 test across 1 file. [2.56s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                      |  4 +-
 test/cli/inspect/inspect-debugger-disable.test.ts | 92 +++++++++++++++++++++++
 2 files changed, 95 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
scripts/build/deps/webkit.ts                           2      2      0
test/cli/inspect/inspect-debugger-disable.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->