### PR TITLE
install: fall back to copyfile when linkat fails with EACCES or EPERM

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -1650,11 +1650,8 @@ impl<'a> PackageInstall<'a> {
                                             entry.path,
                                         )?;
                                     }
-                                    // EACCES/EPERM: filesystems without hardlink
-                                    // support (FUSE, e.g. Android SDCARD) reject
-                                    // linkat this way; fall back to copying like
-                                    // EXDEV. A genuine destination permission
-                                    // error fails the copy with the same errno.
+                                    // FUSE (e.g. Android SDCARD) rejects hardlinks
+                                    // with EACCES/EPERM; fall back to copying.
                                     sys::E::EXDEV | sys::E::EACCES | sys::E::EPERM => {
                                         return Err(crate::Error::NotSameFileSystem);
                                     }

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -1650,7 +1650,12 @@ impl<'a> PackageInstall<'a> {
                                             entry.path,
                                         )?;
                                     }
-                                    sys::E::EXDEV => {
+                                    // EACCES/EPERM: filesystems without hardlink
+                                    // support (FUSE, e.g. Android SDCARD) reject
+                                    // linkat this way; fall back to copying like
+                                    // EXDEV. A genuine destination permission
+                                    // error fails the copy with the same errno.
+                                    sys::E::EXDEV | sys::E::EACCES | sys::E::EPERM => {
                                         return Err(crate::Error::NotSameFileSystem);
                                     }
                                     sys::E::ENXIO => {

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -1650,8 +1650,7 @@ impl<'a> PackageInstall<'a> {
                                             entry.path,
                                         )?;
                                     }
-                                    // FUSE (e.g. Android SDCARD) rejects hardlinks
-                                    // with EACCES/EPERM; fall back to copying.
+                                    // EACCES/EPERM: FUSE (e.g. Android SDCARD) does not support hardlinks
                                     sys::E::EXDEV | sys::E::EACCES | sys::E::EPERM => {
                                         return Err(crate::Error::NotSameFileSystem);
                                     }

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -1631,11 +1631,7 @@ impl<'a> PackageInstall<'a> {
                             );
                         }
                         EntryKind::File => {
-                            // Map raw errno to the error names the caller's
-                            // `NotSameFileSystem` / `ENXIO` checks (and the
-                            // copyfile fallback in `install()`) expect.
-                            // EACCES/EPERM: FUSE (e.g. Android SDCARD) does not
-                            // support hardlinks.
+                            // EACCES/EPERM: FUSE (e.g. Android SDCARD) does not support hardlinks
                             fn map_linkat_err(err: sys::Error) -> crate::Error {
                                 match err.get_errno() {
                                     sys::E::EXDEV | sys::E::EACCES | sys::E::EPERM => {

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -1631,35 +1631,40 @@ impl<'a> PackageInstall<'a> {
                             );
                         }
                         EntryKind::File => {
+                            // Map raw errno to the error names the caller's
+                            // `NotSameFileSystem` / `ENXIO` checks (and the
+                            // copyfile fallback in `install()`) expect.
+                            // EACCES/EPERM: FUSE (e.g. Android SDCARD) does not
+                            // support hardlinks.
+                            fn map_linkat_err(err: sys::Error) -> crate::Error {
+                                match err.get_errno() {
+                                    sys::E::EXDEV | sys::E::EACCES | sys::E::EPERM => {
+                                        crate::Error::NotSameFileSystem
+                                    }
+                                    sys::E::ENXIO => {
+                                        crate::Error::Sys(bun_errno::SystemErrno::ENXIO)
+                                    }
+                                    _ => err.into(),
+                                }
+                            }
+
                             if let Err(err) = sys::linkat(
                                 entry.dir,
                                 entry.basename,
                                 destination_dir.fd(),
                                 entry.path,
                             ) {
-                                // Map raw errno to the error names the caller's
-                                // `NotSameFileSystem` / `ENXIO` checks (and the
-                                // copyfile fallback in `install()`) expect.
-                                match err.get_errno() {
-                                    sys::E::EEXIST => {
-                                        let _ = sys::unlinkat(destination_dir, entry.path);
-                                        sys::linkat(
-                                            entry.dir,
-                                            entry.basename,
-                                            destination_dir.fd(),
-                                            entry.path,
-                                        )?;
-                                    }
-                                    // EACCES/EPERM: FUSE (e.g. Android SDCARD) does not support hardlinks
-                                    sys::E::EXDEV | sys::E::EACCES | sys::E::EPERM => {
-                                        return Err(crate::Error::NotSameFileSystem);
-                                    }
-                                    sys::E::ENXIO => {
-                                        return Err(crate::Error::Sys(
-                                            bun_errno::SystemErrno::ENXIO,
-                                        ));
-                                    }
-                                    _ => return Err(err.into()),
+                                if err.get_errno() == sys::E::EEXIST {
+                                    let _ = sys::unlinkat(destination_dir, entry.path);
+                                    sys::linkat(
+                                        entry.dir,
+                                        entry.basename,
+                                        destination_dir.fd(),
+                                        entry.path,
+                                    )
+                                    .map_err(map_linkat_err)?;
+                                } else {
+                                    return Err(map_linkat_err(err));
                                 }
                             }
 

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -1390,6 +1390,10 @@ impl Task {
 
                             // fallthrough copyfile
                             _ => {
+                                // close the fd the failed hardlink attempt left behind
+                                if let Some(old) = cached_package_dir.take() {
+                                    old.close();
+                                }
                                 *cached_package_dir = match bun_sys::open_dir_for_iteration(
                                     cache_dir,
                                     pkg_cache_dir_subpath.slice(),

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -932,6 +932,16 @@ impl Task {
                                                         | sys::Errno::EACCES
                                                         | sys::Errno::EPERM
                                                 ) {
+                                                    // the hardlink walk advanced the dir cursor; rewind it for
+                                                    // the copy walk (Windows restarts the scan on its own)
+                                                    #[cfg(not(windows))]
+                                                    if let sys::Result::Err(err) =
+                                                        sys::set_file_offset(folder_dir, 0)
+                                                    {
+                                                        return Ok(Yield::failure(
+                                                            TaskError::LinkPackage(err),
+                                                        ));
+                                                    }
                                                     backend = InstallMethod::Copyfile;
                                                     continue 'backend;
                                                 }
@@ -968,20 +978,6 @@ impl Task {
                                     }
 
                                     InstallMethod::Copyfile => {
-                                        // The failed hardlink walk advanced the dir cursor; reopen or the copy walk sees no entries
-                                        let folder_dir = match bun_sys::open_dir_for_iteration(
-                                            Fd::cwd(),
-                                            path,
-                                        ) {
-                                            sys::Result::Ok(fd) => fd,
-                                            sys::Result::Err(err) => {
-                                                return Ok(Yield::failure(TaskError::LinkPackage(
-                                                    err,
-                                                )));
-                                            }
-                                        };
-                                        let _folder_dir_guard = sys::CloseOnDrop::new(folder_dir);
-
                                         #[cfg(windows)]
                                         let mut src_path = OsAutoAbsPath::init();
                                         #[cfg(not(windows))]

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -932,8 +932,7 @@ impl Task {
                                                         | sys::Errno::EACCES
                                                         | sys::Errno::EPERM
                                                 ) {
-                                                    // the hardlink walk advanced the dir cursor; rewind it for
-                                                    // the copy walk (Windows restarts the scan on its own)
+                                                    // rewind the dir cursor the hardlink walk consumed (Windows restarts the scan itself)
                                                     #[cfg(not(windows))]
                                                     if let sys::Result::Err(err) =
                                                         sys::set_file_offset(folder_dir, 0)

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -968,6 +968,22 @@ impl Task {
                                     }
 
                                     InstallMethod::Copyfile => {
+                                        // The failed hardlink walk advanced `folder_dir`'s
+                                        // directory cursor; reopen it or the copy walk
+                                        // sees no entries.
+                                        let folder_dir = match bun_sys::open_dir_for_iteration(
+                                            Fd::cwd(),
+                                            path,
+                                        ) {
+                                            sys::Result::Ok(fd) => fd,
+                                            sys::Result::Err(err) => {
+                                                return Ok(Yield::failure(
+                                                    TaskError::LinkPackage(err),
+                                                ));
+                                            }
+                                        };
+                                        let _folder_dir_guard = sys::CloseOnDrop::new(folder_dir);
+
                                         #[cfg(windows)]
                                         let mut src_path = OsAutoAbsPath::init();
                                         #[cfg(not(windows))]

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -975,9 +975,9 @@ impl Task {
                                         ) {
                                             sys::Result::Ok(fd) => fd,
                                             sys::Result::Err(err) => {
-                                                return Ok(Yield::failure(
-                                                    TaskError::LinkPackage(err),
-                                                ));
+                                                return Ok(Yield::failure(TaskError::LinkPackage(
+                                                    err,
+                                                )));
                                             }
                                         };
                                         let _folder_dir_guard = sys::CloseOnDrop::new(folder_dir);

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -925,7 +925,13 @@ impl Task {
                                         match hardlinker.link()? {
                                             sys::Result::Ok(()) => {}
                                             sys::Result::Err(err) => {
-                                                if err.get_errno() == sys::Errno::EXDEV {
+                                                // EACCES/EPERM: FUSE (e.g. Android SDCARD) does not support hardlinks
+                                                if matches!(
+                                                    err.get_errno(),
+                                                    sys::Errno::EXDEV
+                                                        | sys::Errno::EACCES
+                                                        | sys::Errno::EPERM
+                                                ) {
                                                     backend = InstallMethod::Copyfile;
                                                     continue 'backend;
                                                 }
@@ -1331,7 +1337,11 @@ impl Task {
                                 match hardlinker.link()? {
                                     sys::Result::Ok(()) => {}
                                     sys::Result::Err(err) => {
-                                        if err.get_errno() == sys::Errno::EXDEV {
+                                        // EACCES/EPERM: FUSE (e.g. Android SDCARD) does not support hardlinks
+                                        if matches!(
+                                            err.get_errno(),
+                                            sys::Errno::EXDEV | sys::Errno::EACCES | sys::Errno::EPERM
+                                        ) {
                                             installer.supported_backend.store(
                                                 InstallMethod::Copyfile as u8,
                                                 Ordering::Relaxed,

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -1340,7 +1340,9 @@ impl Task {
                                         // EACCES/EPERM: FUSE (e.g. Android SDCARD) does not support hardlinks
                                         if matches!(
                                             err.get_errno(),
-                                            sys::Errno::EXDEV | sys::Errno::EACCES | sys::Errno::EPERM
+                                            sys::Errno::EXDEV
+                                                | sys::Errno::EACCES
+                                                | sys::Errno::EPERM
                                         ) {
                                             installer.supported_backend.store(
                                                 InstallMethod::Copyfile as u8,

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -968,9 +968,7 @@ impl Task {
                                     }
 
                                     InstallMethod::Copyfile => {
-                                        // The failed hardlink walk advanced `folder_dir`'s
-                                        // directory cursor; reopen it or the copy walk
-                                        // sees no entries.
+                                        // The failed hardlink walk advanced the dir cursor; reopen or the copy walk sees no entries
                                         let folder_dir = match bun_sys::open_dir_for_iteration(
                                             Fd::cwd(),
                                             path,

--- a/test/cli/install/bun-install-hardlink-fallback.test.ts
+++ b/test/cli/install/bun-install-hardlink-fallback.test.ts
@@ -3,8 +3,8 @@
 // hardlink install backend must fall back to copying files, like it already
 // does for EXDEV. https://github.com/oven-sh/bun/issues/36852
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, tempDir } from "harness";
-import { cpSync } from "node:fs";
+import { bunEnv, bunExe, isLinux, isMusl, tempDir } from "harness";
+import { cpSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
@@ -27,7 +27,8 @@ int link(const char *oldpath, const char *newpath) {
 }
 `;
 
-describe.skipIf(!isLinux || !cc)("hardlink backend falls back to copyfile", () => {
+// bun-musl is statically linked, so LD_PRELOAD cannot intercept linkat.
+describe.skipIf(!isLinux || isMusl || !cc)("hardlink backend falls back to copyfile", () => {
   for (const errno of ["EACCES", "EPERM"]) {
     for (const linker of ["hoisted", "isolated"]) {
       test.concurrent(`linkat fails with ${errno}, ${linker} linker`, async () => {
@@ -53,9 +54,9 @@ describe.skipIf(!isLinux || !cc)("hardlink backend falls back to copyfile", () =
             compile.stderr.text(),
             compile.exited,
           ]);
-          expect(compileOut).toBe("");
-          expect(compileErr).toBe("");
-          expect(compileExit).toBe(0);
+          if (compileExit !== 0) {
+            throw new Error(`shim compile failed: ${compileOut}${compileErr}`);
+          }
         }
 
         await using proc = Bun.spawn({
@@ -64,7 +65,7 @@ describe.skipIf(!isLinux || !cc)("hardlink backend falls back to copyfile", () =
           env: {
             ...bunEnv,
             BUN_INSTALL_CACHE_DIR: join(String(dir), "cache"),
-            LD_PRELOAD: join(String(dir), "shim.so"),
+            LD_PRELOAD: [join(String(dir), "shim.so"), bunEnv.LD_PRELOAD].filter(Boolean).join(":"),
           },
           stderr: "pipe",
         });
@@ -72,10 +73,14 @@ describe.skipIf(!isLinux || !cc)("hardlink backend falls back to copyfile", () =
         expect(stderr).not.toContain(errno);
         expect(stdout).toMatch(/\d+ packages? installed/);
         expect(exitCode).toBe(0);
-        expect(await Bun.file(join(String(dir), "node_modules", "bar", "package.json")).json()).toMatchObject({
+        const installed = join(String(dir), "node_modules", "bar", "package.json");
+        expect(await Bun.file(installed).json()).toMatchObject({
           name: "bar",
           version: "0.0.2",
         });
+        // A hardlink from the cache would have nlink >= 2; nlink === 1 proves
+        // the copy fallback ran.
+        expect(statSync(installed).nlink).toBe(1);
       });
     }
   }

--- a/test/cli/install/bun-install-hardlink-fallback.test.ts
+++ b/test/cli/install/bun-install-hardlink-fallback.test.ts
@@ -1,0 +1,76 @@
+// FUSE-backed filesystems (e.g. Android's SDCARD in Termux) do not support
+// hard links and fail linkat with EACCES or EPERM instead of EXDEV. The
+// hardlink install backend must fall back to copying files, like it already
+// does for EXDEV. https://github.com/oven-sh/bun/issues/36852
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { cpSync } from "node:fs";
+import { join } from "node:path";
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+
+const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <errno.h>
+
+int linkat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath,
+           int flags) {
+  (void)olddirfd; (void)oldpath; (void)newdirfd; (void)newpath; (void)flags;
+  errno = EACCES;
+  return -1;
+}
+
+int link(const char *oldpath, const char *newpath) {
+  (void)oldpath; (void)newpath;
+  errno = EACCES;
+  return -1;
+}
+`;
+
+test.skipIf(!isLinux || !cc)(
+  "bun install falls back to copyfile when linkat fails with EACCES",
+  async () => {
+    using dir = tempDir("hardlink-eacces-fallback", {
+      "shim.c": SHIM_C,
+      "package.json": JSON.stringify({
+        name: "hardlink-eacces-fallback",
+        dependencies: { bar: "file:./bar-0.0.2.tgz" },
+      }),
+    });
+    cpSync(join(import.meta.dir, "bar-0.0.2.tgz"), join(String(dir), "bar-0.0.2.tgz"));
+
+    {
+      await using compile = Bun.spawn({
+        cmd: [cc!, "-shared", "-fPIC", "-o", "shim.so", "shim.c"],
+        cwd: String(dir),
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      expect(await compile.stderr.text()).toBe("");
+      expect(await compile.exited).toBe(0);
+    }
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(String(dir), "cache"),
+        LD_PRELOAD: join(String(dir), "shim.so"),
+      },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).not.toContain("EACCES");
+    expect(stdout).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+    expect(await Bun.file(join(String(dir), "node_modules", "bar", "package.json")).json()).toMatchObject({
+      name: "bar",
+      version: "0.0.2",
+    });
+  },
+);

--- a/test/cli/install/bun-install-hardlink-fallback.test.ts
+++ b/test/cli/install/bun-install-hardlink-fallback.test.ts
@@ -36,8 +36,10 @@ describe.skipIf(!isLinux || isMusl || !cc)("hardlink backend falls back to copyf
           "shim.c": shimC(errno),
           "package.json": JSON.stringify({
             name: "hardlink-fallback-test",
-            dependencies: { bar: "file:./bar-0.0.2.tgz" },
+            dependencies: { bar: "file:./bar-0.0.2.tgz", localdep: "file:./localdep" },
           }),
+          "localdep/package.json": JSON.stringify({ name: "localdep", version: "1.2.3" }),
+          "localdep/index.js": "module.exports = 1;",
         });
         cpSync(join(import.meta.dir, "bar-0.0.2.tgz"), join(String(dir), "bar-0.0.2.tgz"));
 
@@ -81,6 +83,16 @@ describe.skipIf(!isLinux || isMusl || !cc)("hardlink backend falls back to copyf
         // A hardlink from the cache would have nlink >= 2; nlink === 1 proves
         // the copy fallback ran.
         expect(statSync(installed).nlink).toBe(1);
+
+        // Folder dependencies take a separate path in the isolated linker
+        // that reuses the folder's dir fd across the hardlink attempt and
+        // the copy fallback; the contents must still be installed.
+        const installedLocal = join(String(dir), "node_modules", "localdep", "package.json");
+        expect(await Bun.file(installedLocal).json()).toMatchObject({
+          name: "localdep",
+          version: "1.2.3",
+        });
+        expect(statSync(installedLocal).nlink).toBe(1);
       });
     }
   }

--- a/test/cli/install/bun-install-hardlink-fallback.test.ts
+++ b/test/cli/install/bun-install-hardlink-fallback.test.ts
@@ -2,68 +2,87 @@
 // hard links and fail linkat with EACCES or EPERM instead of EXDEV. The
 // hardlink install backend must fall back to copying files, like it already
 // does for EXDEV. https://github.com/oven-sh/bun/issues/36852
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { cpSync } from "node:fs";
 import { join } from "node:path";
 
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 
-const SHIM_C = /* c */ `
+const shimC = (errno: string) => /* c */ `
 #define _GNU_SOURCE
 #include <errno.h>
 
 int linkat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath,
            int flags) {
   (void)olddirfd; (void)oldpath; (void)newdirfd; (void)newpath; (void)flags;
-  errno = EACCES;
+  errno = ${errno};
   return -1;
 }
 
 int link(const char *oldpath, const char *newpath) {
   (void)oldpath; (void)newpath;
-  errno = EACCES;
+  errno = ${errno};
   return -1;
 }
 `;
 
-test.skipIf(!isLinux || !cc)("bun install falls back to copyfile when linkat fails with EACCES", async () => {
-  using dir = tempDir("hardlink-eacces-fallback", {
-    "shim.c": SHIM_C,
-    "package.json": JSON.stringify({
-      name: "hardlink-eacces-fallback",
-      dependencies: { bar: "file:./bar-0.0.2.tgz" },
-    }),
-  });
-  cpSync(join(import.meta.dir, "bar-0.0.2.tgz"), join(String(dir), "bar-0.0.2.tgz"));
+describe.skipIf(!isLinux || !cc)("hardlink backend falls back to copyfile", () => {
+  for (const errno of ["EACCES", "EPERM"]) {
+    for (const linker of ["hoisted", "isolated"]) {
+      test.concurrent(`linkat fails with ${errno}, ${linker} linker`, async () => {
+        using dir = tempDir(`hardlink-${errno}-${linker}`, {
+          "shim.c": shimC(errno),
+          "package.json": JSON.stringify({
+            name: "hardlink-fallback-test",
+            dependencies: { bar: "file:./bar-0.0.2.tgz" },
+          }),
+        });
+        cpSync(join(import.meta.dir, "bar-0.0.2.tgz"), join(String(dir), "bar-0.0.2.tgz"));
 
-  {
-    await using compile = Bun.spawn({
-      cmd: [cc!, "-shared", "-fPIC", "-o", "shim.so", "shim.c"],
-      cwd: String(dir),
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    expect(await compile.stderr.text()).toBe("");
-    expect(await compile.exited).toBe(0);
+        {
+          await using compile = Bun.spawn({
+            cmd: [cc!, "-shared", "-fPIC", "-o", "shim.so", "shim.c"],
+            cwd: String(dir),
+            env: bunEnv,
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [compileOut, compileErr, compileExit] = await Promise.all([
+            compile.stdout.text(),
+            compile.stderr.text(),
+            compile.exited,
+          ]);
+          expect(compileOut).toBe("");
+          expect(compileErr).toBe("");
+          expect(compileExit).toBe(0);
+        }
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "install", "--backend", "hardlink", "--linker", linker],
+          cwd: String(dir),
+          env: {
+            ...bunEnv,
+            BUN_INSTALL_CACHE_DIR: join(String(dir), "cache"),
+            LD_PRELOAD: join(String(dir), "shim.so"),
+          },
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([
+          proc.stdout.text(),
+          proc.stderr.text(),
+          proc.exited,
+        ]);
+        expect(stderr).not.toContain(errno);
+        expect(stdout).toMatch(/\d+ packages? installed/);
+        expect(exitCode).toBe(0);
+        expect(
+          await Bun.file(join(String(dir), "node_modules", "bar", "package.json")).json(),
+        ).toMatchObject({
+          name: "bar",
+          version: "0.0.2",
+        });
+      });
+    }
   }
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "install"],
-    cwd: String(dir),
-    env: {
-      ...bunEnv,
-      BUN_INSTALL_CACHE_DIR: join(String(dir), "cache"),
-      LD_PRELOAD: join(String(dir), "shim.so"),
-    },
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("EACCES");
-  expect(stdout).toContain("1 package installed");
-  expect(exitCode).toBe(0);
-  expect(await Bun.file(join(String(dir), "node_modules", "bar", "package.json")).json()).toMatchObject({
-    name: "bar",
-    version: "0.0.2",
-  });
 });

--- a/test/cli/install/bun-install-hardlink-fallback.test.ts
+++ b/test/cli/install/bun-install-hardlink-fallback.test.ts
@@ -68,17 +68,11 @@ describe.skipIf(!isLinux || !cc)("hardlink backend falls back to copyfile", () =
           },
           stderr: "pipe",
         });
-        const [stdout, stderr, exitCode] = await Promise.all([
-          proc.stdout.text(),
-          proc.stderr.text(),
-          proc.exited,
-        ]);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
         expect(stderr).not.toContain(errno);
         expect(stdout).toMatch(/\d+ packages? installed/);
         expect(exitCode).toBe(0);
-        expect(
-          await Bun.file(join(String(dir), "node_modules", "bar", "package.json")).json(),
-        ).toMatchObject({
+        expect(await Bun.file(join(String(dir), "node_modules", "bar", "package.json")).json()).toMatchObject({
           name: "bar",
           version: "0.0.2",
         });

--- a/test/cli/install/bun-install-hardlink-fallback.test.ts
+++ b/test/cli/install/bun-install-hardlink-fallback.test.ts
@@ -27,50 +27,43 @@ int link(const char *oldpath, const char *newpath) {
 }
 `;
 
-test.skipIf(!isLinux || !cc)(
-  "bun install falls back to copyfile when linkat fails with EACCES",
-  async () => {
-    using dir = tempDir("hardlink-eacces-fallback", {
-      "shim.c": SHIM_C,
-      "package.json": JSON.stringify({
-        name: "hardlink-eacces-fallback",
-        dependencies: { bar: "file:./bar-0.0.2.tgz" },
-      }),
-    });
-    cpSync(join(import.meta.dir, "bar-0.0.2.tgz"), join(String(dir), "bar-0.0.2.tgz"));
+test.skipIf(!isLinux || !cc)("bun install falls back to copyfile when linkat fails with EACCES", async () => {
+  using dir = tempDir("hardlink-eacces-fallback", {
+    "shim.c": SHIM_C,
+    "package.json": JSON.stringify({
+      name: "hardlink-eacces-fallback",
+      dependencies: { bar: "file:./bar-0.0.2.tgz" },
+    }),
+  });
+  cpSync(join(import.meta.dir, "bar-0.0.2.tgz"), join(String(dir), "bar-0.0.2.tgz"));
 
-    {
-      await using compile = Bun.spawn({
-        cmd: [cc!, "-shared", "-fPIC", "-o", "shim.so", "shim.c"],
-        cwd: String(dir),
-        env: bunEnv,
-        stderr: "pipe",
-      });
-      expect(await compile.stderr.text()).toBe("");
-      expect(await compile.exited).toBe(0);
-    }
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "install"],
+  {
+    await using compile = Bun.spawn({
+      cmd: [cc!, "-shared", "-fPIC", "-o", "shim.so", "shim.c"],
       cwd: String(dir),
-      env: {
-        ...bunEnv,
-        BUN_INSTALL_CACHE_DIR: join(String(dir), "cache"),
-        LD_PRELOAD: join(String(dir), "shim.so"),
-      },
+      env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
-    expect(stderr).not.toContain("EACCES");
-    expect(stdout).toContain("1 package installed");
-    expect(exitCode).toBe(0);
-    expect(await Bun.file(join(String(dir), "node_modules", "bar", "package.json")).json()).toMatchObject({
-      name: "bar",
-      version: "0.0.2",
-    });
-  },
-);
+    expect(await compile.stderr.text()).toBe("");
+    expect(await compile.exited).toBe(0);
+  }
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: join(String(dir), "cache"),
+      LD_PRELOAD: join(String(dir), "shim.so"),
+    },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("EACCES");
+  expect(stdout).toContain("1 package installed");
+  expect(exitCode).toBe(0);
+  expect(await Bun.file(join(String(dir), "node_modules", "bar", "package.json")).json()).toMatchObject({
+    name: "bar",
+    version: "0.0.2",
+  });
+});


### PR DESCRIPTION
Fixes #36852

### Repro

On Android's FUSE-backed SDCARD (`/storage/emulated/0` in Termux), hard links are not supported and `linkat` fails with `EACCES`/`EPERM`:

```
EACCES: failed copying files from cache to destination for package typescript
Failed to install 1 package
```

Reproducible on Linux with an `LD_PRELOAD` shim that makes `linkat` return `EACCES`: `bun install` fails, while `bun install --backend=copyfile` succeeds under the same shim.

### Cause

The hardlink install backend (the default on Linux) only falls back to the copyfile backend when `linkat` fails with `EXDEV`. Any other errno, including `EACCES`/`EPERM` (what FUSE returns for unsupported hard links), aborts the package install. The same EXDEV-only check exists in the isolated linker's two hardlink fallback sites.

### Fix

Treat `EACCES` and `EPERM` from `linkat` like `EXDEV` and fall back to the copyfile backend, in both the hoisted installer (`install_with_hardlink`) and the isolated installer. A genuine destination permission error is not masked, since the copy attempt then fails with the same errno.

### Verification

New test `test/cli/install/bun-install-hardlink-fallback.test.ts` compiles an `LD_PRELOAD` shim that fails `linkat` with `EACCES` or `EPERM` and asserts `bun install` succeeds with both the hoisted and isolated linkers (Linux glibc only; bun-musl is statically linked so the shim cannot intercept). `nlink === 1` on the installed files proves the copy fallback ran rather than a real hardlink. All four cases fail on current bun and pass with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-hardlink-fallback.test.ts

<!-- robobun:evidence:end -->