### PR TITLE
test: deflake tty-reopen-after-stdin-eof under bun test --parallel (SIGTTOU hang on Alpine)

### DIFF
--- a/test/regression/issue/tty-reopen-after-stdin-eof.test.ts
+++ b/test/regression/issue/tty-reopen-after-stdin-eof.test.ts
@@ -1,44 +1,65 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
+
+// Run `sh -c <cmd>` inside a fresh PTY session and return the child's output
+// as LF-normalized lines. Bun.spawn's inline `terminal:` option creates the
+// PTY and runs setsid()+TIOCSCTTY in the child, so the child is always the
+// foreground process group of its own controlling terminal. That avoids the
+// SIGTTOU stop the no-`script` fallback used to hit under
+// `bun test --parallel`, where the worker is a background pgrp.
+async function runInPty(shellCmd: string, cwd: string): Promise<{ lines: string[]; exitCode: number }> {
+  const chunks: Uint8Array[] = [];
+  await using proc = Bun.spawn({
+    cmd: ["sh", "-c", shellCmd],
+    env: bunEnv,
+    cwd,
+    terminal: {
+      data(_term, data) {
+        chunks.push(data.slice());
+      },
+    },
+  });
+  const exitCode = await proc.exited;
+  const output = Buffer.concat(chunks).toString("utf8");
+  const lines = output
+    .split(/\r?\n/)
+    .map(l => l.trim())
+    .filter(Boolean);
+  return { lines, exitCode };
+}
 
 // Skip on Windows as it doesn't have /dev/tty
 test.skipIf(isWindows)("can reopen /dev/tty after stdin EOF for interactive session", async () => {
   // This test ensures that Bun can reopen /dev/tty after stdin reaches EOF,
   // which is needed for tools like Claude Code that read piped input then
   // switch to interactive mode.
-
-  // Create test script that reads piped input then reopens TTY
   const testScript = `
     const fs = require('fs');
     const tty = require('tty');
-    
-    // Read piped input
+
     let inputData = '';
     process.stdin.on('data', (chunk) => {
       inputData += chunk;
     });
-    
+
     process.stdin.on('end', () => {
       console.log('GOT_INPUT:' + inputData.trim());
-      
-      // After stdin ends, reopen TTY for interaction
       try {
         const fd = fs.openSync('/dev/tty', 'r+');
         console.log('OPENED_TTY:true');
-        
+
         const ttyStream = new tty.ReadStream(fd);
         console.log('CREATED_STREAM:true');
         console.log('POS:' + ttyStream.pos);
         console.log('START:' + ttyStream.start);
-        
-        // Verify we can set raw mode
+
         if (typeof ttyStream.setRawMode === 'function') {
           ttyStream.setRawMode(true);
           console.log('SET_RAW_MODE:true');
           ttyStream.setRawMode(false);
         }
-        
+
         ttyStream.destroy();
         fs.closeSync(fd);
         console.log('SUCCESS:true');
@@ -48,81 +69,27 @@ test.skipIf(isWindows)("can reopen /dev/tty after stdin EOF for interactive sess
         process.exit(1);
       }
     });
-    
+
     if (process.stdin.isTTY) {
       console.log('ERROR:NO_PIPED_INPUT');
       process.exit(1);
     }
   `;
 
-  using dir = tempDir("tty-reopen", {});
+  using dir = tempDir("tty-reopen", { "test.js": testScript });
   const scriptPath = join(String(dir), "test.js");
-  await Bun.write(scriptPath, testScript);
 
-  // Check if script command is available (might not be on Alpine by default)
-  const hasScript = Bun.which("script");
-  if (!hasScript) {
-    // Try without script - if /dev/tty isn't available, test will fail appropriately
-    await using proc = Bun.spawn({
-      cmd: ["sh", "-c", `echo "test input" | ${bunExe()} ${scriptPath}`],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+  const { lines, exitCode } = await runInPty(`echo 'test input' | ${bunExe()} ${scriptPath}`, String(dir));
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    // If it fails with ENXIO, skip the test
-    if (exitCode !== 0 && stdout.includes("ERROR:ENXIO")) {
-      console.log("Skipping test: requires 'script' command for PTY simulation");
-      return;
-    }
-
-    // Otherwise check results - snapshot first to see what happened
-    const output = stdout + (stderr ? "\nSTDERR:\n" + stderr : "");
-    expect(normalizeBunSnapshot(output, dir)).toMatchInlineSnapshot(`
-      "GOT_INPUT:test input
-      OPENED_TTY:true
-      CREATED_STREAM:true
-      POS:undefined
-      START:undefined
-      SET_RAW_MODE:true
-      SUCCESS:true"
-    `);
-    expect(exitCode).toBe(0);
-    return;
-  }
-
-  // Use script command to provide a PTY environment
-  // This simulates a real terminal where /dev/tty is available
-  // macOS and Linux have different script command syntax
-  const isMacOS = process.platform === "darwin";
-  const scriptCmd = isMacOS
-    ? ["script", "-q", "/dev/null", "sh", "-c", `echo "test input" | ${bunExe()} ${scriptPath}`]
-    : ["script", "-q", "-c", `echo "test input" | ${bunExe()} ${scriptPath}`, "/dev/null"];
-
-  await using proc = Bun.spawn({
-    cmd: scriptCmd,
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  // First snapshot the combined output to see what actually happened
-  const output = stdout + (stderr ? "\nSTDERR:\n" + stderr : "");
-  // Use JSON.stringify to make control characters visible
-  const jsonOutput = JSON.stringify(normalizeBunSnapshot(output, dir));
-  // macOS script adds control characters, Linux doesn't
-  const expected = isMacOS
-    ? `"^D\\b\\bGOT_INPUT:test input\\nOPENED_TTY:true\\nCREATED_STREAM:true\\nPOS:undefined\\nSTART:undefined\\nSET_RAW_MODE:true\\nSUCCESS:true"`
-    : `"GOT_INPUT:test input\\nOPENED_TTY:true\\nCREATED_STREAM:true\\nPOS:undefined\\nSTART:undefined\\nSET_RAW_MODE:true\\nSUCCESS:true"`;
-  expect(jsonOutput).toBe(expected);
-
-  // Then check exit code
+  expect(lines).toEqual([
+    "GOT_INPUT:test input",
+    "OPENED_TTY:true",
+    "CREATED_STREAM:true",
+    "POS:undefined",
+    "START:undefined",
+    "SET_RAW_MODE:true",
+    "SUCCESS:true",
+  ]);
   expect(exitCode).toBe(0);
 });
 
@@ -131,40 +98,34 @@ test.skipIf(isWindows)("TTY ReadStream should not set position for character dev
   // This test ensures that when creating a ReadStream with an fd (like for TTY),
   // the position remains undefined so that fs.read uses read() syscall instead
   // of pread() which would fail with ESPIPE on character devices.
-
   const testScript = `
     const fs = require('fs');
     const tty = require('tty');
-    
+
     try {
       const fd = fs.openSync('/dev/tty', 'r+');
       const ttyStream = new tty.ReadStream(fd);
-      
-      // These should be undefined for TTY streams
+
       console.log('POS_TYPE:' + typeof ttyStream.pos);
       console.log('START_TYPE:' + typeof ttyStream.start);
-      
-      // Monkey-patch fs.read to check what position is passed
+
       const originalRead = fs.read;
       let capturedPosition = 'NOT_CALLED';
       let readCalled = false;
       fs.read = function(fd, buffer, offset, length, position, callback) {
         capturedPosition = position;
         readCalled = true;
-        // Don't actually read, just call callback with 0 bytes
         process.nextTick(() => callback(null, 0, buffer));
         return originalRead;
       };
-      
-      // Set up data handler to trigger read
+
       ttyStream.on('data', () => {});
       ttyStream.on('error', () => {});
-      
-      // Immediately log the state since we don't actually need to wait for a real read
+
       console.log('POSITION_PASSED:' + capturedPosition);
       console.log('POSITION_TYPE:' + typeof capturedPosition);
       console.log('READ_CALLED:' + readCalled);
-      
+
       ttyStream.destroy();
       fs.closeSync(fd);
       process.exit(0);
@@ -174,69 +135,17 @@ test.skipIf(isWindows)("TTY ReadStream should not set position for character dev
     }
   `;
 
-  using dir = tempDir("tty-position", {});
+  using dir = tempDir("tty-position", { "test.js": testScript });
   const scriptPath = join(String(dir), "test.js");
-  await Bun.write(scriptPath, testScript);
 
-  // Check if script command is available
-  const hasScript = Bun.which("script");
-  if (!hasScript) {
-    // Try without script
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), scriptPath],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+  const { lines, exitCode } = await runInPty(`${bunExe()} ${scriptPath}`, String(dir));
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    if (exitCode !== 0 && stdout.includes("ERROR:ENXIO")) {
-      console.log("Skipping test: requires 'script' command for PTY simulation");
-      return;
-    }
-
-    // Snapshot first to see what happened
-    const output = stdout + (stderr ? "\nSTDERR:\n" + stderr : "");
-    expect(normalizeBunSnapshot(output, dir)).toMatchInlineSnapshot(`
-      "POS_TYPE:undefined
-      START_TYPE:undefined
-      POSITION_PASSED:NOT_CALLED
-      POSITION_TYPE:string
-      READ_CALLED:false"
-    `);
-    expect(exitCode).toBe(0);
-    return;
-  }
-
-  // Use script command to provide a PTY environment
-  // macOS and Linux have different script command syntax
-  const isMacOS = process.platform === "darwin";
-  const scriptCmd = isMacOS
-    ? ["script", "-q", "/dev/null", bunExe(), scriptPath]
-    : ["script", "-q", "-c", `${bunExe()} ${scriptPath}`, "/dev/null"];
-
-  await using proc = Bun.spawn({
-    cmd: scriptCmd,
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  // First snapshot the combined output to see what actually happened
-  const output = stdout + (stderr ? "\nSTDERR:\n" + stderr : "");
-  // Use JSON.stringify to make control characters visible
-  const jsonOutput = JSON.stringify(normalizeBunSnapshot(output, dir));
-  // macOS script adds control characters, Linux doesn't
-  const expected = isMacOS
-    ? `"^D\\b\\bPOS_TYPE:undefined\\nSTART_TYPE:undefined\\nPOSITION_PASSED:NOT_CALLED\\nPOSITION_TYPE:string\\nREAD_CALLED:false"`
-    : `"POS_TYPE:undefined\\nSTART_TYPE:undefined\\nPOSITION_PASSED:NOT_CALLED\\nPOSITION_TYPE:string\\nREAD_CALLED:false"`;
-  expect(jsonOutput).toBe(expected);
-
-  // Then check exit code
+  expect(lines).toEqual([
+    "POS_TYPE:undefined",
+    "START_TYPE:undefined",
+    "POSITION_PASSED:NOT_CALLED",
+    "POSITION_TYPE:string",
+    "READ_CALLED:false",
+  ]);
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Problem

`test/regression/issue/tty-reopen-after-stdin-eof.test.ts` is the single biggest source of "flaky" warnings in CI: it fails in the parallel batch on **every** Alpine 3.23 build (both x64 and aarch64), then passes on the solo retry. Across the last 400 completed builds it accounts for 340 flaky-annotation entries.

Signature from any recent main build (e.g. [88187](https://buildkite.com/bun/bun/builds/88187)):

```
Interrupted while still running:
  test/regression/issue/tty-reopen-after-stdin-eof.test.ts (245s)
...
parallel bucket: retrying 1 failed and 0 unfinished file(s) one at a time
--- [98/286] test/regression/issue/tty-reopen-after-stdin-eof.test.ts
2 pass / 0 fail ... [72.00ms]
```

The parallel batch idles for ~4 minutes waiting on this one file before the runner's idle timeout kills it.

## Cause

The test wraps its child in `script(1)` to provide a PTY. Alpine images don't have `script`, so the test falls back to spawning `sh -c "echo ... | bun test.js"` directly and relying on the inherited `/dev/tty`.

`bun test --parallel` spawns each worker in its own process group via `setpgid(0, 0)` (same session, no `setsid`). That puts the worker, and everything it spawns, in a **background** process group of the inherited controlling terminal. When the child script then calls `tty.ReadStream#setRawMode(true)`, the `tcsetattr()` inside `Bun__ttySetMode` is issued from a background pgrp, so the kernel delivers `SIGTTOU` and the process is **stopped** (not killed). The test hangs until the runner gives up.

On the solo retry the test runs in the coordinator's (foreground) pgrp, so `tcsetattr()` succeeds. Other Linux lanes have `script`, which creates a fresh session+PTY, so they never hit the fallback.

## Repro

```python
# with a controlling TTY present, `script` hidden from PATH, and >=2 files so
# --parallel actually forks workers:
bun test --parallel=2 test/regression/issue/06467.test.ts \
         test/regression/issue/tty-reopen-after-stdin-eof.test.ts
# -> hangs indefinitely after the first file
```

Standalone confirmation of the mechanism (python):

```
GRANDCHILD: opened /dev/tty fd=3
GRANDCHILD: tcgetattr ok
CHILD: grandchild STOPPED by signal 22 (SIGTTOU=22)
```

## Fix

Replace the `script`/no-`script` branching with `Bun.spawn`'s inline `terminal:` option, which creates a PTY and runs `setsid()` + `ioctl(TIOCSCTTY)` in the child. The spawned `sh` is then always the foreground process group of its own controlling terminal, so the inner `setRawMode()` can never SIGTTOU regardless of where the test itself sits in the process tree.

This also removes:
- the dependency on an external `script` binary
- the macOS-vs-Linux `script` argv differences
- the macOS `^D\b\b` output munging
- the "skip on ENXIO" fallback

Net -91 lines.

## Verification

```
# before, Alpine-equivalent (script hidden, ctty present, --parallel)
=== TIMED OUT after 25s (HANG REPRODUCED) ===

# after, same scenario
3 pass / 0 fail ... [126.00ms]
=== DONE exit=0 in 0.1s ===
```

Also verified the new test passes on macOS arm64 (via `Bun.Terminal`, no `^D` prefix). The assertions on `POS:undefined`/`START:undefined` still exercise the original #22591 regression.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->