### PR TITLE
Bun.serve: hold a ref for FileResponseStream's queued eof task

### DIFF
--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1288,6 +1288,15 @@ fn __bun_release_task_at_shutdown(task: bun_event_loop::Task) -> bool {
             };
             true
         }
+        task_tag::FileResponseStreamEof => {
+            // SAFETY: `on_read_chunk` took a ref for the queued task; adopt it.
+            drop(unsafe {
+                bun_ptr::ScopedRef::<crate::server::FileResponseStream>::adopt(
+                    task.ptr.cast::<crate::server::FileResponseStream>(),
+                )
+            });
+            true
+        }
         // `AsyncFSTask`s are `Box::leak`'d in `create()` and freed by
         // `destroy()` (called from `run_from_js_thread`'s scopeguard).
         // `destroy()` resets `JSPromiseStrong` (touches the StrongRootBlock list)

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -298,13 +298,11 @@ pub(crate) fn run_task(
             holder.run()?;
         }
         task_tag::FileResponseStreamEof => {
-            // SAFETY: tag identifies pointee — the in-flight read holds a ref
-            // on the stream until `on_reader_done` releases it; the guard keeps
-            // that release from freeing the stream inside its own frame.
             let stream = cast_ptr!(crate::server::FileResponseStream);
-            // SAFETY: tag identifies pointee; the in-flight read holds a ref.
+            // SAFETY: tag identifies pointee; `on_read_chunk` took a ref for
+            // this task at enqueue time which this guard adopts.
             let _pin =
-                unsafe { bun_ptr::ScopedRef::<crate::server::FileResponseStream>::new(stream) };
+                unsafe { bun_ptr::ScopedRef::<crate::server::FileResponseStream>::adopt(stream) };
             // SAFETY: `stream` is live for this call (pinned above).
             unsafe { (*stream).on_reader_done() };
         }

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -283,12 +283,8 @@ impl FileResponseStream {
                     // SAFETY: reader entry point; `pause()` does not call back
                     // into this object.
                     self.reader_mut().pause();
-                    // The queued task holds its own ref on `*self`, adopted in
-                    // the `task_tag::FileResponseStreamEof` dispatch arm. The
-                    // in-flight read ref is not sufficient: `read_with_fn`'s
-                    // error arm delivers buffered data here and then calls
-                    // `on_reader_error`, which consumes that ref before the
-                    // task runs.
+                    // Ref for the queued task; adopted in the
+                    // `FileResponseStreamEof` dispatch/shutdown arms.
                     self.ref_();
                     // SAFETY: `vm.event_loop()` returns the live JS loop.
                     unsafe {

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -283,10 +283,14 @@ impl FileResponseStream {
                     // SAFETY: reader entry point; `pause()` does not call back
                     // into this object.
                     self.reader_mut().pause();
-                    // SAFETY: `vm.event_loop()` returns the live JS loop; the
-                    // ref taken for the in-flight read keeps `*self` alive until
-                    // the `task_tag::FileResponseStreamEof` arm calls
-                    // `on_reader_done`.
+                    // The queued task holds its own ref on `*self`, adopted in
+                    // the `task_tag::FileResponseStreamEof` dispatch arm. The
+                    // in-flight read ref is not sufficient: `read_with_fn`'s
+                    // error arm delivers buffered data here and then calls
+                    // `on_reader_error`, which consumes that ref before the
+                    // task runs.
+                    self.ref_();
+                    // SAFETY: `vm.event_loop()` returns the live JS loop.
                     unsafe {
                         (*self.vm.get().event_loop()).enqueue_task(Task::init(self.as_ptr()));
                     }

--- a/test/js/bun/http/serve-file-slice-read-error.test.ts
+++ b/test/js/bun/http/serve-file-slice-read-error.test.ts
@@ -246,11 +246,7 @@ test.skipIf(!isLinux || !cc)(
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Three requests; one injected EIO on request #1's second read. The slice
     // was already satisfied by read #1, so all three responses carry the full

--- a/test/js/bun/http/serve-file-slice-read-error.test.ts
+++ b/test/js/bun/http/serve-file-slice-read-error.test.ts
@@ -240,9 +240,14 @@ test.skipIf(!isLinux || !cc)(
   async () => {
     expect(supervisorBin).toBeDefined();
 
+    // LeakSanitizer's StopTheWorld PTRACE_ATTACHes its own threads; that
+    // fails (EPERM) when the process is already ptraced and LSan aborts
+    // ("LeakSanitizer does not work under ptrace"). Disable it for the
+    // traced child only.
+    const asanOpts = [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":");
     await using proc = Bun.spawn({
       cmd: [supervisorBin!, served, "2", "--", bunExe(), join(String(dir), "fixture.mjs"), served],
-      env: bunEnv,
+      env: { ...bunEnv, ASAN_OPTIONS: asanOpts, LSAN_OPTIONS: "detect_leaks=0" },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/bun/http/serve-file-slice-read-error.test.ts
+++ b/test/js/bun/http/serve-file-slice-read-error.test.ts
@@ -1,0 +1,267 @@
+// Bun.serve returning `Bun.file(path).slice(0, n)` where a read() on the file
+// fails after the first read has already returned more than `n` bytes. Before
+// the fix, FileResponseStream::on_read_chunk enqueued a deferred eof task
+// without holding a ref on the stream, and the read-error path
+// (on_reader_error) consumed the in-flight read ref and finished the stream,
+// so the stream was freed before the queued task ran (heap-use-after-free
+// under ASAN).
+//
+// A small ptrace supervisor injects EIO on the second read() of the served
+// file. Bun issues read() as a raw syscall on Linux (rustix linux_raw
+// backend), so LD_PRELOAD cannot intercept it.
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { join } from "node:path";
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+
+// Usage: fail-nth-read <path> <n> -- <cmd> [args...]
+// Makes the <n>th read() syscall whose fd refers to <path> return -EIO.
+const SUPERVISOR_C = /* c */ `
+#define _GNU_SOURCE
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ptrace.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/user.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#if defined(__aarch64__)
+  #include <linux/elf.h>
+  #include <sys/uio.h>
+#endif
+
+#if defined(__x86_64__)
+  #define SYS_READ_NR 0
+  typedef struct user_regs_struct regs_t;
+  static long reg_nr(regs_t *r) { return (long)r->orig_rax; }
+  static long reg_arg0(regs_t *r) { return (long)r->rdi; }
+  static void reg_set_ret(regs_t *r, long v) { r->rax = (unsigned long long)v; }
+  static int get_regs(pid_t t, regs_t *r) { return ptrace(PTRACE_GETREGS, t, 0, r); }
+  static int set_regs(pid_t t, regs_t *r) { return ptrace(PTRACE_SETREGS, t, 0, r); }
+#elif defined(__aarch64__)
+  #define SYS_READ_NR 63
+  typedef struct user_regs_struct regs_t;
+  static long reg_nr(regs_t *r) { return (long)r->regs[8]; }
+  static long reg_arg0(regs_t *r) { return (long)r->regs[0]; }
+  static void reg_set_ret(regs_t *r, long v) { r->regs[0] = (unsigned long long)v; }
+  static int get_regs(pid_t t, regs_t *r) {
+    struct iovec io = { r, sizeof(*r) };
+    return ptrace(PTRACE_GETREGSET, t, (void *)NT_PRSTATUS, &io);
+  }
+  static int set_regs(pid_t t, regs_t *r) {
+    struct iovec io = { r, sizeof(*r) };
+    return ptrace(PTRACE_SETREGSET, t, (void *)NT_PRSTATUS, &io);
+  }
+#else
+  #error unsupported arch
+#endif
+
+/* Per-tid syscall enter/exit toggle + pending-poison flag. */
+#define MAX_TIDS 256
+static pid_t tid_tab[MAX_TIDS];
+static unsigned char in_call[MAX_TIDS];
+static unsigned char poison[MAX_TIDS];
+static int slot(pid_t t) {
+  int i, free_i = -1;
+  for (i = 0; i < MAX_TIDS; i++) {
+    if (tid_tab[i] == t) return i;
+    if (tid_tab[i] == 0 && free_i < 0) free_i = i;
+  }
+  if (free_i >= 0) { tid_tab[free_i] = t; return free_i; }
+  return 0;
+}
+static void drop(pid_t t) {
+  int i;
+  for (i = 0; i < MAX_TIDS; i++) if (tid_tab[i] == t) {
+    tid_tab[i] = 0; in_call[i] = 0; poison[i] = 0;
+  }
+}
+
+int main(int argc, char **argv) {
+  if (argc < 5 || strcmp(argv[3], "--") != 0) {
+    fprintf(stderr, "usage: %s <path> <n> -- <cmd> [args...]\\n", argv[0]);
+    return 2;
+  }
+  const char *target_path = argv[1];
+  long fail_n = strtol(argv[2], NULL, 10);
+  char **cmd = &argv[4];
+
+  struct stat ts;
+  if (stat(target_path, &ts) != 0) { perror("stat target"); return 2; }
+
+  pid_t child = fork();
+  if (child < 0) { perror("fork"); return 2; }
+  if (child == 0) {
+    if (ptrace(PTRACE_TRACEME, 0, 0, 0) != 0) { perror("TRACEME"); _exit(126); }
+    raise(SIGSTOP);
+    execvp(cmd[0], cmd);
+    perror("execvp");
+    _exit(127);
+  }
+
+  int st;
+  if (waitpid(child, &st, 0) < 0) { perror("waitpid initial"); return 2; }
+  long opts = PTRACE_O_TRACESYSGOOD | PTRACE_O_TRACECLONE | PTRACE_O_TRACEFORK |
+              PTRACE_O_TRACEVFORK | PTRACE_O_TRACEEXEC | PTRACE_O_EXITKILL;
+  if (ptrace(PTRACE_SETOPTIONS, child, 0, opts) != 0) { perror("SETOPTIONS"); return 2; }
+  if (ptrace(PTRACE_SYSCALL, child, 0, 0) != 0) { perror("SYSCALL initial"); return 2; }
+
+  long match_count = 0;
+  int exit_code = -1;
+
+  for (;;) {
+    pid_t t = waitpid(-1, &st, __WALL);
+    if (t < 0) {
+      if (errno == ECHILD) break;
+      if (errno == EINTR) continue;
+      perror("waitpid"); return 2;
+    }
+    if (WIFEXITED(st) || WIFSIGNALED(st)) {
+      if (t == child) {
+        exit_code = WIFEXITED(st) ? WEXITSTATUS(st) : 128 + WTERMSIG(st);
+      }
+      drop(t);
+      continue;
+    }
+    if (!WIFSTOPPED(st)) continue;
+
+    int sig = WSTOPSIG(st);
+    unsigned ev = (unsigned)(st >> 16);
+    if (ev == PTRACE_EVENT_CLONE || ev == PTRACE_EVENT_FORK || ev == PTRACE_EVENT_VFORK) {
+      ptrace(PTRACE_SYSCALL, t, 0, 0);
+      continue;
+    }
+    if (ev == PTRACE_EVENT_EXEC) {
+      /* execve's syscall-exit-stop follows; keep the toggle consistent. */
+      in_call[slot(t)] = 1;
+      poison[slot(t)] = 0;
+      ptrace(PTRACE_SYSCALL, t, 0, 0);
+      continue;
+    }
+    if (sig == (SIGTRAP | 0x80)) {
+      int s = slot(t);
+      in_call[s] ^= 1;
+      regs_t r;
+      if (get_regs(t, &r) != 0) { ptrace(PTRACE_SYSCALL, t, 0, 0); continue; }
+
+      if (in_call[s]) { /* syscall entry */
+        if (reg_nr(&r) == SYS_READ_NR) {
+          long fd = reg_arg0(&r);
+          char linkpath[64];
+          struct stat fs;
+          snprintf(linkpath, sizeof linkpath, "/proc/%d/fd/%ld", (int)t, fd);
+          if (stat(linkpath, &fs) == 0 &&
+              fs.st_dev == ts.st_dev && fs.st_ino == ts.st_ino) {
+            match_count++;
+            if (match_count == fail_n) poison[s] = 1;
+          }
+        }
+      } else { /* syscall exit */
+        if (poison[s]) {
+          poison[s] = 0;
+          reg_set_ret(&r, -EIO);
+          set_regs(t, &r);
+        }
+      }
+      ptrace(PTRACE_SYSCALL, t, 0, 0);
+      continue;
+    }
+    /* Plain SIGTRAP / SIGSTOP are ptrace artifacts; forward real signals so
+       ASAN's SIGSEGV/SIGABRT handler runs. */
+    if (sig == SIGTRAP || sig == SIGSTOP) sig = 0;
+    ptrace(PTRACE_SYSCALL, t, 0, (void *)(long)sig);
+  }
+
+  fprintf(stderr, "[fail-nth-read] matched read() calls on target: %ld\\n", match_count);
+  return exit_code < 0 ? 1 : exit_code;
+}
+`;
+
+// The file is 4 KiB; slicing to 2 KiB keeps us on the BufferedReader path
+// (below the 1 MiB sendfile threshold) and makes read #1 (4096 bytes) exceed
+// max_size=2048 so on_read_chunk enqueues the eof task with state==Progress.
+const FIXTURE_JS = /* js */ `
+const path = process.argv[2];
+const server = Bun.serve({
+  port: 0,
+  hostname: "127.0.0.1",
+  fetch() { return new Response(Bun.file(path).slice(0, 2048)); },
+});
+let okBodies = 0;
+for (let i = 0; i < 3; i++) {
+  try {
+    const r = await fetch(\`http://127.0.0.1:\${server.port}/\`);
+    const b = await r.arrayBuffer();
+    if (b.byteLength === 2048) okBodies++;
+  } catch {}
+}
+server.stop(true);
+console.log("DONE " + okBodies);
+`;
+
+let dir: ReturnType<typeof tempDir> | undefined;
+let supervisorBin: string | undefined;
+let served: string;
+
+beforeAll(async () => {
+  if (!isLinux || !cc) return;
+  dir = tempDir("serve-file-slice-read-error", {
+    "supervisor.c": SUPERVISOR_C,
+    "fixture.mjs": FIXTURE_JS,
+    "served.bin": Buffer.alloc(4096, 97).toString("latin1"),
+  });
+  served = join(String(dir), "served.bin");
+  const out = join(String(dir), "supervisor");
+  await using proc = Bun.spawn({
+    cmd: [cc, "-O0", "-o", out, join(String(dir), "supervisor.c")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (ccExit !== 0) {
+    throw new Error(`supervisor compile failed:\n${ccErr || ccOut}`);
+  }
+  supervisorBin = out;
+});
+
+afterAll(() => {
+  dir?.[Symbol.dispose]();
+});
+
+test.skipIf(!isLinux || !cc)(
+  "Bun.serve Bun.file().slice() survives a read() error after the slice is satisfied",
+  async () => {
+    expect(supervisorBin).toBeDefined();
+
+    await using proc = Bun.spawn({
+      cmd: [supervisorBin!, served, "2", "--", bunExe(), join(String(dir), "fixture.mjs"), served],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // Three requests; one injected EIO on request #1's second read. The slice
+    // was already satisfied by read #1, so all three responses carry the full
+    // 2048 bytes.
+    expect({ stdout: stdout.trim(), stderr }).toEqual({
+      stdout: "DONE 3",
+      stderr: expect.stringContaining("matched read() calls on target:"),
+    });
+    // Injection sanity: each request does two read()s on the served file.
+    const m = stderr.match(/matched read\(\) calls on target:\s*(\d+)/);
+    expect(Number(m?.[1])).toBeGreaterThanOrEqual(2);
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
## Repro

A `Bun.serve` handler returns `new Response(Bun.file(path).slice(0, n))` for a file larger than `n`, and the second `read()` on that file fails (transient disk/NFS/FUSE error). Under ASAN:

```
AddressSanitizer: heap-use-after-free
READ of size 4
    bun_ptr::ScopedRef<FileResponseStream>::new   src/ptr/ref_count.rs:931
    bun_runtime::dispatch::run_task               src/runtime/dispatch.rs:307
freed by:
    ScopedRef<FileResponseStream>::drop
    FileResponseStream::start                     src/runtime/server/FileResponseStream.rs:247
    RequestContext::do_sendfile                   src/runtime/server/RequestContext.rs:1944
```

Reproduced with a ptrace supervisor that injects `EIO` on the second `read()` of the served file (Bun's `read()` is a raw syscall via rustix, so LD_PRELOAD can't intercept it).

## Cause

`PosixBufferedReader::read_with_fn`'s error arm first flushes buffered bytes through `on_read_chunk(.., Progress)`, then calls `on_reader_error`. When the buffered chunk satisfies `max_size`, `on_read_chunk` enqueues a `FileResponseStreamEof` task and ends the response. The old SAFETY comment assumed the in-flight read ref (`READ_REF_HELD`) keeps the stream alive until that task runs, but `on_reader_error` calls `take_read_ref()` and `finish()` in the same frame, dropping that ref and the owner ref. Back in `start()` the scope guard drops the last ref and frees the `Box` while the task is still queued.

## Fix

The task takes its own ref at enqueue time; the `FileResponseStreamEof` dispatch arm adopts it instead of bumping a fresh one. `on_reader_done`/`finish()` are already idempotent, so a task that runs after the error path has already finished the stream is a no-op.

## Verification

```
# without fix (git stash -- src/): ASAN heap-use-after-free, exit 1
# with fix:
bun bd test test/js/bun/http/serve-file-slice-read-error.test.ts
(pass) Bun.serve Bun.file().slice() survives a read() error after the slice is satisfied [406.94ms]
```

`test/js/bun/http/bun-serve-file.test.ts` (104 tests) passes unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve-file-slice-read-error.test.ts

<!-- robobun:evidence:end -->