### PR TITLE
timers: reschedule timer when _idleStart is written

### DIFF
--- a/src/runtime/timer/TimeoutObject.rs
+++ b/src/runtime/timer/TimeoutObject.rs
@@ -122,11 +122,14 @@ impl TimeoutObject {
     }
 
     pub(crate) fn set_idle_start(
-        _this: &Self,
+        this: &Self,
         this_value: JSValue,
         global: &JSGlobalObject,
         value: JSValue,
     ) {
+        if let Some(ms) = value.get_number() {
+            this.internals.set_idle_start(ms);
+        }
         js::idle_start_set_cached(this_value, global, value);
     }
 }

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -940,6 +940,35 @@ impl TimerObjectInternals {
         Ok(this_value)
     }
 
+    /// Setter body for `Timeout#_idleStart`. Node computes a timer's deadline
+    /// as `_idleStart + _idleTimeout`, so writing `_idleStart` moves the
+    /// deadline. Next.js relies on `t2._idleStart = t1._idleStart` to make two
+    /// `setTimeout(fn)` calls fire in the same event-loop turn (before any
+    /// `setImmediate` scheduled from `t1`'s callback).
+    pub(crate) fn set_idle_start(&self, idle_start_ms: f64) {
+        if self.flags.get().kind() == Kind::SetImmediate
+            || self.flags.get().has_cleared_timer()
+            || self.event_loop_timer_state() != EventLoopTimerState::ACTIVE
+            || !idle_start_ms.is_finite()
+        {
+            return;
+        }
+
+        let state = crate::jsc_hooks::runtime_state();
+        debug_assert!(!state.is_null(), "RuntimeState not installed");
+
+        let scheduled_time =
+            Timespec::EPOCH.add_ms(idle_start_ms as i64 + i64::from(self.interval.get()));
+        // SAFETY: `state` is the boxed per-thread `RuntimeState`; fresh
+        // `&mut` to `.timer` for this call only. The timer is ACTIVE so
+        // `update()` removes then re-inserts with no refcount change.
+        unsafe {
+            (*state)
+                .timer
+                .update(self.event_loop_timer(), &scheduled_time)
+        };
+    }
+
     pub(crate) fn do_refresh(
         &self,
         global_object: &JSGlobalObject,

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -957,8 +957,8 @@ impl TimerObjectInternals {
         let state = crate::jsc_hooks::runtime_state();
         debug_assert!(!state.is_null(), "RuntimeState not installed");
 
-        let scheduled_time =
-            Timespec::EPOCH.add_ms(idle_start_ms as i64 + i64::from(self.interval.get()));
+        let scheduled_time = Timespec::EPOCH
+            .add_ms((idle_start_ms as i64).saturating_add(i64::from(self.interval.get())));
         // SAFETY: `state` is the boxed per-thread `RuntimeState`; fresh
         // `&mut` to `.timer` for this call only. The timer is ACTIVE so
         // `update()` removes then re-inserts with no refcount change.

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -940,11 +940,8 @@ impl TimerObjectInternals {
         Ok(this_value)
     }
 
-    /// Setter body for `Timeout#_idleStart`. Node computes a timer's deadline
-    /// as `_idleStart + _idleTimeout`, so writing `_idleStart` moves the
-    /// deadline. Next.js relies on `t2._idleStart = t1._idleStart` to make two
-    /// `setTimeout(fn)` calls fire in the same event-loop turn (before any
-    /// `setImmediate` scheduled from `t1`'s callback).
+    /// Node's deadline is `_idleStart + _idleTimeout`; writing `_idleStart`
+    /// must move the heap entry so `t2._idleStart = t1._idleStart` works.
     pub(crate) fn set_idle_start(&self, idle_start_ms: f64) {
         if self.flags.get().kind() == Kind::SetImmediate
             || self.flags.get().has_cleared_timer()

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -954,8 +954,10 @@ impl TimerObjectInternals {
         let state = crate::jsc_hooks::runtime_state();
         debug_assert!(!state.is_null(), "RuntimeState not installed");
 
-        let scheduled_time = Timespec::EPOCH
-            .add_ms((idle_start_ms as i64).saturating_add(i64::from(self.interval.get())));
+        let ms = (idle_start_ms as i64)
+            .saturating_add(i64::from(self.interval.get()))
+            .max(0);
+        let scheduled_time = Timespec::EPOCH.add_ms(ms);
         // SAFETY: `state` is the boxed per-thread `RuntimeState`; fresh
         // `&mut` to `.timer` for this call only. The timer is ACTIVE so
         // `update()` removes then re-inserts with no refcount change.

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -220,6 +220,70 @@ describe("clear", () => {
   });
 });
 
+describe("_idleStart", () => {
+  // https://github.com/oven-sh/bun/issues/26508
+  // Next.js 16 Cache Components writes `t2._idleStart = t1._idleStart` so two
+  // `setTimeout(fn)` calls share a deadline and both fire before any
+  // `setImmediate` scheduled from `t1`'s callback.
+  it("reschedules the timer when written (Next.js pattern)", async () => {
+    const script = `
+      async function once() {
+        let immediateRan = false;
+        let order = [];
+        const t1 = setTimeout(() => {
+          order.push("t1");
+          setImmediate(() => { immediateRan = true; });
+        });
+        // Force the monotonic clock past a millisecond boundary so t2 would
+        // land in a later event-loop turn without the _idleStart assignment.
+        { const s = performance.now(); while (performance.now() - s < 2) {} }
+        const { promise, resolve } = Promise.withResolvers();
+        const t2 = setTimeout(() => {
+          order.push("t2");
+          resolve({ immediateRan, order: order.join(",") });
+        });
+        t2._idleStart = t1._idleStart;
+        return promise;
+      }
+      for (let i = 0; i < 50; i++) {
+        const { immediateRan, order } = await once();
+        if (immediateRan) {
+          console.log("FAIL: immediate ran before t2 on iteration " + i);
+          process.exit(1);
+        }
+        if (order !== "t1,t2") {
+          console.log("FAIL: wrong order " + order + " on iteration " + i);
+          process.exit(1);
+        }
+      }
+      console.log("ok");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
+  });
+
+  it("ignores non-finite values and cleared timers", async () => {
+    const t1 = setTimeout(() => {}, 10) as any;
+    t1._idleStart = "not a number";
+    expect(t1._idleStart).toBe("not a number");
+    t1._idleStart = NaN;
+    expect(Number.isNaN(t1._idleStart)).toBeTrue();
+    t1._idleStart = Infinity;
+    expect(t1._idleStart).toBe(Infinity);
+    clearTimeout(t1);
+    t1._idleStart = 0;
+    expect(t1._idleStart).toBe(0);
+  });
+});
+
 describe.each(["with", "without"])("setImmediate %s timers running", mode => {
   // TODO(@190n) #17901 did not fix this for Windows
   it.todoIf(isWindows && mode == "with")(

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -282,6 +282,15 @@ describe("_idleStart", () => {
     t1._idleStart = 0;
     expect(t1._idleStart).toBe(0);
   });
+
+  it("does not overflow for extreme finite values", () => {
+    const t1 = setTimeout(() => {}, 10) as any;
+    t1._idleStart = Number.MAX_VALUE;
+    expect(t1._idleStart).toBe(Number.MAX_VALUE);
+    t1._idleStart = -Number.MAX_VALUE;
+    expect(t1._idleStart).toBe(-Number.MAX_VALUE);
+    clearTimeout(t1);
+  });
 });
 
 describe.each(["with", "without"])("setImmediate %s timers running", mode => {


### PR DESCRIPTION
Fixes #26508.

## Repro

Next.js 16's [`app-render-scheduling.ts`](https://github.com/vercel/next.js/blob/31b62520366aefef9d6800cd519157a16f958052/packages/next/src/server/app-render/app-render-scheduling.ts#L29-L49) creates two `setTimeout(fn)` calls and then writes `t2._idleStart = t1._idleStart` so both timers share a deadline and fire in the same event-loop turn, before any `setImmediate` scheduled from `t1`'s callback.

```js
let immediateRan = false;
const t1 = setTimeout(() => {
  setImmediate(() => { immediateRan = true; });
});
// force the monotonic clock past a millisecond boundary
{ const s = performance.now(); while (performance.now() - s < 2) {} }
const t2 = setTimeout(() => {
  if (immediateRan) process.exit(1);
});
t2._idleStart = t1._idleStart;
```

100 iterations: **Node** 0 failures, **Bun (before)** 94 failures, **Bun (after)** 0 failures.

## Cause

`TimeoutObject::set_idle_start` (added in #26021) only cached the JS value. It never updated the `EventLoopTimer.next` deadline in the native timer heap, so the assignment had no scheduling effect and `t2` could fire in a later turn after the `setImmediate`.

## Fix

`TimerObjectInternals::set_idle_start` recomputes the deadline as `Timespec::EPOCH.add_ms(idle_start_ms + interval)` and calls `All::update()` to remove and re-insert the timer. The heap comparison in `EventLoopTimer::less` already collapses sub-millisecond precision for JS timers and uses the insertion epoch as tiebreak, so after `t2._idleStart = t1._idleStart` the two timers compare equal on deadline and `t1` still fires first (lower epoch).

The setter is a no-op for cleared timers, non-ACTIVE timers, and non-finite values; the JS value is always cached regardless.

## Verification

New `_idleStart` describe in `test/js/node/timers/node-timers.test.ts`:
- "reschedules the timer when written (Next.js pattern)": spawns a subprocess running 50 iterations of the busy-loop repro, asserting the immediate never runs between `t1` and `t2` and order is always `t1,t2`. Fails on `USE_SYSTEM_BUN=1` ("FAIL: immediate ran before t2 on iteration 0"), passes with `bun bd test`.
- "ignores non-finite values and cleared timers": edge-case coverage for string/NaN/Infinity/post-clear writes.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/timers/node-timers.test.ts

<!-- robobun:evidence:end -->