### PR TITLE
docs(test): keep shard timings uploading when a test fails

### DIFF
--- a/docs/test/index.mdx
+++ b/docs/test/index.mdx
@@ -386,6 +386,7 @@ For a suite with thousands of test files, `bun test` has several knobs that stac
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         shard: [1, 2, 3, 4]
     steps:
@@ -403,11 +404,13 @@ jobs:
             --timings=.bun-test-timings/next/${{ matrix.shard }}.json \
             $(ls .bun-test-timings/*.json 2>/dev/null | sed 's/^/--timings=/')
       - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
         with:
           name: timings-${{ matrix.shard }}
           path: .bun-test-timings/next/${{ matrix.shard }}.json
   save-timings:
     needs: test
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/docs/test/index.mdx
+++ b/docs/test/index.mdx
@@ -385,6 +385,7 @@ For a suite with thousands of test files, `bun test` has several knobs that stac
 ```yaml title=".github/workflows/test.yml" icon="github"
 jobs:
   test:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -393,7 +394,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun install
-      # last successful run's per-shard timings (nothing on the very first run)
+      # previous run's per-shard timings (nothing on the very first run)
       - uses: actions/cache/restore@v4
         with:
           path: .bun-test-timings


### PR DESCRIPTION
## What

Fixes the GitHub Actions recipe in `docs/test/index.mdx` under **Large codebases → step 5 "Keep the timings fresh automatically"** so that per-shard timing files are still uploaded and cached when a test fails.

## Why

As written, `actions/upload-artifact@v4` and the `save-timings:` job have no `if:`, so they inherit `if: success()`. The matrix also defaults to `fail-fast: true`. That means:

- a shard with a single failing test skips uploading its `.bun-test-timings/next/N.json`
- `save-timings` (`needs: test`) is skipped unless every matrix shard passed
- one failing shard cancels the other still-running shards

So on any suite with a flaky test, the timings cache never populates and `--shard` stays on file-count round-robin forever. `bun test --update-timings` deliberately writes its timings file on failure/bail so partial runs still contribute; the workflow shouldn't throw that away.

## Change

```diff
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         shard: [1, 2, 3, 4]
@@
       - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
         with:
           name: timings-${{ matrix.shard }}
           path: .bun-test-timings/next/${{ matrix.shard }}.json
   save-timings:
     needs: test
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
```

Docs-only; no code changes.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->