### PR TITLE
bun:jsc: profile() accepts any callable, not just JSFunction cells

### DIFF
--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -699,8 +699,6 @@ JSC_DEFINE_HOST_FUNCTION(functionRunProfiler, (JSGlobalObject * globalObject, Ca
         return JSValue::encode(JSValue {});
     }
 
-    JSC::JSFunction* function = uncheckedDowncast<JSC::JSFunction>(callbackValue);
-
     if (sampleValue.isNumber()) {
         unsigned sampleInterval = sampleValue.toUInt32(globalObject);
         samplingProfiler.setTimingInterval(Seconds::fromMicroseconds(sampleInterval));
@@ -751,11 +749,11 @@ JSC_DEFINE_HOST_FUNCTION(functionRunProfiler, (JSGlobalObject * globalObject, Ca
         return {};
     };
 
-    JSC::CallData callData = JSC::getCallData(function);
+    JSC::CallData callData = JSC::getCallData(callbackValue);
 
     samplingProfiler.noticeCurrentThreadAsJSCExecutionThread();
     samplingProfiler.start();
-    JSValue returnValue = JSC::profiledCall(globalObject, ProfilingReason::API, function, callData, JSC::jsUndefined(), args);
+    JSValue returnValue = JSC::profiledCall(globalObject, ProfilingReason::API, callbackValue, callData, JSC::jsUndefined(), args);
 
     if (returnValue.isEmpty() || throwScope.exception()) {
         return JSValue::encode(reportFailure(vm));

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -232,6 +232,28 @@ describe("bun:jsc", () => {
     expect(result3.stackTraces).toBeDefined();
     expect(result3.stackTraces.traces.length).toBeGreaterThan(0);
   });
+
+  it("profile accepts a callable Proxy", async () => {
+    // functionRunProfiler used to uncheckedDowncast<JSFunction> the callback after only
+    // checking isCallable(), which aborts asserts builds when the callable is a ProxyObject.
+    const script = `
+      const { profile } = require("bun:jsc");
+      const result = profile(new Proxy(function () { return 1; }, {}));
+      if (!result || typeof result.functions !== "string" || !("stackTraces" in result)) {
+        throw new Error("unexpected profile() result keys: " + JSON.stringify(result && Object.keys(result)));
+      }
+      console.log("ok");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 it("deserialize rejects an object reference index outside the deserialized object pool", async () => {


### PR DESCRIPTION
## Repro

```js
const { profile } = require("bun:jsc");
profile(new Proxy(function () { return 1; }, {}));
```

On an asserts build (debug, or release-asan) this aborts with SIGABRT:

```
JSC::reportZappedCellAndCrash (JSCell.cpp:371)
  <- WTF::uncheckedDowncast<JSC::JSFunction> (JSCast.h:338)
  <- functionRunProfiler (src/jsc/modules/BunJSCModule.h:702)
```

Release builds without asserts return the profile result normally; the mistyped pointer is only passed to `getCallData()` / `profiledCall()`, which dispatch via the cell's method table and never dereference it as a `JSFunction`.

## Cause

`functionRunProfiler` gates the callback on `!isCallable()` and then does `uncheckedDowncast<JSC::JSFunction>(callbackValue)`. A `Proxy` wrapping a function is callable but is a `ProxyObject` cell, not a `JSFunction` subclass, so `uncheckedDowncast`'s inherits assertion trips.

## Fix

Drop the `JSFunction*` local entirely. Both `JSC::getCallData()` and `JSC::profiledCall()` have `JSValue` overloads and dispatch via the actual cell's method table, so the downcast was never needed.

## Verification

```
# without fix (src/ stashed), bun bd:
(fail) bun:jsc > profile accepts a callable Proxy   # subprocess aborted, empty stdout

# with fix, bun bd:
(pass) bun:jsc > profile accepts a callable Proxy [309.55ms]
# full file: 37 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/jsc/bun-jsc.test.ts

<!-- robobun:evidence:end -->