### PR TITLE
structuredClone: clamp deserialized array pre-allocation to payload bounds

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -3960,6 +3960,10 @@ DeserializationResult CloneDeserializer::deserialize()
     WalkerState state = StateUnknown;
     JSValue outValue;
 
+    // Each serialized (index, value) pair is at least a uint32 index plus a 1-byte value tag,
+    // so the whole payload can encode at most this many array entries in total.
+    uint64_t arrayEntryBudget = static_cast<uint64_t>(m_end - m_ptr) / (sizeof(uint32_t) + 1);
+
     while (1) {
         switch (state) {
         arrayStartState:
@@ -3970,17 +3974,17 @@ DeserializationResult CloneDeserializer::deserialize()
             if (!read(length)) {
                 goto error;
             }
-            // Each indexed entry is at least a uint32 index plus a 1-byte value tag, so the
-            // remaining input bounds how many entries can exist; setLength() restores .length.
-            uint32_t initialCapacity = static_cast<uint32_t>(std::min<uint64_t>(length, static_cast<uint64_t>(m_end - m_ptr) / (sizeof(uint32_t) + 1)));
-            JSArray* outArray = constructEmptyArray(m_globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), initialCapacity);
+            JSArray* outArray;
+            if (static_cast<uint64_t>(length) <= arrayEntryBudget) {
+                arrayEntryBudget -= length;
+                outArray = constructEmptyArray(m_globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), length);
+            } else {
+                outArray = JSArray::tryCreate(vm, m_globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithArrayStorage), length);
+                if (!outArray) [[unlikely]]
+                    throwOutOfMemoryError(m_lexicalGlobalObject, scope);
+            }
             if (scope.exception()) [[unlikely]]
                 goto error;
-            if (initialCapacity != length) {
-                outArray->setLength(m_lexicalGlobalObject, length);
-                if (scope.exception()) [[unlikely]]
-                    goto error;
-            }
             addToObjectPool(outArray);
             outputObjectStack.append(outArray);
         }

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -3970,11 +3970,8 @@ DeserializationResult CloneDeserializer::deserialize()
             if (!read(length)) {
                 goto error;
             }
-            // Each indexed entry is at least a 4-byte index plus a 1-byte value tag, so the
-            // payload cannot hold more than remaining/5 entries. Clamping the initial
-            // allocation to that bound prevents a forged length field from allocating up to
-            // ~1 GB of contiguous storage from a tiny payload; setLength() then restores the
-            // declared .length and lets JSC pick sparse storage for the hole-filled tail.
+            // Each indexed entry is at least a uint32 index plus a 1-byte value tag, so the
+            // remaining input bounds how many entries can exist; setLength() restores .length.
             uint32_t initialCapacity = static_cast<uint32_t>(std::min<uint64_t>(length, static_cast<uint64_t>(m_end - m_ptr) / (sizeof(uint32_t) + 1)));
             JSArray* outArray = constructEmptyArray(m_globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), initialCapacity);
             if (scope.exception()) [[unlikely]]

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -3970,9 +3970,20 @@ DeserializationResult CloneDeserializer::deserialize()
             if (!read(length)) {
                 goto error;
             }
-            JSArray* outArray = constructEmptyArray(m_globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), length);
+            // Each indexed entry is at least a 4-byte index plus a 1-byte value tag, so the
+            // payload cannot hold more than remaining/5 entries. Clamping the initial
+            // allocation to that bound prevents a forged length field from allocating up to
+            // ~1 GB of contiguous storage from a tiny payload; setLength() then restores the
+            // declared .length and lets JSC pick sparse storage for the hole-filled tail.
+            uint32_t initialCapacity = static_cast<uint32_t>(std::min<uint64_t>(length, static_cast<uint64_t>(m_end - m_ptr) / (sizeof(uint32_t) + 1)));
+            JSArray* outArray = constructEmptyArray(m_globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), initialCapacity);
             if (scope.exception()) [[unlikely]]
                 goto error;
+            if (initialCapacity != length) {
+                outArray->setLength(m_lexicalGlobalObject, length);
+                if (scope.exception()) [[unlikely]]
+                    goto error;
+            }
             addToObjectPool(outArray);
             outputObjectStack.append(outArray);
         }

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -24,7 +24,7 @@ import {
   totalCompileTime,
 } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBuildKite, isWindows } from "harness";
+import { bunEnv, bunExe, isASAN, isBuildKite, isDebug, isWindows } from "harness";
 
 describe("bun:jsc", () => {
   function count() {
@@ -342,9 +342,36 @@ it("deserialize does not pre-allocate array storage from an untrusted length fie
       zero: out[0],
       isArray: Array.isArray(out),
     }));
+    // Nested variant: every nested ArrayTag is counted against the same shared
+    // budget, so 2000 nested arrays whose lengths each equal floor(remaining/5)
+    // cannot re-spend the same input bytes 2000 times.
+    const header = new Uint8Array(serialize(undefined)).slice(0, -1);
+    const depth = 2000;
+    const nest = Buffer.alloc(header.length + 5 + (depth - 1) * 9 + depth * 4);
+    nest.set(header, 0);
+    let p = header.length;
+    nest[p++] = 1; // ArrayTag
+    nest.writeUInt32LE(Math.floor((nest.length - (p + 4)) / 5), p); p += 4;
+    for (let k = 1; k < depth; k++) {
+      nest.writeUInt32LE(0, p); p += 4; // index
+      nest[p++] = 1; // ArrayTag
+      nest.writeUInt32LE(Math.floor((nest.length - (p + 4)) / 5), p); p += 4;
+    }
+    for (let k = 0; k < depth; k++) { nest.writeUInt32LE(0xffffffff, p); p += 4; }
+    const nestRssBefore = process.memoryUsage().rss;
+    const nestOut = deserialize(nest);
+    const nestRssDeltaMB = (process.memoryUsage().rss - nestRssBefore) / (1024 * 1024);
+    let d = nestOut, measuredDepth = 1;
+    while (Array.isArray(d[0])) { d = d[0]; measuredDepth++; }
+    console.log(JSON.stringify({
+      bytes: nest.length,
+      rssDeltaMB: Math.round(nestRssDeltaMB),
+      depth: measuredDepth,
+      outerLength: nestOut.length,
+    }));
     // Legitimate arrays still round-trip. The sparse case is short enough that
-    // the declared length exceeds (remaining bytes)/5, so it exercises the
-    // clamp + setLength path; the dense case exercises the unchanged fast path.
+    // the declared length exceeds the entry budget, so it exercises the
+    // ArrayStorage path; the dense case exercises the unchanged fast path.
     const sparse = new Array(10);
     sparse[3] = "x";
     const dense = [1, 2, 3, 4, 5];
@@ -363,10 +390,11 @@ it("deserialize does not pre-allocate array storage from an untrusted length fie
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  const [forged, roundTrip] = stdout
+  const [forged, nested, roundTrip] = stdout
     .trim()
     .split("\n")
     .map(line => JSON.parse(line));
+  const rssLimitMB = isASAN || isDebug ? 40 : 20;
   expect({ ...forged, rssDeltaMB: undefined }).toEqual({
     rssDeltaMB: undefined,
     length: 100_000_000,
@@ -375,7 +403,15 @@ it("deserialize does not pre-allocate array storage from an untrusted length fie
     isArray: true,
   });
   // Without the clamp this allocates ~800 MB of contiguous storage.
-  expect(forged.rssDeltaMB).toBeLessThan(100);
+  expect(forged.rssDeltaMB).toBeLessThan(rssLimitMB);
+  expect({ ...nested, rssDeltaMB: undefined }).toEqual({
+    rssDeltaMB: undefined,
+    bytes: 26000,
+    depth: 2000,
+    outerLength: 5198,
+  });
+  // Without the shared budget every level re-spends the same input bytes.
+  expect(nested.rssDeltaMB).toBeLessThan(rssLimitMB);
   expect(roundTrip).toEqual({
     sparse: { length: 10, keys: ["3"], three: "x", hole: false },
     dense: { length: 5, values: [1, 2, 3, 4, 5] },

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -320,6 +320,66 @@ it("deserialize rejects a typed array whose backing store is not an array buffer
   expect(exitCode).toBe(0);
 });
 
+it("deserialize does not pre-allocate array storage from an untrusted length field", async () => {
+  // Serialize [7], then overwrite the ArrayTag's uint32 length with 1e8. The
+  // payload still only holds one element, so the deserializer must not allocate
+  // 1e8 contiguous slots (~800 MB) up front just because the header says so.
+  const script = `
+    import { serialize, deserialize } from "bun:jsc";
+    const length = 100_000_000;
+    const base = Buffer.from(serialize([7]));
+    const tag = base.indexOf(Buffer.from([1 /* ArrayTag */, 1, 0, 0, 0 /* length 1 LE */]));
+    if (tag < 0) throw new Error("ArrayTag not found in " + base.toString("hex"));
+    const payload = Buffer.from(base);
+    payload.writeUInt32LE(length, tag + 1);
+    const rssBefore = process.memoryUsage().rss;
+    const out = deserialize(payload);
+    const rssDeltaMB = (process.memoryUsage().rss - rssBefore) / (1024 * 1024);
+    console.log(JSON.stringify({
+      rssDeltaMB: Math.round(rssDeltaMB),
+      length: out.length,
+      keys: Object.keys(out).length,
+      zero: out[0],
+      isArray: Array.isArray(out),
+    }));
+    // Legitimate arrays still round-trip. The sparse case is short enough that
+    // the declared length exceeds (remaining bytes)/5, so it exercises the
+    // clamp + setLength path; the dense case exercises the unchanged fast path.
+    const sparse = new Array(10);
+    sparse[3] = "x";
+    const dense = [1, 2, 3, 4, 5];
+    const rtSparse = deserialize(serialize(sparse));
+    const rtDense = deserialize(serialize(dense));
+    console.log(JSON.stringify({
+      sparse: { length: rtSparse.length, keys: Object.keys(rtSparse), three: rtSparse[3], hole: 0 in rtSparse },
+      dense: { length: rtDense.length, values: rtDense },
+    }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const [forged, roundTrip] = stdout.trim().split("\n").map(line => JSON.parse(line));
+  expect({ ...forged, rssDeltaMB: undefined }).toEqual({
+    rssDeltaMB: undefined,
+    length: 100_000_000,
+    keys: 1,
+    zero: 7,
+    isArray: true,
+  });
+  // Without the clamp this allocates ~800 MB of contiguous storage.
+  expect(forged.rssDeltaMB).toBeLessThan(100);
+  expect(roundTrip).toEqual({
+    sparse: { length: 10, keys: ["3"], three: "x", hole: false },
+    dense: { length: 5, values: [1, 2, 3, 4, 5] },
+  });
+  expect(exitCode).toBe(0);
+});
+
 it("deserialize rejects a RegExp record whose pattern does not parse", async () => {
   // A serialized RegExp whose pattern bytes are rewritten to an unparseable
   // expression must be rejected at deserialize time instead of producing a

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -363,7 +363,10 @@ it("deserialize does not pre-allocate array storage from an untrusted length fie
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  const [forged, roundTrip] = stdout.trim().split("\n").map(line => JSON.parse(line));
+  const [forged, roundTrip] = stdout
+    .trim()
+    .split("\n")
+    .map(line => JSON.parse(line));
   expect({ ...forged, rssDeltaMB: undefined }).toEqual({
     rssDeltaMB: undefined,
     length: 100_000_000,


### PR DESCRIPTION
## What

`CloneDeserializer::deserialize()` read the `ArrayTag` length field and passed it straight to `constructEmptyArray()`, so a 22-byte payload with a forged length of `100_000_000` allocated ~800 MB of contiguous butterfly storage before reading a single element. JSC only falls back to sparse storage at `MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH` (134 217 728), so any declared length just below that cutoff was honoured in full: one short message, ~1 GB RSS. Nesting made it worse: every nested `ArrayTag` re-counted the same remaining bytes against a fresh per-array bound, and every intermediate array is retained in the object pool, so 40 000 nested arrays from a 360 KB payload could pre-allocate on the order of 11 GB.

Reach: `bun:jsc` `deserialize`, `node:v8` `deserialize`, advanced-serialization IPC, and any code that deserializes bytes it did not itself produce (disk/redis caches, queue framings). Same-process `structuredClone`/`postMessage` are not amplified because the sender has to build the array first.

## Repro

```js
const { serialize, deserialize } = require("bun:jsc");
const base = Buffer.from(serialize([7]));
const i = base.indexOf(Buffer.from([1, 1, 0, 0, 0]));   // ArrayTag + length=1
const payload = Buffer.from(base);
payload.writeUInt32LE(100_000_000, i + 1);              // length := 1e8
const rss0 = process.memoryUsage().rss;
const r = deserialize(payload);
console.log(`RSS +${((process.memoryUsage().rss - rss0) / 1e6) | 0} MB, length ${r.length}, keys ${Object.keys(r).length}`);
```
Before: `RSS +800 MB, length 100000000, keys 1` (~500 ms).
After: `RSS +0 MB, length 100000000, keys 1` (~0 ms).

Node.js rejects the equivalent V8-format payload in 0 ms because V8's deserializer refuses a declared dense-array length that cannot fit in the remaining input.

## Fix

Each serialized (index, value) pair is at least `sizeof(uint32_t)` for the index plus one byte for the value tag, so the whole payload can encode at most `(m_end - m_ptr) / 5` entries in total. Track that as a single `arrayEntryBudget` for the entire `deserialize()` call. When an `ArrayTag`'s declared length fits in the remaining budget, pre-allocate as before and subtract it from the budget; when it does not, build the array directly with `ArrayWithArrayStorage` (a fixed 4-slot vector plus a length field) and let `putDirectIndex` populate it, so over-budget arrays cost O(entries actually present) instead of O(declared length). Aggregate contiguous pre-allocation across the call is now bounded by roughly 1.6x the payload size.

Dense arrays whose payload actually carries the elements are unaffected: their lengths fit the budget, so `constructEmptyArray(length)` runs as before. Sparse arrays round-trip with identical `.length`, own keys, and hole positions.

Upstream WebCore's `SerializedScriptValue.cpp` has the same unbounded `constructEmptyArray(length)` call.

## Verification

- `bun bd test test/js/bun/jsc/bun-jsc.test.ts` (37 pass)
- `bun bd test test/js/web/workers/structured-clone.test.ts test/js/web/structured-clone-fastpath.test.ts test/js/web/workers/structuredClone-classes.test.ts` (380 pass)
- New test fails on the released binary with `Received: 763` MB and covers both the single forged length and the nested variant

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/jsc/bun-jsc.test.ts

<!-- robobun:evidence:end -->