### PR TITLE
bun test --isolate: cache internal-module UnlinkedFunctionExecutable per-VM

### DIFF
--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -30,6 +30,7 @@ class GlobalObject;
 
 namespace Bun {
 class StrongRootBlock;
+struct InternalModuleExecutableCache;
 }
 
 namespace WebCore {
@@ -140,6 +141,12 @@ public:
     // only owner once the previous global is GC'd, so a weak map would empty
     // after every swap.
     WTF::UncheckedKeyHashMap<WTF::String, RefPtr<JSC::SourceProvider>> isolationSourceProviderCache;
+
+    // See InternalModuleExecutableCache (InternalModuleRegistry.cpp).
+    struct InternalModuleExecutableCacheDeleter {
+        void operator()(Bun::InternalModuleExecutableCache*) const;
+    };
+    std::unique_ptr<Bun::InternalModuleExecutableCache, InternalModuleExecutableCacheDeleter> internalModuleExecutableCache;
 
 private:
     bool isWebCoreJSClientData() const final { return true; }

--- a/src/jsc/bindings/InternalModuleRegistry.cpp
+++ b/src/jsc/bindings/InternalModuleRegistry.cpp
@@ -6,6 +6,7 @@
 #include <JavaScriptCore/LazyPropertyInlines.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
 #include <JavaScriptCore/JSModuleLoader.h>
+#include <JavaScriptCore/StrongInlines.h>
 #include <JavaScriptCore/Debugger.h>
 #include <utility>
 
@@ -13,7 +14,25 @@
 #include "wtf/Forward.h"
 
 #include "NativeModuleImpl.h"
+
+extern "C" bool isBunTest;
+extern "C" bool Bun__VM__useIsolationSourceProviderCache(void* bunVM);
+
 namespace Bun {
+
+// createBuiltinExecutable bypasses CodeCache, so without this per-VM cache
+// every --isolate global re-parses + re-bytecodegens each internal module body.
+// Strong: a Weak would clear once the outgoing global's JSFunction is collected.
+struct InternalModuleExecutableCache {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(InternalModuleExecutableCache);
+
+public:
+    struct Entry {
+        JSC::SourceCode source;
+        JSC::Strong<JSC::UnlinkedFunctionExecutable> executable;
+    };
+    std::array<Entry, BUN_INTERNAL_MODULE_COUNT> entries {};
+};
 
 extern "C" bool BunTest__shouldGenerateCodeCoverage(BunString sourceURL);
 extern "C" void ByteRangeMapping__generate(BunString sourceURL, BunString code, int sourceID);
@@ -33,24 +52,48 @@ static void maybeAddCodeCoverage(JSC::VM& vm, const JSC::SourceCode& code)
 // JS builtin that acts as a module. In debug mode, we use a different implementation that reads
 // from the developer's filesystem. This allows reloading code without recompiling bindings.
 
-JSC::JSValue generateModule(JSC::JSGlobalObject* globalObject, JSC::VM& vm, const String& SOURCE, const String& moduleName, const String& urlString)
+JSC::JSValue generateModule(JSC::JSGlobalObject* globalObject, JSC::VM& vm, InternalModuleRegistry::Field id, const String& SOURCE, const String& moduleName, const String& urlString)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    auto&& origin = SourceOrigin(WTF::URL(urlString));
-    SourceCode source = JSC::makeSource(SOURCE, origin, JSC::SourceTaintedOrigin::Untainted, moduleName);
-    maybeAddCodeCoverage(vm, source);
-    JSFunction* func
-        = JSFunction::create(
-            vm, globalObject,
-            createBuiltinExecutable(
-                vm, source,
-                Identifier::fromString(vm, moduleName),
-                ImplementationVisibility::Public,
-                ConstructorKind::None,
-                ConstructAbility::CannotConstruct,
-                InlineAttribute::None)
-                ->link(vm, nullptr, source),
-            static_cast<JSC::JSGlobalObject*>(globalObject));
+
+    JSC::UnlinkedFunctionExecutable* unlinked = nullptr;
+    JSC::SourceCode source;
+#ifndef BUN_DYNAMIC_JS_LOAD_PATH
+    auto* clientData = WebCore::clientData(vm);
+    if (auto* cache = clientData->internalModuleExecutableCache.get()) {
+        auto& entry = cache->entries[static_cast<unsigned>(id)];
+        if (entry.executable) {
+            unlinked = entry.executable.get();
+            source = entry.source;
+        }
+    }
+#endif
+    if (!unlinked) {
+        auto&& origin = SourceOrigin(WTF::URL(urlString));
+        source = JSC::makeSource(SOURCE, origin, JSC::SourceTaintedOrigin::Untainted, moduleName);
+        maybeAddCodeCoverage(vm, source);
+        unlinked = createBuiltinExecutable(
+            vm, source,
+            Identifier::fromString(vm, moduleName),
+            ImplementationVisibility::Public,
+            ConstructorKind::None,
+            ConstructAbility::CannotConstruct,
+            InlineAttribute::None);
+#ifndef BUN_DYNAMIC_JS_LOAD_PATH
+        if (isBunTest && Bun__VM__useIsolationSourceProviderCache(clientData->bunVM)) {
+            if (!clientData->internalModuleExecutableCache)
+                clientData->internalModuleExecutableCache.reset(new InternalModuleExecutableCache);
+            auto& entry = clientData->internalModuleExecutableCache->entries[static_cast<unsigned>(id)];
+            entry.source = source;
+            entry.executable.set(vm, unlinked);
+        }
+#endif
+    }
+
+    JSFunction* func = JSFunction::create(
+        vm, globalObject,
+        unlinked->link(vm, nullptr, source),
+        static_cast<JSC::JSGlobalObject*>(globalObject));
 
     RETURN_IF_EXCEPTION(throwScope, {});
     if (globalObject->hasDebugger() && globalObject->debugger()->isInteractivelyDebugging()) [[unlikely]] {
@@ -98,12 +141,12 @@ ALWAYS_INLINE JSC::JSValue generateNativeModule(
 }
 
 #ifdef BUN_DYNAMIC_JS_LOAD_PATH
-JSValue initializeInternalModuleFromDisk(JSGlobalObject* globalObject, VM& vm, const WTF::String& moduleName, WTF::String fileBase, const WTF::String& urlString)
+JSValue initializeInternalModuleFromDisk(JSGlobalObject* globalObject, VM& vm, InternalModuleRegistry::Field id, const WTF::String& moduleName, WTF::String fileBase, const WTF::String& urlString)
 {
     WTF::String file = makeString(ASCIILiteral::fromLiteralUnsafe(BUN_DYNAMIC_JS_LOAD_PATH), "/"_s, WTF::move(fileBase));
     if (auto contents = WTF::FileSystemImpl::readEntireFile(file)) {
         auto string = WTF::String::fromUTF8(contents.value());
-        return generateModule(globalObject, vm, string, moduleName, urlString);
+        return generateModule(globalObject, vm, id, string, moduleName, urlString);
     } else {
         printf("\nFATAL: bun-debug failed to load bundled version of \"%s\" at \"%s\" (was it deleted?)\n"
                "Please re-compile Bun to continue.\n\n",
@@ -112,7 +155,7 @@ JSValue initializeInternalModuleFromDisk(JSGlobalObject* globalObject, VM& vm, c
     }
 }
 #define INTERNAL_MODULE_REGISTRY_GENERATE(globalObject, vm, moduleId, filename, OFFSET, LENGTH, urlString) \
-    return initializeInternalModuleFromDisk(globalObject, vm, moduleId, filename, urlString)
+    return initializeInternalModuleFromDisk(globalObject, vm, id, moduleId, filename, urlString)
 #else
 
 // The module sources are linked as one read-only blob (bun_internal_modules_data,
@@ -120,7 +163,7 @@ JSValue initializeInternalModuleFromDisk(JSGlobalObject* globalObject, VM& vm, c
 // a known offset/length. createWithoutCopying is the same path the old
 // ASCIILiteral → String conversion took.
 #define INTERNAL_MODULE_REGISTRY_GENERATE(globalObject, vm, moduleId, filename, OFFSET, LENGTH, urlString)                         \
-    return generateModule(globalObject, vm,                                                                                        \
+    return generateModule(globalObject, vm, id,                                                                                    \
         WTF::String(WTF::StringImpl::createWithoutCopying(std::span<const char>(bun_internal_modules_data + (OFFSET), (LENGTH)))), \
         moduleId, urlString)
 #endif
@@ -196,5 +239,10 @@ JSC_DEFINE_HOST_FUNCTION(InternalModuleRegistry::jsCreateInternalModuleById, (JS
 }
 
 } // namespace Bun
+
+void WebCore::JSVMClientData::InternalModuleExecutableCacheDeleter::operator()(Bun::InternalModuleExecutableCache* p) const
+{
+    delete p;
+}
 
 #undef INTERNAL_MODULE_REGISTRY_GENERATE


### PR DESCRIPTION
Split out of #36871.

`InternalModuleRegistry::generateModule` calls `createBuiltinExecutable`, which bypasses `CodeCache` and allocates a fresh `UnlinkedFunctionExecutable` on every call. Under `--isolate` each fresh global therefore re-parses and re-bytecodegens every `node:*` / `bun:*` / `internal:*` module body it touches (the nested `UnlinkedFunctionCodeBlock`s hang off the executable, so a fresh one means a full body parse on first call).

This caches the executable and its `SourceCode` per-VM, indexed by `InternalModuleRegistry::Field`, using `Strong<UnlinkedFunctionExecutable>` so the entry outlives the outgoing global. Subsequent globals re-`link()` and re-evaluate without re-parsing. The cache populates only when `isBunTest && useIsolationSourceProviderCache` (the same gate as the existing per-VM `SourceProvider` cache) and is skipped under `BUN_DYNAMIC_JS_LOAD_PATH` so debug-build on-disk edits to `src/js/*` keep reloading between files.

No semantic change: the module body still re-evaluates in each global.

### Benchmark

500 test files, each importing `node:fs` + `node:events` + `node:util` + `node:stream`, 16-core Linux release:

| | wall | user |
|---|--:|--:|
| before | 12.4s | 12.9s |
| after | **3.8s** | 4.7s |

`test/cli/test/isolation.test.ts` passes (21/21).