### PR TITLE
resolver: keep cached DirEntry when a stale-generation refresh fails

### DIFF
--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1270,13 +1270,7 @@ pub mod fs {
             let mut entries = match self.readdir(store_fd, prev, dir, generation, handle, iterator)
             {
                 Ok(e) => e,
-                Err(err) => {
-                    if let Some(existing) = in_place {
-                        // SAFETY: see above.
-                        unsafe { (*existing).data.clear() };
-                    }
-                    return self.read_directory_error(dir, err, in_place.is_some());
-                }
+                Err(err) => return self.read_directory_error(dir, err, in_place.is_some()),
             };
 
             if bun_core::FeatureFlags::ENABLE_ENTRY_CACHE {
@@ -1597,11 +1591,7 @@ pub mod fs {
                     // the two diverge: `O_DIRECTORY` only vs `O_RDONLY|O_DIRECTORY`.
                     let handle = match bun_sys::open_dir_for_iteration(Fd::cwd(), dir) {
                         Ok(h) => h,
-                        Err(err) => {
-                            // SAFETY: see above.
-                            unsafe { (*e_ptr).data.clear() };
-                            return self.read_directory_error(dir, err.into(), true).ok();
-                        }
+                        Err(err) => return self.read_directory_error(dir, err.into(), true).ok(),
                     };
                     let _close_guard = scopeguard::guard(handle, |h| {
                         let _ = bun_sys::close(h);
@@ -1615,11 +1605,7 @@ pub mod fs {
                             // SAFETY: see above — slot is exclusively owned here.
                             unsafe { *e_ptr = new_entry };
                         }
-                        Err(err) => {
-                            // SAFETY: see above.
-                            unsafe { (*e_ptr).data.clear() };
-                            return self.read_directory_error(dir, err, true).ok();
-                        }
+                        Err(err) => return self.read_directory_error(dir, err, true).ok(),
                     }
                 }
             }

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1112,12 +1112,22 @@ pub mod fs {
 
         /// Cache (or threadlocal-
         /// stash) an `EntriesOption::Err` for `dir` and hand back its address.
+        ///
+        /// `refreshing_in_place` is set when the slot already holds a live
+        /// `Entries(&'static mut DirEntry)` whose stale-generation re-read
+        /// just failed. Overwriting that slot with `Err` (or re-pointing the
+        /// index at `NOT_FOUND`) would orphan the leaked `Box<DirEntry>`
+        /// behind the reference, and closing its cached `.fd` is unsafe
+        /// (copies live in `Watcher.watchlist`, `ParseTask.contents_or_fd`,
+        /// and `DirectoryWatchStore`). Leave the slot alone and hand back a
+        /// threadlocal `Err`; the next lookup re-tries the open.
         fn read_directory_error(
             &mut self,
             dir: &[u8],
             err: crate::Error,
+            refreshing_in_place: bool,
         ) -> crate::CrateResult<&'static mut EntriesOption> {
-            if bun_core::FeatureFlags::ENABLE_ENTRY_CACHE {
+            if bun_core::FeatureFlags::ENABLE_ENTRY_CACHE && !refreshing_in_place {
                 let mut get_or_put_result = self.entries.get_or_put(dir)?;
                 if err == crate::Error::Sys(bun_errno::SystemErrno::ENOENT) {
                     self.entries.mark_not_found(get_or_put_result);
@@ -1223,7 +1233,7 @@ pub mod fs {
                 Some(h) => h,
                 None => match self.open_dir(dir) {
                     Ok(h) => h,
-                    Err(err) => return self.read_directory_error(dir, err),
+                    Err(err) => return self.read_directory_error(dir, err, in_place.is_some()),
                 },
             };
 
@@ -1265,7 +1275,7 @@ pub mod fs {
                         // SAFETY: see above.
                         unsafe { (*existing).data.clear() };
                     }
-                    return self.read_directory_error(dir, err);
+                    return self.read_directory_error(dir, err, in_place.is_some());
                 }
             };
 
@@ -1590,7 +1600,7 @@ pub mod fs {
                         Err(err) => {
                             // SAFETY: see above.
                             unsafe { (*e_ptr).data.clear() };
-                            return self.read_directory_error(dir, err.into()).ok();
+                            return self.read_directory_error(dir, err.into(), true).ok();
                         }
                     };
                     let _close_guard = scopeguard::guard(handle, |h| {
@@ -1608,7 +1618,7 @@ pub mod fs {
                         Err(err) => {
                             // SAFETY: see above.
                             unsafe { (*e_ptr).data.clear() };
-                            return self.read_directory_error(dir, err).ok();
+                            return self.read_directory_error(dir, err, true).ok();
                         }
                     }
                 }

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1112,15 +1112,7 @@ pub mod fs {
 
         /// Cache (or threadlocal-
         /// stash) an `EntriesOption::Err` for `dir` and hand back its address.
-        ///
-        /// `refreshing_in_place` is set when the slot already holds a live
-        /// `Entries(&'static mut DirEntry)` whose stale-generation re-read
-        /// just failed. Overwriting that slot with `Err` (or re-pointing the
-        /// index at `NOT_FOUND`) would orphan the leaked `Box<DirEntry>`
-        /// behind the reference, and closing its cached `.fd` is unsafe
-        /// (copies live in `Watcher.watchlist`, `ParseTask.contents_or_fd`,
-        /// and `DirectoryWatchStore`). Leave the slot alone and hand back a
-        /// threadlocal `Err`; the next lookup re-tries the open.
+        /// `refreshing_in_place` skips the cache write so the slot's live `DirEntry` stays reachable.
         fn read_directory_error(
             &mut self,
             dir: &[u8],

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -494,6 +494,50 @@ describe("Bun.build", () => {
     Bun.gc(true);
   });
 
+  // A second in-process Bun.build() re-reads cached directories whose listing
+  // predates the current bundle generation. When that re-read fails (the
+  // directory was replaced with a regular file, so open() returns ENOTDIR),
+  // the error path used to overwrite the cache slot with an Err variant. That
+  // orphaned the Box<DirEntry> behind the previous Entries value and cached
+  // the Err for every later generation, so a third build after the directory
+  // was restored still failed to resolve through it.
+  test.concurrent.skipIf(isWindows)("rebuilding after a cached directory is replaced with a file", async () => {
+    using dir = tempDir("rebuild-dir-replaced", {
+      "package.json": `{}`,
+      "driver.ts": `
+          import { rmSync, writeFileSync, mkdirSync } from "node:fs";
+          import { join } from "node:path";
+          const root = process.argv[2];
+          const sub = join(root, "sub");
+          const entry = join(root, "entry.js");
+          const first = await Bun.build({ entrypoints: [entry], throw: false });
+          if (!first.success) throw new AggregateError(first.logs, "first build failed");
+          rmSync(sub, { recursive: true, force: true });
+          writeFileSync(sub, "");
+          const second = await Bun.build({ entrypoints: [entry], throw: false });
+          if (second.success) throw new Error("second build should have failed to resolve ./sub/mod.js");
+          rmSync(sub, { force: true });
+          mkdirSync(sub);
+          writeFileSync(join(sub, "mod.js"), "export const value = 2;\\n");
+          const third = await Bun.build({ entrypoints: [entry], throw: false });
+          if (!third.success) throw new AggregateError(third.logs, "third build failed");
+          console.log("OK");
+        `,
+      "entry.js": `import { value } from "./sub/mod.js"; console.log(value);\n`,
+      "sub/mod.js": `export const value = 1;\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "driver.ts", String(dir)],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr: stderr.trim() }).toEqual({ stdout: "OK", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
   // https://github.com/oven-sh/bun/issues/33099
   // A package reached through a symlinked node_modules entry caches its file
   // descriptor in the resolver. A second in-process Bun.build() used to reuse a

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -501,7 +501,7 @@ describe("Bun.build", () => {
   // orphaned the Box<DirEntry> behind the previous Entries value and cached
   // the Err for every later generation, so a third build after the directory
   // was restored still failed to resolve through it.
-  test.concurrent.skipIf(isWindows)("rebuilding after a cached directory is replaced with a file", async () => {
+  test.concurrent("rebuilding after a cached directory is replaced with a file", async () => {
     using dir = tempDir("rebuild-dir-replaced", {
       "package.json": `{}`,
       "driver.ts": `

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -516,6 +516,8 @@ describe("Bun.build", () => {
           writeFileSync(sub, "");
           const second = await Bun.build({ entrypoints: [entry], throw: false });
           if (second.success) throw new Error("second build should have failed to resolve ./sub/mod.js");
+          if (!second.logs.some(l => String(l.message ?? l).includes("./sub/mod.js")))
+            throw new AggregateError(second.logs, "second build failed for an unrelated reason");
           rmSync(sub, { force: true });
           mkdirSync(sub);
           writeFileSync(join(sub, "mod.js"), "export const value = 2;\\n");

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -514,10 +514,19 @@ describe("Bun.build", () => {
           if (!first.success) throw new AggregateError(first.logs, "first build failed");
           rmSync(sub, { recursive: true, force: true });
           writeFileSync(sub, "");
-          const second = await Bun.build({ entrypoints: [entry], throw: false });
-          if (second.success) throw new Error("second build should have failed to resolve ./sub/mod.js");
-          if (!second.logs.some(l => String(l.message ?? l).includes("./sub/mod.js")))
-            throw new AggregateError(second.logs, "second build failed for an unrelated reason");
+          // BundleThread bumps the generation after its queue drains, which may
+          // be after the first build's promise has already resolved. Until it
+          // does, a build reuses the stale listing and fails reading the file
+          // (ENOTDIR) instead of resolving; re-build until the resolver itself
+          // reports the failure.
+          let second;
+          for (let i = 0; ; i++) {
+            second = await Bun.build({ entrypoints: [entry], throw: false });
+            if (second.success) throw new Error("second build should have failed to resolve ./sub/mod.js");
+            if (second.logs.some(l => String(l.message ?? l).includes("Could not resolve"))) break;
+            if (i === 100) throw new AggregateError(second.logs, "second build never reported a resolve error");
+            await Bun.sleep(5);
+          }
           rmSync(sub, { force: true });
           mkdirSync(sub);
           writeFileSync(join(sub, "mod.js"), "export const value = 2;\\n");


### PR DESCRIPTION
## Repro

```js
// build #1 caches ./sub at generation 0
await Bun.build({ entrypoints: ["./entry.js"] });  // entry.js: import "./sub/mod.js"

// ./sub is replaced with a regular file
fs.rmSync("./sub", { recursive: true });
fs.writeFileSync("./sub", "");
await Bun.build({ entrypoints: ["./entry.js"] });  // fails (ENOTDIR), caches Err

// ./sub is a directory again
fs.rmSync("./sub");
fs.mkdirSync("./sub");
fs.writeFileSync("./sub/mod.js", "export const value = 2;");
await Bun.build({ entrypoints: ["./entry.js"] });  // still fails: cached Err is never retried
```

## Cause

`read_directory_with_iterator` and `entries_at_locked` re-read a cached directory in place when its stored generation is older than the current bundle generation (`BundleThread` bumps the generation between `Bun.build()` calls). When that re-read fails, both routed through `read_directory_error`, which either writes `EntriesOption::Err` into the BSSMap slot or re-points the hash index at `NOT_FOUND`.

The slot previously held `Entries(&'static mut DirEntry)` where the reference points at a `Box<DirEntry>` leaked via `heap::into_raw`. Overwriting the slot drops the reference and orphans the Box together with its `data` map. The directory's cached `.fd` cannot safely be closed here either: copies of the descriptor live in `Watcher.watchlist`, `ParseTask.contents_or_fd`, and the bake `DirectoryWatchStore`, so closing it would turn into a use-after-close once the fd value is reused.

Separately, the cached `Err` carries no generation, so the `Entries(e) if e.generation < generation` arm never matches it and the directory stays unresolvable for the rest of the process even after it reappears.

## Fix

`read_directory_error` now takes a `refreshing_in_place` flag. When set, it returns a threadlocal `Err` and leaves the slot alone. The existing `Entries` value (and the Box and fd behind it) stay reachable. The next lookup at the same or a later generation sees `e.generation < generation`, retries the open, and either succeeds (directory is back) or returns another transient error.

The fresh-slot path (`refreshing_in_place == false`) is unchanged: a directory that has never been listed still caches its error.

## Verification

New test `rebuilding after a cached directory is replaced with a file` in `test/bundler/bun-build-api.test.ts` drives three in-process `Bun.build()` calls as above and asserts the third succeeds. It fails on main with `Could not resolve: "./sub/mod.js"` and passes with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->