### PR TITLE
js_parser: don't leak the import.meta.hot drop flag into the next call

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -678,10 +678,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
                         if name == b"accept" {
                             if !enabled {
-                                // Only ask `e_call` to drop the enclosing call when there is
-                                // one: the flag is parser-wide and `e_call` is the only
-                                // consumer, so setting it for a bare property read would
-                                // leak into the next unrelated call expression.
                                 if identifier_opts.is_call_target() {
                                     p.method_call_must_be_replaced_with_undefined = true;
                                 }

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -678,7 +678,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
                         if name == b"accept" {
                             if !enabled {
-                                p.method_call_must_be_replaced_with_undefined = true;
+                                // Only ask `e_call` to drop the enclosing call when there is
+                                // one: the flag is parser-wide and `e_call` is the only
+                                // consumer, so setting it for a bare property read would
+                                // leak into the next unrelated call expression.
+                                if identifier_opts.is_call_target() {
+                                    p.method_call_must_be_replaced_with_undefined = true;
+                                }
                                 return Some(Expr {
                                     data: js_ast::ExprData::EUndefined(E::Undefined),
                                     loc,
@@ -712,7 +718,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     loc,
                                 ));
                             } else {
-                                p.method_call_must_be_replaced_with_undefined = true;
+                                if identifier_opts.is_call_target() {
+                                    p.method_call_must_be_replaced_with_undefined = true;
+                                }
                                 return Some(Expr {
                                     data: js_ast::ExprData::EUndefined(E::Undefined),
                                     loc,

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -667,6 +667,61 @@ describe("bundler", () => {
       api.expectFile("/out.js").not.toContain("import.meta.hot");
     },
   });
+  // Reading an `import.meta.hot` method without calling it must not cause the
+  // next unrelated call expression to be dropped from the output.
+  itBundled("minify/ImportMetaHotReadWithoutCall", {
+    files: {
+      "/entry.ts": `
+        globalThis.sink = import.meta.hot.accept;
+        console.log("after-accept");
+        globalThis.sink = import.meta.hot.dispose;
+        console.log("after-dispose");
+        globalThis.sink = [
+          import.meta.hot.decline,
+          import.meta.hot.prune,
+          import.meta.hot.invalidate,
+          import.meta.hot.on,
+          import.meta.hot.off,
+          import.meta.hot.send,
+        ];
+        console.log("after-array");
+        // Direct calls are still stripped.
+        import.meta.hot.accept(() => console.log("FAIL-accept-call"));
+        import.meta.hot.dispose(() => console.log("FAIL-dispose-call"));
+        console.log("after-calls");
+      `,
+    },
+    outfile: "/out.js",
+    run: {
+      stdout: "after-accept\nafter-dispose\nafter-array\nafter-calls",
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain("after-accept");
+      expect(out).toContain("after-dispose");
+      expect(out).toContain("after-array");
+      expect(out).toContain("after-calls");
+      expect(out).not.toContain("FAIL");
+      expect(out).not.toContain("import.meta.hot");
+    },
+  });
+  itBundled("minify/ImportMetaHotReadWithoutCallNoBundle", {
+    files: {
+      "/entry.ts": `
+        globalThis.sink = import.meta.hot.accept;
+        console.log("after-accept");
+        globalThis.sink = import.meta.hot.dispose;
+        console.log("after-dispose");
+      `,
+    },
+    bundling: false,
+    outfile: "/out.js",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain("after-accept");
+      expect(out).toContain("after-dispose");
+    },
+  });
   itBundled("minify/ProductionMode", {
     files: {
       "/entry.jsx": `


### PR DESCRIPTION
## Problem

With HMR disabled (the default for `bun build`), reading an `import.meta.hot` method without calling it silently drops the next unrelated call expression in the file:

```js
// in.js
globalThis.x = import.meta.hot.accept;
foo();
bar();
```
```
$ bun build --no-bundle in.js
globalThis.x = undefined;
bar();
```

`foo()` is gone. The same happens for `dispose` / `decline` / `prune` / `invalidate` / `on` / `off` / `send`, and for both `--no-bundle` and the default bundling mode.

## Cause

`maybe_rewrite_property_access` (src/js_parser/fold.rs) handles the `HotEnabled | HotDisabled` target. When HMR is off, the `accept` branch and the `decline|dispose|prune|invalidate|on|off|send` branch both do:

```rust
p.method_call_must_be_replaced_with_undefined = true;
return Some(EUndefined);
```

`method_call_must_be_replaced_with_undefined` is a parser-wide flag that `e_call` reads (and then clears) after visiting its own target. The `--drop` path that uses the same flag (visit_expr.rs `e_identifier` / `e_dot`) gates its write on `in_.property_access_for_method_call_maybe_should_replace_with_undefined`, which `e_call` sets only while visiting its target chain. The `import.meta.hot` path has no such gate, so a bare property read sets the flag with no enclosing `e_call` to consume it, and the next call anywhere in the module picks it up and is replaced with `undefined`.

## Fix

Gate both writes on `identifier_opts.is_call_target()`. That bit is true exactly when the property access node is `p.call_target`, i.e. when an enclosing `e_call` set it and will consume the flag on return. A bare read still folds to `undefined`; it just no longer poisons an unrelated call.

## Tests

Two new cases in `test/bundler/bundler_minify.test.ts` next to the existing `ImportMetaHotTreeShaking` coverage:

- `minify/ImportMetaHotReadWithoutCall` (bundled, run): reads every affected method name without calling, asserts each following `console.log` is present in the output and runs, and re-asserts that direct calls are still stripped.
- `minify/ImportMetaHotReadWithoutCallNoBundle`: `--no-bundle` variant of the repro.

Both fail on `main` (the `after-*` lines are missing from the bundle) and pass with this change. `bundler_minify.test.ts` (44 pass), `bundler_drop.test.ts` (14 pass) and `bake/dev-and-prod.test.ts` (12 pass) are green.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts
bun test v1.4.0 (3964047a3)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [580.19ms]
(pass) bundler > minify/StringAdditionFolding [107.26ms]
(pass) bundler > minify/FunctionExpressionRemoveName [106.50ms]
(pass) bundler > minify/KeepNamesPreservesNames [128.93ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [85.82ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1164.19ms]
(pass) bundler > minify/MergeAdjacentVars [389.61ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [398.83ms]
(pass) bundler > minify/Infinity [117.67ms]
(pass) bundler > minify+whitespace/Infinity [93.94ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [378.00ms]
(pass) bundler > minify/InlineArraySpread [86.36ms]
(pass) bundler > minify/ForAndWhileLoopsWithMissingBlock [369.28ms]
(pass) bundler > minify/MissingExpressionBlocks [433.44ms]
(pass) bundler > minify/BunRequireStatement [1014.57ms]
(pass) bundler > minify/SwitchUndefined [547.82ms]
(pass)
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [13.13ms]
(pass) bundler > minify/StringAdditionFolding [3.30ms]
(pass) bundler > minify/FunctionExpressionRemoveName [3.49ms]
(pass) bundler > minify/KeepNamesPreservesNames [3.20ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [3.08ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [22.46ms]
(pass) bundler > minify/MergeAdjacentVars [17.74ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [17.81ms]
(pass) bundler > minify/Infinity [3.28ms]
(pass) bundler > minify+whitespace/Infinity [2.90ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [16.57ms]
(pass) bundler > minify/InlineArraySpread [3.32ms]
(pass) bundler > minify/ForAndWhileLoopsWithMissingBlock [16.10ms]
(pass) bundler > minify/MissingExpressionBlocks [19.54ms]
(pass) bundler > minify/BunRequireStatement [27.67ms]
(pass) bundler > minify/SwitchUndefined [20.71ms]
(pass) bundler > minify/RequireInDeadBranch [3.55ms]
(pass) bundler > minify/TypeOfRequire [3.09ms]
(pass) bundler > minify/RequireMainToImportMetaMain [2.97ms]
(pass) bundler > minify/Con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts
bun test v1.4.0 (3964047a3)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [580.02ms]
(pass) bundler > minify/StringAdditionFolding [103.83ms]
(pass) bundler > minify/FunctionExpressionRemoveName [108.87ms]
(pass) bundler > minify/KeepNamesPreservesNames [119.82ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [104.53ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1140.06ms]
(pass) bundler > minify/MergeAdjacentVars [380.38ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [413.30ms]
(pass) bundler > minify/Infinity [99.89ms]
(pass) bundler > minify+whitespace/Infinity [94.15ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [380.06ms]
(pass) bundler > minify/InlineArraySpread [95.45ms]
(pass) bundler > minify/ForAndWhileLoopsWithMissingBlock [382.14ms]
(pass) bundler > minify/MissingExpressionBlocks [442.22ms]
(pass) bundler > minify/BunRequireStatement [1010.48ms]
(pass) bundler > minify/SwitchUndefined [538.04ms]
(pass)
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 690ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/111] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_http_types v0.0.0 (/workspace/bun/src/http_types)
[1m[92m   Compiling[0m bun_analytics v0.0.0 (/workspace/bun/src/analytics)
[1m[92m   Compiling[0m bun_threading v0.0.0 (/workspace/bun/src/threading)
[1m[92m   Compiling[0m bun_libarchive v0.0.0 (/workspace/bun/src/libarchive)
[1m[92m   Compiling[0m bun_boringssl v0.0.0 (/workspace/bun/src/boringssl)
[1m[92m   Compiling[0m bun_glob v0.0.0 (/workspace/bun/src/glob)
[1m[92m   Compiling[0m bun_md v0.0.0 (/workspace/bun/src/md)
[1m[92m   Compiling[0m bun_ast v0.0.0 (/workspace/bun/src/ast)
[1m[92m   Compiling[0m bun_dns v0.0.0 (/workspace/bun/src/dns)
[1m[92m   Compiling[0m digest v0.10.7
[1m[92m   Compiling[0m cipher v0.4.4
[1m[92m   Compiling[0m rust-argon2 v3.0.0
[1m[92m   Compiling[0m bun_spawn_sys v0.0.0 (/workspac
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/fold.rs               |  8 ++++--
 test/bundler/bundler_minify.test.ts | 55 +++++++++++++++++++++++++++++++++++++
 2 files changed, 61 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/js_parser/fold.rs                    4      4      0
test/bundler/bundler_minify.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->