### PR TITLE
resolver: close the store_fd directory handle when readdir fails

### DIFF
--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1168,6 +1168,9 @@ pub mod fs {
         // https://twitter.com/jarredsumner/status/1655464485245845506
         /// Caller borrows the returned `EntriesOption`. When `FeatureFlags::ENABLE_ENTRY_CACHE`
         /// is `false`, it is not safe to store this pointer past the current function call.
+        ///
+        /// `maybe_handle` is owned: on success it is published into the cached
+        /// `DirEntry.fd` when `store_fd`; on any error before that it is closed.
         pub fn read_directory_with_iterator<I: DirEntryIterator>(
             &mut self,
             dir_maybe_trail_slash: &[u8],
@@ -1230,7 +1233,7 @@ pub mod fs {
             let close_even_if_published = !store_fd || self.need_to_close_files();
             let handle_published = core::cell::Cell::new(false);
             let _close_guard = scopeguard::guard((), |()| {
-                if !had_handle && (close_even_if_published || !handle_published.get()) {
+                if !handle_published.get() || (!had_handle && close_even_if_published) {
                     let _ = bun_sys::close(handle);
                 }
             });

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1180,6 +1180,18 @@ pub mod fs {
             let dir = strings::paths::without_trailing_slash_windows_path(dir_maybe_trail_slash);
 
             crate::Resolver::assert_valid_cache_key(dir);
+
+            let had_handle = maybe_handle.is_some();
+            let close_even_if_published = !store_fd || self.need_to_close_files();
+            let owned_handle = core::cell::Cell::new(maybe_handle);
+            let handle_published = core::cell::Cell::new(false);
+            let _close_guard = scopeguard::guard((), |()| {
+                let Some(h) = owned_handle.get() else { return };
+                if !handle_published.get() || (!had_handle && close_even_if_published) {
+                    let _ = bun_sys::close(h);
+                }
+            });
+
             let mut cache_result: Option<bun_alloc::Result> = None;
             let _unlock_guard = if bun_core::FeatureFlags::ENABLE_ENTRY_CACHE {
                 Some(self.entries_mutex.lock_guard())
@@ -1219,22 +1231,16 @@ pub mod fs {
                 }
             }
 
-            let had_handle = maybe_handle.is_some();
-            let handle: Fd = match maybe_handle {
+            let handle: Fd = match owned_handle.get() {
                 Some(h) => h,
                 None => match self.open_dir(dir) {
-                    Ok(h) => h,
+                    Ok(h) => {
+                        owned_handle.set(Some(h));
+                        h
+                    }
                     Err(err) => return self.read_directory_error(dir, err),
                 },
             };
-
-            let close_even_if_published = !store_fd || self.need_to_close_files();
-            let handle_published = core::cell::Cell::new(false);
-            let _close_guard = scopeguard::guard((), |()| {
-                if !handle_published.get() || (!had_handle && close_even_if_published) {
-                    let _ = bun_sys::close(handle);
-                }
-            });
 
             // if we get this far, it's a real directory, so we can just store the dir name.
             // An in-place refresh always keeps the slot's existing interned name: callers

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1227,8 +1227,6 @@ pub mod fs {
                 },
             };
 
-            // Close a freshly-opened handle on every exit path until it is
-            // published into the returned DirEntry (the `store_fd` success path).
             let close_even_if_published = !store_fd || self.need_to_close_files();
             let handle_published = core::cell::Cell::new(false);
             let _close_guard = scopeguard::guard((), |()| {

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1231,10 +1231,10 @@ pub mod fs {
             // is published into the returned DirEntry; `handle_published` flips
             // once that happens so the `store_fd` success path keeps the fd while
             // the `?`/error returns below still close it.
-            let should_close_handle = !had_handle && (!store_fd || self.need_to_close_files());
+            let close_even_if_published = !store_fd || self.need_to_close_files();
             let handle_published = core::cell::Cell::new(false);
             let _close_guard = scopeguard::guard((), |()| {
-                if !had_handle && (should_close_handle || !handle_published.get()) {
+                if !had_handle && (close_even_if_published || !handle_published.get()) {
                     let _ = bun_sys::close(handle);
                 }
             });

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1168,7 +1168,7 @@ pub mod fs {
         // https://twitter.com/jarredsumner/status/1655464485245845506
         /// Caller borrows the returned `EntriesOption`. When `FeatureFlags::ENABLE_ENTRY_CACHE`
         /// is `false`, it is not safe to store this pointer past the current function call.
-        /// `maybe_handle` is owned: published into `DirEntry.fd` on success when `store_fd`, closed otherwise.
+        /// `maybe_handle` is owned by this call.
         pub fn read_directory_with_iterator<I: DirEntryIterator>(
             &mut self,
             dir_maybe_trail_slash: &[u8],
@@ -1270,6 +1270,10 @@ pub mod fs {
                     e
                 }
                 Err(err) => {
+                    // A non-void iterator has already observed the fd for every
+                    // entry yielded before the failure; closing now would use a
+                    // freed fd in the caller's queued work. Leak instead.
+                    handle_published.set(store_fd && !I::IS_VOID);
                     if let Some(existing) = in_place {
                         // SAFETY: see above.
                         unsafe { (*existing).data.clear() };

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1227,10 +1227,8 @@ pub mod fs {
                 },
             };
 
-            // A freshly-opened handle is ours to close on every exit path until it
-            // is published into the returned DirEntry; `handle_published` flips
-            // once that happens so the `store_fd` success path keeps the fd while
-            // the `?`/error returns below still close it.
+            // Close a freshly-opened handle on every exit path until it is
+            // published into the returned DirEntry (the `store_fd` success path).
             let close_even_if_published = !store_fd || self.need_to_close_files();
             let handle_published = core::cell::Cell::new(false);
             let _close_guard = scopeguard::guard((), |()| {
@@ -1263,8 +1261,6 @@ pub mod fs {
             let mut entries = match self.readdir(store_fd, prev, dir, generation, handle, iterator)
             {
                 Ok(e) => {
-                    // `e.fd == handle` when `store_fd`; every remaining path moves
-                    // `e` into long-lived storage before the next `?`.
                     handle_published.set(true);
                     e
                 }

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1270,9 +1270,7 @@ pub mod fs {
                     e
                 }
                 Err(err) => {
-                    // A non-void iterator has already observed the fd for every
-                    // entry yielded before the failure; closing now would use a
-                    // freed fd in the caller's queued work. Leak instead.
+                    // Non-void iterators already hold the fd; closing would use-after-free it.
                     handle_published.set(store_fd && !I::IS_VOID);
                     if let Some(existing) = in_place {
                         // SAFETY: see above.

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1266,7 +1266,7 @@ pub mod fs {
             let mut entries = match self.readdir(store_fd, prev, dir, generation, handle, iterator)
             {
                 Ok(e) => {
-                    handle_published.set(true);
+                    handle_published.set(e.fd == handle);
                     e
                 }
                 Err(err) => {

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1294,6 +1294,7 @@ pub mod fs {
                 }
                 if store_fd && !entries.fd.is_valid() {
                     entries.fd = handle;
+                    handle_published.set(true);
                 }
 
                 // SAFETY: `entries_ptr` is either a live BSSMap slot (`in_place`) or a fresh

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1227,12 +1227,15 @@ pub mod fs {
                 },
             };
 
-            // Close the handle on every exit path. Use
-            // scopeguard so close happens even if `readdir`/`put` early-return with `?`.
+            // A freshly-opened handle is ours to close on every exit path until it
+            // is published into the returned DirEntry; `handle_published` flips
+            // once that happens so the `store_fd` success path keeps the fd while
+            // the `?`/error returns below still close it.
             let should_close_handle = !had_handle && (!store_fd || self.need_to_close_files());
-            let _close_guard = scopeguard::guard(handle, move |h| {
-                if should_close_handle {
-                    let _ = bun_sys::close(h);
+            let handle_published = core::cell::Cell::new(false);
+            let _close_guard = scopeguard::guard((), |()| {
+                if !had_handle && (should_close_handle || !handle_published.get()) {
+                    let _ = bun_sys::close(handle);
                 }
             });
 
@@ -1259,7 +1262,12 @@ pub mod fs {
             });
             let mut entries = match self.readdir(store_fd, prev, dir, generation, handle, iterator)
             {
-                Ok(e) => e,
+                Ok(e) => {
+                    // `e.fd == handle` when `store_fd`; every remaining path moves
+                    // `e` into long-lived storage before the next `?`.
+                    handle_published.set(true);
+                    e
+                }
                 Err(err) => {
                     if let Some(existing) = in_place {
                         // SAFETY: see above.

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1168,9 +1168,7 @@ pub mod fs {
         // https://twitter.com/jarredsumner/status/1655464485245845506
         /// Caller borrows the returned `EntriesOption`. When `FeatureFlags::ENABLE_ENTRY_CACHE`
         /// is `false`, it is not safe to store this pointer past the current function call.
-        ///
-        /// `maybe_handle` is owned: on success it is published into the cached
-        /// `DirEntry.fd` when `store_fd`; on any error before that it is closed.
+        /// `maybe_handle` is owned: published into `DirEntry.fd` on success when `store_fd`, closed otherwise.
         pub fn read_directory_with_iterator<I: DirEntryIterator>(
             &mut self,
             dir_maybe_trail_slash: &[u8],

--- a/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
+++ b/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
@@ -167,18 +167,17 @@ test.skipIf(skip)("resolver closes a caller-supplied directory fd when readdir f
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const m = stdout.match(/LEAKED=(\d+)/);
   // unreachable-marker stays undiscovered iff the shim made the marker dirs
   // unreadable; if bun stops routing getdents64 through libc syscall() this trips.
   expect({
-    leaked: m?.[0],
-    shimFired: !stderr.includes("unreachable-marker"),
-    onePass: stderr.includes("1 pass"),
+    leaked: stdout.match(/LEAKED=\d+/)?.[0] ?? stdout,
+    passCount: stderr.match(/(\d+) pass/)?.[1] ?? stderr,
+    sawUnreachable: stderr.includes("unreachable-marker"),
     exitCode,
   }).toEqual({
     leaked: "LEAKED=0",
-    shimFired: true,
-    onePass: true,
+    passCount: "1",
+    sawUnreachable: false,
     exitCode: 0,
   });
 });

--- a/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
+++ b/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
@@ -135,49 +135,55 @@ test.skipIf(skip)(
 );
 
 // The `bun test` scanner opens each subdirectory itself and hands the fd to
-// read_directory_with_iterator(Some(fd)), which is the had_handle=true arm of
-// the same guard. The scanner's Dir guard is disarmed via into_raw(), so the
-// function owns the fd on that path too.
-test.skipIf(skip)("resolver closes a caller-supplied directory fd when readdir fails (bun test scanner)", async () => {
-  const files: Record<string, string> = {
-    "package.json": "{}",
-    "count.test.ts": /* ts */ `
+// read_directory_with_iterator(Some(fd), iterator=ScannerDirIter). The iterator
+// queues ScanEntry { relative_dir: fd } for every entry it sees during
+// iteration, so when a later getdents64 batch fails the queued entries still
+// hold the fd and closing it here would be a use-after-close in the scan loop.
+// The guard therefore treats the fd as published once a non-void iterator is in
+// play, so the scanner's readdir-error path still holds one fd per directory.
+test.skipIf(skip)(
+  "bun test scanner keeps the directory fd when readdir fails (non-void iterator dispatched it)",
+  async () => {
+    const files: Record<string, string> = {
+      "package.json": "{}",
+      "count.test.ts": /* ts */ `
         import { test } from "bun:test";
         import { readdirSync, readlinkSync } from "node:fs";
         test("count", () => {
-          let leaked = 0;
+          let held = 0;
           for (const name of readdirSync("/proc/self/fd")) {
             try {
-              if (readlinkSync("/proc/self/fd/" + name).includes("${MARKER}")) leaked++;
+              if (readlinkSync("/proc/self/fd/" + name).includes("${MARKER}")) held++;
             } catch {}
           }
-          console.log("LEAKED=" + leaked);
+          console.log("HELD=" + held);
         });
       `,
-  };
-  for (let i = 0; i < DIR_COUNT; i++)
-    files[`d${i}${MARKER}/unreachable.test.ts`] =
-      `import { test } from "bun:test"; test("unreachable-marker", () => {});`;
-  using scanDir = tempDir("resolver-readdir-scanner-leak", files);
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "."],
-    cwd: String(scanDir),
-    env: shimEnv(),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  // unreachable-marker stays undiscovered iff the shim made the marker dirs
-  // unreadable; if bun stops routing getdents64 through libc syscall() this trips.
-  expect({
-    leaked: stdout.match(/LEAKED=\d+/)?.[0] ?? stdout,
-    passCount: stderr.match(/(\d+) pass/)?.[1] ?? stderr,
-    sawUnreachable: stderr.includes("unreachable-marker"),
-    exitCode,
-  }).toEqual({
-    leaked: "LEAKED=0",
-    passCount: "1",
-    sawUnreachable: false,
-    exitCode: 0,
-  });
-});
+    };
+    for (let i = 0; i < DIR_COUNT; i++)
+      files[`d${i}${MARKER}/unreachable.test.ts`] =
+        `import { test } from "bun:test"; test("unreachable-marker", () => {});`;
+    using scanDir = tempDir("resolver-readdir-scanner-hold", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "."],
+      cwd: String(scanDir),
+      env: shimEnv(),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // unreachable-marker stays undiscovered iff the shim made the marker dirs
+    // unreadable; if bun stops routing getdents64 through libc syscall() this trips.
+    expect({
+      held: stdout.match(/HELD=\d+/)?.[0] ?? stdout,
+      passCount: stderr.match(/(\d+) pass/)?.[1] ?? stderr,
+      sawUnreachable: stderr.includes("unreachable-marker"),
+      exitCode,
+    }).toEqual({
+      held: `HELD=${DIR_COUNT}`,
+      passCount: "1",
+      sawUnreachable: false,
+      exitCode: 0,
+    });
+  },
+);

--- a/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
+++ b/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
@@ -155,7 +155,8 @@ test.skipIf(skip)("resolver closes a caller-supplied directory fd when readdir f
         });
       `,
   };
-  for (let i = 0; i < DIR_COUNT; i++) files[`d${i}${MARKER}/noop.txt`] = "";
+  for (let i = 0; i < DIR_COUNT; i++)
+    files[`d${i}${MARKER}/unreachable.test.ts`] = `import { test } from "bun:test"; test("unreachable-marker", () => {});`;
   using scanDir = tempDir("resolver-readdir-scanner-leak", files);
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", "."],
@@ -166,9 +167,12 @@ test.skipIf(skip)("resolver closes a caller-supplied directory fd when readdir f
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const m = stdout.match(/LEAKED=(\d+)/);
-  expect({ leaked: m?.[0], stderr: stderr.includes("1 pass"), exitCode }).toEqual({
+  // unreachable-marker stays undiscovered iff the shim made the marker dirs
+  // unreadable; if bun stops routing getdents64 through libc syscall() this trips.
+  expect({ leaked: m?.[0], shimFired: !stderr.includes("unreachable-marker"), onePass: stderr.includes("1 pass"), exitCode }).toEqual({
     leaked: "LEAKED=0",
-    stderr: true,
+    shimFired: true,
+    onePass: true,
     exitCode: 0,
   });
 });

--- a/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
+++ b/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
@@ -138,12 +138,10 @@ test.skipIf(skip)(
 // read_directory_with_iterator(Some(fd)), which is the had_handle=true arm of
 // the same guard. The scanner's Dir guard is disarmed via into_raw(), so the
 // function owns the fd on that path too.
-test.skipIf(skip)(
-  "resolver closes a caller-supplied directory fd when readdir fails (bun test scanner)",
-  async () => {
-    const files: Record<string, string> = {
-      "package.json": "{}",
-      "count.test.ts": /* ts */ `
+test.skipIf(skip)("resolver closes a caller-supplied directory fd when readdir fails (bun test scanner)", async () => {
+  const files: Record<string, string> = {
+    "package.json": "{}",
+    "count.test.ts": /* ts */ `
         import { test } from "bun:test";
         import { readdirSync, readlinkSync } from "node:fs";
         test("count", () => {
@@ -156,22 +154,21 @@ test.skipIf(skip)(
           console.log("LEAKED=" + leaked);
         });
       `,
-    };
-    for (let i = 0; i < DIR_COUNT; i++) files[`d${i}${MARKER}/noop.txt`] = "";
-    using scanDir = tempDir("resolver-readdir-scanner-leak", files);
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "."],
-      cwd: String(scanDir),
-      env: shimEnv(),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const m = stdout.match(/LEAKED=(\d+)/);
-    expect({ leaked: m?.[0], stderr: stderr.includes("1 pass"), exitCode }).toEqual({
-      leaked: "LEAKED=0",
-      stderr: true,
-      exitCode: 0,
-    });
-  },
-);
+  };
+  for (let i = 0; i < DIR_COUNT; i++) files[`d${i}${MARKER}/noop.txt`] = "";
+  using scanDir = tempDir("resolver-readdir-scanner-leak", files);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "."],
+    cwd: String(scanDir),
+    env: shimEnv(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const m = stdout.match(/LEAKED=(\d+)/);
+  expect({ leaked: m?.[0], stderr: stderr.includes("1 pass"), exitCode }).toEqual({
+    leaked: "LEAKED=0",
+    stderr: true,
+    exitCode: 0,
+  });
+});

--- a/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
+++ b/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
@@ -156,7 +156,8 @@ test.skipIf(skip)("resolver closes a caller-supplied directory fd when readdir f
       `,
   };
   for (let i = 0; i < DIR_COUNT; i++)
-    files[`d${i}${MARKER}/unreachable.test.ts`] = `import { test } from "bun:test"; test("unreachable-marker", () => {});`;
+    files[`d${i}${MARKER}/unreachable.test.ts`] =
+      `import { test } from "bun:test"; test("unreachable-marker", () => {});`;
   using scanDir = tempDir("resolver-readdir-scanner-leak", files);
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", "."],
@@ -169,7 +170,12 @@ test.skipIf(skip)("resolver closes a caller-supplied directory fd when readdir f
   const m = stdout.match(/LEAKED=(\d+)/);
   // unreachable-marker stays undiscovered iff the shim made the marker dirs
   // unreadable; if bun stops routing getdents64 through libc syscall() this trips.
-  expect({ leaked: m?.[0], shimFired: !stderr.includes("unreachable-marker"), onePass: stderr.includes("1 pass"), exitCode }).toEqual({
+  expect({
+    leaked: m?.[0],
+    shimFired: !stderr.includes("unreachable-marker"),
+    onePass: stderr.includes("1 pass"),
+    exitCode,
+  }).toEqual({
     leaked: "LEAKED=0",
     shimFired: true,
     onePass: true,

--- a/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
+++ b/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
@@ -58,10 +58,13 @@ long syscall(long number, ...) {
 const INNER = /* ts */ `
 import { readdirSync, readlinkSync } from "node:fs";
 const N = ${DIR_COUNT};
+let failed = 0;
 for (let i = 0; i < N; i++) {
   try {
     require.resolve("./d" + i + "${MARKER}/m.ts");
-  } catch {}
+  } catch {
+    failed++;
+  }
 }
 let leaked = 0;
 for (const name of readdirSync("/proc/self/fd")) {
@@ -70,7 +73,7 @@ for (const name of readdirSync("/proc/self/fd")) {
     if (target.includes("${MARKER}")) leaked++;
   } catch {}
 }
-console.log("LEAKED=" + leaked);
+console.log("FAILED=" + failed + " LEAKED=" + leaked);
 process.exit(0);
 `;
 
@@ -115,7 +118,12 @@ test.skipIf(!isLinux || isMusl || !cc)(
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const m = stdout.match(/LEAKED=(\d+)/);
-    expect({ stdout: m?.[0], stderr, exitCode }).toEqual({ stdout: "LEAKED=0", stderr: "", exitCode: 0 });
+    // FAILED=DIR_COUNT proves the shim actually fired; if bun stops routing
+    // getdents64 through libc's syscall() the resolves succeed and this trips.
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: `FAILED=${DIR_COUNT} LEAKED=0`,
+      stderr: "",
+      exitCode: 0,
+    });
   },
 );

--- a/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
+++ b/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
@@ -106,14 +106,20 @@ afterAll(() => {
 
 // LD_PRELOAD interposition requires a dynamic libc; the musl build links libc
 // statically, so the shim cannot intercept syscall() there.
-test.skipIf(!isLinux || isMusl || !cc)(
-  "resolver closes the directory fd when readdir fails after a successful open (store_fd)",
+const skip = !isLinux || isMusl || !cc;
+
+function shimEnv() {
+  const existing = bunEnv.LD_PRELOAD;
+  return { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath };
+}
+
+test.skipIf(skip)(
+  "resolver closes the directory fd when readdir fails after a successful open (store_fd, fresh handle)",
   async () => {
-    const existing = bunEnv.LD_PRELOAD;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "--hot", "inner.ts"],
       cwd: String(dir),
-      env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath },
+      env: shimEnv(),
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -123,6 +129,48 @@ test.skipIf(!isLinux || isMusl || !cc)(
     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
       stdout: `FAILED=${DIR_COUNT} LEAKED=0`,
       stderr: "",
+      exitCode: 0,
+    });
+  },
+);
+
+// The `bun test` scanner opens each subdirectory itself and hands the fd to
+// read_directory_with_iterator(Some(fd)), which is the had_handle=true arm of
+// the same guard. The scanner's Dir guard is disarmed via into_raw(), so the
+// function owns the fd on that path too.
+test.skipIf(skip)(
+  "resolver closes a caller-supplied directory fd when readdir fails (bun test scanner)",
+  async () => {
+    const files: Record<string, string> = {
+      "package.json": "{}",
+      "count.test.ts": /* ts */ `
+        import { test } from "bun:test";
+        import { readdirSync, readlinkSync } from "node:fs";
+        test("count", () => {
+          let leaked = 0;
+          for (const name of readdirSync("/proc/self/fd")) {
+            try {
+              if (readlinkSync("/proc/self/fd/" + name).includes("${MARKER}")) leaked++;
+            } catch {}
+          }
+          console.log("LEAKED=" + leaked);
+        });
+      `,
+    };
+    for (let i = 0; i < DIR_COUNT; i++) files[`d${i}${MARKER}/noop.txt`] = "";
+    using scanDir = tempDir("resolver-readdir-scanner-leak", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "."],
+      cwd: String(scanDir),
+      env: shimEnv(),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const m = stdout.match(/LEAKED=(\d+)/);
+    expect({ leaked: m?.[0], stderr: stderr.includes("1 pass"), exitCode }).toEqual({
+      leaked: "LEAKED=0",
+      stderr: true,
       exitCode: 0,
     });
   },

--- a/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
+++ b/test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts
@@ -1,0 +1,121 @@
+// The resolver opens a directory and then iterates it via getdents64. When the
+// open succeeds but iteration fails, and the resolver was asked to cache the
+// fd (store_fd, set by bun test / --hot / --watch / install), the fd must be
+// closed on that error path. The guard that closes it used to be gated on the
+// "don't store" condition, so a store_fd run leaked one directory fd per
+// failed read.
+//
+// getdents64 is reached through libc's variadic syscall(), so an LD_PRELOAD
+// shim can make it fail with EIO for fds whose /proc/self/fd target contains a
+// marker string. The inner process runs under --hot (store_fd=true), resolves
+// one path per marker directory, then counts open fds that still point at a
+// marker directory.
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, isMusl, tempDir } from "harness";
+import { join } from "node:path";
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+const DIR_COUNT = 16;
+const MARKER = "__FAIL_GETDENTS__";
+
+const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+static long (*real_syscall)(long, long, long, long, long, long, long);
+
+long syscall(long number, ...) {
+  va_list ap;
+  long a, b, c, d, e, f;
+  va_start(ap, number);
+  a = va_arg(ap, long); b = va_arg(ap, long); c = va_arg(ap, long);
+  d = va_arg(ap, long); e = va_arg(ap, long); f = va_arg(ap, long);
+  va_end(ap);
+  if (!real_syscall)
+    real_syscall = (long (*)(long, long, long, long, long, long, long))dlsym(RTLD_NEXT, "syscall");
+  if (number == SYS_getdents64) {
+    char link[64], target[4096];
+    snprintf(link, sizeof link, "/proc/self/fd/%ld", a);
+    ssize_t n = readlink(link, target, sizeof(target) - 1);
+    if (n > 0) {
+      target[n] = 0;
+      if (strstr(target, "${MARKER}")) {
+        errno = EIO;
+        return -1;
+      }
+    }
+  }
+  return real_syscall(number, a, b, c, d, e, f);
+}
+`;
+
+const INNER = /* ts */ `
+import { readdirSync, readlinkSync } from "node:fs";
+const N = ${DIR_COUNT};
+for (let i = 0; i < N; i++) {
+  try {
+    require.resolve("./d" + i + "${MARKER}/m.ts");
+  } catch {}
+}
+let leaked = 0;
+for (const name of readdirSync("/proc/self/fd")) {
+  try {
+    const target = readlinkSync("/proc/self/fd/" + name);
+    if (target.includes("${MARKER}")) leaked++;
+  } catch {}
+}
+console.log("LEAKED=" + leaked);
+process.exit(0);
+`;
+
+let dir: ReturnType<typeof tempDir>;
+let shimPath: string;
+
+beforeAll(async () => {
+  if (!isLinux || isMusl || !cc) return;
+  const files: Record<string, string> = {
+    "shim.c": SHIM_C,
+    "inner.ts": INNER,
+    "package.json": "{}",
+  };
+  for (let i = 0; i < DIR_COUNT; i++) files[`d${i}${MARKER}/m.ts`] = `export {};\n`;
+  dir = tempDir("resolver-readdir-fail-leak", files);
+  shimPath = join(String(dir), "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+});
+
+afterAll(() => {
+  dir?.[Symbol.dispose]();
+});
+
+// LD_PRELOAD interposition requires a dynamic libc; the musl build links libc
+// statically, so the shim cannot intercept syscall() there.
+test.skipIf(!isLinux || isMusl || !cc)(
+  "resolver closes the directory fd when readdir fails after a successful open (store_fd)",
+  async () => {
+    const existing = bunEnv.LD_PRELOAD;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--hot", "inner.ts"],
+      cwd: String(dir),
+      env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const m = stdout.match(/LEAKED=(\d+)/);
+    expect({ stdout: m?.[0], stderr, exitCode }).toEqual({ stdout: "LEAKED=0", stderr: "", exitCode: 0 });
+  },
+);


### PR DESCRIPTION
## Repro

Under any mode that caches directory fds (`bun --hot`, `bun --watch`, `bun install`, `bun test`), resolve a path whose parent directory can be opened but whose `getdents64` fails:

```
FAILED=16 LEAKED=32   # bun --hot: 16 directories, 2 opens each via the bust-and-retry in VirtualMachine resolve
```

`getdents64` failing after a successful `open(O_DIRECTORY)` is rare but reachable: a filesystem that returns EIO mid-iteration, a FUSE mount that disappears between the two syscalls, or a directory the process may search but not read. The runtime's NotFound retry in `VirtualMachine` also busts the cached `Err` and re-opens once per `require.resolve`, so an unresolvable directory leaks one fd on every call rather than once total.

## Cause

`read_directory_with_iterator` opens the directory (or accepts one from the caller), then sets up a scopeguard to close it. The guard was gated on `!had_handle && (!store_fd || need_to_close_files())`: the "we never intended to cache this fd" condition. When `store_fd` is set and `need_to_close_files()` is false (always on Windows; on POSIX once the raised rlimit puts the process well under its fd budget), that condition is false and the guard never closes.

On the success path that is what we want: `entries.fd = handle` publishes the fd into the cached `DirEntry`. On the early-return paths it leaks: `DirnameStore::append_slice(...)?` and `readdir(...)` returning `Err` both return before the fd is published, and `DirEntry` has no `Drop`.

## Fix

The guard now holds `Cell<Option<Fd>>` initialized from `maybe_handle` and is armed before any exit path. It closes whenever the handle has not been published, with the pre-existing close-after-publish behaviour for a freshly-opened fd we never intended to cache kept under `!had_handle`. `open_dir` writes into the same cell on a cache miss. `handle_published` is set when `readdir` returns `Ok` with `e.fd == handle`, so the success path is unchanged.

One exception to "close when not published": when the iterator is non-void (only the `bun test` scanner), `readdir` dispatches the fd to the iterator for every entry it yields, so a later iteration failure leaves queued `ScanEntry { relative_dir: fd }` values that the scan loop will still use. Closing there would be a use-after-close against those queued entries, so the Err arm with a non-void iterator keeps the pre-PR hold-and-leak behaviour. Every `read_directory` caller (`load_as_file`, install, lockfile) uses the void iterator and gets the close.

`RealFS::kind()` shares the same gate expression in its symlink branch; it is excluded here because its failure points (`fstat`, `get_fd_path`) route through rustix's linux_raw backend and cannot be driven by the LD_PRELOAD shim, so there is no fail-before proof available. It has been handed off separately.

## Verification

`test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts` builds an LD_PRELOAD shim that makes `syscall(SYS_getdents64, fd, ...)` fail with EIO when the fd's `/proc/self/fd` target contains a marker string, then:

- runs `bun --hot inner.ts` (so `resolver.store_fd = true`, `maybe_handle = None`, void iterator), resolves one path per marker directory, and asserts `FAILED=16 LEAKED=0` (`FAILED` proves the shim fired);
- runs `bun test .` over a tree with marker subdirectories so the scanner opens each one and hands the fd in with its non-void iterator, and asserts `HELD=16` (the fds stay valid for queued work; this guards the use-after-close regression).

Before: `LEAKED=32`. After: `LEAKED=0`. The scanner test passes on both, by design.

`test/js/bun/resolve/resolve.test.ts`, `test/cli/test/bun-test.test.ts`, `test/js/bun/resolve/import-meta.test.js`, and `test/cli/hot/hot.test.ts` are unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolver-readdir-error-fd-leak.test.ts

<!-- robobun:evidence:end -->