### PR TITLE
cli: report an error for over-PATH_MAX --cpu-prof-dir / --heap-prof-dir instead of panicking

### DIFF
--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -177,10 +177,7 @@ fn build_output_path(
         generate_default_filename(&mut filename_buf, is_md_format)?
     };
 
-    // `dir` and `name` are user-controlled CLI bytes, and AutoAbsPath is
-    // CheckLength::ASSUME (over-long input panics in PooledBuf slice indexing
-    // rather than returning Err), so bound the combined length before touching
-    // the buffer. One byte is reserved for `slice_z`'s NUL.
+    // dir/name are unbounded CLI input; AutoAbsPath (CheckLength::ASSUME) panics on overflow.
     let sep_for_dir = usize::from(!config.dir.is_empty());
     let upper_bound = path
         .len()

--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -5,7 +5,7 @@ use crate::VM;
 use bun_core::{OwnedString, String as BunString};
 #[cfg(windows)]
 use bun_paths::OSPathBuffer;
-use bun_paths::{MAX_PATH_BYTES, PathBuffer};
+use bun_paths::{AutoAbsPathChecked, PathBuffer};
 use bun_sys::{self, Errno, Fd, FdDirExt as _};
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
@@ -102,8 +102,8 @@ fn write_profile_to_file(
     let profile_slice = profile_string.to_utf8();
     // (defer profile_slice.deinit() — handled by Drop on Utf8Slice)
 
-    // Determine the output path using AutoAbsPath
-    let mut path_buf = bun_paths::AutoAbsPath::init_top_level_dir();
+    // dir/name are unbounded CLI input, so use the length-checked variant.
+    let mut path_buf = AutoAbsPathChecked::init_top_level_dir();
     // (defer path_buf.deinit() — handled by Drop)
 
     build_output_path(&mut path_buf, config, is_md_format)?;
@@ -147,7 +147,7 @@ fn write_profile_to_file(
 }
 
 fn build_output_path(
-    path: &mut bun_paths::AutoAbsPath,
+    path: &mut AutoAbsPathChecked,
     config: &CPUProfilerConfig,
     is_md_format: bool,
 ) -> Result<(), ProfilerError> {
@@ -177,25 +177,12 @@ fn build_output_path(
         generate_default_filename(&mut filename_buf, is_md_format)?
     };
 
-    // dir/name are unbounded CLI input; AutoAbsPath (CheckLength::ASSUME) panics on overflow.
-    let sep_for_dir = usize::from(!config.dir.is_empty());
-    let upper_bound = path
-        .len()
-        .saturating_add(sep_for_dir)
-        .saturating_add(config.dir.len())
-        .saturating_add(1)
-        .saturating_add(filename.len());
-    if upper_bound >= MAX_PATH_BYTES {
-        return Err(ProfilerError::FilenameTooLong);
-    }
-
-    // Append directory if specified
     if !config.dir.is_empty() {
-        path.join(&[config.dir]).expect("bounded above");
+        path.join(&[config.dir])
+            .map_err(|_| ProfilerError::FilenameTooLong)?;
     }
-
-    // Append filename
-    path.append(filename).expect("bounded above");
+    path.append(filename)
+        .map_err(|_| ProfilerError::FilenameTooLong)?;
 
     Ok(())
 }

--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -5,7 +5,7 @@ use crate::VM;
 use bun_core::{OwnedString, String as BunString};
 #[cfg(windows)]
 use bun_paths::OSPathBuffer;
-use bun_paths::PathBuffer;
+use bun_paths::{MAX_PATH_BYTES, PathBuffer};
 use bun_sys::{self, Errno, Fd, FdDirExt as _};
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
@@ -177,15 +177,28 @@ fn build_output_path(
         generate_default_filename(&mut filename_buf, is_md_format)?
     };
 
+    // `dir` and `name` are user-controlled CLI bytes, and AutoAbsPath is
+    // CheckLength::ASSUME (over-long input panics in PooledBuf slice indexing
+    // rather than returning Err), so bound the combined length before touching
+    // the buffer. One byte is reserved for `slice_z`'s NUL.
+    let sep_for_dir = usize::from(!config.dir.is_empty());
+    let upper_bound = path
+        .len()
+        .saturating_add(sep_for_dir)
+        .saturating_add(config.dir.len())
+        .saturating_add(1)
+        .saturating_add(filename.len());
+    if upper_bound >= MAX_PATH_BYTES {
+        return Err(ProfilerError::FilenameTooLong);
+    }
+
     // Append directory if specified
     if !config.dir.is_empty() {
-        // AutoAbsPath uses CheckLength::ASSUME — Err arm is unreachable.
-        // See paths/Path.rs `options::Result` note.
-        path.join(&[config.dir]).expect("unreachable");
+        path.join(&[config.dir]).expect("bounded above");
     }
 
     // Append filename
-    path.append(filename).expect("unreachable");
+    path.append(filename).expect("bounded above");
 
     Ok(())
 }

--- a/src/jsc/BunHeapProfiler.rs
+++ b/src/jsc/BunHeapProfiler.rs
@@ -1,7 +1,7 @@
 use crate::CrateError as Error;
 use bun_core::{Output, Timespec, TimespecMockMode};
 use bun_core::{OwnedString, String as BunString};
-use bun_paths::{AutoAbsPath, PathBuffer, resolve_path};
+use bun_paths::{AutoAbsPath, MAX_PATH_BYTES, PathBuffer, resolve_path};
 use bun_sys::{self as sys, E, Fd, FdDirExt};
 
 use crate::VM;
@@ -107,6 +107,21 @@ fn build_output_path(path: &mut AutoAbsPath, config: &HeapProfilerConfig) -> Res
     } else {
         generate_default_filename(&mut filename_buf, config.text_format)?
     };
+
+    // `dir` and `name` are user-controlled CLI bytes, and AutoAbsPath is
+    // CheckLength::ASSUME (over-long input panics in PooledBuf slice indexing
+    // rather than returning Err), so bound the combined length before touching
+    // the buffer. One byte is reserved for `slice_z`'s NUL.
+    let sep_for_dir = usize::from(!config.dir.is_empty());
+    let upper_bound = path
+        .len()
+        .saturating_add(sep_for_dir)
+        .saturating_add(config.dir.len())
+        .saturating_add(1)
+        .saturating_add(filename.len());
+    if upper_bound >= MAX_PATH_BYTES {
+        return Err(Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
+    }
 
     // Append directory if specified
     if !config.dir.is_empty() {

--- a/src/jsc/BunHeapProfiler.rs
+++ b/src/jsc/BunHeapProfiler.rs
@@ -108,10 +108,7 @@ fn build_output_path(path: &mut AutoAbsPath, config: &HeapProfilerConfig) -> Res
         generate_default_filename(&mut filename_buf, config.text_format)?
     };
 
-    // `dir` and `name` are user-controlled CLI bytes, and AutoAbsPath is
-    // CheckLength::ASSUME (over-long input panics in PooledBuf slice indexing
-    // rather than returning Err), so bound the combined length before touching
-    // the buffer. One byte is reserved for `slice_z`'s NUL.
+    // dir/name are unbounded CLI input; AutoAbsPath (CheckLength::ASSUME) panics on overflow.
     let sep_for_dir = usize::from(!config.dir.is_empty());
     let upper_bound = path
         .len()

--- a/src/jsc/BunHeapProfiler.rs
+++ b/src/jsc/BunHeapProfiler.rs
@@ -1,7 +1,7 @@
 use crate::CrateError as Error;
 use bun_core::{Output, Timespec, TimespecMockMode};
 use bun_core::{OwnedString, String as BunString};
-use bun_paths::{AutoAbsPath, MAX_PATH_BYTES, PathBuffer, resolve_path};
+use bun_paths::{AutoAbsPathChecked, PathBuffer, resolve_path};
 use bun_sys::{self as sys, E, Fd, FdDirExt};
 
 use crate::VM;
@@ -42,8 +42,8 @@ pub(crate) fn generate_and_write_profile(
     // Freed by Drop on ZigStringSlice.
     let profile_slice = profile_string.to_utf8();
 
-    // Determine the output path using AutoAbsPath
-    let mut path_buf = AutoAbsPath::init_top_level_dir();
+    // dir/name are unbounded CLI input, so use the length-checked variant.
+    let mut path_buf = AutoAbsPathChecked::init_top_level_dir();
     // `defer path_buf.deinit()` — handled by Drop.
 
     build_output_path(&mut path_buf, config)?;
@@ -99,7 +99,10 @@ pub(crate) fn generate_and_write_profile(
     Ok(())
 }
 
-fn build_output_path(path: &mut AutoAbsPath, config: &HeapProfilerConfig) -> Result<(), Error> {
+fn build_output_path(
+    path: &mut AutoAbsPathChecked,
+    config: &HeapProfilerConfig,
+) -> Result<(), Error> {
     // Generate filename
     let mut filename_buf = PathBuffer::uninit();
     let filename: &[u8] = if !config.name.is_empty() {
@@ -108,24 +111,9 @@ fn build_output_path(path: &mut AutoAbsPath, config: &HeapProfilerConfig) -> Res
         generate_default_filename(&mut filename_buf, config.text_format)?
     };
 
-    // dir/name are unbounded CLI input; AutoAbsPath (CheckLength::ASSUME) panics on overflow.
-    let sep_for_dir = usize::from(!config.dir.is_empty());
-    let upper_bound = path
-        .len()
-        .saturating_add(sep_for_dir)
-        .saturating_add(config.dir.len())
-        .saturating_add(1)
-        .saturating_add(filename.len());
-    if upper_bound >= MAX_PATH_BYTES {
-        return Err(Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
-    }
-
-    // Append directory if specified
     if !config.dir.is_empty() {
         path.append(config.dir)?;
     }
-
-    // Append filename
     path.append(filename)?;
     Ok(())
 }

--- a/src/paths/Path.rs
+++ b/src/paths/Path.rs
@@ -582,10 +582,7 @@ pub type AbsPath<
 /// Absolute path with auto separator.
 pub type AutoAbsPath = Path<u8, { Kind::ABS }, { PathSeparators::AUTO }>;
 
-/// Absolute path with auto separator and `CheckLength::CheckForGreaterThanMaxPath`.
-/// `from`/`append`/`append_fmt`/`join` return `Err(MaxPathExceeded)` on overflow
-/// instead of panicking in `PooledBuf` slice indexing. Use for unbounded user
-/// input (CLI args, JS strings).
+/// [`AutoAbsPath`] that returns `Err(MaxPathExceeded)` on overflow. Use for unbounded user input.
 pub type AutoAbsPathChecked =
     Path<u8, { Kind::ABS }, { PathSeparators::AUTO }, { CheckLength::CHECK }>;
 

--- a/src/paths/Path.rs
+++ b/src/paths/Path.rs
@@ -1106,6 +1106,12 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
             }
         }
 
+        if CheckLength::from_u8(CHECK) == CheckLength::CheckForGreaterThanMaxPath
+            && self.len() + 1 + part.len() >= U::MAX_PATH
+        {
+            return Err(PathError::MaxPathExceeded);
+        }
+
         // The four (C, U) arms are dispatched below via TypeId checks, which
         // const-fold to a single arm per monomorphization.
         use core::any::TypeId;

--- a/src/paths/Path.rs
+++ b/src/paths/Path.rs
@@ -80,6 +80,7 @@ pub mod options {
     }
     impl CheckLength {
         pub(crate) const ASSUME: u8 = 0;
+        pub(crate) const CHECK: u8 = 1;
         #[inline(always)]
         pub(crate) const fn from_u8(v: u8) -> Self {
             if v == 0 {
@@ -581,6 +582,13 @@ pub type AbsPath<
 /// Absolute path with auto separator.
 pub type AutoAbsPath = Path<u8, { Kind::ABS }, { PathSeparators::AUTO }>;
 
+/// Absolute path with auto separator and `CheckLength::CheckForGreaterThanMaxPath`.
+/// `from`/`append`/`append_fmt`/`join` return `Err(MaxPathExceeded)` on overflow
+/// instead of panicking in `PooledBuf` slice indexing. Use for unbounded user
+/// input (CLI args, JS strings).
+pub type AutoAbsPathChecked =
+    Path<u8, { Kind::ABS }, { PathSeparators::AUTO }, { CheckLength::CHECK }>;
+
 /// `RelPath(opts)` — forces `kind = .rel`.
 pub type RelPath<
     U = u8,
@@ -1072,9 +1080,21 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
             // `unsafe`) — the u8 impl is `fn(s) { s }`, the u16 default is
             // `unreachable!()` and is const-folded out in this monomorphisation.
             let parts_u8: &[&[u8]] = U::id_u8_slices(parts);
-            let joined = sep_dispatch!(join_abs_string_buf(cloned_slice, pooled, parts_u8));
+            let joined = if CheckLength::from_u8(CHECK) == CheckLength::CheckForGreaterThanMaxPath {
+                match sep_dispatch!(join_abs_string_buf_checked(cloned_slice, pooled, parts_u8)) {
+                    Some(j) => j,
+                    None => return Err(PathError::MaxPathExceeded),
+                }
+            } else {
+                sep_dispatch!(join_abs_string_buf(cloned_slice, pooled, parts_u8))
+            };
 
             let trimmed = trim_input(TrimInputKind::Abs, joined);
+            if CheckLength::from_u8(CHECK) == CheckLength::CheckForGreaterThanMaxPath
+                && trimmed.len() >= U::MAX_PATH
+            {
+                return Err(PathError::MaxPathExceeded);
+            }
             self._buf.len = trimmed.len();
         }
         Ok(())

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -357,7 +357,8 @@ pub use path_buffer_pool::os_path_buffer_pool;
 #[path = "Path.rs"]
 pub mod path;
 pub use path::{
-    AbsPath, AutoAbsPath, AutoRelPath, Path, PathUnit, RelPath, options as path_options,
+    AbsPath, AutoAbsPath, AutoAbsPathChecked, AutoRelPath, Path, PathUnit, RelPath,
+    options as path_options,
 };
 
 /// Generic surface for the `buf` parameter on path-builder helpers

--- a/test/cli/heap-prof.test.ts
+++ b/test/cli/heap-prof.test.ts
@@ -235,7 +235,7 @@ test.skipIf(isWindows).each([
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("done");
-  expect(stderr).toContain("ENAMETOOLONG");
+  expect(stderr).toContain("MaxPathExceeded");
   expect(stderr).toContain("Failed to write heap profile");
   expect(exitCode).toBe(0);
   expect(proc.signalCode).toBeNull();

--- a/test/cli/heap-prof.test.ts
+++ b/test/cli/heap-prof.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 const testScript = `const arr = []; for (let i = 0; i < 100; i++) arr.push({ x: i, y: "hello" + i }); console.log("done");`;
@@ -207,6 +207,32 @@ test("--heap-prof-name and --heap-prof-dir work together", async () => {
   // Check the profile exists in the specified location
   const profilePath = join(String(dir), "output", "custom.heapsnapshot");
   expect(Bun.file(profilePath).size).toBeGreaterThan(0);
+});
+
+// On Windows the path buffer is ~98 KB and the CreateProcess command-line
+// limit is ~32 KB, so an overflowing CLI argument cannot be delivered. On
+// POSIX 5000 bytes exceeds the fixed path buffer (Linux 4096, macOS 1024).
+test.skipIf(isWindows).each([
+  ["--heap-prof-dir", Buffer.alloc(5000, "d").toString()],
+  ["--heap-prof-name", Buffer.alloc(5000, "n").toString()],
+])("%s longer than PATH_MAX reports an error instead of panicking", async (flag, value) => {
+  using dir = tempDir("heap-prof-pathmax", {});
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--heap-prof", flag, value, "-e", `console.log("done");`],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("done");
+  expect(stderr).toContain("ENAMETOOLONG");
+  expect(stderr).toContain("Failed to write heap profile");
+  expect(exitCode).toBe(0);
+  expect(proc.signalCode).toBeNull();
 });
 
 test("--heap-prof-name without --heap-prof or --heap-prof-md shows warning", async () => {

--- a/test/cli/heap-prof.test.ts
+++ b/test/cli/heap-prof.test.ts
@@ -211,15 +211,21 @@ test("--heap-prof-name and --heap-prof-dir work together", async () => {
 
 // On Windows the path buffer is ~98 KB and the CreateProcess command-line
 // limit is ~32 KB, so an overflowing CLI argument cannot be delivered. On
-// POSIX 5000 bytes exceeds the fixed path buffer (Linux 4096, macOS 1024).
+// POSIX 5000 bytes exceeds the fixed path buffer (Linux 4096, macOS 1024);
+// 2500 + 2500 exercises the combined bound with components that fit
+// individually on Linux.
 test.skipIf(isWindows).each([
-  ["--heap-prof-dir", Buffer.alloc(5000, "d").toString()],
-  ["--heap-prof-name", Buffer.alloc(5000, "n").toString()],
-])("%s longer than PATH_MAX reports an error instead of panicking", async (flag, value) => {
+  ["--heap-prof-dir", ["--heap-prof-dir", Buffer.alloc(5000, "d").toString()]],
+  ["--heap-prof-name", ["--heap-prof-name", Buffer.alloc(5000, "n").toString()]],
+  [
+    "--heap-prof-dir + --heap-prof-name combined",
+    ["--heap-prof-dir", Buffer.alloc(2500, "d").toString(), "--heap-prof-name", Buffer.alloc(2500, "n").toString()],
+  ],
+] as const)("%s longer than PATH_MAX reports an error instead of panicking", async (_label, args) => {
   using dir = tempDir("heap-prof-pathmax", {});
 
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "--heap-prof", flag, value, "-e", `console.log("done");`],
+    cmd: [bunExe(), "--heap-prof", ...args, "-e", `console.log("done");`],
     cwd: String(dir),
     env: bunEnv,
     stdout: "pipe",

--- a/test/cli/run/cpu-prof.test.ts
+++ b/test/cli/run/cpu-prof.test.ts
@@ -127,17 +127,23 @@ describe.concurrent("--cpu-prof", () => {
 
   // On Windows the path buffer is ~98 KB and the CreateProcess command-line
   // limit is ~32 KB, so an overflowing CLI argument cannot be delivered. On
-  // POSIX 5000 bytes exceeds the fixed path buffer (Linux 4096, macOS 1024).
+  // POSIX 5000 bytes exceeds the fixed path buffer (Linux 4096, macOS 1024);
+  // 2500 + 2500 exercises the combined bound with components that fit
+  // individually on Linux.
   test.skipIf(isWindows).each([
-    ["--cpu-prof-dir", Buffer.alloc(5000, "d").toString()],
-    ["--cpu-prof-name", Buffer.alloc(5000, "n").toString()],
-  ])("%s longer than PATH_MAX reports an error instead of panicking", async (flag, value) => {
+    ["--cpu-prof-dir", ["--cpu-prof-dir", Buffer.alloc(5000, "d").toString()]],
+    ["--cpu-prof-name", ["--cpu-prof-name", Buffer.alloc(5000, "n").toString()]],
+    [
+      "--cpu-prof-dir + --cpu-prof-name combined",
+      ["--cpu-prof-dir", Buffer.alloc(2500, "d").toString(), "--cpu-prof-name", Buffer.alloc(2500, "n").toString()],
+    ],
+  ] as const)("%s longer than PATH_MAX reports an error instead of panicking", async (_label, args) => {
     using dir = tempDir("cpu-prof-pathmax", {
       "test.js": `const end = Date.now() + 60; while (Date.now() < end) {}`,
     });
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "--cpu-prof", flag, value, "test.js"],
+      cmd: [bunExe(), "--cpu-prof", ...args, "test.js"],
       cwd: String(dir),
       env: bunEnv,
       stdout: "pipe",

--- a/test/cli/run/cpu-prof.test.ts
+++ b/test/cli/run/cpu-prof.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync } from "fs";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 // Every workload below is time-bounded for 100ms. On Windows JSC's
@@ -123,6 +123,34 @@ describe.concurrent("--cpu-prof", () => {
     const files = readdirSync(String(dir));
     expect(files).toContain(customName);
     expect(exitCode).toBe(0);
+  });
+
+  // On Windows the path buffer is ~98 KB and the CreateProcess command-line
+  // limit is ~32 KB, so an overflowing CLI argument cannot be delivered. On
+  // POSIX 5000 bytes exceeds the fixed path buffer (Linux 4096, macOS 1024).
+  test.skipIf(isWindows).each([
+    ["--cpu-prof-dir", Buffer.alloc(5000, "d").toString()],
+    ["--cpu-prof-name", Buffer.alloc(5000, "n").toString()],
+  ])("%s longer than PATH_MAX reports an error instead of panicking", async (flag, value) => {
+    using dir = tempDir("cpu-prof-pathmax", {
+      "test.js": `const end = Date.now() + 60; while (Date.now() < end) {}`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--cpu-prof", flag, value, "test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("");
+    expect(stderr).toContain("FilenameTooLong");
+    expect(stderr).toContain("Failed to write CPU profile");
+    expect(exitCode).toBe(0);
+    expect(proc.signalCode).toBeNull();
   });
 
   test("--cpu-prof-dir sets custom directory", async () => {


### PR DESCRIPTION
### What

`--cpu-prof-dir`, `--cpu-prof-name`, `--heap-prof-dir`, or `--heap-prof-name` with a value whose length pushes the output path past `PATH_MAX` crashed the whole process at exit and lost the profile:

```
panic: range end index 4106 out of range for slice of length 4095
panic: index out of bounds: the len is 4096 but the index is 4096
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

A value that is merely too long for the filesystem but still fits the buffer (e.g. 3000 bytes on Linux) already produced the `WriteFailed: Failed to write CPU profile` warning and exited cleanly; the panic only fired at the `PATH_MAX` boundary.

### Repro

```sh
bun --cpu-prof --cpu-prof-dir="$(printf 'd%.0s' {1..4085})" -e 'const e=Date.now()+60; while(Date.now()<e);'
```

### Cause

`build_output_path` in both `src/jsc/BunCPUProfiler.rs` and `src/jsc/BunHeapProfiler.rs` writes the dir and filename into an `AutoAbsPath`, which is `CheckLength::ASSUME`: over-long input does not return `Err(MaxPathExceeded)` but panics inside `PooledBuf::append` slice indexing. The in-code `// Err arm is unreachable` annotation assumed the inputs were bounded, but both `config.dir` and `config.name` are raw CLI bytes.

### Fix

Add a public `bun_paths::AutoAbsPathChecked` alias (`CheckLength::CheckForGreaterThanMaxPath`) and make `Path::join` honor `CheckLength` by routing through `join_abs_string_buf_checked` in that mode, so `from`/`append`/`append_fmt`/`join` all return `Err(MaxPathExceeded)` on overflow. `ASSUME`-mode callers (the default, and all existing users) are unchanged.

Both profilers switch to `AutoAbsPathChecked` and propagate the error with `?`, dropping the `.expect("unreachable")` unwraps. The overflow surfaces as the existing `FilenameTooLong: Failed to write CPU profile` / `MaxPathExceeded: Failed to write heap profile` warning and the process exits cleanly.

### Verification

New parameterized cases in `test/cli/run/cpu-prof.test.ts` and `test/cli/heap-prof.test.ts` pass 5000-byte `--*-prof-dir` / `--*-prof-name` values, plus a 2500+2500 combined case, and assert the warning text, `exitCode === 0`, and `signalCode === null`. They fail before (SIGABRT with the panic above) and pass after. Skipped on Windows, where the path buffer is ~98 KB and the `CreateProcess` command-line limit (~32 KB) prevents delivering an overflowing argument.

The `--cpu-prof-dir=inner --cpu-prof-name=/abs/x` debug-assert case (absolute name appended onto a rooted path) is already covered by #32570, which switches `append` to `join` for the filename; this PR is only about the `PATH_MAX` overflow.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/heap-prof.test.ts test/cli/run/cpu-prof.test.ts

<!-- robobun:evidence:end -->