### PR TITLE
inspector: capture test line numbers for retroactive TestReporter.found events

### DIFF
--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1696,7 +1696,7 @@ pub struct BaseScope {
     pub(crate) has_callback: bool,
     /// this value is 0 unless the debugger is active and the scope has a debugger id
     pub(crate) test_id_for_debugger: i32,
-    /// only available if using junit reporter, otherwise 0
+    /// only captured when the junit reporter or the inspector is enabled, otherwise 0
     pub(crate) line_no: u32,
 }
 impl BaseScope {

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -815,9 +815,6 @@ pub(crate) fn format_label(
 
 pub(crate) fn capture_test_line_number(callframe: &CallFrame, global_this: &JSGlobalObject) -> u32 {
     if let Some(runner) = Jest::runner() {
-        // The stored line is consumed by the JUnit reporter and by the
-        // inspector's retroactive `TestReporter.found` walk (which runs after
-        // the call frame is gone). Skip the stack walk when neither needs it.
         if runner.test_options.reporters.junit || global_this.bun_vm().is_inspector_enabled() {
             unsafe extern "C" {
                 fn Bun__CallFrame__getLineNumber(

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -815,7 +815,10 @@ pub(crate) fn format_label(
 
 pub(crate) fn capture_test_line_number(callframe: &CallFrame, global_this: &JSGlobalObject) -> u32 {
     if let Some(runner) = Jest::runner() {
-        if runner.test_options.reporters.junit {
+        // The stored line is consumed by the JUnit reporter and by the
+        // inspector's retroactive `TestReporter.found` walk (which runs after
+        // the call frame is gone). Skip the stack walk when neither needs it.
+        if runner.test_options.reporters.junit || global_this.bun_vm().is_inspector_enabled() {
             unsafe extern "C" {
                 fn Bun__CallFrame__getLineNumber(
                     callframe: *const CallFrame,

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -296,6 +296,20 @@ afterAll(async () => {
     const describeNames = describes.map(d => d.name).sort();
     expect(describeNames).toEqual(["suite A", "suite B"]);
 
+    // Retroactively reported tests must carry real source locations, the same
+    // as tests reported live during collection. The retroactive path reads the
+    // stored line number, which previously was only captured for the JUnit
+    // reporter and otherwise left at 0.
+    for (const t of testsArray) {
+      expect(t.url).toEndWith("delayed.test.ts");
+      expect(t.line).toBeGreaterThan(0);
+    }
+    // Spot-check an exact line to catch off-by-one regressions. "test A1" is on
+    // line 6 of delayed.test.ts (leading newline in the template literal makes
+    // the import on line 2).
+    const testA1 = tests.find(t => t.name === "test A1");
+    expect(testA1?.line).toBe(6);
+
     // Receiving the retroactive `found` events proves TestReporter.enable has been
     // processed on the JS thread. Release A1 so its `end` event fires with the agent
     // enabled, then wait for all three tests to report completion.


### PR DESCRIPTION
## Problem

When a debugger client sends `TestReporter.enable` after test collection has already started, `bun test` walks the already-discovered scope tree and emits a `TestReporter.found` event for each test. Every one of those events carried `line: 0` (and no `scriptId`), so IDE test explorers placed them at the top of the file.

The same tests carry real line numbers when `TestReporter.enable` is sent before `Inspector.initialized`, and also on the late path if `--reporter=junit` happens to be on.

```
enable early:         describe:group line=2, test:one line=3, test:two line=4, ...
enable late:          describe:group line=0, test:one line=0, test:two line=0, ...
enable late + junit:  describe:group line=2, test:one line=3, test:two line=4, ...
```

## Cause

The live path (`InspectorTestReporterAgent::reportTestFound`) derives the source location directly from the live `CallFrame`. The retroactive path has no call frame, so it reads `BaseScope::line_no`, which is populated by `capture_test_line_number` in `src/runtime/test_runner/jest.rs`. That function only walked the stack when `test_options.reporters.junit` was set; line capture was originally added for the JUnit reporter and the inspector path inherited the zero.

## Fix

Also capture the line number at test registration time when an inspector is attached (`vm.debugger.is_some()`), so the retroactive walker has a real source location to emit. The common case (no inspector, no junit) still skips the stack walk.

## Verification

Extended the existing retroactive-enable test in `test/cli/inspect/test-reporter.test.ts` to assert that every retroactively reported `TestReporter.found` event has `line > 0` and the correct `url`, with an exact-line spot check.

```
# before fix
error: expect(received).toBeGreaterThan(expected)
Expected: > 0
Received: 0

# after fix
(pass) TestReporter inspector protocol > retroactively reports tests when TestReporter.enable is called after tests are discovered
(pass) TestReporter inspector protocol > assigns unique test IDs when TestReporter.enable lands mid-collection
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/test-reporter.test.ts
bun test v1.4.0 (7498925f2)

test/cli/inspect/test-reporter.test.ts:
300 |     // as tests reported live during collection. The retroactive path reads the
301 |     // stored line number, which previously was only captured for the JUnit
302 |     // reporter and otherwise left at 0.
303 |     for (const t of testsArray) {
304 |       expect(t.url).toEndWith("delayed.test.ts");
305 |       expect(t.line).toBeGreaterThan(0);
                           ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 0
Received: 0

      at <anonymous> (/workspace/bun/test/cli/inspect/test-reporter.test.ts:305:22)
(fail) TestReporter inspector protocol > retroactively reports tests when TestReporter.enable is called after tests are discovered [1832.08ms]
(pass) TestReporter inspector protocol > assigns unique test IDs when TestReporter.enable lands mid-collection [1531.59ms]

 1 pass
 1 fail
 19 expect() calls
Ran 2 tests across 1 file. [5.64s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/inspect/test-reporter.test.ts:
300 |     // as tests reported live during collection. The retroactive path reads the
301 |     // stored line number, which previously was only captured for the JUnit
302 |     // reporter and otherwise left at 0.
303 |     for (const t of testsArray) {
304 |       expect(t.url).toEndWith("delayed.test.ts");
305 |       expect(t.line).toBeGreaterThan(0);
                           ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 0
Received: 0

      at <anonymous> (/workspace/bun/test/cli/inspect/test-reporter.test.ts:305:22)
(fail) TestReporter inspector protocol > retroactively reports tests when TestReporter.enable is called after tests are discovered [35.51ms]
killed 1 dangling process
(fail) TestReporter inspector protocol > assigns unique test IDs when TestReporter.enable lands mid-collection [5000.21ms]
  ^ this test timed out after 5000ms.

 0 pass
 2 fail
 7 expect() calls
Ran 2 tests across 1 file. [5.18s]
__F:2:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/test-reporter.test.ts
bun test v1.4.0 (7498925f2)

test/cli/inspect/test-reporter.test.ts:
(pass) TestReporter inspector protocol > retroactively reports tests when TestReporter.enable is called after tests are discovered [1604.40ms]
(pass) TestReporter inspector protocol > assigns unique test IDs when TestReporter.enable lands mid-collection [1536.59ms]

 2 pass
 0 fail
 30 expect() calls
Ran 2 tests across 1 file. [5.18s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 700ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/bun_test.rs    |  2 +-
 src/runtime/test_runner/jest.rs        |  2 +-
 test/cli/inspect/test-reporter.test.ts | 14 ++++++++++++++
 3 files changed, 16 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/test_runner/bun_test.rs         1      1      0
src/runtime/test_runner/jest.rs             3      3      0
test/cli/inspect/test-reporter.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->