### PR TITLE
inspector: keep BunFrontendDevServer/HTTPServer agents alive across reconnects

### DIFF
--- a/src/jsc/bindings/InspectorBunFrontendDevServerAgent.cpp
+++ b/src/jsc/bindings/InspectorBunFrontendDevServerAgent.cpp
@@ -35,8 +35,7 @@ void InspectorBunFrontendDevServerAgent::didCreateFrontendAndBackend()
 
 void InspectorBunFrontendDevServerAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
-    m_frontendDispatcher = nullptr;
-    m_enabled = false;
+    disable();
 }
 
 Protocol::ErrorStringOr<void> InspectorBunFrontendDevServerAgent::enable()

--- a/src/jsc/bindings/InspectorHTTPServerAgent.cpp
+++ b/src/jsc/bindings/InspectorHTTPServerAgent.cpp
@@ -44,8 +44,7 @@ void InspectorHTTPServerAgent::didCreateFrontendAndBackend()
 
 void InspectorHTTPServerAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
-    m_frontendDispatcher = nullptr;
-    m_enabled = false;
+    disable();
 }
 
 Protocol::ErrorStringOr<void> InspectorHTTPServerAgent::enable()

--- a/test/cli/inspect/BunFrontendDevServer.test.ts
+++ b/test/cli/inspect/BunFrontendDevServer.test.ts
@@ -1000,13 +1000,25 @@ function decodeGraphUpdate(buffer) {
 // agent's constructor, a second inspector client that reconnected and called
 // enable() would never receive any events: m_enabled flipped back to true but
 // every emitter still bailed on the null dispatcher guard.
-test("BunFrontendDevServer domain keeps emitting after an inspector reconnect", async () => {
+test("BunFrontendDevServer and HTTPServer domains keep emitting after an inspector reconnect", async () => {
   using dir = tempDir("bun-frontend-dev-server-reconnect", {
     "index.html": `<!doctype html><script type="module" src="./app.ts"></script><h1>x</h1>`,
     "app.ts": `export const x: number = 0;`,
     "server.ts": `
       import html from "./index.html";
-      const server = Bun.serve({ port: 0, routes: { "/": html }, development: true });
+      const server = Bun.serve({
+        port: 0,
+        development: true,
+        routes: {
+          "/": html,
+          // Each inspector session hits this to make the HTTPServer agent emit
+          // HTTPServer.listen / HTTPServer.close for a throwaway server.
+          "/ping-http-agent": () => {
+            Bun.serve({ port: 0, fetch: () => new Response("") }).stop();
+            return new Response("ok");
+          },
+        },
+      });
       console.log("SERVER_URL=" + server.url);
     `,
   });
@@ -1048,11 +1060,13 @@ test("BunFrontendDevServer domain keeps emitting after an inspector reconnect", 
 
     let nextId = 1;
     const pending = new Map<number, (msg: any) => void>();
-    const firstEvent = Promise.withResolvers<string>();
+    const firstDevServerEvent = Promise.withResolvers<string>();
+    const firstHttpServerEvent = Promise.withResolvers<string>();
     ws.addEventListener("message", ({ data }) => {
       const msg = JSON.parse(String(data));
       if (msg.id !== undefined) pending.get(msg.id)?.(msg);
-      else if (msg.method?.startsWith("BunFrontendDevServer.")) firstEvent.resolve(msg.method);
+      else if (msg.method?.startsWith("BunFrontendDevServer.")) firstDevServerEvent.resolve(msg.method);
+      else if (msg.method?.startsWith("HTTPServer.")) firstHttpServerEvent.resolve(msg.method);
     });
     const send = (method: string) => {
       const id = nextId++;
@@ -1064,22 +1078,26 @@ test("BunFrontendDevServer domain keeps emitting after an inspector reconnect", 
 
     await send("Inspector.enable");
     await send("BunFrontendDevServer.enable");
+    await send("HTTPServer.enable");
     await send("Inspector.initialized");
 
-    // Opening an HMR WebSocket makes the dev server emit
-    // BunFrontendDevServer.clientConnected. If the agent's dispatcher is gone
-    // this resolves to the timeout sentinel instead.
+    // Opening an HMR WebSocket emits BunFrontendDevServer.clientConnected;
+    // hitting /ping-http-agent starts and stops a Bun.serve instance, emitting
+    // HTTPServer.listen. If either agent's dispatcher is gone the
+    // corresponding promise resolves to the timeout sentinel instead.
     const hmr = new WebSocket(hmrUrl);
     hmr.binaryType = "arraybuffer";
     const hmrOpen = Promise.withResolvers<void>();
     hmr.addEventListener("open", () => hmrOpen.resolve());
     hmr.addEventListener("error", e => hmrOpen.reject(e));
     await hmrOpen.promise;
+    await fetch(new URL("/ping-http-agent", serverUrl)).then(r => r.blob());
 
-    const result = await Promise.race([
-      firstEvent.promise,
-      Bun.sleep(3000).then(() => "timeout: no BunFrontendDevServer events"),
-    ]);
+    const timeout = Bun.sleep(3000).then(() => "timeout: no events");
+    const result = {
+      devServer: await Promise.race([firstDevServerEvent.promise, timeout]),
+      httpServer: await Promise.race([firstHttpServerEvent.promise, timeout]),
+    };
     hmr.close();
 
     const closed = Promise.withResolvers<void>();
@@ -1090,11 +1108,16 @@ test("BunFrontendDevServer domain keeps emitting after an inspector reconnect", 
   }
 
   // The first session has always worked; the second and third sessions
-  // previously received zero events for the rest of the process.
-  expect(await session()).toBe("BunFrontendDevServer.clientConnected");
-  expect(await session()).toBe("BunFrontendDevServer.clientConnected");
-  expect(await session()).toBe("BunFrontendDevServer.clientConnected");
-}, 30000);
+  // previously received zero events from either domain for the rest of the
+  // process.
+  const expected = {
+    devServer: "BunFrontendDevServer.clientConnected",
+    httpServer: "HTTPServer.listen",
+  };
+  expect(await session()).toEqual(expected);
+  expect(await session()).toEqual(expected);
+  expect(await session()).toEqual(expected);
+});
 
 function decodeAndAppendServerError(r: DataViewReader) {
   const owner = r.u32();

--- a/test/cli/inspect/BunFrontendDevServer.test.ts
+++ b/test/cli/inspect/BunFrontendDevServer.test.ts
@@ -3,7 +3,7 @@ import { decodeSerializedError } from "bake/error-serialization.ts";
 import { Subprocess, spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunExe, bunEnv as env, isPosix, tmpdirSync } from "harness";
+import { bunExe, bunEnv as env, isPosix, tempDir, tmpdirSync } from "harness";
 import path, { join } from "node:path";
 import { InspectorSession, connect } from "./junit-reporter";
 import { SocketFramer } from "./socket-framer";
@@ -993,6 +993,108 @@ function decodeGraphUpdate(buffer) {
     clientEdges,
   };
 }
+
+// The BunFrontendDevServer and HTTPServer inspector agents used to null their
+// frontend dispatcher in willDestroyFrontendAndBackend, which runs on every
+// frontend disconnect. Because the dispatcher was only ever created in the
+// agent's constructor, a second inspector client that reconnected and called
+// enable() would never receive any events: m_enabled flipped back to true but
+// every emitter still bailed on the null dispatcher guard.
+test("BunFrontendDevServer domain keeps emitting after an inspector reconnect", async () => {
+  using dir = tempDir("bun-frontend-dev-server-reconnect", {
+    "index.html": `<!doctype html><script type="module" src="./app.ts"></script><h1>x</h1>`,
+    "app.ts": `export const x: number = 0;`,
+    "server.ts": `
+      import html from "./index.html";
+      const server = Bun.serve({ port: 0, routes: { "/": html }, development: true });
+      console.log("SERVER_URL=" + server.url);
+    `,
+  });
+
+  await using child = spawn({
+    cmd: [bunExe(), "--inspect=ws://127.0.0.1:0/", join(String(dir), "server.ts")],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  async function readUntil(stream: ReadableStream, regex: RegExp) {
+    let text = "";
+    const decoder = new TextDecoder();
+    for await (const chunk of stream) {
+      text += decoder.decode(chunk);
+      const m = text.match(regex);
+      if (m) return m[1];
+    }
+    throw new Error(`did not find ${regex} in:\n${text}`);
+  }
+
+  const inspectorUrl = await readUntil(child.stderr, /(ws:\/\/[^\s]+)/);
+  const serverUrl = await readUntil(child.stdout, /SERVER_URL=(http:\/\/[^\s]+)/);
+
+  // Force the dev server to materialize so /_bun/hmr accepts connections.
+  await fetch(serverUrl).then(r => r.blob());
+  const hmrUrl = new URL(serverUrl);
+  hmrUrl.protocol = "ws:";
+  hmrUrl.pathname = "/_bun/hmr";
+
+  async function session() {
+    const ws = new WebSocket(inspectorUrl);
+    const opened = Promise.withResolvers<void>();
+    ws.addEventListener("open", () => opened.resolve());
+    ws.addEventListener("error", e => opened.reject(e));
+    await opened.promise;
+
+    let nextId = 1;
+    const pending = new Map<number, (msg: any) => void>();
+    const firstEvent = Promise.withResolvers<string>();
+    ws.addEventListener("message", ({ data }) => {
+      const msg = JSON.parse(String(data));
+      if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+      else if (msg.method?.startsWith("BunFrontendDevServer.")) firstEvent.resolve(msg.method);
+    });
+    const send = (method: string) => {
+      const id = nextId++;
+      const { promise, resolve } = Promise.withResolvers<any>();
+      pending.set(id, resolve);
+      ws.send(JSON.stringify({ id, method }));
+      return promise;
+    };
+
+    await send("Inspector.enable");
+    await send("BunFrontendDevServer.enable");
+    await send("Inspector.initialized");
+
+    // Opening an HMR WebSocket makes the dev server emit
+    // BunFrontendDevServer.clientConnected. If the agent's dispatcher is gone
+    // this resolves to the timeout sentinel instead.
+    const hmr = new WebSocket(hmrUrl);
+    hmr.binaryType = "arraybuffer";
+    const hmrOpen = Promise.withResolvers<void>();
+    hmr.addEventListener("open", () => hmrOpen.resolve());
+    hmr.addEventListener("error", e => hmrOpen.reject(e));
+    await hmrOpen.promise;
+
+    const result = await Promise.race([
+      firstEvent.promise,
+      Bun.sleep(3000).then(() => "timeout: no BunFrontendDevServer events"),
+    ]);
+    hmr.close();
+
+    const closed = Promise.withResolvers<void>();
+    ws.addEventListener("close", () => closed.resolve());
+    ws.close();
+    await closed.promise;
+    return result;
+  }
+
+  // The first session has always worked; the second and third sessions
+  // previously received zero events for the rest of the process.
+  expect(await session()).toBe("BunFrontendDevServer.clientConnected");
+  expect(await session()).toBe("BunFrontendDevServer.clientConnected");
+  expect(await session()).toBe("BunFrontendDevServer.clientConnected");
+}, 30000);
 
 function decodeAndAppendServerError(r: DataViewReader) {
   const owner = r.u32();


### PR DESCRIPTION
## Problem

With `--inspect` and `bun ./index.html` (or any `Bun.serve` with HTML routes), the `BunFrontendDevServer.*` inspector domain goes permanently silent after the first inspector client disconnects. Every subsequent client can `enable()` the domain successfully but never receives `bundleStart`/`bundleComplete`/`bundleFailed`/`clientConnected`/... events for the rest of the process. The `HTTPServer.*` domain has the same bug.

```
client #1 BunFrontendDevServer events = 2
client #2 BunFrontendDevServer events = 0
client #3 BunFrontendDevServer events = 0
```

## Cause

`JSGlobalObjectInspectorController::disconnectFrontend` calls `willDestroyFrontendAndBackend` on every agent whenever any frontend disconnects. `InspectorBunFrontendDevServerAgent` and `InspectorHTTPServerAgent` both did:

```cpp
void InspectorBunFrontendDevServerAgent::willDestroyFrontendAndBackend(DisconnectReason)
{
    m_frontendDispatcher = nullptr;
    m_enabled = false;
}
```

The dispatcher is only ever created in the constructor, so after the first disconnect every later `enable()` flipped `m_enabled` back to true while every emitter kept bailing on the `!m_frontendDispatcher` guard.

## Fix

Call `disable()` instead, matching `InspectorTestReporterAgent`, `InspectorLifecycleAgent`, and WebKit's own agents (`InspectorConsoleAgent`, `InspectorDebuggerAgent`, ...). The dispatcher holds a reference to the controller's long-lived `FrontendRouter`, so it stays valid across connect/disconnect cycles. This also clears the Rust-side agent pointer on disconnect so the dev server stops notifying a disabled agent between connections.

## Verification

New test in `test/cli/inspect/BunFrontendDevServer.test.ts` connects three inspector WebSocket clients in sequence; each enables `BunFrontendDevServer` and opens an HMR socket to trigger `clientConnected`. Before this change the second client times out waiting for the event; after, all three receive it.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/BunFrontendDevServer.test.ts
bun test v1.4.0 (50cbf4c5a)

test/cli/inspect/BunFrontendDevServer.test.ts:
(pass) BunFrontendDevServer inspector protocol > should receive clientConnected and clientDisconnected events [34.17ms]
(pass) BunFrontendDevServer inspector protocol > should notify on bundleStart and bundleComplete events [195.68ms]
(pass) BunFrontendDevServer inspector protocol > should notify on bundleFailed events [149.10ms]
(pass) BunFrontendDevServer inspector protocol > should notify on clientNavigated events [23.34ms]
(pass) BunFrontendDevServer inspector protocol > sends exactly one clientNavigated event per SetUrl message [60.60ms]
(pass) BunFrontendDevServer inspector protocol > should notify on consoleLog events [20.89ms]
(todo) BunFrontendDevServer inspector protocol > should notify on clientErrorReported events
(todo) BunFrontendDevServer inspector protocol > should notify on graphUpdate events
1113 |   const expected = {
1114 |     devServer: "BunFrontendDevServer.clientConnected",
1115 |     httpSer
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (2d9ce1462)

test/cli/inspect/BunFrontendDevServer.test.ts:
(pass) BunFrontendDevServer inspector protocol > should receive clientConnected and clientDisconnected events [1.38ms]
(pass) BunFrontendDevServer inspector protocol > should notify on bundleStart and bundleComplete events [3.24ms]
(pass) BunFrontendDevServer inspector protocol > should notify on bundleFailed events [104.88ms]
(pass) BunFrontendDevServer inspector protocol > should notify on clientNavigated events [4.81ms]
(pass) BunFrontendDevServer inspector protocol > sends exactly one clientNavigated event per SetUrl message [1.23ms]
(pass) BunFrontendDevServer inspector protocol > should notify on consoleLog events [0.89ms]
(todo) BunFrontendDevServer inspector protocol > should notify on clientErrorReported events
(todo) BunFrontendDevServer inspector protocol > should notify on graphUpdate events
(pass) BunFrontendDevServer and HTTPServer domains keep emitting after an inspector reconnect [18.70ms]

 7 pass
 2 todo
 0 fail
 2 snapshots, 40 expect() calls
Ran 9 tests across 1 file. [287.00ms]
__F:0:S:2
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/BunFrontendDevServer.test.ts
bun test v1.4.0 (50cbf4c5a)

test/cli/inspect/BunFrontendDevServer.test.ts:
(pass) BunFrontendDevServer inspector protocol > should receive clientConnected and clientDisconnected events [34.50ms]
(pass) BunFrontendDevServer inspector protocol > should notify on bundleStart and bundleComplete events [192.57ms]
(pass) BunFrontendDevServer inspector protocol > should notify on bundleFailed events [148.22ms]
(pass) BunFrontendDevServer inspector protocol > should notify on clientNavigated events [23.33ms]
(pass) BunFrontendDevServer inspector protocol > sends exactly one clientNavigated event per SetUrl message [55.37ms]
(pass) BunFrontendDevServer inspector protocol > should notify on consoleLog events [20.10ms]
(todo) BunFrontendDevServer inspector protocol > should notify on clientErrorReported events
(todo) BunFrontendDevServer inspector protocol > should notify on graphUpdate events
(pass) BunFrontendDevServer and HTTPServer domains keep emitting after an inspector reconnect [661.69ms]

 7
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 619ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[2/8] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/8] gen cpp.rs (cppbind)
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../InspectorBunFrontendDevServerAgent.cpp         |   3 +-
 src/jsc/bindings/InspectorHTTPServerAgent.cpp      |   3 +-
 test/cli/inspect/BunFrontendDevServer.test.ts      | 127 ++++++++++++++++++++-
 3 files changed, 128 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/bindings/InspectorBunFrontendDevServerAgent.cpp      1      1      0
src/jsc/bindings/InspectorHTTPServerAgent.cpp                1      1      0
test/cli/inspect/BunFrontendDevServer.test.ts                1      4      0
```

</details>

<!-- robobun:evidence:end -->