### PR TITLE
test(valkey): run recovery.test.ts against an in-process RESP server

### DIFF
--- a/test/js/valkey/reliability/recovery.test.ts
+++ b/test/js/valkey/reliability/recovery.test.ts
@@ -142,12 +142,7 @@ describe("Valkey: Recovery after failure (#29925)", () => {
       // was terminal — every subsequent command got "Connection has
       // failed" and there was no way to recover short of replacing the
       // client instance.
-      const failed = await client.get("recovery:k").then(
-        () => "resolved",
-        (e: Error) => e,
-      );
-      expect(failed).toBeInstanceOf(Error);
-      expect((failed as Error).message).toMatch(/connection/i);
+      await expect(client.get("recovery:k")).rejects.toThrow(/connection/i);
 
       // The key assertion: explicit connect() recovers the client.
       // Without the fix this either hung forever (because the new HELLO

--- a/test/js/valkey/reliability/recovery.test.ts
+++ b/test/js/valkey/reliability/recovery.test.ts
@@ -1,6 +1,5 @@
-import { RedisClient } from "bun";
+import { RedisClient, type Socket, type TCPSocketListener } from "bun";
 import { describe, expect, test } from "bun:test";
-import { DEFAULT_REDIS_OPTIONS, DEFAULT_REDIS_URL, isEnabled } from "../test-utils";
 
 // https://github.com/oven-sh/bun/issues/29925
 //
@@ -22,10 +21,105 @@ import { DEFAULT_REDIS_OPTIONS, DEFAULT_REDIS_URL, isEnabled } from "../test-uti
 // `is_authenticated = true` from the prior session caused the new HELLO
 // response to be silently dropped, so `status` never transitioned back to
 // `.connected`.
-describe.skipIf(!isEnabled)("Valkey: Recovery after failure (#29925)", () => {
+//
+// These tests exercise the client-side state machine only. An in-process
+// RESP server is enough (and lets this file run without docker; see also
+// test/regression/issue/29925.test.ts for the real-redis-server version).
+
+const CRLF = "\r\n";
+const bulk = (s: string) => `$${Buffer.byteLength(s)}${CRLF}${s}${CRLF}`;
+
+type SocketState = { buf: Buffer };
+
+/**
+ * Minimal in-process RESP server with a key-value store, answering HELLO
+ * (simple `+OK`, which the client accepts as an authenticated handshake),
+ * SET/GET, and `+OK` for anything else. Enough to drive the client through
+ * connected → closed → connect() → connected and back.
+ */
+function createRespServer() {
+  const store = new Map<string, string>();
+  let connections = 0;
+  const server: TCPSocketListener<SocketState> = Bun.listen<SocketState>({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(s) {
+        s.data = { buf: Buffer.alloc(0) };
+        connections++;
+      },
+      error() {},
+      close() {},
+      data(s, raw) {
+        const st = s.data;
+        st.buf = Buffer.concat([st.buf, raw]);
+        // Parse complete client RESP command frames: `*N\r\n($len\r\n<data>\r\n){N}`.
+        for (;;) {
+          const b = st.buf;
+          if (!b.length || b[0] !== 0x2a) break; // '*'
+          const headerEnd = b.indexOf(CRLF);
+          if (headerEnd < 0) break;
+          const argc = parseInt(b.subarray(1, headerEnd).toString("latin1"), 10);
+          let pos = headerEnd + 2;
+          const fields: string[] = [];
+          let complete = true;
+          for (let i = 0; i < argc; i++) {
+            if (pos >= b.length || b[pos] !== 0x24) {
+              complete = false;
+              break;
+            } // '$'
+            const lenEnd = b.indexOf(CRLF, pos);
+            if (lenEnd < 0) {
+              complete = false;
+              break;
+            }
+            const len = parseInt(b.subarray(pos + 1, lenEnd).toString("latin1"), 10);
+            const next = lenEnd + 2 + len + 2;
+            if (next > b.length) {
+              complete = false;
+              break;
+            }
+            fields.push(b.subarray(lenEnd + 2, lenEnd + 2 + len).toString("latin1"));
+            pos = next;
+          }
+          if (!complete) break;
+          st.buf = b.subarray(pos);
+          dispatch(s, fields);
+        }
+      },
+    },
+  });
+
+  function dispatch(s: Socket<SocketState>, fields: string[]) {
+    const cmd = fields[0]?.toUpperCase();
+    if (cmd === "HELLO") {
+      s.write(`+OK${CRLF}`);
+    } else if (cmd === "SET") {
+      store.set(fields[1], fields[2]);
+      s.write(`+OK${CRLF}`);
+    } else if (cmd === "GET") {
+      const v = store.get(fields[1]);
+      s.write(v === undefined ? `_${CRLF}` : bulk(v));
+    } else {
+      s.write(`+OK${CRLF}`);
+    }
+  }
+
+  return {
+    url: `redis://127.0.0.1:${server.port}`,
+    get connections() {
+      return connections;
+    },
+    [Symbol.dispose]() {
+      server.stop(true);
+    },
+  };
+}
+
+describe("Valkey: Recovery after failure (#29925)", () => {
   test("client.connect() recovers after the client enters the failed state", async () => {
-    const client = new RedisClient(DEFAULT_REDIS_URL, {
-      ...DEFAULT_REDIS_OPTIONS,
+    using server = createRespServer();
+    const client = new RedisClient(server.url, {
       connectionTimeout: 2000,
       autoReconnect: false,
       maxRetries: 0,
@@ -42,12 +136,18 @@ describe.skipIf(!isEnabled)("Valkey: Recovery after failure (#29925)", () => {
       // set. `close()` is the deterministic way to reach it without
       // having to wait for the reconnect-exhaustion retry loop.
       client.close();
+      expect(client.connected).toBe(false);
 
       // While the client is failed, commands reject. Before the fix this
       // was terminal — every subsequent command got "Connection has
       // failed" and there was no way to recover short of replacing the
       // client instance.
-      await expect(client.get("recovery:k")).rejects.toThrow(/connection/i);
+      const failed = await client.get("recovery:k").then(
+        () => "resolved",
+        (e: Error) => e,
+      );
+      expect(failed).toBeInstanceOf(Error);
+      expect((failed as Error).message).toMatch(/connection/i);
 
       // The key assertion: explicit connect() recovers the client.
       // Without the fix this either hung forever (because the new HELLO
@@ -56,6 +156,7 @@ describe.skipIf(!isEnabled)("Valkey: Recovery after failure (#29925)", () => {
       // command.
       await client.connect();
       expect(client.connected).toBe(true);
+      expect(server.connections).toBe(2);
 
       // A full round-trip after recovery confirms the client is actually
       // usable, not just carrying a stale `connected` flag.
@@ -71,16 +172,20 @@ describe.skipIf(!isEnabled)("Valkey: Recovery after failure (#29925)", () => {
   // true from the prior session, causing the new HELLO response to be
   // dropped by `handleResponse` and the connect promise to hang.
   test("repeated close()/connect()/send() cycles do not lock up", async () => {
-    const client = new RedisClient(DEFAULT_REDIS_URL, DEFAULT_REDIS_OPTIONS);
+    using server = createRespServer();
+    const client = new RedisClient(server.url, { connectionTimeout: 2000 });
     try {
+      const replies: unknown[] = [];
       for (let i = 0; i < 3; i++) {
         if (client.connected) {
           client.close();
         }
         await client.connect();
         expect(client.connected).toBe(true);
-        expect(await client.send("FLUSHALL", ["SYNC"])).toBe("OK");
+        replies.push(await client.send("FLUSHALL", ["SYNC"]));
       }
+      expect(replies).toEqual(["OK", "OK", "OK"]);
+      expect(server.connections).toBe(3);
     } finally {
       client.close();
     }

--- a/test/regression/issue/29925.test.ts
+++ b/test/regression/issue/29925.test.ts
@@ -11,9 +11,9 @@
 // HELLO response to be silently dropped, so `status` never transitioned
 // back to `.connected`.
 //
-// This file mirrors the docker-based coverage in
-// `test/js/valkey/reliability/recovery.test.ts` but spawns a local
-// `redis-server` so the gate runs it without docker.
+// `test/js/valkey/reliability/recovery.test.ts` covers the same client
+// state-machine transitions against an in-process RESP mock; this file
+// exercises them against a real `redis-server` binary.
 
 import { describe, expect, test } from "bun:test";
 import { bunEnv, isWindows, randomPort } from "harness";


### PR DESCRIPTION
## What does this PR do?

`test/js/valkey/reliability/recovery.test.ts` ran for up to **66s** on the debian-13 x64-asan lane (build 88691) even though its two tests do less than 100ms of work. All of that time was the module-scope `beforeAll` that importing `../test-utils` registers: ensure the `redis_unified` docker service via the coordinator, start a unix-socket proxy, construct six `RedisClient` instances, and initialise one of them. None of that is used here; the tests create their own clients.

The file covers the #29925 / #22808 regressions, which are both client-side state-machine bugs (`flags.failed` not cleared on `connect()`, `is_authenticated` not reset on a fresh socket so the new `HELLO` reply is dropped). Any server that answers `HELLO` and a couple of commands exercises them, so this PR swaps the docker dependency for an in-process RESP server (`Bun.listen({ port: 0 })`), the same pattern `resp-nesting-depth.test.ts` and `valkey-incremental-scan.test.ts` already use. `test/regression/issue/29925.test.ts` continues to cover the same scenarios against a real `redis-server`; its header comment is updated to reflect the new split.

## Why is this correct?

`#29925` / `#22808` live entirely in `ValkeyClient::on_open` / `do_connect`: the fix resets `flags.failed`, `is_authenticated` and `is_selecting_db_internal` when a new socket opens. The mock answers `HELLO` with `+OK` (which `handle_hello_response` accepts as an authenticated handshake) and echoes `SET`/`GET`, so the client walks through the exact same `connected → close() → failed → connect() → on_open → HELLO → connected` path it would against real redis. The failure modes the original tests catch (the post-reconnect `get` rejecting with "Connection has failed", or `connect()` hanging because the stale `is_authenticated` swallows the new `HELLO`) reproduce identically against the mock.

## Other changes

- `describe.skipIf(!isEnabled)` is gone, so the file now runs on every platform instead of only where docker is available.
- The second test no longer issues `FLUSHALL SYNC` against the shared CI redis (it still sends the same command, the mock just replies `+OK`).
- Second test's `connectionTimeout` is now an explicit `2000` instead of the 10s default it inherited from `DEFAULT_REDIS_OPTIONS`.
- Added assertions: `client.connected === false` after `close()`, and a connection counter on the mock to prove each `connect()` really opened a new socket.

## Verification

| | before (`test-utils` docker path) | after (in-process RESP) |
|---|---|---|
| debug+ASAN, local | 2.84s file / 78ms tests | 2.15s file / 75ms tests |
| release, local | 183ms file | 166ms file |
| CI debian-13 x64-asan, worst case | 66s | n/a (no docker round-trip) |
| `expect()` calls | 11 | 12 |
| platforms | docker only | all |

5/5 clean runs under `bun bd test` (debug+ASAN).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->