### PR TITLE
test(cron): run cron-parse algorithm checks in-process via { tz: "UTC" }

### DIFF
--- a/test/js/bun/cron/cron-parse.test.ts
+++ b/test/js/bun/cron/cron-parse.test.ts
@@ -1,72 +1,57 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isDebug } from "harness";
 
 // Bun.cron.parse() and the in-process Bun.cron(schedule, handler) interpret
-// schedules in the system's local time zone — matching the OS-level
+// schedules in the system's local time zone, matching the OS-level
 // Bun.cron(path, schedule, title) overload (crontab/launchd/schtasks). The
-// algorithm tests below spawn under TZ=UTC so the expected values are
+// algorithm tests below pin { tz: "UTC" } so the expected values are
 // independent of the host's zone. Zone-sensitive and DST cases live in
 // cron-local-time.test.ts.
 
-async function parseUTC(expr: string, fromISO: string): Promise<string> {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `process.stdout.write(String(Bun.cron.parse(${JSON.stringify(expr)}, new Date(${JSON.stringify(fromISO)}))?.toISOString() ?? "null"))`,
-    ],
-    env: { ...bunEnv, TZ: "UTC" },
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
-  return stdout;
+function parseUTC(expr: string, fromISO: string): string {
+  return Bun.cron.parse(expr, new Date(fromISO), { tz: "UTC" })?.toISOString() ?? "null";
 }
 
-describe.concurrent("Bun.cron.parse — algorithm (pinned TZ=UTC)", () => {
-  test("weekday matching uses local day-of-week", async () => {
+describe("Bun.cron.parse — algorithm (pinned tz: UTC)", () => {
+  test("weekday matching uses local day-of-week", () => {
     // 2026-06-15 is a Monday in UTC.
-    expect(await parseUTC("0 12 * * MON", "2026-06-14T23:00:00Z")).toBe("2026-06-15T12:00:00.000Z");
+    expect(parseUTC("0 12 * * MON", "2026-06-14T23:00:00Z")).toBe("2026-06-15T12:00:00.000Z");
   });
 
-  test("strictly-after: from = exact match returns the next occurrence", async () => {
-    expect(await parseUTC("0 9 * * *", "2026-06-15T09:00:00Z")).toBe("2026-06-16T09:00:00.000Z");
+  test("strictly-after: from = exact match returns the next occurrence", () => {
+    expect(parseUTC("0 9 * * *", "2026-06-15T09:00:00Z")).toBe("2026-06-16T09:00:00.000Z");
   });
 
-  test("Feb 29 finds next leap year", async () => {
-    expect(await parseUTC("0 0 29 2 *", "2026-01-01T00:00:00Z")).toBe("2028-02-29T00:00:00.000Z");
+  test("Feb 29 finds next leap year", () => {
+    expect(parseUTC("0 0 29 2 *", "2026-01-01T00:00:00Z")).toBe("2028-02-29T00:00:00.000Z");
   });
 
   test("impossible day/month (Feb 30) returns null quickly", () => {
     const t = performance.now();
     expect(Bun.cron.parse("0 0 30 2 *", new Date("2026-01-01T00:00:00Z"), { tz: "UTC" })).toBeNull();
-    expect(performance.now() - t).toBeLessThan(50);
+    // Guards against the search spinning through the full 8-year window; that
+    // pathological loop is orders of magnitude above this ceiling even under
+    // ASAN, where the first in-process parse (tzdata init) is ~150ms.
+    expect(performance.now() - t).toBeLessThan(isDebug ? 1000 : 50);
   });
 
-  test("DOM/DOW OR semantics when both restricted", async () => {
+  test("DOM/DOW OR semantics when both restricted", () => {
     // 0 0 13 * 5 → every 13th OR every Friday. From 2026-01-01 (Thu), first is Fri Jan 2.
-    expect(await parseUTC("0 0 13 * 5", "2026-01-01T00:00:00Z")).toBe("2026-01-02T00:00:00.000Z");
+    expect(parseUTC("0 0 13 * 5", "2026-01-01T00:00:00Z")).toBe("2026-01-02T00:00:00.000Z");
   });
 });
 
-describe.concurrent("Bun.cron.parse — weekday 7 = Sunday in ranges", () => {
+describe("Bun.cron.parse — weekday 7 = Sunday in ranges", () => {
   // 2026-01-01 is a Thursday. next() is strictly-after, so the first match for
   // an every-day schedule is 2026-01-02.
-  test("1-7 means Mon-Sun (every day)", async () => {
-    expect(await parseUTC("0 0 * * 1-7", "2026-01-01T00:00:00Z")).toBe("2026-01-02T00:00:00.000Z");
-  });
-  test("5-7 means Fri-Sun", async () => {
-    expect(await parseUTC("0 0 * * 5-7", "2026-01-01T00:00:00Z")).toBe("2026-01-02T00:00:00.000Z");
-  });
-  test("6-7 means Sat-Sun", async () => {
-    expect(await parseUTC("0 0 * * 6-7", "2026-01-01T00:00:00Z")).toBe("2026-01-03T00:00:00.000Z");
-  });
-  test("0-7 means every day", async () => {
-    expect(await parseUTC("0 0 * * 0-7", "2026-01-01T00:00:00Z")).toBe("2026-01-02T00:00:00.000Z");
-  });
-  test("scalar 7 still means Sunday", async () => {
-    expect(await parseUTC("0 0 * * 7", "2026-01-01T00:00:00Z")).toBe("2026-01-04T00:00:00.000Z");
+  test.each([
+    ["1-7", "Mon-Sun (every day)", "2026-01-02T00:00:00.000Z"],
+    ["5-7", "Fri-Sun", "2026-01-02T00:00:00.000Z"],
+    ["6-7", "Sat-Sun", "2026-01-03T00:00:00.000Z"],
+    ["0-7", "every day", "2026-01-02T00:00:00.000Z"],
+    ["7", "Sunday (scalar)", "2026-01-04T00:00:00.000Z"],
+  ])("0 0 * * %s means %s", (dow, _desc, expected) => {
+    expect(parseUTC(`0 0 * * ${dow}`, "2026-01-01T00:00:00Z")).toBe(expected);
   });
 });
 
@@ -90,19 +75,24 @@ describe("Bun.cron.parse — invalid `from` argument", () => {
     expect(() => Bun.cron.parse("* * * * *", new Date(from))).toThrow("Invalid date value");
   });
 
-  test("accepts the Date range boundary", async () => {
+  // The ±8.64e15 boundary values exercise WTF::GregorianDateTime at its limits,
+  // and 1e300 used to hit a native panic; both stay in a subprocess so a
+  // regression in either can't take down the test runner. Pins TZ=UTC via env
+  // to test the CronTz::Local path the original regression was in.
+  test("accepts the Date range boundary and rejects 1e300 without crashing", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
-        `const out = [];
+        `const out = {};
          // from = +8.64e15 is +275760-09-13T00:00:00Z; the next occurrence falls
          // past the representable range → null, not an Invalid Date.
-         out.push(Bun.cron.parse("* * * * *", 8.64e15));
+         out.upper = Bun.cron.parse("* * * * *", 8.64e15);
          // from = -8.64e15 is -271821-04-20T00:00:00Z; next minute is in range.
-         out.push(Bun.cron.parse("* * * * *", -8.64e15)?.toISOString());
+         out.lower = Bun.cron.parse("* * * * *", -8.64e15)?.toISOString();
          // Just inside the upper boundary: next minute lands exactly on 8.64e15.
-         out.push(Bun.cron.parse("* * * * *", 8.64e15 - 60_000)?.getTime());
+         out.inside = Bun.cron.parse("* * * * *", 8.64e15 - 60_000)?.getTime();
+         try { Bun.cron.parse("* * * * *", 1e300); } catch (e) { out.huge = e.message; }
          process.stdout.write(JSON.stringify(out));`,
       ],
       env: { ...bunEnv, TZ: "UTC" },
@@ -110,23 +100,14 @@ describe("Bun.cron.parse — invalid `from` argument", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
-      out: [null, "-271821-04-20T00:01:00.000Z", 8.64e15],
+      out: {
+        upper: null,
+        lower: "-271821-04-20T00:01:00.000Z",
+        inside: 8.64e15,
+        huge: "Invalid date value",
+      },
       stderr: "",
       exitCode: 0,
     });
-  });
-
-  test("does not crash the process on 1e300", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `try { Bun.cron.parse("* * * * *", 1e300); } catch (e) { process.stdout.write(e.message); }`,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "Invalid date value", stderr: "", exitCode: 0 });
   });
 });


### PR DESCRIPTION
## What

`test/js/bun/cron/cron-parse.test.ts` was spawning a fresh `bun -e` subprocess with `TZ=UTC` for every algorithm assertion (11 spawns total) so results would be independent of the host's time zone. That made the file ~11s on alpine 3.23 x64 debug+ASAN (build #88691).

Since #35122 added `{ tz: "UTC" }` to `Bun.cron.parse`, the 9 pure algorithm checks can run in-process with identical zone-independence. The two boundary/crash-isolation subprocesses are merged into one, so the file now spawns once.

Also fixes a pre-existing flake: the `"impossible day/month (Feb 30) returns null quickly"` assertion `toBeLessThan(50)` was failing at ~165ms on debug+ASAN when it ran cold (tzdata init on first `{ tz }` call). The threshold is now `isDebug ? 1000 : 50`, which still catches the 8-year-spin regression it guards against.

## Why this is correct

The tests exist to pin the next-occurrence algorithm under a fixed zone. `{ tz: "UTC" }` goes through `CronTz::Named("UTC")` and `TZ=UTC` goes through `CronTz::Local`; both feed the same `ParsedCron::next()` logic and the same GregorianDateTime fields, so the assertions are unchanged. Verified by running the new file under `TZ=UTC`, `TZ=America/New_York`, `TZ=Asia/Kolkata`, and `TZ=Pacific/Chatham` (the last two have non-integer-hour offsets): 22/22 pass in each.

The one remaining subprocess still pins `TZ=UTC` via env and calls `Bun.cron.parse` without `{ tz }`, so the `CronTz::Local` path at the ±8.64e15 boundary is still covered exactly as before.

## Changes

- `parseUTC()`: subprocess with `TZ=UTC` env → in-process `Bun.cron.parse(expr, from, { tz: "UTC" })`
- weekday-7 block: 5 near-identical tests → one `test.each`
- Feb-30 timing ceiling: `50` → `isDebug ? 1000 : 50`
- `"accepts the Date range boundary"` + `"does not crash on 1e300"`: 2 spawns → 1 spawn, assertions merged into one `.toEqual`
- dropped `describe.concurrent` (tests are now synchronous)

## Verification

`time bun bd test test/js/bun/cron/cron-parse.test.ts` on linux x64 debug+ASAN:

| | before | after |
|---|---|---|
| wall | 8.1s | 4.4s |
| runner | 7.2s | 3.5s |
| subprocess spawns | 11 | 1 |
| pass/fail | 22 pass, 1 fail (timing flake) | 22 pass |

No tests removed or skipped; every expected value is preserved.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/cron/cron-parse.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/cron/cron-parse.test.ts
bun test v1.4.0 (f2197a224)

test/js/bun/cron/cron-parse.test.ts:
(pass) Bun.cron.parse — algorithm (pinned tz: UTC) > weekday matching uses local day-of-week [193.92ms]
(pass) Bun.cron.parse — algorithm (pinned tz: UTC) > strictly-after: from = exact match returns the next occurrence [2.95ms]
(pass) Bun.cron.parse — algorithm (pinned tz: UTC) > Feb 29 finds next leap year [2.09ms]
(pass) Bun.cron.parse — algorithm (pinned tz: UTC) > impossible day/month (Feb 30) returns null quickly [5.16ms]
(pass) Bun.cron.parse — algorithm (pinned tz: UTC) > DOM/DOW OR semantics when both restricted [2.17ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 0 0 * * 1-7 means Mon-Sun (every day) [2.24ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 0 0 * * 5-7 means Fri-Sun [0.71ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 0 0 * * 6-7 means Sat-Sun [0.70ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 0 0 * * 0-7 means every day [0.68ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 0 0 * * 7 means Sunday (scalar) [0.51ms]
(pass) Bun.cron.parse — invalid `from` argument > throws for out-of-range/non-finite ms: 1e+300 [6.95ms]
(pass) Bun.cron.parse — invalid `from` argument > throws for out-of-range/non-finite ms: -1e+300 [1.18ms]
(pass) Bun.cron.parse — invalid `from` argument > throws for out-of-range/non-finite ms: 4000000000000000000 [0.91ms]
(pass) Bun.cron.parse — invalid `from` argument > throws for out-of-range/non-finite ms: 8700000000000000 [0.87ms]
(pass) Bun.cron.parse — invalid `from` argument > throws for out-of-range/non-finite ms: -8700000000000000 [1.27ms]
(pass) Bun.cron.parse — invalid `from` argument > throws for out-of-range/non-finite ms: 8640000000000001 [0.86ms]
(pass) Bun.cron.parse — invalid `from` argument > throws for out-of-range/non-finite ms: -86
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/cron/cron-parse.test.ts | 105 +++++++++++++++---------------------
 1 file changed, 43 insertions(+), 62 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
test/js/bun/cron/cron-parse.test.ts      1      2      0
```

</details>

**self-review** · no surviving concerns

27 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->