### PR TITLE
test(install): run dev/peer priority tests against local verdaccio

### DIFF
--- a/test/cli/install/test-dev-peer-dependency-priority.test.ts
+++ b/test/cli/install/test-dev-peer-dependency-priority.test.ts
@@ -2,11 +2,6 @@ import { afterAll, beforeAll, expect, test } from "bun:test";
 import { VerdaccioRegistry, bunEnv, bunExe, stderrForInstall, tempDir } from "harness";
 import { join } from "path";
 
-// These tests previously fetched jquery / typescript / next from registry.npmjs.org
-// (including all of next's transitive dependencies) which pushed the wall time past
-// ten seconds on some CI lanes. They now resolve the same scenarios against the
-// local verdaccio fixture using the `no-deps` package so nothing touches the public
-// internet.
 const registry = new VerdaccioRegistry();
 
 beforeAll(async () => {
@@ -68,7 +63,7 @@ test.concurrent("workspace devDependencies should take priority over peerDepende
   // The devDependency (workspace) must win: only the workspace entry is recorded.
   const lockfile = await Bun.file(join(String(dir), "bun.lock")).text();
   expect(lockfile).toContain("no-deps@workspace:packages/no-deps");
-  expect(lockfile).not.toContain("no-deps@1.0.0");
+  expect(lockfile).not.toContain(registry.registryUrl());
 
   // Re-install with the registry pointed at a server that fails every request. If
   // bun tried to re-resolve the peer dependency it would hit this server.
@@ -128,6 +123,7 @@ test.concurrent("devDependencies and peerDependencies with different versions sh
 
   const lockfile = await Bun.file(join(String(dir), "bun.lock")).text();
   expect(lockfile).toContain("utils@workspace:packages/utils");
+  expect(lockfile).not.toContain(registry.registryUrl());
 });
 
 test.concurrent("dependency behavior comparison prioritizes devDependencies", async () => {
@@ -182,13 +178,13 @@ test.concurrent("Next.js monorepo scenario should not make unnecessary network r
         "no-deps": "^1.0.0", // would resolve to 1.1.0 from the registry
       },
     }),
-    "packages/web/test.js": `console.log(require("no-deps/package.json").version);`,
+    "packages/web/test.js": `console.log(require("no-deps").version);`,
     "packages/no-deps/package.json": JSON.stringify({
       name: "no-deps",
       version: "2.0.0",
       main: "index.js",
     }),
-    "packages/no-deps/index.js": `module.exports = require("./package.json");`,
+    "packages/no-deps/index.js": `module.exports = { version: "2.0.0-workspace" };`,
   });
 
   // Initial install against the local registry.
@@ -198,9 +194,10 @@ test.concurrent("Next.js monorepo scenario should not make unnecessary network r
     expect(exitCode).toBe(0);
   }
 
+  // The devDependency (workspace) must win: no registry tarball is recorded.
   const lockfile = await Bun.file(join(String(dir), "bun.lock")).text();
   expect(lockfile).toContain("no-deps@workspace:packages/no-deps");
-  expect(lockfile).not.toContain("no-deps@1.");
+  expect(lockfile).not.toContain(registry.registryUrl());
 
   // Re-install with a registry that fails every request. devDependencies taking
   // priority means the workspace copy is already linked and no lookup is needed.
@@ -222,9 +219,9 @@ test.concurrent("Next.js monorepo scenario should not make unnecessary network r
   }
   expect(registryHits).toBe(0);
 
-  // The linked module is the workspace copy (devDependency), not the registry ^1.0.0.
+  // The linked module is the workspace copy (devDependency), not the registry copy.
   const { stdout, stderr, exitCode } = await spawnBun(["packages/web/test.js"], String(dir));
   expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("2.0.0");
+  expect(stdout.trim()).toBe("2.0.0-workspace");
   expect(exitCode).toBe(0);
 });

--- a/test/cli/install/test-dev-peer-dependency-priority.test.ts
+++ b/test/cli/install/test-dev-peer-dependency-priority.test.ts
@@ -1,114 +1,99 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { VerdaccioRegistry, bunEnv, bunExe, stderrForInstall, tempDir } from "harness";
 import { join } from "path";
 
-// Each test has its own tempDirWithFiles and spawns its own processes; nothing is shared.
+// These tests previously fetched jquery / typescript / next from registry.npmjs.org
+// (including all of next's transitive dependencies) which pushed the wall time past
+// ten seconds on some CI lanes. They now resolve the same scenarios against the
+// local verdaccio fixture using the `no-deps` package so nothing touches the public
+// internet.
+const registry = new VerdaccioRegistry();
+
+beforeAll(async () => {
+  await registry.start();
+});
+
+afterAll(() => {
+  registry.stop();
+});
+
+async function spawnBun(cmd: string[], cwd: string) {
+  await using proc = Bun.spawn({ cmd: [bunExe(), ...cmd], cwd, env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr: stderrForInstall(rawStderr), exitCode };
+}
+
+function bunfig(registryUrl: string, linker?: "isolated") {
+  let text = `[install]\ncache = false\nregistry = "${registryUrl}"\n`;
+  if (linker) text += `linker = "${linker}"\n`;
+  return text;
+}
+
+// Each test has its own tempDir and spawns its own processes; nothing is shared.
 test.concurrent("workspace devDependencies should take priority over peerDependencies for resolution", async () => {
   await using dir = tempDir("dev-peer-priority", {
     "package.json": JSON.stringify({
       name: "test-monorepo",
       version: "1.0.0",
-      workspaces: {
-        packages: ["packages/*"],
-        nodeLinker: "isolated",
-      },
+      workspaces: ["packages/*"],
     }),
+    "bunfig.toml": bunfig(registry.registryUrl(), "isolated"),
     "packages/lib/package.json": JSON.stringify({
       name: "lib",
       version: "1.0.0",
-      dependencies: {},
       devDependencies: {
-        "jquery": "workspace:*", // Use workspace protocol for dev
+        "no-deps": "workspace:*", // workspace protocol for dev
       },
       peerDependencies: {
-        "jquery": "3.7.0", // Range wants 3.7.0
+        "no-deps": "1.0.0", // would resolve from the registry
       },
     }),
-    "packages/lib/test.js": `const dep = require("jquery"); console.log(dep.version);`,
-    // Only provide workspace package with version 2.0.0
-    "packages/my-dep/package.json": JSON.stringify({
-      name: "jquery",
+    "packages/lib/test.js": `console.log(require("no-deps").version);`,
+    // Workspace provides 2.0.0; the peer range asks for 1.0.0.
+    "packages/no-deps/package.json": JSON.stringify({
+      name: "no-deps",
       version: "2.0.0",
       main: "index.js",
     }),
-    "packages/my-dep/index.js": `module.exports = { version: "2.0.0" };`,
+    "packages/no-deps/index.js": `module.exports = { version: "2.0.0-workspace" };`,
   });
 
-  // Run initial install
-  let { stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(
-    resolve => {
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
-        cwd: dir,
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+  // Initial install against the local registry.
+  {
+    const { stderr, exitCode } = await spawnBun(["install"], String(dir));
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
 
-      proc.exited.then(exitCode => {
-        Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
-          resolve({ stdout, stderr, exitCode });
-        });
-      });
+  // The devDependency (workspace) must win: only the workspace entry is recorded.
+  const lockfile = await Bun.file(join(String(dir), "bun.lock")).text();
+  expect(lockfile).toContain("no-deps@workspace:packages/no-deps");
+  expect(lockfile).not.toContain("no-deps@1.0.0");
+
+  // Re-install with the registry pointed at a server that fails every request. If
+  // bun tried to re-resolve the peer dependency it would hit this server.
+  let registryHits = 0;
+  await using deadRegistry = Bun.serve({
+    port: 0,
+    fetch() {
+      registryHits++;
+      return new Response("unreachable", { status: 500 });
     },
-  );
-
-  if (exitCode !== 0) {
-    console.error("Install failed with exit code:", exitCode);
-    console.error("stdout:", stdout);
-    console.error("stderr:", stderr);
-  }
-  expect(exitCode).toBe(0);
-
-  // Now run bun install with a dead registry to ensure no network requests
-  ({ stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(resolve => {
-    const proc = Bun.spawn({
-      cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
-      cwd: dir,
-      env: {
-        ...bunEnv,
-        NPM_CONFIG_REGISTRY: "http://localhost:9999/", // Dead URL - will fail if used
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    proc.exited.then(exitCode => {
-      Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
-        resolve({ stdout, stderr, exitCode });
-      });
-    });
-  }));
-
-  if (exitCode !== 0) {
-    console.error("Install failed with exit code:", exitCode);
-    console.error("stdout:", stdout);
-    console.error("stderr:", stderr);
-  }
-  expect(exitCode).toBe(0);
-
-  // Check that no network requests were made for packages that should be resolved locally
-  expect(stderr).not.toContain("GET");
-  expect(stderr).not.toContain("http");
-
-  // Check that the lockfile was created correctly
-  const lockfilePath = join(dir, "bun.lock");
-  expect(await Bun.file(lockfilePath).exists()).toBe(true);
-
-  // Verify that version 2.0.0 (devDependency) was linked
-  // If peerDependency range ^1.0.0 was used, it would try to fetch from npm and fail
-  const testResult = await new Promise<string>(resolve => {
-    const proc = Bun.spawn({
-      cmd: [bunExe(), "packages/lib/test.js"],
-      cwd: dir,
-      env: bunEnv,
-      stdout: "pipe",
-    });
-
-    new Response(proc.stdout).text().then(resolve);
   });
+  await Bun.write(join(String(dir), "bunfig.toml"), bunfig(String(deadRegistry.url), "isolated"));
 
-  expect(testResult.trim()).toBe("2.0.0");
+  {
+    const { stderr, exitCode } = await spawnBun(["install"], String(dir));
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+  expect(registryHits).toBe(0);
+
+  // The linked module is the workspace copy (devDependency), not the registry 1.0.0.
+  const { stdout, stderr, exitCode } = await spawnBun(["packages/lib/test.js"], String(dir));
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("2.0.0-workspace");
+  expect(exitCode).toBe(0);
 });
 
 test.concurrent("devDependencies and peerDependencies with different versions should coexist", async () => {
@@ -116,15 +101,12 @@ test.concurrent("devDependencies and peerDependencies with different versions sh
     "package.json": JSON.stringify({
       name: "test-monorepo",
       version: "1.0.0",
-      workspaces: {
-        packages: ["packages/*"],
-        nodeLinker: "isolated",
-      },
+      workspaces: ["packages/*"],
     }),
+    "bunfig.toml": bunfig(registry.registryUrl(), "isolated"),
     "packages/lib/package.json": JSON.stringify({
       name: "lib",
       version: "1.0.0",
-      dependencies: {},
       devDependencies: {
         "utils": "1.0.0",
       },
@@ -132,193 +114,117 @@ test.concurrent("devDependencies and peerDependencies with different versions sh
         "utils": "^1.0.0",
       },
     }),
-    "packages/lib/index.js": `console.log("lib");`,
     "packages/utils/package.json": JSON.stringify({
       name: "utils",
       version: "1.0.0",
       main: "index.js",
     }),
-    "packages/utils/index.js": `console.log("utils");`,
+    "packages/utils/index.js": `module.exports = { version: "1.0.0" };`,
   });
 
-  // Run bun install in the monorepo
-  const { stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(
-    resolve => {
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
-        cwd: dir,
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-
-      proc.exited.then(exitCode => {
-        Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
-          resolve({ stdout, stderr, exitCode });
-        });
-      });
-    },
-  );
-
-  if (exitCode !== 0) {
-    console.error("Install failed with exit code:", exitCode);
-    console.error("stdout:", stdout);
-    console.error("stderr:", stderr);
-  }
+  const { stderr, exitCode } = await spawnBun(["install"], String(dir));
+  expect(stderr).not.toContain("error:");
   expect(exitCode).toBe(0);
 
-  // Check that the lockfile was created correctly
-  const lockfilePath = join(dir, "bun.lock");
-  expect(await Bun.file(lockfilePath).exists()).toBe(true);
+  const lockfile = await Bun.file(join(String(dir), "bun.lock")).text();
+  expect(lockfile).toContain("utils@workspace:packages/utils");
 });
 
 test.concurrent("dependency behavior comparison prioritizes devDependencies", async () => {
+  // No workspace here: both ranges resolve against the registry. The devDependency
+  // pins 1.0.0 while the peerDependency range would otherwise float to 1.1.0.
   await using dir = tempDir("behavior-comparison", {
     "package.json": JSON.stringify({
       name: "test-app",
       version: "1.0.0",
-      dependencies: {},
       devDependencies: {
-        "typescript": "^5.0.0",
+        "no-deps": "1.0.0",
       },
       peerDependencies: {
-        "typescript": "^4.0.0 || ^5.0.0",
+        "no-deps": "^1.0.0",
       },
     }),
-    "index.js": `console.log("app");`,
+    "bunfig.toml": bunfig(registry.registryUrl()),
   });
 
-  // Run bun install
-  const { stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(
-    resolve => {
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
-        cwd: dir,
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-
-      proc.exited.then(exitCode => {
-        Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
-          resolve({ stdout, stderr, exitCode });
-        });
-      });
-    },
-  );
-
-  if (exitCode !== 0) {
-    console.error("Install failed with exit code:", exitCode);
-    console.error("stdout:", stdout);
-    console.error("stderr:", stderr);
-  }
+  const { stderr, exitCode } = await spawnBun(["install"], String(dir));
+  expect(stderr).not.toContain("error:");
   expect(exitCode).toBe(0);
 
-  // Check that the lockfile was created correctly
-  const lockfilePath = join(dir, "bun.lock");
-  expect(await Bun.file(lockfilePath).exists()).toBe(true);
+  // devDependency wins: 1.0.0 is installed, not the 1.1.0 the peer range would pick.
+  const lockfile = await Bun.file(join(String(dir), "bun.lock")).text();
+  expect(lockfile).toContain("no-deps@1.0.0");
+  expect(lockfile).not.toContain("no-deps@1.1.0");
+
+  const installed = await Bun.file(join(String(dir), "node_modules", "no-deps", "package.json")).json();
+  expect(installed).toMatchObject({ name: "no-deps", version: "1.0.0" });
 });
 
 test.concurrent("Next.js monorepo scenario should not make unnecessary network requests", async () => {
+  // Same shape as the original Next.js canary repro but with a registry package that
+  // has no transitive dependencies. The devDependency is a plain semver that matches
+  // the workspace package; the peerDependency range would pull a different version
+  // from the registry if it took priority.
   await using dir = tempDir("nextjs-monorepo", {
     "package.json": JSON.stringify({
       name: "nextjs-monorepo",
       version: "1.0.0",
-      workspaces: {
-        packages: ["packages/*"],
-        nodeLinker: "isolated",
-      },
+      workspaces: ["packages/*"],
     }),
+    "bunfig.toml": bunfig(registry.registryUrl(), "isolated"),
     "packages/web/package.json": JSON.stringify({
       name: "web",
       version: "1.0.0",
-      dependencies: {},
       devDependencies: {
-        "next": "15.0.0-canary.119", // Specific canary version for dev
+        "no-deps": "2.0.0", // matches the workspace package exactly
       },
       peerDependencies: {
-        "next": "^14.0.0 || ^15.0.0", // Range that would accept 14.x or 15.x stable
+        "no-deps": "^1.0.0", // would resolve to 1.1.0 from the registry
       },
     }),
-    "packages/web/test.js": `const next = require("next/package.json"); console.log(next.version);`,
-    // Only provide the canary version that matches devDependencies
-    "packages/next/package.json": JSON.stringify({
-      name: "next",
-      version: "15.0.0-canary.119",
+    "packages/web/test.js": `console.log(require("no-deps/package.json").version);`,
+    "packages/no-deps/package.json": JSON.stringify({
+      name: "no-deps",
+      version: "2.0.0",
       main: "index.js",
     }),
-    "packages/next/index.js": `console.log("next workspace");`,
+    "packages/no-deps/index.js": `module.exports = require("./package.json");`,
   });
 
-  // Run initial install
-  let { stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(
-    resolve => {
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
-        cwd: dir,
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      proc.exited.then(exitCode => {
-        Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
-          resolve({ stdout, stderr, exitCode });
-        });
-      });
-    },
-  );
-
-  if (exitCode !== 0) {
-    console.error("Install failed with exit code:", exitCode);
-    console.error("stdout:", stdout);
-    console.error("stderr:", stderr);
+  // Initial install against the local registry.
+  {
+    const { stderr, exitCode } = await spawnBun(["install"], String(dir));
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
   }
-  expect(exitCode).toBe(0);
 
-  // Run bun install with dead registry
-  ({ stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(resolve => {
-    const proc = Bun.spawn({
-      cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
-      cwd: dir,
-      env: {
-        ...bunEnv,
-        NPM_CONFIG_REGISTRY: "http://localhost:9999/", // Dead URL
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+  const lockfile = await Bun.file(join(String(dir), "bun.lock")).text();
+  expect(lockfile).toContain("no-deps@workspace:packages/no-deps");
+  expect(lockfile).not.toContain("no-deps@1.");
 
-    proc.exited.then(exitCode => {
-      Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
-        resolve({ stdout, stderr, exitCode });
-      });
-    });
-  }));
-
-  expect(exitCode).toBe(0);
-
-  // The key test: should not make network requests for packages that exist in workspace
-  // When devDependencies are prioritized over peerDependencies, the workspace version should be used
-  expect(stderr).not.toContain("GET");
-  expect(stderr).not.toContain("404");
-  expect(stderr).not.toContain("http");
-
-  // Check that the lockfile was created correctly
-  const lockfilePath = join(dir, "bun.lock");
-  expect(await Bun.file(lockfilePath).exists()).toBe(true);
-
-  // Verify that version 15.0.0-canary.119 (devDependency) was used
-  // If peer range was used, it would try to fetch a stable version from npm and fail
-  const testResult = await new Promise<string>(resolve => {
-    const proc = Bun.spawn({
-      cmd: [bunExe(), "packages/web/test.js"],
-      cwd: dir,
-      env: bunEnv,
-      stdout: "pipe",
-    });
-
-    new Response(proc.stdout).text().then(resolve);
+  // Re-install with a registry that fails every request. devDependencies taking
+  // priority means the workspace copy is already linked and no lookup is needed.
+  let registryHits = 0;
+  await using deadRegistry = Bun.serve({
+    port: 0,
+    fetch() {
+      registryHits++;
+      return new Response("unreachable", { status: 500 });
+    },
   });
+  await Bun.write(join(String(dir), "bunfig.toml"), bunfig(String(deadRegistry.url), "isolated"));
 
-  expect(testResult.trim()).toBe("15.0.0-canary.119");
+  {
+    const { stderr, exitCode } = await spawnBun(["install"], String(dir));
+    expect(stderr).not.toContain("error:");
+    expect(stderr).not.toContain("GET");
+    expect(exitCode).toBe(0);
+  }
+  expect(registryHits).toBe(0);
+
+  // The linked module is the workspace copy (devDependency), not the registry ^1.0.0.
+  const { stdout, stderr, exitCode } = await spawnBun(["packages/web/test.js"], String(dir));
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("2.0.0");
+  expect(exitCode).toBe(0);
 });

--- a/test/cli/install/test-dev-peer-dependency-priority.test.ts
+++ b/test/cli/install/test-dev-peer-dependency-priority.test.ts
@@ -214,7 +214,6 @@ test.concurrent("Next.js monorepo scenario should not make unnecessary network r
   {
     const { stderr, exitCode } = await spawnBun(["install"], String(dir));
     expect(stderr).not.toContain("error:");
-    expect(stderr).not.toContain("GET");
     expect(exitCode).toBe(0);
   }
   expect(registryHits).toBe(0);


### PR DESCRIPTION
### What does this PR do?

`test/cli/install/test-dev-peer-dependency-priority.test.ts` was fetching `jquery`, `typescript` and `next` from registry.npmjs.org on every run. The `next` install in particular pulls in react, react-dom, sharp, every `@next/swc-*` platform package, etc. On alpine 3.23 x64 (build #88691) this file took ~11s; locally on a cold cache the Next.js test hits the 5s per-test timeout.

This points the same four scenarios at the local verdaccio fixture's `no-deps` package (versions 1.0.0 / 1.1.0 / 2.0.0) so the file never touches the public internet and its wall time is stable regardless of cache state. Nothing about the behaviour under test changes: a workspace package still collides with a registry package of the same name, the `devDependencies` entry still uses a different spec from the `peerDependencies` entry, and we still verify that the dev entry is what gets linked and that a second install makes zero registry requests.

While in here:

- Replace the hardcoded `http://localhost:9999/` "dead registry" with a port-0 `Bun.serve` that counts requests, so the "no network on second install" check is a positive `expect(hits).toBe(0)` instead of scanning stderr for `GET`.
- Assert the resolved version in `bun.lock` and (for the non-workspace case) in `node_modules/no-deps/package.json`, instead of only checking that `bun.lock` exists.
- Check `stderr` before `exitCode` so a failure reports the actual error.
- Collapse the hand-rolled `new Promise` + `new Response(proc.stdout).text()` spawn boilerplate into a small helper that uses `await using`.

### How did you verify your code works?

Locally with `bun bd test test/cli/install/test-dev-peer-dependency-priority.test.ts`:

| | before | after |
| --- | --- | --- |
| cold bun-install cache | 7.4s, Next.js case times out | 3.6s, all pass |
| warm cache | 2.8-3.0s | 3.5-3.6s |
| `expect()` calls | 17 | 29 |

The warm-cache "after" number includes ~0.8s of verdaccio startup; the win is that the cold-cache path (what CI sees on a fresh lane) no longer depends on npmjs.org latency, and the file can no longer flake on the 5s default timeout.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/install/test-dev-peer-dependency-priority.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/install/test-dev-peer-dependency-priority.test.ts
bun test v1.4.0 (07ebec9bb)

test/cli/install/test-dev-peer-dependency-priority.test.ts:
(pass) devDependencies and peerDependencies with different versions should coexist [167.02ms]
(pass) dependency behavior comparison prioritizes devDependencies [204.37ms]
(pass) workspace devDependencies should take priority over peerDependencies for resolution [681.09ms]
(pass) Next.js monorepo scenario should not make unnecessary network requests [622.51ms]

 4 pass
 0 fail
 29 expect() calls
Ran 4 tests across 1 file. [3.49s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../test-dev-peer-dependency-priority.test.ts      | 358 ++++++++-------------
 1 file changed, 130 insertions(+), 228 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…t/cli/install/test-dev-peer-dependency-priority.test.ts      4      9      0
```

</details>

<!-- robobun:evidence:end -->