### PR TITLE
test(http): speed up leaks-test.test.ts and fix its local ASAN detection

### DIFF
--- a/test/js/bun/http/leaks-test.test.ts
+++ b/test/js/bun/http/leaks-test.test.ts
@@ -3,26 +3,26 @@ import { bunRun } from "harness";
 import { join } from "path";
 
 // This test was never leaking, as far as i can tell.
-test.concurrent(
-  "request error doesn't leak",
-  async () => {
-    expect(await bunRun(join(import.meta.dir, "request-constructor-leak-fixture.js"))).toSpawn();
-  },
-  60_000,
-);
+test.concurrent("request error doesn't leak", async () => {
+  const result = await bunRun(join(import.meta.dir, "request-constructor-leak-fixture.js"));
+  expect(result.stdout).toMatch(/^RSS: \d+ MB$/);
+  expect(result).toSpawn();
+});
 
-test.concurrent(
-  "response error doesn't leak",
-  async () => {
-    expect(await bunRun(join(import.meta.dir, "response-constructor-leak-fixture.js"))).toSpawn();
-  },
-  60_000,
-);
+test.concurrent("response error doesn't leak", async () => {
+  const result = await bunRun(join(import.meta.dir, "response-constructor-leak-fixture.js"));
+  expect(result.stdout).toMatch(/^RSS: \d+ MB$/);
+  expect(result).toSpawn();
+});
 
 test.concurrent(
   "server.fetch(string) doesn't leak the URL buffer",
   async () => {
-    expect(await bunRun(join(import.meta.dir, "server-fetch-string-leak-fixture.js"))).toSpawn();
+    const result = await bunRun(join(import.meta.dir, "server-fetch-string-leak-fixture.js"));
+    expect(result.stdout).toMatch(/^RSS delta: -?\d+(\.\d+)? MB$/);
+    expect(result).toSpawn();
   },
-  60_000,
+  // Under debug-ASAN the fixture runs 4096*2 server.fetch() calls to clear the
+  // ASAN quarantine ceiling; that legitimately exceeds the 5s default.
+  30_000,
 );

--- a/test/js/bun/http/request-constructor-leak-fixture.js
+++ b/test/js/bun/http/request-constructor-leak-fixture.js
@@ -8,17 +8,24 @@ const rss =
   process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
     ? Bun.unsafe.memoryFootprint
     : process.memoryUsage.rss;
-const buf = new Uint8Array(1024 * 1024 * 16);
+// 1 MiB body. The Request constructor copies the body before the throwing
+// `signal` coercion runs, and under ASAN that copy is O(size). 1 MiB * 1000
+// still produces ~1 GiB of leak if the body is retained, which clears the
+// threshold below while keeping the loop under ~2s on debug-ASAN.
+const buf = new Uint8Array(1024 * 1024);
+// Buffer.alloc(n, fill).toString() instead of "...".repeat(n): repeat() is
+// very slow on debug JavaScriptCore builds (see test/CLAUDE.md).
+const longHost = Buffer.alloc(35 * 1024, "superduperlongurlwowsuchlengthicant").toString();
+const longContentType = Buffer.alloc(64 * 1024, "yo de lay ").toString();
 
 for (var i = 0; i < 1000; i++) {
   try {
-    new Request("http://" + "superduperlongurlwowsuchlengthicant".repeat(1024) + ".com/" + i, {
+    new Request("http://" + longHost + ".com/" + i, {
       body: buf,
       signal: Symbol("leaky-error"),
       headers: {
         // That means the string needs to be long enough to otherwise show up with a 0-length body.
-        ["Content-Type"]:
-          "yo de lay  yo de lay  yo de lay  yo de lay  yo de lay  yo de lay  ".repeat(1024) + Math.random(),
+        ["Content-Type"]: longContentType + Math.random(),
         "Invalid-Header-Name-☺️": "1",
       },
     });

--- a/test/js/bun/http/request-constructor-leak-fixture.js
+++ b/test/js/bun/http/request-constructor-leak-fixture.js
@@ -8,11 +8,11 @@ const rss =
   process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
     ? Bun.unsafe.memoryFootprint
     : process.memoryUsage.rss;
-// 1 MiB body. The Request constructor copies the body before the throwing
-// `signal` coercion runs, and under ASAN that copy is O(size). 1 MiB * 1000
-// still produces ~1 GiB of leak if the body is retained, which clears the
-// threshold below while keeping the loop under ~2s on debug-ASAN.
-const buf = new Uint8Array(1024 * 1024);
+// 2 MiB body. The Request constructor copies the body before the throwing
+// `signal` coercion runs, and under ASAN that copy is O(size). 2 MiB * 1000
+// produces ~2 GiB of leak if the body is retained, ~2x the 1 GiB threshold
+// below, while keeping the loop under ~3s on debug-ASAN.
+const buf = new Uint8Array(2 * 1024 * 1024);
 // Buffer.alloc(n, fill).toString() instead of "...".repeat(n): repeat() is
 // very slow on debug JavaScriptCore builds (see test/CLAUDE.md).
 const longHost = Buffer.alloc(35 * 1024, "superduperlongurlwowsuchlengthicant").toString();

--- a/test/js/bun/http/response-constructor-leak-fixture.js
+++ b/test/js/bun/http/response-constructor-leak-fixture.js
@@ -9,6 +9,9 @@ const rss =
     ? Bun.unsafe.memoryFootprint
     : process.memoryUsage.rss;
 const buf = new Uint8Array(1024 * 1024 * 32);
+// Buffer.alloc(n, fill).toString() instead of "...".repeat(n): repeat() is
+// very slow on debug JavaScriptCore builds (see test/CLAUDE.md).
+const longContentType = Buffer.alloc(64 * 1024, "yo de lay ").toString();
 
 for (var i = 0; i < 1000; i++) {
   try {
@@ -19,8 +22,7 @@ for (var i = 0; i < 1000; i++) {
       status: 200,
       headers: {
         // That means the string needs to be long enough to otherwise show up with a 0-length body.
-        ["Content-Type"]:
-          "yo de lay  yo de lay  yo de lay  yo de lay  yo de lay  yo de lay  ".repeat(1024) + Math.random(),
+        ["Content-Type"]: longContentType + Math.random(),
       },
     });
   } catch (e) {}

--- a/test/js/bun/http/server-fetch-string-leak-fixture.js
+++ b/test/js/bun/http/server-fetch-string-leak-fixture.js
@@ -7,7 +7,15 @@ const rss =
   process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
     ? Bun.unsafe.memoryFootprint
     : process.memoryUsage.rss;
-const isASAN = process.execPath.includes("bun-asan");
+// Detect ASAN from the runtime, not the binary name. A local `bun bd` debug
+// build is ASAN-instrumented but named `bun-debug`, so the name check alone
+// picks the wrong branch and trips the non-ASAN threshold.
+let isASAN;
+try {
+  isASAN = require("bun:internal-for-testing").isASANEnabled();
+} catch {
+  isASAN = process.execPath.includes("bun-asan");
+}
 using server = Bun.serve({
   port: 0,
   fetch() {
@@ -15,7 +23,7 @@ using server = Bun.serve({
   },
 });
 
-const longPath = "/" + Buffer.alloc(32 * 1024, "p").toString();
+const longPath = "/" + Buffer.alloc(64 * 1024, "p").toString();
 const absolute = `http://${server.hostname}:${server.port}${longPath}`;
 
 // Warm up so RSS baseline stabilizes before we measure.
@@ -27,9 +35,10 @@ Bun.gc(true);
 const before = rss();
 
 // Under ASAN the quarantine (default 256 MB) retains freed URL buffers, so the
-// no-leak baseline alone is ~256 MB. Run more iterations so the leak signature
-// (~40 KB/call, never freed → never quarantined) clears the quarantine ceiling.
-const iterations = isASAN ? 8192 : 4096;
+// no-leak baseline alone is a few hundred MB. Run enough iterations so the
+// leak signature (~72 KB/call, never freed → never quarantined) clears the
+// quarantine ceiling.
+const iterations = isASAN ? 4096 : 2048;
 for (let i = 0; i < iterations; i++) {
   await server.fetch(absolute);
   await server.fetch(longPath);
@@ -40,9 +49,10 @@ const after = rss();
 const deltaMB = (after - before) / 1024 / 1024;
 console.log("RSS delta:", deltaMB.toFixed(1), "MB");
 
-// 4096 iterations * 2 calls * ~32 KiB = ~256 MiB leaked when broken.
+// 2048 iterations * 2 calls * ~64 KiB = ~256 MiB leaked when broken.
 // With the fix, growth is a few MiB of allocator jitter at most.
-// ASAN: ~648 MB leaked vs ~256 MB quarantine no-leak baseline.
+// ASAN: ~512 MiB of leaked URL buffers + allocator slack vs ~320 MiB
+// quarantine no-leak baseline; threshold sits between.
 if (deltaMB > (isASAN ? 450 : 64)) {
   console.error("server.fetch(string) leaked URL buffers");
   process.exit(1);

--- a/test/js/bun/http/server-fetch-string-leak-fixture.js
+++ b/test/js/bun/http/server-fetch-string-leak-fixture.js
@@ -51,8 +51,8 @@ console.log("RSS delta:", deltaMB.toFixed(1), "MB");
 
 // 2048 iterations * 2 calls * ~64 KiB = ~256 MiB leaked when broken.
 // With the fix, growth is a few MiB of allocator jitter at most.
-// ASAN: ~512 MiB of leaked URL buffers + allocator slack vs ~320 MiB
-// quarantine no-leak baseline; threshold sits between.
+// ASAN: ~649 MB leaked (measured with the Cow->Box::leak regression
+// reintroduced) vs ~325 MB quarantine no-leak baseline.
 if (deltaMB > (isASAN ? 450 : 64)) {
   console.error("server.fetch(string) leaked URL buffers");
   process.exit(1);


### PR DESCRIPTION
Cuts `bun bd test test/js/bun/http/leaks-test.test.ts` from **11.7s** to **7.7s** on a debug-ASAN build and fixes a false-positive failure in the `server.fetch(string)` leak test when run via `bun bd` locally.

## What changed

### `request-constructor-leak-fixture.js` (9.8s → 2.0s)

The Request constructor copies the body buffer before the `signal` option is coerced (which is where the fixture's `Symbol` throws), so under ASAN each of the 1000 iterations paid for a 16 MiB poison/copy/unpoison. Shrinking the body to 2 MiB keeps the leak signature at ~2000 MiB against the existing 1024 MiB threshold (~2x margin; observed no-leak RSS: 69 MB release, ~610 MB debug-ASAN) while dropping per-iteration cost ~8x. Also hoisted the per-iteration `.repeat(1024)` strings into `Buffer.alloc().toString()` built once up front.

### `server-fetch-string-leak-fixture.js` (bug fix + ~25% faster)

The fixture branched on `process.execPath.includes("bun-asan")`. A local `bun bd` debug build is ASAN-instrumented but named `bun-debug`, so the fixture took the non-ASAN branch (4096 iterations, 64 MB threshold) and observed ~190 MB of ASAN quarantine growth, failing the test. It now uses `require("bun:internal-for-testing").isASANEnabled()` with the name check as a fallback, matching how `harness.ts` detects ASAN.

With detection fixed the fixture becomes the file's long pole, so the path is doubled to 64 KiB and iterations halved (8192 → 4096 ASAN, 4096 → 2048 non-ASAN). The total leak signature is unchanged (~512 MiB under ASAN, ~256 MiB release) and the 450 MB / 64 MB thresholds are untouched. Measured no-leak delta under debug-ASAN is 323-329 MB across five runs, well under 450.

### `response-constructor-leak-fixture.js`

Hoisted the in-loop `.repeat(1024)` to a `Buffer.alloc().toString()`. Already sub-second; no other change.

### `leaks-test.test.ts`

- Assert the fixture stdout actually prints its `RSS: N MB` / `RSS delta: N MB` line before the `.toSpawn()` exit-code check.
- Drop the blanket 60 s timeouts on the two sub-second tests.
- Keep a 30 s ceiling on the `server.fetch` test, which legitimately exceeds the 5 s default under debug-ASAN.

## Why this is correct

No leak threshold was loosened. The only workload changes trade size for iteration count such that the byte total that would leak is preserved (request: 2 MiB × 1000 = 2000 MiB vs 1024 MiB threshold; server.fetch ASAN: 64 KiB × 2 × 4096 = 512 MiB vs 450 MiB threshold). The ASAN-detection change mirrors `test/harness.ts`'s `detectASAN()`.

## Verification

```
# before (on main)
(pass) response error doesn't leak [971.56ms]
(fail) server.fetch(string) doesn't leak the URL buffer [3435.65ms]   # false positive on bun-debug
(pass) request error doesn't leak [9724.28ms]
Ran 3 tests across 1 file. [11.71s]

# after
(pass) response error doesn't leak [956.46ms]
(pass) request error doesn't leak [1983.39ms]
(pass) server.fetch(string) doesn't leak the URL buffer [5659.29ms]
Ran 3 tests across 1 file. [7.75s]
```

server.fetch no-leak delta, 5 consecutive debug-ASAN runs: `324.7, 323.7, 329.2, 326.4, 327.6 MB` (threshold 450).

Release (`USE_SYSTEM_BUN=1`): all three pass in 479 ms.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 4 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/leaks-test.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/leaks-test.test.ts
bun test v1.4.0 (821b63be9)

test/js/bun/http/leaks-test.test.ts:
(pass) response error doesn't leak [969.27ms]
(pass) request error doesn't leak [1967.50ms]
(pass) server.fetch(string) doesn't leak the URL buffer [5531.40ms]

 3 pass
 0 fail
 6 expect() calls
Ran 3 tests across 1 file. [7.57s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/leaks-test.test.ts                | 32 +++++++++++-----------
 .../bun/http/request-constructor-leak-fixture.js   | 15 +++++++---
 .../bun/http/response-constructor-leak-fixture.js  |  6 ++--
 .../bun/http/server-fetch-string-leak-fixture.js   | 24 +++++++++++-----
 4 files changed, 48 insertions(+), 29 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
test/js/bun/http/leaks-test.test.ts                        2      4      0
test/js/bun/http/request-constructor-leak-fixture.js       2      2      0
test/js/bun/http/response-constructor-leak-fixture.js      1      1      0
test/js/bun/http/server-fetch-string-leak-fixture.js       2      4      0
```

</details>

<!-- robobun:evidence:end -->