### PR TITLE
Add Bun.spawnAndWait(): async spawn with buffered SyncSubprocess result

### DIFF
--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -610,7 +610,8 @@ interface SyncSubprocess {
   success: boolean;
   resourceUsage: ResourceUsage;
   signalCode?: string;
-  exitedDueToTimeout?: true;
+  exitedDueToTimeout?: boolean;
+  exitedDueToMaxBuffer?: boolean;
   pid: number;
 }
 

--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -448,6 +448,38 @@ As a rule of thumb, the asynchronous `Bun.spawn` API is better for HTTP servers 
 
 ---
 
+## Async buffered API (`Bun.spawnAndWait()`)
+
+`Bun.spawnAndWait` returns a `Promise` that resolves with the same `SyncSubprocess` result as `Bun.spawnSync` (buffered `stdout`/`stderr` as `Buffer`, `exitCode`, `success`, `signalCode`, `resourceUsage`, `pid`) without blocking the event loop.
+
+```ts
+const result = await Bun.spawnAndWait(["echo", "hello"]);
+
+console.log(result.stdout.toString()); // => "hello\n"
+console.log(result.exitCode); // => 0
+console.log(result.success); // => true
+```
+
+Like `Bun.spawnSync`, `stdout` and `stderr` default to `"pipe"` and are returned as `Buffer` objects, and the `timeout` and `maxBuffer` options are supported (along with `exitedDueToTimeout` and `exitedDueToMaxBuffer` on the result). Unlike `Bun.spawnSync`, the event loop continues running while the process executes, so timers, network requests, and other async work proceed normally.
+
+```ts
+const result = await Bun.spawnAndWait({
+  cmd: ["curl", "-s", "https://example.com"],
+  timeout: 5_000,
+  maxBuffer: 1024 * 1024,
+});
+
+if (result.success) {
+  console.log(result.stdout.toString());
+} else if (result.exitedDueToTimeout) {
+  console.error("timed out");
+}
+```
+
+This is useful when you want the simplicity of `spawnSync`'s buffered result but cannot block the event loop, such as inside an HTTP handler or when running multiple subprocesses concurrently with `Promise.all`.
+
+---
+
 ## Benchmarks
 
 <Note>
@@ -492,9 +524,11 @@ The following is a reference of the Spawn API and types. The real types have com
 interface Bun {
   spawn(command: string[], options?: SpawnOptions.OptionsObject): Subprocess;
   spawnSync(command: string[], options?: SpawnOptions.OptionsObject): SyncSubprocess;
+  spawnAndWait(command: string[], options?: SpawnOptions.OptionsObject): Promise<SyncSubprocess>;
 
   spawn(options: { cmd: string[] } & SpawnOptions.OptionsObject): Subprocess;
   spawnSync(options: { cmd: string[] } & SpawnOptions.OptionsObject): SyncSubprocess;
+  spawnAndWait(options: { cmd: string[] } & SpawnOptions.OptionsObject): Promise<SyncSubprocess>;
 }
 
 namespace SpawnOptions {

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7555,6 +7555,97 @@ declare module "bun" {
   ): SyncSubprocess<Out, Err>;
 
   /**
+   * Spawn a new process and wait for it to exit, returning a promise that
+   * resolves with the same result shape as {@link Bun.spawnSync}: buffered
+   * `stdout` and `stderr` as `Buffer`, `exitCode`, `success`, `signalCode`,
+   * `resourceUsage`, and `pid`.
+   *
+   * Unlike {@link Bun.spawnSync}, this does not block the event loop. Unlike
+   * {@link Bun.spawn}, the result contains buffered `Buffer` objects instead
+   * of `ReadableStream`.
+   *
+   * Like {@link Bun.spawnSync}, `stdout` and `stderr` default to `"pipe"` and
+   * the `timeout` and `maxBuffer` options are supported.
+   *
+   * @category Process Management
+   *
+   * ```js
+   * const { stdout } = await Bun.spawnAndWait({
+   *   cmd: ["echo", "hello"],
+   * });
+   * console.log(stdout.toString()); // "hello\n"
+   * ```
+   */
+  function spawnAndWait<
+    const In extends SpawnOptions.Writable = "ignore",
+    const Out extends SpawnOptions.Readable = "pipe",
+    const Err extends SpawnOptions.Readable = "pipe",
+  >(
+    options: SpawnOptions.SpawnSyncOptions<In, Out, Err> & {
+      /**
+       * The command to run
+       *
+       * The first argument is resolved to an absolute executable path. It must be a file, not a directory.
+       *
+       * If you explicitly set `PATH` in `env`, that `PATH` is used to resolve the executable instead of the default `PATH`.
+       *
+       * To check if the command exists before running it, use `Bun.which(bin)`.
+       *
+       * @example
+       * ```ts
+       * const result = await Bun.spawnAndWait({ cmd: ["echo", "hello"] });
+       * ```
+       */
+      cmd: string[];
+
+      onExit?: never;
+    },
+  ): Promise<SyncSubprocess<Out, Err>>;
+
+  /**
+   * Spawn a new process and wait for it to exit, returning a promise that
+   * resolves with the same result shape as {@link Bun.spawnSync}: buffered
+   * `stdout` and `stderr` as `Buffer`, `exitCode`, `success`, `signalCode`,
+   * `resourceUsage`, and `pid`.
+   *
+   * Unlike {@link Bun.spawnSync}, this does not block the event loop. Unlike
+   * {@link Bun.spawn}, the result contains buffered `Buffer` objects instead
+   * of `ReadableStream`.
+   *
+   * Like {@link Bun.spawnSync}, `stdout` and `stderr` default to `"pipe"` and
+   * the `timeout` and `maxBuffer` options are supported.
+   *
+   * @category Process Management
+   *
+   * ```js
+   * const { stdout } = await Bun.spawnAndWait(["echo", "hello"]);
+   * console.log(stdout.toString()); // "hello\n"
+   * ```
+   */
+  function spawnAndWait<
+    const In extends SpawnOptions.Writable = "ignore",
+    const Out extends SpawnOptions.Readable = "pipe",
+    const Err extends SpawnOptions.Readable = "pipe",
+  >(
+    /**
+     * The command to run
+     *
+     * The first argument is resolved to an absolute executable path. It must be a file, not a directory.
+     *
+     * If you explicitly set `PATH` in `env`, that `PATH` is used to resolve the executable instead of the default `PATH`.
+     *
+     * To check if the command exists before running it, use `Bun.which(bin)`.
+     *
+     * @example
+     * ```ts
+     * const result = await Bun.spawnAndWait(["echo", "hello"]);
+     * ```
+     */
+    cmds: string[],
+    options?: SpawnOptions.SpawnSyncOptions<In, Out, Err>,
+  ): Promise<SyncSubprocess<Out, Err>>;
+
+  /**
    * Controller object passed to the `scheduled()` handler when a cron job fires.
    *
    * Compatible with [Cloudflare Workers' ScheduledController](https://developers.cloudflare.com/workers/runtime-apis/handlers/scheduled/).

--- a/src/jsc/bindings/BunObject+exports.h
+++ b/src/jsc/bindings/BunObject+exports.h
@@ -74,6 +74,7 @@
     macro(shrink) \
     macro(sleepSync) \
     macro(spawn) \
+    macro(spawnAndWait) \
     macro(spawnSync) \
     macro(udpSocket) \
     macro(which) \

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -1015,6 +1015,7 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
     sleep                                          functionBunSleep                                                    DontDelete|Function 1
     sleepSync                                      BunObject_callback_sleepSync                                        DontDelete|Function 1
     spawn                                          BunObject_callback_spawn                                            DontDelete|Function 1
+    spawnAndWait                                   BunObject_callback_spawnAndWait                                     DontDelete|Function 1
     spawnSync                                      BunObject_callback_spawnSync                                        DontDelete|Function 1
     stderr                                         BunObject_lazyPropCb_wrap_stderr                                    DontDelete|PropertyCallback
     stdin                                          BunObject_lazyPropCb_wrap_stdin                                     DontDelete|PropertyCallback

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -140,6 +140,15 @@ mod static_adapters {
         crate::api::js_bun_spawn_bindings::spawn_sync(g, a0, a1)
     }
 
+    pub(super) fn subprocess_spawn_and_wait(
+        g: &JSGlobalObject,
+        cf: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let [a0] = cf.arguments_as_array::<1>();
+        let a1 = cf.arguments().get(1).copied();
+        crate::api::js_bun_spawn_bindings::spawn_and_wait(g, a0, a1)
+    }
+
     pub(super) fn js_bundler_build(g: &JSGlobalObject, cf: &CallFrame) -> JsResult<JSValue> {
         crate::api::js_bundler::JSBundler::build_fn(g, cf)
     }
@@ -302,6 +311,7 @@ pub mod bun_object {
         BunObject_callback_shrink => super::shrink,
         BunObject_callback_sleepSync => super::sleep_sync,
         BunObject_callback_spawn => super::static_adapters::subprocess_spawn,
+        BunObject_callback_spawnAndWait => super::static_adapters::subprocess_spawn_and_wait,
         BunObject_callback_spawnSync => super::static_adapters::subprocess_spawn_sync,
         BunObject_callback_udpSocket => super::static_adapters::udp_socket,
         BunObject_callback_which => super::which,

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -301,8 +301,7 @@ pub(crate) fn spawn_sync(
     spawn_maybe_sync::<true, false>(global_this, args, secondary_args_value)
 }
 
-/// Bun.spawnAndWait() calls this. Async spawn that resolves with the same
-/// result shape as `Bun.spawnSync` (buffered stdout/stderr, exitCode, etc.).
+/// Bun.spawnAndWait() calls this.
 pub(crate) fn spawn_and_wait(
     global_this: &JSGlobalObject,
     args: JSValue,
@@ -1817,8 +1816,6 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
         }
 
         if BUFFERED_ASYNC {
-            // `out` keeps the JS Subprocess cell reachable for this frame; the
-            // returned promise is what the caller receives.
             out.ensure_still_alive();
             let promise = jsc::JSPromise::create(global_this).to_js();
             subprocess
@@ -1827,10 +1824,6 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
             // Balanced by the `deref()` in `maybe_resolve_spawn_and_wait`.
             subprocess.ref_();
             subprocess.update_has_pending_activity();
-            // Process may already have exited and pipes closed before we got
-            // here; resolve immediately if so. Otherwise the `on_process_exit`
-            // / `on_close_io` hooks (including the `send_exit_notification`
-            // scopeguard above) resolve it.
             subprocess.maybe_resolve_spawn_and_wait();
             return Ok(promise);
         }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -610,7 +610,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
                         let mut stdio_iter = stdio_val.array_iterator(global_this)?;
                         let mut i: i32 = 0;
                         while let Some(value) = stdio_iter.next()? {
-                            Stdio::extract(&mut stdio[i as usize], global_this, i, value, IS_SYNC)?;
+                            Stdio::extract(&mut stdio[i as usize], global_this, i, value, IS_SYNC || BUFFERED_ASYNC)?;
                             if i == 2 {
                                 break;
                             }
@@ -653,15 +653,15 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
                 }
             } else {
                 if let Some(value) = args.get(global_this, "stdin")? {
-                    Stdio::extract(&mut stdio[0], global_this, 0, value, IS_SYNC)?;
+                    Stdio::extract(&mut stdio[0], global_this, 0, value, IS_SYNC || BUFFERED_ASYNC)?;
                 }
 
                 if let Some(value) = args.get(global_this, "stderr")? {
-                    Stdio::extract(&mut stdio[2], global_this, 2, value, IS_SYNC)?;
+                    Stdio::extract(&mut stdio[2], global_this, 2, value, IS_SYNC || BUFFERED_ASYNC)?;
                 }
 
                 if let Some(value) = args.get(global_this, "stdout")? {
-                    Stdio::extract(&mut stdio[1], global_this, 1, value, IS_SYNC)?;
+                    Stdio::extract(&mut stdio[1], global_this, 1, value, IS_SYNC || BUFFERED_ASYNC)?;
                 }
             }
 
@@ -1311,8 +1311,10 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
         stdin: JsCell::new(Writable::Ignore),
         stdout: JsCell::new(Readable::Ignore),
         stderr: JsCell::new(Readable::Ignore),
-        // 1=JS (released in Subprocess::finalize), 2=Process exit handler
-        // (released in Subprocess::on_process_exit; stranded if child outlives VM teardown).
+        // 1=JS wrapper (released in Subprocess::finalize) or, for
+        // spawnAndWait, the pending promise (released in
+        // maybe_resolve_spawn_and_wait); 2=Process exit handler (released in
+        // Subprocess::on_process_exit). Last one out runs Subprocess::deinit.
         ref_count: bun_ptr::RefCount::init_exact_refs(2),
         stdio_pipes: JsCell::new(core::mem::take(&mut spawned_extra_pipes)),
         ipc_data: Cell::new(None),
@@ -1392,11 +1394,10 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
         Err(err) => {
             // ref_count = 2 from the aggregate above, but neither the JS
             // wrapper nor the process exit handler are wired up yet, so
-            // release both. stdout/stderr are still `.ignore` — close the raw
-            // spawned pipe handles directly since `Readable.init()` will not
-            // run. `finalizeStreams()` here only closes `stdio_pipes` and the
-            // pidfd; stdin/stdout/stderr are `.ignore` so their `closeIO` is a
-            // no-op.
+            // release both; the second `deref()` runs `Subprocess::deinit`
+            // (stdio_pipes, pidfd, Process ref, MaxBuf, IPC queue).
+            // stdout/stderr are still `.ignore` — close the raw spawned pipe
+            // handles directly since `Readable.init()` will not run.
             #[cfg(unix)]
             {
                 if let Some(fd) = spawned_stdout {
@@ -1428,26 +1429,6 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
                     }
                 }
             }
-            subprocess.finalize_streams();
-            subprocess.process_mut().detach();
-            if let Some(ipc_data) = subprocess.ipc_data.take() {
-                // SAFETY: owned ref from `SendQueue::new` above; nothing else
-                // holds it yet (no socket wired, no task scheduled).
-                unsafe {
-                    (*ipc_data.as_ptr()).detach();
-                    <IPC::SendQueue as bun_ptr::CellRefCounted>::deref(ipc_data.as_ptr());
-                }
-            }
-            // Release the intrusive ref
-            // (finalize() won't run on this error path).
-            // SAFETY: this error path returns without ever reading `process` again.
-            unsafe { Process::deref(subprocess.process.as_ptr()) };
-            let mut mb = subprocess.stdout_maxbuf.get();
-            MaxBuf::remove_from_subprocess(&mut mb);
-            subprocess.stdout_maxbuf.set(mb);
-            let mut mb = subprocess.stderr_maxbuf.get();
-            MaxBuf::remove_from_subprocess(&mut mb);
-            subprocess.stderr_maxbuf.set(mb);
             subprocess.deref();
             subprocess.deref();
             // Note: `Writable::init` returns
@@ -1634,13 +1615,15 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
         }
     }
 
-    let out = if !IS_SYNC {
+    let out = if !IS_SYNC && !BUFFERED_ASYNC {
         // `subprocess_ptr` came from `heap::alloc` above and has not yet been
         // wrapped; ownership transfers to the C++ JS cell (released via
         // `SubprocessClass__finalize`). Use the raw-ptr entrypoint instead of
         // the by-value `JsClass::to_js` (which would re-box).
         SubprocessT::to_js_from_ptr(subprocess_ptr, global_this)
     } else {
+        // spawnSync / spawnAndWait never hand the Subprocess to JS; slot 1 of
+        // the refcount is released explicitly (finalize() / promise settle).
         JSValue::ZERO
     };
     if out != JSValue::ZERO {
@@ -1682,7 +1665,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
             subprocess.set_event_loop_timer_refd(true);
         }
 
-        debug_assert!(out != JSValue::ZERO);
+        debug_assert!(BUFFERED_ASYNC || out != JSValue::ZERO);
 
         if !BUFFERED_ASYNC {
             if on_exit_callback.is_cell() {
@@ -1698,15 +1681,15 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
             if ipc_callback.is_cell() {
                 Subprocess::js::ipc_callback_set_cached(out, global_this, ipc_callback);
             }
-        }
 
-        if let Stdio::ReadableStream(rs) = &stdio[0] {
-            Subprocess::js::stdin_set_cached(out, global_this, rs.value);
-        }
+            if let Stdio::ReadableStream(rs) = &stdio[0] {
+                Subprocess::js::stdin_set_cached(out, global_this, rs.value);
+            }
 
-        // Cache the terminal JS value if a terminal was created
-        if terminal_js_value != JSValue::ZERO {
-            Subprocess::js::terminal_set_cached(out, global_this, terminal_js_value);
+            // Cache the terminal JS value if a terminal was created
+            if terminal_js_value != JSValue::ZERO {
+                Subprocess::js::terminal_set_cached(out, global_this, terminal_js_value);
+            }
         }
 
         match subprocess.process_mut().watch() {
@@ -1724,8 +1707,17 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
     let subprocess_ptr_exit = subprocess_ptr;
     scopeguard::defer! {
         if send_exit_notification {
-            // SAFETY: subprocess_ptr is live for the lifetime of this defer.
-            let proc = unsafe { &*subprocess_ptr_exit }.process_mut();
+            // SAFETY: subprocess_ptr is live until `on_exit` below dispatches
+            // `on_process_exit`, which may drop the last Subprocess ref (and
+            // with it the Subprocess's ref on `proc`); nothing reads
+            // `subprocess_ptr_exit` after that call.
+            let proc: *mut Process = unsafe { (*subprocess_ptr_exit).process.as_ptr() };
+            // Keep `proc` alive across its own exit dispatch, like the pidfd /
+            // waiter-thread paths do with their queued +1.
+            // SAFETY: `proc` is the live Process owned by the Subprocess.
+            let _keep = unsafe { bun_ptr::ScopedRef::<Process>::new(proc) };
+            // SAFETY: `_keep` holds `proc` live for this scope.
+            let proc = unsafe { &mut *proc };
             if proc.has_exited() {
                 // process has already exited, we called wait4(), but we did not call onProcessExit()
                 // SAFETY: all-zero is a valid Rusage (POD).
@@ -1769,6 +1761,11 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
         if let Err(err) = Writable::buffer_writer_mut(buffer).start() {
             let _ = subprocess.try_kill(subprocess.kill_signal);
             let _ = global_this.throw_value(err.to_js(global_this));
+            if BUFFERED_ASYNC {
+                // No wrapper and no promise will ever own slot 1; release it
+                // so the exit handler's deref tears the Subprocess down.
+                subprocess.deref();
+            }
             return Err(JsError::Thrown);
         }
     }
@@ -1824,14 +1821,14 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
         }
 
         if BUFFERED_ASYNC {
-            out.ensure_still_alive();
+            // Slot 1 of the refcount is owned by this pending promise and
+            // released in `maybe_resolve_spawn_and_wait`. If the child was
+            // already reaped, the `send_exit_notification` scopeguard above
+            // dispatches `on_process_exit` on the way out of this frame.
             let promise = jsc::JSPromise::create(global_this).to_js();
             subprocess
                 .spawn_and_wait_promise
                 .with_mut(|p| p.set(global_this, promise));
-            // Balanced by the `deref()` in `maybe_resolve_spawn_and_wait`.
-            subprocess.ref_();
-            subprocess.update_has_pending_activity();
             return Ok(promise);
         }
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -2032,8 +2032,12 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
 
     subprocess.update_has_pending_activity();
 
-    let sync_value =
-        subprocess.build_sync_result(global_this, timeout.is_some(), did_timeout, max_buffer.is_some());
+    let sync_value = subprocess.build_sync_result(
+        global_this,
+        timeout.is_some(),
+        did_timeout,
+        max_buffer.is_some(),
+    );
     // SAFETY: `subprocess_ptr` was produced by `heap::into_raw(Box::new(...))`
     // above (spawnSync path: never handed to a JS wrapper); reclaim ownership.
     // `subprocess` (`&mut *subprocess_ptr`) is not used after this line.

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -475,7 +475,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
         }
 
         if !args.is_empty() && args.is_object() {
-            // Reject terminal option on spawnSync
+            // Reject terminal option on spawnSync / spawnAndWait
             if IS_SYNC || BUFFERED_ASYNC {
                 if args.get_truthy(global_this, "terminal")?.is_some() {
                     return Err(global_this.throw_invalid_arguments(format_args!(

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1826,7 +1826,6 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
             // Balanced by the `deref()` in `maybe_resolve_spawn_and_wait`.
             subprocess.ref_();
             subprocess.update_has_pending_activity();
-            subprocess.maybe_resolve_spawn_and_wait();
             return Ok(promise);
         }
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1335,8 +1335,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
         stdin: JsCell::new(Writable::Ignore),
         stdout: JsCell::new(Readable::Ignore),
         stderr: JsCell::new(Readable::Ignore),
-        // 1=JS wrapper / spawnSync owner / spawnAndWait promise,
-        // 2=Process exit handler. Last one out runs Subprocess::deinit.
+        // 1=JS wrapper / spawnSync owner / spawnAndWait promise; 2=exit handler.
         ref_count: bun_ptr::RefCount::init_exact_refs(2),
         stdio_pipes: JsCell::new(core::mem::take(&mut spawned_extra_pipes)),
         ipc_data: Cell::new(None),
@@ -1414,9 +1413,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
     ) {
         Ok(v) => subprocess.stdin.set(v),
         Err(err) => {
-            // Neither owner is wired up yet: release both refs below (the
-            // second runs `deinit`). stdout/stderr are still `.ignore`, so
-            // close the raw spawned handles here.
+            // Neither owner is wired up yet; stdout/stderr are still `.ignore`.
             #[cfg(unix)]
             {
                 if let Some(fd) = spawned_stdout {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -622,7 +622,13 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
                             // extract() leaves `out_stdio` untouched when `value` is undefined, so this
                             // must be initialized to a sane default instead of `undefined`.
                             let mut new_item: Stdio = Stdio::Ignore;
-                            Stdio::extract(&mut new_item, global_this, i, value, IS_SYNC)?;
+                            Stdio::extract(
+                                &mut new_item,
+                                global_this,
+                                i,
+                                value,
+                                IS_SYNC || BUFFERED_ASYNC,
+                            )?;
 
                             let opt = match new_item.as_spawn_option(i) {
                                 stdio::ResultT::Result(opt) => opt,

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -289,7 +289,7 @@ pub(crate) fn spawn(
     args: JSValue,
     secondary_args_value: Option<JSValue>,
 ) -> JsResult<JSValue> {
-    spawn_maybe_sync::<false>(global_this, args, secondary_args_value)
+    spawn_maybe_sync::<false, false>(global_this, args, secondary_args_value)
 }
 
 /// Bun.spawnSync() calls this.
@@ -298,14 +298,26 @@ pub(crate) fn spawn_sync(
     args: JSValue,
     secondary_args_value: Option<JSValue>,
 ) -> JsResult<JSValue> {
-    spawn_maybe_sync::<true>(global_this, args, secondary_args_value)
+    spawn_maybe_sync::<true, false>(global_this, args, secondary_args_value)
 }
 
-fn spawn_maybe_sync<const IS_SYNC: bool>(
+/// Bun.spawnAndWait() calls this. Async spawn that resolves with the same
+/// result shape as `Bun.spawnSync` (buffered stdout/stderr, exitCode, etc.).
+pub(crate) fn spawn_and_wait(
+    global_this: &JSGlobalObject,
+    args: JSValue,
+    secondary_args_value: Option<JSValue>,
+) -> JsResult<JSValue> {
+    spawn_maybe_sync::<false, true>(global_this, args, secondary_args_value)
+}
+
+fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
     global_this: &JSGlobalObject,
     args_: JSValue,
     secondary_args_value: Option<JSValue>,
 ) -> JsResult<JSValue> {
+    const { assert!(!(IS_SYNC && BUFFERED_ASYNC)) };
+
     if IS_SYNC {
         // We skip this on Windows due to test failures.
         #[cfg(not(windows))]
@@ -334,7 +346,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
 
     let mut stdio: [Stdio; 3] = [Stdio::Ignore, Stdio::Pipe, Stdio::Inherit];
 
-    if IS_SYNC {
+    if IS_SYNC || BUFFERED_ASYNC {
         stdio[1] = Stdio::Pipe;
         stdio[2] = Stdio::Pipe;
     }
@@ -465,16 +477,21 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
 
         if !args.is_empty() && args.is_object() {
             // Reject terminal option on spawnSync
-            if IS_SYNC {
+            if IS_SYNC || BUFFERED_ASYNC {
                 if args.get_truthy(global_this, "terminal")?.is_some() {
                     return Err(global_this.throw_invalid_arguments(format_args!(
-                        "terminal option is only supported for Bun.spawn, not Bun.spawnSync",
+                        "terminal option is only supported for Bun.spawn, not Bun.{}",
+                        if BUFFERED_ASYNC {
+                            "spawnAndWait"
+                        } else {
+                            "spawnSync"
+                        },
                     )));
                 }
             }
 
             // This must run before the stdio parsing happens
-            if !IS_SYNC {
+            if !IS_SYNC && !BUFFERED_ASYNC {
                 if let Some(val) = args.get_truthy(global_this, "ipc")? {
                     if val.is_cell() && val.is_callable() {
                         maybe_ipc_mode = Some('ipc_mode: {
@@ -643,7 +660,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                 }
             }
 
-            if !IS_SYNC {
+            if !IS_SYNC && !BUFFERED_ASYNC {
                 if let Some(lazy_val) = args.get(global_this, "lazy")? {
                     if lazy_val.is_boolean() {
                         lazy = lazy_val.to_boolean();
@@ -1318,6 +1335,9 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
             crate::timer::EventLoopTimerTag::SubprocessTimeout,
         )),
         exited_due_to_maxbuf: Cell::new(None),
+        spawn_and_wait_promise: JsCell::new(jsc::StrongOptional::empty()),
+        spawn_and_wait_had_timeout: Cell::new(BUFFERED_ASYNC && timeout.is_some()),
+        spawn_and_wait_had_max_buffer: Cell::new(BUFFERED_ASYNC && max_buffer.is_some()),
     }));
     // SAFETY: subprocess_ptr is a freshly-boxed Subprocess; we hold the only reference.
     let subprocess = unsafe { &mut *subprocess_ptr };
@@ -1795,6 +1815,26 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                     .on_subprocess_spawn(NonNull::new_unchecked(subprocess.process.as_ptr()))
             };
         }
+
+        if BUFFERED_ASYNC {
+            // `out` keeps the JS Subprocess cell reachable for this frame; the
+            // returned promise is what the caller receives.
+            out.ensure_still_alive();
+            let promise = jsc::JSPromise::create(global_this).to_js();
+            subprocess
+                .spawn_and_wait_promise
+                .with_mut(|p| p.set(global_this, promise));
+            // Balanced by the `deref()` in `maybe_resolve_spawn_and_wait`.
+            subprocess.ref_();
+            subprocess.update_has_pending_activity();
+            // Process may already have exited and pipes closed before we got
+            // here; resolve immediately if so. Otherwise the `on_process_exit`
+            // / `on_close_io` hooks (including the `send_exit_notification`
+            // scopeguard above) resolve it.
+            subprocess.maybe_resolve_spawn_and_wait();
+            return Ok(promise);
+        }
+
         return Ok(out);
     }
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -610,7 +610,13 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
                         let mut stdio_iter = stdio_val.array_iterator(global_this)?;
                         let mut i: i32 = 0;
                         while let Some(value) = stdio_iter.next()? {
-                            Stdio::extract(&mut stdio[i as usize], global_this, i, value, IS_SYNC || BUFFERED_ASYNC)?;
+                            Stdio::extract(
+                                &mut stdio[i as usize],
+                                global_this,
+                                i,
+                                value,
+                                IS_SYNC || BUFFERED_ASYNC,
+                            )?;
                             if i == 2 {
                                 break;
                             }
@@ -653,15 +659,33 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
                 }
             } else {
                 if let Some(value) = args.get(global_this, "stdin")? {
-                    Stdio::extract(&mut stdio[0], global_this, 0, value, IS_SYNC || BUFFERED_ASYNC)?;
+                    Stdio::extract(
+                        &mut stdio[0],
+                        global_this,
+                        0,
+                        value,
+                        IS_SYNC || BUFFERED_ASYNC,
+                    )?;
                 }
 
                 if let Some(value) = args.get(global_this, "stderr")? {
-                    Stdio::extract(&mut stdio[2], global_this, 2, value, IS_SYNC || BUFFERED_ASYNC)?;
+                    Stdio::extract(
+                        &mut stdio[2],
+                        global_this,
+                        2,
+                        value,
+                        IS_SYNC || BUFFERED_ASYNC,
+                    )?;
                 }
 
                 if let Some(value) = args.get(global_this, "stdout")? {
-                    Stdio::extract(&mut stdio[1], global_this, 1, value, IS_SYNC || BUFFERED_ASYNC)?;
+                    Stdio::extract(
+                        &mut stdio[1],
+                        global_this,
+                        1,
+                        value,
+                        IS_SYNC || BUFFERED_ASYNC,
+                    )?;
                 }
             }
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1025,7 +1025,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
     env_array.push(core::ptr::null());
     argv.push(core::ptr::null());
 
-    if IS_SYNC {
+    if IS_SYNC || BUFFERED_ASYNC {
         for (i, io) in stdio.iter_mut().enumerate() {
             io.to_sync(i as u32);
         }
@@ -1778,7 +1778,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
     // paths the caller never receives the Subprocess, so the OwnedFd slot
     // must remain for the GC'd wrapper's finalize_streams to close.
     #[cfg(not(windows))]
-    if !socket_fd_indices.is_empty() {
+    if !BUFFERED_ASYNC && !socket_fd_indices.is_empty() {
         subprocess.stdio_pipes.with_mut(|pipes| {
             for j in &socket_fd_indices {
                 if let Some(slot @ ExtraPipe::OwnedFd(_)) = pipes.get_mut(*j) {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1678,18 +1678,20 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
 
         debug_assert!(out != JSValue::ZERO);
 
-        if on_exit_callback.is_cell() {
-            Subprocess::js::on_exit_callback_set_cached(out, global_this, on_exit_callback);
-        }
-        if on_disconnect_callback.is_cell() {
-            Subprocess::js::on_disconnect_callback_set_cached(
-                out,
-                global_this,
-                on_disconnect_callback,
-            );
-        }
-        if ipc_callback.is_cell() {
-            Subprocess::js::ipc_callback_set_cached(out, global_this, ipc_callback);
+        if !BUFFERED_ASYNC {
+            if on_exit_callback.is_cell() {
+                Subprocess::js::on_exit_callback_set_cached(out, global_this, on_exit_callback);
+            }
+            if on_disconnect_callback.is_cell() {
+                Subprocess::js::on_disconnect_callback_set_cached(
+                    out,
+                    global_this,
+                    on_disconnect_callback,
+                );
+            }
+            if ipc_callback.is_cell() {
+                Subprocess::js::ipc_callback_set_cached(out, global_this, ipc_callback);
+            }
         }
 
         if let Stdio::ReadableStream(rs) = &stdio[0] {
@@ -2030,65 +2032,14 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
 
     subprocess.update_has_pending_activity();
 
-    let signal_code = SubprocessT::get_signal_code(subprocess, global_this);
-    let exit_code = SubprocessT::get_exit_code(subprocess, global_this);
-    let stdout = subprocess
-        .stdout
-        .with_mut(|s| s.to_buffered_value(global_this))?;
-    let stderr = subprocess
-        .stderr
-        .with_mut(|s| s.to_buffered_value(global_this))?;
-    let resource_usage: JSValue = if !global_this.has_exception() {
-        subprocess.create_resource_usage_object(global_this)?
-    } else {
-        JSValue::ZERO
-    };
-    let exited_due_to_timeout = did_timeout;
-    let exited_due_to_max_buffer = subprocess.exited_due_to_maxbuf.get();
-    let result_pid = JSValue::js_number_from_int32(subprocess.pid());
+    let sync_value =
+        subprocess.build_sync_result(global_this, timeout.is_some(), did_timeout, max_buffer.is_some());
     // SAFETY: `subprocess_ptr` was produced by `heap::into_raw(Box::new(...))`
     // above (spawnSync path: never handed to a JS wrapper); reclaim ownership.
     // `subprocess` (`&mut *subprocess_ptr`) is not used after this line.
     SubprocessT::finalize(unsafe { Box::from_raw(subprocess_ptr) });
 
-    let sync_value = JSValue::create_empty_object(global_this, 0);
-    sync_value.put(global_this, b"exitCode", exit_code);
-    if !signal_code.is_empty_or_undefined_or_null() {
-        sync_value.put(global_this, b"signalCode", signal_code);
-    }
-    sync_value.put(global_this, b"stdout", stdout);
-    sync_value.put(global_this, b"stderr", stderr);
-    sync_value.put(
-        global_this,
-        b"success",
-        JSValue::from(exit_code.is_int32() && exit_code.as_int32() == 0),
-    );
-    sync_value.put(global_this, b"resourceUsage", resource_usage);
-    if timeout.is_some() {
-        sync_value.put(
-            global_this,
-            b"exitedDueToTimeout",
-            if exited_due_to_timeout {
-                JSValue::TRUE
-            } else {
-                JSValue::FALSE
-            },
-        );
-    }
-    if max_buffer.is_some() {
-        sync_value.put(
-            global_this,
-            b"exitedDueToMaxBuffer",
-            if exited_due_to_max_buffer.is_some() {
-                JSValue::TRUE
-            } else {
-                JSValue::FALSE
-            },
-        );
-    }
-    sync_value.put(global_this, b"pid", result_pid);
-
-    Ok(sync_value)
+    sync_value
 }
 
 fn throw_command_not_found(global_this: &JSGlobalObject, command: &[u8]) -> JsError {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1335,10 +1335,8 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
         stdin: JsCell::new(Writable::Ignore),
         stdout: JsCell::new(Readable::Ignore),
         stderr: JsCell::new(Readable::Ignore),
-        // 1=JS wrapper (released in Subprocess::finalize) or, for
-        // spawnAndWait, the pending promise (released in
-        // maybe_resolve_spawn_and_wait); 2=Process exit handler (released in
-        // Subprocess::on_process_exit). Last one out runs Subprocess::deinit.
+        // 1=JS wrapper / spawnSync owner / spawnAndWait promise,
+        // 2=Process exit handler. Last one out runs Subprocess::deinit.
         ref_count: bun_ptr::RefCount::init_exact_refs(2),
         stdio_pipes: JsCell::new(core::mem::take(&mut spawned_extra_pipes)),
         ipc_data: Cell::new(None),
@@ -1416,12 +1414,9 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
     ) {
         Ok(v) => subprocess.stdin.set(v),
         Err(err) => {
-            // ref_count = 2 from the aggregate above, but neither the JS
-            // wrapper nor the process exit handler are wired up yet, so
-            // release both; the second `deref()` runs `Subprocess::deinit`
-            // (stdio_pipes, pidfd, Process ref, MaxBuf, IPC queue).
-            // stdout/stderr are still `.ignore` — close the raw spawned pipe
-            // handles directly since `Readable.init()` will not run.
+            // Neither owner is wired up yet: release both refs below (the
+            // second runs `deinit`). stdout/stderr are still `.ignore`, so
+            // close the raw spawned handles here.
             #[cfg(unix)]
             {
                 if let Some(fd) = spawned_stdout {
@@ -1646,8 +1641,6 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
         // the by-value `JsClass::to_js` (which would re-box).
         SubprocessT::to_js_from_ptr(subprocess_ptr, global_this)
     } else {
-        // spawnSync / spawnAndWait never hand the Subprocess to JS; slot 1 of
-        // the refcount is released explicitly (finalize() / promise settle).
         JSValue::ZERO
     };
     if out != JSValue::ZERO {
@@ -1731,14 +1724,10 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
     let subprocess_ptr_exit = subprocess_ptr;
     scopeguard::defer! {
         if send_exit_notification {
-            // SAFETY: subprocess_ptr is live until `on_exit` below dispatches
-            // `on_process_exit`, which may drop the last Subprocess ref (and
-            // with it the Subprocess's ref on `proc`); nothing reads
-            // `subprocess_ptr_exit` after that call.
+            // SAFETY: subprocess_ptr is live here; `on_exit` below may drop its
+            // last ref (and its ref on `proc`), so nothing reads it afterwards.
             let proc: *mut Process = unsafe { (*subprocess_ptr_exit).process.as_ptr() };
-            // Keep `proc` alive across its own exit dispatch, like the pidfd /
-            // waiter-thread paths do with their queued +1.
-            // SAFETY: `proc` is the live Process owned by the Subprocess.
+            // SAFETY: live Process; hold +1 across its own exit dispatch.
             let _keep = unsafe { bun_ptr::ScopedRef::<Process>::new(proc) };
             // SAFETY: `_keep` holds `proc` live for this scope.
             let proc = unsafe { &mut *proc };
@@ -1786,8 +1775,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
             let _ = subprocess.try_kill(subprocess.kill_signal);
             let _ = global_this.throw_value(err.to_js(global_this));
             if BUFFERED_ASYNC {
-                // No wrapper and no promise will ever own slot 1; release it
-                // so the exit handler's deref tears the Subprocess down.
+                // Nothing will own slot 1; the exit handler's deref then runs deinit.
                 subprocess.deref();
             }
             return Err(JsError::Thrown);
@@ -1845,10 +1833,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool, const BUFFERED_ASYNC: bool>(
         }
 
         if BUFFERED_ASYNC {
-            // Slot 1 of the refcount is owned by this pending promise and
-            // released in `maybe_resolve_spawn_and_wait`. If the child was
-            // already reaped, the `send_exit_notification` scopeguard above
-            // dispatches `on_process_exit` on the way out of this frame.
+            // Owns slot 1 of the refcount; released in `maybe_resolve_spawn_and_wait`.
             let promise = jsc::JSPromise::create(global_this).to_js();
             subprocess
                 .spawn_and_wait_promise

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -445,7 +445,7 @@ impl Stdio {
                     // Bun.spawnSync's result has no .stdio, so the caller
                     // could never receive the fd it's supposed to own.
                     return Err(global.throw_invalid_arguments(format_args!(
-                        "stdio: 'socket-fd' cannot be used with spawnSync"
+                        "stdio: 'socket-fd' cannot be used with spawnSync or spawnAndWait"
                     )));
                 }
                 *out_stdio = Stdio::SocketFd;

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -409,9 +409,8 @@ impl Stdio {
         Ok(())
     }
 
-    /// `is_sync`: the caller only returns a buffered result object (spawnSync /
-    /// spawnAndWait), so options that need a live `Subprocess` handle
-    /// (ReadableStream stdin, 'socket-fd') are rejected.
+    /// `is_sync`: buffered-result caller (spawnSync / spawnAndWait); rejects
+    /// options that need a live Subprocess handle.
     pub(crate) fn extract(
         out_stdio: &mut Stdio,
         global: &JSGlobalObject,

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -442,8 +442,8 @@ impl Stdio {
                     )));
                 }
                 if is_sync {
-                    // Bun.spawnSync's result has no .stdio, so the caller
-                    // could never receive the fd it's supposed to own.
+                    // spawnSync/spawnAndWait results have no .stdio, so the
+                    // caller could never receive the fd it's supposed to own.
                     return Err(global.throw_invalid_arguments(format_args!(
                         "stdio: 'socket-fd' cannot be used with spawnSync or spawnAndWait"
                     )));

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -442,8 +442,7 @@ impl Stdio {
                     )));
                 }
                 if is_sync {
-                    // spawnSync/spawnAndWait results have no .stdio, so the
-                    // caller could never receive the fd it's supposed to own.
+                    // spawnSync/spawnAndWait results have no .stdio to hand the fd to.
                     return Err(global.throw_invalid_arguments(format_args!(
                         "stdio: 'socket-fd' cannot be used with spawnSync or spawnAndWait"
                     )));

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -409,8 +409,7 @@ impl Stdio {
         Ok(())
     }
 
-    /// `is_sync`: buffered-result caller (spawnSync / spawnAndWait); rejects
-    /// options that need a live Subprocess handle.
+    /// `is_sync`: spawnSync / spawnAndWait (no live Subprocess handle).
     pub(crate) fn extract(
         out_stdio: &mut Stdio,
         global: &JSGlobalObject,

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -363,7 +363,7 @@ impl Stdio {
             webcore::body::Value::Locked(_) => {
                 if is_sync {
                     return Err(global.throw_invalid_arguments(format_args!(
-                        "ReadableStream cannot be used in sync mode"
+                        "ReadableStream body as stdio is only supported with Bun.spawn"
                     )));
                 }
 
@@ -409,6 +409,9 @@ impl Stdio {
         Ok(())
     }
 
+    /// `is_sync`: the caller only returns a buffered result object (spawnSync /
+    /// spawnAndWait), so options that need a live `Subprocess` handle
+    /// (ReadableStream stdin, 'socket-fd') are rejected.
     pub(crate) fn extract(
         out_stdio: &mut Stdio,
         global: &JSGlobalObject,
@@ -535,7 +538,7 @@ impl Stdio {
 
             if is_sync {
                 return Err(global.throw_invalid_arguments(format_args!(
-                    "'{}' ReadableStream cannot be used in sync mode",
+                    "'{}' ReadableStream is only supported with Bun.spawn",
                     bstr::BStr::new(name),
                 )));
             }

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -1367,7 +1367,7 @@ impl Subprocess<'_> {
         }
     }
 
-    // This must only be run once per Subprocess
+    // Idempotent: called eagerly from `finalize()` and again from `deinit()`.
     pub(crate) fn finalize_streams(&self) {
         bun_output::scoped_log!(Subprocess, "finalizeStreams");
         self.close_process();

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -574,7 +574,12 @@ impl Subprocess<'_> {
         // SAFETY: event_loop points into the live VM and outlives this scope.
         let _guard = unsafe { bun_jsc::event_loop::EventLoop::enter_scope(event_loop) };
 
-        match self.build_spawn_and_wait_result(global_this) {
+        match self.build_sync_result(
+            global_this,
+            self.spawn_and_wait_had_timeout.get(),
+            self.event_loop_timer.get().state == EventLoopTimerState::FIRED,
+            self.spawn_and_wait_had_max_buffer.get(),
+        ) {
             Ok(result) => {
                 let _ = promise.resolve(global_this, result);
             }
@@ -590,13 +595,23 @@ impl Subprocess<'_> {
         self.deref();
     }
 
-    /// Build the `SyncSubprocess`-shaped result object for `Bun.spawnAndWait()`.
-    fn build_spawn_and_wait_result(&self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
+    /// Build the `SyncSubprocess`-shaped result for `Bun.spawnSync` / `Bun.spawnAndWait`.
+    pub(crate) fn build_sync_result(
+        &self,
+        global_this: &JSGlobalObject,
+        had_timeout: bool,
+        did_timeout: bool,
+        had_max_buffer: bool,
+    ) -> JsResult<JSValue> {
         let signal_code = self.get_signal_code(global_this);
         let exit_code = self.get_exit_code(global_this);
         let stdout = self.stdout.with_mut(|s| s.to_buffered_value(global_this))?;
         let stderr = self.stderr.with_mut(|s| s.to_buffered_value(global_this))?;
-        let resource_usage = self.create_resource_usage_object(global_this)?;
+        let resource_usage = if !global_this.has_exception() {
+            self.create_resource_usage_object(global_this)?
+        } else {
+            JSValue::ZERO
+        };
         let result_pid = JSValue::js_number_from_int32(self.pid());
 
         let sync_value = JSValue::create_empty_object(global_this, 0);
@@ -612,18 +627,18 @@ impl Subprocess<'_> {
             JSValue::from(exit_code.is_int32() && exit_code.as_int32() == 0),
         );
         sync_value.put(global_this, b"resourceUsage", resource_usage);
-        if self.spawn_and_wait_had_timeout.get() {
+        if had_timeout {
             sync_value.put(
                 global_this,
                 b"exitedDueToTimeout",
-                if self.event_loop_timer.get().state == EventLoopTimerState::FIRED {
+                if did_timeout {
                     JSValue::TRUE
                 } else {
                     JSValue::FALSE
                 },
             );
         }
-        if self.spawn_and_wait_had_max_buffer.get() {
+        if had_max_buffer {
             sync_value.put(
                 global_this,
                 b"exitedDueToMaxBuffer",

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -113,9 +113,7 @@ pub use bun_spawn::process::StdioKind;
 // codegen shim hands to whichever method JS calls next. `UnsafeCell`-backed
 // fields suppress `noalias` on the outer `&Subprocess`, making the miscompile
 // structurally impossible.
-// Intrusive ref-count: owned-resource teardown lives in [`Subprocess::deinit`],
-// which runs when the last ref drops (JS finalizer, process-exit handler,
-// stdin sink, or a pending `spawnAndWait` promise), not in the GC finalizer.
+// Intrusive ref-count; teardown runs in [`Subprocess::deinit`] on last deref.
 #[derive(bun_ptr::RefCounted)]
 #[ref_count(destroy = Subprocess::deinit)]
 pub struct Subprocess<'a> {
@@ -1411,10 +1409,8 @@ impl Subprocess<'_> {
         }
     }
 
-    /// GC finalizer for the `JSSubprocess` wrapper (also used by `spawnSync`
-    /// as its explicit owner release). Drops the wrapper's +1 and force-releases
-    /// refs whose callbacks can no longer fire once the wrapper is gone; the
-    /// owned-resource teardown itself lives in [`Subprocess::deinit`].
+    /// JS wrapper finalizer (and spawnSync's explicit release): drops that
+    /// owner's +1. Resource teardown is in [`Subprocess::deinit`].
     pub fn finalize(self: Box<Self>) {
         bun_output::scoped_log!(Subprocess, "finalize");
         // Refcounted: the trailing `this.deref()` releases the JS wrapper's +1;
@@ -1434,8 +1430,6 @@ impl Subprocess<'_> {
             !this.compute_has_pending_activity()
                 || VirtualMachine::VirtualMachine::get().is_shutting_down()
         );
-        // Nobody can observe the streams anymore; stop readers now rather than
-        // waiting for the last ref.
         this.finalize_streams();
 
         // `Writable::init()` took a +1 (`subprocess.ref_()`, guarded by
@@ -1458,9 +1452,8 @@ impl Subprocess<'_> {
             this.deref();
         }
 
-        // At VM teardown the wrapper can be swept while the child is still
-        // running; the exit handler would then fire into a dead VM, so detach
-        // it and release the ref it would have released.
+        // Swept at VM teardown with the child still running: the exit handler
+        // can no longer fire, so release its ref here.
         let exit_handler_pending = this.process().exit_handler.is_some();
         this.process_mut().detach();
         if exit_handler_pending {
@@ -1471,13 +1464,8 @@ impl Subprocess<'_> {
         this.deref();
     }
 
-    /// `RefCount` destructor: runs when the last ref drops, from whichever
-    /// owner that was (GC finalizer, `on_process_exit`, `on_stdin_destroyed`,
-    /// or `maybe_resolve_spawn_and_wait`). Every step is idempotent with the
-    /// eager calls in [`finalize`](Self::finalize) / `on_process_exit`.
-    ///
-    /// Safe fn: only reachable via the `#[ref_count(destroy = …)]` derive,
-    /// whose generated trait `destructor` upholds the sole-owner contract.
+    /// `RefCount` destructor (last deref, whoever held it). Each step is
+    /// idempotent with the eager calls in `finalize` / `on_process_exit`.
     fn deinit(this: *mut Self) {
         bun_output::scoped_log!(Subprocess, "deinit");
         // SAFETY: refcount == 0 ⇒ `this` is the unique owner of a live Box.

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -1420,7 +1420,11 @@ impl Subprocess<'_> {
         // access it after it's been freed We cannot call any methods which
         // access GC'd values during the finalizer
         this.this_value.with_mut(|v| v.finalize());
+        let spawn_and_wait_pending = this.spawn_and_wait_promise.get().has();
         this.spawn_and_wait_promise.with_mut(|p| p.deinit());
+        if spawn_and_wait_pending {
+            this.deref();
+        }
 
         this.clear_abort_signal();
 

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -1409,8 +1409,7 @@ impl Subprocess<'_> {
         }
     }
 
-    /// JS wrapper finalizer (and spawnSync's explicit release): drops that
-    /// owner's +1. Resource teardown is in [`Subprocess::deinit`].
+    /// JS wrapper finalizer / spawnSync release; teardown is in [`Subprocess::deinit`].
     pub fn finalize(self: Box<Self>) {
         bun_output::scoped_log!(Subprocess, "finalize");
         // Refcounted: the trailing `this.deref()` releases the JS wrapper's +1;
@@ -1452,8 +1451,7 @@ impl Subprocess<'_> {
             this.deref();
         }
 
-        // Swept at VM teardown with the child still running: the exit handler
-        // can no longer fire, so release its ref here.
+        // Swept at VM teardown with the child still running.
         let exit_handler_pending = this.process().exit_handler.is_some();
         this.process_mut().detach();
         if exit_handler_pending {
@@ -1464,8 +1462,7 @@ impl Subprocess<'_> {
         this.deref();
     }
 
-    /// `RefCount` destructor (last deref, whoever held it). Each step is
-    /// idempotent with the eager calls in `finalize` / `on_process_exit`.
+    /// `RefCount` destructor; idempotent with `finalize` / `on_process_exit`.
     fn deinit(this: *mut Self) {
         bun_output::scoped_log!(Subprocess, "deinit");
         // SAFETY: refcount == 0 ⇒ `this` is the unique owner of a live Box.

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -164,13 +164,8 @@ pub struct Subprocess<'a> {
     pub(crate) stderr_maxbuf: Cell<Option<NonNull<MaxBuf::MaxBuf>>>,
     pub(crate) exited_due_to_maxbuf: Cell<Option<MaxBuf::Kind>>,
 
-    /// Pending promise for `Bun.spawnAndWait()`. Resolved with the same result
-    /// shape as `Bun.spawnSync` once the process has exited and both
-    /// stdout/stderr pipes have closed.
+    /// Pending `Bun.spawnAndWait()` promise; resolved once exited and pipes closed.
     pub(crate) spawn_and_wait_promise: JsCell<jsc::StrongOptional>,
-    /// Whether `timeout` / `maxBuffer` were passed to `Bun.spawnAndWait()`, so
-    /// the result includes `exitedDueToTimeout` / `exitedDueToMaxBuffer` only
-    /// when the caller asked for a bound (matches `Bun.spawnSync`).
     pub(crate) spawn_and_wait_had_timeout: Cell<bool>,
     pub(crate) spawn_and_wait_had_max_buffer: Cell<bool>,
 }
@@ -553,9 +548,6 @@ impl Subprocess<'_> {
         }
     }
 
-    /// Resolve the pending `Bun.spawnAndWait()` promise once the process has
-    /// exited and neither stdout nor stderr is still an active pipe reader.
-    /// Balances the extra `ref_()` taken in `spawn_and_wait`.
     pub(crate) fn maybe_resolve_spawn_and_wait(&self) {
         if !self.process().has_exited() {
             return;

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -602,12 +602,8 @@ impl Subprocess<'_> {
     fn build_spawn_and_wait_result(&self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         let signal_code = self.get_signal_code(global_this);
         let exit_code = self.get_exit_code(global_this);
-        let stdout = self
-            .stdout
-            .with_mut(|s| s.to_buffered_value(global_this))?;
-        let stderr = self
-            .stderr
-            .with_mut(|s| s.to_buffered_value(global_this))?;
+        let stdout = self.stdout.with_mut(|s| s.to_buffered_value(global_this))?;
+        let stderr = self.stderr.with_mut(|s| s.to_buffered_value(global_this))?;
         let resource_usage = self.create_resource_usage_object(global_this)?;
         let result_pid = JSValue::js_number_from_int32(self.pid());
 

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -163,6 +163,16 @@ pub struct Subprocess<'a> {
     pub(crate) stdout_maxbuf: Cell<Option<NonNull<MaxBuf::MaxBuf>>>,
     pub(crate) stderr_maxbuf: Cell<Option<NonNull<MaxBuf::MaxBuf>>>,
     pub(crate) exited_due_to_maxbuf: Cell<Option<MaxBuf::Kind>>,
+
+    /// Pending promise for `Bun.spawnAndWait()`. Resolved with the same result
+    /// shape as `Bun.spawnSync` once the process has exited and both
+    /// stdout/stderr pipes have closed.
+    pub(crate) spawn_and_wait_promise: JsCell<jsc::StrongOptional>,
+    /// Whether `timeout` / `maxBuffer` were passed to `Bun.spawnAndWait()`, so
+    /// the result includes `exitedDueToTimeout` / `exitedDueToMaxBuffer` only
+    /// when the caller asked for a bound (matches `Bun.spawnSync`).
+    pub(crate) spawn_and_wait_had_timeout: Cell<bool>,
+    pub(crate) spawn_and_wait_had_max_buffer: Cell<bool>,
 }
 
 bun_event_loop::impl_timer_owner!(Subprocess<'_>; from_timer_ptr => event_loop_timer);
@@ -417,6 +427,10 @@ impl Subprocess<'_> {
     }
 
     pub(crate) fn compute_has_pending_activity(&self) -> bool {
+        if self.spawn_and_wait_promise.get().has() {
+            return true;
+        }
+
         // `ipc_data` is never set back to `None` after init, so checking only
         // for `is_some()` would keep the JSSubprocess strongly referenced for the
         // lifetime of the VM. The IPC side contributes pending activity until
@@ -533,6 +547,108 @@ impl Subprocess<'_> {
         // later completes and reaches here, we must re-evaluate so the JsRef can
         // be downgraded and the JSSubprocess + buffered output become collectable.
         self.update_has_pending_activity();
+
+        if self.spawn_and_wait_promise.get().has() {
+            self.maybe_resolve_spawn_and_wait();
+        }
+    }
+
+    /// Resolve the pending `Bun.spawnAndWait()` promise once the process has
+    /// exited and neither stdout nor stderr is still an active pipe reader.
+    /// Balances the extra `ref_()` taken in `spawn_and_wait`.
+    pub(crate) fn maybe_resolve_spawn_and_wait(&self) {
+        if !self.process().has_exited() {
+            return;
+        }
+        if matches!(self.stdout.get(), Readable::Pipe(_)) {
+            return;
+        }
+        if matches!(self.stderr.get(), Readable::Pipe(_)) {
+            return;
+        }
+
+        let Some(promise_js) = self.spawn_and_wait_promise.with_mut(|p| p.try_swap()) else {
+            return;
+        };
+        let Some(promise) = promise_js.as_any_promise() else {
+            self.update_has_pending_activity();
+            self.deref();
+            return;
+        };
+
+        let global_this = self.global_this;
+        let global_this = global_this.get();
+        let event_loop = global_this.bun_vm().as_mut().event_loop();
+        // SAFETY: event_loop points into the live VM and outlives this scope.
+        let _guard = unsafe { bun_jsc::event_loop::EventLoop::enter_scope(event_loop) };
+
+        match self.build_spawn_and_wait_result(global_this) {
+            Ok(result) => {
+                let _ = promise.resolve(global_this, result);
+            }
+            Err(_) => {
+                let err = global_this
+                    .try_take_exception()
+                    .unwrap_or(JSValue::UNDEFINED);
+                let _ = promise.reject(global_this, err);
+            }
+        }
+
+        self.update_has_pending_activity();
+        self.deref();
+    }
+
+    /// Build the `SyncSubprocess`-shaped result object for `Bun.spawnAndWait()`.
+    fn build_spawn_and_wait_result(&self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
+        let signal_code = self.get_signal_code(global_this);
+        let exit_code = self.get_exit_code(global_this);
+        let stdout = self
+            .stdout
+            .with_mut(|s| s.to_buffered_value(global_this))?;
+        let stderr = self
+            .stderr
+            .with_mut(|s| s.to_buffered_value(global_this))?;
+        let resource_usage = self.create_resource_usage_object(global_this)?;
+        let result_pid = JSValue::js_number_from_int32(self.pid());
+
+        let sync_value = JSValue::create_empty_object(global_this, 0);
+        sync_value.put(global_this, b"exitCode", exit_code);
+        if !signal_code.is_empty_or_undefined_or_null() {
+            sync_value.put(global_this, b"signalCode", signal_code);
+        }
+        sync_value.put(global_this, b"stdout", stdout);
+        sync_value.put(global_this, b"stderr", stderr);
+        sync_value.put(
+            global_this,
+            b"success",
+            JSValue::from(exit_code.is_int32() && exit_code.as_int32() == 0),
+        );
+        sync_value.put(global_this, b"resourceUsage", resource_usage);
+        if self.spawn_and_wait_had_timeout.get() {
+            sync_value.put(
+                global_this,
+                b"exitedDueToTimeout",
+                if self.event_loop_timer.get().state == EventLoopTimerState::FIRED {
+                    JSValue::TRUE
+                } else {
+                    JSValue::FALSE
+                },
+            );
+        }
+        if self.spawn_and_wait_had_max_buffer.get() {
+            sync_value.put(
+                global_this,
+                b"exitedDueToMaxBuffer",
+                if self.exited_due_to_maxbuf.get().is_some() {
+                    JSValue::TRUE
+                } else {
+                    JSValue::FALSE
+                },
+            );
+        }
+        sync_value.put(global_this, b"pid", result_pid);
+
+        Ok(sync_value)
     }
 
     pub(crate) fn js_ref(&self) {
@@ -1186,6 +1302,11 @@ impl Subprocess<'_> {
         if !did_update_has_pending_activity {
             self.update_has_pending_activity();
         }
+
+        if self.spawn_and_wait_promise.get().has() {
+            self.maybe_resolve_spawn_and_wait();
+        }
+
         self.disconnect_ipc(true);
         self.deref();
     }
@@ -1296,6 +1417,7 @@ impl Subprocess<'_> {
         // access it after it's been freed We cannot call any methods which
         // access GC'd values during the finalizer
         this.this_value.with_mut(|v| v.finalize());
+        this.spawn_and_wait_promise.with_mut(|p| p.deinit());
 
         this.clear_abort_signal();
 

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -113,14 +113,16 @@ pub use bun_spawn::process::StdioKind;
 // codegen shim hands to whichever method JS calls next. `UnsafeCell`-backed
 // fields suppress `noalias` on the outer `&Subprocess`, making the miscompile
 // structurally impossible.
-// Intrusive ref-count: `RefPtr<Subprocess>` provides ref/deref and frees the
-// Box when ref_count → 0; `deinit` runs when the last ref drops.
+// Intrusive ref-count: owned-resource teardown lives in [`Subprocess::deinit`],
+// which runs when the last ref drops (JS finalizer, process-exit handler,
+// stdin sink, or a pending `spawnAndWait` promise), not in the GC finalizer.
 #[derive(bun_ptr::RefCounted)]
+#[ref_count(destroy = Subprocess::deinit)]
 pub struct Subprocess<'a> {
     pub(crate) ref_count: RefCount<Subprocess<'a>>,
     /// Intrusively-refcounted `Process`. Allocated via
     /// `heap::alloc` in `Process::init_posix`/`init_windows`; the +1 ref
-    /// from construction is released in [`Subprocess::finalize`] via
+    /// from construction is released in [`Subprocess::deinit`] via
     /// `Process::deref()`. Not `Arc` — `Process` carries its own
     /// `ThreadSafeRefCount` and crosses the `ProcessAutoKiller`/waiter-thread
     /// boundary by raw identity, so wrapping in `Arc` would double-count and
@@ -422,10 +424,6 @@ impl Subprocess<'_> {
     }
 
     pub(crate) fn compute_has_pending_activity(&self) -> bool {
-        if self.spawn_and_wait_promise.get().has() {
-            return true;
-        }
-
         // `ipc_data` is never set back to `None` after init, so checking only
         // for `is_some()` would keep the JSSubprocess strongly referenced for the
         // lifetime of the VM. The IPC side contributes pending activity until
@@ -452,6 +450,10 @@ impl Subprocess<'_> {
 
     pub(crate) fn update_has_pending_activity(&self) {
         if self.flags.get().contains(Flags::IS_SYNC) {
+            return;
+        }
+        // No JS wrapper (spawnAndWait) or already finalized.
+        if self.this_value.get().is_empty() {
             return;
         }
 
@@ -563,7 +565,6 @@ impl Subprocess<'_> {
             return;
         };
         let Some(promise) = promise_js.as_any_promise() else {
-            self.update_has_pending_activity();
             self.deref();
             return;
         };
@@ -591,7 +592,7 @@ impl Subprocess<'_> {
             }
         }
 
-        self.update_has_pending_activity();
+        // Releases the pending-promise ref; may run `deinit` and free `self`.
         self.deref();
     }
 
@@ -1410,6 +1411,10 @@ impl Subprocess<'_> {
         }
     }
 
+    /// GC finalizer for the `JSSubprocess` wrapper (also used by `spawnSync`
+    /// as its explicit owner release). Drops the wrapper's +1 and force-releases
+    /// refs whose callbacks can no longer fire once the wrapper is gone; the
+    /// owned-resource teardown itself lives in [`Subprocess::deinit`].
     pub fn finalize(self: Box<Self>) {
         bun_output::scoped_log!(Subprocess, "finalize");
         // Refcounted: the trailing `this.deref()` releases the JS wrapper's +1;
@@ -1420,11 +1425,8 @@ impl Subprocess<'_> {
         // access it after it's been freed We cannot call any methods which
         // access GC'd values during the finalizer
         this.this_value.with_mut(|v| v.finalize());
-        let spawn_and_wait_pending = this.spawn_and_wait_promise.get().has();
-        this.spawn_and_wait_promise.with_mut(|p| p.deinit());
-        if spawn_and_wait_pending {
-            this.deref();
-        }
+        this.update_flags(|f| f.insert(Flags::FINALIZED));
+        debug_assert!(!this.spawn_and_wait_promise.get().has());
 
         this.clear_abort_signal();
 
@@ -1432,6 +1434,8 @@ impl Subprocess<'_> {
             !this.compute_has_pending_activity()
                 || VirtualMachine::VirtualMachine::get().is_shutting_down()
         );
+        // Nobody can observe the streams anymore; stop readers now rather than
+        // waiting for the last ref.
         this.finalize_streams();
 
         // `Writable::init()` took a +1 (`subprocess.ref_()`, guarded by
@@ -1454,31 +1458,51 @@ impl Subprocess<'_> {
             this.deref();
         }
 
+        // At VM teardown the wrapper can be swept while the child is still
+        // running; the exit handler would then fire into a dead VM, so detach
+        // it and release the ref it would have released.
         let exit_handler_pending = this.process().exit_handler.is_some();
         this.process_mut().detach();
         if exit_handler_pending {
             this.deref();
         }
-        // Release the intrusive ref now,
-        // not when `ref_count` → 0. The raw `*mut Process` is left dangling but
-        // no code path reads `this.process` after this (finalize runs once).
-        // SAFETY: `process` is the live Box-backed Process; deref() frees it
-        // when its own ThreadSafeRefCount reaches zero.
-        unsafe { Process::deref(this.process.as_ptr()) };
 
-        if this.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
-            Self::timer_all().remove(this.event_loop_timer.as_ptr());
+        // The wrapper's own +1; may run `deinit`.
+        this.deref();
+    }
+
+    /// `RefCount` destructor: runs when the last ref drops, from whichever
+    /// owner that was (GC finalizer, `on_process_exit`, `on_stdin_destroyed`,
+    /// or `maybe_resolve_spawn_and_wait`). Every step is idempotent with the
+    /// eager calls in [`finalize`](Self::finalize) / `on_process_exit`.
+    ///
+    /// Safe fn: only reachable via the `#[ref_count(destroy = …)]` derive,
+    /// whose generated trait `destructor` upholds the sole-owner contract.
+    fn deinit(this: *mut Self) {
+        bun_output::scoped_log!(Subprocess, "deinit");
+        // SAFETY: refcount == 0 ⇒ `this` is the unique owner of a live Box.
+        let this_ref: &Self = unsafe { &*this };
+
+        this_ref.clear_abort_signal();
+        this_ref.finalize_streams();
+        this_ref.process_mut().detach();
+        // SAFETY: `process` is the live Box-backed Process holding the +1 from
+        // `to_process`; nothing reads `this.process` after this.
+        unsafe { Process::deref(this_ref.process.as_ptr()) };
+
+        if this_ref.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
+            Self::timer_all().remove(this_ref.event_loop_timer.as_ptr());
         }
-        this.set_event_loop_timer_refd(false);
+        this_ref.set_event_loop_timer_refd(false);
 
-        let mut mb = this.stdout_maxbuf.get();
+        let mut mb = this_ref.stdout_maxbuf.get();
         MaxBuf::MaxBuf::remove_from_subprocess(&mut mb);
-        this.stdout_maxbuf.set(mb);
-        let mut mb = this.stderr_maxbuf.get();
+        this_ref.stdout_maxbuf.set(mb);
+        let mut mb = this_ref.stderr_maxbuf.get();
         MaxBuf::MaxBuf::remove_from_subprocess(&mut mb);
-        this.stderr_maxbuf.set(mb);
+        this_ref.stderr_maxbuf.set(mb);
 
-        if let Some(ipc_data) = this.ipc_data.take() {
+        if let Some(ipc_data) = this_ref.ipc_data.take() {
             // In normal operation the socket is already `.closed` by the time we
             // get here (that is what allowed `computeHasPendingActivity` to drop
             // to false and let GC collect us). Detach and release our ref; any
@@ -1491,8 +1515,8 @@ impl Subprocess<'_> {
             }
         }
 
-        this.update_flags(|f| f.insert(Flags::FINALIZED));
-        this.deref();
+        // SAFETY: allocated via `heap::into_raw(Box::new(..))` in `spawn_maybe_sync`.
+        drop(unsafe { bun_core::heap::take(this) });
     }
 
     pub(crate) fn get_exited(&self, this_value: JSValue, global_this: &JSGlobalObject) -> JSValue {

--- a/test/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts
@@ -18,6 +18,6 @@ describe("spawnSync with ReadableStream stdin", () => {
         stdin: stream,
         stdout: "pipe",
       }),
-    ).toThrowErrorMatchingInlineSnapshot(`"'stdin' ReadableStream cannot be used in sync mode"`);
+    ).toThrowErrorMatchingInlineSnapshot(`"'stdin' ReadableStream is only supported with Bun.spawn"`);
   });
 });

--- a/test/js/bun/spawn/spawnAndWait.test.ts
+++ b/test/js/bun/spawn/spawnAndWait.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+describe.concurrent("Bun.spawnAndWait basics", () => {
+  test("basic stdout", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", "console.log('hello')"],
+      env: bunEnv,
+    });
+    expect(result.stdout.toString()).toBe("hello\n");
+    expect(result.stderr.toString()).toBe("");
+    expect(result.success).toBe(true);
+    expect(result.pid).toBeGreaterThan(0);
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("stderr is captured by default", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", "console.error('err output')"],
+      env: bunEnv,
+    });
+    expect(result.stderr.toString()).toBe("err output\n");
+    expect(result.stdout.toString()).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("array form", async () => {
+    const result = await Bun.spawnAndWait([bunExe(), "-e", "process.stdout.write('hi')"], {
+      env: bunEnv,
+    });
+    expect(result.stdout.toString()).toBe("hi");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("non-zero exit code", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", "process.exit(42)"],
+      env: bunEnv,
+    });
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(42);
+  });
+
+  test("returns a real Promise", async () => {
+    const promise = Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", ""],
+      env: bunEnv,
+    });
+    expect(promise).toBeInstanceOf(Promise);
+    const result = await promise;
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("stdout and stderr are Buffers", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", "console.log('out'); console.error('err')"],
+      env: bunEnv,
+    });
+    expect(Buffer.isBuffer(result.stdout)).toBe(true);
+    expect(Buffer.isBuffer(result.stderr)).toBe(true);
+    expect(result.stdout.toString()).toBe("out\n");
+    expect(result.stderr.toString()).toBe("err\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("resourceUsage is present", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", ""],
+      env: bunEnv,
+    });
+    expect(result.resourceUsage).toBeDefined();
+    expect(typeof result.resourceUsage.maxRSS).toBe("number");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("large output is buffered correctly", async () => {
+    const size = 256 * 1024;
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", `process.stdout.write(Buffer.alloc(${size}, 'x'))`],
+      env: bunEnv,
+    });
+    expect(result.stdout.length).toBe(size);
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("signalCode when killed", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", "process.kill(process.pid, 'SIGTERM'); await Bun.sleep(1000)"],
+      env: bunEnv,
+    });
+    if (isWindows) {
+      expect(result.success).toBe(false);
+    } else {
+      expect(result.signalCode).toBe("SIGTERM");
+      expect(result.exitCode).toBe(null);
+      expect(result.success).toBe(false);
+    }
+  });
+
+  test("cwd option", async () => {
+    using dir = tempDir("spawnAndWait-cwd", {
+      "marker.txt": "",
+    });
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", "console.log(require('fs').existsSync('marker.txt'))"],
+      env: bunEnv,
+      cwd: String(dir),
+    });
+    expect(result.stdout.toString().trim()).toBe("true");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("env option", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", "console.log(process.env.MY_TEST_VAR)"],
+      env: { ...bunEnv, MY_TEST_VAR: "hello_from_env" },
+    });
+    expect(result.stdout.toString().trim()).toBe("hello_from_env");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("stdin as Uint8Array", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", "process.stdout.write(await Bun.stdin.text())"],
+      env: bunEnv,
+      stdin: new TextEncoder().encode("from stdin"),
+    });
+    expect(result.stdout.toString()).toBe("from stdin");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("stdout: 'ignore' yields undefined", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", "console.log('discarded')"],
+      env: bunEnv,
+      stdout: "ignore",
+    });
+    expect(result.stdout).toBeUndefined();
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("concurrent spawns run in parallel", async () => {
+    const results = await Promise.all(
+      [1, 2, 3].map(i =>
+        Bun.spawnAndWait({
+          cmd: [bunExe(), "-e", `console.log(${i})`],
+          env: bunEnv,
+        }),
+      ),
+    );
+    expect(results.map(r => r.stdout.toString().trim())).toEqual(["1", "2", "3"]);
+    for (const r of results) expect(r.exitCode).toBe(0);
+  });
+});
+
+test("does not block the event loop", async () => {
+  let tick = 0;
+  const interval = setInterval(() => {
+    tick++;
+  }, 10);
+  try {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", "await Bun.sleep(200)"],
+      env: bunEnv,
+    });
+    expect(result.exitCode).toBe(0);
+  } finally {
+    clearInterval(interval);
+  }
+  // spawnSync would block the event loop and the interval would not fire.
+  expect(tick).toBeGreaterThan(0);
+});
+
+test("ENOENT rejects synchronously", () => {
+  expect(() =>
+    Bun.spawnAndWait({
+      cmd: ["this-binary-definitely-does-not-exist-12345"],
+      env: bunEnv,
+    }),
+  ).toThrow();
+});
+
+test("terminal option is rejected", () => {
+  expect(() =>
+    Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", ""],
+      env: bunEnv,
+      // @ts-expect-error - not allowed on spawnAndWait
+      terminal: {},
+    }),
+  ).toThrow(/spawnAndWait/);
+});
+
+describe.concurrent("timeout", () => {
+  test("fires and sets exitedDueToTimeout", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", "await Bun.sleep(30_000)"],
+      env: bunEnv,
+      timeout: 100,
+      killSignal: "SIGKILL",
+    });
+    expect(result.exitedDueToTimeout).toBe(true);
+    expect(result.success).toBe(false);
+  });
+
+  test("does not fire when process exits first", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", ""],
+      env: bunEnv,
+      timeout: 60_000,
+    });
+    expect(result.exitedDueToTimeout).toBe(false);
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("key is absent when not requested", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", ""],
+      env: bunEnv,
+    });
+    expect("exitedDueToTimeout" in result).toBe(false);
+  });
+});
+
+describe.concurrent("maxBuffer", () => {
+  test("kills the process and sets exitedDueToMaxBuffer", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "exec", "yes"],
+      env: bunEnv,
+      maxBuffer: 256,
+      killSignal: isWindows ? "SIGKILL" : "SIGHUP",
+    });
+    expect(result.exitedDueToMaxBuffer).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.signalCode).toBe(isWindows ? "SIGKILL" : "SIGHUP");
+    expect(result.stdout.toString("utf-8")).toStartWith("y\n".repeat(128));
+    expect(result.exitCode).toBe(null);
+  });
+
+  test("not exceeded", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", "console.log('short')"],
+      env: bunEnv,
+      maxBuffer: 1024 * 1024,
+    });
+    expect(result.exitedDueToMaxBuffer).toBe(false);
+    expect(result.stdout.toString()).toBe("short\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("key is absent when not requested", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", ""],
+      env: bunEnv,
+    });
+    expect("exitedDueToMaxBuffer" in result).toBe(false);
+  });
+});
+
+test("AbortSignal aborts and resolves", async () => {
+  const ac = new AbortController();
+  const promise = Bun.spawnAndWait({
+    cmd: [bunExe(), "-e", "await Bun.sleep(30_000)"],
+    env: bunEnv,
+    signal: ac.signal,
+    killSignal: "SIGKILL",
+  });
+  ac.abort();
+  const result = await promise;
+  expect(result.success).toBe(false);
+});

--- a/test/js/bun/spawn/spawnAndWait.test.ts
+++ b/test/js/bun/spawn/spawnAndWait.test.ts
@@ -129,6 +129,16 @@ describe.concurrent("Bun.spawnAndWait basics", () => {
     expect(result.exitCode).toBe(0);
   });
 
+  test("stdin: 'pipe' is treated as ignore (matches spawnSync)", async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", "process.stdout.write(await Bun.stdin.text())"],
+      env: bunEnv,
+      stdin: "pipe",
+    });
+    expect(result.stdout.toString()).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
   test("stdout: 'ignore' yields undefined", async () => {
     const result = await Bun.spawnAndWait({
       cmd: [bunExe(), "-e", "console.log('discarded')"],

--- a/test/js/bun/spawn/spawnAndWait.test.ts
+++ b/test/js/bun/spawn/spawnAndWait.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
+import { readdirSync } from "node:fs";
 
 describe.concurrent("Bun.spawnAndWait basics", () => {
   test("basic stdout", async () => {
@@ -190,20 +191,50 @@ test("ENOENT throws synchronously", () => {
   ).toThrow(expect.objectContaining({ code: "ENOENT" }));
 });
 
-test("onExit is ignored and does not leak the internal Subprocess", async () => {
+test("onExit is ignored at runtime", async () => {
   let called = false;
   const result = await Bun.spawnAndWait({
     cmd: [bunExe(), "-e", "console.log('hi')"],
     env: bunEnv,
     // @ts-expect-error - onExit is not in SpawnSyncOptions; must be a silent no-op at runtime
-    onExit(proc: any) {
+    onExit() {
       called = true;
-      proc.stdout;
     },
   });
   expect(called).toBe(false);
   expect(result.stdout.toString()).toBe("hi\n");
   expect(result.exitCode).toBe(0);
+});
+
+test("stdin ReadableStream is rejected (matches spawnSync)", () => {
+  expect(() =>
+    Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", ""],
+      env: bunEnv,
+      stdin: new ReadableStream({ start(c) { c.close(); } }),
+    }),
+  ).toThrow("'stdin' ReadableStream is only supported with Bun.spawn");
+});
+
+// Teardown is refcount-driven: pipes, pidfd, and extra stdio fds are released
+// when the promise settles, without waiting for GC to finalize a wrapper.
+test.skipIf(!isLinux)("releases fds when the promise settles, without GC", async () => {
+  const countFds = () => readdirSync("/proc/self/fd").length;
+  const once = async () => {
+    const result = await Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", "console.log('x')"],
+      env: bunEnv,
+      stdio: [Buffer.from("in"), "pipe", "pipe", "pipe"],
+    });
+    expect(result.exitCode).toBe(0);
+  };
+  // Warm up any lazily-opened runtime fds.
+  await once();
+  const before = countFds();
+  for (let i = 0; i < 10; i++) {
+    await once();
+  }
+  expect(countFds()).toBe(before);
 });
 
 test("stdio: 'socket-fd' is rejected", () => {

--- a/test/js/bun/spawn/spawnAndWait.test.ts
+++ b/test/js/bun/spawn/spawnAndWait.test.ts
@@ -213,7 +213,7 @@ test("stdio: 'socket-fd' is rejected", () => {
       env: bunEnv,
       stdio: ["ignore", "pipe", "pipe", "socket-fd"],
     }),
-  ).toThrow(/socket-fd/);
+  ).toThrow("stdio: 'socket-fd' cannot be used with spawnSync or spawnAndWait");
 });
 
 test("terminal option is rejected", () => {

--- a/test/js/bun/spawn/spawnAndWait.test.ts
+++ b/test/js/bun/spawn/spawnAndWait.test.ts
@@ -206,7 +206,7 @@ test("onExit is ignored and does not leak the internal Subprocess", async () => 
   expect(result.exitCode).toBe(0);
 });
 
-test.skipIf(isWindows)("stdio: 'socket-fd' is rejected", () => {
+test("stdio: 'socket-fd' is rejected", () => {
   expect(() =>
     Bun.spawnAndWait({
       cmd: [bunExe(), "-e", ""],

--- a/test/js/bun/spawn/spawnAndWait.test.ts
+++ b/test/js/bun/spawn/spawnAndWait.test.ts
@@ -180,6 +180,22 @@ test("ENOENT throws synchronously", () => {
   ).toThrow(expect.objectContaining({ code: "ENOENT" }));
 });
 
+test("onExit is ignored and does not leak the internal Subprocess", async () => {
+  let called = false;
+  const result = await Bun.spawnAndWait({
+    cmd: [bunExe(), "-e", "console.log('hi')"],
+    env: bunEnv,
+    // @ts-expect-error - onExit is not in SpawnSyncOptions; must be a silent no-op at runtime
+    onExit(proc: any) {
+      called = true;
+      proc.stdout;
+    },
+  });
+  expect(called).toBe(false);
+  expect(result.stdout.toString()).toBe("hi\n");
+  expect(result.exitCode).toBe(0);
+});
+
 test("terminal option is rejected", () => {
   expect(() =>
     Bun.spawnAndWait({

--- a/test/js/bun/spawn/spawnAndWait.test.ts
+++ b/test/js/bun/spawn/spawnAndWait.test.ts
@@ -206,6 +206,16 @@ test("onExit is ignored and does not leak the internal Subprocess", async () => 
   expect(result.exitCode).toBe(0);
 });
 
+test.skipIf(isWindows)("stdio: 'socket-fd' is rejected", () => {
+  expect(() =>
+    Bun.spawnAndWait({
+      cmd: [bunExe(), "-e", ""],
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe", "socket-fd"],
+    }),
+  ).toThrow(/socket-fd/);
+});
+
 test("terminal option is rejected", () => {
   expect(() =>
     Bun.spawnAndWait({

--- a/test/js/bun/spawn/spawnAndWait.test.ts
+++ b/test/js/bun/spawn/spawnAndWait.test.ts
@@ -211,7 +211,11 @@ test("stdin ReadableStream is rejected (matches spawnSync)", () => {
     Bun.spawnAndWait({
       cmd: [bunExe(), "-e", ""],
       env: bunEnv,
-      stdin: new ReadableStream({ start(c) { c.close(); } }),
+      stdin: new ReadableStream({
+        start(c) {
+          c.close();
+        },
+      }),
     }),
   ).toThrow("'stdin' ReadableStream is only supported with Bun.spawn");
 });

--- a/test/js/bun/spawn/spawnAndWait.test.ts
+++ b/test/js/bun/spawn/spawnAndWait.test.ts
@@ -171,13 +171,13 @@ test("does not block the event loop", async () => {
   expect(tick).toBeGreaterThan(0);
 });
 
-test("ENOENT rejects synchronously", () => {
+test("ENOENT throws synchronously", () => {
   expect(() =>
     Bun.spawnAndWait({
       cmd: ["this-binary-definitely-does-not-exist-12345"],
       env: bunEnv,
     }),
-  ).toThrow();
+  ).toThrow(expect.objectContaining({ code: "ENOENT" }));
 });
 
 test("terminal option is rejected", () => {
@@ -268,5 +268,7 @@ test("AbortSignal aborts and resolves", async () => {
   });
   ac.abort();
   const result = await promise;
+  expect(result.signalCode).toBe("SIGKILL");
   expect(result.success).toBe(false);
+  expect(result.exitCode).toBe(null);
 });


### PR DESCRIPTION
`Bun.spawnAndWait` returns a `Promise` that resolves with the same result shape as `Bun.spawnSync` (`stdout`/`stderr` as `Buffer`, `exitCode`, `success`, `signalCode`, `resourceUsage`, `exitedDueToTimeout`, `exitedDueToMaxBuffer`, `pid`) without blocking the event loop.

```ts
const { stdout, exitCode } = await Bun.spawnAndWait(["echo", "hello"]);
console.log(stdout.toString()); // "hello\n"
```

Like `Bun.spawnSync`:
- `stdout` and `stderr` default to `"pipe"` and are returned as `Buffer`
- `timeout` and `maxBuffer` are supported (and surface `exitedDueToTimeout` / `exitedDueToMaxBuffer` on the result)
- `terminal` is rejected

Unlike `Bun.spawnSync`, the event loop keeps running while the child process executes, so this works inside HTTP handlers and with `Promise.all` for concurrent spawns.

## Implementation

Adds a second const generic `BUFFERED_ASYNC` to `spawn_maybe_sync` that:
- runs the existing async spawn path (`IS_SYNC = false`)
- defaults `stdio[1]`/`stdio[2]` to `Pipe`; rejects `terminal`, `'socket-fd'`, and ReadableStream stdin like `spawnSync`; ignores `lazy`/`ipc`/`onExit`
- never creates a `JSSubprocess` wrapper: it stores a pending `JSPromise` as a `Strong` on the `Subprocess` and returns that

`Subprocess` teardown is now refcount-driven rather than GC-driven. `Subprocess::finalize()` (the wrapper's GC finalizer) used to be where all owned-resource release lived (`finalize_streams()`, `Process` detach/deref, MaxBuf, timeout timer, IPC queue) while the `RefCount` destructor only dropped the Box. That teardown moves into `Subprocess::deinit`, the `#[ref_count(destroy = ...)]` destructor, so whoever drops the last ref runs it; `finalize()` keeps only what is about the wrapper going away (mark `this_value` finalized, stop readers, force-release refs whose callbacks cannot fire at VM teardown, then `deref()`).

For `spawnAndWait`, `init_exact_refs(2)` is {exit handler, pending promise}. `on_process_exit` and `on_close_io` call `maybe_resolve_spawn_and_wait` once the process has exited and neither stdout nor stderr is still an active `Readable::Pipe`; that builds the result via the shared `build_sync_result` (also used by the `spawnSync` tail), resolves the promise, and derefs. The exit handler's tail deref is the other ref; last one out runs `deinit`. The only GC root involved is the `Strong` on the returned promise, and fds (pidfd, extra stdio pipes) are released as soon as the promise settles with no GC pass.

`timeout` and `maxBuffer` already worked on the async spawn path (via the `event_loop_timer` and `MaxBuf` wiring); this surfaces their result flags.

Supersedes #27437 (closed; pre-Rust implementation).

## Tests

`test/js/bun/spawn/spawnAndWait.test.ts`: stdout/stderr buffering, `success`/`exitCode`/`signalCode`/`pid`/`resourceUsage`, `stdin` as `Uint8Array` and `"pipe"`, `stdout: "ignore"`, `cwd`/`env`, `Promise.all` concurrency, event-loop non-blocking, `ENOENT` throwing synchronously, rejection of `terminal` / `'socket-fd'` / ReadableStream stdin, `onExit` ignored, the `timeout` / `maxBuffer` / `AbortSignal` bounded-wait paths, and (Linux) fds back to baseline right after the promise settles without any `Bun.gc()`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawnAndWait.test.ts

<!-- robobun:evidence:end -->
