### PR TITLE
Bun.cron.parse: return null at the upper Date boundary with { tz }

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5824,6 +5824,10 @@ extern "C" [[ZIG_EXPORT(nothrow)]] double Bun__gregorianDateTimeToMSInZone(JSC::
     int year, int month, int day, int hour, int minute, int second, int millisecond, uint32_t tzID)
 {
     UNUSED_PARAM(globalObject);
+    // PlainDate's constructor asserts the year; getEpochNanosecondsFor would
+    // return a range error anyway, so report out-of-range as NaN up front.
+    if (!JSC::ISO8601::isYearWithinLimits(year))
+        return std::numeric_limits<double>::quiet_NaN();
     auto tz = JSC::TimeZone::fromID(tzID);
     JSC::ISO8601::PlainDate date { year, static_cast<unsigned>(month), static_cast<unsigned>(day) };
     JSC::ISO8601::PlainTime time { static_cast<unsigned>(hour), static_cast<unsigned>(minute),

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5824,8 +5824,6 @@ extern "C" [[ZIG_EXPORT(nothrow)]] double Bun__gregorianDateTimeToMSInZone(JSC::
     int year, int month, int day, int hour, int minute, int second, int millisecond, uint32_t tzID)
 {
     UNUSED_PARAM(globalObject);
-    // PlainDate's constructor asserts the year; getEpochNanosecondsFor would
-    // return a range error anyway, so report out-of-range as NaN up front.
     if (!JSC::ISO8601::isYearWithinLimits(year))
         return std::numeric_limits<double>::quiet_NaN();
     auto tz = JSC::TimeZone::fromID(tzID);

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -2167,10 +2167,6 @@ pub(crate) fn cron_parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
     let Some(next_ms) = parsed.next(global, from_ms, tz)? else {
         return Ok(JSValue::NULL);
     };
-    // Return null (not Invalid Date) so callers can rely on `=== null` for "no future match".
-    if next_ms > jsc::wtf::MAX_ECMASCRIPT_TIME {
-        return Ok(JSValue::NULL);
-    }
     Ok(JSValue::from_date_number(global, next_ms))
 }
 

--- a/src/runtime/api/cron_parser.rs
+++ b/src/runtime/api/cron_parser.rs
@@ -220,9 +220,7 @@ impl CronExpression {
                 }
             }
         }
-        // NaN here means `dt` maps past the ECMAScript Date range (the Named
-        // tz path returns NaN for out-of-range epochs). Surface it so `next()`
-        // stops walking instead of treating it like a DST-skipped minute.
+        // NaN = past the Date range: surface it so next() stops, don't treat as DST-skipped.
         Ok(if result.is_nan() || result > from_ms {
             Some(result)
         } else {

--- a/src/runtime/api/cron_parser.rs
+++ b/src/runtime/api/cron_parser.rs
@@ -14,6 +14,7 @@
 //!   - Nicknames: @yearly, @annually, @monthly, @weekly, @daily, @midnight, @hourly
 
 use bun_core::strings;
+use bun_jsc::wtf::MAX_ECMASCRIPT_TIME;
 use bun_jsc::{GregorianDateTime, JSGlobalObject, JsResult};
 
 /// Time zone for `CronExpression::next`.
@@ -219,7 +220,14 @@ impl CronExpression {
                 }
             }
         }
-        Ok(if result > from_ms { Some(result) } else { None })
+        // NaN here means `dt` maps past the ECMAScript Date range (the Named
+        // tz path returns NaN for out-of-range epochs). Surface it so `next()`
+        // stops walking instead of treating it like a DST-skipped minute.
+        Ok(if result.is_nan() || result > from_ms {
+            Some(result)
+        } else {
+            None
+        })
     }
 
     /// Compute the next time (in ms since epoch) that matches this expression
@@ -282,7 +290,7 @@ impl CronExpression {
             }
 
             if let Some(r) = self.resolve_local_match(global_object, tz, dt, from_ms, from_dt)? {
-                return Ok(Some(r));
+                return Ok((r <= MAX_ECMASCRIPT_TIME).then_some(r));
             }
             dt.minute += 1;
         }

--- a/test/js/bun/cron/cron-parse.test.ts
+++ b/test/js/bun/cron/cron-parse.test.ts
@@ -39,6 +39,9 @@ describe.concurrent("Bun.cron.parse — algorithm (pinned TZ=UTC)", () => {
   });
 
   test("impossible day/month (Feb 30) returns null quickly", () => {
+    // Resolve the zone once before timing so ICU's first-open cost (debug+ASAN)
+    // isn't charged to the walk this test bounds.
+    Bun.cron.parse("* * * * *", 0, { tz: "UTC" });
     const t = performance.now();
     expect(Bun.cron.parse("0 0 30 2 *", new Date("2026-01-01T00:00:00Z"), { tz: "UTC" })).toBeNull();
     expect(performance.now() - t).toBeLessThan(50);
@@ -115,6 +118,44 @@ describe("Bun.cron.parse — invalid `from` argument", () => {
       exitCode: 0,
     });
   });
+
+  // With { tz }, the upper boundary used to crash (debug assert in
+  // JSC::ISO8601::PlainDate once the wall-clock walk crossed year 275760) or
+  // return Invalid Date. Spawn so the assert shows up as a subprocess exit.
+  test.concurrent.each(["UTC", "America/New_York", "Asia/Tokyo"])(
+    "accepts the Date range boundary with { tz: %p }",
+    async tz => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const tz = ${JSON.stringify(tz)};
+           const fmt = r => r === null ? "null" : Number.isNaN(r.getTime()) ? "invalid" : r.getTime();
+           const lo = Bun.cron.parse("* * * * *", -8.64e15, { tz });
+           const out = [
+             // Next minute is past the range → null (NaN-from-range case).
+             fmt(Bun.cron.parse("* * * * *", 8.64e15, { tz })),
+             // Next Jan 1 is in year 275761 → null (out-of-range year case).
+             fmt(Bun.cron.parse("0 0 1 1 *", 8.64e15, { tz })),
+             // One minute inside the upper boundary lands exactly on it.
+             fmt(Bun.cron.parse("* * * * *", 8.64e15 - 60_000, { tz })),
+             // Lower boundary still finds a valid in-range instant (exact value
+             // depends on the zone's LMT offset at -271821, so just check category).
+             lo instanceof Date && lo.getTime() > -8.64e15 && lo.getTime() < -8.64e15 + 86_400_000,
+           ];
+           process.stdout.write(JSON.stringify(out));`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+        out: ["null", "null", 8.64e15, true],
+        stderr: "",
+        exitCode: 0,
+      });
+    },
+  );
 
   test("does not crash the process on 1e300", async () => {
     await using proc = Bun.spawn({


### PR DESCRIPTION
## What

`Bun.cron.parse()` with a `{ tz }` option crashed a debug assert (and returned `Invalid Date` in release) when `from` was at or near the upper ECMAScript Date boundary and the next match fell past it. The local-time path already returned `null` there; the `{ tz }` path introduced in #35122 did not.

## Repro

```sh
$ bun -e 'console.log(Bun.cron.parse("* * * * *", 8.64e15, { tz: "UTC" }))'
```

Debug:
```
ASSERTION FAILED: isYearWithinLimits(year) || year == outOfRangeYear
JavaScriptCore/ISO8601.h(370) : JSC::ISO8601::PlainDate::PlainDate(int32_t, unsigned int, unsigned int)
```

Release: `Invalid Date` (expected `null`, same as `TZ=UTC bun -e 'console.log(Bun.cron.parse("* * * * *", 8.64e15))'`).

Also reproduces with `America/New_York`, `Asia/Tokyo`, and with schedules whose next match is in year 275761 (e.g. `"0 0 1 1 *"` at `8.64e15`).

## Cause

`CronExpression::next()` walks wall-clock time forward from `from_ms`. At `from_ms = 8.64e15` (which is `+275760-09-13T00:00:00Z`), every candidate past that instant is out of the ECMAScript Date range. For a named tz, `Bun__gregorianDateTimeToMSInZone` calls `getEpochNanosecondsFor`, which returns a range error that the binding maps to NaN. `resolve_local_match` compared that NaN with `> from_ms` (false) and reported `None`, which `next()` interprets as "DST-skipped minute, keep walking". The walk then advanced until the year rolled past 275760, at which point the binding constructs `JSC::ISO8601::PlainDate { 275761, ... }` whose constructor asserts `isYearWithinLimits`.

## Fix

- `Bun__gregorianDateTimeToMSInZone`: return NaN for years outside `JSC::ISO8601::isYearWithinLimits` instead of constructing a `PlainDate` that asserts; `getEpochNanosecondsFor` would have produced a range error (NaN) for that date anyway.
- `resolve_local_match`: surface NaN as `Some(NaN)` so `next()` sees "out of range" rather than "keep walking".
- `next()`: clamp the returned instant to `MAX_ECMASCRIPT_TIME` (`None` past it, which also catches NaN). Both callers now see `None` for an out-of-range match; the per-caller clamp in `cron_parse` is subsumed and removed.

Also adds an ICU warm-up before the "Feb 30 returns null quickly" timing assertion; that test's 50 ms bound was being spent on ICU's first-open under debug+ASAN.

## Verification

`bun bd test test/js/bun/cron/cron-parse.test.ts` (and `cron-local-time.test.ts`, `cron.test.ts`): 26 / 84 / 63-skipped pass. The new `{ tz }` boundary cases crash with the PlainDate assertion on main.