### PR TITLE
shell: support ReadableStream stdin redirect via SinkHandle

### DIFF
--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -363,13 +363,7 @@ impl<'a> Writable<'a> {
                     //
                     // The call re-enters via the writer backref, so no `&mut
                     // FileSink` is materialized across it.
-                    // SAFETY: `pipe_ref` keeps the sink live.
-                    unsafe {
-                        FileSink::on_attached_process_exit(
-                            pipe_ref.as_ptr(),
-                            &subprocess.process().status,
-                        )
-                    };
+                    FileSink::attached_process_exited(&pipe_ref, &subprocess.process().status);
                     // The wrapper takes its own ref; `pipe_ref` drops after.
                     Self::pipe_sink_mut(&pipe_ref).to_js(global_this)
                 } else {

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -722,6 +722,13 @@ impl Builtin {
                         me.stderr = BuiltinIO::ArrayBuf { buf, i: 0 };
                     }
                 } else if crate::webcore::ReadableStream::is_readable_stream(jsval) {
+                    if !redirect.stdin() {
+                        let _ = global.throw(format_args!(
+                            "{}",
+                            crate::shell::states::cmd::STREAM_REDIRECT_NOT_STDIN
+                        ));
+                        return Some(Yield::failed());
+                    }
                     let name = Self::of(interp, cmd).kind.as_str();
                     let _ = global.throw(format_args!(
                         "ReadableStream cannot be redirected to a builtin command ('{name}'). \

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -721,6 +721,13 @@ impl Builtin {
                         };
                         me.stderr = BuiltinIO::ArrayBuf { buf, i: 0 };
                     }
+                } else if crate::webcore::ReadableStream::is_readable_stream(jsval) {
+                    let name = Self::of(interp, cmd).kind.as_str();
+                    let _ = global.throw(format_args!(
+                        "ReadableStream cannot be redirected to a builtin command ('{name}'). \
+                         Use an external command or buffer the stream first",
+                    ));
+                    return Some(Yield::failed());
                 } else if let Some(body) =
                     crate::webcore::body::Value::from_request_or_response(jsval)
                 {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -53,6 +53,10 @@ pub enum Exec {
     Subproc(Box<SubprocExec>),
 }
 
+/// Thrown for a `ReadableStream` redirect other than `< ${stream}`.
+pub(crate) const STREAM_REDIRECT_NOT_STDIN: &str =
+    "ReadableStream cannot be used for stdout or stderr; only '< ${...}' (stdin) is supported";
+
 impl Cmd {
     /// Borrow the AST node this `Cmd` was built from.
     ///
@@ -771,10 +775,7 @@ impl Cmd {
                     crate::webcore::ReadableStream::from_js(jsval, global)?
                 {
                     if !flags.stdin() {
-                        return Err(global.throw(format_args!(
-                            "ReadableStream cannot be used for stdout or stderr; \
-                             only '< ${{...}}' (stdin) is supported"
-                        )));
+                        return Err(global.throw(format_args!("{STREAM_REDIRECT_NOT_STDIN}")));
                     }
                     if stream.is_disturbed_or_locked(global) {
                         return Err(global

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -767,8 +767,32 @@ impl Cmd {
                             STDERR_NO as i32,
                         )?;
                     }
-                } else if crate::webcore::ReadableStream::from_js(jsval, global)?.is_some() {
-                    panic!("TODO SHELL READABLE STREAM");
+                } else if let Some(mut stream) =
+                    crate::webcore::ReadableStream::from_js(jsval, global)?
+                {
+                    if !flags.stdin() {
+                        return Err(global.throw(format_args!(
+                            "ReadableStream cannot be used for stdout or stderr; \
+                             only '< ${{...}}' (stdin) is supported"
+                        )));
+                    }
+                    if stream.is_disturbed_or_locked(global) {
+                        return Err(global
+                            .err(
+                                crate::jsc::ErrorCode::INVALID_STATE,
+                                format_args!(
+                                    "ReadableStream redirected to stdin has already been used"
+                                ),
+                            )
+                            .throw());
+                    }
+                    // Fully-buffered / not-yet-started file-backed streams collapse
+                    // to a blob and take the existing `StaticPipeWriter` path.
+                    if let Some(blob) = stream.to_any_blob(global) {
+                        stdio[STDIN_NO].extract_blob(global, blob, STDIN_NO as i32)?;
+                    } else {
+                        stdio[STDIN_NO] = Stdio::ReadableStream(stream);
+                    }
                 } else if let Some(req) = jsval.as_::<crate::webcore::Response>() {
                     // SAFETY: `as_` returns a live JSC-owned `*mut Response`;
                     // `get_body_value` is `&self`.

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -737,18 +737,26 @@ impl ShellSubprocess {
         // (they store it on StaticPipeWriter / PipeReader as a backref).
         let mut slot = Box::<Subprocess>::new_uninit();
         let subprocess: *mut Subprocess = slot.as_mut_ptr();
-        // SAFETY: `out_subproc` points at the `SubprocExec.child` slot inside
-        // the heap-stable `Box<SubprocExec>` staged by the caller before this
-        // call; no `&` to that slot is live (the caller's `&mut Cmd` borrow
-        // ended before the call). Written *before* any callback below
-        // (`watch`/`start`/`read_all`) so re-entrant `Cmd` callbacks see a
-        // populated `exec.subproc.child`.
-        unsafe { *out_subproc = subprocess };
 
         let stdin = match Writable::init(stdio0, event_loop, subprocess, spawn_stdin) {
             Ok(w) => w,
-            Err(WritableInitError::UnexpectedCreatingStdin) => {
-                panic!("unexpected error while creating stdin");
+            Err(err) => {
+                #[cfg(not(windows))]
+                {
+                    let _ = spawn_stdout.map(Fd::close);
+                    let _ = spawn_stderr.map(Fd::close);
+                }
+                #[cfg(windows)]
+                {
+                    // `WindowsSpawnResult::drop` uv_closes handed-back slots.
+                    spawn_result.stdout = spawn_stdout;
+                    spawn_result.stderr = spawn_stderr;
+                }
+                spawn_result.dispose_failed_spawn();
+                return Err(match err {
+                    WritableInitError::Sys(e) => ShellErr::Sys(e.to_shell_system_error()),
+                    WritableInitError::StreamAssign(msg) => ShellErr::Custom(msg),
+                });
             }
         };
         let stdout = Readable::init(
@@ -796,6 +804,13 @@ impl ShellSubprocess {
         // sound.
         // SAFETY: fully initialised by the `write` above.
         let _ = bun_core::heap::into_raw(unsafe { slot.assume_init() });
+        // SAFETY: `out_subproc` points at the `SubprocExec.child` slot inside
+        // the heap-stable `Box<SubprocExec>` staged by the caller before this
+        // call; no `&` to that slot is live (the caller's `&mut Cmd` borrow
+        // ended before the call). Written once the Subprocess is initialised
+        // and *before* any callback below (`watch`/`start`/`read_all`) so
+        // re-entrant `Cmd` callbacks see a populated `exec.subproc.child`.
+        unsafe { *out_subproc = subprocess };
         // SAFETY: `subprocess` is the just-allocated `ShellSubprocess`; the
         // owning `Cmd` outlives the `Process` exit callback. All accesses
         // below are scoped so no borrow of the Subprocess spans the
@@ -809,37 +824,6 @@ impl ShellSubprocess {
                 ));
         }
         let _ = scopeguard::ScopeGuard::into_inner(stdio_guard);
-
-        // Wire the FileSink's close-signal back to the enclosing `Writable` so
-        // `Writable::on_close` (drops the `Arc<FileSink>`) runs when the sink
-        // finishes. `stdin` lives inside the Box-allocated `Subprocess` at a
-        // stable address, so the self-referential raw pointer is sound for the
-        // life of the subprocess. Only reachable on Windows (POSIX
-        // `Writable::init` never returns `Pipe` for shell stdio).
-        {
-            // Derive `stdin_ptr` from the raw heap pointer (`subprocess`), not
-            // the local `subproc: &mut` reborrow — the pointer is stored
-            // long-term in `FileSink::source` and dereferenced from
-            // `Writable::on_close` after this frame returns. Under Stacked
-            // Borrows a child of `subproc`'s tag would be invalidated when
-            // that borrow ends; rooting in the allocation's provenance keeps
-            // it valid for the box's lifetime.
-            // SAFETY: `subprocess` is the live, fully-initialised heap alloc.
-            let stdin_ptr: *mut Writable = unsafe { &raw mut (*subprocess).stdin };
-            // SAFETY: reborrow as a child of `stdin_ptr` so it does not
-            // invalidate the sibling we store in `source`.
-            if let Writable::Pipe(pipe) = unsafe { &mut *stdin_ptr } {
-                // SAFETY: shell is single-threaded; the FileSink allocation is
-                // disjoint from `*stdin_ptr`. `stdin_ptr` outlives the sink —
-                // the Subprocess owns both and `Writable::on_close` is the only
-                // path that drops it.
-                pipe.source
-                    .set(webcore::streams::SourceHandle::ShellWritable(
-                        // SAFETY: `stdin_ptr` is the live `&raw mut` writable (write provenance).
-                        unsafe { bun_ptr::BackRef::from_raw_mut(stdin_ptr) },
-                    ));
-            }
-        }
 
         // SAFETY: scoped access; `watch` does not re-enter the subprocess.
         match unsafe { (*subprocess).proc().watch() } {
@@ -932,14 +916,34 @@ impl ShellSubprocess {
             break 'brk None;
         };
 
-        let Some(code) = exit_code else { return };
+        // A `< ${stream}` stdin closes with the child: stop the stream and
+        // release the sink. Taken out of the slot first, so nothing borrows
+        // `*this` across the sink's close callbacks.
+        // SAFETY: caller contract; the borrow ends at the `;`.
+        let stream_stdin = unsafe { (*this).stdin.take_pipe() };
+        let stdin_closed = stream_stdin.is_some();
+        if let Some(sink) = stream_stdin {
+            FileSink::attached_process_exited(&sink, status);
+        }
+
+        if exit_code.is_none() && !stdin_closed {
+            return;
+        }
         // SAFETY: caller contract; `CmdHandle` is `Copy`, no borrow is kept.
         let handle = unsafe { (*this).cmd_parent };
         // SAFETY: the owning Cmd outlives its subprocess; the `&mut Cmd` ends
         // before the Yield runs.
         let cmd = unsafe { handle.cmd_mut() };
         cmd.base.interrupted |= interrupted;
-        let y = cmd.on_exit(code.into());
+        let mut y = match exit_code {
+            Some(code) => cmd.on_exit(code.into()),
+            None => Yield::suspended(),
+        };
+        if stdin_closed {
+            // Stdin was still open, so `on_exit` could not finish the Cmd.
+            debug_assert!(matches!(y, Yield::Suspended));
+            y = cmd.buffered_input_close();
+        }
         // May free `*this`.
         y.run(&handle.interp);
     }
@@ -951,11 +955,15 @@ impl ShellSubprocess {
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum WritableInitError {
-    #[error("UnexpectedCreatingStdin")]
-    UnexpectedCreatingStdin,
+    #[error("{0}")]
+    Sys(bun_sys::Error),
+    /// `assign_to_stream` threw synchronously; carries the formatted message.
+    #[error("Failed to pipe ReadableStream to stdin")]
+    StreamAssign(Box<[u8]>),
 }
 
 pub enum Writable {
+    /// A `< ${stream}` stdin: the sink the stream is piped into.
     Pipe(RefPtr<FileSink>),
     Fd(Fd),
     Buffer(RefPtr<StaticPipeWriter>),
@@ -965,20 +973,17 @@ pub enum Writable {
 }
 
 impl Writable {
-    // When the stream has closed we need to be notified to prevent a use-after-free
-    // We can test for this use-after-free by enabling hot module reloading on a file and then saving it twice
-    pub fn on_close(&mut self, _: Option<bun_sys::Error>) {
-        match self {
-            Writable::Buffer(_) | Writable::Pipe(_) => {
-                // Dropping the Arc on reassignment below derefs.
+    /// Take the `< ${stream}` sink out of the slot.
+    fn take_pipe(&mut self) -> Option<RefPtr<FileSink>> {
+        match core::mem::replace(self, Writable::Ignore) {
+            Writable::Pipe(pipe) => Some(pipe),
+            other => {
+                *self = other;
+                None
             }
-            _ => {}
         }
-        *self = Writable::Ignore;
     }
-}
 
-impl Writable {
     pub(crate) fn init(
         stdio: Stdio,
         event_loop: EventLoopHandle,
@@ -1000,16 +1005,15 @@ impl Writable {
                         // FileSink's writer.
                         let uv_pipe: *mut _ = bun_core::heap::into_raw(buf);
                         let pipe = FileSink::create_with_pipe(event_loop, uv_pipe);
-                        if let bun_sys::Result::Err(_err) =
+                        if let bun_sys::Result::Err(e) =
                             pipe.writer.with_mut(|w| w.start_with_current_pipe())
                         {
-                            return Err(WritableInitError::UnexpectedCreatingStdin);
+                            return Err(WritableInitError::Sys(e));
                         }
 
-                        // TODO: uncoment this when is ready, commented because was not compiling
-                        // subprocess.weak_file_sink_stdin_ptr = pipe;
-                        // subprocess.flags.has_stdin_destructor_called = false;
-
+                        if let Stdio::ReadableStream(rs) = &mut stdio {
+                            return Self::assign_stream(pipe, rs, event_loop);
+                        }
                         return Ok(Writable::Pipe(pipe));
                     }
                     return Ok(Writable::Inherit);
@@ -1104,9 +1108,25 @@ impl Writable {
                 Stdio::Inherit => Ok(Writable::Inherit),
                 Stdio::Path(_) | Stdio::Ignore => Ok(Writable::Ignore),
                 Stdio::Ipc | Stdio::Capture(_) => Ok(Writable::Ignore),
-                Stdio::ReadableStream(_) => {
-                    // The shell never uses this
-                    panic!("Unimplemented stdin readable_stream");
+                Stdio::ReadableStream(rs) => {
+                    let fd = result.unwrap();
+                    if let bun_sys::Result::Err(e) = bun_sys::set_nonblocking(fd) {
+                        fd.close();
+                        return Err(WritableInitError::Sys(e));
+                    }
+                    let pipe = FileSink::create(event_loop, fd);
+                    if let bun_sys::Result::Err(e) = pipe.writer.with_mut(|w| w.start(fd, true)) {
+                        // The writer did not take `fd`; nothing else closes it.
+                        fd.close();
+                        return Err(WritableInitError::Sys(e));
+                    }
+                    // The fd is a socketpair half, same as `Bun.spawn` stdin.
+                    pipe.writer.with_mut(|w| {
+                        if let Some(poll) = w.handle.get_poll() {
+                            poll.set_flag(bun_io::FilePollFlag::Socket);
+                        }
+                    });
+                    Self::assign_stream(pipe, rs, event_loop)
                 }
                 Stdio::SocketFd => {
                     // The shell never uses this; rejected at i < 3 anyway.
@@ -1114,6 +1134,61 @@ impl Writable {
                 }
             }
         }
+    }
+
+    /// Wire `stream` into the stdin sink (native `SinkHandle` wire first, JS
+    /// pump fallback). A synchronous throw consumes the sink.
+    fn assign_stream(
+        pipe: RefPtr<FileSink>,
+        stream: &mut webcore::ReadableStream,
+        event_loop: EventLoopHandle,
+    ) -> Result<Writable, WritableInitError> {
+        // ReadableStream stdin only exists for JS-origin shells.
+        let global_ptr = event_loop.global_object();
+        assert!(
+            !global_ptr.is_null(),
+            "ReadableStream stdin requires the JS event loop"
+        );
+        let global = jsc::JSGlobalObject::opaque_ref(global_ptr.cast());
+        // SAFETY: `pipe` is the only handle to the sink `init` just created,
+        // so nothing else borrows it.
+        let result = unsafe { &mut *pipe.as_ptr() }.assign_to_stream(stream, global);
+        // Success shapes: undefined/null/empty (drained or natively wired) or
+        // a promise (pump in flight). Anything else is a synchronous throw —
+        // an `Error` instance or any other thrown value propagated as-is.
+        let thrown = if let Some(err) = result.to_error() {
+            Some(err)
+        } else if global.has_exception() {
+            global.clear_exception_except_termination();
+            Some(jsc::JSValue::UNDEFINED)
+        } else if !result.is_empty_or_undefined_or_null() && result.as_any_promise().is_none() {
+            Some(result)
+        } else {
+            None
+        };
+        if let Some(err) = thrown {
+            // `fmt::Write` (unlike `format!`/`io::Write`) propagates the
+            // formatter `Err` that `fmt_string` produces when the thrown
+            // value's `toString()` itself throws.
+            use core::fmt::Write as _;
+            let mut msg = String::new();
+            if err.is_undefined()
+                || write!(
+                    &mut msg,
+                    "Failed to pipe ReadableStream to stdin: {}",
+                    err.fmt_string(global)
+                )
+                .is_err()
+            {
+                global.clear_exception_except_termination();
+                msg.clear();
+                msg.push_str("Failed to pipe ReadableStream to stdin");
+            }
+            return Err(WritableInitError::StreamAssign(
+                msg.into_bytes().into_boxed_slice(),
+            ));
+        }
+        Ok(Writable::Pipe(pipe))
     }
 
     // Note: there is intentionally no `Writable::toJS` here — the shell never

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -331,6 +331,13 @@ impl FileSink {
         }
     }
 
+    /// [`on_attached_process_exit`](Self::on_attached_process_exit) for an
+    /// owner that holds the sink through a [`RefPtr`].
+    pub(crate) fn attached_process_exited(this: &RefPtr<FileSink>, status: &SpawnStatus) {
+        // SAFETY: `this` holds a ref, and `as_ptr` is the allocation's own pointer.
+        unsafe { Self::on_attached_process_exit(this.as_ptr(), status) }
+    }
+
     /// # Safety
     /// `this` must be the canonical live `*mut FileSink` (see
     /// [`on_attached_process_exit`](Self::on_attached_process_exit)). `WritablePending::run`

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -968,7 +968,6 @@ pub enum SourceHandle {
     /// The `'static` bound erases the `&JSGlobalObject` borrow carried in
     /// `Subprocess<'a>`; the pointed-at allocation outlives this handle.
     Subprocess(BackRef<crate::api::bun::subprocess::Subprocess<'static>>),
-    ShellWritable(BackRef<crate::shell::subproc::Writable, bun_ptr::Mut>),
     FetchResponseBody(BackRef<crate::webcore::fetch::fetch_tasklet::FetchTasklet, bun_ptr::Mut>),
     ServerRequestBody(crate::server::AnyRequestContext),
     S3DownloadBody(BackRef<crate::webcore::s3::client::S3DownloadStreamWrapper>),
@@ -1011,8 +1010,6 @@ impl SourceHandle {
             SourceHandle::ByteStream(p) => p.on_close(err),
             SourceHandle::FileReader(p) => p.on_close(err),
             SourceHandle::Subprocess(p) => p.on_close(err),
-            // SAFETY: live backref; cleared before the pointee is freed.
-            SourceHandle::ShellWritable(mut p) => unsafe { p.get_mut() }.on_close(err),
             SourceHandle::FetchResponseBody(p) => p.on_stream_cancelled(),
             SourceHandle::S3DownloadBody(p) => p.on_stream_cancelled(),
             SourceHandle::ServerRequestBody(_) => {}
@@ -1077,7 +1074,7 @@ impl SourceHandle {
                 p.on_cancel();
             }
             // Remaining variants leave `on_ready` at the trait default (no-op).
-            SourceHandle::Subprocess(_) | SourceHandle::ShellWritable(_) => {}
+            SourceHandle::Subprocess(_) => {}
         }
     }
 
@@ -1094,7 +1091,6 @@ impl SourceHandle {
             | SourceHandle::ByteStream(_)
             | SourceHandle::FileReader(_)
             | SourceHandle::Subprocess(_)
-            | SourceHandle::ShellWritable(_)
             | SourceHandle::HTMLRewriter(_)
             | SourceHandle::TestingCancelOnDrain(_) => {}
         }
@@ -1111,7 +1107,6 @@ impl SourceHandle {
             | SourceHandle::ByteStream(_)
             | SourceHandle::FileReader(_)
             | SourceHandle::Subprocess(_)
-            | SourceHandle::ShellWritable(_)
             | SourceHandle::HTMLRewriter(_)
             | SourceHandle::TestingCancelOnDrain(_) => {}
         }

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -1592,6 +1592,14 @@ impl WindowsSpawnResult {
     pub fn to_process_handle(&mut self, event_loop: impl Sized) -> ProcessHandle {
         ProcessHandle(self.to_process(event_loop))
     }
+
+    /// Kill and release a child whose post-spawn stdio setup failed.
+    /// Consumes the result so `Drop` also closes stdio pipes still held.
+    pub fn dispose_failed_spawn(mut self) {
+        let process = self.to_process_handle(());
+        let _ = process.kill(bun_core::SignalCode::SIGKILL as u8);
+        // Dropping the handle closes the process and releases its ref.
+    }
 }
 
 #[cfg(windows)]
@@ -1756,6 +1764,9 @@ pub trait SpawnResultExt: Sized {
     fn to_process_handle(self, event_loop: EventLoopHandle) -> ProcessHandle {
         ProcessHandle(self.to_process(event_loop))
     }
+
+    /// Kill, reap, and release a child whose post-spawn stdio setup failed.
+    fn dispose_failed_spawn(self);
 }
 
 #[cfg(unix)]
@@ -1763,6 +1774,22 @@ impl SpawnResultExt for PosixSpawnResult {
     fn to_process(self, event_loop: EventLoopHandle) -> RefPtr<Process> {
         // SAFETY: `init_posix` heap-allocates the `Process` with its initial ref.
         unsafe { RefPtr::from_raw(Process::init_posix(&self, event_loop)) }
+    }
+
+    fn dispose_failed_spawn(self) {
+        // `Process::kill` no-ops while `Poller::Detached` (pre-`watch()`);
+        // signal the pid directly so the blocking reap terminates.
+        unsafe extern "C" {
+            #[link_name = "kill"]
+            safe fn libc_kill(pid: libc::pid_t, sig: c_int) -> c_int;
+        }
+        let _ = libc_kill(self.pid, bun_core::SignalCode::SIGKILL as c_int);
+        let _ = posix_spawn::wait4(self.pid, 0, None);
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        if let Some(pidfd) = self.pidfd {
+            use bun_sys::FdExt as _;
+            Fd::from_native(pidfd).close();
+        }
     }
 }
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3470,6 +3470,11 @@ describe("redirect stdin from ReadableStream", () => {
     await expect(runWithErrorPromise(() => $`${BUN} -e 0 2> ${s2}`)).resolves.toThrow(
       /ReadableStream cannot be used for stdout or stderr/,
     );
+    // A builtin gives the same reason, not the stdin-only "use an external command" hint.
+    const s3 = new ReadableStream({ pull: c => c.close() });
+    await expect(runWithErrorPromise(() => $`echo hi > ${s3}`)).resolves.toThrow(
+      /ReadableStream cannot be used for stdout or stderr/,
+    );
   });
 
   test("locked stream throws", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3354,6 +3354,187 @@ test("stdin redirect from a Uint8Array sends the bytes captured when the command
   expect(result.exitCode).toBe(0);
 }, 60_000);
 
+describe("redirect stdin from ReadableStream", () => {
+  // External command: on POSIX `cat` is external, on Windows it's a builtin,
+  // so use a spawned Bun child everywhere.
+  const childPump = `process.stdout.write(await Bun.stdin.text())`;
+
+  test.concurrent("native source (subprocess stdout)", async () => {
+    // https://github.com/oven-sh/bun/issues/18262
+    await using proc = Bun.spawn({
+      cmd: [BUN, "-e", "process.stdout.write('hello from stream')"],
+      env: bunEnv,
+      stdout: "pipe",
+    });
+    const out = await $`${BUN} -e ${childPump} < ${proc.stdout}`.env(bunEnv).nothrow().quiet();
+    expect({ stdout: out.stdout.toString(), exitCode: out.exitCode }).toEqual({
+      stdout: "hello from stream",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("native source, large payload with backpressure", async () => {
+    const size = 256 * 1024;
+    await using proc = Bun.spawn({
+      cmd: [BUN, "-e", `process.stdout.write(Buffer.alloc(${size}, 'x'))`],
+      env: bunEnv,
+      stdout: "pipe",
+    });
+    const out = await $`${BUN} -e ${childPump} < ${proc.stdout}`.env(bunEnv).nothrow().quiet();
+    expect(out.stdout.equals(Buffer.alloc(size, "x"))).toBe(true);
+    expect(out.exitCode).toBe(0);
+  });
+
+  test.concurrent("Bun.file().stream() collapses to the blob path", async () => {
+    using dir = tempDir("shell-stream-file", { "input.txt": "file-content" });
+    const stream = Bun.file(join(String(dir), "input.txt")).stream();
+    const out = await $`${BUN} -e ${childPump} < ${stream}`.env(bunEnv).nothrow().quiet();
+    expect({ stdout: out.stdout.toString(), exitCode: out.exitCode }).toEqual({
+      stdout: "file-content",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("native ByteStream source (fetch response.body)", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () =>
+        new Response(
+          new ReadableStream({
+            async pull(c) {
+              c.enqueue(Buffer.from("http-"));
+              await Bun.sleep(0);
+              c.enqueue(Buffer.from("body"));
+              c.close();
+            },
+          }),
+        ),
+    });
+    const res = await fetch(server.url);
+    const out = await $`${BUN} -e ${childPump} < ${res.body}`.env(bunEnv).nothrow().quiet();
+    expect({ stdout: out.stdout.toString(), exitCode: out.exitCode }).toEqual({
+      stdout: "http-body",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("JS-backed multi-chunk stream", async () => {
+    const stream = new ReadableStream({
+      async pull(c) {
+        c.enqueue(new TextEncoder().encode("chunk1 "));
+        await Bun.sleep(0);
+        c.enqueue(new TextEncoder().encode("chunk2"));
+        c.close();
+      },
+    });
+    const out = await $`${BUN} -e ${childPump} < ${stream}`.env(bunEnv).nothrow().quiet();
+    expect({ stdout: out.stdout.toString(), exitCode: out.exitCode }).toEqual({
+      stdout: "chunk1 chunk2",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("child exits while stream is still producing", async () => {
+    const { promise: cancelled, resolve: onCancel } = Promise.withResolvers<true>();
+    const stream = new ReadableStream({
+      async pull(c) {
+        c.enqueue(new TextEncoder().encode("x"));
+        await Bun.sleep(0);
+      },
+      cancel() {
+        onCancel(true);
+      },
+    });
+    // Child reads 3 bytes then exits; the shell must cancel the stream and
+    // finish the command with the child's exit status.
+    const child = `
+      const b = Buffer.alloc(3);
+      let n = 0;
+      while (n < 3) { const r = require('fs').readSync(0, b, n, 3 - n); if (r <= 0) break; n += r; }
+      process.stdout.write(b.subarray(0, n));
+    `;
+    const out = await $`${BUN} -e ${child} < ${stream}`.env(bunEnv).nothrow().quiet();
+    expect({ stdout: out.stdout.toString(), exitCode: out.exitCode }).toEqual({
+      stdout: "xxx",
+      exitCode: 0,
+    });
+    expect(await cancelled).toBe(true);
+  });
+
+  test("stdout/stderr redirect throws", async () => {
+    const s1 = new ReadableStream({ pull: c => c.close() });
+    await expect(runWithErrorPromise(() => $`${BUN} -e 0 > ${s1}`)).resolves.toThrow(
+      /ReadableStream cannot be used for stdout or stderr/,
+    );
+    const s2 = new ReadableStream({ pull: c => c.close() });
+    await expect(runWithErrorPromise(() => $`${BUN} -e 0 2> ${s2}`)).resolves.toThrow(
+      /ReadableStream cannot be used for stdout or stderr/,
+    );
+  });
+
+  test("locked stream throws", async () => {
+    const s = new ReadableStream({ pull: c => (c.enqueue(new Uint8Array([65])), c.close()) });
+    const r = s.getReader();
+    await expect(runWithErrorPromise(() => $`${BUN} -e 0 < ${s}`)).resolves.toThrow(/already been used/);
+    r.releaseLock();
+  });
+
+  test("disturbed stream throws", async () => {
+    const s = new ReadableStream({ pull: c => (c.enqueue(new Uint8Array([65])), c.close()) });
+    const r = s.getReader();
+    await r.read();
+    r.releaseLock();
+    await expect(runWithErrorPromise(() => $`${BUN} -e 0 < ${s}`)).resolves.toThrow(/already been used/);
+  });
+
+  test("redirect to a builtin throws", async () => {
+    const s = new ReadableStream({ pull: c => (c.enqueue(new Uint8Array([65])), c.close()) });
+    await expect(runWithErrorPromise(() => $`echo < ${s}`)).resolves.toThrow(
+      /ReadableStream cannot be redirected to a builtin command/,
+    );
+  });
+
+  test.concurrent("direct stream whose pull() throws synchronously fails the command", async () => {
+    const s = new ReadableStream({
+      type: "direct",
+      pull() {
+        throw new Error("boom-sync");
+      },
+    });
+    const out = await $`${BUN} -e ${childPump} < ${s}`.env(bunEnv).nothrow().quiet();
+    expect(out.stderr.toString()).toContain("Failed to pipe ReadableStream to stdin: Error: boom-sync");
+    expect(out.exitCode).toBe(1);
+  });
+
+  test.concurrent("direct stream whose pull() throws a non-Error value fails the command", async () => {
+    const s = new ReadableStream({
+      type: "direct",
+      pull() {
+        throw { foo: 1 };
+      },
+    });
+    const out = await $`${BUN} -e ${childPump} < ${s}`.env(bunEnv).nothrow().quiet();
+    expect(out.stderr.toString()).toContain("Failed to pipe ReadableStream to stdin");
+    expect(out.exitCode).toBe(1);
+  });
+
+  test.concurrent("direct stream whose pull() throws a value with a throwing toString()", async () => {
+    const s = new ReadableStream({
+      type: "direct",
+      pull() {
+        throw {
+          toString() {
+            throw 0;
+          },
+        };
+      },
+    });
+    const out = await $`${BUN} -e ${childPump} < ${s}`.env(bunEnv).nothrow().quiet();
+    expect(out.stderr.toString()).toContain("Failed to pipe ReadableStream to stdin");
+    expect(out.exitCode).toBe(1);
+  });
+});
+
 describe("stdin redirect from a zero-length buffer delivers EOF to the spawned command", () => {
   // A spawned command reading stdin (cat) must see EOF when the redirect
   // source is an empty ArrayBuffer/TypedArray, same as an empty Blob.


### PR DESCRIPTION
### Problem
- `` Bun.$`cmd < ${readableStream}` `` crashes the process with `panic: TODO SHELL READABLE STREAM` (`Cmd::init_subproc_redirections`, `src/runtime/shell/states/Cmd.rs`). A second panic, `Unimplemented stdin readable_stream`, is in `Writable::init` (`src/runtime/shell/subproc.rs`).
- The shell stdin can only take a buffer that it already holds.

### Fix
- `Writable::init` wraps the child's stdin pipe in a `FileSink` and calls `FileSink::assign_to_stream`. A native `ByteStream` or `FileReader` source is wired to `SinkHandle::FileSink`, with backpressure and no JS. Any other stream uses the JS pump.
- `on_process_exit` takes the sink out of its slot, tells it that the child exited, and closes the `Cmd`'s stdin. An early child exit cancels the stream.
- A failed setup returns an error, and `dispose_failed_spawn` (`src/spawn/process.rs`) kills and reaps the child. A thrown non-`Error` value also fails the command.
- A stream redirect is stdin only. A locked or disturbed stream throws `ERR_INVALID_STATE`. A builtin command throws.
- Verified: `test/js/bun/shell/bunshell.test.ts` (13 new tests, stock bun panics). Also the `spawn-stdin-readable-stream*` suites and `shell-pipe-read-fault.test.ts`, on Linux debug ASAN and Windows.

### Background
- A `FileSink` is the native writer for an fd or a pipe. `Bun.spawn({ stdin: stream })` uses it.
- A `SinkHandle` is the tagged pointer that a native stream source holds to its consumer. The source writes bytes to the sink through it.
- A `SourceHandle` is the reverse pointer. The sink uses it to ask for more data or to cancel.
- A shell `Cmd` finishes when it has an exit code and each piped stdio is closed.

<details><summary>Notes</summary>

- Deleted: `SourceHandle::ShellWritable`, `shell::Writable::on_close`, and the block in `spawn_maybe_sync_impl` that wired them. Shell stdin is never `Stdio::Pipe`, so that block could not run. `WritableInitError::UnexpectedCreatingStdin` and its panic are replaced by `Sys` and `StreamAssign`.
- `*out_subproc` is now written once the `Subprocess` is initialised. The stream assignment can run user JS. If that JS ends the process, the `Cmd` must not hold a pointer to memory that is not initialised.
- `FileSink::attached_process_exited(&RefPtr<FileSink>, ..)` is a safe wrapper over `on_attached_process_exit`. The `Bun.spawn` call site that holds a `RefPtr` uses it too. The other call site holds a weak `NonNull` and is unchanged.
- New `unsafe` in the shell code: one `&mut *pipe.as_ptr()` to call `assign_to_stream(&mut self)` on the sink that `init` just created (the idiom of `subprocess::Writable::pipe_sink_mut`), and one `(*this).stdin.take_pipe()` in `on_process_exit`, which takes a raw `this` on main.
- `Bun.file(path).stream()` and a fully buffered stream collapse to a blob (`to_any_blob`) and take the `StaticPipeWriter` path.
- Leak probe, 25 iterations for each path (native source, JS stream, synchronous throw, non-`Error` throw, early child exit): fd delta 0, live `FileSink` delta 0, no zombie child.
- Also run: all of `bunshell.test.ts` (449 pass), `exec.test.ts`, `lazy.test.ts`, `bunshell-file.test.ts`. `rust:check-all` passes on 12 targets. clippy is clean.
- Rebased on main after #41436, #40516 and #40478. The shell now holds the sink as `RefPtr<FileSink>`, and one `Cmd::finish_if_done` finishes the command from the event that arrives last.
- Supersedes #30550, #33996, #35314, #35551.

</details>

Fixes #18262

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->