### PR TITLE
test(url): switch pathToFileURL leak fixture to bounded RSS delta

### DIFF
--- a/test/js/node/url/pathToFileURL-leak-fixture.js
+++ b/test/js/node/url/pathToFileURL-leak-fixture.js
@@ -1,21 +1,39 @@
-var longPath = Buffer.alloc(1021, "Z").toString();
-const isDebugBuildOfBun = globalThis?.Bun?.revision?.includes("debug");
-// ASAN's quarantine retains freed allocations (default 256 MB) and shadow
-// memory raises the absolute RSS floor; widen the cap to avoid false positives.
-const isASAN = process.execPath.includes("bun-asan");
+// Regression fixture for https://github.com/oven-sh/bun/pull/16784:
+// pathToFileURL leaked the native WTF::String for the resolved path on
+// every call (refcount was incremented but never released), which grew
+// RSS by ~3.4 KB per call.
+//
+// Instead of running hundreds of thousands of iterations and checking an
+// absolute RSS ceiling (which has to be branched for debug vs ASAN and is
+// slow on ASAN lanes), run a short warmup to let allocator pools settle,
+// sample RSS, run a measurement batch with a GC after each round so
+// collectible URL wrappers don't accumulate, then assert the growth is
+// bounded. The parent test spawns this with ASAN's free-quarantine
+// disabled so freed native allocations are returned immediately; with that
+// the no-leak delta is ~0 MB on release and <2 MB under debug+ASAN, while
+// the original leak would add ~14 MB over the measurement batch.
+import { pathToFileURL } from "url";
+
+const longPath = Buffer.alloc(1021, "Z").toString();
 const rss =
   process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
     ? Bun.unsafe.memoryFootprint
     : process.memoryUsage.rss;
-import { pathToFileURL } from "url";
-for (let i = 0; i < 1024 * (isDebugBuildOfBun ? 32 : 256); i++) {
-  pathToFileURL(longPath);
+
+function batch(n) {
+  for (let i = 0; i < n; i++) pathToFileURL(longPath);
+  Bun.gc(true);
 }
-Bun.gc(true);
-const limitMB = isASAN ? 700 : 250;
-const rssMB = (rss() / 1024 / 1024) | 0;
-console.log("RSS", rssMB, "MB");
-if (rssMB > limitMB) {
-  // On macOS, this was 860 MB.
-  throw new Error("RSS is too high. Must be less than " + limitMB + "MB");
+
+for (let i = 0; i < 4; i++) batch(512);
+const baseline = rss();
+
+for (let i = 0; i < 8; i++) batch(512);
+const after = rss();
+
+const deltaMB = (after - baseline) / 1024 / 1024;
+console.log("RSS delta", deltaMB.toFixed(1), "MB (baseline", (baseline / 1024 / 1024) | 0, "MB)");
+
+if (deltaMB > 8) {
+  throw new Error("pathToFileURL leaked " + deltaMB.toFixed(1) + " MB over 4096 calls");
 }

--- a/test/js/node/url/pathToFileURL-leak-fixture.js
+++ b/test/js/node/url/pathToFileURL-leak-fixture.js
@@ -1,20 +1,24 @@
 // Regression fixture for https://github.com/oven-sh/bun/pull/16784:
-// pathToFileURL leaked the native WTF::String for the resolved path on
-// every call (refcount was incremented but never released), which grew
-// RSS by ~3.4 KB per call.
+// pathToFileURL leaked one Latin1 WTF::StringImpl for the resolved path
+// per call, because the BunString returned from
+// ResolvePath__joinAbsStringBufCurrentPlatformBunString was converted via
+// toWTFString() instead of transferToWTFString() and never deref'd.
 //
 // Instead of running hundreds of thousands of iterations and checking an
 // absolute RSS ceiling (which has to be branched for debug vs ASAN and is
 // slow on ASAN lanes), run a short warmup to let allocator pools settle,
-// sample RSS, run a measurement batch with a GC after each round so
-// collectible URL wrappers don't accumulate, then assert the growth is
-// bounded. The parent test spawns this with ASAN's free-quarantine
-// disabled so freed native allocations are returned immediately; with that
-// the no-leak delta is ~0 MB on release and <2 MB under debug+ASAN, while
-// the original leak would add ~14 MB over the measurement batch.
+// sample RSS, run a measurement batch with a GC after each round so the
+// collectible DOMURL wrappers are reclaimed and only genuinely leaked
+// native allocations accumulate, then assert the growth is bounded. The
+// parent test spawns this with ASAN's free-quarantine disabled so freed
+// native allocations are returned immediately.
+//
+// With the leak reintroduced (PathInlines.h transferToWTFString ->
+// toWTFString) and the 4000-byte relative path below, the measured delta
+// over 4096 measurement calls is 18-19 MB; without the leak it is <2 MB.
 import { pathToFileURL } from "url";
 
-const longPath = Buffer.alloc(1021, "Z").toString();
+const longPath = Buffer.alloc(4000, "Z").toString();
 const rss =
   process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
     ? Bun.unsafe.memoryFootprint

--- a/test/js/node/url/pathToFileURL.test.ts
+++ b/test/js/node/url/pathToFileURL.test.ts
@@ -18,7 +18,7 @@ test.concurrent(
     expect(stdout).toStartWith("RSS delta");
     expect(exitCode).toBe(0);
   },
-  30_000,
+  60_000,
 );
 
 test("pathToFileURL escapes special characters", () => {

--- a/test/js/node/url/pathToFileURL.test.ts
+++ b/test/js/node/url/pathToFileURL.test.ts
@@ -1,15 +1,24 @@
 import { expect, test } from "bun:test";
-import { bunRun } from "harness";
+import { bunEnv, bunRun } from "harness";
 import path from "path";
 
 test.concurrent(
   "pathToFileURL doesn't leak memory",
   async () => {
-    const { stdout, stderr, exitCode } = await bunRun(path.join(import.meta.dir, "pathToFileURL-leak-fixture.js"));
-    if (exitCode !== 0) console.error(stderr || stdout);
+    const { stdout, stderr, exitCode } = await bunRun(path.join(import.meta.dir, "pathToFileURL-leak-fixture.js"), {
+      // ASAN holds freed allocations in a 256 MB quarantine by default, which
+      // inflates the fixture's RSS delta and previously forced a separate
+      // isASAN threshold. Disabling the quarantine keeps the delta build-type
+      // agnostic and lets the fixture use ~40x fewer iterations.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0", "thread_local_quarantine_size_kb=0"]
+        .filter(Boolean)
+        .join(":"),
+    });
+    expect(stderr).toBe("");
+    expect(stdout).toStartWith("RSS delta");
     expect(exitCode).toBe(0);
   },
-  300_000,
+  30_000,
 );
 
 test("pathToFileURL escapes special characters", () => {


### PR DESCRIPTION
## Problem

`test/js/node/url/pathToFileURL.test.ts` was the slowest file on the x64-asan lane at ~17s wall time (build #88691), spent entirely in the leak fixture.

The fixture ran `pathToFileURL(<relative path>)` for `1024 * (isDebugBuildOfBun ? 32 : 256)` iterations and compared absolute RSS to a ceiling that branched on `isDebug` and `isASAN`. Two of those checks were broken:

- `isDebugBuildOfBun = Bun.revision.includes("debug")` is always false: `Bun.revision` is the bare commit SHA. The canonical check is `Bun.version.includes("debug")`. So debug builds ran the full 262144 iterations instead of 32768.
- `isASAN = process.execPath.includes("bun-asan")` is only true on CI's named binary, not on a local `bun-debug` build (which is also ASAN-instrumented). So a local `bun bd test` applied the 250 MB non-ASAN ceiling and failed.

Net effect locally under `bun bd test`: 262144 iterations at ~1.5 ms/call (debug+ASAN) = ~6.5 minutes, then a spurious failure.

## Fix

Replace the absolute-RSS ceiling with a bounded-delta check so no build-type branching is needed:

1. Spawn the fixture with `ASAN_OPTIONS=...:quarantine_size_mb=0:thread_local_quarantine_size_kb=0` so freed native allocations are returned immediately instead of parked in ASAN's 256 MB quarantine. This is the same pattern used by the fetch/archive/json5 leak tests.
2. Warm up with 4 rounds of 512 calls (full GC after each) so allocator pools settle, then sample baseline RSS.
3. Run 8 more rounds of 512 calls (GC after each so JS URL wrappers don't accumulate) and sample RSS again.
4. Assert the delta is at most 8 MB.

The relative path is widened from 1021 to 4000 bytes. #16784's leak is a single Latin1 `WTF::StringImpl` of the resolved path per call, so the per-call leak scales with path length; at 1021 bytes the measured regression signal over 4096 calls is only ~5 MB, which the 8 MB threshold would not catch.

Iteration count drops 262144 -> 6144 (~43x). Timeout drops 300 s -> 60 s. The `isDebug` / `isASAN` special-casing and their broken detection are removed.

## Verification

The threshold was set from actual measurement, not back-of-envelope: the leak was reintroduced locally by flipping `PathInlines.h` `transferToWTFString()` back to `toWTFString()`, rebuilding, and running the fixture.

| build | no-leak delta | with-leak delta |
| --- | --- | --- |
| release | -2.1 to 0.9 MB | (not measured) |
| debug+ASAN, `quarantine_size_mb=0` | -1.2 to 1.3 MB | 18.0 - 19.0 MB |

With-leak run output under `bun bd test`:

```
error: pathToFileURL leaked 18.0 MB over 4096 calls
(fail) pathToFileURL doesn't leak memory [28520.30ms]
```

Without the leak:

```
$ bun bd test test/js/node/url/pathToFileURL.test.ts
(pass) pathToFileURL doesn't leak memory [28341.72ms]
(pass) pathToFileURL escapes special characters
 2 pass  0 fail

$ ./build/release/bun test test/js/node/url/pathToFileURL.test.ts
(pass) pathToFileURL doesn't leak memory [260.82ms]
(pass) pathToFileURL escapes special characters
 2 pass  0 fail
```

On the x64-asan CI lane (release+ASAN), 6144 iterations at ~3x the original per-call cost projects to ~1-2 s, down from 17 s.

## Assertion improvements

- `expect(stderr).toBe("")` and `expect(stdout).toStartWith("RSS delta")` run before the exit-code check, so a failing run shows the fixture's output directly instead of just `exitCode: 1`.
- The fixture's `console.log` includes both the delta and the absolute baseline.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/url/pathToFileURL.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/url/pathToFileURL.test.ts
bun test v1.4.0 (672e2bf13)

test/js/node/url/pathToFileURL.test.ts:
(pass) pathToFileURL doesn't leak memory [28396.07ms]
(pass) pathToFileURL escapes special characters [13.17ms]

 2 pass
 0 fail
 17 expect() calls
Ran 2 tests across 1 file. [30.38s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/url/pathToFileURL-leak-fixture.js | 52 ++++++++++++++++++--------
 test/js/node/url/pathToFileURL.test.ts         | 17 +++++++--
 2 files changed, 50 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
test/js/node/url/pathToFileURL-leak-fixture.js      2      3      0
test/js/node/url/pathToFileURL.test.ts              2      3      0
```

</details>

<!-- robobun:evidence:end -->