### PR TITLE
Bun.CryptoHasher: coerce algorithm once so HMAC reads the live key

### DIFF
--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -489,32 +489,32 @@ impl CryptoHasher {
             return Err(global.throw_invalid_arguments(format_args!("Invalid algorithm name")));
         }
 
-        let mut hmac_key: Option<StringOrBuffer> = None;
-        // `defer { if (hmac_key) |*key| key.deinit(); }` — handled by Drop on `hmac_key`.
-
-        if !hmac_value.is_empty_or_undefined_or_null() {
-            hmac_key = match StringOrBuffer::from_js(global, hmac_value)? {
-                Some(k) => Some(k),
-                None => {
-                    return Err(global
-                        .throw_invalid_arguments(format_args!("key must be a string or buffer")));
-                }
-            };
-        }
-
         let init = 'brk: {
-            if let Some(key) = &hmac_key {
-                let chosen_algorithm: evp::Algorithm = {
+            if !hmac_value.is_empty_or_undefined_or_null() {
+                // `algorithm` borrows the JSString produced by the coercion
+                // above, which nothing roots; resolve it to an enum before the
+                // key capture below can run user JS (a String-object key's
+                // toString()) and GC the backing string.
+                let chosen_algorithm: Option<evp::Algorithm> = {
                     let slice = algorithm.to_slice();
-                    match evp::lookup_ignore_case(slice.slice()) {
-                        Some(v) => v,
-                        None => {
-                            return Err(global.throw_invalid_arguments(format_args!(
-                                "algorithm must be one of {}",
-                                evp::ALGORITHM_ONE_OF
-                            )));
-                        }
+                    evp::lookup_ignore_case(slice.slice())
+                };
+
+                let key = match StringOrBuffer::from_js(global, hmac_value)? {
+                    Some(k) => k,
+                    None => {
+                        return Err(global.throw_invalid_arguments(format_args!(
+                            "key must be a string or buffer"
+                        )));
                     }
+                };
+                // `defer key.deinit()` — handled by Drop on `key`.
+
+                let Some(chosen_algorithm) = chosen_algorithm else {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "algorithm must be one of {}",
+                        evp::ALGORITHM_ONE_OF
+                    )));
                 };
 
                 break 'brk CryptoHasher::Hmac(JsCell::new(Some(

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -504,11 +504,11 @@ impl CryptoHasher {
 
         let init = 'brk: {
             if let Some(key) = &hmac_key {
-                // Inlined `JSValue::to_enum_from_map` (the `is_string` guard
-                // already ran above) so the lookup goes through the
-                // length-gated `evp::lookup_ignore_case` directly.
+                // Reuse the `algorithm` ZigString coerced above; coercing
+                // `algorithm_name` again would call user `toString()` a second
+                // time after `key`'s backing slice has been captured.
                 let chosen_algorithm: evp::Algorithm = {
-                    let slice = algorithm_name.to_slice(global)?;
+                    let slice = algorithm.to_slice();
                     match evp::lookup_ignore_case(slice.slice()) {
                         Some(v) => v,
                         None => {

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -504,9 +504,6 @@ impl CryptoHasher {
 
         let init = 'brk: {
             if let Some(key) = &hmac_key {
-                // Reuse the `algorithm` ZigString coerced above; coercing
-                // `algorithm_name` again would call user `toString()` a second
-                // time after `key`'s backing slice has been captured.
                 let chosen_algorithm: evp::Algorithm = {
                     let slice = algorithm.to_slice();
                     match evp::lookup_ignore_case(slice.slice()) {

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -494,10 +494,8 @@ impl CryptoHasher {
 
         let init = 'brk: {
             if !hmac_value.is_empty_or_undefined_or_null() {
-                // `algorithm` borrows the JSString produced by the coercion
-                // above, which nothing roots; resolve it to an enum before the
-                // key capture below can run user JS (a String-object key's
-                // toString()) and GC the backing string.
+                // Consume the borrowed bytes now: the key coercion below can
+                // run user JS and GC the string backing `algorithm`.
                 let chosen_algorithm: Option<evp::Algorithm> = {
                     let slice = algorithm.to_slice();
                     evp::lookup_ignore_case(slice.slice())

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -262,8 +262,6 @@ impl CryptoHasher {
             }
             string_value.get_zig_string(global)?
         };
-        // Own the borrowed bytes: the argument coercions below can run user JS
-        // (a String-object toString()) and GC the string backing the view.
         let algorithm = algorithm.to_slice_clone();
 
         // Node.BlobOrStringOrBuffer
@@ -494,8 +492,6 @@ impl CryptoHasher {
 
         let init = 'brk: {
             if !hmac_value.is_empty_or_undefined_or_null() {
-                // Consume the borrowed bytes now: the key coercion below can
-                // run user JS and GC the string backing `algorithm`.
                 let chosen_algorithm: Option<evp::Algorithm> = {
                     let slice = algorithm.to_slice();
                     evp::lookup_ignore_case(slice.slice())

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -262,6 +262,9 @@ impl CryptoHasher {
             }
             string_value.get_zig_string(global)?
         };
+        // Own the borrowed bytes: the argument coercions below can run user JS
+        // (a String-object toString()) and GC the string backing the view.
+        let algorithm = algorithm.to_slice_clone();
 
         // Node.BlobOrStringOrBuffer
         let Some(input_arg) = next_eat() else {
@@ -298,7 +301,7 @@ impl CryptoHasher {
             buffer.buffer = ArrayBuffer::from_typed_array(global, buffer.buffer.value);
         }
 
-        Self::hash_(global, algorithm, &input, output)
+        Self::hash_(global, ZigString::from_utf8(algorithm.slice()), &input, output)
     }
 
     fn throw_hmac_consumed(global: &JSGlobalObject) -> JsError {

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -193,10 +193,11 @@ describe("HMAC", () => {
     // toString() after the key slice is captured lets user code free the
     // backing store, so HMAC::init sees recycled heap instead of the key.
     const source = /* js */ `
-      import { createHmac } from "node:crypto";
+      import { createHmac, createHash } from "node:crypto";
       const N = 1 << 20;
       const hmac = k => createHmac("sha256", k).update("payload").digest("hex");
-      const out = { second: [], first: [], gcKey: [], errorOrder: null };
+      const sha = createHash("sha256").update("payload").digest("hex");
+      const out = { second: [], first: [], gcKey: [], hashGc: [], errorOrder: null };
       for (let i = 0; i < 5; i++) {
         const key = new Uint8Array(N).fill(0x41);
         const orig = key.slice();
@@ -252,6 +253,27 @@ describe("HMAC", () => {
         const got = new Bun.CryptoHasher(alg, key).update("payload").digest("hex");
         out.gcKey.push({ calls, ok: got === hmac("secret-key") });
       }
+      // Static hash() has the same shape: the output-encoding coercion runs
+      // after the algorithm string was coerced, and GC pressure there must
+      // not invalidate the algorithm.
+      for (let i = 0; i < 3; i++) {
+        let calls = 0;
+        const alg = new String("sha256");
+        // Build a fresh, non-atomized string each call so nothing roots it.
+        alg.toString = () => {
+          calls++;
+          return ("sha256" + i).slice(0, 6);
+        };
+        const spray = [];
+        const enc = new String("hex");
+        enc.toString = () => {
+          Bun.gc(true);
+          for (let j = 0; j < 8; j++) spray.push(new Uint8Array(N).fill(0x5a));
+          return "hex";
+        };
+        const got = Bun.CryptoHasher.hash(alg, "payload", enc);
+        out.hashGc.push({ calls, ok: got === sha });
+      }
       // Error ordering: the key is coerced before the algorithm is validated,
       // so a throwing key toString() wins over an unsupported algorithm.
       {
@@ -290,6 +312,11 @@ describe("HMAC", () => {
         { calls: 1, detached: true, ok: true },
       ],
       gcKey: [
+        { calls: 1, ok: true },
+        { calls: 1, ok: true },
+        { calls: 1, ok: true },
+      ],
+      hashGc: [
         { calls: 1, ok: true },
         { calls: 1, ok: true },
         { calls: 1, ok: true },

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, withoutAggressiveGC } from "harness";
-import { createHash } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 
 test("Bun.file in CryptoHasher is not supported yet", () => {
   expect(() => Bun.SHA1.hash(Bun.file(import.meta.path))).toThrow();
@@ -187,6 +187,60 @@ test("Bun.sha reads its buffers only after every argument has been coerced", asy
 });
 
 describe("HMAC", () => {
+  test("constructor coerces the algorithm once and reads the key before any later coercion", async () => {
+    // The algorithm argument must be stringified exactly once, and that one
+    // coercion must happen before the hmac key's bytes are read. A second
+    // toString() after the key slice is captured lets user code free the
+    // backing store, so HMAC::init sees recycled heap instead of the key.
+    const source = /* js */ `
+      import { createHmac } from "node:crypto";
+      const N = 1 << 20;
+      const attempts = [];
+      for (let i = 0; i < 5; i++) {
+        const key = new Uint8Array(N).fill(0x41);
+        const orig = key.slice();
+        const spray = [];
+        let calls = 0;
+        const alg = new String("sha256");
+        alg.toString = () => {
+          if (++calls > 1) {
+            key.buffer.transfer(0);
+            for (let j = 0; j < 8; j++) spray.push(new Uint8Array(N).fill(0x5a));
+          }
+          return "sha256";
+        };
+        const got = new Bun.CryptoHasher(alg, key).update("payload").digest("hex");
+        const want = createHmac("sha256", orig).update("payload").digest("hex");
+        attempts.push({ calls, ok: got === want });
+      }
+      console.log(JSON.stringify(attempts));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const attempts = JSON.parse(stdout.trim());
+    expect(attempts).toEqual([
+      { calls: 1, ok: true },
+      { calls: 1, ok: true },
+      { calls: 1, ok: true },
+      { calls: 1, ok: true },
+      { calls: 1, ok: true },
+    ]);
+    expect(exitCode).toBe(0);
+
+    // The non-hostile case: a primitive-string algorithm + buffer key must
+    // produce the same digest as node:crypto's createHmac.
+    const keyBuf = Buffer.alloc(64, 0x41);
+    expect(new Bun.CryptoHasher("sha256", keyBuf).update("payload").digest("hex")).toBe(
+      createHmac("sha256", keyBuf).update("payload").digest("hex"),
+    );
+  });
+
   const hashes = {
     "sha1": "e2e1f7f597941d9b0021978618218a9e08731426",
     "sha256": "c7a7c96c73af32ea6e5b1ca6768b1d822249eb88f85160433d7b09bb2b21e170",

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -195,7 +195,8 @@ describe("HMAC", () => {
     const source = /* js */ `
       import { createHmac } from "node:crypto";
       const N = 1 << 20;
-      const attempts = [];
+      const hmac = k => createHmac("sha256", k).update("payload").digest("hex");
+      const out = { second: [], first: [] };
       for (let i = 0; i < 5; i++) {
         const key = new Uint8Array(N).fill(0x41);
         const orig = key.slice();
@@ -210,10 +211,27 @@ describe("HMAC", () => {
           return "sha256";
         };
         const got = new Bun.CryptoHasher(alg, key).update("payload").digest("hex");
-        const want = createHmac("sha256", orig).update("payload").digest("hex");
-        attempts.push({ calls, ok: got === want });
+        out.second.push({ calls, ok: got === hmac(orig) });
       }
-      console.log(JSON.stringify(attempts));
+      // Detaching during the single toString() must yield HMAC(empty key):
+      // the algorithm is coerced before the key is captured, so the key
+      // capture sees the already-detached buffer as zero-length.
+      for (let i = 0; i < 3; i++) {
+        const key = new Uint8Array(N).fill(0x41);
+        const spray = [];
+        let calls = 0;
+        const alg = new String("sha256");
+        alg.toString = () => {
+          if (++calls === 1) {
+            key.buffer.transfer(0);
+            for (let j = 0; j < 8; j++) spray.push(new Uint8Array(N).fill(0x5a));
+          }
+          return "sha256";
+        };
+        const got = new Bun.CryptoHasher(alg, key).update("payload").digest("hex");
+        out.first.push({ calls, detached: key.byteLength === 0, ok: got === hmac(new Uint8Array(0)) });
+      }
+      console.log(JSON.stringify(out));
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", source],
@@ -223,14 +241,20 @@ describe("HMAC", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    const attempts = JSON.parse(stdout.trim());
-    expect(attempts).toEqual([
-      { calls: 1, ok: true },
-      { calls: 1, ok: true },
-      { calls: 1, ok: true },
-      { calls: 1, ok: true },
-      { calls: 1, ok: true },
-    ]);
+    expect(JSON.parse(stdout.trim())).toEqual({
+      second: [
+        { calls: 1, ok: true },
+        { calls: 1, ok: true },
+        { calls: 1, ok: true },
+        { calls: 1, ok: true },
+        { calls: 1, ok: true },
+      ],
+      first: [
+        { calls: 1, detached: true, ok: true },
+        { calls: 1, detached: true, ok: true },
+        { calls: 1, detached: true, ok: true },
+      ],
+    });
     expect(exitCode).toBe(0);
 
     // The non-hostile case: a primitive-string algorithm + buffer key must

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -196,7 +196,7 @@ describe("HMAC", () => {
       import { createHmac } from "node:crypto";
       const N = 1 << 20;
       const hmac = k => createHmac("sha256", k).update("payload").digest("hex");
-      const out = { second: [], first: [] };
+      const out = { second: [], first: [], gcKey: [] };
       for (let i = 0; i < 5; i++) {
         const key = new Uint8Array(N).fill(0x41);
         const orig = key.slice();
@@ -231,6 +231,27 @@ describe("HMAC", () => {
         const got = new Bun.CryptoHasher(alg, key).update("payload").digest("hex");
         out.first.push({ calls, detached: key.byteLength === 0, ok: got === hmac(new Uint8Array(0)) });
       }
+      // A String-object key coerces via its own toString(), which runs after
+      // the algorithm string was coerced. GC pressure in that window must not
+      // invalidate the algorithm: the digest must use sha256 and the real key.
+      for (let i = 0; i < 3; i++) {
+        let calls = 0;
+        const alg = new String("sha256");
+        // Build a fresh, non-atomized string each call so nothing roots it.
+        alg.toString = () => {
+          calls++;
+          return ("sha256" + i).slice(0, 6);
+        };
+        const spray = [];
+        const key = new String("secret-key");
+        key.toString = () => {
+          Bun.gc(true);
+          for (let j = 0; j < 8; j++) spray.push(new Uint8Array(N).fill(0x5a));
+          return "secret-key";
+        };
+        const got = new Bun.CryptoHasher(alg, key).update("payload").digest("hex");
+        out.gcKey.push({ calls, ok: got === hmac("secret-key") });
+      }
       console.log(JSON.stringify(out));
     `;
     await using proc = Bun.spawn({
@@ -253,6 +274,11 @@ describe("HMAC", () => {
         { calls: 1, detached: true, ok: true },
         { calls: 1, detached: true, ok: true },
         { calls: 1, detached: true, ok: true },
+      ],
+      gcKey: [
+        { calls: 1, ok: true },
+        { calls: 1, ok: true },
+        { calls: 1, ok: true },
       ],
     });
     expect(exitCode).toBe(0);

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -196,7 +196,7 @@ describe("HMAC", () => {
       import { createHmac } from "node:crypto";
       const N = 1 << 20;
       const hmac = k => createHmac("sha256", k).update("payload").digest("hex");
-      const out = { second: [], first: [], gcKey: [] };
+      const out = { second: [], first: [], gcKey: [], errorOrder: null };
       for (let i = 0; i < 5; i++) {
         const key = new Uint8Array(N).fill(0x41);
         const orig = key.slice();
@@ -252,6 +252,20 @@ describe("HMAC", () => {
         const got = new Bun.CryptoHasher(alg, key).update("payload").digest("hex");
         out.gcKey.push({ calls, ok: got === hmac("secret-key") });
       }
+      // Error ordering: the key is coerced before the algorithm is validated,
+      // so a throwing key toString() wins over an unsupported algorithm.
+      {
+        const key = new String("secret-key");
+        key.toString = () => {
+          throw new Error("key conversion failed");
+        };
+        try {
+          new Bun.CryptoHasher("unsupported-algorithm", key);
+          out.errorOrder = "no throw";
+        } catch (e) {
+          out.errorOrder = e.message;
+        }
+      }
       console.log(JSON.stringify(out));
     `;
     await using proc = Bun.spawn({
@@ -280,6 +294,7 @@ describe("HMAC", () => {
         { calls: 1, ok: true },
         { calls: 1, ok: true },
       ],
+      errorOrder: "key conversion failed",
     });
     expect(exitCode).toBe(0);
 


### PR DESCRIPTION
`new Bun.CryptoHasher(algorithm, hmacKey)` stringified `algorithm` twice when `hmacKey` was present: once via `get_zig_string()` before capturing the key, then again via `JSValue::to_slice()` after the key's `(ptr,len)` was borrowed. A `String`-object algorithm whose second `toString()` detaches the key's ArrayBuffer left `HMAC::init` reading a freed + recycled backing store, so the MAC was silently computed under whatever bytes the allocator handed back next.

## Reproduction

```js
import { createHmac } from "node:crypto";
const N = 1 << 20;
const key = new Uint8Array(N).fill(0x41), orig = key.slice();
let calls = 0, spray = [];
const alg = new String("sha256");
alg.toString = () => {
  if (++calls === 2) { key.buffer.transfer(0); for (let i = 0; i < 8; i++) spray.push(new Uint8Array(N).fill(0x5a)); }
  return "sha256";
};
const got = new Bun.CryptoHasher(alg, key).update("payload").digest("hex");
const want = createHmac("sha256", orig).update("payload").digest("hex");
console.log({ calls, ok: got === want });
// before: { calls: 2, ok: false }  (digest == HMAC(0x5a-filled block))
```

On the shipping canary this reproduces 5/5; the digest equals `HMAC(recycled 0x5a block)` on every attempt.

## Fix

Coerce `algorithm` once and resolve it to its `evp::Algorithm` enum value before the key is captured. The borrowed string bytes are fully consumed before `StringOrBuffer::from_js` runs (which can re-enter user JS for a `String`-object key), and `HMAC::init` follows the key capture with no JS in between, so nothing derived from JS memory is read after a reentry point. Error ordering is unchanged: an invalid key type still reports before an unknown algorithm (verified against the release binary).

The static `Bun.CryptoHasher.hash()` had the same shape (the algorithm `ZigString` borrowed across the output and input coercions); it now clones the algorithm bytes before either coercion runs.

#35757 would independently fix the use-after-free by pinning the `StringOrBuffer` input, but the double `toString()` on `algorithm` is observable on its own and is fixed here regardless.

## Verification

The test spawns a child covering five scenarios: the free + respray reproduction above (5 attempts, asserting `{ calls: 1, ok: true }`), detaching the key during the single algorithm `toString()` (must yield HMAC over an empty key), a `String`-object key whose `toString()` forces GC + respray while the algorithm came from a freshly built string (the digest must still use sha256 and the real key), the same GC + respray shape against the static `hash()` via a `String`-object output encoding, and a throwing key `toString()` with an unsupported algorithm (the key coercion error wins). The file fails on main (`calls: 2`, wrong digests) and passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-cryptohasher.test.ts
bun test v1.4.0 (57071a188)

test/js/bun/util/bun-cryptohasher.test.ts:
(pass) Bun.file in CryptoHasher is not supported yet [11.02ms]
(pass) CryptoHasher update should throw when no parameter/null/undefined is passed [6.55ms]
(pass) CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto [36.69ms]
(pass) CryptoHasher throws on non-latin1 algorithm names instead of crashing [9.03ms]
(pass) static hash reads the input buffer only after every argument has been coerced [405.54ms]
(pass) Bun.sha reads its buffers only after every argument has been coerced [385.53ms]
296 |       stdout: "pipe",
297 |       stderr: "pipe",
298 |     });
299 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
300 |     expect(stderr).toBe("");
301 |     expect(JSON.parse(stdout.trim())).toEqual({
                                            ^
error: expect(received).toEqual(expected)

  {
    "errorOrder": "key conversion failed",
    "first
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (b58cd4685)

test/js/bun/util/bun-cryptohasher.test.ts:
(pass) Bun.file in CryptoHasher is not supported yet [0.20ms]
(pass) CryptoHasher update should throw when no parameter/null/undefined is passed [0.05ms]
(pass) CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto [0.45ms]
(pass) CryptoHasher throws on non-latin1 algorithm names instead of crashing [0.15ms]
(pass) static hash reads the input buffer only after every argument has been coerced [8.93ms]
(pass) Bun.sha reads its buffers only after every argument has been coerced [7.51ms]
296 |       stdout: "pipe",
297 |       stderr: "pipe",
298 |     });
299 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
300 |     expect(stderr).toBe("");
301 |     expect(JSON.parse(stdout.trim())).toEqual({
                                            ^
error: expect(received).toEqual(expected)

  {
    "errorOrder": "key conversion failed",
    "first": [
      {
-       "calls": 1,
+       "calls": 2,
        "detached": true,
        "ok": true,
      },
      {
-       "calls": 1,
+       "calls": 2,
        "detache
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-cryptohasher.test.ts
bun test v1.4.0 (57071a188)

test/js/bun/util/bun-cryptohasher.test.ts:
(pass) Bun.file in CryptoHasher is not supported yet [11.59ms]
(pass) CryptoHasher update should throw when no parameter/null/undefined is passed [6.18ms]
(pass) CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto [36.10ms]
(pass) CryptoHasher throws on non-latin1 algorithm names instead of crashing [9.50ms]
(pass) static hash reads the input buffer only after every argument has been coerced [400.95ms]
(pass) Bun.sha reads its buffers only after every argument has been coerced [390.73ms]
(pass) HMAC > constructor coerces the algorithm once and reads the key before any later coercion [1259.39ms]
(pass) HMAC > sha1 (key: String) [14.03ms]
(pass) HMAC > sha256 (key: String) [5.54ms]
(pass) HMAC > sha384 (key: String) [3.42ms]
(pass) HMAC > sha512 (key: String) [3.31ms]
(pass) HMAC > blake2b512 (key: String) [3.42ms]
(pass) HMAC > md5 (key: String) [3.60ms]
(pass) HMAC > sha224 (key: String) [3.28ms]
(pass) 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     57071a188c
  features     baseline

22 deps, 106 codegen, 1175 objects in 652ms

ninja: Entering directory `/workspace/bun/build/release'
[1/133] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 239 extern-C blocks audited
[2/133] gen cpp.rs (cppbind)
[3/133] gen BunObject.lut.h
Generating /workspace/bun/build/release/codegen/BunObject.lut.h from /workspace/bun/src/jsc/bindings/BunObject.cpp
[4/133] gen JS modules (bundle-modules)
Preprocess modules (8677ms)
Bundle modules (80ms)
Postprocesss modules (248ms)
Bundle Functions (627ms)
Generate Code (27ms)

[9.68s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  84 internal functions across 17 files
[4/132] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_cor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/crypto/CryptoHasher.rs        |  50 +++++-----
 test/js/bun/util/bun-cryptohasher.test.ts | 148 +++++++++++++++++++++++++++++-
 2 files changed, 169 insertions(+), 29 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/crypto/CryptoHasher.rs             6      9      0
test/js/bun/util/bun-cryptohasher.test.ts      4     14      0
```

</details>

<!-- robobun:evidence:end -->
