### PR TITLE
loader: document the empty `--loader` extension, accept it in bunfig too

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -87,6 +87,8 @@ Configure how Bun maps file extensions to loaders. This is useful for loading fi
 [loader]
 # when a .bagel file is imported, treat it like a tsx file
 ".bagel" = "tsx"
+# an empty extension maps files that have none, which Bun otherwise treats as tsx
+"" = "ts"
 ```
 
 Bun supports the following loaders:

--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -198,7 +198,8 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--loader" type="string">
-  Parse files with <code>.ext:loader</code>, e.g. <code>--loader .js:jsx</code>. Valid loaders: <code>js</code>,{" "}
+  Parse files with <code>.ext:loader</code>, e.g. <code>--loader .js:jsx</code>. An empty extension maps
+  files that have none, e.g. <code>--loader :ts</code>. Valid loaders: <code>js</code>,{" "}
   <code>jsx</code>, <code>ts</code>, <code>tsx</code>, <code>json</code>, <code>toml</code>, <code>text</code>,{" "}
   <code>file</code>, <code>wasm</code>, <code>napi</code>. Alias: <code>-l</code>
 </ParamField>

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1065,10 +1065,8 @@ impl<'a> Parser<'a> {
                 let key = key_expr
                     .as_string(self.bump)
                     .expect("infallible: type checked");
-                if key.is_empty() {
-                    continue;
-                }
-                if key[0] != b'.' {
+                // An empty key maps files with no extension, as `--loader :ts` does.
+                if !key.is_empty() && key[0] != b'.' {
                     self.add_error(
                         key_expr.loc,
                         b"file extension for loader must start with a '.'",

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -159,7 +159,7 @@ pub(crate) const TRANSPILER_PARAMS_: &[ParamType] = &[
         "--feature <STR>...               Enable a feature flag for dead-code elimination, e.g. --feature=SUPER_SECRET"
     ),
     parse_param!(
-        "-l, --loader <STR>...             Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, text, file, wasm, napi"
+        "-l, --loader <STR>...             Parse files with .ext:loader, e.g. --loader .js:jsx, or :ts for extensionless files. Valid loaders: js, jsx, ts, tsx, json, toml, text, file, wasm, napi"
     ),
     parse_param!(
         "--no-macros                       Disable macros from being executed in the bundler, transpiler and runtime"

--- a/src/runtime/cli/Arguments.zig
+++ b/src/runtime/cli/Arguments.zig
@@ -67,7 +67,7 @@ pub const transpiler_params_ = [_]ParamType{
     clap.parseParam("-d, --define <STR>...              Substitute K:V while parsing, e.g. --define process.env.NODE_ENV:\"development\". Values are parsed as JSON.") catch unreachable,
     clap.parseParam("--drop <STR>...                   Remove function calls, e.g. --drop=console removes all console.* calls.") catch unreachable,
     clap.parseParam("--feature <STR>...               Enable a feature flag for dead-code elimination, e.g. --feature=SUPER_SECRET") catch unreachable,
-    clap.parseParam("-l, --loader <STR>...             Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, text, file, wasm, napi") catch unreachable,
+    clap.parseParam("-l, --loader <STR>...             Parse files with .ext:loader, e.g. --loader .js:jsx, or :ts for extensionless files. Valid loaders: js, jsx, ts, tsx, json, toml, text, file, wasm, napi") catch unreachable,
     clap.parseParam("--no-macros                       Disable macros from being executed in the bundler, transpiler and runtime") catch unreachable,
     clap.parseParam("--jsx-factory <STR>               Changes the function called when compiling JSX elements using the classic JSX runtime") catch unreachable,
     clap.parseParam("--jsx-fragment <STR>              Changes the function called when compiling JSX fragments") catch unreachable,

--- a/src/runtime/cli/bunfig.zig
+++ b/src/runtime/cli/bunfig.zig
@@ -1188,8 +1188,8 @@ pub const Bunfig = struct {
 
                 for (properties, 0..) |item, i| {
                     const key = item.key.?.asString(allocator).?;
-                    if (key.len == 0) continue;
-                    if (key[0] != '.') {
+                    // An empty key maps files with no extension, as `--loader :ts` does.
+                    if (key.len > 0 and key[0] != '.') {
                         try this.addError(item.key.?.loc, "file extension for loader must start with a '.'");
                     }
                     var value = item.value.?;

--- a/test/cli/run/run-extensionless.test.ts
+++ b/test/cli/run/run-extensionless.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tempDirWithFiles, tmpdirSync } from "harness";
 import { join } from "path";
 
 describe.concurrent("run-extensionless", () => {
@@ -25,6 +25,53 @@ describe.concurrent("run-extensionless", () => {
 
     await using proc = Bun.spawn({
       cmd: [join(dir, "./cool")],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+    });
+    const stdout = await proc.stdout.text();
+    expect(stdout).toEqual("hello world\n");
+  });
+
+  // `--loader` takes an empty extension, which maps files that have none. `<T>(x: T) => x`
+  // is a generic arrow to the ts loader and an unclosed tag to the tsx loader, so it parses
+  // only when the mapping took effect.
+  test("--loader with an empty extension sets the loader for extensionless files", async () => {
+    const dir = tmpdirSync();
+    mkdirSync(dir, { recursive: true });
+    await Bun.write(join(dir, "cool"), "const id = <T>(x: T) => x; console.log(id('hello world'));");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--loader=:ts", join(dir, "./cool")],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+    });
+    const stdout = await proc.stdout.text();
+    expect(stdout).toEqual("hello world\n");
+  });
+
+  test("[loader] with an empty extension sets the loader for extensionless files", async () => {
+    const dir = tempDirWithFiles("bunfig-loader-extensionless", {
+      cool: "const id = <T>(x: T) => x; console.log(id('hello world'));",
+      "bunfig.toml": '[loader]\n"" = "ts"\n',
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(dir, "./cool")],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+    });
+    const stdout = await proc.stdout.text();
+    expect(stdout).toEqual("hello world\n");
+  });
+
+  test("--loader with an empty extension applies to imported extensionless files", async () => {
+    const dir = tmpdirSync();
+    mkdirSync(dir, { recursive: true });
+    await Bun.write(join(dir, "dep"), "export const id = <T>(x: T) => x;");
+    await Bun.write(join(dir, "main.ts"), "import { id } from './dep'; console.log(id('hello world'));");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--loader=:ts", join(dir, "./main.ts")],
       cwd: dir,
       env: bunEnv,
       stdout: "pipe",


### PR DESCRIPTION
Mostly a documentation gap.

`--loader` already accepts an empty extension, mapping files that have none —
which matters because Bun reads extensionless files with the `tsx` loader, where
a generic arrow (`<T>(x: T) => x`) is an unclosed tag. `colon_list_type`
deliberately allows the empty key, but `--help` and the docs both imply an
extension is required, so the capability is undiscoverable and untested.

Briefly, how it threw me off: I concluded the mapping didn't exist at all — the
flag docs implied it, and the bunfig spelling failed silently rather than saying
anything.

Included here:

- `--help` (both copies) and the `bun run` / bunfig docs pages mention the empty
  extension
- bunfig `[loader]` accepts an empty key, matching the CLI. The zig parser's
  `continue` for that key also left an uninitialized entry in the loader map, so
  a bunfig containing one sent extensionless imports through the `file` loader
- tests for both spellings, and for an extensionless file reached by an import

Repro of the bunfig behavior on 1.3.14:

```console
$ cat bunfig.toml
[loader]
"" = "ts"
".foo" = "ts"
$ echo 'export const x = 1;' > mod
$ bun -e 'console.log(await import("./mod"))'
Module {
  __esModule: true,
  default: "/tmp/repro/mod",
}
```

I haven't built Bun locally: the four `--loader` tests pass against a released
1.3.14, while the bunfig test needs the parser change compiled, so CI is its
first real run.

The zig → rust migration is clearly in flight — this touches both copies of the
parser and of the help text. Please take it as a sketch of one way it could land
rather than a finished patch; happy to reshape it to whatever fits the
transition.
