### PR TITLE
node:http2: copy goaway opaqueData before writing over JS-backed sockets

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -6603,10 +6603,8 @@ impl H2FrameParser {
             if callframe.arguments_count() >= 3 {
                 if !opaque_data_arg.is_empty_or_undefined_or_null() {
                     if let Some(array_buffer) = opaque_data_arg.as_array_buffer(global_object) {
-                        // send_go_away's write() can re-enter JS on JS-backed sockets (cork flush →
-                        // onWrite → Duplex write), and that JS can detach/transfer this buffer. Own
-                        // the bytes before any JS can run so the GOAWAY payload is what the caller
-                        // passed, not whatever later occupies that heap block.
+                        // write() re-enters JS on JS-backed sockets (cork flush → onWrite), where
+                        // user code can detach this buffer; own the bytes before that can happen.
                         let copied = array_buffer.byte_slice().to_vec();
                         this.send_go_away(
                             0,

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -6603,11 +6603,15 @@ impl H2FrameParser {
             if callframe.arguments_count() >= 3 {
                 if !opaque_data_arg.is_empty_or_undefined_or_null() {
                     if let Some(array_buffer) = opaque_data_arg.as_array_buffer(global_object) {
-                        let slice = array_buffer.byte_slice();
+                        // send_go_away's write() can re-enter JS on JS-backed sockets (cork flush →
+                        // onWrite → Duplex write), and that JS can detach/transfer this buffer. Own
+                        // the bytes before any JS can run so the GOAWAY payload is what the caller
+                        // passed, not whatever later occupies that heap block.
+                        let copied = array_buffer.byte_slice().to_vec();
                         this.send_go_away(
                             0,
                             ErrorCode(error_code as u32),
-                            slice,
+                            &copied,
                             last_stream_id,
                             false,
                         );

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -6603,8 +6603,7 @@ impl H2FrameParser {
             if callframe.arguments_count() >= 3 {
                 if !opaque_data_arg.is_empty_or_undefined_or_null() {
                     if let Some(array_buffer) = opaque_data_arg.as_array_buffer(global_object) {
-                        // write() re-enters JS on JS-backed sockets (cork flush → onWrite), where
-                        // user code can detach this buffer; own the bytes before that can happen.
+                        // Own the bytes: write() re-enters JS on JS-backed sockets and can detach this.
                         let copied = array_buffer.byte_slice().to_vec();
                         this.send_go_away(
                             0,

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1926,6 +1926,65 @@ it("http2 session.goaway() sends custom data", async done => {
   });
 });
 
+it("http2 session.goaway() opaqueData survives re-entrant buffer detach over a JS Duplex", async () => {
+  // The cork-flush path re-enters JS (onWrite → Duplex _write) when the transport is a JS
+  // stream. If that JS detaches the opaqueData ArrayBuffer mid-write, the GOAWAY payload must
+  // still be the bytes the caller passed, not whatever later occupies that heap block.
+  const fixture = `
+    const http2 = require("node:http2");
+    const { Duplex } = require("node:stream");
+    const N = 256 * 1024;
+    let opaque = new Uint8Array(N).fill(0x41);
+    const spray = [], received = [];
+    let armed = false, fired = false;
+    const duplex = new Duplex({
+      read() {},
+      write(chunk, enc, cb) {
+        received.push(Buffer.from(chunk));
+        if (armed && !fired && chunk.length >= 16384) {
+          fired = true;
+          opaque.buffer.transfer(0);
+          opaque = null;
+          Bun.gc(true);
+          for (let i = 0; i < 64; i++) spray.push(new Uint8Array(N).fill(0x5a));
+        }
+        cb();
+      },
+    });
+    const session = http2.connect("http://127.0.0.1:1", { createConnection: () => duplex });
+    session.on("error", () => {});
+    session.once("connect", () => {
+      setImmediate(() => {
+        received.length = 0;
+        armed = true;
+        session.goaway(0, 0, opaque);
+        setImmediate(() => {
+          const all = Buffer.concat(received);
+          let off = 0;
+          while (off + 9 <= all.length && all[off + 3] !== 7) off += 9 + all.readUIntBE(off, 3);
+          const len = all.readUIntBE(off, 3);
+          const payload = all.subarray(off + 17, off + 9 + len);
+          let ok = 0;
+          for (const b of payload) if (b === 0x41) ok++;
+          console.log(JSON.stringify({ fired, declared: payload.length, ok }));
+          process.exit(0);
+        });
+      });
+    });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout.trim());
+  expect(result).toEqual({ fired: true, declared: 256 * 1024, ok: 256 * 1024 });
+  expect(exitCode).toBe(0);
+});
+
 it("http2 server sends protocol-error GOAWAY on stream 0", async () => {
   // RFC 9113 section 6.8: GOAWAY frames MUST be sent with a stream identifier
   // of 0 in the frame header; the last processed stream id lives in the

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1933,44 +1933,46 @@ it("http2 session.goaway() opaqueData survives re-entrant buffer detach over a J
   const fixture = `
     const http2 = require("node:http2");
     const { Duplex } = require("node:stream");
-    const N = 256 * 1024;
+    const N = 64 * 1024;
+    const GOAWAY_WIRE_SIZE = 9 + 8 + N;
     let opaque = new Uint8Array(N).fill(0x41);
     const spray = [], received = [];
-    let armed = false, fired = false;
+    let armed = false, fired = false, total = 0, onComplete;
     const duplex = new Duplex({
       read() {},
       write(chunk, enc, cb) {
-        received.push(Buffer.from(chunk));
-        if (armed && !fired && chunk.length >= 16384) {
-          fired = true;
-          opaque.buffer.transfer(0);
-          opaque = null;
-          Bun.gc(true);
-          for (let i = 0; i < 64; i++) spray.push(new Uint8Array(N).fill(0x5a));
+        if (armed) {
+          received.push(Buffer.from(chunk));
+          total += chunk.length;
+          if (!fired && chunk.length >= 16384) {
+            fired = true;
+            opaque.buffer.transfer(0);
+            opaque = null;
+            Bun.gc(true);
+            for (let i = 0; i < 16; i++) spray.push(new Uint8Array(N).fill(0x5a));
+          }
+          if (total >= GOAWAY_WIRE_SIZE && onComplete) onComplete();
         }
         cb();
       },
     });
     const session = http2.connect("http://127.0.0.1:1", { createConnection: () => duplex });
     session.on("error", () => {});
-    session.once("connect", () => {
-      setImmediate(() => {
-        received.length = 0;
-        armed = true;
-        session.goaway(0, 0, opaque);
-        setImmediate(() => {
-          const all = Buffer.concat(received);
-          let off = 0;
-          while (off + 9 <= all.length && all[off + 3] !== 7) off += 9 + all.readUIntBE(off, 3);
-          const len = all.readUIntBE(off, 3);
-          const payload = all.subarray(off + 17, off + 9 + len);
-          let ok = 0;
-          for (const b of payload) if (b === 0x41) ok++;
-          console.log(JSON.stringify({ fired, declared: payload.length, ok }));
-          process.exit(0);
-        });
-      });
-    });
+    await new Promise(r => session.once("connect", r));
+    await new Promise(r => setImmediate(r));
+    armed = true;
+    const complete = new Promise(r => (onComplete = r));
+    session.goaway(0, 0, opaque);
+    if (total < GOAWAY_WIRE_SIZE) await complete;
+    const all = Buffer.concat(received);
+    let off = 0;
+    while (off + 9 <= all.length && all[off + 3] !== 7) off += 9 + all.readUIntBE(off, 3);
+    const len = all.readUIntBE(off, 3);
+    const payload = all.subarray(off + 17, off + 9 + len);
+    let ok = 0;
+    for (const b of payload) if (b === 0x41) ok++;
+    console.log(JSON.stringify({ fired, declared: payload.length, ok }));
+    process.exit(0);
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", fixture],
@@ -1981,9 +1983,9 @@ it("http2 session.goaway() opaqueData survives re-entrant buffer detach over a J
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   const result = JSON.parse(stdout.trim());
-  expect(result).toEqual({ fired: true, declared: 256 * 1024, ok: 256 * 1024 });
+  expect(result).toEqual({ fired: true, declared: 64 * 1024, ok: 64 * 1024 });
   expect(exitCode).toBe(0);
-});
+}, 15_000);
 
 it("http2 server sends protocol-error GOAWAY on stream 0", async () => {
   // RFC 9113 section 6.8: GOAWAY frames MUST be sent with a stream identifier


### PR DESCRIPTION
## What

`session.goaway(code, lastStreamID, opaqueData)` over a JS (non-native) transport could send freed/recycled heap bytes to the peer as GOAWAY debug data when `opaqueData` exceeds the 16 KiB cork buffer.

## Reproduction

```js
import http2 from "node:http2";
import { Duplex } from "node:stream";
const N = 256 * 1024;
let opaque = new Uint8Array(N).fill(0x41);
const spray = [], received = []; let armed = false, fired = false;
const duplex = new Duplex({
  read() {},
  write(chunk, enc, cb) {
    received.push(Buffer.from(chunk));
    if (armed && !fired && chunk.length >= 16384) {
      fired = true;
      opaque.buffer.transfer(0); opaque = null; Bun.gc(true);
      for (let i = 0; i < 64; i++) spray.push(new Uint8Array(N).fill(0x5a));
    }
    cb();
  },
});
const session = http2.connect("http://localhost:1", { createConnection: () => duplex });
session.on("error", () => {});
await new Promise(r => session.once("connect", r));
await new Promise(r => setImmediate(r));
received.length = 0; armed = true;
session.goaway(0, 0, opaque);
// GOAWAY payload on the wire: { declared: 262144, orig_0x41: 16367, recycled_0x5a: 245777 }
```

245,777 of the 262,144 declared payload bytes come from the resprayed block, not the original `opaqueData`. No ASan report (ArrayBuffer backing store is bmalloc/Gigacage); the wire-content oracle is the proof.

## Cause

`H2FrameParser.goaway` borrows the `opaqueData` ArrayBuffer (`as_array_buffer` + `byte_slice()`) and passes the slice into `send_go_away`, which calls `self.write(debug_data)`. `write()`'s cork loop fills the 16 KiB cork, then `flush_cork_buffer()` → `_write()` → `BunSocket::None` arm calls `onWrite`, which runs `http2.ts`'s `socket.write(buffer)` → the user Duplex's `write()` synchronously. That JS can detach/transfer the original buffer; the loop then resumes `bytes = &bytes[avail..]` over the freed backing store, and `send_go_away` also copies the whole stale slice again via `binary_type.to_js(debug_data)`.

Native TCP/TLS sessions (`generic_write`) do not re-enter JS mid-write and are unaffected.

## Fix

Copy `opaqueData` into an owned `Vec<u8>` at the JS boundary before any `_write` can run, matching the existing defensive copy in `read()` at `h2_frame_parser.rs:9321`. `goaway()` runs at most once per session lifetime so the copy is not on a hot path.

## Scope

The `write_stream` / `send_data` single-frame no-padding branch (`h2_frame_parser.rs:7311`) passes the same kind of borrowed slice through `write()` and is intentionally left out of this PR. The ledger's control probe of `Http2Stream.write` over the same Duplex measured it SAFE (61,440/61,440 DATA bytes original); that probe used a multi-frame payload which copies into the owned batch buffer. The single-frame window is narrow (payload 16,335-16,374 bytes with cork pre-filled), the trigger requires the user to detach the buffer they are themselves writing from inside their own transport, and DATA is the hot path. A `BunSocket::None`-gated copy there can be a follow-up if wanted.

## Verification

Before: `{ declared: 262144, orig_0x41: 16367, recycled_0x5a: 245777 }` (3/3 runs)
After: `{ declared: 262144, orig_0x41: 262144, recycled_0x5a: 0 }` (3/3 runs)

All 16 existing goaway tests in `test/js/node/http2/node-http2.test.js` pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (469921408)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [756.87ms]
(pass) node none > Client Basics > should be able to send a POST request [523.75ms]
(pass) node none > Client Basics > constants [19.59ms]
(pass) node none > Client Basics > getDefaultSettings [6.87ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [21.93ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [4.76ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.38ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [4.92ms]
(pass) node none > Client Basics > should be able to send data using end [553.94ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [543.61ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release without fix: 6 skipped
bun test v1.4.0-canary.1 (e83b85e67)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.85ms]
(pass) node none > Client Basics > getDefaultSettings [0.14ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.41ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.11ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.06ms]
(pass) node none > Client Basics > is possible to abort request [1.73ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.73ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.64ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.17ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [36.20ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > should fail to con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (469921408)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [757.22ms]
(pass) node none > Client Basics > should be able to send a POST request [518.14ms]
(pass) node none > Client Basics > constants [19.74ms]
(pass) node none > Client Basics > getDefaultSettings [7.15ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.13ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.14ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.49ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.48ms]
(pass) node none > Client Basics > should be able to send data using end [551.48ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [540.35ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 650ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 02s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.0-canary.1+469921408
[build] done
bun test v1.4.0-canary.1 (469921408)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.80ms]
(pass) node none > Client Basics > getDefaultSettings [0.14ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.36ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too sma
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2_frame_parser.rs |  5 +--
 test/js/node/http2/node-http2.test.js  | 61 ++++++++++++++++++++++++++++++++++
 2 files changed, 64 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/api/bun/h2_frame_parser.rs      7      4      0
test/js/node/http2/node-http2.test.js       4      3      0
```

</details>

<!-- robobun:evidence:end -->
