### PR TITLE
webcore(URL): propagate toString exceptions in revokeObjectURL instead of panicking

### DIFF
--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -147,8 +147,9 @@ fn bun_revoke_object_url(
     }
     // `to_bun_string` returns a +1 ref; `bun_core::String` is `Copy` (no Drop),
     // so wrap in `OwnedString` for scope-exit `deref()`.
-    let str =
-        bun_core::OwnedString::new(url_arg.to_bun_string(global_object).expect("unreachable"));
+    // `is_string()` is `is_string_like()` and admits `StringObject`, so
+    // `to_bun_string` can still observe a user `toString` that throws.
+    let str = bun_core::OwnedString::new(url_arg.to_bun_string(global_object)?);
     if !str.has_prefix_comptime(b"blob:") {
         return Ok(JSValue::UNDEFINED);
     }

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -417,6 +417,31 @@ describe("object URL prefix check", () => {
     expect(resolveObjectURL(real)).toBeUndefined();
   });
 
+  // `is_string()` admits `StringObject`, so `to_bun_string` can hit a user
+  // `toString` that throws; that must surface as a catchable JS exception.
+  test("revokeObjectURL propagates a throwing toString on a String object", async () => {
+    const fixture = `
+      const s = new String("blob:x");
+      s.toString = () => { throw new Error("boom"); };
+      s[Symbol.toPrimitive] = () => { throw new Error("boom"); };
+      try { URL.revokeObjectURL(s); } catch (e) { console.log("caught", e.message); }
+      console.log("survived");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "caught boom\nsurvived\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
   // bun_core::String::{has_prefix_comptime, eql_comptime} used to scan or
   // transcode the entire string before comparing a short ASCII literal. With
   // an O(literal) check this workload is effectively free; with an O(n) check


### PR DESCRIPTION
## What

`URL.revokeObjectURL(stringObject)` aborted the process with `panic: unreachable: Thrown` when the argument was a `String` object whose `toString` / `Symbol.toPrimitive` throws.

## Repro

```js
const s = new String("blob:x");
s.toString = () => { throw new Error("boom"); };
s[Symbol.toPrimitive] = () => { throw new Error("boom"); };
try { URL.revokeObjectURL(s); } catch (e) { console.log("caught", e.message); }
console.log("survived");
```

Before: `panic: unreachable: Thrown` at `webcore/ObjectURLRegistry.rs:151:73`, process aborts.
Node v26: prints `caught boom` then `survived`.

## Cause

`bun_revoke_object_url` gates on `url_arg.is_string()`, but `JSValue::is_string()` is `is_string_like()` and admits `StringObject` / `DerivedStringObject`. The following `url_arg.to_bun_string(global_object).expect("unreachable")` therefore still reaches a user `toString`, and when that throws the `Err` hits `.expect` and panics.

## Fix

Replace `.expect("unreachable")` with `?` so the JS exception propagates. This matches `js_function_resolve_object_url` a few lines down in the same file, and matches Node.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/web/url/url.test.ts -t "throwing toString"   # fails: SIGABRT, panic: unreachable
bun bd test test/js/web/url/url.test.ts -t "throwing toString"                 # passes
bun bd test test/js/web/url/url.test.ts                                        # 19 pass
```

A grep for `(to_bun_string|to_slice|get_zig_string|to_js_string)(...).(expect|unwrap)` over `src/runtime` (ffi excluded) finds only this site.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/url/url.test.ts
bun test v1.4.0 (0fbfdd119)

test/js/web/url/url.test.ts:
(pass) url > URL throws [12.55ms]
(pass) url > should have correct origin and protocol [11.96ms]
(pass) url > blob urls [7.93ms]
(pass) url > prints [7.67ms]
(pass) url > works [12.45ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [1.72ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined) [0.32ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:b) [0.28ms]
(pass) url > URL.canParse > URL.canParse(a:/b, undefined) [0.22ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:/b) [0.26ms]
(pass) url > URL.canParse > URL.canParse(https://test:test, undefined) [0.26ms]
(pass) url > URL.canParse > URL.canParse(a, https://b/) [0.29ms]
(pass) url > URL.canParse > URL.canParse.length should be 1 [1.40ms]
(pass) url > URLSearchParams constructed from an object interleaves Get with value conversion [4.46ms]
(pass) url.searchParams lazy href sync > reflects mutations in every URL getter and across component setters [19.40ms]
(pas
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/url/url.test.ts:
(pass) url > URL throws [0.16ms]
(pass) url > should have correct origin and protocol [0.14ms]
(pass) url > blob urls [0.09ms]
(pass) url > prints [0.17ms]
(pass) url > works [0.14ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [0.02ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined)
(pass) url > URL.canParse > URL.canParse(undefined, a:b)
(pass) url > URL.canParse > URL.canParse(a:/b, undefined)
(pass) url > URL.canParse > URL.canParse(undefined, a:/b)
(pass) url > URL.canParse > URL.canParse(https://test:test, undefined)
(pass) url > URL.canParse > URL.canParse(a, https://b/)
(pass) url > URL.canParse > URL.canParse.length should be 1 [0.01ms]
(pass) url > URLSearchParams constructed from an object interleaves Get with value conversion [0.06ms]
(pass) url.searchParams lazy href sync > reflects mutations in every URL getter and across component setters [0.27ms]
375 |       stderr: "pipe",
376 |       timeout: 15_000,
377 |       killSignal: "SIGKILL",
378 |     });
379 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/url/url.test.ts
bun test v1.4.0 (0fbfdd119)

test/js/web/url/url.test.ts:
(pass) url > URL throws [12.80ms]
(pass) url > should have correct origin and protocol [11.97ms]
(pass) url > blob urls [7.87ms]
(pass) url > prints [7.09ms]
(pass) url > works [12.84ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [1.81ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined) [0.32ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:b) [0.26ms]
(pass) url > URL.canParse > URL.canParse(a:/b, undefined) [0.24ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:/b) [0.26ms]
(pass) url > URL.canParse > URL.canParse(https://test:test, undefined) [0.24ms]
(pass) url > URL.canParse > URL.canParse(a, https://b/) [0.31ms]
(pass) url > URL.canParse > URL.canParse.length should be 1 [1.41ms]
(pass) url > URLSearchParams constructed from an object interleaves Get with value conversion [5.01ms]
(pass) url.searchParams lazy href sync > reflects mutations in every URL getter and across component setters [19.14ms]
(pas
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0fbfdd119b
  features     baseline

22 deps, 108 codegen, 1175 objects in 820ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [4.00ms]
[2/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [3.00ms]
[4/1238] gen ErrorCode+*.h
[5/1238] gen bindgenv2
[6/1238] gen .bind.ts → GeneratedBindings.cpp
[7/1238] fetch picohttpparser
[picohttpparser] up to date
[8/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1238] fetch zlib
[zlib] up to date
[10/1238] fetch zstd
[zstd] up to date
[11/1238] fetch tinycc
[tinycc] up to date
[12/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/ObjectURLRegistry.rs |  5 +++--
 test/js/web/url/url.test.ts              | 25 +++++++++++++++++++++++++
 2 files changed, 28 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/runtime/webcore/ObjectURLRegistry.rs      1      1      0
test/js/web/url/url.test.ts                   2      1      0
```

</details>

<!-- robobun:evidence:end -->