### PR TITLE
node:tls: pass the thrown Error, not the internal exception wrapper, to 'error' over a Duplex transport

### DIFF
--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -245,18 +245,18 @@ impl UpgradedDuplex {
             let buffer = match bun_jsc::array_buffer::BinaryType::Buffer.to_js(data, &global) {
                 Ok(b) => b,
                 Err(err) => {
-                    (self.handlers.on_error)(self.handlers.ctx, global.take_exception(err));
+                    (self.handlers.on_error)(self.handlers.ctx, global.take_error(err));
                     return;
                 }
             };
             buffer.ensure_still_alive();
 
             if let Err(err) = write_or_end.call(&global, duplex, &[buffer]) {
-                (self.handlers.on_error)(self.handlers.ctx, global.take_exception(err));
+                (self.handlers.on_error)(self.handlers.ctx, global.take_error(err));
             }
         } else {
             if let Err(err) = write_or_end.call(&global, duplex, &[JSValue::NULL]) {
-                (self.handlers.on_error)(self.handlers.ctx, global.take_exception(err));
+                (self.handlers.on_error)(self.handlers.ctx, global.take_error(err));
             }
         }
     }

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -186,7 +186,7 @@ extern "C" fn select_alpn_callback(
                         // The selection's ToString threw (a Symbol or a throwing
                         // toString): hand it to `error` like the callback's own
                         // throw, then refuse the protocol.
-                        let err_value = global.take_exception(err);
+                        let err_value = global.take_error(err);
                         crate::dispatch::fold(
                             handlers.call_error_handler(this_value, &[this_value, err_value]),
                         );

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2171,7 +2171,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         let output_value = match handlers.binary_type.get().to_js(data, &global) {
             Ok(v) => v,
             Err(err) => {
-                return this.handle_error(global.take_exception(err));
+                return this.handle_error(global.take_error(err));
             }
         };
 

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -1547,6 +1547,64 @@ describe.concurrent("TLS server: write() to the accepted socket from inside its 
   }
 });
 
+it("alpnCallback: a selection whose ToString throws surfaces the thrown Error, not an engine-internal cell", async () => {
+  // The thrown value must reach the `error` handler as a plain Error, not the
+  // JSC::Exception wrapper cell: `Object.prototype.toString.call` on the cell
+  // aborts the process and `instanceof Error` on it is false. The crash fires
+  // on the first property load of the value, so probe it in a subprocess.
+  using dir = tempDir("alpn-tostring-throw", {
+    "fixture.cjs": `
+      const tlsMod = require("node:tls");
+      const server = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        tls: { key: ${JSON.stringify(tls.key)}, cert: ${JSON.stringify(tls.cert)} },
+        socket: {
+          alpnCallback() {
+            // Not a boolean, and ToString on it throws a TypeError.
+            return Symbol("alpn-choice");
+          },
+          data() {},
+          error(_socket, v) {
+            const tag = Object.prototype.toString.call(v);
+            console.log("error:" + (v instanceof Error) + ":" + tag + ":" + (v && v.name));
+          },
+          close() {},
+        },
+      });
+      const client = tlsMod.connect({
+        port: server.port,
+        host: "127.0.0.1",
+        ca: ${JSON.stringify(tls.cert)},
+        servername: "localhost",
+        ALPNProtocols: ["x/1"],
+      });
+      // The server refuses the connection with a fatal no_application_protocol
+      // alert after its error handler ran; either client event ends the test.
+      client.on("error", () => server.stop(true));
+      client.on("secureConnect", () => {
+        client.end();
+        server.stop(true);
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.cjs"],
+    env: { ...bunEnv, ASAN_OPTIONS: "symbolize=0:abort_on_error=1:allow_user_segv_handler=1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ lines: stdout.trim().split(/\r?\n/), stderr, exitCode }).toEqual({
+    lines: ["error:true:[object Error]:TypeError"],
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 // Bun.connect() on a Windows named pipe takes a dedicated early branch in
 // Listener.connectInner that heap-allocates a standalone Handlers block. That
 // block's `.mode` must be `.client` so Handlers.markInactive() destroys it on

--- a/test/js/node/tls/node-tls-duplex-write-throw-error-value.test.ts
+++ b/test/js/node/tls/node-tls-duplex-write-throw-error-value.test.ts
@@ -7,7 +7,7 @@
 // error message is lost.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tls as certs } from "harness";
+import { bunEnv, bunExe, tls as certs, tempDir } from "harness";
 
 test("tls over Duplex: throwing transport write surfaces the thrown Error, not an engine-internal cell", async () => {
   using dir = tempDir("tls-duplex-throw", {

--- a/test/js/node/tls/node-tls-duplex-write-throw-error-value.test.ts
+++ b/test/js/node/tls/node-tls-duplex-write-throw-error-value.test.ts
@@ -1,0 +1,77 @@
+// When a TLS connection is wrapped around a user-supplied Duplex transport and
+// that Duplex's `write()` throws synchronously, the thrown value must reach the
+// TLSSocket's `'error'` listener as a plain Error, not the engine-internal
+// JSC::Exception wrapper cell. The wrapper cell has no prototype:
+// `Object.prototype.toString.call` on it aborts the process, property loads on
+// it trip a debug assertion inside `synthesizePrototype`, and the user's own
+// error message is lost.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir, tls as certs } from "harness";
+
+test("tls over Duplex: throwing transport write surfaces the thrown Error, not an engine-internal cell", async () => {
+  using dir = tempDir("tls-duplex-throw", {
+    "fixture.cjs": `
+      const tls = require("node:tls");
+      const { Duplex } = require("node:stream");
+      const key = ${JSON.stringify(certs.key)};
+      const cert = ${JSON.stringify(certs.cert)};
+
+      let armed = false;
+      let fired = 0;
+      class Wire extends Duplex {
+        _write(chunk, enc, cb) {
+          if (armed && this.hook && fired++ === 0) throw new Error("boom-in-transport-_write");
+          this.peer.push(Buffer.from(chunk));
+          cb();
+        }
+        _read() {}
+      }
+      const c = new Wire();
+      const s = new Wire();
+      c.peer = s;
+      s.peer = c;
+      c.hook = true;
+
+      process.on("uncaughtException", e => console.log("uncaught:" + (e && e.message)));
+
+      const srv = new tls.TLSSocket(s, { isServer: true, key, cert });
+      srv.on("error", () => {});
+      srv.resume();
+
+      const cli = tls.connect({ socket: c, rejectUnauthorized: false });
+      cli.on("error", v => {
+        // The crash under test fires on the first property load / toString of
+        // the value: in debug builds even node:events' own \`err.code\` read
+        // trips a JSC assertion before this listener runs at all.
+        const tag = Object.prototype.toString.call(v);
+        console.log("error:" + (v instanceof Error) + ":" + tag + ":" + (v && v.message));
+      });
+      cli.on("secureConnect", () => {
+        armed = true;
+        cli.write(Buffer.alloc(64 * 1024, 0x41));
+        setImmediate(() => setImmediate(() => process.exit(0)));
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.cjs"],
+    env: { ...bunEnv, ASAN_OPTIONS: "symbolize=0:abort_on_error=1:allow_user_segv_handler=1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The server side sees the truncated handshake bytes and may report its own
+  // protocol error as an uncaughtException; the assertion below only cares
+  // that the client's `'error'` listener received the user's thrown Error.
+  const lines = stdout.trim().split(/\r?\n/);
+  expect({ lines, stderr, exitCode }).toEqual({
+    lines: expect.arrayContaining(["error:true:[object Error]:boom-in-transport-_write"]),
+    stderr: "",
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
### Problem

`tls.connect({ socket: duplex })` / `new TLSSocket(duplex)` over a user-supplied Duplex: when the duplex's `_write` throws synchronously during a TLS write, the TLSSocket's `'error'` listener receives the engine-internal `JSC::Exception` wrapper cell instead of the thrown Error:

- `v instanceof Error` is `false`, `v.message` is `undefined`, `Bun.inspect(v)` prints `[native code: Exception]`
- `Object.prototype.toString.call(v)` aborts the process (SIGABRT) on release builds
- debug builds assert `isSymbol()` in `JSValue::synthesizePrototype` on the first property read, before the listener even runs (node:events reads `err.code` in its emit path)

Node delivers the Error (as a write EPROTO plus an uncaughtException); it never crashes.

### Cause

`UpgradedDuplex::call_write_or_end` forwarded `global.take_exception(err)` to `handlers.on_error`. `take_exception` returns the `JSC::Exception*` cell itself, not `Exception::value()`; that cell flowed unchanged through `TLSSocket::handle_error` into JS. `take_error` is the unwrapping variant used by the other `call_error_handler` feeds in `socket_body.rs`.

### Fix

Use `global.take_error(err)` at every site in these files that fed a raw exception cell to an error handler:

- the three `on_error` sites in `UpgradedDuplex::call_write_or_end`
- `TLSSocket::on_data`'s binary-type conversion error branch
- the ALPN selection path in `socket_body.rs` (review catch): when ToString of the `alpnCallback` return value throws, the cell reached the socket's `error` handler the same way

`udp_socket.rs` has two same-shape `take_exception` feeds, but its `call_error_handler` keys its termination guard on the Exception cell itself (`err.is_termination_exception()`, udp_socket.rs:818), so the swap is not a drop-in change there and is left out of this PR.

### Verification

New test `test/js/node/tls/node-tls-duplex-write-throw-error-value.test.ts` wires two TLSSockets over an in-memory Duplex pair whose client `_write` throws after the handshake, and asserts the `'error'` listener sees `instanceof Error`, `[object Error]`, and the original message.

- without the fix: subprocess dies with SIGABRT (exit 134) at `Object.prototype.toString.call`
- with the fix: prints `error:true:[object Error]:boom-in-transport-_write`, exits 0

New test in `test/js/bun/net/socket.test.ts` covers the ALPN path: a `Bun.listen` server whose `alpnCallback` returns a Symbol. Without the fix the subprocess aborts the same way; with it the `error` handler receives a real TypeError.

Also ran `node-tls-duplex-close-throw-uaf.test.ts` (exercises the `end()`-throws path now going through `take_error`), `node-tls-upgrade.test.ts`, and `node-tls-connect.test.ts`: all pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->
