### PR TITLE
Fix process abort when expect matcher utils inspect a value whose custom inspect throws

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1802,28 +1802,18 @@ pub mod formatter {
 
     impl core::fmt::Display for ZigFormatter<'_, '_> {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            // Move the unique `&mut Formatter` out of the cell for the body;
-            // re-seat it (and clear `remaining_values`) on the way out so the
-            // adapter stays reusable.
+            // Move the unique `&mut Formatter` out of the cell for the body and
+            // re-seat it on the way out so the adapter stays reusable.
             let formatter: &mut Formatter<'_> = self
                 .formatter
                 .take()
                 .expect("ZigFormatter::fmt re-entered or used after consumption");
 
-            let one = [self.value];
-            formatter.remaining_values = bun_ptr::RawSlice::new(&one);
+            let mut sink = bun_io::FmtAdapter::new(f);
+            let result = formatter
+                .format_value::<false>(self.value, &mut sink)
+                .map_err(|_| core::fmt::Error);
 
-            let result = (|| {
-                let tag =
-                    Tag::get(self.value, formatter.global_this).map_err(|_| core::fmt::Error)?;
-                let mut sink = bun_io::FmtAdapter::new(f);
-                let global = formatter.global_this;
-                formatter
-                    .format::<false>(tag, &mut sink, self.value, global)
-                    .map_err(|_| core::fmt::Error)
-            })();
-
-            formatter.remaining_values = bun_ptr::RawSlice::EMPTY;
             self.formatter.set(Some(formatter));
             result
         }
@@ -5674,6 +5664,11 @@ pub mod formatter {
             }
         }
 
+        /// Format one value whose tag the caller already computed. This is the
+        /// step `print_as` recurses through for nested values, so it must not
+        /// touch `remaining_values` (the pending `%s`-style arguments of the
+        /// enclosing top-level format). Top-level single-value callers use
+        /// [`Self::format_value`].
         #[inline(always)]
         pub fn format<const ENABLE_ANSI_COLORS: bool>(
             &mut self,
@@ -5692,12 +5687,12 @@ pub mod formatter {
             self.print_as::<ENABLE_ANSI_COLORS>(result.tag.tag(), writer, value, result.cell)
         }
 
-        /// Format a single value into `writer`, propagating a JS exception
-        /// thrown while inspecting it (e.g. a throwing `[inspect.custom]`).
-        /// Use this instead of the `Display` adapter ([`ZigFormatter`]) when a
-        /// `JsResult` caller needs the error: `Display` can only report
-        /// `fmt::Error`, which panics inside `io::Write::write_fmt` when the
-        /// sink itself did not fail.
+        /// Top-level entry point: format a single value into `writer`,
+        /// propagating a JS exception thrown while inspecting it (e.g. a
+        /// throwing `[inspect.custom]`). The `Display` adapter
+        /// ([`ZigFormatter`]) wraps this and can only report `fmt::Error`,
+        /// which panics inside `io::Write::write_fmt` when the sink itself did
+        /// not fail, so a `JsResult` caller should call this directly.
         pub fn format_value<const ENABLE_ANSI_COLORS: bool>(
             &mut self,
             value: JSValue,

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1802,8 +1802,6 @@ pub mod formatter {
 
     impl core::fmt::Display for ZigFormatter<'_, '_> {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            // Move the unique `&mut Formatter` out of the cell for the body and
-            // re-seat it on the way out so the adapter stays reusable.
             let formatter: &mut Formatter<'_> = self
                 .formatter
                 .take()
@@ -5664,11 +5662,8 @@ pub mod formatter {
             }
         }
 
-        /// Format one value whose tag the caller already computed. This is the
-        /// step `print_as` recurses through for nested values, so it must not
-        /// touch `remaining_values` (the pending `%s`-style arguments of the
-        /// enclosing top-level format). Top-level single-value callers use
-        /// [`Self::format_value`].
+        /// Recursive step (nested values re-enter here), so it leaves
+        /// `remaining_values` alone. Top-level callers use [`Self::format_value`].
         #[inline(always)]
         pub fn format<const ENABLE_ANSI_COLORS: bool>(
             &mut self,
@@ -5687,12 +5682,8 @@ pub mod formatter {
             self.print_as::<ENABLE_ANSI_COLORS>(result.tag.tag(), writer, value, result.cell)
         }
 
-        /// Top-level entry point: format a single value into `writer`,
-        /// propagating a JS exception thrown while inspecting it (e.g. a
-        /// throwing `[inspect.custom]`). The `Display` adapter
-        /// ([`ZigFormatter`]) wraps this and can only report `fmt::Error`,
-        /// which panics inside `io::Write::write_fmt` when the sink itself did
-        /// not fail, so a `JsResult` caller should call this directly.
+        /// Format one top-level value, returning the `JsError` if inspecting it
+        /// throws. [`ZigFormatter`] wraps this but can only report `fmt::Error`.
         pub fn format_value<const ENABLE_ANSI_COLORS: bool>(
             &mut self,
             value: JSValue,

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -5662,8 +5662,6 @@ pub mod formatter {
             }
         }
 
-        /// Recursive step (nested values re-enter here), so it leaves
-        /// `remaining_values` alone. Top-level callers use [`Self::format_value`].
         #[inline(always)]
         pub fn format<const ENABLE_ANSI_COLORS: bool>(
             &mut self,
@@ -5682,8 +5680,12 @@ pub mod formatter {
             self.print_as::<ENABLE_ANSI_COLORS>(result.tag.tag(), writer, value, result.cell)
         }
 
-        /// Format one top-level value, returning the `JsError` if inspecting it
-        /// throws. [`ZigFormatter`] wraps this but can only report `fmt::Error`.
+        /// Format a single value into `writer`, propagating a JS exception
+        /// thrown while inspecting it (e.g. a throwing `[inspect.custom]`).
+        /// Use this instead of the `Display` adapter ([`ZigFormatter`]) when a
+        /// `JsResult` caller needs the error: `Display` can only report
+        /// `fmt::Error`, which panics inside `io::Write::write_fmt` when the
+        /// sink itself did not fail.
         pub fn format_value<const ENABLE_ANSI_COLORS: bool>(
             &mut self,
             value: JSValue,

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2795,10 +2795,6 @@ impl ExpectMatcherUtils {
             }
         }
 
-        // `format_value` (not the `Display` adapter) so a JS exception thrown
-        // while inspecting `value` (e.g. a throwing `[util.inspect.custom]`)
-        // propagates as a catchable error instead of tripping
-        // `io::Write::write_fmt`'s mismatched-error panic.
         let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
         formatter.format_value::<false>(value, &mut mutable_string)?;
 

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2787,63 +2787,49 @@ impl ExpectMatcherUtils {
         value: JSValue,
         color_or_null: Option<&'static str>,
     ) -> JsResult<JSValue> {
-        use std::io::Write as _;
         let mut mutable_string = bun_core::MutableString::init_2048()?;
-
-        // MutableString already writes to an in-memory Vec, so no extra
-        // buffering layer is needed.
-        let writer = mutable_string.writer();
 
         if let Some(color) = color_or_null {
             if Output::enable_ansi_colors_stderr() {
-                // MutableString writes to a Vec; can't fail.
-                let _ = writer.write_all(Output::pretty_fmt::<true>(color).as_ref());
+                let _ = mutable_string.write_all(Output::pretty_fmt::<true>(color).as_ref());
             }
         }
 
+        // `format_value` (not the `Display` adapter) so a JS exception thrown
+        // while inspecting `value` (e.g. a throwing `[util.inspect.custom]`)
+        // propagates as a catchable error instead of tripping
+        // `io::Write::write_fmt`'s mismatched-error panic.
         let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
-        let _ = write!(writer, "{}", value.to_fmt(&mut formatter));
+        formatter.format_value::<false>(value, &mut mutable_string)?;
 
         if color_or_null.is_some() {
             if Output::enable_ansi_colors_stderr() {
-                let _ = writer.write_all(Output::pretty_fmt::<true>("<r>").as_ref());
+                let _ = mutable_string.write_all(Output::pretty_fmt::<true>("<r>").as_ref());
             }
         }
 
-        // buffered_writer.flush() — no-op with direct Vec writer
-
         bun_jsc::bun_string_jsc::create_utf8_for_js(global_this, mutable_string.slice())
-    }
-
-    #[inline]
-    fn print_value_catched(
-        global_this: &JSGlobalObject,
-        value: JSValue,
-        color_or_null: Option<&'static str>,
-    ) -> JSValue {
-        Self::print_value(global_this, value, color_or_null)
-            .unwrap_or_else(|_| global_this.throw_out_of_memory_value())
     }
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn stringify(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let arguments = callframe.arguments();
         let value = if arguments.is_empty() { JSValue::UNDEFINED } else { arguments[0] };
-        Ok(Self::print_value_catched(global_this, value, None))
+        Self::print_value(global_this, value, None)
     }
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn print_expected(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let arguments = callframe.arguments();
         let value = if arguments.is_empty() { JSValue::UNDEFINED } else { arguments[0] };
-        Ok(Self::print_value_catched(global_this, value, Some("<green>")))
+        Self::print_value(global_this, value, Some("<green>"))
     }
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn print_received(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let arguments = callframe.arguments();
         let value = if arguments.is_empty() { JSValue::UNDEFINED } else { arguments[0] };
-        Ok(Self::print_value_catched(global_this, value, Some("<red>")))
+        Self::print_value(global_this, value, Some("<red>"))
     }
 
     #[bun_jsc::host_fn(method)]

--- a/test/js/bun/test/expect-extend-matcher-utils-throw.test.ts
+++ b/test/js/bun/test/expect-extend-matcher-utils-throw.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+
+// Inspecting a value can run user code (e.g. a custom inspect method) that
+// throws. The matcher utils must surface that as a catchable JS exception,
+// not abort the process.
+test("matcher utils propagate exceptions thrown while inspecting the value", () => {
+  const caught: Record<string, unknown> = {};
+  expect.extend({
+    _printThrowingValue(received) {
+      try {
+        this.utils.stringify(received);
+      } catch (e) {
+        caught.stringify = e;
+      }
+      try {
+        this.utils.printExpected(received);
+      } catch (e) {
+        caught.printExpected = e;
+      }
+      try {
+        this.utils.printReceived(received);
+      } catch (e) {
+        caught.printReceived = e;
+      }
+      return { pass: true, message: () => "" };
+    },
+  });
+
+  // @ts-expect-error: _printThrowingValue is registered dynamically via expect.extend
+  expect({
+    [Symbol.for("nodejs.util.inspect.custom")]() {
+      throw new Error("inspect failed");
+    },
+  })._printThrowingValue();
+
+  expect(Object.keys(caught)).toEqual(["stringify", "printExpected", "printReceived"]);
+  for (const error of Object.values(caught)) {
+    expect(error).toHaveProperty("message", "inspect failed");
+  }
+});

--- a/test/js/bun/test/expect-extend-matcher-utils-throw.test.ts
+++ b/test/js/bun/test/expect-extend-matcher-utils-throw.test.ts
@@ -1,40 +1,51 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
-// Inspecting a value can run user code (e.g. a custom inspect method) that
-// throws. The matcher utils must surface that as a catchable JS exception,
-// not abort the process.
-test("matcher utils propagate exceptions thrown while inspecting the value", () => {
-  const caught: Record<string, unknown> = {};
-  expect.extend({
-    _printThrowingValue(received) {
-      try {
-        this.utils.stringify(received);
-      } catch (e) {
-        caught.stringify = e;
-      }
-      try {
-        this.utils.printExpected(received);
-      } catch (e) {
-        caught.printExpected = e;
-      }
-      try {
-        this.utils.printReceived(received);
-      } catch (e) {
-        caught.printReceived = e;
-      }
-      return { pass: true, message: () => "" };
-    },
+// Inspecting a value can run user code (a custom inspect method) that throws.
+// The matcher utils must surface that as a catchable JS exception. The
+// unfixed build aborts the process instead, so the input runs in a child.
+test("matcher utils propagate exceptions thrown while inspecting the value", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        import { expect } from "bun:test";
+        const caught = {};
+        expect.extend({
+          _printThrowingValue(received) {
+            for (const util of ["stringify", "printExpected", "printReceived"]) {
+              try {
+                this.utils[util](received);
+                caught[util] = "did not throw";
+              } catch (e) {
+                caught[util] = e.message;
+              }
+            }
+            return { pass: true, message: () => "" };
+          },
+        });
+        expect({
+          [Symbol.for("nodejs.util.inspect.custom")]() {
+            throw new Error("inspect failed");
+          },
+        })._printThrowingValue();
+        console.log(JSON.stringify(caught));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
   });
 
-  // @ts-expect-error: _printThrowingValue is registered dynamically via expect.extend
-  expect({
-    [Symbol.for("nodejs.util.inspect.custom")]() {
-      throw new Error("inspect failed");
-    },
-  })._printThrowingValue();
-
-  expect(Object.keys(caught)).toEqual(["stringify", "printExpected", "printReceived"]);
-  for (const error of Object.values(caught)) {
-    expect(error).toHaveProperty("message", "inspect failed");
-  }
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({
+      stringify: "inspect failed",
+      printExpected: "inspect failed",
+      printReceived: "inspect failed",
+    }),
+    stderr: "",
+    exitCode: 0,
+  });
 });


### PR DESCRIPTION
### Problem
- In an `expect.extend` matcher, `this.utils.printReceived(v)`, `printExpected(v)`, and `stringify(v)` abort the process when inspecting `v` throws (for example a throwing `[Symbol.for("nodejs.util.inspect.custom")]`). The user's own try/catch never runs. Panic message: `a formatting trait implementation returned an error when the underlying stream did not`.
- Cause: `ExpectMatcherUtils::print_value` (`src/runtime/test_runner/expect.rs`) formatted the value through the `Display` adapter into a `std::io::Write` sink. The JS exception became `fmt::Error`, the in-memory sink reported no error, and `io::Write::write_fmt` panics on that combination. The `let _ =` around the write cannot stop a panic.

### Fix
- `print_value` calls `Formatter::format_value` (landed on main in #36911) and returns its `JsResult`. The exception from the user's inspect method now surfaces as a normal catchable error from all three utils. `print_value_catched`, which turned every error into an out of memory error, is removed.
- `ZigFormatter`'s `Display` impl now delegates to `format_value` instead of carrying its own copy of the same body. `Formatter::format` stays as the recursive step (see the review thread).
- Correct because the matcher pipeline already propagates `JsResult` from host functions, so returning the error is the existing convention for this code.
- Verified: `test/js/bun/test/expect-extend-matcher-utils-throw.test.ts` runs the input in a child process. On bun 1.4.0-canary (1498d7b77) the child exits 134 with the panic above and the test fails. With this change it passes. Also ran `expect.test.js`, `expect-extend*.test.*`, `mock-fn.test.js`, `jest-extended.test.js`, `util/inspect*.test.js`, `shell/bunshell.test.ts`, and the `test.each` title test from #36911.

### Background
- `Formatter` (`src/jsc/ConsoleObject.rs`) is the `console.log` / `Bun.inspect` printer. `format` prints one value whose tag is already known and is what nested values recurse through. `format_value` is the top-level wrapper that computes the tag and seats `remaining_values` (the pending `%s` arguments) for a single value.
- `ZigFormatter` is a `Display` adapter over `Formatter` used by `to_fmt` in error messages. `Display::fmt` can only return `fmt::Error`, so it loses the JS exception. That is fine when the consumer is `core::fmt::Write` (how `throw(format_args!(..))` renders), and a panic when the consumer is `std::io::Write` on a sink that cannot fail.

<details><summary>Notes</summary>

Survey of the same class: of the 153 `to_fmt` consumers in `src/`, three render through `std::io::Write::write_fmt` or `.unwrap()` the result and are user reachable. They are this site, `format_label` in `jest.rs` (#36911, merged), and `bun_inspect` in `BunObject.rs` (#30980). The rest render through `JSGlobalObject::throw` / `create_error_instance` / `ErrorCode::fmt`, which use `core::fmt::Write` and tolerate a failing `Display`. `ipc.rs` formats through `scoped_log!`, which is debug-build only.

</details>

