### PR TITLE
node:vm: propagate exceptions from context-option getters instead of aborting

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -640,8 +640,8 @@ void decorateParseErrorStack(JSGlobalObject* globalObject, VM& vm, JSObject* err
     writeArrowHeaderStack(vm, errorInstance, url, reportedLine, sourceLineText, caretColumn, stack);
 }
 
-// Returns an encoded exception if the options are invalid.
-// Otherwise, returns an empty optional.
+// Returns an engaged optional when an exception is pending (invalid options,
+// or a throwing accessor on the options object). Otherwise, returns an empty optional.
 std::optional<JSC::EncodedJSValue> getNodeVMContextOptions(JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSValue optionsArg, NodeVMContextOptions& outOptions, ASCIILiteral codeGenerationKey, JSValue* importer)
 {
     if (importer) {
@@ -659,7 +659,7 @@ std::optional<JSC::EncodedJSValue> getNodeVMContextOptions(JSGlobalObject* globa
 
     // Check name property
     auto nameValue = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "name"_s));
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
     if (nameValue) {
         if (!nameValue.isUndefined() && !nameValue.isString()) {
             return ERR::INVALID_ARG_TYPE(scope, globalObject, "options.name"_s, "string"_s, nameValue);
@@ -668,7 +668,7 @@ std::optional<JSC::EncodedJSValue> getNodeVMContextOptions(JSGlobalObject* globa
 
     // Check origin property
     auto originValue = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "origin"_s));
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
     if (originValue) {
         if (!originValue.isUndefined() && !originValue.isString()) {
             return ERR::INVALID_ARG_TYPE(scope, globalObject, "options.origin"_s, "string"_s, originValue);
@@ -676,7 +676,7 @@ std::optional<JSC::EncodedJSValue> getNodeVMContextOptions(JSGlobalObject* globa
     }
 
     JSValue importModuleDynamicallyValue = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "importModuleDynamically"_s));
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
 
     if (importModuleDynamicallyValue) {
         if (importer && importModuleDynamicallyValue && (importModuleDynamicallyValue.isCallable() || isUseMainContextDefaultLoaderConstant(globalObject, importModuleDynamicallyValue))) {
@@ -688,12 +688,12 @@ std::optional<JSC::EncodedJSValue> getNodeVMContextOptions(JSGlobalObject* globa
     // queue. Validated here (not only in vm.ts) so native entry points like
     // script.runInNewContext reject invalid values the way Node does.
     JSValue microtaskModeValue = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "microtaskMode"_s));
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
     if (microtaskModeValue && !microtaskModeValue.isUndefined()) {
         bool isAfterEvaluate = false;
         if (microtaskModeValue.isString()) {
             String microtaskMode = microtaskModeValue.toWTFString(globalObject);
-            RETURN_IF_EXCEPTION(scope, {});
+            RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
             isAfterEvaluate = microtaskMode == "afterEvaluate"_s;
         }
         if (!isAfterEvaluate) {
@@ -704,7 +704,7 @@ std::optional<JSC::EncodedJSValue> getNodeVMContextOptions(JSGlobalObject* globa
     }
 
     JSValue codeGenerationValue = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, codeGenerationKey));
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
 
     if (codeGenerationValue) {
         if (codeGenerationValue.isUndefined()) {
@@ -718,25 +718,25 @@ std::optional<JSC::EncodedJSValue> getNodeVMContextOptions(JSGlobalObject* globa
         JSObject* codeGenerationObject = asObject(codeGenerationValue);
 
         auto allowStringsValue = codeGenerationObject->getIfPropertyExists(globalObject, Identifier::fromString(vm, "strings"_s));
-        RETURN_IF_EXCEPTION(scope, {});
+        RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
         if (allowStringsValue) {
             if (!allowStringsValue.isBoolean()) {
                 return ERR::INVALID_ARG_TYPE(scope, globalObject, WTF::makeString("options."_s, codeGenerationKey, ".strings"_s), "boolean"_s, allowStringsValue);
             }
 
             outOptions.allowStrings = allowStringsValue.toBoolean(globalObject);
-            RETURN_IF_EXCEPTION(scope, {});
+            RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
         }
 
         auto allowWasmValue = codeGenerationObject->getIfPropertyExists(globalObject, Identifier::fromString(vm, "wasm"_s));
-        RETURN_IF_EXCEPTION(scope, {});
+        RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
         if (allowWasmValue) {
             if (!allowWasmValue.isBoolean()) {
                 return ERR::INVALID_ARG_TYPE(scope, globalObject, WTF::makeString("options."_s, codeGenerationKey, ".wasm"_s), "boolean"_s, allowWasmValue);
             }
 
             outOptions.allowWasm = allowWasmValue.toBoolean(globalObject);
-            RETURN_IF_EXCEPTION(scope, {});
+            RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
         }
     }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -640,9 +640,7 @@ void decorateParseErrorStack(JSGlobalObject* globalObject, VM& vm, JSObject* err
     writeArrowHeaderStack(vm, errorInstance, url, reportedLine, sourceLineText, caretColumn, stack);
 }
 
-// Returns an engaged optional when an exception is pending (invalid options,
-// or a throwing accessor on the options object). Otherwise, returns an empty optional.
-std::optional<JSC::EncodedJSValue> getNodeVMContextOptions(JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSValue optionsArg, NodeVMContextOptions& outOptions, ASCIILiteral codeGenerationKey, JSValue* importer)
+void getNodeVMContextOptions(JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSValue optionsArg, NodeVMContextOptions& outOptions, ASCIILiteral codeGenerationKey, JSValue* importer)
 {
     if (importer) {
         *importer = jsUndefined();
@@ -652,31 +650,33 @@ std::optional<JSC::EncodedJSValue> getNodeVMContextOptions(JSGlobalObject* globa
 
     // If options is provided, validate name and origin properties
     if (!optionsArg.isObject()) {
-        return std::nullopt;
+        return;
     }
 
     JSObject* options = asObject(optionsArg);
 
     // Check name property
     auto nameValue = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "name"_s));
-    RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, );
     if (nameValue) {
         if (!nameValue.isUndefined() && !nameValue.isString()) {
-            return ERR::INVALID_ARG_TYPE(scope, globalObject, "options.name"_s, "string"_s, nameValue);
+            ERR::INVALID_ARG_TYPE(scope, globalObject, "options.name"_s, "string"_s, nameValue);
+            return;
         }
     }
 
     // Check origin property
     auto originValue = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "origin"_s));
-    RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, );
     if (originValue) {
         if (!originValue.isUndefined() && !originValue.isString()) {
-            return ERR::INVALID_ARG_TYPE(scope, globalObject, "options.origin"_s, "string"_s, originValue);
+            ERR::INVALID_ARG_TYPE(scope, globalObject, "options.origin"_s, "string"_s, originValue);
+            return;
         }
     }
 
     JSValue importModuleDynamicallyValue = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "importModuleDynamically"_s));
-    RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, );
 
     if (importModuleDynamicallyValue) {
         if (importer && importModuleDynamicallyValue && (importModuleDynamicallyValue.isCallable() || isUseMainContextDefaultLoaderConstant(globalObject, importModuleDynamicallyValue))) {
@@ -688,59 +688,61 @@ std::optional<JSC::EncodedJSValue> getNodeVMContextOptions(JSGlobalObject* globa
     // queue. Validated here (not only in vm.ts) so native entry points like
     // script.runInNewContext reject invalid values the way Node does.
     JSValue microtaskModeValue = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "microtaskMode"_s));
-    RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, );
     if (microtaskModeValue && !microtaskModeValue.isUndefined()) {
         bool isAfterEvaluate = false;
         if (microtaskModeValue.isString()) {
             String microtaskMode = microtaskModeValue.toWTFString(globalObject);
-            RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
+            RETURN_IF_EXCEPTION(scope, );
             isAfterEvaluate = microtaskMode == "afterEvaluate"_s;
         }
         if (!isAfterEvaluate) {
             static constexpr ASCIILiteral oneOf[] = { "afterEvaluate"_s, "undefined"_s };
-            return ERR::INVALID_ARG_VALUE(scope, globalObject, "options.microtaskMode"_s, "must be one of: "_s, microtaskModeValue, oneOf);
+            ERR::INVALID_ARG_VALUE(scope, globalObject, "options.microtaskMode"_s, "must be one of: "_s, microtaskModeValue, oneOf);
+            return;
         }
         outOptions.ownMicrotaskQueue = true;
     }
 
     JSValue codeGenerationValue = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, codeGenerationKey));
-    RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, );
 
     if (codeGenerationValue) {
         if (codeGenerationValue.isUndefined()) {
-            return std::nullopt;
+            return;
         }
 
         if (!codeGenerationValue.isObject()) {
-            return ERR::INVALID_ARG_TYPE(scope, globalObject, WTF::makeString("options."_s, codeGenerationKey), "object"_s, codeGenerationValue);
+            ERR::INVALID_ARG_TYPE(scope, globalObject, WTF::makeString("options."_s, codeGenerationKey), "object"_s, codeGenerationValue);
+            return;
         }
 
         JSObject* codeGenerationObject = asObject(codeGenerationValue);
 
         auto allowStringsValue = codeGenerationObject->getIfPropertyExists(globalObject, Identifier::fromString(vm, "strings"_s));
-        RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
+        RETURN_IF_EXCEPTION(scope, );
         if (allowStringsValue) {
             if (!allowStringsValue.isBoolean()) {
-                return ERR::INVALID_ARG_TYPE(scope, globalObject, WTF::makeString("options."_s, codeGenerationKey, ".strings"_s), "boolean"_s, allowStringsValue);
+                ERR::INVALID_ARG_TYPE(scope, globalObject, WTF::makeString("options."_s, codeGenerationKey, ".strings"_s), "boolean"_s, allowStringsValue);
+                return;
             }
 
             outOptions.allowStrings = allowStringsValue.toBoolean(globalObject);
-            RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
+            RETURN_IF_EXCEPTION(scope, );
         }
 
         auto allowWasmValue = codeGenerationObject->getIfPropertyExists(globalObject, Identifier::fromString(vm, "wasm"_s));
-        RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
+        RETURN_IF_EXCEPTION(scope, );
         if (allowWasmValue) {
             if (!allowWasmValue.isBoolean()) {
-                return ERR::INVALID_ARG_TYPE(scope, globalObject, WTF::makeString("options."_s, codeGenerationKey, ".wasm"_s), "boolean"_s, allowWasmValue);
+                ERR::INVALID_ARG_TYPE(scope, globalObject, WTF::makeString("options."_s, codeGenerationKey, ".wasm"_s), "boolean"_s, allowWasmValue);
+                return;
             }
 
             outOptions.allowWasm = allowWasmValue.toBoolean(globalObject);
-            RETURN_IF_EXCEPTION(scope, JSC::encodedJSValue());
+            RETURN_IF_EXCEPTION(scope, );
         }
     }
-
-    return std::nullopt;
 }
 
 NodeVMGlobalObject* getGlobalObjectFromContext(JSGlobalObject* globalObject, JSValue contextValue, bool canThrow)
@@ -1431,9 +1433,8 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleRunInNewContext, (JSGlobalObject * globalObject
 
     JSValue globalObjectDynamicImportCallback;
 
-    if (auto encodedException = getNodeVMContextOptions(globalObject, vm, scope, contextOptionsArg, contextOptions, "contextCodeGeneration", &globalObjectDynamicImportCallback)) {
-        return *encodedException;
-    }
+    getNodeVMContextOptions(globalObject, vm, scope, contextOptionsArg, contextOptions, "contextCodeGeneration", &globalObjectDynamicImportCallback);
+    RETURN_IF_EXCEPTION(scope, {});
 
     contextOptions.notContextified = notContextified;
 
@@ -1666,9 +1667,8 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
 
     JSValue importer;
 
-    if (auto encodedException = getNodeVMContextOptions(globalObject, vm, scope, optionsArg, contextOptions, "codeGeneration", &importer)) {
-        return *encodedException;
-    }
+    getNodeVMContextOptions(globalObject, vm, scope, optionsArg, contextOptions, "codeGeneration", &importer);
+    RETURN_IF_EXCEPTION(scope, {});
 
     contextOptions.notContextified = notContextified;
 

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -33,7 +33,7 @@ bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Excepti
 // `url` must be caller-resolved: `new Script` falls back to evalmachine.<anonymous>
 // when no filename was provided; compileFunction has no such default.
 void decorateParseErrorStack(JSGlobalObject* globalObject, VM& vm, JSObject* error, StringView sourceString, const String& url, const JSC::ParserError& parseError, OrdinalNumber lineOffset);
-std::optional<JSC::EncodedJSValue> getNodeVMContextOptions(JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSValue optionsArg, NodeVMContextOptions& outOptions, ASCIILiteral codeGenerationKey, JSValue* importer);
+void getNodeVMContextOptions(JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSValue optionsArg, NodeVMContextOptions& outOptions, ASCIILiteral codeGenerationKey, JSValue* importer);
 NodeVMGlobalObject* getGlobalObjectFromContext(JSGlobalObject* globalObject, JSValue contextValue, bool canThrow);
 JSC::EncodedJSValue INVALID_ARG_VALUE_VM_VARIATION(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, WTF::ASCIILiteral name, JSC::JSValue value);
 // For vm.compileFunction we need to return an anonymous function expression. This code is adapted from/inspired by JSC::constructFunction, which is used for function declarations.

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -636,9 +636,8 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInNewContext, (JSGlobalObject * globalObject, 
     NodeVMContextOptions contextOptions {};
     JSValue importer;
 
-    if (auto encodedException = getNodeVMContextOptions(globalObject, vm, scope, contextOptionsArg, contextOptions, "contextCodeGeneration", &importer)) {
-        return *encodedException;
-    }
+    getNodeVMContextOptions(globalObject, vm, scope, contextOptionsArg, contextOptions, "contextCodeGeneration", &importer);
+    RETURN_IF_EXCEPTION(scope, {});
 
     contextOptions.notContextified = notContextified;
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1016,21 +1016,21 @@ describe("context options with throwing getters", () => {
   // Without the fix, reading these options with a pending exception aborted
   // the process, so run the matrix in a subprocess.
   test.concurrent("the getter's exception propagates to the caller", async () => {
-    // Each entry point tests the context-option keys it actually reads
-    // (the Script path takes contextCodeGeneration, not codeGeneration).
+    // Each entry point tests the context-option keys it actually reads:
+    // createContext takes codeGeneration, Script#runInNewContext takes
+    // contextCodeGeneration, and vm.runInNewContext goes through both.
     // A dotted key puts the throwing getter on the nested object.
-    const contextKeys = (codeGenerationKey: string) => [
+    const codeGenerationKeys = (key: string) => [key, `${key}.strings`, `${key}.wasm`];
+    const contextKeys = (...codeGenerationKeyNames: string[]) => [
       "name",
       "origin",
-      codeGenerationKey,
-      `${codeGenerationKey}.strings`,
-      `${codeGenerationKey}.wasm`,
+      ...codeGenerationKeyNames.flatMap(codeGenerationKeys),
       "importModuleDynamically",
       "microtaskMode",
     ];
     const matrix = {
       createContext: contextKeys("codeGeneration"),
-      runInNewContext: contextKeys("codeGeneration"),
+      runInNewContext: contextKeys("codeGeneration", "contextCodeGeneration"),
       scriptRunInNewContext: contextKeys("contextCodeGeneration"),
     };
     const code = `

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1018,10 +1018,20 @@ describe("context options with throwing getters", () => {
   test.concurrent("the getter's exception propagates to the caller", async () => {
     // Each entry point tests the context-option keys it actually reads
     // (the Script path takes contextCodeGeneration, not codeGeneration).
+    // A dotted key puts the throwing getter on the nested object.
+    const contextKeys = (codeGenerationKey: string) => [
+      "name",
+      "origin",
+      codeGenerationKey,
+      `${codeGenerationKey}.strings`,
+      `${codeGenerationKey}.wasm`,
+      "importModuleDynamically",
+      "microtaskMode",
+    ];
     const matrix = {
-      createContext: ["name", "origin", "codeGeneration", "importModuleDynamically"],
-      runInNewContext: ["name", "origin", "codeGeneration", "importModuleDynamically"],
-      scriptRunInNewContext: ["name", "origin", "contextCodeGeneration", "importModuleDynamically"],
+      createContext: contextKeys("codeGeneration"),
+      runInNewContext: contextKeys("codeGeneration"),
+      scriptRunInNewContext: contextKeys("contextCodeGeneration"),
     };
     const code = `
       const vm = require("node:vm");
@@ -1034,7 +1044,10 @@ describe("context options with throwing getters", () => {
       for (const [entry, keys] of Object.entries(matrix)) {
         for (const key of keys) {
           const opts = {};
-          Object.defineProperty(opts, key, {
+          const path = key.split(".");
+          let target = opts;
+          for (const part of path.slice(0, -1)) target = target[part] = {};
+          Object.defineProperty(target, path.at(-1), {
             get() { throw new Error("getter:" + key); },
             enumerable: true,
           });
@@ -1058,6 +1071,7 @@ describe("context options with throwing getters", () => {
       Object.entries(matrix)
         .flatMap(([entry, keys]) => keys.map(key => `${entry} ${key} getter:${key}`))
         .join("\n") + "\nsurvived\n";
+    expect(stderr).toBe("");
     expect(stdout).toBe(expected);
     expect(exitCode).toBe(0);
   });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1012,6 +1012,57 @@ describe("codeGeneration options", () => {
   });
 });
 
+describe("context options with throwing getters", () => {
+  // Without the fix, reading these options with a pending exception aborted
+  // the process, so run the matrix in a subprocess.
+  test.concurrent("the getter's exception propagates to the caller", async () => {
+    // Each entry point tests the context-option keys it actually reads
+    // (the Script path takes contextCodeGeneration, not codeGeneration).
+    const matrix = {
+      createContext: ["name", "origin", "codeGeneration", "importModuleDynamically"],
+      runInNewContext: ["name", "origin", "codeGeneration", "importModuleDynamically"],
+      scriptRunInNewContext: ["name", "origin", "contextCodeGeneration", "importModuleDynamically"],
+    };
+    const code = `
+      const vm = require("node:vm");
+      const matrix = ${JSON.stringify(matrix)};
+      const entryPoints = {
+        createContext: opts => vm.createContext({}, opts),
+        runInNewContext: opts => vm.runInNewContext("1", {}, opts),
+        scriptRunInNewContext: opts => new vm.Script("1").runInNewContext({}, opts),
+      };
+      for (const [entry, keys] of Object.entries(matrix)) {
+        for (const key of keys) {
+          const opts = {};
+          Object.defineProperty(opts, key, {
+            get() { throw new Error("getter:" + key); },
+            enumerable: true,
+          });
+          try {
+            entryPoints[entry](opts);
+            console.log(entry, key, "did not throw");
+          } catch (e) {
+            console.log(entry, key, e.message);
+          }
+        }
+      }
+      console.log("survived");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const expected =
+      Object.entries(matrix)
+        .flatMap(([entry, keys]) => keys.map(key => `${entry} ${key} getter:${key}`))
+        .join("\n") + "\nsurvived\n";
+    expect(stdout).toBe(expected);
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("DONT_CONTEXTIFY", () => {
   test("globalThis prototype chain stays inside the sandbox realm", () => {
     const ctx = createContext(constants.DONT_CONTEXTIFY);


### PR DESCRIPTION
### What does this PR do?

A `node:vm` context-options object with a throwing accessor aborted the process instead of throwing to the caller:

```js
const vm = require("node:vm");
try {
  vm.createContext({}, { get name() { throw new Error("T") } });
} catch (e) {
  console.log("caught", e.message); // never reached
}
console.log("survived");            // never reached: SIGABRT, exit 134
```

Same for `origin`, `codeGeneration` / `contextCodeGeneration` (and their nested `strings` / `wasm`), `importModuleDynamically`, and `microtaskMode` on the `Script#runInNewContext` path, via `vm.createContext`, `vm.runInNewContext` and `new vm.Script(..).runInNewContext`. Release builds die with a silent SIGABRT; debug builds hit `ASSERTION FAILED: Unexpected exception observed ... ExceptionScope::assertNoException()`. Node propagates the getter's error.

**Cause:** `getNodeVMContextOptions()` in `src/jsc/bindings/NodeVM.cpp` returned `std::optional<JSC::EncodedJSValue>`, where an engaged optional meant "exception pending, bail out". Every property read inside it used `RETURN_IF_EXCEPTION(scope, {})`, and `{}` for that return type is `std::nullopt`, which the callers read as success. They then went on to construct a `NodeVMGlobalObject` with the getter's exception still pending.

(`microtaskMode` only looked unaffected through `vm.createContext` / `vm.runInNewContext` because `vm.ts` reads it JS-side first; `Script#runInNewContext` reads it natively and aborted the same way.)

**Fix:** the optional's payload was always encoded 0 and no caller used it, so `getNodeVMContextOptions()` is now `void` and the three callers `RETURN_IF_EXCEPTION` after the call, the same shape as the other option helpers in this file (`BaseVMOptions::fromJS`, `validateTimeout`, ...). That fixes the abort and means a future `RETURN_IF_EXCEPTION(scope, {})` in this function can't reintroduce it.

### How did you verify your code works?

New test in `test/js/node/vm/vm.test.ts` ("context options with throwing getters") runs the key x entry-point matrix (including the nested `strings` / `wasm` getters and `microtaskMode`) in a subprocess and checks every getter's error reaches the caller, stderr is empty, and the process survives.

- `USE_SYSTEM_BUN=1 bun test test/js/node/vm/vm.test.ts -t "throwing getters"`: fails (subprocess aborts, empty stdout)
- `bun bd test test/js/node/vm/vm.test.ts`: 214 pass / 0 fail
- repro is clean under `BUN_JSC_validateExceptionChecks=1`; invalid-type options still throw `ERR_INVALID_ARG_TYPE` / `ERR_INVALID_ARG_VALUE`
- `test-vm-codegen.js`, `test-vm-options-validation.js`, `test-vm-create-context-*.js`, `test-vm-run-in-new-context.js`, `test-vm-context.js`, `test-vm-is-context.js`, `test-vm-context-dont-contextify.js` still pass

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (6c0e55208)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [20.65ms]
(pass) vm > runInContext() > can return a value [14.66ms]
(pass) vm > runInContext() > can return a complex value [14.79ms]
(pass) vm > runInContext() > can return the last value [14.20ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [15.90ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.10ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [14.50ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.12ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.11ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [14.15ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [14.22ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [14.57ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release without fix: 8 failed, 62 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.39ms]
(pass) vm > runInContext() > can return a value [0.20ms]
(pass) vm > runInContext() > can return a complex value [0.21ms]
(pass) vm > runInContext() > can return the last value [0.20ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.22ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.21ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.20ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (6c0e55208)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [20.66ms]
(pass) vm > runInContext() > can return a value [14.36ms]
(pass) vm > runInContext() > can return a complex value [14.87ms]
(pass) vm > runInContext() > can return the last value [14.54ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [15.68ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.14ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [14.69ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [14.66ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [14.84ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [14.35ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [14.70ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [14.18ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 656ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/69] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[2/69] cxx obj/unified/UnifiedSource-src_jsc_bindings_vm-0.cpp.o
[3/69] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[4/69] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[5/69] gen cpp.rs (cppbind)
[5/69] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVM.cpp       | 58 +++++++++++++++++-----------------
 src/jsc/bindings/NodeVM.h         |  2 +-
 src/jsc/bindings/NodeVMScript.cpp |  5 ++-
 test/js/node/vm/vm.test.ts        | 65 +++++++++++++++++++++++++++++++++++++++
 4 files changed, 97 insertions(+), 33 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/jsc/bindings/NodeVM.cpp            6      5      0
src/jsc/bindings/NodeVM.h              1      1      0
src/jsc/bindings/NodeVMScript.cpp      1      1      0
test/js/node/vm/vm.test.ts             6      5      0
```

</details>

<!-- robobun:evidence:end -->