### PR TITLE
test runner: don't panic formatting a FormData whose toJSON is not callable

### DIFF
--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1582,20 +1582,27 @@ impl<'a> Formatter<'a> {
                         }
                         return Ok(());
                     } else if bun_jsc::DOMFormData::from_js(value).is_some() {
-                        let to_json_function = value.get(self.global_this, "toJSON")?.unwrap();
+                        if let Some(to_json_function) = value
+                            .get(self.global_this, "toJSON")?
+                            .filter(|f| f.is_callable())
+                        {
+                            self.add_for_new_line(b"FormData (entries) ".len());
+                            writer.write_all(
+                                pretty_fmt_const::<ENABLE_ANSI_COLORS>(
+                                    "<r><blue>FormData<r> <d>(entries)<r> ",
+                                )
+                                .as_bytes(),
+                            );
 
-                        self.add_for_new_line(b"FormData (entries) ".len());
-                        writer.write_all(
-                            pretty_fmt_const::<ENABLE_ANSI_COLORS>(
-                                "<r><blue>FormData<r> <d>(entries)<r> ",
-                            )
-                            .as_bytes(),
-                        );
+                            return self.print_as::<W, { Tag::Object }, ENABLE_ANSI_COLORS>(
+                                writer.ctx,
+                                to_json_function.call(self.global_this, value, &[])?,
+                                JSType::Object,
+                            );
+                        }
 
                         return self.print_as::<W, { Tag::Object }, ENABLE_ANSI_COLORS>(
-                            writer.ctx,
-                            to_json_function.call(self.global_this, value, &[])?,
-                            JSType::Object,
+                            writer.ctx, value, JSType::Event,
                         );
                     } else if let Some(timer) = value.as_class_ref::<crate::timer::TimeoutObject>() {
                         self.add_for_new_line(

--- a/test/js/bun/test/expect-formdata-tojson-crash.test.ts
+++ b/test/js/bun/test/expect-formdata-tojson-crash.test.ts
@@ -18,6 +18,13 @@ test("failing matcher on FormData without a callable toJSON does not abort the t
         Object.setPrototypeOf(fd, null);
         expect(fd).toEqual(1 as any);
       });
+
+      test("toJSON is a non-callable value", () => {
+        const fd = new FormData();
+        fd.append("a", "b");
+        Object.defineProperty(fd, "toJSON", { value: 42 });
+        expect(fd).toEqual(1 as any);
+      });
     `,
   });
 
@@ -32,6 +39,9 @@ test("failing matcher on FormData without a callable toJSON does not abort the t
   const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toContain("Received: FormData");
-  expect(stderr).toContain("2 fail");
+  // The non-callable toJSON is printed as a property rather than being called.
+  expect(stderr).toContain(`"toJSON": 42`);
+  expect(stderr).not.toContain("is not a function");
+  expect(stderr).toContain("3 fail");
   expect(exitCode).toBe(1);
 });

--- a/test/js/bun/test/expect-formdata-tojson-crash.test.ts
+++ b/test/js/bun/test/expect-formdata-tojson-crash.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("failing matcher on FormData without a callable toJSON does not abort the test runner", async () => {
+  using dir = tempDir("formdata-tojson-crash", {
+    "formdata.test.ts": `
+      import { test, expect } from "bun:test";
+
+      test("toJSON shadowed with undefined", () => {
+        const fd = new FormData();
+        Object.defineProperty(fd, "toJSON", { value: undefined });
+        expect(fd).toEqual(1 as any);
+      });
+
+      test("null prototype", () => {
+        const fd = new FormData();
+        fd.append("a", "b");
+        Object.setPrototypeOf(fd, null);
+        expect(fd).toEqual(1 as any);
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "formdata.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Received: FormData");
+  expect(stderr).toContain("2 fail");
+  expect(exitCode).toBe(1);
+});

--- a/test/js/bun/test/expect-formdata-tojson-crash.test.ts
+++ b/test/js/bun/test/expect-formdata-tojson-crash.test.ts
@@ -25,10 +25,11 @@ test("failing matcher on FormData without a callable toJSON does not abort the t
     cmd: [bunExe(), "test", "formdata.test.ts"],
     env: bunEnv,
     cwd: String(dir),
+    stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toContain("Received: FormData");
   expect(stderr).toContain("2 fail");


### PR DESCRIPTION
### Repro

```js
// bun test ./x.test.mjs
import { test, expect } from "bun:test";
test("x", () => {
  const fd = new FormData();
  Object.defineProperty(fd, "toJSON", { value: undefined }); // or Object.setPrototypeOf(fd, null)
  expect(fd).toEqual(1);
});
```

```
panic: called `Option::unwrap()` on a `None` value
src/runtime/test_runner/pretty_format.rs:1585:87
oh no: Bun has crashed ... (exit 134)
```

One failing assertion takes down the entire `bun test` run.

### Cause

The FormData branch of the jest pretty-formatter (`Tag::Private` in `pretty_format.rs`) did `value.get(global, "toJSON")?.unwrap()`. `JSValue::get` returns `None` when the property is missing or `undefined`, so a FormData with `toJSON` shadowed by `undefined`, or with its prototype swapped out, panicked as soon as any failing matcher tried to print the received value.

### Fix

Only take the `toJSON` path when the property exists and is callable; otherwise fall through to the generic object printer (same shape `ConsoleObject.rs` already uses for `console.log` / `Bun.inspect`, which is why those never crashed). The callable check also covers `toJSON: 42`, which previously threw from inside the formatter instead of printing the value.

### Verification

`test/js/bun/test/expect-formdata-tojson-crash.test.ts` spawns `bun test` on a fixture with the three variants (`toJSON: undefined`, null prototype, `toJSON: 42`) and asserts the run reports `3 fail` / exit 1 with the FormData printed in the diff. Before the fix the child aborts with the panic above.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-formdata-tojson-crash.test.ts
bun test v1.4.0 (fa3a236a3)

test/js/bun/test/expect-formdata-tojson-crash.test.ts:
killed 1 dangling process
(fail) failing matcher on FormData without a callable toJSON does not abort the test runner [5005.66ms]
  ^ this test timed out after 5000ms.

 0 pass
 1 fail
Ran 1 test across 1 file. [6.98s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (fd458fc5d)

test/js/bun/test/expect-formdata-tojson-crash.test.ts:
(pass) failing matcher on FormData without a callable toJSON does not abort the test runner [8.69ms]

 1 pass
 0 fail
 5 expect() calls
Ran 1 test across 1 file. [157.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-formdata-tojson-crash.test.ts
bun test v1.4.0 (fa3a236a3)

test/js/bun/test/expect-formdata-tojson-crash.test.ts:
(pass) failing matcher on FormData without a callable toJSON does not abort the test runner [355.62ms]

 1 pass
 0 fail
 5 expect() calls
Ran 1 test across 1 file. [2.34s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 708ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/pretty_format.rs           | 29 ++++++++-----
 .../bun/test/expect-formdata-tojson-crash.test.ts  | 47 ++++++++++++++++++++++
 2 files changed, 65 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/runtime/test_runner/pretty_format.rs                   4      4      0
test/js/bun/test/expect-formdata-tojson-crash.test.ts      3      6      0
```

</details>

<!-- robobun:evidence:end -->