### PR TITLE
node:http2: don't hold a thread-local borrow across the padded DATA write

### DIFF
--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -268,9 +268,8 @@ pub struct RareData {
 
     pub(crate) temp_pipe_read_buffer: Option<Box<PipeReadBuffer>>,
 
-    /// `node:http2` assembles one PADDED DATA frame payload at a time here. Handed out by
-    /// value (see [`Self::take_h2_padded_frame_buffer`]) because the socket write it feeds
-    /// can re-enter JS and reach the same path again before the buffer comes back.
+    /// `node:http2` PADDED DATA scratch; handed out by value because the write it feeds
+    /// can re-enter JS and take again (see [`Self::take_h2_padded_frame_buffer`]).
     h2_padded_frame_buffer: Option<Box<H2PaddedFrameBuffer>>,
 
     // There is intentionally no `aws_signature_cache` field — storage lives in
@@ -388,8 +387,7 @@ impl PathBuf {
 // remains a stable path for existing callers.
 pub use bun_event_loop::PipeReadBuffer;
 
-/// One HTTP/2 PADDED DATA frame payload (pad-length byte + data + padding), at most one
-/// max-size frame.
+/// One max-size HTTP/2 PADDED DATA frame payload (pad-length byte + data + padding).
 pub type H2PaddedFrameBuffer = [u8; 16384];
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -671,18 +669,15 @@ impl RareData {
             .get_or_insert_with(bun_core::boxed_zeroed::<PipeReadBuffer>)
     }
 
-    /// Take the padded-frame scratch out of its slot (lazily allocated). Taken by value
-    /// rather than borrowed: the socket write it feeds can re-enter JS and reach this
-    /// path again, and that nested caller finds the slot empty and allocates its own.
+    /// Take the padded-frame scratch out of its slot (lazily allocated); a nested
+    /// caller finds the slot empty and allocates its own.
     pub fn take_h2_padded_frame_buffer(&mut self) -> Box<H2PaddedFrameBuffer> {
         self.h2_padded_frame_buffer
             .take()
             .unwrap_or_else(bun_core::boxed_zeroed::<H2PaddedFrameBuffer>)
     }
 
-    /// Hand the buffer from [`Self::take_h2_padded_frame_buffer`] back for reuse. With
-    /// nested takes in flight the slot keeps whichever buffer returns first and the
-    /// rest drop.
+    /// Hand a taken buffer back; the slot keeps the first one returned.
     pub fn put_back_h2_padded_frame_buffer(&mut self, buffer: Box<H2PaddedFrameBuffer>) {
         self.h2_padded_frame_buffer.get_or_insert(buffer);
     }

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -268,6 +268,11 @@ pub struct RareData {
 
     pub(crate) temp_pipe_read_buffer: Option<Box<PipeReadBuffer>>,
 
+    /// `node:http2` assembles one PADDED DATA frame payload at a time here. Handed out by
+    /// value (see [`Self::take_h2_padded_frame_buffer`]) because the socket write it feeds
+    /// can re-enter JS and reach the same path again before the buffer comes back.
+    h2_padded_frame_buffer: Option<Box<H2PaddedFrameBuffer>>,
+
     // There is intentionally no `aws_signature_cache` field — storage lives in
     // `bun_s3_signing::credentials::AWS_SIGNATURE_CACHE` (process static; it
     // was always reached via the main-thread VM, so it was a singleton in
@@ -326,6 +331,7 @@ impl Default for RareData {
             memory_pressure_watcher: None,
             listening_sockets_for_watch_mode: Mutex::new(Vec::new()),
             temp_pipe_read_buffer: None,
+            h2_padded_frame_buffer: None,
             s3_default_client: Strong::empty(),
             node_quic_callbacks: Strong::empty(),
             default_csrf_secret: Box::default(),
@@ -381,6 +387,10 @@ impl PathBuf {
 // with `MiniEventLoop`'s scratch buffer). Re-export so `rare_data::PipeReadBuffer`
 // remains a stable path for existing callers.
 pub use bun_event_loop::PipeReadBuffer;
+
+/// One HTTP/2 PADDED DATA frame payload (pad-length byte + data + padding), at most one
+/// max-size frame.
+pub type H2PaddedFrameBuffer = [u8; 16384];
 
 // ──────────────────────────────────────────────────────────────────────────
 // ProxyEnvStorage
@@ -659,6 +669,22 @@ impl RareData {
     pub fn pipe_read_buffer(&mut self) -> &mut PipeReadBuffer {
         self.temp_pipe_read_buffer
             .get_or_insert_with(bun_core::boxed_zeroed::<PipeReadBuffer>)
+    }
+
+    /// Take the padded-frame scratch out of its slot (lazily allocated). Taken by value
+    /// rather than borrowed: the socket write it feeds can re-enter JS and reach this
+    /// path again, and that nested caller finds the slot empty and allocates its own.
+    pub fn take_h2_padded_frame_buffer(&mut self) -> Box<H2PaddedFrameBuffer> {
+        self.h2_padded_frame_buffer
+            .take()
+            .unwrap_or_else(bun_core::boxed_zeroed::<H2PaddedFrameBuffer>)
+    }
+
+    /// Hand the buffer from [`Self::take_h2_padded_frame_buffer`] back for reuse. With
+    /// nested takes in flight the slot keeps whichever buffer returns first and the
+    /// rest drop.
+    pub fn put_back_h2_padded_frame_buffer(&mut self, buffer: Box<H2PaddedFrameBuffer>) {
+        self.h2_padded_frame_buffer.get_or_insert(buffer);
     }
 
     pub fn boring_engine(&mut self) -> *mut boring::ENGINE {
@@ -1043,9 +1069,9 @@ fn get_tls_default_ciphers_from_js(
 
 impl Drop for RareData {
     fn drop(&mut self) {
-        // temp_pipe_read_buffer / spawn_sync_event_loop_ / s3_default_client /
-        // default_csrf_secret / cleanup_hooks / cron_jobs / path_buf /
-        // tls_default_ciphers:
+        // temp_pipe_read_buffer / h2_padded_frame_buffer / spawn_sync_event_loop_ /
+        // s3_default_client / default_csrf_secret / cleanup_hooks / cron_jobs /
+        // path_buf / tls_default_ciphers:
         // all dropped automatically via field Drop.
 
         if let Some(engine) = self.boring_ssl_engine.take() {

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -268,8 +268,7 @@ pub struct RareData {
 
     pub(crate) temp_pipe_read_buffer: Option<Box<PipeReadBuffer>>,
 
-    /// `node:http2` PADDED DATA scratch; handed out by value because the write it feeds
-    /// can re-enter JS and take again (see [`Self::take_h2_padded_frame_buffer`]).
+    /// `node:http2` PADDED DATA scratch; see [`Self::take_h2_padded_frame_buffer`].
     h2_padded_frame_buffer: Option<Box<H2PaddedFrameBuffer>>,
 
     // There is intentionally no `aws_signature_cache` field — storage lives in
@@ -669,8 +668,9 @@ impl RareData {
             .get_or_insert_with(bun_core::boxed_zeroed::<PipeReadBuffer>)
     }
 
-    /// Take the padded-frame scratch out of its slot (lazily allocated); a nested
-    /// caller finds the slot empty and allocates its own.
+    /// Take the padded-frame scratch out of its slot (lazily allocated). By value rather
+    /// than borrowed: the socket write it feeds can re-enter JS and reach this path
+    /// again, and that nested caller then finds the slot empty and allocates its own.
     pub fn take_h2_padded_frame_buffer(&mut self) -> Box<H2PaddedFrameBuffer> {
         self.h2_padded_frame_buffer
             .take()

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1119,10 +1119,6 @@ thread_local! {
     // pool allocation itself.
     static POOL: RefCell<Option<Box<ManuallyDrop<H2FrameParserHiveAllocator>>>> =
         const { RefCell::new(None) };
-    // Scratch for assembling one PADDED DATA payload. Moved out of the slot while in use
-    // (see `DirectWriterStruct::write_padded`): the write can flush the cork and re-enter
-    // JS, and a nested padded write must get its own buffer.
-    static PADDED_PAYLOAD_BUFFER: Cell<Option<Box<[u8]>>> = const { Cell::new(None) };
 }
 
 /// One wire-order piece of a multi-frame send_data batch (see BATCH_SEGMENTS).
@@ -6148,20 +6144,14 @@ impl DirectWriterStruct {
     /// Writes the payload of a PADDED DATA frame: the pad length, `data`, then `padding`
     /// zero bytes (RFC 9113 6.1). The caller has already written the frame header.
     fn write_padded(&mut self, data: &[u8], padding: u8) -> bun_io::Result<()> {
-        let payload_size = 1 + data.len() + padding as usize;
-        // `write()` can flush the cork and, over a JS-backed transport, re-enter JS that
-        // reaches send_data()/flush_queue() again before this frame's bytes are all corked.
-        // Own the scratch for the duration so that nested padded write neither trips a held
-        // borrow nor overwrites bytes this write is still copying from.
-        let mut buffer = PADDED_PAYLOAD_BUFFER
-            .take()
-            .unwrap_or_else(|| vec![0u8; H2_CORK_BUFFER_SIZE].into_boxed_slice());
-        buffer[0] = padding;
-        buffer[1..=data.len()].copy_from_slice(data);
-        buffer[1 + data.len()..payload_size].fill(0);
-        let result = self.write_all(&buffer[..payload_size]);
-        PADDED_PAYLOAD_BUFFER.set(Some(buffer));
-        result
+        // Assembled in a buffer this call owns: `write()` can flush the cork and, over a
+        // JS-backed transport, re-enter JS that reaches send_data()/flush_queue() again
+        // before this frame is fully corked, so no shared scratch may be live across it.
+        let mut payload = Vec::with_capacity(1 + data.len() + padding as usize);
+        payload.push(padding);
+        payload.extend_from_slice(data);
+        payload.resize(payload.len() + padding as usize, 0);
+        self.write_all(&payload)
     }
 }
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -6143,8 +6143,7 @@ impl bun_io::Write for DirectWriterStruct {
 impl DirectWriterStruct {
     /// The payload of a PADDED DATA frame (RFC 9113 6.1); the caller wrote the frame header.
     fn write_padded(&mut self, data: &[u8], padding: u8) -> bun_io::Result<()> {
-        // Owned per call: over a JS-backed transport, `write()` can re-enter
-        // send_data()/flush_queue() before this frame is fully corked.
+        // Owned per call: `write()` can re-enter this path through a JS transport mid-frame.
         let mut payload = Vec::with_capacity(1 + data.len() + padding as usize);
         payload.push(padding);
         payload.extend_from_slice(data);

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1093,10 +1093,9 @@ type H2FrameParserHiveAllocator = HiveArrayFallback<H2FrameParser, 256>;
 const H2_CORK_BUFFER_SIZE: usize = 16384;
 
 thread_local! {
-    // Boxed so only a pointer lives in static TLS — these two buffers are 32 KB
-    // combined and would otherwise dominate PT_TLS MemSiz on every thread
-    // (see test/js/bun/binary/tls-segment-size). Lazily allocated on first
-    // HTTP/2 access; threads that never touch h2 pay nothing.
+    // Boxed so only a pointer lives in static TLS — a 16 KB buffer would otherwise
+    // dominate PT_TLS MemSiz on every thread (see test/js/bun/binary/tls-segment-size).
+    // Lazily allocated on first HTTP/2 access; threads that never touch h2 pay nothing.
     static CORK_BUFFER: RefCell<Box<[u8; H2_CORK_BUFFER_SIZE]>> =
         RefCell::new(Box::new([0u8; H2_CORK_BUFFER_SIZE]));
     static CORK_OFFSET: Cell<u16> = const { Cell::new(0) };
@@ -6143,12 +6142,26 @@ impl bun_io::Write for DirectWriterStruct {
 impl DirectWriterStruct {
     /// The payload of a PADDED DATA frame (RFC 9113 6.1); the caller wrote the frame header.
     fn write_padded(&mut self, data: &[u8], padding: u8) -> bun_io::Result<()> {
-        // Owned per call: `write()` can re-enter this path through a JS transport mid-frame.
-        let mut payload = Vec::with_capacity(1 + data.len() + padding as usize);
-        payload.push(padding);
-        payload.extend_from_slice(data);
-        payload.resize(payload.len() + padding as usize, 0);
-        self.write_all(&payload)
+        let payload_size = 1 + data.len() + padding as usize;
+        // The VM's shared scratch, taken by value: `write()` can re-enter this path
+        // through a JS transport mid-frame, and the nested call must not alias (or trip
+        // a borrow of) the buffer this one is still writing from.
+        let global = self.writer.global();
+        let mut buffer = global
+            .bun_vm()
+            .as_mut()
+            .rare_data()
+            .take_h2_padded_frame_buffer();
+        buffer[0] = padding;
+        buffer[1..=data.len()].copy_from_slice(data);
+        buffer[1 + data.len()..payload_size].fill(0);
+        let result = self.write_all(&buffer[..payload_size]);
+        global
+            .bun_vm()
+            .as_mut()
+            .rare_data()
+            .put_back_h2_padded_frame_buffer(buffer);
+        result
     }
 }
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -6141,12 +6141,10 @@ impl bun_io::Write for DirectWriterStruct {
 }
 
 impl DirectWriterStruct {
-    /// Writes the payload of a PADDED DATA frame: the pad length, `data`, then `padding`
-    /// zero bytes (RFC 9113 6.1). The caller has already written the frame header.
+    /// The payload of a PADDED DATA frame (RFC 9113 6.1); the caller wrote the frame header.
     fn write_padded(&mut self, data: &[u8], padding: u8) -> bun_io::Result<()> {
-        // Assembled in a buffer this call owns: `write()` can flush the cork and, over a
-        // JS-backed transport, re-enter JS that reaches send_data()/flush_queue() again
-        // before this frame is fully corked, so no shared scratch may be live across it.
+        // Owned per call: over a JS-backed transport, `write()` can re-enter
+        // send_data()/flush_queue() before this frame is fully corked.
         let mut payload = Vec::with_capacity(1 + data.len() + padding as usize);
         payload.push(padding);
         payload.extend_from_slice(data);

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1119,7 +1119,10 @@ thread_local! {
     // pool allocation itself.
     static POOL: RefCell<Option<Box<ManuallyDrop<H2FrameParserHiveAllocator>>>> =
         const { RefCell::new(None) };
-    static SHARED_REQUEST_BUFFER: RefCell<Box<[u8; 16384]>> = RefCell::new(Box::new([0u8; 16384]));
+    // Scratch for assembling one PADDED DATA payload. Moved out of the slot while in use
+    // (see `DirectWriterStruct::write_padded`): the write can flush the cork and re-enter
+    // JS, and a nested padded write must get its own buffer.
+    static PADDED_PAYLOAD_BUFFER: Cell<Option<Box<[u8]>>> = const { Cell::new(None) };
 }
 
 /// One wire-order piece of a multi-frame send_data batch (see BATCH_SEGMENTS).
@@ -1738,19 +1741,7 @@ impl Stream {
                     };
                     let _ = data_header.write(&mut writer);
                     if padding != 0 {
-                        break 'brk SHARED_REQUEST_BUFFER.with_borrow_mut(|buffer| {
-                            // SAFETY: src/dst may overlap — use ptr::copy (memmove)
-                            unsafe {
-                                core::ptr::copy(
-                                    able_to_send.as_ptr(),
-                                    buffer.as_mut_ptr().add(1),
-                                    able_to_send.len(),
-                                );
-                            }
-                            buffer[0] = padding;
-                            buffer[1 + able_to_send.len()..payload_size].fill(0);
-                            writer.write_all(&buffer[0..payload_size]).is_ok()
-                        });
+                        break 'brk writer.write_padded(&able_to_send, padding).is_ok();
                     } else {
                         break 'brk writer.write_all(&able_to_send).is_ok();
                     }
@@ -1802,19 +1793,7 @@ impl Stream {
                     };
                     let _ = data_header.write(&mut writer);
                     if padding != 0 {
-                        break 'brk SHARED_REQUEST_BUFFER.with_borrow_mut(|buffer| {
-                            // SAFETY: src/dst may overlap — ptr::copy is memmove; dst capacity covers payload_size
-                            unsafe {
-                                core::ptr::copy(
-                                    frame_slice.as_ptr(),
-                                    buffer.as_mut_ptr().add(1),
-                                    frame_slice.len(),
-                                );
-                            }
-                            buffer[0] = padding;
-                            buffer[1 + frame_slice.len()..payload_size].fill(0);
-                            writer.write_all(&buffer[0..payload_size]).is_ok()
-                        });
+                        break 'brk writer.write_padded(frame_slice, padding).is_ok();
                     } else {
                         break 'brk writer.write_all(frame_slice).is_ok();
                     }
@@ -6165,6 +6144,27 @@ impl bun_io::Write for DirectWriterStruct {
     }
 }
 
+impl DirectWriterStruct {
+    /// Writes the payload of a PADDED DATA frame: the pad length, `data`, then `padding`
+    /// zero bytes (RFC 9113 6.1). The caller has already written the frame header.
+    fn write_padded(&mut self, data: &[u8], padding: u8) -> bun_io::Result<()> {
+        let payload_size = 1 + data.len() + padding as usize;
+        // `write()` can flush the cork and, over a JS-backed transport, re-enter JS that
+        // reaches send_data()/flush_queue() again before this frame's bytes are all corked.
+        // Own the scratch for the duration so that nested padded write neither trips a held
+        // borrow nor overwrites bytes this write is still copying from.
+        let mut buffer = PADDED_PAYLOAD_BUFFER
+            .take()
+            .unwrap_or_else(|| vec![0u8; H2_CORK_BUFFER_SIZE].into_boxed_slice());
+        buffer[0] = padding;
+        buffer[1..=data.len()].copy_from_slice(data);
+        buffer[1 + data.len()..payload_size].fill(0);
+        let result = self.write_all(&buffer[..payload_size]);
+        PADDED_PAYLOAD_BUFFER.set(Some(buffer));
+        result
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // H2FrameParser impl — JS host fns (part 1)
 // ──────────────────────────────────────────────────────────────────────────
@@ -7294,19 +7294,7 @@ impl H2FrameParser {
                         let mut writer = self.to_writer();
                         let _ = data_header.write(&mut writer);
                         if padding != 0 {
-                            SHARED_REQUEST_BUFFER.with_borrow_mut(|buffer| {
-                                // SAFETY: src/dst may overlap — ptr::copy is memmove; dst capacity covers payload_size
-                                unsafe {
-                                    core::ptr::copy(
-                                        slice.as_ptr(),
-                                        buffer.as_mut_ptr().add(1),
-                                        slice.len(),
-                                    );
-                                }
-                                buffer[0] = padding;
-                                buffer[1 + slice.len()..payload_size].fill(0);
-                                let _ = writer.write_all(&buffer[0..payload_size]);
-                            });
+                            let _ = writer.write_padded(slice, padding);
                         } else {
                             let _ = writer.write_all(slice);
                         }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -6143,9 +6143,8 @@ impl DirectWriterStruct {
     /// The payload of a PADDED DATA frame (RFC 9113 6.1); the caller wrote the frame header.
     fn write_padded(&mut self, data: &[u8], padding: u8) -> bun_io::Result<()> {
         let payload_size = 1 + data.len() + padding as usize;
-        // The VM's shared scratch, taken by value: `write()` can re-enter this path
-        // through a JS transport mid-frame, and the nested call must not alias (or trip
-        // a borrow of) the buffer this one is still writing from.
+        // Taken by value: `write()` can re-enter this path through a JS transport
+        // mid-frame, and the nested call must not alias the buffer in use here.
         let global = self.writer.global();
         let mut buffer = global
             .bun_vm()

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -6143,8 +6143,7 @@ impl DirectWriterStruct {
     /// The payload of a PADDED DATA frame (RFC 9113 6.1); the caller wrote the frame header.
     fn write_padded(&mut self, data: &[u8], padding: u8) -> bun_io::Result<()> {
         let payload_size = 1 + data.len() + padding as usize;
-        // Taken by value: `write()` can re-enter this path through a JS transport
-        // mid-frame, and the nested call must not alias the buffer in use here.
+        // Taken by value so a re-entrant call gets its own; see take_h2_padded_frame_buffer.
         let global = self.writer.global();
         let mut buffer = global
             .bun_vm()

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1987,6 +1987,71 @@ it("http2 session.goaway() opaqueData survives re-entrant buffer detach over a J
   expect(exitCode).toBe(0);
 }, 15_000);
 
+it("http2 padded DATA write survives a re-entrant stream write from a JS Duplex _write", async () => {
+  // With padding enabled, a single-frame DATA write that crosses the 16 KiB cork boundary
+  // flushes the cork into the JS transport mid-frame (onWrite → Duplex _write). A transport
+  // that writes to another padded stream from inside its _write re-enters the same padded
+  // send path while the outer frame is still being assembled. That must neither abort the
+  // process nor clobber the outer frame's bytes: every payload byte of all three writes has
+  // to reach the transport (same totals as node).
+  const fixture = `
+    const http2 = require("node:http2");
+    const { Duplex } = require("node:stream");
+    // fill: 13000 -> 9+13256 corked; outer: 12000 -> 9+12256, crosses the cork boundary;
+    // side: 3000 -> 9+3256, written from inside the transport _write during that flush.
+    const EXPECTED_WIRE = 9 + 13256 + 9 + 12256 + 9 + 3256;
+    let side, armed = false, reentered = false, total = 0, onComplete;
+    const counts = { 0x41: 0, 0x42: 0, 0x43: 0 };
+    const duplex = new Duplex({
+      read() {},
+      write(chunk, enc, cb) {
+        if (armed) {
+          for (const b of chunk) if (b in counts) counts[b]++;
+          total += chunk.length;
+          if (!reentered) {
+            reentered = true;
+            side.write(Buffer.alloc(3000, 0x42));
+          }
+          if (total >= EXPECTED_WIRE && onComplete) onComplete();
+        }
+        cb();
+      },
+    });
+    const session = http2.connect("http://127.0.0.1:1", {
+      createConnection: () => duplex,
+      paddingStrategy: http2.constants.PADDING_STRATEGY_MAX,
+    });
+    session.on("error", () => {});
+    await new Promise(r => session.once("connect", r));
+    const frame = (type, flags) => Buffer.from([0, 0, 0, type, flags, 0, 0, 0, 0]);
+    // server preface by hand: empty SETTINGS, then the ACK for the client's SETTINGS
+    duplex.push(Buffer.concat([frame(4, 0), frame(4, 1)]));
+    await new Promise(r => setImmediate(r));
+    side = session.request({ ":method": "POST", ":path": "/side" }, { endStream: false });
+    const outer = session.request({ ":method": "POST", ":path": "/outer" }, { endStream: false });
+    const fill = session.request({ ":method": "POST", ":path": "/fill" }, { endStream: false });
+    for (const s of [side, outer, fill]) s.on("error", () => {});
+    await new Promise(r => setImmediate(r)); // HEADERS leave the cork at the end of the tick
+    const complete = new Promise(r => (onComplete = r));
+    fill.write(Buffer.alloc(13000, 0x43));
+    armed = true;
+    outer.write(Buffer.alloc(12000, 0x41));
+    if (total < EXPECTED_WIRE) await complete;
+    console.log(JSON.stringify({ reentered, total, A: counts[0x41], B: counts[0x42], C: counts[0x43] }));
+    process.exit(0);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({ reentered: true, total: 28795, A: 12000, B: 3000, C: 13000 });
+  expect(exitCode).toBe(0);
+});
+
 it("http2 server sends protocol-error GOAWAY on stream 0", async () => {
   // RFC 9113 section 6.8: GOAWAY frames MUST be sent with a stream identifier
   // of 0 in the frame header; the last processed stream id lives in the

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2002,13 +2002,18 @@ it("http2 padded DATA write survives a re-entrant stream write from a JS Duplex 
     const EXPECTED_WIRE = 9 + 13256 + 9 + 12256 + 9 + 3256;
     let side, armed = false, reentered = false, total = 0, onComplete;
     const counts = { 0x41: 0, 0x42: 0, 0x43: 0 };
+    const fail = what => err => {
+      console.error(what, err);
+      process.exit(1);
+    };
     const duplex = new Duplex({
       read() {},
       write(chunk, enc, cb) {
         if (armed) {
           for (const b of chunk) if (b in counts) counts[b]++;
           total += chunk.length;
-          if (!reentered) {
+          // The first chunk carrying outer's payload is the mid-frame cork flush.
+          if (!reentered && chunk.includes(0x41)) {
             reentered = true;
             side.write(Buffer.alloc(3000, 0x42));
           }
@@ -2021,7 +2026,7 @@ it("http2 padded DATA write survives a re-entrant stream write from a JS Duplex 
       createConnection: () => duplex,
       paddingStrategy: http2.constants.PADDING_STRATEGY_MAX,
     });
-    session.on("error", () => {});
+    session.on("error", fail("session error"));
     await new Promise(r => session.once("connect", r));
     const frame = (type, flags) => Buffer.from([0, 0, 0, type, flags, 0, 0, 0, 0]);
     // server preface by hand: empty SETTINGS, then the ACK for the client's SETTINGS
@@ -2030,8 +2035,10 @@ it("http2 padded DATA write survives a re-entrant stream write from a JS Duplex 
     side = session.request({ ":method": "POST", ":path": "/side" }, { endStream: false });
     const outer = session.request({ ":method": "POST", ":path": "/outer" }, { endStream: false });
     const fill = session.request({ ":method": "POST", ":path": "/fill" }, { endStream: false });
-    for (const s of [side, outer, fill]) s.on("error", () => {});
-    await new Promise(r => setImmediate(r)); // HEADERS leave the cork at the end of the tick
+    for (const s of [side, outer, fill]) s.on("error", fail("stream error"));
+    // The three HEADERS frames leave the cork in this tick's deferred auto-flush, which runs
+    // before the loop reaches the next immediate.
+    await new Promise(r => setImmediate(r));
     const complete = new Promise(r => (onComplete = r));
     fill.write(Buffer.alloc(13000, 0x43));
     armed = true;


### PR DESCRIPTION
## What

`node:http2` over a user-supplied Duplex transport (`createConnection`) with `paddingStrategy` enabled: writing to a second stream from inside the transport's `_write` aborts the process with `panic: RefCell already borrowed`.

## Reproduction

```js
import http2 from "node:http2";
import { Duplex } from "node:stream";
let req2, armed = false, fired = 0;
const duplex = new Duplex({
  read() {},
  write(chunk, enc, cb) { if (armed && fired++ === 0) req2.write(new Uint8Array(3000).fill(0x42)); cb(); },
  final(cb) { cb(); },
});
const session = http2.connect("http://localhost:1", { createConnection: () => duplex, paddingStrategy: http2.constants.PADDING_STRATEGY_MAX });
session.on("error", () => {});
await new Promise(r => session.once("connect", r));
const f = (t, fl, sid, p) => { const h = Buffer.alloc(9); h.writeUIntBE(p.length, 0, 3); h[3] = t; h[4] = fl; h.writeUInt32BE(sid, 5); return Buffer.concat([h, p]); };
const set = Buffer.alloc(6); set.writeUInt16BE(4, 0); set.writeUInt32BE(0x7fffffff, 2);
const wu = Buffer.alloc(4); wu.writeUInt32BE(0x70000000, 0);
duplex.push(Buffer.concat([f(4, 0, 0, set), f(8, 0, 0, wu), f(4, 1, 0, Buffer.alloc(0))])); // server preface by hand
await new Promise(r => setTimeout(r, 50));
req2 = session.request({ ":method": "POST", ":path": "/side" }, { endStream: false }); req2.on("error", () => {});
const req = session.request({ ":method": "POST", ":path": "/" }, { endStream: false }); req.on("error", () => {});
await new Promise(r => setTimeout(r, 30));
const pad = session.request({ ":method": "POST", ":path": "/pad", "x-pad": "q".repeat(15000) }, { endStream: false }); pad.on("error", () => {}); // ~13 KB corked HEADERS
armed = true;
req.write(new Uint8Array(12000).fill(0x41));   // padded DATA (12256+9) crosses the 16 KiB cork -> flush -> duplex.write() -> req2.write()
await new Promise(r => setTimeout(r, 100));
console.log("no crash");
```

Before: `panic: RefCell already borrowed` / "oh no: Bun has crashed", exit 134, every run (`core::cell::panic_already_borrowed` <- `H2FrameParser::send_data` <- `write_stream`). Node v26.3.0 prints `no crash`.

## Cause

`send_data`'s padded single-frame branch (and the two padded branches in `Stream::flush_queue`) built the payload inside `SHARED_REQUEST_BUFFER.with_borrow_mut(|buffer| { ...; writer.write_all(&buffer[..payload_size]) })`, so the `write_all` ran inside the borrow. When the frame crosses the cork boundary, `write()` -> `flush_cork_buffer()` -> `_write()` -> `onWrite` runs the Duplex `_write` (user JS) with the thread-local still mutably borrowed; the nested `req2.write()` -> `send_data` borrows it again and panics. Native TCP/TLS transports never run JS from `_write`, so only JS-backed transports are affected.

The rest of the write path already follows the rule that no thread-local borrow is held across `_write` (`uncork`, `flush_batch_buffer`, `flush_cork_buffer` move their Vec out first); these three sites predate it.

## Fix

Add `DirectWriterStruct::write_padded(data, padding)` and use it at all three sites. The scratch stays shared and reusable, but it now lives in the VM's `RareData` (per review: a thread-local static is wrong with worker_threads; per-VM is the right scope). `write_padded` takes the buffer out of its `rare_data` slot by value for the duration of the write, so nothing is borrowed across `write()`: a re-entrant padded write finds the slot empty, allocates its own buffer, and the slot keeps one buffer for reuse when they return. `SHARED_REQUEST_BUFFER` is removed, along with the three `unsafe { ptr::copy }` blocks.

Frame ordering on the wire when a JS transport re-enters the session mid-frame is unchanged by this PR (it behaves like the unpadded path does today, see #36918 for that); this only removes the abort and keeps each frame's own bytes intact.

## Verification

New test in `test/js/node/http2/node-http2.test.js`: three padded DATA writes in one tick over a JS Duplex (a corked fill frame, an outer frame that crosses the cork boundary, and a side-stream write issued from inside the transport's `_write` during that flush), then counts the payload bytes that reach the transport. Expected `{ reentered: true, total: 28795, A: 12000, B: 3000, C: 13000 }`, which is also what node v26.3.0 produces for the same script.

- before (release and debug+ASAN): subprocess aborts with `panic: RefCell already borrowed`, test fails
- after: passes; full `node-http2.test.js`: 311 pass, 6 skip, 0 fail

Related: #36905 (merged) and #36910 cover the borrowed-payload side of the same re-entrant Duplex write path; this one is independent of both (the padded path already copied its payload, the problem was the held borrow).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (110748b30)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [762.93ms]
(pass) node none > Client Basics > should be able to send a POST request [526.52ms]
(pass) node none > Client Basics > constants [19.71ms]
(pass) node none > Client Basics > getDefaultSettings [7.26ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.03ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [4.89ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.46ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [4.85ms]
(pass) node none > Client Basics > should be able to send data using end [558.09ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [549.02ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release without fix: 2 failed, 6 skipped
bun test v1.4.0-canary.1 (b66764ff3)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.85ms]
(pass) node none > Client Basics > getDefaultSettings [0.15ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.40ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.10ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.06ms]
(pass) node none > Client Basics > is possible to abort request [3.70ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.83ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.75ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.18ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [57.33ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > close callback [53
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (110748b30)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [1184.19ms]
(pass) node none > Client Basics > should be able to send a POST request [774.97ms]
(pass) node none > Client Basics > constants [31.96ms]
(pass) node none > Client Basics > getDefaultSettings [11.95ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [33.02ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [4.86ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.52ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.46ms]
(pass) node none > Client Basics > should be able to send data using end [827.20ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [806.11ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receivin
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 930ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/124] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/124] gen cpp.rs (cppbind)
[2/124] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_alloc v0.0.0 (/workspace/bun/src/bun_alloc)
[1m[92m   Compiling[0m bun_libdeflate_sys v0.0.0 (/workspace/bun/src/libdeflate_sys)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/sr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/rare_data.rs                   | 27 ++++++++++--
 src/runtime/api/bun/h2_frame_parser.rs | 75 ++++++++++++++--------------------
 test/js/node/http2/node-http2.test.js  | 72 ++++++++++++++++++++++++++++++++
 3 files changed, 127 insertions(+), 47 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/jsc/rare_data.rs                        4      8      0
src/runtime/api/bun/h2_frame_parser.rs     11     13      0
test/js/node/http2/node-http2.test.js       3      5      0
```

</details>

<!-- robobun:evidence:end -->