### PR TITLE
Bun.openInEditor: read options before borrowing the editor context

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -956,7 +956,7 @@ fn open_in_editor(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
     let vm = global_this.bun_vm();
     let mut arguments = ArgumentsSlice::init(vm, callframe.arguments());
     let mut path = ZigStringSlice::EMPTY;
-    let mut editor_choice: Option<Editor> = None;
+    let mut editor_name: Option<ZigStringSlice> = None;
     let mut line: Option<ZigStringSlice> = None;
     let mut column: Option<ZigStringSlice> = None;
 
@@ -964,59 +964,65 @@ fn open_in_editor(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
         path = file_path_.to_slice(global_this)?;
     }
 
+    // Option getters and `toString` run arbitrary user JS that may re-enter
+    // this function, so every JS-visible coercion must finish before the
+    // EDITOR_CONTEXT borrow below is taken (re-entry while borrowed panics).
+    if let Some(opts) = arguments.next_eat() {
+        if !opts.is_undefined_or_null() {
+            if let Some(editor_val) = opts.get_truthy(global_this, "editor")? {
+                editor_name = Some(editor_val.to_slice(global_this)?);
+            }
+
+            if let Some(line_) = opts.get_truthy(global_this, "line")? {
+                line = Some(line_.to_slice(global_this)?);
+            }
+
+            if let Some(column_) = opts.get_truthy(global_this, "column")? {
+                column = Some(column_.to_slice(global_this)?);
+            }
+        }
+    }
+
     EDITOR_CONTEXT.with(|cell| -> JsResult<JSValue> {
         let mut slot = cell.borrow_mut();
         let slot = &mut *slot;
         let edit = &mut slot.ctx;
         let env = vm.transpiler.env_mut();
+        let mut editor_choice: Option<Editor> = None;
 
-        if let Some(opts) = arguments.next_eat() {
-            if !opts.is_undefined_or_null() {
-                if let Some(editor_val) = opts.get_truthy(global_this, "editor")? {
-                    let sliced = editor_val.to_slice(global_this)?;
-                    let prev_name = edit.name;
+        if let Some(sliced) = &editor_name {
+            let prev_name = edit.name;
 
-                    if !strings::eql_long(prev_name, sliced.slice(), true) {
-                        let prev = core::mem::take(edit);
-                        // Own the bytes in `name_storage` and
-                        // hand back a thread-lifetime borrow.
-                        let prev_storage =
-                            core::mem::replace(&mut slot.name_storage, sliced.slice().to_vec());
-                        // SAFETY: `name_storage` lives in a thread_local that
-                        // outlives any caller; we never reallocate it while
-                        // `edit.name` is observed (single-threaded JS VM).
-                        edit.name =
-                            unsafe { bun_ptr::detach_lifetime(slot.name_storage.as_slice()) };
-                        edit.detect_editor(env);
-                        editor_choice = edit.editor;
-                        if editor_choice.is_none() {
-                            slot.name_storage = prev_storage;
-                            *edit = prev;
-                            return Err(global_this.throw(format_args!(
-                                "Could not find editor \"{}\"",
-                                bstr::BStr::new(sliced.slice()),
-                            )));
-                        } else if edit.name.as_ptr() == edit.path.as_ptr() {
-                            // `detect_editor` aliased `path` to `name` (absolute
-                            // editor path). `name` is backed by `slot.name_storage`,
-                            // which a later call may drop while the detached editor
-                            // thread is still reading argv[0]. Give `path`
-                            // process-lifetime storage, matching every other
-                            // `detect_editor` branch.
-                            edit.path = bun_resolver::fs::FileSystem::instance()
-                                .dirname_store
-                                .append_slice(edit.path)
-                                .expect("unreachable");
-                        }
-                    }
-                }
-
-                if let Some(line_) = opts.get_truthy(global_this, "line")? {
-                    line = Some(line_.to_slice(global_this)?);
-                }
-
-                if let Some(column_) = opts.get_truthy(global_this, "column")? {
-                    column = Some(column_.to_slice(global_this)?);
+            if !strings::eql_long(prev_name, sliced.slice(), true) {
+                let prev = core::mem::take(edit);
+                // Own the bytes in `name_storage` and
+                // hand back a thread-lifetime borrow.
+                let prev_storage =
+                    core::mem::replace(&mut slot.name_storage, sliced.slice().to_vec());
+                // SAFETY: `name_storage` lives in a thread_local that
+                // outlives any caller; we never reallocate it while
+                // `edit.name` is observed (single-threaded JS VM).
+                edit.name = unsafe { bun_ptr::detach_lifetime(slot.name_storage.as_slice()) };
+                edit.detect_editor(env);
+                editor_choice = edit.editor;
+                if editor_choice.is_none() {
+                    slot.name_storage = prev_storage;
+                    *edit = prev;
+                    return Err(global_this.throw(format_args!(
+                        "Could not find editor \"{}\"",
+                        bstr::BStr::new(sliced.slice()),
+                    )));
+                } else if edit.name.as_ptr() == edit.path.as_ptr() {
+                    // `detect_editor` aliased `path` to `name` (absolute
+                    // editor path). `name` is backed by `slot.name_storage`,
+                    // which a later call may drop while the detached editor
+                    // thread is still reading argv[0]. Give `path`
+                    // process-lifetime storage, matching every other
+                    // `detect_editor` branch.
+                    edit.path = bun_resolver::fs::FileSystem::instance()
+                        .dirname_store
+                        .append_slice(edit.path)
+                        .expect("unreachable");
                 }
             }
         }

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -3,6 +3,53 @@ import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { existsSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 
+// Option getters and toString run user JS that may call Bun.openInEditor
+// again. The editor slot used to stay mutably borrowed across those
+// callbacks, so re-entry aborted with "panic: RefCell already borrowed".
+// Linux-only so editor detection stays inert: with an empty PATH and no
+// EDITOR/VISUAL nothing is found (macOS would probe /Applications).
+test.skipIf(!isLinux)("Bun.openInEditor survives re-entrant calls from option getters", async () => {
+  using dir = tempDir("open-in-editor-reentrant", {
+    "empty-path/.keep": "",
+    "run.js": `
+      const reenter = () => {
+        try { Bun.openInEditor("/nonexistent/f.txt", { editor: "zzz_no_editor" }); } catch {}
+      };
+      const variants = [
+        { get editor() { reenter(); return "zzz_no_editor"; } },
+        { editor: { toString() { reenter(); return "zzz_no_editor"; } } },
+        { line: { toString() { reenter(); return "1"; } } },
+        { get column() { reenter(); return "2"; } },
+      ];
+      for (const opts of variants) {
+        try { Bun.openInEditor("/nonexistent/f.txt", opts); } catch {}
+        console.log("ok");
+      }
+    `,
+  });
+
+  const env: Record<string, string | undefined> = {
+    ...bunEnv,
+    PATH: join(String(dir), "empty-path"),
+  };
+  delete env.EDITOR;
+  delete env.VISUAL;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.js"],
+    env,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim().split("\n")).toEqual(["ok", "ok", "ok", "ok"]);
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});
+
 // On Linux, JSC uses SIGPWR to suspend/resume threads for GC and the libpas
 // scavenger. Bun.openInEditor spawns a detached thread that goes through
 // bun.spawnSync, whose signal-forwarding setup must not touch SIGPWR or the

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -43,8 +43,9 @@ test.skipIf(!isLinux)("Bun.openInEditor survives re-entrant calls from option ge
     stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(stderr).toBe("");
   expect(stdout.trim().split("\n")).toEqual(["ok", "ok", "ok", "ok"]);
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);


### PR DESCRIPTION
### Problem

`Bun.openInEditor(path, opts)` aborts the process when an option accessor re-enters the API:

```js
let d = 0;
const opts = { get editor() {
  if (d++ === 0) { try { Bun.openInEditor("/nonexistent/f.txt", { editor: "zzz_no_editor" }); } catch {} }
  return "zzz_no_editor";
} };
Bun.openInEditor("/nonexistent/f.txt", opts);
```

```
panic: RefCell already borrowed
```

Top frame: `core::cell::panic_already_borrowed` <- `open_in_editor` (src/runtime/api/BunObject.rs). Same abort for an `editor` `toString`, a `line` `toString`, or a `column` getter. Deterministic on 1.4.0-canary; nothing needs to be spawned.

### Cause

The whole option-parsing body runs inside `EDITOR_CONTEXT.with(|cell| cell.borrow_mut())`. While that thread-local `RefCell` is mutably borrowed, `opts.get_truthy(global, "editor")` / `"line"` / `"column"` and the `to_slice` coercions call user JS. A re-entrant `Bun.openInEditor` call from any of those hooks hits `borrow_mut()` again and panics.

### Fix

Read and coerce `editor`, `line`, and `column` to strings before taking the `EDITOR_CONTEXT` borrow. Only the slot update (`detect_editor`, name caching) and `editor.open()` remain inside it, and neither can call back into JS, so the borrow can no longer be held across user code.

Minor observable change: options are now read upfront, so when the named editor cannot be found, the `line`/`column` getters run before the error is thrown instead of being skipped.

### Verification

New test in `test/js/bun/util/open-in-editor-gc.test.ts` spawns a child that exercises all four re-entrant variants (editor getter, editor toString, line toString, column getter) with an empty `PATH` so no real editor is ever detected or spawned. Without the fix the child aborts with the panic above (exit 134); with it the child prints all four markers and exits 0.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/open-in-editor-gc.test.ts

<!-- robobun:evidence:end -->